### PR TITLE
rename and move TestTranslateNameConflictUnion

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -1,37 +1,54 @@
-package zed
+package zed_test
 
 import (
 	"testing"
 
+	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/zson"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestContextLookupTypeNamedErrors(t *testing.T) {
-	zctx := NewContext()
+	zctx := zed.NewContext()
 
-	_, err := zctx.LookupTypeNamed("\xff", TypeNull)
+	_, err := zctx.LookupTypeNamed("\xff", zed.TypeNull)
 	assert.EqualError(t, err, `bad type name "\xff": invalid UTF-8`)
 
-	_, err = zctx.LookupTypeNamed("null", TypeNull)
+	_, err = zctx.LookupTypeNamed("null", zed.TypeNull)
 	assert.EqualError(t, err, `bad type name "null": primitive type name`)
 }
 
 func TestContextLookupTypeNamedAndLookupTypeDef(t *testing.T) {
-	zctx := NewContext()
+	zctx := zed.NewContext()
 
 	assert.Nil(t, zctx.LookupTypeDef("x"))
 
-	named1, err := zctx.LookupTypeNamed("x", TypeNull)
+	named1, err := zctx.LookupTypeNamed("x", zed.TypeNull)
 	require.NoError(t, err)
 	assert.Same(t, named1, zctx.LookupTypeDef("x"))
 
-	named2, err := zctx.LookupTypeNamed("x", TypeInt8)
+	named2, err := zctx.LookupTypeNamed("x", zed.TypeInt8)
 	require.NoError(t, err)
 	assert.Same(t, named2, zctx.LookupTypeDef("x"))
 
-	named3, err := zctx.LookupTypeNamed("x", TypeNull)
+	named3, err := zctx.LookupTypeNamed("x", zed.TypeNull)
 	require.NoError(t, err)
 	assert.Same(t, named3, zctx.LookupTypeDef("x"))
 	assert.Same(t, named3, named1)
+}
+
+func TestContextTranslateTypeNameConflictUnion(t *testing.T) {
+	// This test confirms that a union with complicated type renaming is properly
+	// decoded.  There was a bug where child typedefs would override the
+	// top level typedef in TranslateType so foo in the value below had
+	// two of the same union type instead of the two it should have had.
+	zctx := zed.NewContext()
+	val := zson.MustParseValue(zctx, `[{x:{y:63}}(=foo),{x:{abcdef:{x:{y:127}}(foo)}}(=foo)]`)
+	foreign := zed.NewContext()
+	twin, err := foreign.TranslateType(val.Type)
+	require.NoError(t, err)
+	union := twin.(*zed.TypeArray).Type.(*zed.TypeUnion)
+	assert.Equal(t, `foo={x:{abcdef:foo={x:{y:int64}}}}`, zson.String(union.Types[0]))
+	assert.Equal(t, `foo={x:{y:int64}}`, zson.String(union.Types[1]))
 }

--- a/zed_test.go
+++ b/zed_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/brimdata/zed/zio/anyio"
 	"github.com/brimdata/zed/zio/parquetio"
 	"github.com/brimdata/zed/zio/zngio"
-	"github.com/brimdata/zed/zson"
 	"github.com/brimdata/zed/ztest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -180,19 +179,4 @@ func runOneBoomerang(t *testing.T, format, data string) {
 	require.NoError(t, boomerangWriter.Close())
 
 	require.Equal(t, baseline.String(), boomerang.String(), "baseline and boomerang differ")
-}
-
-func TestTranslateNameConflictUnion(t *testing.T) {
-	// This test confirms that a union with complicated type renaming is properly
-	// decoded.  There was a bug where child typedefs would override the
-	// top level typedef in TranslateTypeValue so foo in the value below had
-	// two of the same union type instead of the two it should have had.
-	zctx := zed.NewContext()
-	val := zson.MustParseValue(zctx, `[{x:{y:63}}(=foo),{x:{abcdef:{x:{y:127}}(foo)}}(=foo)]`)
-	foreign := zed.NewContext()
-	twin, err := foreign.TranslateType(val.Type)
-	require.NoError(t, err)
-	union := twin.(*zed.TypeArray).Type.(*zed.TypeUnion)
-	assert.Equal(t, `foo={x:{abcdef:foo={x:{y:int64}}}}`, zson.String(union.Types[0]))
-	assert.Equal(t, `foo={x:{y:int64}}`, zson.String(union.Types[1]))
 }


### PR DESCRIPTION
This is a test of (*Context).TranslateType, so rename it to incoporate the method name and move it to context_test.go with the other Context method tests.

Since the test uses package zson, moving it requires changing the context_test.go package to zed_test to avoid an import cycle.