### PR TITLE
fix test flakiness in docs/language/operators/from.md

### DIFF
--- a/docs/language/operators/from.md
+++ b/docs/language/operators/from.md
@@ -74,7 +74,7 @@ by the following commands:
 ```mdtest-command
 export ZED_LAKE=example
 zed -q init
-zed -q create coinflips
+zed -q create -orderby flip:desc coinflips
 echo '{flip:1,result:"heads"} {flip:2,result:"tails"}' | zed -q -use coinflips load -
 zed -q -use coinflips branch trial 
 echo '{flip:3,result:"heads"}' | zed -q -use coinflips@trial load -


### PR DESCRIPTION
An mdtest in docs/language/operators/from.md went flaky in #4352 because it assumes data objects are scanned in deterministic order.  Fix that by setting an appropriate pool key for the affected pool.