### PR TITLE
runtime/expr: fix subbenchmark names in BenchmarkSort

### DIFF
--- a/runtime/expr/sort_test.go
+++ b/runtime/expr/sort_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/zson"
 )
 
 func BenchmarkSort(b *testing.B) {
@@ -18,7 +19,7 @@ func BenchmarkSort(b *testing.B) {
 		{zed.TypeString, func() []byte { return strconv.AppendUint(nil, rand.Uint64(), 16) }},
 	}
 	for _, c := range cases {
-		b.Run(c.typ.Kind().String(), func(b *testing.B) {
+		b.Run(zson.FormatType(c.typ), func(b *testing.B) {
 			cmp := NewComparator(false, false, &This{})
 			vals := make([]zed.Value, 1048576)
 			var sorter Sorter


### PR DESCRIPTION
Before:

    $ go test ./runtime/expr -bench BenchmarkSort
    goos: darwin
    goarch: arm64
    pkg: github.com/brimdata/zed/runtime/expr
    BenchmarkSort/primitive-10         	       3	 473237667 ns/op
    BenchmarkSort/primitive#01-10      	       1	1019121708 ns/op
    BenchmarkSort/primitive#02-10      	       1	1435500792 ns/op
    PASS
    ok  	github.com/brimdata/zed/runtime/expr	6.188s

After:

    $ go test ./runtime/expr -bench BenchmarkSort
    goos: darwin
    goarch: arm64
    pkg: github.com/brimdata/zed/runtime/expr
    BenchmarkSort/int64-10         	       3	 471964417 ns/op
    BenchmarkSort/uint64-10        	       1	1009214541 ns/op
    BenchmarkSort/string-10        	       1	1433023666 ns/op
    PASS
    ok  	github.com/brimdata/zed/runtime/expr	6.169s