### PR TITLE
Use replacement for deprecated set-output

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Extract branch name
-      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
       id: extract_branch
     - name: Lint
       run: make markdown-lint

--- a/.github/workflows/notify-downstream-merge.yml
+++ b/.github/workflows/notify-downstream-merge.yml
@@ -27,7 +27,7 @@ jobs:
         # Pull request
         # https://developer.github.com/v3/pulls/
         merged=$(jq .pull_request.merged "${GITHUB_EVENT_PATH}")
-        echo "::set-output name=merged::$merged"
+        echo "merged=$merged" >> $GITHUB_OUTPUT
       id: vars
     - name: Post PR closed event, if the close was a merge
       if: steps.vars.outputs.merged == 'true'


### PR DESCRIPTION
It was recently [announced](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) that the `set-output` syntax is being deprecated in Actions. I tested out the replacement syntax in a personal repo to get a feel for it and it works as described, so here's changes to our own Workflows to adopt the new approach.