### PR TITLE
zson: use netip.ParseAddr in (*Parser).matchPrimitive

### DIFF
--- a/zson/parser-values.go
+++ b/zson/parser-values.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/netip"
 	"strconv"
 	"time"
 
@@ -200,7 +201,7 @@ func (p *Parser) matchPrimitive() (*astzed.Primitive, error) {
 		typ = "duration"
 	} else if _, _, err := net.ParseCIDR(s); err == nil {
 		typ = "net"
-	} else if ip := net.ParseIP(s); ip != nil {
+	} else if _, err := netip.ParseAddr(s); err == nil {
 		typ = "ip"
 	} else if len(s) >= 2 && s[0:2] == "0x" {
 		if len(s) == 2 {


### PR DESCRIPTION
matchPrimitive calls net.ParseIP to detect IP addresses, but that function allocates memory on success.  Call netip.ParseAddr instead since it never allocates memory.