### PR TITLE
go fix ./...

### DIFF
--- a/mdtest/heavy_test.go
+++ b/mdtest/heavy_test.go
@@ -1,5 +1,4 @@
 //go:build heavy
-// +build heavy
 
 package mdtest
 

--- a/pkg/fs/open.go
+++ b/pkg/fs/open.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package fs
 

--- a/pkg/storage/uri_notwindows.go
+++ b/pkg/storage/uri_notwindows.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package storage
 

--- a/pkg/storage/uri_notwindows_test.go
+++ b/pkg/storage/uri_notwindows_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package storage
 

--- a/zio/anyio/fifo_test.go
+++ b/zio/anyio/fifo_test.go
@@ -1,5 +1,4 @@
 //go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
-// +build darwin dragonfly freebsd linux netbsd openbsd
 
 package anyio
 


### PR DESCRIPTION
Beginning with Go 1.18, "go fix" removes obsolete "// +build" lines in modules declaring "go 1.18" or later in go.mod.