### PR TITLE
Fix meta queries on empty pools

### DIFF
--- a/compiler/semantic/op.go
+++ b/compiler/semantic/op.go
@@ -218,7 +218,7 @@ func semPoolWithName(ctx context.Context, scope *Scope, p *ast.Pool, poolName st
 		}
 	}
 	if p.Spec.Meta != "" {
-		if commitID != ksuid.Nil {
+		if commit != "" {
 			return &dag.CommitMeta{
 				Kind:      "CommitMeta",
 				Meta:      p.Spec.Meta,

--- a/lake/ztests/meta-empty-pool.yaml
+++ b/lake/ztests/meta-empty-pool.yaml
@@ -1,0 +1,16 @@
+script: |
+  export ZED_LAKE=test
+  zed init -q
+  zed create -q test
+  zed log -use test
+  zed query 'from test@main:objects'
+  zed query 'from test@main:partitions'
+  zed query 'from test@main:rawlog'
+  zed query 'from test@main:indexes'
+  zed query 'from test@main:vectors'
+
+outputs: 
+  - name: stdout
+    data: ""
+  - name: stderr
+    data: ""

--- a/runtime/exec/meta.go
+++ b/runtime/exec/meta.go
@@ -194,7 +194,7 @@ func NewCommitMetaPlanner(ctx context.Context, zctx *zed.Context, r *lake.Root, 
 		if err != nil {
 			return nil, err
 		}
-		reader, err := partitionReader(ctx, zctx, p.Layout, snap)
+		reader, err := partitionReader(ctx, zctx, p.Layout, snap, filter)
 		if err != nil {
 			return nil, err
 		}

--- a/runtime/exec/partition.go
+++ b/runtime/exec/partition.go
@@ -13,6 +13,7 @@ import (
 	"github.com/brimdata/zed/runtime/expr"
 	"github.com/brimdata/zed/runtime/expr/extent"
 	"github.com/brimdata/zed/runtime/meta"
+	"github.com/brimdata/zed/zbuf"
 	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zson"
 	"github.com/segmentio/ksuid"
@@ -114,12 +115,12 @@ func sortObjects(o order.Which, objects []*data.Object) {
 	}
 }
 
-func partitionReader(ctx context.Context, zctx *zed.Context, layout order.Layout, snap commits.View) (zio.Reader, error) {
+func partitionReader(ctx context.Context, zctx *zed.Context, layout order.Layout, snap commits.View, filter zbuf.Filter) (zio.Reader, error) {
 	ch := make(chan meta.Partition)
 	ctx, cancel := context.WithCancel(ctx)
 	var scanErr error
 	go func() {
-		scanErr = ScanPartitions(ctx, snap, layout, nil, ch)
+		scanErr = ScanPartitions(ctx, snap, layout, filter, ch)
 		close(ch)
 	}()
 	m := zson.NewZNGMarshalerWithContext(zctx)

--- a/service/ztests/meta-empty-pool.yaml
+++ b/service/ztests/meta-empty-pool.yaml
@@ -1,0 +1,20 @@
+script: |
+  source service.sh
+  zed create -q test
+  zed log -use test
+  zed query 'from test@main:objects'
+  zed query 'from test@main:partitions'
+  zed query 'from test@main:rawlog'
+  zed query 'from test@main:indexes'
+  zed query 'from test@main:vectors'
+
+inputs:
+  - name: service.sh
+    source: service.sh
+
+outputs: 
+  - name: stdout
+    data: ""
+  - name: stderr
+    data: ""
+


### PR DESCRIPTION
Fix bug with running meta commit queries on empty pools. Previously the error message would state that the meta type for the commit did not exist when it did. Change this so the query remains a meta commit query and a query on an empty snapshot is run.

This pr also fixes a panic that occurred when running a partitions meta query on an empty pool.

Closes #3029