### PR TITLE
pkg/storage: rename URI.AppendPath to JoinPath and simplify

### DIFF
--- a/lake/commits/store.go
+++ b/lake/commits/store.go
@@ -78,7 +78,7 @@ func (s *Store) Get(ctx context.Context, commit ksuid.KSUID) (*Object, error) {
 }
 
 func (s *Store) pathOf(commit ksuid.KSUID) *storage.URI {
-	return s.path.AppendPath(commit.String() + ".zng")
+	return s.path.JoinPath(commit.String() + ".zng")
 }
 
 func (s *Store) Put(ctx context.Context, o *Object) error {
@@ -174,7 +174,7 @@ func (s *Store) putSnapshot(ctx context.Context, commit ksuid.KSUID, snap *Snaps
 }
 
 func (s *Store) snapshotPathOf(commit ksuid.KSUID) *storage.URI {
-	return s.path.AppendPath(commit.String() + ".snap.zng")
+	return s.path.JoinPath(commit.String() + ".snap.zng")
 }
 
 // Path return the entire path from the commit object to the root

--- a/lake/data/object.go
+++ b/lake/data/object.go
@@ -128,7 +128,7 @@ func (o Object) Span(order order.Which) *extent.Generic {
 // a data object so they can all be deleted with the storage engine's
 // DeleteByPrefix method.
 func (o Object) ObjectPrefix(path *storage.URI) *storage.URI {
-	return path.AppendPath(o.ID.String())
+	return path.JoinPath(o.ID.String())
 }
 
 func (o Object) SequenceURI(path *storage.URI) *storage.URI {
@@ -136,11 +136,11 @@ func (o Object) SequenceURI(path *storage.URI) *storage.URI {
 }
 
 func SequenceURI(path *storage.URI, id ksuid.KSUID) *storage.URI {
-	return path.AppendPath(fmt.Sprintf("%s.zng", id))
+	return path.JoinPath(fmt.Sprintf("%s.zng", id))
 }
 
 func (o Object) SeekIndexURI(path *storage.URI) *storage.URI {
-	return path.AppendPath(fmt.Sprintf("%s-seek.zng", o.ID))
+	return path.JoinPath(fmt.Sprintf("%s-seek.zng", o.ID))
 }
 
 func (o Object) VectorURI(path *storage.URI) *storage.URI {
@@ -148,7 +148,7 @@ func (o Object) VectorURI(path *storage.URI) *storage.URI {
 }
 
 func VectorURI(path *storage.URI, id ksuid.KSUID) *storage.URI {
-	return path.AppendPath(fmt.Sprintf("%s.vng", id))
+	return path.JoinPath(fmt.Sprintf("%s.vng", id))
 }
 
 func (o Object) Range() string {

--- a/lake/index/object.go
+++ b/lake/index/object.go
@@ -27,7 +27,7 @@ func (o Object) Path(path *storage.URI) *storage.URI {
 }
 
 func ObjectPath(path *storage.URI, ruleID, id ksuid.KSUID) *storage.URI {
-	return path.AppendPath(ruleID.String(), id.String()+".zng")
+	return path.JoinPath(ruleID.String(), id.String()+".zng")
 }
 
 type Map map[ksuid.KSUID]ObjectRules

--- a/lake/journal/queue.go
+++ b/lake/journal/queue.go
@@ -40,8 +40,8 @@ func New(engine storage.Engine, path *storage.URI) *Queue {
 	return &Queue{
 		engine:   engine,
 		path:     path,
-		headPath: path.AppendPath("HEAD"),
-		tailPath: path.AppendPath("TAIL"),
+		headPath: path.JoinPath("HEAD"),
+		tailPath: path.JoinPath("TAIL"),
 	}
 }
 
@@ -140,7 +140,7 @@ func (q *Queue) NewReader(ctx context.Context, head, tail ID) *Reader {
 }
 
 func (q *Queue) uri(id ID) *storage.URI {
-	return q.path.AppendPath(fmt.Sprintf("%d.%s", id, ext))
+	return q.path.JoinPath(fmt.Sprintf("%d.%s", id, ext))
 }
 
 func (q *Queue) Load(ctx context.Context, id ID) ([]byte, error) {

--- a/lake/journal/store.go
+++ b/lake/journal/store.go
@@ -186,7 +186,7 @@ func (s *Store) putSnapshot(ctx context.Context, at ID, table map[string]Entry) 
 }
 
 func (s *Store) snapshotURI() *storage.URI {
-	return s.journal.path.AppendPath(fmt.Sprintf("snap.%s", ext))
+	return s.journal.path.JoinPath(fmt.Sprintf("snap.%s", ext))
 }
 
 func (s *Store) stale() bool {

--- a/lake/pool.go
+++ b/lake/pool.go
@@ -38,7 +38,7 @@ func CreatePool(ctx context.Context, config *pools.Config, engine storage.Engine
 	poolPath := config.Path(root)
 	// branchesPath is the path to the kvs journal of BranchConfigs
 	// for the pool while the commit log is stored in <pool-id>/<branch-id>.
-	branchesPath := poolPath.AppendPath(BranchesTag)
+	branchesPath := poolPath.JoinPath(BranchesTag)
 	// create the branches journal store
 	_, err := branches.CreateStore(ctx, engine, branchesPath)
 	if err != nil {
@@ -52,7 +52,7 @@ func CreatePool(ctx context.Context, config *pools.Config, engine storage.Engine
 
 func CreateBranch(ctx context.Context, poolConfig *pools.Config, engine storage.Engine, root *storage.URI, name string, parent ksuid.KSUID) (*branches.Config, error) {
 	poolPath := poolConfig.Path(root)
-	branchesPath := poolPath.AppendPath(BranchesTag)
+	branchesPath := poolPath.JoinPath(BranchesTag)
 	store, err := branches.OpenStore(ctx, engine, branchesPath)
 	if err != nil {
 		return nil, err
@@ -69,12 +69,12 @@ func CreateBranch(ctx context.Context, poolConfig *pools.Config, engine storage.
 
 func OpenPool(ctx context.Context, config *pools.Config, engine storage.Engine, root *storage.URI) (*Pool, error) {
 	path := config.Path(root)
-	branchesPath := path.AppendPath(BranchesTag)
+	branchesPath := path.JoinPath(BranchesTag)
 	branches, err := branches.OpenStore(ctx, engine, branchesPath)
 	if err != nil {
 		return nil, err
 	}
-	commitsPath := path.AppendPath(CommitsTag)
+	commitsPath := path.JoinPath(CommitsTag)
 	commits, err := commits.OpenStore(engine, commitsPath)
 	if err != nil {
 		return nil, err
@@ -205,9 +205,9 @@ func (p *Pool) Main(ctx context.Context) (BranchMeta, error) {
 }
 
 func DataPath(poolPath *storage.URI) *storage.URI {
-	return poolPath.AppendPath(DataTag)
+	return poolPath.JoinPath(DataTag)
 }
 
 func IndexPath(poolPath *storage.URI) *storage.URI {
-	return poolPath.AppendPath(IndexTag)
+	return poolPath.JoinPath(IndexTag)
 }

--- a/lake/pools/config.go
+++ b/lake/pools/config.go
@@ -42,5 +42,5 @@ func (p *Config) Key() string {
 }
 
 func (p *Config) Path(root *storage.URI) *storage.URI {
-	return root.AppendPath(p.ID.String())
+	return root.JoinPath(p.ID.String())
 }

--- a/lake/root.go
+++ b/lake/root.go
@@ -90,8 +90,8 @@ func CreateOrOpen(ctx context.Context, engine storage.Engine, path *storage.URI)
 }
 
 func (r *Root) createConfig(ctx context.Context) error {
-	poolPath := r.path.AppendPath(PoolsTag)
-	rulesPath := r.path.AppendPath(IndexRulesTag)
+	poolPath := r.path.JoinPath(PoolsTag)
+	rulesPath := r.path.JoinPath(IndexRulesTag)
 	var err error
 	r.pools, err = pools.CreateStore(ctx, r.engine, poolPath)
 	if err != nil {
@@ -108,8 +108,8 @@ func (r *Root) loadConfig(ctx context.Context) error {
 	if err := r.readLakeMagic(ctx); err != nil {
 		return err
 	}
-	poolPath := r.path.AppendPath(PoolsTag)
-	rulesPath := r.path.AppendPath(IndexRulesTag)
+	poolPath := r.path.JoinPath(PoolsTag)
+	rulesPath := r.path.JoinPath(IndexRulesTag)
 	var err error
 	r.pools, err = pools.OpenStore(ctx, r.engine, poolPath)
 	if err != nil {
@@ -135,7 +135,7 @@ func (r *Root) writeLakeMagic(ctx context.Context) error {
 	if err := serializer.Close(); err != nil {
 		return err
 	}
-	path := r.path.AppendPath(LakeMagicFile)
+	path := r.path.JoinPath(LakeMagicFile)
 	err := r.engine.PutIfNotExists(ctx, path, serializer.Bytes())
 	if err == storage.ErrNotSupported {
 		//XXX workaround for now: see issue #2686
@@ -146,7 +146,7 @@ func (r *Root) writeLakeMagic(ctx context.Context) error {
 }
 
 func (r *Root) readLakeMagic(ctx context.Context) error {
-	path := r.path.AppendPath(LakeMagicFile)
+	path := r.path.JoinPath(LakeMagicFile)
 	reader, err := r.engine.Get(ctx, path)
 	if err != nil {
 		return err

--- a/pkg/storage/uri.go
+++ b/pkg/storage/uri.go
@@ -41,12 +41,8 @@ func (u *URI) HasScheme(s Scheme) bool {
 	return Scheme(u.Scheme) == s
 }
 
-func (p *URI) AppendPath(elem ...string) *URI {
-	u := *p
-	for _, el := range elem {
-		u.Path = u.Path + "/" + el
-	}
-	return &u
+func (p *URI) JoinPath(elem ...string) *URI {
+	return (*URI)((*url.URL)(p).JoinPath(elem...))
 }
 
 func (u *URI) RelPath(target URI) string {

--- a/zio/emitter/sizesplitter.go
+++ b/zio/emitter/sizesplitter.go
@@ -80,7 +80,7 @@ func (s *sizeSplitter) Write(val *zed.Value) error {
 }
 
 func (s *sizeSplitter) nextFile() error {
-	path := s.dir.AppendPath(s.prefix + strconv.Itoa(s.seq) + s.ext)
+	path := s.dir.JoinPath(s.prefix + strconv.Itoa(s.seq) + s.ext)
 	s.seq++
 	wc, err := s.engine.Put(s.ctx, path)
 	if err != nil {

--- a/zio/emitter/split.go
+++ b/zio/emitter/split.go
@@ -82,7 +82,7 @@ func (s *Split) path(r *zed.Value) *storage.URI {
 			s.seen[_path] = struct{}{}
 		}
 	}
-	return s.dir.AppendPath(s.prefix + uniq + s.ext)
+	return s.dir.JoinPath(s.prefix + uniq + s.ext)
 }
 
 func (s *Split) Close() error {

--- a/zio/emitter/split_test.go
+++ b/zio/emitter/split_test.go
@@ -28,9 +28,9 @@ func TestDirS3Source(t *testing.T) {
 	defer ctrl.Finish()
 	engine := storagemock.NewMockEngine(ctrl)
 
-	engine.EXPECT().Put(context.Background(), uri.AppendPath("conn.zson")).
+	engine.EXPECT().Put(context.Background(), uri.JoinPath("conn.zson")).
 		Return(&nopCloser{bytes.NewBuffer(nil)}, nil)
-	engine.EXPECT().Put(context.Background(), uri.AppendPath("http.zson")).
+	engine.EXPECT().Put(context.Background(), uri.JoinPath("http.zson")).
 		Return(&nopCloser{bytes.NewBuffer(nil)}, nil)
 
 	r := zsonio.NewReader(zed.NewContext(), strings.NewReader(input))


### PR DESCRIPTION
URI.AppendPath is identical to url.URL.JoinPath, which was added in Go 1.19.  Rename URI.AppendPath to JoinPath for consistency and simplify its implementation by calling URL.JoinPath.