### PR TITLE
traverse named type in IsUnionType

### DIFF
--- a/runtime/expr/ztests/shape-cast-from-union.yaml
+++ b/runtime/expr/ztests/shape-cast-from-union.yaml
@@ -4,7 +4,9 @@ zed: |
 input: |
   {from:null((int64,string)),to:<string>}
   {from:null(int64)((int64,string)),to:<string>}
+  {from:null(int64_named=int64)(union_named=(int64_named,string)),to:<string>}
   {from:1((int64,string)),to:<string>}
+  {from:1(int64_named=int64)(union_named=(int64_named,string)),to:<string>}
   {from:1(int8)((int8,string)),to:<(int64,string)>}
   {from:1((int64,string)),to:<(int8,string)>}
   {from:"one"((int64,string)),to:<string>}
@@ -17,7 +19,9 @@ input: |
 output: |
   null(string)
   null(string)
+  null(string)
   "1"
+  "1(=int64_named)"
   error("createStep: incompatible types (int8,string) and (int64,string)")
   error("createStep: incompatible types (int64,string) and (int8,string)")
   "one"

--- a/type.go
+++ b/type.go
@@ -327,7 +327,7 @@ func InnerType(typ Type) Type {
 }
 
 func IsUnionType(typ Type) bool {
-	_, ok := typ.(*TypeUnion)
+	_, ok := TypeUnder(typ).(*TypeUnion)
 	return ok
 }
 


### PR DESCRIPTION
IsUnionType was created before the function that became TypeUnder and never updated to call it.  This causes a cast from named type inside a named union type to fail.  Fix by calling TypeUnder in IsUnionType.