### PR TITLE
Makefile: enable "go vet" stdmethods analyzer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 #PEG_DEP=peg
 
 vet:
-	@go vet -stdmethods=false ./...
+	@go vet ./...
 
 fmt:
 	gofmt -s -w .


### PR DESCRIPTION
It has run cleanly since zio/zngio.(*Encoder).WriteTo was removed in #4237.