### PR TITLE
service: add csv.delim query param to load API

### DIFF
--- a/docs/lake/api.md
+++ b/docs/lake/api.md
@@ -145,7 +145,6 @@ POST /pool/{pool}/branch/{branch}
 | Content-Type | string | header | MIME type of the posted content. If undefined, the service will attempt to introspect the data and determine type automatically. |
 | csv.delim | string | query | Exactly one character specifing the field delimiter for CSV data. Defaults to ",". |
 
-
 **Example Request**
 
 ```

--- a/docs/lake/api.md
+++ b/docs/lake/api.md
@@ -143,6 +143,8 @@ POST /pool/{pool}/branch/{branch}
 | branch | string | path | **Required.** Name of branch to which data will be loaded. |
 |   | various | body | **Required.** Contents of the posted data. |
 | Content-Type | string | header | MIME type of the posted content. If undefined, the service will attempt to introspect the data and determine type automatically. |
+| csv.delim | string | query | Exactly one character specifing the field delimiter for CSV data. Defaults to ",". |
+
 
 **Example Request**
 

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -24,6 +24,7 @@ import (
 	"github.com/brimdata/zed/service/srverr"
 	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zio/anyio"
+	"github.com/brimdata/zed/zio/csvio"
 	"github.com/brimdata/zed/zio/zngio"
 	"github.com/segmentio/ksuid"
 )
@@ -347,6 +348,14 @@ func handleBranchLoad(c *Core, w *ResponseWriter, r *Request) {
 	if !ok {
 		return
 	}
+	var csvDelim rune
+	if s := r.URL.Query().Get("csv.delim"); s != "" {
+		if len(s) != 1 {
+			w.Error(srverr.ErrInvalid(`invalid query param "csv.delim": must be exactly one character`))
+			return
+		}
+		csvDelim = rune(s[0])
+	}
 	message, ok := r.decodeCommitMessage(w)
 	if !ok {
 		return
@@ -390,6 +399,7 @@ func handleBranchLoad(c *Core, w *ResponseWriter, r *Request) {
 	}
 	opts := anyio.ReaderOpts{
 		Format: format,
+		CSV:    csvio.ReaderOpts{Delim: csvDelim},
 		// Force validation of ZNG when loading into the lake.
 		ZNG: zngio.ReaderOpts{Validate: true},
 	}

--- a/service/ztests/curl-load-csv.yaml
+++ b/service/ztests/curl-load-csv.yaml
@@ -1,0 +1,29 @@
+script: |
+  source service.sh
+  zed create -q test
+  curl -H Content-Type:text/csv --data-binary @in.csv \
+    --fail $ZED_LAKE/pool/test/branch/main | zq -z commit:=0 -
+  curl -H Content-Type:text/csv --data-binary @in-dot.csv \
+    --fail $ZED_LAKE/pool/test/branch/main?csv.delim=. | zq -z commit:=0 -
+  echo //
+  zed query -z 'from test'
+
+inputs:
+  - name: in.csv
+    data: |
+      a,b
+      1,2
+  - name: in-dot.csv
+    data: |
+      a.b
+      3.4
+  - name: service.sh
+
+outputs:
+  - name: stdout
+    data: |
+      {commit:0,warnings:[]([string])}
+      {commit:0,warnings:[]([string])}
+      //
+      {a:1.,b:2.}
+      {a:3.,b:4.}


### PR DESCRIPTION
The csv.delim query parameter to the load API (POST /pool/{pool}/branch/{branch}) specifies the field delimiter for CSV input, allowing use of a character other than ",".

For #4238.