### PR TITLE
Expand "from" doc

### DIFF
--- a/docs/language/operators/README.md
+++ b/docs/language/operators/README.md
@@ -9,11 +9,11 @@ and appear as the components of a dataflow pipeline.
 * [combine](combine.md) - combine parallel paths into a single output
 * [cut](cut.md) - extract subsets of record fields into new records
 * [drop](drop.md) - drop fields from record values
-* [file](file.md) - source data from a file
+* [file](from.md) - source data from a file
 * [from](from.md) - source data from pools, files, or URIs
 * [fork](fork.md) - copy values to parallel paths
 * [fuse](fuse.md) - coerce all input values into a merged type
-* [get](get.md) - source data from a URI
+* [get](from.md) - source data from a URI
 * [head](head.md) - copy leading values of input sequence
 * [join](join.md) - combine data from two inputs using a join predicate
 * [over](over.md) - traverse nested values as a lateral query

--- a/docs/language/operators/README.md
+++ b/docs/language/operators/README.md
@@ -9,9 +9,11 @@ and appear as the components of a dataflow pipeline.
 * [combine](combine.md) - combine parallel paths into a single output
 * [cut](cut.md) - extract subsets of record fields into new records
 * [drop](drop.md) - drop fields from record values
+* [file](file.md) - source data from a file
 * [from](from.md) - source data from pools, files, or URIs
 * [fork](fork.md) - copy values to parallel paths
 * [fuse](fuse.md) - coerce all input values into a merged type
+* [get](get.md) - source data from a URI
 * [head](head.md) - copy leading values of input sequence
 * [join](join.md) - combine data from two inputs using a join predicate
 * [over](over.md) - traverse nested values as a lateral query

--- a/docs/language/operators/file.md
+++ b/docs/language/operators/file.md
@@ -1,0 +1,7 @@
+### Operator
+
+&emsp; **file** &mdash; source data from a file
+
+### Synopsis
+
+`file` is a shorthand notation for `from`. See the [from operator](from.md) documentation for details.

--- a/docs/language/operators/from.md
+++ b/docs/language/operators/from.md
@@ -5,11 +5,13 @@
 ### Synopsis
 
 ```
-from <pool>[@<tag>] [ => <leg> ]
+from <pool>[@<branch|id>]
+from <pattern>
 file <path> [format <format>]
 get <uri> [format <format>]
 from (
-   pool <pool>[@<tag>] [ => <leg> ]
+   pool <pool>[@<branch|id>] [ => <leg> ]
+   pool <pattern> [ => <leg> ]
    file <path> [format <format>] [ => <leg> ]
    get <uri> [format <format>] [ => <leg> ]
    ...
@@ -19,16 +21,26 @@ from (
 
 The `from` operator identifies one or more data sources and transmits
 their data to its output.  A data source can be
-* the name of a data pool in a Zed lake;
+* the name of a data pool in a Zed lake, optionally at a specific [branch or commit ID](../../commands/zed.md#142-commitish);
+* the names of multiple data pools, expressed as a [regular expression](../overview.md#711-regular-expressions) or [glob](../overview.md#712-globs) pattern;
 * a path to a file; or
 * an HTTP, HTTPS, or S3 URI.
 Paths and URIs may be followed by an optional format specifier.
 
-In the first three forms, a single source is connected to a single output.
-In the fourth form, multiple sources are accessed in parallel and may be
+Sourcing data from pools is only possible when querying a lake, such as
+via the [`zed` command](../../commands/zed.md) or
+[Zed lake API](../../lake/api.md). Sourcing data from files is only possible
+with the [`zq` command](../../commands/zq.md).
+
+When a single pool name is specified without `@`-referencing a commit or ID, or
+when using a pool pattern, the tip of the `main` branch of each pool is
+accessed.
+
+In the first four forms, a single source is connected to a single output.
+In the fifth form, multiple sources are accessed in parallel and may be
 [joined](join.md), [combined](combine.md), or [merged](merge.md).
 
-A data path can be split with the `fork` operator as in
+A data path can be split with the [fork operator](fork.md) as in
 ```
 from PoolOne | fork (
   => op1 | op2 | ...
@@ -45,7 +57,7 @@ from (
 ```
 
 Similarly, data can be routed to different paths with replication
-using `switch`:
+using the [switch operator](switch.md):
 ```
 from ... | switch color (
   case "red" => op1 | op2 | ...
@@ -54,20 +66,105 @@ from ... | switch color (
 ) | ...
 ```
 
-The output of a fork consists of multiple legs that must be merged.
-If the downstream operator expects a single input, then the output legs are
-merged with an automatically inserted [combine operator](combine.md).
+### Input Data
+
+Examples below below assume the existence of the Zed lake created and populated
+by the following commands:
+
+```mdtest-command
+export ZED_LAKE=example
+zed -q init
+zed -q create coinflips
+echo '{flip:1,result:"heads"} {flip:2,result:"tails"}' | zed -q -use coinflips load -
+zed -q -use coinflips branch trial 
+echo '{flip:3,result:"heads"}' | zed -q -use coinflips@trial load -
+zed -q create numbers
+echo '{number:1,word:"one"} {number:2,word:"two"} {number:3,word:"three"}' | zed -q -use numbers load -
+zed ls | awk '{ print $1 }'
+```
+
+The lake then contains the two pools:
+
+```mdtest-output
+coinflips
+numbers
+```
+
+The following file `hello.zson` is also used.
+
+```mdtest-input hello.zson
+{greeting:"hello world!"}
+```
 
 ### Examples
 
-_Copy input to two paths and merge_
+_Source structured data from a local file_
+
 ```mdtest-command
-echo '1 2' | zq -z 'fork (=>pass =>pass) | sort this' -
+zq -z 'file hello.zson | yield greeting'
 ```
 =>
 ```mdtest-output
-1
-1
-2
-2
+"hello world!"
+```
+
+_Source data from a local file, but in line format_
+```mdtest-command
+zq -z 'file hello.zson format line | head 1'
+```
+=>
+```mdtest-output
+"{greeting:\"hello world!\"}"
+```
+
+_Source structured data from a URI_
+```mdtest-command
+zq -z 'get https://raw.githubusercontent.com/brimdata/zui-insiders/main/package.json | yield productName'
+```
+=>
+```mdtest-output
+"Zui - Insiders"
+```
+
+_Source data from a pool, defaulting to the `main` branch_
+```mdtest-command
+zed -lake example query -z 'from coinflips'
+```
+=>
+```mdtest-output
+{flip:2,result:"tails"}
+{flip:1,result:"heads"}
+```
+
+_Source data from a specific branch of a pool_
+```mdtest-command
+zed -lake example query -z 'from coinflips@trial'
+```
+=>
+```mdtest-output
+{flip:3,result:"heads"}
+{flip:2,result:"tails"}
+{flip:1,result:"heads"}
+```
+
+_Count the number of records in all pools_
+```mdtest-command
+zed -lake example query -f text 'from * | count()'
+```
+=>
+```mdtest-output
+5
+```
+_Join the data from multiple pools_
+```mdtest-command
+zed -lake example query -z '
+  from (
+    pool coinflips => sort flip
+    pool numbers => sort number
+  ) | join on flip=number word'
+```
+=>
+```mdtest-output
+{flip:1,result:"heads",word:"one"}
+{flip:2,result:"tails",word:"two"}
 ```

--- a/docs/language/operators/from.md
+++ b/docs/language/operators/from.md
@@ -127,7 +127,7 @@ zq -z 'get https://raw.githubusercontent.com/brimdata/zui-insiders/main/package.
 "Zui - Insiders"
 ```
 
-_Source data from a pool, defaulting to the `main` branch_
+_Source data from the `main` branch of a pool
 ```mdtest-command
 zed -lake example query -z 'from coinflips'
 ```

--- a/docs/language/operators/from.md
+++ b/docs/language/operators/from.md
@@ -40,7 +40,7 @@ In the first four forms, a single source is connected to a single output.
 In the fifth form, multiple sources are accessed in parallel and may be
 [joined](join.md), [combined](combine.md), or [merged](merge.md).
 
-A data path can be split with the [fork operator](fork.md) as in
+A data path can be split with the [`fork` operator](fork.md) as in
 ```
 from PoolOne | fork (
   => op1 | op2 | ...
@@ -57,7 +57,7 @@ from (
 ```
 
 Similarly, data can be routed to different paths with replication
-using the [switch operator](switch.md):
+using the [`switch` operator](switch.md):
 ```
 from ... | switch color (
   case "red" => op1 | op2 | ...

--- a/docs/language/operators/from.md
+++ b/docs/language/operators/from.md
@@ -21,7 +21,7 @@ from (
 
 The `from` operator identifies one or more data sources and transmits
 their data to its output.  A data source can be
-* the name of a data pool in a Zed lake, optionally at a specific [branch or commit ID](../../commands/zed.md#142-commitish);
+* the name of a data pool in a Zed lake, with optional [commitish](../../commands/zed.md#142-commitish);
 * the names of multiple data pools, expressed as a [regular expression](../overview.md#711-regular-expressions) or [glob](../overview.md#712-globs) pattern;
 * a path to a file; or
 * an HTTP, HTTPS, or S3 URI.

--- a/docs/language/operators/from.md
+++ b/docs/language/operators/from.md
@@ -25,7 +25,7 @@ their data to its output.  A data source can be
 * the names of multiple data pools, expressed as a [regular expression](../overview.md#711-regular-expressions) or [glob](../overview.md#712-globs) pattern;
 * a path to a file; or
 * an HTTP, HTTPS, or S3 URI.
-Paths and URIs may be followed by an optional format specifier.
+Paths and URIs may be followed by an optional [format](../../commands/zq.md#2-input-formats)  specifier.
 
 Sourcing data from pools is only possible when querying a lake, such as
 via the [`zed` command](../../commands/zed.md) or

--- a/docs/language/operators/from.md
+++ b/docs/language/operators/from.md
@@ -80,7 +80,7 @@ zed -q -use coinflips branch trial
 echo '{flip:3,result:"heads"}' | zed -q -use coinflips@trial load -
 zed -q create numbers
 echo '{number:1,word:"one"} {number:2,word:"two"} {number:3,word:"three"}' | zed -q -use numbers load -
-zed ls | awk '{ print $1 }'
+zed ls | awk '{ print $1 }' | sort
 ```
 
 The lake then contains the two pools:

--- a/docs/language/operators/from.md
+++ b/docs/language/operators/from.md
@@ -111,7 +111,7 @@ zq -z 'file hello.zson | yield greeting'
 
 _Source data from a local file, but in line format_
 ```mdtest-command
-zq -z 'file hello.zson format line | head 1'
+zq -z 'file hello.zson format line'
 ```
 =>
 ```mdtest-output

--- a/docs/language/operators/from.md
+++ b/docs/language/operators/from.md
@@ -5,12 +5,12 @@
 ### Synopsis
 
 ```
-from <pool>[@<branch|id>]
+from <pool>[@<commitish>]
 from <pattern>
 file <path> [format <format>]
 get <uri> [format <format>]
 from (
-   pool <pool>[@<branch|id>] [ => <leg> ]
+   pool <pool>[@<commitish>] [ => <leg> ]
    pool <pattern>
    file <path> [format <format>] [ => <leg> ]
    get <uri> [format <format>] [ => <leg> ]

--- a/docs/language/operators/from.md
+++ b/docs/language/operators/from.md
@@ -11,7 +11,7 @@ file <path> [format <format>]
 get <uri> [format <format>]
 from (
    pool <pool>[@<branch|id>] [ => <leg> ]
-   pool <pattern> [ => <leg> ]
+   pool <pattern>
    file <path> [format <format>] [ => <leg> ]
    get <uri> [format <format>] [ => <leg> ]
    ...

--- a/docs/language/operators/from.md
+++ b/docs/language/operators/from.md
@@ -148,7 +148,7 @@ zed -lake example query -z 'from coinflips@trial'
 {flip:1,result:"heads"}
 ```
 
-_Count the number of records in the `main` branch of all pools_
+_Count the number of values in the `main` branch of all pools_
 ```mdtest-command
 zed -lake example query -f text 'from * | count()'
 ```

--- a/docs/language/operators/from.md
+++ b/docs/language/operators/from.md
@@ -127,7 +127,7 @@ zq -z 'get https://raw.githubusercontent.com/brimdata/zui-insiders/main/package.
 "Zui - Insiders"
 ```
 
-_Source data from the `main` branch of a pool
+_Source data from the `main` branch of a pool_
 ```mdtest-command
 zed -lake example query -z 'from coinflips'
 ```

--- a/docs/language/operators/from.md
+++ b/docs/language/operators/from.md
@@ -119,11 +119,11 @@ zq -z 'file hello.zson format line | head 1'
 ```
 
 _Source structured data from a URI_
-```mdtest-command
+```
 zq -z 'get https://raw.githubusercontent.com/brimdata/zui-insiders/main/package.json | yield productName'
 ```
 =>
-```mdtest-output
+```
 "Zui - Insiders"
 ```
 

--- a/docs/language/operators/from.md
+++ b/docs/language/operators/from.md
@@ -147,7 +147,7 @@ zed -lake example query -z 'from coinflips@trial'
 {flip:1,result:"heads"}
 ```
 
-_Count the number of records in all pools_
+_Count the number of records in the `main` branch of all pools_
 ```mdtest-command
 zed -lake example query -f text 'from * | count()'
 ```

--- a/docs/language/operators/from.md
+++ b/docs/language/operators/from.md
@@ -80,14 +80,15 @@ zed -q -use coinflips branch trial
 echo '{flip:3,result:"heads"}' | zed -q -use coinflips@trial load -
 zed -q create numbers
 echo '{number:1,word:"one"} {number:2,word:"two"} {number:3,word:"three"}' | zed -q -use numbers load -
-zed ls | awk '{ print $1 }' | sort
+zed query -f text 'from :branches | yield pool.name + "@" + branch.name | sort'
 ```
 
 The lake then contains the two pools:
 
 ```mdtest-output
-coinflips
-numbers
+coinflips@main
+coinflips@trial
+numbers@main
 ```
 
 The following file `hello.zson` is also used.

--- a/docs/language/operators/get.md
+++ b/docs/language/operators/get.md
@@ -1,0 +1,7 @@
+### Operator
+
+&emsp; **get** &mdash; source data from a URI
+
+### Synopsis
+
+`get` is a shorthand notation for `from`. See the [from operator](from.md) documentation for details.


### PR DESCRIPTION
The multi-pool access with `from` introduced in #4072 was missing from the docs, and the `from` docs have been incomplete in other ways or some time. Here I've attempted to bring things up to date.

Closes #4077