### PR TITLE
regexp func: Allow regexp literal as first argument

### DIFF
--- a/compiler/parser/parser.es.js
+++ b/compiler/parser/parser.es.js
@@ -708,63 +708,69 @@ function peg$parse(input, options) {
       peg$c296 = function(s) {
             return {"kind": "String", "text": s}
           },
-      peg$c297 = function(first, e) { return e },
-      peg$c298 = "]",
-      peg$c299 = peg$literalExpectation("]", false),
-      peg$c300 = function(from, to) {
+      peg$c297 = "regexp",
+      peg$c298 = peg$literalExpectation("regexp", false),
+      peg$c299 = function(args, where) {
+            return {"kind": "Call", "name": "regexp", "args": args, "where": where}
+          },
+      peg$c300 = function(first, e) { return e },
+      peg$c301 = function(v) { return {"kind": "Primitive", "type": "string", "text": v} },
+      peg$c302 = "]",
+      peg$c303 = peg$literalExpectation("]", false),
+      peg$c304 = function(from, to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs":to}]
           
           },
-      peg$c301 = function(to) {
+      peg$c305 = function(to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs": null, "rhs":to}]
           
           },
-      peg$c302 = function(expr) { return ["[", expr] },
-      peg$c303 = function(id) { return [".", id] },
-      peg$c304 = function(exprs, locals, scope) {
+      peg$c306 = function(expr) { return ["[", expr] },
+      peg$c307 = function(id) { return [".", id] },
+      peg$c308 = function(exprs, locals, scope) {
             return {"kind": "OverExpr", "locals": locals, "exprs": exprs, "scope": scope}
           },
-      peg$c305 = "}",
-      peg$c306 = peg$literalExpectation("}", false),
-      peg$c307 = function(elems) {
+      peg$c309 = "}",
+      peg$c310 = peg$literalExpectation("}", false),
+      peg$c311 = function(elems) {
             return {"kind":"RecordExpr", "elems":elems}
           },
-      peg$c308 = function(elem) { return elem },
-      peg$c309 = "...",
-      peg$c310 = peg$literalExpectation("...", false),
-      peg$c311 = function(expr) {
+      peg$c312 = function(elem) { return elem },
+      peg$c313 = "...",
+      peg$c314 = peg$literalExpectation("...", false),
+      peg$c315 = function(expr) {
             return {"kind":"Spread", "expr": expr}
           },
-      peg$c312 = function(name, value) {
+      peg$c316 = function(name, value) {
             return {"kind":"Field","name": name, "value": value}
           },
-      peg$c313 = function(elems) {
+      peg$c317 = function(elems) {
             return {"kind":"ArrayExpr", "elems":elems }
           },
-      peg$c314 = "|[",
-      peg$c315 = peg$literalExpectation("|[", false),
-      peg$c316 = "]|",
-      peg$c317 = peg$literalExpectation("]|", false),
-      peg$c318 = function(elems) {
+      peg$c318 = "|[",
+      peg$c319 = peg$literalExpectation("|[", false),
+      peg$c320 = "]|",
+      peg$c321 = peg$literalExpectation("]|", false),
+      peg$c322 = function(elems) {
             return {"kind":"SetExpr", "elems":elems }
           },
-      peg$c319 = function(e) { return {"kind":"VectorValue","expr":e} },
-      peg$c320 = "|{",
-      peg$c321 = peg$literalExpectation("|{", false),
-      peg$c322 = "}|",
-      peg$c323 = peg$literalExpectation("}|", false),
-      peg$c324 = function(exprs) {
+      peg$c323 = function(e) { return {"kind":"VectorValue","expr":e} },
+      peg$c324 = "|{",
+      peg$c325 = peg$literalExpectation("|{", false),
+      peg$c326 = "}|",
+      peg$c327 = peg$literalExpectation("}|", false),
+      peg$c328 = function(exprs) {
             return {"kind":"MapExpr", "entries":exprs }
           },
-      peg$c325 = function(e) { return e },
-      peg$c326 = function(key, value) {
+      peg$c329 = function(e) { return e },
+      peg$c330 = function(key, value) {
             return {"key": key, "value": value}
           },
-      peg$c327 = function(selection, from, joins, where, groupby, having, orderby, limit) {
+      peg$c331 = function(selection, from, joins, where, groupby, having, orderby, limit) {
             return {
               
             "kind": "SQLExpr",
@@ -786,19 +792,19 @@ function peg$parse(input, options) {
             "limit": limit }
           
           },
-      peg$c328 = function(assignments) { return assignments },
-      peg$c329 = function(rhs, opt) {
+      peg$c332 = function(assignments) { return assignments },
+      peg$c333 = function(rhs, opt) {
             let m = {"kind": "Assignment", "lhs": null, "rhs": rhs};
             if (opt) {
               m["lhs"] = opt[3];
             }
             return m
           },
-      peg$c330 = function(table, alias) {
+      peg$c334 = function(table, alias) {
             return {"table": table, "alias": alias}
           },
-      peg$c331 = function(first, join) { return join },
-      peg$c332 = function(style, table, alias, leftKey, rightKey) {
+      peg$c335 = function(first, join) { return join },
+      peg$c336 = function(style, table, alias, leftKey, rightKey) {
             return {
               
             "table": table,
@@ -812,120 +818,120 @@ function peg$parse(input, options) {
             "alias": alias}
           
           },
-      peg$c333 = function(style) { return style },
-      peg$c334 = function(keys, order) {
+      peg$c337 = function(style) { return style },
+      peg$c338 = function(keys, order) {
             return {"kind": "SQLOrderBy", "keys": keys, "order":order}
           },
-      peg$c335 = function(dir) { return dir },
-      peg$c336 = function(count) { return count },
-      peg$c337 = peg$literalExpectation("select", true),
-      peg$c338 = function() { return "select" },
-      peg$c339 = "as",
-      peg$c340 = peg$literalExpectation("as", true),
-      peg$c341 = function() { return "as" },
-      peg$c342 = peg$literalExpectation("from", true),
-      peg$c343 = function() { return "from" },
-      peg$c344 = peg$literalExpectation("join", true),
-      peg$c345 = function() { return "join" },
-      peg$c346 = peg$literalExpectation("where", true),
-      peg$c347 = function() { return "where" },
-      peg$c348 = "group",
-      peg$c349 = peg$literalExpectation("group", true),
-      peg$c350 = function() { return "group" },
-      peg$c351 = "by",
-      peg$c352 = peg$literalExpectation("by", true),
-      peg$c353 = function() { return "by" },
-      peg$c354 = "having",
-      peg$c355 = peg$literalExpectation("having", true),
-      peg$c356 = function() { return "having" },
-      peg$c357 = peg$literalExpectation("order", true),
-      peg$c358 = function() { return "order" },
-      peg$c359 = "on",
-      peg$c360 = peg$literalExpectation("on", true),
-      peg$c361 = function() { return "on" },
-      peg$c362 = "limit",
-      peg$c363 = peg$literalExpectation("limit", true),
-      peg$c364 = function() { return "limit" },
-      peg$c365 = peg$literalExpectation("asc", true),
-      peg$c366 = peg$literalExpectation("desc", true),
-      peg$c367 = peg$literalExpectation("anti", true),
-      peg$c368 = peg$literalExpectation("left", true),
-      peg$c369 = peg$literalExpectation("right", true),
-      peg$c370 = peg$literalExpectation("inner", true),
-      peg$c371 = function(v) {
+      peg$c339 = function(dir) { return dir },
+      peg$c340 = function(count) { return count },
+      peg$c341 = peg$literalExpectation("select", true),
+      peg$c342 = function() { return "select" },
+      peg$c343 = "as",
+      peg$c344 = peg$literalExpectation("as", true),
+      peg$c345 = function() { return "as" },
+      peg$c346 = peg$literalExpectation("from", true),
+      peg$c347 = function() { return "from" },
+      peg$c348 = peg$literalExpectation("join", true),
+      peg$c349 = function() { return "join" },
+      peg$c350 = peg$literalExpectation("where", true),
+      peg$c351 = function() { return "where" },
+      peg$c352 = "group",
+      peg$c353 = peg$literalExpectation("group", true),
+      peg$c354 = function() { return "group" },
+      peg$c355 = "by",
+      peg$c356 = peg$literalExpectation("by", true),
+      peg$c357 = function() { return "by" },
+      peg$c358 = "having",
+      peg$c359 = peg$literalExpectation("having", true),
+      peg$c360 = function() { return "having" },
+      peg$c361 = peg$literalExpectation("order", true),
+      peg$c362 = function() { return "order" },
+      peg$c363 = "on",
+      peg$c364 = peg$literalExpectation("on", true),
+      peg$c365 = function() { return "on" },
+      peg$c366 = "limit",
+      peg$c367 = peg$literalExpectation("limit", true),
+      peg$c368 = function() { return "limit" },
+      peg$c369 = peg$literalExpectation("asc", true),
+      peg$c370 = peg$literalExpectation("desc", true),
+      peg$c371 = peg$literalExpectation("anti", true),
+      peg$c372 = peg$literalExpectation("left", true),
+      peg$c373 = peg$literalExpectation("right", true),
+      peg$c374 = peg$literalExpectation("inner", true),
+      peg$c375 = function(v) {
             return {"kind": "Primitive", "type": "net", "text": v}
           },
-      peg$c372 = function(v) {
+      peg$c376 = function(v) {
             return {"kind": "Primitive", "type": "ip", "text": v}
           },
-      peg$c373 = function(v) {
+      peg$c377 = function(v) {
             return {"kind": "Primitive", "type": "float64", "text": v}
           },
-      peg$c374 = function(v) {
+      peg$c378 = function(v) {
             return {"kind": "Primitive", "type": "int64", "text": v}
           },
-      peg$c375 = "true",
-      peg$c376 = peg$literalExpectation("true", false),
-      peg$c377 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
-      peg$c378 = "false",
-      peg$c379 = peg$literalExpectation("false", false),
-      peg$c380 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
-      peg$c381 = "null",
-      peg$c382 = peg$literalExpectation("null", false),
-      peg$c383 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
-      peg$c384 = "0x",
-      peg$c385 = peg$literalExpectation("0x", false),
-      peg$c386 = function() {
+      peg$c379 = "true",
+      peg$c380 = peg$literalExpectation("true", false),
+      peg$c381 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
+      peg$c382 = "false",
+      peg$c383 = peg$literalExpectation("false", false),
+      peg$c384 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
+      peg$c385 = "null",
+      peg$c386 = peg$literalExpectation("null", false),
+      peg$c387 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
+      peg$c388 = "0x",
+      peg$c389 = peg$literalExpectation("0x", false),
+      peg$c390 = function() {
       	return {"kind": "Primitive", "type": "bytes", "text": text()}
         },
-      peg$c387 = function(typ) {
+      peg$c391 = function(typ) {
             return {"kind": "TypeValue", "value": typ}
           },
-      peg$c388 = function(name) { return name },
-      peg$c389 = function(name, opt) {
+      peg$c392 = function(name) { return name },
+      peg$c393 = function(name, opt) {
             if (opt) {
               return {"kind": "TypeDef", "name": name, "type": opt[3]}
             }
             return {"kind": "TypeName", "name": name}
           },
-      peg$c390 = function(name) {
+      peg$c394 = function(name) {
             return {"kind": "TypeName", "name": name}
           },
-      peg$c391 = function(u) { return u },
-      peg$c392 = function(types) {
+      peg$c395 = function(u) { return u },
+      peg$c396 = function(types) {
             return {"kind": "TypeUnion", "types": types}
           },
-      peg$c393 = function(typ) { return typ },
-      peg$c394 = function(fields) {
+      peg$c397 = function(typ) { return typ },
+      peg$c398 = function(fields) {
             return {"kind":"TypeRecord", "fields":fields}
           },
-      peg$c395 = function(typ) {
+      peg$c399 = function(typ) {
             return {"kind":"TypeArray", "type":typ}
           },
-      peg$c396 = function(typ) {
+      peg$c400 = function(typ) {
             return {"kind":"TypeSet", "type":typ}
           },
-      peg$c397 = function(keyType, valType) {
+      peg$c401 = function(keyType, valType) {
             return {"kind":"TypeMap", "key_type":keyType, "val_type": valType}
           },
-      peg$c398 = function(v) {
+      peg$c402 = function(v) {
             if (v.length == 0) {
               return {"kind": "Primitive", "type": "string", "text": ""}
             }
             return makeTemplateExprChain(v)
           },
-      peg$c399 = "\"",
-      peg$c400 = peg$literalExpectation("\"", false),
-      peg$c401 = "'",
-      peg$c402 = peg$literalExpectation("'", false),
-      peg$c403 = function(v) {
+      peg$c403 = "\"",
+      peg$c404 = peg$literalExpectation("\"", false),
+      peg$c405 = "'",
+      peg$c406 = peg$literalExpectation("'", false),
+      peg$c407 = function(v) {
             return {"kind": "Primitive", "type": "string", "text": joinChars(v)}
           },
-      peg$c404 = "\\",
-      peg$c405 = peg$literalExpectation("\\", false),
-      peg$c406 = "${",
-      peg$c407 = peg$literalExpectation("${", false),
-      peg$c408 = function(e) {
+      peg$c408 = "\\",
+      peg$c409 = peg$literalExpectation("\\", false),
+      peg$c410 = "${",
+      peg$c411 = peg$literalExpectation("${", false),
+      peg$c412 = function(e) {
             return {
               
             "kind": "Cast",
@@ -939,191 +945,191 @@ function peg$parse(input, options) {
             "value": {"kind": "TypePrimitive", "name": "string"}}}
           
           },
-      peg$c409 = "uint8",
-      peg$c410 = peg$literalExpectation("uint8", false),
-      peg$c411 = "uint16",
-      peg$c412 = peg$literalExpectation("uint16", false),
-      peg$c413 = "uint32",
-      peg$c414 = peg$literalExpectation("uint32", false),
-      peg$c415 = "uint64",
-      peg$c416 = peg$literalExpectation("uint64", false),
-      peg$c417 = "int8",
-      peg$c418 = peg$literalExpectation("int8", false),
-      peg$c419 = "int16",
-      peg$c420 = peg$literalExpectation("int16", false),
-      peg$c421 = "int32",
-      peg$c422 = peg$literalExpectation("int32", false),
-      peg$c423 = "int64",
-      peg$c424 = peg$literalExpectation("int64", false),
-      peg$c425 = "float32",
-      peg$c426 = peg$literalExpectation("float32", false),
-      peg$c427 = "float64",
-      peg$c428 = peg$literalExpectation("float64", false),
-      peg$c429 = "bool",
-      peg$c430 = peg$literalExpectation("bool", false),
-      peg$c431 = "string",
-      peg$c432 = peg$literalExpectation("string", false),
-      peg$c433 = "duration",
-      peg$c434 = peg$literalExpectation("duration", false),
-      peg$c435 = "time",
-      peg$c436 = peg$literalExpectation("time", false),
-      peg$c437 = "bytes",
-      peg$c438 = peg$literalExpectation("bytes", false),
-      peg$c439 = "ip",
-      peg$c440 = peg$literalExpectation("ip", false),
-      peg$c441 = "net",
-      peg$c442 = peg$literalExpectation("net", false),
-      peg$c443 = function() {
+      peg$c413 = "uint8",
+      peg$c414 = peg$literalExpectation("uint8", false),
+      peg$c415 = "uint16",
+      peg$c416 = peg$literalExpectation("uint16", false),
+      peg$c417 = "uint32",
+      peg$c418 = peg$literalExpectation("uint32", false),
+      peg$c419 = "uint64",
+      peg$c420 = peg$literalExpectation("uint64", false),
+      peg$c421 = "int8",
+      peg$c422 = peg$literalExpectation("int8", false),
+      peg$c423 = "int16",
+      peg$c424 = peg$literalExpectation("int16", false),
+      peg$c425 = "int32",
+      peg$c426 = peg$literalExpectation("int32", false),
+      peg$c427 = "int64",
+      peg$c428 = peg$literalExpectation("int64", false),
+      peg$c429 = "float32",
+      peg$c430 = peg$literalExpectation("float32", false),
+      peg$c431 = "float64",
+      peg$c432 = peg$literalExpectation("float64", false),
+      peg$c433 = "bool",
+      peg$c434 = peg$literalExpectation("bool", false),
+      peg$c435 = "string",
+      peg$c436 = peg$literalExpectation("string", false),
+      peg$c437 = "duration",
+      peg$c438 = peg$literalExpectation("duration", false),
+      peg$c439 = "time",
+      peg$c440 = peg$literalExpectation("time", false),
+      peg$c441 = "bytes",
+      peg$c442 = peg$literalExpectation("bytes", false),
+      peg$c443 = "ip",
+      peg$c444 = peg$literalExpectation("ip", false),
+      peg$c445 = "net",
+      peg$c446 = peg$literalExpectation("net", false),
+      peg$c447 = function() {
                 return {"kind": "TypePrimitive", "name": text()}
               },
-      peg$c444 = function(name, typ) {
+      peg$c448 = function(name, typ) {
             return {"name": name, "type": typ}
           },
-      peg$c445 = "and",
-      peg$c446 = peg$literalExpectation("and", false),
-      peg$c447 = "AND",
-      peg$c448 = peg$literalExpectation("AND", false),
-      peg$c449 = function() { return "and" },
-      peg$c450 = "or",
-      peg$c451 = peg$literalExpectation("or", false),
-      peg$c452 = "OR",
-      peg$c453 = peg$literalExpectation("OR", false),
-      peg$c454 = function() { return "or" },
-      peg$c456 = "NOT",
-      peg$c457 = peg$literalExpectation("NOT", false),
-      peg$c458 = function() { return "not" },
-      peg$c459 = peg$literalExpectation("by", false),
-      peg$c460 = /^[A-Za-z_$]/,
-      peg$c461 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c462 = /^[0-9]/,
-      peg$c463 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c464 = function(id) { return {"kind": "ID", "name": id} },
-      peg$c465 = "$",
-      peg$c466 = peg$literalExpectation("$", false),
-      peg$c467 = "T",
-      peg$c468 = peg$literalExpectation("T", false),
-      peg$c469 = function() {
+      peg$c449 = "and",
+      peg$c450 = peg$literalExpectation("and", false),
+      peg$c451 = "AND",
+      peg$c452 = peg$literalExpectation("AND", false),
+      peg$c453 = function() { return "and" },
+      peg$c454 = "or",
+      peg$c455 = peg$literalExpectation("or", false),
+      peg$c456 = "OR",
+      peg$c457 = peg$literalExpectation("OR", false),
+      peg$c458 = function() { return "or" },
+      peg$c460 = "NOT",
+      peg$c461 = peg$literalExpectation("NOT", false),
+      peg$c462 = function() { return "not" },
+      peg$c463 = peg$literalExpectation("by", false),
+      peg$c464 = /^[A-Za-z_$]/,
+      peg$c465 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c466 = /^[0-9]/,
+      peg$c467 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c468 = function(id) { return {"kind": "ID", "name": id} },
+      peg$c469 = "$",
+      peg$c470 = peg$literalExpectation("$", false),
+      peg$c471 = "T",
+      peg$c472 = peg$literalExpectation("T", false),
+      peg$c473 = function() {
             return {"kind": "Primitive", "type": "time", "text": text()}
           },
-      peg$c470 = "Z",
-      peg$c471 = peg$literalExpectation("Z", false),
-      peg$c472 = function() {
+      peg$c474 = "Z",
+      peg$c475 = peg$literalExpectation("Z", false),
+      peg$c476 = function() {
             return {"kind": "Primitive", "type": "duration", "text": text()}
           },
-      peg$c473 = "ns",
-      peg$c474 = peg$literalExpectation("ns", false),
-      peg$c475 = "us",
-      peg$c476 = peg$literalExpectation("us", false),
-      peg$c477 = "ms",
-      peg$c478 = peg$literalExpectation("ms", false),
-      peg$c479 = "s",
-      peg$c480 = peg$literalExpectation("s", false),
-      peg$c481 = "m",
-      peg$c482 = peg$literalExpectation("m", false),
-      peg$c483 = "h",
-      peg$c484 = peg$literalExpectation("h", false),
-      peg$c485 = "d",
-      peg$c486 = peg$literalExpectation("d", false),
-      peg$c487 = "w",
-      peg$c488 = peg$literalExpectation("w", false),
-      peg$c489 = "y",
-      peg$c490 = peg$literalExpectation("y", false),
-      peg$c491 = function(a, b) {
+      peg$c477 = "ns",
+      peg$c478 = peg$literalExpectation("ns", false),
+      peg$c479 = "us",
+      peg$c480 = peg$literalExpectation("us", false),
+      peg$c481 = "ms",
+      peg$c482 = peg$literalExpectation("ms", false),
+      peg$c483 = "s",
+      peg$c484 = peg$literalExpectation("s", false),
+      peg$c485 = "m",
+      peg$c486 = peg$literalExpectation("m", false),
+      peg$c487 = "h",
+      peg$c488 = peg$literalExpectation("h", false),
+      peg$c489 = "d",
+      peg$c490 = peg$literalExpectation("d", false),
+      peg$c491 = "w",
+      peg$c492 = peg$literalExpectation("w", false),
+      peg$c493 = "y",
+      peg$c494 = peg$literalExpectation("y", false),
+      peg$c495 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c492 = "::",
-      peg$c493 = peg$literalExpectation("::", false),
-      peg$c494 = function(a, b, d, e) {
+      peg$c496 = "::",
+      peg$c497 = peg$literalExpectation("::", false),
+      peg$c498 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c495 = function(a, b) {
+      peg$c499 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c496 = function(a, b) {
+      peg$c500 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c497 = function() {
+      peg$c501 = function() {
             return "::"
           },
-      peg$c498 = function(v) { return ":" + v },
-      peg$c499 = function(v) { return v + ":" },
-      peg$c500 = function(a, m) {
+      peg$c502 = function(v) { return ":" + v },
+      peg$c503 = function(v) { return v + ":" },
+      peg$c504 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c501 = function(a, m) {
+      peg$c505 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c502 = function(s) { return parseInt(s) },
-      peg$c503 = function() {
+      peg$c506 = function(s) { return parseInt(s) },
+      peg$c507 = function() {
             return text()
           },
-      peg$c504 = "e",
-      peg$c505 = peg$literalExpectation("e", true),
-      peg$c506 = /^[+\-]/,
-      peg$c507 = peg$classExpectation(["+", "-"], false, false),
-      peg$c508 = "NaN",
-      peg$c509 = peg$literalExpectation("NaN", false),
-      peg$c510 = "Inf",
-      peg$c511 = peg$literalExpectation("Inf", false),
-      peg$c512 = /^[0-9a-fA-F]/,
-      peg$c513 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c514 = function(v) { return joinChars(v) },
-      peg$c515 = peg$anyExpectation(),
-      peg$c516 = function(head, tail) { return head + joinChars(tail) },
-      peg$c517 = /^[a-zA-Z_.:\/%#@~]/,
-      peg$c518 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
-      peg$c519 = function(head, tail) {
+      peg$c508 = "e",
+      peg$c509 = peg$literalExpectation("e", true),
+      peg$c510 = /^[+\-]/,
+      peg$c511 = peg$classExpectation(["+", "-"], false, false),
+      peg$c512 = "NaN",
+      peg$c513 = peg$literalExpectation("NaN", false),
+      peg$c514 = "Inf",
+      peg$c515 = peg$literalExpectation("Inf", false),
+      peg$c516 = /^[0-9a-fA-F]/,
+      peg$c517 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c518 = function(v) { return joinChars(v) },
+      peg$c519 = peg$anyExpectation(),
+      peg$c520 = function(head, tail) { return head + joinChars(tail) },
+      peg$c521 = /^[a-zA-Z_.:\/%#@~]/,
+      peg$c522 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
+      peg$c523 = function(head, tail) {
             return head + joinChars(tail)
           },
-      peg$c520 = function() { return "*"},
-      peg$c521 = function() { return "=" },
-      peg$c522 = function() { return "\\*" },
-      peg$c523 = "b",
-      peg$c524 = peg$literalExpectation("b", false),
-      peg$c525 = function() { return "\b" },
-      peg$c526 = "f",
-      peg$c527 = peg$literalExpectation("f", false),
-      peg$c528 = function() { return "\f" },
-      peg$c529 = "n",
-      peg$c530 = peg$literalExpectation("n", false),
-      peg$c531 = function() { return "\n" },
-      peg$c532 = "r",
-      peg$c533 = peg$literalExpectation("r", false),
-      peg$c534 = function() { return "\r" },
-      peg$c535 = "t",
-      peg$c536 = peg$literalExpectation("t", false),
-      peg$c537 = function() { return "\t" },
-      peg$c538 = "v",
-      peg$c539 = peg$literalExpectation("v", false),
-      peg$c540 = function() { return "\v" },
-      peg$c541 = function() { return "*" },
-      peg$c542 = "u",
-      peg$c543 = peg$literalExpectation("u", false),
-      peg$c544 = function(chars) {
+      peg$c524 = function() { return "*"},
+      peg$c525 = function() { return "=" },
+      peg$c526 = function() { return "\\*" },
+      peg$c527 = "b",
+      peg$c528 = peg$literalExpectation("b", false),
+      peg$c529 = function() { return "\b" },
+      peg$c530 = "f",
+      peg$c531 = peg$literalExpectation("f", false),
+      peg$c532 = function() { return "\f" },
+      peg$c533 = "n",
+      peg$c534 = peg$literalExpectation("n", false),
+      peg$c535 = function() { return "\n" },
+      peg$c536 = "r",
+      peg$c537 = peg$literalExpectation("r", false),
+      peg$c538 = function() { return "\r" },
+      peg$c539 = "t",
+      peg$c540 = peg$literalExpectation("t", false),
+      peg$c541 = function() { return "\t" },
+      peg$c542 = "v",
+      peg$c543 = peg$literalExpectation("v", false),
+      peg$c544 = function() { return "\v" },
+      peg$c545 = function() { return "*" },
+      peg$c546 = "u",
+      peg$c547 = peg$literalExpectation("u", false),
+      peg$c548 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c545 = /^[^\/\\]/,
-      peg$c546 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c547 = /^[\0-\x1F\\]/,
-      peg$c548 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c549 = peg$otherExpectation("whitespace"),
-      peg$c550 = "\t",
-      peg$c551 = peg$literalExpectation("\t", false),
-      peg$c552 = "\x0B",
-      peg$c553 = peg$literalExpectation("\x0B", false),
-      peg$c554 = "\f",
-      peg$c555 = peg$literalExpectation("\f", false),
-      peg$c556 = " ",
-      peg$c557 = peg$literalExpectation(" ", false),
-      peg$c558 = "\xA0",
-      peg$c559 = peg$literalExpectation("\xA0", false),
-      peg$c560 = "\uFEFF",
-      peg$c561 = peg$literalExpectation("\uFEFF", false),
-      peg$c562 = /^[\n\r\u2028\u2029]/,
-      peg$c563 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c564 = peg$otherExpectation("comment"),
-      peg$c569 = "//",
-      peg$c570 = peg$literalExpectation("//", false),
+      peg$c549 = /^[^\/\\]/,
+      peg$c550 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c551 = /^[\0-\x1F\\]/,
+      peg$c552 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c553 = peg$otherExpectation("whitespace"),
+      peg$c554 = "\t",
+      peg$c555 = peg$literalExpectation("\t", false),
+      peg$c556 = "\x0B",
+      peg$c557 = peg$literalExpectation("\x0B", false),
+      peg$c558 = "\f",
+      peg$c559 = peg$literalExpectation("\f", false),
+      peg$c560 = " ",
+      peg$c561 = peg$literalExpectation(" ", false),
+      peg$c562 = "\xA0",
+      peg$c563 = peg$literalExpectation("\xA0", false),
+      peg$c564 = "\uFEFF",
+      peg$c565 = peg$literalExpectation("\uFEFF", false),
+      peg$c566 = /^[\n\r\u2028\u2029]/,
+      peg$c567 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c568 = peg$otherExpectation("comment"),
+      peg$c573 = "//",
+      peg$c574 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -7603,52 +7609,58 @@ function peg$parse(input, options) {
 
     s0 = peg$parseGrep();
     if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$currPos;
-      peg$silentFails++;
-      s2 = peg$parseFuncGuard();
-      peg$silentFails--;
-      if (s2 === peg$FAILED) {
-        s1 = void 0;
-      } else {
-        peg$currPos = s1;
-        s1 = peg$FAILED;
-      }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parseIdentifierName();
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parse__();
-          if (s3 !== peg$FAILED) {
-            if (input.charCodeAt(peg$currPos) === 40) {
-              s4 = peg$c15;
-              peg$currPos++;
-            } else {
-              s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c16); }
-            }
-            if (s4 !== peg$FAILED) {
-              s5 = peg$parse__();
-              if (s5 !== peg$FAILED) {
-                s6 = peg$parseFunctionArgs();
-                if (s6 !== peg$FAILED) {
-                  s7 = peg$parse__();
-                  if (s7 !== peg$FAILED) {
-                    if (input.charCodeAt(peg$currPos) === 41) {
-                      s8 = peg$c17;
-                      peg$currPos++;
-                    } else {
-                      s8 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c18); }
-                    }
-                    if (s8 !== peg$FAILED) {
-                      s9 = peg$parseWhereClause();
-                      if (s9 === peg$FAILED) {
-                        s9 = null;
+      s0 = peg$parseRegexpFunc();
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$currPos;
+        peg$silentFails++;
+        s2 = peg$parseFuncGuard();
+        peg$silentFails--;
+        if (s2 === peg$FAILED) {
+          s1 = void 0;
+        } else {
+          peg$currPos = s1;
+          s1 = peg$FAILED;
+        }
+        if (s1 !== peg$FAILED) {
+          s2 = peg$parseIdentifierName();
+          if (s2 !== peg$FAILED) {
+            s3 = peg$parse__();
+            if (s3 !== peg$FAILED) {
+              if (input.charCodeAt(peg$currPos) === 40) {
+                s4 = peg$c15;
+                peg$currPos++;
+              } else {
+                s4 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c16); }
+              }
+              if (s4 !== peg$FAILED) {
+                s5 = peg$parse__();
+                if (s5 !== peg$FAILED) {
+                  s6 = peg$parseFunctionArgs();
+                  if (s6 !== peg$FAILED) {
+                    s7 = peg$parse__();
+                    if (s7 !== peg$FAILED) {
+                      if (input.charCodeAt(peg$currPos) === 41) {
+                        s8 = peg$c17;
+                        peg$currPos++;
+                      } else {
+                        s8 = peg$FAILED;
+                        if (peg$silentFails === 0) { peg$fail(peg$c18); }
                       }
-                      if (s9 !== peg$FAILED) {
-                        peg$savedPos = s0;
-                        s1 = peg$c291(s2, s6, s9);
-                        s0 = s1;
+                      if (s8 !== peg$FAILED) {
+                        s9 = peg$parseWhereClause();
+                        if (s9 === peg$FAILED) {
+                          s9 = null;
+                        }
+                        if (s9 !== peg$FAILED) {
+                          peg$savedPos = s0;
+                          s1 = peg$c291(s2, s6, s9);
+                          s0 = s1;
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$FAILED;
+                        }
                       } else {
                         peg$currPos = s0;
                         s0 = peg$FAILED;
@@ -7681,9 +7693,6 @@ function peg$parse(input, options) {
           peg$currPos = s0;
           s0 = peg$FAILED;
         }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
       }
     }
 
@@ -7842,6 +7851,206 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseRegexpFunc() {
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 6) === peg$c297) {
+      s1 = peg$c297;
+      peg$currPos += 6;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c298); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse__();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 40) {
+          s3 = peg$c15;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c16); }
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse__();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseRegexpFuncArgs();
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parse__();
+              if (s6 !== peg$FAILED) {
+                if (input.charCodeAt(peg$currPos) === 41) {
+                  s7 = peg$c17;
+                  peg$currPos++;
+                } else {
+                  s7 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c18); }
+                }
+                if (s7 !== peg$FAILED) {
+                  s8 = peg$parseWhereClause();
+                  if (s8 === peg$FAILED) {
+                    s8 = null;
+                  }
+                  if (s8 !== peg$FAILED) {
+                    peg$savedPos = s0;
+                    s1 = peg$c299(s5, s8);
+                    s0 = s1;
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseRegexpFuncArgs() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseRegexpFuncArg();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 44) {
+          s5 = peg$c98;
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c99); }
+        }
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseConditionalExpr();
+            if (s7 !== peg$FAILED) {
+              peg$savedPos = s3;
+              s4 = peg$c300(s1, s7);
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse__();
+        if (s4 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 44) {
+            s5 = peg$c98;
+            peg$currPos++;
+          } else {
+            s5 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c99); }
+          }
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseConditionalExpr();
+              if (s7 !== peg$FAILED) {
+                peg$savedPos = s3;
+                s4 = peg$c300(s1, s7);
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c101(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parse__();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c3();
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
+  function peg$parseRegexpFuncArg() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    s1 = peg$parseRegexpPattern();
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c301(s1);
+    }
+    s0 = s1;
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseConditionalExpr();
+    }
+
+    return s0;
+  }
+
   function peg$parseOptionalExprs() {
     var s0, s1;
 
@@ -7882,7 +8091,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c297(s1, s7);
+              s4 = peg$c300(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7918,7 +8127,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c297(s1, s7);
+                s4 = peg$c300(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -8028,15 +8237,15 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s7 = peg$c298;
+                  s7 = peg$c302;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c299); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c303); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c300(s2, s6);
+                  s1 = peg$c304(s2, s6);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8091,15 +8300,15 @@ function peg$parse(input, options) {
               s5 = peg$parseAdditiveExpr();
               if (s5 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s6 = peg$c298;
+                  s6 = peg$c302;
                   peg$currPos++;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c299); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c303); }
                 }
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c301(s5);
+                  s1 = peg$c305(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8138,15 +8347,15 @@ function peg$parse(input, options) {
           s2 = peg$parseConditionalExpr();
           if (s2 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s3 = peg$c298;
+              s3 = peg$c302;
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c299); }
+              if (peg$silentFails === 0) { peg$fail(peg$c303); }
             }
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c302(s2);
+              s1 = peg$c306(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8173,7 +8382,7 @@ function peg$parse(input, options) {
             s2 = peg$parseIdentifier();
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c303(s2);
+              s1 = peg$c307(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8342,7 +8551,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSequential();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c304(s3, s4, s8);
+                    s1 = peg$c308(s3, s4, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -8399,15 +8608,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c305;
+              s5 = peg$c309;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c306); }
+              if (peg$silentFails === 0) { peg$fail(peg$c310); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c307(s3);
+              s1 = peg$c311(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8489,7 +8698,7 @@ function peg$parse(input, options) {
           s4 = peg$parseRecordElem();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c308(s4);
+            s1 = peg$c312(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8529,12 +8738,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c309) {
-      s1 = peg$c309;
+    if (input.substr(peg$currPos, 3) === peg$c313) {
+      s1 = peg$c313;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c310); }
+      if (peg$silentFails === 0) { peg$fail(peg$c314); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8542,7 +8751,7 @@ function peg$parse(input, options) {
         s3 = peg$parseConditionalExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c311(s3);
+          s1 = peg$c315(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8581,7 +8790,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c312(s1, s5);
+              s1 = peg$c316(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8626,15 +8835,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s5 = peg$c298;
+              s5 = peg$c302;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c299); }
+              if (peg$silentFails === 0) { peg$fail(peg$c303); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c313(s3);
+              s1 = peg$c317(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8664,12 +8873,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c314) {
-      s1 = peg$c314;
+    if (input.substr(peg$currPos, 2) === peg$c318) {
+      s1 = peg$c318;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c315); }
+      if (peg$silentFails === 0) { peg$fail(peg$c319); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8678,16 +8887,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c316) {
-              s5 = peg$c316;
+            if (input.substr(peg$currPos, 2) === peg$c320) {
+              s5 = peg$c320;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c317); }
+              if (peg$silentFails === 0) { peg$fail(peg$c321); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c318(s3);
+              s1 = peg$c322(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8736,7 +8945,7 @@ function peg$parse(input, options) {
             s7 = peg$parseVectorElem();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c297(s1, s7);
+              s4 = peg$c300(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -8772,7 +8981,7 @@ function peg$parse(input, options) {
               s7 = peg$parseVectorElem();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c297(s1, s7);
+                s4 = peg$c300(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -8825,7 +9034,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c319(s1);
+        s1 = peg$c323(s1);
       }
       s0 = s1;
     }
@@ -8837,12 +9046,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c320) {
-      s1 = peg$c320;
+    if (input.substr(peg$currPos, 2) === peg$c324) {
+      s1 = peg$c324;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c321); }
+      if (peg$silentFails === 0) { peg$fail(peg$c325); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8851,16 +9060,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c322) {
-              s5 = peg$c322;
+            if (input.substr(peg$currPos, 2) === peg$c326) {
+              s5 = peg$c326;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c323); }
+              if (peg$silentFails === 0) { peg$fail(peg$c327); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c324(s3);
+              s1 = peg$c328(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8942,7 +9151,7 @@ function peg$parse(input, options) {
           s4 = peg$parseEntry();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c325(s4);
+            s1 = peg$c329(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8985,7 +9194,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c326(s1, s5);
+              s1 = peg$c330(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9050,7 +9259,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSQLLimit();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c327(s1, s2, s3, s4, s5, s6, s7, s8);
+                    s1 = peg$c331(s1, s2, s3, s4, s5, s6, s7, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -9128,7 +9337,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSQLAssignments();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c328(s3);
+            s1 = peg$c332(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9185,7 +9394,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c329(s1, s2);
+        s1 = peg$c333(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9311,7 +9520,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c330(s4, s5);
+              s1 = peg$c334(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9466,7 +9675,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSQLJoin();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s3;
-        s4 = peg$c331(s1, s4);
+        s4 = peg$c335(s1, s4);
       }
       s3 = s4;
       while (s3 !== peg$FAILED) {
@@ -9475,7 +9684,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSQLJoin();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s3;
-          s4 = peg$c331(s1, s4);
+          s4 = peg$c335(s1, s4);
         }
         s3 = s4;
       }
@@ -9537,7 +9746,7 @@ function peg$parse(input, options) {
                               s14 = peg$parseJoinKey();
                               if (s14 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c332(s1, s5, s6, s10, s14);
+                                s1 = peg$c336(s1, s5, s6, s10, s14);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -9617,7 +9826,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c333(s2);
+        s1 = peg$c337(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9776,7 +9985,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseSQLOrder();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c334(s6, s7);
+                  s1 = peg$c338(s6, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -9822,7 +10031,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c335(s2);
+        s1 = peg$c339(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9858,7 +10067,7 @@ function peg$parse(input, options) {
           s4 = peg$parseUInt();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c336(s4);
+            s1 = peg$c340(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9898,11 +10107,11 @@ function peg$parse(input, options) {
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c337); }
+      if (peg$silentFails === 0) { peg$fail(peg$c341); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c338();
+      s1 = peg$c342();
     }
     s0 = s1;
 
@@ -9913,16 +10122,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c339) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c343) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c340); }
+      if (peg$silentFails === 0) { peg$fail(peg$c344); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c341();
+      s1 = peg$c345();
     }
     s0 = s1;
 
@@ -9938,11 +10147,11 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c342); }
+      if (peg$silentFails === 0) { peg$fail(peg$c346); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c343();
+      s1 = peg$c347();
     }
     s0 = s1;
 
@@ -9958,11 +10167,11 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c344); }
+      if (peg$silentFails === 0) { peg$fail(peg$c348); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c345();
+      s1 = peg$c349();
     }
     s0 = s1;
 
@@ -9978,11 +10187,11 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c346); }
+      if (peg$silentFails === 0) { peg$fail(peg$c350); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c347();
+      s1 = peg$c351();
     }
     s0 = s1;
 
@@ -9993,16 +10202,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c348) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c352) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c349); }
+      if (peg$silentFails === 0) { peg$fail(peg$c353); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c350();
+      s1 = peg$c354();
     }
     s0 = s1;
 
@@ -10013,16 +10222,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c351) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c355) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c352); }
+      if (peg$silentFails === 0) { peg$fail(peg$c356); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c353();
+      s1 = peg$c357();
     }
     s0 = s1;
 
@@ -10033,16 +10242,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c354) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c358) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c355); }
+      if (peg$silentFails === 0) { peg$fail(peg$c359); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c356();
+      s1 = peg$c360();
     }
     s0 = s1;
 
@@ -10058,11 +10267,11 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c357); }
+      if (peg$silentFails === 0) { peg$fail(peg$c361); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c358();
+      s1 = peg$c362();
     }
     s0 = s1;
 
@@ -10073,16 +10282,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c359) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c363) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c360); }
+      if (peg$silentFails === 0) { peg$fail(peg$c364); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c361();
+      s1 = peg$c365();
     }
     s0 = s1;
 
@@ -10093,16 +10302,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c362) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c366) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c363); }
+      if (peg$silentFails === 0) { peg$fail(peg$c367); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c364();
+      s1 = peg$c368();
     }
     s0 = s1;
 
@@ -10118,7 +10327,7 @@ function peg$parse(input, options) {
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c365); }
+      if (peg$silentFails === 0) { peg$fail(peg$c369); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10138,7 +10347,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c366); }
+      if (peg$silentFails === 0) { peg$fail(peg$c370); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10158,7 +10367,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c367); }
+      if (peg$silentFails === 0) { peg$fail(peg$c371); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10178,7 +10387,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c368); }
+      if (peg$silentFails === 0) { peg$fail(peg$c372); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10198,7 +10407,7 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c369); }
+      if (peg$silentFails === 0) { peg$fail(peg$c373); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10218,7 +10427,7 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c370); }
+      if (peg$silentFails === 0) { peg$fail(peg$c374); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10320,7 +10529,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c371(s1);
+        s1 = peg$c375(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10335,7 +10544,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP4Net();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c371(s1);
+        s1 = peg$c375(s1);
       }
       s0 = s1;
     }
@@ -10361,7 +10570,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c372(s1);
+        s1 = peg$c376(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10376,7 +10585,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c372(s1);
+        s1 = peg$c376(s1);
       }
       s0 = s1;
     }
@@ -10391,7 +10600,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFloatString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c373(s1);
+      s1 = peg$c377(s1);
     }
     s0 = s1;
 
@@ -10405,7 +10614,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c374(s1);
+      s1 = peg$c378(s1);
     }
     s0 = s1;
 
@@ -10416,30 +10625,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c375) {
-      s1 = peg$c375;
+    if (input.substr(peg$currPos, 4) === peg$c379) {
+      s1 = peg$c379;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c376); }
+      if (peg$silentFails === 0) { peg$fail(peg$c380); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c377();
+      s1 = peg$c381();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c378) {
-        s1 = peg$c378;
+      if (input.substr(peg$currPos, 5) === peg$c382) {
+        s1 = peg$c382;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c379); }
+        if (peg$silentFails === 0) { peg$fail(peg$c383); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c380();
+        s1 = peg$c384();
       }
       s0 = s1;
     }
@@ -10451,16 +10660,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c381) {
-      s1 = peg$c381;
+    if (input.substr(peg$currPos, 4) === peg$c385) {
+      s1 = peg$c385;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c382); }
+      if (peg$silentFails === 0) { peg$fail(peg$c386); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c383();
+      s1 = peg$c387();
     }
     s0 = s1;
 
@@ -10471,12 +10680,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c384) {
-      s1 = peg$c384;
+    if (input.substr(peg$currPos, 2) === peg$c388) {
+      s1 = peg$c388;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c385); }
+      if (peg$silentFails === 0) { peg$fail(peg$c389); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -10487,7 +10696,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c386();
+        s1 = peg$c390();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10524,7 +10733,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c387(s2);
+          s1 = peg$c391(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10551,7 +10760,7 @@ function peg$parse(input, options) {
       s1 = peg$parsePrimitiveType();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c387(s1);
+        s1 = peg$c391(s1);
       }
       s0 = s1;
     }
@@ -10591,7 +10800,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c388(s1);
+        s1 = peg$c392(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10643,7 +10852,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c389(s1, s2);
+          s1 = peg$c393(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10658,7 +10867,7 @@ function peg$parse(input, options) {
         s1 = peg$parseQuotedString();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c390(s1);
+          s1 = peg$c394(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
@@ -10684,7 +10893,7 @@ function peg$parse(input, options) {
                 }
                 if (s4 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c391(s3);
+                  s1 = peg$c395(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10716,7 +10925,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTypeList();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c392(s1);
+      s1 = peg$c396(s1);
     }
     s0 = s1;
 
@@ -10774,7 +10983,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c393(s4);
+            s1 = peg$c397(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10815,15 +11024,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c305;
+              s5 = peg$c309;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c306); }
+              if (peg$silentFails === 0) { peg$fail(peg$c310); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c394(s3);
+              s1 = peg$c398(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -10862,15 +11071,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c298;
+                s5 = peg$c302;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c299); }
+                if (peg$silentFails === 0) { peg$fail(peg$c303); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c395(s3);
+                s1 = peg$c399(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -10894,12 +11103,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c314) {
-          s1 = peg$c314;
+        if (input.substr(peg$currPos, 2) === peg$c318) {
+          s1 = peg$c318;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c315); }
+          if (peg$silentFails === 0) { peg$fail(peg$c319); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -10908,16 +11117,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c316) {
-                  s5 = peg$c316;
+                if (input.substr(peg$currPos, 2) === peg$c320) {
+                  s5 = peg$c320;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c317); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c321); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c396(s3);
+                  s1 = peg$c400(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10941,12 +11150,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c320) {
-            s1 = peg$c320;
+          if (input.substr(peg$currPos, 2) === peg$c324) {
+            s1 = peg$c324;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c321); }
+            if (peg$silentFails === 0) { peg$fail(peg$c325); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -10969,16 +11178,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c322) {
-                            s9 = peg$c322;
+                          if (input.substr(peg$currPos, 2) === peg$c326) {
+                            s9 = peg$c326;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c323); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c327); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c397(s3, s7);
+                            s1 = peg$c401(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -11030,7 +11239,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTemplateLiteralParts();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c398(s1);
+      s1 = peg$c402(s1);
     }
     s0 = s1;
 
@@ -11042,11 +11251,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c399;
+      s1 = peg$c403;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c400); }
+      if (peg$silentFails === 0) { peg$fail(peg$c404); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -11057,11 +11266,11 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c399;
+          s3 = peg$c403;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c400); }
+          if (peg$silentFails === 0) { peg$fail(peg$c404); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
@@ -11082,11 +11291,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c401;
+        s1 = peg$c405;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c402); }
+        if (peg$silentFails === 0) { peg$fail(peg$c406); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -11097,11 +11306,11 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c401;
+            s3 = peg$c405;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c402); }
+            if (peg$silentFails === 0) { peg$fail(peg$c406); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
@@ -11142,7 +11351,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c403(s1);
+        s1 = peg$c407(s1);
       }
       s0 = s1;
     }
@@ -11155,19 +11364,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c404;
+      s1 = peg$c408;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c405); }
+      if (peg$silentFails === 0) { peg$fail(peg$c409); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c406) {
-        s2 = peg$c406;
+      if (input.substr(peg$currPos, 2) === peg$c410) {
+        s2 = peg$c410;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c407); }
+        if (peg$silentFails === 0) { peg$fail(peg$c411); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11185,12 +11394,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c406) {
-        s2 = peg$c406;
+      if (input.substr(peg$currPos, 2) === peg$c410) {
+        s2 = peg$c410;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c407); }
+        if (peg$silentFails === 0) { peg$fail(peg$c411); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -11236,7 +11445,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c403(s1);
+        s1 = peg$c407(s1);
       }
       s0 = s1;
     }
@@ -11249,19 +11458,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c404;
+      s1 = peg$c408;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c405); }
+      if (peg$silentFails === 0) { peg$fail(peg$c409); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c406) {
-        s2 = peg$c406;
+      if (input.substr(peg$currPos, 2) === peg$c410) {
+        s2 = peg$c410;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c407); }
+        if (peg$silentFails === 0) { peg$fail(peg$c411); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11279,12 +11488,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c406) {
-        s2 = peg$c406;
+      if (input.substr(peg$currPos, 2) === peg$c410) {
+        s2 = peg$c410;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c407); }
+        if (peg$silentFails === 0) { peg$fail(peg$c411); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -11316,12 +11525,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c406) {
-      s1 = peg$c406;
+    if (input.substr(peg$currPos, 2) === peg$c410) {
+      s1 = peg$c410;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c407); }
+      if (peg$silentFails === 0) { peg$fail(peg$c411); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -11331,15 +11540,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c305;
+              s5 = peg$c309;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c306); }
+              if (peg$silentFails === 0) { peg$fail(peg$c310); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c408(s3);
+              s1 = peg$c412(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11369,140 +11578,140 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c409) {
-      s1 = peg$c409;
+    if (input.substr(peg$currPos, 5) === peg$c413) {
+      s1 = peg$c413;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c410); }
+      if (peg$silentFails === 0) { peg$fail(peg$c414); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c411) {
-        s1 = peg$c411;
+      if (input.substr(peg$currPos, 6) === peg$c415) {
+        s1 = peg$c415;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c412); }
+        if (peg$silentFails === 0) { peg$fail(peg$c416); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c413) {
-          s1 = peg$c413;
+        if (input.substr(peg$currPos, 6) === peg$c417) {
+          s1 = peg$c417;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c414); }
+          if (peg$silentFails === 0) { peg$fail(peg$c418); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c415) {
-            s1 = peg$c415;
+          if (input.substr(peg$currPos, 6) === peg$c419) {
+            s1 = peg$c419;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c416); }
+            if (peg$silentFails === 0) { peg$fail(peg$c420); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c417) {
-              s1 = peg$c417;
+            if (input.substr(peg$currPos, 4) === peg$c421) {
+              s1 = peg$c421;
               peg$currPos += 4;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c418); }
+              if (peg$silentFails === 0) { peg$fail(peg$c422); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 5) === peg$c419) {
-                s1 = peg$c419;
+              if (input.substr(peg$currPos, 5) === peg$c423) {
+                s1 = peg$c423;
                 peg$currPos += 5;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c420); }
+                if (peg$silentFails === 0) { peg$fail(peg$c424); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c421) {
-                  s1 = peg$c421;
+                if (input.substr(peg$currPos, 5) === peg$c425) {
+                  s1 = peg$c425;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c422); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c426); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c423) {
-                    s1 = peg$c423;
+                  if (input.substr(peg$currPos, 5) === peg$c427) {
+                    s1 = peg$c427;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c424); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c428); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7) === peg$c425) {
-                      s1 = peg$c425;
+                    if (input.substr(peg$currPos, 7) === peg$c429) {
+                      s1 = peg$c429;
                       peg$currPos += 7;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c426); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c430); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 7) === peg$c427) {
-                        s1 = peg$c427;
+                      if (input.substr(peg$currPos, 7) === peg$c431) {
+                        s1 = peg$c431;
                         peg$currPos += 7;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c428); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c432); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 4) === peg$c429) {
-                          s1 = peg$c429;
+                        if (input.substr(peg$currPos, 4) === peg$c433) {
+                          s1 = peg$c433;
                           peg$currPos += 4;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c430); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c434); }
                         }
                         if (s1 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 6) === peg$c431) {
-                            s1 = peg$c431;
+                          if (input.substr(peg$currPos, 6) === peg$c435) {
+                            s1 = peg$c435;
                             peg$currPos += 6;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c432); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c436); }
                           }
                           if (s1 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 8) === peg$c433) {
-                              s1 = peg$c433;
+                            if (input.substr(peg$currPos, 8) === peg$c437) {
+                              s1 = peg$c437;
                               peg$currPos += 8;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c434); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c438); }
                             }
                             if (s1 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 4) === peg$c435) {
-                                s1 = peg$c435;
+                              if (input.substr(peg$currPos, 4) === peg$c439) {
+                                s1 = peg$c439;
                                 peg$currPos += 4;
                               } else {
                                 s1 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c436); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c440); }
                               }
                               if (s1 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 5) === peg$c437) {
-                                  s1 = peg$c437;
+                                if (input.substr(peg$currPos, 5) === peg$c441) {
+                                  s1 = peg$c441;
                                   peg$currPos += 5;
                                 } else {
                                   s1 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c438); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c442); }
                                 }
                                 if (s1 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 2) === peg$c439) {
-                                    s1 = peg$c439;
+                                  if (input.substr(peg$currPos, 2) === peg$c443) {
+                                    s1 = peg$c443;
                                     peg$currPos += 2;
                                   } else {
                                     s1 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c440); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c444); }
                                   }
                                   if (s1 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 3) === peg$c441) {
-                                      s1 = peg$c441;
+                                    if (input.substr(peg$currPos, 3) === peg$c445) {
+                                      s1 = peg$c445;
                                       peg$currPos += 3;
                                     } else {
                                       s1 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c442); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c446); }
                                     }
                                     if (s1 === peg$FAILED) {
                                       if (input.substr(peg$currPos, 4) === peg$c10) {
@@ -11513,12 +11722,12 @@ function peg$parse(input, options) {
                                         if (peg$silentFails === 0) { peg$fail(peg$c11); }
                                       }
                                       if (s1 === peg$FAILED) {
-                                        if (input.substr(peg$currPos, 4) === peg$c381) {
-                                          s1 = peg$c381;
+                                        if (input.substr(peg$currPos, 4) === peg$c385) {
+                                          s1 = peg$c385;
                                           peg$currPos += 4;
                                         } else {
                                           s1 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c382); }
+                                          if (peg$silentFails === 0) { peg$fail(peg$c386); }
                                         }
                                       }
                                     }
@@ -11540,7 +11749,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c443();
+      s1 = peg$c447();
     }
     s0 = s1;
 
@@ -11603,7 +11812,7 @@ function peg$parse(input, options) {
           s4 = peg$parseTypeField();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c393(s4);
+            s1 = peg$c397(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11646,7 +11855,7 @@ function peg$parse(input, options) {
             s5 = peg$parseType();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c444(s1, s5);
+              s1 = peg$c448(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11687,20 +11896,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c445) {
-      s1 = peg$c445;
+    if (input.substr(peg$currPos, 3) === peg$c449) {
+      s1 = peg$c449;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c446); }
+      if (peg$silentFails === 0) { peg$fail(peg$c450); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c447) {
-        s1 = peg$c447;
+      if (input.substr(peg$currPos, 3) === peg$c451) {
+        s1 = peg$c451;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c448); }
+        if (peg$silentFails === 0) { peg$fail(peg$c452); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -11716,7 +11925,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c449();
+        s1 = peg$c453();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11734,64 +11943,17 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c450) {
-      s1 = peg$c450;
+    if (input.substr(peg$currPos, 2) === peg$c454) {
+      s1 = peg$c454;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c451); }
+      if (peg$silentFails === 0) { peg$fail(peg$c455); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c452) {
-        s1 = peg$c452;
-        peg$currPos += 2;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c453); }
-      }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      peg$silentFails++;
-      s3 = peg$parseIdentifierRest();
-      peg$silentFails--;
-      if (s3 === peg$FAILED) {
-        s2 = void 0;
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c454();
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseNotToken() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c286) {
-      s1 = peg$c286;
-      peg$currPos += 3;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c287); }
-    }
-    if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c456) {
+      if (input.substr(peg$currPos, 2) === peg$c456) {
         s1 = peg$c456;
-        peg$currPos += 3;
+        peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$c457); }
@@ -11824,16 +11986,25 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseByToken() {
+  function peg$parseNotToken() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c351) {
-      s1 = peg$c351;
-      peg$currPos += 2;
+    if (input.substr(peg$currPos, 3) === peg$c286) {
+      s1 = peg$c286;
+      peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c459); }
+      if (peg$silentFails === 0) { peg$fail(peg$c287); }
+    }
+    if (s1 === peg$FAILED) {
+      if (input.substr(peg$currPos, 3) === peg$c460) {
+        s1 = peg$c460;
+        peg$currPos += 3;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c461); }
+      }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -11848,7 +12019,45 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c353();
+        s1 = peg$c462();
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseByToken() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2) === peg$c355) {
+      s1 = peg$c355;
+      peg$currPos += 2;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c463); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$currPos;
+      peg$silentFails++;
+      s3 = peg$parseIdentifierRest();
+      peg$silentFails--;
+      if (s3 === peg$FAILED) {
+        s2 = void 0;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c357();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11865,12 +12074,12 @@ function peg$parse(input, options) {
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c460.test(input.charAt(peg$currPos))) {
+    if (peg$c464.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c461); }
+      if (peg$silentFails === 0) { peg$fail(peg$c465); }
     }
 
     return s0;
@@ -11881,12 +12090,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c462.test(input.charAt(peg$currPos))) {
+      if (peg$c466.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c463); }
+        if (peg$silentFails === 0) { peg$fail(peg$c467); }
       }
     }
 
@@ -11900,7 +12109,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c464(s1);
+      s1 = peg$c468(s1);
     }
     s0 = s1;
 
@@ -11972,11 +12181,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 36) {
-        s1 = peg$c465;
+        s1 = peg$c469;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c466); }
+        if (peg$silentFails === 0) { peg$fail(peg$c470); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11986,11 +12195,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c404;
+          s1 = peg$c408;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c405); }
+          if (peg$silentFails === 0) { peg$fail(peg$c409); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseIDGuard();
@@ -12098,17 +12307,17 @@ function peg$parse(input, options) {
     s1 = peg$parseFullDate();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 84) {
-        s2 = peg$c467;
+        s2 = peg$c471;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c468); }
+        if (peg$silentFails === 0) { peg$fail(peg$c472); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseFullTime();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c469();
+          s1 = peg$c473();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -12182,36 +12391,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (peg$c462.test(input.charAt(peg$currPos))) {
+    if (peg$c466.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c463); }
+      if (peg$silentFails === 0) { peg$fail(peg$c467); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c462.test(input.charAt(peg$currPos))) {
+      if (peg$c466.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c463); }
+        if (peg$silentFails === 0) { peg$fail(peg$c467); }
       }
       if (s2 !== peg$FAILED) {
-        if (peg$c462.test(input.charAt(peg$currPos))) {
+        if (peg$c466.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c463); }
+          if (peg$silentFails === 0) { peg$fail(peg$c467); }
         }
         if (s3 !== peg$FAILED) {
-          if (peg$c462.test(input.charAt(peg$currPos))) {
+          if (peg$c466.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c463); }
+            if (peg$silentFails === 0) { peg$fail(peg$c467); }
           }
           if (s4 !== peg$FAILED) {
             s1 = [s1, s2, s3, s4];
@@ -12240,20 +12449,20 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c462.test(input.charAt(peg$currPos))) {
+    if (peg$c466.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c463); }
+      if (peg$silentFails === 0) { peg$fail(peg$c467); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c462.test(input.charAt(peg$currPos))) {
+      if (peg$c466.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c463); }
+        if (peg$silentFails === 0) { peg$fail(peg$c467); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -12328,22 +12537,22 @@ function peg$parse(input, options) {
               }
               if (s7 !== peg$FAILED) {
                 s8 = [];
-                if (peg$c462.test(input.charAt(peg$currPos))) {
+                if (peg$c466.test(input.charAt(peg$currPos))) {
                   s9 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s9 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c463); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c467); }
                 }
                 if (s9 !== peg$FAILED) {
                   while (s9 !== peg$FAILED) {
                     s8.push(s9);
-                    if (peg$c462.test(input.charAt(peg$currPos))) {
+                    if (peg$c466.test(input.charAt(peg$currPos))) {
                       s9 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c463); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c467); }
                     }
                   }
                 } else {
@@ -12398,11 +12607,11 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     if (input.charCodeAt(peg$currPos) === 90) {
-      s0 = peg$c470;
+      s0 = peg$c474;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c471); }
+      if (peg$silentFails === 0) { peg$fail(peg$c475); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
@@ -12445,22 +12654,22 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 s7 = [];
-                if (peg$c462.test(input.charAt(peg$currPos))) {
+                if (peg$c466.test(input.charAt(peg$currPos))) {
                   s8 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s8 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c463); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c467); }
                 }
                 if (s8 !== peg$FAILED) {
                   while (s8 !== peg$FAILED) {
                     s7.push(s8);
-                    if (peg$c462.test(input.charAt(peg$currPos))) {
+                    if (peg$c466.test(input.charAt(peg$currPos))) {
                       s8 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s8 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c463); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c467); }
                     }
                   }
                 } else {
@@ -12563,7 +12772,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c472();
+        s1 = peg$c476();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12625,76 +12834,76 @@ function peg$parse(input, options) {
   function peg$parseTimeUnit() {
     var s0;
 
-    if (input.substr(peg$currPos, 2) === peg$c473) {
-      s0 = peg$c473;
+    if (input.substr(peg$currPos, 2) === peg$c477) {
+      s0 = peg$c477;
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c474); }
+      if (peg$silentFails === 0) { peg$fail(peg$c478); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c475) {
-        s0 = peg$c475;
+      if (input.substr(peg$currPos, 2) === peg$c479) {
+        s0 = peg$c479;
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c476); }
+        if (peg$silentFails === 0) { peg$fail(peg$c480); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c477) {
-          s0 = peg$c477;
+        if (input.substr(peg$currPos, 2) === peg$c481) {
+          s0 = peg$c481;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c478); }
+          if (peg$silentFails === 0) { peg$fail(peg$c482); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 115) {
-            s0 = peg$c479;
+            s0 = peg$c483;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c480); }
+            if (peg$silentFails === 0) { peg$fail(peg$c484); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c481;
+              s0 = peg$c485;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c482); }
+              if (peg$silentFails === 0) { peg$fail(peg$c486); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 104) {
-                s0 = peg$c483;
+                s0 = peg$c487;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c484); }
+                if (peg$silentFails === 0) { peg$fail(peg$c488); }
               }
               if (s0 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 100) {
-                  s0 = peg$c485;
+                  s0 = peg$c489;
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c486); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c490); }
                 }
                 if (s0 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 119) {
-                    s0 = peg$c487;
+                    s0 = peg$c491;
                     peg$currPos++;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c488); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c492); }
                   }
                   if (s0 === peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 121) {
-                      s0 = peg$c489;
+                      s0 = peg$c493;
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c490); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c494); }
                     }
                   }
                 }
@@ -12879,7 +13088,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c491(s1, s2);
+        s1 = peg$c495(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12900,12 +13109,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c492) {
-            s3 = peg$c492;
+          if (input.substr(peg$currPos, 2) === peg$c496) {
+            s3 = peg$c496;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c493); }
+            if (peg$silentFails === 0) { peg$fail(peg$c497); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -12918,7 +13127,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c494(s1, s2, s4, s5);
+                s1 = peg$c498(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -12942,12 +13151,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c492) {
-          s1 = peg$c492;
+        if (input.substr(peg$currPos, 2) === peg$c496) {
+          s1 = peg$c496;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c493); }
+          if (peg$silentFails === 0) { peg$fail(peg$c497); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -12960,7 +13169,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c495(s2, s3);
+              s1 = peg$c499(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -12985,16 +13194,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c492) {
-                s3 = peg$c492;
+              if (input.substr(peg$currPos, 2) === peg$c496) {
+                s3 = peg$c496;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c493); }
+                if (peg$silentFails === 0) { peg$fail(peg$c497); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c496(s1, s2);
+                s1 = peg$c500(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -13010,16 +13219,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c492) {
-              s1 = peg$c492;
+            if (input.substr(peg$currPos, 2) === peg$c496) {
+              s1 = peg$c496;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c493); }
+              if (peg$silentFails === 0) { peg$fail(peg$c497); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c497();
+              s1 = peg$c501();
             }
             s0 = s1;
           }
@@ -13056,7 +13265,7 @@ function peg$parse(input, options) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c498(s2);
+        s1 = peg$c502(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13085,7 +13294,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c499(s1);
+        s1 = peg$c503(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13116,7 +13325,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c500(s1, s3);
+          s1 = peg$c504(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13151,7 +13360,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c501(s1, s3);
+          s1 = peg$c505(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13176,7 +13385,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c502(s1);
+      s1 = peg$c506(s1);
     }
     s0 = s1;
 
@@ -13199,22 +13408,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c462.test(input.charAt(peg$currPos))) {
+    if (peg$c466.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c463); }
+      if (peg$silentFails === 0) { peg$fail(peg$c467); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c462.test(input.charAt(peg$currPos))) {
+        if (peg$c466.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c463); }
+          if (peg$silentFails === 0) { peg$fail(peg$c467); }
         }
       }
     } else {
@@ -13274,22 +13483,22 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c462.test(input.charAt(peg$currPos))) {
+      if (peg$c466.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c463); }
+        if (peg$silentFails === 0) { peg$fail(peg$c467); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c462.test(input.charAt(peg$currPos))) {
+          if (peg$c466.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c463); }
+            if (peg$silentFails === 0) { peg$fail(peg$c467); }
           }
         }
       } else {
@@ -13305,21 +13514,21 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c462.test(input.charAt(peg$currPos))) {
+          if (peg$c466.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c463); }
+            if (peg$silentFails === 0) { peg$fail(peg$c467); }
           }
           while (s5 !== peg$FAILED) {
             s4.push(s5);
-            if (peg$c462.test(input.charAt(peg$currPos))) {
+            if (peg$c466.test(input.charAt(peg$currPos))) {
               s5 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c463); }
+              if (peg$silentFails === 0) { peg$fail(peg$c467); }
             }
           }
           if (s4 !== peg$FAILED) {
@@ -13329,7 +13538,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c503();
+              s1 = peg$c507();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13373,22 +13582,22 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c462.test(input.charAt(peg$currPos))) {
+          if (peg$c466.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c463); }
+            if (peg$silentFails === 0) { peg$fail(peg$c467); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c462.test(input.charAt(peg$currPos))) {
+              if (peg$c466.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c463); }
+                if (peg$silentFails === 0) { peg$fail(peg$c467); }
               }
             }
           } else {
@@ -13401,7 +13610,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c503();
+              s1 = peg$c507();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13440,20 +13649,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c504) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c508) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c505); }
+      if (peg$silentFails === 0) { peg$fail(peg$c509); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c506.test(input.charAt(peg$currPos))) {
+      if (peg$c510.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c507); }
+        if (peg$silentFails === 0) { peg$fail(peg$c511); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -13482,12 +13691,12 @@ function peg$parse(input, options) {
   function peg$parseNaN() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c508) {
-      s0 = peg$c508;
+    if (input.substr(peg$currPos, 3) === peg$c512) {
+      s0 = peg$c512;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c509); }
+      if (peg$silentFails === 0) { peg$fail(peg$c513); }
     }
 
     return s0;
@@ -13517,12 +13726,12 @@ function peg$parse(input, options) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c510) {
-        s2 = peg$c510;
+      if (input.substr(peg$currPos, 3) === peg$c514) {
+        s2 = peg$c514;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c511); }
+        if (peg$silentFails === 0) { peg$fail(peg$c515); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -13565,12 +13774,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c512.test(input.charAt(peg$currPos))) {
+    if (peg$c516.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c513); }
+      if (peg$silentFails === 0) { peg$fail(peg$c517); }
     }
 
     return s0;
@@ -13581,11 +13790,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c399;
+      s1 = peg$c403;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c400); }
+      if (peg$silentFails === 0) { peg$fail(peg$c404); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -13596,15 +13805,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c399;
+          s3 = peg$c403;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c400); }
+          if (peg$silentFails === 0) { peg$fail(peg$c404); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c514(s2);
+          s1 = peg$c518(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13621,11 +13830,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c401;
+        s1 = peg$c405;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c402); }
+        if (peg$silentFails === 0) { peg$fail(peg$c406); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -13636,15 +13845,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c401;
+            s3 = peg$c405;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c402); }
+            if (peg$silentFails === 0) { peg$fail(peg$c406); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c514(s2);
+            s1 = peg$c518(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -13670,11 +13879,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c399;
+      s2 = peg$c403;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c400); }
+      if (peg$silentFails === 0) { peg$fail(peg$c404); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -13692,7 +13901,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c515); }
+        if (peg$silentFails === 0) { peg$fail(peg$c519); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -13709,11 +13918,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c404;
+        s1 = peg$c408;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c405); }
+        if (peg$silentFails === 0) { peg$fail(peg$c409); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -13748,7 +13957,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c516(s1, s2);
+        s1 = peg$c520(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13777,12 +13986,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (peg$c517.test(input.charAt(peg$currPos))) {
+    if (peg$c521.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c518); }
+      if (peg$silentFails === 0) { peg$fail(peg$c522); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -13798,12 +14007,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseKeyWordStart();
     if (s0 === peg$FAILED) {
-      if (peg$c462.test(input.charAt(peg$currPos))) {
+      if (peg$c466.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c463); }
+        if (peg$silentFails === 0) { peg$fail(peg$c467); }
       }
     }
 
@@ -13815,11 +14024,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c404;
+      s1 = peg$c408;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c405); }
+      if (peg$silentFails === 0) { peg$fail(peg$c409); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseKeywordEscape();
@@ -13878,7 +14087,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c519(s3, s4);
+            s1 = peg$c523(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -13996,7 +14205,7 @@ function peg$parse(input, options) {
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c520();
+          s1 = peg$c524();
         }
         s0 = s1;
       }
@@ -14010,12 +14219,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseGlobStart();
     if (s0 === peg$FAILED) {
-      if (peg$c462.test(input.charAt(peg$currPos))) {
+      if (peg$c466.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c463); }
+        if (peg$silentFails === 0) { peg$fail(peg$c467); }
       }
     }
 
@@ -14027,11 +14236,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c404;
+      s1 = peg$c408;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c405); }
+      if (peg$silentFails === 0) { peg$fail(peg$c409); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseGlobEscape();
@@ -14067,7 +14276,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c521();
+      s1 = peg$c525();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -14081,16 +14290,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c522();
+        s1 = peg$c526();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c506.test(input.charAt(peg$currPos))) {
+        if (peg$c510.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c507); }
+          if (peg$silentFails === 0) { peg$fail(peg$c511); }
         }
       }
     }
@@ -14105,11 +14314,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c401;
+      s2 = peg$c405;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c402); }
+      if (peg$silentFails === 0) { peg$fail(peg$c406); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -14127,7 +14336,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c515); }
+        if (peg$silentFails === 0) { peg$fail(peg$c519); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14144,11 +14353,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c404;
+        s1 = peg$c408;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c405); }
+        if (peg$silentFails === 0) { peg$fail(peg$c409); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -14184,20 +14393,20 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c401;
+      s0 = peg$c405;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c402); }
+      if (peg$silentFails === 0) { peg$fail(peg$c406); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s1 = peg$c399;
+        s1 = peg$c403;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c400); }
+        if (peg$silentFails === 0) { peg$fail(peg$c404); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14206,94 +14415,94 @@ function peg$parse(input, options) {
       s0 = s1;
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c404;
+          s0 = peg$c408;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c405); }
+          if (peg$silentFails === 0) { peg$fail(peg$c409); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c523;
+            s1 = peg$c527;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c524); }
+            if (peg$silentFails === 0) { peg$fail(peg$c528); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c525();
+            s1 = peg$c529();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c526;
+              s1 = peg$c530;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c527); }
+              if (peg$silentFails === 0) { peg$fail(peg$c531); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c528();
+              s1 = peg$c532();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c529;
+                s1 = peg$c533;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c530); }
+                if (peg$silentFails === 0) { peg$fail(peg$c534); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c531();
+                s1 = peg$c535();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c532;
+                  s1 = peg$c536;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c533); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c537); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c534();
+                  s1 = peg$c538();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c535;
+                    s1 = peg$c539;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c536); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c540); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c537();
+                    s1 = peg$c541();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c538;
+                      s1 = peg$c542;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c539); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c543); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c540();
+                      s1 = peg$c544();
                     }
                     s0 = s1;
                   }
@@ -14321,7 +14530,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c521();
+      s1 = peg$c525();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -14335,16 +14544,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c541();
+        s1 = peg$c545();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c506.test(input.charAt(peg$currPos))) {
+        if (peg$c510.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c507); }
+          if (peg$silentFails === 0) { peg$fail(peg$c511); }
         }
       }
     }
@@ -14357,11 +14566,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c542;
+      s1 = peg$c546;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c543); }
+      if (peg$silentFails === 0) { peg$fail(peg$c547); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -14393,7 +14602,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c544(s2);
+        s1 = peg$c548(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14406,11 +14615,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c542;
+        s1 = peg$c546;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c543); }
+        if (peg$silentFails === 0) { peg$fail(peg$c547); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
@@ -14477,15 +14686,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c305;
+              s4 = peg$c309;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c306); }
+              if (peg$silentFails === 0) { peg$fail(peg$c310); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c544(s3);
+              s1 = peg$c548(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -14569,21 +14778,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c545.test(input.charAt(peg$currPos))) {
+    if (peg$c549.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c546); }
+      if (peg$silentFails === 0) { peg$fail(peg$c550); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s3 = peg$c404;
+        s3 = peg$c408;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c405); }
+        if (peg$silentFails === 0) { peg$fail(peg$c409); }
       }
       if (s3 !== peg$FAILED) {
         if (input.length > peg$currPos) {
@@ -14591,7 +14800,7 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c515); }
+          if (peg$silentFails === 0) { peg$fail(peg$c519); }
         }
         if (s4 !== peg$FAILED) {
           s3 = [s3, s4];
@@ -14608,21 +14817,21 @@ function peg$parse(input, options) {
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c545.test(input.charAt(peg$currPos))) {
+        if (peg$c549.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c546); }
+          if (peg$silentFails === 0) { peg$fail(peg$c550); }
         }
         if (s2 === peg$FAILED) {
           s2 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 92) {
-            s3 = peg$c404;
+            s3 = peg$c408;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c405); }
+            if (peg$silentFails === 0) { peg$fail(peg$c409); }
           }
           if (s3 !== peg$FAILED) {
             if (input.length > peg$currPos) {
@@ -14630,7 +14839,7 @@ function peg$parse(input, options) {
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c515); }
+              if (peg$silentFails === 0) { peg$fail(peg$c519); }
             }
             if (s4 !== peg$FAILED) {
               s3 = [s3, s4];
@@ -14660,12 +14869,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c547.test(input.charAt(peg$currPos))) {
+    if (peg$c551.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c548); }
+      if (peg$silentFails === 0) { peg$fail(peg$c552); }
     }
 
     return s0;
@@ -14723,7 +14932,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c515); }
+      if (peg$silentFails === 0) { peg$fail(peg$c519); }
     }
 
     return s0;
@@ -14734,51 +14943,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c550;
+      s0 = peg$c554;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c551); }
+      if (peg$silentFails === 0) { peg$fail(peg$c555); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c552;
+        s0 = peg$c556;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c553); }
+        if (peg$silentFails === 0) { peg$fail(peg$c557); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c554;
+          s0 = peg$c558;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c555); }
+          if (peg$silentFails === 0) { peg$fail(peg$c559); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c556;
+            s0 = peg$c560;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c557); }
+            if (peg$silentFails === 0) { peg$fail(peg$c561); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c558;
+              s0 = peg$c562;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c559); }
+              if (peg$silentFails === 0) { peg$fail(peg$c563); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c560;
+                s0 = peg$c564;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c561); }
+                if (peg$silentFails === 0) { peg$fail(peg$c565); }
               }
             }
           }
@@ -14787,7 +14996,7 @@ function peg$parse(input, options) {
     }
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c549); }
+      if (peg$silentFails === 0) { peg$fail(peg$c553); }
     }
 
     return s0;
@@ -14796,12 +15005,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c562.test(input.charAt(peg$currPos))) {
+    if (peg$c566.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c563); }
+      if (peg$silentFails === 0) { peg$fail(peg$c567); }
     }
 
     return s0;
@@ -14814,7 +15023,7 @@ function peg$parse(input, options) {
     s0 = peg$parseSingleLineComment();
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c564); }
+      if (peg$silentFails === 0) { peg$fail(peg$c568); }
     }
 
     return s0;
@@ -14824,12 +15033,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c569) {
-      s1 = peg$c569;
+    if (input.substr(peg$currPos, 2) === peg$c573) {
+      s1 = peg$c573;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c570); }
+      if (peg$silentFails === 0) { peg$fail(peg$c574); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -14909,7 +15118,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c515); }
+      if (peg$silentFails === 0) { peg$fail(peg$c519); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/compiler/parser/parser.es.js
+++ b/compiler/parser/parser.es.js
@@ -692,85 +692,85 @@ function peg$parse(input, options) {
       peg$c290 = function(typ, expr) {
             return {"kind": "Cast", "expr": expr, "type": typ}
           },
-      peg$c291 = function(fn, args, where) {
+      peg$c291 = "regexp",
+      peg$c292 = peg$literalExpectation("regexp", false),
+      peg$c293 = function(arg0Text, arg1, where) {
+            let arg0 = {"kind": "Primitive", "type": "string", "text": arg0Text};
+            return {"kind": "Call", "name": "regexp", "args": [arg0, arg1], "where": where}
+          },
+      peg$c294 = function(fn, args, where) {
             return {"kind": "Call", "name": fn, "args": args, "where": where}
           },
-      peg$c292 = function(o) { return [o] },
-      peg$c293 = "grep",
-      peg$c294 = peg$literalExpectation("grep", false),
-      peg$c295 = function(pattern, opt) {
+      peg$c295 = function(o) { return [o] },
+      peg$c296 = "grep",
+      peg$c297 = peg$literalExpectation("grep", false),
+      peg$c298 = function(pattern, opt) {
             let m = {"kind": "Grep", "pattern": pattern, "expr": {"kind": "ID", "name": "this"}};
             if (opt) {
               m["expr"] = opt[2];
             }
             return m
           },
-      peg$c296 = function(s) {
+      peg$c299 = function(s) {
             return {"kind": "String", "text": s}
           },
-      peg$c297 = "regexp",
-      peg$c298 = peg$literalExpectation("regexp", false),
-      peg$c299 = function(args, where) {
-            return {"kind": "Call", "name": "regexp", "args": args, "where": where}
-          },
       peg$c300 = function(first, e) { return e },
-      peg$c301 = function(v) { return {"kind": "Primitive", "type": "string", "text": v} },
-      peg$c302 = "]",
-      peg$c303 = peg$literalExpectation("]", false),
-      peg$c304 = function(from, to) {
+      peg$c301 = "]",
+      peg$c302 = peg$literalExpectation("]", false),
+      peg$c303 = function(from, to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs":to}]
           
           },
-      peg$c305 = function(to) {
+      peg$c304 = function(to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs": null, "rhs":to}]
           
           },
-      peg$c306 = function(expr) { return ["[", expr] },
-      peg$c307 = function(id) { return [".", id] },
-      peg$c308 = function(exprs, locals, scope) {
+      peg$c305 = function(expr) { return ["[", expr] },
+      peg$c306 = function(id) { return [".", id] },
+      peg$c307 = function(exprs, locals, scope) {
             return {"kind": "OverExpr", "locals": locals, "exprs": exprs, "scope": scope}
           },
-      peg$c309 = "}",
-      peg$c310 = peg$literalExpectation("}", false),
-      peg$c311 = function(elems) {
+      peg$c308 = "}",
+      peg$c309 = peg$literalExpectation("}", false),
+      peg$c310 = function(elems) {
             return {"kind":"RecordExpr", "elems":elems}
           },
-      peg$c312 = function(elem) { return elem },
-      peg$c313 = "...",
-      peg$c314 = peg$literalExpectation("...", false),
-      peg$c315 = function(expr) {
+      peg$c311 = function(elem) { return elem },
+      peg$c312 = "...",
+      peg$c313 = peg$literalExpectation("...", false),
+      peg$c314 = function(expr) {
             return {"kind":"Spread", "expr": expr}
           },
-      peg$c316 = function(name, value) {
+      peg$c315 = function(name, value) {
             return {"kind":"Field","name": name, "value": value}
           },
-      peg$c317 = function(elems) {
+      peg$c316 = function(elems) {
             return {"kind":"ArrayExpr", "elems":elems }
           },
-      peg$c318 = "|[",
-      peg$c319 = peg$literalExpectation("|[", false),
-      peg$c320 = "]|",
-      peg$c321 = peg$literalExpectation("]|", false),
-      peg$c322 = function(elems) {
+      peg$c317 = "|[",
+      peg$c318 = peg$literalExpectation("|[", false),
+      peg$c319 = "]|",
+      peg$c320 = peg$literalExpectation("]|", false),
+      peg$c321 = function(elems) {
             return {"kind":"SetExpr", "elems":elems }
           },
-      peg$c323 = function(e) { return {"kind":"VectorValue","expr":e} },
-      peg$c324 = "|{",
-      peg$c325 = peg$literalExpectation("|{", false),
-      peg$c326 = "}|",
-      peg$c327 = peg$literalExpectation("}|", false),
-      peg$c328 = function(exprs) {
+      peg$c322 = function(e) { return {"kind":"VectorValue","expr":e} },
+      peg$c323 = "|{",
+      peg$c324 = peg$literalExpectation("|{", false),
+      peg$c325 = "}|",
+      peg$c326 = peg$literalExpectation("}|", false),
+      peg$c327 = function(exprs) {
             return {"kind":"MapExpr", "entries":exprs }
           },
-      peg$c329 = function(e) { return e },
-      peg$c330 = function(key, value) {
+      peg$c328 = function(e) { return e },
+      peg$c329 = function(key, value) {
             return {"key": key, "value": value}
           },
-      peg$c331 = function(selection, from, joins, where, groupby, having, orderby, limit) {
+      peg$c330 = function(selection, from, joins, where, groupby, having, orderby, limit) {
             return {
               
             "kind": "SQLExpr",
@@ -792,19 +792,19 @@ function peg$parse(input, options) {
             "limit": limit }
           
           },
-      peg$c332 = function(assignments) { return assignments },
-      peg$c333 = function(rhs, opt) {
+      peg$c331 = function(assignments) { return assignments },
+      peg$c332 = function(rhs, opt) {
             let m = {"kind": "Assignment", "lhs": null, "rhs": rhs};
             if (opt) {
               m["lhs"] = opt[3];
             }
             return m
           },
-      peg$c334 = function(table, alias) {
+      peg$c333 = function(table, alias) {
             return {"table": table, "alias": alias}
           },
-      peg$c335 = function(first, join) { return join },
-      peg$c336 = function(style, table, alias, leftKey, rightKey) {
+      peg$c334 = function(first, join) { return join },
+      peg$c335 = function(style, table, alias, leftKey, rightKey) {
             return {
               
             "table": table,
@@ -818,120 +818,120 @@ function peg$parse(input, options) {
             "alias": alias}
           
           },
-      peg$c337 = function(style) { return style },
-      peg$c338 = function(keys, order) {
+      peg$c336 = function(style) { return style },
+      peg$c337 = function(keys, order) {
             return {"kind": "SQLOrderBy", "keys": keys, "order":order}
           },
-      peg$c339 = function(dir) { return dir },
-      peg$c340 = function(count) { return count },
-      peg$c341 = peg$literalExpectation("select", true),
-      peg$c342 = function() { return "select" },
-      peg$c343 = "as",
-      peg$c344 = peg$literalExpectation("as", true),
-      peg$c345 = function() { return "as" },
-      peg$c346 = peg$literalExpectation("from", true),
-      peg$c347 = function() { return "from" },
-      peg$c348 = peg$literalExpectation("join", true),
-      peg$c349 = function() { return "join" },
-      peg$c350 = peg$literalExpectation("where", true),
-      peg$c351 = function() { return "where" },
-      peg$c352 = "group",
-      peg$c353 = peg$literalExpectation("group", true),
-      peg$c354 = function() { return "group" },
-      peg$c355 = "by",
-      peg$c356 = peg$literalExpectation("by", true),
-      peg$c357 = function() { return "by" },
-      peg$c358 = "having",
-      peg$c359 = peg$literalExpectation("having", true),
-      peg$c360 = function() { return "having" },
-      peg$c361 = peg$literalExpectation("order", true),
-      peg$c362 = function() { return "order" },
-      peg$c363 = "on",
-      peg$c364 = peg$literalExpectation("on", true),
-      peg$c365 = function() { return "on" },
-      peg$c366 = "limit",
-      peg$c367 = peg$literalExpectation("limit", true),
-      peg$c368 = function() { return "limit" },
-      peg$c369 = peg$literalExpectation("asc", true),
-      peg$c370 = peg$literalExpectation("desc", true),
-      peg$c371 = peg$literalExpectation("anti", true),
-      peg$c372 = peg$literalExpectation("left", true),
-      peg$c373 = peg$literalExpectation("right", true),
-      peg$c374 = peg$literalExpectation("inner", true),
-      peg$c375 = function(v) {
+      peg$c338 = function(dir) { return dir },
+      peg$c339 = function(count) { return count },
+      peg$c340 = peg$literalExpectation("select", true),
+      peg$c341 = function() { return "select" },
+      peg$c342 = "as",
+      peg$c343 = peg$literalExpectation("as", true),
+      peg$c344 = function() { return "as" },
+      peg$c345 = peg$literalExpectation("from", true),
+      peg$c346 = function() { return "from" },
+      peg$c347 = peg$literalExpectation("join", true),
+      peg$c348 = function() { return "join" },
+      peg$c349 = peg$literalExpectation("where", true),
+      peg$c350 = function() { return "where" },
+      peg$c351 = "group",
+      peg$c352 = peg$literalExpectation("group", true),
+      peg$c353 = function() { return "group" },
+      peg$c354 = "by",
+      peg$c355 = peg$literalExpectation("by", true),
+      peg$c356 = function() { return "by" },
+      peg$c357 = "having",
+      peg$c358 = peg$literalExpectation("having", true),
+      peg$c359 = function() { return "having" },
+      peg$c360 = peg$literalExpectation("order", true),
+      peg$c361 = function() { return "order" },
+      peg$c362 = "on",
+      peg$c363 = peg$literalExpectation("on", true),
+      peg$c364 = function() { return "on" },
+      peg$c365 = "limit",
+      peg$c366 = peg$literalExpectation("limit", true),
+      peg$c367 = function() { return "limit" },
+      peg$c368 = peg$literalExpectation("asc", true),
+      peg$c369 = peg$literalExpectation("desc", true),
+      peg$c370 = peg$literalExpectation("anti", true),
+      peg$c371 = peg$literalExpectation("left", true),
+      peg$c372 = peg$literalExpectation("right", true),
+      peg$c373 = peg$literalExpectation("inner", true),
+      peg$c374 = function(v) {
             return {"kind": "Primitive", "type": "net", "text": v}
           },
-      peg$c376 = function(v) {
+      peg$c375 = function(v) {
             return {"kind": "Primitive", "type": "ip", "text": v}
           },
-      peg$c377 = function(v) {
+      peg$c376 = function(v) {
             return {"kind": "Primitive", "type": "float64", "text": v}
           },
-      peg$c378 = function(v) {
+      peg$c377 = function(v) {
             return {"kind": "Primitive", "type": "int64", "text": v}
           },
-      peg$c379 = "true",
-      peg$c380 = peg$literalExpectation("true", false),
-      peg$c381 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
-      peg$c382 = "false",
-      peg$c383 = peg$literalExpectation("false", false),
-      peg$c384 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
-      peg$c385 = "null",
-      peg$c386 = peg$literalExpectation("null", false),
-      peg$c387 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
-      peg$c388 = "0x",
-      peg$c389 = peg$literalExpectation("0x", false),
-      peg$c390 = function() {
+      peg$c378 = "true",
+      peg$c379 = peg$literalExpectation("true", false),
+      peg$c380 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
+      peg$c381 = "false",
+      peg$c382 = peg$literalExpectation("false", false),
+      peg$c383 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
+      peg$c384 = "null",
+      peg$c385 = peg$literalExpectation("null", false),
+      peg$c386 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
+      peg$c387 = "0x",
+      peg$c388 = peg$literalExpectation("0x", false),
+      peg$c389 = function() {
       	return {"kind": "Primitive", "type": "bytes", "text": text()}
         },
-      peg$c391 = function(typ) {
+      peg$c390 = function(typ) {
             return {"kind": "TypeValue", "value": typ}
           },
-      peg$c392 = function(name) { return name },
-      peg$c393 = function(name, opt) {
+      peg$c391 = function(name) { return name },
+      peg$c392 = function(name, opt) {
             if (opt) {
               return {"kind": "TypeDef", "name": name, "type": opt[3]}
             }
             return {"kind": "TypeName", "name": name}
           },
-      peg$c394 = function(name) {
+      peg$c393 = function(name) {
             return {"kind": "TypeName", "name": name}
           },
-      peg$c395 = function(u) { return u },
-      peg$c396 = function(types) {
+      peg$c394 = function(u) { return u },
+      peg$c395 = function(types) {
             return {"kind": "TypeUnion", "types": types}
           },
-      peg$c397 = function(typ) { return typ },
-      peg$c398 = function(fields) {
+      peg$c396 = function(typ) { return typ },
+      peg$c397 = function(fields) {
             return {"kind":"TypeRecord", "fields":fields}
           },
-      peg$c399 = function(typ) {
+      peg$c398 = function(typ) {
             return {"kind":"TypeArray", "type":typ}
           },
-      peg$c400 = function(typ) {
+      peg$c399 = function(typ) {
             return {"kind":"TypeSet", "type":typ}
           },
-      peg$c401 = function(keyType, valType) {
+      peg$c400 = function(keyType, valType) {
             return {"kind":"TypeMap", "key_type":keyType, "val_type": valType}
           },
-      peg$c402 = function(v) {
+      peg$c401 = function(v) {
             if (v.length == 0) {
               return {"kind": "Primitive", "type": "string", "text": ""}
             }
             return makeTemplateExprChain(v)
           },
-      peg$c403 = "\"",
-      peg$c404 = peg$literalExpectation("\"", false),
-      peg$c405 = "'",
-      peg$c406 = peg$literalExpectation("'", false),
-      peg$c407 = function(v) {
+      peg$c402 = "\"",
+      peg$c403 = peg$literalExpectation("\"", false),
+      peg$c404 = "'",
+      peg$c405 = peg$literalExpectation("'", false),
+      peg$c406 = function(v) {
             return {"kind": "Primitive", "type": "string", "text": joinChars(v)}
           },
-      peg$c408 = "\\",
-      peg$c409 = peg$literalExpectation("\\", false),
-      peg$c410 = "${",
-      peg$c411 = peg$literalExpectation("${", false),
-      peg$c412 = function(e) {
+      peg$c407 = "\\",
+      peg$c408 = peg$literalExpectation("\\", false),
+      peg$c409 = "${",
+      peg$c410 = peg$literalExpectation("${", false),
+      peg$c411 = function(e) {
             return {
               
             "kind": "Cast",
@@ -945,191 +945,191 @@ function peg$parse(input, options) {
             "value": {"kind": "TypePrimitive", "name": "string"}}}
           
           },
-      peg$c413 = "uint8",
-      peg$c414 = peg$literalExpectation("uint8", false),
-      peg$c415 = "uint16",
-      peg$c416 = peg$literalExpectation("uint16", false),
-      peg$c417 = "uint32",
-      peg$c418 = peg$literalExpectation("uint32", false),
-      peg$c419 = "uint64",
-      peg$c420 = peg$literalExpectation("uint64", false),
-      peg$c421 = "int8",
-      peg$c422 = peg$literalExpectation("int8", false),
-      peg$c423 = "int16",
-      peg$c424 = peg$literalExpectation("int16", false),
-      peg$c425 = "int32",
-      peg$c426 = peg$literalExpectation("int32", false),
-      peg$c427 = "int64",
-      peg$c428 = peg$literalExpectation("int64", false),
-      peg$c429 = "float32",
-      peg$c430 = peg$literalExpectation("float32", false),
-      peg$c431 = "float64",
-      peg$c432 = peg$literalExpectation("float64", false),
-      peg$c433 = "bool",
-      peg$c434 = peg$literalExpectation("bool", false),
-      peg$c435 = "string",
-      peg$c436 = peg$literalExpectation("string", false),
-      peg$c437 = "duration",
-      peg$c438 = peg$literalExpectation("duration", false),
-      peg$c439 = "time",
-      peg$c440 = peg$literalExpectation("time", false),
-      peg$c441 = "bytes",
-      peg$c442 = peg$literalExpectation("bytes", false),
-      peg$c443 = "ip",
-      peg$c444 = peg$literalExpectation("ip", false),
-      peg$c445 = "net",
-      peg$c446 = peg$literalExpectation("net", false),
-      peg$c447 = function() {
+      peg$c412 = "uint8",
+      peg$c413 = peg$literalExpectation("uint8", false),
+      peg$c414 = "uint16",
+      peg$c415 = peg$literalExpectation("uint16", false),
+      peg$c416 = "uint32",
+      peg$c417 = peg$literalExpectation("uint32", false),
+      peg$c418 = "uint64",
+      peg$c419 = peg$literalExpectation("uint64", false),
+      peg$c420 = "int8",
+      peg$c421 = peg$literalExpectation("int8", false),
+      peg$c422 = "int16",
+      peg$c423 = peg$literalExpectation("int16", false),
+      peg$c424 = "int32",
+      peg$c425 = peg$literalExpectation("int32", false),
+      peg$c426 = "int64",
+      peg$c427 = peg$literalExpectation("int64", false),
+      peg$c428 = "float32",
+      peg$c429 = peg$literalExpectation("float32", false),
+      peg$c430 = "float64",
+      peg$c431 = peg$literalExpectation("float64", false),
+      peg$c432 = "bool",
+      peg$c433 = peg$literalExpectation("bool", false),
+      peg$c434 = "string",
+      peg$c435 = peg$literalExpectation("string", false),
+      peg$c436 = "duration",
+      peg$c437 = peg$literalExpectation("duration", false),
+      peg$c438 = "time",
+      peg$c439 = peg$literalExpectation("time", false),
+      peg$c440 = "bytes",
+      peg$c441 = peg$literalExpectation("bytes", false),
+      peg$c442 = "ip",
+      peg$c443 = peg$literalExpectation("ip", false),
+      peg$c444 = "net",
+      peg$c445 = peg$literalExpectation("net", false),
+      peg$c446 = function() {
                 return {"kind": "TypePrimitive", "name": text()}
               },
-      peg$c448 = function(name, typ) {
+      peg$c447 = function(name, typ) {
             return {"name": name, "type": typ}
           },
-      peg$c449 = "and",
-      peg$c450 = peg$literalExpectation("and", false),
-      peg$c451 = "AND",
-      peg$c452 = peg$literalExpectation("AND", false),
-      peg$c453 = function() { return "and" },
-      peg$c454 = "or",
-      peg$c455 = peg$literalExpectation("or", false),
-      peg$c456 = "OR",
-      peg$c457 = peg$literalExpectation("OR", false),
-      peg$c458 = function() { return "or" },
-      peg$c460 = "NOT",
-      peg$c461 = peg$literalExpectation("NOT", false),
-      peg$c462 = function() { return "not" },
-      peg$c463 = peg$literalExpectation("by", false),
-      peg$c464 = /^[A-Za-z_$]/,
-      peg$c465 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c466 = /^[0-9]/,
-      peg$c467 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c468 = function(id) { return {"kind": "ID", "name": id} },
-      peg$c469 = "$",
-      peg$c470 = peg$literalExpectation("$", false),
-      peg$c471 = "T",
-      peg$c472 = peg$literalExpectation("T", false),
-      peg$c473 = function() {
+      peg$c448 = "and",
+      peg$c449 = peg$literalExpectation("and", false),
+      peg$c450 = "AND",
+      peg$c451 = peg$literalExpectation("AND", false),
+      peg$c452 = function() { return "and" },
+      peg$c453 = "or",
+      peg$c454 = peg$literalExpectation("or", false),
+      peg$c455 = "OR",
+      peg$c456 = peg$literalExpectation("OR", false),
+      peg$c457 = function() { return "or" },
+      peg$c459 = "NOT",
+      peg$c460 = peg$literalExpectation("NOT", false),
+      peg$c461 = function() { return "not" },
+      peg$c462 = peg$literalExpectation("by", false),
+      peg$c463 = /^[A-Za-z_$]/,
+      peg$c464 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c465 = /^[0-9]/,
+      peg$c466 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c467 = function(id) { return {"kind": "ID", "name": id} },
+      peg$c468 = "$",
+      peg$c469 = peg$literalExpectation("$", false),
+      peg$c470 = "T",
+      peg$c471 = peg$literalExpectation("T", false),
+      peg$c472 = function() {
             return {"kind": "Primitive", "type": "time", "text": text()}
           },
-      peg$c474 = "Z",
-      peg$c475 = peg$literalExpectation("Z", false),
-      peg$c476 = function() {
+      peg$c473 = "Z",
+      peg$c474 = peg$literalExpectation("Z", false),
+      peg$c475 = function() {
             return {"kind": "Primitive", "type": "duration", "text": text()}
           },
-      peg$c477 = "ns",
-      peg$c478 = peg$literalExpectation("ns", false),
-      peg$c479 = "us",
-      peg$c480 = peg$literalExpectation("us", false),
-      peg$c481 = "ms",
-      peg$c482 = peg$literalExpectation("ms", false),
-      peg$c483 = "s",
-      peg$c484 = peg$literalExpectation("s", false),
-      peg$c485 = "m",
-      peg$c486 = peg$literalExpectation("m", false),
-      peg$c487 = "h",
-      peg$c488 = peg$literalExpectation("h", false),
-      peg$c489 = "d",
-      peg$c490 = peg$literalExpectation("d", false),
-      peg$c491 = "w",
-      peg$c492 = peg$literalExpectation("w", false),
-      peg$c493 = "y",
-      peg$c494 = peg$literalExpectation("y", false),
-      peg$c495 = function(a, b) {
+      peg$c476 = "ns",
+      peg$c477 = peg$literalExpectation("ns", false),
+      peg$c478 = "us",
+      peg$c479 = peg$literalExpectation("us", false),
+      peg$c480 = "ms",
+      peg$c481 = peg$literalExpectation("ms", false),
+      peg$c482 = "s",
+      peg$c483 = peg$literalExpectation("s", false),
+      peg$c484 = "m",
+      peg$c485 = peg$literalExpectation("m", false),
+      peg$c486 = "h",
+      peg$c487 = peg$literalExpectation("h", false),
+      peg$c488 = "d",
+      peg$c489 = peg$literalExpectation("d", false),
+      peg$c490 = "w",
+      peg$c491 = peg$literalExpectation("w", false),
+      peg$c492 = "y",
+      peg$c493 = peg$literalExpectation("y", false),
+      peg$c494 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c496 = "::",
-      peg$c497 = peg$literalExpectation("::", false),
-      peg$c498 = function(a, b, d, e) {
+      peg$c495 = "::",
+      peg$c496 = peg$literalExpectation("::", false),
+      peg$c497 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c499 = function(a, b) {
+      peg$c498 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c500 = function(a, b) {
+      peg$c499 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c501 = function() {
+      peg$c500 = function() {
             return "::"
           },
-      peg$c502 = function(v) { return ":" + v },
-      peg$c503 = function(v) { return v + ":" },
-      peg$c504 = function(a, m) {
+      peg$c501 = function(v) { return ":" + v },
+      peg$c502 = function(v) { return v + ":" },
+      peg$c503 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c505 = function(a, m) {
+      peg$c504 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c506 = function(s) { return parseInt(s) },
-      peg$c507 = function() {
+      peg$c505 = function(s) { return parseInt(s) },
+      peg$c506 = function() {
             return text()
           },
-      peg$c508 = "e",
-      peg$c509 = peg$literalExpectation("e", true),
-      peg$c510 = /^[+\-]/,
-      peg$c511 = peg$classExpectation(["+", "-"], false, false),
-      peg$c512 = "NaN",
-      peg$c513 = peg$literalExpectation("NaN", false),
-      peg$c514 = "Inf",
-      peg$c515 = peg$literalExpectation("Inf", false),
-      peg$c516 = /^[0-9a-fA-F]/,
-      peg$c517 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c518 = function(v) { return joinChars(v) },
-      peg$c519 = peg$anyExpectation(),
-      peg$c520 = function(head, tail) { return head + joinChars(tail) },
-      peg$c521 = /^[a-zA-Z_.:\/%#@~]/,
-      peg$c522 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
-      peg$c523 = function(head, tail) {
+      peg$c507 = "e",
+      peg$c508 = peg$literalExpectation("e", true),
+      peg$c509 = /^[+\-]/,
+      peg$c510 = peg$classExpectation(["+", "-"], false, false),
+      peg$c511 = "NaN",
+      peg$c512 = peg$literalExpectation("NaN", false),
+      peg$c513 = "Inf",
+      peg$c514 = peg$literalExpectation("Inf", false),
+      peg$c515 = /^[0-9a-fA-F]/,
+      peg$c516 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c517 = function(v) { return joinChars(v) },
+      peg$c518 = peg$anyExpectation(),
+      peg$c519 = function(head, tail) { return head + joinChars(tail) },
+      peg$c520 = /^[a-zA-Z_.:\/%#@~]/,
+      peg$c521 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
+      peg$c522 = function(head, tail) {
             return head + joinChars(tail)
           },
-      peg$c524 = function() { return "*"},
-      peg$c525 = function() { return "=" },
-      peg$c526 = function() { return "\\*" },
-      peg$c527 = "b",
-      peg$c528 = peg$literalExpectation("b", false),
-      peg$c529 = function() { return "\b" },
-      peg$c530 = "f",
-      peg$c531 = peg$literalExpectation("f", false),
-      peg$c532 = function() { return "\f" },
-      peg$c533 = "n",
-      peg$c534 = peg$literalExpectation("n", false),
-      peg$c535 = function() { return "\n" },
-      peg$c536 = "r",
-      peg$c537 = peg$literalExpectation("r", false),
-      peg$c538 = function() { return "\r" },
-      peg$c539 = "t",
-      peg$c540 = peg$literalExpectation("t", false),
-      peg$c541 = function() { return "\t" },
-      peg$c542 = "v",
-      peg$c543 = peg$literalExpectation("v", false),
-      peg$c544 = function() { return "\v" },
-      peg$c545 = function() { return "*" },
-      peg$c546 = "u",
-      peg$c547 = peg$literalExpectation("u", false),
-      peg$c548 = function(chars) {
+      peg$c523 = function() { return "*"},
+      peg$c524 = function() { return "=" },
+      peg$c525 = function() { return "\\*" },
+      peg$c526 = "b",
+      peg$c527 = peg$literalExpectation("b", false),
+      peg$c528 = function() { return "\b" },
+      peg$c529 = "f",
+      peg$c530 = peg$literalExpectation("f", false),
+      peg$c531 = function() { return "\f" },
+      peg$c532 = "n",
+      peg$c533 = peg$literalExpectation("n", false),
+      peg$c534 = function() { return "\n" },
+      peg$c535 = "r",
+      peg$c536 = peg$literalExpectation("r", false),
+      peg$c537 = function() { return "\r" },
+      peg$c538 = "t",
+      peg$c539 = peg$literalExpectation("t", false),
+      peg$c540 = function() { return "\t" },
+      peg$c541 = "v",
+      peg$c542 = peg$literalExpectation("v", false),
+      peg$c543 = function() { return "\v" },
+      peg$c544 = function() { return "*" },
+      peg$c545 = "u",
+      peg$c546 = peg$literalExpectation("u", false),
+      peg$c547 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c549 = /^[^\/\\]/,
-      peg$c550 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c551 = /^[\0-\x1F\\]/,
-      peg$c552 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c553 = peg$otherExpectation("whitespace"),
-      peg$c554 = "\t",
-      peg$c555 = peg$literalExpectation("\t", false),
-      peg$c556 = "\x0B",
-      peg$c557 = peg$literalExpectation("\x0B", false),
-      peg$c558 = "\f",
-      peg$c559 = peg$literalExpectation("\f", false),
-      peg$c560 = " ",
-      peg$c561 = peg$literalExpectation(" ", false),
-      peg$c562 = "\xA0",
-      peg$c563 = peg$literalExpectation("\xA0", false),
-      peg$c564 = "\uFEFF",
-      peg$c565 = peg$literalExpectation("\uFEFF", false),
-      peg$c566 = /^[\n\r\u2028\u2029]/,
-      peg$c567 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c568 = peg$otherExpectation("comment"),
-      peg$c573 = "//",
-      peg$c574 = peg$literalExpectation("//", false),
+      peg$c548 = /^[^\/\\]/,
+      peg$c549 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c550 = /^[\0-\x1F\\]/,
+      peg$c551 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c552 = peg$otherExpectation("whitespace"),
+      peg$c553 = "\t",
+      peg$c554 = peg$literalExpectation("\t", false),
+      peg$c555 = "\x0B",
+      peg$c556 = peg$literalExpectation("\x0B", false),
+      peg$c557 = "\f",
+      peg$c558 = peg$literalExpectation("\f", false),
+      peg$c559 = " ",
+      peg$c560 = peg$literalExpectation(" ", false),
+      peg$c561 = "\xA0",
+      peg$c562 = peg$literalExpectation("\xA0", false),
+      peg$c563 = "\uFEFF",
+      peg$c564 = peg$literalExpectation("\uFEFF", false),
+      peg$c565 = /^[\n\r\u2028\u2029]/,
+      peg$c566 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c567 = peg$otherExpectation("comment"),
+      peg$c572 = "//",
+      peg$c573 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -7605,11 +7605,113 @@ function peg$parse(input, options) {
   }
 
   function peg$parseFunction() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12;
 
     s0 = peg$parseGrep();
     if (s0 === peg$FAILED) {
-      s0 = peg$parseRegexpFunc();
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 6) === peg$c291) {
+        s1 = peg$c291;
+        peg$currPos += 6;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c292); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parse__();
+        if (s2 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 40) {
+            s3 = peg$c15;
+            peg$currPos++;
+          } else {
+            s3 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c16); }
+          }
+          if (s3 !== peg$FAILED) {
+            s4 = peg$parse__();
+            if (s4 !== peg$FAILED) {
+              s5 = peg$parseRegexpPattern();
+              if (s5 !== peg$FAILED) {
+                s6 = peg$parse__();
+                if (s6 !== peg$FAILED) {
+                  if (input.charCodeAt(peg$currPos) === 44) {
+                    s7 = peg$c98;
+                    peg$currPos++;
+                  } else {
+                    s7 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c99); }
+                  }
+                  if (s7 !== peg$FAILED) {
+                    s8 = peg$parse__();
+                    if (s8 !== peg$FAILED) {
+                      s9 = peg$parseConditionalExpr();
+                      if (s9 !== peg$FAILED) {
+                        s10 = peg$parse__();
+                        if (s10 !== peg$FAILED) {
+                          if (input.charCodeAt(peg$currPos) === 41) {
+                            s11 = peg$c17;
+                            peg$currPos++;
+                          } else {
+                            s11 = peg$FAILED;
+                            if (peg$silentFails === 0) { peg$fail(peg$c18); }
+                          }
+                          if (s11 !== peg$FAILED) {
+                            s12 = peg$parseWhereClause();
+                            if (s12 === peg$FAILED) {
+                              s12 = null;
+                            }
+                            if (s12 !== peg$FAILED) {
+                              peg$savedPos = s0;
+                              s1 = peg$c293(s5, s9, s12);
+                              s0 = s1;
+                            } else {
+                              peg$currPos = s0;
+                              s0 = peg$FAILED;
+                            }
+                          } else {
+                            peg$currPos = s0;
+                            s0 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         s1 = peg$currPos;
@@ -7655,7 +7757,7 @@ function peg$parse(input, options) {
                         }
                         if (s9 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c291(s2, s6, s9);
+                          s1 = peg$c294(s2, s6, s9);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -7706,7 +7808,7 @@ function peg$parse(input, options) {
     s1 = peg$parseOverExpr();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c292(s1);
+      s1 = peg$c295(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -7720,12 +7822,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c293) {
-      s1 = peg$c293;
+    if (input.substr(peg$currPos, 4) === peg$c296) {
+      s1 = peg$c296;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c294); }
+      if (peg$silentFails === 0) { peg$fail(peg$c297); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -7793,7 +7895,7 @@ function peg$parse(input, options) {
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c295(s5, s7);
+                    s1 = peg$c298(s5, s7);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -7842,210 +7944,10 @@ function peg$parse(input, options) {
         s1 = peg$parseQuotedString();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c296(s1);
+          s1 = peg$c299(s1);
         }
         s0 = s1;
       }
-    }
-
-    return s0;
-  }
-
-  function peg$parseRegexpFunc() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c297) {
-      s1 = peg$c297;
-      peg$currPos += 6;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c298); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse__();
-      if (s2 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c15;
-          peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c16); }
-        }
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parse__();
-          if (s4 !== peg$FAILED) {
-            s5 = peg$parseRegexpFuncArgs();
-            if (s5 !== peg$FAILED) {
-              s6 = peg$parse__();
-              if (s6 !== peg$FAILED) {
-                if (input.charCodeAt(peg$currPos) === 41) {
-                  s7 = peg$c17;
-                  peg$currPos++;
-                } else {
-                  s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c18); }
-                }
-                if (s7 !== peg$FAILED) {
-                  s8 = peg$parseWhereClause();
-                  if (s8 === peg$FAILED) {
-                    s8 = null;
-                  }
-                  if (s8 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c299(s5, s8);
-                    s0 = s1;
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseRegexpFuncArgs() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
-
-    s0 = peg$currPos;
-    s1 = peg$parseRegexpFuncArg();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$currPos;
-      s4 = peg$parse__();
-      if (s4 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c98;
-          peg$currPos++;
-        } else {
-          s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c99); }
-        }
-        if (s5 !== peg$FAILED) {
-          s6 = peg$parse__();
-          if (s6 !== peg$FAILED) {
-            s7 = peg$parseConditionalExpr();
-            if (s7 !== peg$FAILED) {
-              peg$savedPos = s3;
-              s4 = peg$c300(s1, s7);
-              s3 = s4;
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s3;
-        s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = peg$parse__();
-        if (s4 !== peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c98;
-            peg$currPos++;
-          } else {
-            s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c99); }
-          }
-          if (s5 !== peg$FAILED) {
-            s6 = peg$parse__();
-            if (s6 !== peg$FAILED) {
-              s7 = peg$parseConditionalExpr();
-              if (s7 !== peg$FAILED) {
-                peg$savedPos = s3;
-                s4 = peg$c300(s1, s7);
-                s3 = s4;
-              } else {
-                peg$currPos = s3;
-                s3 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c101(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$parse__();
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c3();
-      }
-      s0 = s1;
-    }
-
-    return s0;
-  }
-
-  function peg$parseRegexpFuncArg() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    s1 = peg$parseRegexpPattern();
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c301(s1);
-    }
-    s0 = s1;
-    if (s0 === peg$FAILED) {
-      s0 = peg$parseConditionalExpr();
     }
 
     return s0;
@@ -8237,15 +8139,15 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s7 = peg$c302;
+                  s7 = peg$c301;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c303); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c302); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c304(s2, s6);
+                  s1 = peg$c303(s2, s6);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8300,15 +8202,15 @@ function peg$parse(input, options) {
               s5 = peg$parseAdditiveExpr();
               if (s5 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s6 = peg$c302;
+                  s6 = peg$c301;
                   peg$currPos++;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c303); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c302); }
                 }
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c305(s5);
+                  s1 = peg$c304(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8347,15 +8249,15 @@ function peg$parse(input, options) {
           s2 = peg$parseConditionalExpr();
           if (s2 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s3 = peg$c302;
+              s3 = peg$c301;
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c303); }
+              if (peg$silentFails === 0) { peg$fail(peg$c302); }
             }
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c306(s2);
+              s1 = peg$c305(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8382,7 +8284,7 @@ function peg$parse(input, options) {
             s2 = peg$parseIdentifier();
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c307(s2);
+              s1 = peg$c306(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8551,7 +8453,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSequential();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c308(s3, s4, s8);
+                    s1 = peg$c307(s3, s4, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -8608,15 +8510,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c309;
+              s5 = peg$c308;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c310); }
+              if (peg$silentFails === 0) { peg$fail(peg$c309); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c311(s3);
+              s1 = peg$c310(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8698,7 +8600,7 @@ function peg$parse(input, options) {
           s4 = peg$parseRecordElem();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c312(s4);
+            s1 = peg$c311(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8738,12 +8640,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c313) {
-      s1 = peg$c313;
+    if (input.substr(peg$currPos, 3) === peg$c312) {
+      s1 = peg$c312;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c314); }
+      if (peg$silentFails === 0) { peg$fail(peg$c313); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8751,7 +8653,7 @@ function peg$parse(input, options) {
         s3 = peg$parseConditionalExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c315(s3);
+          s1 = peg$c314(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8790,7 +8692,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c316(s1, s5);
+              s1 = peg$c315(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8835,15 +8737,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s5 = peg$c302;
+              s5 = peg$c301;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c303); }
+              if (peg$silentFails === 0) { peg$fail(peg$c302); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c317(s3);
+              s1 = peg$c316(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8873,12 +8775,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c318) {
-      s1 = peg$c318;
+    if (input.substr(peg$currPos, 2) === peg$c317) {
+      s1 = peg$c317;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c319); }
+      if (peg$silentFails === 0) { peg$fail(peg$c318); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8887,16 +8789,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c320) {
-              s5 = peg$c320;
+            if (input.substr(peg$currPos, 2) === peg$c319) {
+              s5 = peg$c319;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c321); }
+              if (peg$silentFails === 0) { peg$fail(peg$c320); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c322(s3);
+              s1 = peg$c321(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9034,7 +8936,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c323(s1);
+        s1 = peg$c322(s1);
       }
       s0 = s1;
     }
@@ -9046,12 +8948,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c324) {
-      s1 = peg$c324;
+    if (input.substr(peg$currPos, 2) === peg$c323) {
+      s1 = peg$c323;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c325); }
+      if (peg$silentFails === 0) { peg$fail(peg$c324); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -9060,16 +8962,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c326) {
-              s5 = peg$c326;
+            if (input.substr(peg$currPos, 2) === peg$c325) {
+              s5 = peg$c325;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c327); }
+              if (peg$silentFails === 0) { peg$fail(peg$c326); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c328(s3);
+              s1 = peg$c327(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9151,7 +9053,7 @@ function peg$parse(input, options) {
           s4 = peg$parseEntry();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c329(s4);
+            s1 = peg$c328(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9194,7 +9096,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c330(s1, s5);
+              s1 = peg$c329(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9259,7 +9161,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSQLLimit();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c331(s1, s2, s3, s4, s5, s6, s7, s8);
+                    s1 = peg$c330(s1, s2, s3, s4, s5, s6, s7, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -9337,7 +9239,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSQLAssignments();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c332(s3);
+            s1 = peg$c331(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9394,7 +9296,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c333(s1, s2);
+        s1 = peg$c332(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9520,7 +9422,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c334(s4, s5);
+              s1 = peg$c333(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9675,7 +9577,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSQLJoin();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s3;
-        s4 = peg$c335(s1, s4);
+        s4 = peg$c334(s1, s4);
       }
       s3 = s4;
       while (s3 !== peg$FAILED) {
@@ -9684,7 +9586,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSQLJoin();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s3;
-          s4 = peg$c335(s1, s4);
+          s4 = peg$c334(s1, s4);
         }
         s3 = s4;
       }
@@ -9746,7 +9648,7 @@ function peg$parse(input, options) {
                               s14 = peg$parseJoinKey();
                               if (s14 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c336(s1, s5, s6, s10, s14);
+                                s1 = peg$c335(s1, s5, s6, s10, s14);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -9826,7 +9728,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c337(s2);
+        s1 = peg$c336(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9985,7 +9887,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseSQLOrder();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c338(s6, s7);
+                  s1 = peg$c337(s6, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10031,7 +9933,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c339(s2);
+        s1 = peg$c338(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10067,7 +9969,7 @@ function peg$parse(input, options) {
           s4 = peg$parseUInt();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c340(s4);
+            s1 = peg$c339(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10107,11 +10009,11 @@ function peg$parse(input, options) {
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c341); }
+      if (peg$silentFails === 0) { peg$fail(peg$c340); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c342();
+      s1 = peg$c341();
     }
     s0 = s1;
 
@@ -10122,16 +10024,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c343) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c342) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c344); }
+      if (peg$silentFails === 0) { peg$fail(peg$c343); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c345();
+      s1 = peg$c344();
     }
     s0 = s1;
 
@@ -10147,11 +10049,11 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c346); }
+      if (peg$silentFails === 0) { peg$fail(peg$c345); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c347();
+      s1 = peg$c346();
     }
     s0 = s1;
 
@@ -10167,11 +10069,11 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c348); }
+      if (peg$silentFails === 0) { peg$fail(peg$c347); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c349();
+      s1 = peg$c348();
     }
     s0 = s1;
 
@@ -10187,11 +10089,11 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c350); }
+      if (peg$silentFails === 0) { peg$fail(peg$c349); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c351();
+      s1 = peg$c350();
     }
     s0 = s1;
 
@@ -10202,16 +10104,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c352) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c351) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c353); }
+      if (peg$silentFails === 0) { peg$fail(peg$c352); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c354();
+      s1 = peg$c353();
     }
     s0 = s1;
 
@@ -10222,16 +10124,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c355) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c354) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c356); }
+      if (peg$silentFails === 0) { peg$fail(peg$c355); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c357();
+      s1 = peg$c356();
     }
     s0 = s1;
 
@@ -10242,16 +10144,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c358) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c357) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c359); }
+      if (peg$silentFails === 0) { peg$fail(peg$c358); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c360();
+      s1 = peg$c359();
     }
     s0 = s1;
 
@@ -10267,11 +10169,11 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c361); }
+      if (peg$silentFails === 0) { peg$fail(peg$c360); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c362();
+      s1 = peg$c361();
     }
     s0 = s1;
 
@@ -10282,16 +10184,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c363) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c362) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c364); }
+      if (peg$silentFails === 0) { peg$fail(peg$c363); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c365();
+      s1 = peg$c364();
     }
     s0 = s1;
 
@@ -10302,16 +10204,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c366) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c365) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c367); }
+      if (peg$silentFails === 0) { peg$fail(peg$c366); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c368();
+      s1 = peg$c367();
     }
     s0 = s1;
 
@@ -10327,7 +10229,7 @@ function peg$parse(input, options) {
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c369); }
+      if (peg$silentFails === 0) { peg$fail(peg$c368); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10347,7 +10249,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c370); }
+      if (peg$silentFails === 0) { peg$fail(peg$c369); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10367,7 +10269,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c371); }
+      if (peg$silentFails === 0) { peg$fail(peg$c370); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10387,7 +10289,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c372); }
+      if (peg$silentFails === 0) { peg$fail(peg$c371); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10407,7 +10309,7 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c373); }
+      if (peg$silentFails === 0) { peg$fail(peg$c372); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10427,7 +10329,7 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c374); }
+      if (peg$silentFails === 0) { peg$fail(peg$c373); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10529,7 +10431,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c375(s1);
+        s1 = peg$c374(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10544,7 +10446,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP4Net();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c375(s1);
+        s1 = peg$c374(s1);
       }
       s0 = s1;
     }
@@ -10570,7 +10472,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c376(s1);
+        s1 = peg$c375(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10585,7 +10487,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c376(s1);
+        s1 = peg$c375(s1);
       }
       s0 = s1;
     }
@@ -10600,7 +10502,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFloatString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c377(s1);
+      s1 = peg$c376(s1);
     }
     s0 = s1;
 
@@ -10614,7 +10516,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c378(s1);
+      s1 = peg$c377(s1);
     }
     s0 = s1;
 
@@ -10625,30 +10527,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c379) {
-      s1 = peg$c379;
+    if (input.substr(peg$currPos, 4) === peg$c378) {
+      s1 = peg$c378;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c380); }
+      if (peg$silentFails === 0) { peg$fail(peg$c379); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c381();
+      s1 = peg$c380();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c382) {
-        s1 = peg$c382;
+      if (input.substr(peg$currPos, 5) === peg$c381) {
+        s1 = peg$c381;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c383); }
+        if (peg$silentFails === 0) { peg$fail(peg$c382); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c384();
+        s1 = peg$c383();
       }
       s0 = s1;
     }
@@ -10660,16 +10562,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c385) {
-      s1 = peg$c385;
+    if (input.substr(peg$currPos, 4) === peg$c384) {
+      s1 = peg$c384;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c386); }
+      if (peg$silentFails === 0) { peg$fail(peg$c385); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c387();
+      s1 = peg$c386();
     }
     s0 = s1;
 
@@ -10680,12 +10582,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c388) {
-      s1 = peg$c388;
+    if (input.substr(peg$currPos, 2) === peg$c387) {
+      s1 = peg$c387;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c389); }
+      if (peg$silentFails === 0) { peg$fail(peg$c388); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -10696,7 +10598,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c390();
+        s1 = peg$c389();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10733,7 +10635,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c391(s2);
+          s1 = peg$c390(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10760,7 +10662,7 @@ function peg$parse(input, options) {
       s1 = peg$parsePrimitiveType();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c391(s1);
+        s1 = peg$c390(s1);
       }
       s0 = s1;
     }
@@ -10800,7 +10702,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c392(s1);
+        s1 = peg$c391(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10852,7 +10754,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c393(s1, s2);
+          s1 = peg$c392(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10867,7 +10769,7 @@ function peg$parse(input, options) {
         s1 = peg$parseQuotedString();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c394(s1);
+          s1 = peg$c393(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
@@ -10893,7 +10795,7 @@ function peg$parse(input, options) {
                 }
                 if (s4 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c395(s3);
+                  s1 = peg$c394(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10925,7 +10827,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTypeList();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c396(s1);
+      s1 = peg$c395(s1);
     }
     s0 = s1;
 
@@ -10983,7 +10885,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c397(s4);
+            s1 = peg$c396(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11024,15 +10926,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c309;
+              s5 = peg$c308;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c310); }
+              if (peg$silentFails === 0) { peg$fail(peg$c309); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c398(s3);
+              s1 = peg$c397(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11071,15 +10973,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c302;
+                s5 = peg$c301;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c303); }
+                if (peg$silentFails === 0) { peg$fail(peg$c302); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c399(s3);
+                s1 = peg$c398(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -11103,12 +11005,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c318) {
-          s1 = peg$c318;
+        if (input.substr(peg$currPos, 2) === peg$c317) {
+          s1 = peg$c317;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c319); }
+          if (peg$silentFails === 0) { peg$fail(peg$c318); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -11117,16 +11019,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c320) {
-                  s5 = peg$c320;
+                if (input.substr(peg$currPos, 2) === peg$c319) {
+                  s5 = peg$c319;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c321); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c320); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c400(s3);
+                  s1 = peg$c399(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -11150,12 +11052,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c324) {
-            s1 = peg$c324;
+          if (input.substr(peg$currPos, 2) === peg$c323) {
+            s1 = peg$c323;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c325); }
+            if (peg$silentFails === 0) { peg$fail(peg$c324); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -11178,16 +11080,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c326) {
-                            s9 = peg$c326;
+                          if (input.substr(peg$currPos, 2) === peg$c325) {
+                            s9 = peg$c325;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c327); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c326); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c401(s3, s7);
+                            s1 = peg$c400(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -11239,7 +11141,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTemplateLiteralParts();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c402(s1);
+      s1 = peg$c401(s1);
     }
     s0 = s1;
 
@@ -11251,11 +11153,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c403;
+      s1 = peg$c402;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c404); }
+      if (peg$silentFails === 0) { peg$fail(peg$c403); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -11266,11 +11168,11 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c403;
+          s3 = peg$c402;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c404); }
+          if (peg$silentFails === 0) { peg$fail(peg$c403); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
@@ -11291,11 +11193,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c405;
+        s1 = peg$c404;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c406); }
+        if (peg$silentFails === 0) { peg$fail(peg$c405); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -11306,11 +11208,11 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c405;
+            s3 = peg$c404;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c406); }
+            if (peg$silentFails === 0) { peg$fail(peg$c405); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
@@ -11351,7 +11253,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c407(s1);
+        s1 = peg$c406(s1);
       }
       s0 = s1;
     }
@@ -11364,19 +11266,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c408;
+      s1 = peg$c407;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c409); }
+      if (peg$silentFails === 0) { peg$fail(peg$c408); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c410) {
-        s2 = peg$c410;
+      if (input.substr(peg$currPos, 2) === peg$c409) {
+        s2 = peg$c409;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c411); }
+        if (peg$silentFails === 0) { peg$fail(peg$c410); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11394,12 +11296,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c410) {
-        s2 = peg$c410;
+      if (input.substr(peg$currPos, 2) === peg$c409) {
+        s2 = peg$c409;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c411); }
+        if (peg$silentFails === 0) { peg$fail(peg$c410); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -11445,7 +11347,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c407(s1);
+        s1 = peg$c406(s1);
       }
       s0 = s1;
     }
@@ -11458,19 +11360,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c408;
+      s1 = peg$c407;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c409); }
+      if (peg$silentFails === 0) { peg$fail(peg$c408); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c410) {
-        s2 = peg$c410;
+      if (input.substr(peg$currPos, 2) === peg$c409) {
+        s2 = peg$c409;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c411); }
+        if (peg$silentFails === 0) { peg$fail(peg$c410); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11488,12 +11390,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c410) {
-        s2 = peg$c410;
+      if (input.substr(peg$currPos, 2) === peg$c409) {
+        s2 = peg$c409;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c411); }
+        if (peg$silentFails === 0) { peg$fail(peg$c410); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -11525,12 +11427,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c410) {
-      s1 = peg$c410;
+    if (input.substr(peg$currPos, 2) === peg$c409) {
+      s1 = peg$c409;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c411); }
+      if (peg$silentFails === 0) { peg$fail(peg$c410); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -11540,15 +11442,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c309;
+              s5 = peg$c308;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c310); }
+              if (peg$silentFails === 0) { peg$fail(peg$c309); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c412(s3);
+              s1 = peg$c411(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11578,140 +11480,140 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c413) {
-      s1 = peg$c413;
+    if (input.substr(peg$currPos, 5) === peg$c412) {
+      s1 = peg$c412;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c414); }
+      if (peg$silentFails === 0) { peg$fail(peg$c413); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c415) {
-        s1 = peg$c415;
+      if (input.substr(peg$currPos, 6) === peg$c414) {
+        s1 = peg$c414;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c416); }
+        if (peg$silentFails === 0) { peg$fail(peg$c415); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c417) {
-          s1 = peg$c417;
+        if (input.substr(peg$currPos, 6) === peg$c416) {
+          s1 = peg$c416;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c418); }
+          if (peg$silentFails === 0) { peg$fail(peg$c417); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c419) {
-            s1 = peg$c419;
+          if (input.substr(peg$currPos, 6) === peg$c418) {
+            s1 = peg$c418;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c420); }
+            if (peg$silentFails === 0) { peg$fail(peg$c419); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c421) {
-              s1 = peg$c421;
+            if (input.substr(peg$currPos, 4) === peg$c420) {
+              s1 = peg$c420;
               peg$currPos += 4;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c422); }
+              if (peg$silentFails === 0) { peg$fail(peg$c421); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 5) === peg$c423) {
-                s1 = peg$c423;
+              if (input.substr(peg$currPos, 5) === peg$c422) {
+                s1 = peg$c422;
                 peg$currPos += 5;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c424); }
+                if (peg$silentFails === 0) { peg$fail(peg$c423); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c425) {
-                  s1 = peg$c425;
+                if (input.substr(peg$currPos, 5) === peg$c424) {
+                  s1 = peg$c424;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c426); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c425); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c427) {
-                    s1 = peg$c427;
+                  if (input.substr(peg$currPos, 5) === peg$c426) {
+                    s1 = peg$c426;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c428); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c427); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7) === peg$c429) {
-                      s1 = peg$c429;
+                    if (input.substr(peg$currPos, 7) === peg$c428) {
+                      s1 = peg$c428;
                       peg$currPos += 7;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c430); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c429); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 7) === peg$c431) {
-                        s1 = peg$c431;
+                      if (input.substr(peg$currPos, 7) === peg$c430) {
+                        s1 = peg$c430;
                         peg$currPos += 7;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c432); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c431); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 4) === peg$c433) {
-                          s1 = peg$c433;
+                        if (input.substr(peg$currPos, 4) === peg$c432) {
+                          s1 = peg$c432;
                           peg$currPos += 4;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c434); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c433); }
                         }
                         if (s1 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 6) === peg$c435) {
-                            s1 = peg$c435;
+                          if (input.substr(peg$currPos, 6) === peg$c434) {
+                            s1 = peg$c434;
                             peg$currPos += 6;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c436); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c435); }
                           }
                           if (s1 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 8) === peg$c437) {
-                              s1 = peg$c437;
+                            if (input.substr(peg$currPos, 8) === peg$c436) {
+                              s1 = peg$c436;
                               peg$currPos += 8;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c438); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c437); }
                             }
                             if (s1 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 4) === peg$c439) {
-                                s1 = peg$c439;
+                              if (input.substr(peg$currPos, 4) === peg$c438) {
+                                s1 = peg$c438;
                                 peg$currPos += 4;
                               } else {
                                 s1 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c440); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c439); }
                               }
                               if (s1 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 5) === peg$c441) {
-                                  s1 = peg$c441;
+                                if (input.substr(peg$currPos, 5) === peg$c440) {
+                                  s1 = peg$c440;
                                   peg$currPos += 5;
                                 } else {
                                   s1 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c442); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c441); }
                                 }
                                 if (s1 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 2) === peg$c443) {
-                                    s1 = peg$c443;
+                                  if (input.substr(peg$currPos, 2) === peg$c442) {
+                                    s1 = peg$c442;
                                     peg$currPos += 2;
                                   } else {
                                     s1 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c444); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c443); }
                                   }
                                   if (s1 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 3) === peg$c445) {
-                                      s1 = peg$c445;
+                                    if (input.substr(peg$currPos, 3) === peg$c444) {
+                                      s1 = peg$c444;
                                       peg$currPos += 3;
                                     } else {
                                       s1 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c446); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c445); }
                                     }
                                     if (s1 === peg$FAILED) {
                                       if (input.substr(peg$currPos, 4) === peg$c10) {
@@ -11722,12 +11624,12 @@ function peg$parse(input, options) {
                                         if (peg$silentFails === 0) { peg$fail(peg$c11); }
                                       }
                                       if (s1 === peg$FAILED) {
-                                        if (input.substr(peg$currPos, 4) === peg$c385) {
-                                          s1 = peg$c385;
+                                        if (input.substr(peg$currPos, 4) === peg$c384) {
+                                          s1 = peg$c384;
                                           peg$currPos += 4;
                                         } else {
                                           s1 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c386); }
+                                          if (peg$silentFails === 0) { peg$fail(peg$c385); }
                                         }
                                       }
                                     }
@@ -11749,7 +11651,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c447();
+      s1 = peg$c446();
     }
     s0 = s1;
 
@@ -11812,7 +11714,7 @@ function peg$parse(input, options) {
           s4 = peg$parseTypeField();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c397(s4);
+            s1 = peg$c396(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11855,7 +11757,7 @@ function peg$parse(input, options) {
             s5 = peg$parseType();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c448(s1, s5);
+              s1 = peg$c447(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11896,20 +11798,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c449) {
-      s1 = peg$c449;
+    if (input.substr(peg$currPos, 3) === peg$c448) {
+      s1 = peg$c448;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c450); }
+      if (peg$silentFails === 0) { peg$fail(peg$c449); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c451) {
-        s1 = peg$c451;
+      if (input.substr(peg$currPos, 3) === peg$c450) {
+        s1 = peg$c450;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c452); }
+        if (peg$silentFails === 0) { peg$fail(peg$c451); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -11925,7 +11827,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c453();
+        s1 = peg$c452();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11943,20 +11845,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c454) {
-      s1 = peg$c454;
+    if (input.substr(peg$currPos, 2) === peg$c453) {
+      s1 = peg$c453;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c455); }
+      if (peg$silentFails === 0) { peg$fail(peg$c454); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c456) {
-        s1 = peg$c456;
+      if (input.substr(peg$currPos, 2) === peg$c455) {
+        s1 = peg$c455;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c457); }
+        if (peg$silentFails === 0) { peg$fail(peg$c456); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -11972,7 +11874,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c458();
+        s1 = peg$c457();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11998,12 +11900,12 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$c287); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c460) {
-        s1 = peg$c460;
+      if (input.substr(peg$currPos, 3) === peg$c459) {
+        s1 = peg$c459;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c461); }
+        if (peg$silentFails === 0) { peg$fail(peg$c460); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -12019,7 +11921,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c462();
+        s1 = peg$c461();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12037,12 +11939,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c355) {
-      s1 = peg$c355;
+    if (input.substr(peg$currPos, 2) === peg$c354) {
+      s1 = peg$c354;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c463); }
+      if (peg$silentFails === 0) { peg$fail(peg$c462); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -12057,7 +11959,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c357();
+        s1 = peg$c356();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12074,12 +11976,12 @@ function peg$parse(input, options) {
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c464.test(input.charAt(peg$currPos))) {
+    if (peg$c463.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c465); }
+      if (peg$silentFails === 0) { peg$fail(peg$c464); }
     }
 
     return s0;
@@ -12090,12 +11992,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c466.test(input.charAt(peg$currPos))) {
+      if (peg$c465.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c467); }
+        if (peg$silentFails === 0) { peg$fail(peg$c466); }
       }
     }
 
@@ -12109,7 +12011,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c468(s1);
+      s1 = peg$c467(s1);
     }
     s0 = s1;
 
@@ -12181,11 +12083,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 36) {
-        s1 = peg$c469;
+        s1 = peg$c468;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c470); }
+        if (peg$silentFails === 0) { peg$fail(peg$c469); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -12195,11 +12097,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c408;
+          s1 = peg$c407;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c409); }
+          if (peg$silentFails === 0) { peg$fail(peg$c408); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseIDGuard();
@@ -12307,17 +12209,17 @@ function peg$parse(input, options) {
     s1 = peg$parseFullDate();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 84) {
-        s2 = peg$c471;
+        s2 = peg$c470;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c472); }
+        if (peg$silentFails === 0) { peg$fail(peg$c471); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseFullTime();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c473();
+          s1 = peg$c472();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -12391,36 +12293,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (peg$c466.test(input.charAt(peg$currPos))) {
+    if (peg$c465.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c467); }
+      if (peg$silentFails === 0) { peg$fail(peg$c466); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c466.test(input.charAt(peg$currPos))) {
+      if (peg$c465.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c467); }
+        if (peg$silentFails === 0) { peg$fail(peg$c466); }
       }
       if (s2 !== peg$FAILED) {
-        if (peg$c466.test(input.charAt(peg$currPos))) {
+        if (peg$c465.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c467); }
+          if (peg$silentFails === 0) { peg$fail(peg$c466); }
         }
         if (s3 !== peg$FAILED) {
-          if (peg$c466.test(input.charAt(peg$currPos))) {
+          if (peg$c465.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c467); }
+            if (peg$silentFails === 0) { peg$fail(peg$c466); }
           }
           if (s4 !== peg$FAILED) {
             s1 = [s1, s2, s3, s4];
@@ -12449,20 +12351,20 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c466.test(input.charAt(peg$currPos))) {
+    if (peg$c465.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c467); }
+      if (peg$silentFails === 0) { peg$fail(peg$c466); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c466.test(input.charAt(peg$currPos))) {
+      if (peg$c465.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c467); }
+        if (peg$silentFails === 0) { peg$fail(peg$c466); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -12537,22 +12439,22 @@ function peg$parse(input, options) {
               }
               if (s7 !== peg$FAILED) {
                 s8 = [];
-                if (peg$c466.test(input.charAt(peg$currPos))) {
+                if (peg$c465.test(input.charAt(peg$currPos))) {
                   s9 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s9 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c467); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c466); }
                 }
                 if (s9 !== peg$FAILED) {
                   while (s9 !== peg$FAILED) {
                     s8.push(s9);
-                    if (peg$c466.test(input.charAt(peg$currPos))) {
+                    if (peg$c465.test(input.charAt(peg$currPos))) {
                       s9 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c467); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c466); }
                     }
                   }
                 } else {
@@ -12607,11 +12509,11 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     if (input.charCodeAt(peg$currPos) === 90) {
-      s0 = peg$c474;
+      s0 = peg$c473;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c475); }
+      if (peg$silentFails === 0) { peg$fail(peg$c474); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
@@ -12654,22 +12556,22 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 s7 = [];
-                if (peg$c466.test(input.charAt(peg$currPos))) {
+                if (peg$c465.test(input.charAt(peg$currPos))) {
                   s8 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s8 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c467); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c466); }
                 }
                 if (s8 !== peg$FAILED) {
                   while (s8 !== peg$FAILED) {
                     s7.push(s8);
-                    if (peg$c466.test(input.charAt(peg$currPos))) {
+                    if (peg$c465.test(input.charAt(peg$currPos))) {
                       s8 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s8 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c467); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c466); }
                     }
                   }
                 } else {
@@ -12772,7 +12674,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c476();
+        s1 = peg$c475();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12834,76 +12736,76 @@ function peg$parse(input, options) {
   function peg$parseTimeUnit() {
     var s0;
 
-    if (input.substr(peg$currPos, 2) === peg$c477) {
-      s0 = peg$c477;
+    if (input.substr(peg$currPos, 2) === peg$c476) {
+      s0 = peg$c476;
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c478); }
+      if (peg$silentFails === 0) { peg$fail(peg$c477); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c479) {
-        s0 = peg$c479;
+      if (input.substr(peg$currPos, 2) === peg$c478) {
+        s0 = peg$c478;
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c480); }
+        if (peg$silentFails === 0) { peg$fail(peg$c479); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c481) {
-          s0 = peg$c481;
+        if (input.substr(peg$currPos, 2) === peg$c480) {
+          s0 = peg$c480;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c482); }
+          if (peg$silentFails === 0) { peg$fail(peg$c481); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 115) {
-            s0 = peg$c483;
+            s0 = peg$c482;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c484); }
+            if (peg$silentFails === 0) { peg$fail(peg$c483); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c485;
+              s0 = peg$c484;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c486); }
+              if (peg$silentFails === 0) { peg$fail(peg$c485); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 104) {
-                s0 = peg$c487;
+                s0 = peg$c486;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c488); }
+                if (peg$silentFails === 0) { peg$fail(peg$c487); }
               }
               if (s0 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 100) {
-                  s0 = peg$c489;
+                  s0 = peg$c488;
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c490); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c489); }
                 }
                 if (s0 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 119) {
-                    s0 = peg$c491;
+                    s0 = peg$c490;
                     peg$currPos++;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c492); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c491); }
                   }
                   if (s0 === peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 121) {
-                      s0 = peg$c493;
+                      s0 = peg$c492;
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c494); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c493); }
                     }
                   }
                 }
@@ -13088,7 +12990,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c495(s1, s2);
+        s1 = peg$c494(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13109,12 +13011,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c496) {
-            s3 = peg$c496;
+          if (input.substr(peg$currPos, 2) === peg$c495) {
+            s3 = peg$c495;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c497); }
+            if (peg$silentFails === 0) { peg$fail(peg$c496); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -13127,7 +13029,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c498(s1, s2, s4, s5);
+                s1 = peg$c497(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -13151,12 +13053,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c496) {
-          s1 = peg$c496;
+        if (input.substr(peg$currPos, 2) === peg$c495) {
+          s1 = peg$c495;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c497); }
+          if (peg$silentFails === 0) { peg$fail(peg$c496); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -13169,7 +13071,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c499(s2, s3);
+              s1 = peg$c498(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13194,16 +13096,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c496) {
-                s3 = peg$c496;
+              if (input.substr(peg$currPos, 2) === peg$c495) {
+                s3 = peg$c495;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c497); }
+                if (peg$silentFails === 0) { peg$fail(peg$c496); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c500(s1, s2);
+                s1 = peg$c499(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -13219,16 +13121,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c496) {
-              s1 = peg$c496;
+            if (input.substr(peg$currPos, 2) === peg$c495) {
+              s1 = peg$c495;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c497); }
+              if (peg$silentFails === 0) { peg$fail(peg$c496); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c501();
+              s1 = peg$c500();
             }
             s0 = s1;
           }
@@ -13265,7 +13167,7 @@ function peg$parse(input, options) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c502(s2);
+        s1 = peg$c501(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13294,7 +13196,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c503(s1);
+        s1 = peg$c502(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13325,7 +13227,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c504(s1, s3);
+          s1 = peg$c503(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13360,7 +13262,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c505(s1, s3);
+          s1 = peg$c504(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13385,7 +13287,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c506(s1);
+      s1 = peg$c505(s1);
     }
     s0 = s1;
 
@@ -13408,22 +13310,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c466.test(input.charAt(peg$currPos))) {
+    if (peg$c465.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c467); }
+      if (peg$silentFails === 0) { peg$fail(peg$c466); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c466.test(input.charAt(peg$currPos))) {
+        if (peg$c465.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c467); }
+          if (peg$silentFails === 0) { peg$fail(peg$c466); }
         }
       }
     } else {
@@ -13483,22 +13385,22 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c466.test(input.charAt(peg$currPos))) {
+      if (peg$c465.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c467); }
+        if (peg$silentFails === 0) { peg$fail(peg$c466); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c466.test(input.charAt(peg$currPos))) {
+          if (peg$c465.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c467); }
+            if (peg$silentFails === 0) { peg$fail(peg$c466); }
           }
         }
       } else {
@@ -13514,21 +13416,21 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c466.test(input.charAt(peg$currPos))) {
+          if (peg$c465.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c467); }
+            if (peg$silentFails === 0) { peg$fail(peg$c466); }
           }
           while (s5 !== peg$FAILED) {
             s4.push(s5);
-            if (peg$c466.test(input.charAt(peg$currPos))) {
+            if (peg$c465.test(input.charAt(peg$currPos))) {
               s5 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c467); }
+              if (peg$silentFails === 0) { peg$fail(peg$c466); }
             }
           }
           if (s4 !== peg$FAILED) {
@@ -13538,7 +13440,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c507();
+              s1 = peg$c506();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13582,22 +13484,22 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c466.test(input.charAt(peg$currPos))) {
+          if (peg$c465.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c467); }
+            if (peg$silentFails === 0) { peg$fail(peg$c466); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c466.test(input.charAt(peg$currPos))) {
+              if (peg$c465.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c467); }
+                if (peg$silentFails === 0) { peg$fail(peg$c466); }
               }
             }
           } else {
@@ -13610,7 +13512,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c507();
+              s1 = peg$c506();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13649,20 +13551,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c508) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c507) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c509); }
+      if (peg$silentFails === 0) { peg$fail(peg$c508); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c510.test(input.charAt(peg$currPos))) {
+      if (peg$c509.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c511); }
+        if (peg$silentFails === 0) { peg$fail(peg$c510); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -13691,12 +13593,12 @@ function peg$parse(input, options) {
   function peg$parseNaN() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c512) {
-      s0 = peg$c512;
+    if (input.substr(peg$currPos, 3) === peg$c511) {
+      s0 = peg$c511;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c513); }
+      if (peg$silentFails === 0) { peg$fail(peg$c512); }
     }
 
     return s0;
@@ -13726,12 +13628,12 @@ function peg$parse(input, options) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c514) {
-        s2 = peg$c514;
+      if (input.substr(peg$currPos, 3) === peg$c513) {
+        s2 = peg$c513;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c515); }
+        if (peg$silentFails === 0) { peg$fail(peg$c514); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -13774,12 +13676,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c516.test(input.charAt(peg$currPos))) {
+    if (peg$c515.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c517); }
+      if (peg$silentFails === 0) { peg$fail(peg$c516); }
     }
 
     return s0;
@@ -13790,11 +13692,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c403;
+      s1 = peg$c402;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c404); }
+      if (peg$silentFails === 0) { peg$fail(peg$c403); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -13805,15 +13707,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c403;
+          s3 = peg$c402;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c404); }
+          if (peg$silentFails === 0) { peg$fail(peg$c403); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c518(s2);
+          s1 = peg$c517(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13830,11 +13732,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c405;
+        s1 = peg$c404;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c406); }
+        if (peg$silentFails === 0) { peg$fail(peg$c405); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -13845,15 +13747,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c405;
+            s3 = peg$c404;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c406); }
+            if (peg$silentFails === 0) { peg$fail(peg$c405); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c518(s2);
+            s1 = peg$c517(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -13879,11 +13781,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c403;
+      s2 = peg$c402;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c404); }
+      if (peg$silentFails === 0) { peg$fail(peg$c403); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -13901,7 +13803,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c519); }
+        if (peg$silentFails === 0) { peg$fail(peg$c518); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -13918,11 +13820,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c408;
+        s1 = peg$c407;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c409); }
+        if (peg$silentFails === 0) { peg$fail(peg$c408); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -13957,7 +13859,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c520(s1, s2);
+        s1 = peg$c519(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13986,12 +13888,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (peg$c521.test(input.charAt(peg$currPos))) {
+    if (peg$c520.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c522); }
+      if (peg$silentFails === 0) { peg$fail(peg$c521); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -14007,12 +13909,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseKeyWordStart();
     if (s0 === peg$FAILED) {
-      if (peg$c466.test(input.charAt(peg$currPos))) {
+      if (peg$c465.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c467); }
+        if (peg$silentFails === 0) { peg$fail(peg$c466); }
       }
     }
 
@@ -14024,11 +13926,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c408;
+      s1 = peg$c407;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c409); }
+      if (peg$silentFails === 0) { peg$fail(peg$c408); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseKeywordEscape();
@@ -14087,7 +13989,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c523(s3, s4);
+            s1 = peg$c522(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -14205,7 +14107,7 @@ function peg$parse(input, options) {
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c524();
+          s1 = peg$c523();
         }
         s0 = s1;
       }
@@ -14219,12 +14121,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseGlobStart();
     if (s0 === peg$FAILED) {
-      if (peg$c466.test(input.charAt(peg$currPos))) {
+      if (peg$c465.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c467); }
+        if (peg$silentFails === 0) { peg$fail(peg$c466); }
       }
     }
 
@@ -14236,11 +14138,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c408;
+      s1 = peg$c407;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c409); }
+      if (peg$silentFails === 0) { peg$fail(peg$c408); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseGlobEscape();
@@ -14276,7 +14178,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c525();
+      s1 = peg$c524();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -14290,16 +14192,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c526();
+        s1 = peg$c525();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c510.test(input.charAt(peg$currPos))) {
+        if (peg$c509.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c511); }
+          if (peg$silentFails === 0) { peg$fail(peg$c510); }
         }
       }
     }
@@ -14314,11 +14216,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c405;
+      s2 = peg$c404;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c406); }
+      if (peg$silentFails === 0) { peg$fail(peg$c405); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -14336,7 +14238,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c519); }
+        if (peg$silentFails === 0) { peg$fail(peg$c518); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14353,11 +14255,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c408;
+        s1 = peg$c407;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c409); }
+        if (peg$silentFails === 0) { peg$fail(peg$c408); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -14393,20 +14295,20 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c405;
+      s0 = peg$c404;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c406); }
+      if (peg$silentFails === 0) { peg$fail(peg$c405); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s1 = peg$c403;
+        s1 = peg$c402;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c404); }
+        if (peg$silentFails === 0) { peg$fail(peg$c403); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14415,94 +14317,94 @@ function peg$parse(input, options) {
       s0 = s1;
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c408;
+          s0 = peg$c407;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c409); }
+          if (peg$silentFails === 0) { peg$fail(peg$c408); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c527;
+            s1 = peg$c526;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c528); }
+            if (peg$silentFails === 0) { peg$fail(peg$c527); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c529();
+            s1 = peg$c528();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c530;
+              s1 = peg$c529;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c531); }
+              if (peg$silentFails === 0) { peg$fail(peg$c530); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c532();
+              s1 = peg$c531();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c533;
+                s1 = peg$c532;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c534); }
+                if (peg$silentFails === 0) { peg$fail(peg$c533); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c535();
+                s1 = peg$c534();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c536;
+                  s1 = peg$c535;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c537); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c536); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c538();
+                  s1 = peg$c537();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c539;
+                    s1 = peg$c538;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c540); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c539); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c541();
+                    s1 = peg$c540();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c542;
+                      s1 = peg$c541;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c543); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c542); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c544();
+                      s1 = peg$c543();
                     }
                     s0 = s1;
                   }
@@ -14530,7 +14432,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c525();
+      s1 = peg$c524();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -14544,16 +14446,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c545();
+        s1 = peg$c544();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c510.test(input.charAt(peg$currPos))) {
+        if (peg$c509.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c511); }
+          if (peg$silentFails === 0) { peg$fail(peg$c510); }
         }
       }
     }
@@ -14566,11 +14468,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c546;
+      s1 = peg$c545;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c547); }
+      if (peg$silentFails === 0) { peg$fail(peg$c546); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -14602,7 +14504,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c548(s2);
+        s1 = peg$c547(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14615,11 +14517,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c546;
+        s1 = peg$c545;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c547); }
+        if (peg$silentFails === 0) { peg$fail(peg$c546); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
@@ -14686,15 +14588,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c309;
+              s4 = peg$c308;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c310); }
+              if (peg$silentFails === 0) { peg$fail(peg$c309); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c548(s3);
+              s1 = peg$c547(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -14778,21 +14680,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c549.test(input.charAt(peg$currPos))) {
+    if (peg$c548.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c550); }
+      if (peg$silentFails === 0) { peg$fail(peg$c549); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s3 = peg$c408;
+        s3 = peg$c407;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c409); }
+        if (peg$silentFails === 0) { peg$fail(peg$c408); }
       }
       if (s3 !== peg$FAILED) {
         if (input.length > peg$currPos) {
@@ -14800,7 +14702,7 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c519); }
+          if (peg$silentFails === 0) { peg$fail(peg$c518); }
         }
         if (s4 !== peg$FAILED) {
           s3 = [s3, s4];
@@ -14817,21 +14719,21 @@ function peg$parse(input, options) {
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c549.test(input.charAt(peg$currPos))) {
+        if (peg$c548.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c550); }
+          if (peg$silentFails === 0) { peg$fail(peg$c549); }
         }
         if (s2 === peg$FAILED) {
           s2 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 92) {
-            s3 = peg$c408;
+            s3 = peg$c407;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c409); }
+            if (peg$silentFails === 0) { peg$fail(peg$c408); }
           }
           if (s3 !== peg$FAILED) {
             if (input.length > peg$currPos) {
@@ -14839,7 +14741,7 @@ function peg$parse(input, options) {
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c519); }
+              if (peg$silentFails === 0) { peg$fail(peg$c518); }
             }
             if (s4 !== peg$FAILED) {
               s3 = [s3, s4];
@@ -14869,12 +14771,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c551.test(input.charAt(peg$currPos))) {
+    if (peg$c550.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c552); }
+      if (peg$silentFails === 0) { peg$fail(peg$c551); }
     }
 
     return s0;
@@ -14932,7 +14834,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c519); }
+      if (peg$silentFails === 0) { peg$fail(peg$c518); }
     }
 
     return s0;
@@ -14943,51 +14845,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c554;
+      s0 = peg$c553;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c555); }
+      if (peg$silentFails === 0) { peg$fail(peg$c554); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c556;
+        s0 = peg$c555;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c557); }
+        if (peg$silentFails === 0) { peg$fail(peg$c556); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c558;
+          s0 = peg$c557;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c559); }
+          if (peg$silentFails === 0) { peg$fail(peg$c558); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c560;
+            s0 = peg$c559;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c561); }
+            if (peg$silentFails === 0) { peg$fail(peg$c560); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c562;
+              s0 = peg$c561;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c563); }
+              if (peg$silentFails === 0) { peg$fail(peg$c562); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c564;
+                s0 = peg$c563;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c565); }
+                if (peg$silentFails === 0) { peg$fail(peg$c564); }
               }
             }
           }
@@ -14996,7 +14898,7 @@ function peg$parse(input, options) {
     }
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c553); }
+      if (peg$silentFails === 0) { peg$fail(peg$c552); }
     }
 
     return s0;
@@ -15005,12 +14907,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c566.test(input.charAt(peg$currPos))) {
+    if (peg$c565.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c567); }
+      if (peg$silentFails === 0) { peg$fail(peg$c566); }
     }
 
     return s0;
@@ -15023,7 +14925,7 @@ function peg$parse(input, options) {
     s0 = peg$parseSingleLineComment();
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c568); }
+      if (peg$silentFails === 0) { peg$fail(peg$c567); }
     }
 
     return s0;
@@ -15033,12 +14935,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c573) {
-      s1 = peg$c573;
+    if (input.substr(peg$currPos, 2) === peg$c572) {
+      s1 = peg$c572;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c574); }
+      if (peg$silentFails === 0) { peg$fail(peg$c573); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -15118,7 +15020,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c519); }
+      if (peg$silentFails === 0) { peg$fail(peg$c518); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -5384,64 +5384,68 @@ var g = &grammar{
 						pos:  position{line: 716, col: 5, offset: 20881},
 						name: "Grep",
 					},
+					&ruleRefExpr{
+						pos:  position{line: 717, col: 5, offset: 20890},
+						name: "RegexpFunc",
+					},
 					&actionExpr{
-						pos: position{line: 717, col: 5, offset: 20890},
-						run: (*parser).callonFunction3,
+						pos: position{line: 718, col: 5, offset: 20905},
+						run: (*parser).callonFunction4,
 						expr: &seqExpr{
-							pos: position{line: 717, col: 5, offset: 20890},
+							pos: position{line: 718, col: 5, offset: 20905},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 717, col: 5, offset: 20890},
+									pos: position{line: 718, col: 5, offset: 20905},
 									expr: &ruleRefExpr{
-										pos:  position{line: 717, col: 6, offset: 20891},
+										pos:  position{line: 718, col: 6, offset: 20906},
 										name: "FuncGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 717, col: 16, offset: 20901},
+									pos:   position{line: 718, col: 16, offset: 20916},
 									label: "fn",
 									expr: &ruleRefExpr{
-										pos:  position{line: 717, col: 19, offset: 20904},
+										pos:  position{line: 718, col: 19, offset: 20919},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 717, col: 34, offset: 20919},
+									pos:  position{line: 718, col: 34, offset: 20934},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 717, col: 37, offset: 20922},
+									pos:        position{line: 718, col: 37, offset: 20937},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 717, col: 41, offset: 20926},
+									pos:  position{line: 718, col: 41, offset: 20941},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 717, col: 44, offset: 20929},
+									pos:   position{line: 718, col: 44, offset: 20944},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 717, col: 49, offset: 20934},
+										pos:  position{line: 718, col: 49, offset: 20949},
 										name: "FunctionArgs",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 717, col: 62, offset: 20947},
+									pos:  position{line: 718, col: 62, offset: 20962},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 717, col: 65, offset: 20950},
+									pos:        position{line: 718, col: 65, offset: 20965},
 									val:        ")",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 717, col: 69, offset: 20954},
+									pos:   position{line: 718, col: 69, offset: 20969},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 717, col: 75, offset: 20960},
+										pos: position{line: 718, col: 75, offset: 20975},
 										expr: &ruleRefExpr{
-											pos:  position{line: 717, col: 75, offset: 20960},
+											pos:  position{line: 718, col: 75, offset: 20975},
 											name: "WhereClause",
 										},
 									},
@@ -5454,24 +5458,24 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionArgs",
-			pos:  position{line: 721, col: 1, offset: 21081},
+			pos:  position{line: 722, col: 1, offset: 21096},
 			expr: &choiceExpr{
-				pos: position{line: 722, col: 5, offset: 21098},
+				pos: position{line: 723, col: 5, offset: 21113},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 722, col: 5, offset: 21098},
+						pos: position{line: 723, col: 5, offset: 21113},
 						run: (*parser).callonFunctionArgs2,
 						expr: &labeledExpr{
-							pos:   position{line: 722, col: 5, offset: 21098},
+							pos:   position{line: 723, col: 5, offset: 21113},
 							label: "o",
 							expr: &ruleRefExpr{
-								pos:  position{line: 722, col: 7, offset: 21100},
+								pos:  position{line: 723, col: 7, offset: 21115},
 								name: "OverExpr",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 723, col: 5, offset: 21146},
+						pos:  position{line: 724, col: 5, offset: 21161},
 						name: "OptionalExprs",
 					},
 				},
@@ -5479,75 +5483,75 @@ var g = &grammar{
 		},
 		{
 			name: "Grep",
-			pos:  position{line: 725, col: 1, offset: 21161},
+			pos:  position{line: 726, col: 1, offset: 21176},
 			expr: &actionExpr{
-				pos: position{line: 726, col: 5, offset: 21170},
+				pos: position{line: 727, col: 5, offset: 21185},
 				run: (*parser).callonGrep1,
 				expr: &seqExpr{
-					pos: position{line: 726, col: 5, offset: 21170},
+					pos: position{line: 727, col: 5, offset: 21185},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 726, col: 5, offset: 21170},
+							pos:        position{line: 727, col: 5, offset: 21185},
 							val:        "grep",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 726, col: 12, offset: 21177},
+							pos:  position{line: 727, col: 12, offset: 21192},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 726, col: 15, offset: 21180},
+							pos:        position{line: 727, col: 15, offset: 21195},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 726, col: 19, offset: 21184},
+							pos:  position{line: 727, col: 19, offset: 21199},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 726, col: 22, offset: 21187},
+							pos:   position{line: 727, col: 22, offset: 21202},
 							label: "pattern",
 							expr: &ruleRefExpr{
-								pos:  position{line: 726, col: 30, offset: 21195},
+								pos:  position{line: 727, col: 30, offset: 21210},
 								name: "Pattern",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 726, col: 38, offset: 21203},
+							pos:  position{line: 727, col: 38, offset: 21218},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 726, col: 42, offset: 21207},
+							pos:   position{line: 727, col: 42, offset: 21222},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 726, col: 46, offset: 21211},
+								pos: position{line: 727, col: 46, offset: 21226},
 								expr: &seqExpr{
-									pos: position{line: 726, col: 47, offset: 21212},
+									pos: position{line: 727, col: 47, offset: 21227},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 726, col: 47, offset: 21212},
+											pos:        position{line: 727, col: 47, offset: 21227},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 726, col: 51, offset: 21216},
+											pos:  position{line: 727, col: 51, offset: 21231},
 											name: "__",
 										},
 										&choiceExpr{
-											pos: position{line: 726, col: 56, offset: 21221},
+											pos: position{line: 727, col: 56, offset: 21236},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 726, col: 56, offset: 21221},
+													pos:  position{line: 727, col: 56, offset: 21236},
 													name: "OverExpr",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 726, col: 67, offset: 21232},
+													pos:  position{line: 727, col: 67, offset: 21247},
 													name: "Expr",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 726, col: 73, offset: 21238},
+											pos:  position{line: 727, col: 73, offset: 21253},
 											name: "__",
 										},
 									},
@@ -5555,7 +5559,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 726, col: 78, offset: 21243},
+							pos:        position{line: 727, col: 78, offset: 21258},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -5565,26 +5569,26 @@ var g = &grammar{
 		},
 		{
 			name: "Pattern",
-			pos:  position{line: 734, col: 1, offset: 21484},
+			pos:  position{line: 735, col: 1, offset: 21499},
 			expr: &choiceExpr{
-				pos: position{line: 735, col: 5, offset: 21496},
+				pos: position{line: 736, col: 5, offset: 21511},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 735, col: 5, offset: 21496},
+						pos:  position{line: 736, col: 5, offset: 21511},
 						name: "Regexp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 736, col: 5, offset: 21507},
+						pos:  position{line: 737, col: 5, offset: 21522},
 						name: "Glob",
 					},
 					&actionExpr{
-						pos: position{line: 737, col: 5, offset: 21516},
+						pos: position{line: 738, col: 5, offset: 21531},
 						run: (*parser).callonPattern4,
 						expr: &labeledExpr{
-							pos:   position{line: 737, col: 5, offset: 21516},
+							pos:   position{line: 738, col: 5, offset: 21531},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 737, col: 7, offset: 21518},
+								pos:  position{line: 738, col: 7, offset: 21533},
 								name: "QuotedString",
 							},
 						},
@@ -5593,20 +5597,175 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "OptionalExprs",
-			pos:  position{line: 741, col: 1, offset: 21610},
+			name: "RegexpFunc",
+			pos:  position{line: 742, col: 1, offset: 21625},
+			expr: &actionExpr{
+				pos: position{line: 743, col: 5, offset: 21640},
+				run: (*parser).callonRegexpFunc1,
+				expr: &seqExpr{
+					pos: position{line: 743, col: 5, offset: 21640},
+					exprs: []interface{}{
+						&litMatcher{
+							pos:        position{line: 743, col: 5, offset: 21640},
+							val:        "regexp",
+							ignoreCase: false,
+						},
+						&ruleRefExpr{
+							pos:  position{line: 743, col: 14, offset: 21649},
+							name: "__",
+						},
+						&litMatcher{
+							pos:        position{line: 743, col: 17, offset: 21652},
+							val:        "(",
+							ignoreCase: false,
+						},
+						&ruleRefExpr{
+							pos:  position{line: 743, col: 21, offset: 21656},
+							name: "__",
+						},
+						&labeledExpr{
+							pos:   position{line: 743, col: 24, offset: 21659},
+							label: "args",
+							expr: &ruleRefExpr{
+								pos:  position{line: 743, col: 29, offset: 21664},
+								name: "RegexpFuncArgs",
+							},
+						},
+						&ruleRefExpr{
+							pos:  position{line: 743, col: 44, offset: 21679},
+							name: "__",
+						},
+						&litMatcher{
+							pos:        position{line: 743, col: 47, offset: 21682},
+							val:        ")",
+							ignoreCase: false,
+						},
+						&labeledExpr{
+							pos:   position{line: 743, col: 51, offset: 21686},
+							label: "where",
+							expr: &zeroOrOneExpr{
+								pos: position{line: 743, col: 57, offset: 21692},
+								expr: &ruleRefExpr{
+									pos:  position{line: 743, col: 57, offset: 21692},
+									name: "WhereClause",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "RegexpFuncArgs",
+			pos:  position{line: 747, col: 1, offset: 21819},
 			expr: &choiceExpr{
-				pos: position{line: 742, col: 5, offset: 21628},
+				pos: position{line: 748, col: 5, offset: 21838},
+				alternatives: []interface{}{
+					&actionExpr{
+						pos: position{line: 748, col: 5, offset: 21838},
+						run: (*parser).callonRegexpFuncArgs2,
+						expr: &seqExpr{
+							pos: position{line: 748, col: 5, offset: 21838},
+							exprs: []interface{}{
+								&labeledExpr{
+									pos:   position{line: 748, col: 5, offset: 21838},
+									label: "first",
+									expr: &ruleRefExpr{
+										pos:  position{line: 748, col: 11, offset: 21844},
+										name: "RegexpFuncArg",
+									},
+								},
+								&labeledExpr{
+									pos:   position{line: 748, col: 25, offset: 21858},
+									label: "rest",
+									expr: &zeroOrMoreExpr{
+										pos: position{line: 748, col: 30, offset: 21863},
+										expr: &actionExpr{
+											pos: position{line: 748, col: 31, offset: 21864},
+											run: (*parser).callonRegexpFuncArgs8,
+											expr: &seqExpr{
+												pos: position{line: 748, col: 31, offset: 21864},
+												exprs: []interface{}{
+													&ruleRefExpr{
+														pos:  position{line: 748, col: 31, offset: 21864},
+														name: "__",
+													},
+													&litMatcher{
+														pos:        position{line: 748, col: 34, offset: 21867},
+														val:        ",",
+														ignoreCase: false,
+													},
+													&ruleRefExpr{
+														pos:  position{line: 748, col: 38, offset: 21871},
+														name: "__",
+													},
+													&labeledExpr{
+														pos:   position{line: 748, col: 41, offset: 21874},
+														label: "e",
+														expr: &ruleRefExpr{
+															pos:  position{line: 748, col: 43, offset: 21876},
+															name: "Expr",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 751, col: 5, offset: 21988},
+						run: (*parser).callonRegexpFuncArgs15,
+						expr: &ruleRefExpr{
+							pos:  position{line: 751, col: 5, offset: 21988},
+							name: "__",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "RegexpFuncArg",
+			pos:  position{line: 753, col: 1, offset: 22024},
+			expr: &choiceExpr{
+				pos: position{line: 754, col: 5, offset: 22042},
+				alternatives: []interface{}{
+					&actionExpr{
+						pos: position{line: 754, col: 5, offset: 22042},
+						run: (*parser).callonRegexpFuncArg2,
+						expr: &labeledExpr{
+							pos:   position{line: 754, col: 5, offset: 22042},
+							label: "v",
+							expr: &ruleRefExpr{
+								pos:  position{line: 754, col: 7, offset: 22044},
+								name: "RegexpPattern",
+							},
+						},
+					},
+					&ruleRefExpr{
+						pos:  position{line: 755, col: 5, offset: 22151},
+						name: "Expr",
+					},
+				},
+			},
+		},
+		{
+			name: "OptionalExprs",
+			pos:  position{line: 758, col: 1, offset: 22158},
+			expr: &choiceExpr{
+				pos: position{line: 759, col: 5, offset: 22176},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 742, col: 5, offset: 21628},
+						pos:  position{line: 759, col: 5, offset: 22176},
 						name: "Exprs",
 					},
 					&actionExpr{
-						pos: position{line: 743, col: 5, offset: 21638},
+						pos: position{line: 760, col: 5, offset: 22186},
 						run: (*parser).callonOptionalExprs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 743, col: 5, offset: 21638},
+							pos:  position{line: 760, col: 5, offset: 22186},
 							name: "__",
 						},
 					},
@@ -5615,50 +5774,50 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 745, col: 1, offset: 21674},
+			pos:  position{line: 762, col: 1, offset: 22222},
 			expr: &actionExpr{
-				pos: position{line: 746, col: 5, offset: 21684},
+				pos: position{line: 763, col: 5, offset: 22232},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 746, col: 5, offset: 21684},
+					pos: position{line: 763, col: 5, offset: 22232},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 746, col: 5, offset: 21684},
+							pos:   position{line: 763, col: 5, offset: 22232},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 746, col: 11, offset: 21690},
+								pos:  position{line: 763, col: 11, offset: 22238},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 746, col: 16, offset: 21695},
+							pos:   position{line: 763, col: 16, offset: 22243},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 746, col: 21, offset: 21700},
+								pos: position{line: 763, col: 21, offset: 22248},
 								expr: &actionExpr{
-									pos: position{line: 746, col: 22, offset: 21701},
+									pos: position{line: 763, col: 22, offset: 22249},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 746, col: 22, offset: 21701},
+										pos: position{line: 763, col: 22, offset: 22249},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 746, col: 22, offset: 21701},
+												pos:  position{line: 763, col: 22, offset: 22249},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 746, col: 25, offset: 21704},
+												pos:        position{line: 763, col: 25, offset: 22252},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 746, col: 29, offset: 21708},
+												pos:  position{line: 763, col: 29, offset: 22256},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 746, col: 32, offset: 21711},
+												pos:   position{line: 763, col: 32, offset: 22259},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 746, col: 34, offset: 21713},
+													pos:  position{line: 763, col: 34, offset: 22261},
 													name: "Expr",
 												},
 											},
@@ -5673,35 +5832,35 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 750, col: 1, offset: 21822},
+			pos:  position{line: 767, col: 1, offset: 22370},
 			expr: &actionExpr{
-				pos: position{line: 751, col: 5, offset: 21836},
+				pos: position{line: 768, col: 5, offset: 22384},
 				run: (*parser).callonDerefExpr1,
 				expr: &seqExpr{
-					pos: position{line: 751, col: 5, offset: 21836},
+					pos: position{line: 768, col: 5, offset: 22384},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 751, col: 5, offset: 21836},
+							pos: position{line: 768, col: 5, offset: 22384},
 							expr: &ruleRefExpr{
-								pos:  position{line: 751, col: 6, offset: 21837},
+								pos:  position{line: 768, col: 6, offset: 22385},
 								name: "IP6",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 751, col: 10, offset: 21841},
+							pos:   position{line: 768, col: 10, offset: 22389},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 751, col: 16, offset: 21847},
+								pos:  position{line: 768, col: 16, offset: 22395},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 751, col: 27, offset: 21858},
+							pos:   position{line: 768, col: 27, offset: 22406},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 751, col: 32, offset: 21863},
+								pos: position{line: 768, col: 32, offset: 22411},
 								expr: &ruleRefExpr{
-									pos:  position{line: 751, col: 33, offset: 21864},
+									pos:  position{line: 768, col: 33, offset: 22412},
 									name: "Deref",
 								},
 							},
@@ -5712,55 +5871,55 @@ var g = &grammar{
 		},
 		{
 			name: "Deref",
-			pos:  position{line: 755, col: 1, offset: 21932},
+			pos:  position{line: 772, col: 1, offset: 22480},
 			expr: &choiceExpr{
-				pos: position{line: 756, col: 5, offset: 21942},
+				pos: position{line: 773, col: 5, offset: 22490},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 756, col: 5, offset: 21942},
+						pos: position{line: 773, col: 5, offset: 22490},
 						run: (*parser).callonDeref2,
 						expr: &seqExpr{
-							pos: position{line: 756, col: 5, offset: 21942},
+							pos: position{line: 773, col: 5, offset: 22490},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 756, col: 5, offset: 21942},
+									pos:        position{line: 773, col: 5, offset: 22490},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 756, col: 9, offset: 21946},
+									pos:   position{line: 773, col: 9, offset: 22494},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 756, col: 14, offset: 21951},
+										pos:  position{line: 773, col: 14, offset: 22499},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 756, col: 27, offset: 21964},
+									pos:  position{line: 773, col: 27, offset: 22512},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 756, col: 30, offset: 21967},
+									pos:        position{line: 773, col: 30, offset: 22515},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 756, col: 34, offset: 21971},
+									pos:  position{line: 773, col: 34, offset: 22519},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 756, col: 37, offset: 21974},
+									pos:   position{line: 773, col: 37, offset: 22522},
 									label: "to",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 756, col: 40, offset: 21977},
+										pos: position{line: 773, col: 40, offset: 22525},
 										expr: &ruleRefExpr{
-											pos:  position{line: 756, col: 40, offset: 21977},
+											pos:  position{line: 773, col: 40, offset: 22525},
 											name: "AdditiveExpr",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 756, col: 54, offset: 21991},
+									pos:        position{line: 773, col: 54, offset: 22539},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5768,39 +5927,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 762, col: 5, offset: 22162},
+						pos: position{line: 779, col: 5, offset: 22710},
 						run: (*parser).callonDeref14,
 						expr: &seqExpr{
-							pos: position{line: 762, col: 5, offset: 22162},
+							pos: position{line: 779, col: 5, offset: 22710},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 762, col: 5, offset: 22162},
+									pos:        position{line: 779, col: 5, offset: 22710},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 762, col: 9, offset: 22166},
+									pos:  position{line: 779, col: 9, offset: 22714},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 762, col: 12, offset: 22169},
+									pos:        position{line: 779, col: 12, offset: 22717},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 762, col: 16, offset: 22173},
+									pos:  position{line: 779, col: 16, offset: 22721},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 762, col: 19, offset: 22176},
+									pos:   position{line: 779, col: 19, offset: 22724},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 762, col: 22, offset: 22179},
+										pos:  position{line: 779, col: 22, offset: 22727},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 762, col: 35, offset: 22192},
+									pos:        position{line: 779, col: 35, offset: 22740},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5808,26 +5967,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 768, col: 5, offset: 22363},
+						pos: position{line: 785, col: 5, offset: 22911},
 						run: (*parser).callonDeref23,
 						expr: &seqExpr{
-							pos: position{line: 768, col: 5, offset: 22363},
+							pos: position{line: 785, col: 5, offset: 22911},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 768, col: 5, offset: 22363},
+									pos:        position{line: 785, col: 5, offset: 22911},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 768, col: 9, offset: 22367},
+									pos:   position{line: 785, col: 9, offset: 22915},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 768, col: 14, offset: 22372},
+										pos:  position{line: 785, col: 14, offset: 22920},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 768, col: 19, offset: 22377},
+									pos:        position{line: 785, col: 19, offset: 22925},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5835,21 +5994,21 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 769, col: 5, offset: 22426},
+						pos: position{line: 786, col: 5, offset: 22974},
 						run: (*parser).callonDeref29,
 						expr: &seqExpr{
-							pos: position{line: 769, col: 5, offset: 22426},
+							pos: position{line: 786, col: 5, offset: 22974},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 769, col: 5, offset: 22426},
+									pos:        position{line: 786, col: 5, offset: 22974},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 769, col: 9, offset: 22430},
+									pos:   position{line: 786, col: 9, offset: 22978},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 769, col: 12, offset: 22433},
+										pos:  position{line: 786, col: 12, offset: 22981},
 										name: "Identifier",
 									},
 								},
@@ -5861,59 +6020,59 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 771, col: 1, offset: 22484},
+			pos:  position{line: 788, col: 1, offset: 23032},
 			expr: &choiceExpr{
-				pos: position{line: 772, col: 5, offset: 22496},
+				pos: position{line: 789, col: 5, offset: 23044},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 772, col: 5, offset: 22496},
+						pos:  position{line: 789, col: 5, offset: 23044},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 773, col: 5, offset: 22507},
+						pos:  position{line: 790, col: 5, offset: 23055},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 774, col: 5, offset: 22517},
+						pos:  position{line: 791, col: 5, offset: 23065},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 775, col: 5, offset: 22525},
+						pos:  position{line: 792, col: 5, offset: 23073},
 						name: "Map",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 776, col: 5, offset: 22533},
+						pos:  position{line: 793, col: 5, offset: 23081},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 777, col: 5, offset: 22545},
+						pos: position{line: 794, col: 5, offset: 23093},
 						run: (*parser).callonPrimary7,
 						expr: &seqExpr{
-							pos: position{line: 777, col: 5, offset: 22545},
+							pos: position{line: 794, col: 5, offset: 23093},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 777, col: 5, offset: 22545},
+									pos:        position{line: 794, col: 5, offset: 23093},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 777, col: 9, offset: 22549},
+									pos:  position{line: 794, col: 9, offset: 23097},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 777, col: 12, offset: 22552},
+									pos:   position{line: 794, col: 12, offset: 23100},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 777, col: 17, offset: 22557},
+										pos:  position{line: 794, col: 17, offset: 23105},
 										name: "OverExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 777, col: 26, offset: 22566},
+									pos:  position{line: 794, col: 26, offset: 23114},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 777, col: 29, offset: 22569},
+									pos:        position{line: 794, col: 29, offset: 23117},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5921,34 +6080,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 778, col: 5, offset: 22599},
+						pos: position{line: 795, col: 5, offset: 23147},
 						run: (*parser).callonPrimary15,
 						expr: &seqExpr{
-							pos: position{line: 778, col: 5, offset: 22599},
+							pos: position{line: 795, col: 5, offset: 23147},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 778, col: 5, offset: 22599},
+									pos:        position{line: 795, col: 5, offset: 23147},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 778, col: 9, offset: 22603},
+									pos:  position{line: 795, col: 9, offset: 23151},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 778, col: 12, offset: 22606},
+									pos:   position{line: 795, col: 12, offset: 23154},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 778, col: 17, offset: 22611},
+										pos:  position{line: 795, col: 17, offset: 23159},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 778, col: 22, offset: 22616},
+									pos:  position{line: 795, col: 22, offset: 23164},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 778, col: 25, offset: 22619},
+									pos:        position{line: 795, col: 25, offset: 23167},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5960,59 +6119,59 @@ var g = &grammar{
 		},
 		{
 			name: "OverExpr",
-			pos:  position{line: 780, col: 1, offset: 22645},
+			pos:  position{line: 797, col: 1, offset: 23193},
 			expr: &actionExpr{
-				pos: position{line: 781, col: 5, offset: 22658},
+				pos: position{line: 798, col: 5, offset: 23206},
 				run: (*parser).callonOverExpr1,
 				expr: &seqExpr{
-					pos: position{line: 781, col: 5, offset: 22658},
+					pos: position{line: 798, col: 5, offset: 23206},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 781, col: 5, offset: 22658},
+							pos:        position{line: 798, col: 5, offset: 23206},
 							val:        "over",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 781, col: 12, offset: 22665},
+							pos:  position{line: 798, col: 12, offset: 23213},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 781, col: 14, offset: 22667},
+							pos:   position{line: 798, col: 14, offset: 23215},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 781, col: 20, offset: 22673},
+								pos:  position{line: 798, col: 20, offset: 23221},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 781, col: 26, offset: 22679},
+							pos:   position{line: 798, col: 26, offset: 23227},
 							label: "locals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 781, col: 33, offset: 22686},
+								pos: position{line: 798, col: 33, offset: 23234},
 								expr: &ruleRefExpr{
-									pos:  position{line: 781, col: 33, offset: 22686},
+									pos:  position{line: 798, col: 33, offset: 23234},
 									name: "Locals",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 781, col: 41, offset: 22694},
+							pos:  position{line: 798, col: 41, offset: 23242},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 781, col: 44, offset: 22697},
+							pos:        position{line: 798, col: 44, offset: 23245},
 							val:        "|",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 781, col: 48, offset: 22701},
+							pos:  position{line: 798, col: 48, offset: 23249},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 781, col: 51, offset: 22704},
+							pos:   position{line: 798, col: 51, offset: 23252},
 							label: "scope",
 							expr: &ruleRefExpr{
-								pos:  position{line: 781, col: 57, offset: 22710},
+								pos:  position{line: 798, col: 57, offset: 23258},
 								name: "Sequential",
 							},
 						},
@@ -6022,36 +6181,36 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 785, col: 1, offset: 22841},
+			pos:  position{line: 802, col: 1, offset: 23389},
 			expr: &actionExpr{
-				pos: position{line: 786, col: 5, offset: 22852},
+				pos: position{line: 803, col: 5, offset: 23400},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 786, col: 5, offset: 22852},
+					pos: position{line: 803, col: 5, offset: 23400},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 786, col: 5, offset: 22852},
+							pos:        position{line: 803, col: 5, offset: 23400},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 786, col: 9, offset: 22856},
+							pos:  position{line: 803, col: 9, offset: 23404},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 786, col: 12, offset: 22859},
+							pos:   position{line: 803, col: 12, offset: 23407},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 786, col: 18, offset: 22865},
+								pos:  position{line: 803, col: 18, offset: 23413},
 								name: "RecordElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 786, col: 30, offset: 22877},
+							pos:  position{line: 803, col: 30, offset: 23425},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 786, col: 33, offset: 22880},
+							pos:        position{line: 803, col: 33, offset: 23428},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -6061,31 +6220,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElems",
-			pos:  position{line: 790, col: 1, offset: 22970},
+			pos:  position{line: 807, col: 1, offset: 23518},
 			expr: &choiceExpr{
-				pos: position{line: 791, col: 5, offset: 22986},
+				pos: position{line: 808, col: 5, offset: 23534},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 791, col: 5, offset: 22986},
+						pos: position{line: 808, col: 5, offset: 23534},
 						run: (*parser).callonRecordElems2,
 						expr: &seqExpr{
-							pos: position{line: 791, col: 5, offset: 22986},
+							pos: position{line: 808, col: 5, offset: 23534},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 791, col: 5, offset: 22986},
+									pos:   position{line: 808, col: 5, offset: 23534},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 791, col: 11, offset: 22992},
+										pos:  position{line: 808, col: 11, offset: 23540},
 										name: "RecordElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 791, col: 22, offset: 23003},
+									pos:   position{line: 808, col: 22, offset: 23551},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 791, col: 27, offset: 23008},
+										pos: position{line: 808, col: 27, offset: 23556},
 										expr: &ruleRefExpr{
-											pos:  position{line: 791, col: 27, offset: 23008},
+											pos:  position{line: 808, col: 27, offset: 23556},
 											name: "RecordElemTail",
 										},
 									},
@@ -6094,10 +6253,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 794, col: 5, offset: 23107},
+						pos: position{line: 811, col: 5, offset: 23655},
 						run: (*parser).callonRecordElems9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 794, col: 5, offset: 23107},
+							pos:  position{line: 811, col: 5, offset: 23655},
 							name: "__",
 						},
 					},
@@ -6106,31 +6265,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElemTail",
-			pos:  position{line: 796, col: 1, offset: 23143},
+			pos:  position{line: 813, col: 1, offset: 23691},
 			expr: &actionExpr{
-				pos: position{line: 796, col: 18, offset: 23160},
+				pos: position{line: 813, col: 18, offset: 23708},
 				run: (*parser).callonRecordElemTail1,
 				expr: &seqExpr{
-					pos: position{line: 796, col: 18, offset: 23160},
+					pos: position{line: 813, col: 18, offset: 23708},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 796, col: 18, offset: 23160},
+							pos:  position{line: 813, col: 18, offset: 23708},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 796, col: 21, offset: 23163},
+							pos:        position{line: 813, col: 21, offset: 23711},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 796, col: 25, offset: 23167},
+							pos:  position{line: 813, col: 25, offset: 23715},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 796, col: 28, offset: 23170},
+							pos:   position{line: 813, col: 28, offset: 23718},
 							label: "elem",
 							expr: &ruleRefExpr{
-								pos:  position{line: 796, col: 33, offset: 23175},
+								pos:  position{line: 813, col: 33, offset: 23723},
 								name: "RecordElem",
 							},
 						},
@@ -6140,20 +6299,20 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElem",
-			pos:  position{line: 798, col: 1, offset: 23208},
+			pos:  position{line: 815, col: 1, offset: 23756},
 			expr: &choiceExpr{
-				pos: position{line: 799, col: 5, offset: 23223},
+				pos: position{line: 816, col: 5, offset: 23771},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 799, col: 5, offset: 23223},
+						pos:  position{line: 816, col: 5, offset: 23771},
 						name: "Spread",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 800, col: 5, offset: 23234},
+						pos:  position{line: 817, col: 5, offset: 23782},
 						name: "Field",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 801, col: 5, offset: 23244},
+						pos:  position{line: 818, col: 5, offset: 23792},
 						name: "Identifier",
 					},
 				},
@@ -6161,27 +6320,27 @@ var g = &grammar{
 		},
 		{
 			name: "Spread",
-			pos:  position{line: 803, col: 1, offset: 23256},
+			pos:  position{line: 820, col: 1, offset: 23804},
 			expr: &actionExpr{
-				pos: position{line: 804, col: 5, offset: 23267},
+				pos: position{line: 821, col: 5, offset: 23815},
 				run: (*parser).callonSpread1,
 				expr: &seqExpr{
-					pos: position{line: 804, col: 5, offset: 23267},
+					pos: position{line: 821, col: 5, offset: 23815},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 804, col: 5, offset: 23267},
+							pos:        position{line: 821, col: 5, offset: 23815},
 							val:        "...",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 804, col: 11, offset: 23273},
+							pos:  position{line: 821, col: 11, offset: 23821},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 804, col: 14, offset: 23276},
+							pos:   position{line: 821, col: 14, offset: 23824},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 804, col: 19, offset: 23281},
+								pos:  position{line: 821, col: 19, offset: 23829},
 								name: "Expr",
 							},
 						},
@@ -6191,39 +6350,39 @@ var g = &grammar{
 		},
 		{
 			name: "Field",
-			pos:  position{line: 808, col: 1, offset: 23367},
+			pos:  position{line: 825, col: 1, offset: 23915},
 			expr: &actionExpr{
-				pos: position{line: 809, col: 5, offset: 23377},
+				pos: position{line: 826, col: 5, offset: 23925},
 				run: (*parser).callonField1,
 				expr: &seqExpr{
-					pos: position{line: 809, col: 5, offset: 23377},
+					pos: position{line: 826, col: 5, offset: 23925},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 809, col: 5, offset: 23377},
+							pos:   position{line: 826, col: 5, offset: 23925},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 809, col: 10, offset: 23382},
+								pos:  position{line: 826, col: 10, offset: 23930},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 809, col: 20, offset: 23392},
+							pos:  position{line: 826, col: 20, offset: 23940},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 809, col: 23, offset: 23395},
+							pos:        position{line: 826, col: 23, offset: 23943},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 809, col: 27, offset: 23399},
+							pos:  position{line: 826, col: 27, offset: 23947},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 809, col: 30, offset: 23402},
+							pos:   position{line: 826, col: 30, offset: 23950},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 809, col: 36, offset: 23408},
+								pos:  position{line: 826, col: 36, offset: 23956},
 								name: "Expr",
 							},
 						},
@@ -6233,36 +6392,36 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 813, col: 1, offset: 23508},
+			pos:  position{line: 830, col: 1, offset: 24056},
 			expr: &actionExpr{
-				pos: position{line: 814, col: 5, offset: 23518},
+				pos: position{line: 831, col: 5, offset: 24066},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 814, col: 5, offset: 23518},
+					pos: position{line: 831, col: 5, offset: 24066},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 814, col: 5, offset: 23518},
+							pos:        position{line: 831, col: 5, offset: 24066},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 814, col: 9, offset: 23522},
+							pos:  position{line: 831, col: 9, offset: 24070},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 814, col: 12, offset: 23525},
+							pos:   position{line: 831, col: 12, offset: 24073},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 814, col: 18, offset: 23531},
+								pos:  position{line: 831, col: 18, offset: 24079},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 814, col: 30, offset: 23543},
+							pos:  position{line: 831, col: 30, offset: 24091},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 814, col: 33, offset: 23546},
+							pos:        position{line: 831, col: 33, offset: 24094},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -6272,36 +6431,36 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 818, col: 1, offset: 23636},
+			pos:  position{line: 835, col: 1, offset: 24184},
 			expr: &actionExpr{
-				pos: position{line: 819, col: 5, offset: 23644},
+				pos: position{line: 836, col: 5, offset: 24192},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 819, col: 5, offset: 23644},
+					pos: position{line: 836, col: 5, offset: 24192},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 819, col: 5, offset: 23644},
+							pos:        position{line: 836, col: 5, offset: 24192},
 							val:        "|[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 819, col: 10, offset: 23649},
+							pos:  position{line: 836, col: 10, offset: 24197},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 819, col: 13, offset: 23652},
+							pos:   position{line: 836, col: 13, offset: 24200},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 819, col: 19, offset: 23658},
+								pos:  position{line: 836, col: 19, offset: 24206},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 819, col: 31, offset: 23670},
+							pos:  position{line: 836, col: 31, offset: 24218},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 819, col: 34, offset: 23673},
+							pos:        position{line: 836, col: 34, offset: 24221},
 							val:        "]|",
 							ignoreCase: false,
 						},
@@ -6311,53 +6470,53 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElems",
-			pos:  position{line: 823, col: 1, offset: 23762},
+			pos:  position{line: 840, col: 1, offset: 24310},
 			expr: &choiceExpr{
-				pos: position{line: 824, col: 5, offset: 23778},
+				pos: position{line: 841, col: 5, offset: 24326},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 824, col: 5, offset: 23778},
+						pos: position{line: 841, col: 5, offset: 24326},
 						run: (*parser).callonVectorElems2,
 						expr: &seqExpr{
-							pos: position{line: 824, col: 5, offset: 23778},
+							pos: position{line: 841, col: 5, offset: 24326},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 824, col: 5, offset: 23778},
+									pos:   position{line: 841, col: 5, offset: 24326},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 824, col: 11, offset: 23784},
+										pos:  position{line: 841, col: 11, offset: 24332},
 										name: "VectorElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 824, col: 22, offset: 23795},
+									pos:   position{line: 841, col: 22, offset: 24343},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 824, col: 27, offset: 23800},
+										pos: position{line: 841, col: 27, offset: 24348},
 										expr: &actionExpr{
-											pos: position{line: 824, col: 28, offset: 23801},
+											pos: position{line: 841, col: 28, offset: 24349},
 											run: (*parser).callonVectorElems8,
 											expr: &seqExpr{
-												pos: position{line: 824, col: 28, offset: 23801},
+												pos: position{line: 841, col: 28, offset: 24349},
 												exprs: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 824, col: 28, offset: 23801},
+														pos:  position{line: 841, col: 28, offset: 24349},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 824, col: 31, offset: 23804},
+														pos:        position{line: 841, col: 31, offset: 24352},
 														val:        ",",
 														ignoreCase: false,
 													},
 													&ruleRefExpr{
-														pos:  position{line: 824, col: 35, offset: 23808},
+														pos:  position{line: 841, col: 35, offset: 24356},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 824, col: 38, offset: 23811},
+														pos:   position{line: 841, col: 38, offset: 24359},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 824, col: 40, offset: 23813},
+															pos:  position{line: 841, col: 40, offset: 24361},
 															name: "VectorElem",
 														},
 													},
@@ -6370,10 +6529,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 827, col: 5, offset: 23931},
+						pos: position{line: 844, col: 5, offset: 24479},
 						run: (*parser).callonVectorElems15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 827, col: 5, offset: 23931},
+							pos:  position{line: 844, col: 5, offset: 24479},
 							name: "__",
 						},
 					},
@@ -6382,22 +6541,22 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElem",
-			pos:  position{line: 829, col: 1, offset: 23967},
+			pos:  position{line: 846, col: 1, offset: 24515},
 			expr: &choiceExpr{
-				pos: position{line: 830, col: 5, offset: 23982},
+				pos: position{line: 847, col: 5, offset: 24530},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 830, col: 5, offset: 23982},
+						pos:  position{line: 847, col: 5, offset: 24530},
 						name: "Spread",
 					},
 					&actionExpr{
-						pos: position{line: 831, col: 5, offset: 23993},
+						pos: position{line: 848, col: 5, offset: 24541},
 						run: (*parser).callonVectorElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 831, col: 5, offset: 23993},
+							pos:   position{line: 848, col: 5, offset: 24541},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 831, col: 7, offset: 23995},
+								pos:  position{line: 848, col: 7, offset: 24543},
 								name: "Expr",
 							},
 						},
@@ -6407,36 +6566,36 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 833, col: 1, offset: 24071},
+			pos:  position{line: 850, col: 1, offset: 24619},
 			expr: &actionExpr{
-				pos: position{line: 834, col: 5, offset: 24079},
+				pos: position{line: 851, col: 5, offset: 24627},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 834, col: 5, offset: 24079},
+					pos: position{line: 851, col: 5, offset: 24627},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 834, col: 5, offset: 24079},
+							pos:        position{line: 851, col: 5, offset: 24627},
 							val:        "|{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 834, col: 10, offset: 24084},
+							pos:  position{line: 851, col: 10, offset: 24632},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 834, col: 13, offset: 24087},
+							pos:   position{line: 851, col: 13, offset: 24635},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 834, col: 19, offset: 24093},
+								pos:  position{line: 851, col: 19, offset: 24641},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 834, col: 27, offset: 24101},
+							pos:  position{line: 851, col: 27, offset: 24649},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 834, col: 30, offset: 24104},
+							pos:        position{line: 851, col: 30, offset: 24652},
 							val:        "}|",
 							ignoreCase: false,
 						},
@@ -6446,31 +6605,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 838, col: 1, offset: 24195},
+			pos:  position{line: 855, col: 1, offset: 24743},
 			expr: &choiceExpr{
-				pos: position{line: 839, col: 5, offset: 24207},
+				pos: position{line: 856, col: 5, offset: 24755},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 839, col: 5, offset: 24207},
+						pos: position{line: 856, col: 5, offset: 24755},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 839, col: 5, offset: 24207},
+							pos: position{line: 856, col: 5, offset: 24755},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 839, col: 5, offset: 24207},
+									pos:   position{line: 856, col: 5, offset: 24755},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 839, col: 11, offset: 24213},
+										pos:  position{line: 856, col: 11, offset: 24761},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 839, col: 17, offset: 24219},
+									pos:   position{line: 856, col: 17, offset: 24767},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 839, col: 22, offset: 24224},
+										pos: position{line: 856, col: 22, offset: 24772},
 										expr: &ruleRefExpr{
-											pos:  position{line: 839, col: 22, offset: 24224},
+											pos:  position{line: 856, col: 22, offset: 24772},
 											name: "EntryTail",
 										},
 									},
@@ -6479,10 +6638,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 842, col: 5, offset: 24318},
+						pos: position{line: 859, col: 5, offset: 24866},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 842, col: 5, offset: 24318},
+							pos:  position{line: 859, col: 5, offset: 24866},
 							name: "__",
 						},
 					},
@@ -6491,31 +6650,31 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 845, col: 1, offset: 24355},
+			pos:  position{line: 862, col: 1, offset: 24903},
 			expr: &actionExpr{
-				pos: position{line: 845, col: 13, offset: 24367},
+				pos: position{line: 862, col: 13, offset: 24915},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 845, col: 13, offset: 24367},
+					pos: position{line: 862, col: 13, offset: 24915},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 845, col: 13, offset: 24367},
+							pos:  position{line: 862, col: 13, offset: 24915},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 845, col: 16, offset: 24370},
+							pos:        position{line: 862, col: 16, offset: 24918},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 845, col: 20, offset: 24374},
+							pos:  position{line: 862, col: 20, offset: 24922},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 845, col: 23, offset: 24377},
+							pos:   position{line: 862, col: 23, offset: 24925},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 845, col: 25, offset: 24379},
+								pos:  position{line: 862, col: 25, offset: 24927},
 								name: "Entry",
 							},
 						},
@@ -6525,39 +6684,39 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 847, col: 1, offset: 24404},
+			pos:  position{line: 864, col: 1, offset: 24952},
 			expr: &actionExpr{
-				pos: position{line: 848, col: 5, offset: 24414},
+				pos: position{line: 865, col: 5, offset: 24962},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 848, col: 5, offset: 24414},
+					pos: position{line: 865, col: 5, offset: 24962},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 848, col: 5, offset: 24414},
+							pos:   position{line: 865, col: 5, offset: 24962},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 848, col: 9, offset: 24418},
+								pos:  position{line: 865, col: 9, offset: 24966},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 848, col: 14, offset: 24423},
+							pos:  position{line: 865, col: 14, offset: 24971},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 848, col: 17, offset: 24426},
+							pos:        position{line: 865, col: 17, offset: 24974},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 848, col: 21, offset: 24430},
+							pos:  position{line: 865, col: 21, offset: 24978},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 848, col: 24, offset: 24433},
+							pos:   position{line: 865, col: 24, offset: 24981},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 848, col: 30, offset: 24439},
+								pos:  position{line: 865, col: 30, offset: 24987},
 								name: "Expr",
 							},
 						},
@@ -6567,92 +6726,92 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOp",
-			pos:  position{line: 854, col: 1, offset: 24546},
+			pos:  position{line: 871, col: 1, offset: 25094},
 			expr: &actionExpr{
-				pos: position{line: 855, col: 5, offset: 24556},
+				pos: position{line: 872, col: 5, offset: 25104},
 				run: (*parser).callonSQLOp1,
 				expr: &seqExpr{
-					pos: position{line: 855, col: 5, offset: 24556},
+					pos: position{line: 872, col: 5, offset: 25104},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 855, col: 5, offset: 24556},
+							pos:   position{line: 872, col: 5, offset: 25104},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 855, col: 15, offset: 24566},
+								pos:  position{line: 872, col: 15, offset: 25114},
 								name: "SQLSelect",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 856, col: 5, offset: 24580},
+							pos:   position{line: 873, col: 5, offset: 25128},
 							label: "from",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 856, col: 10, offset: 24585},
+								pos: position{line: 873, col: 10, offset: 25133},
 								expr: &ruleRefExpr{
-									pos:  position{line: 856, col: 10, offset: 24585},
+									pos:  position{line: 873, col: 10, offset: 25133},
 									name: "SQLFrom",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 857, col: 5, offset: 24598},
+							pos:   position{line: 874, col: 5, offset: 25146},
 							label: "joins",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 857, col: 11, offset: 24604},
+								pos: position{line: 874, col: 11, offset: 25152},
 								expr: &ruleRefExpr{
-									pos:  position{line: 857, col: 11, offset: 24604},
+									pos:  position{line: 874, col: 11, offset: 25152},
 									name: "SQLJoins",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 858, col: 5, offset: 24618},
+							pos:   position{line: 875, col: 5, offset: 25166},
 							label: "where",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 858, col: 11, offset: 24624},
+								pos: position{line: 875, col: 11, offset: 25172},
 								expr: &ruleRefExpr{
-									pos:  position{line: 858, col: 11, offset: 24624},
+									pos:  position{line: 875, col: 11, offset: 25172},
 									name: "SQLWhere",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 859, col: 5, offset: 24638},
+							pos:   position{line: 876, col: 5, offset: 25186},
 							label: "groupby",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 859, col: 13, offset: 24646},
+								pos: position{line: 876, col: 13, offset: 25194},
 								expr: &ruleRefExpr{
-									pos:  position{line: 859, col: 13, offset: 24646},
+									pos:  position{line: 876, col: 13, offset: 25194},
 									name: "SQLGroupBy",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 860, col: 5, offset: 24662},
+							pos:   position{line: 877, col: 5, offset: 25210},
 							label: "having",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 860, col: 12, offset: 24669},
+								pos: position{line: 877, col: 12, offset: 25217},
 								expr: &ruleRefExpr{
-									pos:  position{line: 860, col: 12, offset: 24669},
+									pos:  position{line: 877, col: 12, offset: 25217},
 									name: "SQLHaving",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 861, col: 5, offset: 24684},
+							pos:   position{line: 878, col: 5, offset: 25232},
 							label: "orderby",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 861, col: 13, offset: 24692},
+								pos: position{line: 878, col: 13, offset: 25240},
 								expr: &ruleRefExpr{
-									pos:  position{line: 861, col: 13, offset: 24692},
+									pos:  position{line: 878, col: 13, offset: 25240},
 									name: "SQLOrderBy",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 862, col: 5, offset: 24708},
+							pos:   position{line: 879, col: 5, offset: 25256},
 							label: "limit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 862, col: 11, offset: 24714},
+								pos:  position{line: 879, col: 11, offset: 25262},
 								name: "SQLLimit",
 							},
 						},
@@ -6662,26 +6821,26 @@ var g = &grammar{
 		},
 		{
 			name: "SQLSelect",
-			pos:  position{line: 886, col: 1, offset: 25081},
+			pos:  position{line: 903, col: 1, offset: 25629},
 			expr: &choiceExpr{
-				pos: position{line: 887, col: 5, offset: 25095},
+				pos: position{line: 904, col: 5, offset: 25643},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 887, col: 5, offset: 25095},
+						pos: position{line: 904, col: 5, offset: 25643},
 						run: (*parser).callonSQLSelect2,
 						expr: &seqExpr{
-							pos: position{line: 887, col: 5, offset: 25095},
+							pos: position{line: 904, col: 5, offset: 25643},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 887, col: 5, offset: 25095},
+									pos:  position{line: 904, col: 5, offset: 25643},
 									name: "SELECT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 887, col: 12, offset: 25102},
+									pos:  position{line: 904, col: 12, offset: 25650},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 887, col: 14, offset: 25104},
+									pos:        position{line: 904, col: 14, offset: 25652},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -6689,24 +6848,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 888, col: 5, offset: 25132},
+						pos: position{line: 905, col: 5, offset: 25680},
 						run: (*parser).callonSQLSelect7,
 						expr: &seqExpr{
-							pos: position{line: 888, col: 5, offset: 25132},
+							pos: position{line: 905, col: 5, offset: 25680},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 888, col: 5, offset: 25132},
+									pos:  position{line: 905, col: 5, offset: 25680},
 									name: "SELECT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 888, col: 12, offset: 25139},
+									pos:  position{line: 905, col: 12, offset: 25687},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 888, col: 14, offset: 25141},
+									pos:   position{line: 905, col: 14, offset: 25689},
 									label: "assignments",
 									expr: &ruleRefExpr{
-										pos:  position{line: 888, col: 26, offset: 25153},
+										pos:  position{line: 905, col: 26, offset: 25701},
 										name: "SQLAssignments",
 									},
 								},
@@ -6718,43 +6877,43 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAssignment",
-			pos:  position{line: 890, col: 1, offset: 25197},
+			pos:  position{line: 907, col: 1, offset: 25745},
 			expr: &actionExpr{
-				pos: position{line: 891, col: 5, offset: 25215},
+				pos: position{line: 908, col: 5, offset: 25763},
 				run: (*parser).callonSQLAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 891, col: 5, offset: 25215},
+					pos: position{line: 908, col: 5, offset: 25763},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 891, col: 5, offset: 25215},
+							pos:   position{line: 908, col: 5, offset: 25763},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 891, col: 9, offset: 25219},
+								pos:  position{line: 908, col: 9, offset: 25767},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 891, col: 14, offset: 25224},
+							pos:   position{line: 908, col: 14, offset: 25772},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 891, col: 18, offset: 25228},
+								pos: position{line: 908, col: 18, offset: 25776},
 								expr: &seqExpr{
-									pos: position{line: 891, col: 19, offset: 25229},
+									pos: position{line: 908, col: 19, offset: 25777},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 891, col: 19, offset: 25229},
+											pos:  position{line: 908, col: 19, offset: 25777},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 891, col: 21, offset: 25231},
+											pos:  position{line: 908, col: 21, offset: 25779},
 											name: "AS",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 891, col: 24, offset: 25234},
+											pos:  position{line: 908, col: 24, offset: 25782},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 891, col: 26, offset: 25236},
+											pos:  position{line: 908, col: 26, offset: 25784},
 											name: "Lval",
 										},
 									},
@@ -6767,50 +6926,50 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAssignments",
-			pos:  position{line: 899, col: 1, offset: 25427},
+			pos:  position{line: 916, col: 1, offset: 25975},
 			expr: &actionExpr{
-				pos: position{line: 900, col: 5, offset: 25446},
+				pos: position{line: 917, col: 5, offset: 25994},
 				run: (*parser).callonSQLAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 900, col: 5, offset: 25446},
+					pos: position{line: 917, col: 5, offset: 25994},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 900, col: 5, offset: 25446},
+							pos:   position{line: 917, col: 5, offset: 25994},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 900, col: 11, offset: 25452},
+								pos:  position{line: 917, col: 11, offset: 26000},
 								name: "SQLAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 900, col: 25, offset: 25466},
+							pos:   position{line: 917, col: 25, offset: 26014},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 900, col: 30, offset: 25471},
+								pos: position{line: 917, col: 30, offset: 26019},
 								expr: &actionExpr{
-									pos: position{line: 900, col: 31, offset: 25472},
+									pos: position{line: 917, col: 31, offset: 26020},
 									run: (*parser).callonSQLAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 900, col: 31, offset: 25472},
+										pos: position{line: 917, col: 31, offset: 26020},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 900, col: 31, offset: 25472},
+												pos:  position{line: 917, col: 31, offset: 26020},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 900, col: 34, offset: 25475},
+												pos:        position{line: 917, col: 34, offset: 26023},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 900, col: 38, offset: 25479},
+												pos:  position{line: 917, col: 38, offset: 26027},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 900, col: 41, offset: 25482},
+												pos:   position{line: 917, col: 41, offset: 26030},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 900, col: 46, offset: 25487},
+													pos:  position{line: 917, col: 46, offset: 26035},
 													name: "SQLAssignment",
 												},
 											},
@@ -6825,43 +6984,43 @@ var g = &grammar{
 		},
 		{
 			name: "SQLFrom",
-			pos:  position{line: 904, col: 1, offset: 25608},
+			pos:  position{line: 921, col: 1, offset: 26156},
 			expr: &choiceExpr{
-				pos: position{line: 905, col: 5, offset: 25620},
+				pos: position{line: 922, col: 5, offset: 26168},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 905, col: 5, offset: 25620},
+						pos: position{line: 922, col: 5, offset: 26168},
 						run: (*parser).callonSQLFrom2,
 						expr: &seqExpr{
-							pos: position{line: 905, col: 5, offset: 25620},
+							pos: position{line: 922, col: 5, offset: 26168},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 905, col: 5, offset: 25620},
+									pos:  position{line: 922, col: 5, offset: 26168},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 905, col: 7, offset: 25622},
+									pos:  position{line: 922, col: 7, offset: 26170},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 905, col: 12, offset: 25627},
+									pos:  position{line: 922, col: 12, offset: 26175},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 905, col: 14, offset: 25629},
+									pos:   position{line: 922, col: 14, offset: 26177},
 									label: "table",
 									expr: &ruleRefExpr{
-										pos:  position{line: 905, col: 20, offset: 25635},
+										pos:  position{line: 922, col: 20, offset: 26183},
 										name: "SQLTable",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 905, col: 29, offset: 25644},
+									pos:   position{line: 922, col: 29, offset: 26192},
 									label: "alias",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 905, col: 35, offset: 25650},
+										pos: position{line: 922, col: 35, offset: 26198},
 										expr: &ruleRefExpr{
-											pos:  position{line: 905, col: 35, offset: 25650},
+											pos:  position{line: 922, col: 35, offset: 26198},
 											name: "SQLAlias",
 										},
 									},
@@ -6870,25 +7029,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 908, col: 5, offset: 25745},
+						pos: position{line: 925, col: 5, offset: 26293},
 						run: (*parser).callonSQLFrom12,
 						expr: &seqExpr{
-							pos: position{line: 908, col: 5, offset: 25745},
+							pos: position{line: 925, col: 5, offset: 26293},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 908, col: 5, offset: 25745},
+									pos:  position{line: 925, col: 5, offset: 26293},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 908, col: 7, offset: 25747},
+									pos:  position{line: 925, col: 7, offset: 26295},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 908, col: 12, offset: 25752},
+									pos:  position{line: 925, col: 12, offset: 26300},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 908, col: 14, offset: 25754},
+									pos:        position{line: 925, col: 14, offset: 26302},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -6900,33 +7059,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAlias",
-			pos:  position{line: 910, col: 1, offset: 25779},
+			pos:  position{line: 927, col: 1, offset: 26327},
 			expr: &choiceExpr{
-				pos: position{line: 911, col: 5, offset: 25792},
+				pos: position{line: 928, col: 5, offset: 26340},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 911, col: 5, offset: 25792},
+						pos: position{line: 928, col: 5, offset: 26340},
 						run: (*parser).callonSQLAlias2,
 						expr: &seqExpr{
-							pos: position{line: 911, col: 5, offset: 25792},
+							pos: position{line: 928, col: 5, offset: 26340},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 911, col: 5, offset: 25792},
+									pos:  position{line: 928, col: 5, offset: 26340},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 911, col: 7, offset: 25794},
+									pos:  position{line: 928, col: 7, offset: 26342},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 911, col: 10, offset: 25797},
+									pos:  position{line: 928, col: 10, offset: 26345},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 911, col: 12, offset: 25799},
+									pos:   position{line: 928, col: 12, offset: 26347},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 911, col: 15, offset: 25802},
+										pos:  position{line: 928, col: 15, offset: 26350},
 										name: "Lval",
 									},
 								},
@@ -6934,36 +7093,36 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 912, col: 5, offset: 25830},
+						pos: position{line: 929, col: 5, offset: 26378},
 						run: (*parser).callonSQLAlias9,
 						expr: &seqExpr{
-							pos: position{line: 912, col: 5, offset: 25830},
+							pos: position{line: 929, col: 5, offset: 26378},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 912, col: 5, offset: 25830},
+									pos:  position{line: 929, col: 5, offset: 26378},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 912, col: 7, offset: 25832},
+									pos: position{line: 929, col: 7, offset: 26380},
 									expr: &seqExpr{
-										pos: position{line: 912, col: 9, offset: 25834},
+										pos: position{line: 929, col: 9, offset: 26382},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 912, col: 9, offset: 25834},
+												pos:  position{line: 929, col: 9, offset: 26382},
 												name: "SQLTokenSentinels",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 912, col: 27, offset: 25852},
+												pos:  position{line: 929, col: 27, offset: 26400},
 												name: "_",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 912, col: 30, offset: 25855},
+									pos:   position{line: 929, col: 30, offset: 26403},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 912, col: 33, offset: 25858},
+										pos:  position{line: 929, col: 33, offset: 26406},
 										name: "Lval",
 									},
 								},
@@ -6975,42 +7134,42 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTable",
-			pos:  position{line: 914, col: 1, offset: 25883},
+			pos:  position{line: 931, col: 1, offset: 26431},
 			expr: &ruleRefExpr{
-				pos:  position{line: 915, col: 5, offset: 25896},
+				pos:  position{line: 932, col: 5, offset: 26444},
 				name: "Expr",
 			},
 		},
 		{
 			name: "SQLJoins",
-			pos:  position{line: 917, col: 1, offset: 25902},
+			pos:  position{line: 934, col: 1, offset: 26450},
 			expr: &actionExpr{
-				pos: position{line: 918, col: 5, offset: 25915},
+				pos: position{line: 935, col: 5, offset: 26463},
 				run: (*parser).callonSQLJoins1,
 				expr: &seqExpr{
-					pos: position{line: 918, col: 5, offset: 25915},
+					pos: position{line: 935, col: 5, offset: 26463},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 918, col: 5, offset: 25915},
+							pos:   position{line: 935, col: 5, offset: 26463},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 918, col: 11, offset: 25921},
+								pos:  position{line: 935, col: 11, offset: 26469},
 								name: "SQLJoin",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 918, col: 19, offset: 25929},
+							pos:   position{line: 935, col: 19, offset: 26477},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 918, col: 24, offset: 25934},
+								pos: position{line: 935, col: 24, offset: 26482},
 								expr: &actionExpr{
-									pos: position{line: 918, col: 25, offset: 25935},
+									pos: position{line: 935, col: 25, offset: 26483},
 									run: (*parser).callonSQLJoins7,
 									expr: &labeledExpr{
-										pos:   position{line: 918, col: 25, offset: 25935},
+										pos:   position{line: 935, col: 25, offset: 26483},
 										label: "join",
 										expr: &ruleRefExpr{
-											pos:  position{line: 918, col: 30, offset: 25940},
+											pos:  position{line: 935, col: 30, offset: 26488},
 											name: "SQLJoin",
 										},
 									},
@@ -7023,90 +7182,90 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoin",
-			pos:  position{line: 922, col: 1, offset: 26055},
+			pos:  position{line: 939, col: 1, offset: 26603},
 			expr: &actionExpr{
-				pos: position{line: 923, col: 5, offset: 26067},
+				pos: position{line: 940, col: 5, offset: 26615},
 				run: (*parser).callonSQLJoin1,
 				expr: &seqExpr{
-					pos: position{line: 923, col: 5, offset: 26067},
+					pos: position{line: 940, col: 5, offset: 26615},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 923, col: 5, offset: 26067},
+							pos:   position{line: 940, col: 5, offset: 26615},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 923, col: 11, offset: 26073},
+								pos:  position{line: 940, col: 11, offset: 26621},
 								name: "SQLJoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 923, col: 24, offset: 26086},
+							pos:  position{line: 940, col: 24, offset: 26634},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 923, col: 26, offset: 26088},
+							pos:  position{line: 940, col: 26, offset: 26636},
 							name: "JOIN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 923, col: 31, offset: 26093},
+							pos:  position{line: 940, col: 31, offset: 26641},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 923, col: 33, offset: 26095},
+							pos:   position{line: 940, col: 33, offset: 26643},
 							label: "table",
 							expr: &ruleRefExpr{
-								pos:  position{line: 923, col: 39, offset: 26101},
+								pos:  position{line: 940, col: 39, offset: 26649},
 								name: "SQLTable",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 923, col: 48, offset: 26110},
+							pos:   position{line: 940, col: 48, offset: 26658},
 							label: "alias",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 923, col: 54, offset: 26116},
+								pos: position{line: 940, col: 54, offset: 26664},
 								expr: &ruleRefExpr{
-									pos:  position{line: 923, col: 54, offset: 26116},
+									pos:  position{line: 940, col: 54, offset: 26664},
 									name: "SQLAlias",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 923, col: 64, offset: 26126},
+							pos:  position{line: 940, col: 64, offset: 26674},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 923, col: 66, offset: 26128},
+							pos:  position{line: 940, col: 66, offset: 26676},
 							name: "ON",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 923, col: 69, offset: 26131},
+							pos:  position{line: 940, col: 69, offset: 26679},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 923, col: 71, offset: 26133},
+							pos:   position{line: 940, col: 71, offset: 26681},
 							label: "leftKey",
 							expr: &ruleRefExpr{
-								pos:  position{line: 923, col: 79, offset: 26141},
+								pos:  position{line: 940, col: 79, offset: 26689},
 								name: "JoinKey",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 923, col: 87, offset: 26149},
+							pos:  position{line: 940, col: 87, offset: 26697},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 923, col: 90, offset: 26152},
+							pos:        position{line: 940, col: 90, offset: 26700},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 923, col: 94, offset: 26156},
+							pos:  position{line: 940, col: 94, offset: 26704},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 923, col: 97, offset: 26159},
+							pos:   position{line: 940, col: 97, offset: 26707},
 							label: "rightKey",
 							expr: &ruleRefExpr{
-								pos:  position{line: 923, col: 106, offset: 26168},
+								pos:  position{line: 940, col: 106, offset: 26716},
 								name: "JoinKey",
 							},
 						},
@@ -7116,40 +7275,40 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoinStyle",
-			pos:  position{line: 938, col: 1, offset: 26399},
+			pos:  position{line: 955, col: 1, offset: 26947},
 			expr: &choiceExpr{
-				pos: position{line: 939, col: 5, offset: 26416},
+				pos: position{line: 956, col: 5, offset: 26964},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 939, col: 5, offset: 26416},
+						pos: position{line: 956, col: 5, offset: 26964},
 						run: (*parser).callonSQLJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 939, col: 5, offset: 26416},
+							pos: position{line: 956, col: 5, offset: 26964},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 939, col: 5, offset: 26416},
+									pos:  position{line: 956, col: 5, offset: 26964},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 939, col: 7, offset: 26418},
+									pos:   position{line: 956, col: 7, offset: 26966},
 									label: "style",
 									expr: &choiceExpr{
-										pos: position{line: 939, col: 14, offset: 26425},
+										pos: position{line: 956, col: 14, offset: 26973},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 939, col: 14, offset: 26425},
+												pos:  position{line: 956, col: 14, offset: 26973},
 												name: "ANTI",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 939, col: 21, offset: 26432},
+												pos:  position{line: 956, col: 21, offset: 26980},
 												name: "INNER",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 939, col: 29, offset: 26440},
+												pos:  position{line: 956, col: 29, offset: 26988},
 												name: "LEFT",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 939, col: 36, offset: 26447},
+												pos:  position{line: 956, col: 36, offset: 26995},
 												name: "RIGHT",
 											},
 										},
@@ -7159,10 +7318,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 940, col: 5, offset: 26480},
+						pos: position{line: 957, col: 5, offset: 27028},
 						run: (*parser).callonSQLJoinStyle11,
 						expr: &litMatcher{
-							pos:        position{line: 940, col: 5, offset: 26480},
+							pos:        position{line: 957, col: 5, offset: 27028},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7172,30 +7331,30 @@ var g = &grammar{
 		},
 		{
 			name: "SQLWhere",
-			pos:  position{line: 942, col: 1, offset: 26508},
+			pos:  position{line: 959, col: 1, offset: 27056},
 			expr: &actionExpr{
-				pos: position{line: 943, col: 5, offset: 26521},
+				pos: position{line: 960, col: 5, offset: 27069},
 				run: (*parser).callonSQLWhere1,
 				expr: &seqExpr{
-					pos: position{line: 943, col: 5, offset: 26521},
+					pos: position{line: 960, col: 5, offset: 27069},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 943, col: 5, offset: 26521},
+							pos:  position{line: 960, col: 5, offset: 27069},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 943, col: 7, offset: 26523},
+							pos:  position{line: 960, col: 7, offset: 27071},
 							name: "WHERE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 943, col: 13, offset: 26529},
+							pos:  position{line: 960, col: 13, offset: 27077},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 943, col: 15, offset: 26531},
+							pos:   position{line: 960, col: 15, offset: 27079},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 943, col: 20, offset: 26536},
+								pos:  position{line: 960, col: 20, offset: 27084},
 								name: "LogicalOrExpr",
 							},
 						},
@@ -7205,38 +7364,38 @@ var g = &grammar{
 		},
 		{
 			name: "SQLGroupBy",
-			pos:  position{line: 945, col: 1, offset: 26572},
+			pos:  position{line: 962, col: 1, offset: 27120},
 			expr: &actionExpr{
-				pos: position{line: 946, col: 5, offset: 26587},
+				pos: position{line: 963, col: 5, offset: 27135},
 				run: (*parser).callonSQLGroupBy1,
 				expr: &seqExpr{
-					pos: position{line: 946, col: 5, offset: 26587},
+					pos: position{line: 963, col: 5, offset: 27135},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 946, col: 5, offset: 26587},
+							pos:  position{line: 963, col: 5, offset: 27135},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 946, col: 7, offset: 26589},
+							pos:  position{line: 963, col: 7, offset: 27137},
 							name: "GROUP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 946, col: 13, offset: 26595},
+							pos:  position{line: 963, col: 13, offset: 27143},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 946, col: 15, offset: 26597},
+							pos:  position{line: 963, col: 15, offset: 27145},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 946, col: 18, offset: 26600},
+							pos:  position{line: 963, col: 18, offset: 27148},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 946, col: 20, offset: 26602},
+							pos:   position{line: 963, col: 20, offset: 27150},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 946, col: 28, offset: 26610},
+								pos:  position{line: 963, col: 28, offset: 27158},
 								name: "FieldExprs",
 							},
 						},
@@ -7246,30 +7405,30 @@ var g = &grammar{
 		},
 		{
 			name: "SQLHaving",
-			pos:  position{line: 948, col: 1, offset: 26646},
+			pos:  position{line: 965, col: 1, offset: 27194},
 			expr: &actionExpr{
-				pos: position{line: 949, col: 5, offset: 26660},
+				pos: position{line: 966, col: 5, offset: 27208},
 				run: (*parser).callonSQLHaving1,
 				expr: &seqExpr{
-					pos: position{line: 949, col: 5, offset: 26660},
+					pos: position{line: 966, col: 5, offset: 27208},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 949, col: 5, offset: 26660},
+							pos:  position{line: 966, col: 5, offset: 27208},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 949, col: 7, offset: 26662},
+							pos:  position{line: 966, col: 7, offset: 27210},
 							name: "HAVING",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 949, col: 14, offset: 26669},
+							pos:  position{line: 966, col: 14, offset: 27217},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 949, col: 16, offset: 26671},
+							pos:   position{line: 966, col: 16, offset: 27219},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 949, col: 21, offset: 26676},
+								pos:  position{line: 966, col: 21, offset: 27224},
 								name: "LogicalOrExpr",
 							},
 						},
@@ -7279,46 +7438,46 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOrderBy",
-			pos:  position{line: 951, col: 1, offset: 26712},
+			pos:  position{line: 968, col: 1, offset: 27260},
 			expr: &actionExpr{
-				pos: position{line: 952, col: 5, offset: 26727},
+				pos: position{line: 969, col: 5, offset: 27275},
 				run: (*parser).callonSQLOrderBy1,
 				expr: &seqExpr{
-					pos: position{line: 952, col: 5, offset: 26727},
+					pos: position{line: 969, col: 5, offset: 27275},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 952, col: 5, offset: 26727},
+							pos:  position{line: 969, col: 5, offset: 27275},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 952, col: 7, offset: 26729},
+							pos:  position{line: 969, col: 7, offset: 27277},
 							name: "ORDER",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 952, col: 13, offset: 26735},
+							pos:  position{line: 969, col: 13, offset: 27283},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 952, col: 15, offset: 26737},
+							pos:  position{line: 969, col: 15, offset: 27285},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 952, col: 18, offset: 26740},
+							pos:  position{line: 969, col: 18, offset: 27288},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 952, col: 20, offset: 26742},
+							pos:   position{line: 969, col: 20, offset: 27290},
 							label: "keys",
 							expr: &ruleRefExpr{
-								pos:  position{line: 952, col: 25, offset: 26747},
+								pos:  position{line: 969, col: 25, offset: 27295},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 952, col: 31, offset: 26753},
+							pos:   position{line: 969, col: 31, offset: 27301},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 952, col: 37, offset: 26759},
+								pos:  position{line: 969, col: 37, offset: 27307},
 								name: "SQLOrder",
 							},
 						},
@@ -7328,32 +7487,32 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOrder",
-			pos:  position{line: 956, col: 1, offset: 26869},
+			pos:  position{line: 973, col: 1, offset: 27417},
 			expr: &choiceExpr{
-				pos: position{line: 957, col: 5, offset: 26882},
+				pos: position{line: 974, col: 5, offset: 27430},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 957, col: 5, offset: 26882},
+						pos: position{line: 974, col: 5, offset: 27430},
 						run: (*parser).callonSQLOrder2,
 						expr: &seqExpr{
-							pos: position{line: 957, col: 5, offset: 26882},
+							pos: position{line: 974, col: 5, offset: 27430},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 957, col: 5, offset: 26882},
+									pos:  position{line: 974, col: 5, offset: 27430},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 957, col: 7, offset: 26884},
+									pos:   position{line: 974, col: 7, offset: 27432},
 									label: "dir",
 									expr: &choiceExpr{
-										pos: position{line: 957, col: 12, offset: 26889},
+										pos: position{line: 974, col: 12, offset: 27437},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 957, col: 12, offset: 26889},
+												pos:  position{line: 974, col: 12, offset: 27437},
 												name: "ASC",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 957, col: 18, offset: 26895},
+												pos:  position{line: 974, col: 18, offset: 27443},
 												name: "DESC",
 											},
 										},
@@ -7363,10 +7522,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 958, col: 5, offset: 26925},
+						pos: position{line: 975, col: 5, offset: 27473},
 						run: (*parser).callonSQLOrder9,
 						expr: &litMatcher{
-							pos:        position{line: 958, col: 5, offset: 26925},
+							pos:        position{line: 975, col: 5, offset: 27473},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7376,33 +7535,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLLimit",
-			pos:  position{line: 960, col: 1, offset: 26951},
+			pos:  position{line: 977, col: 1, offset: 27499},
 			expr: &choiceExpr{
-				pos: position{line: 961, col: 5, offset: 26964},
+				pos: position{line: 978, col: 5, offset: 27512},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 961, col: 5, offset: 26964},
+						pos: position{line: 978, col: 5, offset: 27512},
 						run: (*parser).callonSQLLimit2,
 						expr: &seqExpr{
-							pos: position{line: 961, col: 5, offset: 26964},
+							pos: position{line: 978, col: 5, offset: 27512},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 961, col: 5, offset: 26964},
+									pos:  position{line: 978, col: 5, offset: 27512},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 961, col: 7, offset: 26966},
+									pos:  position{line: 978, col: 7, offset: 27514},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 961, col: 13, offset: 26972},
+									pos:  position{line: 978, col: 13, offset: 27520},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 961, col: 15, offset: 26974},
+									pos:   position{line: 978, col: 15, offset: 27522},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 961, col: 21, offset: 26980},
+										pos:  position{line: 978, col: 21, offset: 27528},
 										name: "UInt",
 									},
 								},
@@ -7410,10 +7569,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 962, col: 5, offset: 27011},
+						pos: position{line: 979, col: 5, offset: 27559},
 						run: (*parser).callonSQLLimit9,
 						expr: &litMatcher{
-							pos:        position{line: 962, col: 5, offset: 27011},
+							pos:        position{line: 979, col: 5, offset: 27559},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7423,12 +7582,12 @@ var g = &grammar{
 		},
 		{
 			name: "SELECT",
-			pos:  position{line: 964, col: 1, offset: 27033},
+			pos:  position{line: 981, col: 1, offset: 27581},
 			expr: &actionExpr{
-				pos: position{line: 964, col: 10, offset: 27042},
+				pos: position{line: 981, col: 10, offset: 27590},
 				run: (*parser).callonSELECT1,
 				expr: &litMatcher{
-					pos:        position{line: 964, col: 10, offset: 27042},
+					pos:        position{line: 981, col: 10, offset: 27590},
 					val:        "select",
 					ignoreCase: true,
 				},
@@ -7436,12 +7595,12 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 965, col: 1, offset: 27077},
+			pos:  position{line: 982, col: 1, offset: 27625},
 			expr: &actionExpr{
-				pos: position{line: 965, col: 6, offset: 27082},
+				pos: position{line: 982, col: 6, offset: 27630},
 				run: (*parser).callonAS1,
 				expr: &litMatcher{
-					pos:        position{line: 965, col: 6, offset: 27082},
+					pos:        position{line: 982, col: 6, offset: 27630},
 					val:        "as",
 					ignoreCase: true,
 				},
@@ -7449,12 +7608,12 @@ var g = &grammar{
 		},
 		{
 			name: "FROM",
-			pos:  position{line: 966, col: 1, offset: 27109},
+			pos:  position{line: 983, col: 1, offset: 27657},
 			expr: &actionExpr{
-				pos: position{line: 966, col: 8, offset: 27116},
+				pos: position{line: 983, col: 8, offset: 27664},
 				run: (*parser).callonFROM1,
 				expr: &litMatcher{
-					pos:        position{line: 966, col: 8, offset: 27116},
+					pos:        position{line: 983, col: 8, offset: 27664},
 					val:        "from",
 					ignoreCase: true,
 				},
@@ -7462,12 +7621,12 @@ var g = &grammar{
 		},
 		{
 			name: "JOIN",
-			pos:  position{line: 967, col: 1, offset: 27147},
+			pos:  position{line: 984, col: 1, offset: 27695},
 			expr: &actionExpr{
-				pos: position{line: 967, col: 8, offset: 27154},
+				pos: position{line: 984, col: 8, offset: 27702},
 				run: (*parser).callonJOIN1,
 				expr: &litMatcher{
-					pos:        position{line: 967, col: 8, offset: 27154},
+					pos:        position{line: 984, col: 8, offset: 27702},
 					val:        "join",
 					ignoreCase: true,
 				},
@@ -7475,12 +7634,12 @@ var g = &grammar{
 		},
 		{
 			name: "WHERE",
-			pos:  position{line: 968, col: 1, offset: 27185},
+			pos:  position{line: 985, col: 1, offset: 27733},
 			expr: &actionExpr{
-				pos: position{line: 968, col: 9, offset: 27193},
+				pos: position{line: 985, col: 9, offset: 27741},
 				run: (*parser).callonWHERE1,
 				expr: &litMatcher{
-					pos:        position{line: 968, col: 9, offset: 27193},
+					pos:        position{line: 985, col: 9, offset: 27741},
 					val:        "where",
 					ignoreCase: true,
 				},
@@ -7488,12 +7647,12 @@ var g = &grammar{
 		},
 		{
 			name: "GROUP",
-			pos:  position{line: 969, col: 1, offset: 27226},
+			pos:  position{line: 986, col: 1, offset: 27774},
 			expr: &actionExpr{
-				pos: position{line: 969, col: 9, offset: 27234},
+				pos: position{line: 986, col: 9, offset: 27782},
 				run: (*parser).callonGROUP1,
 				expr: &litMatcher{
-					pos:        position{line: 969, col: 9, offset: 27234},
+					pos:        position{line: 986, col: 9, offset: 27782},
 					val:        "group",
 					ignoreCase: true,
 				},
@@ -7501,12 +7660,12 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 970, col: 1, offset: 27267},
+			pos:  position{line: 987, col: 1, offset: 27815},
 			expr: &actionExpr{
-				pos: position{line: 970, col: 6, offset: 27272},
+				pos: position{line: 987, col: 6, offset: 27820},
 				run: (*parser).callonBY1,
 				expr: &litMatcher{
-					pos:        position{line: 970, col: 6, offset: 27272},
+					pos:        position{line: 987, col: 6, offset: 27820},
 					val:        "by",
 					ignoreCase: true,
 				},
@@ -7514,12 +7673,12 @@ var g = &grammar{
 		},
 		{
 			name: "HAVING",
-			pos:  position{line: 971, col: 1, offset: 27299},
+			pos:  position{line: 988, col: 1, offset: 27847},
 			expr: &actionExpr{
-				pos: position{line: 971, col: 10, offset: 27308},
+				pos: position{line: 988, col: 10, offset: 27856},
 				run: (*parser).callonHAVING1,
 				expr: &litMatcher{
-					pos:        position{line: 971, col: 10, offset: 27308},
+					pos:        position{line: 988, col: 10, offset: 27856},
 					val:        "having",
 					ignoreCase: true,
 				},
@@ -7527,12 +7686,12 @@ var g = &grammar{
 		},
 		{
 			name: "ORDER",
-			pos:  position{line: 972, col: 1, offset: 27343},
+			pos:  position{line: 989, col: 1, offset: 27891},
 			expr: &actionExpr{
-				pos: position{line: 972, col: 9, offset: 27351},
+				pos: position{line: 989, col: 9, offset: 27899},
 				run: (*parser).callonORDER1,
 				expr: &litMatcher{
-					pos:        position{line: 972, col: 9, offset: 27351},
+					pos:        position{line: 989, col: 9, offset: 27899},
 					val:        "order",
 					ignoreCase: true,
 				},
@@ -7540,12 +7699,12 @@ var g = &grammar{
 		},
 		{
 			name: "ON",
-			pos:  position{line: 973, col: 1, offset: 27384},
+			pos:  position{line: 990, col: 1, offset: 27932},
 			expr: &actionExpr{
-				pos: position{line: 973, col: 6, offset: 27389},
+				pos: position{line: 990, col: 6, offset: 27937},
 				run: (*parser).callonON1,
 				expr: &litMatcher{
-					pos:        position{line: 973, col: 6, offset: 27389},
+					pos:        position{line: 990, col: 6, offset: 27937},
 					val:        "on",
 					ignoreCase: true,
 				},
@@ -7553,12 +7712,12 @@ var g = &grammar{
 		},
 		{
 			name: "LIMIT",
-			pos:  position{line: 974, col: 1, offset: 27416},
+			pos:  position{line: 991, col: 1, offset: 27964},
 			expr: &actionExpr{
-				pos: position{line: 974, col: 9, offset: 27424},
+				pos: position{line: 991, col: 9, offset: 27972},
 				run: (*parser).callonLIMIT1,
 				expr: &litMatcher{
-					pos:        position{line: 974, col: 9, offset: 27424},
+					pos:        position{line: 991, col: 9, offset: 27972},
 					val:        "limit",
 					ignoreCase: true,
 				},
@@ -7566,12 +7725,12 @@ var g = &grammar{
 		},
 		{
 			name: "ASC",
-			pos:  position{line: 975, col: 1, offset: 27457},
+			pos:  position{line: 992, col: 1, offset: 28005},
 			expr: &actionExpr{
-				pos: position{line: 975, col: 7, offset: 27463},
+				pos: position{line: 992, col: 7, offset: 28011},
 				run: (*parser).callonASC1,
 				expr: &litMatcher{
-					pos:        position{line: 975, col: 7, offset: 27463},
+					pos:        position{line: 992, col: 7, offset: 28011},
 					val:        "asc",
 					ignoreCase: true,
 				},
@@ -7579,12 +7738,12 @@ var g = &grammar{
 		},
 		{
 			name: "DESC",
-			pos:  position{line: 976, col: 1, offset: 27492},
+			pos:  position{line: 993, col: 1, offset: 28040},
 			expr: &actionExpr{
-				pos: position{line: 976, col: 8, offset: 27499},
+				pos: position{line: 993, col: 8, offset: 28047},
 				run: (*parser).callonDESC1,
 				expr: &litMatcher{
-					pos:        position{line: 976, col: 8, offset: 27499},
+					pos:        position{line: 993, col: 8, offset: 28047},
 					val:        "desc",
 					ignoreCase: true,
 				},
@@ -7592,12 +7751,12 @@ var g = &grammar{
 		},
 		{
 			name: "ANTI",
-			pos:  position{line: 977, col: 1, offset: 27530},
+			pos:  position{line: 994, col: 1, offset: 28078},
 			expr: &actionExpr{
-				pos: position{line: 977, col: 8, offset: 27537},
+				pos: position{line: 994, col: 8, offset: 28085},
 				run: (*parser).callonANTI1,
 				expr: &litMatcher{
-					pos:        position{line: 977, col: 8, offset: 27537},
+					pos:        position{line: 994, col: 8, offset: 28085},
 					val:        "anti",
 					ignoreCase: true,
 				},
@@ -7605,12 +7764,12 @@ var g = &grammar{
 		},
 		{
 			name: "LEFT",
-			pos:  position{line: 978, col: 1, offset: 27568},
+			pos:  position{line: 995, col: 1, offset: 28116},
 			expr: &actionExpr{
-				pos: position{line: 978, col: 8, offset: 27575},
+				pos: position{line: 995, col: 8, offset: 28123},
 				run: (*parser).callonLEFT1,
 				expr: &litMatcher{
-					pos:        position{line: 978, col: 8, offset: 27575},
+					pos:        position{line: 995, col: 8, offset: 28123},
 					val:        "left",
 					ignoreCase: true,
 				},
@@ -7618,12 +7777,12 @@ var g = &grammar{
 		},
 		{
 			name: "RIGHT",
-			pos:  position{line: 979, col: 1, offset: 27606},
+			pos:  position{line: 996, col: 1, offset: 28154},
 			expr: &actionExpr{
-				pos: position{line: 979, col: 9, offset: 27614},
+				pos: position{line: 996, col: 9, offset: 28162},
 				run: (*parser).callonRIGHT1,
 				expr: &litMatcher{
-					pos:        position{line: 979, col: 9, offset: 27614},
+					pos:        position{line: 996, col: 9, offset: 28162},
 					val:        "right",
 					ignoreCase: true,
 				},
@@ -7631,12 +7790,12 @@ var g = &grammar{
 		},
 		{
 			name: "INNER",
-			pos:  position{line: 980, col: 1, offset: 27647},
+			pos:  position{line: 997, col: 1, offset: 28195},
 			expr: &actionExpr{
-				pos: position{line: 980, col: 9, offset: 27655},
+				pos: position{line: 997, col: 9, offset: 28203},
 				run: (*parser).callonINNER1,
 				expr: &litMatcher{
-					pos:        position{line: 980, col: 9, offset: 27655},
+					pos:        position{line: 997, col: 9, offset: 28203},
 					val:        "inner",
 					ignoreCase: true,
 				},
@@ -7644,48 +7803,48 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTokenSentinels",
-			pos:  position{line: 982, col: 1, offset: 27689},
+			pos:  position{line: 999, col: 1, offset: 28237},
 			expr: &choiceExpr{
-				pos: position{line: 983, col: 5, offset: 27711},
+				pos: position{line: 1000, col: 5, offset: 28259},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 983, col: 5, offset: 27711},
+						pos:  position{line: 1000, col: 5, offset: 28259},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 983, col: 14, offset: 27720},
+						pos:  position{line: 1000, col: 14, offset: 28268},
 						name: "AS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 983, col: 19, offset: 27725},
+						pos:  position{line: 1000, col: 19, offset: 28273},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 983, col: 27, offset: 27733},
+						pos:  position{line: 1000, col: 27, offset: 28281},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 983, col: 34, offset: 27740},
+						pos:  position{line: 1000, col: 34, offset: 28288},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 983, col: 42, offset: 27748},
+						pos:  position{line: 1000, col: 42, offset: 28296},
 						name: "GROUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 983, col: 50, offset: 27756},
+						pos:  position{line: 1000, col: 50, offset: 28304},
 						name: "HAVING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 983, col: 59, offset: 27765},
+						pos:  position{line: 1000, col: 59, offset: 28313},
 						name: "ORDER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 983, col: 67, offset: 27773},
+						pos:  position{line: 1000, col: 67, offset: 28321},
 						name: "LIMIT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 983, col: 75, offset: 27781},
+						pos:  position{line: 1000, col: 75, offset: 28329},
 						name: "ON",
 					},
 				},
@@ -7693,52 +7852,52 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 987, col: 1, offset: 27807},
+			pos:  position{line: 1004, col: 1, offset: 28355},
 			expr: &choiceExpr{
-				pos: position{line: 988, col: 5, offset: 27819},
+				pos: position{line: 1005, col: 5, offset: 28367},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 988, col: 5, offset: 27819},
+						pos:  position{line: 1005, col: 5, offset: 28367},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 989, col: 5, offset: 27835},
+						pos:  position{line: 1006, col: 5, offset: 28383},
 						name: "TemplateLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 990, col: 5, offset: 27855},
+						pos:  position{line: 1007, col: 5, offset: 28403},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 991, col: 5, offset: 27873},
+						pos:  position{line: 1008, col: 5, offset: 28421},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 992, col: 5, offset: 27892},
+						pos:  position{line: 1009, col: 5, offset: 28440},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 993, col: 5, offset: 27909},
+						pos:  position{line: 1010, col: 5, offset: 28457},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 994, col: 5, offset: 27922},
+						pos:  position{line: 1011, col: 5, offset: 28470},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 995, col: 5, offset: 27931},
+						pos:  position{line: 1012, col: 5, offset: 28479},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 996, col: 5, offset: 27948},
+						pos:  position{line: 1013, col: 5, offset: 28496},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 997, col: 5, offset: 27967},
+						pos:  position{line: 1014, col: 5, offset: 28515},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 998, col: 5, offset: 27986},
+						pos:  position{line: 1015, col: 5, offset: 28534},
 						name: "NullLiteral",
 					},
 				},
@@ -7746,28 +7905,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 1000, col: 1, offset: 27999},
+			pos:  position{line: 1017, col: 1, offset: 28547},
 			expr: &choiceExpr{
-				pos: position{line: 1001, col: 5, offset: 28017},
+				pos: position{line: 1018, col: 5, offset: 28565},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1001, col: 5, offset: 28017},
+						pos: position{line: 1018, col: 5, offset: 28565},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1001, col: 5, offset: 28017},
+							pos: position{line: 1018, col: 5, offset: 28565},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1001, col: 5, offset: 28017},
+									pos:   position{line: 1018, col: 5, offset: 28565},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1001, col: 7, offset: 28019},
+										pos:  position{line: 1018, col: 7, offset: 28567},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1001, col: 14, offset: 28026},
+									pos: position{line: 1018, col: 14, offset: 28574},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1001, col: 15, offset: 28027},
+										pos:  position{line: 1018, col: 15, offset: 28575},
 										name: "IdentifierRest",
 									},
 								},
@@ -7775,13 +7934,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1004, col: 5, offset: 28142},
+						pos: position{line: 1021, col: 5, offset: 28690},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1004, col: 5, offset: 28142},
+							pos:   position{line: 1021, col: 5, offset: 28690},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1004, col: 7, offset: 28144},
+								pos:  position{line: 1021, col: 7, offset: 28692},
 								name: "IP4Net",
 							},
 						},
@@ -7791,28 +7950,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 1008, col: 1, offset: 28248},
+			pos:  position{line: 1025, col: 1, offset: 28796},
 			expr: &choiceExpr{
-				pos: position{line: 1009, col: 5, offset: 28267},
+				pos: position{line: 1026, col: 5, offset: 28815},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1009, col: 5, offset: 28267},
+						pos: position{line: 1026, col: 5, offset: 28815},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1009, col: 5, offset: 28267},
+							pos: position{line: 1026, col: 5, offset: 28815},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1009, col: 5, offset: 28267},
+									pos:   position{line: 1026, col: 5, offset: 28815},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1009, col: 7, offset: 28269},
+										pos:  position{line: 1026, col: 7, offset: 28817},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1009, col: 11, offset: 28273},
+									pos: position{line: 1026, col: 11, offset: 28821},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1009, col: 12, offset: 28274},
+										pos:  position{line: 1026, col: 12, offset: 28822},
 										name: "IdentifierRest",
 									},
 								},
@@ -7820,13 +7979,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1012, col: 5, offset: 28388},
+						pos: position{line: 1029, col: 5, offset: 28936},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1012, col: 5, offset: 28388},
+							pos:   position{line: 1029, col: 5, offset: 28936},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1012, col: 7, offset: 28390},
+								pos:  position{line: 1029, col: 7, offset: 28938},
 								name: "IP",
 							},
 						},
@@ -7836,15 +7995,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 1016, col: 1, offset: 28489},
+			pos:  position{line: 1033, col: 1, offset: 29037},
 			expr: &actionExpr{
-				pos: position{line: 1017, col: 5, offset: 28506},
+				pos: position{line: 1034, col: 5, offset: 29054},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1017, col: 5, offset: 28506},
+					pos:   position{line: 1034, col: 5, offset: 29054},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1017, col: 7, offset: 28508},
+						pos:  position{line: 1034, col: 7, offset: 29056},
 						name: "FloatString",
 					},
 				},
@@ -7852,15 +8011,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 1021, col: 1, offset: 28621},
+			pos:  position{line: 1038, col: 1, offset: 29169},
 			expr: &actionExpr{
-				pos: position{line: 1022, col: 5, offset: 28640},
+				pos: position{line: 1039, col: 5, offset: 29188},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1022, col: 5, offset: 28640},
+					pos:   position{line: 1039, col: 5, offset: 29188},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1022, col: 7, offset: 28642},
+						pos:  position{line: 1039, col: 7, offset: 29190},
 						name: "IntString",
 					},
 				},
@@ -7868,24 +8027,24 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 1026, col: 1, offset: 28751},
+			pos:  position{line: 1043, col: 1, offset: 29299},
 			expr: &choiceExpr{
-				pos: position{line: 1027, col: 5, offset: 28770},
+				pos: position{line: 1044, col: 5, offset: 29318},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1027, col: 5, offset: 28770},
+						pos: position{line: 1044, col: 5, offset: 29318},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &litMatcher{
-							pos:        position{line: 1027, col: 5, offset: 28770},
+							pos:        position{line: 1044, col: 5, offset: 29318},
 							val:        "true",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1028, col: 5, offset: 28883},
+						pos: position{line: 1045, col: 5, offset: 29431},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &litMatcher{
-							pos:        position{line: 1028, col: 5, offset: 28883},
+							pos:        position{line: 1045, col: 5, offset: 29431},
 							val:        "false",
 							ignoreCase: false,
 						},
@@ -7895,12 +8054,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 1030, col: 1, offset: 28994},
+			pos:  position{line: 1047, col: 1, offset: 29542},
 			expr: &actionExpr{
-				pos: position{line: 1031, col: 5, offset: 29010},
+				pos: position{line: 1048, col: 5, offset: 29558},
 				run: (*parser).callonNullLiteral1,
 				expr: &litMatcher{
-					pos:        position{line: 1031, col: 5, offset: 29010},
+					pos:        position{line: 1048, col: 5, offset: 29558},
 					val:        "null",
 					ignoreCase: false,
 				},
@@ -7908,22 +8067,22 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 1033, col: 1, offset: 29116},
+			pos:  position{line: 1050, col: 1, offset: 29664},
 			expr: &actionExpr{
-				pos: position{line: 1034, col: 5, offset: 29133},
+				pos: position{line: 1051, col: 5, offset: 29681},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1034, col: 5, offset: 29133},
+					pos: position{line: 1051, col: 5, offset: 29681},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1034, col: 5, offset: 29133},
+							pos:        position{line: 1051, col: 5, offset: 29681},
 							val:        "0x",
 							ignoreCase: false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1034, col: 10, offset: 29138},
+							pos: position{line: 1051, col: 10, offset: 29686},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1034, col: 10, offset: 29138},
+								pos:  position{line: 1051, col: 10, offset: 29686},
 								name: "HexDigit",
 							},
 						},
@@ -7933,28 +8092,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 1038, col: 1, offset: 29253},
+			pos:  position{line: 1055, col: 1, offset: 29801},
 			expr: &actionExpr{
-				pos: position{line: 1039, col: 5, offset: 29269},
+				pos: position{line: 1056, col: 5, offset: 29817},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1039, col: 5, offset: 29269},
+					pos: position{line: 1056, col: 5, offset: 29817},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1039, col: 5, offset: 29269},
+							pos:        position{line: 1056, col: 5, offset: 29817},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1039, col: 9, offset: 29273},
+							pos:   position{line: 1056, col: 9, offset: 29821},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1039, col: 13, offset: 29277},
+								pos:  position{line: 1056, col: 13, offset: 29825},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1039, col: 18, offset: 29282},
+							pos:        position{line: 1056, col: 18, offset: 29830},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -7964,22 +8123,22 @@ var g = &grammar{
 		},
 		{
 			name: "CastType",
-			pos:  position{line: 1043, col: 1, offset: 29371},
+			pos:  position{line: 1060, col: 1, offset: 29919},
 			expr: &choiceExpr{
-				pos: position{line: 1044, col: 5, offset: 29384},
+				pos: position{line: 1061, col: 5, offset: 29932},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1044, col: 5, offset: 29384},
+						pos:  position{line: 1061, col: 5, offset: 29932},
 						name: "TypeLiteral",
 					},
 					&actionExpr{
-						pos: position{line: 1045, col: 5, offset: 29400},
+						pos: position{line: 1062, col: 5, offset: 29948},
 						run: (*parser).callonCastType3,
 						expr: &labeledExpr{
-							pos:   position{line: 1045, col: 5, offset: 29400},
+							pos:   position{line: 1062, col: 5, offset: 29948},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1045, col: 9, offset: 29404},
+								pos:  position{line: 1062, col: 9, offset: 29952},
 								name: "PrimitiveType",
 							},
 						},
@@ -7989,20 +8148,20 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1049, col: 1, offset: 29503},
+			pos:  position{line: 1066, col: 1, offset: 30051},
 			expr: &choiceExpr{
-				pos: position{line: 1050, col: 5, offset: 29512},
+				pos: position{line: 1067, col: 5, offset: 30060},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1050, col: 5, offset: 29512},
+						pos:  position{line: 1067, col: 5, offset: 30060},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1051, col: 5, offset: 29528},
+						pos:  position{line: 1068, col: 5, offset: 30076},
 						name: "AmbiguousType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1052, col: 5, offset: 29546},
+						pos:  position{line: 1069, col: 5, offset: 30094},
 						name: "ComplexType",
 					},
 				},
@@ -8010,28 +8169,28 @@ var g = &grammar{
 		},
 		{
 			name: "AmbiguousType",
-			pos:  position{line: 1054, col: 1, offset: 29559},
+			pos:  position{line: 1071, col: 1, offset: 30107},
 			expr: &choiceExpr{
-				pos: position{line: 1055, col: 5, offset: 29577},
+				pos: position{line: 1072, col: 5, offset: 30125},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1055, col: 5, offset: 29577},
+						pos: position{line: 1072, col: 5, offset: 30125},
 						run: (*parser).callonAmbiguousType2,
 						expr: &seqExpr{
-							pos: position{line: 1055, col: 5, offset: 29577},
+							pos: position{line: 1072, col: 5, offset: 30125},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1055, col: 5, offset: 29577},
+									pos:   position{line: 1072, col: 5, offset: 30125},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1055, col: 10, offset: 29582},
+										pos:  position{line: 1072, col: 10, offset: 30130},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1055, col: 24, offset: 29596},
+									pos: position{line: 1072, col: 24, offset: 30144},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1055, col: 25, offset: 29597},
+										pos:  position{line: 1072, col: 25, offset: 30145},
 										name: "IdentifierRest",
 									},
 								},
@@ -8039,42 +8198,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1056, col: 5, offset: 29637},
+						pos: position{line: 1073, col: 5, offset: 30185},
 						run: (*parser).callonAmbiguousType8,
 						expr: &seqExpr{
-							pos: position{line: 1056, col: 5, offset: 29637},
+							pos: position{line: 1073, col: 5, offset: 30185},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1056, col: 5, offset: 29637},
+									pos:   position{line: 1073, col: 5, offset: 30185},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1056, col: 10, offset: 29642},
+										pos:  position{line: 1073, col: 10, offset: 30190},
 										name: "IdentifierName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1056, col: 25, offset: 29657},
+									pos:   position{line: 1073, col: 25, offset: 30205},
 									label: "opt",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1056, col: 29, offset: 29661},
+										pos: position{line: 1073, col: 29, offset: 30209},
 										expr: &seqExpr{
-											pos: position{line: 1056, col: 30, offset: 29662},
+											pos: position{line: 1073, col: 30, offset: 30210},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 1056, col: 30, offset: 29662},
+													pos:  position{line: 1073, col: 30, offset: 30210},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1056, col: 33, offset: 29665},
+													pos:        position{line: 1073, col: 33, offset: 30213},
 													val:        "=",
 													ignoreCase: false,
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1056, col: 37, offset: 29669},
+													pos:  position{line: 1073, col: 37, offset: 30217},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1056, col: 40, offset: 29672},
+													pos:  position{line: 1073, col: 40, offset: 30220},
 													name: "Type",
 												},
 											},
@@ -8085,42 +8244,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1062, col: 5, offset: 29904},
+						pos: position{line: 1079, col: 5, offset: 30452},
 						run: (*parser).callonAmbiguousType19,
 						expr: &labeledExpr{
-							pos:   position{line: 1062, col: 5, offset: 29904},
+							pos:   position{line: 1079, col: 5, offset: 30452},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1062, col: 10, offset: 29909},
+								pos:  position{line: 1079, col: 10, offset: 30457},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1065, col: 5, offset: 30009},
+						pos: position{line: 1082, col: 5, offset: 30557},
 						run: (*parser).callonAmbiguousType22,
 						expr: &seqExpr{
-							pos: position{line: 1065, col: 5, offset: 30009},
+							pos: position{line: 1082, col: 5, offset: 30557},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1065, col: 5, offset: 30009},
+									pos:        position{line: 1082, col: 5, offset: 30557},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1065, col: 9, offset: 30013},
+									pos:  position{line: 1082, col: 9, offset: 30561},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1065, col: 12, offset: 30016},
+									pos:   position{line: 1082, col: 12, offset: 30564},
 									label: "u",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1065, col: 14, offset: 30018},
+										pos:  position{line: 1082, col: 14, offset: 30566},
 										name: "TypeUnion",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1065, col: 25, offset: 30029},
+									pos:        position{line: 1082, col: 25, offset: 30577},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -8132,15 +8291,15 @@ var g = &grammar{
 		},
 		{
 			name: "TypeUnion",
-			pos:  position{line: 1067, col: 1, offset: 30052},
+			pos:  position{line: 1084, col: 1, offset: 30600},
 			expr: &actionExpr{
-				pos: position{line: 1068, col: 5, offset: 30066},
+				pos: position{line: 1085, col: 5, offset: 30614},
 				run: (*parser).callonTypeUnion1,
 				expr: &labeledExpr{
-					pos:   position{line: 1068, col: 5, offset: 30066},
+					pos:   position{line: 1085, col: 5, offset: 30614},
 					label: "types",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1068, col: 11, offset: 30072},
+						pos:  position{line: 1085, col: 11, offset: 30620},
 						name: "TypeList",
 					},
 				},
@@ -8148,28 +8307,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1072, col: 1, offset: 30168},
+			pos:  position{line: 1089, col: 1, offset: 30716},
 			expr: &actionExpr{
-				pos: position{line: 1073, col: 5, offset: 30181},
+				pos: position{line: 1090, col: 5, offset: 30729},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1073, col: 5, offset: 30181},
+					pos: position{line: 1090, col: 5, offset: 30729},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1073, col: 5, offset: 30181},
+							pos:   position{line: 1090, col: 5, offset: 30729},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1073, col: 11, offset: 30187},
+								pos:  position{line: 1090, col: 11, offset: 30735},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1073, col: 16, offset: 30192},
+							pos:   position{line: 1090, col: 16, offset: 30740},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1073, col: 21, offset: 30197},
+								pos: position{line: 1090, col: 21, offset: 30745},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1073, col: 21, offset: 30197},
+									pos:  position{line: 1090, col: 21, offset: 30745},
 									name: "TypeListTail",
 								},
 							},
@@ -8180,31 +8339,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1077, col: 1, offset: 30291},
+			pos:  position{line: 1094, col: 1, offset: 30839},
 			expr: &actionExpr{
-				pos: position{line: 1077, col: 16, offset: 30306},
+				pos: position{line: 1094, col: 16, offset: 30854},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1077, col: 16, offset: 30306},
+					pos: position{line: 1094, col: 16, offset: 30854},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1077, col: 16, offset: 30306},
+							pos:  position{line: 1094, col: 16, offset: 30854},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1077, col: 19, offset: 30309},
+							pos:        position{line: 1094, col: 19, offset: 30857},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1077, col: 23, offset: 30313},
+							pos:  position{line: 1094, col: 23, offset: 30861},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1077, col: 26, offset: 30316},
+							pos:   position{line: 1094, col: 26, offset: 30864},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1077, col: 30, offset: 30320},
+								pos:  position{line: 1094, col: 30, offset: 30868},
 								name: "Type",
 							},
 						},
@@ -8214,39 +8373,39 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 1079, col: 1, offset: 30346},
+			pos:  position{line: 1096, col: 1, offset: 30894},
 			expr: &choiceExpr{
-				pos: position{line: 1080, col: 5, offset: 30362},
+				pos: position{line: 1097, col: 5, offset: 30910},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1080, col: 5, offset: 30362},
+						pos: position{line: 1097, col: 5, offset: 30910},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 1080, col: 5, offset: 30362},
+							pos: position{line: 1097, col: 5, offset: 30910},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1080, col: 5, offset: 30362},
+									pos:        position{line: 1097, col: 5, offset: 30910},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1080, col: 9, offset: 30366},
+									pos:  position{line: 1097, col: 9, offset: 30914},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1080, col: 12, offset: 30369},
+									pos:   position{line: 1097, col: 12, offset: 30917},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1080, col: 19, offset: 30376},
+										pos:  position{line: 1097, col: 19, offset: 30924},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1080, col: 33, offset: 30390},
+									pos:  position{line: 1097, col: 33, offset: 30938},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1080, col: 36, offset: 30393},
+									pos:        position{line: 1097, col: 36, offset: 30941},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -8254,34 +8413,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1083, col: 5, offset: 30488},
+						pos: position{line: 1100, col: 5, offset: 31036},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 1083, col: 5, offset: 30488},
+							pos: position{line: 1100, col: 5, offset: 31036},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1083, col: 5, offset: 30488},
+									pos:        position{line: 1100, col: 5, offset: 31036},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1083, col: 9, offset: 30492},
+									pos:  position{line: 1100, col: 9, offset: 31040},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1083, col: 12, offset: 30495},
+									pos:   position{line: 1100, col: 12, offset: 31043},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1083, col: 16, offset: 30499},
+										pos:  position{line: 1100, col: 16, offset: 31047},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1083, col: 21, offset: 30504},
+									pos:  position{line: 1100, col: 21, offset: 31052},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1083, col: 24, offset: 30507},
+									pos:        position{line: 1100, col: 24, offset: 31055},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -8289,34 +8448,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1086, col: 5, offset: 30596},
+						pos: position{line: 1103, col: 5, offset: 31144},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 1086, col: 5, offset: 30596},
+							pos: position{line: 1103, col: 5, offset: 31144},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1086, col: 5, offset: 30596},
+									pos:        position{line: 1103, col: 5, offset: 31144},
 									val:        "|[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1086, col: 10, offset: 30601},
+									pos:  position{line: 1103, col: 10, offset: 31149},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1086, col: 14, offset: 30605},
+									pos:   position{line: 1103, col: 14, offset: 31153},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1086, col: 18, offset: 30609},
+										pos:  position{line: 1103, col: 18, offset: 31157},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1086, col: 23, offset: 30614},
+									pos:  position{line: 1103, col: 23, offset: 31162},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1086, col: 26, offset: 30617},
+									pos:        position{line: 1103, col: 26, offset: 31165},
 									val:        "]|",
 									ignoreCase: false,
 								},
@@ -8324,55 +8483,55 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1089, col: 5, offset: 30705},
+						pos: position{line: 1106, col: 5, offset: 31253},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 1089, col: 5, offset: 30705},
+							pos: position{line: 1106, col: 5, offset: 31253},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1089, col: 5, offset: 30705},
+									pos:        position{line: 1106, col: 5, offset: 31253},
 									val:        "|{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1089, col: 10, offset: 30710},
+									pos:  position{line: 1106, col: 10, offset: 31258},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1089, col: 13, offset: 30713},
+									pos:   position{line: 1106, col: 13, offset: 31261},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1089, col: 21, offset: 30721},
+										pos:  position{line: 1106, col: 21, offset: 31269},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1089, col: 26, offset: 30726},
+									pos:  position{line: 1106, col: 26, offset: 31274},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1089, col: 29, offset: 30729},
+									pos:        position{line: 1106, col: 29, offset: 31277},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1089, col: 33, offset: 30733},
+									pos:  position{line: 1106, col: 33, offset: 31281},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1089, col: 36, offset: 30736},
+									pos:   position{line: 1106, col: 36, offset: 31284},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1089, col: 44, offset: 30744},
+										pos:  position{line: 1106, col: 44, offset: 31292},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1089, col: 49, offset: 30749},
+									pos:  position{line: 1106, col: 49, offset: 31297},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1089, col: 52, offset: 30752},
+									pos:        position{line: 1106, col: 52, offset: 31300},
 									val:        "}|",
 									ignoreCase: false,
 								},
@@ -8384,15 +8543,15 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateLiteral",
-			pos:  position{line: 1093, col: 1, offset: 30866},
+			pos:  position{line: 1110, col: 1, offset: 31414},
 			expr: &actionExpr{
-				pos: position{line: 1094, col: 5, offset: 30886},
+				pos: position{line: 1111, col: 5, offset: 31434},
 				run: (*parser).callonTemplateLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1094, col: 5, offset: 30886},
+					pos:   position{line: 1111, col: 5, offset: 31434},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1094, col: 7, offset: 30888},
+						pos:  position{line: 1111, col: 7, offset: 31436},
 						name: "TemplateLiteralParts",
 					},
 				},
@@ -8400,34 +8559,34 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateLiteralParts",
-			pos:  position{line: 1101, col: 1, offset: 31104},
+			pos:  position{line: 1118, col: 1, offset: 31652},
 			expr: &choiceExpr{
-				pos: position{line: 1102, col: 5, offset: 31129},
+				pos: position{line: 1119, col: 5, offset: 31677},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1102, col: 5, offset: 31129},
+						pos: position{line: 1119, col: 5, offset: 31677},
 						run: (*parser).callonTemplateLiteralParts2,
 						expr: &seqExpr{
-							pos: position{line: 1102, col: 5, offset: 31129},
+							pos: position{line: 1119, col: 5, offset: 31677},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1102, col: 5, offset: 31129},
+									pos:        position{line: 1119, col: 5, offset: 31677},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1102, col: 9, offset: 31133},
+									pos:   position{line: 1119, col: 9, offset: 31681},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1102, col: 11, offset: 31135},
+										pos: position{line: 1119, col: 11, offset: 31683},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1102, col: 11, offset: 31135},
+											pos:  position{line: 1119, col: 11, offset: 31683},
 											name: "TemplateDoubleQuotedPart",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1102, col: 37, offset: 31161},
+									pos:        position{line: 1119, col: 37, offset: 31709},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -8435,29 +8594,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1103, col: 5, offset: 31187},
+						pos: position{line: 1120, col: 5, offset: 31735},
 						run: (*parser).callonTemplateLiteralParts9,
 						expr: &seqExpr{
-							pos: position{line: 1103, col: 5, offset: 31187},
+							pos: position{line: 1120, col: 5, offset: 31735},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1103, col: 5, offset: 31187},
+									pos:        position{line: 1120, col: 5, offset: 31735},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1103, col: 9, offset: 31191},
+									pos:   position{line: 1120, col: 9, offset: 31739},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1103, col: 11, offset: 31193},
+										pos: position{line: 1120, col: 11, offset: 31741},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1103, col: 11, offset: 31193},
+											pos:  position{line: 1120, col: 11, offset: 31741},
 											name: "TemplateSingleQuotedPart",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1103, col: 37, offset: 31219},
+									pos:        position{line: 1120, col: 37, offset: 31767},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -8469,24 +8628,24 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateDoubleQuotedPart",
-			pos:  position{line: 1105, col: 1, offset: 31242},
+			pos:  position{line: 1122, col: 1, offset: 31790},
 			expr: &choiceExpr{
-				pos: position{line: 1106, col: 5, offset: 31271},
+				pos: position{line: 1123, col: 5, offset: 31819},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1106, col: 5, offset: 31271},
+						pos:  position{line: 1123, col: 5, offset: 31819},
 						name: "TemplateExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1107, col: 5, offset: 31288},
+						pos: position{line: 1124, col: 5, offset: 31836},
 						run: (*parser).callonTemplateDoubleQuotedPart3,
 						expr: &labeledExpr{
-							pos:   position{line: 1107, col: 5, offset: 31288},
+							pos:   position{line: 1124, col: 5, offset: 31836},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1107, col: 7, offset: 31290},
+								pos: position{line: 1124, col: 7, offset: 31838},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1107, col: 7, offset: 31290},
+									pos:  position{line: 1124, col: 7, offset: 31838},
 									name: "TemplateDoubleQuotedChar",
 								},
 							},
@@ -8497,26 +8656,26 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateDoubleQuotedChar",
-			pos:  position{line: 1111, col: 1, offset: 31427},
+			pos:  position{line: 1128, col: 1, offset: 31975},
 			expr: &choiceExpr{
-				pos: position{line: 1112, col: 5, offset: 31456},
+				pos: position{line: 1129, col: 5, offset: 32004},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1112, col: 5, offset: 31456},
+						pos: position{line: 1129, col: 5, offset: 32004},
 						run: (*parser).callonTemplateDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1112, col: 5, offset: 31456},
+							pos: position{line: 1129, col: 5, offset: 32004},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1112, col: 5, offset: 31456},
+									pos:        position{line: 1129, col: 5, offset: 32004},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1112, col: 10, offset: 31461},
+									pos:   position{line: 1129, col: 10, offset: 32009},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1112, col: 12, offset: 31463},
+										pos:        position{line: 1129, col: 12, offset: 32011},
 										val:        "${",
 										ignoreCase: false,
 									},
@@ -8525,24 +8684,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1113, col: 5, offset: 31490},
+						pos: position{line: 1130, col: 5, offset: 32038},
 						run: (*parser).callonTemplateDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1113, col: 5, offset: 31490},
+							pos: position{line: 1130, col: 5, offset: 32038},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1113, col: 5, offset: 31490},
+									pos: position{line: 1130, col: 5, offset: 32038},
 									expr: &litMatcher{
-										pos:        position{line: 1113, col: 8, offset: 31493},
+										pos:        position{line: 1130, col: 8, offset: 32041},
 										val:        "${",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1113, col: 15, offset: 31500},
+									pos:   position{line: 1130, col: 15, offset: 32048},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1113, col: 17, offset: 31502},
+										pos:  position{line: 1130, col: 17, offset: 32050},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -8554,24 +8713,24 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateSingleQuotedPart",
-			pos:  position{line: 1115, col: 1, offset: 31538},
+			pos:  position{line: 1132, col: 1, offset: 32086},
 			expr: &choiceExpr{
-				pos: position{line: 1116, col: 5, offset: 31567},
+				pos: position{line: 1133, col: 5, offset: 32115},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1116, col: 5, offset: 31567},
+						pos:  position{line: 1133, col: 5, offset: 32115},
 						name: "TemplateExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1117, col: 5, offset: 31584},
+						pos: position{line: 1134, col: 5, offset: 32132},
 						run: (*parser).callonTemplateSingleQuotedPart3,
 						expr: &labeledExpr{
-							pos:   position{line: 1117, col: 5, offset: 31584},
+							pos:   position{line: 1134, col: 5, offset: 32132},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1117, col: 7, offset: 31586},
+								pos: position{line: 1134, col: 7, offset: 32134},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1117, col: 7, offset: 31586},
+									pos:  position{line: 1134, col: 7, offset: 32134},
 									name: "TemplateSingleQuotedChar",
 								},
 							},
@@ -8582,26 +8741,26 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateSingleQuotedChar",
-			pos:  position{line: 1121, col: 1, offset: 31723},
+			pos:  position{line: 1138, col: 1, offset: 32271},
 			expr: &choiceExpr{
-				pos: position{line: 1122, col: 5, offset: 31752},
+				pos: position{line: 1139, col: 5, offset: 32300},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1122, col: 5, offset: 31752},
+						pos: position{line: 1139, col: 5, offset: 32300},
 						run: (*parser).callonTemplateSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1122, col: 5, offset: 31752},
+							pos: position{line: 1139, col: 5, offset: 32300},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1122, col: 5, offset: 31752},
+									pos:        position{line: 1139, col: 5, offset: 32300},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1122, col: 10, offset: 31757},
+									pos:   position{line: 1139, col: 10, offset: 32305},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1122, col: 12, offset: 31759},
+										pos:        position{line: 1139, col: 12, offset: 32307},
 										val:        "${",
 										ignoreCase: false,
 									},
@@ -8610,24 +8769,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1123, col: 5, offset: 31786},
+						pos: position{line: 1140, col: 5, offset: 32334},
 						run: (*parser).callonTemplateSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1123, col: 5, offset: 31786},
+							pos: position{line: 1140, col: 5, offset: 32334},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1123, col: 5, offset: 31786},
+									pos: position{line: 1140, col: 5, offset: 32334},
 									expr: &litMatcher{
-										pos:        position{line: 1123, col: 8, offset: 31789},
+										pos:        position{line: 1140, col: 8, offset: 32337},
 										val:        "${",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1123, col: 15, offset: 31796},
+									pos:   position{line: 1140, col: 15, offset: 32344},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1123, col: 17, offset: 31798},
+										pos:  position{line: 1140, col: 17, offset: 32346},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -8639,36 +8798,36 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateExpr",
-			pos:  position{line: 1125, col: 1, offset: 31834},
+			pos:  position{line: 1142, col: 1, offset: 32382},
 			expr: &actionExpr{
-				pos: position{line: 1126, col: 5, offset: 31851},
+				pos: position{line: 1143, col: 5, offset: 32399},
 				run: (*parser).callonTemplateExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1126, col: 5, offset: 31851},
+					pos: position{line: 1143, col: 5, offset: 32399},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1126, col: 5, offset: 31851},
+							pos:        position{line: 1143, col: 5, offset: 32399},
 							val:        "${",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1126, col: 10, offset: 31856},
+							pos:  position{line: 1143, col: 10, offset: 32404},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1126, col: 13, offset: 31859},
+							pos:   position{line: 1143, col: 13, offset: 32407},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1126, col: 15, offset: 31861},
+								pos:  position{line: 1143, col: 15, offset: 32409},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1126, col: 20, offset: 31866},
+							pos:  position{line: 1143, col: 20, offset: 32414},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1126, col: 23, offset: 31869},
+							pos:        position{line: 1143, col: 23, offset: 32417},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -8678,105 +8837,105 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1141, col: 1, offset: 32165},
+			pos:  position{line: 1158, col: 1, offset: 32713},
 			expr: &actionExpr{
-				pos: position{line: 1142, col: 5, offset: 32183},
+				pos: position{line: 1159, col: 5, offset: 32731},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1142, col: 9, offset: 32187},
+					pos: position{line: 1159, col: 9, offset: 32735},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1142, col: 9, offset: 32187},
+							pos:        position{line: 1159, col: 9, offset: 32735},
 							val:        "uint8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1142, col: 19, offset: 32197},
+							pos:        position{line: 1159, col: 19, offset: 32745},
 							val:        "uint16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1142, col: 30, offset: 32208},
+							pos:        position{line: 1159, col: 30, offset: 32756},
 							val:        "uint32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1142, col: 41, offset: 32219},
+							pos:        position{line: 1159, col: 41, offset: 32767},
 							val:        "uint64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1143, col: 9, offset: 32236},
+							pos:        position{line: 1160, col: 9, offset: 32784},
 							val:        "int8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1143, col: 18, offset: 32245},
+							pos:        position{line: 1160, col: 18, offset: 32793},
 							val:        "int16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1143, col: 28, offset: 32255},
+							pos:        position{line: 1160, col: 28, offset: 32803},
 							val:        "int32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1143, col: 38, offset: 32265},
+							pos:        position{line: 1160, col: 38, offset: 32813},
 							val:        "int64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1144, col: 9, offset: 32281},
+							pos:        position{line: 1161, col: 9, offset: 32829},
 							val:        "float32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1144, col: 21, offset: 32293},
+							pos:        position{line: 1161, col: 21, offset: 32841},
 							val:        "float64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1145, col: 9, offset: 32311},
+							pos:        position{line: 1162, col: 9, offset: 32859},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1145, col: 18, offset: 32320},
+							pos:        position{line: 1162, col: 18, offset: 32868},
 							val:        "string",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1146, col: 9, offset: 32337},
+							pos:        position{line: 1163, col: 9, offset: 32885},
 							val:        "duration",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1146, col: 22, offset: 32350},
+							pos:        position{line: 1163, col: 22, offset: 32898},
 							val:        "time",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1147, col: 9, offset: 32365},
+							pos:        position{line: 1164, col: 9, offset: 32913},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1148, col: 9, offset: 32381},
+							pos:        position{line: 1165, col: 9, offset: 32929},
 							val:        "ip",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1148, col: 16, offset: 32388},
+							pos:        position{line: 1165, col: 16, offset: 32936},
 							val:        "net",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1149, col: 9, offset: 32402},
+							pos:        position{line: 1166, col: 9, offset: 32950},
 							val:        "type",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1149, col: 18, offset: 32411},
+							pos:        position{line: 1166, col: 18, offset: 32959},
 							val:        "null",
 							ignoreCase: false,
 						},
@@ -8786,31 +8945,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1153, col: 1, offset: 32527},
+			pos:  position{line: 1170, col: 1, offset: 33075},
 			expr: &choiceExpr{
-				pos: position{line: 1154, col: 5, offset: 32545},
+				pos: position{line: 1171, col: 5, offset: 33093},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1154, col: 5, offset: 32545},
+						pos: position{line: 1171, col: 5, offset: 33093},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1154, col: 5, offset: 32545},
+							pos: position{line: 1171, col: 5, offset: 33093},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1154, col: 5, offset: 32545},
+									pos:   position{line: 1171, col: 5, offset: 33093},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1154, col: 11, offset: 32551},
+										pos:  position{line: 1171, col: 11, offset: 33099},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1154, col: 21, offset: 32561},
+									pos:   position{line: 1171, col: 21, offset: 33109},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1154, col: 26, offset: 32566},
+										pos: position{line: 1171, col: 26, offset: 33114},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1154, col: 26, offset: 32566},
+											pos:  position{line: 1171, col: 26, offset: 33114},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -8819,10 +8978,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1157, col: 5, offset: 32668},
+						pos: position{line: 1174, col: 5, offset: 33216},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1157, col: 5, offset: 32668},
+							pos:        position{line: 1174, col: 5, offset: 33216},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -8832,31 +8991,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1159, col: 1, offset: 32692},
+			pos:  position{line: 1176, col: 1, offset: 33240},
 			expr: &actionExpr{
-				pos: position{line: 1159, col: 21, offset: 32712},
+				pos: position{line: 1176, col: 21, offset: 33260},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1159, col: 21, offset: 32712},
+					pos: position{line: 1176, col: 21, offset: 33260},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1159, col: 21, offset: 32712},
+							pos:  position{line: 1176, col: 21, offset: 33260},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1159, col: 24, offset: 32715},
+							pos:        position{line: 1176, col: 24, offset: 33263},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1159, col: 28, offset: 32719},
+							pos:  position{line: 1176, col: 28, offset: 33267},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1159, col: 31, offset: 32722},
+							pos:   position{line: 1176, col: 31, offset: 33270},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1159, col: 35, offset: 32726},
+								pos:  position{line: 1176, col: 35, offset: 33274},
 								name: "TypeField",
 							},
 						},
@@ -8866,39 +9025,39 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1161, col: 1, offset: 32757},
+			pos:  position{line: 1178, col: 1, offset: 33305},
 			expr: &actionExpr{
-				pos: position{line: 1162, col: 5, offset: 32771},
+				pos: position{line: 1179, col: 5, offset: 33319},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1162, col: 5, offset: 32771},
+					pos: position{line: 1179, col: 5, offset: 33319},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1162, col: 5, offset: 32771},
+							pos:   position{line: 1179, col: 5, offset: 33319},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1162, col: 10, offset: 32776},
+								pos:  position{line: 1179, col: 10, offset: 33324},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1162, col: 20, offset: 32786},
+							pos:  position{line: 1179, col: 20, offset: 33334},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1162, col: 23, offset: 32789},
+							pos:        position{line: 1179, col: 23, offset: 33337},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1162, col: 27, offset: 32793},
+							pos:  position{line: 1179, col: 27, offset: 33341},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1162, col: 30, offset: 32796},
+							pos:   position{line: 1179, col: 30, offset: 33344},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1162, col: 34, offset: 32800},
+								pos:  position{line: 1179, col: 34, offset: 33348},
 								name: "Type",
 							},
 						},
@@ -8908,16 +9067,16 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 1166, col: 1, offset: 32882},
+			pos:  position{line: 1183, col: 1, offset: 33430},
 			expr: &choiceExpr{
-				pos: position{line: 1167, col: 5, offset: 32896},
+				pos: position{line: 1184, col: 5, offset: 33444},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1167, col: 5, offset: 32896},
+						pos:  position{line: 1184, col: 5, offset: 33444},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1168, col: 5, offset: 32915},
+						pos:  position{line: 1185, col: 5, offset: 33463},
 						name: "QuotedString",
 					},
 				},
@@ -8925,32 +9084,32 @@ var g = &grammar{
 		},
 		{
 			name: "AndToken",
-			pos:  position{line: 1170, col: 1, offset: 32929},
+			pos:  position{line: 1187, col: 1, offset: 33477},
 			expr: &actionExpr{
-				pos: position{line: 1170, col: 12, offset: 32940},
+				pos: position{line: 1187, col: 12, offset: 33488},
 				run: (*parser).callonAndToken1,
 				expr: &seqExpr{
-					pos: position{line: 1170, col: 12, offset: 32940},
+					pos: position{line: 1187, col: 12, offset: 33488},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 1170, col: 13, offset: 32941},
+							pos: position{line: 1187, col: 13, offset: 33489},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1170, col: 13, offset: 32941},
+									pos:        position{line: 1187, col: 13, offset: 33489},
 									val:        "and",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1170, col: 21, offset: 32949},
+									pos:        position{line: 1187, col: 21, offset: 33497},
 									val:        "AND",
 									ignoreCase: false,
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1170, col: 28, offset: 32956},
+							pos: position{line: 1187, col: 28, offset: 33504},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1170, col: 29, offset: 32957},
+								pos:  position{line: 1187, col: 29, offset: 33505},
 								name: "IdentifierRest",
 							},
 						},
@@ -8960,32 +9119,32 @@ var g = &grammar{
 		},
 		{
 			name: "OrToken",
-			pos:  position{line: 1171, col: 1, offset: 32994},
+			pos:  position{line: 1188, col: 1, offset: 33542},
 			expr: &actionExpr{
-				pos: position{line: 1171, col: 11, offset: 33004},
+				pos: position{line: 1188, col: 11, offset: 33552},
 				run: (*parser).callonOrToken1,
 				expr: &seqExpr{
-					pos: position{line: 1171, col: 11, offset: 33004},
+					pos: position{line: 1188, col: 11, offset: 33552},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 1171, col: 12, offset: 33005},
+							pos: position{line: 1188, col: 12, offset: 33553},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1171, col: 12, offset: 33005},
+									pos:        position{line: 1188, col: 12, offset: 33553},
 									val:        "or",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1171, col: 19, offset: 33012},
+									pos:        position{line: 1188, col: 19, offset: 33560},
 									val:        "OR",
 									ignoreCase: false,
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1171, col: 25, offset: 33018},
+							pos: position{line: 1188, col: 25, offset: 33566},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1171, col: 26, offset: 33019},
+								pos:  position{line: 1188, col: 26, offset: 33567},
 								name: "IdentifierRest",
 							},
 						},
@@ -8995,22 +9154,22 @@ var g = &grammar{
 		},
 		{
 			name: "InToken",
-			pos:  position{line: 1172, col: 1, offset: 33055},
+			pos:  position{line: 1189, col: 1, offset: 33603},
 			expr: &actionExpr{
-				pos: position{line: 1172, col: 11, offset: 33065},
+				pos: position{line: 1189, col: 11, offset: 33613},
 				run: (*parser).callonInToken1,
 				expr: &seqExpr{
-					pos: position{line: 1172, col: 11, offset: 33065},
+					pos: position{line: 1189, col: 11, offset: 33613},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1172, col: 11, offset: 33065},
+							pos:        position{line: 1189, col: 11, offset: 33613},
 							val:        "in",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1172, col: 16, offset: 33070},
+							pos: position{line: 1189, col: 16, offset: 33618},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1172, col: 17, offset: 33071},
+								pos:  position{line: 1189, col: 17, offset: 33619},
 								name: "IdentifierRest",
 							},
 						},
@@ -9020,32 +9179,32 @@ var g = &grammar{
 		},
 		{
 			name: "NotToken",
-			pos:  position{line: 1173, col: 1, offset: 33107},
+			pos:  position{line: 1190, col: 1, offset: 33655},
 			expr: &actionExpr{
-				pos: position{line: 1173, col: 12, offset: 33118},
+				pos: position{line: 1190, col: 12, offset: 33666},
 				run: (*parser).callonNotToken1,
 				expr: &seqExpr{
-					pos: position{line: 1173, col: 12, offset: 33118},
+					pos: position{line: 1190, col: 12, offset: 33666},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 1173, col: 13, offset: 33119},
+							pos: position{line: 1190, col: 13, offset: 33667},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1173, col: 13, offset: 33119},
+									pos:        position{line: 1190, col: 13, offset: 33667},
 									val:        "not",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1173, col: 21, offset: 33127},
+									pos:        position{line: 1190, col: 21, offset: 33675},
 									val:        "NOT",
 									ignoreCase: false,
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1173, col: 28, offset: 33134},
+							pos: position{line: 1190, col: 28, offset: 33682},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1173, col: 29, offset: 33135},
+								pos:  position{line: 1190, col: 29, offset: 33683},
 								name: "IdentifierRest",
 							},
 						},
@@ -9055,22 +9214,22 @@ var g = &grammar{
 		},
 		{
 			name: "ByToken",
-			pos:  position{line: 1174, col: 1, offset: 33172},
+			pos:  position{line: 1191, col: 1, offset: 33720},
 			expr: &actionExpr{
-				pos: position{line: 1174, col: 11, offset: 33182},
+				pos: position{line: 1191, col: 11, offset: 33730},
 				run: (*parser).callonByToken1,
 				expr: &seqExpr{
-					pos: position{line: 1174, col: 11, offset: 33182},
+					pos: position{line: 1191, col: 11, offset: 33730},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1174, col: 11, offset: 33182},
+							pos:        position{line: 1191, col: 11, offset: 33730},
 							val:        "by",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1174, col: 16, offset: 33187},
+							pos: position{line: 1191, col: 16, offset: 33735},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1174, col: 17, offset: 33188},
+								pos:  position{line: 1191, col: 17, offset: 33736},
 								name: "IdentifierRest",
 							},
 						},
@@ -9080,9 +9239,9 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1176, col: 1, offset: 33225},
+			pos:  position{line: 1193, col: 1, offset: 33773},
 			expr: &charClassMatcher{
-				pos:        position{line: 1176, col: 19, offset: 33243},
+				pos:        position{line: 1193, col: 19, offset: 33791},
 				val:        "[A-Za-z_$]",
 				chars:      []rune{'_', '$'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -9092,16 +9251,16 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1178, col: 1, offset: 33255},
+			pos:  position{line: 1195, col: 1, offset: 33803},
 			expr: &choiceExpr{
-				pos: position{line: 1178, col: 18, offset: 33272},
+				pos: position{line: 1195, col: 18, offset: 33820},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1178, col: 18, offset: 33272},
+						pos:  position{line: 1195, col: 18, offset: 33820},
 						name: "IdentifierStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1178, col: 36, offset: 33290},
+						pos:        position{line: 1195, col: 36, offset: 33838},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9112,15 +9271,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1180, col: 1, offset: 33297},
+			pos:  position{line: 1197, col: 1, offset: 33845},
 			expr: &actionExpr{
-				pos: position{line: 1181, col: 5, offset: 33312},
+				pos: position{line: 1198, col: 5, offset: 33860},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1181, col: 5, offset: 33312},
+					pos:   position{line: 1198, col: 5, offset: 33860},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1181, col: 8, offset: 33315},
+						pos:  position{line: 1198, col: 8, offset: 33863},
 						name: "IdentifierName",
 					},
 				},
@@ -9128,29 +9287,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1183, col: 1, offset: 33396},
+			pos:  position{line: 1200, col: 1, offset: 33944},
 			expr: &choiceExpr{
-				pos: position{line: 1184, col: 5, offset: 33415},
+				pos: position{line: 1201, col: 5, offset: 33963},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1184, col: 5, offset: 33415},
+						pos: position{line: 1201, col: 5, offset: 33963},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1184, col: 5, offset: 33415},
+							pos: position{line: 1201, col: 5, offset: 33963},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1184, col: 5, offset: 33415},
+									pos: position{line: 1201, col: 5, offset: 33963},
 									expr: &seqExpr{
-										pos: position{line: 1184, col: 7, offset: 33417},
+										pos: position{line: 1201, col: 7, offset: 33965},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1184, col: 7, offset: 33417},
+												pos:  position{line: 1201, col: 7, offset: 33965},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1184, col: 15, offset: 33425},
+												pos: position{line: 1201, col: 15, offset: 33973},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1184, col: 16, offset: 33426},
+													pos:  position{line: 1201, col: 16, offset: 33974},
 													name: "IdentifierRest",
 												},
 											},
@@ -9158,13 +9317,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1184, col: 32, offset: 33442},
+									pos:  position{line: 1201, col: 32, offset: 33990},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1184, col: 48, offset: 33458},
+									pos: position{line: 1201, col: 48, offset: 34006},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1184, col: 48, offset: 33458},
+										pos:  position{line: 1201, col: 48, offset: 34006},
 										name: "IdentifierRest",
 									},
 								},
@@ -9172,30 +9331,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1185, col: 5, offset: 33510},
+						pos: position{line: 1202, col: 5, offset: 34058},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 1185, col: 5, offset: 33510},
+							pos:        position{line: 1202, col: 5, offset: 34058},
 							val:        "$",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1186, col: 5, offset: 33549},
+						pos: position{line: 1203, col: 5, offset: 34097},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 1186, col: 5, offset: 33549},
+							pos: position{line: 1203, col: 5, offset: 34097},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1186, col: 5, offset: 33549},
+									pos:        position{line: 1203, col: 5, offset: 34097},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1186, col: 10, offset: 33554},
+									pos:   position{line: 1203, col: 10, offset: 34102},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1186, col: 13, offset: 33557},
+										pos:  position{line: 1203, col: 13, offset: 34105},
 										name: "IDGuard",
 									},
 								},
@@ -9203,39 +9362,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1188, col: 5, offset: 33648},
+						pos: position{line: 1205, col: 5, offset: 34196},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 1188, col: 5, offset: 33648},
+							pos:        position{line: 1205, col: 5, offset: 34196},
 							val:        "type",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1189, col: 5, offset: 33690},
+						pos: position{line: 1206, col: 5, offset: 34238},
 						run: (*parser).callonIdentifierName21,
 						expr: &seqExpr{
-							pos: position{line: 1189, col: 5, offset: 33690},
+							pos: position{line: 1206, col: 5, offset: 34238},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1189, col: 5, offset: 33690},
+									pos:   position{line: 1206, col: 5, offset: 34238},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1189, col: 8, offset: 33693},
+										pos:  position{line: 1206, col: 8, offset: 34241},
 										name: "SQLTokenSentinels",
 									},
 								},
 								&andExpr{
-									pos: position{line: 1189, col: 26, offset: 33711},
+									pos: position{line: 1206, col: 26, offset: 34259},
 									expr: &seqExpr{
-										pos: position{line: 1189, col: 28, offset: 33713},
+										pos: position{line: 1206, col: 28, offset: 34261},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1189, col: 28, offset: 33713},
+												pos:  position{line: 1206, col: 28, offset: 34261},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1189, col: 31, offset: 33716},
+												pos:        position{line: 1206, col: 31, offset: 34264},
 												val:        "(",
 												ignoreCase: false,
 											},
@@ -9250,24 +9409,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1191, col: 1, offset: 33741},
+			pos:  position{line: 1208, col: 1, offset: 34289},
 			expr: &choiceExpr{
-				pos: position{line: 1192, col: 5, offset: 33753},
+				pos: position{line: 1209, col: 5, offset: 34301},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1192, col: 5, offset: 33753},
+						pos:  position{line: 1209, col: 5, offset: 34301},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1193, col: 5, offset: 33772},
+						pos:  position{line: 1210, col: 5, offset: 34320},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1194, col: 5, offset: 33788},
+						pos:  position{line: 1211, col: 5, offset: 34336},
 						name: "NaN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1195, col: 5, offset: 33796},
+						pos:  position{line: 1212, col: 5, offset: 34344},
 						name: "Infinity",
 					},
 				},
@@ -9275,24 +9434,24 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1197, col: 1, offset: 33806},
+			pos:  position{line: 1214, col: 1, offset: 34354},
 			expr: &actionExpr{
-				pos: position{line: 1198, col: 5, offset: 33815},
+				pos: position{line: 1215, col: 5, offset: 34363},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1198, col: 5, offset: 33815},
+					pos: position{line: 1215, col: 5, offset: 34363},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1198, col: 5, offset: 33815},
+							pos:  position{line: 1215, col: 5, offset: 34363},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1198, col: 14, offset: 33824},
+							pos:        position{line: 1215, col: 14, offset: 34372},
 							val:        "T",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1198, col: 18, offset: 33828},
+							pos:  position{line: 1215, col: 18, offset: 34376},
 							name: "FullTime",
 						},
 					},
@@ -9301,30 +9460,30 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1202, col: 1, offset: 33948},
+			pos:  position{line: 1219, col: 1, offset: 34496},
 			expr: &seqExpr{
-				pos: position{line: 1202, col: 12, offset: 33959},
+				pos: position{line: 1219, col: 12, offset: 34507},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1202, col: 12, offset: 33959},
+						pos:  position{line: 1219, col: 12, offset: 34507},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1202, col: 15, offset: 33962},
+						pos:        position{line: 1219, col: 15, offset: 34510},
 						val:        "-",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1202, col: 19, offset: 33966},
+						pos:  position{line: 1219, col: 19, offset: 34514},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1202, col: 22, offset: 33969},
+						pos:        position{line: 1219, col: 22, offset: 34517},
 						val:        "-",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1202, col: 26, offset: 33973},
+						pos:  position{line: 1219, col: 26, offset: 34521},
 						name: "D2",
 					},
 				},
@@ -9332,33 +9491,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1204, col: 1, offset: 33977},
+			pos:  position{line: 1221, col: 1, offset: 34525},
 			expr: &seqExpr{
-				pos: position{line: 1204, col: 6, offset: 33982},
+				pos: position{line: 1221, col: 6, offset: 34530},
 				exprs: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1204, col: 6, offset: 33982},
+						pos:        position{line: 1221, col: 6, offset: 34530},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1204, col: 11, offset: 33987},
+						pos:        position{line: 1221, col: 11, offset: 34535},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1204, col: 16, offset: 33992},
+						pos:        position{line: 1221, col: 16, offset: 34540},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1204, col: 21, offset: 33997},
+						pos:        position{line: 1221, col: 21, offset: 34545},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9369,19 +9528,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1205, col: 1, offset: 34003},
+			pos:  position{line: 1222, col: 1, offset: 34551},
 			expr: &seqExpr{
-				pos: position{line: 1205, col: 6, offset: 34008},
+				pos: position{line: 1222, col: 6, offset: 34556},
 				exprs: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1205, col: 6, offset: 34008},
+						pos:        position{line: 1222, col: 6, offset: 34556},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1205, col: 11, offset: 34013},
+						pos:        position{line: 1222, col: 11, offset: 34561},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9392,16 +9551,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1207, col: 1, offset: 34020},
+			pos:  position{line: 1224, col: 1, offset: 34568},
 			expr: &seqExpr{
-				pos: position{line: 1207, col: 12, offset: 34031},
+				pos: position{line: 1224, col: 12, offset: 34579},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1207, col: 12, offset: 34031},
+						pos:  position{line: 1224, col: 12, offset: 34579},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1207, col: 24, offset: 34043},
+						pos:  position{line: 1224, col: 24, offset: 34591},
 						name: "TimeOffset",
 					},
 				},
@@ -9409,46 +9568,46 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1209, col: 1, offset: 34055},
+			pos:  position{line: 1226, col: 1, offset: 34603},
 			expr: &seqExpr{
-				pos: position{line: 1209, col: 15, offset: 34069},
+				pos: position{line: 1226, col: 15, offset: 34617},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1209, col: 15, offset: 34069},
+						pos:  position{line: 1226, col: 15, offset: 34617},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1209, col: 18, offset: 34072},
+						pos:        position{line: 1226, col: 18, offset: 34620},
 						val:        ":",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1209, col: 22, offset: 34076},
+						pos:  position{line: 1226, col: 22, offset: 34624},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1209, col: 25, offset: 34079},
+						pos:        position{line: 1226, col: 25, offset: 34627},
 						val:        ":",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1209, col: 29, offset: 34083},
+						pos:  position{line: 1226, col: 29, offset: 34631},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1209, col: 32, offset: 34086},
+						pos: position{line: 1226, col: 32, offset: 34634},
 						expr: &seqExpr{
-							pos: position{line: 1209, col: 33, offset: 34087},
+							pos: position{line: 1226, col: 33, offset: 34635},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1209, col: 33, offset: 34087},
+									pos:        position{line: 1226, col: 33, offset: 34635},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1209, col: 37, offset: 34091},
+									pos: position{line: 1226, col: 37, offset: 34639},
 									expr: &charClassMatcher{
-										pos:        position{line: 1209, col: 37, offset: 34091},
+										pos:        position{line: 1226, col: 37, offset: 34639},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -9463,60 +9622,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1211, col: 1, offset: 34101},
+			pos:  position{line: 1228, col: 1, offset: 34649},
 			expr: &choiceExpr{
-				pos: position{line: 1212, col: 5, offset: 34116},
+				pos: position{line: 1229, col: 5, offset: 34664},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1212, col: 5, offset: 34116},
+						pos:        position{line: 1229, col: 5, offset: 34664},
 						val:        "Z",
 						ignoreCase: false,
 					},
 					&seqExpr{
-						pos: position{line: 1213, col: 5, offset: 34124},
+						pos: position{line: 1230, col: 5, offset: 34672},
 						exprs: []interface{}{
 							&choiceExpr{
-								pos: position{line: 1213, col: 6, offset: 34125},
+								pos: position{line: 1230, col: 6, offset: 34673},
 								alternatives: []interface{}{
 									&litMatcher{
-										pos:        position{line: 1213, col: 6, offset: 34125},
+										pos:        position{line: 1230, col: 6, offset: 34673},
 										val:        "+",
 										ignoreCase: false,
 									},
 									&litMatcher{
-										pos:        position{line: 1213, col: 12, offset: 34131},
+										pos:        position{line: 1230, col: 12, offset: 34679},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1213, col: 17, offset: 34136},
+								pos:  position{line: 1230, col: 17, offset: 34684},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1213, col: 20, offset: 34139},
+								pos:        position{line: 1230, col: 20, offset: 34687},
 								val:        ":",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1213, col: 24, offset: 34143},
+								pos:  position{line: 1230, col: 24, offset: 34691},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1213, col: 27, offset: 34146},
+								pos: position{line: 1230, col: 27, offset: 34694},
 								expr: &seqExpr{
-									pos: position{line: 1213, col: 28, offset: 34147},
+									pos: position{line: 1230, col: 28, offset: 34695},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1213, col: 28, offset: 34147},
+											pos:        position{line: 1230, col: 28, offset: 34695},
 											val:        ".",
 											ignoreCase: false,
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1213, col: 32, offset: 34151},
+											pos: position{line: 1230, col: 32, offset: 34699},
 											expr: &charClassMatcher{
-												pos:        position{line: 1213, col: 32, offset: 34151},
+												pos:        position{line: 1230, col: 32, offset: 34699},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -9533,32 +9692,32 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1215, col: 1, offset: 34161},
+			pos:  position{line: 1232, col: 1, offset: 34709},
 			expr: &actionExpr{
-				pos: position{line: 1216, col: 5, offset: 34174},
+				pos: position{line: 1233, col: 5, offset: 34722},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1216, col: 5, offset: 34174},
+					pos: position{line: 1233, col: 5, offset: 34722},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 1216, col: 5, offset: 34174},
+							pos: position{line: 1233, col: 5, offset: 34722},
 							expr: &litMatcher{
-								pos:        position{line: 1216, col: 5, offset: 34174},
+								pos:        position{line: 1233, col: 5, offset: 34722},
 								val:        "-",
 								ignoreCase: false,
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1216, col: 10, offset: 34179},
+							pos: position{line: 1233, col: 10, offset: 34727},
 							expr: &seqExpr{
-								pos: position{line: 1216, col: 11, offset: 34180},
+								pos: position{line: 1233, col: 11, offset: 34728},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1216, col: 11, offset: 34180},
+										pos:  position{line: 1233, col: 11, offset: 34728},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1216, col: 19, offset: 34188},
+										pos:  position{line: 1233, col: 19, offset: 34736},
 										name: "TimeUnit",
 									},
 								},
@@ -9570,26 +9729,26 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1220, col: 1, offset: 34314},
+			pos:  position{line: 1237, col: 1, offset: 34862},
 			expr: &seqExpr{
-				pos: position{line: 1220, col: 11, offset: 34324},
+				pos: position{line: 1237, col: 11, offset: 34872},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1220, col: 11, offset: 34324},
+						pos:  position{line: 1237, col: 11, offset: 34872},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1220, col: 16, offset: 34329},
+						pos: position{line: 1237, col: 16, offset: 34877},
 						expr: &seqExpr{
-							pos: position{line: 1220, col: 17, offset: 34330},
+							pos: position{line: 1237, col: 17, offset: 34878},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1220, col: 17, offset: 34330},
+									pos:        position{line: 1237, col: 17, offset: 34878},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1220, col: 21, offset: 34334},
+									pos:  position{line: 1237, col: 21, offset: 34882},
 									name: "UInt",
 								},
 							},
@@ -9600,52 +9759,52 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1222, col: 1, offset: 34342},
+			pos:  position{line: 1239, col: 1, offset: 34890},
 			expr: &choiceExpr{
-				pos: position{line: 1223, col: 5, offset: 34355},
+				pos: position{line: 1240, col: 5, offset: 34903},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1223, col: 5, offset: 34355},
+						pos:        position{line: 1240, col: 5, offset: 34903},
 						val:        "ns",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1224, col: 5, offset: 34364},
+						pos:        position{line: 1241, col: 5, offset: 34912},
 						val:        "us",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1225, col: 5, offset: 34373},
+						pos:        position{line: 1242, col: 5, offset: 34921},
 						val:        "ms",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1226, col: 5, offset: 34382},
+						pos:        position{line: 1243, col: 5, offset: 34930},
 						val:        "s",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1227, col: 5, offset: 34390},
+						pos:        position{line: 1244, col: 5, offset: 34938},
 						val:        "m",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1228, col: 5, offset: 34398},
+						pos:        position{line: 1245, col: 5, offset: 34946},
 						val:        "h",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1229, col: 5, offset: 34406},
+						pos:        position{line: 1246, col: 5, offset: 34954},
 						val:        "d",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1230, col: 5, offset: 34414},
+						pos:        position{line: 1247, col: 5, offset: 34962},
 						val:        "w",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1231, col: 5, offset: 34422},
+						pos:        position{line: 1248, col: 5, offset: 34970},
 						val:        "y",
 						ignoreCase: false,
 					},
@@ -9654,42 +9813,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1233, col: 1, offset: 34427},
+			pos:  position{line: 1250, col: 1, offset: 34975},
 			expr: &actionExpr{
-				pos: position{line: 1234, col: 5, offset: 34434},
+				pos: position{line: 1251, col: 5, offset: 34982},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1234, col: 5, offset: 34434},
+					pos: position{line: 1251, col: 5, offset: 34982},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1234, col: 5, offset: 34434},
+							pos:  position{line: 1251, col: 5, offset: 34982},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1234, col: 10, offset: 34439},
+							pos:        position{line: 1251, col: 10, offset: 34987},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1234, col: 14, offset: 34443},
+							pos:  position{line: 1251, col: 14, offset: 34991},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1234, col: 19, offset: 34448},
+							pos:        position{line: 1251, col: 19, offset: 34996},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1234, col: 23, offset: 34452},
+							pos:  position{line: 1251, col: 23, offset: 35000},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1234, col: 28, offset: 34457},
+							pos:        position{line: 1251, col: 28, offset: 35005},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1234, col: 32, offset: 34461},
+							pos:  position{line: 1251, col: 32, offset: 35009},
 							name: "UInt",
 						},
 					},
@@ -9698,42 +9857,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1236, col: 1, offset: 34498},
+			pos:  position{line: 1253, col: 1, offset: 35046},
 			expr: &actionExpr{
-				pos: position{line: 1237, col: 5, offset: 34506},
+				pos: position{line: 1254, col: 5, offset: 35054},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1237, col: 5, offset: 34506},
+					pos: position{line: 1254, col: 5, offset: 35054},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1237, col: 5, offset: 34506},
+							pos: position{line: 1254, col: 5, offset: 35054},
 							expr: &seqExpr{
-								pos: position{line: 1237, col: 8, offset: 34509},
+								pos: position{line: 1254, col: 8, offset: 35057},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1237, col: 8, offset: 34509},
+										pos:  position{line: 1254, col: 8, offset: 35057},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1237, col: 12, offset: 34513},
+										pos:        position{line: 1254, col: 12, offset: 35061},
 										val:        ":",
 										ignoreCase: false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1237, col: 16, offset: 34517},
+										pos:  position{line: 1254, col: 16, offset: 35065},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1237, col: 20, offset: 34521},
+										pos: position{line: 1254, col: 20, offset: 35069},
 										expr: &choiceExpr{
-											pos: position{line: 1237, col: 22, offset: 34523},
+											pos: position{line: 1254, col: 22, offset: 35071},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 1237, col: 22, offset: 34523},
+													pos:  position{line: 1254, col: 22, offset: 35071},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1237, col: 33, offset: 34534},
+													pos:        position{line: 1254, col: 33, offset: 35082},
 													val:        ":",
 													ignoreCase: false,
 												},
@@ -9744,10 +9903,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1237, col: 39, offset: 34540},
+							pos:   position{line: 1254, col: 39, offset: 35088},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1237, col: 41, offset: 34542},
+								pos:  position{line: 1254, col: 41, offset: 35090},
 								name: "IP6Variations",
 							},
 						},
@@ -9757,32 +9916,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1241, col: 1, offset: 34706},
+			pos:  position{line: 1258, col: 1, offset: 35254},
 			expr: &choiceExpr{
-				pos: position{line: 1242, col: 5, offset: 34724},
+				pos: position{line: 1259, col: 5, offset: 35272},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1242, col: 5, offset: 34724},
+						pos: position{line: 1259, col: 5, offset: 35272},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1242, col: 5, offset: 34724},
+							pos: position{line: 1259, col: 5, offset: 35272},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1242, col: 5, offset: 34724},
+									pos:   position{line: 1259, col: 5, offset: 35272},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1242, col: 7, offset: 34726},
+										pos: position{line: 1259, col: 7, offset: 35274},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1242, col: 7, offset: 34726},
+											pos:  position{line: 1259, col: 7, offset: 35274},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1242, col: 17, offset: 34736},
+									pos:   position{line: 1259, col: 17, offset: 35284},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1242, col: 19, offset: 34738},
+										pos:  position{line: 1259, col: 19, offset: 35286},
 										name: "IP6Tail",
 									},
 								},
@@ -9790,51 +9949,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1245, col: 5, offset: 34802},
+						pos: position{line: 1262, col: 5, offset: 35350},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1245, col: 5, offset: 34802},
+							pos: position{line: 1262, col: 5, offset: 35350},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1245, col: 5, offset: 34802},
+									pos:   position{line: 1262, col: 5, offset: 35350},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1245, col: 7, offset: 34804},
+										pos:  position{line: 1262, col: 7, offset: 35352},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1245, col: 11, offset: 34808},
+									pos:   position{line: 1262, col: 11, offset: 35356},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1245, col: 13, offset: 34810},
+										pos: position{line: 1262, col: 13, offset: 35358},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1245, col: 13, offset: 34810},
+											pos:  position{line: 1262, col: 13, offset: 35358},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1245, col: 23, offset: 34820},
+									pos:        position{line: 1262, col: 23, offset: 35368},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1245, col: 28, offset: 34825},
+									pos:   position{line: 1262, col: 28, offset: 35373},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1245, col: 30, offset: 34827},
+										pos: position{line: 1262, col: 30, offset: 35375},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1245, col: 30, offset: 34827},
+											pos:  position{line: 1262, col: 30, offset: 35375},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1245, col: 40, offset: 34837},
+									pos:   position{line: 1262, col: 40, offset: 35385},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1245, col: 42, offset: 34839},
+										pos:  position{line: 1262, col: 42, offset: 35387},
 										name: "IP6Tail",
 									},
 								},
@@ -9842,32 +10001,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1248, col: 5, offset: 34938},
+						pos: position{line: 1265, col: 5, offset: 35486},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1248, col: 5, offset: 34938},
+							pos: position{line: 1265, col: 5, offset: 35486},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1248, col: 5, offset: 34938},
+									pos:        position{line: 1265, col: 5, offset: 35486},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1248, col: 10, offset: 34943},
+									pos:   position{line: 1265, col: 10, offset: 35491},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1248, col: 12, offset: 34945},
+										pos: position{line: 1265, col: 12, offset: 35493},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1248, col: 12, offset: 34945},
+											pos:  position{line: 1265, col: 12, offset: 35493},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1248, col: 22, offset: 34955},
+									pos:   position{line: 1265, col: 22, offset: 35503},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1248, col: 24, offset: 34957},
+										pos:  position{line: 1265, col: 24, offset: 35505},
 										name: "IP6Tail",
 									},
 								},
@@ -9875,32 +10034,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1251, col: 5, offset: 35028},
+						pos: position{line: 1268, col: 5, offset: 35576},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1251, col: 5, offset: 35028},
+							pos: position{line: 1268, col: 5, offset: 35576},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1251, col: 5, offset: 35028},
+									pos:   position{line: 1268, col: 5, offset: 35576},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1251, col: 7, offset: 35030},
+										pos:  position{line: 1268, col: 7, offset: 35578},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1251, col: 11, offset: 35034},
+									pos:   position{line: 1268, col: 11, offset: 35582},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1251, col: 13, offset: 35036},
+										pos: position{line: 1268, col: 13, offset: 35584},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1251, col: 13, offset: 35036},
+											pos:  position{line: 1268, col: 13, offset: 35584},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1251, col: 23, offset: 35046},
+									pos:        position{line: 1268, col: 23, offset: 35594},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -9908,10 +10067,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1254, col: 5, offset: 35114},
+						pos: position{line: 1271, col: 5, offset: 35662},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 1254, col: 5, offset: 35114},
+							pos:        position{line: 1271, col: 5, offset: 35662},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -9921,16 +10080,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1258, col: 1, offset: 35151},
+			pos:  position{line: 1275, col: 1, offset: 35699},
 			expr: &choiceExpr{
-				pos: position{line: 1259, col: 5, offset: 35163},
+				pos: position{line: 1276, col: 5, offset: 35711},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1259, col: 5, offset: 35163},
+						pos:  position{line: 1276, col: 5, offset: 35711},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1260, col: 5, offset: 35170},
+						pos:  position{line: 1277, col: 5, offset: 35718},
 						name: "Hex",
 					},
 				},
@@ -9938,23 +10097,23 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1262, col: 1, offset: 35175},
+			pos:  position{line: 1279, col: 1, offset: 35723},
 			expr: &actionExpr{
-				pos: position{line: 1262, col: 12, offset: 35186},
+				pos: position{line: 1279, col: 12, offset: 35734},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1262, col: 12, offset: 35186},
+					pos: position{line: 1279, col: 12, offset: 35734},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1262, col: 12, offset: 35186},
+							pos:        position{line: 1279, col: 12, offset: 35734},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1262, col: 16, offset: 35190},
+							pos:   position{line: 1279, col: 16, offset: 35738},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1262, col: 18, offset: 35192},
+								pos:  position{line: 1279, col: 18, offset: 35740},
 								name: "Hex",
 							},
 						},
@@ -9964,23 +10123,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1264, col: 1, offset: 35230},
+			pos:  position{line: 1281, col: 1, offset: 35778},
 			expr: &actionExpr{
-				pos: position{line: 1264, col: 12, offset: 35241},
+				pos: position{line: 1281, col: 12, offset: 35789},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1264, col: 12, offset: 35241},
+					pos: position{line: 1281, col: 12, offset: 35789},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1264, col: 12, offset: 35241},
+							pos:   position{line: 1281, col: 12, offset: 35789},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1264, col: 14, offset: 35243},
+								pos:  position{line: 1281, col: 14, offset: 35791},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1264, col: 18, offset: 35247},
+							pos:        position{line: 1281, col: 18, offset: 35795},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -9990,31 +10149,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1266, col: 1, offset: 35285},
+			pos:  position{line: 1283, col: 1, offset: 35833},
 			expr: &actionExpr{
-				pos: position{line: 1267, col: 5, offset: 35296},
+				pos: position{line: 1284, col: 5, offset: 35844},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1267, col: 5, offset: 35296},
+					pos: position{line: 1284, col: 5, offset: 35844},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1267, col: 5, offset: 35296},
+							pos:   position{line: 1284, col: 5, offset: 35844},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1267, col: 7, offset: 35298},
+								pos:  position{line: 1284, col: 7, offset: 35846},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1267, col: 10, offset: 35301},
+							pos:        position{line: 1284, col: 10, offset: 35849},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1267, col: 14, offset: 35305},
+							pos:   position{line: 1284, col: 14, offset: 35853},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1267, col: 16, offset: 35307},
+								pos:  position{line: 1284, col: 16, offset: 35855},
 								name: "UInt",
 							},
 						},
@@ -10024,31 +10183,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1271, col: 1, offset: 35380},
+			pos:  position{line: 1288, col: 1, offset: 35928},
 			expr: &actionExpr{
-				pos: position{line: 1272, col: 5, offset: 35391},
+				pos: position{line: 1289, col: 5, offset: 35939},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1272, col: 5, offset: 35391},
+					pos: position{line: 1289, col: 5, offset: 35939},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1272, col: 5, offset: 35391},
+							pos:   position{line: 1289, col: 5, offset: 35939},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1272, col: 7, offset: 35393},
+								pos:  position{line: 1289, col: 7, offset: 35941},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1272, col: 11, offset: 35397},
+							pos:        position{line: 1289, col: 11, offset: 35945},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1272, col: 15, offset: 35401},
+							pos:   position{line: 1289, col: 15, offset: 35949},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1272, col: 17, offset: 35403},
+								pos:  position{line: 1289, col: 17, offset: 35951},
 								name: "UInt",
 							},
 						},
@@ -10058,15 +10217,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1276, col: 1, offset: 35466},
+			pos:  position{line: 1293, col: 1, offset: 36014},
 			expr: &actionExpr{
-				pos: position{line: 1277, col: 4, offset: 35474},
+				pos: position{line: 1294, col: 4, offset: 36022},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1277, col: 4, offset: 35474},
+					pos:   position{line: 1294, col: 4, offset: 36022},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1277, col: 6, offset: 35476},
+						pos:  position{line: 1294, col: 6, offset: 36024},
 						name: "UIntString",
 					},
 				},
@@ -10074,16 +10233,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1279, col: 1, offset: 35516},
+			pos:  position{line: 1296, col: 1, offset: 36064},
 			expr: &choiceExpr{
-				pos: position{line: 1280, col: 5, offset: 35530},
+				pos: position{line: 1297, col: 5, offset: 36078},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1280, col: 5, offset: 35530},
+						pos:  position{line: 1297, col: 5, offset: 36078},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1281, col: 5, offset: 35545},
+						pos:  position{line: 1298, col: 5, offset: 36093},
 						name: "MinusIntString",
 					},
 				},
@@ -10091,14 +10250,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1283, col: 1, offset: 35561},
+			pos:  position{line: 1300, col: 1, offset: 36109},
 			expr: &actionExpr{
-				pos: position{line: 1283, col: 14, offset: 35574},
+				pos: position{line: 1300, col: 14, offset: 36122},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1283, col: 14, offset: 35574},
+					pos: position{line: 1300, col: 14, offset: 36122},
 					expr: &charClassMatcher{
-						pos:        position{line: 1283, col: 14, offset: 35574},
+						pos:        position{line: 1300, col: 14, offset: 36122},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10109,20 +10268,20 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1285, col: 1, offset: 35613},
+			pos:  position{line: 1302, col: 1, offset: 36161},
 			expr: &actionExpr{
-				pos: position{line: 1286, col: 5, offset: 35632},
+				pos: position{line: 1303, col: 5, offset: 36180},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1286, col: 5, offset: 35632},
+					pos: position{line: 1303, col: 5, offset: 36180},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1286, col: 5, offset: 35632},
+							pos:        position{line: 1303, col: 5, offset: 36180},
 							val:        "-",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1286, col: 9, offset: 35636},
+							pos:  position{line: 1303, col: 9, offset: 36184},
 							name: "UIntString",
 						},
 					},
@@ -10131,28 +10290,28 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1288, col: 1, offset: 35679},
+			pos:  position{line: 1305, col: 1, offset: 36227},
 			expr: &choiceExpr{
-				pos: position{line: 1289, col: 5, offset: 35695},
+				pos: position{line: 1306, col: 5, offset: 36243},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1289, col: 5, offset: 35695},
+						pos: position{line: 1306, col: 5, offset: 36243},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1289, col: 5, offset: 35695},
+							pos: position{line: 1306, col: 5, offset: 36243},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1289, col: 5, offset: 35695},
+									pos: position{line: 1306, col: 5, offset: 36243},
 									expr: &litMatcher{
-										pos:        position{line: 1289, col: 5, offset: 35695},
+										pos:        position{line: 1306, col: 5, offset: 36243},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1289, col: 10, offset: 35700},
+									pos: position{line: 1306, col: 10, offset: 36248},
 									expr: &charClassMatcher{
-										pos:        position{line: 1289, col: 10, offset: 35700},
+										pos:        position{line: 1306, col: 10, offset: 36248},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10160,14 +10319,14 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1289, col: 17, offset: 35707},
+									pos:        position{line: 1306, col: 17, offset: 36255},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1289, col: 21, offset: 35711},
+									pos: position{line: 1306, col: 21, offset: 36259},
 									expr: &charClassMatcher{
-										pos:        position{line: 1289, col: 21, offset: 35711},
+										pos:        position{line: 1306, col: 21, offset: 36259},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10175,9 +10334,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1289, col: 28, offset: 35718},
+									pos: position{line: 1306, col: 28, offset: 36266},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1289, col: 28, offset: 35718},
+										pos:  position{line: 1306, col: 28, offset: 36266},
 										name: "ExponentPart",
 									},
 								},
@@ -10185,28 +10344,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1292, col: 5, offset: 35777},
+						pos: position{line: 1309, col: 5, offset: 36325},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1292, col: 5, offset: 35777},
+							pos: position{line: 1309, col: 5, offset: 36325},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1292, col: 5, offset: 35777},
+									pos: position{line: 1309, col: 5, offset: 36325},
 									expr: &litMatcher{
-										pos:        position{line: 1292, col: 5, offset: 35777},
+										pos:        position{line: 1309, col: 5, offset: 36325},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1292, col: 10, offset: 35782},
+									pos:        position{line: 1309, col: 10, offset: 36330},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1292, col: 14, offset: 35786},
+									pos: position{line: 1309, col: 14, offset: 36334},
 									expr: &charClassMatcher{
-										pos:        position{line: 1292, col: 14, offset: 35786},
+										pos:        position{line: 1309, col: 14, offset: 36334},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10214,9 +10373,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1292, col: 21, offset: 35793},
+									pos: position{line: 1309, col: 21, offset: 36341},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1292, col: 21, offset: 35793},
+										pos:  position{line: 1309, col: 21, offset: 36341},
 										name: "ExponentPart",
 									},
 								},
@@ -10224,17 +10383,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1295, col: 5, offset: 35852},
+						pos: position{line: 1312, col: 5, offset: 36400},
 						run: (*parser).callonFloatString22,
 						expr: &choiceExpr{
-							pos: position{line: 1295, col: 7, offset: 35854},
+							pos: position{line: 1312, col: 7, offset: 36402},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1295, col: 7, offset: 35854},
+									pos:  position{line: 1312, col: 7, offset: 36402},
 									name: "NaN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1295, col: 13, offset: 35860},
+									pos:  position{line: 1312, col: 13, offset: 36408},
 									name: "Infinity",
 								},
 							},
@@ -10245,19 +10404,19 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1298, col: 1, offset: 35904},
+			pos:  position{line: 1315, col: 1, offset: 36452},
 			expr: &seqExpr{
-				pos: position{line: 1298, col: 16, offset: 35919},
+				pos: position{line: 1315, col: 16, offset: 36467},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1298, col: 16, offset: 35919},
+						pos:        position{line: 1315, col: 16, offset: 36467},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1298, col: 21, offset: 35924},
+						pos: position{line: 1315, col: 21, offset: 36472},
 						expr: &charClassMatcher{
-							pos:        position{line: 1298, col: 21, offset: 35924},
+							pos:        position{line: 1315, col: 21, offset: 36472},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -10265,7 +10424,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1298, col: 27, offset: 35930},
+						pos:  position{line: 1315, col: 27, offset: 36478},
 						name: "UIntString",
 					},
 				},
@@ -10273,31 +10432,31 @@ var g = &grammar{
 		},
 		{
 			name: "NaN",
-			pos:  position{line: 1300, col: 1, offset: 35942},
+			pos:  position{line: 1317, col: 1, offset: 36490},
 			expr: &litMatcher{
-				pos:        position{line: 1300, col: 7, offset: 35948},
+				pos:        position{line: 1317, col: 7, offset: 36496},
 				val:        "NaN",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "Infinity",
-			pos:  position{line: 1302, col: 1, offset: 35955},
+			pos:  position{line: 1319, col: 1, offset: 36503},
 			expr: &seqExpr{
-				pos: position{line: 1302, col: 12, offset: 35966},
+				pos: position{line: 1319, col: 12, offset: 36514},
 				exprs: []interface{}{
 					&zeroOrOneExpr{
-						pos: position{line: 1302, col: 12, offset: 35966},
+						pos: position{line: 1319, col: 12, offset: 36514},
 						expr: &choiceExpr{
-							pos: position{line: 1302, col: 13, offset: 35967},
+							pos: position{line: 1319, col: 13, offset: 36515},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1302, col: 13, offset: 35967},
+									pos:        position{line: 1319, col: 13, offset: 36515},
 									val:        "-",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1302, col: 19, offset: 35973},
+									pos:        position{line: 1319, col: 19, offset: 36521},
 									val:        "+",
 									ignoreCase: false,
 								},
@@ -10305,7 +10464,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1302, col: 25, offset: 35979},
+						pos:        position{line: 1319, col: 25, offset: 36527},
 						val:        "Inf",
 						ignoreCase: false,
 					},
@@ -10314,14 +10473,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1304, col: 1, offset: 35986},
+			pos:  position{line: 1321, col: 1, offset: 36534},
 			expr: &actionExpr{
-				pos: position{line: 1304, col: 7, offset: 35992},
+				pos: position{line: 1321, col: 7, offset: 36540},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1304, col: 7, offset: 35992},
+					pos: position{line: 1321, col: 7, offset: 36540},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1304, col: 7, offset: 35992},
+						pos:  position{line: 1321, col: 7, offset: 36540},
 						name: "HexDigit",
 					},
 				},
@@ -10329,9 +10488,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1306, col: 1, offset: 36034},
+			pos:  position{line: 1323, col: 1, offset: 36582},
 			expr: &charClassMatcher{
-				pos:        position{line: 1306, col: 12, offset: 36045},
+				pos:        position{line: 1323, col: 12, offset: 36593},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -10340,34 +10499,34 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1308, col: 1, offset: 36058},
+			pos:  position{line: 1325, col: 1, offset: 36606},
 			expr: &choiceExpr{
-				pos: position{line: 1309, col: 5, offset: 36075},
+				pos: position{line: 1326, col: 5, offset: 36623},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1309, col: 5, offset: 36075},
+						pos: position{line: 1326, col: 5, offset: 36623},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 1309, col: 5, offset: 36075},
+							pos: position{line: 1326, col: 5, offset: 36623},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1309, col: 5, offset: 36075},
+									pos:        position{line: 1326, col: 5, offset: 36623},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1309, col: 9, offset: 36079},
+									pos:   position{line: 1326, col: 9, offset: 36627},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1309, col: 11, offset: 36081},
+										pos: position{line: 1326, col: 11, offset: 36629},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1309, col: 11, offset: 36081},
+											pos:  position{line: 1326, col: 11, offset: 36629},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1309, col: 29, offset: 36099},
+									pos:        position{line: 1326, col: 29, offset: 36647},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -10375,29 +10534,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1310, col: 5, offset: 36136},
+						pos: position{line: 1327, col: 5, offset: 36684},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 1310, col: 5, offset: 36136},
+							pos: position{line: 1327, col: 5, offset: 36684},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1310, col: 5, offset: 36136},
+									pos:        position{line: 1327, col: 5, offset: 36684},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1310, col: 9, offset: 36140},
+									pos:   position{line: 1327, col: 9, offset: 36688},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1310, col: 11, offset: 36142},
+										pos: position{line: 1327, col: 11, offset: 36690},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1310, col: 11, offset: 36142},
+											pos:  position{line: 1327, col: 11, offset: 36690},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1310, col: 29, offset: 36160},
+									pos:        position{line: 1327, col: 29, offset: 36708},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -10409,55 +10568,55 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1312, col: 1, offset: 36194},
+			pos:  position{line: 1329, col: 1, offset: 36742},
 			expr: &choiceExpr{
-				pos: position{line: 1313, col: 5, offset: 36215},
+				pos: position{line: 1330, col: 5, offset: 36763},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1313, col: 5, offset: 36215},
+						pos: position{line: 1330, col: 5, offset: 36763},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1313, col: 5, offset: 36215},
+							pos: position{line: 1330, col: 5, offset: 36763},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1313, col: 5, offset: 36215},
+									pos: position{line: 1330, col: 5, offset: 36763},
 									expr: &choiceExpr{
-										pos: position{line: 1313, col: 7, offset: 36217},
+										pos: position{line: 1330, col: 7, offset: 36765},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1313, col: 7, offset: 36217},
+												pos:        position{line: 1330, col: 7, offset: 36765},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1313, col: 13, offset: 36223},
+												pos:  position{line: 1330, col: 13, offset: 36771},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1313, col: 26, offset: 36236,
+									line: 1330, col: 26, offset: 36784,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1314, col: 5, offset: 36273},
+						pos: position{line: 1331, col: 5, offset: 36821},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1314, col: 5, offset: 36273},
+							pos: position{line: 1331, col: 5, offset: 36821},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1314, col: 5, offset: 36273},
+									pos:        position{line: 1331, col: 5, offset: 36821},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1314, col: 10, offset: 36278},
+									pos:   position{line: 1331, col: 10, offset: 36826},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1314, col: 12, offset: 36280},
+										pos:  position{line: 1331, col: 12, offset: 36828},
 										name: "EscapeSequence",
 									},
 								},
@@ -10469,28 +10628,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1316, col: 1, offset: 36314},
+			pos:  position{line: 1333, col: 1, offset: 36862},
 			expr: &actionExpr{
-				pos: position{line: 1317, col: 5, offset: 36326},
+				pos: position{line: 1334, col: 5, offset: 36874},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1317, col: 5, offset: 36326},
+					pos: position{line: 1334, col: 5, offset: 36874},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1317, col: 5, offset: 36326},
+							pos:   position{line: 1334, col: 5, offset: 36874},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1317, col: 10, offset: 36331},
+								pos:  position{line: 1334, col: 10, offset: 36879},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1317, col: 23, offset: 36344},
+							pos:   position{line: 1334, col: 23, offset: 36892},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1317, col: 28, offset: 36349},
+								pos: position{line: 1334, col: 28, offset: 36897},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1317, col: 28, offset: 36349},
+									pos:  position{line: 1334, col: 28, offset: 36897},
 									name: "KeyWordRest",
 								},
 							},
@@ -10501,16 +10660,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1319, col: 1, offset: 36411},
+			pos:  position{line: 1336, col: 1, offset: 36959},
 			expr: &choiceExpr{
-				pos: position{line: 1320, col: 5, offset: 36428},
+				pos: position{line: 1337, col: 5, offset: 36976},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1320, col: 5, offset: 36428},
+						pos:  position{line: 1337, col: 5, offset: 36976},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1321, col: 5, offset: 36445},
+						pos:  position{line: 1338, col: 5, offset: 36993},
 						name: "KeyWordEsc",
 					},
 				},
@@ -10518,12 +10677,12 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1323, col: 1, offset: 36457},
+			pos:  position{line: 1340, col: 1, offset: 37005},
 			expr: &actionExpr{
-				pos: position{line: 1323, col: 16, offset: 36472},
+				pos: position{line: 1340, col: 16, offset: 37020},
 				run: (*parser).callonKeyWordChars1,
 				expr: &charClassMatcher{
-					pos:        position{line: 1323, col: 16, offset: 36472},
+					pos:        position{line: 1340, col: 16, offset: 37020},
 					val:        "[a-zA-Z_.:/%#@~]",
 					chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 					ranges:     []rune{'a', 'z', 'A', 'Z'},
@@ -10534,16 +10693,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1325, col: 1, offset: 36521},
+			pos:  position{line: 1342, col: 1, offset: 37069},
 			expr: &choiceExpr{
-				pos: position{line: 1326, col: 5, offset: 36537},
+				pos: position{line: 1343, col: 5, offset: 37085},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1326, col: 5, offset: 36537},
+						pos:  position{line: 1343, col: 5, offset: 37085},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1327, col: 5, offset: 36554},
+						pos:        position{line: 1344, col: 5, offset: 37102},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10554,30 +10713,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1329, col: 1, offset: 36561},
+			pos:  position{line: 1346, col: 1, offset: 37109},
 			expr: &actionExpr{
-				pos: position{line: 1329, col: 14, offset: 36574},
+				pos: position{line: 1346, col: 14, offset: 37122},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1329, col: 14, offset: 36574},
+					pos: position{line: 1346, col: 14, offset: 37122},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1329, col: 14, offset: 36574},
+							pos:        position{line: 1346, col: 14, offset: 37122},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1329, col: 19, offset: 36579},
+							pos:   position{line: 1346, col: 19, offset: 37127},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1329, col: 22, offset: 36582},
+								pos: position{line: 1346, col: 22, offset: 37130},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1329, col: 22, offset: 36582},
+										pos:  position{line: 1346, col: 22, offset: 37130},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1329, col: 38, offset: 36598},
+										pos:  position{line: 1346, col: 38, offset: 37146},
 										name: "EscapeSequence",
 									},
 								},
@@ -10589,42 +10748,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1331, col: 1, offset: 36634},
+			pos:  position{line: 1348, col: 1, offset: 37182},
 			expr: &actionExpr{
-				pos: position{line: 1332, col: 5, offset: 36650},
+				pos: position{line: 1349, col: 5, offset: 37198},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1332, col: 5, offset: 36650},
+					pos: position{line: 1349, col: 5, offset: 37198},
 					exprs: []interface{}{
 						&andExpr{
-							pos: position{line: 1332, col: 5, offset: 36650},
+							pos: position{line: 1349, col: 5, offset: 37198},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1332, col: 6, offset: 36651},
+								pos:  position{line: 1349, col: 6, offset: 37199},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1332, col: 22, offset: 36667},
+							pos: position{line: 1349, col: 22, offset: 37215},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1332, col: 23, offset: 36668},
+								pos:  position{line: 1349, col: 23, offset: 37216},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1332, col: 35, offset: 36680},
+							pos:   position{line: 1349, col: 35, offset: 37228},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1332, col: 40, offset: 36685},
+								pos:  position{line: 1349, col: 40, offset: 37233},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1332, col: 50, offset: 36695},
+							pos:   position{line: 1349, col: 50, offset: 37243},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1332, col: 55, offset: 36700},
+								pos: position{line: 1349, col: 55, offset: 37248},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1332, col: 55, offset: 36700},
+									pos:  position{line: 1349, col: 55, offset: 37248},
 									name: "GlobRest",
 								},
 							},
@@ -10635,27 +10794,27 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1336, col: 1, offset: 36769},
+			pos:  position{line: 1353, col: 1, offset: 37317},
 			expr: &choiceExpr{
-				pos: position{line: 1336, col: 19, offset: 36787},
+				pos: position{line: 1353, col: 19, offset: 37335},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1336, col: 19, offset: 36787},
+						pos:  position{line: 1353, col: 19, offset: 37335},
 						name: "KeyWordStart",
 					},
 					&seqExpr{
-						pos: position{line: 1336, col: 34, offset: 36802},
+						pos: position{line: 1353, col: 34, offset: 37350},
 						exprs: []interface{}{
 							&oneOrMoreExpr{
-								pos: position{line: 1336, col: 34, offset: 36802},
+								pos: position{line: 1353, col: 34, offset: 37350},
 								expr: &litMatcher{
-									pos:        position{line: 1336, col: 34, offset: 36802},
+									pos:        position{line: 1353, col: 34, offset: 37350},
 									val:        "*",
 									ignoreCase: false,
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1336, col: 39, offset: 36807},
+								pos:  position{line: 1353, col: 39, offset: 37355},
 								name: "KeyWordRest",
 							},
 						},
@@ -10665,19 +10824,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1337, col: 1, offset: 36819},
+			pos:  position{line: 1354, col: 1, offset: 37367},
 			expr: &seqExpr{
-				pos: position{line: 1337, col: 15, offset: 36833},
+				pos: position{line: 1354, col: 15, offset: 37381},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1337, col: 15, offset: 36833},
+						pos: position{line: 1354, col: 15, offset: 37381},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1337, col: 15, offset: 36833},
+							pos:  position{line: 1354, col: 15, offset: 37381},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1337, col: 28, offset: 36846},
+						pos:        position{line: 1354, col: 28, offset: 37394},
 						val:        "*",
 						ignoreCase: false,
 					},
@@ -10686,23 +10845,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1339, col: 1, offset: 36851},
+			pos:  position{line: 1356, col: 1, offset: 37399},
 			expr: &choiceExpr{
-				pos: position{line: 1340, col: 5, offset: 36865},
+				pos: position{line: 1357, col: 5, offset: 37413},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1340, col: 5, offset: 36865},
+						pos:  position{line: 1357, col: 5, offset: 37413},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1341, col: 5, offset: 36882},
+						pos:  position{line: 1358, col: 5, offset: 37430},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1342, col: 5, offset: 36894},
+						pos: position{line: 1359, col: 5, offset: 37442},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1342, col: 5, offset: 36894},
+							pos:        position{line: 1359, col: 5, offset: 37442},
 							val:        "*",
 							ignoreCase: false,
 						},
@@ -10712,16 +10871,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1344, col: 1, offset: 36918},
+			pos:  position{line: 1361, col: 1, offset: 37466},
 			expr: &choiceExpr{
-				pos: position{line: 1345, col: 5, offset: 36931},
+				pos: position{line: 1362, col: 5, offset: 37479},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1345, col: 5, offset: 36931},
+						pos:  position{line: 1362, col: 5, offset: 37479},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1346, col: 5, offset: 36945},
+						pos:        position{line: 1363, col: 5, offset: 37493},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10732,30 +10891,30 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1348, col: 1, offset: 36952},
+			pos:  position{line: 1365, col: 1, offset: 37500},
 			expr: &actionExpr{
-				pos: position{line: 1348, col: 11, offset: 36962},
+				pos: position{line: 1365, col: 11, offset: 37510},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1348, col: 11, offset: 36962},
+					pos: position{line: 1365, col: 11, offset: 37510},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1348, col: 11, offset: 36962},
+							pos:        position{line: 1365, col: 11, offset: 37510},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1348, col: 16, offset: 36967},
+							pos:   position{line: 1365, col: 16, offset: 37515},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1348, col: 19, offset: 36970},
+								pos: position{line: 1365, col: 19, offset: 37518},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1348, col: 19, offset: 36970},
+										pos:  position{line: 1365, col: 19, offset: 37518},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1348, col: 32, offset: 36983},
+										pos:  position{line: 1365, col: 32, offset: 37531},
 										name: "EscapeSequence",
 									},
 								},
@@ -10767,30 +10926,30 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1350, col: 1, offset: 37019},
+			pos:  position{line: 1367, col: 1, offset: 37567},
 			expr: &choiceExpr{
-				pos: position{line: 1351, col: 5, offset: 37034},
+				pos: position{line: 1368, col: 5, offset: 37582},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1351, col: 5, offset: 37034},
+						pos: position{line: 1368, col: 5, offset: 37582},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1351, col: 5, offset: 37034},
+							pos:        position{line: 1368, col: 5, offset: 37582},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1352, col: 5, offset: 37062},
+						pos: position{line: 1369, col: 5, offset: 37610},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1352, col: 5, offset: 37062},
+							pos:        position{line: 1369, col: 5, offset: 37610},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1353, col: 5, offset: 37092},
+						pos:        position{line: 1370, col: 5, offset: 37640},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -10801,55 +10960,55 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1356, col: 1, offset: 37099},
+			pos:  position{line: 1373, col: 1, offset: 37647},
 			expr: &choiceExpr{
-				pos: position{line: 1357, col: 5, offset: 37120},
+				pos: position{line: 1374, col: 5, offset: 37668},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1357, col: 5, offset: 37120},
+						pos: position{line: 1374, col: 5, offset: 37668},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1357, col: 5, offset: 37120},
+							pos: position{line: 1374, col: 5, offset: 37668},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1357, col: 5, offset: 37120},
+									pos: position{line: 1374, col: 5, offset: 37668},
 									expr: &choiceExpr{
-										pos: position{line: 1357, col: 7, offset: 37122},
+										pos: position{line: 1374, col: 7, offset: 37670},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1357, col: 7, offset: 37122},
+												pos:        position{line: 1374, col: 7, offset: 37670},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1357, col: 13, offset: 37128},
+												pos:  position{line: 1374, col: 13, offset: 37676},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1357, col: 26, offset: 37141,
+									line: 1374, col: 26, offset: 37689,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1358, col: 5, offset: 37178},
+						pos: position{line: 1375, col: 5, offset: 37726},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1358, col: 5, offset: 37178},
+							pos: position{line: 1375, col: 5, offset: 37726},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1358, col: 5, offset: 37178},
+									pos:        position{line: 1375, col: 5, offset: 37726},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1358, col: 10, offset: 37183},
+									pos:   position{line: 1375, col: 10, offset: 37731},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1358, col: 12, offset: 37185},
+										pos:  position{line: 1375, col: 12, offset: 37733},
 										name: "EscapeSequence",
 									},
 								},
@@ -10861,16 +11020,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1360, col: 1, offset: 37219},
+			pos:  position{line: 1377, col: 1, offset: 37767},
 			expr: &choiceExpr{
-				pos: position{line: 1361, col: 5, offset: 37238},
+				pos: position{line: 1378, col: 5, offset: 37786},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1361, col: 5, offset: 37238},
+						pos:  position{line: 1378, col: 5, offset: 37786},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1362, col: 5, offset: 37259},
+						pos:  position{line: 1379, col: 5, offset: 37807},
 						name: "UnicodeEscape",
 					},
 				},
@@ -10878,79 +11037,79 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1364, col: 1, offset: 37274},
+			pos:  position{line: 1381, col: 1, offset: 37822},
 			expr: &choiceExpr{
-				pos: position{line: 1365, col: 5, offset: 37295},
+				pos: position{line: 1382, col: 5, offset: 37843},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1365, col: 5, offset: 37295},
+						pos:        position{line: 1382, col: 5, offset: 37843},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1366, col: 5, offset: 37303},
+						pos: position{line: 1383, col: 5, offset: 37851},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1366, col: 5, offset: 37303},
+							pos:        position{line: 1383, col: 5, offset: 37851},
 							val:        "\"",
 							ignoreCase: false,
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1367, col: 5, offset: 37343},
+						pos:        position{line: 1384, col: 5, offset: 37891},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1368, col: 5, offset: 37352},
+						pos: position{line: 1385, col: 5, offset: 37900},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1368, col: 5, offset: 37352},
+							pos:        position{line: 1385, col: 5, offset: 37900},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1369, col: 5, offset: 37381},
+						pos: position{line: 1386, col: 5, offset: 37929},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1369, col: 5, offset: 37381},
+							pos:        position{line: 1386, col: 5, offset: 37929},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1370, col: 5, offset: 37410},
+						pos: position{line: 1387, col: 5, offset: 37958},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1370, col: 5, offset: 37410},
+							pos:        position{line: 1387, col: 5, offset: 37958},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1371, col: 5, offset: 37439},
+						pos: position{line: 1388, col: 5, offset: 37987},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1371, col: 5, offset: 37439},
+							pos:        position{line: 1388, col: 5, offset: 37987},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1372, col: 5, offset: 37468},
+						pos: position{line: 1389, col: 5, offset: 38016},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1372, col: 5, offset: 37468},
+							pos:        position{line: 1389, col: 5, offset: 38016},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1373, col: 5, offset: 37497},
+						pos: position{line: 1390, col: 5, offset: 38045},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1373, col: 5, offset: 37497},
+							pos:        position{line: 1390, col: 5, offset: 38045},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -10960,30 +11119,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1375, col: 1, offset: 37523},
+			pos:  position{line: 1392, col: 1, offset: 38071},
 			expr: &choiceExpr{
-				pos: position{line: 1376, col: 5, offset: 37541},
+				pos: position{line: 1393, col: 5, offset: 38089},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1376, col: 5, offset: 37541},
+						pos: position{line: 1393, col: 5, offset: 38089},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1376, col: 5, offset: 37541},
+							pos:        position{line: 1393, col: 5, offset: 38089},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1377, col: 5, offset: 37569},
+						pos: position{line: 1394, col: 5, offset: 38117},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1377, col: 5, offset: 37569},
+							pos:        position{line: 1394, col: 5, offset: 38117},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1378, col: 5, offset: 37597},
+						pos:        position{line: 1395, col: 5, offset: 38145},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -10994,41 +11153,41 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1380, col: 1, offset: 37603},
+			pos:  position{line: 1397, col: 1, offset: 38151},
 			expr: &choiceExpr{
-				pos: position{line: 1381, col: 5, offset: 37621},
+				pos: position{line: 1398, col: 5, offset: 38169},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1381, col: 5, offset: 37621},
+						pos: position{line: 1398, col: 5, offset: 38169},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1381, col: 5, offset: 37621},
+							pos: position{line: 1398, col: 5, offset: 38169},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1381, col: 5, offset: 37621},
+									pos:        position{line: 1398, col: 5, offset: 38169},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1381, col: 9, offset: 37625},
+									pos:   position{line: 1398, col: 9, offset: 38173},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1381, col: 16, offset: 37632},
+										pos: position{line: 1398, col: 16, offset: 38180},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1381, col: 16, offset: 37632},
+												pos:  position{line: 1398, col: 16, offset: 38180},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1381, col: 25, offset: 37641},
+												pos:  position{line: 1398, col: 25, offset: 38189},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1381, col: 34, offset: 37650},
+												pos:  position{line: 1398, col: 34, offset: 38198},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1381, col: 43, offset: 37659},
+												pos:  position{line: 1398, col: 43, offset: 38207},
 												name: "HexDigit",
 											},
 										},
@@ -11038,63 +11197,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1384, col: 5, offset: 37722},
+						pos: position{line: 1401, col: 5, offset: 38270},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1384, col: 5, offset: 37722},
+							pos: position{line: 1401, col: 5, offset: 38270},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1384, col: 5, offset: 37722},
+									pos:        position{line: 1401, col: 5, offset: 38270},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1384, col: 9, offset: 37726},
+									pos:        position{line: 1401, col: 9, offset: 38274},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1384, col: 13, offset: 37730},
+									pos:   position{line: 1401, col: 13, offset: 38278},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1384, col: 20, offset: 37737},
+										pos: position{line: 1401, col: 20, offset: 38285},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1384, col: 20, offset: 37737},
+												pos:  position{line: 1401, col: 20, offset: 38285},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1384, col: 29, offset: 37746},
+												pos: position{line: 1401, col: 29, offset: 38294},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1384, col: 29, offset: 37746},
+													pos:  position{line: 1401, col: 29, offset: 38294},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1384, col: 39, offset: 37756},
+												pos: position{line: 1401, col: 39, offset: 38304},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1384, col: 39, offset: 37756},
+													pos:  position{line: 1401, col: 39, offset: 38304},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1384, col: 49, offset: 37766},
+												pos: position{line: 1401, col: 49, offset: 38314},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1384, col: 49, offset: 37766},
+													pos:  position{line: 1401, col: 49, offset: 38314},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1384, col: 59, offset: 37776},
+												pos: position{line: 1401, col: 59, offset: 38324},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1384, col: 59, offset: 37776},
+													pos:  position{line: 1401, col: 59, offset: 38324},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1384, col: 69, offset: 37786},
+												pos: position{line: 1401, col: 69, offset: 38334},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1384, col: 69, offset: 37786},
+													pos:  position{line: 1401, col: 69, offset: 38334},
 													name: "HexDigit",
 												},
 											},
@@ -11102,7 +11261,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1384, col: 80, offset: 37797},
+									pos:        position{line: 1401, col: 80, offset: 38345},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -11114,35 +11273,35 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPattern",
-			pos:  position{line: 1388, col: 1, offset: 37851},
+			pos:  position{line: 1405, col: 1, offset: 38399},
 			expr: &actionExpr{
-				pos: position{line: 1389, col: 5, offset: 37869},
+				pos: position{line: 1406, col: 5, offset: 38417},
 				run: (*parser).callonRegexpPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1389, col: 5, offset: 37869},
+					pos: position{line: 1406, col: 5, offset: 38417},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1389, col: 5, offset: 37869},
+							pos:        position{line: 1406, col: 5, offset: 38417},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1389, col: 9, offset: 37873},
+							pos:   position{line: 1406, col: 9, offset: 38421},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1389, col: 14, offset: 37878},
+								pos:  position{line: 1406, col: 14, offset: 38426},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1389, col: 25, offset: 37889},
+							pos:        position{line: 1406, col: 25, offset: 38437},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1389, col: 29, offset: 37893},
+							pos: position{line: 1406, col: 29, offset: 38441},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1389, col: 30, offset: 37894},
+								pos:  position{line: 1406, col: 30, offset: 38442},
 								name: "KeyWordStart",
 							},
 						},
@@ -11152,32 +11311,32 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1391, col: 1, offset: 37929},
+			pos:  position{line: 1408, col: 1, offset: 38477},
 			expr: &actionExpr{
-				pos: position{line: 1392, col: 5, offset: 37944},
+				pos: position{line: 1409, col: 5, offset: 38492},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1392, col: 5, offset: 37944},
+					pos: position{line: 1409, col: 5, offset: 38492},
 					expr: &choiceExpr{
-						pos: position{line: 1392, col: 6, offset: 37945},
+						pos: position{line: 1409, col: 6, offset: 38493},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 1392, col: 6, offset: 37945},
+								pos:        position{line: 1409, col: 6, offset: 38493},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&seqExpr{
-								pos: position{line: 1392, col: 15, offset: 37954},
+								pos: position{line: 1409, col: 15, offset: 38502},
 								exprs: []interface{}{
 									&litMatcher{
-										pos:        position{line: 1392, col: 15, offset: 37954},
+										pos:        position{line: 1409, col: 15, offset: 38502},
 										val:        "\\",
 										ignoreCase: false,
 									},
 									&anyMatcher{
-										line: 1392, col: 20, offset: 37959,
+										line: 1409, col: 20, offset: 38507,
 									},
 								},
 							},
@@ -11188,9 +11347,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1394, col: 1, offset: 37995},
+			pos:  position{line: 1411, col: 1, offset: 38543},
 			expr: &charClassMatcher{
-				pos:        position{line: 1395, col: 5, offset: 38011},
+				pos:        position{line: 1412, col: 5, offset: 38559},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -11200,42 +11359,42 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1397, col: 1, offset: 38026},
+			pos:  position{line: 1414, col: 1, offset: 38574},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1397, col: 6, offset: 38031},
+				pos: position{line: 1414, col: 6, offset: 38579},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1397, col: 6, offset: 38031},
+					pos:  position{line: 1414, col: 6, offset: 38579},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 1399, col: 1, offset: 38042},
+			pos:  position{line: 1416, col: 1, offset: 38590},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1399, col: 6, offset: 38047},
+				pos: position{line: 1416, col: 6, offset: 38595},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1399, col: 6, offset: 38047},
+					pos:  position{line: 1416, col: 6, offset: 38595},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1401, col: 1, offset: 38058},
+			pos:  position{line: 1418, col: 1, offset: 38606},
 			expr: &choiceExpr{
-				pos: position{line: 1402, col: 5, offset: 38071},
+				pos: position{line: 1419, col: 5, offset: 38619},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1402, col: 5, offset: 38071},
+						pos:  position{line: 1419, col: 5, offset: 38619},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1403, col: 5, offset: 38086},
+						pos:  position{line: 1420, col: 5, offset: 38634},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1404, col: 5, offset: 38105},
+						pos:  position{line: 1421, col: 5, offset: 38653},
 						name: "Comment",
 					},
 				},
@@ -11243,45 +11402,45 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1406, col: 1, offset: 38114},
+			pos:  position{line: 1423, col: 1, offset: 38662},
 			expr: &anyMatcher{
-				line: 1407, col: 5, offset: 38134,
+				line: 1424, col: 5, offset: 38682,
 			},
 		},
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1409, col: 1, offset: 38137},
+			pos:         position{line: 1426, col: 1, offset: 38685},
 			expr: &choiceExpr{
-				pos: position{line: 1410, col: 5, offset: 38165},
+				pos: position{line: 1427, col: 5, offset: 38713},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1410, col: 5, offset: 38165},
+						pos:        position{line: 1427, col: 5, offset: 38713},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1411, col: 5, offset: 38174},
+						pos:        position{line: 1428, col: 5, offset: 38722},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1412, col: 5, offset: 38183},
+						pos:        position{line: 1429, col: 5, offset: 38731},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1413, col: 5, offset: 38192},
+						pos:        position{line: 1430, col: 5, offset: 38740},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1414, col: 5, offset: 38200},
+						pos:        position{line: 1431, col: 5, offset: 38748},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1415, col: 5, offset: 38213},
+						pos:        position{line: 1432, col: 5, offset: 38761},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -11290,9 +11449,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1417, col: 1, offset: 38223},
+			pos:  position{line: 1434, col: 1, offset: 38771},
 			expr: &charClassMatcher{
-				pos:        position{line: 1418, col: 5, offset: 38242},
+				pos:        position{line: 1435, col: 5, offset: 38790},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -11302,45 +11461,45 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1424, col: 1, offset: 38572},
+			pos:         position{line: 1441, col: 1, offset: 39120},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1427, col: 5, offset: 38643},
+				pos:  position{line: 1444, col: 5, offset: 39191},
 				name: "SingleLineComment",
 			},
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1429, col: 1, offset: 38662},
+			pos:  position{line: 1446, col: 1, offset: 39210},
 			expr: &seqExpr{
-				pos: position{line: 1430, col: 5, offset: 38683},
+				pos: position{line: 1447, col: 5, offset: 39231},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1430, col: 5, offset: 38683},
+						pos:        position{line: 1447, col: 5, offset: 39231},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1430, col: 10, offset: 38688},
+						pos: position{line: 1447, col: 10, offset: 39236},
 						expr: &seqExpr{
-							pos: position{line: 1430, col: 11, offset: 38689},
+							pos: position{line: 1447, col: 11, offset: 39237},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1430, col: 11, offset: 38689},
+									pos: position{line: 1447, col: 11, offset: 39237},
 									expr: &litMatcher{
-										pos:        position{line: 1430, col: 12, offset: 38690},
+										pos:        position{line: 1447, col: 12, offset: 39238},
 										val:        "*/",
 										ignoreCase: false,
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1430, col: 17, offset: 38695},
+									pos:  position{line: 1447, col: 17, offset: 39243},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1430, col: 35, offset: 38713},
+						pos:        position{line: 1447, col: 35, offset: 39261},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -11349,29 +11508,29 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1432, col: 1, offset: 38719},
+			pos:  position{line: 1449, col: 1, offset: 39267},
 			expr: &seqExpr{
-				pos: position{line: 1433, col: 5, offset: 38741},
+				pos: position{line: 1450, col: 5, offset: 39289},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1433, col: 5, offset: 38741},
+						pos:        position{line: 1450, col: 5, offset: 39289},
 						val:        "//",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1433, col: 10, offset: 38746},
+						pos: position{line: 1450, col: 10, offset: 39294},
 						expr: &seqExpr{
-							pos: position{line: 1433, col: 11, offset: 38747},
+							pos: position{line: 1450, col: 11, offset: 39295},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1433, col: 11, offset: 38747},
+									pos: position{line: 1450, col: 11, offset: 39295},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1433, col: 12, offset: 38748},
+										pos:  position{line: 1450, col: 12, offset: 39296},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1433, col: 27, offset: 38763},
+									pos:  position{line: 1450, col: 27, offset: 39311},
 									name: "SourceCharacter",
 								},
 							},
@@ -11382,19 +11541,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1435, col: 1, offset: 38782},
+			pos:  position{line: 1452, col: 1, offset: 39330},
 			expr: &seqExpr{
-				pos: position{line: 1435, col: 7, offset: 38788},
+				pos: position{line: 1452, col: 7, offset: 39336},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1435, col: 7, offset: 38788},
+						pos: position{line: 1452, col: 7, offset: 39336},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1435, col: 7, offset: 38788},
+							pos:  position{line: 1452, col: 7, offset: 39336},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1435, col: 19, offset: 38800},
+						pos:  position{line: 1452, col: 19, offset: 39348},
 						name: "LineTerminator",
 					},
 				},
@@ -11402,16 +11561,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1437, col: 1, offset: 38816},
+			pos:  position{line: 1454, col: 1, offset: 39364},
 			expr: &choiceExpr{
-				pos: position{line: 1437, col: 7, offset: 38822},
+				pos: position{line: 1454, col: 7, offset: 39370},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1437, col: 7, offset: 38822},
+						pos:  position{line: 1454, col: 7, offset: 39370},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1437, col: 11, offset: 38826},
+						pos:  position{line: 1454, col: 11, offset: 39374},
 						name: "EOF",
 					},
 				},
@@ -11419,21 +11578,21 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1439, col: 1, offset: 38831},
+			pos:  position{line: 1456, col: 1, offset: 39379},
 			expr: &notExpr{
-				pos: position{line: 1439, col: 7, offset: 38837},
+				pos: position{line: 1456, col: 7, offset: 39385},
 				expr: &anyMatcher{
-					line: 1439, col: 8, offset: 38838,
+					line: 1456, col: 8, offset: 39386,
 				},
 			},
 		},
 		{
 			name: "EOKW",
-			pos:  position{line: 1441, col: 1, offset: 38841},
+			pos:  position{line: 1458, col: 1, offset: 39389},
 			expr: &notExpr{
-				pos: position{line: 1441, col: 8, offset: 38848},
+				pos: position{line: 1458, col: 8, offset: 39396},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1441, col: 9, offset: 38849},
+					pos:  position{line: 1458, col: 9, offset: 39397},
 					name: "KeyWordChars",
 				},
 			},
@@ -13119,15 +13278,15 @@ func (p *parser) callonCast1() (interface{}, error) {
 	return p.cur.onCast1(stack["typ"], stack["expr"])
 }
 
-func (c *current) onFunction3(fn, args, where interface{}) (interface{}, error) {
+func (c *current) onFunction4(fn, args, where interface{}) (interface{}, error) {
 	return map[string]interface{}{"kind": "Call", "name": fn, "args": args, "where": where}, nil
 
 }
 
-func (p *parser) callonFunction3() (interface{}, error) {
+func (p *parser) callonFunction4() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onFunction3(stack["fn"], stack["args"], stack["where"])
+	return p.cur.onFunction4(stack["fn"], stack["args"], stack["where"])
 }
 
 func (c *current) onFunctionArgs2(o interface{}) (interface{}, error) {
@@ -13164,6 +13323,58 @@ func (p *parser) callonPattern4() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onPattern4(stack["s"])
+}
+
+func (c *current) onRegexpFunc1(args, where interface{}) (interface{}, error) {
+	return map[string]interface{}{"kind": "Call", "name": "regexp", "args": args, "where": where}, nil
+
+}
+
+func (p *parser) callonRegexpFunc1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onRegexpFunc1(stack["args"], stack["where"])
+}
+
+func (c *current) onRegexpFuncArgs8(e interface{}) (interface{}, error) {
+	return e, nil
+}
+
+func (p *parser) callonRegexpFuncArgs8() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onRegexpFuncArgs8(stack["e"])
+}
+
+func (c *current) onRegexpFuncArgs2(first, rest interface{}) (interface{}, error) {
+	return append([]interface{}{first}, (rest.([]interface{}))...), nil
+
+}
+
+func (p *parser) callonRegexpFuncArgs2() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onRegexpFuncArgs2(stack["first"], stack["rest"])
+}
+
+func (c *current) onRegexpFuncArgs15() (interface{}, error) {
+	return []interface{}{}, nil
+}
+
+func (p *parser) callonRegexpFuncArgs15() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onRegexpFuncArgs15()
+}
+
+func (c *current) onRegexpFuncArg2(v interface{}) (interface{}, error) {
+	return map[string]interface{}{"kind": "Primitive", "type": "string", "text": v}, nil
+}
+
+func (p *parser) callonRegexpFuncArg2() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onRegexpFuncArg2(stack["v"])
 }
 
 func (c *current) onOptionalExprs3() (interface{}, error) {

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -5384,68 +5384,140 @@ var g = &grammar{
 						pos:  position{line: 716, col: 5, offset: 20881},
 						name: "Grep",
 					},
-					&ruleRefExpr{
-						pos:  position{line: 717, col: 5, offset: 20890},
-						name: "RegexpFunc",
-					},
 					&actionExpr{
-						pos: position{line: 718, col: 5, offset: 20905},
-						run: (*parser).callonFunction4,
+						pos: position{line: 718, col: 5, offset: 20936},
+						run: (*parser).callonFunction3,
 						expr: &seqExpr{
-							pos: position{line: 718, col: 5, offset: 20905},
+							pos: position{line: 718, col: 5, offset: 20936},
 							exprs: []interface{}{
-								&notExpr{
-									pos: position{line: 718, col: 5, offset: 20905},
-									expr: &ruleRefExpr{
-										pos:  position{line: 718, col: 6, offset: 20906},
-										name: "FuncGuard",
-									},
-								},
-								&labeledExpr{
-									pos:   position{line: 718, col: 16, offset: 20916},
-									label: "fn",
-									expr: &ruleRefExpr{
-										pos:  position{line: 718, col: 19, offset: 20919},
-										name: "IdentifierName",
-									},
+								&litMatcher{
+									pos:        position{line: 718, col: 5, offset: 20936},
+									val:        "regexp",
+									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 718, col: 34, offset: 20934},
+									pos:  position{line: 718, col: 14, offset: 20945},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 718, col: 37, offset: 20937},
+									pos:        position{line: 718, col: 17, offset: 20948},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 718, col: 41, offset: 20941},
+									pos:  position{line: 718, col: 21, offset: 20952},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 718, col: 44, offset: 20944},
-									label: "args",
+									pos:   position{line: 718, col: 24, offset: 20955},
+									label: "arg0Text",
 									expr: &ruleRefExpr{
-										pos:  position{line: 718, col: 49, offset: 20949},
-										name: "FunctionArgs",
+										pos:  position{line: 718, col: 33, offset: 20964},
+										name: "RegexpPattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 718, col: 62, offset: 20962},
+									pos:  position{line: 718, col: 47, offset: 20978},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 718, col: 65, offset: 20965},
+									pos:        position{line: 718, col: 50, offset: 20981},
+									val:        ",",
+									ignoreCase: false,
+								},
+								&ruleRefExpr{
+									pos:  position{line: 718, col: 54, offset: 20985},
+									name: "__",
+								},
+								&labeledExpr{
+									pos:   position{line: 718, col: 57, offset: 20988},
+									label: "arg1",
+									expr: &ruleRefExpr{
+										pos:  position{line: 718, col: 62, offset: 20993},
+										name: "Expr",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 718, col: 67, offset: 20998},
+									name: "__",
+								},
+								&litMatcher{
+									pos:        position{line: 718, col: 70, offset: 21001},
 									val:        ")",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 718, col: 69, offset: 20969},
+									pos:   position{line: 718, col: 74, offset: 21005},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 718, col: 75, offset: 20975},
+										pos: position{line: 718, col: 80, offset: 21011},
 										expr: &ruleRefExpr{
-											pos:  position{line: 718, col: 75, offset: 20975},
+											pos:  position{line: 718, col: 80, offset: 21011},
+											name: "WhereClause",
+										},
+									},
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 722, col: 5, offset: 21259},
+						run: (*parser).callonFunction21,
+						expr: &seqExpr{
+							pos: position{line: 722, col: 5, offset: 21259},
+							exprs: []interface{}{
+								&notExpr{
+									pos: position{line: 722, col: 5, offset: 21259},
+									expr: &ruleRefExpr{
+										pos:  position{line: 722, col: 6, offset: 21260},
+										name: "FuncGuard",
+									},
+								},
+								&labeledExpr{
+									pos:   position{line: 722, col: 16, offset: 21270},
+									label: "fn",
+									expr: &ruleRefExpr{
+										pos:  position{line: 722, col: 19, offset: 21273},
+										name: "IdentifierName",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 722, col: 34, offset: 21288},
+									name: "__",
+								},
+								&litMatcher{
+									pos:        position{line: 722, col: 37, offset: 21291},
+									val:        "(",
+									ignoreCase: false,
+								},
+								&ruleRefExpr{
+									pos:  position{line: 722, col: 41, offset: 21295},
+									name: "__",
+								},
+								&labeledExpr{
+									pos:   position{line: 722, col: 44, offset: 21298},
+									label: "args",
+									expr: &ruleRefExpr{
+										pos:  position{line: 722, col: 49, offset: 21303},
+										name: "FunctionArgs",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 722, col: 62, offset: 21316},
+									name: "__",
+								},
+								&litMatcher{
+									pos:        position{line: 722, col: 65, offset: 21319},
+									val:        ")",
+									ignoreCase: false,
+								},
+								&labeledExpr{
+									pos:   position{line: 722, col: 69, offset: 21323},
+									label: "where",
+									expr: &zeroOrOneExpr{
+										pos: position{line: 722, col: 75, offset: 21329},
+										expr: &ruleRefExpr{
+											pos:  position{line: 722, col: 75, offset: 21329},
 											name: "WhereClause",
 										},
 									},
@@ -5458,24 +5530,24 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionArgs",
-			pos:  position{line: 722, col: 1, offset: 21096},
+			pos:  position{line: 726, col: 1, offset: 21450},
 			expr: &choiceExpr{
-				pos: position{line: 723, col: 5, offset: 21113},
+				pos: position{line: 727, col: 5, offset: 21467},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 723, col: 5, offset: 21113},
+						pos: position{line: 727, col: 5, offset: 21467},
 						run: (*parser).callonFunctionArgs2,
 						expr: &labeledExpr{
-							pos:   position{line: 723, col: 5, offset: 21113},
+							pos:   position{line: 727, col: 5, offset: 21467},
 							label: "o",
 							expr: &ruleRefExpr{
-								pos:  position{line: 723, col: 7, offset: 21115},
+								pos:  position{line: 727, col: 7, offset: 21469},
 								name: "OverExpr",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 724, col: 5, offset: 21161},
+						pos:  position{line: 728, col: 5, offset: 21515},
 						name: "OptionalExprs",
 					},
 				},
@@ -5483,75 +5555,75 @@ var g = &grammar{
 		},
 		{
 			name: "Grep",
-			pos:  position{line: 726, col: 1, offset: 21176},
+			pos:  position{line: 730, col: 1, offset: 21530},
 			expr: &actionExpr{
-				pos: position{line: 727, col: 5, offset: 21185},
+				pos: position{line: 731, col: 5, offset: 21539},
 				run: (*parser).callonGrep1,
 				expr: &seqExpr{
-					pos: position{line: 727, col: 5, offset: 21185},
+					pos: position{line: 731, col: 5, offset: 21539},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 727, col: 5, offset: 21185},
+							pos:        position{line: 731, col: 5, offset: 21539},
 							val:        "grep",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 727, col: 12, offset: 21192},
+							pos:  position{line: 731, col: 12, offset: 21546},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 727, col: 15, offset: 21195},
+							pos:        position{line: 731, col: 15, offset: 21549},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 727, col: 19, offset: 21199},
+							pos:  position{line: 731, col: 19, offset: 21553},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 727, col: 22, offset: 21202},
+							pos:   position{line: 731, col: 22, offset: 21556},
 							label: "pattern",
 							expr: &ruleRefExpr{
-								pos:  position{line: 727, col: 30, offset: 21210},
+								pos:  position{line: 731, col: 30, offset: 21564},
 								name: "Pattern",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 727, col: 38, offset: 21218},
+							pos:  position{line: 731, col: 38, offset: 21572},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 727, col: 42, offset: 21222},
+							pos:   position{line: 731, col: 42, offset: 21576},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 727, col: 46, offset: 21226},
+								pos: position{line: 731, col: 46, offset: 21580},
 								expr: &seqExpr{
-									pos: position{line: 727, col: 47, offset: 21227},
+									pos: position{line: 731, col: 47, offset: 21581},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 727, col: 47, offset: 21227},
+											pos:        position{line: 731, col: 47, offset: 21581},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 727, col: 51, offset: 21231},
+											pos:  position{line: 731, col: 51, offset: 21585},
 											name: "__",
 										},
 										&choiceExpr{
-											pos: position{line: 727, col: 56, offset: 21236},
+											pos: position{line: 731, col: 56, offset: 21590},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 727, col: 56, offset: 21236},
+													pos:  position{line: 731, col: 56, offset: 21590},
 													name: "OverExpr",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 727, col: 67, offset: 21247},
+													pos:  position{line: 731, col: 67, offset: 21601},
 													name: "Expr",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 727, col: 73, offset: 21253},
+											pos:  position{line: 731, col: 73, offset: 21607},
 											name: "__",
 										},
 									},
@@ -5559,7 +5631,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 727, col: 78, offset: 21258},
+							pos:        position{line: 731, col: 78, offset: 21612},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -5569,26 +5641,26 @@ var g = &grammar{
 		},
 		{
 			name: "Pattern",
-			pos:  position{line: 735, col: 1, offset: 21499},
+			pos:  position{line: 739, col: 1, offset: 21853},
 			expr: &choiceExpr{
-				pos: position{line: 736, col: 5, offset: 21511},
+				pos: position{line: 740, col: 5, offset: 21865},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 736, col: 5, offset: 21511},
+						pos:  position{line: 740, col: 5, offset: 21865},
 						name: "Regexp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 737, col: 5, offset: 21522},
+						pos:  position{line: 741, col: 5, offset: 21876},
 						name: "Glob",
 					},
 					&actionExpr{
-						pos: position{line: 738, col: 5, offset: 21531},
+						pos: position{line: 742, col: 5, offset: 21885},
 						run: (*parser).callonPattern4,
 						expr: &labeledExpr{
-							pos:   position{line: 738, col: 5, offset: 21531},
+							pos:   position{line: 742, col: 5, offset: 21885},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 738, col: 7, offset: 21533},
+								pos:  position{line: 742, col: 7, offset: 21887},
 								name: "QuotedString",
 							},
 						},
@@ -5597,175 +5669,20 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "RegexpFunc",
-			pos:  position{line: 742, col: 1, offset: 21625},
-			expr: &actionExpr{
-				pos: position{line: 743, col: 5, offset: 21640},
-				run: (*parser).callonRegexpFunc1,
-				expr: &seqExpr{
-					pos: position{line: 743, col: 5, offset: 21640},
-					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 743, col: 5, offset: 21640},
-							val:        "regexp",
-							ignoreCase: false,
-						},
-						&ruleRefExpr{
-							pos:  position{line: 743, col: 14, offset: 21649},
-							name: "__",
-						},
-						&litMatcher{
-							pos:        position{line: 743, col: 17, offset: 21652},
-							val:        "(",
-							ignoreCase: false,
-						},
-						&ruleRefExpr{
-							pos:  position{line: 743, col: 21, offset: 21656},
-							name: "__",
-						},
-						&labeledExpr{
-							pos:   position{line: 743, col: 24, offset: 21659},
-							label: "args",
-							expr: &ruleRefExpr{
-								pos:  position{line: 743, col: 29, offset: 21664},
-								name: "RegexpFuncArgs",
-							},
-						},
-						&ruleRefExpr{
-							pos:  position{line: 743, col: 44, offset: 21679},
-							name: "__",
-						},
-						&litMatcher{
-							pos:        position{line: 743, col: 47, offset: 21682},
-							val:        ")",
-							ignoreCase: false,
-						},
-						&labeledExpr{
-							pos:   position{line: 743, col: 51, offset: 21686},
-							label: "where",
-							expr: &zeroOrOneExpr{
-								pos: position{line: 743, col: 57, offset: 21692},
-								expr: &ruleRefExpr{
-									pos:  position{line: 743, col: 57, offset: 21692},
-									name: "WhereClause",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "RegexpFuncArgs",
-			pos:  position{line: 747, col: 1, offset: 21819},
-			expr: &choiceExpr{
-				pos: position{line: 748, col: 5, offset: 21838},
-				alternatives: []interface{}{
-					&actionExpr{
-						pos: position{line: 748, col: 5, offset: 21838},
-						run: (*parser).callonRegexpFuncArgs2,
-						expr: &seqExpr{
-							pos: position{line: 748, col: 5, offset: 21838},
-							exprs: []interface{}{
-								&labeledExpr{
-									pos:   position{line: 748, col: 5, offset: 21838},
-									label: "first",
-									expr: &ruleRefExpr{
-										pos:  position{line: 748, col: 11, offset: 21844},
-										name: "RegexpFuncArg",
-									},
-								},
-								&labeledExpr{
-									pos:   position{line: 748, col: 25, offset: 21858},
-									label: "rest",
-									expr: &zeroOrMoreExpr{
-										pos: position{line: 748, col: 30, offset: 21863},
-										expr: &actionExpr{
-											pos: position{line: 748, col: 31, offset: 21864},
-											run: (*parser).callonRegexpFuncArgs8,
-											expr: &seqExpr{
-												pos: position{line: 748, col: 31, offset: 21864},
-												exprs: []interface{}{
-													&ruleRefExpr{
-														pos:  position{line: 748, col: 31, offset: 21864},
-														name: "__",
-													},
-													&litMatcher{
-														pos:        position{line: 748, col: 34, offset: 21867},
-														val:        ",",
-														ignoreCase: false,
-													},
-													&ruleRefExpr{
-														pos:  position{line: 748, col: 38, offset: 21871},
-														name: "__",
-													},
-													&labeledExpr{
-														pos:   position{line: 748, col: 41, offset: 21874},
-														label: "e",
-														expr: &ruleRefExpr{
-															pos:  position{line: 748, col: 43, offset: 21876},
-															name: "Expr",
-														},
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 751, col: 5, offset: 21988},
-						run: (*parser).callonRegexpFuncArgs15,
-						expr: &ruleRefExpr{
-							pos:  position{line: 751, col: 5, offset: 21988},
-							name: "__",
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "RegexpFuncArg",
-			pos:  position{line: 753, col: 1, offset: 22024},
-			expr: &choiceExpr{
-				pos: position{line: 754, col: 5, offset: 22042},
-				alternatives: []interface{}{
-					&actionExpr{
-						pos: position{line: 754, col: 5, offset: 22042},
-						run: (*parser).callonRegexpFuncArg2,
-						expr: &labeledExpr{
-							pos:   position{line: 754, col: 5, offset: 22042},
-							label: "v",
-							expr: &ruleRefExpr{
-								pos:  position{line: 754, col: 7, offset: 22044},
-								name: "RegexpPattern",
-							},
-						},
-					},
-					&ruleRefExpr{
-						pos:  position{line: 755, col: 5, offset: 22151},
-						name: "Expr",
-					},
-				},
-			},
-		},
-		{
 			name: "OptionalExprs",
-			pos:  position{line: 758, col: 1, offset: 22158},
+			pos:  position{line: 746, col: 1, offset: 21979},
 			expr: &choiceExpr{
-				pos: position{line: 759, col: 5, offset: 22176},
+				pos: position{line: 747, col: 5, offset: 21997},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 759, col: 5, offset: 22176},
+						pos:  position{line: 747, col: 5, offset: 21997},
 						name: "Exprs",
 					},
 					&actionExpr{
-						pos: position{line: 760, col: 5, offset: 22186},
+						pos: position{line: 748, col: 5, offset: 22007},
 						run: (*parser).callonOptionalExprs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 760, col: 5, offset: 22186},
+							pos:  position{line: 748, col: 5, offset: 22007},
 							name: "__",
 						},
 					},
@@ -5774,50 +5691,50 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 762, col: 1, offset: 22222},
+			pos:  position{line: 750, col: 1, offset: 22043},
 			expr: &actionExpr{
-				pos: position{line: 763, col: 5, offset: 22232},
+				pos: position{line: 751, col: 5, offset: 22053},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 763, col: 5, offset: 22232},
+					pos: position{line: 751, col: 5, offset: 22053},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 763, col: 5, offset: 22232},
+							pos:   position{line: 751, col: 5, offset: 22053},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 763, col: 11, offset: 22238},
+								pos:  position{line: 751, col: 11, offset: 22059},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 763, col: 16, offset: 22243},
+							pos:   position{line: 751, col: 16, offset: 22064},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 763, col: 21, offset: 22248},
+								pos: position{line: 751, col: 21, offset: 22069},
 								expr: &actionExpr{
-									pos: position{line: 763, col: 22, offset: 22249},
+									pos: position{line: 751, col: 22, offset: 22070},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 763, col: 22, offset: 22249},
+										pos: position{line: 751, col: 22, offset: 22070},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 763, col: 22, offset: 22249},
+												pos:  position{line: 751, col: 22, offset: 22070},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 763, col: 25, offset: 22252},
+												pos:        position{line: 751, col: 25, offset: 22073},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 763, col: 29, offset: 22256},
+												pos:  position{line: 751, col: 29, offset: 22077},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 763, col: 32, offset: 22259},
+												pos:   position{line: 751, col: 32, offset: 22080},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 763, col: 34, offset: 22261},
+													pos:  position{line: 751, col: 34, offset: 22082},
 													name: "Expr",
 												},
 											},
@@ -5832,35 +5749,35 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 767, col: 1, offset: 22370},
+			pos:  position{line: 755, col: 1, offset: 22191},
 			expr: &actionExpr{
-				pos: position{line: 768, col: 5, offset: 22384},
+				pos: position{line: 756, col: 5, offset: 22205},
 				run: (*parser).callonDerefExpr1,
 				expr: &seqExpr{
-					pos: position{line: 768, col: 5, offset: 22384},
+					pos: position{line: 756, col: 5, offset: 22205},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 768, col: 5, offset: 22384},
+							pos: position{line: 756, col: 5, offset: 22205},
 							expr: &ruleRefExpr{
-								pos:  position{line: 768, col: 6, offset: 22385},
+								pos:  position{line: 756, col: 6, offset: 22206},
 								name: "IP6",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 768, col: 10, offset: 22389},
+							pos:   position{line: 756, col: 10, offset: 22210},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 768, col: 16, offset: 22395},
+								pos:  position{line: 756, col: 16, offset: 22216},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 768, col: 27, offset: 22406},
+							pos:   position{line: 756, col: 27, offset: 22227},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 768, col: 32, offset: 22411},
+								pos: position{line: 756, col: 32, offset: 22232},
 								expr: &ruleRefExpr{
-									pos:  position{line: 768, col: 33, offset: 22412},
+									pos:  position{line: 756, col: 33, offset: 22233},
 									name: "Deref",
 								},
 							},
@@ -5871,55 +5788,55 @@ var g = &grammar{
 		},
 		{
 			name: "Deref",
-			pos:  position{line: 772, col: 1, offset: 22480},
+			pos:  position{line: 760, col: 1, offset: 22301},
 			expr: &choiceExpr{
-				pos: position{line: 773, col: 5, offset: 22490},
+				pos: position{line: 761, col: 5, offset: 22311},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 773, col: 5, offset: 22490},
+						pos: position{line: 761, col: 5, offset: 22311},
 						run: (*parser).callonDeref2,
 						expr: &seqExpr{
-							pos: position{line: 773, col: 5, offset: 22490},
+							pos: position{line: 761, col: 5, offset: 22311},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 773, col: 5, offset: 22490},
+									pos:        position{line: 761, col: 5, offset: 22311},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 773, col: 9, offset: 22494},
+									pos:   position{line: 761, col: 9, offset: 22315},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 773, col: 14, offset: 22499},
+										pos:  position{line: 761, col: 14, offset: 22320},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 773, col: 27, offset: 22512},
+									pos:  position{line: 761, col: 27, offset: 22333},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 773, col: 30, offset: 22515},
+									pos:        position{line: 761, col: 30, offset: 22336},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 773, col: 34, offset: 22519},
+									pos:  position{line: 761, col: 34, offset: 22340},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 773, col: 37, offset: 22522},
+									pos:   position{line: 761, col: 37, offset: 22343},
 									label: "to",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 773, col: 40, offset: 22525},
+										pos: position{line: 761, col: 40, offset: 22346},
 										expr: &ruleRefExpr{
-											pos:  position{line: 773, col: 40, offset: 22525},
+											pos:  position{line: 761, col: 40, offset: 22346},
 											name: "AdditiveExpr",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 773, col: 54, offset: 22539},
+									pos:        position{line: 761, col: 54, offset: 22360},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5927,39 +5844,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 779, col: 5, offset: 22710},
+						pos: position{line: 767, col: 5, offset: 22531},
 						run: (*parser).callonDeref14,
 						expr: &seqExpr{
-							pos: position{line: 779, col: 5, offset: 22710},
+							pos: position{line: 767, col: 5, offset: 22531},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 779, col: 5, offset: 22710},
+									pos:        position{line: 767, col: 5, offset: 22531},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 779, col: 9, offset: 22714},
+									pos:  position{line: 767, col: 9, offset: 22535},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 779, col: 12, offset: 22717},
+									pos:        position{line: 767, col: 12, offset: 22538},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 779, col: 16, offset: 22721},
+									pos:  position{line: 767, col: 16, offset: 22542},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 779, col: 19, offset: 22724},
+									pos:   position{line: 767, col: 19, offset: 22545},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 779, col: 22, offset: 22727},
+										pos:  position{line: 767, col: 22, offset: 22548},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 779, col: 35, offset: 22740},
+									pos:        position{line: 767, col: 35, offset: 22561},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5967,26 +5884,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 785, col: 5, offset: 22911},
+						pos: position{line: 773, col: 5, offset: 22732},
 						run: (*parser).callonDeref23,
 						expr: &seqExpr{
-							pos: position{line: 785, col: 5, offset: 22911},
+							pos: position{line: 773, col: 5, offset: 22732},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 785, col: 5, offset: 22911},
+									pos:        position{line: 773, col: 5, offset: 22732},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 785, col: 9, offset: 22915},
+									pos:   position{line: 773, col: 9, offset: 22736},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 785, col: 14, offset: 22920},
+										pos:  position{line: 773, col: 14, offset: 22741},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 785, col: 19, offset: 22925},
+									pos:        position{line: 773, col: 19, offset: 22746},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5994,21 +5911,21 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 786, col: 5, offset: 22974},
+						pos: position{line: 774, col: 5, offset: 22795},
 						run: (*parser).callonDeref29,
 						expr: &seqExpr{
-							pos: position{line: 786, col: 5, offset: 22974},
+							pos: position{line: 774, col: 5, offset: 22795},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 786, col: 5, offset: 22974},
+									pos:        position{line: 774, col: 5, offset: 22795},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 786, col: 9, offset: 22978},
+									pos:   position{line: 774, col: 9, offset: 22799},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 786, col: 12, offset: 22981},
+										pos:  position{line: 774, col: 12, offset: 22802},
 										name: "Identifier",
 									},
 								},
@@ -6020,59 +5937,59 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 788, col: 1, offset: 23032},
+			pos:  position{line: 776, col: 1, offset: 22853},
 			expr: &choiceExpr{
-				pos: position{line: 789, col: 5, offset: 23044},
+				pos: position{line: 777, col: 5, offset: 22865},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 789, col: 5, offset: 23044},
+						pos:  position{line: 777, col: 5, offset: 22865},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 790, col: 5, offset: 23055},
+						pos:  position{line: 778, col: 5, offset: 22876},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 791, col: 5, offset: 23065},
+						pos:  position{line: 779, col: 5, offset: 22886},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 792, col: 5, offset: 23073},
+						pos:  position{line: 780, col: 5, offset: 22894},
 						name: "Map",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 793, col: 5, offset: 23081},
+						pos:  position{line: 781, col: 5, offset: 22902},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 794, col: 5, offset: 23093},
+						pos: position{line: 782, col: 5, offset: 22914},
 						run: (*parser).callonPrimary7,
 						expr: &seqExpr{
-							pos: position{line: 794, col: 5, offset: 23093},
+							pos: position{line: 782, col: 5, offset: 22914},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 794, col: 5, offset: 23093},
+									pos:        position{line: 782, col: 5, offset: 22914},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 794, col: 9, offset: 23097},
+									pos:  position{line: 782, col: 9, offset: 22918},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 794, col: 12, offset: 23100},
+									pos:   position{line: 782, col: 12, offset: 22921},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 794, col: 17, offset: 23105},
+										pos:  position{line: 782, col: 17, offset: 22926},
 										name: "OverExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 794, col: 26, offset: 23114},
+									pos:  position{line: 782, col: 26, offset: 22935},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 794, col: 29, offset: 23117},
+									pos:        position{line: 782, col: 29, offset: 22938},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -6080,34 +5997,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 795, col: 5, offset: 23147},
+						pos: position{line: 783, col: 5, offset: 22968},
 						run: (*parser).callonPrimary15,
 						expr: &seqExpr{
-							pos: position{line: 795, col: 5, offset: 23147},
+							pos: position{line: 783, col: 5, offset: 22968},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 795, col: 5, offset: 23147},
+									pos:        position{line: 783, col: 5, offset: 22968},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 795, col: 9, offset: 23151},
+									pos:  position{line: 783, col: 9, offset: 22972},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 795, col: 12, offset: 23154},
+									pos:   position{line: 783, col: 12, offset: 22975},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 795, col: 17, offset: 23159},
+										pos:  position{line: 783, col: 17, offset: 22980},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 795, col: 22, offset: 23164},
+									pos:  position{line: 783, col: 22, offset: 22985},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 795, col: 25, offset: 23167},
+									pos:        position{line: 783, col: 25, offset: 22988},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -6119,59 +6036,59 @@ var g = &grammar{
 		},
 		{
 			name: "OverExpr",
-			pos:  position{line: 797, col: 1, offset: 23193},
+			pos:  position{line: 785, col: 1, offset: 23014},
 			expr: &actionExpr{
-				pos: position{line: 798, col: 5, offset: 23206},
+				pos: position{line: 786, col: 5, offset: 23027},
 				run: (*parser).callonOverExpr1,
 				expr: &seqExpr{
-					pos: position{line: 798, col: 5, offset: 23206},
+					pos: position{line: 786, col: 5, offset: 23027},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 798, col: 5, offset: 23206},
+							pos:        position{line: 786, col: 5, offset: 23027},
 							val:        "over",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 798, col: 12, offset: 23213},
+							pos:  position{line: 786, col: 12, offset: 23034},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 798, col: 14, offset: 23215},
+							pos:   position{line: 786, col: 14, offset: 23036},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 798, col: 20, offset: 23221},
+								pos:  position{line: 786, col: 20, offset: 23042},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 798, col: 26, offset: 23227},
+							pos:   position{line: 786, col: 26, offset: 23048},
 							label: "locals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 798, col: 33, offset: 23234},
+								pos: position{line: 786, col: 33, offset: 23055},
 								expr: &ruleRefExpr{
-									pos:  position{line: 798, col: 33, offset: 23234},
+									pos:  position{line: 786, col: 33, offset: 23055},
 									name: "Locals",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 798, col: 41, offset: 23242},
+							pos:  position{line: 786, col: 41, offset: 23063},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 798, col: 44, offset: 23245},
+							pos:        position{line: 786, col: 44, offset: 23066},
 							val:        "|",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 798, col: 48, offset: 23249},
+							pos:  position{line: 786, col: 48, offset: 23070},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 798, col: 51, offset: 23252},
+							pos:   position{line: 786, col: 51, offset: 23073},
 							label: "scope",
 							expr: &ruleRefExpr{
-								pos:  position{line: 798, col: 57, offset: 23258},
+								pos:  position{line: 786, col: 57, offset: 23079},
 								name: "Sequential",
 							},
 						},
@@ -6181,36 +6098,36 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 802, col: 1, offset: 23389},
+			pos:  position{line: 790, col: 1, offset: 23210},
 			expr: &actionExpr{
-				pos: position{line: 803, col: 5, offset: 23400},
+				pos: position{line: 791, col: 5, offset: 23221},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 803, col: 5, offset: 23400},
+					pos: position{line: 791, col: 5, offset: 23221},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 803, col: 5, offset: 23400},
+							pos:        position{line: 791, col: 5, offset: 23221},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 803, col: 9, offset: 23404},
+							pos:  position{line: 791, col: 9, offset: 23225},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 803, col: 12, offset: 23407},
+							pos:   position{line: 791, col: 12, offset: 23228},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 803, col: 18, offset: 23413},
+								pos:  position{line: 791, col: 18, offset: 23234},
 								name: "RecordElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 803, col: 30, offset: 23425},
+							pos:  position{line: 791, col: 30, offset: 23246},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 803, col: 33, offset: 23428},
+							pos:        position{line: 791, col: 33, offset: 23249},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -6220,31 +6137,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElems",
-			pos:  position{line: 807, col: 1, offset: 23518},
+			pos:  position{line: 795, col: 1, offset: 23339},
 			expr: &choiceExpr{
-				pos: position{line: 808, col: 5, offset: 23534},
+				pos: position{line: 796, col: 5, offset: 23355},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 808, col: 5, offset: 23534},
+						pos: position{line: 796, col: 5, offset: 23355},
 						run: (*parser).callonRecordElems2,
 						expr: &seqExpr{
-							pos: position{line: 808, col: 5, offset: 23534},
+							pos: position{line: 796, col: 5, offset: 23355},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 808, col: 5, offset: 23534},
+									pos:   position{line: 796, col: 5, offset: 23355},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 808, col: 11, offset: 23540},
+										pos:  position{line: 796, col: 11, offset: 23361},
 										name: "RecordElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 808, col: 22, offset: 23551},
+									pos:   position{line: 796, col: 22, offset: 23372},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 808, col: 27, offset: 23556},
+										pos: position{line: 796, col: 27, offset: 23377},
 										expr: &ruleRefExpr{
-											pos:  position{line: 808, col: 27, offset: 23556},
+											pos:  position{line: 796, col: 27, offset: 23377},
 											name: "RecordElemTail",
 										},
 									},
@@ -6253,10 +6170,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 811, col: 5, offset: 23655},
+						pos: position{line: 799, col: 5, offset: 23476},
 						run: (*parser).callonRecordElems9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 811, col: 5, offset: 23655},
+							pos:  position{line: 799, col: 5, offset: 23476},
 							name: "__",
 						},
 					},
@@ -6265,31 +6182,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElemTail",
-			pos:  position{line: 813, col: 1, offset: 23691},
+			pos:  position{line: 801, col: 1, offset: 23512},
 			expr: &actionExpr{
-				pos: position{line: 813, col: 18, offset: 23708},
+				pos: position{line: 801, col: 18, offset: 23529},
 				run: (*parser).callonRecordElemTail1,
 				expr: &seqExpr{
-					pos: position{line: 813, col: 18, offset: 23708},
+					pos: position{line: 801, col: 18, offset: 23529},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 813, col: 18, offset: 23708},
+							pos:  position{line: 801, col: 18, offset: 23529},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 813, col: 21, offset: 23711},
+							pos:        position{line: 801, col: 21, offset: 23532},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 813, col: 25, offset: 23715},
+							pos:  position{line: 801, col: 25, offset: 23536},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 813, col: 28, offset: 23718},
+							pos:   position{line: 801, col: 28, offset: 23539},
 							label: "elem",
 							expr: &ruleRefExpr{
-								pos:  position{line: 813, col: 33, offset: 23723},
+								pos:  position{line: 801, col: 33, offset: 23544},
 								name: "RecordElem",
 							},
 						},
@@ -6299,20 +6216,20 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElem",
-			pos:  position{line: 815, col: 1, offset: 23756},
+			pos:  position{line: 803, col: 1, offset: 23577},
 			expr: &choiceExpr{
-				pos: position{line: 816, col: 5, offset: 23771},
+				pos: position{line: 804, col: 5, offset: 23592},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 816, col: 5, offset: 23771},
+						pos:  position{line: 804, col: 5, offset: 23592},
 						name: "Spread",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 817, col: 5, offset: 23782},
+						pos:  position{line: 805, col: 5, offset: 23603},
 						name: "Field",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 818, col: 5, offset: 23792},
+						pos:  position{line: 806, col: 5, offset: 23613},
 						name: "Identifier",
 					},
 				},
@@ -6320,27 +6237,27 @@ var g = &grammar{
 		},
 		{
 			name: "Spread",
-			pos:  position{line: 820, col: 1, offset: 23804},
+			pos:  position{line: 808, col: 1, offset: 23625},
 			expr: &actionExpr{
-				pos: position{line: 821, col: 5, offset: 23815},
+				pos: position{line: 809, col: 5, offset: 23636},
 				run: (*parser).callonSpread1,
 				expr: &seqExpr{
-					pos: position{line: 821, col: 5, offset: 23815},
+					pos: position{line: 809, col: 5, offset: 23636},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 821, col: 5, offset: 23815},
+							pos:        position{line: 809, col: 5, offset: 23636},
 							val:        "...",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 821, col: 11, offset: 23821},
+							pos:  position{line: 809, col: 11, offset: 23642},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 821, col: 14, offset: 23824},
+							pos:   position{line: 809, col: 14, offset: 23645},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 821, col: 19, offset: 23829},
+								pos:  position{line: 809, col: 19, offset: 23650},
 								name: "Expr",
 							},
 						},
@@ -6350,39 +6267,39 @@ var g = &grammar{
 		},
 		{
 			name: "Field",
-			pos:  position{line: 825, col: 1, offset: 23915},
+			pos:  position{line: 813, col: 1, offset: 23736},
 			expr: &actionExpr{
-				pos: position{line: 826, col: 5, offset: 23925},
+				pos: position{line: 814, col: 5, offset: 23746},
 				run: (*parser).callonField1,
 				expr: &seqExpr{
-					pos: position{line: 826, col: 5, offset: 23925},
+					pos: position{line: 814, col: 5, offset: 23746},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 826, col: 5, offset: 23925},
+							pos:   position{line: 814, col: 5, offset: 23746},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 826, col: 10, offset: 23930},
+								pos:  position{line: 814, col: 10, offset: 23751},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 826, col: 20, offset: 23940},
+							pos:  position{line: 814, col: 20, offset: 23761},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 826, col: 23, offset: 23943},
+							pos:        position{line: 814, col: 23, offset: 23764},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 826, col: 27, offset: 23947},
+							pos:  position{line: 814, col: 27, offset: 23768},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 826, col: 30, offset: 23950},
+							pos:   position{line: 814, col: 30, offset: 23771},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 826, col: 36, offset: 23956},
+								pos:  position{line: 814, col: 36, offset: 23777},
 								name: "Expr",
 							},
 						},
@@ -6392,36 +6309,36 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 830, col: 1, offset: 24056},
+			pos:  position{line: 818, col: 1, offset: 23877},
 			expr: &actionExpr{
-				pos: position{line: 831, col: 5, offset: 24066},
+				pos: position{line: 819, col: 5, offset: 23887},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 831, col: 5, offset: 24066},
+					pos: position{line: 819, col: 5, offset: 23887},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 831, col: 5, offset: 24066},
+							pos:        position{line: 819, col: 5, offset: 23887},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 831, col: 9, offset: 24070},
+							pos:  position{line: 819, col: 9, offset: 23891},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 831, col: 12, offset: 24073},
+							pos:   position{line: 819, col: 12, offset: 23894},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 831, col: 18, offset: 24079},
+								pos:  position{line: 819, col: 18, offset: 23900},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 831, col: 30, offset: 24091},
+							pos:  position{line: 819, col: 30, offset: 23912},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 831, col: 33, offset: 24094},
+							pos:        position{line: 819, col: 33, offset: 23915},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -6431,36 +6348,36 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 835, col: 1, offset: 24184},
+			pos:  position{line: 823, col: 1, offset: 24005},
 			expr: &actionExpr{
-				pos: position{line: 836, col: 5, offset: 24192},
+				pos: position{line: 824, col: 5, offset: 24013},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 836, col: 5, offset: 24192},
+					pos: position{line: 824, col: 5, offset: 24013},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 836, col: 5, offset: 24192},
+							pos:        position{line: 824, col: 5, offset: 24013},
 							val:        "|[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 836, col: 10, offset: 24197},
+							pos:  position{line: 824, col: 10, offset: 24018},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 836, col: 13, offset: 24200},
+							pos:   position{line: 824, col: 13, offset: 24021},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 836, col: 19, offset: 24206},
+								pos:  position{line: 824, col: 19, offset: 24027},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 836, col: 31, offset: 24218},
+							pos:  position{line: 824, col: 31, offset: 24039},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 836, col: 34, offset: 24221},
+							pos:        position{line: 824, col: 34, offset: 24042},
 							val:        "]|",
 							ignoreCase: false,
 						},
@@ -6470,53 +6387,53 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElems",
-			pos:  position{line: 840, col: 1, offset: 24310},
+			pos:  position{line: 828, col: 1, offset: 24131},
 			expr: &choiceExpr{
-				pos: position{line: 841, col: 5, offset: 24326},
+				pos: position{line: 829, col: 5, offset: 24147},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 841, col: 5, offset: 24326},
+						pos: position{line: 829, col: 5, offset: 24147},
 						run: (*parser).callonVectorElems2,
 						expr: &seqExpr{
-							pos: position{line: 841, col: 5, offset: 24326},
+							pos: position{line: 829, col: 5, offset: 24147},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 841, col: 5, offset: 24326},
+									pos:   position{line: 829, col: 5, offset: 24147},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 841, col: 11, offset: 24332},
+										pos:  position{line: 829, col: 11, offset: 24153},
 										name: "VectorElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 841, col: 22, offset: 24343},
+									pos:   position{line: 829, col: 22, offset: 24164},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 841, col: 27, offset: 24348},
+										pos: position{line: 829, col: 27, offset: 24169},
 										expr: &actionExpr{
-											pos: position{line: 841, col: 28, offset: 24349},
+											pos: position{line: 829, col: 28, offset: 24170},
 											run: (*parser).callonVectorElems8,
 											expr: &seqExpr{
-												pos: position{line: 841, col: 28, offset: 24349},
+												pos: position{line: 829, col: 28, offset: 24170},
 												exprs: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 841, col: 28, offset: 24349},
+														pos:  position{line: 829, col: 28, offset: 24170},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 841, col: 31, offset: 24352},
+														pos:        position{line: 829, col: 31, offset: 24173},
 														val:        ",",
 														ignoreCase: false,
 													},
 													&ruleRefExpr{
-														pos:  position{line: 841, col: 35, offset: 24356},
+														pos:  position{line: 829, col: 35, offset: 24177},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 841, col: 38, offset: 24359},
+														pos:   position{line: 829, col: 38, offset: 24180},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 841, col: 40, offset: 24361},
+															pos:  position{line: 829, col: 40, offset: 24182},
 															name: "VectorElem",
 														},
 													},
@@ -6529,10 +6446,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 844, col: 5, offset: 24479},
+						pos: position{line: 832, col: 5, offset: 24300},
 						run: (*parser).callonVectorElems15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 844, col: 5, offset: 24479},
+							pos:  position{line: 832, col: 5, offset: 24300},
 							name: "__",
 						},
 					},
@@ -6541,22 +6458,22 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElem",
-			pos:  position{line: 846, col: 1, offset: 24515},
+			pos:  position{line: 834, col: 1, offset: 24336},
 			expr: &choiceExpr{
-				pos: position{line: 847, col: 5, offset: 24530},
+				pos: position{line: 835, col: 5, offset: 24351},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 847, col: 5, offset: 24530},
+						pos:  position{line: 835, col: 5, offset: 24351},
 						name: "Spread",
 					},
 					&actionExpr{
-						pos: position{line: 848, col: 5, offset: 24541},
+						pos: position{line: 836, col: 5, offset: 24362},
 						run: (*parser).callonVectorElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 848, col: 5, offset: 24541},
+							pos:   position{line: 836, col: 5, offset: 24362},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 848, col: 7, offset: 24543},
+								pos:  position{line: 836, col: 7, offset: 24364},
 								name: "Expr",
 							},
 						},
@@ -6566,36 +6483,36 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 850, col: 1, offset: 24619},
+			pos:  position{line: 838, col: 1, offset: 24440},
 			expr: &actionExpr{
-				pos: position{line: 851, col: 5, offset: 24627},
+				pos: position{line: 839, col: 5, offset: 24448},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 851, col: 5, offset: 24627},
+					pos: position{line: 839, col: 5, offset: 24448},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 851, col: 5, offset: 24627},
+							pos:        position{line: 839, col: 5, offset: 24448},
 							val:        "|{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 851, col: 10, offset: 24632},
+							pos:  position{line: 839, col: 10, offset: 24453},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 851, col: 13, offset: 24635},
+							pos:   position{line: 839, col: 13, offset: 24456},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 851, col: 19, offset: 24641},
+								pos:  position{line: 839, col: 19, offset: 24462},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 851, col: 27, offset: 24649},
+							pos:  position{line: 839, col: 27, offset: 24470},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 851, col: 30, offset: 24652},
+							pos:        position{line: 839, col: 30, offset: 24473},
 							val:        "}|",
 							ignoreCase: false,
 						},
@@ -6605,31 +6522,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 855, col: 1, offset: 24743},
+			pos:  position{line: 843, col: 1, offset: 24564},
 			expr: &choiceExpr{
-				pos: position{line: 856, col: 5, offset: 24755},
+				pos: position{line: 844, col: 5, offset: 24576},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 856, col: 5, offset: 24755},
+						pos: position{line: 844, col: 5, offset: 24576},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 856, col: 5, offset: 24755},
+							pos: position{line: 844, col: 5, offset: 24576},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 856, col: 5, offset: 24755},
+									pos:   position{line: 844, col: 5, offset: 24576},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 856, col: 11, offset: 24761},
+										pos:  position{line: 844, col: 11, offset: 24582},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 856, col: 17, offset: 24767},
+									pos:   position{line: 844, col: 17, offset: 24588},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 856, col: 22, offset: 24772},
+										pos: position{line: 844, col: 22, offset: 24593},
 										expr: &ruleRefExpr{
-											pos:  position{line: 856, col: 22, offset: 24772},
+											pos:  position{line: 844, col: 22, offset: 24593},
 											name: "EntryTail",
 										},
 									},
@@ -6638,10 +6555,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 859, col: 5, offset: 24866},
+						pos: position{line: 847, col: 5, offset: 24687},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 859, col: 5, offset: 24866},
+							pos:  position{line: 847, col: 5, offset: 24687},
 							name: "__",
 						},
 					},
@@ -6650,31 +6567,31 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 862, col: 1, offset: 24903},
+			pos:  position{line: 850, col: 1, offset: 24724},
 			expr: &actionExpr{
-				pos: position{line: 862, col: 13, offset: 24915},
+				pos: position{line: 850, col: 13, offset: 24736},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 862, col: 13, offset: 24915},
+					pos: position{line: 850, col: 13, offset: 24736},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 862, col: 13, offset: 24915},
+							pos:  position{line: 850, col: 13, offset: 24736},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 862, col: 16, offset: 24918},
+							pos:        position{line: 850, col: 16, offset: 24739},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 862, col: 20, offset: 24922},
+							pos:  position{line: 850, col: 20, offset: 24743},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 862, col: 23, offset: 24925},
+							pos:   position{line: 850, col: 23, offset: 24746},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 862, col: 25, offset: 24927},
+								pos:  position{line: 850, col: 25, offset: 24748},
 								name: "Entry",
 							},
 						},
@@ -6684,39 +6601,39 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 864, col: 1, offset: 24952},
+			pos:  position{line: 852, col: 1, offset: 24773},
 			expr: &actionExpr{
-				pos: position{line: 865, col: 5, offset: 24962},
+				pos: position{line: 853, col: 5, offset: 24783},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 865, col: 5, offset: 24962},
+					pos: position{line: 853, col: 5, offset: 24783},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 865, col: 5, offset: 24962},
+							pos:   position{line: 853, col: 5, offset: 24783},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 865, col: 9, offset: 24966},
+								pos:  position{line: 853, col: 9, offset: 24787},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 865, col: 14, offset: 24971},
+							pos:  position{line: 853, col: 14, offset: 24792},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 865, col: 17, offset: 24974},
+							pos:        position{line: 853, col: 17, offset: 24795},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 865, col: 21, offset: 24978},
+							pos:  position{line: 853, col: 21, offset: 24799},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 865, col: 24, offset: 24981},
+							pos:   position{line: 853, col: 24, offset: 24802},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 865, col: 30, offset: 24987},
+								pos:  position{line: 853, col: 30, offset: 24808},
 								name: "Expr",
 							},
 						},
@@ -6726,92 +6643,92 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOp",
-			pos:  position{line: 871, col: 1, offset: 25094},
+			pos:  position{line: 859, col: 1, offset: 24915},
 			expr: &actionExpr{
-				pos: position{line: 872, col: 5, offset: 25104},
+				pos: position{line: 860, col: 5, offset: 24925},
 				run: (*parser).callonSQLOp1,
 				expr: &seqExpr{
-					pos: position{line: 872, col: 5, offset: 25104},
+					pos: position{line: 860, col: 5, offset: 24925},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 872, col: 5, offset: 25104},
+							pos:   position{line: 860, col: 5, offset: 24925},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 872, col: 15, offset: 25114},
+								pos:  position{line: 860, col: 15, offset: 24935},
 								name: "SQLSelect",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 873, col: 5, offset: 25128},
+							pos:   position{line: 861, col: 5, offset: 24949},
 							label: "from",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 873, col: 10, offset: 25133},
+								pos: position{line: 861, col: 10, offset: 24954},
 								expr: &ruleRefExpr{
-									pos:  position{line: 873, col: 10, offset: 25133},
+									pos:  position{line: 861, col: 10, offset: 24954},
 									name: "SQLFrom",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 874, col: 5, offset: 25146},
+							pos:   position{line: 862, col: 5, offset: 24967},
 							label: "joins",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 874, col: 11, offset: 25152},
+								pos: position{line: 862, col: 11, offset: 24973},
 								expr: &ruleRefExpr{
-									pos:  position{line: 874, col: 11, offset: 25152},
+									pos:  position{line: 862, col: 11, offset: 24973},
 									name: "SQLJoins",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 875, col: 5, offset: 25166},
+							pos:   position{line: 863, col: 5, offset: 24987},
 							label: "where",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 875, col: 11, offset: 25172},
+								pos: position{line: 863, col: 11, offset: 24993},
 								expr: &ruleRefExpr{
-									pos:  position{line: 875, col: 11, offset: 25172},
+									pos:  position{line: 863, col: 11, offset: 24993},
 									name: "SQLWhere",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 876, col: 5, offset: 25186},
+							pos:   position{line: 864, col: 5, offset: 25007},
 							label: "groupby",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 876, col: 13, offset: 25194},
+								pos: position{line: 864, col: 13, offset: 25015},
 								expr: &ruleRefExpr{
-									pos:  position{line: 876, col: 13, offset: 25194},
+									pos:  position{line: 864, col: 13, offset: 25015},
 									name: "SQLGroupBy",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 877, col: 5, offset: 25210},
+							pos:   position{line: 865, col: 5, offset: 25031},
 							label: "having",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 877, col: 12, offset: 25217},
+								pos: position{line: 865, col: 12, offset: 25038},
 								expr: &ruleRefExpr{
-									pos:  position{line: 877, col: 12, offset: 25217},
+									pos:  position{line: 865, col: 12, offset: 25038},
 									name: "SQLHaving",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 878, col: 5, offset: 25232},
+							pos:   position{line: 866, col: 5, offset: 25053},
 							label: "orderby",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 878, col: 13, offset: 25240},
+								pos: position{line: 866, col: 13, offset: 25061},
 								expr: &ruleRefExpr{
-									pos:  position{line: 878, col: 13, offset: 25240},
+									pos:  position{line: 866, col: 13, offset: 25061},
 									name: "SQLOrderBy",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 879, col: 5, offset: 25256},
+							pos:   position{line: 867, col: 5, offset: 25077},
 							label: "limit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 879, col: 11, offset: 25262},
+								pos:  position{line: 867, col: 11, offset: 25083},
 								name: "SQLLimit",
 							},
 						},
@@ -6821,26 +6738,26 @@ var g = &grammar{
 		},
 		{
 			name: "SQLSelect",
-			pos:  position{line: 903, col: 1, offset: 25629},
+			pos:  position{line: 891, col: 1, offset: 25450},
 			expr: &choiceExpr{
-				pos: position{line: 904, col: 5, offset: 25643},
+				pos: position{line: 892, col: 5, offset: 25464},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 904, col: 5, offset: 25643},
+						pos: position{line: 892, col: 5, offset: 25464},
 						run: (*parser).callonSQLSelect2,
 						expr: &seqExpr{
-							pos: position{line: 904, col: 5, offset: 25643},
+							pos: position{line: 892, col: 5, offset: 25464},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 904, col: 5, offset: 25643},
+									pos:  position{line: 892, col: 5, offset: 25464},
 									name: "SELECT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 904, col: 12, offset: 25650},
+									pos:  position{line: 892, col: 12, offset: 25471},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 904, col: 14, offset: 25652},
+									pos:        position{line: 892, col: 14, offset: 25473},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -6848,24 +6765,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 905, col: 5, offset: 25680},
+						pos: position{line: 893, col: 5, offset: 25501},
 						run: (*parser).callonSQLSelect7,
 						expr: &seqExpr{
-							pos: position{line: 905, col: 5, offset: 25680},
+							pos: position{line: 893, col: 5, offset: 25501},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 905, col: 5, offset: 25680},
+									pos:  position{line: 893, col: 5, offset: 25501},
 									name: "SELECT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 905, col: 12, offset: 25687},
+									pos:  position{line: 893, col: 12, offset: 25508},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 905, col: 14, offset: 25689},
+									pos:   position{line: 893, col: 14, offset: 25510},
 									label: "assignments",
 									expr: &ruleRefExpr{
-										pos:  position{line: 905, col: 26, offset: 25701},
+										pos:  position{line: 893, col: 26, offset: 25522},
 										name: "SQLAssignments",
 									},
 								},
@@ -6877,43 +6794,43 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAssignment",
-			pos:  position{line: 907, col: 1, offset: 25745},
+			pos:  position{line: 895, col: 1, offset: 25566},
 			expr: &actionExpr{
-				pos: position{line: 908, col: 5, offset: 25763},
+				pos: position{line: 896, col: 5, offset: 25584},
 				run: (*parser).callonSQLAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 908, col: 5, offset: 25763},
+					pos: position{line: 896, col: 5, offset: 25584},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 908, col: 5, offset: 25763},
+							pos:   position{line: 896, col: 5, offset: 25584},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 908, col: 9, offset: 25767},
+								pos:  position{line: 896, col: 9, offset: 25588},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 908, col: 14, offset: 25772},
+							pos:   position{line: 896, col: 14, offset: 25593},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 908, col: 18, offset: 25776},
+								pos: position{line: 896, col: 18, offset: 25597},
 								expr: &seqExpr{
-									pos: position{line: 908, col: 19, offset: 25777},
+									pos: position{line: 896, col: 19, offset: 25598},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 908, col: 19, offset: 25777},
+											pos:  position{line: 896, col: 19, offset: 25598},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 908, col: 21, offset: 25779},
+											pos:  position{line: 896, col: 21, offset: 25600},
 											name: "AS",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 908, col: 24, offset: 25782},
+											pos:  position{line: 896, col: 24, offset: 25603},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 908, col: 26, offset: 25784},
+											pos:  position{line: 896, col: 26, offset: 25605},
 											name: "Lval",
 										},
 									},
@@ -6926,50 +6843,50 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAssignments",
-			pos:  position{line: 916, col: 1, offset: 25975},
+			pos:  position{line: 904, col: 1, offset: 25796},
 			expr: &actionExpr{
-				pos: position{line: 917, col: 5, offset: 25994},
+				pos: position{line: 905, col: 5, offset: 25815},
 				run: (*parser).callonSQLAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 917, col: 5, offset: 25994},
+					pos: position{line: 905, col: 5, offset: 25815},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 917, col: 5, offset: 25994},
+							pos:   position{line: 905, col: 5, offset: 25815},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 917, col: 11, offset: 26000},
+								pos:  position{line: 905, col: 11, offset: 25821},
 								name: "SQLAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 917, col: 25, offset: 26014},
+							pos:   position{line: 905, col: 25, offset: 25835},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 917, col: 30, offset: 26019},
+								pos: position{line: 905, col: 30, offset: 25840},
 								expr: &actionExpr{
-									pos: position{line: 917, col: 31, offset: 26020},
+									pos: position{line: 905, col: 31, offset: 25841},
 									run: (*parser).callonSQLAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 917, col: 31, offset: 26020},
+										pos: position{line: 905, col: 31, offset: 25841},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 917, col: 31, offset: 26020},
+												pos:  position{line: 905, col: 31, offset: 25841},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 917, col: 34, offset: 26023},
+												pos:        position{line: 905, col: 34, offset: 25844},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 917, col: 38, offset: 26027},
+												pos:  position{line: 905, col: 38, offset: 25848},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 917, col: 41, offset: 26030},
+												pos:   position{line: 905, col: 41, offset: 25851},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 917, col: 46, offset: 26035},
+													pos:  position{line: 905, col: 46, offset: 25856},
 													name: "SQLAssignment",
 												},
 											},
@@ -6984,43 +6901,43 @@ var g = &grammar{
 		},
 		{
 			name: "SQLFrom",
-			pos:  position{line: 921, col: 1, offset: 26156},
+			pos:  position{line: 909, col: 1, offset: 25977},
 			expr: &choiceExpr{
-				pos: position{line: 922, col: 5, offset: 26168},
+				pos: position{line: 910, col: 5, offset: 25989},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 922, col: 5, offset: 26168},
+						pos: position{line: 910, col: 5, offset: 25989},
 						run: (*parser).callonSQLFrom2,
 						expr: &seqExpr{
-							pos: position{line: 922, col: 5, offset: 26168},
+							pos: position{line: 910, col: 5, offset: 25989},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 922, col: 5, offset: 26168},
+									pos:  position{line: 910, col: 5, offset: 25989},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 922, col: 7, offset: 26170},
+									pos:  position{line: 910, col: 7, offset: 25991},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 922, col: 12, offset: 26175},
+									pos:  position{line: 910, col: 12, offset: 25996},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 922, col: 14, offset: 26177},
+									pos:   position{line: 910, col: 14, offset: 25998},
 									label: "table",
 									expr: &ruleRefExpr{
-										pos:  position{line: 922, col: 20, offset: 26183},
+										pos:  position{line: 910, col: 20, offset: 26004},
 										name: "SQLTable",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 922, col: 29, offset: 26192},
+									pos:   position{line: 910, col: 29, offset: 26013},
 									label: "alias",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 922, col: 35, offset: 26198},
+										pos: position{line: 910, col: 35, offset: 26019},
 										expr: &ruleRefExpr{
-											pos:  position{line: 922, col: 35, offset: 26198},
+											pos:  position{line: 910, col: 35, offset: 26019},
 											name: "SQLAlias",
 										},
 									},
@@ -7029,25 +6946,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 925, col: 5, offset: 26293},
+						pos: position{line: 913, col: 5, offset: 26114},
 						run: (*parser).callonSQLFrom12,
 						expr: &seqExpr{
-							pos: position{line: 925, col: 5, offset: 26293},
+							pos: position{line: 913, col: 5, offset: 26114},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 925, col: 5, offset: 26293},
+									pos:  position{line: 913, col: 5, offset: 26114},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 925, col: 7, offset: 26295},
+									pos:  position{line: 913, col: 7, offset: 26116},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 925, col: 12, offset: 26300},
+									pos:  position{line: 913, col: 12, offset: 26121},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 925, col: 14, offset: 26302},
+									pos:        position{line: 913, col: 14, offset: 26123},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -7059,33 +6976,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAlias",
-			pos:  position{line: 927, col: 1, offset: 26327},
+			pos:  position{line: 915, col: 1, offset: 26148},
 			expr: &choiceExpr{
-				pos: position{line: 928, col: 5, offset: 26340},
+				pos: position{line: 916, col: 5, offset: 26161},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 928, col: 5, offset: 26340},
+						pos: position{line: 916, col: 5, offset: 26161},
 						run: (*parser).callonSQLAlias2,
 						expr: &seqExpr{
-							pos: position{line: 928, col: 5, offset: 26340},
+							pos: position{line: 916, col: 5, offset: 26161},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 928, col: 5, offset: 26340},
+									pos:  position{line: 916, col: 5, offset: 26161},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 928, col: 7, offset: 26342},
+									pos:  position{line: 916, col: 7, offset: 26163},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 928, col: 10, offset: 26345},
+									pos:  position{line: 916, col: 10, offset: 26166},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 928, col: 12, offset: 26347},
+									pos:   position{line: 916, col: 12, offset: 26168},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 928, col: 15, offset: 26350},
+										pos:  position{line: 916, col: 15, offset: 26171},
 										name: "Lval",
 									},
 								},
@@ -7093,36 +7010,36 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 929, col: 5, offset: 26378},
+						pos: position{line: 917, col: 5, offset: 26199},
 						run: (*parser).callonSQLAlias9,
 						expr: &seqExpr{
-							pos: position{line: 929, col: 5, offset: 26378},
+							pos: position{line: 917, col: 5, offset: 26199},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 929, col: 5, offset: 26378},
+									pos:  position{line: 917, col: 5, offset: 26199},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 929, col: 7, offset: 26380},
+									pos: position{line: 917, col: 7, offset: 26201},
 									expr: &seqExpr{
-										pos: position{line: 929, col: 9, offset: 26382},
+										pos: position{line: 917, col: 9, offset: 26203},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 929, col: 9, offset: 26382},
+												pos:  position{line: 917, col: 9, offset: 26203},
 												name: "SQLTokenSentinels",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 929, col: 27, offset: 26400},
+												pos:  position{line: 917, col: 27, offset: 26221},
 												name: "_",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 929, col: 30, offset: 26403},
+									pos:   position{line: 917, col: 30, offset: 26224},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 929, col: 33, offset: 26406},
+										pos:  position{line: 917, col: 33, offset: 26227},
 										name: "Lval",
 									},
 								},
@@ -7134,42 +7051,42 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTable",
-			pos:  position{line: 931, col: 1, offset: 26431},
+			pos:  position{line: 919, col: 1, offset: 26252},
 			expr: &ruleRefExpr{
-				pos:  position{line: 932, col: 5, offset: 26444},
+				pos:  position{line: 920, col: 5, offset: 26265},
 				name: "Expr",
 			},
 		},
 		{
 			name: "SQLJoins",
-			pos:  position{line: 934, col: 1, offset: 26450},
+			pos:  position{line: 922, col: 1, offset: 26271},
 			expr: &actionExpr{
-				pos: position{line: 935, col: 5, offset: 26463},
+				pos: position{line: 923, col: 5, offset: 26284},
 				run: (*parser).callonSQLJoins1,
 				expr: &seqExpr{
-					pos: position{line: 935, col: 5, offset: 26463},
+					pos: position{line: 923, col: 5, offset: 26284},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 935, col: 5, offset: 26463},
+							pos:   position{line: 923, col: 5, offset: 26284},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 935, col: 11, offset: 26469},
+								pos:  position{line: 923, col: 11, offset: 26290},
 								name: "SQLJoin",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 935, col: 19, offset: 26477},
+							pos:   position{line: 923, col: 19, offset: 26298},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 935, col: 24, offset: 26482},
+								pos: position{line: 923, col: 24, offset: 26303},
 								expr: &actionExpr{
-									pos: position{line: 935, col: 25, offset: 26483},
+									pos: position{line: 923, col: 25, offset: 26304},
 									run: (*parser).callonSQLJoins7,
 									expr: &labeledExpr{
-										pos:   position{line: 935, col: 25, offset: 26483},
+										pos:   position{line: 923, col: 25, offset: 26304},
 										label: "join",
 										expr: &ruleRefExpr{
-											pos:  position{line: 935, col: 30, offset: 26488},
+											pos:  position{line: 923, col: 30, offset: 26309},
 											name: "SQLJoin",
 										},
 									},
@@ -7182,90 +7099,90 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoin",
-			pos:  position{line: 939, col: 1, offset: 26603},
+			pos:  position{line: 927, col: 1, offset: 26424},
 			expr: &actionExpr{
-				pos: position{line: 940, col: 5, offset: 26615},
+				pos: position{line: 928, col: 5, offset: 26436},
 				run: (*parser).callonSQLJoin1,
 				expr: &seqExpr{
-					pos: position{line: 940, col: 5, offset: 26615},
+					pos: position{line: 928, col: 5, offset: 26436},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 940, col: 5, offset: 26615},
+							pos:   position{line: 928, col: 5, offset: 26436},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 940, col: 11, offset: 26621},
+								pos:  position{line: 928, col: 11, offset: 26442},
 								name: "SQLJoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 940, col: 24, offset: 26634},
+							pos:  position{line: 928, col: 24, offset: 26455},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 940, col: 26, offset: 26636},
+							pos:  position{line: 928, col: 26, offset: 26457},
 							name: "JOIN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 940, col: 31, offset: 26641},
+							pos:  position{line: 928, col: 31, offset: 26462},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 940, col: 33, offset: 26643},
+							pos:   position{line: 928, col: 33, offset: 26464},
 							label: "table",
 							expr: &ruleRefExpr{
-								pos:  position{line: 940, col: 39, offset: 26649},
+								pos:  position{line: 928, col: 39, offset: 26470},
 								name: "SQLTable",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 940, col: 48, offset: 26658},
+							pos:   position{line: 928, col: 48, offset: 26479},
 							label: "alias",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 940, col: 54, offset: 26664},
+								pos: position{line: 928, col: 54, offset: 26485},
 								expr: &ruleRefExpr{
-									pos:  position{line: 940, col: 54, offset: 26664},
+									pos:  position{line: 928, col: 54, offset: 26485},
 									name: "SQLAlias",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 940, col: 64, offset: 26674},
+							pos:  position{line: 928, col: 64, offset: 26495},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 940, col: 66, offset: 26676},
+							pos:  position{line: 928, col: 66, offset: 26497},
 							name: "ON",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 940, col: 69, offset: 26679},
+							pos:  position{line: 928, col: 69, offset: 26500},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 940, col: 71, offset: 26681},
+							pos:   position{line: 928, col: 71, offset: 26502},
 							label: "leftKey",
 							expr: &ruleRefExpr{
-								pos:  position{line: 940, col: 79, offset: 26689},
+								pos:  position{line: 928, col: 79, offset: 26510},
 								name: "JoinKey",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 940, col: 87, offset: 26697},
+							pos:  position{line: 928, col: 87, offset: 26518},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 940, col: 90, offset: 26700},
+							pos:        position{line: 928, col: 90, offset: 26521},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 940, col: 94, offset: 26704},
+							pos:  position{line: 928, col: 94, offset: 26525},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 940, col: 97, offset: 26707},
+							pos:   position{line: 928, col: 97, offset: 26528},
 							label: "rightKey",
 							expr: &ruleRefExpr{
-								pos:  position{line: 940, col: 106, offset: 26716},
+								pos:  position{line: 928, col: 106, offset: 26537},
 								name: "JoinKey",
 							},
 						},
@@ -7275,40 +7192,40 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoinStyle",
-			pos:  position{line: 955, col: 1, offset: 26947},
+			pos:  position{line: 943, col: 1, offset: 26768},
 			expr: &choiceExpr{
-				pos: position{line: 956, col: 5, offset: 26964},
+				pos: position{line: 944, col: 5, offset: 26785},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 956, col: 5, offset: 26964},
+						pos: position{line: 944, col: 5, offset: 26785},
 						run: (*parser).callonSQLJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 956, col: 5, offset: 26964},
+							pos: position{line: 944, col: 5, offset: 26785},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 956, col: 5, offset: 26964},
+									pos:  position{line: 944, col: 5, offset: 26785},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 956, col: 7, offset: 26966},
+									pos:   position{line: 944, col: 7, offset: 26787},
 									label: "style",
 									expr: &choiceExpr{
-										pos: position{line: 956, col: 14, offset: 26973},
+										pos: position{line: 944, col: 14, offset: 26794},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 956, col: 14, offset: 26973},
+												pos:  position{line: 944, col: 14, offset: 26794},
 												name: "ANTI",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 956, col: 21, offset: 26980},
+												pos:  position{line: 944, col: 21, offset: 26801},
 												name: "INNER",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 956, col: 29, offset: 26988},
+												pos:  position{line: 944, col: 29, offset: 26809},
 												name: "LEFT",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 956, col: 36, offset: 26995},
+												pos:  position{line: 944, col: 36, offset: 26816},
 												name: "RIGHT",
 											},
 										},
@@ -7318,10 +7235,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 957, col: 5, offset: 27028},
+						pos: position{line: 945, col: 5, offset: 26849},
 						run: (*parser).callonSQLJoinStyle11,
 						expr: &litMatcher{
-							pos:        position{line: 957, col: 5, offset: 27028},
+							pos:        position{line: 945, col: 5, offset: 26849},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7331,30 +7248,30 @@ var g = &grammar{
 		},
 		{
 			name: "SQLWhere",
-			pos:  position{line: 959, col: 1, offset: 27056},
+			pos:  position{line: 947, col: 1, offset: 26877},
 			expr: &actionExpr{
-				pos: position{line: 960, col: 5, offset: 27069},
+				pos: position{line: 948, col: 5, offset: 26890},
 				run: (*parser).callonSQLWhere1,
 				expr: &seqExpr{
-					pos: position{line: 960, col: 5, offset: 27069},
+					pos: position{line: 948, col: 5, offset: 26890},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 960, col: 5, offset: 27069},
+							pos:  position{line: 948, col: 5, offset: 26890},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 960, col: 7, offset: 27071},
+							pos:  position{line: 948, col: 7, offset: 26892},
 							name: "WHERE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 960, col: 13, offset: 27077},
+							pos:  position{line: 948, col: 13, offset: 26898},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 960, col: 15, offset: 27079},
+							pos:   position{line: 948, col: 15, offset: 26900},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 960, col: 20, offset: 27084},
+								pos:  position{line: 948, col: 20, offset: 26905},
 								name: "LogicalOrExpr",
 							},
 						},
@@ -7364,38 +7281,38 @@ var g = &grammar{
 		},
 		{
 			name: "SQLGroupBy",
-			pos:  position{line: 962, col: 1, offset: 27120},
+			pos:  position{line: 950, col: 1, offset: 26941},
 			expr: &actionExpr{
-				pos: position{line: 963, col: 5, offset: 27135},
+				pos: position{line: 951, col: 5, offset: 26956},
 				run: (*parser).callonSQLGroupBy1,
 				expr: &seqExpr{
-					pos: position{line: 963, col: 5, offset: 27135},
+					pos: position{line: 951, col: 5, offset: 26956},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 963, col: 5, offset: 27135},
+							pos:  position{line: 951, col: 5, offset: 26956},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 963, col: 7, offset: 27137},
+							pos:  position{line: 951, col: 7, offset: 26958},
 							name: "GROUP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 963, col: 13, offset: 27143},
+							pos:  position{line: 951, col: 13, offset: 26964},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 963, col: 15, offset: 27145},
+							pos:  position{line: 951, col: 15, offset: 26966},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 963, col: 18, offset: 27148},
+							pos:  position{line: 951, col: 18, offset: 26969},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 963, col: 20, offset: 27150},
+							pos:   position{line: 951, col: 20, offset: 26971},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 963, col: 28, offset: 27158},
+								pos:  position{line: 951, col: 28, offset: 26979},
 								name: "FieldExprs",
 							},
 						},
@@ -7405,30 +7322,30 @@ var g = &grammar{
 		},
 		{
 			name: "SQLHaving",
-			pos:  position{line: 965, col: 1, offset: 27194},
+			pos:  position{line: 953, col: 1, offset: 27015},
 			expr: &actionExpr{
-				pos: position{line: 966, col: 5, offset: 27208},
+				pos: position{line: 954, col: 5, offset: 27029},
 				run: (*parser).callonSQLHaving1,
 				expr: &seqExpr{
-					pos: position{line: 966, col: 5, offset: 27208},
+					pos: position{line: 954, col: 5, offset: 27029},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 966, col: 5, offset: 27208},
+							pos:  position{line: 954, col: 5, offset: 27029},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 966, col: 7, offset: 27210},
+							pos:  position{line: 954, col: 7, offset: 27031},
 							name: "HAVING",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 966, col: 14, offset: 27217},
+							pos:  position{line: 954, col: 14, offset: 27038},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 966, col: 16, offset: 27219},
+							pos:   position{line: 954, col: 16, offset: 27040},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 966, col: 21, offset: 27224},
+								pos:  position{line: 954, col: 21, offset: 27045},
 								name: "LogicalOrExpr",
 							},
 						},
@@ -7438,46 +7355,46 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOrderBy",
-			pos:  position{line: 968, col: 1, offset: 27260},
+			pos:  position{line: 956, col: 1, offset: 27081},
 			expr: &actionExpr{
-				pos: position{line: 969, col: 5, offset: 27275},
+				pos: position{line: 957, col: 5, offset: 27096},
 				run: (*parser).callonSQLOrderBy1,
 				expr: &seqExpr{
-					pos: position{line: 969, col: 5, offset: 27275},
+					pos: position{line: 957, col: 5, offset: 27096},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 969, col: 5, offset: 27275},
+							pos:  position{line: 957, col: 5, offset: 27096},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 969, col: 7, offset: 27277},
+							pos:  position{line: 957, col: 7, offset: 27098},
 							name: "ORDER",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 969, col: 13, offset: 27283},
+							pos:  position{line: 957, col: 13, offset: 27104},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 969, col: 15, offset: 27285},
+							pos:  position{line: 957, col: 15, offset: 27106},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 969, col: 18, offset: 27288},
+							pos:  position{line: 957, col: 18, offset: 27109},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 969, col: 20, offset: 27290},
+							pos:   position{line: 957, col: 20, offset: 27111},
 							label: "keys",
 							expr: &ruleRefExpr{
-								pos:  position{line: 969, col: 25, offset: 27295},
+								pos:  position{line: 957, col: 25, offset: 27116},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 969, col: 31, offset: 27301},
+							pos:   position{line: 957, col: 31, offset: 27122},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 969, col: 37, offset: 27307},
+								pos:  position{line: 957, col: 37, offset: 27128},
 								name: "SQLOrder",
 							},
 						},
@@ -7487,32 +7404,32 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOrder",
-			pos:  position{line: 973, col: 1, offset: 27417},
+			pos:  position{line: 961, col: 1, offset: 27238},
 			expr: &choiceExpr{
-				pos: position{line: 974, col: 5, offset: 27430},
+				pos: position{line: 962, col: 5, offset: 27251},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 974, col: 5, offset: 27430},
+						pos: position{line: 962, col: 5, offset: 27251},
 						run: (*parser).callonSQLOrder2,
 						expr: &seqExpr{
-							pos: position{line: 974, col: 5, offset: 27430},
+							pos: position{line: 962, col: 5, offset: 27251},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 974, col: 5, offset: 27430},
+									pos:  position{line: 962, col: 5, offset: 27251},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 974, col: 7, offset: 27432},
+									pos:   position{line: 962, col: 7, offset: 27253},
 									label: "dir",
 									expr: &choiceExpr{
-										pos: position{line: 974, col: 12, offset: 27437},
+										pos: position{line: 962, col: 12, offset: 27258},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 974, col: 12, offset: 27437},
+												pos:  position{line: 962, col: 12, offset: 27258},
 												name: "ASC",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 974, col: 18, offset: 27443},
+												pos:  position{line: 962, col: 18, offset: 27264},
 												name: "DESC",
 											},
 										},
@@ -7522,10 +7439,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 975, col: 5, offset: 27473},
+						pos: position{line: 963, col: 5, offset: 27294},
 						run: (*parser).callonSQLOrder9,
 						expr: &litMatcher{
-							pos:        position{line: 975, col: 5, offset: 27473},
+							pos:        position{line: 963, col: 5, offset: 27294},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7535,33 +7452,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLLimit",
-			pos:  position{line: 977, col: 1, offset: 27499},
+			pos:  position{line: 965, col: 1, offset: 27320},
 			expr: &choiceExpr{
-				pos: position{line: 978, col: 5, offset: 27512},
+				pos: position{line: 966, col: 5, offset: 27333},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 978, col: 5, offset: 27512},
+						pos: position{line: 966, col: 5, offset: 27333},
 						run: (*parser).callonSQLLimit2,
 						expr: &seqExpr{
-							pos: position{line: 978, col: 5, offset: 27512},
+							pos: position{line: 966, col: 5, offset: 27333},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 978, col: 5, offset: 27512},
+									pos:  position{line: 966, col: 5, offset: 27333},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 978, col: 7, offset: 27514},
+									pos:  position{line: 966, col: 7, offset: 27335},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 978, col: 13, offset: 27520},
+									pos:  position{line: 966, col: 13, offset: 27341},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 978, col: 15, offset: 27522},
+									pos:   position{line: 966, col: 15, offset: 27343},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 978, col: 21, offset: 27528},
+										pos:  position{line: 966, col: 21, offset: 27349},
 										name: "UInt",
 									},
 								},
@@ -7569,10 +7486,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 979, col: 5, offset: 27559},
+						pos: position{line: 967, col: 5, offset: 27380},
 						run: (*parser).callonSQLLimit9,
 						expr: &litMatcher{
-							pos:        position{line: 979, col: 5, offset: 27559},
+							pos:        position{line: 967, col: 5, offset: 27380},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7582,12 +7499,12 @@ var g = &grammar{
 		},
 		{
 			name: "SELECT",
-			pos:  position{line: 981, col: 1, offset: 27581},
+			pos:  position{line: 969, col: 1, offset: 27402},
 			expr: &actionExpr{
-				pos: position{line: 981, col: 10, offset: 27590},
+				pos: position{line: 969, col: 10, offset: 27411},
 				run: (*parser).callonSELECT1,
 				expr: &litMatcher{
-					pos:        position{line: 981, col: 10, offset: 27590},
+					pos:        position{line: 969, col: 10, offset: 27411},
 					val:        "select",
 					ignoreCase: true,
 				},
@@ -7595,12 +7512,12 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 982, col: 1, offset: 27625},
+			pos:  position{line: 970, col: 1, offset: 27446},
 			expr: &actionExpr{
-				pos: position{line: 982, col: 6, offset: 27630},
+				pos: position{line: 970, col: 6, offset: 27451},
 				run: (*parser).callonAS1,
 				expr: &litMatcher{
-					pos:        position{line: 982, col: 6, offset: 27630},
+					pos:        position{line: 970, col: 6, offset: 27451},
 					val:        "as",
 					ignoreCase: true,
 				},
@@ -7608,12 +7525,12 @@ var g = &grammar{
 		},
 		{
 			name: "FROM",
-			pos:  position{line: 983, col: 1, offset: 27657},
+			pos:  position{line: 971, col: 1, offset: 27478},
 			expr: &actionExpr{
-				pos: position{line: 983, col: 8, offset: 27664},
+				pos: position{line: 971, col: 8, offset: 27485},
 				run: (*parser).callonFROM1,
 				expr: &litMatcher{
-					pos:        position{line: 983, col: 8, offset: 27664},
+					pos:        position{line: 971, col: 8, offset: 27485},
 					val:        "from",
 					ignoreCase: true,
 				},
@@ -7621,12 +7538,12 @@ var g = &grammar{
 		},
 		{
 			name: "JOIN",
-			pos:  position{line: 984, col: 1, offset: 27695},
+			pos:  position{line: 972, col: 1, offset: 27516},
 			expr: &actionExpr{
-				pos: position{line: 984, col: 8, offset: 27702},
+				pos: position{line: 972, col: 8, offset: 27523},
 				run: (*parser).callonJOIN1,
 				expr: &litMatcher{
-					pos:        position{line: 984, col: 8, offset: 27702},
+					pos:        position{line: 972, col: 8, offset: 27523},
 					val:        "join",
 					ignoreCase: true,
 				},
@@ -7634,12 +7551,12 @@ var g = &grammar{
 		},
 		{
 			name: "WHERE",
-			pos:  position{line: 985, col: 1, offset: 27733},
+			pos:  position{line: 973, col: 1, offset: 27554},
 			expr: &actionExpr{
-				pos: position{line: 985, col: 9, offset: 27741},
+				pos: position{line: 973, col: 9, offset: 27562},
 				run: (*parser).callonWHERE1,
 				expr: &litMatcher{
-					pos:        position{line: 985, col: 9, offset: 27741},
+					pos:        position{line: 973, col: 9, offset: 27562},
 					val:        "where",
 					ignoreCase: true,
 				},
@@ -7647,12 +7564,12 @@ var g = &grammar{
 		},
 		{
 			name: "GROUP",
-			pos:  position{line: 986, col: 1, offset: 27774},
+			pos:  position{line: 974, col: 1, offset: 27595},
 			expr: &actionExpr{
-				pos: position{line: 986, col: 9, offset: 27782},
+				pos: position{line: 974, col: 9, offset: 27603},
 				run: (*parser).callonGROUP1,
 				expr: &litMatcher{
-					pos:        position{line: 986, col: 9, offset: 27782},
+					pos:        position{line: 974, col: 9, offset: 27603},
 					val:        "group",
 					ignoreCase: true,
 				},
@@ -7660,12 +7577,12 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 987, col: 1, offset: 27815},
+			pos:  position{line: 975, col: 1, offset: 27636},
 			expr: &actionExpr{
-				pos: position{line: 987, col: 6, offset: 27820},
+				pos: position{line: 975, col: 6, offset: 27641},
 				run: (*parser).callonBY1,
 				expr: &litMatcher{
-					pos:        position{line: 987, col: 6, offset: 27820},
+					pos:        position{line: 975, col: 6, offset: 27641},
 					val:        "by",
 					ignoreCase: true,
 				},
@@ -7673,12 +7590,12 @@ var g = &grammar{
 		},
 		{
 			name: "HAVING",
-			pos:  position{line: 988, col: 1, offset: 27847},
+			pos:  position{line: 976, col: 1, offset: 27668},
 			expr: &actionExpr{
-				pos: position{line: 988, col: 10, offset: 27856},
+				pos: position{line: 976, col: 10, offset: 27677},
 				run: (*parser).callonHAVING1,
 				expr: &litMatcher{
-					pos:        position{line: 988, col: 10, offset: 27856},
+					pos:        position{line: 976, col: 10, offset: 27677},
 					val:        "having",
 					ignoreCase: true,
 				},
@@ -7686,12 +7603,12 @@ var g = &grammar{
 		},
 		{
 			name: "ORDER",
-			pos:  position{line: 989, col: 1, offset: 27891},
+			pos:  position{line: 977, col: 1, offset: 27712},
 			expr: &actionExpr{
-				pos: position{line: 989, col: 9, offset: 27899},
+				pos: position{line: 977, col: 9, offset: 27720},
 				run: (*parser).callonORDER1,
 				expr: &litMatcher{
-					pos:        position{line: 989, col: 9, offset: 27899},
+					pos:        position{line: 977, col: 9, offset: 27720},
 					val:        "order",
 					ignoreCase: true,
 				},
@@ -7699,12 +7616,12 @@ var g = &grammar{
 		},
 		{
 			name: "ON",
-			pos:  position{line: 990, col: 1, offset: 27932},
+			pos:  position{line: 978, col: 1, offset: 27753},
 			expr: &actionExpr{
-				pos: position{line: 990, col: 6, offset: 27937},
+				pos: position{line: 978, col: 6, offset: 27758},
 				run: (*parser).callonON1,
 				expr: &litMatcher{
-					pos:        position{line: 990, col: 6, offset: 27937},
+					pos:        position{line: 978, col: 6, offset: 27758},
 					val:        "on",
 					ignoreCase: true,
 				},
@@ -7712,12 +7629,12 @@ var g = &grammar{
 		},
 		{
 			name: "LIMIT",
-			pos:  position{line: 991, col: 1, offset: 27964},
+			pos:  position{line: 979, col: 1, offset: 27785},
 			expr: &actionExpr{
-				pos: position{line: 991, col: 9, offset: 27972},
+				pos: position{line: 979, col: 9, offset: 27793},
 				run: (*parser).callonLIMIT1,
 				expr: &litMatcher{
-					pos:        position{line: 991, col: 9, offset: 27972},
+					pos:        position{line: 979, col: 9, offset: 27793},
 					val:        "limit",
 					ignoreCase: true,
 				},
@@ -7725,12 +7642,12 @@ var g = &grammar{
 		},
 		{
 			name: "ASC",
-			pos:  position{line: 992, col: 1, offset: 28005},
+			pos:  position{line: 980, col: 1, offset: 27826},
 			expr: &actionExpr{
-				pos: position{line: 992, col: 7, offset: 28011},
+				pos: position{line: 980, col: 7, offset: 27832},
 				run: (*parser).callonASC1,
 				expr: &litMatcher{
-					pos:        position{line: 992, col: 7, offset: 28011},
+					pos:        position{line: 980, col: 7, offset: 27832},
 					val:        "asc",
 					ignoreCase: true,
 				},
@@ -7738,12 +7655,12 @@ var g = &grammar{
 		},
 		{
 			name: "DESC",
-			pos:  position{line: 993, col: 1, offset: 28040},
+			pos:  position{line: 981, col: 1, offset: 27861},
 			expr: &actionExpr{
-				pos: position{line: 993, col: 8, offset: 28047},
+				pos: position{line: 981, col: 8, offset: 27868},
 				run: (*parser).callonDESC1,
 				expr: &litMatcher{
-					pos:        position{line: 993, col: 8, offset: 28047},
+					pos:        position{line: 981, col: 8, offset: 27868},
 					val:        "desc",
 					ignoreCase: true,
 				},
@@ -7751,12 +7668,12 @@ var g = &grammar{
 		},
 		{
 			name: "ANTI",
-			pos:  position{line: 994, col: 1, offset: 28078},
+			pos:  position{line: 982, col: 1, offset: 27899},
 			expr: &actionExpr{
-				pos: position{line: 994, col: 8, offset: 28085},
+				pos: position{line: 982, col: 8, offset: 27906},
 				run: (*parser).callonANTI1,
 				expr: &litMatcher{
-					pos:        position{line: 994, col: 8, offset: 28085},
+					pos:        position{line: 982, col: 8, offset: 27906},
 					val:        "anti",
 					ignoreCase: true,
 				},
@@ -7764,12 +7681,12 @@ var g = &grammar{
 		},
 		{
 			name: "LEFT",
-			pos:  position{line: 995, col: 1, offset: 28116},
+			pos:  position{line: 983, col: 1, offset: 27937},
 			expr: &actionExpr{
-				pos: position{line: 995, col: 8, offset: 28123},
+				pos: position{line: 983, col: 8, offset: 27944},
 				run: (*parser).callonLEFT1,
 				expr: &litMatcher{
-					pos:        position{line: 995, col: 8, offset: 28123},
+					pos:        position{line: 983, col: 8, offset: 27944},
 					val:        "left",
 					ignoreCase: true,
 				},
@@ -7777,12 +7694,12 @@ var g = &grammar{
 		},
 		{
 			name: "RIGHT",
-			pos:  position{line: 996, col: 1, offset: 28154},
+			pos:  position{line: 984, col: 1, offset: 27975},
 			expr: &actionExpr{
-				pos: position{line: 996, col: 9, offset: 28162},
+				pos: position{line: 984, col: 9, offset: 27983},
 				run: (*parser).callonRIGHT1,
 				expr: &litMatcher{
-					pos:        position{line: 996, col: 9, offset: 28162},
+					pos:        position{line: 984, col: 9, offset: 27983},
 					val:        "right",
 					ignoreCase: true,
 				},
@@ -7790,12 +7707,12 @@ var g = &grammar{
 		},
 		{
 			name: "INNER",
-			pos:  position{line: 997, col: 1, offset: 28195},
+			pos:  position{line: 985, col: 1, offset: 28016},
 			expr: &actionExpr{
-				pos: position{line: 997, col: 9, offset: 28203},
+				pos: position{line: 985, col: 9, offset: 28024},
 				run: (*parser).callonINNER1,
 				expr: &litMatcher{
-					pos:        position{line: 997, col: 9, offset: 28203},
+					pos:        position{line: 985, col: 9, offset: 28024},
 					val:        "inner",
 					ignoreCase: true,
 				},
@@ -7803,48 +7720,48 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTokenSentinels",
-			pos:  position{line: 999, col: 1, offset: 28237},
+			pos:  position{line: 987, col: 1, offset: 28058},
 			expr: &choiceExpr{
-				pos: position{line: 1000, col: 5, offset: 28259},
+				pos: position{line: 988, col: 5, offset: 28080},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1000, col: 5, offset: 28259},
+						pos:  position{line: 988, col: 5, offset: 28080},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1000, col: 14, offset: 28268},
+						pos:  position{line: 988, col: 14, offset: 28089},
 						name: "AS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1000, col: 19, offset: 28273},
+						pos:  position{line: 988, col: 19, offset: 28094},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1000, col: 27, offset: 28281},
+						pos:  position{line: 988, col: 27, offset: 28102},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1000, col: 34, offset: 28288},
+						pos:  position{line: 988, col: 34, offset: 28109},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1000, col: 42, offset: 28296},
+						pos:  position{line: 988, col: 42, offset: 28117},
 						name: "GROUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1000, col: 50, offset: 28304},
+						pos:  position{line: 988, col: 50, offset: 28125},
 						name: "HAVING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1000, col: 59, offset: 28313},
+						pos:  position{line: 988, col: 59, offset: 28134},
 						name: "ORDER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1000, col: 67, offset: 28321},
+						pos:  position{line: 988, col: 67, offset: 28142},
 						name: "LIMIT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1000, col: 75, offset: 28329},
+						pos:  position{line: 988, col: 75, offset: 28150},
 						name: "ON",
 					},
 				},
@@ -7852,52 +7769,52 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 1004, col: 1, offset: 28355},
+			pos:  position{line: 992, col: 1, offset: 28176},
 			expr: &choiceExpr{
-				pos: position{line: 1005, col: 5, offset: 28367},
+				pos: position{line: 993, col: 5, offset: 28188},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1005, col: 5, offset: 28367},
+						pos:  position{line: 993, col: 5, offset: 28188},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1006, col: 5, offset: 28383},
+						pos:  position{line: 994, col: 5, offset: 28204},
 						name: "TemplateLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1007, col: 5, offset: 28403},
+						pos:  position{line: 995, col: 5, offset: 28224},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1008, col: 5, offset: 28421},
+						pos:  position{line: 996, col: 5, offset: 28242},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1009, col: 5, offset: 28440},
+						pos:  position{line: 997, col: 5, offset: 28261},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1010, col: 5, offset: 28457},
+						pos:  position{line: 998, col: 5, offset: 28278},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1011, col: 5, offset: 28470},
+						pos:  position{line: 999, col: 5, offset: 28291},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1012, col: 5, offset: 28479},
+						pos:  position{line: 1000, col: 5, offset: 28300},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1013, col: 5, offset: 28496},
+						pos:  position{line: 1001, col: 5, offset: 28317},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1014, col: 5, offset: 28515},
+						pos:  position{line: 1002, col: 5, offset: 28336},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1015, col: 5, offset: 28534},
+						pos:  position{line: 1003, col: 5, offset: 28355},
 						name: "NullLiteral",
 					},
 				},
@@ -7905,28 +7822,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 1017, col: 1, offset: 28547},
+			pos:  position{line: 1005, col: 1, offset: 28368},
 			expr: &choiceExpr{
-				pos: position{line: 1018, col: 5, offset: 28565},
+				pos: position{line: 1006, col: 5, offset: 28386},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1018, col: 5, offset: 28565},
+						pos: position{line: 1006, col: 5, offset: 28386},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1018, col: 5, offset: 28565},
+							pos: position{line: 1006, col: 5, offset: 28386},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1018, col: 5, offset: 28565},
+									pos:   position{line: 1006, col: 5, offset: 28386},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1018, col: 7, offset: 28567},
+										pos:  position{line: 1006, col: 7, offset: 28388},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1018, col: 14, offset: 28574},
+									pos: position{line: 1006, col: 14, offset: 28395},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1018, col: 15, offset: 28575},
+										pos:  position{line: 1006, col: 15, offset: 28396},
 										name: "IdentifierRest",
 									},
 								},
@@ -7934,13 +7851,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1021, col: 5, offset: 28690},
+						pos: position{line: 1009, col: 5, offset: 28511},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1021, col: 5, offset: 28690},
+							pos:   position{line: 1009, col: 5, offset: 28511},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1021, col: 7, offset: 28692},
+								pos:  position{line: 1009, col: 7, offset: 28513},
 								name: "IP4Net",
 							},
 						},
@@ -7950,28 +7867,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 1025, col: 1, offset: 28796},
+			pos:  position{line: 1013, col: 1, offset: 28617},
 			expr: &choiceExpr{
-				pos: position{line: 1026, col: 5, offset: 28815},
+				pos: position{line: 1014, col: 5, offset: 28636},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1026, col: 5, offset: 28815},
+						pos: position{line: 1014, col: 5, offset: 28636},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1026, col: 5, offset: 28815},
+							pos: position{line: 1014, col: 5, offset: 28636},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1026, col: 5, offset: 28815},
+									pos:   position{line: 1014, col: 5, offset: 28636},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1026, col: 7, offset: 28817},
+										pos:  position{line: 1014, col: 7, offset: 28638},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1026, col: 11, offset: 28821},
+									pos: position{line: 1014, col: 11, offset: 28642},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1026, col: 12, offset: 28822},
+										pos:  position{line: 1014, col: 12, offset: 28643},
 										name: "IdentifierRest",
 									},
 								},
@@ -7979,13 +7896,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1029, col: 5, offset: 28936},
+						pos: position{line: 1017, col: 5, offset: 28757},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1029, col: 5, offset: 28936},
+							pos:   position{line: 1017, col: 5, offset: 28757},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1029, col: 7, offset: 28938},
+								pos:  position{line: 1017, col: 7, offset: 28759},
 								name: "IP",
 							},
 						},
@@ -7995,15 +7912,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 1033, col: 1, offset: 29037},
+			pos:  position{line: 1021, col: 1, offset: 28858},
 			expr: &actionExpr{
-				pos: position{line: 1034, col: 5, offset: 29054},
+				pos: position{line: 1022, col: 5, offset: 28875},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1034, col: 5, offset: 29054},
+					pos:   position{line: 1022, col: 5, offset: 28875},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1034, col: 7, offset: 29056},
+						pos:  position{line: 1022, col: 7, offset: 28877},
 						name: "FloatString",
 					},
 				},
@@ -8011,15 +7928,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 1038, col: 1, offset: 29169},
+			pos:  position{line: 1026, col: 1, offset: 28990},
 			expr: &actionExpr{
-				pos: position{line: 1039, col: 5, offset: 29188},
+				pos: position{line: 1027, col: 5, offset: 29009},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1039, col: 5, offset: 29188},
+					pos:   position{line: 1027, col: 5, offset: 29009},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1039, col: 7, offset: 29190},
+						pos:  position{line: 1027, col: 7, offset: 29011},
 						name: "IntString",
 					},
 				},
@@ -8027,24 +7944,24 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 1043, col: 1, offset: 29299},
+			pos:  position{line: 1031, col: 1, offset: 29120},
 			expr: &choiceExpr{
-				pos: position{line: 1044, col: 5, offset: 29318},
+				pos: position{line: 1032, col: 5, offset: 29139},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1044, col: 5, offset: 29318},
+						pos: position{line: 1032, col: 5, offset: 29139},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &litMatcher{
-							pos:        position{line: 1044, col: 5, offset: 29318},
+							pos:        position{line: 1032, col: 5, offset: 29139},
 							val:        "true",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1045, col: 5, offset: 29431},
+						pos: position{line: 1033, col: 5, offset: 29252},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &litMatcher{
-							pos:        position{line: 1045, col: 5, offset: 29431},
+							pos:        position{line: 1033, col: 5, offset: 29252},
 							val:        "false",
 							ignoreCase: false,
 						},
@@ -8054,12 +7971,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 1047, col: 1, offset: 29542},
+			pos:  position{line: 1035, col: 1, offset: 29363},
 			expr: &actionExpr{
-				pos: position{line: 1048, col: 5, offset: 29558},
+				pos: position{line: 1036, col: 5, offset: 29379},
 				run: (*parser).callonNullLiteral1,
 				expr: &litMatcher{
-					pos:        position{line: 1048, col: 5, offset: 29558},
+					pos:        position{line: 1036, col: 5, offset: 29379},
 					val:        "null",
 					ignoreCase: false,
 				},
@@ -8067,22 +7984,22 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 1050, col: 1, offset: 29664},
+			pos:  position{line: 1038, col: 1, offset: 29485},
 			expr: &actionExpr{
-				pos: position{line: 1051, col: 5, offset: 29681},
+				pos: position{line: 1039, col: 5, offset: 29502},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1051, col: 5, offset: 29681},
+					pos: position{line: 1039, col: 5, offset: 29502},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1051, col: 5, offset: 29681},
+							pos:        position{line: 1039, col: 5, offset: 29502},
 							val:        "0x",
 							ignoreCase: false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1051, col: 10, offset: 29686},
+							pos: position{line: 1039, col: 10, offset: 29507},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1051, col: 10, offset: 29686},
+								pos:  position{line: 1039, col: 10, offset: 29507},
 								name: "HexDigit",
 							},
 						},
@@ -8092,28 +8009,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 1055, col: 1, offset: 29801},
+			pos:  position{line: 1043, col: 1, offset: 29622},
 			expr: &actionExpr{
-				pos: position{line: 1056, col: 5, offset: 29817},
+				pos: position{line: 1044, col: 5, offset: 29638},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1056, col: 5, offset: 29817},
+					pos: position{line: 1044, col: 5, offset: 29638},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1056, col: 5, offset: 29817},
+							pos:        position{line: 1044, col: 5, offset: 29638},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1056, col: 9, offset: 29821},
+							pos:   position{line: 1044, col: 9, offset: 29642},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1056, col: 13, offset: 29825},
+								pos:  position{line: 1044, col: 13, offset: 29646},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1056, col: 18, offset: 29830},
+							pos:        position{line: 1044, col: 18, offset: 29651},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -8123,22 +8040,22 @@ var g = &grammar{
 		},
 		{
 			name: "CastType",
-			pos:  position{line: 1060, col: 1, offset: 29919},
+			pos:  position{line: 1048, col: 1, offset: 29740},
 			expr: &choiceExpr{
-				pos: position{line: 1061, col: 5, offset: 29932},
+				pos: position{line: 1049, col: 5, offset: 29753},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1061, col: 5, offset: 29932},
+						pos:  position{line: 1049, col: 5, offset: 29753},
 						name: "TypeLiteral",
 					},
 					&actionExpr{
-						pos: position{line: 1062, col: 5, offset: 29948},
+						pos: position{line: 1050, col: 5, offset: 29769},
 						run: (*parser).callonCastType3,
 						expr: &labeledExpr{
-							pos:   position{line: 1062, col: 5, offset: 29948},
+							pos:   position{line: 1050, col: 5, offset: 29769},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1062, col: 9, offset: 29952},
+								pos:  position{line: 1050, col: 9, offset: 29773},
 								name: "PrimitiveType",
 							},
 						},
@@ -8148,20 +8065,20 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1066, col: 1, offset: 30051},
+			pos:  position{line: 1054, col: 1, offset: 29872},
 			expr: &choiceExpr{
-				pos: position{line: 1067, col: 5, offset: 30060},
+				pos: position{line: 1055, col: 5, offset: 29881},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1067, col: 5, offset: 30060},
+						pos:  position{line: 1055, col: 5, offset: 29881},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1068, col: 5, offset: 30076},
+						pos:  position{line: 1056, col: 5, offset: 29897},
 						name: "AmbiguousType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1069, col: 5, offset: 30094},
+						pos:  position{line: 1057, col: 5, offset: 29915},
 						name: "ComplexType",
 					},
 				},
@@ -8169,28 +8086,28 @@ var g = &grammar{
 		},
 		{
 			name: "AmbiguousType",
-			pos:  position{line: 1071, col: 1, offset: 30107},
+			pos:  position{line: 1059, col: 1, offset: 29928},
 			expr: &choiceExpr{
-				pos: position{line: 1072, col: 5, offset: 30125},
+				pos: position{line: 1060, col: 5, offset: 29946},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1072, col: 5, offset: 30125},
+						pos: position{line: 1060, col: 5, offset: 29946},
 						run: (*parser).callonAmbiguousType2,
 						expr: &seqExpr{
-							pos: position{line: 1072, col: 5, offset: 30125},
+							pos: position{line: 1060, col: 5, offset: 29946},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1072, col: 5, offset: 30125},
+									pos:   position{line: 1060, col: 5, offset: 29946},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1072, col: 10, offset: 30130},
+										pos:  position{line: 1060, col: 10, offset: 29951},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1072, col: 24, offset: 30144},
+									pos: position{line: 1060, col: 24, offset: 29965},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1072, col: 25, offset: 30145},
+										pos:  position{line: 1060, col: 25, offset: 29966},
 										name: "IdentifierRest",
 									},
 								},
@@ -8198,42 +8115,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1073, col: 5, offset: 30185},
+						pos: position{line: 1061, col: 5, offset: 30006},
 						run: (*parser).callonAmbiguousType8,
 						expr: &seqExpr{
-							pos: position{line: 1073, col: 5, offset: 30185},
+							pos: position{line: 1061, col: 5, offset: 30006},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1073, col: 5, offset: 30185},
+									pos:   position{line: 1061, col: 5, offset: 30006},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1073, col: 10, offset: 30190},
+										pos:  position{line: 1061, col: 10, offset: 30011},
 										name: "IdentifierName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1073, col: 25, offset: 30205},
+									pos:   position{line: 1061, col: 25, offset: 30026},
 									label: "opt",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1073, col: 29, offset: 30209},
+										pos: position{line: 1061, col: 29, offset: 30030},
 										expr: &seqExpr{
-											pos: position{line: 1073, col: 30, offset: 30210},
+											pos: position{line: 1061, col: 30, offset: 30031},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 1073, col: 30, offset: 30210},
+													pos:  position{line: 1061, col: 30, offset: 30031},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1073, col: 33, offset: 30213},
+													pos:        position{line: 1061, col: 33, offset: 30034},
 													val:        "=",
 													ignoreCase: false,
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1073, col: 37, offset: 30217},
+													pos:  position{line: 1061, col: 37, offset: 30038},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1073, col: 40, offset: 30220},
+													pos:  position{line: 1061, col: 40, offset: 30041},
 													name: "Type",
 												},
 											},
@@ -8244,42 +8161,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1079, col: 5, offset: 30452},
+						pos: position{line: 1067, col: 5, offset: 30273},
 						run: (*parser).callonAmbiguousType19,
 						expr: &labeledExpr{
-							pos:   position{line: 1079, col: 5, offset: 30452},
+							pos:   position{line: 1067, col: 5, offset: 30273},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1079, col: 10, offset: 30457},
+								pos:  position{line: 1067, col: 10, offset: 30278},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1082, col: 5, offset: 30557},
+						pos: position{line: 1070, col: 5, offset: 30378},
 						run: (*parser).callonAmbiguousType22,
 						expr: &seqExpr{
-							pos: position{line: 1082, col: 5, offset: 30557},
+							pos: position{line: 1070, col: 5, offset: 30378},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1082, col: 5, offset: 30557},
+									pos:        position{line: 1070, col: 5, offset: 30378},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1082, col: 9, offset: 30561},
+									pos:  position{line: 1070, col: 9, offset: 30382},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1082, col: 12, offset: 30564},
+									pos:   position{line: 1070, col: 12, offset: 30385},
 									label: "u",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1082, col: 14, offset: 30566},
+										pos:  position{line: 1070, col: 14, offset: 30387},
 										name: "TypeUnion",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1082, col: 25, offset: 30577},
+									pos:        position{line: 1070, col: 25, offset: 30398},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -8291,15 +8208,15 @@ var g = &grammar{
 		},
 		{
 			name: "TypeUnion",
-			pos:  position{line: 1084, col: 1, offset: 30600},
+			pos:  position{line: 1072, col: 1, offset: 30421},
 			expr: &actionExpr{
-				pos: position{line: 1085, col: 5, offset: 30614},
+				pos: position{line: 1073, col: 5, offset: 30435},
 				run: (*parser).callonTypeUnion1,
 				expr: &labeledExpr{
-					pos:   position{line: 1085, col: 5, offset: 30614},
+					pos:   position{line: 1073, col: 5, offset: 30435},
 					label: "types",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1085, col: 11, offset: 30620},
+						pos:  position{line: 1073, col: 11, offset: 30441},
 						name: "TypeList",
 					},
 				},
@@ -8307,28 +8224,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1089, col: 1, offset: 30716},
+			pos:  position{line: 1077, col: 1, offset: 30537},
 			expr: &actionExpr{
-				pos: position{line: 1090, col: 5, offset: 30729},
+				pos: position{line: 1078, col: 5, offset: 30550},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1090, col: 5, offset: 30729},
+					pos: position{line: 1078, col: 5, offset: 30550},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1090, col: 5, offset: 30729},
+							pos:   position{line: 1078, col: 5, offset: 30550},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1090, col: 11, offset: 30735},
+								pos:  position{line: 1078, col: 11, offset: 30556},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1090, col: 16, offset: 30740},
+							pos:   position{line: 1078, col: 16, offset: 30561},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1090, col: 21, offset: 30745},
+								pos: position{line: 1078, col: 21, offset: 30566},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1090, col: 21, offset: 30745},
+									pos:  position{line: 1078, col: 21, offset: 30566},
 									name: "TypeListTail",
 								},
 							},
@@ -8339,31 +8256,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1094, col: 1, offset: 30839},
+			pos:  position{line: 1082, col: 1, offset: 30660},
 			expr: &actionExpr{
-				pos: position{line: 1094, col: 16, offset: 30854},
+				pos: position{line: 1082, col: 16, offset: 30675},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1094, col: 16, offset: 30854},
+					pos: position{line: 1082, col: 16, offset: 30675},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1094, col: 16, offset: 30854},
+							pos:  position{line: 1082, col: 16, offset: 30675},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1094, col: 19, offset: 30857},
+							pos:        position{line: 1082, col: 19, offset: 30678},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1094, col: 23, offset: 30861},
+							pos:  position{line: 1082, col: 23, offset: 30682},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1094, col: 26, offset: 30864},
+							pos:   position{line: 1082, col: 26, offset: 30685},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1094, col: 30, offset: 30868},
+								pos:  position{line: 1082, col: 30, offset: 30689},
 								name: "Type",
 							},
 						},
@@ -8373,39 +8290,39 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 1096, col: 1, offset: 30894},
+			pos:  position{line: 1084, col: 1, offset: 30715},
 			expr: &choiceExpr{
-				pos: position{line: 1097, col: 5, offset: 30910},
+				pos: position{line: 1085, col: 5, offset: 30731},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1097, col: 5, offset: 30910},
+						pos: position{line: 1085, col: 5, offset: 30731},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 1097, col: 5, offset: 30910},
+							pos: position{line: 1085, col: 5, offset: 30731},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1097, col: 5, offset: 30910},
+									pos:        position{line: 1085, col: 5, offset: 30731},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1097, col: 9, offset: 30914},
+									pos:  position{line: 1085, col: 9, offset: 30735},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1097, col: 12, offset: 30917},
+									pos:   position{line: 1085, col: 12, offset: 30738},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1097, col: 19, offset: 30924},
+										pos:  position{line: 1085, col: 19, offset: 30745},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1097, col: 33, offset: 30938},
+									pos:  position{line: 1085, col: 33, offset: 30759},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1097, col: 36, offset: 30941},
+									pos:        position{line: 1085, col: 36, offset: 30762},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -8413,34 +8330,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1100, col: 5, offset: 31036},
+						pos: position{line: 1088, col: 5, offset: 30857},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 1100, col: 5, offset: 31036},
+							pos: position{line: 1088, col: 5, offset: 30857},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1100, col: 5, offset: 31036},
+									pos:        position{line: 1088, col: 5, offset: 30857},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1100, col: 9, offset: 31040},
+									pos:  position{line: 1088, col: 9, offset: 30861},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1100, col: 12, offset: 31043},
+									pos:   position{line: 1088, col: 12, offset: 30864},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1100, col: 16, offset: 31047},
+										pos:  position{line: 1088, col: 16, offset: 30868},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1100, col: 21, offset: 31052},
+									pos:  position{line: 1088, col: 21, offset: 30873},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1100, col: 24, offset: 31055},
+									pos:        position{line: 1088, col: 24, offset: 30876},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -8448,34 +8365,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1103, col: 5, offset: 31144},
+						pos: position{line: 1091, col: 5, offset: 30965},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 1103, col: 5, offset: 31144},
+							pos: position{line: 1091, col: 5, offset: 30965},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1103, col: 5, offset: 31144},
+									pos:        position{line: 1091, col: 5, offset: 30965},
 									val:        "|[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1103, col: 10, offset: 31149},
+									pos:  position{line: 1091, col: 10, offset: 30970},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1103, col: 14, offset: 31153},
+									pos:   position{line: 1091, col: 14, offset: 30974},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1103, col: 18, offset: 31157},
+										pos:  position{line: 1091, col: 18, offset: 30978},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1103, col: 23, offset: 31162},
+									pos:  position{line: 1091, col: 23, offset: 30983},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1103, col: 26, offset: 31165},
+									pos:        position{line: 1091, col: 26, offset: 30986},
 									val:        "]|",
 									ignoreCase: false,
 								},
@@ -8483,55 +8400,55 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1106, col: 5, offset: 31253},
+						pos: position{line: 1094, col: 5, offset: 31074},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 1106, col: 5, offset: 31253},
+							pos: position{line: 1094, col: 5, offset: 31074},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1106, col: 5, offset: 31253},
+									pos:        position{line: 1094, col: 5, offset: 31074},
 									val:        "|{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1106, col: 10, offset: 31258},
+									pos:  position{line: 1094, col: 10, offset: 31079},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1106, col: 13, offset: 31261},
+									pos:   position{line: 1094, col: 13, offset: 31082},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1106, col: 21, offset: 31269},
+										pos:  position{line: 1094, col: 21, offset: 31090},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1106, col: 26, offset: 31274},
+									pos:  position{line: 1094, col: 26, offset: 31095},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1106, col: 29, offset: 31277},
+									pos:        position{line: 1094, col: 29, offset: 31098},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1106, col: 33, offset: 31281},
+									pos:  position{line: 1094, col: 33, offset: 31102},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1106, col: 36, offset: 31284},
+									pos:   position{line: 1094, col: 36, offset: 31105},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1106, col: 44, offset: 31292},
+										pos:  position{line: 1094, col: 44, offset: 31113},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1106, col: 49, offset: 31297},
+									pos:  position{line: 1094, col: 49, offset: 31118},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1106, col: 52, offset: 31300},
+									pos:        position{line: 1094, col: 52, offset: 31121},
 									val:        "}|",
 									ignoreCase: false,
 								},
@@ -8543,15 +8460,15 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateLiteral",
-			pos:  position{line: 1110, col: 1, offset: 31414},
+			pos:  position{line: 1098, col: 1, offset: 31235},
 			expr: &actionExpr{
-				pos: position{line: 1111, col: 5, offset: 31434},
+				pos: position{line: 1099, col: 5, offset: 31255},
 				run: (*parser).callonTemplateLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1111, col: 5, offset: 31434},
+					pos:   position{line: 1099, col: 5, offset: 31255},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1111, col: 7, offset: 31436},
+						pos:  position{line: 1099, col: 7, offset: 31257},
 						name: "TemplateLiteralParts",
 					},
 				},
@@ -8559,34 +8476,34 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateLiteralParts",
-			pos:  position{line: 1118, col: 1, offset: 31652},
+			pos:  position{line: 1106, col: 1, offset: 31473},
 			expr: &choiceExpr{
-				pos: position{line: 1119, col: 5, offset: 31677},
+				pos: position{line: 1107, col: 5, offset: 31498},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1119, col: 5, offset: 31677},
+						pos: position{line: 1107, col: 5, offset: 31498},
 						run: (*parser).callonTemplateLiteralParts2,
 						expr: &seqExpr{
-							pos: position{line: 1119, col: 5, offset: 31677},
+							pos: position{line: 1107, col: 5, offset: 31498},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1119, col: 5, offset: 31677},
+									pos:        position{line: 1107, col: 5, offset: 31498},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1119, col: 9, offset: 31681},
+									pos:   position{line: 1107, col: 9, offset: 31502},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1119, col: 11, offset: 31683},
+										pos: position{line: 1107, col: 11, offset: 31504},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1119, col: 11, offset: 31683},
+											pos:  position{line: 1107, col: 11, offset: 31504},
 											name: "TemplateDoubleQuotedPart",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1119, col: 37, offset: 31709},
+									pos:        position{line: 1107, col: 37, offset: 31530},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -8594,29 +8511,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1120, col: 5, offset: 31735},
+						pos: position{line: 1108, col: 5, offset: 31556},
 						run: (*parser).callonTemplateLiteralParts9,
 						expr: &seqExpr{
-							pos: position{line: 1120, col: 5, offset: 31735},
+							pos: position{line: 1108, col: 5, offset: 31556},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1120, col: 5, offset: 31735},
+									pos:        position{line: 1108, col: 5, offset: 31556},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1120, col: 9, offset: 31739},
+									pos:   position{line: 1108, col: 9, offset: 31560},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1120, col: 11, offset: 31741},
+										pos: position{line: 1108, col: 11, offset: 31562},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1120, col: 11, offset: 31741},
+											pos:  position{line: 1108, col: 11, offset: 31562},
 											name: "TemplateSingleQuotedPart",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1120, col: 37, offset: 31767},
+									pos:        position{line: 1108, col: 37, offset: 31588},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -8628,24 +8545,24 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateDoubleQuotedPart",
-			pos:  position{line: 1122, col: 1, offset: 31790},
+			pos:  position{line: 1110, col: 1, offset: 31611},
 			expr: &choiceExpr{
-				pos: position{line: 1123, col: 5, offset: 31819},
+				pos: position{line: 1111, col: 5, offset: 31640},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1123, col: 5, offset: 31819},
+						pos:  position{line: 1111, col: 5, offset: 31640},
 						name: "TemplateExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1124, col: 5, offset: 31836},
+						pos: position{line: 1112, col: 5, offset: 31657},
 						run: (*parser).callonTemplateDoubleQuotedPart3,
 						expr: &labeledExpr{
-							pos:   position{line: 1124, col: 5, offset: 31836},
+							pos:   position{line: 1112, col: 5, offset: 31657},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1124, col: 7, offset: 31838},
+								pos: position{line: 1112, col: 7, offset: 31659},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1124, col: 7, offset: 31838},
+									pos:  position{line: 1112, col: 7, offset: 31659},
 									name: "TemplateDoubleQuotedChar",
 								},
 							},
@@ -8656,26 +8573,26 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateDoubleQuotedChar",
-			pos:  position{line: 1128, col: 1, offset: 31975},
+			pos:  position{line: 1116, col: 1, offset: 31796},
 			expr: &choiceExpr{
-				pos: position{line: 1129, col: 5, offset: 32004},
+				pos: position{line: 1117, col: 5, offset: 31825},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1129, col: 5, offset: 32004},
+						pos: position{line: 1117, col: 5, offset: 31825},
 						run: (*parser).callonTemplateDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1129, col: 5, offset: 32004},
+							pos: position{line: 1117, col: 5, offset: 31825},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1129, col: 5, offset: 32004},
+									pos:        position{line: 1117, col: 5, offset: 31825},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1129, col: 10, offset: 32009},
+									pos:   position{line: 1117, col: 10, offset: 31830},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1129, col: 12, offset: 32011},
+										pos:        position{line: 1117, col: 12, offset: 31832},
 										val:        "${",
 										ignoreCase: false,
 									},
@@ -8684,24 +8601,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1130, col: 5, offset: 32038},
+						pos: position{line: 1118, col: 5, offset: 31859},
 						run: (*parser).callonTemplateDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1130, col: 5, offset: 32038},
+							pos: position{line: 1118, col: 5, offset: 31859},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1130, col: 5, offset: 32038},
+									pos: position{line: 1118, col: 5, offset: 31859},
 									expr: &litMatcher{
-										pos:        position{line: 1130, col: 8, offset: 32041},
+										pos:        position{line: 1118, col: 8, offset: 31862},
 										val:        "${",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1130, col: 15, offset: 32048},
+									pos:   position{line: 1118, col: 15, offset: 31869},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1130, col: 17, offset: 32050},
+										pos:  position{line: 1118, col: 17, offset: 31871},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -8713,24 +8630,24 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateSingleQuotedPart",
-			pos:  position{line: 1132, col: 1, offset: 32086},
+			pos:  position{line: 1120, col: 1, offset: 31907},
 			expr: &choiceExpr{
-				pos: position{line: 1133, col: 5, offset: 32115},
+				pos: position{line: 1121, col: 5, offset: 31936},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1133, col: 5, offset: 32115},
+						pos:  position{line: 1121, col: 5, offset: 31936},
 						name: "TemplateExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1134, col: 5, offset: 32132},
+						pos: position{line: 1122, col: 5, offset: 31953},
 						run: (*parser).callonTemplateSingleQuotedPart3,
 						expr: &labeledExpr{
-							pos:   position{line: 1134, col: 5, offset: 32132},
+							pos:   position{line: 1122, col: 5, offset: 31953},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1134, col: 7, offset: 32134},
+								pos: position{line: 1122, col: 7, offset: 31955},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1134, col: 7, offset: 32134},
+									pos:  position{line: 1122, col: 7, offset: 31955},
 									name: "TemplateSingleQuotedChar",
 								},
 							},
@@ -8741,26 +8658,26 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateSingleQuotedChar",
-			pos:  position{line: 1138, col: 1, offset: 32271},
+			pos:  position{line: 1126, col: 1, offset: 32092},
 			expr: &choiceExpr{
-				pos: position{line: 1139, col: 5, offset: 32300},
+				pos: position{line: 1127, col: 5, offset: 32121},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1139, col: 5, offset: 32300},
+						pos: position{line: 1127, col: 5, offset: 32121},
 						run: (*parser).callonTemplateSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1139, col: 5, offset: 32300},
+							pos: position{line: 1127, col: 5, offset: 32121},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1139, col: 5, offset: 32300},
+									pos:        position{line: 1127, col: 5, offset: 32121},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1139, col: 10, offset: 32305},
+									pos:   position{line: 1127, col: 10, offset: 32126},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1139, col: 12, offset: 32307},
+										pos:        position{line: 1127, col: 12, offset: 32128},
 										val:        "${",
 										ignoreCase: false,
 									},
@@ -8769,24 +8686,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1140, col: 5, offset: 32334},
+						pos: position{line: 1128, col: 5, offset: 32155},
 						run: (*parser).callonTemplateSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1140, col: 5, offset: 32334},
+							pos: position{line: 1128, col: 5, offset: 32155},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1140, col: 5, offset: 32334},
+									pos: position{line: 1128, col: 5, offset: 32155},
 									expr: &litMatcher{
-										pos:        position{line: 1140, col: 8, offset: 32337},
+										pos:        position{line: 1128, col: 8, offset: 32158},
 										val:        "${",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1140, col: 15, offset: 32344},
+									pos:   position{line: 1128, col: 15, offset: 32165},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1140, col: 17, offset: 32346},
+										pos:  position{line: 1128, col: 17, offset: 32167},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -8798,36 +8715,36 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateExpr",
-			pos:  position{line: 1142, col: 1, offset: 32382},
+			pos:  position{line: 1130, col: 1, offset: 32203},
 			expr: &actionExpr{
-				pos: position{line: 1143, col: 5, offset: 32399},
+				pos: position{line: 1131, col: 5, offset: 32220},
 				run: (*parser).callonTemplateExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1143, col: 5, offset: 32399},
+					pos: position{line: 1131, col: 5, offset: 32220},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1143, col: 5, offset: 32399},
+							pos:        position{line: 1131, col: 5, offset: 32220},
 							val:        "${",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1143, col: 10, offset: 32404},
+							pos:  position{line: 1131, col: 10, offset: 32225},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1143, col: 13, offset: 32407},
+							pos:   position{line: 1131, col: 13, offset: 32228},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1143, col: 15, offset: 32409},
+								pos:  position{line: 1131, col: 15, offset: 32230},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1143, col: 20, offset: 32414},
+							pos:  position{line: 1131, col: 20, offset: 32235},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1143, col: 23, offset: 32417},
+							pos:        position{line: 1131, col: 23, offset: 32238},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -8837,105 +8754,105 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1158, col: 1, offset: 32713},
+			pos:  position{line: 1146, col: 1, offset: 32534},
 			expr: &actionExpr{
-				pos: position{line: 1159, col: 5, offset: 32731},
+				pos: position{line: 1147, col: 5, offset: 32552},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1159, col: 9, offset: 32735},
+					pos: position{line: 1147, col: 9, offset: 32556},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1159, col: 9, offset: 32735},
+							pos:        position{line: 1147, col: 9, offset: 32556},
 							val:        "uint8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1159, col: 19, offset: 32745},
+							pos:        position{line: 1147, col: 19, offset: 32566},
 							val:        "uint16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1159, col: 30, offset: 32756},
+							pos:        position{line: 1147, col: 30, offset: 32577},
 							val:        "uint32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1159, col: 41, offset: 32767},
+							pos:        position{line: 1147, col: 41, offset: 32588},
 							val:        "uint64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1160, col: 9, offset: 32784},
+							pos:        position{line: 1148, col: 9, offset: 32605},
 							val:        "int8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1160, col: 18, offset: 32793},
+							pos:        position{line: 1148, col: 18, offset: 32614},
 							val:        "int16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1160, col: 28, offset: 32803},
+							pos:        position{line: 1148, col: 28, offset: 32624},
 							val:        "int32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1160, col: 38, offset: 32813},
+							pos:        position{line: 1148, col: 38, offset: 32634},
 							val:        "int64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1161, col: 9, offset: 32829},
+							pos:        position{line: 1149, col: 9, offset: 32650},
 							val:        "float32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1161, col: 21, offset: 32841},
+							pos:        position{line: 1149, col: 21, offset: 32662},
 							val:        "float64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1162, col: 9, offset: 32859},
+							pos:        position{line: 1150, col: 9, offset: 32680},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1162, col: 18, offset: 32868},
+							pos:        position{line: 1150, col: 18, offset: 32689},
 							val:        "string",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1163, col: 9, offset: 32885},
+							pos:        position{line: 1151, col: 9, offset: 32706},
 							val:        "duration",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1163, col: 22, offset: 32898},
+							pos:        position{line: 1151, col: 22, offset: 32719},
 							val:        "time",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1164, col: 9, offset: 32913},
+							pos:        position{line: 1152, col: 9, offset: 32734},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1165, col: 9, offset: 32929},
+							pos:        position{line: 1153, col: 9, offset: 32750},
 							val:        "ip",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1165, col: 16, offset: 32936},
+							pos:        position{line: 1153, col: 16, offset: 32757},
 							val:        "net",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1166, col: 9, offset: 32950},
+							pos:        position{line: 1154, col: 9, offset: 32771},
 							val:        "type",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1166, col: 18, offset: 32959},
+							pos:        position{line: 1154, col: 18, offset: 32780},
 							val:        "null",
 							ignoreCase: false,
 						},
@@ -8945,31 +8862,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1170, col: 1, offset: 33075},
+			pos:  position{line: 1158, col: 1, offset: 32896},
 			expr: &choiceExpr{
-				pos: position{line: 1171, col: 5, offset: 33093},
+				pos: position{line: 1159, col: 5, offset: 32914},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1171, col: 5, offset: 33093},
+						pos: position{line: 1159, col: 5, offset: 32914},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1171, col: 5, offset: 33093},
+							pos: position{line: 1159, col: 5, offset: 32914},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1171, col: 5, offset: 33093},
+									pos:   position{line: 1159, col: 5, offset: 32914},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1171, col: 11, offset: 33099},
+										pos:  position{line: 1159, col: 11, offset: 32920},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1171, col: 21, offset: 33109},
+									pos:   position{line: 1159, col: 21, offset: 32930},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1171, col: 26, offset: 33114},
+										pos: position{line: 1159, col: 26, offset: 32935},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1171, col: 26, offset: 33114},
+											pos:  position{line: 1159, col: 26, offset: 32935},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -8978,10 +8895,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1174, col: 5, offset: 33216},
+						pos: position{line: 1162, col: 5, offset: 33037},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1174, col: 5, offset: 33216},
+							pos:        position{line: 1162, col: 5, offset: 33037},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -8991,31 +8908,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1176, col: 1, offset: 33240},
+			pos:  position{line: 1164, col: 1, offset: 33061},
 			expr: &actionExpr{
-				pos: position{line: 1176, col: 21, offset: 33260},
+				pos: position{line: 1164, col: 21, offset: 33081},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1176, col: 21, offset: 33260},
+					pos: position{line: 1164, col: 21, offset: 33081},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1176, col: 21, offset: 33260},
+							pos:  position{line: 1164, col: 21, offset: 33081},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1176, col: 24, offset: 33263},
+							pos:        position{line: 1164, col: 24, offset: 33084},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1176, col: 28, offset: 33267},
+							pos:  position{line: 1164, col: 28, offset: 33088},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1176, col: 31, offset: 33270},
+							pos:   position{line: 1164, col: 31, offset: 33091},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1176, col: 35, offset: 33274},
+								pos:  position{line: 1164, col: 35, offset: 33095},
 								name: "TypeField",
 							},
 						},
@@ -9025,39 +8942,39 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1178, col: 1, offset: 33305},
+			pos:  position{line: 1166, col: 1, offset: 33126},
 			expr: &actionExpr{
-				pos: position{line: 1179, col: 5, offset: 33319},
+				pos: position{line: 1167, col: 5, offset: 33140},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1179, col: 5, offset: 33319},
+					pos: position{line: 1167, col: 5, offset: 33140},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1179, col: 5, offset: 33319},
+							pos:   position{line: 1167, col: 5, offset: 33140},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1179, col: 10, offset: 33324},
+								pos:  position{line: 1167, col: 10, offset: 33145},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1179, col: 20, offset: 33334},
+							pos:  position{line: 1167, col: 20, offset: 33155},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1179, col: 23, offset: 33337},
+							pos:        position{line: 1167, col: 23, offset: 33158},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1179, col: 27, offset: 33341},
+							pos:  position{line: 1167, col: 27, offset: 33162},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1179, col: 30, offset: 33344},
+							pos:   position{line: 1167, col: 30, offset: 33165},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1179, col: 34, offset: 33348},
+								pos:  position{line: 1167, col: 34, offset: 33169},
 								name: "Type",
 							},
 						},
@@ -9067,16 +8984,16 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 1183, col: 1, offset: 33430},
+			pos:  position{line: 1171, col: 1, offset: 33251},
 			expr: &choiceExpr{
-				pos: position{line: 1184, col: 5, offset: 33444},
+				pos: position{line: 1172, col: 5, offset: 33265},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1184, col: 5, offset: 33444},
+						pos:  position{line: 1172, col: 5, offset: 33265},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1185, col: 5, offset: 33463},
+						pos:  position{line: 1173, col: 5, offset: 33284},
 						name: "QuotedString",
 					},
 				},
@@ -9084,32 +9001,32 @@ var g = &grammar{
 		},
 		{
 			name: "AndToken",
-			pos:  position{line: 1187, col: 1, offset: 33477},
+			pos:  position{line: 1175, col: 1, offset: 33298},
 			expr: &actionExpr{
-				pos: position{line: 1187, col: 12, offset: 33488},
+				pos: position{line: 1175, col: 12, offset: 33309},
 				run: (*parser).callonAndToken1,
 				expr: &seqExpr{
-					pos: position{line: 1187, col: 12, offset: 33488},
+					pos: position{line: 1175, col: 12, offset: 33309},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 1187, col: 13, offset: 33489},
+							pos: position{line: 1175, col: 13, offset: 33310},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1187, col: 13, offset: 33489},
+									pos:        position{line: 1175, col: 13, offset: 33310},
 									val:        "and",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1187, col: 21, offset: 33497},
+									pos:        position{line: 1175, col: 21, offset: 33318},
 									val:        "AND",
 									ignoreCase: false,
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1187, col: 28, offset: 33504},
+							pos: position{line: 1175, col: 28, offset: 33325},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1187, col: 29, offset: 33505},
+								pos:  position{line: 1175, col: 29, offset: 33326},
 								name: "IdentifierRest",
 							},
 						},
@@ -9119,32 +9036,32 @@ var g = &grammar{
 		},
 		{
 			name: "OrToken",
-			pos:  position{line: 1188, col: 1, offset: 33542},
+			pos:  position{line: 1176, col: 1, offset: 33363},
 			expr: &actionExpr{
-				pos: position{line: 1188, col: 11, offset: 33552},
+				pos: position{line: 1176, col: 11, offset: 33373},
 				run: (*parser).callonOrToken1,
 				expr: &seqExpr{
-					pos: position{line: 1188, col: 11, offset: 33552},
+					pos: position{line: 1176, col: 11, offset: 33373},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 1188, col: 12, offset: 33553},
+							pos: position{line: 1176, col: 12, offset: 33374},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1188, col: 12, offset: 33553},
+									pos:        position{line: 1176, col: 12, offset: 33374},
 									val:        "or",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1188, col: 19, offset: 33560},
+									pos:        position{line: 1176, col: 19, offset: 33381},
 									val:        "OR",
 									ignoreCase: false,
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1188, col: 25, offset: 33566},
+							pos: position{line: 1176, col: 25, offset: 33387},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1188, col: 26, offset: 33567},
+								pos:  position{line: 1176, col: 26, offset: 33388},
 								name: "IdentifierRest",
 							},
 						},
@@ -9154,22 +9071,22 @@ var g = &grammar{
 		},
 		{
 			name: "InToken",
-			pos:  position{line: 1189, col: 1, offset: 33603},
+			pos:  position{line: 1177, col: 1, offset: 33424},
 			expr: &actionExpr{
-				pos: position{line: 1189, col: 11, offset: 33613},
+				pos: position{line: 1177, col: 11, offset: 33434},
 				run: (*parser).callonInToken1,
 				expr: &seqExpr{
-					pos: position{line: 1189, col: 11, offset: 33613},
+					pos: position{line: 1177, col: 11, offset: 33434},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1189, col: 11, offset: 33613},
+							pos:        position{line: 1177, col: 11, offset: 33434},
 							val:        "in",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1189, col: 16, offset: 33618},
+							pos: position{line: 1177, col: 16, offset: 33439},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1189, col: 17, offset: 33619},
+								pos:  position{line: 1177, col: 17, offset: 33440},
 								name: "IdentifierRest",
 							},
 						},
@@ -9179,32 +9096,32 @@ var g = &grammar{
 		},
 		{
 			name: "NotToken",
-			pos:  position{line: 1190, col: 1, offset: 33655},
+			pos:  position{line: 1178, col: 1, offset: 33476},
 			expr: &actionExpr{
-				pos: position{line: 1190, col: 12, offset: 33666},
+				pos: position{line: 1178, col: 12, offset: 33487},
 				run: (*parser).callonNotToken1,
 				expr: &seqExpr{
-					pos: position{line: 1190, col: 12, offset: 33666},
+					pos: position{line: 1178, col: 12, offset: 33487},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 1190, col: 13, offset: 33667},
+							pos: position{line: 1178, col: 13, offset: 33488},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1190, col: 13, offset: 33667},
+									pos:        position{line: 1178, col: 13, offset: 33488},
 									val:        "not",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1190, col: 21, offset: 33675},
+									pos:        position{line: 1178, col: 21, offset: 33496},
 									val:        "NOT",
 									ignoreCase: false,
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1190, col: 28, offset: 33682},
+							pos: position{line: 1178, col: 28, offset: 33503},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1190, col: 29, offset: 33683},
+								pos:  position{line: 1178, col: 29, offset: 33504},
 								name: "IdentifierRest",
 							},
 						},
@@ -9214,22 +9131,22 @@ var g = &grammar{
 		},
 		{
 			name: "ByToken",
-			pos:  position{line: 1191, col: 1, offset: 33720},
+			pos:  position{line: 1179, col: 1, offset: 33541},
 			expr: &actionExpr{
-				pos: position{line: 1191, col: 11, offset: 33730},
+				pos: position{line: 1179, col: 11, offset: 33551},
 				run: (*parser).callonByToken1,
 				expr: &seqExpr{
-					pos: position{line: 1191, col: 11, offset: 33730},
+					pos: position{line: 1179, col: 11, offset: 33551},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1191, col: 11, offset: 33730},
+							pos:        position{line: 1179, col: 11, offset: 33551},
 							val:        "by",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1191, col: 16, offset: 33735},
+							pos: position{line: 1179, col: 16, offset: 33556},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1191, col: 17, offset: 33736},
+								pos:  position{line: 1179, col: 17, offset: 33557},
 								name: "IdentifierRest",
 							},
 						},
@@ -9239,9 +9156,9 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1193, col: 1, offset: 33773},
+			pos:  position{line: 1181, col: 1, offset: 33594},
 			expr: &charClassMatcher{
-				pos:        position{line: 1193, col: 19, offset: 33791},
+				pos:        position{line: 1181, col: 19, offset: 33612},
 				val:        "[A-Za-z_$]",
 				chars:      []rune{'_', '$'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -9251,16 +9168,16 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1195, col: 1, offset: 33803},
+			pos:  position{line: 1183, col: 1, offset: 33624},
 			expr: &choiceExpr{
-				pos: position{line: 1195, col: 18, offset: 33820},
+				pos: position{line: 1183, col: 18, offset: 33641},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1195, col: 18, offset: 33820},
+						pos:  position{line: 1183, col: 18, offset: 33641},
 						name: "IdentifierStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1195, col: 36, offset: 33838},
+						pos:        position{line: 1183, col: 36, offset: 33659},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9271,15 +9188,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1197, col: 1, offset: 33845},
+			pos:  position{line: 1185, col: 1, offset: 33666},
 			expr: &actionExpr{
-				pos: position{line: 1198, col: 5, offset: 33860},
+				pos: position{line: 1186, col: 5, offset: 33681},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1198, col: 5, offset: 33860},
+					pos:   position{line: 1186, col: 5, offset: 33681},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1198, col: 8, offset: 33863},
+						pos:  position{line: 1186, col: 8, offset: 33684},
 						name: "IdentifierName",
 					},
 				},
@@ -9287,29 +9204,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1200, col: 1, offset: 33944},
+			pos:  position{line: 1188, col: 1, offset: 33765},
 			expr: &choiceExpr{
-				pos: position{line: 1201, col: 5, offset: 33963},
+				pos: position{line: 1189, col: 5, offset: 33784},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1201, col: 5, offset: 33963},
+						pos: position{line: 1189, col: 5, offset: 33784},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1201, col: 5, offset: 33963},
+							pos: position{line: 1189, col: 5, offset: 33784},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1201, col: 5, offset: 33963},
+									pos: position{line: 1189, col: 5, offset: 33784},
 									expr: &seqExpr{
-										pos: position{line: 1201, col: 7, offset: 33965},
+										pos: position{line: 1189, col: 7, offset: 33786},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1201, col: 7, offset: 33965},
+												pos:  position{line: 1189, col: 7, offset: 33786},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1201, col: 15, offset: 33973},
+												pos: position{line: 1189, col: 15, offset: 33794},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1201, col: 16, offset: 33974},
+													pos:  position{line: 1189, col: 16, offset: 33795},
 													name: "IdentifierRest",
 												},
 											},
@@ -9317,13 +9234,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1201, col: 32, offset: 33990},
+									pos:  position{line: 1189, col: 32, offset: 33811},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1201, col: 48, offset: 34006},
+									pos: position{line: 1189, col: 48, offset: 33827},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1201, col: 48, offset: 34006},
+										pos:  position{line: 1189, col: 48, offset: 33827},
 										name: "IdentifierRest",
 									},
 								},
@@ -9331,30 +9248,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1202, col: 5, offset: 34058},
+						pos: position{line: 1190, col: 5, offset: 33879},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 1202, col: 5, offset: 34058},
+							pos:        position{line: 1190, col: 5, offset: 33879},
 							val:        "$",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1203, col: 5, offset: 34097},
+						pos: position{line: 1191, col: 5, offset: 33918},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 1203, col: 5, offset: 34097},
+							pos: position{line: 1191, col: 5, offset: 33918},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1203, col: 5, offset: 34097},
+									pos:        position{line: 1191, col: 5, offset: 33918},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1203, col: 10, offset: 34102},
+									pos:   position{line: 1191, col: 10, offset: 33923},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1203, col: 13, offset: 34105},
+										pos:  position{line: 1191, col: 13, offset: 33926},
 										name: "IDGuard",
 									},
 								},
@@ -9362,39 +9279,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1205, col: 5, offset: 34196},
+						pos: position{line: 1193, col: 5, offset: 34017},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 1205, col: 5, offset: 34196},
+							pos:        position{line: 1193, col: 5, offset: 34017},
 							val:        "type",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1206, col: 5, offset: 34238},
+						pos: position{line: 1194, col: 5, offset: 34059},
 						run: (*parser).callonIdentifierName21,
 						expr: &seqExpr{
-							pos: position{line: 1206, col: 5, offset: 34238},
+							pos: position{line: 1194, col: 5, offset: 34059},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1206, col: 5, offset: 34238},
+									pos:   position{line: 1194, col: 5, offset: 34059},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1206, col: 8, offset: 34241},
+										pos:  position{line: 1194, col: 8, offset: 34062},
 										name: "SQLTokenSentinels",
 									},
 								},
 								&andExpr{
-									pos: position{line: 1206, col: 26, offset: 34259},
+									pos: position{line: 1194, col: 26, offset: 34080},
 									expr: &seqExpr{
-										pos: position{line: 1206, col: 28, offset: 34261},
+										pos: position{line: 1194, col: 28, offset: 34082},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1206, col: 28, offset: 34261},
+												pos:  position{line: 1194, col: 28, offset: 34082},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1206, col: 31, offset: 34264},
+												pos:        position{line: 1194, col: 31, offset: 34085},
 												val:        "(",
 												ignoreCase: false,
 											},
@@ -9409,24 +9326,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1208, col: 1, offset: 34289},
+			pos:  position{line: 1196, col: 1, offset: 34110},
 			expr: &choiceExpr{
-				pos: position{line: 1209, col: 5, offset: 34301},
+				pos: position{line: 1197, col: 5, offset: 34122},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1209, col: 5, offset: 34301},
+						pos:  position{line: 1197, col: 5, offset: 34122},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1210, col: 5, offset: 34320},
+						pos:  position{line: 1198, col: 5, offset: 34141},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1211, col: 5, offset: 34336},
+						pos:  position{line: 1199, col: 5, offset: 34157},
 						name: "NaN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1212, col: 5, offset: 34344},
+						pos:  position{line: 1200, col: 5, offset: 34165},
 						name: "Infinity",
 					},
 				},
@@ -9434,24 +9351,24 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1214, col: 1, offset: 34354},
+			pos:  position{line: 1202, col: 1, offset: 34175},
 			expr: &actionExpr{
-				pos: position{line: 1215, col: 5, offset: 34363},
+				pos: position{line: 1203, col: 5, offset: 34184},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1215, col: 5, offset: 34363},
+					pos: position{line: 1203, col: 5, offset: 34184},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1215, col: 5, offset: 34363},
+							pos:  position{line: 1203, col: 5, offset: 34184},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1215, col: 14, offset: 34372},
+							pos:        position{line: 1203, col: 14, offset: 34193},
 							val:        "T",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1215, col: 18, offset: 34376},
+							pos:  position{line: 1203, col: 18, offset: 34197},
 							name: "FullTime",
 						},
 					},
@@ -9460,30 +9377,30 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1219, col: 1, offset: 34496},
+			pos:  position{line: 1207, col: 1, offset: 34317},
 			expr: &seqExpr{
-				pos: position{line: 1219, col: 12, offset: 34507},
+				pos: position{line: 1207, col: 12, offset: 34328},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1219, col: 12, offset: 34507},
+						pos:  position{line: 1207, col: 12, offset: 34328},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1219, col: 15, offset: 34510},
+						pos:        position{line: 1207, col: 15, offset: 34331},
 						val:        "-",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1219, col: 19, offset: 34514},
+						pos:  position{line: 1207, col: 19, offset: 34335},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1219, col: 22, offset: 34517},
+						pos:        position{line: 1207, col: 22, offset: 34338},
 						val:        "-",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1219, col: 26, offset: 34521},
+						pos:  position{line: 1207, col: 26, offset: 34342},
 						name: "D2",
 					},
 				},
@@ -9491,33 +9408,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1221, col: 1, offset: 34525},
+			pos:  position{line: 1209, col: 1, offset: 34346},
 			expr: &seqExpr{
-				pos: position{line: 1221, col: 6, offset: 34530},
+				pos: position{line: 1209, col: 6, offset: 34351},
 				exprs: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1221, col: 6, offset: 34530},
+						pos:        position{line: 1209, col: 6, offset: 34351},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1221, col: 11, offset: 34535},
+						pos:        position{line: 1209, col: 11, offset: 34356},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1221, col: 16, offset: 34540},
+						pos:        position{line: 1209, col: 16, offset: 34361},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1221, col: 21, offset: 34545},
+						pos:        position{line: 1209, col: 21, offset: 34366},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9528,19 +9445,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1222, col: 1, offset: 34551},
+			pos:  position{line: 1210, col: 1, offset: 34372},
 			expr: &seqExpr{
-				pos: position{line: 1222, col: 6, offset: 34556},
+				pos: position{line: 1210, col: 6, offset: 34377},
 				exprs: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1222, col: 6, offset: 34556},
+						pos:        position{line: 1210, col: 6, offset: 34377},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1222, col: 11, offset: 34561},
+						pos:        position{line: 1210, col: 11, offset: 34382},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9551,16 +9468,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1224, col: 1, offset: 34568},
+			pos:  position{line: 1212, col: 1, offset: 34389},
 			expr: &seqExpr{
-				pos: position{line: 1224, col: 12, offset: 34579},
+				pos: position{line: 1212, col: 12, offset: 34400},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1224, col: 12, offset: 34579},
+						pos:  position{line: 1212, col: 12, offset: 34400},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1224, col: 24, offset: 34591},
+						pos:  position{line: 1212, col: 24, offset: 34412},
 						name: "TimeOffset",
 					},
 				},
@@ -9568,46 +9485,46 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1226, col: 1, offset: 34603},
+			pos:  position{line: 1214, col: 1, offset: 34424},
 			expr: &seqExpr{
-				pos: position{line: 1226, col: 15, offset: 34617},
+				pos: position{line: 1214, col: 15, offset: 34438},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1226, col: 15, offset: 34617},
+						pos:  position{line: 1214, col: 15, offset: 34438},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1226, col: 18, offset: 34620},
+						pos:        position{line: 1214, col: 18, offset: 34441},
 						val:        ":",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1226, col: 22, offset: 34624},
+						pos:  position{line: 1214, col: 22, offset: 34445},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1226, col: 25, offset: 34627},
+						pos:        position{line: 1214, col: 25, offset: 34448},
 						val:        ":",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1226, col: 29, offset: 34631},
+						pos:  position{line: 1214, col: 29, offset: 34452},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1226, col: 32, offset: 34634},
+						pos: position{line: 1214, col: 32, offset: 34455},
 						expr: &seqExpr{
-							pos: position{line: 1226, col: 33, offset: 34635},
+							pos: position{line: 1214, col: 33, offset: 34456},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1226, col: 33, offset: 34635},
+									pos:        position{line: 1214, col: 33, offset: 34456},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1226, col: 37, offset: 34639},
+									pos: position{line: 1214, col: 37, offset: 34460},
 									expr: &charClassMatcher{
-										pos:        position{line: 1226, col: 37, offset: 34639},
+										pos:        position{line: 1214, col: 37, offset: 34460},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -9622,60 +9539,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1228, col: 1, offset: 34649},
+			pos:  position{line: 1216, col: 1, offset: 34470},
 			expr: &choiceExpr{
-				pos: position{line: 1229, col: 5, offset: 34664},
+				pos: position{line: 1217, col: 5, offset: 34485},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1229, col: 5, offset: 34664},
+						pos:        position{line: 1217, col: 5, offset: 34485},
 						val:        "Z",
 						ignoreCase: false,
 					},
 					&seqExpr{
-						pos: position{line: 1230, col: 5, offset: 34672},
+						pos: position{line: 1218, col: 5, offset: 34493},
 						exprs: []interface{}{
 							&choiceExpr{
-								pos: position{line: 1230, col: 6, offset: 34673},
+								pos: position{line: 1218, col: 6, offset: 34494},
 								alternatives: []interface{}{
 									&litMatcher{
-										pos:        position{line: 1230, col: 6, offset: 34673},
+										pos:        position{line: 1218, col: 6, offset: 34494},
 										val:        "+",
 										ignoreCase: false,
 									},
 									&litMatcher{
-										pos:        position{line: 1230, col: 12, offset: 34679},
+										pos:        position{line: 1218, col: 12, offset: 34500},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1230, col: 17, offset: 34684},
+								pos:  position{line: 1218, col: 17, offset: 34505},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1230, col: 20, offset: 34687},
+								pos:        position{line: 1218, col: 20, offset: 34508},
 								val:        ":",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1230, col: 24, offset: 34691},
+								pos:  position{line: 1218, col: 24, offset: 34512},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1230, col: 27, offset: 34694},
+								pos: position{line: 1218, col: 27, offset: 34515},
 								expr: &seqExpr{
-									pos: position{line: 1230, col: 28, offset: 34695},
+									pos: position{line: 1218, col: 28, offset: 34516},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1230, col: 28, offset: 34695},
+											pos:        position{line: 1218, col: 28, offset: 34516},
 											val:        ".",
 											ignoreCase: false,
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1230, col: 32, offset: 34699},
+											pos: position{line: 1218, col: 32, offset: 34520},
 											expr: &charClassMatcher{
-												pos:        position{line: 1230, col: 32, offset: 34699},
+												pos:        position{line: 1218, col: 32, offset: 34520},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -9692,32 +9609,32 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1232, col: 1, offset: 34709},
+			pos:  position{line: 1220, col: 1, offset: 34530},
 			expr: &actionExpr{
-				pos: position{line: 1233, col: 5, offset: 34722},
+				pos: position{line: 1221, col: 5, offset: 34543},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1233, col: 5, offset: 34722},
+					pos: position{line: 1221, col: 5, offset: 34543},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 1233, col: 5, offset: 34722},
+							pos: position{line: 1221, col: 5, offset: 34543},
 							expr: &litMatcher{
-								pos:        position{line: 1233, col: 5, offset: 34722},
+								pos:        position{line: 1221, col: 5, offset: 34543},
 								val:        "-",
 								ignoreCase: false,
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1233, col: 10, offset: 34727},
+							pos: position{line: 1221, col: 10, offset: 34548},
 							expr: &seqExpr{
-								pos: position{line: 1233, col: 11, offset: 34728},
+								pos: position{line: 1221, col: 11, offset: 34549},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1233, col: 11, offset: 34728},
+										pos:  position{line: 1221, col: 11, offset: 34549},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1233, col: 19, offset: 34736},
+										pos:  position{line: 1221, col: 19, offset: 34557},
 										name: "TimeUnit",
 									},
 								},
@@ -9729,26 +9646,26 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1237, col: 1, offset: 34862},
+			pos:  position{line: 1225, col: 1, offset: 34683},
 			expr: &seqExpr{
-				pos: position{line: 1237, col: 11, offset: 34872},
+				pos: position{line: 1225, col: 11, offset: 34693},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1237, col: 11, offset: 34872},
+						pos:  position{line: 1225, col: 11, offset: 34693},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1237, col: 16, offset: 34877},
+						pos: position{line: 1225, col: 16, offset: 34698},
 						expr: &seqExpr{
-							pos: position{line: 1237, col: 17, offset: 34878},
+							pos: position{line: 1225, col: 17, offset: 34699},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1237, col: 17, offset: 34878},
+									pos:        position{line: 1225, col: 17, offset: 34699},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1237, col: 21, offset: 34882},
+									pos:  position{line: 1225, col: 21, offset: 34703},
 									name: "UInt",
 								},
 							},
@@ -9759,52 +9676,52 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1239, col: 1, offset: 34890},
+			pos:  position{line: 1227, col: 1, offset: 34711},
 			expr: &choiceExpr{
-				pos: position{line: 1240, col: 5, offset: 34903},
+				pos: position{line: 1228, col: 5, offset: 34724},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1240, col: 5, offset: 34903},
+						pos:        position{line: 1228, col: 5, offset: 34724},
 						val:        "ns",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1241, col: 5, offset: 34912},
+						pos:        position{line: 1229, col: 5, offset: 34733},
 						val:        "us",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1242, col: 5, offset: 34921},
+						pos:        position{line: 1230, col: 5, offset: 34742},
 						val:        "ms",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1243, col: 5, offset: 34930},
+						pos:        position{line: 1231, col: 5, offset: 34751},
 						val:        "s",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1244, col: 5, offset: 34938},
+						pos:        position{line: 1232, col: 5, offset: 34759},
 						val:        "m",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1245, col: 5, offset: 34946},
+						pos:        position{line: 1233, col: 5, offset: 34767},
 						val:        "h",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1246, col: 5, offset: 34954},
+						pos:        position{line: 1234, col: 5, offset: 34775},
 						val:        "d",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1247, col: 5, offset: 34962},
+						pos:        position{line: 1235, col: 5, offset: 34783},
 						val:        "w",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1248, col: 5, offset: 34970},
+						pos:        position{line: 1236, col: 5, offset: 34791},
 						val:        "y",
 						ignoreCase: false,
 					},
@@ -9813,42 +9730,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1250, col: 1, offset: 34975},
+			pos:  position{line: 1238, col: 1, offset: 34796},
 			expr: &actionExpr{
-				pos: position{line: 1251, col: 5, offset: 34982},
+				pos: position{line: 1239, col: 5, offset: 34803},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1251, col: 5, offset: 34982},
+					pos: position{line: 1239, col: 5, offset: 34803},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1251, col: 5, offset: 34982},
+							pos:  position{line: 1239, col: 5, offset: 34803},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1251, col: 10, offset: 34987},
+							pos:        position{line: 1239, col: 10, offset: 34808},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1251, col: 14, offset: 34991},
+							pos:  position{line: 1239, col: 14, offset: 34812},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1251, col: 19, offset: 34996},
+							pos:        position{line: 1239, col: 19, offset: 34817},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1251, col: 23, offset: 35000},
+							pos:  position{line: 1239, col: 23, offset: 34821},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1251, col: 28, offset: 35005},
+							pos:        position{line: 1239, col: 28, offset: 34826},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1251, col: 32, offset: 35009},
+							pos:  position{line: 1239, col: 32, offset: 34830},
 							name: "UInt",
 						},
 					},
@@ -9857,42 +9774,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1253, col: 1, offset: 35046},
+			pos:  position{line: 1241, col: 1, offset: 34867},
 			expr: &actionExpr{
-				pos: position{line: 1254, col: 5, offset: 35054},
+				pos: position{line: 1242, col: 5, offset: 34875},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1254, col: 5, offset: 35054},
+					pos: position{line: 1242, col: 5, offset: 34875},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1254, col: 5, offset: 35054},
+							pos: position{line: 1242, col: 5, offset: 34875},
 							expr: &seqExpr{
-								pos: position{line: 1254, col: 8, offset: 35057},
+								pos: position{line: 1242, col: 8, offset: 34878},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1254, col: 8, offset: 35057},
+										pos:  position{line: 1242, col: 8, offset: 34878},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1254, col: 12, offset: 35061},
+										pos:        position{line: 1242, col: 12, offset: 34882},
 										val:        ":",
 										ignoreCase: false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1254, col: 16, offset: 35065},
+										pos:  position{line: 1242, col: 16, offset: 34886},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1254, col: 20, offset: 35069},
+										pos: position{line: 1242, col: 20, offset: 34890},
 										expr: &choiceExpr{
-											pos: position{line: 1254, col: 22, offset: 35071},
+											pos: position{line: 1242, col: 22, offset: 34892},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 1254, col: 22, offset: 35071},
+													pos:  position{line: 1242, col: 22, offset: 34892},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1254, col: 33, offset: 35082},
+													pos:        position{line: 1242, col: 33, offset: 34903},
 													val:        ":",
 													ignoreCase: false,
 												},
@@ -9903,10 +9820,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1254, col: 39, offset: 35088},
+							pos:   position{line: 1242, col: 39, offset: 34909},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1254, col: 41, offset: 35090},
+								pos:  position{line: 1242, col: 41, offset: 34911},
 								name: "IP6Variations",
 							},
 						},
@@ -9916,32 +9833,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1258, col: 1, offset: 35254},
+			pos:  position{line: 1246, col: 1, offset: 35075},
 			expr: &choiceExpr{
-				pos: position{line: 1259, col: 5, offset: 35272},
+				pos: position{line: 1247, col: 5, offset: 35093},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1259, col: 5, offset: 35272},
+						pos: position{line: 1247, col: 5, offset: 35093},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1259, col: 5, offset: 35272},
+							pos: position{line: 1247, col: 5, offset: 35093},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1259, col: 5, offset: 35272},
+									pos:   position{line: 1247, col: 5, offset: 35093},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1259, col: 7, offset: 35274},
+										pos: position{line: 1247, col: 7, offset: 35095},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1259, col: 7, offset: 35274},
+											pos:  position{line: 1247, col: 7, offset: 35095},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1259, col: 17, offset: 35284},
+									pos:   position{line: 1247, col: 17, offset: 35105},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1259, col: 19, offset: 35286},
+										pos:  position{line: 1247, col: 19, offset: 35107},
 										name: "IP6Tail",
 									},
 								},
@@ -9949,51 +9866,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1262, col: 5, offset: 35350},
+						pos: position{line: 1250, col: 5, offset: 35171},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1262, col: 5, offset: 35350},
+							pos: position{line: 1250, col: 5, offset: 35171},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1262, col: 5, offset: 35350},
+									pos:   position{line: 1250, col: 5, offset: 35171},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1262, col: 7, offset: 35352},
+										pos:  position{line: 1250, col: 7, offset: 35173},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1262, col: 11, offset: 35356},
+									pos:   position{line: 1250, col: 11, offset: 35177},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1262, col: 13, offset: 35358},
+										pos: position{line: 1250, col: 13, offset: 35179},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1262, col: 13, offset: 35358},
+											pos:  position{line: 1250, col: 13, offset: 35179},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1262, col: 23, offset: 35368},
+									pos:        position{line: 1250, col: 23, offset: 35189},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1262, col: 28, offset: 35373},
+									pos:   position{line: 1250, col: 28, offset: 35194},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1262, col: 30, offset: 35375},
+										pos: position{line: 1250, col: 30, offset: 35196},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1262, col: 30, offset: 35375},
+											pos:  position{line: 1250, col: 30, offset: 35196},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1262, col: 40, offset: 35385},
+									pos:   position{line: 1250, col: 40, offset: 35206},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1262, col: 42, offset: 35387},
+										pos:  position{line: 1250, col: 42, offset: 35208},
 										name: "IP6Tail",
 									},
 								},
@@ -10001,32 +9918,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1265, col: 5, offset: 35486},
+						pos: position{line: 1253, col: 5, offset: 35307},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1265, col: 5, offset: 35486},
+							pos: position{line: 1253, col: 5, offset: 35307},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1265, col: 5, offset: 35486},
+									pos:        position{line: 1253, col: 5, offset: 35307},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1265, col: 10, offset: 35491},
+									pos:   position{line: 1253, col: 10, offset: 35312},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1265, col: 12, offset: 35493},
+										pos: position{line: 1253, col: 12, offset: 35314},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1265, col: 12, offset: 35493},
+											pos:  position{line: 1253, col: 12, offset: 35314},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1265, col: 22, offset: 35503},
+									pos:   position{line: 1253, col: 22, offset: 35324},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1265, col: 24, offset: 35505},
+										pos:  position{line: 1253, col: 24, offset: 35326},
 										name: "IP6Tail",
 									},
 								},
@@ -10034,32 +9951,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1268, col: 5, offset: 35576},
+						pos: position{line: 1256, col: 5, offset: 35397},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1268, col: 5, offset: 35576},
+							pos: position{line: 1256, col: 5, offset: 35397},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1268, col: 5, offset: 35576},
+									pos:   position{line: 1256, col: 5, offset: 35397},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1268, col: 7, offset: 35578},
+										pos:  position{line: 1256, col: 7, offset: 35399},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1268, col: 11, offset: 35582},
+									pos:   position{line: 1256, col: 11, offset: 35403},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1268, col: 13, offset: 35584},
+										pos: position{line: 1256, col: 13, offset: 35405},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1268, col: 13, offset: 35584},
+											pos:  position{line: 1256, col: 13, offset: 35405},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1268, col: 23, offset: 35594},
+									pos:        position{line: 1256, col: 23, offset: 35415},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -10067,10 +9984,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1271, col: 5, offset: 35662},
+						pos: position{line: 1259, col: 5, offset: 35483},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 1271, col: 5, offset: 35662},
+							pos:        position{line: 1259, col: 5, offset: 35483},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -10080,16 +9997,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1275, col: 1, offset: 35699},
+			pos:  position{line: 1263, col: 1, offset: 35520},
 			expr: &choiceExpr{
-				pos: position{line: 1276, col: 5, offset: 35711},
+				pos: position{line: 1264, col: 5, offset: 35532},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1276, col: 5, offset: 35711},
+						pos:  position{line: 1264, col: 5, offset: 35532},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1277, col: 5, offset: 35718},
+						pos:  position{line: 1265, col: 5, offset: 35539},
 						name: "Hex",
 					},
 				},
@@ -10097,23 +10014,23 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1279, col: 1, offset: 35723},
+			pos:  position{line: 1267, col: 1, offset: 35544},
 			expr: &actionExpr{
-				pos: position{line: 1279, col: 12, offset: 35734},
+				pos: position{line: 1267, col: 12, offset: 35555},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1279, col: 12, offset: 35734},
+					pos: position{line: 1267, col: 12, offset: 35555},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1279, col: 12, offset: 35734},
+							pos:        position{line: 1267, col: 12, offset: 35555},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1279, col: 16, offset: 35738},
+							pos:   position{line: 1267, col: 16, offset: 35559},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1279, col: 18, offset: 35740},
+								pos:  position{line: 1267, col: 18, offset: 35561},
 								name: "Hex",
 							},
 						},
@@ -10123,23 +10040,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1281, col: 1, offset: 35778},
+			pos:  position{line: 1269, col: 1, offset: 35599},
 			expr: &actionExpr{
-				pos: position{line: 1281, col: 12, offset: 35789},
+				pos: position{line: 1269, col: 12, offset: 35610},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1281, col: 12, offset: 35789},
+					pos: position{line: 1269, col: 12, offset: 35610},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1281, col: 12, offset: 35789},
+							pos:   position{line: 1269, col: 12, offset: 35610},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1281, col: 14, offset: 35791},
+								pos:  position{line: 1269, col: 14, offset: 35612},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1281, col: 18, offset: 35795},
+							pos:        position{line: 1269, col: 18, offset: 35616},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -10149,31 +10066,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1283, col: 1, offset: 35833},
+			pos:  position{line: 1271, col: 1, offset: 35654},
 			expr: &actionExpr{
-				pos: position{line: 1284, col: 5, offset: 35844},
+				pos: position{line: 1272, col: 5, offset: 35665},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1284, col: 5, offset: 35844},
+					pos: position{line: 1272, col: 5, offset: 35665},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1284, col: 5, offset: 35844},
+							pos:   position{line: 1272, col: 5, offset: 35665},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1284, col: 7, offset: 35846},
+								pos:  position{line: 1272, col: 7, offset: 35667},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1284, col: 10, offset: 35849},
+							pos:        position{line: 1272, col: 10, offset: 35670},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1284, col: 14, offset: 35853},
+							pos:   position{line: 1272, col: 14, offset: 35674},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1284, col: 16, offset: 35855},
+								pos:  position{line: 1272, col: 16, offset: 35676},
 								name: "UInt",
 							},
 						},
@@ -10183,31 +10100,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1288, col: 1, offset: 35928},
+			pos:  position{line: 1276, col: 1, offset: 35749},
 			expr: &actionExpr{
-				pos: position{line: 1289, col: 5, offset: 35939},
+				pos: position{line: 1277, col: 5, offset: 35760},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1289, col: 5, offset: 35939},
+					pos: position{line: 1277, col: 5, offset: 35760},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1289, col: 5, offset: 35939},
+							pos:   position{line: 1277, col: 5, offset: 35760},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1289, col: 7, offset: 35941},
+								pos:  position{line: 1277, col: 7, offset: 35762},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1289, col: 11, offset: 35945},
+							pos:        position{line: 1277, col: 11, offset: 35766},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1289, col: 15, offset: 35949},
+							pos:   position{line: 1277, col: 15, offset: 35770},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1289, col: 17, offset: 35951},
+								pos:  position{line: 1277, col: 17, offset: 35772},
 								name: "UInt",
 							},
 						},
@@ -10217,15 +10134,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1293, col: 1, offset: 36014},
+			pos:  position{line: 1281, col: 1, offset: 35835},
 			expr: &actionExpr{
-				pos: position{line: 1294, col: 4, offset: 36022},
+				pos: position{line: 1282, col: 4, offset: 35843},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1294, col: 4, offset: 36022},
+					pos:   position{line: 1282, col: 4, offset: 35843},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1294, col: 6, offset: 36024},
+						pos:  position{line: 1282, col: 6, offset: 35845},
 						name: "UIntString",
 					},
 				},
@@ -10233,16 +10150,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1296, col: 1, offset: 36064},
+			pos:  position{line: 1284, col: 1, offset: 35885},
 			expr: &choiceExpr{
-				pos: position{line: 1297, col: 5, offset: 36078},
+				pos: position{line: 1285, col: 5, offset: 35899},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1297, col: 5, offset: 36078},
+						pos:  position{line: 1285, col: 5, offset: 35899},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1298, col: 5, offset: 36093},
+						pos:  position{line: 1286, col: 5, offset: 35914},
 						name: "MinusIntString",
 					},
 				},
@@ -10250,14 +10167,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1300, col: 1, offset: 36109},
+			pos:  position{line: 1288, col: 1, offset: 35930},
 			expr: &actionExpr{
-				pos: position{line: 1300, col: 14, offset: 36122},
+				pos: position{line: 1288, col: 14, offset: 35943},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1300, col: 14, offset: 36122},
+					pos: position{line: 1288, col: 14, offset: 35943},
 					expr: &charClassMatcher{
-						pos:        position{line: 1300, col: 14, offset: 36122},
+						pos:        position{line: 1288, col: 14, offset: 35943},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10268,20 +10185,20 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1302, col: 1, offset: 36161},
+			pos:  position{line: 1290, col: 1, offset: 35982},
 			expr: &actionExpr{
-				pos: position{line: 1303, col: 5, offset: 36180},
+				pos: position{line: 1291, col: 5, offset: 36001},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1303, col: 5, offset: 36180},
+					pos: position{line: 1291, col: 5, offset: 36001},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1303, col: 5, offset: 36180},
+							pos:        position{line: 1291, col: 5, offset: 36001},
 							val:        "-",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1303, col: 9, offset: 36184},
+							pos:  position{line: 1291, col: 9, offset: 36005},
 							name: "UIntString",
 						},
 					},
@@ -10290,28 +10207,28 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1305, col: 1, offset: 36227},
+			pos:  position{line: 1293, col: 1, offset: 36048},
 			expr: &choiceExpr{
-				pos: position{line: 1306, col: 5, offset: 36243},
+				pos: position{line: 1294, col: 5, offset: 36064},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1306, col: 5, offset: 36243},
+						pos: position{line: 1294, col: 5, offset: 36064},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1306, col: 5, offset: 36243},
+							pos: position{line: 1294, col: 5, offset: 36064},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1306, col: 5, offset: 36243},
+									pos: position{line: 1294, col: 5, offset: 36064},
 									expr: &litMatcher{
-										pos:        position{line: 1306, col: 5, offset: 36243},
+										pos:        position{line: 1294, col: 5, offset: 36064},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1306, col: 10, offset: 36248},
+									pos: position{line: 1294, col: 10, offset: 36069},
 									expr: &charClassMatcher{
-										pos:        position{line: 1306, col: 10, offset: 36248},
+										pos:        position{line: 1294, col: 10, offset: 36069},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10319,14 +10236,14 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1306, col: 17, offset: 36255},
+									pos:        position{line: 1294, col: 17, offset: 36076},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1306, col: 21, offset: 36259},
+									pos: position{line: 1294, col: 21, offset: 36080},
 									expr: &charClassMatcher{
-										pos:        position{line: 1306, col: 21, offset: 36259},
+										pos:        position{line: 1294, col: 21, offset: 36080},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10334,9 +10251,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1306, col: 28, offset: 36266},
+									pos: position{line: 1294, col: 28, offset: 36087},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1306, col: 28, offset: 36266},
+										pos:  position{line: 1294, col: 28, offset: 36087},
 										name: "ExponentPart",
 									},
 								},
@@ -10344,28 +10261,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1309, col: 5, offset: 36325},
+						pos: position{line: 1297, col: 5, offset: 36146},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1309, col: 5, offset: 36325},
+							pos: position{line: 1297, col: 5, offset: 36146},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1309, col: 5, offset: 36325},
+									pos: position{line: 1297, col: 5, offset: 36146},
 									expr: &litMatcher{
-										pos:        position{line: 1309, col: 5, offset: 36325},
+										pos:        position{line: 1297, col: 5, offset: 36146},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1309, col: 10, offset: 36330},
+									pos:        position{line: 1297, col: 10, offset: 36151},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1309, col: 14, offset: 36334},
+									pos: position{line: 1297, col: 14, offset: 36155},
 									expr: &charClassMatcher{
-										pos:        position{line: 1309, col: 14, offset: 36334},
+										pos:        position{line: 1297, col: 14, offset: 36155},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10373,9 +10290,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1309, col: 21, offset: 36341},
+									pos: position{line: 1297, col: 21, offset: 36162},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1309, col: 21, offset: 36341},
+										pos:  position{line: 1297, col: 21, offset: 36162},
 										name: "ExponentPart",
 									},
 								},
@@ -10383,17 +10300,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1312, col: 5, offset: 36400},
+						pos: position{line: 1300, col: 5, offset: 36221},
 						run: (*parser).callonFloatString22,
 						expr: &choiceExpr{
-							pos: position{line: 1312, col: 7, offset: 36402},
+							pos: position{line: 1300, col: 7, offset: 36223},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1312, col: 7, offset: 36402},
+									pos:  position{line: 1300, col: 7, offset: 36223},
 									name: "NaN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1312, col: 13, offset: 36408},
+									pos:  position{line: 1300, col: 13, offset: 36229},
 									name: "Infinity",
 								},
 							},
@@ -10404,19 +10321,19 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1315, col: 1, offset: 36452},
+			pos:  position{line: 1303, col: 1, offset: 36273},
 			expr: &seqExpr{
-				pos: position{line: 1315, col: 16, offset: 36467},
+				pos: position{line: 1303, col: 16, offset: 36288},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1315, col: 16, offset: 36467},
+						pos:        position{line: 1303, col: 16, offset: 36288},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1315, col: 21, offset: 36472},
+						pos: position{line: 1303, col: 21, offset: 36293},
 						expr: &charClassMatcher{
-							pos:        position{line: 1315, col: 21, offset: 36472},
+							pos:        position{line: 1303, col: 21, offset: 36293},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -10424,7 +10341,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1315, col: 27, offset: 36478},
+						pos:  position{line: 1303, col: 27, offset: 36299},
 						name: "UIntString",
 					},
 				},
@@ -10432,31 +10349,31 @@ var g = &grammar{
 		},
 		{
 			name: "NaN",
-			pos:  position{line: 1317, col: 1, offset: 36490},
+			pos:  position{line: 1305, col: 1, offset: 36311},
 			expr: &litMatcher{
-				pos:        position{line: 1317, col: 7, offset: 36496},
+				pos:        position{line: 1305, col: 7, offset: 36317},
 				val:        "NaN",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "Infinity",
-			pos:  position{line: 1319, col: 1, offset: 36503},
+			pos:  position{line: 1307, col: 1, offset: 36324},
 			expr: &seqExpr{
-				pos: position{line: 1319, col: 12, offset: 36514},
+				pos: position{line: 1307, col: 12, offset: 36335},
 				exprs: []interface{}{
 					&zeroOrOneExpr{
-						pos: position{line: 1319, col: 12, offset: 36514},
+						pos: position{line: 1307, col: 12, offset: 36335},
 						expr: &choiceExpr{
-							pos: position{line: 1319, col: 13, offset: 36515},
+							pos: position{line: 1307, col: 13, offset: 36336},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1319, col: 13, offset: 36515},
+									pos:        position{line: 1307, col: 13, offset: 36336},
 									val:        "-",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1319, col: 19, offset: 36521},
+									pos:        position{line: 1307, col: 19, offset: 36342},
 									val:        "+",
 									ignoreCase: false,
 								},
@@ -10464,7 +10381,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1319, col: 25, offset: 36527},
+						pos:        position{line: 1307, col: 25, offset: 36348},
 						val:        "Inf",
 						ignoreCase: false,
 					},
@@ -10473,14 +10390,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1321, col: 1, offset: 36534},
+			pos:  position{line: 1309, col: 1, offset: 36355},
 			expr: &actionExpr{
-				pos: position{line: 1321, col: 7, offset: 36540},
+				pos: position{line: 1309, col: 7, offset: 36361},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1321, col: 7, offset: 36540},
+					pos: position{line: 1309, col: 7, offset: 36361},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1321, col: 7, offset: 36540},
+						pos:  position{line: 1309, col: 7, offset: 36361},
 						name: "HexDigit",
 					},
 				},
@@ -10488,9 +10405,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1323, col: 1, offset: 36582},
+			pos:  position{line: 1311, col: 1, offset: 36403},
 			expr: &charClassMatcher{
-				pos:        position{line: 1323, col: 12, offset: 36593},
+				pos:        position{line: 1311, col: 12, offset: 36414},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -10499,34 +10416,34 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1325, col: 1, offset: 36606},
+			pos:  position{line: 1313, col: 1, offset: 36427},
 			expr: &choiceExpr{
-				pos: position{line: 1326, col: 5, offset: 36623},
+				pos: position{line: 1314, col: 5, offset: 36444},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1326, col: 5, offset: 36623},
+						pos: position{line: 1314, col: 5, offset: 36444},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 1326, col: 5, offset: 36623},
+							pos: position{line: 1314, col: 5, offset: 36444},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1326, col: 5, offset: 36623},
+									pos:        position{line: 1314, col: 5, offset: 36444},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1326, col: 9, offset: 36627},
+									pos:   position{line: 1314, col: 9, offset: 36448},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1326, col: 11, offset: 36629},
+										pos: position{line: 1314, col: 11, offset: 36450},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1326, col: 11, offset: 36629},
+											pos:  position{line: 1314, col: 11, offset: 36450},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1326, col: 29, offset: 36647},
+									pos:        position{line: 1314, col: 29, offset: 36468},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -10534,29 +10451,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1327, col: 5, offset: 36684},
+						pos: position{line: 1315, col: 5, offset: 36505},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 1327, col: 5, offset: 36684},
+							pos: position{line: 1315, col: 5, offset: 36505},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1327, col: 5, offset: 36684},
+									pos:        position{line: 1315, col: 5, offset: 36505},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1327, col: 9, offset: 36688},
+									pos:   position{line: 1315, col: 9, offset: 36509},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1327, col: 11, offset: 36690},
+										pos: position{line: 1315, col: 11, offset: 36511},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1327, col: 11, offset: 36690},
+											pos:  position{line: 1315, col: 11, offset: 36511},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1327, col: 29, offset: 36708},
+									pos:        position{line: 1315, col: 29, offset: 36529},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -10568,55 +10485,55 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1329, col: 1, offset: 36742},
+			pos:  position{line: 1317, col: 1, offset: 36563},
 			expr: &choiceExpr{
-				pos: position{line: 1330, col: 5, offset: 36763},
+				pos: position{line: 1318, col: 5, offset: 36584},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1330, col: 5, offset: 36763},
+						pos: position{line: 1318, col: 5, offset: 36584},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1330, col: 5, offset: 36763},
+							pos: position{line: 1318, col: 5, offset: 36584},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1330, col: 5, offset: 36763},
+									pos: position{line: 1318, col: 5, offset: 36584},
 									expr: &choiceExpr{
-										pos: position{line: 1330, col: 7, offset: 36765},
+										pos: position{line: 1318, col: 7, offset: 36586},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1330, col: 7, offset: 36765},
+												pos:        position{line: 1318, col: 7, offset: 36586},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1330, col: 13, offset: 36771},
+												pos:  position{line: 1318, col: 13, offset: 36592},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1330, col: 26, offset: 36784,
+									line: 1318, col: 26, offset: 36605,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1331, col: 5, offset: 36821},
+						pos: position{line: 1319, col: 5, offset: 36642},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1331, col: 5, offset: 36821},
+							pos: position{line: 1319, col: 5, offset: 36642},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1331, col: 5, offset: 36821},
+									pos:        position{line: 1319, col: 5, offset: 36642},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1331, col: 10, offset: 36826},
+									pos:   position{line: 1319, col: 10, offset: 36647},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1331, col: 12, offset: 36828},
+										pos:  position{line: 1319, col: 12, offset: 36649},
 										name: "EscapeSequence",
 									},
 								},
@@ -10628,28 +10545,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1333, col: 1, offset: 36862},
+			pos:  position{line: 1321, col: 1, offset: 36683},
 			expr: &actionExpr{
-				pos: position{line: 1334, col: 5, offset: 36874},
+				pos: position{line: 1322, col: 5, offset: 36695},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1334, col: 5, offset: 36874},
+					pos: position{line: 1322, col: 5, offset: 36695},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1334, col: 5, offset: 36874},
+							pos:   position{line: 1322, col: 5, offset: 36695},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1334, col: 10, offset: 36879},
+								pos:  position{line: 1322, col: 10, offset: 36700},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1334, col: 23, offset: 36892},
+							pos:   position{line: 1322, col: 23, offset: 36713},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1334, col: 28, offset: 36897},
+								pos: position{line: 1322, col: 28, offset: 36718},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1334, col: 28, offset: 36897},
+									pos:  position{line: 1322, col: 28, offset: 36718},
 									name: "KeyWordRest",
 								},
 							},
@@ -10660,16 +10577,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1336, col: 1, offset: 36959},
+			pos:  position{line: 1324, col: 1, offset: 36780},
 			expr: &choiceExpr{
-				pos: position{line: 1337, col: 5, offset: 36976},
+				pos: position{line: 1325, col: 5, offset: 36797},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1337, col: 5, offset: 36976},
+						pos:  position{line: 1325, col: 5, offset: 36797},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1338, col: 5, offset: 36993},
+						pos:  position{line: 1326, col: 5, offset: 36814},
 						name: "KeyWordEsc",
 					},
 				},
@@ -10677,12 +10594,12 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1340, col: 1, offset: 37005},
+			pos:  position{line: 1328, col: 1, offset: 36826},
 			expr: &actionExpr{
-				pos: position{line: 1340, col: 16, offset: 37020},
+				pos: position{line: 1328, col: 16, offset: 36841},
 				run: (*parser).callonKeyWordChars1,
 				expr: &charClassMatcher{
-					pos:        position{line: 1340, col: 16, offset: 37020},
+					pos:        position{line: 1328, col: 16, offset: 36841},
 					val:        "[a-zA-Z_.:/%#@~]",
 					chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 					ranges:     []rune{'a', 'z', 'A', 'Z'},
@@ -10693,16 +10610,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1342, col: 1, offset: 37069},
+			pos:  position{line: 1330, col: 1, offset: 36890},
 			expr: &choiceExpr{
-				pos: position{line: 1343, col: 5, offset: 37085},
+				pos: position{line: 1331, col: 5, offset: 36906},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1343, col: 5, offset: 37085},
+						pos:  position{line: 1331, col: 5, offset: 36906},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1344, col: 5, offset: 37102},
+						pos:        position{line: 1332, col: 5, offset: 36923},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10713,30 +10630,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1346, col: 1, offset: 37109},
+			pos:  position{line: 1334, col: 1, offset: 36930},
 			expr: &actionExpr{
-				pos: position{line: 1346, col: 14, offset: 37122},
+				pos: position{line: 1334, col: 14, offset: 36943},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1346, col: 14, offset: 37122},
+					pos: position{line: 1334, col: 14, offset: 36943},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1346, col: 14, offset: 37122},
+							pos:        position{line: 1334, col: 14, offset: 36943},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1346, col: 19, offset: 37127},
+							pos:   position{line: 1334, col: 19, offset: 36948},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1346, col: 22, offset: 37130},
+								pos: position{line: 1334, col: 22, offset: 36951},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1346, col: 22, offset: 37130},
+										pos:  position{line: 1334, col: 22, offset: 36951},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1346, col: 38, offset: 37146},
+										pos:  position{line: 1334, col: 38, offset: 36967},
 										name: "EscapeSequence",
 									},
 								},
@@ -10748,42 +10665,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1348, col: 1, offset: 37182},
+			pos:  position{line: 1336, col: 1, offset: 37003},
 			expr: &actionExpr{
-				pos: position{line: 1349, col: 5, offset: 37198},
+				pos: position{line: 1337, col: 5, offset: 37019},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1349, col: 5, offset: 37198},
+					pos: position{line: 1337, col: 5, offset: 37019},
 					exprs: []interface{}{
 						&andExpr{
-							pos: position{line: 1349, col: 5, offset: 37198},
+							pos: position{line: 1337, col: 5, offset: 37019},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1349, col: 6, offset: 37199},
+								pos:  position{line: 1337, col: 6, offset: 37020},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1349, col: 22, offset: 37215},
+							pos: position{line: 1337, col: 22, offset: 37036},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1349, col: 23, offset: 37216},
+								pos:  position{line: 1337, col: 23, offset: 37037},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1349, col: 35, offset: 37228},
+							pos:   position{line: 1337, col: 35, offset: 37049},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1349, col: 40, offset: 37233},
+								pos:  position{line: 1337, col: 40, offset: 37054},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1349, col: 50, offset: 37243},
+							pos:   position{line: 1337, col: 50, offset: 37064},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1349, col: 55, offset: 37248},
+								pos: position{line: 1337, col: 55, offset: 37069},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1349, col: 55, offset: 37248},
+									pos:  position{line: 1337, col: 55, offset: 37069},
 									name: "GlobRest",
 								},
 							},
@@ -10794,27 +10711,27 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1353, col: 1, offset: 37317},
+			pos:  position{line: 1341, col: 1, offset: 37138},
 			expr: &choiceExpr{
-				pos: position{line: 1353, col: 19, offset: 37335},
+				pos: position{line: 1341, col: 19, offset: 37156},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1353, col: 19, offset: 37335},
+						pos:  position{line: 1341, col: 19, offset: 37156},
 						name: "KeyWordStart",
 					},
 					&seqExpr{
-						pos: position{line: 1353, col: 34, offset: 37350},
+						pos: position{line: 1341, col: 34, offset: 37171},
 						exprs: []interface{}{
 							&oneOrMoreExpr{
-								pos: position{line: 1353, col: 34, offset: 37350},
+								pos: position{line: 1341, col: 34, offset: 37171},
 								expr: &litMatcher{
-									pos:        position{line: 1353, col: 34, offset: 37350},
+									pos:        position{line: 1341, col: 34, offset: 37171},
 									val:        "*",
 									ignoreCase: false,
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1353, col: 39, offset: 37355},
+								pos:  position{line: 1341, col: 39, offset: 37176},
 								name: "KeyWordRest",
 							},
 						},
@@ -10824,19 +10741,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1354, col: 1, offset: 37367},
+			pos:  position{line: 1342, col: 1, offset: 37188},
 			expr: &seqExpr{
-				pos: position{line: 1354, col: 15, offset: 37381},
+				pos: position{line: 1342, col: 15, offset: 37202},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1354, col: 15, offset: 37381},
+						pos: position{line: 1342, col: 15, offset: 37202},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1354, col: 15, offset: 37381},
+							pos:  position{line: 1342, col: 15, offset: 37202},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1354, col: 28, offset: 37394},
+						pos:        position{line: 1342, col: 28, offset: 37215},
 						val:        "*",
 						ignoreCase: false,
 					},
@@ -10845,23 +10762,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1356, col: 1, offset: 37399},
+			pos:  position{line: 1344, col: 1, offset: 37220},
 			expr: &choiceExpr{
-				pos: position{line: 1357, col: 5, offset: 37413},
+				pos: position{line: 1345, col: 5, offset: 37234},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1357, col: 5, offset: 37413},
+						pos:  position{line: 1345, col: 5, offset: 37234},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1358, col: 5, offset: 37430},
+						pos:  position{line: 1346, col: 5, offset: 37251},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1359, col: 5, offset: 37442},
+						pos: position{line: 1347, col: 5, offset: 37263},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1359, col: 5, offset: 37442},
+							pos:        position{line: 1347, col: 5, offset: 37263},
 							val:        "*",
 							ignoreCase: false,
 						},
@@ -10871,16 +10788,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1361, col: 1, offset: 37466},
+			pos:  position{line: 1349, col: 1, offset: 37287},
 			expr: &choiceExpr{
-				pos: position{line: 1362, col: 5, offset: 37479},
+				pos: position{line: 1350, col: 5, offset: 37300},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1362, col: 5, offset: 37479},
+						pos:  position{line: 1350, col: 5, offset: 37300},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1363, col: 5, offset: 37493},
+						pos:        position{line: 1351, col: 5, offset: 37314},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10891,30 +10808,30 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1365, col: 1, offset: 37500},
+			pos:  position{line: 1353, col: 1, offset: 37321},
 			expr: &actionExpr{
-				pos: position{line: 1365, col: 11, offset: 37510},
+				pos: position{line: 1353, col: 11, offset: 37331},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1365, col: 11, offset: 37510},
+					pos: position{line: 1353, col: 11, offset: 37331},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1365, col: 11, offset: 37510},
+							pos:        position{line: 1353, col: 11, offset: 37331},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1365, col: 16, offset: 37515},
+							pos:   position{line: 1353, col: 16, offset: 37336},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1365, col: 19, offset: 37518},
+								pos: position{line: 1353, col: 19, offset: 37339},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1365, col: 19, offset: 37518},
+										pos:  position{line: 1353, col: 19, offset: 37339},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1365, col: 32, offset: 37531},
+										pos:  position{line: 1353, col: 32, offset: 37352},
 										name: "EscapeSequence",
 									},
 								},
@@ -10926,30 +10843,30 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1367, col: 1, offset: 37567},
+			pos:  position{line: 1355, col: 1, offset: 37388},
 			expr: &choiceExpr{
-				pos: position{line: 1368, col: 5, offset: 37582},
+				pos: position{line: 1356, col: 5, offset: 37403},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1368, col: 5, offset: 37582},
+						pos: position{line: 1356, col: 5, offset: 37403},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1368, col: 5, offset: 37582},
+							pos:        position{line: 1356, col: 5, offset: 37403},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1369, col: 5, offset: 37610},
+						pos: position{line: 1357, col: 5, offset: 37431},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1369, col: 5, offset: 37610},
+							pos:        position{line: 1357, col: 5, offset: 37431},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1370, col: 5, offset: 37640},
+						pos:        position{line: 1358, col: 5, offset: 37461},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -10960,55 +10877,55 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1373, col: 1, offset: 37647},
+			pos:  position{line: 1361, col: 1, offset: 37468},
 			expr: &choiceExpr{
-				pos: position{line: 1374, col: 5, offset: 37668},
+				pos: position{line: 1362, col: 5, offset: 37489},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1374, col: 5, offset: 37668},
+						pos: position{line: 1362, col: 5, offset: 37489},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1374, col: 5, offset: 37668},
+							pos: position{line: 1362, col: 5, offset: 37489},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1374, col: 5, offset: 37668},
+									pos: position{line: 1362, col: 5, offset: 37489},
 									expr: &choiceExpr{
-										pos: position{line: 1374, col: 7, offset: 37670},
+										pos: position{line: 1362, col: 7, offset: 37491},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1374, col: 7, offset: 37670},
+												pos:        position{line: 1362, col: 7, offset: 37491},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1374, col: 13, offset: 37676},
+												pos:  position{line: 1362, col: 13, offset: 37497},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1374, col: 26, offset: 37689,
+									line: 1362, col: 26, offset: 37510,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1375, col: 5, offset: 37726},
+						pos: position{line: 1363, col: 5, offset: 37547},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1375, col: 5, offset: 37726},
+							pos: position{line: 1363, col: 5, offset: 37547},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1375, col: 5, offset: 37726},
+									pos:        position{line: 1363, col: 5, offset: 37547},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1375, col: 10, offset: 37731},
+									pos:   position{line: 1363, col: 10, offset: 37552},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1375, col: 12, offset: 37733},
+										pos:  position{line: 1363, col: 12, offset: 37554},
 										name: "EscapeSequence",
 									},
 								},
@@ -11020,16 +10937,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1377, col: 1, offset: 37767},
+			pos:  position{line: 1365, col: 1, offset: 37588},
 			expr: &choiceExpr{
-				pos: position{line: 1378, col: 5, offset: 37786},
+				pos: position{line: 1366, col: 5, offset: 37607},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1378, col: 5, offset: 37786},
+						pos:  position{line: 1366, col: 5, offset: 37607},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1379, col: 5, offset: 37807},
+						pos:  position{line: 1367, col: 5, offset: 37628},
 						name: "UnicodeEscape",
 					},
 				},
@@ -11037,79 +10954,79 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1381, col: 1, offset: 37822},
+			pos:  position{line: 1369, col: 1, offset: 37643},
 			expr: &choiceExpr{
-				pos: position{line: 1382, col: 5, offset: 37843},
+				pos: position{line: 1370, col: 5, offset: 37664},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1382, col: 5, offset: 37843},
+						pos:        position{line: 1370, col: 5, offset: 37664},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1383, col: 5, offset: 37851},
+						pos: position{line: 1371, col: 5, offset: 37672},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1383, col: 5, offset: 37851},
+							pos:        position{line: 1371, col: 5, offset: 37672},
 							val:        "\"",
 							ignoreCase: false,
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1384, col: 5, offset: 37891},
+						pos:        position{line: 1372, col: 5, offset: 37712},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1385, col: 5, offset: 37900},
+						pos: position{line: 1373, col: 5, offset: 37721},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1385, col: 5, offset: 37900},
+							pos:        position{line: 1373, col: 5, offset: 37721},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1386, col: 5, offset: 37929},
+						pos: position{line: 1374, col: 5, offset: 37750},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1386, col: 5, offset: 37929},
+							pos:        position{line: 1374, col: 5, offset: 37750},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1387, col: 5, offset: 37958},
+						pos: position{line: 1375, col: 5, offset: 37779},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1387, col: 5, offset: 37958},
+							pos:        position{line: 1375, col: 5, offset: 37779},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1388, col: 5, offset: 37987},
+						pos: position{line: 1376, col: 5, offset: 37808},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1388, col: 5, offset: 37987},
+							pos:        position{line: 1376, col: 5, offset: 37808},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1389, col: 5, offset: 38016},
+						pos: position{line: 1377, col: 5, offset: 37837},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1389, col: 5, offset: 38016},
+							pos:        position{line: 1377, col: 5, offset: 37837},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1390, col: 5, offset: 38045},
+						pos: position{line: 1378, col: 5, offset: 37866},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1390, col: 5, offset: 38045},
+							pos:        position{line: 1378, col: 5, offset: 37866},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -11119,30 +11036,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1392, col: 1, offset: 38071},
+			pos:  position{line: 1380, col: 1, offset: 37892},
 			expr: &choiceExpr{
-				pos: position{line: 1393, col: 5, offset: 38089},
+				pos: position{line: 1381, col: 5, offset: 37910},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1393, col: 5, offset: 38089},
+						pos: position{line: 1381, col: 5, offset: 37910},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1393, col: 5, offset: 38089},
+							pos:        position{line: 1381, col: 5, offset: 37910},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1394, col: 5, offset: 38117},
+						pos: position{line: 1382, col: 5, offset: 37938},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1394, col: 5, offset: 38117},
+							pos:        position{line: 1382, col: 5, offset: 37938},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1395, col: 5, offset: 38145},
+						pos:        position{line: 1383, col: 5, offset: 37966},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -11153,41 +11070,41 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1397, col: 1, offset: 38151},
+			pos:  position{line: 1385, col: 1, offset: 37972},
 			expr: &choiceExpr{
-				pos: position{line: 1398, col: 5, offset: 38169},
+				pos: position{line: 1386, col: 5, offset: 37990},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1398, col: 5, offset: 38169},
+						pos: position{line: 1386, col: 5, offset: 37990},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1398, col: 5, offset: 38169},
+							pos: position{line: 1386, col: 5, offset: 37990},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1398, col: 5, offset: 38169},
+									pos:        position{line: 1386, col: 5, offset: 37990},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1398, col: 9, offset: 38173},
+									pos:   position{line: 1386, col: 9, offset: 37994},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1398, col: 16, offset: 38180},
+										pos: position{line: 1386, col: 16, offset: 38001},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1398, col: 16, offset: 38180},
+												pos:  position{line: 1386, col: 16, offset: 38001},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1398, col: 25, offset: 38189},
+												pos:  position{line: 1386, col: 25, offset: 38010},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1398, col: 34, offset: 38198},
+												pos:  position{line: 1386, col: 34, offset: 38019},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1398, col: 43, offset: 38207},
+												pos:  position{line: 1386, col: 43, offset: 38028},
 												name: "HexDigit",
 											},
 										},
@@ -11197,63 +11114,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1401, col: 5, offset: 38270},
+						pos: position{line: 1389, col: 5, offset: 38091},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1401, col: 5, offset: 38270},
+							pos: position{line: 1389, col: 5, offset: 38091},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1401, col: 5, offset: 38270},
+									pos:        position{line: 1389, col: 5, offset: 38091},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1401, col: 9, offset: 38274},
+									pos:        position{line: 1389, col: 9, offset: 38095},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1401, col: 13, offset: 38278},
+									pos:   position{line: 1389, col: 13, offset: 38099},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1401, col: 20, offset: 38285},
+										pos: position{line: 1389, col: 20, offset: 38106},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1401, col: 20, offset: 38285},
+												pos:  position{line: 1389, col: 20, offset: 38106},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1401, col: 29, offset: 38294},
+												pos: position{line: 1389, col: 29, offset: 38115},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1401, col: 29, offset: 38294},
+													pos:  position{line: 1389, col: 29, offset: 38115},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1401, col: 39, offset: 38304},
+												pos: position{line: 1389, col: 39, offset: 38125},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1401, col: 39, offset: 38304},
+													pos:  position{line: 1389, col: 39, offset: 38125},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1401, col: 49, offset: 38314},
+												pos: position{line: 1389, col: 49, offset: 38135},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1401, col: 49, offset: 38314},
+													pos:  position{line: 1389, col: 49, offset: 38135},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1401, col: 59, offset: 38324},
+												pos: position{line: 1389, col: 59, offset: 38145},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1401, col: 59, offset: 38324},
+													pos:  position{line: 1389, col: 59, offset: 38145},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1401, col: 69, offset: 38334},
+												pos: position{line: 1389, col: 69, offset: 38155},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1401, col: 69, offset: 38334},
+													pos:  position{line: 1389, col: 69, offset: 38155},
 													name: "HexDigit",
 												},
 											},
@@ -11261,7 +11178,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1401, col: 80, offset: 38345},
+									pos:        position{line: 1389, col: 80, offset: 38166},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -11273,35 +11190,35 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPattern",
-			pos:  position{line: 1405, col: 1, offset: 38399},
+			pos:  position{line: 1393, col: 1, offset: 38220},
 			expr: &actionExpr{
-				pos: position{line: 1406, col: 5, offset: 38417},
+				pos: position{line: 1394, col: 5, offset: 38238},
 				run: (*parser).callonRegexpPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1406, col: 5, offset: 38417},
+					pos: position{line: 1394, col: 5, offset: 38238},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1406, col: 5, offset: 38417},
+							pos:        position{line: 1394, col: 5, offset: 38238},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1406, col: 9, offset: 38421},
+							pos:   position{line: 1394, col: 9, offset: 38242},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1406, col: 14, offset: 38426},
+								pos:  position{line: 1394, col: 14, offset: 38247},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1406, col: 25, offset: 38437},
+							pos:        position{line: 1394, col: 25, offset: 38258},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1406, col: 29, offset: 38441},
+							pos: position{line: 1394, col: 29, offset: 38262},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1406, col: 30, offset: 38442},
+								pos:  position{line: 1394, col: 30, offset: 38263},
 								name: "KeyWordStart",
 							},
 						},
@@ -11311,32 +11228,32 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1408, col: 1, offset: 38477},
+			pos:  position{line: 1396, col: 1, offset: 38298},
 			expr: &actionExpr{
-				pos: position{line: 1409, col: 5, offset: 38492},
+				pos: position{line: 1397, col: 5, offset: 38313},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1409, col: 5, offset: 38492},
+					pos: position{line: 1397, col: 5, offset: 38313},
 					expr: &choiceExpr{
-						pos: position{line: 1409, col: 6, offset: 38493},
+						pos: position{line: 1397, col: 6, offset: 38314},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 1409, col: 6, offset: 38493},
+								pos:        position{line: 1397, col: 6, offset: 38314},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&seqExpr{
-								pos: position{line: 1409, col: 15, offset: 38502},
+								pos: position{line: 1397, col: 15, offset: 38323},
 								exprs: []interface{}{
 									&litMatcher{
-										pos:        position{line: 1409, col: 15, offset: 38502},
+										pos:        position{line: 1397, col: 15, offset: 38323},
 										val:        "\\",
 										ignoreCase: false,
 									},
 									&anyMatcher{
-										line: 1409, col: 20, offset: 38507,
+										line: 1397, col: 20, offset: 38328,
 									},
 								},
 							},
@@ -11347,9 +11264,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1411, col: 1, offset: 38543},
+			pos:  position{line: 1399, col: 1, offset: 38364},
 			expr: &charClassMatcher{
-				pos:        position{line: 1412, col: 5, offset: 38559},
+				pos:        position{line: 1400, col: 5, offset: 38380},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -11359,42 +11276,42 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1414, col: 1, offset: 38574},
+			pos:  position{line: 1402, col: 1, offset: 38395},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1414, col: 6, offset: 38579},
+				pos: position{line: 1402, col: 6, offset: 38400},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1414, col: 6, offset: 38579},
+					pos:  position{line: 1402, col: 6, offset: 38400},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 1416, col: 1, offset: 38590},
+			pos:  position{line: 1404, col: 1, offset: 38411},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1416, col: 6, offset: 38595},
+				pos: position{line: 1404, col: 6, offset: 38416},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1416, col: 6, offset: 38595},
+					pos:  position{line: 1404, col: 6, offset: 38416},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1418, col: 1, offset: 38606},
+			pos:  position{line: 1406, col: 1, offset: 38427},
 			expr: &choiceExpr{
-				pos: position{line: 1419, col: 5, offset: 38619},
+				pos: position{line: 1407, col: 5, offset: 38440},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1419, col: 5, offset: 38619},
+						pos:  position{line: 1407, col: 5, offset: 38440},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1420, col: 5, offset: 38634},
+						pos:  position{line: 1408, col: 5, offset: 38455},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1421, col: 5, offset: 38653},
+						pos:  position{line: 1409, col: 5, offset: 38474},
 						name: "Comment",
 					},
 				},
@@ -11402,45 +11319,45 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1423, col: 1, offset: 38662},
+			pos:  position{line: 1411, col: 1, offset: 38483},
 			expr: &anyMatcher{
-				line: 1424, col: 5, offset: 38682,
+				line: 1412, col: 5, offset: 38503,
 			},
 		},
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1426, col: 1, offset: 38685},
+			pos:         position{line: 1414, col: 1, offset: 38506},
 			expr: &choiceExpr{
-				pos: position{line: 1427, col: 5, offset: 38713},
+				pos: position{line: 1415, col: 5, offset: 38534},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1427, col: 5, offset: 38713},
+						pos:        position{line: 1415, col: 5, offset: 38534},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1428, col: 5, offset: 38722},
+						pos:        position{line: 1416, col: 5, offset: 38543},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1429, col: 5, offset: 38731},
+						pos:        position{line: 1417, col: 5, offset: 38552},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1430, col: 5, offset: 38740},
+						pos:        position{line: 1418, col: 5, offset: 38561},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1431, col: 5, offset: 38748},
+						pos:        position{line: 1419, col: 5, offset: 38569},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1432, col: 5, offset: 38761},
+						pos:        position{line: 1420, col: 5, offset: 38582},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -11449,9 +11366,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1434, col: 1, offset: 38771},
+			pos:  position{line: 1422, col: 1, offset: 38592},
 			expr: &charClassMatcher{
-				pos:        position{line: 1435, col: 5, offset: 38790},
+				pos:        position{line: 1423, col: 5, offset: 38611},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -11461,45 +11378,45 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1441, col: 1, offset: 39120},
+			pos:         position{line: 1429, col: 1, offset: 38941},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1444, col: 5, offset: 39191},
+				pos:  position{line: 1432, col: 5, offset: 39012},
 				name: "SingleLineComment",
 			},
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1446, col: 1, offset: 39210},
+			pos:  position{line: 1434, col: 1, offset: 39031},
 			expr: &seqExpr{
-				pos: position{line: 1447, col: 5, offset: 39231},
+				pos: position{line: 1435, col: 5, offset: 39052},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1447, col: 5, offset: 39231},
+						pos:        position{line: 1435, col: 5, offset: 39052},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1447, col: 10, offset: 39236},
+						pos: position{line: 1435, col: 10, offset: 39057},
 						expr: &seqExpr{
-							pos: position{line: 1447, col: 11, offset: 39237},
+							pos: position{line: 1435, col: 11, offset: 39058},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1447, col: 11, offset: 39237},
+									pos: position{line: 1435, col: 11, offset: 39058},
 									expr: &litMatcher{
-										pos:        position{line: 1447, col: 12, offset: 39238},
+										pos:        position{line: 1435, col: 12, offset: 39059},
 										val:        "*/",
 										ignoreCase: false,
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1447, col: 17, offset: 39243},
+									pos:  position{line: 1435, col: 17, offset: 39064},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1447, col: 35, offset: 39261},
+						pos:        position{line: 1435, col: 35, offset: 39082},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -11508,29 +11425,29 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1449, col: 1, offset: 39267},
+			pos:  position{line: 1437, col: 1, offset: 39088},
 			expr: &seqExpr{
-				pos: position{line: 1450, col: 5, offset: 39289},
+				pos: position{line: 1438, col: 5, offset: 39110},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1450, col: 5, offset: 39289},
+						pos:        position{line: 1438, col: 5, offset: 39110},
 						val:        "//",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1450, col: 10, offset: 39294},
+						pos: position{line: 1438, col: 10, offset: 39115},
 						expr: &seqExpr{
-							pos: position{line: 1450, col: 11, offset: 39295},
+							pos: position{line: 1438, col: 11, offset: 39116},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1450, col: 11, offset: 39295},
+									pos: position{line: 1438, col: 11, offset: 39116},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1450, col: 12, offset: 39296},
+										pos:  position{line: 1438, col: 12, offset: 39117},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1450, col: 27, offset: 39311},
+									pos:  position{line: 1438, col: 27, offset: 39132},
 									name: "SourceCharacter",
 								},
 							},
@@ -11541,19 +11458,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1452, col: 1, offset: 39330},
+			pos:  position{line: 1440, col: 1, offset: 39151},
 			expr: &seqExpr{
-				pos: position{line: 1452, col: 7, offset: 39336},
+				pos: position{line: 1440, col: 7, offset: 39157},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1452, col: 7, offset: 39336},
+						pos: position{line: 1440, col: 7, offset: 39157},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1452, col: 7, offset: 39336},
+							pos:  position{line: 1440, col: 7, offset: 39157},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1452, col: 19, offset: 39348},
+						pos:  position{line: 1440, col: 19, offset: 39169},
 						name: "LineTerminator",
 					},
 				},
@@ -11561,16 +11478,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1454, col: 1, offset: 39364},
+			pos:  position{line: 1442, col: 1, offset: 39185},
 			expr: &choiceExpr{
-				pos: position{line: 1454, col: 7, offset: 39370},
+				pos: position{line: 1442, col: 7, offset: 39191},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1454, col: 7, offset: 39370},
+						pos:  position{line: 1442, col: 7, offset: 39191},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1454, col: 11, offset: 39374},
+						pos:  position{line: 1442, col: 11, offset: 39195},
 						name: "EOF",
 					},
 				},
@@ -11578,21 +11495,21 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1456, col: 1, offset: 39379},
+			pos:  position{line: 1444, col: 1, offset: 39200},
 			expr: &notExpr{
-				pos: position{line: 1456, col: 7, offset: 39385},
+				pos: position{line: 1444, col: 7, offset: 39206},
 				expr: &anyMatcher{
-					line: 1456, col: 8, offset: 39386,
+					line: 1444, col: 8, offset: 39207,
 				},
 			},
 		},
 		{
 			name: "EOKW",
-			pos:  position{line: 1458, col: 1, offset: 39389},
+			pos:  position{line: 1446, col: 1, offset: 39210},
 			expr: &notExpr{
-				pos: position{line: 1458, col: 8, offset: 39396},
+				pos: position{line: 1446, col: 8, offset: 39217},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1458, col: 9, offset: 39397},
+					pos:  position{line: 1446, col: 9, offset: 39218},
 					name: "KeyWordChars",
 				},
 			},
@@ -13278,15 +13195,27 @@ func (p *parser) callonCast1() (interface{}, error) {
 	return p.cur.onCast1(stack["typ"], stack["expr"])
 }
 
-func (c *current) onFunction4(fn, args, where interface{}) (interface{}, error) {
+func (c *current) onFunction3(arg0Text, arg1, where interface{}) (interface{}, error) {
+	var arg0 = map[string]interface{}{"kind": "Primitive", "type": "string", "text": arg0Text}
+	return map[string]interface{}{"kind": "Call", "name": "regexp", "args": []interface{}{arg0, arg1}, "where": where}, nil
+
+}
+
+func (p *parser) callonFunction3() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onFunction3(stack["arg0Text"], stack["arg1"], stack["where"])
+}
+
+func (c *current) onFunction21(fn, args, where interface{}) (interface{}, error) {
 	return map[string]interface{}{"kind": "Call", "name": fn, "args": args, "where": where}, nil
 
 }
 
-func (p *parser) callonFunction4() (interface{}, error) {
+func (p *parser) callonFunction21() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onFunction4(stack["fn"], stack["args"], stack["where"])
+	return p.cur.onFunction21(stack["fn"], stack["args"], stack["where"])
 }
 
 func (c *current) onFunctionArgs2(o interface{}) (interface{}, error) {
@@ -13323,58 +13252,6 @@ func (p *parser) callonPattern4() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onPattern4(stack["s"])
-}
-
-func (c *current) onRegexpFunc1(args, where interface{}) (interface{}, error) {
-	return map[string]interface{}{"kind": "Call", "name": "regexp", "args": args, "where": where}, nil
-
-}
-
-func (p *parser) callonRegexpFunc1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onRegexpFunc1(stack["args"], stack["where"])
-}
-
-func (c *current) onRegexpFuncArgs8(e interface{}) (interface{}, error) {
-	return e, nil
-}
-
-func (p *parser) callonRegexpFuncArgs8() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onRegexpFuncArgs8(stack["e"])
-}
-
-func (c *current) onRegexpFuncArgs2(first, rest interface{}) (interface{}, error) {
-	return append([]interface{}{first}, (rest.([]interface{}))...), nil
-
-}
-
-func (p *parser) callonRegexpFuncArgs2() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onRegexpFuncArgs2(stack["first"], stack["rest"])
-}
-
-func (c *current) onRegexpFuncArgs15() (interface{}, error) {
-	return []interface{}{}, nil
-}
-
-func (p *parser) callonRegexpFuncArgs15() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onRegexpFuncArgs15()
-}
-
-func (c *current) onRegexpFuncArg2(v interface{}) (interface{}, error) {
-	return map[string]interface{}{"kind": "Primitive", "type": "string", "text": v}, nil
-}
-
-func (p *parser) callonRegexpFuncArg2() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onRegexpFuncArg2(stack["v"])
 }
 
 func (c *current) onOptionalExprs3() (interface{}, error) {

--- a/compiler/parser/parser.js
+++ b/compiler/parser/parser.js
@@ -717,63 +717,69 @@ function peg$parse(input, options) {
       peg$c296 = function(s) {
             return {"kind": "String", "text": s}
           },
-      peg$c297 = function(first, e) { return e },
-      peg$c298 = "]",
-      peg$c299 = peg$literalExpectation("]", false),
-      peg$c300 = function(from, to) {
+      peg$c297 = "regexp",
+      peg$c298 = peg$literalExpectation("regexp", false),
+      peg$c299 = function(args, where) {
+            return {"kind": "Call", "name": "regexp", "args": args, "where": where}
+          },
+      peg$c300 = function(first, e) { return e },
+      peg$c301 = function(v) { return {"kind": "Primitive", "type": "string", "text": v} },
+      peg$c302 = "]",
+      peg$c303 = peg$literalExpectation("]", false),
+      peg$c304 = function(from, to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs":to}]
           
           },
-      peg$c301 = function(to) {
+      peg$c305 = function(to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs": null, "rhs":to}]
           
           },
-      peg$c302 = function(expr) { return ["[", expr] },
-      peg$c303 = function(id) { return [".", id] },
-      peg$c304 = function(exprs, locals, scope) {
+      peg$c306 = function(expr) { return ["[", expr] },
+      peg$c307 = function(id) { return [".", id] },
+      peg$c308 = function(exprs, locals, scope) {
             return {"kind": "OverExpr", "locals": locals, "exprs": exprs, "scope": scope}
           },
-      peg$c305 = "}",
-      peg$c306 = peg$literalExpectation("}", false),
-      peg$c307 = function(elems) {
+      peg$c309 = "}",
+      peg$c310 = peg$literalExpectation("}", false),
+      peg$c311 = function(elems) {
             return {"kind":"RecordExpr", "elems":elems}
           },
-      peg$c308 = function(elem) { return elem },
-      peg$c309 = "...",
-      peg$c310 = peg$literalExpectation("...", false),
-      peg$c311 = function(expr) {
+      peg$c312 = function(elem) { return elem },
+      peg$c313 = "...",
+      peg$c314 = peg$literalExpectation("...", false),
+      peg$c315 = function(expr) {
             return {"kind":"Spread", "expr": expr}
           },
-      peg$c312 = function(name, value) {
+      peg$c316 = function(name, value) {
             return {"kind":"Field","name": name, "value": value}
           },
-      peg$c313 = function(elems) {
+      peg$c317 = function(elems) {
             return {"kind":"ArrayExpr", "elems":elems }
           },
-      peg$c314 = "|[",
-      peg$c315 = peg$literalExpectation("|[", false),
-      peg$c316 = "]|",
-      peg$c317 = peg$literalExpectation("]|", false),
-      peg$c318 = function(elems) {
+      peg$c318 = "|[",
+      peg$c319 = peg$literalExpectation("|[", false),
+      peg$c320 = "]|",
+      peg$c321 = peg$literalExpectation("]|", false),
+      peg$c322 = function(elems) {
             return {"kind":"SetExpr", "elems":elems }
           },
-      peg$c319 = function(e) { return {"kind":"VectorValue","expr":e} },
-      peg$c320 = "|{",
-      peg$c321 = peg$literalExpectation("|{", false),
-      peg$c322 = "}|",
-      peg$c323 = peg$literalExpectation("}|", false),
-      peg$c324 = function(exprs) {
+      peg$c323 = function(e) { return {"kind":"VectorValue","expr":e} },
+      peg$c324 = "|{",
+      peg$c325 = peg$literalExpectation("|{", false),
+      peg$c326 = "}|",
+      peg$c327 = peg$literalExpectation("}|", false),
+      peg$c328 = function(exprs) {
             return {"kind":"MapExpr", "entries":exprs }
           },
-      peg$c325 = function(e) { return e },
-      peg$c326 = function(key, value) {
+      peg$c329 = function(e) { return e },
+      peg$c330 = function(key, value) {
             return {"key": key, "value": value}
           },
-      peg$c327 = function(selection, from, joins, where, groupby, having, orderby, limit) {
+      peg$c331 = function(selection, from, joins, where, groupby, having, orderby, limit) {
             return {
               
             "kind": "SQLExpr",
@@ -795,19 +801,19 @@ function peg$parse(input, options) {
             "limit": limit }
           
           },
-      peg$c328 = function(assignments) { return assignments },
-      peg$c329 = function(rhs, opt) {
+      peg$c332 = function(assignments) { return assignments },
+      peg$c333 = function(rhs, opt) {
             let m = {"kind": "Assignment", "lhs": null, "rhs": rhs}
             if (opt) {
               m["lhs"] = opt[3]
             }
             return m
           },
-      peg$c330 = function(table, alias) {
+      peg$c334 = function(table, alias) {
             return {"table": table, "alias": alias}
           },
-      peg$c331 = function(first, join) { return join },
-      peg$c332 = function(style, table, alias, leftKey, rightKey) {
+      peg$c335 = function(first, join) { return join },
+      peg$c336 = function(style, table, alias, leftKey, rightKey) {
             return {
               
             "table": table,
@@ -821,120 +827,120 @@ function peg$parse(input, options) {
             "alias": alias}
           
           },
-      peg$c333 = function(style) { return style },
-      peg$c334 = function(keys, order) {
+      peg$c337 = function(style) { return style },
+      peg$c338 = function(keys, order) {
             return {"kind": "SQLOrderBy", "keys": keys, "order":order}
           },
-      peg$c335 = function(dir) { return dir },
-      peg$c336 = function(count) { return count },
-      peg$c337 = peg$literalExpectation("select", true),
-      peg$c338 = function() { return "select" },
-      peg$c339 = "as",
-      peg$c340 = peg$literalExpectation("as", true),
-      peg$c341 = function() { return "as" },
-      peg$c342 = peg$literalExpectation("from", true),
-      peg$c343 = function() { return "from" },
-      peg$c344 = peg$literalExpectation("join", true),
-      peg$c345 = function() { return "join" },
-      peg$c346 = peg$literalExpectation("where", true),
-      peg$c347 = function() { return "where" },
-      peg$c348 = "group",
-      peg$c349 = peg$literalExpectation("group", true),
-      peg$c350 = function() { return "group" },
-      peg$c351 = "by",
-      peg$c352 = peg$literalExpectation("by", true),
-      peg$c353 = function() { return "by" },
-      peg$c354 = "having",
-      peg$c355 = peg$literalExpectation("having", true),
-      peg$c356 = function() { return "having" },
-      peg$c357 = peg$literalExpectation("order", true),
-      peg$c358 = function() { return "order" },
-      peg$c359 = "on",
-      peg$c360 = peg$literalExpectation("on", true),
-      peg$c361 = function() { return "on" },
-      peg$c362 = "limit",
-      peg$c363 = peg$literalExpectation("limit", true),
-      peg$c364 = function() { return "limit" },
-      peg$c365 = peg$literalExpectation("asc", true),
-      peg$c366 = peg$literalExpectation("desc", true),
-      peg$c367 = peg$literalExpectation("anti", true),
-      peg$c368 = peg$literalExpectation("left", true),
-      peg$c369 = peg$literalExpectation("right", true),
-      peg$c370 = peg$literalExpectation("inner", true),
-      peg$c371 = function(v) {
+      peg$c339 = function(dir) { return dir },
+      peg$c340 = function(count) { return count },
+      peg$c341 = peg$literalExpectation("select", true),
+      peg$c342 = function() { return "select" },
+      peg$c343 = "as",
+      peg$c344 = peg$literalExpectation("as", true),
+      peg$c345 = function() { return "as" },
+      peg$c346 = peg$literalExpectation("from", true),
+      peg$c347 = function() { return "from" },
+      peg$c348 = peg$literalExpectation("join", true),
+      peg$c349 = function() { return "join" },
+      peg$c350 = peg$literalExpectation("where", true),
+      peg$c351 = function() { return "where" },
+      peg$c352 = "group",
+      peg$c353 = peg$literalExpectation("group", true),
+      peg$c354 = function() { return "group" },
+      peg$c355 = "by",
+      peg$c356 = peg$literalExpectation("by", true),
+      peg$c357 = function() { return "by" },
+      peg$c358 = "having",
+      peg$c359 = peg$literalExpectation("having", true),
+      peg$c360 = function() { return "having" },
+      peg$c361 = peg$literalExpectation("order", true),
+      peg$c362 = function() { return "order" },
+      peg$c363 = "on",
+      peg$c364 = peg$literalExpectation("on", true),
+      peg$c365 = function() { return "on" },
+      peg$c366 = "limit",
+      peg$c367 = peg$literalExpectation("limit", true),
+      peg$c368 = function() { return "limit" },
+      peg$c369 = peg$literalExpectation("asc", true),
+      peg$c370 = peg$literalExpectation("desc", true),
+      peg$c371 = peg$literalExpectation("anti", true),
+      peg$c372 = peg$literalExpectation("left", true),
+      peg$c373 = peg$literalExpectation("right", true),
+      peg$c374 = peg$literalExpectation("inner", true),
+      peg$c375 = function(v) {
             return {"kind": "Primitive", "type": "net", "text": v}
           },
-      peg$c372 = function(v) {
+      peg$c376 = function(v) {
             return {"kind": "Primitive", "type": "ip", "text": v}
           },
-      peg$c373 = function(v) {
+      peg$c377 = function(v) {
             return {"kind": "Primitive", "type": "float64", "text": v}
           },
-      peg$c374 = function(v) {
+      peg$c378 = function(v) {
             return {"kind": "Primitive", "type": "int64", "text": v}
           },
-      peg$c375 = "true",
-      peg$c376 = peg$literalExpectation("true", false),
-      peg$c377 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
-      peg$c378 = "false",
-      peg$c379 = peg$literalExpectation("false", false),
-      peg$c380 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
-      peg$c381 = "null",
-      peg$c382 = peg$literalExpectation("null", false),
-      peg$c383 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
-      peg$c384 = "0x",
-      peg$c385 = peg$literalExpectation("0x", false),
-      peg$c386 = function() {
+      peg$c379 = "true",
+      peg$c380 = peg$literalExpectation("true", false),
+      peg$c381 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
+      peg$c382 = "false",
+      peg$c383 = peg$literalExpectation("false", false),
+      peg$c384 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
+      peg$c385 = "null",
+      peg$c386 = peg$literalExpectation("null", false),
+      peg$c387 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
+      peg$c388 = "0x",
+      peg$c389 = peg$literalExpectation("0x", false),
+      peg$c390 = function() {
       	return {"kind": "Primitive", "type": "bytes", "text": text()}
         },
-      peg$c387 = function(typ) {
+      peg$c391 = function(typ) {
             return {"kind": "TypeValue", "value": typ}
           },
-      peg$c388 = function(name) { return name },
-      peg$c389 = function(name, opt) {
+      peg$c392 = function(name) { return name },
+      peg$c393 = function(name, opt) {
             if (opt) {
               return {"kind": "TypeDef", "name": name, "type": opt[3]}
             }
             return {"kind": "TypeName", "name": name}
           },
-      peg$c390 = function(name) {
+      peg$c394 = function(name) {
             return {"kind": "TypeName", "name": name}
           },
-      peg$c391 = function(u) { return u },
-      peg$c392 = function(types) {
+      peg$c395 = function(u) { return u },
+      peg$c396 = function(types) {
             return {"kind": "TypeUnion", "types": types}
           },
-      peg$c393 = function(typ) { return typ },
-      peg$c394 = function(fields) {
+      peg$c397 = function(typ) { return typ },
+      peg$c398 = function(fields) {
             return {"kind":"TypeRecord", "fields":fields}
           },
-      peg$c395 = function(typ) {
+      peg$c399 = function(typ) {
             return {"kind":"TypeArray", "type":typ}
           },
-      peg$c396 = function(typ) {
+      peg$c400 = function(typ) {
             return {"kind":"TypeSet", "type":typ}
           },
-      peg$c397 = function(keyType, valType) {
+      peg$c401 = function(keyType, valType) {
             return {"kind":"TypeMap", "key_type":keyType, "val_type": valType}
           },
-      peg$c398 = function(v) {
+      peg$c402 = function(v) {
             if (v.length == 0) {
               return {"kind": "Primitive", "type": "string", "text": ""}
             }
             return makeTemplateExprChain(v)
           },
-      peg$c399 = "\"",
-      peg$c400 = peg$literalExpectation("\"", false),
-      peg$c401 = "'",
-      peg$c402 = peg$literalExpectation("'", false),
-      peg$c403 = function(v) {
+      peg$c403 = "\"",
+      peg$c404 = peg$literalExpectation("\"", false),
+      peg$c405 = "'",
+      peg$c406 = peg$literalExpectation("'", false),
+      peg$c407 = function(v) {
             return {"kind": "Primitive", "type": "string", "text": joinChars(v)}
           },
-      peg$c404 = "\\",
-      peg$c405 = peg$literalExpectation("\\", false),
-      peg$c406 = "${",
-      peg$c407 = peg$literalExpectation("${", false),
-      peg$c408 = function(e) {
+      peg$c408 = "\\",
+      peg$c409 = peg$literalExpectation("\\", false),
+      peg$c410 = "${",
+      peg$c411 = peg$literalExpectation("${", false),
+      peg$c412 = function(e) {
             return {
               
             "kind": "Cast",
@@ -948,196 +954,196 @@ function peg$parse(input, options) {
             "value": {"kind": "TypePrimitive", "name": "string"}}}
           
           },
-      peg$c409 = "uint8",
-      peg$c410 = peg$literalExpectation("uint8", false),
-      peg$c411 = "uint16",
-      peg$c412 = peg$literalExpectation("uint16", false),
-      peg$c413 = "uint32",
-      peg$c414 = peg$literalExpectation("uint32", false),
-      peg$c415 = "uint64",
-      peg$c416 = peg$literalExpectation("uint64", false),
-      peg$c417 = "int8",
-      peg$c418 = peg$literalExpectation("int8", false),
-      peg$c419 = "int16",
-      peg$c420 = peg$literalExpectation("int16", false),
-      peg$c421 = "int32",
-      peg$c422 = peg$literalExpectation("int32", false),
-      peg$c423 = "int64",
-      peg$c424 = peg$literalExpectation("int64", false),
-      peg$c425 = "float32",
-      peg$c426 = peg$literalExpectation("float32", false),
-      peg$c427 = "float64",
-      peg$c428 = peg$literalExpectation("float64", false),
-      peg$c429 = "bool",
-      peg$c430 = peg$literalExpectation("bool", false),
-      peg$c431 = "string",
-      peg$c432 = peg$literalExpectation("string", false),
-      peg$c433 = "duration",
-      peg$c434 = peg$literalExpectation("duration", false),
-      peg$c435 = "time",
-      peg$c436 = peg$literalExpectation("time", false),
-      peg$c437 = "bytes",
-      peg$c438 = peg$literalExpectation("bytes", false),
-      peg$c439 = "ip",
-      peg$c440 = peg$literalExpectation("ip", false),
-      peg$c441 = "net",
-      peg$c442 = peg$literalExpectation("net", false),
-      peg$c443 = function() {
+      peg$c413 = "uint8",
+      peg$c414 = peg$literalExpectation("uint8", false),
+      peg$c415 = "uint16",
+      peg$c416 = peg$literalExpectation("uint16", false),
+      peg$c417 = "uint32",
+      peg$c418 = peg$literalExpectation("uint32", false),
+      peg$c419 = "uint64",
+      peg$c420 = peg$literalExpectation("uint64", false),
+      peg$c421 = "int8",
+      peg$c422 = peg$literalExpectation("int8", false),
+      peg$c423 = "int16",
+      peg$c424 = peg$literalExpectation("int16", false),
+      peg$c425 = "int32",
+      peg$c426 = peg$literalExpectation("int32", false),
+      peg$c427 = "int64",
+      peg$c428 = peg$literalExpectation("int64", false),
+      peg$c429 = "float32",
+      peg$c430 = peg$literalExpectation("float32", false),
+      peg$c431 = "float64",
+      peg$c432 = peg$literalExpectation("float64", false),
+      peg$c433 = "bool",
+      peg$c434 = peg$literalExpectation("bool", false),
+      peg$c435 = "string",
+      peg$c436 = peg$literalExpectation("string", false),
+      peg$c437 = "duration",
+      peg$c438 = peg$literalExpectation("duration", false),
+      peg$c439 = "time",
+      peg$c440 = peg$literalExpectation("time", false),
+      peg$c441 = "bytes",
+      peg$c442 = peg$literalExpectation("bytes", false),
+      peg$c443 = "ip",
+      peg$c444 = peg$literalExpectation("ip", false),
+      peg$c445 = "net",
+      peg$c446 = peg$literalExpectation("net", false),
+      peg$c447 = function() {
                 return {"kind": "TypePrimitive", "name": text()}
               },
-      peg$c444 = function(name, typ) {
+      peg$c448 = function(name, typ) {
             return {"name": name, "type": typ}
           },
-      peg$c445 = "and",
-      peg$c446 = peg$literalExpectation("and", false),
-      peg$c447 = "AND",
-      peg$c448 = peg$literalExpectation("AND", false),
-      peg$c449 = function() { return "and" },
-      peg$c450 = "or",
-      peg$c451 = peg$literalExpectation("or", false),
-      peg$c452 = "OR",
-      peg$c453 = peg$literalExpectation("OR", false),
-      peg$c454 = function() { return "or" },
-      peg$c455 = function() { return "in" },
-      peg$c456 = "NOT",
-      peg$c457 = peg$literalExpectation("NOT", false),
-      peg$c458 = function() { return "not" },
-      peg$c459 = peg$literalExpectation("by", false),
-      peg$c460 = /^[A-Za-z_$]/,
-      peg$c461 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c462 = /^[0-9]/,
-      peg$c463 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c464 = function(id) { return {"kind": "ID", "name": id} },
-      peg$c465 = "$",
-      peg$c466 = peg$literalExpectation("$", false),
-      peg$c467 = "T",
-      peg$c468 = peg$literalExpectation("T", false),
-      peg$c469 = function() {
+      peg$c449 = "and",
+      peg$c450 = peg$literalExpectation("and", false),
+      peg$c451 = "AND",
+      peg$c452 = peg$literalExpectation("AND", false),
+      peg$c453 = function() { return "and" },
+      peg$c454 = "or",
+      peg$c455 = peg$literalExpectation("or", false),
+      peg$c456 = "OR",
+      peg$c457 = peg$literalExpectation("OR", false),
+      peg$c458 = function() { return "or" },
+      peg$c459 = function() { return "in" },
+      peg$c460 = "NOT",
+      peg$c461 = peg$literalExpectation("NOT", false),
+      peg$c462 = function() { return "not" },
+      peg$c463 = peg$literalExpectation("by", false),
+      peg$c464 = /^[A-Za-z_$]/,
+      peg$c465 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c466 = /^[0-9]/,
+      peg$c467 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c468 = function(id) { return {"kind": "ID", "name": id} },
+      peg$c469 = "$",
+      peg$c470 = peg$literalExpectation("$", false),
+      peg$c471 = "T",
+      peg$c472 = peg$literalExpectation("T", false),
+      peg$c473 = function() {
             return {"kind": "Primitive", "type": "time", "text": text()}
           },
-      peg$c470 = "Z",
-      peg$c471 = peg$literalExpectation("Z", false),
-      peg$c472 = function() {
+      peg$c474 = "Z",
+      peg$c475 = peg$literalExpectation("Z", false),
+      peg$c476 = function() {
             return {"kind": "Primitive", "type": "duration", "text": text()}
           },
-      peg$c473 = "ns",
-      peg$c474 = peg$literalExpectation("ns", false),
-      peg$c475 = "us",
-      peg$c476 = peg$literalExpectation("us", false),
-      peg$c477 = "ms",
-      peg$c478 = peg$literalExpectation("ms", false),
-      peg$c479 = "s",
-      peg$c480 = peg$literalExpectation("s", false),
-      peg$c481 = "m",
-      peg$c482 = peg$literalExpectation("m", false),
-      peg$c483 = "h",
-      peg$c484 = peg$literalExpectation("h", false),
-      peg$c485 = "d",
-      peg$c486 = peg$literalExpectation("d", false),
-      peg$c487 = "w",
-      peg$c488 = peg$literalExpectation("w", false),
-      peg$c489 = "y",
-      peg$c490 = peg$literalExpectation("y", false),
-      peg$c491 = function(a, b) {
+      peg$c477 = "ns",
+      peg$c478 = peg$literalExpectation("ns", false),
+      peg$c479 = "us",
+      peg$c480 = peg$literalExpectation("us", false),
+      peg$c481 = "ms",
+      peg$c482 = peg$literalExpectation("ms", false),
+      peg$c483 = "s",
+      peg$c484 = peg$literalExpectation("s", false),
+      peg$c485 = "m",
+      peg$c486 = peg$literalExpectation("m", false),
+      peg$c487 = "h",
+      peg$c488 = peg$literalExpectation("h", false),
+      peg$c489 = "d",
+      peg$c490 = peg$literalExpectation("d", false),
+      peg$c491 = "w",
+      peg$c492 = peg$literalExpectation("w", false),
+      peg$c493 = "y",
+      peg$c494 = peg$literalExpectation("y", false),
+      peg$c495 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c492 = "::",
-      peg$c493 = peg$literalExpectation("::", false),
-      peg$c494 = function(a, b, d, e) {
+      peg$c496 = "::",
+      peg$c497 = peg$literalExpectation("::", false),
+      peg$c498 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c495 = function(a, b) {
+      peg$c499 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c496 = function(a, b) {
+      peg$c500 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c497 = function() {
+      peg$c501 = function() {
             return "::"
           },
-      peg$c498 = function(v) { return ":" + v },
-      peg$c499 = function(v) { return v + ":" },
-      peg$c500 = function(a, m) {
+      peg$c502 = function(v) { return ":" + v },
+      peg$c503 = function(v) { return v + ":" },
+      peg$c504 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c501 = function(a, m) {
+      peg$c505 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c502 = function(s) { return parseInt(s) },
-      peg$c503 = function() {
+      peg$c506 = function(s) { return parseInt(s) },
+      peg$c507 = function() {
             return text()
           },
-      peg$c504 = "e",
-      peg$c505 = peg$literalExpectation("e", true),
-      peg$c506 = /^[+\-]/,
-      peg$c507 = peg$classExpectation(["+", "-"], false, false),
-      peg$c508 = "NaN",
-      peg$c509 = peg$literalExpectation("NaN", false),
-      peg$c510 = "Inf",
-      peg$c511 = peg$literalExpectation("Inf", false),
-      peg$c512 = /^[0-9a-fA-F]/,
-      peg$c513 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c514 = function(v) { return joinChars(v) },
-      peg$c515 = peg$anyExpectation(),
-      peg$c516 = function(head, tail) { return head + joinChars(tail) },
-      peg$c517 = /^[a-zA-Z_.:\/%#@~]/,
-      peg$c518 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
-      peg$c519 = function(head, tail) {
+      peg$c508 = "e",
+      peg$c509 = peg$literalExpectation("e", true),
+      peg$c510 = /^[+\-]/,
+      peg$c511 = peg$classExpectation(["+", "-"], false, false),
+      peg$c512 = "NaN",
+      peg$c513 = peg$literalExpectation("NaN", false),
+      peg$c514 = "Inf",
+      peg$c515 = peg$literalExpectation("Inf", false),
+      peg$c516 = /^[0-9a-fA-F]/,
+      peg$c517 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c518 = function(v) { return joinChars(v) },
+      peg$c519 = peg$anyExpectation(),
+      peg$c520 = function(head, tail) { return head + joinChars(tail) },
+      peg$c521 = /^[a-zA-Z_.:\/%#@~]/,
+      peg$c522 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
+      peg$c523 = function(head, tail) {
             return head + joinChars(tail)
           },
-      peg$c520 = function() { return "*"},
-      peg$c521 = function() { return "=" },
-      peg$c522 = function() { return "\\*" },
-      peg$c523 = "b",
-      peg$c524 = peg$literalExpectation("b", false),
-      peg$c525 = function() { return "\b" },
-      peg$c526 = "f",
-      peg$c527 = peg$literalExpectation("f", false),
-      peg$c528 = function() { return "\f" },
-      peg$c529 = "n",
-      peg$c530 = peg$literalExpectation("n", false),
-      peg$c531 = function() { return "\n" },
-      peg$c532 = "r",
-      peg$c533 = peg$literalExpectation("r", false),
-      peg$c534 = function() { return "\r" },
-      peg$c535 = "t",
-      peg$c536 = peg$literalExpectation("t", false),
-      peg$c537 = function() { return "\t" },
-      peg$c538 = "v",
-      peg$c539 = peg$literalExpectation("v", false),
-      peg$c540 = function() { return "\v" },
-      peg$c541 = function() { return "*" },
-      peg$c542 = "u",
-      peg$c543 = peg$literalExpectation("u", false),
-      peg$c544 = function(chars) {
+      peg$c524 = function() { return "*"},
+      peg$c525 = function() { return "=" },
+      peg$c526 = function() { return "\\*" },
+      peg$c527 = "b",
+      peg$c528 = peg$literalExpectation("b", false),
+      peg$c529 = function() { return "\b" },
+      peg$c530 = "f",
+      peg$c531 = peg$literalExpectation("f", false),
+      peg$c532 = function() { return "\f" },
+      peg$c533 = "n",
+      peg$c534 = peg$literalExpectation("n", false),
+      peg$c535 = function() { return "\n" },
+      peg$c536 = "r",
+      peg$c537 = peg$literalExpectation("r", false),
+      peg$c538 = function() { return "\r" },
+      peg$c539 = "t",
+      peg$c540 = peg$literalExpectation("t", false),
+      peg$c541 = function() { return "\t" },
+      peg$c542 = "v",
+      peg$c543 = peg$literalExpectation("v", false),
+      peg$c544 = function() { return "\v" },
+      peg$c545 = function() { return "*" },
+      peg$c546 = "u",
+      peg$c547 = peg$literalExpectation("u", false),
+      peg$c548 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c545 = /^[^\/\\]/,
-      peg$c546 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c547 = /^[\0-\x1F\\]/,
-      peg$c548 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c549 = peg$otherExpectation("whitespace"),
-      peg$c550 = "\t",
-      peg$c551 = peg$literalExpectation("\t", false),
-      peg$c552 = "\x0B",
-      peg$c553 = peg$literalExpectation("\x0B", false),
-      peg$c554 = "\f",
-      peg$c555 = peg$literalExpectation("\f", false),
-      peg$c556 = " ",
-      peg$c557 = peg$literalExpectation(" ", false),
-      peg$c558 = "\xA0",
-      peg$c559 = peg$literalExpectation("\xA0", false),
-      peg$c560 = "\uFEFF",
-      peg$c561 = peg$literalExpectation("\uFEFF", false),
-      peg$c562 = /^[\n\r\u2028\u2029]/,
-      peg$c563 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c564 = peg$otherExpectation("comment"),
-      peg$c565 = "/*",
-      peg$c566 = peg$literalExpectation("/*", false),
-      peg$c567 = "*/",
-      peg$c568 = peg$literalExpectation("*/", false),
-      peg$c569 = "//",
-      peg$c570 = peg$literalExpectation("//", false),
+      peg$c549 = /^[^\/\\]/,
+      peg$c550 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c551 = /^[\0-\x1F\\]/,
+      peg$c552 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c553 = peg$otherExpectation("whitespace"),
+      peg$c554 = "\t",
+      peg$c555 = peg$literalExpectation("\t", false),
+      peg$c556 = "\x0B",
+      peg$c557 = peg$literalExpectation("\x0B", false),
+      peg$c558 = "\f",
+      peg$c559 = peg$literalExpectation("\f", false),
+      peg$c560 = " ",
+      peg$c561 = peg$literalExpectation(" ", false),
+      peg$c562 = "\xA0",
+      peg$c563 = peg$literalExpectation("\xA0", false),
+      peg$c564 = "\uFEFF",
+      peg$c565 = peg$literalExpectation("\uFEFF", false),
+      peg$c566 = /^[\n\r\u2028\u2029]/,
+      peg$c567 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c568 = peg$otherExpectation("comment"),
+      peg$c569 = "/*",
+      peg$c570 = peg$literalExpectation("/*", false),
+      peg$c571 = "*/",
+      peg$c572 = peg$literalExpectation("*/", false),
+      peg$c573 = "//",
+      peg$c574 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -7735,52 +7741,58 @@ function peg$parse(input, options) {
 
     s0 = peg$parseGrep();
     if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$currPos;
-      peg$silentFails++;
-      s2 = peg$parseFuncGuard();
-      peg$silentFails--;
-      if (s2 === peg$FAILED) {
-        s1 = void 0;
-      } else {
-        peg$currPos = s1;
-        s1 = peg$FAILED;
-      }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parseIdentifierName();
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parse__();
-          if (s3 !== peg$FAILED) {
-            if (input.charCodeAt(peg$currPos) === 40) {
-              s4 = peg$c15;
-              peg$currPos++;
-            } else {
-              s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c16); }
-            }
-            if (s4 !== peg$FAILED) {
-              s5 = peg$parse__();
-              if (s5 !== peg$FAILED) {
-                s6 = peg$parseFunctionArgs();
-                if (s6 !== peg$FAILED) {
-                  s7 = peg$parse__();
-                  if (s7 !== peg$FAILED) {
-                    if (input.charCodeAt(peg$currPos) === 41) {
-                      s8 = peg$c17;
-                      peg$currPos++;
-                    } else {
-                      s8 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c18); }
-                    }
-                    if (s8 !== peg$FAILED) {
-                      s9 = peg$parseWhereClause();
-                      if (s9 === peg$FAILED) {
-                        s9 = null;
+      s0 = peg$parseRegexpFunc();
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$currPos;
+        peg$silentFails++;
+        s2 = peg$parseFuncGuard();
+        peg$silentFails--;
+        if (s2 === peg$FAILED) {
+          s1 = void 0;
+        } else {
+          peg$currPos = s1;
+          s1 = peg$FAILED;
+        }
+        if (s1 !== peg$FAILED) {
+          s2 = peg$parseIdentifierName();
+          if (s2 !== peg$FAILED) {
+            s3 = peg$parse__();
+            if (s3 !== peg$FAILED) {
+              if (input.charCodeAt(peg$currPos) === 40) {
+                s4 = peg$c15;
+                peg$currPos++;
+              } else {
+                s4 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c16); }
+              }
+              if (s4 !== peg$FAILED) {
+                s5 = peg$parse__();
+                if (s5 !== peg$FAILED) {
+                  s6 = peg$parseFunctionArgs();
+                  if (s6 !== peg$FAILED) {
+                    s7 = peg$parse__();
+                    if (s7 !== peg$FAILED) {
+                      if (input.charCodeAt(peg$currPos) === 41) {
+                        s8 = peg$c17;
+                        peg$currPos++;
+                      } else {
+                        s8 = peg$FAILED;
+                        if (peg$silentFails === 0) { peg$fail(peg$c18); }
                       }
-                      if (s9 !== peg$FAILED) {
-                        peg$savedPos = s0;
-                        s1 = peg$c291(s2, s6, s9);
-                        s0 = s1;
+                      if (s8 !== peg$FAILED) {
+                        s9 = peg$parseWhereClause();
+                        if (s9 === peg$FAILED) {
+                          s9 = null;
+                        }
+                        if (s9 !== peg$FAILED) {
+                          peg$savedPos = s0;
+                          s1 = peg$c291(s2, s6, s9);
+                          s0 = s1;
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$FAILED;
+                        }
                       } else {
                         peg$currPos = s0;
                         s0 = peg$FAILED;
@@ -7813,9 +7825,6 @@ function peg$parse(input, options) {
           peg$currPos = s0;
           s0 = peg$FAILED;
         }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
       }
     }
 
@@ -7974,6 +7983,206 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseRegexpFunc() {
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 6) === peg$c297) {
+      s1 = peg$c297;
+      peg$currPos += 6;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c298); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse__();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 40) {
+          s3 = peg$c15;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c16); }
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse__();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseRegexpFuncArgs();
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parse__();
+              if (s6 !== peg$FAILED) {
+                if (input.charCodeAt(peg$currPos) === 41) {
+                  s7 = peg$c17;
+                  peg$currPos++;
+                } else {
+                  s7 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c18); }
+                }
+                if (s7 !== peg$FAILED) {
+                  s8 = peg$parseWhereClause();
+                  if (s8 === peg$FAILED) {
+                    s8 = null;
+                  }
+                  if (s8 !== peg$FAILED) {
+                    peg$savedPos = s0;
+                    s1 = peg$c299(s5, s8);
+                    s0 = s1;
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseRegexpFuncArgs() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseRegexpFuncArg();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 44) {
+          s5 = peg$c98;
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c99); }
+        }
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseConditionalExpr();
+            if (s7 !== peg$FAILED) {
+              peg$savedPos = s3;
+              s4 = peg$c300(s1, s7);
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse__();
+        if (s4 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 44) {
+            s5 = peg$c98;
+            peg$currPos++;
+          } else {
+            s5 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c99); }
+          }
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseConditionalExpr();
+              if (s7 !== peg$FAILED) {
+                peg$savedPos = s3;
+                s4 = peg$c300(s1, s7);
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c101(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parse__();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c3();
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
+  function peg$parseRegexpFuncArg() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    s1 = peg$parseRegexpPattern();
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c301(s1);
+    }
+    s0 = s1;
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseConditionalExpr();
+    }
+
+    return s0;
+  }
+
   function peg$parseOptionalExprs() {
     var s0, s1;
 
@@ -8014,7 +8223,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c297(s1, s7);
+              s4 = peg$c300(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -8050,7 +8259,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c297(s1, s7);
+                s4 = peg$c300(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -8160,15 +8369,15 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s7 = peg$c298;
+                  s7 = peg$c302;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c299); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c303); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c300(s2, s6);
+                  s1 = peg$c304(s2, s6);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8223,15 +8432,15 @@ function peg$parse(input, options) {
               s5 = peg$parseAdditiveExpr();
               if (s5 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s6 = peg$c298;
+                  s6 = peg$c302;
                   peg$currPos++;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c299); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c303); }
                 }
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c301(s5);
+                  s1 = peg$c305(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8270,15 +8479,15 @@ function peg$parse(input, options) {
           s2 = peg$parseConditionalExpr();
           if (s2 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s3 = peg$c298;
+              s3 = peg$c302;
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c299); }
+              if (peg$silentFails === 0) { peg$fail(peg$c303); }
             }
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c302(s2);
+              s1 = peg$c306(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8305,7 +8514,7 @@ function peg$parse(input, options) {
             s2 = peg$parseIdentifier();
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c303(s2);
+              s1 = peg$c307(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8474,7 +8683,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSequential();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c304(s3, s4, s8);
+                    s1 = peg$c308(s3, s4, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -8531,15 +8740,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c305;
+              s5 = peg$c309;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c306); }
+              if (peg$silentFails === 0) { peg$fail(peg$c310); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c307(s3);
+              s1 = peg$c311(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8621,7 +8830,7 @@ function peg$parse(input, options) {
           s4 = peg$parseRecordElem();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c308(s4);
+            s1 = peg$c312(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8661,12 +8870,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c309) {
-      s1 = peg$c309;
+    if (input.substr(peg$currPos, 3) === peg$c313) {
+      s1 = peg$c313;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c310); }
+      if (peg$silentFails === 0) { peg$fail(peg$c314); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8674,7 +8883,7 @@ function peg$parse(input, options) {
         s3 = peg$parseConditionalExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c311(s3);
+          s1 = peg$c315(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8713,7 +8922,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c312(s1, s5);
+              s1 = peg$c316(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8758,15 +8967,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s5 = peg$c298;
+              s5 = peg$c302;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c299); }
+              if (peg$silentFails === 0) { peg$fail(peg$c303); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c313(s3);
+              s1 = peg$c317(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8796,12 +9005,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c314) {
-      s1 = peg$c314;
+    if (input.substr(peg$currPos, 2) === peg$c318) {
+      s1 = peg$c318;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c315); }
+      if (peg$silentFails === 0) { peg$fail(peg$c319); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8810,16 +9019,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c316) {
-              s5 = peg$c316;
+            if (input.substr(peg$currPos, 2) === peg$c320) {
+              s5 = peg$c320;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c317); }
+              if (peg$silentFails === 0) { peg$fail(peg$c321); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c318(s3);
+              s1 = peg$c322(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8868,7 +9077,7 @@ function peg$parse(input, options) {
             s7 = peg$parseVectorElem();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c297(s1, s7);
+              s4 = peg$c300(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -8904,7 +9113,7 @@ function peg$parse(input, options) {
               s7 = peg$parseVectorElem();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c297(s1, s7);
+                s4 = peg$c300(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -8957,7 +9166,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c319(s1);
+        s1 = peg$c323(s1);
       }
       s0 = s1;
     }
@@ -8969,12 +9178,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c320) {
-      s1 = peg$c320;
+    if (input.substr(peg$currPos, 2) === peg$c324) {
+      s1 = peg$c324;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c321); }
+      if (peg$silentFails === 0) { peg$fail(peg$c325); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8983,16 +9192,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c322) {
-              s5 = peg$c322;
+            if (input.substr(peg$currPos, 2) === peg$c326) {
+              s5 = peg$c326;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c323); }
+              if (peg$silentFails === 0) { peg$fail(peg$c327); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c324(s3);
+              s1 = peg$c328(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9074,7 +9283,7 @@ function peg$parse(input, options) {
           s4 = peg$parseEntry();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c325(s4);
+            s1 = peg$c329(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9117,7 +9326,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c326(s1, s5);
+              s1 = peg$c330(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9182,7 +9391,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSQLLimit();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c327(s1, s2, s3, s4, s5, s6, s7, s8);
+                    s1 = peg$c331(s1, s2, s3, s4, s5, s6, s7, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -9260,7 +9469,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSQLAssignments();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c328(s3);
+            s1 = peg$c332(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9317,7 +9526,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c329(s1, s2);
+        s1 = peg$c333(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9443,7 +9652,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c330(s4, s5);
+              s1 = peg$c334(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9598,7 +9807,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSQLJoin();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s3;
-        s4 = peg$c331(s1, s4);
+        s4 = peg$c335(s1, s4);
       }
       s3 = s4;
       while (s3 !== peg$FAILED) {
@@ -9607,7 +9816,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSQLJoin();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s3;
-          s4 = peg$c331(s1, s4);
+          s4 = peg$c335(s1, s4);
         }
         s3 = s4;
       }
@@ -9669,7 +9878,7 @@ function peg$parse(input, options) {
                               s14 = peg$parseJoinKey();
                               if (s14 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c332(s1, s5, s6, s10, s14);
+                                s1 = peg$c336(s1, s5, s6, s10, s14);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -9749,7 +9958,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c333(s2);
+        s1 = peg$c337(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9908,7 +10117,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseSQLOrder();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c334(s6, s7);
+                  s1 = peg$c338(s6, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -9954,7 +10163,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c335(s2);
+        s1 = peg$c339(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9990,7 +10199,7 @@ function peg$parse(input, options) {
           s4 = peg$parseUInt();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c336(s4);
+            s1 = peg$c340(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10030,11 +10239,11 @@ function peg$parse(input, options) {
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c337); }
+      if (peg$silentFails === 0) { peg$fail(peg$c341); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c338();
+      s1 = peg$c342();
     }
     s0 = s1;
 
@@ -10045,16 +10254,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c339) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c343) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c340); }
+      if (peg$silentFails === 0) { peg$fail(peg$c344); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c341();
+      s1 = peg$c345();
     }
     s0 = s1;
 
@@ -10070,11 +10279,11 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c342); }
+      if (peg$silentFails === 0) { peg$fail(peg$c346); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c343();
+      s1 = peg$c347();
     }
     s0 = s1;
 
@@ -10090,11 +10299,11 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c344); }
+      if (peg$silentFails === 0) { peg$fail(peg$c348); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c345();
+      s1 = peg$c349();
     }
     s0 = s1;
 
@@ -10110,11 +10319,11 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c346); }
+      if (peg$silentFails === 0) { peg$fail(peg$c350); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c347();
+      s1 = peg$c351();
     }
     s0 = s1;
 
@@ -10125,16 +10334,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c348) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c352) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c349); }
+      if (peg$silentFails === 0) { peg$fail(peg$c353); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c350();
+      s1 = peg$c354();
     }
     s0 = s1;
 
@@ -10145,16 +10354,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c351) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c355) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c352); }
+      if (peg$silentFails === 0) { peg$fail(peg$c356); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c353();
+      s1 = peg$c357();
     }
     s0 = s1;
 
@@ -10165,16 +10374,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c354) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c358) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c355); }
+      if (peg$silentFails === 0) { peg$fail(peg$c359); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c356();
+      s1 = peg$c360();
     }
     s0 = s1;
 
@@ -10190,11 +10399,11 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c357); }
+      if (peg$silentFails === 0) { peg$fail(peg$c361); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c358();
+      s1 = peg$c362();
     }
     s0 = s1;
 
@@ -10205,16 +10414,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c359) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c363) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c360); }
+      if (peg$silentFails === 0) { peg$fail(peg$c364); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c361();
+      s1 = peg$c365();
     }
     s0 = s1;
 
@@ -10225,16 +10434,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c362) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c366) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c363); }
+      if (peg$silentFails === 0) { peg$fail(peg$c367); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c364();
+      s1 = peg$c368();
     }
     s0 = s1;
 
@@ -10250,7 +10459,7 @@ function peg$parse(input, options) {
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c365); }
+      if (peg$silentFails === 0) { peg$fail(peg$c369); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10270,7 +10479,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c366); }
+      if (peg$silentFails === 0) { peg$fail(peg$c370); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10290,7 +10499,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c367); }
+      if (peg$silentFails === 0) { peg$fail(peg$c371); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10310,7 +10519,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c368); }
+      if (peg$silentFails === 0) { peg$fail(peg$c372); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10330,7 +10539,7 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c369); }
+      if (peg$silentFails === 0) { peg$fail(peg$c373); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10350,7 +10559,7 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c370); }
+      if (peg$silentFails === 0) { peg$fail(peg$c374); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10452,7 +10661,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c371(s1);
+        s1 = peg$c375(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10467,7 +10676,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP4Net();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c371(s1);
+        s1 = peg$c375(s1);
       }
       s0 = s1;
     }
@@ -10493,7 +10702,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c372(s1);
+        s1 = peg$c376(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10508,7 +10717,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c372(s1);
+        s1 = peg$c376(s1);
       }
       s0 = s1;
     }
@@ -10523,7 +10732,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFloatString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c373(s1);
+      s1 = peg$c377(s1);
     }
     s0 = s1;
 
@@ -10537,7 +10746,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c374(s1);
+      s1 = peg$c378(s1);
     }
     s0 = s1;
 
@@ -10548,30 +10757,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c375) {
-      s1 = peg$c375;
+    if (input.substr(peg$currPos, 4) === peg$c379) {
+      s1 = peg$c379;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c376); }
+      if (peg$silentFails === 0) { peg$fail(peg$c380); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c377();
+      s1 = peg$c381();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c378) {
-        s1 = peg$c378;
+      if (input.substr(peg$currPos, 5) === peg$c382) {
+        s1 = peg$c382;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c379); }
+        if (peg$silentFails === 0) { peg$fail(peg$c383); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c380();
+        s1 = peg$c384();
       }
       s0 = s1;
     }
@@ -10583,16 +10792,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c381) {
-      s1 = peg$c381;
+    if (input.substr(peg$currPos, 4) === peg$c385) {
+      s1 = peg$c385;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c382); }
+      if (peg$silentFails === 0) { peg$fail(peg$c386); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c383();
+      s1 = peg$c387();
     }
     s0 = s1;
 
@@ -10603,12 +10812,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c384) {
-      s1 = peg$c384;
+    if (input.substr(peg$currPos, 2) === peg$c388) {
+      s1 = peg$c388;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c385); }
+      if (peg$silentFails === 0) { peg$fail(peg$c389); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -10619,7 +10828,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c386();
+        s1 = peg$c390();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10656,7 +10865,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c387(s2);
+          s1 = peg$c391(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10683,7 +10892,7 @@ function peg$parse(input, options) {
       s1 = peg$parsePrimitiveType();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c387(s1);
+        s1 = peg$c391(s1);
       }
       s0 = s1;
     }
@@ -10723,7 +10932,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c388(s1);
+        s1 = peg$c392(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10775,7 +10984,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c389(s1, s2);
+          s1 = peg$c393(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10790,7 +10999,7 @@ function peg$parse(input, options) {
         s1 = peg$parseQuotedString();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c390(s1);
+          s1 = peg$c394(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
@@ -10816,7 +11025,7 @@ function peg$parse(input, options) {
                 }
                 if (s4 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c391(s3);
+                  s1 = peg$c395(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10848,7 +11057,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTypeList();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c392(s1);
+      s1 = peg$c396(s1);
     }
     s0 = s1;
 
@@ -10906,7 +11115,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c393(s4);
+            s1 = peg$c397(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10947,15 +11156,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c305;
+              s5 = peg$c309;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c306); }
+              if (peg$silentFails === 0) { peg$fail(peg$c310); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c394(s3);
+              s1 = peg$c398(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -10994,15 +11203,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c298;
+                s5 = peg$c302;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c299); }
+                if (peg$silentFails === 0) { peg$fail(peg$c303); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c395(s3);
+                s1 = peg$c399(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -11026,12 +11235,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c314) {
-          s1 = peg$c314;
+        if (input.substr(peg$currPos, 2) === peg$c318) {
+          s1 = peg$c318;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c315); }
+          if (peg$silentFails === 0) { peg$fail(peg$c319); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -11040,16 +11249,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c316) {
-                  s5 = peg$c316;
+                if (input.substr(peg$currPos, 2) === peg$c320) {
+                  s5 = peg$c320;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c317); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c321); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c396(s3);
+                  s1 = peg$c400(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -11073,12 +11282,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c320) {
-            s1 = peg$c320;
+          if (input.substr(peg$currPos, 2) === peg$c324) {
+            s1 = peg$c324;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c321); }
+            if (peg$silentFails === 0) { peg$fail(peg$c325); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -11101,16 +11310,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c322) {
-                            s9 = peg$c322;
+                          if (input.substr(peg$currPos, 2) === peg$c326) {
+                            s9 = peg$c326;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c323); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c327); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c397(s3, s7);
+                            s1 = peg$c401(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -11162,7 +11371,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTemplateLiteralParts();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c398(s1);
+      s1 = peg$c402(s1);
     }
     s0 = s1;
 
@@ -11174,11 +11383,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c399;
+      s1 = peg$c403;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c400); }
+      if (peg$silentFails === 0) { peg$fail(peg$c404); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -11189,11 +11398,11 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c399;
+          s3 = peg$c403;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c400); }
+          if (peg$silentFails === 0) { peg$fail(peg$c404); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
@@ -11214,11 +11423,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c401;
+        s1 = peg$c405;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c402); }
+        if (peg$silentFails === 0) { peg$fail(peg$c406); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -11229,11 +11438,11 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c401;
+            s3 = peg$c405;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c402); }
+            if (peg$silentFails === 0) { peg$fail(peg$c406); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
@@ -11274,7 +11483,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c403(s1);
+        s1 = peg$c407(s1);
       }
       s0 = s1;
     }
@@ -11287,19 +11496,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c404;
+      s1 = peg$c408;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c405); }
+      if (peg$silentFails === 0) { peg$fail(peg$c409); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c406) {
-        s2 = peg$c406;
+      if (input.substr(peg$currPos, 2) === peg$c410) {
+        s2 = peg$c410;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c407); }
+        if (peg$silentFails === 0) { peg$fail(peg$c411); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11317,12 +11526,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c406) {
-        s2 = peg$c406;
+      if (input.substr(peg$currPos, 2) === peg$c410) {
+        s2 = peg$c410;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c407); }
+        if (peg$silentFails === 0) { peg$fail(peg$c411); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -11368,7 +11577,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c403(s1);
+        s1 = peg$c407(s1);
       }
       s0 = s1;
     }
@@ -11381,19 +11590,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c404;
+      s1 = peg$c408;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c405); }
+      if (peg$silentFails === 0) { peg$fail(peg$c409); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c406) {
-        s2 = peg$c406;
+      if (input.substr(peg$currPos, 2) === peg$c410) {
+        s2 = peg$c410;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c407); }
+        if (peg$silentFails === 0) { peg$fail(peg$c411); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11411,12 +11620,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c406) {
-        s2 = peg$c406;
+      if (input.substr(peg$currPos, 2) === peg$c410) {
+        s2 = peg$c410;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c407); }
+        if (peg$silentFails === 0) { peg$fail(peg$c411); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -11448,12 +11657,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c406) {
-      s1 = peg$c406;
+    if (input.substr(peg$currPos, 2) === peg$c410) {
+      s1 = peg$c410;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c407); }
+      if (peg$silentFails === 0) { peg$fail(peg$c411); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -11463,15 +11672,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c305;
+              s5 = peg$c309;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c306); }
+              if (peg$silentFails === 0) { peg$fail(peg$c310); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c408(s3);
+              s1 = peg$c412(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11501,140 +11710,140 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c409) {
-      s1 = peg$c409;
+    if (input.substr(peg$currPos, 5) === peg$c413) {
+      s1 = peg$c413;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c410); }
+      if (peg$silentFails === 0) { peg$fail(peg$c414); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c411) {
-        s1 = peg$c411;
+      if (input.substr(peg$currPos, 6) === peg$c415) {
+        s1 = peg$c415;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c412); }
+        if (peg$silentFails === 0) { peg$fail(peg$c416); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c413) {
-          s1 = peg$c413;
+        if (input.substr(peg$currPos, 6) === peg$c417) {
+          s1 = peg$c417;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c414); }
+          if (peg$silentFails === 0) { peg$fail(peg$c418); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c415) {
-            s1 = peg$c415;
+          if (input.substr(peg$currPos, 6) === peg$c419) {
+            s1 = peg$c419;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c416); }
+            if (peg$silentFails === 0) { peg$fail(peg$c420); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c417) {
-              s1 = peg$c417;
+            if (input.substr(peg$currPos, 4) === peg$c421) {
+              s1 = peg$c421;
               peg$currPos += 4;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c418); }
+              if (peg$silentFails === 0) { peg$fail(peg$c422); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 5) === peg$c419) {
-                s1 = peg$c419;
+              if (input.substr(peg$currPos, 5) === peg$c423) {
+                s1 = peg$c423;
                 peg$currPos += 5;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c420); }
+                if (peg$silentFails === 0) { peg$fail(peg$c424); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c421) {
-                  s1 = peg$c421;
+                if (input.substr(peg$currPos, 5) === peg$c425) {
+                  s1 = peg$c425;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c422); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c426); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c423) {
-                    s1 = peg$c423;
+                  if (input.substr(peg$currPos, 5) === peg$c427) {
+                    s1 = peg$c427;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c424); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c428); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7) === peg$c425) {
-                      s1 = peg$c425;
+                    if (input.substr(peg$currPos, 7) === peg$c429) {
+                      s1 = peg$c429;
                       peg$currPos += 7;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c426); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c430); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 7) === peg$c427) {
-                        s1 = peg$c427;
+                      if (input.substr(peg$currPos, 7) === peg$c431) {
+                        s1 = peg$c431;
                         peg$currPos += 7;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c428); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c432); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 4) === peg$c429) {
-                          s1 = peg$c429;
+                        if (input.substr(peg$currPos, 4) === peg$c433) {
+                          s1 = peg$c433;
                           peg$currPos += 4;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c430); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c434); }
                         }
                         if (s1 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 6) === peg$c431) {
-                            s1 = peg$c431;
+                          if (input.substr(peg$currPos, 6) === peg$c435) {
+                            s1 = peg$c435;
                             peg$currPos += 6;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c432); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c436); }
                           }
                           if (s1 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 8) === peg$c433) {
-                              s1 = peg$c433;
+                            if (input.substr(peg$currPos, 8) === peg$c437) {
+                              s1 = peg$c437;
                               peg$currPos += 8;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c434); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c438); }
                             }
                             if (s1 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 4) === peg$c435) {
-                                s1 = peg$c435;
+                              if (input.substr(peg$currPos, 4) === peg$c439) {
+                                s1 = peg$c439;
                                 peg$currPos += 4;
                               } else {
                                 s1 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c436); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c440); }
                               }
                               if (s1 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 5) === peg$c437) {
-                                  s1 = peg$c437;
+                                if (input.substr(peg$currPos, 5) === peg$c441) {
+                                  s1 = peg$c441;
                                   peg$currPos += 5;
                                 } else {
                                   s1 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c438); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c442); }
                                 }
                                 if (s1 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 2) === peg$c439) {
-                                    s1 = peg$c439;
+                                  if (input.substr(peg$currPos, 2) === peg$c443) {
+                                    s1 = peg$c443;
                                     peg$currPos += 2;
                                   } else {
                                     s1 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c440); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c444); }
                                   }
                                   if (s1 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 3) === peg$c441) {
-                                      s1 = peg$c441;
+                                    if (input.substr(peg$currPos, 3) === peg$c445) {
+                                      s1 = peg$c445;
                                       peg$currPos += 3;
                                     } else {
                                       s1 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c442); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c446); }
                                     }
                                     if (s1 === peg$FAILED) {
                                       if (input.substr(peg$currPos, 4) === peg$c10) {
@@ -11645,12 +11854,12 @@ function peg$parse(input, options) {
                                         if (peg$silentFails === 0) { peg$fail(peg$c11); }
                                       }
                                       if (s1 === peg$FAILED) {
-                                        if (input.substr(peg$currPos, 4) === peg$c381) {
-                                          s1 = peg$c381;
+                                        if (input.substr(peg$currPos, 4) === peg$c385) {
+                                          s1 = peg$c385;
                                           peg$currPos += 4;
                                         } else {
                                           s1 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c382); }
+                                          if (peg$silentFails === 0) { peg$fail(peg$c386); }
                                         }
                                       }
                                     }
@@ -11672,7 +11881,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c443();
+      s1 = peg$c447();
     }
     s0 = s1;
 
@@ -11735,7 +11944,7 @@ function peg$parse(input, options) {
           s4 = peg$parseTypeField();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c393(s4);
+            s1 = peg$c397(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11778,7 +11987,7 @@ function peg$parse(input, options) {
             s5 = peg$parseType();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c444(s1, s5);
+              s1 = peg$c448(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11819,20 +12028,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c445) {
-      s1 = peg$c445;
+    if (input.substr(peg$currPos, 3) === peg$c449) {
+      s1 = peg$c449;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c446); }
+      if (peg$silentFails === 0) { peg$fail(peg$c450); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c447) {
-        s1 = peg$c447;
+      if (input.substr(peg$currPos, 3) === peg$c451) {
+        s1 = peg$c451;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c448); }
+        if (peg$silentFails === 0) { peg$fail(peg$c452); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -11848,7 +12057,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c449();
+        s1 = peg$c453();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11866,20 +12075,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c450) {
-      s1 = peg$c450;
+    if (input.substr(peg$currPos, 2) === peg$c454) {
+      s1 = peg$c454;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c451); }
+      if (peg$silentFails === 0) { peg$fail(peg$c455); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c452) {
-        s1 = peg$c452;
+      if (input.substr(peg$currPos, 2) === peg$c456) {
+        s1 = peg$c456;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c453); }
+        if (peg$silentFails === 0) { peg$fail(peg$c457); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -11895,7 +12104,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c454();
+        s1 = peg$c458();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11933,7 +12142,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c455();
+        s1 = peg$c459();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11959,12 +12168,12 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$c287); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c456) {
-        s1 = peg$c456;
+      if (input.substr(peg$currPos, 3) === peg$c460) {
+        s1 = peg$c460;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c457); }
+        if (peg$silentFails === 0) { peg$fail(peg$c461); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -11980,7 +12189,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c458();
+        s1 = peg$c462();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11998,12 +12207,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c351) {
-      s1 = peg$c351;
+    if (input.substr(peg$currPos, 2) === peg$c355) {
+      s1 = peg$c355;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c459); }
+      if (peg$silentFails === 0) { peg$fail(peg$c463); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -12018,7 +12227,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c353();
+        s1 = peg$c357();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12035,12 +12244,12 @@ function peg$parse(input, options) {
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c460.test(input.charAt(peg$currPos))) {
+    if (peg$c464.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c461); }
+      if (peg$silentFails === 0) { peg$fail(peg$c465); }
     }
 
     return s0;
@@ -12051,12 +12260,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c462.test(input.charAt(peg$currPos))) {
+      if (peg$c466.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c463); }
+        if (peg$silentFails === 0) { peg$fail(peg$c467); }
       }
     }
 
@@ -12070,7 +12279,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c464(s1);
+      s1 = peg$c468(s1);
     }
     s0 = s1;
 
@@ -12142,11 +12351,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 36) {
-        s1 = peg$c465;
+        s1 = peg$c469;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c466); }
+        if (peg$silentFails === 0) { peg$fail(peg$c470); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -12156,11 +12365,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c404;
+          s1 = peg$c408;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c405); }
+          if (peg$silentFails === 0) { peg$fail(peg$c409); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseIDGuard();
@@ -12268,17 +12477,17 @@ function peg$parse(input, options) {
     s1 = peg$parseFullDate();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 84) {
-        s2 = peg$c467;
+        s2 = peg$c471;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c468); }
+        if (peg$silentFails === 0) { peg$fail(peg$c472); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseFullTime();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c469();
+          s1 = peg$c473();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -12352,36 +12561,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (peg$c462.test(input.charAt(peg$currPos))) {
+    if (peg$c466.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c463); }
+      if (peg$silentFails === 0) { peg$fail(peg$c467); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c462.test(input.charAt(peg$currPos))) {
+      if (peg$c466.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c463); }
+        if (peg$silentFails === 0) { peg$fail(peg$c467); }
       }
       if (s2 !== peg$FAILED) {
-        if (peg$c462.test(input.charAt(peg$currPos))) {
+        if (peg$c466.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c463); }
+          if (peg$silentFails === 0) { peg$fail(peg$c467); }
         }
         if (s3 !== peg$FAILED) {
-          if (peg$c462.test(input.charAt(peg$currPos))) {
+          if (peg$c466.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c463); }
+            if (peg$silentFails === 0) { peg$fail(peg$c467); }
           }
           if (s4 !== peg$FAILED) {
             s1 = [s1, s2, s3, s4];
@@ -12410,20 +12619,20 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c462.test(input.charAt(peg$currPos))) {
+    if (peg$c466.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c463); }
+      if (peg$silentFails === 0) { peg$fail(peg$c467); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c462.test(input.charAt(peg$currPos))) {
+      if (peg$c466.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c463); }
+        if (peg$silentFails === 0) { peg$fail(peg$c467); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -12498,22 +12707,22 @@ function peg$parse(input, options) {
               }
               if (s7 !== peg$FAILED) {
                 s8 = [];
-                if (peg$c462.test(input.charAt(peg$currPos))) {
+                if (peg$c466.test(input.charAt(peg$currPos))) {
                   s9 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s9 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c463); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c467); }
                 }
                 if (s9 !== peg$FAILED) {
                   while (s9 !== peg$FAILED) {
                     s8.push(s9);
-                    if (peg$c462.test(input.charAt(peg$currPos))) {
+                    if (peg$c466.test(input.charAt(peg$currPos))) {
                       s9 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c463); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c467); }
                     }
                   }
                 } else {
@@ -12568,11 +12777,11 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     if (input.charCodeAt(peg$currPos) === 90) {
-      s0 = peg$c470;
+      s0 = peg$c474;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c471); }
+      if (peg$silentFails === 0) { peg$fail(peg$c475); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
@@ -12615,22 +12824,22 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 s7 = [];
-                if (peg$c462.test(input.charAt(peg$currPos))) {
+                if (peg$c466.test(input.charAt(peg$currPos))) {
                   s8 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s8 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c463); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c467); }
                 }
                 if (s8 !== peg$FAILED) {
                   while (s8 !== peg$FAILED) {
                     s7.push(s8);
-                    if (peg$c462.test(input.charAt(peg$currPos))) {
+                    if (peg$c466.test(input.charAt(peg$currPos))) {
                       s8 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s8 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c463); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c467); }
                     }
                   }
                 } else {
@@ -12733,7 +12942,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c472();
+        s1 = peg$c476();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12795,76 +13004,76 @@ function peg$parse(input, options) {
   function peg$parseTimeUnit() {
     var s0;
 
-    if (input.substr(peg$currPos, 2) === peg$c473) {
-      s0 = peg$c473;
+    if (input.substr(peg$currPos, 2) === peg$c477) {
+      s0 = peg$c477;
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c474); }
+      if (peg$silentFails === 0) { peg$fail(peg$c478); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c475) {
-        s0 = peg$c475;
+      if (input.substr(peg$currPos, 2) === peg$c479) {
+        s0 = peg$c479;
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c476); }
+        if (peg$silentFails === 0) { peg$fail(peg$c480); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c477) {
-          s0 = peg$c477;
+        if (input.substr(peg$currPos, 2) === peg$c481) {
+          s0 = peg$c481;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c478); }
+          if (peg$silentFails === 0) { peg$fail(peg$c482); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 115) {
-            s0 = peg$c479;
+            s0 = peg$c483;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c480); }
+            if (peg$silentFails === 0) { peg$fail(peg$c484); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c481;
+              s0 = peg$c485;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c482); }
+              if (peg$silentFails === 0) { peg$fail(peg$c486); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 104) {
-                s0 = peg$c483;
+                s0 = peg$c487;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c484); }
+                if (peg$silentFails === 0) { peg$fail(peg$c488); }
               }
               if (s0 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 100) {
-                  s0 = peg$c485;
+                  s0 = peg$c489;
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c486); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c490); }
                 }
                 if (s0 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 119) {
-                    s0 = peg$c487;
+                    s0 = peg$c491;
                     peg$currPos++;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c488); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c492); }
                   }
                   if (s0 === peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 121) {
-                      s0 = peg$c489;
+                      s0 = peg$c493;
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c490); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c494); }
                     }
                   }
                 }
@@ -13049,7 +13258,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c491(s1, s2);
+        s1 = peg$c495(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13070,12 +13279,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c492) {
-            s3 = peg$c492;
+          if (input.substr(peg$currPos, 2) === peg$c496) {
+            s3 = peg$c496;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c493); }
+            if (peg$silentFails === 0) { peg$fail(peg$c497); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -13088,7 +13297,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c494(s1, s2, s4, s5);
+                s1 = peg$c498(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -13112,12 +13321,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c492) {
-          s1 = peg$c492;
+        if (input.substr(peg$currPos, 2) === peg$c496) {
+          s1 = peg$c496;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c493); }
+          if (peg$silentFails === 0) { peg$fail(peg$c497); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -13130,7 +13339,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c495(s2, s3);
+              s1 = peg$c499(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13155,16 +13364,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c492) {
-                s3 = peg$c492;
+              if (input.substr(peg$currPos, 2) === peg$c496) {
+                s3 = peg$c496;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c493); }
+                if (peg$silentFails === 0) { peg$fail(peg$c497); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c496(s1, s2);
+                s1 = peg$c500(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -13180,16 +13389,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c492) {
-              s1 = peg$c492;
+            if (input.substr(peg$currPos, 2) === peg$c496) {
+              s1 = peg$c496;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c493); }
+              if (peg$silentFails === 0) { peg$fail(peg$c497); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c497();
+              s1 = peg$c501();
             }
             s0 = s1;
           }
@@ -13226,7 +13435,7 @@ function peg$parse(input, options) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c498(s2);
+        s1 = peg$c502(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13255,7 +13464,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c499(s1);
+        s1 = peg$c503(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13286,7 +13495,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c500(s1, s3);
+          s1 = peg$c504(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13321,7 +13530,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c501(s1, s3);
+          s1 = peg$c505(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13346,7 +13555,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c502(s1);
+      s1 = peg$c506(s1);
     }
     s0 = s1;
 
@@ -13369,22 +13578,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c462.test(input.charAt(peg$currPos))) {
+    if (peg$c466.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c463); }
+      if (peg$silentFails === 0) { peg$fail(peg$c467); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c462.test(input.charAt(peg$currPos))) {
+        if (peg$c466.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c463); }
+          if (peg$silentFails === 0) { peg$fail(peg$c467); }
         }
       }
     } else {
@@ -13444,22 +13653,22 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c462.test(input.charAt(peg$currPos))) {
+      if (peg$c466.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c463); }
+        if (peg$silentFails === 0) { peg$fail(peg$c467); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c462.test(input.charAt(peg$currPos))) {
+          if (peg$c466.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c463); }
+            if (peg$silentFails === 0) { peg$fail(peg$c467); }
           }
         }
       } else {
@@ -13475,21 +13684,21 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c462.test(input.charAt(peg$currPos))) {
+          if (peg$c466.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c463); }
+            if (peg$silentFails === 0) { peg$fail(peg$c467); }
           }
           while (s5 !== peg$FAILED) {
             s4.push(s5);
-            if (peg$c462.test(input.charAt(peg$currPos))) {
+            if (peg$c466.test(input.charAt(peg$currPos))) {
               s5 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c463); }
+              if (peg$silentFails === 0) { peg$fail(peg$c467); }
             }
           }
           if (s4 !== peg$FAILED) {
@@ -13499,7 +13708,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c503();
+              s1 = peg$c507();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13543,22 +13752,22 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c462.test(input.charAt(peg$currPos))) {
+          if (peg$c466.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c463); }
+            if (peg$silentFails === 0) { peg$fail(peg$c467); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c462.test(input.charAt(peg$currPos))) {
+              if (peg$c466.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c463); }
+                if (peg$silentFails === 0) { peg$fail(peg$c467); }
               }
             }
           } else {
@@ -13571,7 +13780,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c503();
+              s1 = peg$c507();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13610,20 +13819,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c504) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c508) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c505); }
+      if (peg$silentFails === 0) { peg$fail(peg$c509); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c506.test(input.charAt(peg$currPos))) {
+      if (peg$c510.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c507); }
+        if (peg$silentFails === 0) { peg$fail(peg$c511); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -13652,12 +13861,12 @@ function peg$parse(input, options) {
   function peg$parseNaN() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c508) {
-      s0 = peg$c508;
+    if (input.substr(peg$currPos, 3) === peg$c512) {
+      s0 = peg$c512;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c509); }
+      if (peg$silentFails === 0) { peg$fail(peg$c513); }
     }
 
     return s0;
@@ -13687,12 +13896,12 @@ function peg$parse(input, options) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c510) {
-        s2 = peg$c510;
+      if (input.substr(peg$currPos, 3) === peg$c514) {
+        s2 = peg$c514;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c511); }
+        if (peg$silentFails === 0) { peg$fail(peg$c515); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -13735,12 +13944,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c512.test(input.charAt(peg$currPos))) {
+    if (peg$c516.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c513); }
+      if (peg$silentFails === 0) { peg$fail(peg$c517); }
     }
 
     return s0;
@@ -13751,11 +13960,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c399;
+      s1 = peg$c403;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c400); }
+      if (peg$silentFails === 0) { peg$fail(peg$c404); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -13766,15 +13975,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c399;
+          s3 = peg$c403;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c400); }
+          if (peg$silentFails === 0) { peg$fail(peg$c404); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c514(s2);
+          s1 = peg$c518(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13791,11 +14000,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c401;
+        s1 = peg$c405;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c402); }
+        if (peg$silentFails === 0) { peg$fail(peg$c406); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -13806,15 +14015,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c401;
+            s3 = peg$c405;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c402); }
+            if (peg$silentFails === 0) { peg$fail(peg$c406); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c514(s2);
+            s1 = peg$c518(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -13840,11 +14049,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c399;
+      s2 = peg$c403;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c400); }
+      if (peg$silentFails === 0) { peg$fail(peg$c404); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -13862,7 +14071,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c515); }
+        if (peg$silentFails === 0) { peg$fail(peg$c519); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -13879,11 +14088,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c404;
+        s1 = peg$c408;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c405); }
+        if (peg$silentFails === 0) { peg$fail(peg$c409); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -13918,7 +14127,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c516(s1, s2);
+        s1 = peg$c520(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13947,12 +14156,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (peg$c517.test(input.charAt(peg$currPos))) {
+    if (peg$c521.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c518); }
+      if (peg$silentFails === 0) { peg$fail(peg$c522); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -13968,12 +14177,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseKeyWordStart();
     if (s0 === peg$FAILED) {
-      if (peg$c462.test(input.charAt(peg$currPos))) {
+      if (peg$c466.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c463); }
+        if (peg$silentFails === 0) { peg$fail(peg$c467); }
       }
     }
 
@@ -13985,11 +14194,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c404;
+      s1 = peg$c408;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c405); }
+      if (peg$silentFails === 0) { peg$fail(peg$c409); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseKeywordEscape();
@@ -14048,7 +14257,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c519(s3, s4);
+            s1 = peg$c523(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -14166,7 +14375,7 @@ function peg$parse(input, options) {
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c520();
+          s1 = peg$c524();
         }
         s0 = s1;
       }
@@ -14180,12 +14389,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseGlobStart();
     if (s0 === peg$FAILED) {
-      if (peg$c462.test(input.charAt(peg$currPos))) {
+      if (peg$c466.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c463); }
+        if (peg$silentFails === 0) { peg$fail(peg$c467); }
       }
     }
 
@@ -14197,11 +14406,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c404;
+      s1 = peg$c408;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c405); }
+      if (peg$silentFails === 0) { peg$fail(peg$c409); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseGlobEscape();
@@ -14237,7 +14446,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c521();
+      s1 = peg$c525();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -14251,16 +14460,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c522();
+        s1 = peg$c526();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c506.test(input.charAt(peg$currPos))) {
+        if (peg$c510.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c507); }
+          if (peg$silentFails === 0) { peg$fail(peg$c511); }
         }
       }
     }
@@ -14275,11 +14484,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c401;
+      s2 = peg$c405;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c402); }
+      if (peg$silentFails === 0) { peg$fail(peg$c406); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -14297,7 +14506,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c515); }
+        if (peg$silentFails === 0) { peg$fail(peg$c519); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14314,11 +14523,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c404;
+        s1 = peg$c408;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c405); }
+        if (peg$silentFails === 0) { peg$fail(peg$c409); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -14354,20 +14563,20 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c401;
+      s0 = peg$c405;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c402); }
+      if (peg$silentFails === 0) { peg$fail(peg$c406); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s1 = peg$c399;
+        s1 = peg$c403;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c400); }
+        if (peg$silentFails === 0) { peg$fail(peg$c404); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14376,94 +14585,94 @@ function peg$parse(input, options) {
       s0 = s1;
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c404;
+          s0 = peg$c408;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c405); }
+          if (peg$silentFails === 0) { peg$fail(peg$c409); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c523;
+            s1 = peg$c527;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c524); }
+            if (peg$silentFails === 0) { peg$fail(peg$c528); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c525();
+            s1 = peg$c529();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c526;
+              s1 = peg$c530;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c527); }
+              if (peg$silentFails === 0) { peg$fail(peg$c531); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c528();
+              s1 = peg$c532();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c529;
+                s1 = peg$c533;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c530); }
+                if (peg$silentFails === 0) { peg$fail(peg$c534); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c531();
+                s1 = peg$c535();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c532;
+                  s1 = peg$c536;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c533); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c537); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c534();
+                  s1 = peg$c538();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c535;
+                    s1 = peg$c539;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c536); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c540); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c537();
+                    s1 = peg$c541();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c538;
+                      s1 = peg$c542;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c539); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c543); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c540();
+                      s1 = peg$c544();
                     }
                     s0 = s1;
                   }
@@ -14491,7 +14700,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c521();
+      s1 = peg$c525();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -14505,16 +14714,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c541();
+        s1 = peg$c545();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c506.test(input.charAt(peg$currPos))) {
+        if (peg$c510.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c507); }
+          if (peg$silentFails === 0) { peg$fail(peg$c511); }
         }
       }
     }
@@ -14527,11 +14736,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c542;
+      s1 = peg$c546;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c543); }
+      if (peg$silentFails === 0) { peg$fail(peg$c547); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -14563,7 +14772,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c544(s2);
+        s1 = peg$c548(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14576,11 +14785,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c542;
+        s1 = peg$c546;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c543); }
+        if (peg$silentFails === 0) { peg$fail(peg$c547); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
@@ -14647,15 +14856,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c305;
+              s4 = peg$c309;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c306); }
+              if (peg$silentFails === 0) { peg$fail(peg$c310); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c544(s3);
+              s1 = peg$c548(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -14739,21 +14948,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c545.test(input.charAt(peg$currPos))) {
+    if (peg$c549.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c546); }
+      if (peg$silentFails === 0) { peg$fail(peg$c550); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s3 = peg$c404;
+        s3 = peg$c408;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c405); }
+        if (peg$silentFails === 0) { peg$fail(peg$c409); }
       }
       if (s3 !== peg$FAILED) {
         if (input.length > peg$currPos) {
@@ -14761,7 +14970,7 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c515); }
+          if (peg$silentFails === 0) { peg$fail(peg$c519); }
         }
         if (s4 !== peg$FAILED) {
           s3 = [s3, s4];
@@ -14778,21 +14987,21 @@ function peg$parse(input, options) {
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c545.test(input.charAt(peg$currPos))) {
+        if (peg$c549.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c546); }
+          if (peg$silentFails === 0) { peg$fail(peg$c550); }
         }
         if (s2 === peg$FAILED) {
           s2 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 92) {
-            s3 = peg$c404;
+            s3 = peg$c408;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c405); }
+            if (peg$silentFails === 0) { peg$fail(peg$c409); }
           }
           if (s3 !== peg$FAILED) {
             if (input.length > peg$currPos) {
@@ -14800,7 +15009,7 @@ function peg$parse(input, options) {
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c515); }
+              if (peg$silentFails === 0) { peg$fail(peg$c519); }
             }
             if (s4 !== peg$FAILED) {
               s3 = [s3, s4];
@@ -14830,12 +15039,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c547.test(input.charAt(peg$currPos))) {
+    if (peg$c551.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c548); }
+      if (peg$silentFails === 0) { peg$fail(peg$c552); }
     }
 
     return s0;
@@ -14893,7 +15102,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c515); }
+      if (peg$silentFails === 0) { peg$fail(peg$c519); }
     }
 
     return s0;
@@ -14904,51 +15113,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c550;
+      s0 = peg$c554;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c551); }
+      if (peg$silentFails === 0) { peg$fail(peg$c555); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c552;
+        s0 = peg$c556;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c553); }
+        if (peg$silentFails === 0) { peg$fail(peg$c557); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c554;
+          s0 = peg$c558;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c555); }
+          if (peg$silentFails === 0) { peg$fail(peg$c559); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c556;
+            s0 = peg$c560;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c557); }
+            if (peg$silentFails === 0) { peg$fail(peg$c561); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c558;
+              s0 = peg$c562;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c559); }
+              if (peg$silentFails === 0) { peg$fail(peg$c563); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c560;
+                s0 = peg$c564;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c561); }
+                if (peg$silentFails === 0) { peg$fail(peg$c565); }
               }
             }
           }
@@ -14958,7 +15167,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c549); }
+      if (peg$silentFails === 0) { peg$fail(peg$c553); }
     }
 
     return s0;
@@ -14967,12 +15176,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c562.test(input.charAt(peg$currPos))) {
+    if (peg$c566.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c563); }
+      if (peg$silentFails === 0) { peg$fail(peg$c567); }
     }
 
     return s0;
@@ -14986,7 +15195,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c564); }
+      if (peg$silentFails === 0) { peg$fail(peg$c568); }
     }
 
     return s0;
@@ -14996,24 +15205,24 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c565) {
-      s1 = peg$c565;
+    if (input.substr(peg$currPos, 2) === peg$c569) {
+      s1 = peg$c569;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c566); }
+      if (peg$silentFails === 0) { peg$fail(peg$c570); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c567) {
-        s5 = peg$c567;
+      if (input.substr(peg$currPos, 2) === peg$c571) {
+        s5 = peg$c571;
         peg$currPos += 2;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c568); }
+        if (peg$silentFails === 0) { peg$fail(peg$c572); }
       }
       peg$silentFails--;
       if (s5 === peg$FAILED) {
@@ -15040,12 +15249,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$currPos;
         peg$silentFails++;
-        if (input.substr(peg$currPos, 2) === peg$c567) {
-          s5 = peg$c567;
+        if (input.substr(peg$currPos, 2) === peg$c571) {
+          s5 = peg$c571;
           peg$currPos += 2;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c568); }
+          if (peg$silentFails === 0) { peg$fail(peg$c572); }
         }
         peg$silentFails--;
         if (s5 === peg$FAILED) {
@@ -15069,12 +15278,12 @@ function peg$parse(input, options) {
         }
       }
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c567) {
-          s3 = peg$c567;
+        if (input.substr(peg$currPos, 2) === peg$c571) {
+          s3 = peg$c571;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c568); }
+          if (peg$silentFails === 0) { peg$fail(peg$c572); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -15099,12 +15308,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c569) {
-      s1 = peg$c569;
+    if (input.substr(peg$currPos, 2) === peg$c573) {
+      s1 = peg$c573;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c570); }
+      if (peg$silentFails === 0) { peg$fail(peg$c574); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -15222,7 +15431,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c515); }
+      if (peg$silentFails === 0) { peg$fail(peg$c519); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/compiler/parser/parser.js
+++ b/compiler/parser/parser.js
@@ -701,85 +701,85 @@ function peg$parse(input, options) {
       peg$c290 = function(typ, expr) {
             return {"kind": "Cast", "expr": expr, "type": typ}
           },
-      peg$c291 = function(fn, args, where) {
+      peg$c291 = "regexp",
+      peg$c292 = peg$literalExpectation("regexp", false),
+      peg$c293 = function(arg0Text, arg1, where) {
+            let arg0 = {"kind": "Primitive", "type": "string", "text": arg0Text}
+            return {"kind": "Call", "name": "regexp", "args": [arg0, arg1], "where": where}
+          },
+      peg$c294 = function(fn, args, where) {
             return {"kind": "Call", "name": fn, "args": args, "where": where}
           },
-      peg$c292 = function(o) { return [o] },
-      peg$c293 = "grep",
-      peg$c294 = peg$literalExpectation("grep", false),
-      peg$c295 = function(pattern, opt) {
+      peg$c295 = function(o) { return [o] },
+      peg$c296 = "grep",
+      peg$c297 = peg$literalExpectation("grep", false),
+      peg$c298 = function(pattern, opt) {
             let m = {"kind": "Grep", "pattern": pattern, "expr": {"kind": "ID", "name": "this"}}
             if (opt) {
               m["expr"] = opt[2]
             }
             return m
           },
-      peg$c296 = function(s) {
+      peg$c299 = function(s) {
             return {"kind": "String", "text": s}
           },
-      peg$c297 = "regexp",
-      peg$c298 = peg$literalExpectation("regexp", false),
-      peg$c299 = function(args, where) {
-            return {"kind": "Call", "name": "regexp", "args": args, "where": where}
-          },
       peg$c300 = function(first, e) { return e },
-      peg$c301 = function(v) { return {"kind": "Primitive", "type": "string", "text": v} },
-      peg$c302 = "]",
-      peg$c303 = peg$literalExpectation("]", false),
-      peg$c304 = function(from, to) {
+      peg$c301 = "]",
+      peg$c302 = peg$literalExpectation("]", false),
+      peg$c303 = function(from, to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs":to}]
           
           },
-      peg$c305 = function(to) {
+      peg$c304 = function(to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs": null, "rhs":to}]
           
           },
-      peg$c306 = function(expr) { return ["[", expr] },
-      peg$c307 = function(id) { return [".", id] },
-      peg$c308 = function(exprs, locals, scope) {
+      peg$c305 = function(expr) { return ["[", expr] },
+      peg$c306 = function(id) { return [".", id] },
+      peg$c307 = function(exprs, locals, scope) {
             return {"kind": "OverExpr", "locals": locals, "exprs": exprs, "scope": scope}
           },
-      peg$c309 = "}",
-      peg$c310 = peg$literalExpectation("}", false),
-      peg$c311 = function(elems) {
+      peg$c308 = "}",
+      peg$c309 = peg$literalExpectation("}", false),
+      peg$c310 = function(elems) {
             return {"kind":"RecordExpr", "elems":elems}
           },
-      peg$c312 = function(elem) { return elem },
-      peg$c313 = "...",
-      peg$c314 = peg$literalExpectation("...", false),
-      peg$c315 = function(expr) {
+      peg$c311 = function(elem) { return elem },
+      peg$c312 = "...",
+      peg$c313 = peg$literalExpectation("...", false),
+      peg$c314 = function(expr) {
             return {"kind":"Spread", "expr": expr}
           },
-      peg$c316 = function(name, value) {
+      peg$c315 = function(name, value) {
             return {"kind":"Field","name": name, "value": value}
           },
-      peg$c317 = function(elems) {
+      peg$c316 = function(elems) {
             return {"kind":"ArrayExpr", "elems":elems }
           },
-      peg$c318 = "|[",
-      peg$c319 = peg$literalExpectation("|[", false),
-      peg$c320 = "]|",
-      peg$c321 = peg$literalExpectation("]|", false),
-      peg$c322 = function(elems) {
+      peg$c317 = "|[",
+      peg$c318 = peg$literalExpectation("|[", false),
+      peg$c319 = "]|",
+      peg$c320 = peg$literalExpectation("]|", false),
+      peg$c321 = function(elems) {
             return {"kind":"SetExpr", "elems":elems }
           },
-      peg$c323 = function(e) { return {"kind":"VectorValue","expr":e} },
-      peg$c324 = "|{",
-      peg$c325 = peg$literalExpectation("|{", false),
-      peg$c326 = "}|",
-      peg$c327 = peg$literalExpectation("}|", false),
-      peg$c328 = function(exprs) {
+      peg$c322 = function(e) { return {"kind":"VectorValue","expr":e} },
+      peg$c323 = "|{",
+      peg$c324 = peg$literalExpectation("|{", false),
+      peg$c325 = "}|",
+      peg$c326 = peg$literalExpectation("}|", false),
+      peg$c327 = function(exprs) {
             return {"kind":"MapExpr", "entries":exprs }
           },
-      peg$c329 = function(e) { return e },
-      peg$c330 = function(key, value) {
+      peg$c328 = function(e) { return e },
+      peg$c329 = function(key, value) {
             return {"key": key, "value": value}
           },
-      peg$c331 = function(selection, from, joins, where, groupby, having, orderby, limit) {
+      peg$c330 = function(selection, from, joins, where, groupby, having, orderby, limit) {
             return {
               
             "kind": "SQLExpr",
@@ -801,19 +801,19 @@ function peg$parse(input, options) {
             "limit": limit }
           
           },
-      peg$c332 = function(assignments) { return assignments },
-      peg$c333 = function(rhs, opt) {
+      peg$c331 = function(assignments) { return assignments },
+      peg$c332 = function(rhs, opt) {
             let m = {"kind": "Assignment", "lhs": null, "rhs": rhs}
             if (opt) {
               m["lhs"] = opt[3]
             }
             return m
           },
-      peg$c334 = function(table, alias) {
+      peg$c333 = function(table, alias) {
             return {"table": table, "alias": alias}
           },
-      peg$c335 = function(first, join) { return join },
-      peg$c336 = function(style, table, alias, leftKey, rightKey) {
+      peg$c334 = function(first, join) { return join },
+      peg$c335 = function(style, table, alias, leftKey, rightKey) {
             return {
               
             "table": table,
@@ -827,120 +827,120 @@ function peg$parse(input, options) {
             "alias": alias}
           
           },
-      peg$c337 = function(style) { return style },
-      peg$c338 = function(keys, order) {
+      peg$c336 = function(style) { return style },
+      peg$c337 = function(keys, order) {
             return {"kind": "SQLOrderBy", "keys": keys, "order":order}
           },
-      peg$c339 = function(dir) { return dir },
-      peg$c340 = function(count) { return count },
-      peg$c341 = peg$literalExpectation("select", true),
-      peg$c342 = function() { return "select" },
-      peg$c343 = "as",
-      peg$c344 = peg$literalExpectation("as", true),
-      peg$c345 = function() { return "as" },
-      peg$c346 = peg$literalExpectation("from", true),
-      peg$c347 = function() { return "from" },
-      peg$c348 = peg$literalExpectation("join", true),
-      peg$c349 = function() { return "join" },
-      peg$c350 = peg$literalExpectation("where", true),
-      peg$c351 = function() { return "where" },
-      peg$c352 = "group",
-      peg$c353 = peg$literalExpectation("group", true),
-      peg$c354 = function() { return "group" },
-      peg$c355 = "by",
-      peg$c356 = peg$literalExpectation("by", true),
-      peg$c357 = function() { return "by" },
-      peg$c358 = "having",
-      peg$c359 = peg$literalExpectation("having", true),
-      peg$c360 = function() { return "having" },
-      peg$c361 = peg$literalExpectation("order", true),
-      peg$c362 = function() { return "order" },
-      peg$c363 = "on",
-      peg$c364 = peg$literalExpectation("on", true),
-      peg$c365 = function() { return "on" },
-      peg$c366 = "limit",
-      peg$c367 = peg$literalExpectation("limit", true),
-      peg$c368 = function() { return "limit" },
-      peg$c369 = peg$literalExpectation("asc", true),
-      peg$c370 = peg$literalExpectation("desc", true),
-      peg$c371 = peg$literalExpectation("anti", true),
-      peg$c372 = peg$literalExpectation("left", true),
-      peg$c373 = peg$literalExpectation("right", true),
-      peg$c374 = peg$literalExpectation("inner", true),
-      peg$c375 = function(v) {
+      peg$c338 = function(dir) { return dir },
+      peg$c339 = function(count) { return count },
+      peg$c340 = peg$literalExpectation("select", true),
+      peg$c341 = function() { return "select" },
+      peg$c342 = "as",
+      peg$c343 = peg$literalExpectation("as", true),
+      peg$c344 = function() { return "as" },
+      peg$c345 = peg$literalExpectation("from", true),
+      peg$c346 = function() { return "from" },
+      peg$c347 = peg$literalExpectation("join", true),
+      peg$c348 = function() { return "join" },
+      peg$c349 = peg$literalExpectation("where", true),
+      peg$c350 = function() { return "where" },
+      peg$c351 = "group",
+      peg$c352 = peg$literalExpectation("group", true),
+      peg$c353 = function() { return "group" },
+      peg$c354 = "by",
+      peg$c355 = peg$literalExpectation("by", true),
+      peg$c356 = function() { return "by" },
+      peg$c357 = "having",
+      peg$c358 = peg$literalExpectation("having", true),
+      peg$c359 = function() { return "having" },
+      peg$c360 = peg$literalExpectation("order", true),
+      peg$c361 = function() { return "order" },
+      peg$c362 = "on",
+      peg$c363 = peg$literalExpectation("on", true),
+      peg$c364 = function() { return "on" },
+      peg$c365 = "limit",
+      peg$c366 = peg$literalExpectation("limit", true),
+      peg$c367 = function() { return "limit" },
+      peg$c368 = peg$literalExpectation("asc", true),
+      peg$c369 = peg$literalExpectation("desc", true),
+      peg$c370 = peg$literalExpectation("anti", true),
+      peg$c371 = peg$literalExpectation("left", true),
+      peg$c372 = peg$literalExpectation("right", true),
+      peg$c373 = peg$literalExpectation("inner", true),
+      peg$c374 = function(v) {
             return {"kind": "Primitive", "type": "net", "text": v}
           },
-      peg$c376 = function(v) {
+      peg$c375 = function(v) {
             return {"kind": "Primitive", "type": "ip", "text": v}
           },
-      peg$c377 = function(v) {
+      peg$c376 = function(v) {
             return {"kind": "Primitive", "type": "float64", "text": v}
           },
-      peg$c378 = function(v) {
+      peg$c377 = function(v) {
             return {"kind": "Primitive", "type": "int64", "text": v}
           },
-      peg$c379 = "true",
-      peg$c380 = peg$literalExpectation("true", false),
-      peg$c381 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
-      peg$c382 = "false",
-      peg$c383 = peg$literalExpectation("false", false),
-      peg$c384 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
-      peg$c385 = "null",
-      peg$c386 = peg$literalExpectation("null", false),
-      peg$c387 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
-      peg$c388 = "0x",
-      peg$c389 = peg$literalExpectation("0x", false),
-      peg$c390 = function() {
+      peg$c378 = "true",
+      peg$c379 = peg$literalExpectation("true", false),
+      peg$c380 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
+      peg$c381 = "false",
+      peg$c382 = peg$literalExpectation("false", false),
+      peg$c383 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
+      peg$c384 = "null",
+      peg$c385 = peg$literalExpectation("null", false),
+      peg$c386 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
+      peg$c387 = "0x",
+      peg$c388 = peg$literalExpectation("0x", false),
+      peg$c389 = function() {
       	return {"kind": "Primitive", "type": "bytes", "text": text()}
         },
-      peg$c391 = function(typ) {
+      peg$c390 = function(typ) {
             return {"kind": "TypeValue", "value": typ}
           },
-      peg$c392 = function(name) { return name },
-      peg$c393 = function(name, opt) {
+      peg$c391 = function(name) { return name },
+      peg$c392 = function(name, opt) {
             if (opt) {
               return {"kind": "TypeDef", "name": name, "type": opt[3]}
             }
             return {"kind": "TypeName", "name": name}
           },
-      peg$c394 = function(name) {
+      peg$c393 = function(name) {
             return {"kind": "TypeName", "name": name}
           },
-      peg$c395 = function(u) { return u },
-      peg$c396 = function(types) {
+      peg$c394 = function(u) { return u },
+      peg$c395 = function(types) {
             return {"kind": "TypeUnion", "types": types}
           },
-      peg$c397 = function(typ) { return typ },
-      peg$c398 = function(fields) {
+      peg$c396 = function(typ) { return typ },
+      peg$c397 = function(fields) {
             return {"kind":"TypeRecord", "fields":fields}
           },
-      peg$c399 = function(typ) {
+      peg$c398 = function(typ) {
             return {"kind":"TypeArray", "type":typ}
           },
-      peg$c400 = function(typ) {
+      peg$c399 = function(typ) {
             return {"kind":"TypeSet", "type":typ}
           },
-      peg$c401 = function(keyType, valType) {
+      peg$c400 = function(keyType, valType) {
             return {"kind":"TypeMap", "key_type":keyType, "val_type": valType}
           },
-      peg$c402 = function(v) {
+      peg$c401 = function(v) {
             if (v.length == 0) {
               return {"kind": "Primitive", "type": "string", "text": ""}
             }
             return makeTemplateExprChain(v)
           },
-      peg$c403 = "\"",
-      peg$c404 = peg$literalExpectation("\"", false),
-      peg$c405 = "'",
-      peg$c406 = peg$literalExpectation("'", false),
-      peg$c407 = function(v) {
+      peg$c402 = "\"",
+      peg$c403 = peg$literalExpectation("\"", false),
+      peg$c404 = "'",
+      peg$c405 = peg$literalExpectation("'", false),
+      peg$c406 = function(v) {
             return {"kind": "Primitive", "type": "string", "text": joinChars(v)}
           },
-      peg$c408 = "\\",
-      peg$c409 = peg$literalExpectation("\\", false),
-      peg$c410 = "${",
-      peg$c411 = peg$literalExpectation("${", false),
-      peg$c412 = function(e) {
+      peg$c407 = "\\",
+      peg$c408 = peg$literalExpectation("\\", false),
+      peg$c409 = "${",
+      peg$c410 = peg$literalExpectation("${", false),
+      peg$c411 = function(e) {
             return {
               
             "kind": "Cast",
@@ -954,196 +954,196 @@ function peg$parse(input, options) {
             "value": {"kind": "TypePrimitive", "name": "string"}}}
           
           },
-      peg$c413 = "uint8",
-      peg$c414 = peg$literalExpectation("uint8", false),
-      peg$c415 = "uint16",
-      peg$c416 = peg$literalExpectation("uint16", false),
-      peg$c417 = "uint32",
-      peg$c418 = peg$literalExpectation("uint32", false),
-      peg$c419 = "uint64",
-      peg$c420 = peg$literalExpectation("uint64", false),
-      peg$c421 = "int8",
-      peg$c422 = peg$literalExpectation("int8", false),
-      peg$c423 = "int16",
-      peg$c424 = peg$literalExpectation("int16", false),
-      peg$c425 = "int32",
-      peg$c426 = peg$literalExpectation("int32", false),
-      peg$c427 = "int64",
-      peg$c428 = peg$literalExpectation("int64", false),
-      peg$c429 = "float32",
-      peg$c430 = peg$literalExpectation("float32", false),
-      peg$c431 = "float64",
-      peg$c432 = peg$literalExpectation("float64", false),
-      peg$c433 = "bool",
-      peg$c434 = peg$literalExpectation("bool", false),
-      peg$c435 = "string",
-      peg$c436 = peg$literalExpectation("string", false),
-      peg$c437 = "duration",
-      peg$c438 = peg$literalExpectation("duration", false),
-      peg$c439 = "time",
-      peg$c440 = peg$literalExpectation("time", false),
-      peg$c441 = "bytes",
-      peg$c442 = peg$literalExpectation("bytes", false),
-      peg$c443 = "ip",
-      peg$c444 = peg$literalExpectation("ip", false),
-      peg$c445 = "net",
-      peg$c446 = peg$literalExpectation("net", false),
-      peg$c447 = function() {
+      peg$c412 = "uint8",
+      peg$c413 = peg$literalExpectation("uint8", false),
+      peg$c414 = "uint16",
+      peg$c415 = peg$literalExpectation("uint16", false),
+      peg$c416 = "uint32",
+      peg$c417 = peg$literalExpectation("uint32", false),
+      peg$c418 = "uint64",
+      peg$c419 = peg$literalExpectation("uint64", false),
+      peg$c420 = "int8",
+      peg$c421 = peg$literalExpectation("int8", false),
+      peg$c422 = "int16",
+      peg$c423 = peg$literalExpectation("int16", false),
+      peg$c424 = "int32",
+      peg$c425 = peg$literalExpectation("int32", false),
+      peg$c426 = "int64",
+      peg$c427 = peg$literalExpectation("int64", false),
+      peg$c428 = "float32",
+      peg$c429 = peg$literalExpectation("float32", false),
+      peg$c430 = "float64",
+      peg$c431 = peg$literalExpectation("float64", false),
+      peg$c432 = "bool",
+      peg$c433 = peg$literalExpectation("bool", false),
+      peg$c434 = "string",
+      peg$c435 = peg$literalExpectation("string", false),
+      peg$c436 = "duration",
+      peg$c437 = peg$literalExpectation("duration", false),
+      peg$c438 = "time",
+      peg$c439 = peg$literalExpectation("time", false),
+      peg$c440 = "bytes",
+      peg$c441 = peg$literalExpectation("bytes", false),
+      peg$c442 = "ip",
+      peg$c443 = peg$literalExpectation("ip", false),
+      peg$c444 = "net",
+      peg$c445 = peg$literalExpectation("net", false),
+      peg$c446 = function() {
                 return {"kind": "TypePrimitive", "name": text()}
               },
-      peg$c448 = function(name, typ) {
+      peg$c447 = function(name, typ) {
             return {"name": name, "type": typ}
           },
-      peg$c449 = "and",
-      peg$c450 = peg$literalExpectation("and", false),
-      peg$c451 = "AND",
-      peg$c452 = peg$literalExpectation("AND", false),
-      peg$c453 = function() { return "and" },
-      peg$c454 = "or",
-      peg$c455 = peg$literalExpectation("or", false),
-      peg$c456 = "OR",
-      peg$c457 = peg$literalExpectation("OR", false),
-      peg$c458 = function() { return "or" },
-      peg$c459 = function() { return "in" },
-      peg$c460 = "NOT",
-      peg$c461 = peg$literalExpectation("NOT", false),
-      peg$c462 = function() { return "not" },
-      peg$c463 = peg$literalExpectation("by", false),
-      peg$c464 = /^[A-Za-z_$]/,
-      peg$c465 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c466 = /^[0-9]/,
-      peg$c467 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c468 = function(id) { return {"kind": "ID", "name": id} },
-      peg$c469 = "$",
-      peg$c470 = peg$literalExpectation("$", false),
-      peg$c471 = "T",
-      peg$c472 = peg$literalExpectation("T", false),
-      peg$c473 = function() {
+      peg$c448 = "and",
+      peg$c449 = peg$literalExpectation("and", false),
+      peg$c450 = "AND",
+      peg$c451 = peg$literalExpectation("AND", false),
+      peg$c452 = function() { return "and" },
+      peg$c453 = "or",
+      peg$c454 = peg$literalExpectation("or", false),
+      peg$c455 = "OR",
+      peg$c456 = peg$literalExpectation("OR", false),
+      peg$c457 = function() { return "or" },
+      peg$c458 = function() { return "in" },
+      peg$c459 = "NOT",
+      peg$c460 = peg$literalExpectation("NOT", false),
+      peg$c461 = function() { return "not" },
+      peg$c462 = peg$literalExpectation("by", false),
+      peg$c463 = /^[A-Za-z_$]/,
+      peg$c464 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c465 = /^[0-9]/,
+      peg$c466 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c467 = function(id) { return {"kind": "ID", "name": id} },
+      peg$c468 = "$",
+      peg$c469 = peg$literalExpectation("$", false),
+      peg$c470 = "T",
+      peg$c471 = peg$literalExpectation("T", false),
+      peg$c472 = function() {
             return {"kind": "Primitive", "type": "time", "text": text()}
           },
-      peg$c474 = "Z",
-      peg$c475 = peg$literalExpectation("Z", false),
-      peg$c476 = function() {
+      peg$c473 = "Z",
+      peg$c474 = peg$literalExpectation("Z", false),
+      peg$c475 = function() {
             return {"kind": "Primitive", "type": "duration", "text": text()}
           },
-      peg$c477 = "ns",
-      peg$c478 = peg$literalExpectation("ns", false),
-      peg$c479 = "us",
-      peg$c480 = peg$literalExpectation("us", false),
-      peg$c481 = "ms",
-      peg$c482 = peg$literalExpectation("ms", false),
-      peg$c483 = "s",
-      peg$c484 = peg$literalExpectation("s", false),
-      peg$c485 = "m",
-      peg$c486 = peg$literalExpectation("m", false),
-      peg$c487 = "h",
-      peg$c488 = peg$literalExpectation("h", false),
-      peg$c489 = "d",
-      peg$c490 = peg$literalExpectation("d", false),
-      peg$c491 = "w",
-      peg$c492 = peg$literalExpectation("w", false),
-      peg$c493 = "y",
-      peg$c494 = peg$literalExpectation("y", false),
-      peg$c495 = function(a, b) {
+      peg$c476 = "ns",
+      peg$c477 = peg$literalExpectation("ns", false),
+      peg$c478 = "us",
+      peg$c479 = peg$literalExpectation("us", false),
+      peg$c480 = "ms",
+      peg$c481 = peg$literalExpectation("ms", false),
+      peg$c482 = "s",
+      peg$c483 = peg$literalExpectation("s", false),
+      peg$c484 = "m",
+      peg$c485 = peg$literalExpectation("m", false),
+      peg$c486 = "h",
+      peg$c487 = peg$literalExpectation("h", false),
+      peg$c488 = "d",
+      peg$c489 = peg$literalExpectation("d", false),
+      peg$c490 = "w",
+      peg$c491 = peg$literalExpectation("w", false),
+      peg$c492 = "y",
+      peg$c493 = peg$literalExpectation("y", false),
+      peg$c494 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c496 = "::",
-      peg$c497 = peg$literalExpectation("::", false),
-      peg$c498 = function(a, b, d, e) {
+      peg$c495 = "::",
+      peg$c496 = peg$literalExpectation("::", false),
+      peg$c497 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c499 = function(a, b) {
+      peg$c498 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c500 = function(a, b) {
+      peg$c499 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c501 = function() {
+      peg$c500 = function() {
             return "::"
           },
-      peg$c502 = function(v) { return ":" + v },
-      peg$c503 = function(v) { return v + ":" },
-      peg$c504 = function(a, m) {
+      peg$c501 = function(v) { return ":" + v },
+      peg$c502 = function(v) { return v + ":" },
+      peg$c503 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c505 = function(a, m) {
+      peg$c504 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c506 = function(s) { return parseInt(s) },
-      peg$c507 = function() {
+      peg$c505 = function(s) { return parseInt(s) },
+      peg$c506 = function() {
             return text()
           },
-      peg$c508 = "e",
-      peg$c509 = peg$literalExpectation("e", true),
-      peg$c510 = /^[+\-]/,
-      peg$c511 = peg$classExpectation(["+", "-"], false, false),
-      peg$c512 = "NaN",
-      peg$c513 = peg$literalExpectation("NaN", false),
-      peg$c514 = "Inf",
-      peg$c515 = peg$literalExpectation("Inf", false),
-      peg$c516 = /^[0-9a-fA-F]/,
-      peg$c517 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c518 = function(v) { return joinChars(v) },
-      peg$c519 = peg$anyExpectation(),
-      peg$c520 = function(head, tail) { return head + joinChars(tail) },
-      peg$c521 = /^[a-zA-Z_.:\/%#@~]/,
-      peg$c522 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
-      peg$c523 = function(head, tail) {
+      peg$c507 = "e",
+      peg$c508 = peg$literalExpectation("e", true),
+      peg$c509 = /^[+\-]/,
+      peg$c510 = peg$classExpectation(["+", "-"], false, false),
+      peg$c511 = "NaN",
+      peg$c512 = peg$literalExpectation("NaN", false),
+      peg$c513 = "Inf",
+      peg$c514 = peg$literalExpectation("Inf", false),
+      peg$c515 = /^[0-9a-fA-F]/,
+      peg$c516 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c517 = function(v) { return joinChars(v) },
+      peg$c518 = peg$anyExpectation(),
+      peg$c519 = function(head, tail) { return head + joinChars(tail) },
+      peg$c520 = /^[a-zA-Z_.:\/%#@~]/,
+      peg$c521 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
+      peg$c522 = function(head, tail) {
             return head + joinChars(tail)
           },
-      peg$c524 = function() { return "*"},
-      peg$c525 = function() { return "=" },
-      peg$c526 = function() { return "\\*" },
-      peg$c527 = "b",
-      peg$c528 = peg$literalExpectation("b", false),
-      peg$c529 = function() { return "\b" },
-      peg$c530 = "f",
-      peg$c531 = peg$literalExpectation("f", false),
-      peg$c532 = function() { return "\f" },
-      peg$c533 = "n",
-      peg$c534 = peg$literalExpectation("n", false),
-      peg$c535 = function() { return "\n" },
-      peg$c536 = "r",
-      peg$c537 = peg$literalExpectation("r", false),
-      peg$c538 = function() { return "\r" },
-      peg$c539 = "t",
-      peg$c540 = peg$literalExpectation("t", false),
-      peg$c541 = function() { return "\t" },
-      peg$c542 = "v",
-      peg$c543 = peg$literalExpectation("v", false),
-      peg$c544 = function() { return "\v" },
-      peg$c545 = function() { return "*" },
-      peg$c546 = "u",
-      peg$c547 = peg$literalExpectation("u", false),
-      peg$c548 = function(chars) {
+      peg$c523 = function() { return "*"},
+      peg$c524 = function() { return "=" },
+      peg$c525 = function() { return "\\*" },
+      peg$c526 = "b",
+      peg$c527 = peg$literalExpectation("b", false),
+      peg$c528 = function() { return "\b" },
+      peg$c529 = "f",
+      peg$c530 = peg$literalExpectation("f", false),
+      peg$c531 = function() { return "\f" },
+      peg$c532 = "n",
+      peg$c533 = peg$literalExpectation("n", false),
+      peg$c534 = function() { return "\n" },
+      peg$c535 = "r",
+      peg$c536 = peg$literalExpectation("r", false),
+      peg$c537 = function() { return "\r" },
+      peg$c538 = "t",
+      peg$c539 = peg$literalExpectation("t", false),
+      peg$c540 = function() { return "\t" },
+      peg$c541 = "v",
+      peg$c542 = peg$literalExpectation("v", false),
+      peg$c543 = function() { return "\v" },
+      peg$c544 = function() { return "*" },
+      peg$c545 = "u",
+      peg$c546 = peg$literalExpectation("u", false),
+      peg$c547 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c549 = /^[^\/\\]/,
-      peg$c550 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c551 = /^[\0-\x1F\\]/,
-      peg$c552 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c553 = peg$otherExpectation("whitespace"),
-      peg$c554 = "\t",
-      peg$c555 = peg$literalExpectation("\t", false),
-      peg$c556 = "\x0B",
-      peg$c557 = peg$literalExpectation("\x0B", false),
-      peg$c558 = "\f",
-      peg$c559 = peg$literalExpectation("\f", false),
-      peg$c560 = " ",
-      peg$c561 = peg$literalExpectation(" ", false),
-      peg$c562 = "\xA0",
-      peg$c563 = peg$literalExpectation("\xA0", false),
-      peg$c564 = "\uFEFF",
-      peg$c565 = peg$literalExpectation("\uFEFF", false),
-      peg$c566 = /^[\n\r\u2028\u2029]/,
-      peg$c567 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c568 = peg$otherExpectation("comment"),
-      peg$c569 = "/*",
-      peg$c570 = peg$literalExpectation("/*", false),
-      peg$c571 = "*/",
-      peg$c572 = peg$literalExpectation("*/", false),
-      peg$c573 = "//",
-      peg$c574 = peg$literalExpectation("//", false),
+      peg$c548 = /^[^\/\\]/,
+      peg$c549 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c550 = /^[\0-\x1F\\]/,
+      peg$c551 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c552 = peg$otherExpectation("whitespace"),
+      peg$c553 = "\t",
+      peg$c554 = peg$literalExpectation("\t", false),
+      peg$c555 = "\x0B",
+      peg$c556 = peg$literalExpectation("\x0B", false),
+      peg$c557 = "\f",
+      peg$c558 = peg$literalExpectation("\f", false),
+      peg$c559 = " ",
+      peg$c560 = peg$literalExpectation(" ", false),
+      peg$c561 = "\xA0",
+      peg$c562 = peg$literalExpectation("\xA0", false),
+      peg$c563 = "\uFEFF",
+      peg$c564 = peg$literalExpectation("\uFEFF", false),
+      peg$c565 = /^[\n\r\u2028\u2029]/,
+      peg$c566 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c567 = peg$otherExpectation("comment"),
+      peg$c568 = "/*",
+      peg$c569 = peg$literalExpectation("/*", false),
+      peg$c570 = "*/",
+      peg$c571 = peg$literalExpectation("*/", false),
+      peg$c572 = "//",
+      peg$c573 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -7737,11 +7737,113 @@ function peg$parse(input, options) {
   }
 
   function peg$parseFunction() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12;
 
     s0 = peg$parseGrep();
     if (s0 === peg$FAILED) {
-      s0 = peg$parseRegexpFunc();
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 6) === peg$c291) {
+        s1 = peg$c291;
+        peg$currPos += 6;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c292); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parse__();
+        if (s2 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 40) {
+            s3 = peg$c15;
+            peg$currPos++;
+          } else {
+            s3 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c16); }
+          }
+          if (s3 !== peg$FAILED) {
+            s4 = peg$parse__();
+            if (s4 !== peg$FAILED) {
+              s5 = peg$parseRegexpPattern();
+              if (s5 !== peg$FAILED) {
+                s6 = peg$parse__();
+                if (s6 !== peg$FAILED) {
+                  if (input.charCodeAt(peg$currPos) === 44) {
+                    s7 = peg$c98;
+                    peg$currPos++;
+                  } else {
+                    s7 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c99); }
+                  }
+                  if (s7 !== peg$FAILED) {
+                    s8 = peg$parse__();
+                    if (s8 !== peg$FAILED) {
+                      s9 = peg$parseConditionalExpr();
+                      if (s9 !== peg$FAILED) {
+                        s10 = peg$parse__();
+                        if (s10 !== peg$FAILED) {
+                          if (input.charCodeAt(peg$currPos) === 41) {
+                            s11 = peg$c17;
+                            peg$currPos++;
+                          } else {
+                            s11 = peg$FAILED;
+                            if (peg$silentFails === 0) { peg$fail(peg$c18); }
+                          }
+                          if (s11 !== peg$FAILED) {
+                            s12 = peg$parseWhereClause();
+                            if (s12 === peg$FAILED) {
+                              s12 = null;
+                            }
+                            if (s12 !== peg$FAILED) {
+                              peg$savedPos = s0;
+                              s1 = peg$c293(s5, s9, s12);
+                              s0 = s1;
+                            } else {
+                              peg$currPos = s0;
+                              s0 = peg$FAILED;
+                            }
+                          } else {
+                            peg$currPos = s0;
+                            s0 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         s1 = peg$currPos;
@@ -7787,7 +7889,7 @@ function peg$parse(input, options) {
                         }
                         if (s9 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c291(s2, s6, s9);
+                          s1 = peg$c294(s2, s6, s9);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -7838,7 +7940,7 @@ function peg$parse(input, options) {
     s1 = peg$parseOverExpr();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c292(s1);
+      s1 = peg$c295(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -7852,12 +7954,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c293) {
-      s1 = peg$c293;
+    if (input.substr(peg$currPos, 4) === peg$c296) {
+      s1 = peg$c296;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c294); }
+      if (peg$silentFails === 0) { peg$fail(peg$c297); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -7925,7 +8027,7 @@ function peg$parse(input, options) {
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c295(s5, s7);
+                    s1 = peg$c298(s5, s7);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -7974,210 +8076,10 @@ function peg$parse(input, options) {
         s1 = peg$parseQuotedString();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c296(s1);
+          s1 = peg$c299(s1);
         }
         s0 = s1;
       }
-    }
-
-    return s0;
-  }
-
-  function peg$parseRegexpFunc() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c297) {
-      s1 = peg$c297;
-      peg$currPos += 6;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c298); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse__();
-      if (s2 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c15;
-          peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c16); }
-        }
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parse__();
-          if (s4 !== peg$FAILED) {
-            s5 = peg$parseRegexpFuncArgs();
-            if (s5 !== peg$FAILED) {
-              s6 = peg$parse__();
-              if (s6 !== peg$FAILED) {
-                if (input.charCodeAt(peg$currPos) === 41) {
-                  s7 = peg$c17;
-                  peg$currPos++;
-                } else {
-                  s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c18); }
-                }
-                if (s7 !== peg$FAILED) {
-                  s8 = peg$parseWhereClause();
-                  if (s8 === peg$FAILED) {
-                    s8 = null;
-                  }
-                  if (s8 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c299(s5, s8);
-                    s0 = s1;
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseRegexpFuncArgs() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
-
-    s0 = peg$currPos;
-    s1 = peg$parseRegexpFuncArg();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$currPos;
-      s4 = peg$parse__();
-      if (s4 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c98;
-          peg$currPos++;
-        } else {
-          s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c99); }
-        }
-        if (s5 !== peg$FAILED) {
-          s6 = peg$parse__();
-          if (s6 !== peg$FAILED) {
-            s7 = peg$parseConditionalExpr();
-            if (s7 !== peg$FAILED) {
-              peg$savedPos = s3;
-              s4 = peg$c300(s1, s7);
-              s3 = s4;
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s3;
-        s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = peg$parse__();
-        if (s4 !== peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c98;
-            peg$currPos++;
-          } else {
-            s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c99); }
-          }
-          if (s5 !== peg$FAILED) {
-            s6 = peg$parse__();
-            if (s6 !== peg$FAILED) {
-              s7 = peg$parseConditionalExpr();
-              if (s7 !== peg$FAILED) {
-                peg$savedPos = s3;
-                s4 = peg$c300(s1, s7);
-                s3 = s4;
-              } else {
-                peg$currPos = s3;
-                s3 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c101(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$parse__();
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c3();
-      }
-      s0 = s1;
-    }
-
-    return s0;
-  }
-
-  function peg$parseRegexpFuncArg() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    s1 = peg$parseRegexpPattern();
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c301(s1);
-    }
-    s0 = s1;
-    if (s0 === peg$FAILED) {
-      s0 = peg$parseConditionalExpr();
     }
 
     return s0;
@@ -8369,15 +8271,15 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s7 = peg$c302;
+                  s7 = peg$c301;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c303); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c302); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c304(s2, s6);
+                  s1 = peg$c303(s2, s6);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8432,15 +8334,15 @@ function peg$parse(input, options) {
               s5 = peg$parseAdditiveExpr();
               if (s5 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s6 = peg$c302;
+                  s6 = peg$c301;
                   peg$currPos++;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c303); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c302); }
                 }
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c305(s5);
+                  s1 = peg$c304(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8479,15 +8381,15 @@ function peg$parse(input, options) {
           s2 = peg$parseConditionalExpr();
           if (s2 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s3 = peg$c302;
+              s3 = peg$c301;
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c303); }
+              if (peg$silentFails === 0) { peg$fail(peg$c302); }
             }
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c306(s2);
+              s1 = peg$c305(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8514,7 +8416,7 @@ function peg$parse(input, options) {
             s2 = peg$parseIdentifier();
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c307(s2);
+              s1 = peg$c306(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8683,7 +8585,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSequential();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c308(s3, s4, s8);
+                    s1 = peg$c307(s3, s4, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -8740,15 +8642,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c309;
+              s5 = peg$c308;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c310); }
+              if (peg$silentFails === 0) { peg$fail(peg$c309); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c311(s3);
+              s1 = peg$c310(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8830,7 +8732,7 @@ function peg$parse(input, options) {
           s4 = peg$parseRecordElem();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c312(s4);
+            s1 = peg$c311(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8870,12 +8772,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c313) {
-      s1 = peg$c313;
+    if (input.substr(peg$currPos, 3) === peg$c312) {
+      s1 = peg$c312;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c314); }
+      if (peg$silentFails === 0) { peg$fail(peg$c313); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8883,7 +8785,7 @@ function peg$parse(input, options) {
         s3 = peg$parseConditionalExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c315(s3);
+          s1 = peg$c314(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8922,7 +8824,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c316(s1, s5);
+              s1 = peg$c315(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8967,15 +8869,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s5 = peg$c302;
+              s5 = peg$c301;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c303); }
+              if (peg$silentFails === 0) { peg$fail(peg$c302); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c317(s3);
+              s1 = peg$c316(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9005,12 +8907,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c318) {
-      s1 = peg$c318;
+    if (input.substr(peg$currPos, 2) === peg$c317) {
+      s1 = peg$c317;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c319); }
+      if (peg$silentFails === 0) { peg$fail(peg$c318); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -9019,16 +8921,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c320) {
-              s5 = peg$c320;
+            if (input.substr(peg$currPos, 2) === peg$c319) {
+              s5 = peg$c319;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c321); }
+              if (peg$silentFails === 0) { peg$fail(peg$c320); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c322(s3);
+              s1 = peg$c321(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9166,7 +9068,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c323(s1);
+        s1 = peg$c322(s1);
       }
       s0 = s1;
     }
@@ -9178,12 +9080,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c324) {
-      s1 = peg$c324;
+    if (input.substr(peg$currPos, 2) === peg$c323) {
+      s1 = peg$c323;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c325); }
+      if (peg$silentFails === 0) { peg$fail(peg$c324); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -9192,16 +9094,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c326) {
-              s5 = peg$c326;
+            if (input.substr(peg$currPos, 2) === peg$c325) {
+              s5 = peg$c325;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c327); }
+              if (peg$silentFails === 0) { peg$fail(peg$c326); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c328(s3);
+              s1 = peg$c327(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9283,7 +9185,7 @@ function peg$parse(input, options) {
           s4 = peg$parseEntry();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c329(s4);
+            s1 = peg$c328(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9326,7 +9228,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c330(s1, s5);
+              s1 = peg$c329(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9391,7 +9293,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSQLLimit();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c331(s1, s2, s3, s4, s5, s6, s7, s8);
+                    s1 = peg$c330(s1, s2, s3, s4, s5, s6, s7, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -9469,7 +9371,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSQLAssignments();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c332(s3);
+            s1 = peg$c331(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9526,7 +9428,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c333(s1, s2);
+        s1 = peg$c332(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9652,7 +9554,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c334(s4, s5);
+              s1 = peg$c333(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9807,7 +9709,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSQLJoin();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s3;
-        s4 = peg$c335(s1, s4);
+        s4 = peg$c334(s1, s4);
       }
       s3 = s4;
       while (s3 !== peg$FAILED) {
@@ -9816,7 +9718,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSQLJoin();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s3;
-          s4 = peg$c335(s1, s4);
+          s4 = peg$c334(s1, s4);
         }
         s3 = s4;
       }
@@ -9878,7 +9780,7 @@ function peg$parse(input, options) {
                               s14 = peg$parseJoinKey();
                               if (s14 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c336(s1, s5, s6, s10, s14);
+                                s1 = peg$c335(s1, s5, s6, s10, s14);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -9958,7 +9860,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c337(s2);
+        s1 = peg$c336(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10117,7 +10019,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseSQLOrder();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c338(s6, s7);
+                  s1 = peg$c337(s6, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10163,7 +10065,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c339(s2);
+        s1 = peg$c338(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10199,7 +10101,7 @@ function peg$parse(input, options) {
           s4 = peg$parseUInt();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c340(s4);
+            s1 = peg$c339(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10239,11 +10141,11 @@ function peg$parse(input, options) {
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c341); }
+      if (peg$silentFails === 0) { peg$fail(peg$c340); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c342();
+      s1 = peg$c341();
     }
     s0 = s1;
 
@@ -10254,16 +10156,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c343) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c342) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c344); }
+      if (peg$silentFails === 0) { peg$fail(peg$c343); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c345();
+      s1 = peg$c344();
     }
     s0 = s1;
 
@@ -10279,11 +10181,11 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c346); }
+      if (peg$silentFails === 0) { peg$fail(peg$c345); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c347();
+      s1 = peg$c346();
     }
     s0 = s1;
 
@@ -10299,11 +10201,11 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c348); }
+      if (peg$silentFails === 0) { peg$fail(peg$c347); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c349();
+      s1 = peg$c348();
     }
     s0 = s1;
 
@@ -10319,11 +10221,11 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c350); }
+      if (peg$silentFails === 0) { peg$fail(peg$c349); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c351();
+      s1 = peg$c350();
     }
     s0 = s1;
 
@@ -10334,16 +10236,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c352) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c351) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c353); }
+      if (peg$silentFails === 0) { peg$fail(peg$c352); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c354();
+      s1 = peg$c353();
     }
     s0 = s1;
 
@@ -10354,16 +10256,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c355) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c354) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c356); }
+      if (peg$silentFails === 0) { peg$fail(peg$c355); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c357();
+      s1 = peg$c356();
     }
     s0 = s1;
 
@@ -10374,16 +10276,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c358) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c357) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c359); }
+      if (peg$silentFails === 0) { peg$fail(peg$c358); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c360();
+      s1 = peg$c359();
     }
     s0 = s1;
 
@@ -10399,11 +10301,11 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c361); }
+      if (peg$silentFails === 0) { peg$fail(peg$c360); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c362();
+      s1 = peg$c361();
     }
     s0 = s1;
 
@@ -10414,16 +10316,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c363) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c362) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c364); }
+      if (peg$silentFails === 0) { peg$fail(peg$c363); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c365();
+      s1 = peg$c364();
     }
     s0 = s1;
 
@@ -10434,16 +10336,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c366) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c365) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c367); }
+      if (peg$silentFails === 0) { peg$fail(peg$c366); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c368();
+      s1 = peg$c367();
     }
     s0 = s1;
 
@@ -10459,7 +10361,7 @@ function peg$parse(input, options) {
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c369); }
+      if (peg$silentFails === 0) { peg$fail(peg$c368); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10479,7 +10381,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c370); }
+      if (peg$silentFails === 0) { peg$fail(peg$c369); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10499,7 +10401,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c371); }
+      if (peg$silentFails === 0) { peg$fail(peg$c370); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10519,7 +10421,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c372); }
+      if (peg$silentFails === 0) { peg$fail(peg$c371); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10539,7 +10441,7 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c373); }
+      if (peg$silentFails === 0) { peg$fail(peg$c372); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10559,7 +10461,7 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c374); }
+      if (peg$silentFails === 0) { peg$fail(peg$c373); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10661,7 +10563,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c375(s1);
+        s1 = peg$c374(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10676,7 +10578,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP4Net();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c375(s1);
+        s1 = peg$c374(s1);
       }
       s0 = s1;
     }
@@ -10702,7 +10604,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c376(s1);
+        s1 = peg$c375(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10717,7 +10619,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c376(s1);
+        s1 = peg$c375(s1);
       }
       s0 = s1;
     }
@@ -10732,7 +10634,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFloatString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c377(s1);
+      s1 = peg$c376(s1);
     }
     s0 = s1;
 
@@ -10746,7 +10648,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c378(s1);
+      s1 = peg$c377(s1);
     }
     s0 = s1;
 
@@ -10757,30 +10659,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c379) {
-      s1 = peg$c379;
+    if (input.substr(peg$currPos, 4) === peg$c378) {
+      s1 = peg$c378;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c380); }
+      if (peg$silentFails === 0) { peg$fail(peg$c379); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c381();
+      s1 = peg$c380();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c382) {
-        s1 = peg$c382;
+      if (input.substr(peg$currPos, 5) === peg$c381) {
+        s1 = peg$c381;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c383); }
+        if (peg$silentFails === 0) { peg$fail(peg$c382); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c384();
+        s1 = peg$c383();
       }
       s0 = s1;
     }
@@ -10792,16 +10694,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c385) {
-      s1 = peg$c385;
+    if (input.substr(peg$currPos, 4) === peg$c384) {
+      s1 = peg$c384;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c386); }
+      if (peg$silentFails === 0) { peg$fail(peg$c385); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c387();
+      s1 = peg$c386();
     }
     s0 = s1;
 
@@ -10812,12 +10714,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c388) {
-      s1 = peg$c388;
+    if (input.substr(peg$currPos, 2) === peg$c387) {
+      s1 = peg$c387;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c389); }
+      if (peg$silentFails === 0) { peg$fail(peg$c388); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -10828,7 +10730,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c390();
+        s1 = peg$c389();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10865,7 +10767,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c391(s2);
+          s1 = peg$c390(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10892,7 +10794,7 @@ function peg$parse(input, options) {
       s1 = peg$parsePrimitiveType();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c391(s1);
+        s1 = peg$c390(s1);
       }
       s0 = s1;
     }
@@ -10932,7 +10834,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c392(s1);
+        s1 = peg$c391(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10984,7 +10886,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c393(s1, s2);
+          s1 = peg$c392(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10999,7 +10901,7 @@ function peg$parse(input, options) {
         s1 = peg$parseQuotedString();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c394(s1);
+          s1 = peg$c393(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
@@ -11025,7 +10927,7 @@ function peg$parse(input, options) {
                 }
                 if (s4 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c395(s3);
+                  s1 = peg$c394(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -11057,7 +10959,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTypeList();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c396(s1);
+      s1 = peg$c395(s1);
     }
     s0 = s1;
 
@@ -11115,7 +11017,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c397(s4);
+            s1 = peg$c396(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11156,15 +11058,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c309;
+              s5 = peg$c308;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c310); }
+              if (peg$silentFails === 0) { peg$fail(peg$c309); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c398(s3);
+              s1 = peg$c397(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11203,15 +11105,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c302;
+                s5 = peg$c301;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c303); }
+                if (peg$silentFails === 0) { peg$fail(peg$c302); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c399(s3);
+                s1 = peg$c398(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -11235,12 +11137,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c318) {
-          s1 = peg$c318;
+        if (input.substr(peg$currPos, 2) === peg$c317) {
+          s1 = peg$c317;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c319); }
+          if (peg$silentFails === 0) { peg$fail(peg$c318); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -11249,16 +11151,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c320) {
-                  s5 = peg$c320;
+                if (input.substr(peg$currPos, 2) === peg$c319) {
+                  s5 = peg$c319;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c321); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c320); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c400(s3);
+                  s1 = peg$c399(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -11282,12 +11184,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c324) {
-            s1 = peg$c324;
+          if (input.substr(peg$currPos, 2) === peg$c323) {
+            s1 = peg$c323;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c325); }
+            if (peg$silentFails === 0) { peg$fail(peg$c324); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -11310,16 +11212,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c326) {
-                            s9 = peg$c326;
+                          if (input.substr(peg$currPos, 2) === peg$c325) {
+                            s9 = peg$c325;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c327); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c326); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c401(s3, s7);
+                            s1 = peg$c400(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -11371,7 +11273,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTemplateLiteralParts();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c402(s1);
+      s1 = peg$c401(s1);
     }
     s0 = s1;
 
@@ -11383,11 +11285,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c403;
+      s1 = peg$c402;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c404); }
+      if (peg$silentFails === 0) { peg$fail(peg$c403); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -11398,11 +11300,11 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c403;
+          s3 = peg$c402;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c404); }
+          if (peg$silentFails === 0) { peg$fail(peg$c403); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
@@ -11423,11 +11325,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c405;
+        s1 = peg$c404;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c406); }
+        if (peg$silentFails === 0) { peg$fail(peg$c405); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -11438,11 +11340,11 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c405;
+            s3 = peg$c404;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c406); }
+            if (peg$silentFails === 0) { peg$fail(peg$c405); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
@@ -11483,7 +11385,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c407(s1);
+        s1 = peg$c406(s1);
       }
       s0 = s1;
     }
@@ -11496,19 +11398,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c408;
+      s1 = peg$c407;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c409); }
+      if (peg$silentFails === 0) { peg$fail(peg$c408); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c410) {
-        s2 = peg$c410;
+      if (input.substr(peg$currPos, 2) === peg$c409) {
+        s2 = peg$c409;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c411); }
+        if (peg$silentFails === 0) { peg$fail(peg$c410); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11526,12 +11428,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c410) {
-        s2 = peg$c410;
+      if (input.substr(peg$currPos, 2) === peg$c409) {
+        s2 = peg$c409;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c411); }
+        if (peg$silentFails === 0) { peg$fail(peg$c410); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -11577,7 +11479,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c407(s1);
+        s1 = peg$c406(s1);
       }
       s0 = s1;
     }
@@ -11590,19 +11492,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c408;
+      s1 = peg$c407;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c409); }
+      if (peg$silentFails === 0) { peg$fail(peg$c408); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c410) {
-        s2 = peg$c410;
+      if (input.substr(peg$currPos, 2) === peg$c409) {
+        s2 = peg$c409;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c411); }
+        if (peg$silentFails === 0) { peg$fail(peg$c410); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11620,12 +11522,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c410) {
-        s2 = peg$c410;
+      if (input.substr(peg$currPos, 2) === peg$c409) {
+        s2 = peg$c409;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c411); }
+        if (peg$silentFails === 0) { peg$fail(peg$c410); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -11657,12 +11559,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c410) {
-      s1 = peg$c410;
+    if (input.substr(peg$currPos, 2) === peg$c409) {
+      s1 = peg$c409;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c411); }
+      if (peg$silentFails === 0) { peg$fail(peg$c410); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -11672,15 +11574,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c309;
+              s5 = peg$c308;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c310); }
+              if (peg$silentFails === 0) { peg$fail(peg$c309); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c412(s3);
+              s1 = peg$c411(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11710,140 +11612,140 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c413) {
-      s1 = peg$c413;
+    if (input.substr(peg$currPos, 5) === peg$c412) {
+      s1 = peg$c412;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c414); }
+      if (peg$silentFails === 0) { peg$fail(peg$c413); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c415) {
-        s1 = peg$c415;
+      if (input.substr(peg$currPos, 6) === peg$c414) {
+        s1 = peg$c414;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c416); }
+        if (peg$silentFails === 0) { peg$fail(peg$c415); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c417) {
-          s1 = peg$c417;
+        if (input.substr(peg$currPos, 6) === peg$c416) {
+          s1 = peg$c416;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c418); }
+          if (peg$silentFails === 0) { peg$fail(peg$c417); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c419) {
-            s1 = peg$c419;
+          if (input.substr(peg$currPos, 6) === peg$c418) {
+            s1 = peg$c418;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c420); }
+            if (peg$silentFails === 0) { peg$fail(peg$c419); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c421) {
-              s1 = peg$c421;
+            if (input.substr(peg$currPos, 4) === peg$c420) {
+              s1 = peg$c420;
               peg$currPos += 4;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c422); }
+              if (peg$silentFails === 0) { peg$fail(peg$c421); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 5) === peg$c423) {
-                s1 = peg$c423;
+              if (input.substr(peg$currPos, 5) === peg$c422) {
+                s1 = peg$c422;
                 peg$currPos += 5;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c424); }
+                if (peg$silentFails === 0) { peg$fail(peg$c423); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c425) {
-                  s1 = peg$c425;
+                if (input.substr(peg$currPos, 5) === peg$c424) {
+                  s1 = peg$c424;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c426); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c425); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c427) {
-                    s1 = peg$c427;
+                  if (input.substr(peg$currPos, 5) === peg$c426) {
+                    s1 = peg$c426;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c428); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c427); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7) === peg$c429) {
-                      s1 = peg$c429;
+                    if (input.substr(peg$currPos, 7) === peg$c428) {
+                      s1 = peg$c428;
                       peg$currPos += 7;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c430); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c429); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 7) === peg$c431) {
-                        s1 = peg$c431;
+                      if (input.substr(peg$currPos, 7) === peg$c430) {
+                        s1 = peg$c430;
                         peg$currPos += 7;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c432); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c431); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 4) === peg$c433) {
-                          s1 = peg$c433;
+                        if (input.substr(peg$currPos, 4) === peg$c432) {
+                          s1 = peg$c432;
                           peg$currPos += 4;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c434); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c433); }
                         }
                         if (s1 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 6) === peg$c435) {
-                            s1 = peg$c435;
+                          if (input.substr(peg$currPos, 6) === peg$c434) {
+                            s1 = peg$c434;
                             peg$currPos += 6;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c436); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c435); }
                           }
                           if (s1 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 8) === peg$c437) {
-                              s1 = peg$c437;
+                            if (input.substr(peg$currPos, 8) === peg$c436) {
+                              s1 = peg$c436;
                               peg$currPos += 8;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c438); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c437); }
                             }
                             if (s1 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 4) === peg$c439) {
-                                s1 = peg$c439;
+                              if (input.substr(peg$currPos, 4) === peg$c438) {
+                                s1 = peg$c438;
                                 peg$currPos += 4;
                               } else {
                                 s1 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c440); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c439); }
                               }
                               if (s1 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 5) === peg$c441) {
-                                  s1 = peg$c441;
+                                if (input.substr(peg$currPos, 5) === peg$c440) {
+                                  s1 = peg$c440;
                                   peg$currPos += 5;
                                 } else {
                                   s1 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c442); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c441); }
                                 }
                                 if (s1 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 2) === peg$c443) {
-                                    s1 = peg$c443;
+                                  if (input.substr(peg$currPos, 2) === peg$c442) {
+                                    s1 = peg$c442;
                                     peg$currPos += 2;
                                   } else {
                                     s1 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c444); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c443); }
                                   }
                                   if (s1 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 3) === peg$c445) {
-                                      s1 = peg$c445;
+                                    if (input.substr(peg$currPos, 3) === peg$c444) {
+                                      s1 = peg$c444;
                                       peg$currPos += 3;
                                     } else {
                                       s1 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c446); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c445); }
                                     }
                                     if (s1 === peg$FAILED) {
                                       if (input.substr(peg$currPos, 4) === peg$c10) {
@@ -11854,12 +11756,12 @@ function peg$parse(input, options) {
                                         if (peg$silentFails === 0) { peg$fail(peg$c11); }
                                       }
                                       if (s1 === peg$FAILED) {
-                                        if (input.substr(peg$currPos, 4) === peg$c385) {
-                                          s1 = peg$c385;
+                                        if (input.substr(peg$currPos, 4) === peg$c384) {
+                                          s1 = peg$c384;
                                           peg$currPos += 4;
                                         } else {
                                           s1 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c386); }
+                                          if (peg$silentFails === 0) { peg$fail(peg$c385); }
                                         }
                                       }
                                     }
@@ -11881,7 +11783,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c447();
+      s1 = peg$c446();
     }
     s0 = s1;
 
@@ -11944,7 +11846,7 @@ function peg$parse(input, options) {
           s4 = peg$parseTypeField();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c397(s4);
+            s1 = peg$c396(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11987,7 +11889,7 @@ function peg$parse(input, options) {
             s5 = peg$parseType();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c448(s1, s5);
+              s1 = peg$c447(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -12028,20 +11930,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c449) {
-      s1 = peg$c449;
+    if (input.substr(peg$currPos, 3) === peg$c448) {
+      s1 = peg$c448;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c450); }
+      if (peg$silentFails === 0) { peg$fail(peg$c449); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c451) {
-        s1 = peg$c451;
+      if (input.substr(peg$currPos, 3) === peg$c450) {
+        s1 = peg$c450;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c452); }
+        if (peg$silentFails === 0) { peg$fail(peg$c451); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -12057,7 +11959,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c453();
+        s1 = peg$c452();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12075,20 +11977,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c454) {
-      s1 = peg$c454;
+    if (input.substr(peg$currPos, 2) === peg$c453) {
+      s1 = peg$c453;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c455); }
+      if (peg$silentFails === 0) { peg$fail(peg$c454); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c456) {
-        s1 = peg$c456;
+      if (input.substr(peg$currPos, 2) === peg$c455) {
+        s1 = peg$c455;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c457); }
+        if (peg$silentFails === 0) { peg$fail(peg$c456); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -12104,7 +12006,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c458();
+        s1 = peg$c457();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12142,7 +12044,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c459();
+        s1 = peg$c458();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12168,12 +12070,12 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$c287); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c460) {
-        s1 = peg$c460;
+      if (input.substr(peg$currPos, 3) === peg$c459) {
+        s1 = peg$c459;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c461); }
+        if (peg$silentFails === 0) { peg$fail(peg$c460); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -12189,7 +12091,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c462();
+        s1 = peg$c461();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12207,12 +12109,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c355) {
-      s1 = peg$c355;
+    if (input.substr(peg$currPos, 2) === peg$c354) {
+      s1 = peg$c354;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c463); }
+      if (peg$silentFails === 0) { peg$fail(peg$c462); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -12227,7 +12129,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c357();
+        s1 = peg$c356();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12244,12 +12146,12 @@ function peg$parse(input, options) {
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c464.test(input.charAt(peg$currPos))) {
+    if (peg$c463.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c465); }
+      if (peg$silentFails === 0) { peg$fail(peg$c464); }
     }
 
     return s0;
@@ -12260,12 +12162,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c466.test(input.charAt(peg$currPos))) {
+      if (peg$c465.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c467); }
+        if (peg$silentFails === 0) { peg$fail(peg$c466); }
       }
     }
 
@@ -12279,7 +12181,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c468(s1);
+      s1 = peg$c467(s1);
     }
     s0 = s1;
 
@@ -12351,11 +12253,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 36) {
-        s1 = peg$c469;
+        s1 = peg$c468;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c470); }
+        if (peg$silentFails === 0) { peg$fail(peg$c469); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -12365,11 +12267,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c408;
+          s1 = peg$c407;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c409); }
+          if (peg$silentFails === 0) { peg$fail(peg$c408); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseIDGuard();
@@ -12477,17 +12379,17 @@ function peg$parse(input, options) {
     s1 = peg$parseFullDate();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 84) {
-        s2 = peg$c471;
+        s2 = peg$c470;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c472); }
+        if (peg$silentFails === 0) { peg$fail(peg$c471); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseFullTime();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c473();
+          s1 = peg$c472();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -12561,36 +12463,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (peg$c466.test(input.charAt(peg$currPos))) {
+    if (peg$c465.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c467); }
+      if (peg$silentFails === 0) { peg$fail(peg$c466); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c466.test(input.charAt(peg$currPos))) {
+      if (peg$c465.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c467); }
+        if (peg$silentFails === 0) { peg$fail(peg$c466); }
       }
       if (s2 !== peg$FAILED) {
-        if (peg$c466.test(input.charAt(peg$currPos))) {
+        if (peg$c465.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c467); }
+          if (peg$silentFails === 0) { peg$fail(peg$c466); }
         }
         if (s3 !== peg$FAILED) {
-          if (peg$c466.test(input.charAt(peg$currPos))) {
+          if (peg$c465.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c467); }
+            if (peg$silentFails === 0) { peg$fail(peg$c466); }
           }
           if (s4 !== peg$FAILED) {
             s1 = [s1, s2, s3, s4];
@@ -12619,20 +12521,20 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c466.test(input.charAt(peg$currPos))) {
+    if (peg$c465.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c467); }
+      if (peg$silentFails === 0) { peg$fail(peg$c466); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c466.test(input.charAt(peg$currPos))) {
+      if (peg$c465.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c467); }
+        if (peg$silentFails === 0) { peg$fail(peg$c466); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -12707,22 +12609,22 @@ function peg$parse(input, options) {
               }
               if (s7 !== peg$FAILED) {
                 s8 = [];
-                if (peg$c466.test(input.charAt(peg$currPos))) {
+                if (peg$c465.test(input.charAt(peg$currPos))) {
                   s9 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s9 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c467); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c466); }
                 }
                 if (s9 !== peg$FAILED) {
                   while (s9 !== peg$FAILED) {
                     s8.push(s9);
-                    if (peg$c466.test(input.charAt(peg$currPos))) {
+                    if (peg$c465.test(input.charAt(peg$currPos))) {
                       s9 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c467); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c466); }
                     }
                   }
                 } else {
@@ -12777,11 +12679,11 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     if (input.charCodeAt(peg$currPos) === 90) {
-      s0 = peg$c474;
+      s0 = peg$c473;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c475); }
+      if (peg$silentFails === 0) { peg$fail(peg$c474); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
@@ -12824,22 +12726,22 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 s7 = [];
-                if (peg$c466.test(input.charAt(peg$currPos))) {
+                if (peg$c465.test(input.charAt(peg$currPos))) {
                   s8 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s8 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c467); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c466); }
                 }
                 if (s8 !== peg$FAILED) {
                   while (s8 !== peg$FAILED) {
                     s7.push(s8);
-                    if (peg$c466.test(input.charAt(peg$currPos))) {
+                    if (peg$c465.test(input.charAt(peg$currPos))) {
                       s8 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s8 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c467); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c466); }
                     }
                   }
                 } else {
@@ -12942,7 +12844,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c476();
+        s1 = peg$c475();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13004,76 +12906,76 @@ function peg$parse(input, options) {
   function peg$parseTimeUnit() {
     var s0;
 
-    if (input.substr(peg$currPos, 2) === peg$c477) {
-      s0 = peg$c477;
+    if (input.substr(peg$currPos, 2) === peg$c476) {
+      s0 = peg$c476;
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c478); }
+      if (peg$silentFails === 0) { peg$fail(peg$c477); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c479) {
-        s0 = peg$c479;
+      if (input.substr(peg$currPos, 2) === peg$c478) {
+        s0 = peg$c478;
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c480); }
+        if (peg$silentFails === 0) { peg$fail(peg$c479); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c481) {
-          s0 = peg$c481;
+        if (input.substr(peg$currPos, 2) === peg$c480) {
+          s0 = peg$c480;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c482); }
+          if (peg$silentFails === 0) { peg$fail(peg$c481); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 115) {
-            s0 = peg$c483;
+            s0 = peg$c482;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c484); }
+            if (peg$silentFails === 0) { peg$fail(peg$c483); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c485;
+              s0 = peg$c484;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c486); }
+              if (peg$silentFails === 0) { peg$fail(peg$c485); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 104) {
-                s0 = peg$c487;
+                s0 = peg$c486;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c488); }
+                if (peg$silentFails === 0) { peg$fail(peg$c487); }
               }
               if (s0 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 100) {
-                  s0 = peg$c489;
+                  s0 = peg$c488;
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c490); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c489); }
                 }
                 if (s0 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 119) {
-                    s0 = peg$c491;
+                    s0 = peg$c490;
                     peg$currPos++;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c492); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c491); }
                   }
                   if (s0 === peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 121) {
-                      s0 = peg$c493;
+                      s0 = peg$c492;
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c494); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c493); }
                     }
                   }
                 }
@@ -13258,7 +13160,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c495(s1, s2);
+        s1 = peg$c494(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13279,12 +13181,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c496) {
-            s3 = peg$c496;
+          if (input.substr(peg$currPos, 2) === peg$c495) {
+            s3 = peg$c495;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c497); }
+            if (peg$silentFails === 0) { peg$fail(peg$c496); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -13297,7 +13199,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c498(s1, s2, s4, s5);
+                s1 = peg$c497(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -13321,12 +13223,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c496) {
-          s1 = peg$c496;
+        if (input.substr(peg$currPos, 2) === peg$c495) {
+          s1 = peg$c495;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c497); }
+          if (peg$silentFails === 0) { peg$fail(peg$c496); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -13339,7 +13241,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c499(s2, s3);
+              s1 = peg$c498(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13364,16 +13266,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c496) {
-                s3 = peg$c496;
+              if (input.substr(peg$currPos, 2) === peg$c495) {
+                s3 = peg$c495;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c497); }
+                if (peg$silentFails === 0) { peg$fail(peg$c496); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c500(s1, s2);
+                s1 = peg$c499(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -13389,16 +13291,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c496) {
-              s1 = peg$c496;
+            if (input.substr(peg$currPos, 2) === peg$c495) {
+              s1 = peg$c495;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c497); }
+              if (peg$silentFails === 0) { peg$fail(peg$c496); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c501();
+              s1 = peg$c500();
             }
             s0 = s1;
           }
@@ -13435,7 +13337,7 @@ function peg$parse(input, options) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c502(s2);
+        s1 = peg$c501(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13464,7 +13366,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c503(s1);
+        s1 = peg$c502(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13495,7 +13397,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c504(s1, s3);
+          s1 = peg$c503(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13530,7 +13432,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c505(s1, s3);
+          s1 = peg$c504(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13555,7 +13457,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c506(s1);
+      s1 = peg$c505(s1);
     }
     s0 = s1;
 
@@ -13578,22 +13480,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c466.test(input.charAt(peg$currPos))) {
+    if (peg$c465.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c467); }
+      if (peg$silentFails === 0) { peg$fail(peg$c466); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c466.test(input.charAt(peg$currPos))) {
+        if (peg$c465.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c467); }
+          if (peg$silentFails === 0) { peg$fail(peg$c466); }
         }
       }
     } else {
@@ -13653,22 +13555,22 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c466.test(input.charAt(peg$currPos))) {
+      if (peg$c465.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c467); }
+        if (peg$silentFails === 0) { peg$fail(peg$c466); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c466.test(input.charAt(peg$currPos))) {
+          if (peg$c465.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c467); }
+            if (peg$silentFails === 0) { peg$fail(peg$c466); }
           }
         }
       } else {
@@ -13684,21 +13586,21 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c466.test(input.charAt(peg$currPos))) {
+          if (peg$c465.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c467); }
+            if (peg$silentFails === 0) { peg$fail(peg$c466); }
           }
           while (s5 !== peg$FAILED) {
             s4.push(s5);
-            if (peg$c466.test(input.charAt(peg$currPos))) {
+            if (peg$c465.test(input.charAt(peg$currPos))) {
               s5 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c467); }
+              if (peg$silentFails === 0) { peg$fail(peg$c466); }
             }
           }
           if (s4 !== peg$FAILED) {
@@ -13708,7 +13610,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c507();
+              s1 = peg$c506();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13752,22 +13654,22 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c466.test(input.charAt(peg$currPos))) {
+          if (peg$c465.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c467); }
+            if (peg$silentFails === 0) { peg$fail(peg$c466); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c466.test(input.charAt(peg$currPos))) {
+              if (peg$c465.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c467); }
+                if (peg$silentFails === 0) { peg$fail(peg$c466); }
               }
             }
           } else {
@@ -13780,7 +13682,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c507();
+              s1 = peg$c506();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13819,20 +13721,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c508) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c507) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c509); }
+      if (peg$silentFails === 0) { peg$fail(peg$c508); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c510.test(input.charAt(peg$currPos))) {
+      if (peg$c509.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c511); }
+        if (peg$silentFails === 0) { peg$fail(peg$c510); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -13861,12 +13763,12 @@ function peg$parse(input, options) {
   function peg$parseNaN() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c512) {
-      s0 = peg$c512;
+    if (input.substr(peg$currPos, 3) === peg$c511) {
+      s0 = peg$c511;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c513); }
+      if (peg$silentFails === 0) { peg$fail(peg$c512); }
     }
 
     return s0;
@@ -13896,12 +13798,12 @@ function peg$parse(input, options) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c514) {
-        s2 = peg$c514;
+      if (input.substr(peg$currPos, 3) === peg$c513) {
+        s2 = peg$c513;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c515); }
+        if (peg$silentFails === 0) { peg$fail(peg$c514); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -13944,12 +13846,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c516.test(input.charAt(peg$currPos))) {
+    if (peg$c515.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c517); }
+      if (peg$silentFails === 0) { peg$fail(peg$c516); }
     }
 
     return s0;
@@ -13960,11 +13862,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c403;
+      s1 = peg$c402;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c404); }
+      if (peg$silentFails === 0) { peg$fail(peg$c403); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -13975,15 +13877,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c403;
+          s3 = peg$c402;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c404); }
+          if (peg$silentFails === 0) { peg$fail(peg$c403); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c518(s2);
+          s1 = peg$c517(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -14000,11 +13902,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c405;
+        s1 = peg$c404;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c406); }
+        if (peg$silentFails === 0) { peg$fail(peg$c405); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -14015,15 +13917,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c405;
+            s3 = peg$c404;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c406); }
+            if (peg$silentFails === 0) { peg$fail(peg$c405); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c518(s2);
+            s1 = peg$c517(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -14049,11 +13951,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c403;
+      s2 = peg$c402;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c404); }
+      if (peg$silentFails === 0) { peg$fail(peg$c403); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -14071,7 +13973,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c519); }
+        if (peg$silentFails === 0) { peg$fail(peg$c518); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14088,11 +13990,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c408;
+        s1 = peg$c407;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c409); }
+        if (peg$silentFails === 0) { peg$fail(peg$c408); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -14127,7 +14029,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c520(s1, s2);
+        s1 = peg$c519(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14156,12 +14058,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (peg$c521.test(input.charAt(peg$currPos))) {
+    if (peg$c520.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c522); }
+      if (peg$silentFails === 0) { peg$fail(peg$c521); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -14177,12 +14079,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseKeyWordStart();
     if (s0 === peg$FAILED) {
-      if (peg$c466.test(input.charAt(peg$currPos))) {
+      if (peg$c465.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c467); }
+        if (peg$silentFails === 0) { peg$fail(peg$c466); }
       }
     }
 
@@ -14194,11 +14096,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c408;
+      s1 = peg$c407;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c409); }
+      if (peg$silentFails === 0) { peg$fail(peg$c408); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseKeywordEscape();
@@ -14257,7 +14159,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c523(s3, s4);
+            s1 = peg$c522(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -14375,7 +14277,7 @@ function peg$parse(input, options) {
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c524();
+          s1 = peg$c523();
         }
         s0 = s1;
       }
@@ -14389,12 +14291,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseGlobStart();
     if (s0 === peg$FAILED) {
-      if (peg$c466.test(input.charAt(peg$currPos))) {
+      if (peg$c465.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c467); }
+        if (peg$silentFails === 0) { peg$fail(peg$c466); }
       }
     }
 
@@ -14406,11 +14308,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c408;
+      s1 = peg$c407;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c409); }
+      if (peg$silentFails === 0) { peg$fail(peg$c408); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseGlobEscape();
@@ -14446,7 +14348,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c525();
+      s1 = peg$c524();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -14460,16 +14362,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c526();
+        s1 = peg$c525();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c510.test(input.charAt(peg$currPos))) {
+        if (peg$c509.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c511); }
+          if (peg$silentFails === 0) { peg$fail(peg$c510); }
         }
       }
     }
@@ -14484,11 +14386,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c405;
+      s2 = peg$c404;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c406); }
+      if (peg$silentFails === 0) { peg$fail(peg$c405); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -14506,7 +14408,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c519); }
+        if (peg$silentFails === 0) { peg$fail(peg$c518); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14523,11 +14425,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c408;
+        s1 = peg$c407;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c409); }
+        if (peg$silentFails === 0) { peg$fail(peg$c408); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -14563,20 +14465,20 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c405;
+      s0 = peg$c404;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c406); }
+      if (peg$silentFails === 0) { peg$fail(peg$c405); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s1 = peg$c403;
+        s1 = peg$c402;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c404); }
+        if (peg$silentFails === 0) { peg$fail(peg$c403); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14585,94 +14487,94 @@ function peg$parse(input, options) {
       s0 = s1;
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c408;
+          s0 = peg$c407;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c409); }
+          if (peg$silentFails === 0) { peg$fail(peg$c408); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c527;
+            s1 = peg$c526;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c528); }
+            if (peg$silentFails === 0) { peg$fail(peg$c527); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c529();
+            s1 = peg$c528();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c530;
+              s1 = peg$c529;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c531); }
+              if (peg$silentFails === 0) { peg$fail(peg$c530); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c532();
+              s1 = peg$c531();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c533;
+                s1 = peg$c532;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c534); }
+                if (peg$silentFails === 0) { peg$fail(peg$c533); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c535();
+                s1 = peg$c534();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c536;
+                  s1 = peg$c535;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c537); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c536); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c538();
+                  s1 = peg$c537();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c539;
+                    s1 = peg$c538;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c540); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c539); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c541();
+                    s1 = peg$c540();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c542;
+                      s1 = peg$c541;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c543); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c542); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c544();
+                      s1 = peg$c543();
                     }
                     s0 = s1;
                   }
@@ -14700,7 +14602,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c525();
+      s1 = peg$c524();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -14714,16 +14616,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c545();
+        s1 = peg$c544();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c510.test(input.charAt(peg$currPos))) {
+        if (peg$c509.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c511); }
+          if (peg$silentFails === 0) { peg$fail(peg$c510); }
         }
       }
     }
@@ -14736,11 +14638,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c546;
+      s1 = peg$c545;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c547); }
+      if (peg$silentFails === 0) { peg$fail(peg$c546); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -14772,7 +14674,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c548(s2);
+        s1 = peg$c547(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14785,11 +14687,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c546;
+        s1 = peg$c545;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c547); }
+        if (peg$silentFails === 0) { peg$fail(peg$c546); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
@@ -14856,15 +14758,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c309;
+              s4 = peg$c308;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c310); }
+              if (peg$silentFails === 0) { peg$fail(peg$c309); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c548(s3);
+              s1 = peg$c547(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -14948,21 +14850,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c549.test(input.charAt(peg$currPos))) {
+    if (peg$c548.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c550); }
+      if (peg$silentFails === 0) { peg$fail(peg$c549); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s3 = peg$c408;
+        s3 = peg$c407;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c409); }
+        if (peg$silentFails === 0) { peg$fail(peg$c408); }
       }
       if (s3 !== peg$FAILED) {
         if (input.length > peg$currPos) {
@@ -14970,7 +14872,7 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c519); }
+          if (peg$silentFails === 0) { peg$fail(peg$c518); }
         }
         if (s4 !== peg$FAILED) {
           s3 = [s3, s4];
@@ -14987,21 +14889,21 @@ function peg$parse(input, options) {
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c549.test(input.charAt(peg$currPos))) {
+        if (peg$c548.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c550); }
+          if (peg$silentFails === 0) { peg$fail(peg$c549); }
         }
         if (s2 === peg$FAILED) {
           s2 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 92) {
-            s3 = peg$c408;
+            s3 = peg$c407;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c409); }
+            if (peg$silentFails === 0) { peg$fail(peg$c408); }
           }
           if (s3 !== peg$FAILED) {
             if (input.length > peg$currPos) {
@@ -15009,7 +14911,7 @@ function peg$parse(input, options) {
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c519); }
+              if (peg$silentFails === 0) { peg$fail(peg$c518); }
             }
             if (s4 !== peg$FAILED) {
               s3 = [s3, s4];
@@ -15039,12 +14941,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c551.test(input.charAt(peg$currPos))) {
+    if (peg$c550.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c552); }
+      if (peg$silentFails === 0) { peg$fail(peg$c551); }
     }
 
     return s0;
@@ -15102,7 +15004,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c519); }
+      if (peg$silentFails === 0) { peg$fail(peg$c518); }
     }
 
     return s0;
@@ -15113,51 +15015,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c554;
+      s0 = peg$c553;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c555); }
+      if (peg$silentFails === 0) { peg$fail(peg$c554); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c556;
+        s0 = peg$c555;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c557); }
+        if (peg$silentFails === 0) { peg$fail(peg$c556); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c558;
+          s0 = peg$c557;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c559); }
+          if (peg$silentFails === 0) { peg$fail(peg$c558); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c560;
+            s0 = peg$c559;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c561); }
+            if (peg$silentFails === 0) { peg$fail(peg$c560); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c562;
+              s0 = peg$c561;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c563); }
+              if (peg$silentFails === 0) { peg$fail(peg$c562); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c564;
+                s0 = peg$c563;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c565); }
+                if (peg$silentFails === 0) { peg$fail(peg$c564); }
               }
             }
           }
@@ -15167,7 +15069,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c553); }
+      if (peg$silentFails === 0) { peg$fail(peg$c552); }
     }
 
     return s0;
@@ -15176,12 +15078,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c566.test(input.charAt(peg$currPos))) {
+    if (peg$c565.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c567); }
+      if (peg$silentFails === 0) { peg$fail(peg$c566); }
     }
 
     return s0;
@@ -15195,7 +15097,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c568); }
+      if (peg$silentFails === 0) { peg$fail(peg$c567); }
     }
 
     return s0;
@@ -15205,24 +15107,24 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c569) {
-      s1 = peg$c569;
+    if (input.substr(peg$currPos, 2) === peg$c568) {
+      s1 = peg$c568;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c570); }
+      if (peg$silentFails === 0) { peg$fail(peg$c569); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c571) {
-        s5 = peg$c571;
+      if (input.substr(peg$currPos, 2) === peg$c570) {
+        s5 = peg$c570;
         peg$currPos += 2;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c572); }
+        if (peg$silentFails === 0) { peg$fail(peg$c571); }
       }
       peg$silentFails--;
       if (s5 === peg$FAILED) {
@@ -15249,12 +15151,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$currPos;
         peg$silentFails++;
-        if (input.substr(peg$currPos, 2) === peg$c571) {
-          s5 = peg$c571;
+        if (input.substr(peg$currPos, 2) === peg$c570) {
+          s5 = peg$c570;
           peg$currPos += 2;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c572); }
+          if (peg$silentFails === 0) { peg$fail(peg$c571); }
         }
         peg$silentFails--;
         if (s5 === peg$FAILED) {
@@ -15278,12 +15180,12 @@ function peg$parse(input, options) {
         }
       }
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c571) {
-          s3 = peg$c571;
+        if (input.substr(peg$currPos, 2) === peg$c570) {
+          s3 = peg$c570;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c572); }
+          if (peg$silentFails === 0) { peg$fail(peg$c571); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -15308,12 +15210,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c573) {
-      s1 = peg$c573;
+    if (input.substr(peg$currPos, 2) === peg$c572) {
+      s1 = peg$c572;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c574); }
+      if (peg$silentFails === 0) { peg$fail(peg$c573); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -15431,7 +15333,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c519); }
+      if (peg$silentFails === 0) { peg$fail(peg$c518); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -721,7 +721,11 @@ Cast
 
 Function
   = Grep
-  / RegexpFunc
+  // Special case to handle `regexp(/x/, y)`.
+  / "regexp" __ "(" __ arg0Text:RegexpPattern __ "," __ arg1:Expr __ ")" where:WhereClause? {
+      VAR(arg0) = MAP("kind": "Primitive", "type": "string", "text": arg0Text)
+      RETURN(MAP("kind": "Call", "name": "regexp", "args": ARRAY(arg0, arg1), "where": where))
+    }
   / !FuncGuard fn:IdentifierName __ "(" __ args:FunctionArgs __ ")" where:WhereClause? {
       RETURN(MAP("kind": "Call", "name": fn, "args": args, "where": where))
     }

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -750,22 +750,6 @@ Pattern
       RETURN(MAP("kind": "String", "text": s))
     }
 
-RegexpFunc
-  = "regexp" __ "(" __ args:RegexpFuncArgs __ ")" where:WhereClause? {
-      RETURN(MAP("kind": "Call", "name": "regexp", "args": args, "where": where))
-    }
-
-RegexpFuncArgs
-  = first:RegexpFuncArg rest:(__ "," __ e:Expr { RETURN(e) })* {
-      RETURN(PREPEND(first, rest))
-    }
-  / __ { RETURN(ARRAY()) }
-
-RegexpFuncArg
-  = v:RegexpPattern { RETURN(MAP("kind": "Primitive", "type": "string", "text": v)) }
-  / Expr
-
-
 OptionalExprs
   = Exprs
   / __ { RETURN(ARRAY()) }

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -721,6 +721,7 @@ Cast
 
 Function
   = Grep
+  / RegexpFunc
   / !FuncGuard fn:IdentifierName __ "(" __ args:FunctionArgs __ ")" where:WhereClause? {
       RETURN(MAP("kind": "Call", "name": fn, "args": args, "where": where))
     }
@@ -744,6 +745,22 @@ Pattern
   / s:QuotedString {
       RETURN(MAP("kind": "String", "text": s))
     }
+
+RegexpFunc
+  = "regexp" __ "(" __ args:RegexpFuncArgs __ ")" where:WhereClause? {
+      RETURN(MAP("kind": "Call", "name": "regexp", "args": args, "where": where))
+    }
+
+RegexpFuncArgs
+  = first:RegexpFuncArg rest:(__ "," __ e:Expr { RETURN(e) })* {
+      RETURN(PREPEND(first, rest))
+    }
+  / __ { RETURN(ARRAY()) }
+
+RegexpFuncArg
+  = v:RegexpPattern { RETURN(MAP("kind": "Primitive", "type": "string", "text": v)) }
+  / Expr
+
 
 OptionalExprs
   = Exprs

--- a/docs/language/functions/regexp.md
+++ b/docs/language/functions/regexp.md
@@ -5,14 +5,14 @@
 ### Synopsis
 
 ```
-regexp(re: string, s: string) -> any
+regexp(re: string|regexp, s: string) -> any
 ```
 ### Description
 The _regexp_ function returns an array of strings holding the text
-of the left most match of the regular expression string `re` and the
-matches of each parenthesized subexpression (also known as capturing groups)
-if there are any. A null value indicates
-no match.
+of the left most match of the regular expression `re`, which can be either
+a string value or [regular expression](https://zed.brimdata.io/docs/next/language/overview#711-regular-expressions),
+and the matches of each parenthesized subexpression (also known as capturing
+groups) if there are any. A null value indicates no match.
 
 ### Examples
 

--- a/docs/language/functions/regexp.md
+++ b/docs/language/functions/regexp.md
@@ -18,7 +18,7 @@ no match.
 
 Regexp returns an array of the match and its subexpressions:
 ```mdtest-command
-echo '"seafood fool friend"' | zq -z 'yield regexp("foo(.?) (\\w+) fr.*", this)' -
+echo '"seafood fool friend"' | zq -z 'yield regexp(/foo(.?) (\w+) fr.*/, this)' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/functions/regexp.md
+++ b/docs/language/functions/regexp.md
@@ -10,7 +10,7 @@ regexp(re: string|regexp, s: string) -> any
 ### Description
 The _regexp_ function returns an array of strings holding the text
 of the left most match of the regular expression `re`, which can be either
-a string value or [regular expression](https://zed.brimdata.io/docs/next/language/overview#711-regular-expressions),
+a string value or a [regular expression](../overview.md#711-regular-expressions),
 and the matches of each parenthesized subexpression (also known as capturing
 groups) if there are any. A null value indicates no match.
 


### PR DESCRIPTION
Allow the use of a regexp literal as the first argument for the regexp function.

Close #4148