### PR TITLE
Mention regexp function in Overview doc

### DIFF
--- a/docs/language/overview.md
+++ b/docs/language/overview.md
@@ -1365,16 +1365,17 @@ produces
 {s:"bar"}
 {foo:1}
 ```
-Regular expressions may also appear in the `grep` function:
+Regular expressions may also appear in the [`grep`](functions/grep.md) and
+[`regexp`](functions/regexp.md) functions:
 ```mdtest-command
-echo '"foo" {s:"bar"} {s:"baz"} {foo:1}' | zq -z 'yield grep(/ba.*/, s)' -
+echo '"foo" {s:"bar"} {s:"baz"} {foo:1}' | zq -z 'yield {ba_start:grep(/^ba.*/, s),last_s_char:regexp(/(.)$/,s)[1]}' -
 ```
 produces
 ```mdtest-output
-false
-true
-true
-false
+{ba_start:false,last_s_char:error("missing")}
+{ba_start:true,last_s_char:"r"}
+{ba_start:true,last_s_char:"z"}
+{ba_start:false,last_s_char:error("missing")}
 ```
 
 #### 7.1.2 Globs


### PR DESCRIPTION
While verifying #4148, I noticed that the Overview doc that's linked to from the updated [`regexp`](https://zed.brimdata.io/docs/next/language/functions/regexp) doc doesn't have a symmetrical link back in the other direction. Here I've expanded the existing example to show the `/` regexp syntax for both `grep` and `regexp` at the same time.