### PR TITLE
api/client: add contentType parameter to (*Connection).Load

### DIFF
--- a/api/client/connection.go
+++ b/api/client/connection.go
@@ -330,11 +330,12 @@ func (c *Connection) Compact(ctx context.Context, poolID ksuid.KSUID, branchName
 	return commit, err
 }
 
-func (c *Connection) Load(ctx context.Context, poolID ksuid.KSUID, branchName string, r io.Reader, message api.CommitMessage) (api.CommitResponse, error) {
+// Load loads data from r.  contentType is a media type for r or the empty
+// string, in which case the server will attempt to detect r's format.
+func (c *Connection) Load(ctx context.Context, poolID ksuid.KSUID, branchName, contentType string, r io.Reader, message api.CommitMessage) (api.CommitResponse, error) {
 	path := urlPath("pool", poolID.String(), "branch", branchName)
 	req := c.NewRequest(ctx, http.MethodPost, path, r)
-	// Delete Content-Type so server will perform auto-detection.
-	req.Header.Del("Content-Type")
+	req.Header.Set("Content-Type", contentType)
 	if err := encodeCommitMessage(req, message); err != nil {
 		return api.CommitResponse{}, err
 	}

--- a/api/client/connection_test.go
+++ b/api/client/connection_test.go
@@ -58,7 +58,7 @@ func TestClientRedirectReplay(t *testing.T) {
 		Refresh: "98765",
 	})
 	conn.SetAuthStore(store)
-	_, err := conn.Load(context.Background(), ksuid.New(), "main", strings.NewReader(expected), api.CommitMessage{})
+	_, err := conn.Load(context.Background(), ksuid.New(), "main", "", strings.NewReader(expected), api.CommitMessage{})
 	require.NoError(t, err)
 	assert.Equal(t, expected, body)
 }

--- a/lake/api/remote.go
+++ b/lake/api/remote.go
@@ -102,7 +102,7 @@ func (r *remote) Load(ctx context.Context, _ *zed.Context, poolID ksuid.KSUID, b
 		}
 		pw.CloseWithError(err)
 	}()
-	res, err := r.conn.Load(ctx, poolID, branchName, pr, commit)
+	res, err := r.conn.Load(ctx, poolID, branchName, api.MediaTypeZNG, pr, commit)
 	return res.Commit, err
 }
 

--- a/service/client_test.go
+++ b/service/client_test.go
@@ -92,7 +92,7 @@ func (c *testClient) TestQuery(query string) string {
 }
 
 func (c *testClient) TestLoad(poolID ksuid.KSUID, branchName string, r io.Reader) ksuid.KSUID {
-	commit, err := c.Connection.Load(context.Background(), poolID, branchName, r, api.CommitMessage{})
+	commit, err := c.Connection.Load(context.Background(), poolID, branchName, "", r, api.CommitMessage{})
 	require.NoError(c, err)
 	return commit.Commit
 }


### PR DESCRIPTION
(*Connection).Load does not send a Content-Type request header, causing the server to perform format auto-detection on the request body, but auto-detection isn't desriable for lake/api.(*remote).Load, which always sends ZNG.  Add a contentType parameter to (*Connection).Load, set it to lake/api.MediaTypeZNG in (*remote).Load to disable auto-detection, and set it to the empty string everywhere else to continue auto-detection.