### PR TITLE
Makefile: use curl's --compressed flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,8 @@ $(SAMPLEDATA):
 sampledata: $(SAMPLEDATA)
 
 bin/minio: Makefile
-	@curl -o $@ --create-dirs https://dl.min.io/server/minio/release/$$(go env GOOS)-$$(go env GOARCH)/archive/minio.RELEASE.2022-05-04T07-45-27Z
+	@curl -o $@ --compressed --create-dirs \
+		https://dl.min.io/server/minio/release/$$(go env GOOS)-$$(go env GOARCH)/archive/minio.RELEASE.2022-05-04T07-45-27Z
 	@chmod +x $@
 
 generate:


### PR DESCRIPTION
It can speed up the bin/minio rule's recipe substantially for slow network connections.