### PR TITLE
Mention line mode among the formats not handled by auto-detect

### DIFF
--- a/service/ztests/curl-load-error.yaml
+++ b/service/ztests/curl-load-error.yaml
@@ -16,7 +16,7 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      {"type":"Error","kind":"invalid operation","error":"format detection error\n\tzeek: line 1: bad types/fields definition in zeek header\n\tzjson: line 1: invalid character 'T' looking for beginning of value\n\tzson: ZSON syntax error\n\tzng: malformed zng record\n\tzng21: malformed zng record\n\tcsv: line 1: EOF\n\tjson: invalid character 'T' looking for beginning of value\n\tparquet: auto-detection not supported\n\tzst: auto-detection not supported"}
+      {"type":"Error","kind":"invalid operation","error":"format detection error\n\tzeek: line 1: bad types/fields definition in zeek header\n\tzjson: line 1: invalid character 'T' looking for beginning of value\n\tzson: ZSON syntax error\n\tzng: malformed zng record\n\tzng21: malformed zng record\n\tcsv: line 1: EOF\n\tjson: invalid character 'T' looking for beginning of value\n\tparquet: auto-detection not supported\n\tzst: auto-detection not supported\n\tline: auto-detection not supported"}
       code 400
       {"type":"Error","kind":"invalid operation","error":"unsupported MIME type: unsupported"}
       code 400

--- a/service/ztests/load-garbage.yaml
+++ b/service/ztests/load-garbage.yaml
@@ -22,4 +22,5 @@ outputs:
       	json: invalid character 'T' looking for beginning of value
       	parquet: auto-detection not supported
       	zst: auto-detection not supported
+      	line: auto-detection not supported
       status code 400: no records in request

--- a/zio/anyio/reader.go
+++ b/zio/anyio/reader.go
@@ -101,7 +101,8 @@ func NewReaderWithOpts(zctx *zed.Context, r io.Reader, opts ReaderOpts) (zio.Rea
 
 	parquetErr := errors.New("parquet: auto-detection not supported")
 	zstErr := errors.New("zst: auto-detection not supported")
-	return nil, joinErrs([]error{zeekErr, zjsonErr, zsonErr, zngErr, zng21Err, csvErr, jsonErr, parquetErr, zstErr})
+	lineErr := errors.New("line: auto-detection not supported")
+	return nil, joinErrs([]error{zeekErr, zjsonErr, zsonErr, zngErr, zng21Err, csvErr, jsonErr, parquetErr, zstErr, lineErr})
 }
 
 func joinErrs(errs []error) error {


### PR DESCRIPTION
The input in line mode that was added in #4175 is not covered by auto-detect. This PR includes it among the unsupported formats mentioned when auto-detect cannot successfully read input.