### PR TITLE
ztest: set Bundle.FileName to relative path in Load

### DIFF
--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -174,12 +174,8 @@ func Load(dirname string) ([]Bundle, error) {
 			continue
 		}
 		testname := strings.TrimSuffix(filename, dotyaml)
-		// An absolute path in errors makes the offending file easier to find.
-		filename, err := filepath.Abs(filepath.Join(dirname, filename))
-		var zt *ZTest
-		if err == nil {
-			zt, err = FromYAMLFile(filename)
-		}
+		filename = filepath.Join(dirname, filename)
+		zt, err := FromYAMLFile(filename)
 		bundles = append(bundles, Bundle{testname, filename, zt, err})
 	}
 	return bundles, nil


### PR DESCRIPTION
ztest.Load sets Bundle.FileName to an absolute path under the assumption that this makes the YAML file easier to find.  I don't think it does, so just set the field to the (shorter) relative path.

Before:

    $ make test-system
    --- FAIL: TestZed (4.77s)
        --- FAIL: TestZed/ztests (0.00s)
            --- FAIL: TestZed/ztests/fail (0.01s)
                ztest.go:411: /Users/noah/brimdata/zed/ztests/fail.yaml: exit status 1
    FAIL
    FAIL	github.com/brimdata/zed	15.275s
    FAIL
    make: *** [test-system] Error 1

After:

    $ make test-system
    --- FAIL: TestZed (4.75s)
        --- FAIL: TestZed/ztests (0.00s)
            --- FAIL: TestZed/ztests/fail (0.01s)
                ztest.go:407: ztests/fail.yaml: exit status 1
    FAIL
    FAIL	github.com/brimdata/zed	14.166s
    FAIL
    make: *** [test-system] Error 1