### PR TITLE
add meta-data slicer

### DIFF
--- a/compiler/kernel/expr.go
+++ b/compiler/kernel/expr.go
@@ -235,7 +235,7 @@ func (b *Builder) compileUnary(unary dag.UnaryExpr) (expr.Evaluator, error) {
 	case "!":
 		return expr.NewLogicalNot(b.zctx(), e), nil
 	default:
-		return nil, fmt.Errorf("unknown unary operator %s\n", unary.Op)
+		return nil, fmt.Errorf("unknown unary operator %s", unary.Op)
 	}
 }
 

--- a/compiler/kernel/op.go
+++ b/compiler/kernel/op.go
@@ -593,11 +593,12 @@ func (b *Builder) compileTrunk(trunk *dag.Trunk, parent zbuf.Puller) ([]zbuf.Pul
 			// the metadata here is intercepted by the scanner and these zed values never enter
 			// the flowgraph.  For the metaqueries below, we pass in the flowgraph's type context
 			// because this data does, in fact, flow into the downstream flowgraph.
-			l, err := meta.NewSortedLister(b.pctx.Context, b.pctx.Zctx, lk, pool, src.Commit, filter)
+			zctx := zed.NewContext()
+			l, err := meta.NewSortedLister(b.pctx.Context, zctx, lk, pool, src.Commit, filter)
 			if err != nil {
 				return nil, err
 			}
-			slicer = meta.NewSlicer(l, b.pctx.Zctx, pool.Layout.Order)
+			slicer = meta.NewSlicer(l, zctx, pool.Layout.Order)
 			b.pools[src] = pool
 			b.slicers[src] = slicer
 		}

--- a/compiler/kernel/op.go
+++ b/compiler/kernel/op.go
@@ -43,7 +43,7 @@ var ErrJoinParents = errors.New("join requires two upstream parallel query paths
 type Builder struct {
 	pctx     *op.Context
 	source   *data.Source
-	listers  map[dag.Source]*meta.Lister
+	slicers  map[dag.Source]*meta.Slicer
 	pools    map[dag.Source]*lake.Pool
 	progress *zbuf.Progress
 	deletes  *sync.Map
@@ -54,7 +54,7 @@ func NewBuilder(pctx *op.Context, source *data.Source) *Builder {
 	return &Builder{
 		pctx:    pctx,
 		source:  source,
-		listers: make(map[dag.Source]*meta.Lister),
+		slicers: make(map[dag.Source]*meta.Slicer),
 		pools:   make(map[dag.Source]*lake.Pool),
 		progress: &zbuf.Progress{
 			BytesRead:      0,
@@ -220,6 +220,9 @@ func (b *Builder) compileLeaf(o dag.Op, parent zbuf.Puller) (zbuf.Puller, error)
 			return nil, err
 		}
 		as, err := compileLval(v.As)
+		if err != nil {
+			return nil, err
+		}
 		if len(as) != 1 {
 			return nil, errors.New("explode field must be a top-level field")
 		}
@@ -578,29 +581,34 @@ func (b *Builder) compileTrunk(trunk *dag.Trunk, parent zbuf.Puller) ([]zbuf.Pul
 		// common "from" source are distributed across the collection
 		// of SequenceScanner operators and the upstream parent distributes work
 		// across the parallel instances of trunks.
-		lister, ok := b.listers[src]
+		slicer, ok := b.slicers[src]
 		if !ok {
 			lk := b.source.Lake()
 			pool, err := lk.OpenPool(b.pctx.Context, src.ID)
 			if err != nil {
 				return nil, err
 			}
-			l, err := meta.NewSortedLister(b.pctx.Context, lk, pool, src.Commit, filter)
+			// We pass a new type context in here because we don't want the metadata types to interfere
+			// with the downstream flowgraph.  And there's no need to map between contexts because
+			// the metadata here is intercepted by the scanner and these zed values never enter
+			// the flowgraph.  For the metaqueries below, we pass in the flowgraph's type context
+			// because this data does, in fact, flow into the downstream flowgraph.
+			l, err := meta.NewSortedLister(b.pctx.Context, b.pctx.Zctx, lk, pool, src.Commit, filter)
 			if err != nil {
 				return nil, err
 			}
+			slicer = meta.NewSlicer(l, b.pctx.Zctx, pool.Layout.Order)
 			b.pools[src] = pool
-			b.listers[src] = l
-			lister = l
+			b.slicers[src] = slicer
 		}
 		pool := b.pools[src]
 		if src.Delete {
 			if b.deletes == nil {
 				b.deletes = &sync.Map{}
 			}
-			source = meta.NewDeleter(b.pctx, lister, pool, lister.Snapshot(), filter, b.progress, b.deletes)
+			source = meta.NewDeleter(b.pctx, slicer, pool, slicer.Snapshot(), filter, b.progress, b.deletes)
 		} else {
-			source = meta.NewSequenceScanner(b.pctx, lister, pool, lister.Snapshot(), filter, b.progress)
+			source = meta.NewSequenceScanner(b.pctx, slicer, pool, slicer.Snapshot(), filter, b.progress)
 		}
 	case *dag.PoolMeta:
 		scanner, err := meta.NewPoolMetaScanner(b.pctx.Context, b.pctx.Zctx, b.source.Lake(), src.ID, src.Meta, pushdown)

--- a/lake/writer.go
+++ b/lake/writer.go
@@ -209,6 +209,9 @@ func (w *SortedWriter) Objects() []*data.Object {
 }
 
 func (w *SortedWriter) Close() error {
+	if w.writer == nil {
+		return nil
+	}
 	return w.writer.Close(w.ctx)
 }
 

--- a/lake/ztests/delete.yaml
+++ b/lake/ztests/delete.yaml
@@ -1,7 +1,7 @@
 script: |
   export ZED_LAKE=test
   zed init -q
-  zed create -q test
+  zed create -q -orderby x:desc test
   zed use -q test
   zed load -q 1.zson
   id=$(zed query -f text "from test@main:objects | cut id:=ksuid(id) | tail 1")

--- a/lake/ztests/deterministic-merge.yaml
+++ b/lake/ztests/deterministic-merge.yaml
@@ -1,7 +1,7 @@
 script: |
   export ZED_LAKE=test
   zed init -q
-  zed create -q -S 32B logs
+  zed create -q -S 32B -orderby ts:asc logs
   zed load -q -use logs -
   zed query -z "from logs | *" > 1.zson
   zed query -z "from logs | *" > 2.zson
@@ -10,34 +10,34 @@ inputs:
   - name: stdin
     data: |
       {ts:1970-01-01T00:00:01Z,s:"Potamogalidae-precommissure",v:51}
-      {ts:1970-01-01T00:00:01Z,s:"Galchic-unwheeled",v:51}
-      {ts:1970-01-01T00:00:01Z,s:"protohydrogen-plesiomorphism",v:320}
-      {ts:1970-01-01T00:00:01Z,s:"unethicalness-vallis",v:148}
-      {ts:1970-01-01T00:00:01Z,s:"proceeding-noncausality",v:449}
-      {ts:1970-01-01T00:00:01Z,s:"investitor-dortiship",v:287}
-      {ts:1970-01-01T00:00:01Z,s:"gatelike-nucleolocentrosome",v:336}
-      {ts:1970-01-01T00:00:01Z,s:"subarea-preoffense",v:373}
-      {ts:1970-01-01T00:00:01Z,s:"lacklusterness-Magyarization",v:91}
-      {ts:1970-01-01T00:00:01Z,s:"unendeared-Petasites",v:331}
-      {ts:1970-01-01T00:00:01Z,s:"psalis-Guarnieri",v:456}
-      {ts:1970-01-01T00:00:01Z,s:"harefoot-raucous",v:137}
-      {ts:1970-01-01T00:00:01Z,s:"crosshaul-capersome",v:109}
+      {ts:1970-01-01T00:00:02Z,s:"Galchic-unwheeled",v:51}
+      {ts:1970-01-01T00:00:03Z,s:"protohydrogen-plesiomorphism",v:320}
+      {ts:1970-01-01T00:00:04Z,s:"unethicalness-vallis",v:148}
+      {ts:1970-01-01T00:00:05Z,s:"proceeding-noncausality",v:449}
+      {ts:1970-01-01T00:00:06Z,s:"investitor-dortiship",v:287}
+      {ts:1970-01-01T00:00:08Z,s:"gatelike-nucleolocentrosome",v:336}
+      {ts:1970-01-01T00:00:12Z,s:"subarea-preoffense",v:373}
+      {ts:1970-01-01T00:00:07Z,s:"lacklusterness-Magyarization",v:91}
+      {ts:1970-01-01T00:00:09Z,s:"unendeared-Petasites",v:331}
+      {ts:1970-01-01T00:00:11Z,s:"psalis-Guarnieri",v:456}
+      {ts:1970-01-01T00:00:10Z,s:"harefoot-raucous",v:137}
+      {ts:1970-01-01T00:00:13Z,s:"crosshaul-capersome",v:109}
 
 outputs:
   - name: 1.zson
     data: &1_zson |
-      {ts:1970-01-01T00:00:01Z,s:"protohydrogen-plesiomorphism",v:320}
-      {ts:1970-01-01T00:00:01Z,s:"lacklusterness-Magyarization",v:91}
-      {ts:1970-01-01T00:00:01Z,s:"gatelike-nucleolocentrosome",v:336}
       {ts:1970-01-01T00:00:01Z,s:"Potamogalidae-precommissure",v:51}
-      {ts:1970-01-01T00:00:01Z,s:"proceeding-noncausality",v:449}
-      {ts:1970-01-01T00:00:01Z,s:"unethicalness-vallis",v:148}
-      {ts:1970-01-01T00:00:01Z,s:"unendeared-Petasites",v:331}
-      {ts:1970-01-01T00:00:01Z,s:"investitor-dortiship",v:287}
-      {ts:1970-01-01T00:00:01Z,s:"crosshaul-capersome",v:109}
-      {ts:1970-01-01T00:00:01Z,s:"subarea-preoffense",v:373}
-      {ts:1970-01-01T00:00:01Z,s:"Galchic-unwheeled",v:51}
-      {ts:1970-01-01T00:00:01Z,s:"psalis-Guarnieri",v:456}
-      {ts:1970-01-01T00:00:01Z,s:"harefoot-raucous",v:137}
+      {ts:1970-01-01T00:00:02Z,s:"Galchic-unwheeled",v:51}
+      {ts:1970-01-01T00:00:03Z,s:"protohydrogen-plesiomorphism",v:320}
+      {ts:1970-01-01T00:00:04Z,s:"unethicalness-vallis",v:148}
+      {ts:1970-01-01T00:00:05Z,s:"proceeding-noncausality",v:449}
+      {ts:1970-01-01T00:00:06Z,s:"investitor-dortiship",v:287}
+      {ts:1970-01-01T00:00:07Z,s:"lacklusterness-Magyarization",v:91}
+      {ts:1970-01-01T00:00:08Z,s:"gatelike-nucleolocentrosome",v:336}
+      {ts:1970-01-01T00:00:09Z,s:"unendeared-Petasites",v:331}
+      {ts:1970-01-01T00:00:10Z,s:"harefoot-raucous",v:137}
+      {ts:1970-01-01T00:00:11Z,s:"psalis-Guarnieri",v:456}
+      {ts:1970-01-01T00:00:12Z,s:"subarea-preoffense",v:373}
+      {ts:1970-01-01T00:00:13Z,s:"crosshaul-capersome",v:109}
   - name: 2.zson
     data: *1_zson

--- a/lake/ztests/index/query.yaml
+++ b/lake/ztests/index/query.yaml
@@ -1,3 +1,5 @@
+skip: search index tests disabled as we will reimplement with vcache
+
 script: |
   export ZED_LAKE=test
   zed init -q

--- a/runtime/exec/compact.go
+++ b/runtime/exec/compact.go
@@ -34,9 +34,10 @@ func Compact(ctx context.Context, lk *lake.Root, pool *lake.Pool, branchName str
 		compact.AddDataObject(o)
 	}
 	zctx := zed.NewContext()
-	lister := meta.NewSortedListerFromSnap(ctx, lk, pool, compact, nil)
+	lister := meta.NewSortedListerFromSnap(ctx, zed.NewContext(), lk, pool, compact, nil)
 	octx := op.NewContext(ctx, zctx, nil)
-	puller := meta.NewSequenceScanner(octx, lister, pool, lister.Snapshot(), nil, nil)
+	slicer := meta.NewSlicer(lister, zctx, pool.Layout.Order)
+	puller := meta.NewSequenceScanner(octx, slicer, pool, lister.Snapshot(), nil, nil)
 	w := lake.NewSortedWriter(ctx, pool)
 	if err := zbuf.CopyPuller(w, puller); err != nil {
 		puller.Pull(true)

--- a/runtime/op/meta/deleter.go
+++ b/runtime/op/meta/deleter.go
@@ -105,11 +105,11 @@ func newDeleterScanner(d *Deleter, part Partition) (zbuf.Puller, error) {
 	}
 	for _, o := range part.Objects {
 		//XXX not sure this is right... filter applies here?
-		rg, err := objectRange(d.pctx.Context, d.pool, d.snap, d.filter, o)
+		rg, err := seekRange(d.pctx.Context, d.pool, d.snap, d.filter, o)
 		if err != nil {
 			return nil, err
 		}
-		rc, err := o.NewReader(d.pctx.Context, d.pool.Storage(), d.pool.DataPath, rg)
+		rc, err := o.NewReader(d.pctx.Context, d.pool.Storage(), d.pool.DataPath, *rg)
 		if err != nil {
 			pullersDone()
 			return nil, err

--- a/runtime/op/meta/lister.go
+++ b/runtime/op/meta/lister.go
@@ -19,7 +19,7 @@ import (
 )
 
 // Lister enumerates all the data.Objects in a scan.  A Slicer downstream may
-// optionally organizes objects into non-overlapping partitions for merge on read.
+// optionally organize objects into non-overlapping partitions for merge on read.
 // The optimizer may decide when partitions are necessary based on the order
 // sensitivity of the downstream flowgraph.
 type Lister struct {
@@ -78,13 +78,10 @@ func (l *Lister) Pull(done bool) (zbuf.Batch, error) {
 			return nil, l.err
 		}
 	}
-	if l.err != nil || len(l.objects) == 0 {
-		return nil, l.err
-	}
 	// End after the last object.  XXX we could change this so a scan can appear
 	// inside of a subgraph and be restarted after each time done is called
 	// (like how head/tail work).
-	if len(l.objects) == 0 {
+	if l.err != nil || len(l.objects) == 0 {
 		return nil, l.err
 	}
 	o := l.objects[0]

--- a/runtime/op/meta/lister.go
+++ b/runtime/op/meta/lister.go
@@ -1,7 +1,9 @@
 package meta
 
 import (
+	"bytes"
 	"context"
+	"sort"
 	"sync"
 
 	"github.com/brimdata/zed"
@@ -10,16 +12,16 @@ import (
 	"github.com/brimdata/zed/lake/data"
 	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/runtime/expr"
-	"github.com/brimdata/zed/runtime/expr/extent"
 	"github.com/brimdata/zed/zbuf"
 	"github.com/brimdata/zed/zson"
 	"github.com/segmentio/ksuid"
 	"golang.org/x/sync/errgroup"
 )
 
-// XXX Lister enumerates all the partitions in a scan.  After we get this working,
-// we will modularize further by listing just the objects and having
-// the slicer to organize objects into slices (formerly known as partitions).
+// Lister enumerates all the data.Objects in a scan.  A Slicer downstream may
+// optionally organizes objects into non-overlapping partitions for merge on read.
+// The optimizer may decide when partitions are necessary based on the order
+// sensitivity of the downstream flowgraph.
 type Lister struct {
 	ctx       context.Context
 	pool      *lake.Pool
@@ -28,36 +30,38 @@ type Lister struct {
 	group     *errgroup.Group
 	marshaler *zson.MarshalZNGContext
 	mu        sync.Mutex
-	parts     []Partition
+	objects   []*data.Object
 	err       error
 }
 
 var _ zbuf.Puller = (*Lister)(nil)
 
-func NewSortedLister(ctx context.Context, r *lake.Root, pool *lake.Pool, commit ksuid.KSUID, filter zbuf.Filter) (*Lister, error) {
+func NewSortedLister(ctx context.Context, zctx *zed.Context, r *lake.Root, pool *lake.Pool, commit ksuid.KSUID, filter zbuf.Filter) (*Lister, error) {
 	snap, err := pool.Snapshot(ctx, commit)
 	if err != nil {
 		return nil, err
 	}
-	return NewSortedListerFromSnap(ctx, r, pool, snap, filter), nil
+	return NewSortedListerFromSnap(ctx, zctx, r, pool, snap, filter), nil
 }
 
-func NewSortedListerByID(ctx context.Context, r *lake.Root, poolID, commit ksuid.KSUID, filter zbuf.Filter) (*Lister, error) {
+func NewSortedListerByID(ctx context.Context, zctx *zed.Context, r *lake.Root, poolID, commit ksuid.KSUID, filter zbuf.Filter) (*Lister, error) {
 	pool, err := r.OpenPool(ctx, poolID)
 	if err != nil {
 		return nil, err
 	}
-	return NewSortedLister(ctx, r, pool, commit, filter)
+	return NewSortedLister(ctx, zctx, r, pool, commit, filter)
 }
 
-func NewSortedListerFromSnap(ctx context.Context, r *lake.Root, pool *lake.Pool, snap commits.View, filter zbuf.Filter) *Lister {
+func NewSortedListerFromSnap(ctx context.Context, zctx *zed.Context, r *lake.Root, pool *lake.Pool, snap commits.View, filter zbuf.Filter) *Lister {
+	m := zson.NewZNGMarshalerWithContext(zctx)
+	m.Decorate(zson.StylePackage)
 	return &Lister{
 		ctx:       ctx,
 		pool:      pool,
 		snap:      snap,
 		filter:    filter,
 		group:     &errgroup.Group{},
-		marshaler: zson.NewZNGMarshaler(),
+		marshaler: m,
 	}
 }
 
@@ -68,21 +72,24 @@ func (l *Lister) Snapshot() commits.View {
 func (l *Lister) Pull(done bool) (zbuf.Batch, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	if l.err != nil {
-		return nil, l.err
-	}
-	if l.parts == nil {
-		l.parts, l.err = sortedPartitions(l.snap, l.pool.Layout, l.filter)
+	if l.objects == nil {
+		l.objects, l.err = initObjectScan(l.snap, l.pool.Layout, l.filter)
 		if l.err != nil {
 			return nil, l.err
 		}
 	}
-	if len(l.parts) == 0 {
+	if l.err != nil || len(l.objects) == 0 {
 		return nil, l.err
 	}
-	part := l.parts[0]
-	l.parts = l.parts[1:]
-	val, err := l.marshaler.Marshal(part)
+	// End after the last object.  XXX we could change this so a scan can appear
+	// inside of a subgraph and be restarted after each time done is called
+	// (like how head/tail work).
+	if len(l.objects) == 0 {
+		return nil, l.err
+	}
+	o := l.objects[0]
+	l.objects = l.objects[1:]
+	val, err := l.marshaler.Marshal(o)
 	if err != nil {
 		l.err = err
 		return nil, err
@@ -90,29 +97,63 @@ func (l *Lister) Pull(done bool) (zbuf.Batch, error) {
 	return zbuf.NewArray([]zed.Value{*val}), nil
 }
 
-func filterObjects(objects []*data.Object, filter *expr.SpanFilter, o order.Which) []*data.Object {
-	cmp := expr.NewValueCompareFn(order.Asc, o == order.Asc)
-	out := objects[:0]
-	for _, obj := range objects {
-		span := extent.NewGeneric(obj.First, obj.Last, cmp)
-		if filter == nil || !filter.Eval(span.First(), span.Last()) {
-			out = append(out, obj)
-		}
-	}
-	return out
+type Slice struct {
+	First  *zed.Value
+	Last   *zed.Value
+	Object *data.Object
 }
 
-// sortedPartitions partitions all the data objects in snap overlapping
-// span into non-overlapping partitions, sorts them by pool key and order,
-// and sends them to ch.
-func sortedPartitions(snap commits.View, layout order.Layout, filter zbuf.Filter) ([]Partition, error) {
+func initObjectScan(snap commits.View, layout order.Layout, filter zbuf.Filter) ([]*data.Object, error) {
 	objects := snap.Select(nil, layout.Order)
+	var f *expr.SpanFilter //XXX get rid of this
 	if filter != nil {
-		f, err := filter.AsKeySpanFilter(layout.Primary(), layout.Order)
+		var err error
+		// Order is passed here just to handle nullsmax in the comparison.
+		// So we still need to swap first/last when descending order.
+		f, err = filter.AsKeySpanFilter(layout.Primary(), layout.Order)
 		if err != nil {
 			return nil, err
 		}
-		objects = filterObjects(objects, f, layout.Order)
+		if f != nil {
+			var filtered []*data.Object
+			for _, obj := range objects {
+				first := &obj.First
+				last := &obj.Last
+				if layout.Order == order.Desc {
+					first, last = last, first
+				}
+				if !f.Eval(first, last) {
+					filtered = append(filtered, obj)
+				}
+			}
+			objects = filtered
+		}
 	}
-	return partitionObjects(objects, layout.Order), nil
+	//XXX at some point sorting should be optional.
+	sortObjects(objects, layout.Order)
+	return objects, nil
+}
+
+func sortObjects(objects []*data.Object, o order.Which) {
+	cmp := expr.NewValueCompareFn(o, o == order.Asc) //XXX is nullsMax correct here?
+	lessFunc := func(a, b *data.Object) bool {
+		if cmp(&a.First, &b.First) < 0 {
+			return true
+		}
+		if !bytes.Equal(a.First.Bytes, b.First.Bytes) {
+			return false
+		}
+		if bytes.Equal(a.Last.Bytes, b.Last.Bytes) {
+			// If the pool keys are equal for both the first and last values
+			// in the object, we return false here so that the stable sort preserves
+			// the commit order of the objects in the log. XXX we might want to
+			// simply sort by commit timestamp for a more robust API that does not
+			// presume commit-order in the object snapshot.
+			return false
+		}
+		return cmp(&a.Last, &b.Last) < 0
+	}
+	sort.SliceStable(objects, func(i, j int) bool {
+		return lessFunc(objects[i], objects[j])
+	})
 }

--- a/runtime/op/meta/sequence.go
+++ b/runtime/op/meta/sequence.go
@@ -207,11 +207,7 @@ func seekRange(ctx context.Context, pool *lake.Pool, snap commits.View, filter z
 		if err != nil {
 			return nil, err
 		}
-		r, err := data.LookupSeekRange(ctx, pool.Storage(), pool.DataPath, o, cmp, spanFilter, indexSpan, pool.Layout.Order)
-		if err != nil {
-			return nil, err
-		}
-		return &r, nil
+		return data.LookupSeekRange(ctx, pool.Storage(), pool.DataPath, o, cmp, spanFilter, indexSpan, pool.Layout.Order)
 	}
 	// Scan the entire object.
 	return &seekindex.Range{End: o.Size}, nil

--- a/runtime/op/meta/sequence.go
+++ b/runtime/op/meta/sequence.go
@@ -117,11 +117,11 @@ func newSortedPartitionScanner(p *SequenceScanner, part Partition) (zbuf.Puller,
 		}
 	}
 	for _, o := range part.Objects {
-		rg, err := objectRange(p.pctx.Context, p.pool, p.snap, p.filter, o)
+		rg, err := seekRange(p.pctx.Context, p.pool, p.snap, p.filter, o)
 		if err != nil {
 			return nil, err
 		}
-		rc, err := o.NewReader(p.pctx.Context, p.pool.Storage(), p.pool.DataPath, rg)
+		rc, err := o.NewReader(p.pctx.Context, p.pool.Storage(), p.pool.DataPath, *rg)
 		if err != nil {
 			pullersDone()
 			return nil, err
@@ -167,42 +167,53 @@ func (s *statScanner) Pull(done bool) (zbuf.Batch, error) {
 	return batch, err
 }
 
-func objectRange(ctx context.Context, pool *lake.Pool, snap commits.View, filter zbuf.Filter, o *data.Object) (seekindex.Range, error) {
+func seekRange(ctx context.Context, pool *lake.Pool, snap commits.View, filter zbuf.Filter, o *data.Object) (*seekindex.Range, error) {
 	var indexSpan extent.Span
 	var cropped *expr.SpanFilter
 	//XXX this is suboptimal because we traverse every index rule of every object
 	// even though we should know what rules we need upstream by analyzing the
 	// type of index lookup we're doing and select only the rules needed
+	// XXX let's take out the search index here and implement indexes as part
+	// of VNG.
 	if filter != nil {
 		if idx := index.NewFilter(pool.Storage(), pool.IndexPath, filter); idx != nil {
-			rules, err := snap.LookupIndexObjectRules(o.ID)
+			rules, err := snap.LookupIndexObjectRules(o.ID) // XXX move this into metadata
 			if err != nil && !errors.Is(err, commits.ErrNotFound) {
-				return seekindex.Range{}, err
+				return nil, err
 			}
 			if len(rules) > 0 {
 				indexSpan, err = idx.Apply(ctx, o.ID, rules)
-				if err != nil || indexSpan == nil {
-					return seekindex.Range{}, err
+				if err != nil {
+					return nil, err
 				}
 			}
 		}
 		var err error
 		cropped, err = filter.AsKeyCroppedByFilter(pool.Layout.Primary(), pool.Layout.Order)
 		if err != nil {
-			return seekindex.Range{}, err
+			return nil, err
 		}
 	}
-	cmp := expr.NewValueCompareFn(order.Asc, pool.Layout.Order == order.Asc)
-	span := extent.NewGeneric(o.First, o.Last, cmp)
-	if indexSpan != nil || cropped != nil && cropped.Eval(span.First(), span.Last()) {
+	cmp := expr.NewValueCompareFn(pool.Layout.Order, pool.Layout.Order == order.Asc)
+	//span := extent.NewGeneric(o.First, o.Last, cmp)
+	first := &o.First
+	last := &o.Last
+	if pool.Layout.Order == order.Desc {
+		first, last = last, first
+	}
+	if indexSpan != nil || cropped != nil && cropped.Eval(first, last) {
 		// There's an index available or the object's span is cropped by
 		// p.filter, so use the seek index to find the range to scan.
 		spanFilter, err := filter.AsKeySpanFilter(pool.Layout.Primary(), pool.Layout.Order)
 		if err != nil {
-			return seekindex.Range{}, err
+			return nil, err
 		}
-		return data.LookupSeekRange(ctx, pool.Storage(), pool.DataPath, o, cmp, spanFilter, indexSpan)
+		r, err := data.LookupSeekRange(ctx, pool.Storage(), pool.DataPath, o, cmp, spanFilter, indexSpan, pool.Layout.Order)
+		if err != nil {
+			return nil, err
+		}
+		return &r, nil
 	}
 	// Scan the entire object.
-	return seekindex.Range{End: o.Size}, nil
+	return &seekindex.Range{End: o.Size}, nil
 }

--- a/runtime/op/meta/sequence.go
+++ b/runtime/op/meta/sequence.go
@@ -195,7 +195,6 @@ func seekRange(ctx context.Context, pool *lake.Pool, snap commits.View, filter z
 		}
 	}
 	cmp := expr.NewValueCompareFn(pool.Layout.Order, pool.Layout.Order == order.Asc)
-	//span := extent.NewGeneric(o.First, o.Last, cmp)
 	first := &o.First
 	last := &o.Last
 	if pool.Layout.Order == order.Desc {

--- a/runtime/op/meta/slicer.go
+++ b/runtime/op/meta/slicer.go
@@ -1,165 +1,136 @@
 package meta
 
 import (
-	"bytes"
-	"context"
+	"errors"
 	"fmt"
-	"sort"
+	"sync"
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/lake/commits"
 	"github.com/brimdata/zed/lake/data"
 	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/runtime/expr"
-	"github.com/brimdata/zed/runtime/expr/extent"
 	"github.com/brimdata/zed/zbuf"
-	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zson"
-	"github.com/segmentio/ksuid"
 )
 
-// partitionObjects takes a sorted set of data objects with possibly overlapping
-// key ranges and returns an ordered list of Ranges such that none of the
-// Ranges overlap with one another.  This is the straightforward computational
-// geometry problem of merging overlapping intervals,
-// e.g., https://www.geeksforgeeks.org/merging-intervals/
-//
-// XXX this algorithm doesn't quite do what we want because it continues
-// to merge *anything* that overlaps.  It's easy to fix though.
-// Issue #2538
-func partitionObjects(objects []*data.Object, o order.Which) []Partition {
-	if len(objects) == 0 {
-		return nil
+// Slicer implements an op that pulls data objects and organizes
+// them into overlapping object Slices forming a sequence of
+// non-overlapping Partitions.
+type Slicer struct {
+	parent      zbuf.Puller
+	marshaler   *zson.MarshalZNGContext
+	unmarshaler *zson.UnmarshalZNGContext
+	objects     []*data.Object
+	cmp         expr.CompareFn
+	last        *zed.Value
+	mu          sync.Mutex
+}
+
+func NewSlicer(parent zbuf.Puller, zctx *zed.Context, o order.Which) *Slicer {
+	m := zson.NewZNGMarshalerWithContext(zctx)
+	m.Decorate(zson.StylePackage)
+	return &Slicer{
+		parent:      parent,
+		marshaler:   m,
+		unmarshaler: zson.NewZNGUnmarshaler(),
+		objects:     []*data.Object{},
+		//XXX check nullsmax is consistent for both dirs in lake ops
+		cmp: expr.NewValueCompareFn(o, o == order.Asc),
 	}
-	cmp := expr.NewValueCompareFn(o, o == order.Asc)
-	spans := sortedObjectSpans(objects, cmp)
-	var s stack
-	s.pushObjectSpan(spans[0], cmp)
-	for _, span := range spans[1:] {
-		tos := s.tos()
-		if span.Before(tos.Last()) {
-			s.pushObjectSpan(span, cmp)
+}
+
+func (s *Slicer) Snapshot() commits.View {
+	//XXX
+	return s.parent.(*Lister).Snapshot()
+}
+
+func (s *Slicer) Pull(done bool) (zbuf.Batch, error) {
+	//XXX for now we use a mutex because multiple downstream trunks can call
+	// Pull concurrently here.  We should change this to use a fork.  But for now,
+	// this does not seem like a performance critical issue because the bottleneck
+	// will be each trunk and the lister parent should run fast in comparison.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for {
+		batch, err := s.parent.Pull(done)
+		if err != nil {
+			return nil, err
+		}
+		if batch == nil {
+			return s.nextPartition()
+		}
+		vals := batch.Values()
+		if len(vals) != 1 {
+			// We currently support only one object per batch.
+			return nil, errors.New("system error: Searcher encountered multi-valued batch")
+		}
+		var object data.Object
+		if err := s.unmarshaler.Unmarshal(&vals[0], &object); err != nil {
+			return nil, err
+		}
+		if batch, err := s.stash(&object); batch != nil || err != nil {
+			return batch, err
+		}
+	}
+}
+
+// nextPartition takes collected up slices and forms a partition returning
+// a batch containing a single value comprising the serialized partition.
+func (s *Slicer) nextPartition() (zbuf.Batch, error) {
+	if len(s.objects) == 0 {
+		return nil, nil
+	}
+	var first *zed.Value
+	var last *zed.Value
+	for _, o := range s.objects {
+		if first == nil {
+			first = &o.First
+			last = &o.Last
 		} else {
-			tos.Objects = append(tos.Objects, span.object)
-			tos.Extend(span.Last())
+			if s.cmp(&o.First, first) < 0 {
+				first = &o.First
+			}
+			if s.cmp(&o.Last, last) > 0 {
+				last = &o.Last
+			}
 		}
 	}
-	// On exit, the ranges in the stack are properly sorted so
-	// we just turn the ranges back into partitions.
-	partitions := make([]Partition, 0, len(s))
-	for _, r := range s {
-		partitions = append(partitions, Partition{
-			First:   r.First(),
-			Last:    r.Last(),
-			Objects: r.Objects,
-		})
-	}
-	return partitions
-}
-
-type Range struct {
-	extent.Span
-	Objects []*data.Object
-}
-
-type stack []Range
-
-func (s *stack) pushObjectSpan(span objectSpan, cmp expr.CompareFn) {
-	s.push(Range{
-		Span:    span.Span,
-		Objects: []*data.Object{span.object},
+	val, err := s.marshaler.Marshal(&Partition{
+		First:   first,
+		Last:    last,
+		Objects: s.objects,
 	})
-}
-
-func (s *stack) push(r Range) {
-	*s = append(*s, r)
-}
-
-/* unused right now
-func (s *stack) pop() Range {
-	n := len(*s)
-	p := (*s)[n-1]
-	*s = (*s)[:n-1]
-	return p
-}
-*/
-
-func (s *stack) tos() *Range {
-	return &(*s)[len(*s)-1]
-}
-
-type objectSpan struct {
-	extent.Span
-	object *data.Object
-}
-
-func sortedObjectSpans(objects []*data.Object, cmp expr.CompareFn) []objectSpan {
-	spans := make([]objectSpan, 0, len(objects))
-	for _, o := range objects {
-		spans = append(spans, objectSpan{
-			Span:   extent.NewGeneric(o.First, o.Last, cmp),
-			object: o,
-		})
-	}
-	sort.Slice(spans, func(i, j int) bool {
-		return objectSpanLess(spans[i], spans[j])
-	})
-	return spans
-}
-
-func objectSpanLess(a, b objectSpan) bool {
-	if b.Before(a.First()) {
-		return true
-	}
-	if !bytes.Equal(a.First().Bytes, b.First().Bytes) {
-		return false
-	}
-	if bytes.Equal(a.Last().Bytes, b.Last().Bytes) {
-		if a.object.Count != b.object.Count {
-			return a.object.Count < b.object.Count
-		}
-		return ksuid.Compare(a.object.ID, b.object.ID) < 0
-	}
-	return a.After(b.Last())
-}
-
-func partitionReader(ctx context.Context, zctx *zed.Context, layout order.Layout, snap commits.View, filter zbuf.Filter) (zio.Reader, error) {
-	parts, err := sortedPartitions(snap, layout, filter)
+	s.objects = s.objects[:0]
 	if err != nil {
 		return nil, err
 	}
-	m := zson.NewZNGMarshalerWithContext(zctx)
-	m.Decorate(zson.StylePackage)
-	return readerFunc(func() (*zed.Value, error) {
-		if len(parts) == 0 {
-			return nil, nil
-		}
-		p := parts[0]
-		val, err := m.Marshal(p)
-		parts = parts[1:]
-		return val, err
-	}), nil
+	return zbuf.NewArray([]zed.Value{*val}), nil
 }
 
-func indexObjectReader(ctx context.Context, zctx *zed.Context, snap commits.View, order order.Which) (zio.Reader, error) {
-	indexes := snap.SelectIndexes(nil, order)
-	m := zson.NewZNGMarshalerWithContext(zctx)
-	m.Decorate(zson.StylePackage)
-	return readerFunc(func() (*zed.Value, error) {
-		if len(indexes) == 0 {
-			return nil, nil
+func (s *Slicer) stash(o *data.Object) (zbuf.Batch, error) {
+	var batch zbuf.Batch
+	if len(s.objects) > 0 {
+		// We collect all the subsequent objects that overlap with any object in the
+		// accumulated set so far.  Since first times are non-decreasing this is
+		// guaranteed to generate partitions that are non-decreasing and non-overlapping.
+		if s.cmp(&o.First, s.last) >= 0 {
+			var err error
+			batch, err = s.nextPartition()
+			if err != nil {
+				return nil, err
+			}
+			s.last = nil
 		}
-		val, err := m.Marshal(indexes[0])
-		indexes = indexes[1:]
-		return val, err
-	}), nil
+	}
+	s.objects = append(s.objects, o)
+	if s.last == nil || s.cmp(s.last, &o.Last) < 0 {
+		s.last = &o.Last
+	}
+	return batch, nil
 }
 
-type readerFunc func() (*zed.Value, error)
-
-func (r readerFunc) Read() (*zed.Value, error) { return r() }
-
-// A Partition is a logical view of the records within a time span, stored
+// A Partition is a logical view of the records within a pool-key span, stored
 // in one or more data objects.  This provides a way to return the list of
 // objects that should be scanned along with a span to limit the scan
 // to only the span involved.

--- a/runtime/op/meta/ztests/type-context.yaml
+++ b/runtime/op/meta/ztests/type-context.yaml
@@ -1,0 +1,21 @@
+# This test makes sure the type context from metadata processing doesn't 
+# leak into the flowgraph, except for metaqueries, where it should.
+script: |
+  export ZED_LAKE=test
+  zed init -q
+  zed create -q tmp
+  echo '1 2' | zed load -q -use tmp -
+  echo '3' | zed load -q -use tmp -
+  zed query -z 'from tmp | yield typeof(<"data.Object">)'
+  echo ===
+  zed query -z 'from tmp@main:objects | yield typeof(<"data.Object">)'
+
+outputs:
+  - name: stdout
+    data: |
+      <error(string)>
+      <error(string)>
+      <error(string)>
+      ===
+      <type>
+      <type>

--- a/service/ztests/curl-load-csv.yaml
+++ b/service/ztests/curl-load-csv.yaml
@@ -1,6 +1,6 @@
 script: |
   source service.sh
-  zed create -q test
+  zed create -q -orderby a test
   curl -H Content-Type:text/csv --data-binary @in.csv \
     --fail $ZED_LAKE/pool/test/branch/main | zq -z commit:=0 -
   curl -H Content-Type:text/csv --data-binary @in-dot.csv \

--- a/service/ztests/delete.yaml
+++ b/service/ztests/delete.yaml
@@ -1,6 +1,6 @@
 script: |
   source service.sh
-  zed create -q test
+  zed create -q -orderby x:desc test
   zed use -q test
   zed load -q 1.zson
   id=$(zed query -f text "from test@main:objects | cut id:=ksuid(id) | tail 1")

--- a/service/ztests/index/query.yaml
+++ b/service/ztests/index/query.yaml
@@ -1,3 +1,5 @@
+skip: search index tests disabled as we will reimplement with vcache
+
 script: |
   source service.sh
   zed create -q test


### PR DESCRIPTION
This commit changes the algorithm for forming partitions of non-overlapping metadata objects for in-order scans.  This gets us closer to fine-grained metadata operators so we can add vcache integration to the compiler.

A major implication of these changes is that commit-order scanning when pool keys are of uniform value is no longer maintained.  This isn't as bad as it sounds because this feature never worked anyway at larger scale (when the size of the uniform-key data exceeds the batch parallelism of the merge op the order guarantee can fail and we did not have test coverage for this).  See issue #4351.

We also simplified things to use data.Objects without extent.Spans and changed the logic to use the underlying From/To fields of the data.Object. There is more work to do on this front.

We rearranged the metadata operators to take an explicit zctx so there can be type separation between the metadata processing and downstream operators, but no type separation for metaqueries where the downstream user query operates on the metadata.