### PR TITLE
replace zcode.AppendUvarint with binary.AppendUvarint

### DIFF
--- a/runtime/expr/filter_test.go
+++ b/runtime/expr/filter_test.go
@@ -1,6 +1,7 @@
 package expr_test
 
 import (
+	"encoding/binary"
 	"encoding/hex"
 	"testing"
 
@@ -79,7 +80,7 @@ func runCasesHelper(t *testing.T, record string, cases []testcase, expectBufferF
 				// For FieldNameFinder.Find coverage, we need to
 				// hand BufferFilter.Eval a ZNG values frame
 				// containing rec, assembled here.
-				buf := zcode.AppendUvarint(nil, uint64(rec.Type.ID()))
+				buf := binary.AppendUvarint(nil, uint64(rec.Type.ID()))
 				buf = zcode.Append(buf, rec.Bytes)
 				assert.Equal(t, expected, bf.Eval(zctx, buf),
 					"filter: %q\nvalues:%s\nbuffer:\n%s", c.filter, zson.MustFormatValue(rec), hex.Dump(buf))

--- a/runtime/op/groupby/groupby.go
+++ b/runtime/op/groupby/groupby.go
@@ -2,6 +2,7 @@ package groupby
 
 import (
 	"context"
+	"encoding/binary"
 	"sync"
 
 	"github.com/brimdata/zed"
@@ -337,7 +338,7 @@ func (a *Aggregator) Consume(batch zbuf.Batch, this *zed.Value) error {
 	// We conveniently put the key type code at the end of the key string,
 	// so when we recontruct the key values below, we don't have skip over it.
 	keyType := a.keyTypes.Lookup(types)
-	keyBytes = zcode.AppendUvarint(keyBytes, uint64(keyType))
+	keyBytes = binary.AppendUvarint(keyBytes, uint64(keyType))
 	a.keyCache = keyBytes
 
 	row, ok := a.table[string(keyBytes)]

--- a/type.go
+++ b/type.go
@@ -10,6 +10,7 @@
 package zed
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"sort"
@@ -488,7 +489,7 @@ func appendTypeValue(b zcode.Bytes, t Type, typedefs *map[string]Type) zcode.Byt
 			id = TypeValueNameRef
 		}
 		b = append(b, id)
-		b = zcode.AppendUvarint(b, uint64(len(t.Name)))
+		b = binary.AppendUvarint(b, uint64(len(t.Name)))
 		b = append(b, zcode.Bytes(t.Name)...)
 		if id == TypeValueNameRef {
 			return b
@@ -502,16 +503,16 @@ func appendTypeValue(b zcode.Bytes, t Type, typedefs *map[string]Type) zcode.Byt
 
 	case *TypeRecord:
 		b = append(b, TypeValueRecord)
-		b = zcode.AppendUvarint(b, uint64(len(t.Columns)))
+		b = binary.AppendUvarint(b, uint64(len(t.Columns)))
 		for _, col := range t.Columns {
-			b = zcode.AppendUvarint(b, uint64(len(col.Name)))
+			b = binary.AppendUvarint(b, uint64(len(col.Name)))
 			b = append(b, col.Name...)
 			b = appendTypeValue(b, col.Type, typedefs)
 		}
 		return b
 	case *TypeUnion:
 		b = append(b, TypeValueUnion)
-		b = zcode.AppendUvarint(b, uint64(len(t.Types)))
+		b = binary.AppendUvarint(b, uint64(len(t.Types)))
 		for _, t := range t.Types {
 			b = appendTypeValue(b, t, typedefs)
 		}
@@ -524,9 +525,9 @@ func appendTypeValue(b zcode.Bytes, t Type, typedefs *map[string]Type) zcode.Byt
 		return appendTypeValue(b, t.Type, typedefs)
 	case *TypeEnum:
 		b = append(b, TypeValueEnum)
-		b = zcode.AppendUvarint(b, uint64(len(t.Symbols)))
+		b = binary.AppendUvarint(b, uint64(len(t.Symbols)))
 		for _, s := range t.Symbols {
-			b = zcode.AppendUvarint(b, uint64(len(s)))
+			b = binary.AppendUvarint(b, uint64(len(s)))
 			b = append(b, s...)
 		}
 		return b

--- a/zcode/bytes.go
+++ b/zcode/bytes.go
@@ -40,23 +40,13 @@ func (b Bytes) Body() Bytes {
 // extended buffer.
 func Append(dst Bytes, val []byte) Bytes {
 	if val == nil {
-		return AppendUvarint(dst, tagNull)
+		return binary.AppendUvarint(dst, tagNull)
 	}
-	dst = AppendUvarint(dst, toTag(len(val)))
+	dst = binary.AppendUvarint(dst, toTag(len(val)))
 	return append(dst, val...)
 }
 
-// AppendUvarint is like encoding/binary.PutUvarint but appends to dst instead
-// of writing into it.
-func AppendUvarint(dst []byte, u64 uint64) []byte {
-	for u64 >= 0x80 {
-		dst = append(dst, byte(u64)|0x80)
-		u64 >>= 7
-	}
-	return append(dst, byte(u64))
-}
-
-// SizeOfUvarint returns the number of bytes required by appendUvarint to
+// SizeOfUvarint returns the number of bytes required by binary.AppendUvarint to
 // represent u64.
 func SizeOfUvarint(u64 uint64) int {
 	n := 1

--- a/zcode/zcode_test.go
+++ b/zcode/zcode_test.go
@@ -1,12 +1,9 @@
 package zcode
 
 import (
-	"encoding/binary"
-	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var appendCases = [][][]byte{
@@ -33,45 +30,5 @@ func TestAppend(t *testing.T) {
 			assert.Exactly(t, expected, []byte(it.Next()))
 		}
 		assert.True(t, it.Done())
-	}
-}
-
-func TestUvarint(t *testing.T) {
-	cases := []uint64{
-		0,
-		1,
-		2,
-		126,
-		127,
-		128,
-		(127 << 7) + 126,
-		(127 << 7) + 127,
-		(127 << 7) + 128,
-		math.MaxUint8 - 1,
-		math.MaxUint8,
-		math.MaxUint8 + 1,
-		math.MaxUint16 - 1,
-		math.MaxUint16,
-		math.MaxUint16 + 1,
-		math.MaxUint32 - 1,
-		math.MaxUint32,
-		math.MaxUint32 + 1,
-		math.MaxUint64 - 2,
-		math.MaxUint64 - 1,
-		math.MaxUint64,
-	}
-	for _, c := range cases {
-		buf := AppendUvarint(nil, c)
-		u64, n := binary.Uvarint(buf)
-		require.Len(t, buf, n, "case: %d", c)
-		require.Exactly(t, c, u64, "case: %d", c)
-
-		buf = AppendUvarint(buf, c)
-		u64, n = binary.Uvarint(buf)
-		require.Len(t, buf, n*2, "case: %d", c)
-		require.Exactly(t, c, u64, "case: %d", c)
-		u64, n = binary.Uvarint(buf[n:])
-		require.Len(t, buf, n*2, "case: %d", c)
-		require.Exactly(t, c, u64, "case: %d", c)
 	}
 }

--- a/zio/zng21io/converter.go
+++ b/zio/zng21io/converter.go
@@ -327,7 +327,7 @@ func convertTypeValue(dst, tv zcode.Bytes) (zcode.Bytes, zcode.Bytes, error) {
 			return nil, nil, ErrTrunc
 		}
 		dst = append(dst, zed.TypeValueNameDef)
-		dst = zcode.AppendUvarint(dst, uint64(len(name)))
+		dst = binary.AppendUvarint(dst, uint64(len(name)))
 		dst = append(dst, zcode.Bytes(name)...)
 		return convertTypeValue(dst, tv)
 	case zed21.IDTypeName:
@@ -337,7 +337,7 @@ func convertTypeValue(dst, tv zcode.Bytes) (zcode.Bytes, zcode.Bytes, error) {
 			return nil, nil, ErrTrunc
 		}
 		dst = append(dst, zed.TypeValueNameRef)
-		dst = zcode.AppendUvarint(dst, uint64(len(name)))
+		dst = binary.AppendUvarint(dst, uint64(len(name)))
 		dst = append(dst, zcode.Bytes(name)...)
 		return dst, tv, nil
 	case zed21.IDTypeRecord:
@@ -347,14 +347,14 @@ func convertTypeValue(dst, tv zcode.Bytes) (zcode.Bytes, zcode.Bytes, error) {
 			return nil, nil, ErrTrunc
 		}
 		dst = append(dst, zed.TypeValueRecord)
-		dst = zcode.AppendUvarint(dst, uint64(n))
+		dst = binary.AppendUvarint(dst, uint64(n))
 		for k := 0; k < n; k++ {
 			var name string
 			name, rest := decodeName(tv)
 			if tv == nil {
 				return nil, nil, ErrTrunc
 			}
-			dst = zcode.AppendUvarint(dst, uint64(len(name)))
+			dst = binary.AppendUvarint(dst, uint64(len(name)))
 			dst = append(dst, zcode.Bytes(name)...)
 			var err error
 			dst, tv, err = convertTypeValue(dst, rest)
@@ -384,7 +384,7 @@ func convertTypeValue(dst, tv zcode.Bytes) (zcode.Bytes, zcode.Bytes, error) {
 			return nil, nil, ErrTrunc
 		}
 		dst = append(dst, zed.TypeValueUnion)
-		dst = zcode.AppendUvarint(dst, uint64(n))
+		dst = binary.AppendUvarint(dst, uint64(n))
 		for k := 0; k < n; k++ {
 			var err error
 			dst, tv, err = convertTypeValue(dst, tv)
@@ -400,14 +400,14 @@ func convertTypeValue(dst, tv zcode.Bytes) (zcode.Bytes, zcode.Bytes, error) {
 			return nil, nil, ErrTrunc
 		}
 		dst = append(dst, zed.TypeValueUnion)
-		dst = zcode.AppendUvarint(dst, uint64(n))
+		dst = binary.AppendUvarint(dst, uint64(n))
 		for k := 0; k < n; k++ {
 			var symbol string
 			symbol, tv = decodeName(tv)
 			if tv == nil {
 				return nil, nil, ErrTrunc
 			}
-			dst = zcode.AppendUvarint(dst, uint64(len(symbol)))
+			dst = binary.AppendUvarint(dst, uint64(len(symbol)))
 			dst = append(dst, zcode.Bytes(symbol)...)
 		}
 		return dst, tv, nil

--- a/zio/zng21io/zed21/typetype.go
+++ b/zio/zng21io/zed21/typetype.go
@@ -34,7 +34,7 @@ func appendTypeValue(b zcode.Bytes, t Type, typedefs *map[string]Type) zcode.Byt
 			(*typedefs)[t.Name] = t.Type
 		}
 		b = append(b, id)
-		b = zcode.AppendUvarint(b, uint64(len(t.Name)))
+		b = binary.AppendUvarint(b, uint64(len(t.Name)))
 		b = append(b, zcode.Bytes(t.Name)...)
 		if id == IDTypeName {
 			return b
@@ -42,16 +42,16 @@ func appendTypeValue(b zcode.Bytes, t Type, typedefs *map[string]Type) zcode.Byt
 		return appendTypeValue(b, t.Type, typedefs)
 	case *TypeRecord:
 		b = append(b, IDTypeRecord)
-		b = zcode.AppendUvarint(b, uint64(len(t.Columns)))
+		b = binary.AppendUvarint(b, uint64(len(t.Columns)))
 		for _, col := range t.Columns {
-			b = zcode.AppendUvarint(b, uint64(len(col.Name)))
+			b = binary.AppendUvarint(b, uint64(len(col.Name)))
 			b = append(b, col.Name...)
 			b = appendTypeValue(b, col.Type, typedefs)
 		}
 		return b
 	case *TypeUnion:
 		b = append(b, IDTypeUnion)
-		b = zcode.AppendUvarint(b, uint64(len(t.Types)))
+		b = binary.AppendUvarint(b, uint64(len(t.Types)))
 		for _, t := range t.Types {
 			b = appendTypeValue(b, t, typedefs)
 		}
@@ -64,9 +64,9 @@ func appendTypeValue(b zcode.Bytes, t Type, typedefs *map[string]Type) zcode.Byt
 		return appendTypeValue(b, t.Type, typedefs)
 	case *TypeEnum:
 		b = append(b, IDTypeEnum)
-		b = zcode.AppendUvarint(b, uint64(len(t.Symbols)))
+		b = binary.AppendUvarint(b, uint64(len(t.Symbols)))
 		for _, s := range t.Symbols {
-			b = zcode.AppendUvarint(b, uint64(len(s)))
+			b = binary.AppendUvarint(b, uint64(len(s)))
 			b = append(b, s...)
 		}
 		return b

--- a/zio/zngio/types.go
+++ b/zio/zngio/types.go
@@ -1,11 +1,11 @@
 package zngio
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 
 	"github.com/brimdata/zed"
-	"github.com/brimdata/zed/zcode"
 )
 
 const (
@@ -98,11 +98,11 @@ func (e *Encoder) encodeTypeRecord(ext *zed.TypeRecord) (zed.Type, error) {
 		return nil, err
 	}
 	e.bytes = append(e.bytes, TypeDefRecord)
-	e.bytes = zcode.AppendUvarint(e.bytes, uint64(len(columns)))
+	e.bytes = binary.AppendUvarint(e.bytes, uint64(len(columns)))
 	for _, col := range columns {
-		e.bytes = zcode.AppendUvarint(e.bytes, uint64(len(col.Name)))
+		e.bytes = binary.AppendUvarint(e.bytes, uint64(len(col.Name)))
 		e.bytes = append(e.bytes, col.Name...)
-		e.bytes = zcode.AppendUvarint(e.bytes, uint64(zed.TypeID(col.Type)))
+		e.bytes = binary.AppendUvarint(e.bytes, uint64(zed.TypeID(col.Type)))
 	}
 	return typ, nil
 }
@@ -118,9 +118,9 @@ func (e *Encoder) encodeTypeUnion(ext *zed.TypeUnion) (zed.Type, error) {
 	}
 	typ := e.zctx.LookupTypeUnion(types)
 	e.bytes = append(e.bytes, TypeDefUnion)
-	e.bytes = zcode.AppendUvarint(e.bytes, uint64(len(types)))
+	e.bytes = binary.AppendUvarint(e.bytes, uint64(len(types)))
 	for _, t := range types {
-		e.bytes = zcode.AppendUvarint(e.bytes, uint64(zed.TypeID(t)))
+		e.bytes = binary.AppendUvarint(e.bytes, uint64(zed.TypeID(t)))
 	}
 	return typ, nil
 }
@@ -132,7 +132,7 @@ func (e *Encoder) encodeTypeSet(ext *zed.TypeSet) (*zed.TypeSet, error) {
 	}
 	typ := e.zctx.LookupTypeSet(inner)
 	e.bytes = append(e.bytes, TypeDefSet)
-	e.bytes = zcode.AppendUvarint(e.bytes, uint64(zed.TypeID(inner)))
+	e.bytes = binary.AppendUvarint(e.bytes, uint64(zed.TypeID(inner)))
 	return typ, nil
 }
 
@@ -143,7 +143,7 @@ func (e *Encoder) encodeTypeArray(ext *zed.TypeArray) (*zed.TypeArray, error) {
 	}
 	typ := e.zctx.LookupTypeArray(inner)
 	e.bytes = append(e.bytes, TypeDefArray)
-	e.bytes = zcode.AppendUvarint(e.bytes, uint64(zed.TypeID(inner)))
+	e.bytes = binary.AppendUvarint(e.bytes, uint64(zed.TypeID(inner)))
 	return typ, nil
 }
 
@@ -151,9 +151,9 @@ func (e *Encoder) encodeTypeEnum(ext *zed.TypeEnum) (*zed.TypeEnum, error) {
 	symbols := ext.Symbols
 	typ := e.zctx.LookupTypeEnum(symbols)
 	e.bytes = append(e.bytes, TypeDefEnum)
-	e.bytes = zcode.AppendUvarint(e.bytes, uint64(len(symbols)))
+	e.bytes = binary.AppendUvarint(e.bytes, uint64(len(symbols)))
 	for _, s := range symbols {
-		e.bytes = zcode.AppendUvarint(e.bytes, uint64(len(s)))
+		e.bytes = binary.AppendUvarint(e.bytes, uint64(len(s)))
 		e.bytes = append(e.bytes, s...)
 	}
 	return typ, nil
@@ -170,8 +170,8 @@ func (e *Encoder) encodeTypeMap(ext *zed.TypeMap) (*zed.TypeMap, error) {
 	}
 	typ := e.zctx.LookupTypeMap(keyType, valType)
 	e.bytes = append(e.bytes, TypeDefMap)
-	e.bytes = zcode.AppendUvarint(e.bytes, uint64(zed.TypeID(keyType)))
-	e.bytes = zcode.AppendUvarint(e.bytes, uint64(zed.TypeID(valType)))
+	e.bytes = binary.AppendUvarint(e.bytes, uint64(zed.TypeID(keyType)))
+	e.bytes = binary.AppendUvarint(e.bytes, uint64(zed.TypeID(valType)))
 	return typ, nil
 }
 
@@ -185,9 +185,9 @@ func (e *Encoder) encodeTypeName(ext *zed.TypeNamed) (*zed.TypeNamed, error) {
 		return nil, err
 	}
 	e.bytes = append(e.bytes, TypeDefName)
-	e.bytes = zcode.AppendUvarint(e.bytes, uint64(len(typ.Name)))
+	e.bytes = binary.AppendUvarint(e.bytes, uint64(len(typ.Name)))
 	e.bytes = append(e.bytes, typ.Name...)
-	e.bytes = zcode.AppendUvarint(e.bytes, uint64(zed.TypeID(typ.Type)))
+	e.bytes = binary.AppendUvarint(e.bytes, uint64(zed.TypeID(typ.Type)))
 	return typ, nil
 }
 
@@ -198,7 +198,7 @@ func (e *Encoder) encodeTypeError(ext *zed.TypeError) (*zed.TypeError, error) {
 	}
 	typ := e.zctx.LookupTypeError(inner)
 	e.bytes = append(e.bytes, TypeDefError)
-	e.bytes = zcode.AppendUvarint(e.bytes, uint64(zed.TypeID(typ.Type)))
+	e.bytes = binary.AppendUvarint(e.bytes, uint64(zed.TypeID(typ.Type)))
 	return typ, nil
 }
 

--- a/zio/zngio/writer.go
+++ b/zio/zngio/writer.go
@@ -1,6 +1,7 @@
 package zngio
 
 import (
+	"encoding/binary"
 	"io"
 
 	"github.com/brimdata/zed"
@@ -108,7 +109,7 @@ func (w *Writer) Write(val *zed.Value) error {
 		}
 	}
 	id := zed.TypeID(typ)
-	w.values = zcode.AppendUvarint(w.values, uint64(id))
+	w.values = binary.AppendUvarint(w.values, uint64(id))
 	w.values = zcode.Append(w.values, val.Bytes)
 	if thresh := w.opts.FrameThresh; len(w.values) >= thresh || len(w.types.bytes) >= thresh {
 		return w.flush()
@@ -166,7 +167,7 @@ func (w *Writer) writeBlock(blockType int, b []byte) error {
 func (w *Writer) writeHeader(blockType, size int) error {
 	code := blockType<<4 | (size & 0xf)
 	w.header = append(w.header[:0], byte(code))
-	w.header = zcode.AppendUvarint(w.header, uint64(size>>4))
+	w.header = binary.AppendUvarint(w.header, uint64(size>>4))
 	return w.write(w.header)
 }
 
@@ -174,9 +175,9 @@ func (w *Writer) writeCompHeader(blockType, size, zlen int) error {
 	zlen += 1 + zcode.SizeOfUvarint(uint64(size))
 	code := (blockType << 4) | (zlen & 0xf) | 0x40
 	w.header = append(w.header[:0], byte(code))
-	w.header = zcode.AppendUvarint(w.header, uint64(zlen>>4))
+	w.header = binary.AppendUvarint(w.header, uint64(zlen>>4))
 	w.header = append(w.header, byte(CompressionFormatLZ4))
-	w.header = zcode.AppendUvarint(w.header, uint64(size))
+	w.header = binary.AppendUvarint(w.header, uint64(size))
 	return w.write(w.header)
 }
 


### PR DESCRIPTION
Go 1.19 adds the new function binary.AppendUvarint.  Use it instead of zcode.AppendUvarint and remove the latter.