### PR TITLE
Mention that left/right joins are sometimes known as "outer"

### DIFF
--- a/docs/tutorials/join.md
+++ b/docs/tutorials/join.md
@@ -74,6 +74,10 @@ produces
 
 ## Left Join
 
+:::tip note
+In some databases a left join is called a _left outer join_.
+:::
+
 By performing a left join that targets the same key fields, now all of our
 fruits will be shown in the results even if no one likes them (e.g., `avocado`).
 
@@ -106,6 +110,10 @@ produces
 ```
 
 ## Right join
+
+:::tip note
+In some databases a right join is called a _right outer join_.
+:::
 
 Next we'll change the join type from `left` to `right`. Notice that this causes
 the `note` field from the right-hand input to appear in the joined results.


### PR DESCRIPTION
A community user recently inquired:

> Is there a way to perform outer joins in Zed?

I pointed them at the [join tutorial](https://zed.brimdata.io/docs/next/tutorials/join) doc and explained how what we call "left join" and "right join" are the same as what's also sometimes called "left outer join" and "right outer join" in SQL contexts. The user is all set now that they know this, but the exchange made he realize that we could stand to call it out explicitly in the tutorial just like they do at SQL references like https://www.w3schools.com/sql/sql_join_left.asp.

The syntax I'm using here render in Docusaurus like this:

![image](https://user-images.githubusercontent.com/5934157/209410283-ed718632-2ae1-462c-9186-5d1b96e35ad2.png)
