### PR TITLE
zbuf: replace NewPuller size param and ScannerBatchSize with PullerBatchSize

### DIFF
--- a/cli/outputflags/flags.go
+++ b/cli/outputflags/flags.go
@@ -116,7 +116,7 @@ func (f *Flags) Init() error {
 		f.ZSON.Pretty = 0
 	}
 	if f.unbuffered {
-		zbuf.ScannerBatchSize = 1
+		zbuf.PullerBatchSize = 1
 	}
 	return nil
 }

--- a/runtime/op/fuse/fuse.go
+++ b/runtime/op/fuse/fuse.go
@@ -8,7 +8,6 @@ import (
 )
 
 var MemMaxBytes = 128 * 1024 * 1024
-var BatchSize = 100
 
 type Proc struct {
 	pctx   *op.Context
@@ -65,7 +64,7 @@ func (p *Proc) pullInput() error {
 }
 
 func (p *Proc) pushOutput() error {
-	puller := zbuf.NewPuller(p.fuser, BatchSize)
+	puller := zbuf.NewPuller(p.fuser)
 	for {
 		if err := p.pctx.Err(); err != nil {
 			return err

--- a/runtime/op/groupby/groupby_test.go
+++ b/runtime/op/groupby/groupby_test.go
@@ -269,12 +269,12 @@ func TestGroupbyStreamingSpill(t *testing.T) {
 	// spill before that all records for that key have been
 	// written to the spill.
 	//
-	savedBatchSize := zbuf.ScannerBatchSize
-	zbuf.ScannerBatchSize = 1
+	savedPullerBatchSize := zbuf.PullerBatchSize
+	zbuf.PullerBatchSize = 1
 	savedBatchSizeGroupByLimit := groupby.DefaultLimit
 	groupby.DefaultLimit = 2
 	defer func() {
-		zbuf.ScannerBatchSize = savedBatchSize
+		zbuf.PullerBatchSize = savedPullerBatchSize
 		groupby.DefaultLimit = savedBatchSizeGroupByLimit
 	}()
 

--- a/runtime/op/merge/merge.go
+++ b/runtime/op/merge/merge.go
@@ -78,8 +78,7 @@ func (p *Proc) Pull(done bool) (zbuf.Batch, error) {
 		return batch, nil
 	}
 	heap.Push(p, min)
-	const batchLen = 100 // XXX
-	return zbuf.NewPuller(p, batchLen).Pull(false)
+	return zbuf.NewPuller(p).Pull(false)
 }
 
 func (p *Proc) Read() (*zed.Value, error) {

--- a/runtime/op/merge/merge_test.go
+++ b/runtime/op/merge/merge_test.go
@@ -100,7 +100,7 @@ func TestParallelOrder(t *testing.T) {
 			var parents []zbuf.Puller
 			for _, input := range c.inputs {
 				r := zsonio.NewReader(zctx, strings.NewReader(input))
-				parents = append(parents, zbuf.NewPuller(r, 10))
+				parents = append(parents, zbuf.NewPuller(r))
 			}
 			layout := order.NewLayout(c.order, field.DottedList(c.field))
 			cmp := zbuf.NewComparator(zctx, layout).Compare

--- a/runtime/op/shape/shape.go
+++ b/runtime/op/shape/shape.go
@@ -8,7 +8,6 @@ import (
 )
 
 var MemMaxBytes = 128 * 1024 * 1024
-var BatchSize = 100
 
 type Proc struct {
 	pctx   *op.Context
@@ -66,7 +65,7 @@ func (p *Proc) pullInput() error {
 }
 
 func (p *Proc) pushOutput() error {
-	puller := zbuf.NewPuller(p.shaper, BatchSize)
+	puller := zbuf.NewPuller(p.shaper)
 	for {
 		if err := p.pctx.Err(); err != nil {
 			return err

--- a/runtime/op/sort/sort.go
+++ b/runtime/op/sort/sort.go
@@ -156,7 +156,7 @@ func (p *Proc) send(vals []zed.Value) bool {
 }
 
 func (p *Proc) sendSpills(spiller *spill.MergeSort) bool {
-	puller := zbuf.NewPuller(spiller, 100)
+	puller := zbuf.NewPuller(spiller)
 	for {
 		if err := p.pctx.Err(); err != nil {
 			return false

--- a/zbuf/scanner.go
+++ b/zbuf/scanner.go
@@ -79,8 +79,6 @@ func (p *Progress) Progress() Progress {
 	return p.Copy()
 }
 
-var ScannerBatchSize = 100
-
 // NewScanner returns a Scanner for r that filters records by filterExpr and s.
 // If r implements fmt.Stringer, the scanner reports errors using a prefix of the
 // string returned by its String method.
@@ -113,7 +111,7 @@ func newScanner(ctx context.Context, r zio.Reader, filterExpr Filter) (Scanner, 
 		}
 	}
 	sc := &scanner{reader: r, filter: f, ctx: ctx}
-	sc.Puller = NewPuller(sc, ScannerBatchSize)
+	sc.Puller = NewPuller(sc)
 	return sc, nil
 }
 


### PR DESCRIPTION
NewPuller's second parameter specifies the target number of values per batch, but it's really only used as a conduit for ScannerBatchSize. Replace them with PullerBatchSize.