### PR TITLE
service: support loading Parquet via API

### DIFF
--- a/service/ztests/curl-load-parquet.yaml
+++ b/service/ztests/curl-load-parquet.yaml
@@ -3,7 +3,7 @@ script: |
   zed create -q test
   zq -f parquet in.zson |
     curl -H Content-Type:application/x-parquet --data-binary @- \
-    --fail-with-body $ZED_LAKE/pool/test/branch/main | zq -z commit:=0 -
+    --fail $ZED_LAKE/pool/test/branch/main | zq -z commit:=0 -
   echo //
   zed query -z 'from test'
 

--- a/service/ztests/curl-load-parquet.yaml
+++ b/service/ztests/curl-load-parquet.yaml
@@ -1,0 +1,21 @@
+script: |
+  source service.sh
+  zed create -q test
+  zq -f parquet in.zson |
+    curl -H Content-Type:application/x-parquet --data-binary @- \
+    --fail-with-body $ZED_LAKE/pool/test/branch/main | zq -z commit:=0 -
+  echo //
+  zed query -z 'from test'
+
+inputs:
+  - name: in.zson
+    data: |
+      {x:1}
+  - name: service.sh
+
+outputs:
+  - name: stdout
+    data: |
+      {commit:0,warnings:[]([string])}
+      //
+      {x:1}


### PR DESCRIPTION
When loading data via POST /pool/{pool}/branch/{branch}, if the request content type is application/x-parquet, copy the request body to a temporary file for the benefit of the Parquet reader, which needs a reader that implements io.ReaderAt and io.Seeker.

In the future, we should probably add a way to disable this or limit file size to prevent an adversary from filling the file system. ~~I'll create an issue for this.~~ See #4236.

Closes #4228.