### PR TITLE
pkg/jsonlexer: change New parameter to io.Reader

### DIFF
--- a/pkg/jsonlexer/lexer.go
+++ b/pkg/jsonlexer/lexer.go
@@ -32,9 +32,9 @@ type Lexer struct {
 	err error
 }
 
-func New(br *bufio.Reader) *Lexer {
+func New(r io.Reader) *Lexer {
 	return &Lexer{
-		br:  br,
+		br:  bufio.NewReader(r),
 		buf: make([]byte, 0, 128),
 	}
 }


### PR DESCRIPTION
This package uses a bufio.Reader in Lexer instead of an io.ByteScanner because the former improves performance slightly (0.5% to 1%) in zio/jsonio.Reader.  Accordingly, New takes a *bufio.Reader parameter. To make New a little more general, change its parameter to an io.Reader and wrap that with bufio.NewReader.  (This doesn't affect zio/jsonio.Reader performance because bufio.NewReader returns its argument if it's a bufio.Reader with large enough size.)