### PR TITLE
upgrade to github.com/hashicorp/golang-lru/v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/golang/mock v1.5.0
 	github.com/gorilla/mux v1.7.5-0.20200711200521-98cb6bf42e08
 	github.com/gosuri/uilive v0.0.4
-	github.com/hashicorp/golang-lru v0.5.4
+	github.com/hashicorp/golang-lru/v2 v2.0.1
 	github.com/kr/text v0.2.0
 	github.com/paulbellamy/ratecounter v0.2.0
 	github.com/pbnjay/memory v0.0.0-20190104145345-974d429e7ae4

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,8 @@ github.com/gorilla/mux v1.7.5-0.20200711200521-98cb6bf42e08 h1:kPna6oIGlRXWmg/jk
 github.com/gorilla/mux v1.7.5-0.20200711200521-98cb6bf42e08/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gosuri/uilive v0.0.4 h1:hUEBpQDj8D8jXgtCdBu7sWsy5sbW/5GhuO8KBwJ2jyY=
 github.com/gosuri/uilive v0.0.4/go.mod h1:V/epo5LjjlDE5RJUcqx8dbw+zc93y5Ya3yg8tfZ74VI=
-github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
-github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/v2 v2.0.1 h1:5pv5N1lT1fjLg2VQ5KWc7kmucp2x/kvFOnxuVTqZ6x4=
+github.com/hashicorp/golang-lru/v2 v2.0.1/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=

--- a/pkg/storage/cache/local.go
+++ b/pkg/storage/cache/local.go
@@ -6,19 +6,19 @@ import (
 
 	"github.com/brimdata/zed/lake/data"
 	"github.com/brimdata/zed/pkg/storage"
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 type LocalCache struct {
 	storage.Engine
 	metrics
-	lru       *lru.ARCCache
+	lru       *lru.ARCCache[string, []byte]
 	cacheable Cacheable
 }
 
 func NewLocalCache(engine storage.Engine, cacheable Cacheable, size int, registerer prometheus.Registerer) (*LocalCache, error) {
-	lru, err := lru.NewARC(size)
+	lru, err := lru.NewARC[string, []byte](size)
 	if err != nil {
 		return nil, err
 	}
@@ -38,15 +38,15 @@ func (c *LocalCache) Get(ctx context.Context, u *storage.URI) (storage.Reader, e
 		return c.Engine.Get(ctx, u)
 	}
 	kind, _, _ := data.FileMatch(path.Base(u.Path))
-	if v, ok := c.lru.Get(u.String()); ok {
+	if b, ok := c.lru.Get(u.String()); ok {
 		c.hits.WithLabelValues(kind.Description()).Inc()
-		return storage.NewBytesReader(v.([]byte)), nil
+		return storage.NewBytesReader(b), nil
 	}
-	b, err := c.Engine.Get(ctx, u)
+	b, err := storage.Get(ctx, c.Engine, u)
 	if err != nil {
 		return nil, err
 	}
 	c.lru.Add(u.String(), b)
 	c.misses.WithLabelValues(kind.Description()).Inc()
-	return b, nil
+	return storage.NewBytesReader(b), nil
 }


### PR DESCRIPTION
This version supports generics for compile-time type safety (and allowing removal of type assertions previously required on values returned by Get).

The type safety highlights a bug in pkg/storage/cache.NewLocalCache that's fixed here by calling pkg/storage.Get instead of pkg/storage.Engine.Get.