### PR TITLE
cli: cancel Flags.Init context on SIGPIPE

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -59,7 +59,8 @@ func (f *Flags) Init(all ...Initializer) (context.Context, context.CancelFunc, e
 	if f.cpuprofile != "" {
 		f.runCPUProfile(f.cpuprofile)
 	}
-	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	ctx, cancel := signal.NotifyContext(
+		context.Background(), syscall.SIGINT, syscall.SIGPIPE, syscall.SIGTERM)
 	cleanup := func() {
 		cancel()
 		f.cleanup()


### PR DESCRIPTION
As described at https://pkg.go.dev/os/signal#hdr-SIGPIPE, a Go program that has not expressed interest in SIGPIPE will exit (immediately) on a write to a broken pipe on file descriptor 1 or 2.  This prevents the zed and zq commands from removing temporary directories when either of those file descriptors is connected to a pager that exits before reading to EOF.  Fix this in cli.Flags.Init this by adding SIGPIPE to the list of signal.NotifyContext signals.

Fixes #3782.