### PR TITLE
Queue merged commits for an Autoperf run

### DIFF
--- a/.github/workflows/notify-downstream-merge.yml
+++ b/.github/workflows/notify-downstream-merge.yml
@@ -16,12 +16,6 @@ jobs:
       matrix:
         repo: [brim, brimcap]
     steps:
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1-node16
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: us-east-2
     - name: Populate "merged" variable
       run: |
         # GITHUB_EVENT_PATH
@@ -48,4 +42,8 @@ jobs:
     - name: Queue merged commits for an Autoperf run
       if: steps.vars.outputs.merged == 'true' && ! contains(github.event.pull_request.labels.*.name, 'skip-autoperf')
       run: |
-        aws sqs send-message --queue-url ${{ secrets.AWS_SQS_QUEUE_URL_AUTOPERF }} --message-group-id autoperf --message-body $(jq '.pull_request.merge_commit_sha' "${GITHUB_EVENT_PATH}" | sed 's/"//g')
+        aws sqs send-message --queue-url ${{ secrets.AWS_SQS_QUEUE_URL_AUTOPERF }} --message-group-id autoperf --message-body ${{ github.event.pull_request.merge_commit_sha }}
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: us-east-2

--- a/.github/workflows/notify-downstream-merge.yml
+++ b/.github/workflows/notify-downstream-merge.yml
@@ -16,6 +16,12 @@ jobs:
       matrix:
         repo: [brim, brimcap]
     steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1-node16
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-2
     - name: Populate "merged" variable
       run: |
         # GITHUB_EVENT_PATH
@@ -39,3 +45,7 @@ jobs:
         # https://developer.github.com/v3/repos/#create-a-repository-dispatch-event
         jq '.pull_request | { "event_type": "zed-pr-merged", "client_payload": {body, "branch": .head.ref, merge_commit_sha, number, title, "url": .html_url, "user": .user.login}}' "${GITHUB_EVENT_PATH}" > payload.json
         curl -XPOST -u "${{ secrets.PAT_USERNAME }}:${{ secrets.PAT_TOKEN }}" -H "Accept: application/vnd.github.v3+json"  -H "Content-Type: application/json" https://api.github.com/repos/brimdata/${{ matrix.repo }}/dispatches --data @payload.json
+    - name: Queue merged commits for an Autoperf run
+      if: steps.vars.outputs.merged == 'true' && ! contains(github.event.pull_request.labels.*.name, 'skip-autoperf')
+      run: |
+        aws sqs send-message --queue-url ${{ secrets.AWS_SQS_QUEUE_URL_AUTOPERF }} --message-group-id autoperf --message-body $(jq '.pull_request.merge_commit_sha' "${GITHUB_EVENT_PATH}" | sed 's/"//g')


### PR DESCRIPTION
This change is part of the Autoperf revival. The way I'm planning to trigger Autoperf runs is to push each merged Zed commit SHA into an AWS SQS queue (*). A separate Actions workflow in the Autoperf repo will periodically pull commits off the queue and wake up the Autoperf runner to execute a set of tests.

This differs from the previous approach to Autoperf where we had an always-on VM that continuously executed perf runs for whatever commit was at the tip of `main`. One minor drawback of that approach was perf runs might be skipped if there were multiple merged commits that arrived close together, and this plugs that gap. One silver lining of that approach was that we had lots of repeated runs at the same commits to establish consistency/variance. However, with the new approach nothing would preclude us from pushing the same commit SHA into the queue repeatedly if we still needed to check for that. What ultimately convinced me to go this new direction is that the size of VM that seems appropriate for perf runs would cost nearly $500/mo to keep powered on all the time, so this more frugal approach seems produent.

I tested out the approach taken in this PR in personal repo https://github.com/philrz/sqs-send.

---
(*) - To allow for further cost optimization, the approach in this PR skips the push of the SHA into the queue if the PR happens to have a label "skip-autoperf" attached to it. This way if you're putting up a PR that you know is not going to affect performance (e.g., something that hits just the docs) you can skip the perf run. Of course, if one forgets to add the label, this is not a crisis and the bonus run would just be more of the "consistency/variance" variety from the days of yore.