### PR TITLE
zed: rework (*RecordBuilder).Fields as Type

### DIFF
--- a/recordbuilder.go
+++ b/recordbuilder.go
@@ -186,9 +186,9 @@ func (r *RecordBuilder) Encode() (zcode.Bytes, error) {
 
 // A RecordBuilder understands the shape of the [field.List] from which it was
 // created (i.e., which fields are inside nested records) but not the types.
-// Fields takes types for the individual fields and constructs [Field] slice
-// that reflects the fully typed structure.
-func (r *RecordBuilder) Fields(types []Type) []Field {
+// Type takes types for the individual fields and constructs a [TypeRecord]
+// reflecting the fully typed structure.
+func (r *RecordBuilder) Type(types []Type) *TypeRecord {
 	type rec struct {
 		name   string
 		fields []Field
@@ -217,5 +217,5 @@ func (r *RecordBuilder) Fields(types []Type) []Field {
 	if len(stack) != 1 {
 		panic("Mismatched container begin/end")
 	}
-	return stack[0].fields
+	return r.zctx.MustLookupTypeRecord(stack[0].fields)
 }

--- a/runtime/expr/cutter.go
+++ b/runtime/expr/cutter.go
@@ -106,8 +106,7 @@ func (c *Cutter) lookupTypeRecord(types []zed.Type) *zed.TypeRecord {
 	id := c.outTypes.Lookup(types)
 	typ, ok := c.recordTypes[id]
 	if !ok {
-		cols := c.builder.Fields(types)
-		typ = c.zctx.MustLookupTypeRecord(cols)
+		typ = c.builder.Type(types)
 		c.recordTypes[id] = typ
 	}
 	return typ

--- a/runtime/expr/dropper.go
+++ b/runtime/expr/dropper.go
@@ -66,8 +66,7 @@ func (d *Dropper) newDropper(zctx *zed.Context, r *zed.Value) *dropper {
 	if err != nil {
 		panic(err)
 	}
-	cols := builder.Fields(fieldTypes)
-	typ := d.zctx.MustLookupTypeRecord(cols)
+	typ := builder.Type(fieldTypes)
 	return &dropper{typ, builder, fieldRefs}
 }
 

--- a/runtime/expr/function/nestdotted.go
+++ b/runtime/expr/function/nestdotted.go
@@ -49,7 +49,7 @@ func (n *NestDotted) lookupBuilderAndType(in *zed.TypeRecord) (*zed.RecordBuilde
 	if err != nil {
 		return nil, nil, err
 	}
-	typ := n.zctx.MustLookupTypeRecord(b.Fields(types))
+	typ := b.Type(types)
 	n.builders[in.ID()] = b
 	n.recordTypes[in.ID()] = typ
 	return b, typ, nil

--- a/runtime/op/groupby/groupby.go
+++ b/runtime/op/groupby/groupby.go
@@ -499,10 +499,7 @@ func (a *Aggregator) nextResultFromSpills(ectx expr.Context) (*zed.Value, error)
 		types = append(types, v.Type)
 		a.builder.Append(v.Bytes)
 	}
-	typ, err := a.lookupRecordType(types)
-	if err != nil {
-		return nil, err
-	}
+	typ := a.lookupRecordType(types)
 	bytes, err := a.builder.Encode()
 	if err != nil {
 		return nil, err
@@ -551,10 +548,7 @@ func (a *Aggregator) readTable(flush, partialsOut bool, batch zbuf.Batch) (zbuf.
 			types = append(types, v.Type)
 			a.builder.Append(v.Bytes)
 		}
-		typ, err := a.lookupRecordType(types)
-		if err != nil {
-			return nil, err
-		}
+		typ := a.lookupRecordType(types)
 		zv, err := a.builder.Encode()
 		if err != nil {
 			return nil, err
@@ -574,16 +568,12 @@ func (a *Aggregator) readTable(flush, partialsOut bool, batch zbuf.Batch) (zbuf.
 	return zbuf.NewBatch(batch, recs), nil
 }
 
-func (a *Aggregator) lookupRecordType(types []zed.Type) (*zed.TypeRecord, error) {
+func (a *Aggregator) lookupRecordType(types []zed.Type) *zed.TypeRecord {
 	id := a.outTypes.Lookup(types)
 	typ, ok := a.recordTypes[id]
 	if !ok {
-		var err error
-		typ, err = a.zctx.LookupTypeRecord(a.builder.Fields(types))
-		if err != nil {
-			return nil, err
-		}
+		typ = a.builder.Type(types)
 		a.recordTypes[id] = typ
 	}
-	return typ, nil
+	return typ
 }


### PR DESCRIPTION
The Fields method returns fields that are always used to look up a TypeRecord.  Simplify by moving that lookup into the method (and rename it to Type to match the new behavior).