### PR TITLE
add VNG segment compression

### DIFF
--- a/runtime/vcache/primitive.go
+++ b/runtime/vcache/primitive.go
@@ -24,17 +24,15 @@ func (p *Primitive) NewIter(r io.ReaderAt) (iterator, error) {
 		// (for random access, not used yet).
 		var n int
 		for _, segment := range p.meta.Segmap {
-			n += int(segment.Length)
+			n += int(segment.MemLength)
 		}
 		data := make([]byte, n)
-		off := 0
+		var off int
 		for _, segment := range p.meta.Segmap {
-			section := io.NewSectionReader(r, segment.Offset, int64(segment.Length))
-			if _, err := io.ReadFull(section, data[off:off+int(segment.Length)]); err != nil {
+			if err := segment.Read(r, data[off:]); err != nil {
 				return nil, err
-
 			}
-			off += int(segment.Length)
+			off += int(segment.MemLength)
 		}
 		p.bytes = data
 	}

--- a/vng/vector/segment.go
+++ b/vng/vector/segment.go
@@ -1,14 +1,59 @@
 package vector
 
 import (
+	"fmt"
 	"io"
+	"sync"
+
+	"github.com/pierrec/lz4/v4"
+	"golang.org/x/exp/slices"
+)
+
+// Values for [Segment.CompressionFormat].
+const (
+	CompressionFormatNone uint8 = 0 // No compression
+	CompressionFormatLZ4  uint8 = 1 // LZ4 compression
 )
 
 type Segment struct {
-	Offset int64
-	Length int32
+	Offset            int64 // Offset relative to start of file
+	Length            int32 // Length in file
+	MemLength         int32 // Length in memory
+	CompressionFormat uint8 // Compression format in file
 }
 
-func (s Segment) NewSectionReader(r io.ReaderAt) io.Reader {
-	return io.NewSectionReader(r, s.Offset, int64(s.Length))
+var zbufPool = sync.Pool{
+	New: func() any { return new([]byte) },
+}
+
+// Read reads the segement r, uncompresses it if necessary, and stores it in the
+// first s.MemLength bytes of b. If the length of b is less than s.MemLength,
+// Read returns [io.ErrShortBuffer].
+func (s *Segment) Read(r io.ReaderAt, b []byte) error {
+	if len(b) < int(s.MemLength) {
+		return io.ErrShortBuffer
+	}
+	b = b[:s.MemLength]
+	switch s.CompressionFormat {
+	case CompressionFormatNone:
+		_, err := r.ReadAt(b, s.Offset)
+		return err
+	case CompressionFormatLZ4:
+		zbuf := zbufPool.Get().(*[]byte)
+		defer zbufPool.Put(zbuf)
+		*zbuf = slices.Grow((*zbuf)[:0], int(s.Length))[:s.Length]
+		if _, err := r.ReadAt(*zbuf, s.Offset); err != nil {
+			return err
+		}
+		n, err := lz4.UncompressBlock(*zbuf, b)
+		if err != nil {
+			return err
+		}
+		if n != int(s.MemLength) {
+			return fmt.Errorf("vng: got %d uncompressed bytes, expected %d", n, s.MemLength)
+		}
+		return nil
+	default:
+		return fmt.Errorf("vng: unknown compression format 0x%x", s.CompressionFormat)
+	}
 }


### PR DESCRIPTION
In vng/vector:

* Add a Segment.CompressionFormat field and accompanying CompressionFormatNone and CompressionFormatLZ4 constants

* Add a Segment.MemLength field indicating the segment's in-memory (i.e., uncompressed) length (in contrast with Segment.Length, its in-file length)

* Add (*Segment).Read, which can read both compressed and uncompressed segments

* Update (*Spiller).Write to write a compressed segment if compression is effective and an uncompressed segment if not