### PR TITLE
simplify scans of snapshot metadata

### DIFF
--- a/runtime/op/meta/lister.go
+++ b/runtime/op/meta/lister.go
@@ -8,7 +8,6 @@ import (
 	"github.com/brimdata/zed/lake"
 	"github.com/brimdata/zed/lake/commits"
 	"github.com/brimdata/zed/lake/data"
-	"github.com/brimdata/zed/lake/index"
 	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/runtime/expr"
 	"github.com/brimdata/zed/runtime/expr/extent"
@@ -26,11 +25,11 @@ type Lister struct {
 	pool      *lake.Pool
 	snap      commits.View
 	filter    zbuf.Filter
-	once      sync.Once
-	ch        chan Partition
 	group     *errgroup.Group
 	marshaler *zson.MarshalZNGContext
 	mu        sync.Mutex
+	parts     []Partition
+	err       error
 }
 
 var _ zbuf.Puller = (*Lister)(nil)
@@ -57,8 +56,6 @@ func NewSortedListerFromSnap(ctx context.Context, r *lake.Root, pool *lake.Pool,
 		pool:      pool,
 		snap:      snap,
 		filter:    filter,
-		once:      sync.Once{},
-		ch:        make(chan Partition), //XXX
 		group:     &errgroup.Group{},
 		marshaler: zson.NewZNGMarshaler(),
 	}
@@ -69,58 +66,30 @@ func (l *Lister) Snapshot() commits.View {
 }
 
 func (l *Lister) Pull(done bool) (zbuf.Batch, error) {
-	l.once.Do(func() {
-		l.run()
-	})
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	select {
-	case part := <-l.ch:
-		if part.Objects == nil {
-			err := l.group.Wait()
-			return nil, err
-		}
-		val, err := l.marshaler.Marshal(part)
+	if l.err != nil {
+		return nil, l.err
+	}
+	if l.parts == nil {
+		var err error
+		l.parts, err = sortedPartitions(l.snap, l.pool.Layout, l.filter)
 		if err != nil {
+			l.err = err
 			return nil, err
 		}
-		return zbuf.NewArray([]zed.Value{*val}), nil
-	case <-l.ctx.Done():
-		return nil, l.group.Wait()
 	}
-}
-
-func (l *Lister) run() {
-	var ctx context.Context
-	l.group, ctx = errgroup.WithContext(l.ctx)
-	l.group.Go(func() error {
-		defer close(l.ch)
-		return ScanPartitions(ctx, l.snap, l.pool.Layout, l.filter, l.ch)
-	})
-}
-
-func Scan(ctx context.Context, snap commits.View, o order.Which, ch chan<- data.Object) error {
-	for _, object := range snap.Select(nil, o) {
-		select {
-		case ch <- *object:
-		case <-ctx.Done():
-			return ctx.Err()
-		}
+	if len(l.parts) == 0 {
+		return nil, l.err
 	}
-	return nil
-}
-
-func ScanInOrder(ctx context.Context, snap commits.View, o order.Which, ch chan<- data.Object) error {
-	objects := snap.Select(nil, o)
-	sortObjects(o, objects)
-	for _, object := range objects {
-		select {
-		case ch <- *object:
-		case <-ctx.Done():
-			return ctx.Err()
-		}
+	part := l.parts[0]
+	l.parts = l.parts[1:]
+	val, err := l.marshaler.Marshal(part)
+	if err != nil {
+		l.err = err
+		return nil, err
 	}
-	return nil
+	return zbuf.NewArray([]zed.Value{*val}), nil
 }
 
 func filterObjects(objects []*data.Object, filter *expr.SpanFilter, o order.Which) []*data.Object {
@@ -135,35 +104,17 @@ func filterObjects(objects []*data.Object, filter *expr.SpanFilter, o order.Whic
 	return out
 }
 
-// ScanPartitions partitions all the data objects in snap overlapping
+// sortedPartitions partitions all the data objects in snap overlapping
 // span into non-overlapping partitions, sorts them by pool key and order,
 // and sends them to ch.
-func ScanPartitions(ctx context.Context, snap commits.View, layout order.Layout, filter zbuf.Filter, ch chan<- Partition) error {
+func sortedPartitions(snap commits.View, layout order.Layout, filter zbuf.Filter) ([]Partition, error) {
 	objects := snap.Select(nil, layout.Order)
 	if filter != nil {
 		f, err := filter.AsKeySpanFilter(layout.Primary(), layout.Order)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		objects = filterObjects(objects, f, layout.Order)
 	}
-	for _, p := range PartitionObjects(objects, layout.Order) {
-		select {
-		case ch <- p:
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-	}
-	return nil
-}
-
-func ScanIndexes(ctx context.Context, snap commits.View, o order.Which, ch chan<- *index.Object) error {
-	for _, idx := range snap.SelectIndexes(nil, o) {
-		select {
-		case ch <- idx:
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-	}
-	return nil
+	return partitionObjects(objects, layout.Order), nil
 }

--- a/runtime/op/meta/lister.go
+++ b/runtime/op/meta/lister.go
@@ -72,11 +72,9 @@ func (l *Lister) Pull(done bool) (zbuf.Batch, error) {
 		return nil, l.err
 	}
 	if l.parts == nil {
-		var err error
-		l.parts, err = sortedPartitions(l.snap, l.pool.Layout, l.filter)
-		if err != nil {
-			l.err = err
-			return nil, err
+		l.parts, l.err = sortedPartitions(l.snap, l.pool.Layout, l.filter)
+		if l.err != nil {
+			return nil, l.err
 		}
 	}
 	if len(l.parts) == 0 {

--- a/runtime/op/meta/slicer.go
+++ b/runtime/op/meta/slicer.go
@@ -9,7 +9,6 @@ import (
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/lake/commits"
 	"github.com/brimdata/zed/lake/data"
-	"github.com/brimdata/zed/lake/index"
 	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/runtime/expr"
 	"github.com/brimdata/zed/runtime/expr/extent"
@@ -19,7 +18,7 @@ import (
 	"github.com/segmentio/ksuid"
 )
 
-// PartitionObjects takes a sorted set of data objects with possibly overlapping
+// partitionObjects takes a sorted set of data objects with possibly overlapping
 // key ranges and returns an ordered list of Ranges such that none of the
 // Ranges overlap with one another.  This is the straightforward computational
 // geometry problem of merging overlapping intervals,
@@ -28,7 +27,7 @@ import (
 // XXX this algorithm doesn't quite do what we want because it continues
 // to merge *anything* that overlaps.  It's easy to fix though.
 // Issue #2538
-func PartitionObjects(objects []*data.Object, o order.Which) []Partition {
+func partitionObjects(objects []*data.Object, o order.Which) []Partition {
 	if len(objects) == 0 {
 		return nil
 	}
@@ -124,67 +123,35 @@ func objectSpanLess(a, b objectSpan) bool {
 	return a.After(b.Last())
 }
 
-func sortObjects(o order.Which, objects []*data.Object) {
-	for k, span := range sortedObjectSpans(objects, extent.CompareFunc(o)) {
-		objects[k] = span.object
-	}
-}
-
 func partitionReader(ctx context.Context, zctx *zed.Context, layout order.Layout, snap commits.View, filter zbuf.Filter) (zio.Reader, error) {
-	ch := make(chan Partition)
-	ctx, cancel := context.WithCancel(ctx)
-	var scanErr error
-	go func() {
-		scanErr = ScanPartitions(ctx, snap, layout, filter, ch)
-		close(ch)
-	}()
+	parts, err := sortedPartitions(snap, layout, filter)
+	if err != nil {
+		return nil, err
+	}
 	m := zson.NewZNGMarshalerWithContext(zctx)
 	m.Decorate(zson.StylePackage)
 	return readerFunc(func() (*zed.Value, error) {
-		select {
-		case p := <-ch:
-			if p.Objects == nil {
-				cancel()
-				return nil, scanErr
-			}
-			rec, err := m.Marshal(p)
-			if err != nil {
-				cancel()
-				return nil, err
-			}
-			return rec, nil
-		case <-ctx.Done():
-			return nil, ctx.Err()
+		if len(parts) == 0 {
+			return nil, nil
 		}
+		p := parts[0]
+		val, err := m.Marshal(p)
+		parts = parts[1:]
+		return val, err
 	}), nil
 }
 
 func indexObjectReader(ctx context.Context, zctx *zed.Context, snap commits.View, order order.Which) (zio.Reader, error) {
-	ch := make(chan *index.Object)
-	ctx, cancel := context.WithCancel(ctx)
-	var scanErr error
-	go func() {
-		scanErr = ScanIndexes(ctx, snap, order, ch)
-		close(ch)
-	}()
+	indexes := snap.SelectIndexes(nil, order)
 	m := zson.NewZNGMarshalerWithContext(zctx)
 	m.Decorate(zson.StylePackage)
 	return readerFunc(func() (*zed.Value, error) {
-		select {
-		case p := <-ch:
-			if p == nil {
-				cancel()
-				return nil, scanErr
-			}
-			rec, err := m.Marshal(*p)
-			if err != nil {
-				cancel()
-				return nil, err
-			}
-			return rec, nil
-		case <-ctx.Done():
-			return nil, ctx.Err()
+		if len(indexes) == 0 {
+			return nil, nil
 		}
+		val, err := m.Marshal(indexes[0])
+		indexes = indexes[1:]
+		return val, err
 	}), nil
 }
 


### PR DESCRIPTION
This commit simplifies how snapshot metadata is scanned by embracing the fact that snapshots are stored entirely in memory.  To this end, we removed the channels that streamed metadata as the original intention was that the snapshot would not necessarily fit entirely in memory. However, we can go a long way toward huge Zed lakes with the in-memory constraint and when we want to scale further, we can work a design that is consistent with where the Zed lake architecture lands in the future.

We also removed the unnecessary calls the zbuf.MultiScanner when there was only one scanner and updated some functions that did not need to be exported.

This is part of #4212 