### PR TITLE
enforce Zed spec constraints for named type names

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -7,6 +7,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestContextLookupTypeNamedErrors(t *testing.T) {
+	zctx := NewContext()
+
+	_, err := zctx.LookupTypeNamed("\xff", TypeNull)
+	assert.EqualError(t, err, `bad type name "\xff": invalid UTF-8`)
+
+	_, err = zctx.LookupTypeNamed("null", TypeNull)
+	assert.EqualError(t, err, `bad type name "null": primitive type name`)
+}
+
 func TestContextLookupTypeNamedAndLookupTypeDef(t *testing.T) {
 	zctx := NewContext()
 


### PR DESCRIPTION
The Zed spec requires that a named type name be a valid UTF-8 string and not be a primitive type name.  Enforce those constraints in zed.(*Context).LookupTypeNamed.