### PR TITLE
docs: change record column references to field

### DIFF
--- a/docs/formats/zjson.md
+++ b/docs/formats/zjson.md
@@ -8,7 +8,7 @@ sidebar_label: ZJSON
 ## 1. Introduction
 
 The [Zed data model](zed.md)
-is based on richly typed records with a deterministic column order,
+is based on richly typed records with a deterministic field order,
 as is implemented by the [ZSON](zson.md), [ZNG](zng.md), and [VNG](vng.md) formats.
 Given the ubiquity of JSON, it is desirable to also be able to serialize
 Zed data into the JSON format.   However, encoding Zed data values
@@ -70,7 +70,7 @@ to manipulate the rich, structured Zed types that are implemented on top of
 the basic JavaScript types.
 
 In other words,
-because JSON objects do not have a deterministic column order nor does JSON
+because JSON objects do not have a deterministic field order nor does JSON
 in general have typing beyond the basics (i.e., strings, floating point numbers,
 objects, arrays, and booleans), we decided to encode Zed data with
 its embedded type model all in a layer above regular JSON.
@@ -150,7 +150,7 @@ where each of the fields has the form
   "type": <type>,
 }
 ```
-and `<name>` is a string defining the column name and `<type>` is a
+and `<name>` is a string defining the field name and `<type>` is a
 recursively encoded type.
 
 #### 2.1.2 Array Type
@@ -259,7 +259,7 @@ as described recursively herein,
 is encoded as a string conforming to its ZSON representation, as described in the
 [corresponding section of the ZSON specification](zson.md#23-primitive-values).
 
-For example, a record with three columns --- a string, an array of integers,
+For example, a record with three fields --- a string, an array of integers,
 and an array of union of string, and float64 --- might have a value that looks like this:
 ```
 [ "hello, world", ["1","2","3","4"], ["1:foo", "0:10" ] ]

--- a/docs/formats/zng.md
+++ b/docs/formats/zng.md
@@ -188,21 +188,21 @@ A record typedef creates a new type ID equal to the next stream type ID
 with the following structure:
 ```
 ---------------------------------------------------------
-|0x00|<ncolumns>|<name1><type-id-1><name2><type-id-2>...|
+|0x00|<nfields>|<name1><type-id-1><name2><type-id-2>...|
 ---------------------------------------------------------
 ```
-Record types consist of an ordered set of columns where each column consists of
-a name and its type.  Unlike JSON, the ordering of the columns is significant
+Record types consist of an ordered set of fields where each field consists of
+a name and its type.  Unlike JSON, the ordering of the fields is significant
 and must be preserved through any APIs that consume, process, and emit ZNG records.
 
-A record type is encoded as a count of fields, i.e., `<ncolumns>` from above,
+A record type is encoded as a count of fields, i.e., `<nfields>` from above,
 followed by the field definitions,
 where a field definition is a field name followed by a type ID, i.e.,
 `<name1>` followed by `<type-id-1>` etc. as indicated above.
 
 The field names in a record must be unique.
 
-The `<ncolumns>` value is encoded as a `uvarint`.
+The `<nfields>` value is encoded as a `uvarint`.
 
 The field name is encoded as a UTF-8 string defining a "ZNG identifier".
 The UTF-8 string
@@ -548,10 +548,10 @@ complex type it represents as described below.
 A record type value has the form:
 ```
 ---------------------------------------------------
-|30|<ncolumns>|<name1><typeval><name2><typeval>...|
+|30|<nfields>|<name1><typeval><name2><typeval>...|
 ---------------------------------------------------
 ```
-where `<ncolumns>` is the number of columns in the record encoded as a `uvarint`,
+where `<nfields>` is the number of fields in the record encoded as a `uvarint`,
 `<name1>` etc. are the field names encoded as in the
 record typedef, and each `<typeval>` is a recursive encoding of a type value.
 

--- a/docs/tutorials/schools.md
+++ b/docs/tutorials/schools.md
@@ -1285,7 +1285,7 @@ When a value is missing for a specified field, it will appear as `error("missing
 
 For instance, if we'd made an typographical error in our
 prior example when attempting to reference the `dname` field,
-the misspelled column would appear as embedded missing errors, e.g.,
+the misspelled field would appear as embedded missing errors, e.g.,
 ```mdtest-command dir=testdata/edu
 zq -Z 'avg(AvgScrRead),count() by cname,dnmae | sort -r count' testscores.zson
 ```


### PR DESCRIPTION
This is a follow-up to #4306, which renamed zed.Column to Field.