### PR TITLE
zson: change record column references to field

### DIFF
--- a/lake/ztests/import-check.yaml
+++ b/lake/ztests/import-check.yaml
@@ -2,10 +2,10 @@ script: |
   export ZED_LAKE=test
   zed init -q
   zed create -q logs
-  ! zed load -q -use logs missingcol.zson
+  ! zed load -q -use logs missingfield.zson
 
 inputs:
-  - name: missingcol.zson
+  - name: missingfield.zson
     data: |
       {a:"a",b:"b"} (=foo)
       {a:"a"} (foo)
@@ -13,4 +13,4 @@ inputs:
 outputs:
   - name: stderr
     regexp: |
-      .*record decorator columns \(2\) mismatched with value columns \(1\)
+      .*record decorator fields \(2\) mismatched with value fields \(1\)

--- a/zson/formatter.go
+++ b/zson/formatter.go
@@ -671,13 +671,13 @@ func (f *Formatter) formatTypeBody(typ zed.Type) error {
 
 func (f *Formatter) formatTypeRecord(typ *zed.TypeRecord) {
 	f.build("{")
-	for k, col := range typ.Fields {
+	for k, field := range typ.Fields {
 		if k > 0 {
 			f.build(",")
 		}
-		f.build(QuotedName(col.Name))
+		f.build(QuotedName(field.Name))
 		f.build(":")
-		f.formatType(col.Type)
+		f.formatType(field.Type)
 	}
 	f.build("}")
 }
@@ -771,13 +771,13 @@ func formatType(b *strings.Builder, typedefs map[string]*zed.TypeNamed, typ zed.
 		}
 	case *zed.TypeRecord:
 		b.WriteByte('{')
-		for k, col := range t.Fields {
+		for k, f := range t.Fields {
 			if k > 0 {
 				b.WriteByte(',')
 			}
-			b.WriteString(QuotedName(col.Name))
+			b.WriteString(QuotedName(f.Name))
 			b.WriteString(":")
-			formatType(b, typedefs, col.Type)
+			formatType(b, typedefs, f.Type)
 		}
 		b.WriteByte('}')
 	case *zed.TypeArray:

--- a/zson/zson.go
+++ b/zson/zson.go
@@ -21,8 +21,8 @@ func Implied(typ zed.Type) bool {
 	case *zed.TypeOfInt64, *zed.TypeOfDuration, *zed.TypeOfTime, *zed.TypeOfFloat64, *zed.TypeOfBool, *zed.TypeOfBytes, *zed.TypeOfString, *zed.TypeOfIP, *zed.TypeOfNet, *zed.TypeOfType, *zed.TypeOfNull:
 		return true
 	case *zed.TypeRecord:
-		for _, c := range typ.Fields {
-			if !Implied(c.Type) {
+		for _, f := range typ.Fields {
+			if !Implied(f.Type) {
 				return false
 			}
 		}


### PR DESCRIPTION
This is a follow-up to #4306, which renamed zed.Column to Field.