### PR TITLE
runtime/expr/agg: add missing copy in (*fuse).ConsumeAsPartal

### DIFF
--- a/runtime/expr/agg/fuse.go
+++ b/runtime/expr/agg/fuse.go
@@ -52,7 +52,7 @@ func (f *fuse) ConsumeAsPartial(partial *zed.Value) {
 	if partial.Type != zed.TypeType {
 		panic("fuse: partial not a type value")
 	}
-	f.partials = append(f.partials, *partial)
+	f.partials = append(f.partials, *partial.Copy())
 }
 
 func (f *fuse) ResultAsPartial(zctx *zed.Context) *zed.Value {


### PR DESCRIPTION
Failure to copy zed.Value.Bytes here causes flakiness in runtime/expr/agg/ztests/fuse-partials.yaml that I can trigger reliably with

    GOMAXPROCS=4 go test -count=100 -failfast .