### PR TITLE
runtime/op/combine: fix race in (*Proc).propagateDone

### DIFF
--- a/runtime/op/combine/combine.go
+++ b/runtime/op/combine/combine.go
@@ -108,6 +108,7 @@ func (p *Proc) block(parent *puller) {
 }
 
 func (p *Proc) propagateDone() error {
+	var mu sync.Mutex
 	var wg sync.WaitGroup
 	for _, parent := range p.parents {
 		if parent.blocked {
@@ -130,7 +131,9 @@ func (p *Proc) propagateDone() error {
 				// of them eventually as we loop over each unblocked parent.
 				goto again
 			case parent.doneCh <- struct{}{}:
+				mu.Lock()
 				p.block(parent)
+				mu.Unlock()
 			case <-p.ctx.Done():
 			}
 		}()


### PR DESCRIPTION
Found with "make test-unit GOFLAGS=-race".