### PR TITLE
zed: rename ColumnBuilder to RecordBuilder

### DIFF
--- a/runtime/expr/cutter.go
+++ b/runtime/expr/cutter.go
@@ -11,7 +11,7 @@ import (
 
 type Cutter struct {
 	zctx        *zed.Context
-	builder     *zed.ColumnBuilder
+	builder     *zed.RecordBuilder
 	fieldRefs   field.List
 	fieldExprs  []Evaluator
 	typeCache   []zed.Type
@@ -34,11 +34,11 @@ func NewCutter(zctx *zed.Context, fieldRefs field.List, fieldExprs []Evaluator) 
 			return nil, errors.New("cut: 'this' not allowed (use record literal)")
 		}
 	}
-	var b *zed.ColumnBuilder
+	var b *zed.RecordBuilder
 	if len(fieldRefs) == 0 || !fieldRefs[0].IsEmpty() {
 		// A root field will cause NewColumnBuilder to panic.
 		var err error
-		b, err = zed.NewColumnBuilder(zctx, fieldRefs)
+		b, err = zed.NewRecordBuilder(zctx, fieldRefs)
 		if err != nil {
 			return nil, err
 		}

--- a/runtime/expr/dropper.go
+++ b/runtime/expr/dropper.go
@@ -8,7 +8,7 @@ import (
 
 type dropper struct {
 	typ       zed.Type
-	builder   *zed.ColumnBuilder
+	builder   *zed.RecordBuilder
 	fieldRefs []Evaluator
 }
 
@@ -62,7 +62,7 @@ func (d *Dropper) newDropper(zctx *zed.Context, r *zed.Value) *dropper {
 	for _, f := range fields {
 		fieldRefs = append(fieldRefs, NewDottedExpr(zctx, f))
 	}
-	builder, err := zed.NewColumnBuilder(d.zctx, fields)
+	builder, err := zed.NewRecordBuilder(d.zctx, fields)
 	if err != nil {
 		panic(err)
 	}

--- a/runtime/expr/function/nestdotted.go
+++ b/runtime/expr/function/nestdotted.go
@@ -8,7 +8,7 @@ import (
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#nest_dotted.md
 type NestDotted struct {
 	zctx        *zed.Context
-	builders    map[int]*zed.ColumnBuilder
+	builders    map[int]*zed.RecordBuilder
 	recordTypes map[int]*zed.TypeRecord
 }
 
@@ -22,12 +22,12 @@ type NestDotted struct {
 func NewNestDotted(zctx *zed.Context) *NestDotted {
 	return &NestDotted{
 		zctx:        zctx,
-		builders:    make(map[int]*zed.ColumnBuilder),
+		builders:    make(map[int]*zed.RecordBuilder),
 		recordTypes: make(map[int]*zed.TypeRecord),
 	}
 }
 
-func (n *NestDotted) lookupBuilderAndType(in *zed.TypeRecord) (*zed.ColumnBuilder, *zed.TypeRecord, error) {
+func (n *NestDotted) lookupBuilderAndType(in *zed.TypeRecord) (*zed.RecordBuilder, *zed.TypeRecord, error) {
 	if b, ok := n.builders[in.ID()]; ok {
 		return b, n.recordTypes[in.ID()], nil
 	}
@@ -45,7 +45,7 @@ func (n *NestDotted) lookupBuilderAndType(in *zed.TypeRecord) (*zed.ColumnBuilde
 	if !foundDotted {
 		return nil, nil, nil
 	}
-	b, err := zed.NewColumnBuilder(n.zctx, fields)
+	b, err := zed.NewRecordBuilder(n.zctx, fields)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/runtime/op/groupby/groupby.go
+++ b/runtime/op/groupby/groupby.go
@@ -48,7 +48,7 @@ type Aggregator struct {
 	keyExprs       []expr.Evaluator
 	aggRefs        []expr.Evaluator
 	aggs           []*expr.Aggregator
-	builder        *zed.ColumnBuilder
+	builder        *zed.RecordBuilder
 	recordTypes    map[int]*zed.TypeRecord
 	table          map[string]*Row
 	limit          int
@@ -69,7 +69,7 @@ type Row struct {
 	reducers valRow
 }
 
-func NewAggregator(ctx context.Context, zctx *zed.Context, keyRefs, keyExprs, aggRefs []expr.Evaluator, aggs []*expr.Aggregator, builder *zed.ColumnBuilder, limit int, inputDir order.Direction, partialsIn, partialsOut bool) (*Aggregator, error) {
+func NewAggregator(ctx context.Context, zctx *zed.Context, keyRefs, keyExprs, aggRefs []expr.Evaluator, aggs []*expr.Aggregator, builder *zed.RecordBuilder, limit int, inputDir order.Direction, partialsIn, partialsOut bool) (*Aggregator, error) {
 	if limit == 0 {
 		limit = DefaultLimit
 	}
@@ -125,7 +125,7 @@ func New(pctx *op.Context, parent zbuf.Puller, keys []expr.Assignment, aggNames 
 		names = append(names, e.LHS)
 	}
 	names = append(names, aggNames...)
-	builder, err := zed.NewColumnBuilder(pctx.Zctx, names)
+	builder, err := zed.NewRecordBuilder(pctx.Zctx, names)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This thing builds records so RecordBuilder seems like a better name.