### PR TITLE
zio: add missing copy in Combiner.run

### DIFF
--- a/zio/combiner.go
+++ b/zio/combiner.go
@@ -40,6 +40,12 @@ func (c *Combiner) run() {
 		go func() {
 			for {
 				rec, err := c.readers[idx].Read()
+				if rec != nil {
+					// Make a copy since we don't wait for
+					// Combiner.Read's caller to finish with
+					// this value before we read the next.
+					rec = rec.Copy()
+				}
 				select {
 				case c.results <- combinerResult{err, idx, rec}:
 					if rec == nil || err != nil {


### PR DESCRIPTION
The goroutines created in Combiner.run don't wait for Combiner.Read's caller to finish with a value before they read the next one.  Since a zio.Reader retains ownership of the values it returns, reading the next value may overwrite a value still in use by Combiner.Read's caller.  Fix that by copying a value before sending on the results channel.

To my knowledge, no one has ever observed this bug.  That isn't too surprising since Combiner is used only by brimcap at present.