### PR TITLE
fix flakiness in cmd/zq/ztests/unbuffered.yaml

### DIFF
--- a/cmd/zq/ztests/unbuffered.yaml
+++ b/cmd/zq/ztests/unbuffered.yaml
@@ -6,7 +6,7 @@ script: |
   exec {fd}> fifo
   echo 1 > fifo
   # Wait for out.zson to have size greater than zero.
-  while [ ! -s out.zson -a $((i++)) < 50 ]; do sleep 0.1; done
+  while [ ! -s out.zson -a $((i++)) -lt 50 ]; do sleep 0.1; done
   # Get out.zson contents now, before zq exits.
   cat out.zson
 


### PR DESCRIPTION
This test is flaky because an error in the while loop's test command causes the loop to exit immediately, without waiting for out.zson to have size greater than zero.  Fix that.