### PR TITLE
upgrade to Go 1.19

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ in [runtime/expr/agg](runtime/expr/agg).
 
 ## Development
 
-`zed` requires Go 1.18 or later, and uses [Go modules](https://github.com/golang/go/wiki/Modules).
+`zed` requires Go 1.19 or later, and uses [Go modules](https://github.com/golang/go/wiki/Modules).
 Dependencies are specified in the [`go.mod` file](./go.mod) and fetched
 automatically by commands like `go build` and `go test`.  No explicit
 fetch commands are necessary.  However, you must set the environment

--- a/columnbuilder.go
+++ b/columnbuilder.go
@@ -46,10 +46,11 @@ func (e errNonAdjacent) Unwrap() error {
 // 10. builder.EndContainer()    // for "y"
 //
 // This is encoded into the following fieldInfo objects:
-//  {name: "a", fullname: "a", containerBegins: [], containerEnds: 0}         // step 1
-//  {name: "c", fullname: "b.c", containerBegins: ["b"], containerEnds: 0}      // steps 2-3
-//  {name: "d", fullname: "b.d", containerBegins: [], containerEnds: 1     }    // steps 4-5
-//  {name: "z", fullname: "x.y.z", containerBegins: ["x", "y"], containerEnds: 2} // steps 6-10
+//
+//	{name: "a", fullname: "a", containerBegins: [], containerEnds: 0}         // step 1
+//	{name: "c", fullname: "b.c", containerBegins: ["b"], containerEnds: 0}      // steps 2-3
+//	{name: "d", fullname: "b.d", containerBegins: [], containerEnds: 1     }    // steps 4-5
+//	{name: "z", fullname: "x.y.z", containerBegins: ["x", "y"], containerEnds: 2} // steps 6-10
 type fieldInfo struct {
 	field           field.Path
 	containerBegins []string

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -15064,18 +15064,17 @@ func Entrypoint(ruleName string) Option {
 //
 // Example usage:
 //
-//     input := "input"
-//     stats := Stats{}
-//     _, err := Parse("input-file", []byte(input), Statistics(&stats, "no match"))
-//     if err != nil {
-//         log.Panicln(err)
-//     }
-//     b, err := json.MarshalIndent(stats.ChoiceAltCnt, "", "  ")
-//     if err != nil {
-//         log.Panicln(err)
-//     }
-//     fmt.Println(string(b))
-//
+//	input := "input"
+//	stats := Stats{}
+//	_, err := Parse("input-file", []byte(input), Statistics(&stats, "no match"))
+//	if err != nil {
+//	    log.Panicln(err)
+//	}
+//	b, err := json.MarshalIndent(stats.ChoiceAltCnt, "", "  ")
+//	if err != nil {
+//	    log.Panicln(err)
+//	}
+//	fmt.Println(string(b))
 func Statistics(stats *Stats, choiceNoMatch string) Option {
 	return func(p *parser) Option {
 		oldStats := p.Stats

--- a/compiler/reader.go
+++ b/compiler/reader.go
@@ -23,7 +23,7 @@ func (i *anyCompiler) NewQuery(pctx *op.Context, o ast.Op, readers []zio.Reader)
 	return CompileWithLayout(pctx, o, readers[0], order.Layout{})
 }
 
-//XXX currently used only by group-by test, need to deprecate
+// XXX currently used only by group-by test, need to deprecate
 func CompileWithLayout(pctx *op.Context, o ast.Op, r zio.Reader, layout order.Layout) (*runtime.Query, error) {
 	job, err := NewJob(pctx, o, data.NewSource(nil, nil), nil)
 	if err != nil {

--- a/complex.go
+++ b/complex.go
@@ -235,7 +235,7 @@ func (t *TypeRecord) ID() int {
 	return t.id
 }
 
-//XXX we shouldn't need this... tests are using it
+// XXX we shouldn't need this... tests are using it
 func (t *TypeRecord) Decode(zv zcode.Bytes) ([]Value, error) {
 	if zv == nil {
 		return nil, nil

--- a/docs/install.md
+++ b/docs/install.md
@@ -48,7 +48,7 @@ go install github.com/brimdata/zed/cmd/{zed,zq}@latest
 This installs the `zed` and `zq` binaries in your `$GOPATH/bin`.
 
 > If you don't have Go installed, download and install it from the
-> [Go install page](https://golang.org/doc/install). Go 1.18 or later is
+> [Go install page](https://golang.org/doc/install). Go 1.19 or later is
 > required.
 
 Once installed, run a [quick test](#quick-tests).

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/brimdata/zed
 
-go 1.18
+go 1.19
 
 require (
 	github.com/agnivade/levenshtein v1.1.1

--- a/lake/data/object.go
+++ b/lake/data/object.go
@@ -50,7 +50,7 @@ func (k FileKind) Description() string {
 
 var fileRegex = regexp.MustCompile(`([0-9A-Za-z]{27}-(data|meta)).zng$`)
 
-//XXX this won't work right until we integrate segID
+// XXX this won't work right until we integrate segID
 func FileMatch(s string) (kind FileKind, id ksuid.KSUID, ok bool) {
 	match := fileRegex.FindStringSubmatch(s)
 	if match == nil {

--- a/lake/journal/queue.go
+++ b/lake/journal/queue.go
@@ -91,7 +91,7 @@ func (q *Queue) Boundaries(ctx context.Context) (ID, ID, error) {
 	return head, tail, nil
 }
 
-//XXX This needs concurrency work. See issue #2546.
+// XXX This needs concurrency work. See issue #2546.
 func (q *Queue) Commit(ctx context.Context, b []byte) (ID, error) {
 	head, err := q.ReadHead(ctx)
 	if err != nil {

--- a/lake/pool.go
+++ b/lake/pool.go
@@ -191,7 +191,7 @@ func (p *Pool) BatchifyBranchTips(ctx context.Context, zctx *zed.Context, f expr
 	return recs, nil
 }
 
-//XXX this is inefficient but is only meant for interactive queries...?
+// XXX this is inefficient but is only meant for interactive queries...?
 func (p *Pool) ObjectExists(ctx context.Context, id ksuid.KSUID) (bool, error) {
 	return p.engine.Exists(ctx, data.SequenceURI(p.DataPath, id))
 }

--- a/lake/writer.go
+++ b/lake/writer.go
@@ -48,7 +48,7 @@ type Writer struct {
 
 // NewWriter creates a zio.Writer compliant writer for writing data to an
 // a data pool presuming the input is not guaranteed to be sorted.
-//XXX we should make another writer that takes sorted input and is a bit
+// XXX we should make another writer that takes sorted input and is a bit
 // more efficient.  This other writer could have different commit triggers
 // to do useful things like paritioning given the context is a rollup.
 func NewWriter(ctx context.Context, zctx *zed.Context, pool *Pool) (*Writer, error) {

--- a/mdtest/mdtest.go
+++ b/mdtest/mdtest.go
@@ -6,15 +6,15 @@
 // mdtest-input, mdtest-command, or mdtest-output as the first word.  The
 // mdtest-command and mdtest-output blocks must be paired.
 //
-//    ```mdtest-input file.txt
-//    hello
-//    ```
-//    ```mdtest-command [dir=...] [fails]
-//    cat file.txt
-//    ```
-//    ```mdtest-output [head]
-//    hello
-//    ```
+//	```mdtest-input file.txt
+//	hello
+//	```
+//	```mdtest-command [dir=...] [fails]
+//	cat file.txt
+//	```
+//	```mdtest-output [head]
+//	hello
+//	```
 //
 // The content of each mdtest-command block is fed to "bash -e -o pipefail" on
 // standard input.
@@ -36,14 +36,14 @@
 // block content is ignored, and what remains must be a prefix of the shell
 // output.
 //
-//    ```mdtest-command
-//    echo hello
-//    echo goodbye
-//    ```
-//    ```mdtest-output head
-//    hello
-//    ...
-//    ```
+//	```mdtest-command
+//	echo hello
+//	echo goodbye
+//	```
+//	```mdtest-output head
+//	hello
+//	...
+//	```
 package mdtest
 
 import (

--- a/runtime/expr/boolean.go
+++ b/runtime/expr/boolean.go
@@ -126,7 +126,7 @@ func CompareTime(op string, pattern int64) (Boolean, error) {
 	}, nil
 }
 
-//XXX should just do equality and we should compare in the encoded domain
+// XXX should just do equality and we should compare in the encoded domain
 // and not make copies and have separate cases for len 4 and len 16
 var compareAddr = map[string]func(netip.Addr, netip.Addr) bool{
 	"==": func(a, b netip.Addr) bool { return a.Compare(b) == 0 },

--- a/service/srverr/error.go
+++ b/service/srverr/error.go
@@ -97,10 +97,10 @@ func (e *Error) Message() string {
 }
 
 // Function E generates an error from any mix of:
-// - a Kind
-// - an existing error
-// - a string and optional formatting verbs, like fmt.Errorf (including support
-//	for the `%w` verb).
+//   - a Kind
+//   - an existing error
+//   - a string and optional formatting verbs, like fmt.Errorf (including support
+//     for the `%w` verb).
 //
 // The string & format verbs must be last in the arguments, if present.
 func E(args ...interface{}) error {

--- a/zbuf/array.go
+++ b/zbuf/array.go
@@ -16,7 +16,7 @@ var _ Batch = (*Array)(nil)
 var _ zio.Reader = (*Array)(nil)
 var _ zio.Writer = (*Array)(nil)
 
-//XXX this should take the frame arg too and the procs that create
+// XXX this should take the frame arg too and the procs that create
 // new arrays need to propagate their frames downstream.
 func NewArray(vals []zed.Value) *Array {
 	return &Array{values: vals}

--- a/zfmt/zed.go
+++ b/zfmt/zed.go
@@ -9,7 +9,7 @@ type canonZed struct {
 	formatter
 }
 
-//XXX this needs to change when we use the zson values from the ast
+// XXX this needs to change when we use the zson values from the ast
 func (c *canonZed) literal(e astzed.Primitive) {
 	switch e.Type {
 	case "string", "error":

--- a/zio/zngio/batch.go
+++ b/zio/zngio/batch.go
@@ -49,7 +49,7 @@ func (b *batch) unextend() {
 
 func (b *batch) Values() []zed.Value { return b.vals }
 
-//XXX
+// XXX
 func (b *batch) NewValue(typ zed.Type, bytes zcode.Bytes) *zed.Value {
 	return zed.NewValue(typ, bytes)
 }
@@ -72,7 +72,7 @@ func (b *batch) Unref() {
 	}
 }
 
-//XXX this should be ok, but we should handle nil receiver in scope so push
+// XXX this should be ok, but we should handle nil receiver in scope so push
 // will do the right thing
 func (*batch) Vars() []zed.Value { return nil }
 

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -12,33 +12,33 @@
 //
 // A Zed-style test is defined in a YAML file.
 //
-//    zed: count()
+//	zed: count()
 //
-//    input: |
-//      #0:record[i:int64]
-//      0:[1;]
-//      0:[2;]
+//	input: |
+//	  #0:record[i:int64]
+//	  0:[1;]
+//	  0:[2;]
 //
-//    output: |
-//      #0:record[count:uint64]
-//      0:[2;]
+//	output: |
+//	  #0:record[count:uint64]
+//	  0:[2;]
 //
 // Input format is detected automatically and can be anything recognized by
 // "zq -i auto" (including optional gzip compression).  Output format defaults
 // to tzng but can be set to anything accepted by "zq -f".
 //
-//    zed: count()
+//	zed: count()
 //
-//    input: |
-//      #0:record[i:int64]
-//      0:[1;]
-//      0:[2;]
+//	input: |
+//	  #0:record[i:int64]
+//	  0:[1;]
+//	  0:[2;]
 //
-//    output-flags: -f table
+//	output-flags: -f table
 //
-//    output: |
-//      count
-//      2
+//	output: |
+//	  count
+//	  2
 //
 // Alternatively, tests can be configured to run as shell scripts.
 // In this style of test, arbitrary bash scripts can run chaining together
@@ -53,27 +53,30 @@
 // defining the script, e.g.,
 //
 // inputs:
-//    - name: in1.tzng
-//      data: |
-//         #0:record[i:int64]
-//         0:[1;]
-//    - name: stdin
-//      data: |
-//         #0:record[i:int64]
-//         0:[2;]
+//   - name: in1.tzng
+//     data: |
+//     #0:record[i:int64]
+//     0:[1;]
+//   - name: stdin
+//     data: |
+//     #0:record[i:int64]
+//     0:[2;]
+//
 // script: |
-//    zq -o out.tzng in1.tzng -
-//    zq -o count.tzng "count()" out.tzng
+//
+//	zq -o out.tzng in1.tzng -
+//	zq -o count.tzng "count()" out.tzng
+//
 // outputs:
-//    - name: out.tzng
-//      data: |
-//         #0:record[i:int64]
-//         0:[1;]
-//         0:[2;]
-//    - name: count.tzng
-//      data: |
-//         #0:record[count:uint64]
-//         0:[2;]
+//   - name: out.tzng
+//     data: |
+//     #0:record[i:int64]
+//     0:[1;]
+//     0:[2;]
+//   - name: count.tzng
+//     data: |
+//     #0:record[count:uint64]
+//     0:[2;]
 //
 // Each input and output has a name.  For inputs, a file (source)
 // or inline data (data) may be specified.
@@ -89,21 +92,21 @@
 // Ztest YAML files for a package should reside in a subdirectory named
 // testdata/ztest.
 //
-//     pkg/
-//       pkg.go
-//       pkg_test.go
-//       testdata/
-//         ztest/
-//           test-1.yaml
-//           test-2.yaml
-//           ...
+//	pkg/
+//	  pkg.go
+//	  pkg_test.go
+//	  testdata/
+//	    ztest/
+//	      test-1.yaml
+//	      test-2.yaml
+//	      ...
 //
 // Name YAML files descriptively since each ztest runs as a subtest
 // named for the file that defines it.
 //
 // pkg_test.go should contain a Go test named TestZTest that calls Run.
 //
-//     func TestZTest(t *testing.T) { ztest.Run(t, "testdata/ztest") }
+//	func TestZTest(t *testing.T) { ztest.Run(t, "testdata/ztest") }
 //
 // If the ZTEST_PATH environment variable is unset or empty and the test
 // is not a script test, Run runs ztests in the current process and skips


### PR DESCRIPTION
Go 1.19.3 has been out for a couple of weeks.  It adds new types in sync/atomic that are easier to use.

Changes to Go source files are from "gofmt -s -w .".