### PR TITLE
zson: follow spec regarding digits in identifiers

### DIFF
--- a/zson/analyzer.go
+++ b/zson/analyzer.go
@@ -3,7 +3,6 @@ package zson
 import (
 	"errors"
 	"fmt"
-	"unicode"
 
 	"github.com/brimdata/zed"
 	astzed "github.com/brimdata/zed/compiler/ast/zed"
@@ -184,11 +183,15 @@ func (a Analyzer) enterTypeDef(zctx *zed.Context, name string, typ zed.Type) (*z
 
 func isNumeric(s string) bool {
 	for _, r := range s {
-		if !unicode.IsDigit(r) {
+		if !isDigit(r) {
 			return false
 		}
 	}
 	return true
+}
+
+func isDigit(r rune) bool {
+	return r >= '0' && r <= '9'
 }
 
 func (a Analyzer) convertAny(zctx *zed.Context, val astzed.Any, cast zed.Type) (Value, error) {

--- a/zson/name.go
+++ b/zson/name.go
@@ -10,7 +10,7 @@ func IsIdentifier(s string) bool {
 	}
 	first := true
 	for _, c := range s {
-		if !idChar(c) && (first || !unicode.IsDigit(c)) {
+		if !idChar(c) && (first || !isDigit(c)) {
 			return false
 		}
 		first = false
@@ -28,7 +28,7 @@ func IsTypeName(s string) bool {
 		if !typeChar(c) {
 			return false
 		}
-		if k == 0 && unicode.IsDigit(c) {
+		if k == 0 && isDigit(c) {
 			return false
 		}
 	}
@@ -36,5 +36,5 @@ func IsTypeName(s string) bool {
 }
 
 func typeChar(c rune) bool {
-	return idChar(c) || unicode.IsDigit(c) || c == '.'
+	return idChar(c) || isDigit(c) || c == '.'
 }

--- a/zson/parser-types.go
+++ b/zson/parser-types.go
@@ -2,7 +2,6 @@ package zson
 
 import (
 	"errors"
-	"unicode"
 
 	"github.com/brimdata/zed"
 	astzed "github.com/brimdata/zed/compiler/ast/zed"
@@ -57,7 +56,7 @@ func (p *Parser) matchTypeName() (astzed.Type, error) {
 	if err != nil {
 		return nil, err
 	}
-	if !(idChar(r) || unicode.IsDigit(r) || r == '"') {
+	if !(idChar(r) || isDigit(r) || r == '"') {
 		return nil, nil
 	}
 	name, err := l.scanTypeName()


### PR DESCRIPTION
The ZSON spec allows the digits 0-9 in an identifier while the implementation allows any Unicode decimal digit.  Align the implementation with the spec.

Closes #4014.