### PR TITLE
runtime/vcache: remove unnecessary errgroup.(*Group).SetLimit calls

### DIFF
--- a/runtime/vcache/object.go
+++ b/runtime/vcache/object.go
@@ -71,7 +71,6 @@ func NewObject(ctx context.Context, engine storage.Engine, uri *storage.URI, id 
 		types = append(types, meta.Type(zctx))
 	}
 	var group errgroup.Group
-	group.SetLimit(-1)
 	vectors := make([]Vector, len(metas))
 	for k, meta := range metas {
 		which := k

--- a/runtime/vcache/projection.go
+++ b/runtime/vcache/projection.go
@@ -60,7 +60,6 @@ func findCuts(o *Object, names []string) ([]*cut, error) {
 	var dirty bool
 	cuts := make([]*cut, len(o.types))
 	var group errgroup.Group
-	group.SetLimit(-1)
 	// Loop through each type to determine if there is a cut and build
 	// a cut for that type.  The creation of all the iterators is done
 	// in parallel to avoid synchronous round trips to storage.
@@ -99,7 +98,6 @@ func findCuts(o *Object, names []string) ([]*cut, error) {
 
 func newCut(zctx *zed.Context, typ *zed.TypeRecord, fields []Vector, actuals []string, reader storage.Reader) (*cut, error) {
 	var group errgroup.Group
-	group.SetLimit(-1)
 	iters := make([]iterator, len(actuals))
 	columns := make([]zed.Column, len(actuals))
 	for k, name := range actuals {

--- a/runtime/vcache/record.go
+++ b/runtime/vcache/record.go
@@ -25,7 +25,6 @@ func NewRecord(fields []vector.Field, r io.ReaderAt) (Record, error) {
 func (r Record) NewIter(reader io.ReaderAt) (iterator, error) {
 	fields := make([]iterator, len(r))
 	var group errgroup.Group
-	group.SetLimit(-1)
 	for k, f := range r {
 		which := k
 		field := f

--- a/runtime/vcache/union.go
+++ b/runtime/vcache/union.go
@@ -41,7 +41,6 @@ func (u *Union) NewIter(reader io.ReaderAt) (iterator, error) {
 		u.tags = tags
 	}
 	var group errgroup.Group
-	group.SetLimit(-1)
 	iters := make([]iterator, len(u.values))
 	for k, v := range u.values {
 		which := k


### PR DESCRIPTION
A zero errgroup.Group has no limit on the number of active goroutines, so SetLimit(-1) will have no effect.