### PR TITLE
remove bytes allocation in zio.Reader.Read implementations

### DIFF
--- a/lake/seekindex/writer.go
+++ b/lake/seekindex/writer.go
@@ -30,7 +30,7 @@ func NewWriter(w zio.Writer) *Writer {
 
 func (w *Writer) Write(key zed.Value, count uint64, offset int64) error {
 	b := w.builder
-	b.Reset()
+	b.Truncate()
 	b.Append(key.Bytes)
 	b.Append(zed.EncodeUint(count))
 	b.Append(zed.EncodeInt(offset))

--- a/runtime/vcache/projection.go
+++ b/runtime/vcache/projection.go
@@ -47,7 +47,7 @@ func (p *Projection) Read() (*zed.Value, error) {
 		p.off++
 		c = p.cuts[id]
 	}
-	p.builder.Reset()
+	p.builder.Truncate()
 	if err := c.it(&p.builder); err != nil {
 		return nil, err
 	}

--- a/runtime/vcache/reader.go
+++ b/runtime/vcache/reader.go
@@ -31,7 +31,7 @@ func (r *Reader) Read() (*zed.Value, error) {
 		}
 		r.iters[id] = it
 	}
-	r.builder.Reset()
+	r.builder.Truncate()
 	if err := it(&r.builder); err != nil {
 		return nil, err
 	}

--- a/zio/jsonio/builder.go
+++ b/zio/jsonio/builder.go
@@ -175,7 +175,5 @@ func (b *builder) value() *zed.Value {
 		panic("multiple items")
 	}
 	bytes := b.items[0].zb.Bytes().Body()
-	// Reset gives us ownership of bytes.
-	b.items[0].zb.Reset()
 	return zed.NewValue(b.items[0].typ, bytes)
 }

--- a/zio/parquetio/reader.go
+++ b/zio/parquetio/reader.go
@@ -42,7 +42,7 @@ func (r *Reader) Read() (*zed.Value, error) {
 		}
 		return nil, err
 	}
-	r.builder.Reset()
+	r.builder.Truncate()
 	for _, c := range r.typ.Columns {
 		r.builder.appendValue(c.Type, data[c.Name])
 	}

--- a/zio/peeker_test.go
+++ b/zio/peeker_test.go
@@ -24,6 +24,7 @@ func TestPeeker(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+	rec1 = rec1.Copy()
 	rec2, err := peeker.Peek()
 	if err != nil {
 		t.Error(err)
@@ -35,6 +36,7 @@ func TestPeeker(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+	rec3 = rec3.Copy()
 	if !bytes.Equal(rec1.Bytes, rec3.Bytes) {
 		t.Error("rec1 != rec3")
 	}
@@ -42,6 +44,7 @@ func TestPeeker(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+	rec4 = rec4.Copy()
 	if bytes.Equal(rec3.Bytes, rec4.Bytes) {
 		t.Error("rec3 == rec4")
 	}

--- a/zio/zeekio/builder.go
+++ b/zio/zeekio/builder.go
@@ -21,7 +21,7 @@ type builder struct {
 }
 
 func (b *builder) build(typ *zed.TypeRecord, sourceFields []int, path []byte, data []byte) (*zed.Value, error) {
-	b.Reset()
+	b.Truncate()
 	b.Grow(len(data))
 	columns := typ.Columns
 	if path != nil {

--- a/zio/zjsonio/reader.go
+++ b/zio/zjsonio/reader.go
@@ -54,7 +54,7 @@ func (r *Reader) Read() (*zed.Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	r.builder.Reset()
+	r.builder.Truncate()
 	if err := r.decodeValue(r.builder, typ, object.Value); err != nil {
 		return nil, e(err)
 	}

--- a/zson/builder.go
+++ b/zson/builder.go
@@ -17,7 +17,7 @@ import (
 )
 
 func Build(b *zcode.Builder, val Value) (*zed.Value, error) {
-	b.Reset()
+	b.Truncate()
 	if err := buildValue(b, val); err != nil {
 		return nil, err
 	}

--- a/zst/reader.go
+++ b/zst/reader.go
@@ -79,7 +79,7 @@ func NewReaderFromStorageReader(zctx *zed.Context, r storage.Reader) (*Reader, e
 }
 
 func (r *Reader) Read() (*zed.Value, error) {
-	r.builder.Reset()
+	r.builder.Truncate()
 	typeNo, err := r.root.Read()
 	if err == io.EOF {
 		return nil, nil


### PR DESCRIPTION
Most zio.Reader.Read implementations allocate new storage for the returned zed.Value.Bytes on each call in spite of the fact that the implementation retains ownership of that storage and can reuse it. Remove these extra allocations by switching from zcode.(*Builder).Reset to Truncate and removing an unnecessary Reset in zio/jsonio.

This speeds up the JSON and Zeek readers by about 2% and the Parquet reader by about 5%.

Depends on #4187.