### PR TITLE
lake/index: add missing copy in Writer.Write

### DIFF
--- a/lake/index/writer.go
+++ b/lake/index/writer.go
@@ -55,7 +55,9 @@ func (w *Writer) Write(rec *zed.Value) error {
 		return errors.New("index writer closed")
 	default:
 		w.once.Do(w.indexer.start)
-		w.rwCh <- rec
+		// Make a copy since a zio.Writer.Write implementation must not
+		// retain its parameter.
+		w.rwCh <- rec.Copy()
 		return nil
 	}
 }


### PR DESCRIPTION
A zio.Writer.Write implementation must not retain its parameter, but Writer.Write does.  Fix by copying the parameter before sending it on the channel.