### PR TITLE
cli/lakeflags: remove trailing slash from lake URI

### DIFF
--- a/cli/lakeflags/flags.go
+++ b/cli/lakeflags/flags.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/brimdata/zed/api/client"
 	"github.com/brimdata/zed/api/client/auth0"
@@ -38,11 +39,11 @@ func (l *Flags) SetFlags(fs *flag.FlagSet) {
 	fs.StringVar(&l.ConfigDir, "configdir", dir, "configuration and credentials directory")
 	l.Lake = "http://localhost:9867"
 	if s, ok := os.LookupEnv("ZED_LAKE"); ok {
-		l.Lake = s
+		l.Lake = strings.TrimRight(s, "/")
 		l.LakeSpecified = true
 	}
 	fs.Func("lake", fmt.Sprintf("lake location (env ZED_LAKE) (default %s)", l.Lake), func(s string) error {
-		l.Lake = s
+		l.Lake = strings.TrimRight(s, "/")
 		l.LakeSpecified = true
 		return nil
 	})


### PR DESCRIPTION
We missed this in #4109.

It would be nice to include a test for "zed auth login", but since it depends on the Auth0 service, we don't have an easy way to add one.

Closes #4292.