### PR TITLE
Link to S3 doc

### DIFF
--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -7,7 +7,7 @@ Built-in help for the `zed` command and all of its subcommands is always
 accessible with the `-h` flag.
 
 The [`zq` command](zq.md) offers a convenient slice of `zed` for running
-stand-alone, command-line queries on inputs from files, HTTP URLs, or S3.
+stand-alone, command-line queries on inputs from files, HTTP URLs, or [S3](../integrations/amazon-s3.md).
 `zq` is like [`jq`](https://stedolan.github.io/jq/) but is easier and faster, utilizes the richer
 Zed data model, and interoperates with a number of other formats beyond JSON.
 If you don't need a Zed lake, you can install just the

--- a/docs/commands/zed.md
+++ b/docs/commands/zed.md
@@ -584,7 +584,7 @@ the [input arguments](zq.md#1-usage) can be in
 any [supported format](zq.md#2-input-formats) and
 the input format is auto-detected if `-i` is not provided.  Likewise,
 the inputs may be URLs, in which case, the `load` command streams
-the data from a Web server or S3 and into the lake.
+the data from a Web server or [S3](../integrations/amazon-s3.md) and into the lake.
 
 When data is loaded, it is broken up into objects of a target size determined
 by the pool's `threshold` parameter (which defaults 500MiB but can be configured

--- a/docs/commands/zq.md
+++ b/docs/commands/zq.md
@@ -8,7 +8,7 @@ description: A command-line tool that uses the Zed Language for pipeline-style s
 
 > **TL;DR** `zq` is a command-line tool that uses the [Zed language](../language/README.md)
 for pipeline-style search and analytics.  `zq` can query a variety
-of data formats in files, over HTTP, or in S3 storage.
+of data formats in files, over HTTP, or in [S3](../integrations/amazon-s3.md) storage.
 It is particularly fast when operating on data in the Zed-native [ZNG](../formats/zng.md) format.
 >
 > The `zq` design philosophy blends the query/search-tool approach

--- a/docs/lake/format.md
+++ b/docs/lake/format.md
@@ -211,7 +211,7 @@ the HEAD of the journal is accessed.
 > a file for exclusive access and checking that it has zero length after
 > a successful open.
 
-Second, strong read/write ordering semantics (as exists in Amazon S3)
+Second, strong read/write ordering semantics (as exists in [Amazon S3](../integrations/amazon-s3.md))
 can be used to implement transactional journal updates as follows:
 * _TBD: this is worked out but needs to be written up_
 

--- a/docs/language/overview.md
+++ b/docs/language/overview.md
@@ -108,7 +108,7 @@ In addition to the data sources specified as files on the `zq` command line,
 a source may also be specified with the [`from` operator](operators/from.md).
 
 When running on the command-line, `from` may refer to a file, an HTTP
-endpoint, or an S3 URI.  When running in a [Zed lake](../commands/zed.md), `from` typically
+endpoint, or an [S3](../integrations/amazon-s3.md) URI.  When running in a [Zed lake](../commands/zed.md), `from` typically
 refers to a collection of data called a "data pool" and is referenced using
 the pool's name much as SQL references database tables by their name.
 


### PR DESCRIPTION
Now that there's a doc describing our S3 integration, link to it from the other docs that mention S3.