### PR TITLE
add -auth.audience flag to "zed serve"

### DIFF
--- a/cmd/gentoken/main.go
+++ b/cmd/gentoken/main.go
@@ -21,6 +21,7 @@ var CLI = &charm.Spec{
 type Command struct {
 	charm.Command
 
+	audience       string
 	domain         string
 	expiration     time.Duration
 	privateKeyFile string
@@ -31,6 +32,7 @@ type Command struct {
 
 func New(_ charm.Command, fs *flag.FlagSet) (charm.Command, error) {
 	c := &Command{}
+	fs.StringVar(&c.audience, "audience", "", "audience claim in generated token")
 	fs.StringVar(&c.domain, "domain", "", "domain to use to generate token issuer")
 	fs.DurationVar(&c.expiration, "expiration", 4*time.Hour, "expiry duration for generated token")
 	fs.StringVar(&c.privateKeyFile, "privatekeyfile", "", "path of file containing private key (required)")
@@ -47,7 +49,8 @@ func (c *Command) Run(args []string) error {
 	if c.privateKeyFile == "" {
 		return errors.New("must specify a keyfile")
 	}
-	token, err := auth.GenerateAccessToken(c.keyID, c.privateKeyFile, c.expiration, c.domain, auth.TenantID(c.tenantID), auth.UserID(c.userID))
+	token, err := auth.GenerateAccessToken(
+		c.keyID, c.privateKeyFile, c.expiration, c.audience, c.domain, auth.TenantID(c.tenantID), auth.UserID(c.userID))
 	if err != nil {
 		return fmt.Errorf("GenerateAccessToken failed: %w", err)
 	}

--- a/service/auth/generator.go
+++ b/service/auth/generator.go
@@ -31,13 +31,13 @@ func makeToken(keyID string, keyFile string, claims jwt.MapClaims) (string, erro
 
 // GenerateAccessToken creates a JWT in string format with the expected audience,
 // issuer, and claims to pass zqd authentication checks.
-func GenerateAccessToken(keyID string, privateKeyFile string, expiration time.Duration, domain string, tenantID TenantID, userID UserID) (string, error) {
+func GenerateAccessToken(keyID string, privateKeyFile string, expiration time.Duration, audience, domain string, tenantID TenantID, userID UserID) (string, error) {
 	dstr, err := url.Parse(domain)
 	if err != nil {
 		return "", fmt.Errorf("bad domain URL: %w", err)
 	}
 	return makeToken(keyID, privateKeyFile, jwt.MapClaims{
-		"aud":         AudienceClaimValue,
+		"aud":         audience,
 		"exp":         time.Now().Add(expiration).Unix(),
 		"iss":         dstr.String() + "/",
 		TenantIDClaim: string(tenantID),

--- a/service/auth/validator_test.go
+++ b/service/auth/validator_test.go
@@ -10,13 +10,14 @@ import (
 )
 
 const (
+	testAudience = "testaudience"
 	testKeyID    = "testkey"
 	testKeyFile  = "../testdata/auth-private-key"
 	testJWKSFile = "../testdata/auth-public-jwks.json"
 )
 
 func testValidator(t *testing.T) *TokenValidator {
-	v, err := NewTokenValidator("https://testdomain", testJWKSFile)
+	v, err := NewTokenValidator(testAudience, "https://testdomain", testJWKSFile)
 	require.NoError(t, err)
 	return v
 }
@@ -33,7 +34,7 @@ func TestValidate(t *testing.T) {
 		UserID:   "test_user_id",
 	}
 	token, err := GenerateAccessToken(testKeyID, testKeyFile, 1*time.Hour,
-		"https://testdomain", "test_tenant_id", "test_user_id")
+		testAudience, "https://testdomain", "test_tenant_id", "test_user_id")
 	require.NoError(t, err)
 	validator := testValidator(t)
 
@@ -81,7 +82,7 @@ func TestBadClaims(t *testing.T) {
 		{
 			name: "missing expiration",
 			token: genToken(t, jwt.MapClaims{
-				"aud":         AudienceClaimValue,
+				"aud":         testAudience,
 				"iss":         "https://testdomain/",
 				TenantIDClaim: "test_tenant_id",
 				UserIDClaim:   "test_user_id",
@@ -90,7 +91,7 @@ func TestBadClaims(t *testing.T) {
 		{
 			name: "expired expiration",
 			token: genToken(t, jwt.MapClaims{
-				"aud":         AudienceClaimValue,
+				"aud":         testAudience,
 				"exp":         time.Now().Add(-1 * time.Hour).Unix(),
 				"iss":         "https://testdomain/",
 				TenantIDClaim: "test_tenant_id",
@@ -100,7 +101,7 @@ func TestBadClaims(t *testing.T) {
 		{
 			name: "missing issuer",
 			token: genToken(t, jwt.MapClaims{
-				"aud":         AudienceClaimValue,
+				"aud":         testAudience,
 				"exp":         time.Now().Add(1 * time.Hour).Unix(),
 				TenantIDClaim: "test_tenant_id",
 				UserIDClaim:   "test_user_id",
@@ -109,7 +110,7 @@ func TestBadClaims(t *testing.T) {
 		{
 			name: "invalid issuer",
 			token: genToken(t, jwt.MapClaims{
-				"aud":         AudienceClaimValue,
+				"aud":         testAudience,
 				"exp":         time.Now().Add(1 * time.Hour).Unix(),
 				"iss":         "foo",
 				TenantIDClaim: "test_tenant_id",
@@ -119,7 +120,7 @@ func TestBadClaims(t *testing.T) {
 		{
 			name: "missing user id",
 			token: genToken(t, jwt.MapClaims{
-				"aud":         AudienceClaimValue,
+				"aud":         testAudience,
 				"exp":         time.Now().Add(1 * time.Hour).Unix(),
 				"iss":         "https://testdomain/",
 				TenantIDClaim: "test_tenant_id",
@@ -128,7 +129,7 @@ func TestBadClaims(t *testing.T) {
 		{
 			name: "anonymous user id",
 			token: genToken(t, jwt.MapClaims{
-				"aud":         AudienceClaimValue,
+				"aud":         testAudience,
 				"exp":         time.Now().Add(1 * time.Hour).Unix(),
 				"iss":         "https://testdomain/",
 				TenantIDClaim: "test_tenant_id",
@@ -138,7 +139,7 @@ func TestBadClaims(t *testing.T) {
 		{
 			name: "missing tenant id",
 			token: genToken(t, jwt.MapClaims{
-				"aud":       AudienceClaimValue,
+				"aud":       testAudience,
 				"exp":       time.Now().Add(1 * time.Hour).Unix(),
 				"iss":       "https://testdomain/",
 				UserIDClaim: "test_user_id",
@@ -147,7 +148,7 @@ func TestBadClaims(t *testing.T) {
 		{
 			name: "anonymous user id",
 			token: genToken(t, jwt.MapClaims{
-				"aud":         AudienceClaimValue,
+				"aud":         testAudience,
 				"exp":         time.Now().Add(1 * time.Hour).Unix(),
 				"iss":         "https://testdomain/",
 				TenantIDClaim: AnonymousTenantID,
@@ -167,7 +168,7 @@ func TestBadClaims(t *testing.T) {
 
 func TestKeyID(t *testing.T) {
 	claims := jwt.MapClaims{
-		"aud":         AudienceClaimValue,
+		"aud":         testAudience,
 		"exp":         time.Now().Add(1 * time.Hour).Unix(),
 		"iss":         "https://testdomain/",
 		TenantIDClaim: "test_tenant_id",
@@ -201,7 +202,7 @@ func TestAudienceSlice(t *testing.T) {
 		UserID:   "test_user_id",
 	}
 	token := genToken(t, jwt.MapClaims{
-		"aud":         []string{AudienceClaimValue, "foobar"},
+		"aud":         []string{testAudience, "foobar"},
 		"exp":         time.Now().Add(1 * time.Hour).Unix(),
 		"iss":         "https://testdomain/",
 		TenantIDClaim: "test_tenant_id",

--- a/service/auth_test.go
+++ b/service/auth_test.go
@@ -18,6 +18,7 @@ func testAuthConfig() service.AuthConfig {
 	return service.AuthConfig{
 		Enabled:  true,
 		JWKSPath: "testdata/auth-public-jwks.json",
+		Audience: "testaudience",
 		Domain:   "https://testdomain",
 		ClientID: "testclientid",
 	}
@@ -26,7 +27,7 @@ func testAuthConfig() service.AuthConfig {
 func genToken(t *testing.T, tenantID auth.TenantID, userID auth.UserID) string {
 	ac := testAuthConfig()
 	token, err := auth.GenerateAccessToken("testkey", "testdata/auth-private-key",
-		1*time.Hour, ac.Domain, tenantID, userID)
+		1*time.Hour, ac.Audience, ac.Domain, tenantID, userID)
 	require.NoError(t, err)
 	return token
 }
@@ -80,7 +81,7 @@ func TestAuthMethodGet(t *testing.T) {
 		require.Equal(t, api.AuthMethodResponse{
 			Kind: "auth0",
 			Auth0: &api.AuthMethodAuth0Details{
-				Audience: auth.AudienceClaimValue,
+				Audience: authConfig.Audience,
 				Domain:   authConfig.Domain,
 				ClientID: authConfig.ClientID,
 			},

--- a/service/ztests/auth.yaml
+++ b/service/ztests/auth.yaml
@@ -1,7 +1,7 @@
 script: |
-  LAKE_EXTRA_FLAGS="-auth.enabled=true -auth.clientid=testuser -auth.domain=https://testdomain -auth.jwkspath=auth-public-jwks.json" source service.sh
+  LAKE_EXTRA_FLAGS="-auth.enabled=true -auth.audience=a -auth.clientid=testuser -auth.domain=https://testdomain -auth.jwkspath=auth-public-jwks.json" source service.sh
   zed auth store -configdir user1 -access \
-    $(gentoken -domain https://testdomain -privatekeyfile auth-private-key -keyid testkey -tenantid tenant1 -userid user1)
+    $(gentoken -audience a -domain https://testdomain -privatekeyfile auth-private-key -keyid testkey -tenantid tenant1 -userid user1)
   zed auth verify -configdir user1 
   zed create -configdir user1 -q test0
   # Unauthenticated user should not be able to create a pool.

--- a/service/ztests/python-auth.yaml
+++ b/service/ztests/python-auth.yaml
@@ -7,8 +7,8 @@ script: |
   # -qq supresses warnings about availability of newer pip versions.
   pip install -qq ./zed
 
-  LAKE_EXTRA_FLAGS='-auth.enabled=t -auth.clientid=c -auth.domain=d -auth.jwkspath=auth-public-jwks.json' source service.sh source service.sh
-  token=$(gentoken -domain d -keyid testkey -privatekeyfile auth-private-key -tenantid t -userid u)
+  LAKE_EXTRA_FLAGS='-auth.enabled=t -auth.audience=a -auth.clientid=c -auth.domain=d -auth.jwkspath=auth-public-jwks.json' source service.sh source service.sh
+  token=$(gentoken -audience a -domain d -keyid testkey -privatekeyfile auth-private-key -tenantid t -userid u)
   zed auth store -access $token -lake $ZED_LAKE
 
   python <<EOF


### PR DESCRIPTION
The Auth0 API audience used by "zed serve" (i.e., the audience value in the GET /auth/method response that an authenticating client then sends on to Auth0 in a device code request) is fixed at
https://lake.brimdata.io.  Replace that fixed value with an -auth.audience flag to "zed serve".

The tenant ID and user ID claim names (in service/auth.TenantIDClaim and UserIDClaim) still have a fixed prefix of https://lake.brimdata.io.  We can replace that with the value of the -auth.audience flag separately.

For #4353.