### PR TITLE
Add MIME type for line format to allow loading over the API

### DIFF
--- a/api/mime.go
+++ b/api/mime.go
@@ -11,6 +11,7 @@ const (
 	MediaTypeAny     = "*/*"
 	MediaTypeCSV     = "text/csv"
 	MediaTypeJSON    = "application/json"
+	MediaTypeLine    = "application/x-line"
 	MediaTypeNDJSON  = "application/x-ndjson"
 	MediaTypeParquet = "application/x-parquet"
 	MediaTypeZJSON   = "application/x-zjson"
@@ -43,6 +44,8 @@ func MediaTypeToFormat(s string, dflt string) (string, error) {
 		return "csv", nil
 	case MediaTypeJSON:
 		return "json", nil
+	case MediaTypeLine:
+		return "line", nil
 	case MediaTypeNDJSON:
 		return "ndjson", nil
 	case MediaTypeParquet:
@@ -63,6 +66,8 @@ func FormatToMediaType(format string) string {
 		return MediaTypeCSV
 	case "json":
 		return MediaTypeJSON
+	case "line":
+		return MediaTypeLine
 	case "ndjson":
 		return MediaTypeNDJSON
 	case "parquet":

--- a/service/ztests/curl-load-line.yaml
+++ b/service/ztests/curl-load-line.yaml
@@ -1,0 +1,23 @@
+script: |
+  source service.sh
+  zed create -q test
+  curl -w 'code %{response_code}\n' -X POST -H 'Accept: application/json' \
+    -H 'Content-Type: application/x-line' \
+    --data-binary @f $ZED_LAKE/pool/test/branch/main |
+    sed -E 's/0x[0-9a-f]{40}/xxx/'
+  zed query -z 'from test'
+
+inputs:
+  - name: f
+    data: |
+      hello world
+      goodbye everyone
+  - name: service.sh
+
+outputs:
+  - name: stdout
+    data: |
+      {"commit":"xxx","warnings":[]}
+      code 200
+      "hello world"
+      "goodbye everyone"


### PR DESCRIPTION
After I opened #4227, @nwt helpfully pointed me at `api/mime.go` and indeed I found that making it work was as simple as adding the appropriate mapping for the MIME type.

For example, using this branch and the input data [sample.txt](https://github.com/brimdata/zed/files/10118990/sample.txt), which contains Zeek's text output of cipher descriptions I've been working with lately:

```
$ cat sample.txt
[49292] = TLS_ECDH_RSA_WITH_CAMELLIA_128_GCM_SHA256,
[58] = TLS_DH_ANON_WITH_AES_256_CBC_SHA,
[49304] = TLS_RSA_PSK_WITH_CAMELLIA_128_CBC_SHA256,
...

$ zed create foo
pool created: foo 2IFTTEXqLrBLeU6DwtZskNZYyut

$ curl -X POST -H 'Accept: application/json' -H 'Content-Type: application/x-line' --data-binary @sample.txt http://localhost:9867/pool/foo/branch/main
{"commit":"0x101475e2006876a89e235db533bd4ca6666539c5","warnings":[]}

$ zed query 'from foo | head 3'
"[9] = TLS_RSA_WITH_DES_CBC_SHA,"
"[99] = TLS_DHE_DSS_EXPORT1024_WITH_DES_CBC_SHA,"
"[98] = TLS_RSA_EXPORT1024_WITH_DES_CBC_SHA,"
```

Note that I had to use `--data-binary` with `curl` to get it to leave the newlines intact, but it otherwise seems to do the trick.

I scratched my head for a bit wondering about the appropriate MIME type, with `text/plain` being the other obvious choice. However, that seems generic enough that I expect that hogging it to represent this one specific kind of text file would be a mistake. Therefore I cooked up `application/x-line`. I'm open to other suggestions of course.

If this change is deemed ok, what I'll plan to do in a separate PR is start improving the [media types API docs](https://zed.brimdata.io/docs/lake/api#media-types) to specify which MIME types are supported response content types vs. types for load. Right now it's written as if it's only describing response types, and the [load API docs](https://zed.brimdata.io/docs/lake/api#load-data) speak if MIME type but don't show/reference a table.

Fixes #4227.