### PR TITLE
service: honor Content-Type header for load

### DIFF
--- a/api/client/connection.go
+++ b/api/client/connection.go
@@ -333,6 +333,8 @@ func (c *Connection) Compact(ctx context.Context, poolID ksuid.KSUID, branchName
 func (c *Connection) Load(ctx context.Context, poolID ksuid.KSUID, branchName string, r io.Reader, message api.CommitMessage) (api.CommitResponse, error) {
 	path := urlPath("pool", poolID.String(), "branch", branchName)
 	req := c.NewRequest(ctx, http.MethodPost, path, r)
+	// Delete Content-Type so server will perform auto-detection.
+	req.Header.Del("Content-Type")
 	if err := encodeCommitMessage(req, message); err != nil {
 		return api.CommitResponse{}, err
 	}

--- a/service/ztests/curl-load-error.yaml
+++ b/service/ztests/curl-load-error.yaml
@@ -1,10 +1,14 @@
 script: |
   source service.sh
   zed create -q test
-  curl -w 'code %{response_code}\n' -d @- $ZED_LAKE/pool/test/branch/main
+  # Undetectable format
+  curl -w 'code %{response_code}\n' -d @f $ZED_LAKE/pool/test/branch/main
+  # Unsupported Content-Type
+  curl -w 'code %{response_code}\n' -d '' -H Content-Type:unsupported \
+    $ZED_LAKE/pool/test/branch/main
 
 inputs:
-  - name: stdin
+  - name: f
     data: |
       This is not a detectable format.
   - name: service.sh
@@ -13,4 +17,6 @@ outputs:
   - name: stdout
     data: |
       {"type":"Error","kind":"invalid operation","error":"format detection error\n\tzeek: line 1: bad types/fields definition in zeek header\n\tzjson: line 1: invalid character 'T' looking for beginning of value\n\tzson: ZSON syntax error\n\tzng: malformed zng record\n\tzng21: malformed zng record\n\tcsv: line 1: EOF\n\tjson: invalid character 'T' looking for beginning of value\n\tparquet: auto-detection not supported\n\tzst: auto-detection not supported"}
+      code 400
+      {"type":"Error","kind":"invalid operation","error":"unsupported MIME type: unsupported"}
       code 400


### PR DESCRIPTION
The load endpoint ignores the Content-Type request header and always performs auto-detection.  Honor the header and perform auto-detection only when the header is empty or unset.

To keep tests passing, change api/client.Connection.Load to delete the Content-Type header, which is set to application/x-zng in the request returned by Connection.NewRequest.

This will break loading of data in the app, which currently sends a "Content-Type: application/json" header in load requests. ~~I'll put up a PR to fix that.~~ brimdata/brim#2570 fixes that.