### PR TITLE
Add ZSON as an explicit input format and alphabetize format lists

### DIFF
--- a/cli/inputflags/flags.go
+++ b/cli/inputflags/flags.go
@@ -27,7 +27,7 @@ func (f *Flags) Options() anyio.ReaderOpts {
 }
 
 func (f *Flags) SetFlags(fs *flag.FlagSet, validate bool) {
-	fs.StringVar(&f.Format, "i", "auto", "format of input data [arrows,auto,zng,vng,json,zeek,zjson,csv,parquet,line]")
+	fs.StringVar(&f.Format, "i", "auto", "format of input data [auto,arrows,csv,json,line,parquet,vng,zeek,zjson,zng,zson]")
 	fs.BoolVar(&f.ZNG.Validate, "validate", validate, "validate the input format when reading ZNG streams")
 	fs.IntVar(&f.ZNG.Threads, "threads", 0, "number of threads used for scanning ZNG input")
 	f.ReadMax = auto.NewBytes(zngio.MaxSize)

--- a/cli/outputflags/flags.go
+++ b/cli/outputflags/flags.go
@@ -75,7 +75,7 @@ func (f *Flags) SetFormatFlags(fs *flag.FlagSet) {
 	if f.DefaultFormat == "" {
 		f.DefaultFormat = "zng"
 	}
-	fs.StringVar(&f.Format, "f", f.DefaultFormat, "format for output data [arrows,zng,vng,json,parquet,table,text,csv,lake,zeek,zjson,zson]")
+	fs.StringVar(&f.Format, "f", f.DefaultFormat, "format for output data [arrows,csv,json,lake,parquet,table,text,vng,zeek,zjson,zng,zson]")
 	fs.BoolVar(&f.jsonShortcut, "j", false, "use line-oriented JSON output independent of -f option")
 	fs.BoolVar(&f.zsonShortcut, "z", false, "use line-oriented ZSON output independent of -f option")
 	fs.BoolVar(&f.zsonPretty, "Z", false, "use formatted ZSON output independent of -f option")


### PR DESCRIPTION
While verifying #2517 I happened to notice that ZSON was missing from the explicit list of `-i` input formats, so I'm adding that here. In additional cleanup while I'm at it, I've alphabetized the format lists as well, since I've been making a point of doing this in the app as well. The one exception is that I put `auto` up-front for the input formats since I figure it's a nice courtesy to new users to tip them off that they can probably rely on that rather than having to remember or refer to the exhaustive list of what explicit formats are/aren't available.