### PR TITLE
zst: remove some Object and Reader constructors

### DIFF
--- a/lake/data/writer_test.go
+++ b/lake/data/writer_test.go
@@ -42,7 +42,6 @@ func TestDataReaderWriterVector(t *testing.T) {
 	v, err = reader.Read()
 	require.NoError(t, err)
 	assert.Equal(t, zson.String(v), "{a:3,b:6}")
-	require.NoError(t, reader.Close())
 	require.NoError(t, get.Close())
 	require.NoError(t, data.DeleteVector(ctx, engine, tmp, object.ID))
 	exists, err := engine.Exists(ctx, data.VectorURI(tmp, object.ID))

--- a/runtime/vcache/object.go
+++ b/runtime/vcache/object.go
@@ -51,8 +51,12 @@ func NewObject(ctx context.Context, engine storage.Engine, uri *storage.URI, id 
 	if err != nil {
 		return nil, err
 	}
+	size, err := storage.Size(reader)
+	if err != nil {
+		return nil, err
+	}
 	zctx := zed.NewContext()
-	z, err := zst.NewObjectFromStorageReader(zctx, reader)
+	z, err := zst.NewObject(zctx, reader, size)
 	if err != nil {
 		return nil, err
 	}

--- a/zio/zstio/reader.go
+++ b/zio/zstio/reader.go
@@ -15,7 +15,15 @@ func NewReader(zctx *zed.Context, r io.Reader) (*zst.Reader, error) {
 		if !storage.IsSeekable(reader) {
 			return nil, errors.New("zst must be used with a seekable input")
 		}
-		return zst.NewReaderFromStorageReader(zctx, reader)
+		size, err := storage.Size(reader)
+		if err != nil {
+			return nil, err
+		}
+		o, err := zst.NewObject(zctx, reader, size)
+		if err != nil {
+			return nil, err
+		}
+		return zst.NewReader(o)
 	}
 	// This can't be the zed system (which always using package storage)
 	// so it must be a third party using he zst library.  We could assert

--- a/zst/reader.go
+++ b/zst/reader.go
@@ -1,21 +1,16 @@
 package zst
 
 import (
-	"context"
 	"fmt"
 	"io"
 
 	"github.com/brimdata/zed"
-	"github.com/brimdata/zed/pkg/storage"
 	"github.com/brimdata/zed/zcode"
-	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zst/vector"
 )
 
-// Reader implements zio.Reader and io.Closer.  It reads a vector
-// zst object to generate a stream of zed.Records.
+// Reader implements zio.Reader for a vector ZST object.
 type Reader struct {
-	*Object
 	root    *vector.Int64Reader
 	readers []typedReader
 	builder zcode.Builder
@@ -27,10 +22,7 @@ type typedReader struct {
 	reader vector.Reader
 }
 
-var _ zio.Reader = (*Reader)(nil)
-
-// NewReader returns a Reader ready to read a zst object as zed.Records.
-// Close() should be called when done.  This embeds a zst.Object.
+// NewReader returns a Reader for o.
 func NewReader(o *Object) (*Reader, error) {
 	root := vector.NewInt64Reader(o.root, o.readerAt)
 	readers := make([]typedReader, 0, len(o.maps))
@@ -42,41 +34,10 @@ func NewReader(o *Object) (*Reader, error) {
 		readers = append(readers, typedReader{typ: m.Type(o.zctx), reader: r})
 	}
 	return &Reader{
-		Object:  o,
 		root:    root,
 		readers: readers,
 	}, nil
 
-}
-
-func NewReaderFromPath(ctx context.Context, zctx *zed.Context, engine storage.Engine, path string) (*Reader, error) {
-	object, err := NewObjectFromPath(ctx, zctx, engine, path)
-	if err != nil {
-		return nil, err
-	}
-	if err != nil {
-		object.Close()
-		return nil, err
-	}
-	r, err := NewReader(object)
-	if err != nil {
-		object.Close()
-		return nil, err
-	}
-	return r, nil
-}
-
-func NewReaderFromStorageReader(zctx *zed.Context, r storage.Reader) (*Reader, error) {
-	object, err := NewObjectFromStorageReaderNoCloser(zctx, r)
-	if err != nil {
-		return nil, err
-	}
-	reader, err := NewReader(object)
-	if err != nil {
-		// don't close object as we didn't open the seeker
-		return nil, err
-	}
-	return reader, nil
 }
 
 func (r *Reader) Read() (*zed.Value, error) {


### PR DESCRIPTION
Removing these constructors also makes it possible to remove the Close method from both types.