### PR TITLE
Clean up sidebar indexing

### DIFF
--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -1,8 +1,3 @@
----
-sidebar_position: 3
-sidebar_label: Commands
----
-
 # Command Tooling
 
 The Zed system is managed and queried with the [`zed` command](zed.md),

--- a/docs/commands/zed.md
+++ b/docs/commands/zed.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
 sidebar_label: zed
 ---
 

--- a/docs/commands/zq.md
+++ b/docs/commands/zq.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 0
+sidebar_position: 1
 sidebar_label: zq
 description: A command-line tool that uses the Zed Language for pipeline-style search and analytics.
 ---

--- a/docs/formats/compression.md
+++ b/docs/formats/compression.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 sidebar_label: Compression
 ---
 

--- a/docs/formats/zed.md
+++ b/docs/formats/zed.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 0
+sidebar_position: 1
 sidebar_label: Data Model
 ---
 

--- a/docs/formats/zjson.md
+++ b/docs/formats/zjson.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 sidebar_label: ZJSON
 ---
 

--- a/docs/formats/zng.md
+++ b/docs/formats/zng.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
 sidebar_label: ZNG
 ---
 

--- a/docs/formats/zson.md
+++ b/docs/formats/zson.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 sidebar_label: ZSON
 ---
 

--- a/docs/formats/zst.md
+++ b/docs/formats/zst.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 sidebar_label: ZST
 ---
 

--- a/docs/libraries/go.md
+++ b/docs/libraries/go.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 1
+sidebar_label: Go
+---
+
 # Go
 
 The Zed system was developed in Go so support for Go clients is

--- a/docs/libraries/javascript.md
+++ b/docs/libraries/javascript.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 2
+sidebar_label: Javascript
+---
+
 # Javascript
 
 The [Zealot library](https://github.com/brimdata/brim/tree/main/packages/zealot)

--- a/docs/libraries/python.md
+++ b/docs/libraries/python.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 3
+sidebar_label: Python
+---
+
 # Python
 
 Zed includes preliminary support for Python-based interaction

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -1,8 +1,3 @@
----
-sidebar_position: 3
-sidebar_label: Commands
----
-
 # Tutorials
 
 The tutorials contain a number of overviews of different aspects

--- a/docs/tutorials/join.md
+++ b/docs/tutorials/join.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 sidebar_label: Join
 ---
 

--- a/docs/tutorials/schools.md
+++ b/docs/tutorials/schools.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 sidebar_label: Schools Data
 ---
 

--- a/docs/tutorials/zed.md
+++ b/docs/tutorials/zed.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
 sidebar_label: zed
 ---
 

--- a/docs/tutorials/zq.md
+++ b/docs/tutorials/zq.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 0
+sidebar_position: 1
 sidebar_label: zq
 ---
 


### PR DESCRIPTION
I sat down to make an addition to the docs, but then noticed that there were some inconsistencies with the sidebar indexing that could stand to be cleaned up first. I've eyeballed the rendering after these changes to confirm that the content/order in the sidebar is exactly the same as it was. I'll add some inline comments to point to the reason behind certain less-obvious changes.