### PR TITLE
Add a docs page about AWS S3

### DIFF
--- a/docs/integrations/_category_.yaml
+++ b/docs/integrations/_category_.yaml
@@ -1,0 +1,2 @@
+position: 9
+label: Integrations

--- a/docs/integrations/amazon-s3.md
+++ b/docs/integrations/amazon-s3.md
@@ -35,6 +35,11 @@ are typically input in the first three settings entered during `aws configure`.
    Default region name [*********]: 
    ```
 
+## Endpoint
+
+To use S3-compatible storage not provided by AWS, set the `AWS_S3_ENDPOINT`
+environment variable to the hostname or URI of the provider.
+
 ## Wildcard Support
 
 [Like the AWS CLI tools themselves](https://aws.amazon.com/premiumsupport/knowledge-center/s3-event-notification-filter-wildcard/#:~:text=Because%20the%20wildcard%20asterisk%20character,suffix%20object%20key%20name%20filter.),

--- a/docs/integrations/amazon-s3.md
+++ b/docs/integrations/amazon-s3.md
@@ -18,6 +18,12 @@ You must specify an AWS region via one of the following:
 You can create `~/.aws/config` by installing the
 [AWS CLI](https://aws.amazon.com/cli/) and running `aws configure`.
 
+:::tip Note
+If using S3-compatible storage that does not recognize the concept of regions,
+a region must still be specified, e.g., by providing a dummy value for
+`AWS_REGION`.
+:::
+
 ## Credentials
 
 You must specify AWS credentials via one of the following:

--- a/docs/integrations/amazon-s3.md
+++ b/docs/integrations/amazon-s3.md
@@ -5,8 +5,8 @@ sidebar_label: Amazon S3
 
 # Amazon S3
 
-Zed tools have the ability to utilize [Amazon S3](https://aws.amazon.com/s3/)
-storage. Details on effective use with S3 are described below.
+Zed tools can access [Amazon S3](https://aws.amazon.com/s3/) and
+S3-compatible storage via `s3://` URIs. Details are described below.
 
 ## Credentials
 

--- a/docs/integrations/amazon-s3.md
+++ b/docs/integrations/amazon-s3.md
@@ -1,0 +1,44 @@
+---
+sidebar_position: 1
+sidebar_label: Amazon S3
+---
+
+# Amazon S3
+
+Zed tools have the ability to utilize [Amazon S3](https://aws.amazon.com/s3/)
+storage. Details on effective use with S3 are described below.
+
+## Credentials
+
+The URI parameters that are accepted by Zed components can be `s3://`
+destinations that point to S3 storage. As most S3 buckets are non-public, this
+requires the Zed tooling to have credentials for access. These credentials can
+be provided in one of two ways.
+
+1. If you have the [AWS CLI](https://aws.amazon.com/cli/) tools installed on
+the same system where you're running Zed and have successfully completed
+`aws configure`, the Zed tools will automatically find and use these saved
+credentials and config in their well-known location. If you can successfully
+execute operations such as `aws s3 ls` or `aws s3 cp` against an S3 URI, it is
+expected that the Zed tools will be able to successfully make use of the same
+S3 URI.
+
+2. If the AWS CLI tools are absent or unconfigured, the necessary credentials
+can be set in environment variables `AWS_ACCESS_KEY_ID`,
+`AWS_SECRET_ACCESS_KEY`, and `AWS_REGION`. The values for these are the same as
+are typically input in the first three settings entered during `aws configure`.
+
+   ```
+   $ aws configure
+   AWS Access Key ID [********************]: 
+   AWS Secret Access Key [********************]: 
+   Default region name [*********]: 
+   ```
+
+## Wildcard Support
+
+[Like the AWS CLI tools themselves](https://aws.amazon.com/premiumsupport/knowledge-center/s3-event-notification-filter-wildcard/#:~:text=Because%20the%20wildcard%20asterisk%20character,suffix%20object%20key%20name%20filter.),
+Zed does not currently expand UNIX-style `*` wildcards in S3 URIs. If you
+find this limitation is impacting your workflow, please add your use case
+details as a comment in issue [zed/1994](https://github.com/brimdata/zed/issues/1994)
+to help us track the priority of possible enhancements in this area.

--- a/docs/integrations/amazon-s3.md
+++ b/docs/integrations/amazon-s3.md
@@ -8,32 +8,25 @@ sidebar_label: Amazon S3
 Zed tools can access [Amazon S3](https://aws.amazon.com/s3/) and
 S3-compatible storage via `s3://` URIs. Details are described below.
 
+## Region
+
+You must specify an AWS region via one of the following:
+* The `AWS_REGION` environment variable
+* The `~/.aws/config` file
+* The file specified by the `AWS_CONFIG_FILE` environment variable
+
+You can create `~/.aws/config` by installing the
+[AWS CLI](https://aws.amazon.com/cli/) and running `aws configure`.
+
 ## Credentials
 
-The URI parameters that are accepted by Zed components can be `s3://`
-destinations that point to S3 storage. As most S3 buckets are non-public, this
-requires the Zed tooling to have credentials for access. These credentials can
-be provided in one of two ways.
+You must specify AWS credentials via one of the following:
+* The `AWS_ACCESS_KEY_ID` and`AWS_SECRET_ACCESS_KEY` environment variables
+* The `~/.aws/credentials` file
+* The file specified by the `AWS_SHARED_CREDENTIALS_FILE` environment variable
 
-1. If you have the [AWS CLI](https://aws.amazon.com/cli/) tools installed on
-the same system where you're running Zed and have successfully completed
-`aws configure`, the Zed tools will automatically find and use these saved
-credentials and config in their well-known location. If you can successfully
-execute operations such as `aws s3 ls` or `aws s3 cp` against an S3 URI, it is
-expected that the Zed tools will be able to successfully make use of the same
-S3 URI.
-
-2. If the AWS CLI tools are absent or unconfigured, the necessary credentials
-can be set in environment variables `AWS_ACCESS_KEY_ID`,
-`AWS_SECRET_ACCESS_KEY`, and `AWS_REGION`. The values for these are the same as
-are typically input in the first three settings entered during `aws configure`.
-
-   ```
-   $ aws configure
-   AWS Access Key ID [********************]: 
-   AWS Secret Access Key [********************]: 
-   Default region name [*********]: 
-   ```
+You can create `~/.aws/credentials` by installing the
+[AWS CLI](https://aws.amazon.com/cli/) and running `aws configure`.
 
 ## Endpoint
 


### PR DESCRIPTION
I recently fielded a question from a community user about S3 support in Zed. This led me to realize that we don't have any kind of formal docs at the moment that speak to the current S3 support, so I've added that here. Since I couldn't find a great home in one of the current docs categories, I created a new section called "Integrations" of which this is the first doc.

A follow-on I plan after this PR is to link to it from some other docs that mention S3, including the `from` doc which I also recognized needs a significant update.