### PR TITLE
zio: allow Reader to retain ownership of returned zed.Value

### DIFF
--- a/runtime/vcache/projection.go
+++ b/runtime/vcache/projection.go
@@ -16,6 +16,7 @@ type Projection struct {
 	cuts    []*cut
 	off     int
 	builder zcode.Builder
+	val     zed.Value
 }
 
 type cut struct {
@@ -51,7 +52,8 @@ func (p *Projection) Read() (*zed.Value, error) {
 	if err := c.it(&p.builder); err != nil {
 		return nil, err
 	}
-	return zed.NewValue(c.typ, p.builder.Bytes().Body()), nil
+	p.val = *zed.NewValue(c.typ, p.builder.Bytes().Body())
+	return &p.val, nil
 }
 
 func findCuts(o *Object, names []string) ([]*cut, error) {

--- a/runtime/vcache/reader.go
+++ b/runtime/vcache/reader.go
@@ -11,6 +11,7 @@ type Reader struct {
 	iters   []iterator
 	off     int
 	builder zcode.Builder
+	val     zed.Value
 }
 
 var _ zio.Reader = (*Reader)(nil)
@@ -35,5 +36,6 @@ func (r *Reader) Read() (*zed.Value, error) {
 	if err := it(&r.builder); err != nil {
 		return nil, err
 	}
-	return zed.NewValue(o.types[id], r.builder.Bytes().Body()), nil
+	r.val = *zed.NewValue(o.types[id], r.builder.Bytes().Body())
+	return &r.val, nil
 }

--- a/zio/jsonio/builder.go
+++ b/zio/jsonio/builder.go
@@ -19,6 +19,7 @@ type builder struct {
 	columns  []zed.Column
 	itemptrs []*item
 	types    []zed.Type
+	val      zed.Value
 }
 
 type item struct {
@@ -174,6 +175,7 @@ func (b *builder) value() *zed.Value {
 	if len(b.items) > 1 {
 		panic("multiple items")
 	}
-	bytes := b.items[0].zb.Bytes().Body()
-	return zed.NewValue(b.items[0].typ, bytes)
+	item := &b.items[0]
+	b.val = *zed.NewValue(item.typ, item.zb.Bytes().Body())
+	return &b.val
 }

--- a/zio/lineio/reader.go
+++ b/zio/lineio/reader.go
@@ -9,6 +9,7 @@ import (
 
 type Reader struct {
 	scanner *bufio.Scanner
+	val     zed.Value
 }
 
 func NewReader(r io.Reader) *Reader {
@@ -19,5 +20,6 @@ func (r *Reader) Read() (*zed.Value, error) {
 	if !r.scanner.Scan() || r.scanner.Err() != nil {
 		return nil, r.scanner.Err()
 	}
-	return zed.NewValue(zed.TypeString, r.scanner.Bytes()), nil
+	r.val = *zed.NewValue(zed.TypeString, r.scanner.Bytes())
+	return &r.val, nil
 }

--- a/zio/parquetio/reader.go
+++ b/zio/parquetio/reader.go
@@ -13,6 +13,7 @@ type Reader struct {
 	typ *zed.TypeRecord
 
 	builder builder
+	val     zed.Value
 }
 
 func NewReader(zctx *zed.Context, r io.Reader) (*Reader, error) {
@@ -46,5 +47,6 @@ func (r *Reader) Read() (*zed.Value, error) {
 	for _, c := range r.typ.Columns {
 		r.builder.appendValue(c.Type, data[c.Name])
 	}
-	return zed.NewValue(r.typ, r.builder.Bytes()), nil
+	r.val = *zed.NewValue(r.typ, r.builder.Bytes())
+	return &r.val, nil
 }

--- a/zio/zeekio/builder.go
+++ b/zio/zeekio/builder.go
@@ -18,6 +18,7 @@ type builder struct {
 	buf             []byte
 	fields          [][]byte
 	reorderedFields [][]byte
+	val             zed.Value
 }
 
 func (b *builder) build(typ *zed.TypeRecord, sourceFields []int, path []byte, data []byte) (*zed.Value, error) {
@@ -59,7 +60,8 @@ func (b *builder) build(typ *zed.TypeRecord, sourceFields []int, path []byte, da
 	if len(leftoverFields) != 0 {
 		return nil, errors.New("too many values")
 	}
-	return zed.NewValue(typ, b.Bytes()), nil
+	b.val = *zed.NewValue(typ, b.Bytes())
+	return &b.val, nil
 }
 
 func (b *builder) appendColumns(columns []zed.Column, fields [][]byte) ([][]byte, error) {

--- a/zio/zio.go
+++ b/zio/zio.go
@@ -55,9 +55,9 @@ func NopCloser(w io.Writer) io.WriteCloser {
 // Read never returns a non-nil value and non-nil error together, and it never
 // returns io.EOF.
 //
-// Implementations retain ownership of val.Bytes, and a subsequent Read may
-// overwrite it.  Clients that wish to use val.Bytes after the next Read must
-// make a copy.
+// Implementations retain ownership of val and val.Bytes, and a subsequent Read
+// may overwrite them.  Clients that wish to use val or val.Bytes after the next
+// Read must make a copy.
 type Reader interface {
 	Read() (val *zed.Value, err error)
 }

--- a/zio/zjsonio/reader.go
+++ b/zio/zjsonio/reader.go
@@ -22,6 +22,7 @@ type Reader struct {
 	zctx    *zed.Context
 	decoder decoder
 	builder *zcode.Builder
+	val     zed.Value
 }
 
 func NewReader(zctx *zed.Context, reader io.Reader) *Reader {
@@ -58,7 +59,8 @@ func (r *Reader) Read() (*zed.Value, error) {
 	if err := r.decodeValue(r.builder, typ, object.Value); err != nil {
 		return nil, e(err)
 	}
-	return zed.NewValue(typ, r.builder.Bytes().Body()), nil
+	r.val = *zed.NewValue(typ, r.builder.Bytes().Body())
+	return &r.val, nil
 }
 
 func (r *Reader) decodeValue(b *zcode.Builder, typ zed.Type, body interface{}) error {

--- a/zio/zsonio/reader.go
+++ b/zio/zsonio/reader.go
@@ -37,9 +37,5 @@ func (r *Reader) Read() (*zed.Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	zv, err := zson.Build(r.builder, val)
-	if err != nil {
-		return nil, err
-	}
-	return zed.NewValue(zv.Type, zv.Bytes), nil
+	return zson.Build(r.builder, val)
 }

--- a/zst/reader.go
+++ b/zst/reader.go
@@ -19,6 +19,7 @@ type Reader struct {
 	root    *vector.Int64Reader
 	readers []typedReader
 	builder zcode.Builder
+	val     zed.Value
 }
 
 type typedReader struct {
@@ -91,5 +92,6 @@ func (r *Reader) Read() (*zed.Value, error) {
 	if err := tr.reader.Read(&r.builder); err != nil {
 		return nil, err
 	}
-	return zed.NewValue(tr.typ, r.builder.Bytes().Body()), nil
+	r.val = *zed.NewValue(tr.typ, r.builder.Bytes().Body())
+	return &r.val, nil
 }


### PR DESCRIPTION
A zio.Reader implementation has always retained ownership of the zed.Value.Bytes returned by Read.  There's no reason it shouldn't also retain ownership of the zed.Value, and making this change provides an opportunity to eliminate an allocation in some implementations.