### PR TITLE
object span: Do not return nil span with nil value

### DIFF
--- a/lake/data/object.go
+++ b/lake/data/object.go
@@ -121,10 +121,6 @@ func NewObject() Object {
 }
 
 func (o Object) Span(order order.Which) *extent.Generic {
-	if o.First.Bytes == nil || o.Last.Bytes == nil {
-		//XXX
-		return nil
-	}
 	return extent.NewGenericFromOrder(o.First, o.Last, order)
 }
 


### PR DESCRIPTION
Make it so an object never returns a nil span. If upper or lower or nil trust that compare will properly handle this case.

Closes #4177