### PR TITLE
Skip https://suricata.io link check

### DIFF
--- a/.github/workflows/markdown-link-check-config.json
+++ b/.github/workflows/markdown-link-check-config.json
@@ -1,7 +1,10 @@
 {
   "ignorePatterns": [
     {
-      "pattern": "^http://localhost:9867|^https://suricata.io"
+      "pattern": "^http://localhost:9867"
+    },
+    {
+      "pattern": ^https://suricata.io"
     }
   ],
   "retryOn429": true,

--- a/.github/workflows/markdown-link-check-config.json
+++ b/.github/workflows/markdown-link-check-config.json
@@ -4,7 +4,7 @@
       "pattern": "^http://localhost:9867"
     },
     {
-      "pattern": ^https://suricata.io"
+      "pattern": "^https://suricata.io"
     }
   ],
   "retryOn429": true,

--- a/.github/workflows/markdown-link-check-config.json
+++ b/.github/workflows/markdown-link-check-config.json
@@ -1,7 +1,7 @@
 {
   "ignorePatterns": [
     {
-      "pattern": "^http://localhost:9867"
+      "pattern": "^http://localhost:9867|^https://suricata.io"
     }
   ],
   "retryOn429": true,


### PR DESCRIPTION
The markdown link checker has failed on suricata.io for the past couple nights even though the site seems completely healthy. I created a [personal repo](https://github.com/philrz/linkcheck) to debug the issue and I still can't make sense of it, so I opened https://github.com/gaurav-nelson/github-action-markdown-link-check/issues/170 to see if the creator of the Action has any insight. In the meantime, we might as well skip it.