### PR TITLE
Shorten link to AWS S3 KB entry

### DIFF
--- a/docs/integrations/amazon-s3.md
+++ b/docs/integrations/amazon-s3.md
@@ -41,7 +41,7 @@ environment variable to the hostname or URI of the provider.
 
 ## Wildcard Support
 
-[Like the AWS CLI tools themselves](https://aws.amazon.com/premiumsupport/knowledge-center/s3-event-notification-filter-wildcard/#:~:text=Because%20the%20wildcard%20asterisk%20character,suffix%20object%20key%20name%20filter.),
+[Like the AWS CLI tools themselves](https://aws.amazon.com/premiumsupport/knowledge-center/s3-event-notification-filter-wildcard),
 Zed does not currently expand UNIX-style `*` wildcards in S3 URIs. If you
 find this limitation is impacting your workflow, please add your use case
 details as a comment in issue [zed/1994](https://github.com/brimdata/zed/issues/1994)


### PR DESCRIPTION
In my changes for #4202, I made the mistake of using a link that seemed to come up fine in my browser but the `muffet` link checker later choked on because of its problem with anchors. Thankfully the link works fine without the anchor portion, so I've removed it here. I verified the fix is effective by doing a deploy to a staging test site on Netlify and running `muffet` successfully against that.