### PR TITLE
zio/csvio: omit type decorator for union values

### DIFF
--- a/zio/csvio/writer.go
+++ b/zio/csvio/writer.go
@@ -70,15 +70,14 @@ func (w *Writer) Write(rec *zed.Value) error {
 	for i, it := 0, rec.Bytes.Iter(); i < len(cols) && !it.Done(); i++ {
 		var s string
 		if zb := it.Next(); zb != nil {
-			typ := cols[i].Type
-			id := typ.ID()
-			switch {
-			case id == zed.IDBytes && len(zb) == 0:
-				// We want "" instead of "0x" from typ.Format.
+			val := zed.NewValue(cols[i].Type, zb).Under()
+			switch id := val.Type.ID(); {
+			case id == zed.IDBytes && len(val.Bytes) == 0:
+				// We want "" instead of "0x" for a zero-length value.
 			case id == zed.IDString:
-				s = string(zb)
+				s = string(val.Bytes)
 			default:
-				s = formatValue(typ, zb)
+				s = formatValue(val.Type, val.Bytes)
 				if zed.IsFloat(id) && strings.HasSuffix(s, ".") {
 					s = strings.TrimSuffix(s, ".")
 				}

--- a/zio/csvio/ztests/union.yaml
+++ b/zio/csvio/ztests/union.yaml
@@ -1,0 +1,12 @@
+zed: '*'
+
+input: |
+  {a:1((int64,string))}
+  {a:"one"((int64,string))}
+
+output-flags: -f csv
+
+output: |
+  a
+  1
+  one


### PR DESCRIPTION
To format a Zed union, zio/csvio.Writer.Write calls through formatValue to zson.String, producing a string that includes an unwanted ZSON union type decorator.  Remove that type decorator by calling zed.Value.Under in Write.

Closes #4207.