### PR TITLE
UnmarshalZNG: Explicitly check for type null null

### DIFF
--- a/zson/marshal.go
+++ b/zson/marshal.go
@@ -719,7 +719,9 @@ func (u *UnmarshalZNGContext) decodeAny(zv *zed.Value, v reflect.Value) error {
 		v.Set(reflect.ValueOf(*zv.Copy()))
 		return nil
 	}
-	if zv == zed.Null {
+	if zed.TypeUnder(zv.Type) == zed.TypeNull {
+		// A zed null value should successfully unmarshal to any go type. Typed
+		// nulls however need to be type checked.
 		v.Set(reflect.Zero(v.Type()))
 		return nil
 	}

--- a/zson/marshal_zng_test.go
+++ b/zson/marshal_zng_test.go
@@ -254,11 +254,18 @@ func TestUnmarshalNull(t *testing.T) {
 		var obj struct {
 			Test *testobj `zed:"test"`
 		}
-		val := zson.MustParseValue(zed.NewContext(), "{test: null({Val:int64})}")
+		val := zson.MustParseValue(zed.NewContext(), "{test:null({Val:int64})}")
 		require.NoError(t, zson.UnmarshalZNG(val, &obj))
 		require.Nil(t, obj.Test)
-		val = zson.MustParseValue(zed.NewContext(), "{test: null(ip)}")
+		val = zson.MustParseValue(zed.NewContext(), "{test:null(ip)}")
 		require.EqualError(t, zson.UnmarshalZNG(val, &obj), `cannot unmarshal Zed value "null(ip)" into Go struct`)
+		var slice struct {
+			Test []string `zed:"test"`
+		}
+		slice.Test = []string{"1"}
+		val = zson.MustParseValue(zed.NewContext(), "{test:null}")
+		require.NoError(t, zson.UnmarshalZNG(val, &slice))
+		require.Nil(t, slice.Test)
 	})
 }
 


### PR DESCRIPTION
The simple equality check for type null null values in UnmarshalZNG was resulting erroneous unmarshal errors. Fix this.