### PR TITLE
runtime: change record column references to field

### DIFF
--- a/runtime/expr/agg/avg.go
+++ b/runtime/expr/agg/avg.go
@@ -62,10 +62,9 @@ func (a *Avg) ResultAsPartial(zctx *zed.Context) *zed.Value {
 	var zv zcode.Bytes
 	zv = zed.NewFloat64(a.sum).Encode(zv)
 	zv = zed.NewUint64(a.count).Encode(zv)
-	cols := []zed.Field{
+	typ := zctx.MustLookupTypeRecord([]zed.Field{
 		zed.NewField(sumName, zed.TypeFloat64),
 		zed.NewField(countName, zed.TypeUint64),
-	}
-	typ := zctx.MustLookupTypeRecord(cols)
+	})
 	return zed.NewValue(typ, zv)
 }

--- a/runtime/expr/agg/schema.go
+++ b/runtime/expr/agg/schema.go
@@ -42,15 +42,15 @@ func merge(zctx *zed.Context, a, b zed.Type) zed.Type {
 	}
 	if a, ok := aUnder.(*zed.TypeRecord); ok {
 		if b, ok := bUnder.(*zed.TypeRecord); ok {
-			cols := slices.Clone(a.Fields)
-			for _, c := range b.Fields {
-				if i, ok := columnOfField(cols, c.Name); !ok {
-					cols = append(cols, c)
-				} else if cols[i] != c {
-					cols[i].Type = merge(zctx, cols[i].Type, c.Type)
+			fields := slices.Clone(a.Fields)
+			for _, f := range b.Fields {
+				if i, ok := indexOfField(fields, f.Name); !ok {
+					fields = append(fields, f)
+				} else if fields[i] != f {
+					fields[i].Type = merge(zctx, fields[i].Type, f.Type)
 				}
 			}
-			return zctx.MustLookupTypeRecord(cols)
+			return zctx.MustLookupTypeRecord(fields)
 		}
 	}
 	if a, ok := aUnder.(*zed.TypeArray); ok {
@@ -107,9 +107,9 @@ func appendIfAbsent(types []zed.Type, typ zed.Type) []zed.Type {
 	return append(types, typ)
 }
 
-func columnOfField(cols []zed.Field, name string) (int, bool) {
-	for i, c := range cols {
-		if c.Name == name {
+func indexOfField(fields []zed.Field, name string) (int, bool) {
+	for i, f := range fields {
+		if f.Name == name {
 			return i, true
 		}
 	}

--- a/runtime/expr/agg/ztests/container-partials.yaml
+++ b/runtime/expr/agg/ztests/container-partials.yaml
@@ -1,6 +1,6 @@
 # This test exercises the partials paths in the reducers by doing a group-by
 # with a single-row limit.  We also make sure the partials consumer can handle
-# an empty input by including a record for key "a" with no value column.
+# an empty input by including a record for key "a" with no value field.
 script: |
   zq -z "union(x) by key with -limit 1" in.zson > union.zson
   zq -z "collect(x) by key with -limit 1" in.zson > collect.zson

--- a/runtime/expr/agg/ztests/math-partials.yaml
+++ b/runtime/expr/agg/ztests/math-partials.yaml
@@ -1,6 +1,6 @@
 # This test exercises the partials paths in the reduducers by doing a group-by
 # with a single-row limit.  We also make sure the partials consumer can handle
-# an empty input by inncluding a record for key "a" with no value column.
+# an empty input by inncluding a record for key "a" with no value field.
 script: |
   zq -z "avg(n) by key with -limit 1" in.zson > avg.zson
   zq -z "count() by key with -limit 1" in.zson > count.zson

--- a/runtime/expr/cutter.go
+++ b/runtime/expr/cutter.go
@@ -36,7 +36,7 @@ func NewCutter(zctx *zed.Context, fieldRefs field.List, fieldExprs []Evaluator) 
 	}
 	var b *zed.RecordBuilder
 	if len(fieldRefs) == 0 || !fieldRefs[0].IsEmpty() {
-		// A root field will cause NewColumnBuilder to panic.
+		// A root field will cause NewFieldBuilder to panic.
 		var err error
 		b, err = zed.NewRecordBuilder(zctx, fieldRefs)
 		if err != nil {
@@ -130,5 +130,5 @@ func (c *Cutter) Warning() string {
 	if c.quiet || c.FoundCut() {
 		return ""
 	}
-	return fmt.Sprintf("no record found with columns %s", fieldList(c.fieldExprs))
+	return fmt.Sprintf("no record found with fields %s", fieldList(c.fieldExprs))
 }

--- a/runtime/expr/dropper.go
+++ b/runtime/expr/dropper.go
@@ -77,13 +77,13 @@ func complementFields(drops field.List, prefix field.Path, typ *zed.TypeRecord) 
 	var fields field.List
 	var types []zed.Type
 	var match bool
-	for _, c := range typ.Fields {
-		fld := append(prefix, c.Name)
+	for _, f := range typ.Fields {
+		fld := append(prefix, f.Name)
 		if drops.Has(fld) {
 			match = true
 			continue
 		}
-		if typ, ok := zed.TypeUnder(c.Type).(*zed.TypeRecord); ok {
+		if typ, ok := zed.TypeUnder(f.Type).(*zed.TypeRecord); ok {
 			if fs, ts, m := complementFields(drops, fld, typ); m {
 				fields = append(fields, fs...)
 				types = append(types, ts...)
@@ -92,7 +92,7 @@ func complementFields(drops field.List, prefix field.Path, typ *zed.TypeRecord) 
 			}
 		}
 		fields = append(fields, slices.Clone(fld))
-		types = append(types, c.Type)
+		types = append(types, f.Type)
 	}
 	return fields, types, match
 }

--- a/runtime/expr/fieldnamefinder.go
+++ b/runtime/expr/fieldnamefinder.go
@@ -60,8 +60,8 @@ type FieldNameIter struct {
 }
 
 type fieldNameIterInfo struct {
-	columns []zed.Field
-	offset  int
+	fields []zed.Field
+	offset int
 }
 
 func (f *FieldNameIter) Init(t *zed.TypeRecord) {
@@ -80,9 +80,9 @@ func (f *FieldNameIter) Next() []byte {
 	// Step into non-empty records.
 	for {
 		info := &f.stack[len(f.stack)-1]
-		col := info.columns[info.offset]
-		f.buf = append(f.buf, "."+col.Name...)
-		t, ok := zed.TypeUnder(col.Type).(*zed.TypeRecord)
+		field := info.fields[info.offset]
+		f.buf = append(f.buf, "."+field.Name...)
+		t, ok := zed.TypeUnder(field.Type).(*zed.TypeRecord)
 		if !ok || len(t.Fields) == 0 {
 			break
 		}
@@ -93,10 +93,10 @@ func (f *FieldNameIter) Next() []byte {
 	// Advance our position and step out of records.
 	for len(f.stack) > 0 {
 		info := &f.stack[len(f.stack)-1]
-		col := info.columns[info.offset]
-		f.buf = f.buf[:len(f.buf)-len(col.Name)-1]
+		field := info.fields[info.offset]
+		f.buf = f.buf[:len(f.buf)-len(field.Name)-1]
 		info.offset++
-		if info.offset < len(info.columns) {
+		if info.offset < len(info.fields) {
 			break
 		}
 		f.stack = f.stack[:len(f.stack)-1]

--- a/runtime/expr/filter.go
+++ b/runtime/expr/filter.go
@@ -205,7 +205,7 @@ func (s *searchString) Eval(ectx Context, val *zed.Value) *zed.Value {
 		}
 	}
 	// Memoize the result of a search across the names in the
-	// record columns for each unique record type.
+	// record fields for each unique record type.
 	if s.searchType(val.Type) {
 		return zed.True
 	}

--- a/runtime/expr/function/fields.go
+++ b/runtime/expr/function/fields.go
@@ -20,15 +20,15 @@ func NewFields(zctx *zed.Context) *Fields {
 
 func buildPath(typ *zed.TypeRecord, b *zcode.Builder, prefix []string) []string {
 	var out []string
-	for _, c := range typ.Fields {
-		if typ, ok := zed.TypeUnder(c.Type).(*zed.TypeRecord); ok {
-			buildPath(typ, b, append(prefix, c.Name))
+	for _, f := range typ.Fields {
+		if typ, ok := zed.TypeUnder(f.Type).(*zed.TypeRecord); ok {
+			buildPath(typ, b, append(prefix, f.Name))
 		} else {
 			b.BeginContainer()
 			for _, s := range prefix {
 				b.Append([]byte(s))
 			}
-			b.Append([]byte(c.Name))
+			b.Append([]byte(f.Name))
 			b.EndContainer()
 		}
 	}

--- a/runtime/expr/function/nestdotted.go
+++ b/runtime/expr/function/nestdotted.go
@@ -34,13 +34,13 @@ func (n *NestDotted) lookupBuilderAndType(in *zed.TypeRecord) (*zed.RecordBuilde
 	var foundDotted bool
 	var fields field.List
 	var types []zed.Type
-	for _, c := range in.Fields {
-		dotted := field.Dotted(c.Name)
+	for _, f := range in.Fields {
+		dotted := field.Dotted(f.Name)
 		if len(dotted) > 1 {
 			foundDotted = true
 		}
 		fields = append(fields, dotted)
-		types = append(types, c.Type)
+		types = append(types, f.Type)
 	}
 	if !foundDotted {
 		return nil, nil, nil

--- a/runtime/expr/function/types.go
+++ b/runtime/expr/function/types.go
@@ -143,8 +143,8 @@ func (h *HasError) hasError(t zed.Type, b zcode.Bytes) (bool, bool) {
 	switch typ := typ.(type) {
 	case *zed.TypeRecord:
 		it := b.Iter()
-		for _, col := range typ.Fields {
-			e, c := h.hasError(col.Type, it.Next())
+		for _, f := range typ.Fields {
+			e, c := h.hasError(f.Type, it.Next())
 			hasErr = hasErr || e
 			canCache = !canCache || c
 		}

--- a/runtime/expr/renamer.go
+++ b/runtime/expr/renamer.go
@@ -45,9 +45,9 @@ func (r *Renamer) dstType(typ *zed.TypeRecord, src, dst field.Path) (*zed.TypeRe
 	} else {
 		innerType = typ.Fields[c].Type
 	}
-	newcols := slices.Clone(typ.Fields)
-	newcols[c] = zed.Field{Name: dst[0], Type: innerType}
-	typ, err := r.zctx.LookupTypeRecord(newcols)
+	fields := slices.Clone(typ.Fields)
+	fields[c] = zed.NewField(dst[0], innerType)
+	typ, err := r.zctx.LookupTypeRecord(fields)
 	if err != nil {
 		var dferr *zed.DuplicateFieldError
 		if errors.As(err, &dferr) {

--- a/runtime/expr/spanfilter.go
+++ b/runtime/expr/spanfilter.go
@@ -13,8 +13,8 @@ type SpanFilter struct {
 	eval Evaluator
 
 	builder zcode.Builder
-	cols    []zed.Field
 	ectx    Context
+	fields  []zed.Field
 	val     zed.Value
 	zctx    *zed.Context
 }
@@ -22,20 +22,20 @@ type SpanFilter struct {
 func NewSpanFilter(eval Evaluator) *SpanFilter {
 	return &SpanFilter{
 		eval: eval,
-		cols: []zed.Field{
+		ectx: NewContext(),
+		fields: []zed.Field{
 			{Name: "lower"},
 			{Name: "upper"},
 		},
-		ectx: NewContext(),
 		zctx: zed.NewContext(),
 	}
 }
 
 func (o *SpanFilter) Eval(lower, upper *zed.Value) bool {
-	o.cols[0].Type = lower.Type
-	o.cols[1].Type = upper.Type
-	if o.val.Type == nil || o.cols[0].Type != lower.Type || o.cols[1].Type != upper.Type {
-		o.val.Type = o.zctx.MustLookupTypeRecord(o.cols)
+	o.fields[0].Type = lower.Type
+	o.fields[1].Type = upper.Type
+	if o.val.Type == nil || o.fields[0].Type != lower.Type || o.fields[1].Type != upper.Type {
+		o.val.Type = o.zctx.MustLookupTypeRecord(o.fields)
 	}
 	o.builder.Reset()
 	o.builder.Append(lower.Bytes)

--- a/runtime/op/explode/explode.go
+++ b/runtime/op/explode/explode.go
@@ -18,7 +18,7 @@ type Proc struct {
 }
 
 // New creates a exploder for type typ, where the
-// output records' single column is named name.
+// output records' single field is named name.
 func New(zctx *zed.Context, parent zbuf.Puller, args []expr.Evaluator, typ zed.Type, name string) (zbuf.Puller, error) {
 	return &Proc{
 		parent:  parent,

--- a/runtime/op/groupby/groupby.go
+++ b/runtime/op/groupby/groupby.go
@@ -489,12 +489,12 @@ func (a *Aggregator) nextResultFromSpills(ectx expr.Context) (*zed.Value, error)
 		types = append(types, keyVal.Type)
 		a.builder.Append(keyVal.Bytes)
 	}
-	for _, col := range row {
+	for _, f := range row {
 		var v *zed.Value
 		if a.partialsOut {
-			v = col.ResultAsPartial(a.zctx)
+			v = f.ResultAsPartial(a.zctx)
 		} else {
-			v = col.Result(a.zctx)
+			v = f.Result(a.zctx)
 		}
 		types = append(types, v.Type)
 		a.builder.Append(v.Bytes)
@@ -538,12 +538,12 @@ func (a *Aggregator) readTable(flush, partialsOut bool, batch zbuf.Batch) (zbuf.
 			a.builder.Append(flatVal)
 			types = append(types, typ)
 		}
-		for _, col := range row.reducers {
+		for _, f := range row.reducers {
 			var v *zed.Value
 			if partialsOut {
-				v = col.ResultAsPartial(a.zctx)
+				v = f.ResultAsPartial(a.zctx)
 			} else {
-				v = col.Result(a.zctx)
+				v = f.Result(a.zctx)
 			}
 			types = append(types, v.Type)
 			a.builder.Append(v.Bytes)

--- a/runtime/op/groupby/row.go
+++ b/runtime/op/groupby/row.go
@@ -12,11 +12,11 @@ import (
 type valRow []agg.Function
 
 func newValRow(aggs []*expr.Aggregator) valRow {
-	cols := make([]agg.Function, 0, len(aggs))
+	row := make([]agg.Function, 0, len(aggs))
 	for _, a := range aggs {
-		cols = append(cols, a.NewFunction())
+		row = append(row, a.NewFunction())
 	}
-	return cols
+	return row
 }
 
 func (v valRow) apply(zctx *zed.Context, ectx expr.Context, aggs []*expr.Aggregator, this *zed.Value) {

--- a/runtime/op/join/join.go
+++ b/runtime/op/join/join.go
@@ -205,18 +205,16 @@ func (p *Proc) enterType(combined, left, right *zed.TypeRecord) {
 }
 
 func (p *Proc) buildType(left, right *zed.TypeRecord) (*zed.TypeRecord, error) {
-	cols := make([]zed.Field, 0, len(left.Fields)+len(right.Fields))
-	for _, c := range left.Fields {
-		cols = append(cols, c)
-	}
-	for _, c := range right.Fields {
-		name := c.Name
+	fields := make([]zed.Field, 0, len(left.Fields)+len(right.Fields))
+	fields = append(fields, left.Fields...)
+	for _, f := range right.Fields {
+		name := f.Name
 		for k := 2; left.HasField(name); k++ {
-			name = fmt.Sprintf("%s_%d", c.Name, k)
+			name = fmt.Sprintf("%s_%d", f.Name, k)
 		}
-		cols = append(cols, zed.Field{Name: name, Type: c.Type})
+		fields = append(fields, zed.NewField(name, f.Type))
 	}
-	return p.pctx.Zctx.LookupTypeRecord(cols)
+	return p.pctx.Zctx.LookupTypeRecord(fields)
 }
 
 func (p *Proc) combinedType(left, right *zed.TypeRecord) (*zed.TypeRecord, error) {

--- a/runtime/op/sort/sort.go
+++ b/runtime/op/sort/sort.go
@@ -228,13 +228,13 @@ func GuessSortKey(val *zed.Value) field.Path {
 }
 
 func firstMatchingField(typ *zed.TypeRecord, pred func(id int) bool) field.Path {
-	for _, col := range typ.Fields {
-		if pred(col.Type.ID()) {
-			return field.New(col.Name)
+	for _, f := range typ.Fields {
+		if pred(f.Type.ID()) {
+			return field.New(f.Name)
 		}
-		if typ := zed.TypeRecordOf(col.Type); typ != nil {
-			if f := firstMatchingField(typ, pred); f != nil {
-				return append(field.New(col.Name), f...)
+		if typ := zed.TypeRecordOf(f.Type); typ != nil {
+			if ff := firstMatchingField(typ, pred); ff != nil {
+				return append(field.New(f.Name), ff...)
 			}
 		}
 	}

--- a/runtime/op/traverse/over.go
+++ b/runtime/op/traverse/over.go
@@ -105,20 +105,18 @@ func appendOver(zctx *zed.Context, vals []zed.Value, zv zed.Value) []zed.Value {
 		return vals
 	case *zed.TypeRecord:
 		builder := zcode.NewBuilder()
-		columns := typ.Fields
 		for i, it := 0, zv.Bytes.Iter(); !it.Done(); i++ {
 			builder.Reset()
-			col := columns[i]
+			field := typ.Fields[i]
 			typ := zctx.MustLookupTypeRecord([]zed.Field{
 				{Name: "key", Type: zctx.LookupTypeArray(zed.TypeString)},
-				{Name: "value", Type: col.Type},
+				{Name: "value", Type: field.Type},
 			})
 			builder.BeginContainer()
-			builder.Append(zed.EncodeString(col.Name))
+			builder.Append(zed.EncodeString(field.Name))
 			builder.EndContainer()
 			builder.Append(it.Next())
 			vals = append(vals, *zed.NewValue(typ, builder.Bytes()).Copy())
-
 		}
 		return vals
 	default:

--- a/runtime/vcache/projection.go
+++ b/runtime/vcache/projection.go
@@ -99,10 +99,10 @@ func findCuts(o *Object, names []string) ([]*cut, error) {
 func newCut(zctx *zed.Context, typ *zed.TypeRecord, fields []Vector, actuals []string, reader storage.Reader) (*cut, error) {
 	var group errgroup.Group
 	iters := make([]iterator, len(actuals))
-	columns := make([]zed.Field, len(actuals))
+	outFields := make([]zed.Field, len(actuals))
 	for k, name := range actuals {
 		col, _ := typ.ColumnOfField(name)
-		columns[k] = typ.Fields[col]
+		outFields[k] = typ.Fields[col]
 		which := k
 		group.Go(func() error {
 			it, err := fields[col].NewIter(reader)
@@ -116,7 +116,7 @@ func newCut(zctx *zed.Context, typ *zed.TypeRecord, fields []Vector, actuals []s
 	if err := group.Wait(); err != nil {
 		return nil, err
 	}
-	outType, err := zctx.LookupTypeRecord(columns)
+	outType, err := zctx.LookupTypeRecord(outFields)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is a follow-up to #4306, which renamed zed.Column to Field.