### PR TITLE
runtime/expr: fix malformed empty record from record spread

### DIFF
--- a/runtime/expr/values.go
+++ b/runtime/expr/values.go
@@ -130,10 +130,7 @@ func (r *recordSpreadExpr) Eval(ectx Context, this *zed.Value) *zed.Value {
 		}
 	}
 	if len(object) == 0 {
-		b := r.builder
-		b.Reset()
-		b.Append(nil)
-		return ectx.NewValue(r.zctx.MustLookupTypeRecord([]zed.Field{}), b.Bytes())
+		return ectx.NewValue(r.zctx.MustLookupTypeRecord([]zed.Field{}), []byte{})
 	}
 	r.update(object)
 	b := r.builder


### PR DESCRIPTION
A record spread expression that produces an empty record (e.g., "{...a}" evaluated with "this" bound to a Zed primitive value) results in a zed.Value with malformed bytes, which can cause a panic elsewhere.  Fix this in recordSpreadExpr.Eval by returning a well-formed zed.Value.

For better or worse, we don't have any existing tests for malformed zed.Values, so I'm not adding one here.

Closes #4349.