### PR TITLE
fix pushdown bug in parallelizer

### DIFF
--- a/compiler/optimizer/parallelize.go
+++ b/compiler/optimizer/parallelize.go
@@ -15,7 +15,7 @@ func orderAsDirection(which order.Which) int {
 	return -1
 }
 
-//XXX assume the trunk is from a from op at seq.Ops[0] and we will
+// XXX assume the trunk is from a from op at seq.Ops[0] and we will
 // possible insert an operator at seq.Op[1]
 func (o *Optimizer) parallelizeTrunk(seq *dag.Sequential, trunk *dag.Trunk, replicas int) error {
 	from, ok := seq.Ops[0].(*dag.From)
@@ -223,10 +223,15 @@ func replicateTrunk(from *dag.From, trunk *dag.Trunk, replicas int) {
 				Ops:  copyOps(seq.Ops),
 			}
 		}
+		pd := trunk.Pushdown
+		if pd != nil {
+			pd = copyOp(pd)
+		}
 		replica := dag.Trunk{
-			Kind:   "Trunk",
-			Source: src,
-			Seq:    newSeq,
+			Kind:     "Trunk",
+			Source:   src,
+			Seq:      newSeq,
+			Pushdown: pd,
 		}
 		from.Trunks = append(from.Trunks, replica)
 	}

--- a/compiler/ztests/par-pushdown.yaml
+++ b/compiler/ztests/par-pushdown.yaml
@@ -1,0 +1,12 @@
+script: |
+  export ZED_LAKE=test
+  zed init -q
+  zed create -q -orderby ts test
+  zc -P 3 "from test | x==1" | zq -z "over ops[0].trunks | yield pushdown.expr.kind" -
+
+outputs:
+  - name: stdout
+    data: |
+      "BinaryExpr"
+      "BinaryExpr"
+      "BinaryExpr"


### PR DESCRIPTION
This commit fixes a bug where the pushdown was not replicated into the parallized paths in the optimizer.  This would explain some performance issues where lake queries run slower than the equivalent zq because the pushdown logic would not reach the buffer-filter in the ZNG scanner.