### PR TITLE
vng: change record column references to field

### DIFF
--- a/vng/vector/metadata.go
+++ b/vng/vector/metadata.go
@@ -14,12 +14,12 @@ type Record struct {
 }
 
 func (r *Record) Type(zctx *zed.Context) zed.Type {
-	cols := make([]zed.Field, 0, len(r.Fields))
+	fields := make([]zed.Field, 0, len(r.Fields))
 	for _, field := range r.Fields {
 		typ := field.Values.Type(zctx)
-		cols = append(cols, zed.Field{Name: field.Name, Type: typ})
+		fields = append(fields, zed.Field{Name: field.Name, Type: typ})
 	}
-	return zctx.MustLookupTypeRecord(cols)
+	return zctx.MustLookupTypeRecord(fields)
 }
 
 func (r *Record) LookupField(name string) *Field {

--- a/vng/vector/record.go
+++ b/vng/vector/record.go
@@ -14,10 +14,10 @@ type RecordWriter []*FieldWriter
 
 func NewRecordWriter(typ *zed.TypeRecord, spiller *Spiller) RecordWriter {
 	var r RecordWriter
-	for _, col := range typ.Fields {
+	for _, f := range typ.Fields {
 		fw := &FieldWriter{
-			name:   col.Name,
-			values: NewWriter(col.Type, spiller),
+			name:   f.Name,
+			values: NewWriter(f.Type, spiller),
 		}
 		r = append(r, fw)
 	}


### PR DESCRIPTION
This is a follow-up to #4306, which renamed zed.Column to Field.