### PR TITLE
add -unbuffered flag to zed and zq

### DIFF
--- a/cmd/zq/ztests/unbuffered.yaml
+++ b/cmd/zq/ztests/unbuffered.yaml
@@ -1,0 +1,16 @@
+script: |
+  mkfifo fifo
+  # "-i json" avoids reader buffering.
+  zq -i json -unbuffered -z fifo > out.zson &
+  # Prevent zq from seeing EOF on fifo and exiting before the shell exits.
+  exec {fd}> fifo
+  echo 1 > fifo
+  # Wait for out.zson to have size greater than zero.
+  while [ ! -s out.zson -a $((i++)) < 50 ]; do sleep 0.1; done
+  # Get out.zson contents now, before zq exits.
+  cat out.zson
+
+outputs:
+  - name: stdout
+    data: |
+      1

--- a/zio/emitter/split_test.go
+++ b/zio/emitter/split_test.go
@@ -35,7 +35,7 @@ func TestDirS3Source(t *testing.T) {
 
 	r := zsonio.NewReader(zed.NewContext(), strings.NewReader(input))
 	require.NoError(t, err)
-	w, err := NewSplit(context.Background(), engine, uri, "", anyio.WriterOpts{Format: "zson"})
+	w, err := NewSplit(context.Background(), engine, uri, "", false, anyio.WriterOpts{Format: "zson"})
 	require.NoError(t, err)
 	require.NoError(t, zio.Copy(w, r))
 }


### PR DESCRIPTION
The -unbuffered flag disables most output buffering.  It does this in part at the io.Writer level in zio/emitter and in part by setting zbuf.ScannerBatchSize to 1 to disable batching in non-ZNG scanners created by zbuf.NewScanner.

Limitations:

* Does not disable output buffering due to ZNG framing (but can be combined with -zngframethresh=0 for that)

* Does not disable the initial input buffering necessary for auto-detection (but can be combined with -i for that)

* Does not disable the limited input buffering in most readers