### PR TITLE
add -csv.delim flag to zed and zq

### DIFF
--- a/cli/inputflags/flags.go
+++ b/cli/inputflags/flags.go
@@ -28,6 +28,7 @@ func (f *Flags) Options() anyio.ReaderOpts {
 
 func (f *Flags) SetFlags(fs *flag.FlagSet, validate bool) {
 	fs.StringVar(&f.Format, "i", "auto", "format of input data [auto,arrows,csv,json,line,parquet,vng,zeek,zjson,zng,zson]")
+	fs.StringVar(&f.CSV.Delim, "d", ",", "CSV field delimiter")
 	fs.BoolVar(&f.ZNG.Validate, "validate", validate, "validate the input format when reading ZNG streams")
 	fs.IntVar(&f.ZNG.Threads, "threads", 0, "number of threads used for scanning ZNG input")
 	f.ReadMax = auto.NewBytes(zngio.MaxSize)

--- a/cli/inputflags/flags.go
+++ b/cli/inputflags/flags.go
@@ -28,7 +28,15 @@ func (f *Flags) Options() anyio.ReaderOpts {
 
 func (f *Flags) SetFlags(fs *flag.FlagSet, validate bool) {
 	fs.StringVar(&f.Format, "i", "auto", "format of input data [auto,arrows,csv,json,line,parquet,vng,zeek,zjson,zng,zson]")
-	fs.StringVar(&f.CSV.Delim, "d", ",", "CSV field delimiter")
+	f.CSV.Delim = ','
+	fs.Func("csv.delim", `CSV field delimiter (default ",")`, func (s string) error {
+		if len(s) != 1 {
+			return errors.New("CSV field delimiter must be exactly one character")
+		}
+		f.CSV.Delim = rune(s[0])
+		return nil
+
+	})
 	fs.BoolVar(&f.ZNG.Validate, "validate", validate, "validate the input format when reading ZNG streams")
 	fs.IntVar(&f.ZNG.Threads, "threads", 0, "number of threads used for scanning ZNG input")
 	f.ReadMax = auto.NewBytes(zngio.MaxSize)

--- a/cli/inputflags/flags.go
+++ b/cli/inputflags/flags.go
@@ -29,7 +29,7 @@ func (f *Flags) Options() anyio.ReaderOpts {
 func (f *Flags) SetFlags(fs *flag.FlagSet, validate bool) {
 	fs.StringVar(&f.Format, "i", "auto", "format of input data [auto,arrows,csv,json,line,parquet,vng,zeek,zjson,zng,zson]")
 	f.CSV.Delim = ','
-	fs.Func("csv.delim", `CSV field delimiter (default ",")`, func (s string) error {
+	fs.Func("csv.delim", `CSV field delimiter (default ",")`, func(s string) error {
 		if len(s) != 1 {
 			return errors.New("CSV field delimiter must be exactly one character")
 		}

--- a/zio/anyio/lookup.go
+++ b/zio/anyio/lookup.go
@@ -23,7 +23,7 @@ func lookupReader(zctx *zed.Context, r io.Reader, opts ReaderOpts) (zio.ReadClos
 	case "arrows":
 		return arrowio.NewReader(zctx, r)
 	case "csv":
-		return zio.NopReadCloser(csvio.NewReader(zctx, r)), nil
+		return zio.NopReadCloser(csvio.NewReader(zctx, r, opts.CSV)), nil
 	case "line":
 		return zio.NopReadCloser(lineio.NewReader(r)), nil
 	case "json":

--- a/zio/anyio/reader.go
+++ b/zio/anyio/reader.go
@@ -23,7 +23,7 @@ import (
 
 type ReaderOpts struct {
 	Format string
-        CSV    csvio.ReaderOpts
+	CSV    csvio.ReaderOpts
 	ZNG    zngio.ReaderOpts
 }
 

--- a/zio/anyio/reader.go
+++ b/zio/anyio/reader.go
@@ -23,8 +23,8 @@ import (
 
 type ReaderOpts struct {
 	Format string
+        CSV    csvio.ReaderOpts
 	ZNG    zngio.ReaderOpts
-	CSV    csvio.ReaderOpts
 }
 
 func NewReader(zctx *zed.Context, r io.Reader) (zio.ReadCloser, error) {

--- a/zio/anyio/reader.go
+++ b/zio/anyio/reader.go
@@ -24,6 +24,7 @@ import (
 type ReaderOpts struct {
 	Format string
 	ZNG    zngio.ReaderOpts
+	CSV    csvio.ReaderOpts
 }
 
 func NewReader(zctx *zed.Context, r io.Reader) (zio.ReadCloser, error) {
@@ -123,9 +124,9 @@ func NewReaderWithOpts(zctx *zed.Context, r io.Reader, opts ReaderOpts) (zio.Rea
 		csvErr = errors.New("csv: line 1: no comma found")
 	} else {
 		track.Reset()
-		csvErr = match(csvio.NewReader(zed.NewContext(), track), "csv", 1)
+		csvErr = match(csvio.NewReader(zed.NewContext(), track, opts.CSV), "csv", 1)
 		if csvErr == nil {
-			return zio.NopReadCloser(csvio.NewReader(zctx, recorder)), nil
+			return zio.NopReadCloser(csvio.NewReader(zctx, recorder, opts.CSV)), nil
 		}
 	}
 	track.Reset()

--- a/zio/csvio/reader.go
+++ b/zio/csvio/reader.go
@@ -36,7 +36,7 @@ type ReaderOpts struct {
 func NewReader(zctx *zed.Context, r io.Reader, opts ReaderOpts) *Reader {
 	preprocess := newPreprocess(r)
 	reader := csv.NewReader(preprocess)
-	if opts.Delim != ',' {
+	if opts.Delim != 0 {
 		reader.Comma = opts.Delim
 	}
 	reader.ReuseRecord = true

--- a/zio/csvio/reader.go
+++ b/zio/csvio/reader.go
@@ -19,6 +19,9 @@ type Reader struct {
 	hdr       []string
 	vals      []interface{}
 }
+type ReaderOpts struct {
+	Delim     string
+}
 
 // XXX This is a placeholder for an option that will allow one to convert
 // all csv fields to strings and defer any type coercion presumably to
@@ -29,9 +32,12 @@ type Reader struct {
 //	StringsOnly bool
 //}
 
-func NewReader(zctx *zed.Context, r io.Reader) *Reader {
+func NewReader(zctx *zed.Context, r io.Reader, opts ReaderOpts) *Reader {
 	preprocess := newPreprocess(r)
 	reader := csv.NewReader(preprocess)
+	if opts.Delim != "," {
+		reader.Comma = ';'
+	}
 	reader.ReuseRecord = true
 	reader.TrimLeadingSpace = true
 	return &Reader{

--- a/zio/csvio/reader.go
+++ b/zio/csvio/reader.go
@@ -20,7 +20,7 @@ type Reader struct {
 	vals      []interface{}
 }
 type ReaderOpts struct {
-	Delim     string
+	Delim string
 }
 
 // XXX This is a placeholder for an option that will allow one to convert

--- a/zio/csvio/reader.go
+++ b/zio/csvio/reader.go
@@ -19,8 +19,9 @@ type Reader struct {
 	hdr       []string
 	vals      []interface{}
 }
+
 type ReaderOpts struct {
-	Delim string
+	Delim rune
 }
 
 // XXX This is a placeholder for an option that will allow one to convert
@@ -35,8 +36,8 @@ type ReaderOpts struct {
 func NewReader(zctx *zed.Context, r io.Reader, opts ReaderOpts) *Reader {
 	preprocess := newPreprocess(r)
 	reader := csv.NewReader(preprocess)
-	if opts.Delim != "," {
-		reader.Comma = ';'
+	if opts.Delim != ',' {
+		reader.Comma = opts.Delim
 	}
 	reader.ReuseRecord = true
 	reader.TrimLeadingSpace = true

--- a/zio/csvio/reader_test.go
+++ b/zio/csvio/reader_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestNewReaderUsesContextParameter(t *testing.T) {
 	zctx := zed.NewContext()
-	rec, err := NewReader(zctx, strings.NewReader("f\n1\n"), ReaderOpts{}).Read()
+	rec, err := NewReader(zctx, strings.NewReader("f\n1\n"), ReaderOpts{','}).Read()
 	require.NoError(t, err)
 	typ, err := zctx.LookupType(rec.Type.ID())
 	require.NoError(t, err)

--- a/zio/csvio/reader_test.go
+++ b/zio/csvio/reader_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestNewReaderUsesContextParameter(t *testing.T) {
 	zctx := zed.NewContext()
-	rec, err := NewReader(zctx, strings.NewReader("f\n1\n")).Read()
+	rec, err := NewReader(zctx, strings.NewReader("f\n1\n"), ReaderOpts{}).Read()
 	require.NoError(t, err)
 	typ, err := zctx.LookupType(rec.Type.ID())
 	require.NoError(t, err)

--- a/zio/csvio/reader_test.go
+++ b/zio/csvio/reader_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestNewReaderUsesContextParameter(t *testing.T) {
 	zctx := zed.NewContext()
-	rec, err := NewReader(zctx, strings.NewReader("f\n1\n"), ReaderOpts{','}).Read()
+	rec, err := NewReader(zctx, strings.NewReader("f\n1\n"), ReaderOpts{}).Read()
 	require.NoError(t, err)
 	typ, err := zctx.LookupType(rec.Type.ID())
 	require.NoError(t, err)

--- a/zio/csvio/ztests/reader-delim.yaml
+++ b/zio/csvio/ztests/reader-delim.yaml
@@ -1,6 +1,6 @@
 zed: '*'
 
-input-flags: -i csv -d ";"
+input-flags: -i csv -csv.delim ;
 
 input: |
   a;b;c

--- a/zio/csvio/ztests/reader-delim.yaml
+++ b/zio/csvio/ztests/reader-delim.yaml
@@ -1,0 +1,12 @@
+zed: '*'
+
+input-flags: -i csv -d ";"
+
+input: |
+  a;b;c
+  1;2;3
+  hello;world;4
+
+output: |
+  {a:1.,b:2.,c:3.}
+  {a:"hello",b:"world",c:4.}


### PR DESCRIPTION
The -csv.delim flag specifies the field delimiter for CSV input, allowing use of a character other than ",".

For #4238.