### PR TITLE
change expr.NewValueCompareFn to explicitly take sort order

### DIFF
--- a/cmd/zed/manage/lakemanage/compact.go
+++ b/cmd/zed/manage/lakemanage/compact.go
@@ -9,6 +9,7 @@ import (
 	"github.com/brimdata/zed/lake/pools"
 	"github.com/brimdata/zed/lakeparse"
 	"github.com/brimdata/zed/order"
+	"github.com/brimdata/zed/runtime/expr"
 	"github.com/brimdata/zed/runtime/expr/extent"
 	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zson"
@@ -34,7 +35,7 @@ func CompactionScan(ctx context.Context, it DataObjectIterator, pool *pools.Conf
 		return nil
 	}
 	var nextcold *time.Time
-	cmp := extent.CompareFunc(order.Asc)
+	cmp := expr.NewValueCompareFn(order.Asc, true)
 	run := NewRun(cmp)
 	for {
 		object, err := it.Next()

--- a/index/finder.go
+++ b/index/finder.go
@@ -206,7 +206,7 @@ func compareFn(zctx *zed.Context, kvs []KeyValue) keyCompareFn {
 		accessors[i] = expr.NewDottedExpr(zctx, kvs[i].Key)
 		values[i] = kvs[i].Value
 	}
-	fn := expr.NewValueCompareFn(false)
+	fn := expr.NewValueCompareFn(order.Asc, false)
 	return func(ectx expr.Context, this *zed.Value) int {
 		for i := range kvs {
 			val := accessors[i].Eval(ectx, this)

--- a/runtime/expr/extent/span.go
+++ b/runtime/expr/extent/span.go
@@ -34,20 +34,6 @@ type Generic struct {
 	cmp   expr.CompareFn
 }
 
-// CompareFunc returns a generic comparator suitable for use in a Range
-// based on the order of values in the range, i.e., when order is desc
-// then the first value is larger than the last value and Before is true
-// for larger values while After is true for smaller values, etc.
-func CompareFunc(o order.Which) expr.CompareFn {
-	// The values of nullsMax here (used during lake data reads) and in
-	// zbuf.NewCompareFn (used during lake data writes) must agree.
-	cmp := expr.NewValueCompareFn(o == order.Asc)
-	if o == order.Asc {
-		return cmp
-	}
-	return func(a, b *zed.Value) int { return cmp(b, a) }
-}
-
 // Create a new Range from generic range of zed.Values according
 // to lower and upper.  The range is not sensitive to the absolute order
 // of lower and upper.
@@ -63,7 +49,7 @@ func NewGeneric(lower, upper zed.Value, cmp expr.CompareFn) *Generic {
 }
 
 func NewGenericFromOrder(first, last zed.Value, o order.Which) *Generic {
-	return NewGeneric(first, last, CompareFunc(o))
+	return NewGeneric(first, last, expr.NewValueCompareFn(o, o == order.Asc))
 }
 
 func (g *Generic) In(val *zed.Value) bool {

--- a/runtime/expr/function/compare.go
+++ b/runtime/expr/function/compare.go
@@ -2,6 +2,7 @@ package function
 
 import (
 	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/runtime/expr"
 )
 
@@ -13,8 +14,8 @@ type Compare struct {
 
 func NewCompare(zctx *zed.Context) *Compare {
 	return &Compare{
-		nullsMax: expr.NewValueCompareFn(true),
-		nullsMin: expr.NewValueCompareFn(false),
+		nullsMax: expr.NewValueCompareFn(order.Asc, true),
+		nullsMin: expr.NewValueCompareFn(order.Asc, false),
 		zctx:     zctx,
 	}
 }

--- a/runtime/expr/sort.go
+++ b/runtime/expr/sort.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/runtime/expr/coerce"
 	"github.com/brimdata/zed/zcode"
 	"github.com/brimdata/zed/zson"
@@ -110,8 +111,8 @@ func NewCompareFn(nullsMax bool, exprs ...Evaluator) CompareFn {
 	return NewComparator(nullsMax, false, exprs...).WithMissingAsNull().Compare
 }
 
-func NewValueCompareFn(nullsMax bool) CompareFn {
-	return NewComparator(nullsMax, false, &This{}).Compare
+func NewValueCompareFn(o order.Which, nullsMax bool) CompareFn {
+	return NewComparator(nullsMax, o == order.Desc, &This{}).Compare
 }
 
 type Comparator struct {

--- a/runtime/op/groupby/groupby.go
+++ b/runtime/op/groupby/groupby.go
@@ -80,14 +80,7 @@ func NewAggregator(ctx context.Context, zctx *zed.Context, keyRefs, keyExprs, ag
 		// nullsMax=false for descending order is also expected for streaming
 		// groupby.
 		nullsMax := inputDir > 0
-
-		vs := expr.NewValueCompareFn(order.Asc, nullsMax)
-		if inputDir < 0 {
-			valueCompare = func(a, b *zed.Value) int { return vs(b, a) }
-		} else {
-			valueCompare = vs
-		}
-
+		valueCompare = expr.NewValueCompareFn(order.Which(inputDir < 0), nullsMax)
 		rs := expr.NewCompareFn(true, keyRefs[0])
 		if inputDir < 0 {
 			keyCompare = func(a, b *zed.Value) int { return rs(b, a) }

--- a/runtime/op/groupby/groupby.go
+++ b/runtime/op/groupby/groupby.go
@@ -81,7 +81,7 @@ func NewAggregator(ctx context.Context, zctx *zed.Context, keyRefs, keyExprs, ag
 		// groupby.
 		nullsMax := inputDir > 0
 
-		vs := expr.NewValueCompareFn(nullsMax)
+		vs := expr.NewValueCompareFn(order.Asc, nullsMax)
 		if inputDir < 0 {
 			valueCompare = func(a, b *zed.Value) int { return vs(b, a) }
 		} else {

--- a/runtime/op/join/join.go
+++ b/runtime/op/join/join.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/pkg/field"
 	"github.com/brimdata/zed/runtime/expr"
 	"github.com/brimdata/zed/runtime/op"
@@ -48,7 +49,7 @@ func New(pctx *op.Context, anti, inner bool, left, right zbuf.Puller, leftKey, r
 		left:        newPuller(left, ctx),
 		right:       zio.NewPeeker(newPuller(right, ctx)),
 		// XXX need to make sure nullsmax agrees with inbound merge
-		compare: expr.NewValueCompareFn(false),
+		compare: expr.NewValueCompareFn(order.Asc, false),
 		cutter:  cutter,
 		types:   make(map[int]map[int]*zed.TypeRecord),
 	}, nil

--- a/runtime/op/meta/lister.go
+++ b/runtime/op/meta/lister.go
@@ -91,7 +91,7 @@ func (l *Lister) Pull(done bool) (zbuf.Batch, error) {
 }
 
 func filterObjects(objects []*data.Object, filter *expr.SpanFilter, o order.Which) []*data.Object {
-	cmp := expr.NewValueCompareFn(o == order.Asc)
+	cmp := expr.NewValueCompareFn(order.Asc, o == order.Asc)
 	out := objects[:0]
 	for _, obj := range objects {
 		span := extent.NewGeneric(obj.First, obj.Last, cmp)

--- a/runtime/op/meta/sequence.go
+++ b/runtime/op/meta/sequence.go
@@ -192,7 +192,7 @@ func objectRange(ctx context.Context, pool *lake.Pool, snap commits.View, filter
 			return seekindex.Range{}, err
 		}
 	}
-	cmp := expr.NewValueCompareFn(pool.Layout.Order == order.Asc)
+	cmp := expr.NewValueCompareFn(order.Asc, pool.Layout.Order == order.Asc)
 	span := extent.NewGeneric(o.First, o.Last, cmp)
 	if indexSpan != nil || cropped != nil && cropped.Eval(span.First(), span.Last()) {
 		// There's an index available or the object's span is cropped by

--- a/runtime/op/meta/slicer.go
+++ b/runtime/op/meta/slicer.go
@@ -31,7 +31,7 @@ func partitionObjects(objects []*data.Object, o order.Which) []Partition {
 	if len(objects) == 0 {
 		return nil
 	}
-	cmp := extent.CompareFunc(o)
+	cmp := expr.NewValueCompareFn(o, o == order.Asc)
 	spans := sortedObjectSpans(objects, cmp)
 	var s stack
 	s.pushObjectSpan(spans[0], cmp)


### PR DESCRIPTION
This commit changes expr.NewValueCompareFn to take the sort order, forcing the call sites to explicitly indicate the preumed order of data.  This makes the code a bit easier to follow.

We also deleted extent.CompareFunc since all that did was specify a sort order above NewValueCompareFn.