### PR TITLE
index: change record column references to field

### DIFF
--- a/index/finder.go
+++ b/index/finder.go
@@ -182,7 +182,7 @@ func (f *Finder) LookupAll(ctx context.Context, hits chan<- *zed.Value, kvs []Ke
 	defer reader.Close()
 	for {
 		// As long as we have an exact key-match, where unset key
-		// columns are "don't care", keep reading records and return
+		// fields are "don't care", keep reading records and return
 		// them via the channel.
 		rec, err := lookup(reader, compare, f.meta.Order, EQL)
 		if err != nil {

--- a/index/writer.go
+++ b/index/writer.go
@@ -344,9 +344,9 @@ func (w *indexWriter) addToParentIndex(key *zed.Value, offset int64) error {
 }
 
 func (w *indexWriter) writeIndexRecord(keys *zed.Value, offset int64) error {
-	col := []zed.Field{{Name: w.base.childField, Type: zed.TypeInt64}}
+	fields := []zed.Field{{Name: w.base.childField, Type: zed.TypeInt64}}
 	val := zed.EncodeInt(offset)
-	rec, err := w.base.zctx.AddFields(keys, col, []zed.Value{{Type: zed.TypeInt64, Bytes: val}})
+	rec, err := w.base.zctx.AddFields(keys, fields, []zed.Value{{Type: zed.TypeInt64, Bytes: val}})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is a follow-up to #4306, which renamed zed.Column to Field.