### PR TITLE
Revert "lake.Writer: Use CopyFrom to copy values (#3432)"

### DIFF
--- a/lake/writer.go
+++ b/lake/writer.go
@@ -81,7 +81,11 @@ func (w *Writer) Write(rec *zed.Value) error {
 		}
 		return w.ctx.Err()
 	}
-	w.append(rec)
+	// XXX This call leads to a ton of one-off allocations that burden the GC
+	// and slow down import. We should instead copy the raw record bytes into a
+	// recycled buffer and keep around an array of ts + byte-slice structs for
+	// sorting.
+	w.vals = append(w.vals, *rec.Copy())
 	w.memBuffered += int64(len(rec.Bytes))
 	//XXX change name LogSizeThreshold
 	// XXX the previous logic estimated the object size with divide by 2...?!
@@ -89,16 +93,6 @@ func (w *Writer) Write(rec *zed.Value) error {
 		w.flipBuffers()
 	}
 	return nil
-}
-
-func (w *Writer) append(val *zed.Value) {
-	n := len(w.vals)
-	if n < cap(w.vals) {
-		w.vals = w.vals[:n+1]
-	} else {
-		w.vals = append(w.vals, zed.Value{})
-	}
-	w.vals[n].CopyFrom(val)
 }
 
 func (w *Writer) flipBuffers() {


### PR DESCRIPTION
This reverts commit bc919de1a8e800a16b5a369149e159642ec592d8.

Reason for revert: This impairs performance and uses more memory.