### PR TITLE
change "Zed Lake" to "Zed lake"

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -62,7 +62,7 @@ is the best way to learn about `zq` in depth.
 All of its examples use `zq` commands run on the command line.
 Run `zq -h` for a list of command options and online help.
 
-The [Zed Lake documentation](commands/zed.md)
+The [Zed lake documentation](commands/zed.md)
 is the best way to learn about `zed`.
 All of its examples use `zed` commands run on the command line.
 Run `zed -h` or `-h` with any subcommand for a list of command options

--- a/docs/lake/format.md
+++ b/docs/lake/format.md
@@ -19,9 +19,9 @@ an open specification for the Zed lake storage format described in this document
 As we make progress on the Zed lake model, we will update this document
 as we go.
 
-The Zed Lake storage format is somewhat analagous the emerging
+The Zed lake storage format is somewhat analagous the emerging
 cloud table formats like [Iceberg](https://iceberg.apache.org/spec/),
-but differs but differs in a fundamental way: there are no tables in a Zed Lake.
+but differs but differs in a fundamental way: there are no tables in a Zed lake.
 
 On the contrary, we believe a better approach for organizing modern, eclectic
 data is based on a type system rather than a collection of tables

--- a/docs/tutorials/join.md
+++ b/docs/tutorials/join.md
@@ -146,7 +146,7 @@ pull our respective inputs from named file sources. However, if the inputs are
 stored in pools in a Zed lake, the pool names would instead be specified in the
 `from()` block.
 
-Here we'll load our input data to pools in a temporary Zed Lake, then execute
+Here we'll load our input data to pools in a temporary Zed lake, then execute
 our inner join using `zed query`.
 
 Notice that because we happened to use `-orderby` to sort our pools by the same

--- a/docs/tutorials/zed.md
+++ b/docs/tutorials/zed.md
@@ -282,7 +282,7 @@ $ zed query 'count()'
 ## Running as a service
 
 Now that we've compiled an interesting data set, how might we share this with
-others? Using the `zed serve` command we can launch our Zed Lake as a service
+others? Using the `zed serve` command we can launch our Zed lake as a service
 that will allow multiple clients to query and add data to the same lake. In a
 separate console window run:
 
@@ -317,7 +317,7 @@ $ zed query -Z 'min(created_at), max(created_at)'
 Obviously this is only the tip of the iceberg in terms of things that can be done with
 the `zed` command. Some suggested next steps:
 
-1. Dig deeper into Zed Lakes by having a look at the [`zed` README](../commands/zed.md).
+1. Dig deeper into Zed lakes by having a look at the [`zed` README](../commands/zed.md).
 2. Get a better idea of ways you can query your data by looking at the
 [Zed language documentation](../language/README.md).
 


### PR DESCRIPTION
"Zed Lake" appears instead of "Zed lake" in a handful of places. Replace it with "Zed lake" for consistency.