### PR TITLE
call filepath.ToSlash on subtest names in TestZed

### DIFF
--- a/zed_test.go
+++ b/zed_test.go
@@ -41,7 +41,7 @@ func TestZed(t *testing.T) {
 
 	for d := range dirs {
 		d := d
-		t.Run(d, func(t *testing.T) {
+		t.Run(filepath.ToSlash(d), func(t *testing.T) {
 			t.Parallel()
 			ztest.Run(t, d)
 		})


### PR DESCRIPTION
TestZed uses multi-element directory paths as subtest names.  On Windows, this produces subtest names that contain backslashes instead of slashes, which is undesirable.  Fix this by calling filepath.ToSlash.