### PR TITLE
fix GET /version for zed built by "go install"

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,7 +5,7 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -s -X github.com/brimdata/zed/cli.Version={{ .Tag }}
+      - -s -X github.com/brimdata/zed/cli.version={{ .Tag }}
     goarch:
       - amd64
       - arm64
@@ -19,7 +19,7 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -s -X github.com/brimdata/zed/cli.Version={{ .Tag }}
+      - -s -X github.com/brimdata/zed/cli.version={{ .Tag }}
     goarch:
       - amd64
       - arm64

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 export GO111MODULE=on
 
 VERSION = $(shell git describe --tags --dirty --always)
-LDFLAGS = -s -X github.com/brimdata/zed/cli.Version=$(VERSION)
+LDFLAGS = -s -X github.com/brimdata/zed/cli.version=$(VERSION)
 BUILD_COMMANDS = ./cmd/zed ./cmd/zq
 
 # This enables a shortcut to run a single test from the ./ztests suite, e.g.:

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -9,13 +9,9 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
-	"runtime/debug"
 	"runtime/pprof"
 	"syscall"
 )
-
-// Version is set via the Go linker.  See Makefile.
-var Version string
 
 type Flags struct {
 	showVersion    bool
@@ -36,15 +32,7 @@ type Initializer interface {
 
 func (f *Flags) Init(all ...Initializer) (context.Context, context.CancelFunc, error) {
 	if f.showVersion {
-		if Version == "" {
-			Version = "unknown"
-			if info, ok := debug.ReadBuildInfo(); ok {
-				// This will be "(devel)" for binaries not built
-				// by "go install PACKAGE@VERSION".
-				Version = info.Main.Version
-			}
-		}
-		fmt.Printf("Version: %s\n", Version)
+		fmt.Printf("Version: %s\n", Version())
 		os.Exit(0)
 	}
 	var err error

--- a/cli/version.go
+++ b/cli/version.go
@@ -1,0 +1,23 @@
+package cli
+
+import "runtime/debug"
+
+// version can be set by the linker.
+var version string
+
+// Version returns a version string.  If the version variable in this package
+// was set to a non-empty string by the linker, Version returns that.
+// Otherwise, if build information is available via [debug.ReadBuildInfo],
+// Version returns [debug.Buildinfo].Main.Version.  Otherwise, Version returns
+// "unknown".
+func Version() string {
+	if version != "" {
+		return version
+	}
+	if info, ok := debug.ReadBuildInfo(); ok {
+		// This will be "(devel)" for binaries not built by
+		// "go install PACKAGE@VERSION".
+		return info.Main.Version
+	}
+	return "unknown"
+}

--- a/cmd/zed/serve/command.go
+++ b/cmd/zed/serve/command.go
@@ -50,7 +50,7 @@ type Command struct {
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*root.Command)}
 	c.conf.Auth.SetFlags(f)
-	c.conf.Version = cli.Version
+	c.conf.Version = cli.Version()
 	c.logflags.SetFlags(f)
 	f.IntVar(&c.brimfd, "brimfd", -1, "pipe read fd passed by brim to signal brim closure")
 	f.Func("cors.origin", "CORS allowed origin (may be repeated)", func(s string) error {


### PR DESCRIPTION
For a zed binary built by "go install", a GET /version request always receives a response of '{"version":"unknown"}'.  Fix this changing cli.Version from a variable to a function that calls debug.ReadBuildInfo if the new cli.version variable hasn't be set by the linker.

Closes #4370.