### PR TITLE
upgrade to goreleaser/goreleaser-action@v3 in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     - run: make test-unit
     - run: make test-system
     - run: make test-heavy
-    - uses: goreleaser/goreleaser-action@v2
+    - uses: goreleaser/goreleaser-action@v3
       with:
         args: release --rm-dist
       env:


### PR DESCRIPTION
v2 is deprecated because it uses Node.js 12, which is no longer supported.