### PR TITLE
use "zng." prefix for ZNG-related flags

### DIFF
--- a/cli/inputflags/flags.go
+++ b/cli/inputflags/flags.go
@@ -37,12 +37,12 @@ func (f *Flags) SetFlags(fs *flag.FlagSet, validate bool) {
 		return nil
 
 	})
-	fs.BoolVar(&f.ZNG.Validate, "validate", validate, "validate the input format when reading ZNG streams")
-	fs.IntVar(&f.ZNG.Threads, "threads", 0, "number of threads used for scanning ZNG input")
+	fs.BoolVar(&f.ZNG.Validate, "zng.validate", validate, "validate format when reading ZNG")
+	fs.IntVar(&f.ZNG.Threads, "zng.threads", 0, "number of ZNG read threads (0=GOMAXPROCS)")
 	f.ReadMax = auto.NewBytes(zngio.MaxSize)
-	fs.Var(&f.ReadMax, "readmax", "maximum memory used read buffers in MiB, MB, etc")
+	fs.Var(&f.ReadMax, "zng.readmax", "maximum ZNG read buffer size in MiB, MB, etc.")
 	f.ReadSize = auto.NewBytes(zngio.ReadSize)
-	fs.Var(&f.ReadSize, "readsize", "target memory used read buffers in MiB, MB, etc")
+	fs.Var(&f.ReadSize, "zng.readsize", "target ZNG read buffer size in MiB, MB, etc.")
 }
 
 // Init is called after flags have been parsed.

--- a/cli/outputflags/flags.go
+++ b/cli/outputflags/flags.go
@@ -43,8 +43,8 @@ func (f *Flags) setFlags(fs *flag.FlagSet) {
 	// zio stuff
 	fs.BoolVar(&f.color, "color", true, "enable/disable color formatting for -Z and lake text output")
 	f.ZNG = &zngio.WriterOpts{}
-	fs.BoolVar(&f.ZNG.Compress, "zngcompress", true, "compress ZNG frames")
-	fs.IntVar(&f.ZNG.FrameThresh, "zngframethresh", zngio.DefaultFrameThresh,
+	fs.BoolVar(&f.ZNG.Compress, "zng.compress", true, "compress ZNG frames")
+	fs.IntVar(&f.ZNG.FrameThresh, "zng.framethresh", zngio.DefaultFrameThresh,
 		"minimum ZNG frame size in uncompressed bytes")
 	fs.IntVar(&f.ZSON.Pretty, "pretty", 4,
 		"tab size to pretty print ZSON output (0 for newline-delimited ZSON")

--- a/cmd/zed/dev/indexfile/create/command.go
+++ b/cmd/zed/dev/indexfile/create/command.go
@@ -61,8 +61,8 @@ func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	f.StringVar(&c.outputFile, "o", "index.zng", "name of index output file")
 	f.StringVar(&c.keys, "k", "", "comma-separated list of field names for keys")
 	c.opts.ZNGWriterOpts = &zngio.WriterOpts{}
-	f.BoolVar(&c.opts.ZNGWriterOpts.Compress, "zngcompress", true, "compress ZNG frames")
-	f.IntVar(&c.opts.ZNGWriterOpts.FrameThresh, "zngframethresh", zngio.DefaultFrameThresh,
+	f.BoolVar(&c.opts.ZNGWriterOpts.Compress, "zng.compress", true, "compress ZNG frames")
+	f.IntVar(&c.opts.ZNGWriterOpts.FrameThresh, "zng.framethresh", zngio.DefaultFrameThresh,
 		"minimum ZNG frame size in uncompressed bytes")
 	c.inputFlags.SetFlags(f, true)
 	return c, nil

--- a/index/ztests/btree-clash.yaml
+++ b/index/ztests/btree-clash.yaml
@@ -1,5 +1,5 @@
 script: |
-  zed dev indexfile create -f 50 -zngframethresh 0 -o index.zng -k _child -
+  zed dev indexfile create -f 50 -zng.framethresh 0 -o index.zng -k _child -
   zed dev dig trailer -Z index.zng
 
 inputs:

--- a/index/ztests/flexkey.yaml
+++ b/index/ztests/flexkey.yaml
@@ -1,7 +1,7 @@
 script: |
   zq -o tmp.zng "sum(v) by s | put key:=s | sort key"  babble.zson
   # -x says input keys already sorted and don't create new base records
-  zed dev indexfile create -f 20000 -zngcompress=false -zngframethresh 0 -o index.zng -k key tmp.zng
+  zed dev indexfile create -f 20000 -zng.compress=false -zng.framethresh 0 -o index.zng -k key tmp.zng
   # 50 not in index
   zed dev dig section -z 1 index.zng
   echo ===

--- a/index/ztests/levels.yaml
+++ b/index/ztests/levels.yaml
@@ -1,5 +1,5 @@
 script: |
-  zq 'by s | sort s' babble.zson | zed dev indexfile create -o index.zng -k s -f 200 -zngframethresh 1 -
+  zq 'by s | sort s' babble.zson | zed dev indexfile create -o index.zng -k s -f 200 -zng.framethresh 1 -
   zed dev dig trailer -Z index.zng
   echo ===
   zed dev dig section -z 2 index.zng

--- a/index/ztests/maxlevels.yaml
+++ b/index/ztests/maxlevels.yaml
@@ -1,5 +1,5 @@
 script: |
-  ! zed dev indexfile create -o index.zng -k s -f 20 -zngframethresh 0 babble.zson
+  ! zed dev indexfile create -o index.zng -k s -f 20 -zng.framethresh 0 babble.zson
 
 inputs:
   - name: babble.zson

--- a/index/ztests/multikey-desc.yaml
+++ b/index/ztests/multikey-desc.yaml
@@ -4,7 +4,7 @@ script: |
   # in the base zng index.
   zq -o sorted.zng "sum(v) by s | sort -r sum,s"  babble.zson
   # convert assumes input keys already sorted and doesn't create new base records
-  zed dev indexfile create -f 200 -zngframethresh 0 -order desc -o index.zng -k sum,s sorted.zng
+  zed dev indexfile create -f 200 -zng.framethresh 0 -order desc -o index.zng -k sum,s sorted.zng
   zed dev dig section -z 1 index.zng
   echo ===
   # exact lookup of the one record

--- a/index/ztests/multikey.yaml
+++ b/index/ztests/multikey.yaml
@@ -4,7 +4,7 @@ script: |
   # in the base zng index.
   zq -o sorted.zng "sum(v) by s | sort sum,s"  babble.zson
   # convert assumes input keys already sorted and doesn't create new base records
-  zed dev indexfile create -f 200 -zngframethresh 0 -o index.zng -k sum,s sorted.zng
+  zed dev indexfile create -f 200 -zng.framethresh 0 -o index.zng -k sum,s sorted.zng
   zed dev dig section -z 1 index.zng
   echo ===
   # exact lookup of the one record

--- a/index/ztests/ready.yaml
+++ b/index/ztests/ready.yaml
@@ -1,5 +1,5 @@
 script: |
-  zq "by key | sort key" - | zed dev indexfile create -f 20 -o index.zng -zngframethresh 0 -k key -
+  zq "by key | sort key" - | zed dev indexfile create -f 20 -o index.zng -zng.framethresh 0 -k key -
   zed dev dig section -z 2 index.zng
 
 inputs:

--- a/scripts/perf-compare.sh
+++ b/scripts/perf-compare.sh
@@ -91,7 +91,7 @@ do
         case $OUTPUT in
           ndjson ) zq_flags="$zq_flags -f json -I ../zeek/shaper.zed" zed="| $zed";;
           zeek ) zq_flags="$zq_flags -f zeek -I ../zeek/shaper.zed" zed="| $zed";;
-          zng-uncompressed ) zq_flags="$zq_flags -f zng -zngcompress=false" ;;
+          zng-uncompressed ) zq_flags="$zq_flags -f zng -zng.compress=false" ;;
           * ) zq_flags="$zq_flags -f $OUTPUT" ;;
         esac
         ALL_TIMES=$(time -p (zq $zq_flags "$zed" $DATA/$INPUT/* > /dev/null) 2>&1)

--- a/zio/anyio/ztests/zng-rdwr-comp.yaml
+++ b/zio/anyio/ztests/zng-rdwr-comp.yaml
@@ -1,5 +1,5 @@
 script: |
-  zq -zngcompress=false -o uncomp.zng in.zson
+  zq -zng.compress=false -o uncomp.zng in.zson
   zq  -o comp.zng in.zson
   zq -z uncomp.zng
   echo ===

--- a/zio/zngio/ztests/big-value.yaml
+++ b/zio/zngio/ztests/big-value.yaml
@@ -4,8 +4,8 @@ script: |
     cat out.zng out.zng out.zng out.zng > out2.zng
     mv out2.zng out.zng
   done
-  zq -zngcompress=false -o bigrow.zng "collect(s)" out.zng
-  ! zq  -i zng -o /dev/null -readmax 10KB "count()" bigrow.zng
+  zq -zng.compress=false -o bigrow.zng "collect(s)" out.zng
+  ! zq  -i zng -o /dev/null -zng.readmax 10KB "count()" bigrow.zng
 
 inputs:
   - name: in.zson


### PR DESCRIPTION
Give all ZNG-related flags a common "zng." prefix for clarity and to group them in help text (where flags are alphabetized).