### PR TITLE
zed: remove exported errors unused by package

### DIFF
--- a/value.go
+++ b/value.go
@@ -13,15 +13,8 @@ import (
 )
 
 var (
-	ErrMissingField  = errors.New("record missing a field")
-	ErrExtraField    = errors.New("record with extra field")
-	ErrNotContainer  = errors.New("expected container type, got primitive")
-	ErrNotPrimitive  = errors.New("expected primitive type, got container")
-	ErrTypeIDInvalid = errors.New("zng type ID out of range")
-	ErrBadValue      = errors.New("malformed zng value")
-	ErrBadFormat     = errors.New("malformed zng record")
-	ErrTypeMismatch  = errors.New("type/value mismatch")
-	ErrTypeSyntax    = errors.New("syntax error parsing type string")
+	ErrMissingField = errors.New("record missing a field")
+	ErrNotContainer = errors.New("expected container type, got primitive")
 )
 
 var (

--- a/zio/zjsonio/reader.go
+++ b/zio/zjsonio/reader.go
@@ -124,7 +124,8 @@ func (r *Reader) decodeRecord(b *zcode.Builder, typ *zed.TypeRecord, v interface
 	b.BeginContainer()
 	for k, val := range values {
 		if k >= len(cols) {
-			return zed.ErrExtraField
+			return errors.New("record with extra field")
+
 		}
 		// Each column is either a string value or an array of string values.
 		if val == nil {
@@ -141,7 +142,7 @@ func (r *Reader) decodeRecord(b *zcode.Builder, typ *zed.TypeRecord, v interface
 
 func (r *Reader) decodePrimitive(builder *zcode.Builder, typ zed.Type, v interface{}) error {
 	if zed.IsContainerType(typ) && !zed.IsUnionType(typ) {
-		return zed.ErrNotPrimitive
+		return errors.New("expected primitive type, got container")
 	}
 	if v == nil {
 		builder.Append(nil)

--- a/zio/zngio/parser.go
+++ b/zio/zngio/parser.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/pkg/peeker"
 	"github.com/brimdata/zed/zbuf"
 	"github.com/brimdata/zed/zcode"
 	"golang.org/x/exp/slices"
 )
+
+var errBadFormat = errors.New("malformed zng record")
 
 // parser decodes the framing protocol for ZNG updating and resetting its
 // Zed type context in conformance with ZNG frames.
@@ -125,7 +126,7 @@ func (p *parser) decodeControl(code byte) error {
 		blk.free()
 	}
 	if len(bytes) == 0 {
-		return zed.ErrBadFormat
+		return errBadFormat
 	}
 	// Insert this control message into the result queue to preserve
 	// order between values frames and messages.  Note that a back-to-back
@@ -187,7 +188,7 @@ func (p *parser) readCompressedFrame(code byte) (frame, error) {
 		if err == peeker.ErrBufferOverflow {
 			return frame{}, fmt.Errorf("large value of %d bytes exceeds maximum read buffer", n)
 		}
-		return frame{}, zed.ErrBadFormat
+		return frame{}, errBadFormat
 	}
 	return frame{
 		fmt:  CompressionFormat(format),

--- a/zio/zngio/scanner.go
+++ b/zio/zngio/scanner.go
@@ -302,7 +302,7 @@ func (w *worker) decodeVal(buf *buffer, valRef *zed.Value) error {
 	}
 	n, err := zcode.ReadTag(buf)
 	if err != nil {
-		return zed.ErrBadFormat
+		return errBadFormat
 	}
 	var b []byte
 	if n == 0 {
@@ -313,7 +313,7 @@ func (w *worker) decodeVal(buf *buffer, valRef *zed.Value) error {
 			if err == peeker.ErrBufferOverflow {
 				return fmt.Errorf("large value of %d bytes exceeds maximum read buffer", n)
 			}
-			return zed.ErrBadFormat
+			return errBadFormat
 		}
 	}
 	typ := w.mapperLookupCache.Lookup(id)

--- a/zio/zngio/types.go
+++ b/zio/zngio/types.go
@@ -268,7 +268,7 @@ func (d *Decoder) decode(b *buffer) error {
 func (d *Decoder) readTypeRecord(b *buffer) error {
 	ncol, err := readUvarintAsInt(b)
 	if err != nil {
-		return zed.ErrBadFormat
+		return errBadFormat
 	}
 	var columns []zed.Column
 	for k := 0; k < int(ncol); k++ {
@@ -293,7 +293,7 @@ func (d *Decoder) readColumn(b *buffer) (zed.Column, error) {
 	}
 	id, err := readUvarintAsInt(b)
 	if err != nil {
-		return zed.Column{}, zed.ErrBadFormat
+		return zed.Column{}, errBadFormat
 	}
 	typ, err := d.local.zctx.LookupType(id)
 	if err != nil {
@@ -305,7 +305,7 @@ func (d *Decoder) readColumn(b *buffer) (zed.Column, error) {
 func (d *Decoder) readTypeArray(b *buffer) error {
 	id, err := readUvarintAsInt(b)
 	if err != nil {
-		return zed.ErrBadFormat
+		return errBadFormat
 	}
 	inner, err := d.local.zctx.LookupType(int(id))
 	if err != nil {
@@ -319,7 +319,7 @@ func (d *Decoder) readTypeArray(b *buffer) error {
 func (d *Decoder) readTypeSet(b *buffer) error {
 	id, err := readUvarintAsInt(b)
 	if err != nil {
-		return zed.ErrBadFormat
+		return errBadFormat
 	}
 	innerType, err := d.local.zctx.LookupType(int(id))
 	if err != nil {
@@ -333,7 +333,7 @@ func (d *Decoder) readTypeSet(b *buffer) error {
 func (d *Decoder) readTypeMap(b *buffer) error {
 	id, err := readUvarintAsInt(b)
 	if err != nil {
-		return zed.ErrBadFormat
+		return errBadFormat
 	}
 	keyType, err := d.local.zctx.LookupType(int(id))
 	if err != nil {
@@ -341,7 +341,7 @@ func (d *Decoder) readTypeMap(b *buffer) error {
 	}
 	id, err = readUvarintAsInt(b)
 	if err != nil {
-		return zed.ErrBadFormat
+		return errBadFormat
 	}
 	valType, err := d.local.zctx.LookupType(int(id))
 	if err != nil {
@@ -355,7 +355,7 @@ func (d *Decoder) readTypeMap(b *buffer) error {
 func (d *Decoder) readTypeUnion(b *buffer) error {
 	ntyp, err := readUvarintAsInt(b)
 	if err != nil {
-		return zed.ErrBadFormat
+		return errBadFormat
 	}
 	if ntyp == 0 {
 		return errors.New("type union: zero columns not allowed")
@@ -364,7 +364,7 @@ func (d *Decoder) readTypeUnion(b *buffer) error {
 	for k := 0; k < int(ntyp); k++ {
 		id, err := readUvarintAsInt(b)
 		if err != nil {
-			return zed.ErrBadFormat
+			return errBadFormat
 		}
 		typ, err := d.local.zctx.LookupType(int(id))
 		if err != nil {
@@ -380,7 +380,7 @@ func (d *Decoder) readTypeUnion(b *buffer) error {
 func (d *Decoder) readTypeEnum(b *buffer) error {
 	nsym, err := readUvarintAsInt(b)
 	if err != nil {
-		return zed.ErrBadFormat
+		return errBadFormat
 	}
 	var symbols []string
 	for k := 0; k < int(nsym); k++ {
@@ -398,11 +398,11 @@ func (d *Decoder) readTypeEnum(b *buffer) error {
 func (d *Decoder) readCountedString(b *buffer) (string, error) {
 	n, err := readUvarintAsInt(b)
 	if err != nil {
-		return "", zed.ErrBadFormat
+		return "", errBadFormat
 	}
 	name, err := b.read(n)
 	if err != nil {
-		return "", zed.ErrBadFormat
+		return "", errBadFormat
 	}
 	// pull the name out before the next read which might overwrite the buffer
 	return string(name), nil
@@ -415,7 +415,7 @@ func (d *Decoder) readTypeName(b *buffer) error {
 	}
 	id, err := readUvarintAsInt(b)
 	if err != nil {
-		return zed.ErrBadFormat
+		return errBadFormat
 	}
 	inner, err := d.local.zctx.LookupType(int(id))
 	if err != nil {
@@ -432,7 +432,7 @@ func (d *Decoder) readTypeName(b *buffer) error {
 func (d *Decoder) readTypeError(b *buffer) error {
 	id, err := readUvarintAsInt(b)
 	if err != nil {
-		return zed.ErrBadFormat
+		return errBadFormat
 	}
 	inner, err := d.local.zctx.LookupType(int(id))
 	if err != nil {

--- a/zson/marshal.go
+++ b/zson/marshal.go
@@ -997,7 +997,7 @@ func (u *UnmarshalZNGContext) decodeRecord(zv *zed.Value, sval reflect.Value) er
 	}
 	for i, it := 0, zv.Iter(); !it.Done(); i++ {
 		if i >= len(recType.Columns) {
-			return zed.ErrBadValue
+			return errors.New("malformed Zed value")
 		}
 		itzv := it.Next()
 		name := recType.Columns[i].Name


### PR DESCRIPTION
Package zed exports a number of errors that are either unused or used only in another package.  Remove the unused errors and move the others into the packages that use them (but don't export them since they aren't used outside their new homes).