### PR TITLE
fix cmd/zq/ztests/unbuffered.yaml for bash <= 4.0

### DIFF
--- a/cmd/zq/ztests/unbuffered.yaml
+++ b/cmd/zq/ztests/unbuffered.yaml
@@ -3,7 +3,7 @@ script: |
   # "-i json" avoids reader buffering.
   zq -i json -unbuffered -z fifo > out.zson &
   # Prevent zq from seeing EOF on fifo and exiting before the shell exits.
-  exec {fd}> fifo
+  exec 10> fifo
   echo 1 > fifo
   # Wait for out.zson to have size greater than zero.
   while [ ! -s out.zson -a $((i++)) -lt 50 ]; do sleep 0.1; done


### PR DESCRIPTION
This test uses a feature added in bash 4.1 ("{varname}>", to assign a file descriptor to varname and then redirect that file descriptor). Avoid that feature for compatibility with older bash versions.