### PR TITLE
remove scan range and scan order from DAG

### DIFF
--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -388,12 +388,10 @@ type (
 		Layout *Layout `json:"layout"`
 	}
 	Pool struct {
-		Kind      string   `json:"kind" unpack:""`
-		Spec      PoolSpec `json:"spec"`
-		At        string   `json:"at"`
-		Delete    bool     `json:"delete"`
-		Range     *Range   `json:"range"`
-		ScanOrder string   `json:"scan_order"` // asc, desc, or unknown
+		Kind   string   `json:"kind" unpack:""`
+		Spec   PoolSpec `json:"spec"`
+		At     string   `json:"at"`
+		Delete bool     `json:"delete"`
 	}
 	Explode struct {
 		Kind string      `json:"kind" unpack:""`
@@ -407,12 +405,6 @@ type PoolSpec struct {
 	Pool   Pattern `json:"pool"`
 	Commit string  `json:"commit"`
 	Meta   string  `json:"meta"`
-}
-
-type Range struct {
-	Kind  string `json:"kind" unpack:""`
-	Lower Expr   `json:"lower"`
-	Upper Expr   `json:"upper"`
 }
 
 type Source interface {

--- a/compiler/ast/dag/operator.go
+++ b/compiler/ast/dag/operator.go
@@ -178,13 +178,10 @@ type (
 		Layout order.Layout `json:"layout"`
 	}
 	Pool struct {
-		Kind      string      `json:"kind" unpack:""`
-		ID        ksuid.KSUID `json:"id"`
-		Commit    ksuid.KSUID `json:"commit"`
-		Delete    bool        `json:"delete"`
-		ScanLower Expr        `json:"scan_lower"`
-		ScanUpper Expr        `json:"scan_upper"`
-		ScanOrder string      `json:"scan_order"`
+		Kind   string      `json:"kind" unpack:""`
+		ID     ksuid.KSUID `json:"id"`
+		Commit ksuid.KSUID `json:"commit"`
+		Delete bool        `json:"delete"`
 	}
 	PoolMeta struct {
 		Kind string      `json:"kind" unpack:""`
@@ -192,13 +189,10 @@ type (
 		Meta string      `json:"meta"`
 	}
 	CommitMeta struct {
-		Kind      string      `json:"kind" unpack:""`
-		Pool      ksuid.KSUID `json:"pool"`
-		Commit    ksuid.KSUID `json:"branch"`
-		Meta      string      `json:"meta"`
-		ScanLower Expr        `json:"scan_lower"`
-		ScanUpper Expr        `json:"scan_upper"`
-		ScanOrder string      `json:"scan_order"`
+		Kind   string      `json:"kind" unpack:""`
+		Pool   ksuid.KSUID `json:"pool"`
+		Commit ksuid.KSUID `json:"branch"`
+		Meta   string      `json:"meta"`
 	}
 	LakeMeta struct {
 		Kind string `json:"kind" unpack:""`

--- a/compiler/ast/unpack.go
+++ b/compiler/ast/unpack.go
@@ -52,7 +52,6 @@ var unpacker = unpack.New(
 	Pool{},
 	astzed.Primitive{},
 	Put{},
-	Range{},
 	astzed.Record{},
 	Agg{},
 	Regexp{},

--- a/compiler/parser/parser.es.js
+++ b/compiler/parser/parser.es.js
@@ -554,8 +554,8 @@ function peg$parse(input, options) {
       peg$c200 = function(body) { return body },
       peg$c201 = "pool",
       peg$c202 = peg$literalExpectation("pool", false),
-      peg$c203 = function(spec, at, over, order) {
-            return {"kind": "Pool", "spec": spec, "at": at, "range": over, "scan_order": order}
+      peg$c203 = function(spec, at) {
+            return {"kind": "Pool", "spec": spec, "at": at}
           },
       peg$c204 = "get",
       peg$c205 = peg$literalExpectation("get", false),
@@ -573,85 +573,76 @@ function peg$parse(input, options) {
       peg$c215 = function(id) { return id },
       peg$c216 = /^[0-9a-zA-Z]/,
       peg$c217 = peg$classExpectation([["0", "9"], ["a", "z"], ["A", "Z"]], false, false),
-      peg$c218 = "range",
-      peg$c219 = peg$literalExpectation("range", false),
-      peg$c220 = "to",
-      peg$c221 = peg$literalExpectation("to", false),
-      peg$c222 = function(lower, upper) {
-            return {"kind":"Range","lower": lower, "upper": upper}
-          },
-      peg$c223 = function(pool, commit, meta) {
+      peg$c218 = function(pool, commit, meta) {
             return {"pool": pool, "commit": commit, "meta": meta}
           },
-      peg$c224 = function(meta) {
+      peg$c219 = function(meta) {
             return {"pool": null, "commit": null, "meta": meta}
           },
-      peg$c225 = "@",
-      peg$c226 = peg$literalExpectation("@", false),
-      peg$c227 = function(commit) { return commit },
-      peg$c228 = function(meta) { return meta },
-      peg$c229 = function() { return {"kind": "Glob", "pattern": "*"} },
-      peg$c230 = function(name) { return {"kind": "String", "text": name} },
-      peg$c231 = function() {  return text() },
-      peg$c232 = "order",
-      peg$c233 = peg$literalExpectation("order", false),
-      peg$c234 = function(keys, order) {
+      peg$c220 = "@",
+      peg$c221 = peg$literalExpectation("@", false),
+      peg$c222 = function(commit) { return commit },
+      peg$c223 = function(meta) { return meta },
+      peg$c224 = function() { return {"kind": "Glob", "pattern": "*"} },
+      peg$c225 = function(name) { return {"kind": "String", "text": name} },
+      peg$c226 = function() {  return text() },
+      peg$c227 = "order",
+      peg$c228 = peg$literalExpectation("order", false),
+      peg$c229 = function(keys, order) {
             return {"kind": "Layout", "keys": keys, "order": order}
           },
-      peg$c235 = "format",
-      peg$c236 = peg$literalExpectation("format", false),
-      peg$c237 = function(val) { return val },
-      peg$c238 = ":asc",
-      peg$c239 = peg$literalExpectation(":asc", false),
-      peg$c240 = function() { return "asc" },
-      peg$c241 = ":desc",
-      peg$c242 = peg$literalExpectation(":desc", false),
-      peg$c243 = function() { return "desc" },
-      peg$c244 = "asc",
-      peg$c245 = peg$literalExpectation("asc", false),
-      peg$c246 = "desc",
-      peg$c247 = peg$literalExpectation("desc", false),
-      peg$c248 = "pass",
-      peg$c249 = peg$literalExpectation("pass", false),
-      peg$c250 = function() {
+      peg$c230 = "format",
+      peg$c231 = peg$literalExpectation("format", false),
+      peg$c232 = function(val) { return val },
+      peg$c233 = ":asc",
+      peg$c234 = peg$literalExpectation(":asc", false),
+      peg$c235 = function() { return "asc" },
+      peg$c236 = ":desc",
+      peg$c237 = peg$literalExpectation(":desc", false),
+      peg$c238 = function() { return "desc" },
+      peg$c239 = "asc",
+      peg$c241 = "desc",
+      peg$c243 = "pass",
+      peg$c244 = peg$literalExpectation("pass", false),
+      peg$c245 = function() {
             return {"kind":"Pass"}
           },
-      peg$c251 = "explode",
-      peg$c252 = peg$literalExpectation("explode", false),
-      peg$c253 = function(args, typ, as) {
+      peg$c246 = "explode",
+      peg$c247 = peg$literalExpectation("explode", false),
+      peg$c248 = function(args, typ, as) {
             return {"kind":"Explode", "args": args, "as": as, "type": typ}
           },
-      peg$c254 = "merge",
-      peg$c255 = peg$literalExpectation("merge", false),
-      peg$c256 = function(expr) {
+      peg$c249 = "merge",
+      peg$c250 = peg$literalExpectation("merge", false),
+      peg$c251 = function(expr) {
       	  return {"kind":"Merge", "expr":expr}
           },
-      peg$c257 = "over",
-      peg$c258 = peg$literalExpectation("over", false),
-      peg$c259 = function(exprs, locals, scope) {
+      peg$c252 = "over",
+      peg$c253 = peg$literalExpectation("over", false),
+      peg$c254 = function(exprs, locals, scope) {
             let over = {"kind": "Over", "exprs": exprs, "scope": scope};
             if (locals) {
               return {"kind": "Let", "locals": locals, "over": over}
             }
             return over
           },
-      peg$c260 = function(seq) { return seq },
-      peg$c261 = function(first, a) { return a },
-      peg$c262 = function(name, opt) {
+      peg$c255 = function(seq) { return seq },
+      peg$c256 = function(first, a) { return a },
+      peg$c257 = function(name, opt) {
             let m = {"name": name, "expr": {"kind": "ID", "name": name}};
             if (opt) {
                m["expr"] = opt[3];
             }
             return m
           },
-      peg$c263 = "yield",
-      peg$c264 = peg$literalExpectation("yield", false),
-      peg$c265 = function(exprs) {
+      peg$c258 = "yield",
+      peg$c259 = peg$literalExpectation("yield", false),
+      peg$c260 = function(exprs) {
       	  return {"kind":"Yield", "exprs":exprs}
           },
-      peg$c266 = function(typ) { return typ},
-      peg$c267 = function(lhs) { return lhs },
-      peg$c269 = function(first, rest) {
+      peg$c261 = function(typ) { return typ},
+      peg$c262 = function(lhs) { return lhs },
+      peg$c264 = function(first, rest) {
             let result = [first];
 
             for(let  r of rest) {
@@ -660,13 +651,13 @@ function peg$parse(input, options) {
 
             return result
           },
-      peg$c270 = function(first, rest) {
+      peg$c265 = function(first, rest) {
           return [first, ... rest]
         },
-      peg$c271 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c272 = "?",
-      peg$c273 = peg$literalExpectation("?", false),
-      peg$c274 = function(cond, opt) {
+      peg$c266 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c267 = "?",
+      peg$c268 = peg$literalExpectation("?", false),
+      peg$c269 = function(cond, opt) {
             if (opt) {
               let Then = opt[3];
               let Else = opt[7];
@@ -674,12 +665,12 @@ function peg$parse(input, options) {
             }
             return cond
           },
-      peg$c275 = function(first, op, expr) { return [op, expr] },
-      peg$c276 = function(first, rest) {
+      peg$c270 = function(first, op, expr) { return [op, expr] },
+      peg$c271 = function(first, rest) {
               return makeBinaryExprChain(first, rest)
           },
-      peg$c277 = function(lhs) { return text() },
-      peg$c278 = function(lhs, opAndRHS) {
+      peg$c272 = function(lhs) { return text() },
+      peg$c273 = function(lhs, opAndRHS) {
             if (!opAndRHS) {
               return lhs
             }
@@ -687,106 +678,106 @@ function peg$parse(input, options) {
             let rhs = opAndRHS[3];
             return {"kind": "BinaryExpr", "op": op, "lhs": lhs, "rhs": rhs}
           },
-      peg$c279 = "+",
-      peg$c280 = peg$literalExpectation("+", false),
-      peg$c281 = "-",
-      peg$c282 = peg$literalExpectation("-", false),
-      peg$c283 = "/",
-      peg$c284 = peg$literalExpectation("/", false),
-      peg$c285 = "%",
-      peg$c286 = peg$literalExpectation("%", false),
-      peg$c287 = function(e) {
+      peg$c274 = "+",
+      peg$c275 = peg$literalExpectation("+", false),
+      peg$c276 = "-",
+      peg$c277 = peg$literalExpectation("-", false),
+      peg$c278 = "/",
+      peg$c279 = peg$literalExpectation("/", false),
+      peg$c280 = "%",
+      peg$c281 = peg$literalExpectation("%", false),
+      peg$c282 = function(e) {
               return {"kind": "UnaryExpr", "op": "!", "operand": e}
           },
-      peg$c288 = function(e) {
+      peg$c283 = function(e) {
               return {"kind": "UnaryExpr", "op": "-", "operand": e}
           },
-      peg$c289 = "not",
-      peg$c290 = peg$literalExpectation("not", false),
-      peg$c291 = "select",
-      peg$c292 = peg$literalExpectation("select", false),
-      peg$c293 = function(typ, expr) {
+      peg$c284 = "not",
+      peg$c285 = peg$literalExpectation("not", false),
+      peg$c286 = "select",
+      peg$c287 = peg$literalExpectation("select", false),
+      peg$c288 = function(typ, expr) {
             return {"kind": "Cast", "expr": expr, "type": typ}
           },
-      peg$c294 = "regexp",
-      peg$c295 = peg$literalExpectation("regexp", false),
-      peg$c296 = function(arg0Text, arg1, where) {
+      peg$c289 = "regexp",
+      peg$c290 = peg$literalExpectation("regexp", false),
+      peg$c291 = function(arg0Text, arg1, where) {
             let arg0 = {"kind": "Primitive", "type": "string", "text": arg0Text};
             return {"kind": "Call", "name": "regexp", "args": [arg0, arg1], "where": where}
           },
-      peg$c297 = function(fn, args, where) {
+      peg$c292 = function(fn, args, where) {
             return {"kind": "Call", "name": fn, "args": args, "where": where}
           },
-      peg$c298 = function(o) { return [o] },
-      peg$c299 = "grep",
-      peg$c300 = peg$literalExpectation("grep", false),
-      peg$c301 = function(pattern, opt) {
+      peg$c293 = function(o) { return [o] },
+      peg$c294 = "grep",
+      peg$c295 = peg$literalExpectation("grep", false),
+      peg$c296 = function(pattern, opt) {
             let m = {"kind": "Grep", "pattern": pattern, "expr": {"kind": "ID", "name": "this"}};
             if (opt) {
               m["expr"] = opt[2];
             }
             return m
           },
-      peg$c302 = function(s) {
+      peg$c297 = function(s) {
             return {"kind": "String", "text": s}
           },
-      peg$c303 = function(first, e) { return e },
-      peg$c304 = "]",
-      peg$c305 = peg$literalExpectation("]", false),
-      peg$c306 = function(from, to) {
+      peg$c298 = function(first, e) { return e },
+      peg$c299 = "]",
+      peg$c300 = peg$literalExpectation("]", false),
+      peg$c301 = function(from, to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs":to}]
           
           },
-      peg$c307 = function(to) {
+      peg$c302 = function(to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs": null, "rhs":to}]
           
           },
-      peg$c308 = function(expr) { return ["[", expr] },
-      peg$c309 = function(id) { return [".", id] },
-      peg$c310 = function(exprs, locals, scope) {
+      peg$c303 = function(expr) { return ["[", expr] },
+      peg$c304 = function(id) { return [".", id] },
+      peg$c305 = function(exprs, locals, scope) {
             return {"kind": "OverExpr", "locals": locals, "exprs": exprs, "scope": scope}
           },
-      peg$c311 = "}",
-      peg$c312 = peg$literalExpectation("}", false),
-      peg$c313 = function(elems) {
+      peg$c306 = "}",
+      peg$c307 = peg$literalExpectation("}", false),
+      peg$c308 = function(elems) {
             return {"kind":"RecordExpr", "elems":elems}
           },
-      peg$c314 = function(elem) { return elem },
-      peg$c315 = "...",
-      peg$c316 = peg$literalExpectation("...", false),
-      peg$c317 = function(expr) {
+      peg$c309 = function(elem) { return elem },
+      peg$c310 = "...",
+      peg$c311 = peg$literalExpectation("...", false),
+      peg$c312 = function(expr) {
             return {"kind":"Spread", "expr": expr}
           },
-      peg$c318 = function(name, value) {
+      peg$c313 = function(name, value) {
             return {"kind":"Field","name": name, "value": value}
           },
-      peg$c319 = function(elems) {
+      peg$c314 = function(elems) {
             return {"kind":"ArrayExpr", "elems":elems }
           },
-      peg$c320 = "|[",
-      peg$c321 = peg$literalExpectation("|[", false),
-      peg$c322 = "]|",
-      peg$c323 = peg$literalExpectation("]|", false),
-      peg$c324 = function(elems) {
+      peg$c315 = "|[",
+      peg$c316 = peg$literalExpectation("|[", false),
+      peg$c317 = "]|",
+      peg$c318 = peg$literalExpectation("]|", false),
+      peg$c319 = function(elems) {
             return {"kind":"SetExpr", "elems":elems }
           },
-      peg$c325 = function(e) { return {"kind":"VectorValue","expr":e} },
-      peg$c326 = "|{",
-      peg$c327 = peg$literalExpectation("|{", false),
-      peg$c328 = "}|",
-      peg$c329 = peg$literalExpectation("}|", false),
-      peg$c330 = function(exprs) {
+      peg$c320 = function(e) { return {"kind":"VectorValue","expr":e} },
+      peg$c321 = "|{",
+      peg$c322 = peg$literalExpectation("|{", false),
+      peg$c323 = "}|",
+      peg$c324 = peg$literalExpectation("}|", false),
+      peg$c325 = function(exprs) {
             return {"kind":"MapExpr", "entries":exprs }
           },
-      peg$c331 = function(e) { return e },
-      peg$c332 = function(key, value) {
+      peg$c326 = function(e) { return e },
+      peg$c327 = function(key, value) {
             return {"key": key, "value": value}
           },
-      peg$c333 = function(selection, from, joins, where, groupby, having, orderby, limit) {
+      peg$c328 = function(selection, from, joins, where, groupby, having, orderby, limit) {
             return {
               
             "kind": "SQLExpr",
@@ -808,19 +799,19 @@ function peg$parse(input, options) {
             "limit": limit }
           
           },
-      peg$c334 = function(assignments) { return assignments },
-      peg$c335 = function(rhs, opt) {
+      peg$c329 = function(assignments) { return assignments },
+      peg$c330 = function(rhs, opt) {
             let m = {"kind": "Assignment", "lhs": null, "rhs": rhs};
             if (opt) {
               m["lhs"] = opt[3];
             }
             return m
           },
-      peg$c336 = function(table, alias) {
+      peg$c331 = function(table, alias) {
             return {"table": table, "alias": alias}
           },
-      peg$c337 = function(first, join) { return join },
-      peg$c338 = function(style, table, alias, leftKey, rightKey) {
+      peg$c332 = function(first, join) { return join },
+      peg$c333 = function(style, table, alias, leftKey, rightKey) {
             return {
               
             "table": table,
@@ -834,120 +825,120 @@ function peg$parse(input, options) {
             "alias": alias}
           
           },
-      peg$c339 = function(style) { return style },
-      peg$c340 = function(keys, order) {
+      peg$c334 = function(style) { return style },
+      peg$c335 = function(keys, order) {
             return {"kind": "SQLOrderBy", "keys": keys, "order":order}
           },
-      peg$c341 = function(dir) { return dir },
-      peg$c342 = function(count) { return count },
-      peg$c343 = peg$literalExpectation("select", true),
-      peg$c344 = function() { return "select" },
-      peg$c345 = "as",
-      peg$c346 = peg$literalExpectation("as", true),
-      peg$c347 = function() { return "as" },
-      peg$c348 = peg$literalExpectation("from", true),
-      peg$c349 = function() { return "from" },
-      peg$c350 = peg$literalExpectation("join", true),
-      peg$c351 = function() { return "join" },
-      peg$c352 = peg$literalExpectation("where", true),
-      peg$c353 = function() { return "where" },
-      peg$c354 = "group",
-      peg$c355 = peg$literalExpectation("group", true),
-      peg$c356 = function() { return "group" },
-      peg$c357 = "by",
-      peg$c358 = peg$literalExpectation("by", true),
-      peg$c359 = function() { return "by" },
-      peg$c360 = "having",
-      peg$c361 = peg$literalExpectation("having", true),
-      peg$c362 = function() { return "having" },
-      peg$c363 = peg$literalExpectation("order", true),
-      peg$c364 = function() { return "order" },
-      peg$c365 = "on",
-      peg$c366 = peg$literalExpectation("on", true),
-      peg$c367 = function() { return "on" },
-      peg$c368 = "limit",
-      peg$c369 = peg$literalExpectation("limit", true),
-      peg$c370 = function() { return "limit" },
-      peg$c371 = peg$literalExpectation("asc", true),
-      peg$c372 = peg$literalExpectation("desc", true),
-      peg$c373 = peg$literalExpectation("anti", true),
-      peg$c374 = peg$literalExpectation("left", true),
-      peg$c375 = peg$literalExpectation("right", true),
-      peg$c376 = peg$literalExpectation("inner", true),
-      peg$c377 = function(v) {
+      peg$c336 = function(dir) { return dir },
+      peg$c337 = function(count) { return count },
+      peg$c338 = peg$literalExpectation("select", true),
+      peg$c339 = function() { return "select" },
+      peg$c340 = "as",
+      peg$c341 = peg$literalExpectation("as", true),
+      peg$c342 = function() { return "as" },
+      peg$c343 = peg$literalExpectation("from", true),
+      peg$c344 = function() { return "from" },
+      peg$c345 = peg$literalExpectation("join", true),
+      peg$c346 = function() { return "join" },
+      peg$c347 = peg$literalExpectation("where", true),
+      peg$c348 = function() { return "where" },
+      peg$c349 = "group",
+      peg$c350 = peg$literalExpectation("group", true),
+      peg$c351 = function() { return "group" },
+      peg$c352 = "by",
+      peg$c353 = peg$literalExpectation("by", true),
+      peg$c354 = function() { return "by" },
+      peg$c355 = "having",
+      peg$c356 = peg$literalExpectation("having", true),
+      peg$c357 = function() { return "having" },
+      peg$c358 = peg$literalExpectation("order", true),
+      peg$c359 = function() { return "order" },
+      peg$c360 = "on",
+      peg$c361 = peg$literalExpectation("on", true),
+      peg$c362 = function() { return "on" },
+      peg$c363 = "limit",
+      peg$c364 = peg$literalExpectation("limit", true),
+      peg$c365 = function() { return "limit" },
+      peg$c366 = peg$literalExpectation("asc", true),
+      peg$c367 = peg$literalExpectation("desc", true),
+      peg$c368 = peg$literalExpectation("anti", true),
+      peg$c369 = peg$literalExpectation("left", true),
+      peg$c370 = peg$literalExpectation("right", true),
+      peg$c371 = peg$literalExpectation("inner", true),
+      peg$c372 = function(v) {
             return {"kind": "Primitive", "type": "net", "text": v}
           },
-      peg$c378 = function(v) {
+      peg$c373 = function(v) {
             return {"kind": "Primitive", "type": "ip", "text": v}
           },
-      peg$c379 = function(v) {
+      peg$c374 = function(v) {
             return {"kind": "Primitive", "type": "float64", "text": v}
           },
-      peg$c380 = function(v) {
+      peg$c375 = function(v) {
             return {"kind": "Primitive", "type": "int64", "text": v}
           },
-      peg$c381 = "true",
-      peg$c382 = peg$literalExpectation("true", false),
-      peg$c383 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
-      peg$c384 = "false",
-      peg$c385 = peg$literalExpectation("false", false),
-      peg$c386 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
-      peg$c387 = "null",
-      peg$c388 = peg$literalExpectation("null", false),
-      peg$c389 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
-      peg$c390 = "0x",
-      peg$c391 = peg$literalExpectation("0x", false),
-      peg$c392 = function() {
+      peg$c376 = "true",
+      peg$c377 = peg$literalExpectation("true", false),
+      peg$c378 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
+      peg$c379 = "false",
+      peg$c380 = peg$literalExpectation("false", false),
+      peg$c381 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
+      peg$c382 = "null",
+      peg$c383 = peg$literalExpectation("null", false),
+      peg$c384 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
+      peg$c385 = "0x",
+      peg$c386 = peg$literalExpectation("0x", false),
+      peg$c387 = function() {
       	return {"kind": "Primitive", "type": "bytes", "text": text()}
         },
-      peg$c393 = function(typ) {
+      peg$c388 = function(typ) {
             return {"kind": "TypeValue", "value": typ}
           },
-      peg$c394 = function(name) { return name },
-      peg$c395 = function(name, opt) {
+      peg$c389 = function(name) { return name },
+      peg$c390 = function(name, opt) {
             if (opt) {
               return {"kind": "TypeDef", "name": name, "type": opt[3]}
             }
             return {"kind": "TypeName", "name": name}
           },
-      peg$c396 = function(name) {
+      peg$c391 = function(name) {
             return {"kind": "TypeName", "name": name}
           },
-      peg$c397 = function(u) { return u },
-      peg$c398 = function(types) {
+      peg$c392 = function(u) { return u },
+      peg$c393 = function(types) {
             return {"kind": "TypeUnion", "types": types}
           },
-      peg$c399 = function(typ) { return typ },
-      peg$c400 = function(fields) {
+      peg$c394 = function(typ) { return typ },
+      peg$c395 = function(fields) {
             return {"kind":"TypeRecord", "fields":fields}
           },
-      peg$c401 = function(typ) {
+      peg$c396 = function(typ) {
             return {"kind":"TypeArray", "type":typ}
           },
-      peg$c402 = function(typ) {
+      peg$c397 = function(typ) {
             return {"kind":"TypeSet", "type":typ}
           },
-      peg$c403 = function(keyType, valType) {
+      peg$c398 = function(keyType, valType) {
             return {"kind":"TypeMap", "key_type":keyType, "val_type": valType}
           },
-      peg$c404 = function(v) {
+      peg$c399 = function(v) {
             if (v.length == 0) {
               return {"kind": "Primitive", "type": "string", "text": ""}
             }
             return makeTemplateExprChain(v)
           },
-      peg$c405 = "\"",
-      peg$c406 = peg$literalExpectation("\"", false),
-      peg$c407 = "'",
-      peg$c408 = peg$literalExpectation("'", false),
-      peg$c409 = function(v) {
+      peg$c400 = "\"",
+      peg$c401 = peg$literalExpectation("\"", false),
+      peg$c402 = "'",
+      peg$c403 = peg$literalExpectation("'", false),
+      peg$c404 = function(v) {
             return {"kind": "Primitive", "type": "string", "text": joinChars(v)}
           },
-      peg$c410 = "\\",
-      peg$c411 = peg$literalExpectation("\\", false),
-      peg$c412 = "${",
-      peg$c413 = peg$literalExpectation("${", false),
-      peg$c414 = function(e) {
+      peg$c405 = "\\",
+      peg$c406 = peg$literalExpectation("\\", false),
+      peg$c407 = "${",
+      peg$c408 = peg$literalExpectation("${", false),
+      peg$c409 = function(e) {
             return {
               
             "kind": "Cast",
@@ -961,194 +952,194 @@ function peg$parse(input, options) {
             "value": {"kind": "TypePrimitive", "name": "string"}}}
           
           },
-      peg$c415 = "uint8",
-      peg$c416 = peg$literalExpectation("uint8", false),
-      peg$c417 = "uint16",
-      peg$c418 = peg$literalExpectation("uint16", false),
-      peg$c419 = "uint32",
-      peg$c420 = peg$literalExpectation("uint32", false),
-      peg$c421 = "uint64",
-      peg$c422 = peg$literalExpectation("uint64", false),
-      peg$c423 = "int8",
-      peg$c424 = peg$literalExpectation("int8", false),
-      peg$c425 = "int16",
-      peg$c426 = peg$literalExpectation("int16", false),
-      peg$c427 = "int32",
-      peg$c428 = peg$literalExpectation("int32", false),
-      peg$c429 = "int64",
-      peg$c430 = peg$literalExpectation("int64", false),
-      peg$c431 = "float16",
-      peg$c432 = peg$literalExpectation("float16", false),
-      peg$c433 = "float32",
-      peg$c434 = peg$literalExpectation("float32", false),
-      peg$c435 = "float64",
-      peg$c436 = peg$literalExpectation("float64", false),
-      peg$c437 = "bool",
-      peg$c438 = peg$literalExpectation("bool", false),
-      peg$c439 = "string",
-      peg$c440 = peg$literalExpectation("string", false),
-      peg$c441 = "duration",
-      peg$c442 = peg$literalExpectation("duration", false),
-      peg$c443 = "time",
-      peg$c444 = peg$literalExpectation("time", false),
-      peg$c445 = "bytes",
-      peg$c446 = peg$literalExpectation("bytes", false),
-      peg$c447 = "ip",
-      peg$c448 = peg$literalExpectation("ip", false),
-      peg$c449 = "net",
-      peg$c450 = peg$literalExpectation("net", false),
-      peg$c451 = function() {
+      peg$c410 = "uint8",
+      peg$c411 = peg$literalExpectation("uint8", false),
+      peg$c412 = "uint16",
+      peg$c413 = peg$literalExpectation("uint16", false),
+      peg$c414 = "uint32",
+      peg$c415 = peg$literalExpectation("uint32", false),
+      peg$c416 = "uint64",
+      peg$c417 = peg$literalExpectation("uint64", false),
+      peg$c418 = "int8",
+      peg$c419 = peg$literalExpectation("int8", false),
+      peg$c420 = "int16",
+      peg$c421 = peg$literalExpectation("int16", false),
+      peg$c422 = "int32",
+      peg$c423 = peg$literalExpectation("int32", false),
+      peg$c424 = "int64",
+      peg$c425 = peg$literalExpectation("int64", false),
+      peg$c426 = "float16",
+      peg$c427 = peg$literalExpectation("float16", false),
+      peg$c428 = "float32",
+      peg$c429 = peg$literalExpectation("float32", false),
+      peg$c430 = "float64",
+      peg$c431 = peg$literalExpectation("float64", false),
+      peg$c432 = "bool",
+      peg$c433 = peg$literalExpectation("bool", false),
+      peg$c434 = "string",
+      peg$c435 = peg$literalExpectation("string", false),
+      peg$c436 = "duration",
+      peg$c437 = peg$literalExpectation("duration", false),
+      peg$c438 = "time",
+      peg$c439 = peg$literalExpectation("time", false),
+      peg$c440 = "bytes",
+      peg$c441 = peg$literalExpectation("bytes", false),
+      peg$c442 = "ip",
+      peg$c443 = peg$literalExpectation("ip", false),
+      peg$c444 = "net",
+      peg$c445 = peg$literalExpectation("net", false),
+      peg$c446 = function() {
                 return {"kind": "TypePrimitive", "name": text()}
               },
-      peg$c452 = function(name, typ) {
+      peg$c447 = function(name, typ) {
             return {"name": name, "type": typ}
           },
-      peg$c453 = "and",
-      peg$c454 = peg$literalExpectation("and", false),
-      peg$c455 = "AND",
-      peg$c456 = peg$literalExpectation("AND", false),
-      peg$c457 = function() { return "and" },
-      peg$c458 = "or",
-      peg$c459 = peg$literalExpectation("or", false),
-      peg$c460 = "OR",
-      peg$c461 = peg$literalExpectation("OR", false),
-      peg$c462 = function() { return "or" },
-      peg$c464 = "NOT",
-      peg$c465 = peg$literalExpectation("NOT", false),
-      peg$c466 = function() { return "not" },
-      peg$c467 = peg$literalExpectation("by", false),
-      peg$c468 = /^[A-Za-z_$]/,
-      peg$c469 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c470 = /^[0-9]/,
-      peg$c471 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c472 = function(id) { return {"kind": "ID", "name": id} },
-      peg$c473 = "$",
-      peg$c474 = peg$literalExpectation("$", false),
-      peg$c475 = function(first, id) { return id},
-      peg$c476 = "T",
-      peg$c477 = peg$literalExpectation("T", false),
-      peg$c478 = function() {
+      peg$c448 = "and",
+      peg$c449 = peg$literalExpectation("and", false),
+      peg$c450 = "AND",
+      peg$c451 = peg$literalExpectation("AND", false),
+      peg$c452 = function() { return "and" },
+      peg$c453 = "or",
+      peg$c454 = peg$literalExpectation("or", false),
+      peg$c455 = "OR",
+      peg$c456 = peg$literalExpectation("OR", false),
+      peg$c457 = function() { return "or" },
+      peg$c459 = "NOT",
+      peg$c460 = peg$literalExpectation("NOT", false),
+      peg$c461 = function() { return "not" },
+      peg$c462 = peg$literalExpectation("by", false),
+      peg$c463 = /^[A-Za-z_$]/,
+      peg$c464 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c465 = /^[0-9]/,
+      peg$c466 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c467 = function(id) { return {"kind": "ID", "name": id} },
+      peg$c468 = "$",
+      peg$c469 = peg$literalExpectation("$", false),
+      peg$c470 = function(first, id) { return id},
+      peg$c471 = "T",
+      peg$c472 = peg$literalExpectation("T", false),
+      peg$c473 = function() {
             return {"kind": "Primitive", "type": "time", "text": text()}
           },
-      peg$c479 = "Z",
-      peg$c480 = peg$literalExpectation("Z", false),
-      peg$c481 = function() {
+      peg$c474 = "Z",
+      peg$c475 = peg$literalExpectation("Z", false),
+      peg$c476 = function() {
             return {"kind": "Primitive", "type": "duration", "text": text()}
           },
-      peg$c482 = "ns",
-      peg$c483 = peg$literalExpectation("ns", false),
-      peg$c484 = "us",
-      peg$c485 = peg$literalExpectation("us", false),
-      peg$c486 = "ms",
-      peg$c487 = peg$literalExpectation("ms", false),
-      peg$c488 = "s",
-      peg$c489 = peg$literalExpectation("s", false),
-      peg$c490 = "m",
-      peg$c491 = peg$literalExpectation("m", false),
-      peg$c492 = "h",
-      peg$c493 = peg$literalExpectation("h", false),
-      peg$c494 = "d",
-      peg$c495 = peg$literalExpectation("d", false),
-      peg$c496 = "w",
-      peg$c497 = peg$literalExpectation("w", false),
-      peg$c498 = "y",
-      peg$c499 = peg$literalExpectation("y", false),
-      peg$c500 = function(a, b) {
+      peg$c477 = "ns",
+      peg$c478 = peg$literalExpectation("ns", false),
+      peg$c479 = "us",
+      peg$c480 = peg$literalExpectation("us", false),
+      peg$c481 = "ms",
+      peg$c482 = peg$literalExpectation("ms", false),
+      peg$c483 = "s",
+      peg$c484 = peg$literalExpectation("s", false),
+      peg$c485 = "m",
+      peg$c486 = peg$literalExpectation("m", false),
+      peg$c487 = "h",
+      peg$c488 = peg$literalExpectation("h", false),
+      peg$c489 = "d",
+      peg$c490 = peg$literalExpectation("d", false),
+      peg$c491 = "w",
+      peg$c492 = peg$literalExpectation("w", false),
+      peg$c493 = "y",
+      peg$c494 = peg$literalExpectation("y", false),
+      peg$c495 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c501 = "::",
-      peg$c502 = peg$literalExpectation("::", false),
-      peg$c503 = function(a, b, d, e) {
+      peg$c496 = "::",
+      peg$c497 = peg$literalExpectation("::", false),
+      peg$c498 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c504 = function(a, b) {
+      peg$c499 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c505 = function(a, b) {
+      peg$c500 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c506 = function() {
+      peg$c501 = function() {
             return "::"
           },
-      peg$c507 = function(v) { return ":" + v },
-      peg$c508 = function(v) { return v + ":" },
-      peg$c509 = function(a, m) {
+      peg$c502 = function(v) { return ":" + v },
+      peg$c503 = function(v) { return v + ":" },
+      peg$c504 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c510 = function(a, m) {
+      peg$c505 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c511 = function(s) { return parseInt(s) },
-      peg$c512 = function() {
+      peg$c506 = function(s) { return parseInt(s) },
+      peg$c507 = function() {
             return text()
           },
-      peg$c513 = "e",
-      peg$c514 = peg$literalExpectation("e", true),
-      peg$c515 = /^[+\-]/,
-      peg$c516 = peg$classExpectation(["+", "-"], false, false),
-      peg$c517 = "NaN",
-      peg$c518 = peg$literalExpectation("NaN", false),
-      peg$c519 = "Inf",
-      peg$c520 = peg$literalExpectation("Inf", false),
-      peg$c521 = /^[0-9a-fA-F]/,
-      peg$c522 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c523 = function(v) { return joinChars(v) },
-      peg$c524 = peg$anyExpectation(),
-      peg$c525 = function(head, tail) { return head + joinChars(tail) },
-      peg$c526 = /^[a-zA-Z_.:\/%#@~]/,
-      peg$c527 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
-      peg$c528 = function(head, tail) {
+      peg$c508 = "e",
+      peg$c509 = peg$literalExpectation("e", true),
+      peg$c510 = /^[+\-]/,
+      peg$c511 = peg$classExpectation(["+", "-"], false, false),
+      peg$c512 = "NaN",
+      peg$c513 = peg$literalExpectation("NaN", false),
+      peg$c514 = "Inf",
+      peg$c515 = peg$literalExpectation("Inf", false),
+      peg$c516 = /^[0-9a-fA-F]/,
+      peg$c517 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c518 = function(v) { return joinChars(v) },
+      peg$c519 = peg$anyExpectation(),
+      peg$c520 = function(head, tail) { return head + joinChars(tail) },
+      peg$c521 = /^[a-zA-Z_.:\/%#@~]/,
+      peg$c522 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
+      peg$c523 = function(head, tail) {
             return head + joinChars(tail)
           },
-      peg$c529 = function() { return "*"},
-      peg$c530 = function() { return "=" },
-      peg$c531 = function() { return "\\*" },
-      peg$c532 = "b",
-      peg$c533 = peg$literalExpectation("b", false),
-      peg$c534 = function() { return "\b" },
-      peg$c535 = "f",
-      peg$c536 = peg$literalExpectation("f", false),
-      peg$c537 = function() { return "\f" },
-      peg$c538 = "n",
-      peg$c539 = peg$literalExpectation("n", false),
-      peg$c540 = function() { return "\n" },
-      peg$c541 = "r",
-      peg$c542 = peg$literalExpectation("r", false),
-      peg$c543 = function() { return "\r" },
-      peg$c544 = "t",
-      peg$c545 = peg$literalExpectation("t", false),
-      peg$c546 = function() { return "\t" },
-      peg$c547 = "v",
-      peg$c548 = peg$literalExpectation("v", false),
-      peg$c549 = function() { return "\v" },
-      peg$c550 = function() { return "*" },
-      peg$c551 = "u",
-      peg$c552 = peg$literalExpectation("u", false),
-      peg$c553 = function(chars) {
+      peg$c524 = function() { return "*"},
+      peg$c525 = function() { return "=" },
+      peg$c526 = function() { return "\\*" },
+      peg$c527 = "b",
+      peg$c528 = peg$literalExpectation("b", false),
+      peg$c529 = function() { return "\b" },
+      peg$c530 = "f",
+      peg$c531 = peg$literalExpectation("f", false),
+      peg$c532 = function() { return "\f" },
+      peg$c533 = "n",
+      peg$c534 = peg$literalExpectation("n", false),
+      peg$c535 = function() { return "\n" },
+      peg$c536 = "r",
+      peg$c537 = peg$literalExpectation("r", false),
+      peg$c538 = function() { return "\r" },
+      peg$c539 = "t",
+      peg$c540 = peg$literalExpectation("t", false),
+      peg$c541 = function() { return "\t" },
+      peg$c542 = "v",
+      peg$c543 = peg$literalExpectation("v", false),
+      peg$c544 = function() { return "\v" },
+      peg$c545 = function() { return "*" },
+      peg$c546 = "u",
+      peg$c547 = peg$literalExpectation("u", false),
+      peg$c548 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c554 = /^[^\/\\]/,
-      peg$c555 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c556 = /^[\0-\x1F\\]/,
-      peg$c557 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c558 = peg$otherExpectation("whitespace"),
-      peg$c559 = "\t",
-      peg$c560 = peg$literalExpectation("\t", false),
-      peg$c561 = "\x0B",
-      peg$c562 = peg$literalExpectation("\x0B", false),
-      peg$c563 = "\f",
-      peg$c564 = peg$literalExpectation("\f", false),
-      peg$c565 = " ",
-      peg$c566 = peg$literalExpectation(" ", false),
-      peg$c567 = "\xA0",
-      peg$c568 = peg$literalExpectation("\xA0", false),
-      peg$c569 = "\uFEFF",
-      peg$c570 = peg$literalExpectation("\uFEFF", false),
-      peg$c571 = /^[\n\r\u2028\u2029]/,
-      peg$c572 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c573 = peg$otherExpectation("comment"),
-      peg$c578 = "//",
-      peg$c579 = peg$literalExpectation("//", false),
+      peg$c549 = /^[^\/\\]/,
+      peg$c550 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c551 = /^[\0-\x1F\\]/,
+      peg$c552 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c553 = peg$otherExpectation("whitespace"),
+      peg$c554 = "\t",
+      peg$c555 = peg$literalExpectation("\t", false),
+      peg$c556 = "\x0B",
+      peg$c557 = peg$literalExpectation("\x0B", false),
+      peg$c558 = "\f",
+      peg$c559 = peg$literalExpectation("\f", false),
+      peg$c560 = " ",
+      peg$c561 = peg$literalExpectation(" ", false),
+      peg$c562 = "\xA0",
+      peg$c563 = peg$literalExpectation("\xA0", false),
+      peg$c564 = "\uFEFF",
+      peg$c565 = peg$literalExpectation("\uFEFF", false),
+      peg$c566 = /^[\n\r\u2028\u2029]/,
+      peg$c567 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c568 = peg$otherExpectation("comment"),
+      peg$c573 = "//",
+      peg$c574 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -5381,7 +5372,7 @@ function peg$parse(input, options) {
   }
 
   function peg$parsePoolBody() {
-    var s0, s1, s2, s3, s4;
+    var s0, s1, s2;
 
     s0 = peg$currPos;
     s1 = peg$parsePoolSpec();
@@ -5391,27 +5382,9 @@ function peg$parse(input, options) {
         s2 = null;
       }
       if (s2 !== peg$FAILED) {
-        s3 = peg$parsePoolRange();
-        if (s3 === peg$FAILED) {
-          s3 = null;
-        }
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parseOrderArg();
-          if (s4 === peg$FAILED) {
-            s4 = null;
-          }
-          if (s4 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c203(s1, s2, s3, s4);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
+        peg$savedPos = s0;
+        s1 = peg$c203(s1, s2);
+        s0 = s1;
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -5635,77 +5608,6 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsePoolRange() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
-
-    s0 = peg$currPos;
-    s1 = peg$parse_();
-    if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c218) {
-        s2 = peg$c218;
-        peg$currPos += 5;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c219); }
-      }
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parse_();
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parseLiteral();
-          if (s4 !== peg$FAILED) {
-            s5 = peg$parse_();
-            if (s5 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c220) {
-                s6 = peg$c220;
-                peg$currPos += 2;
-              } else {
-                s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c221); }
-              }
-              if (s6 !== peg$FAILED) {
-                s7 = peg$parse_();
-                if (s7 !== peg$FAILED) {
-                  s8 = peg$parseLiteral();
-                  if (s8 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c222(s4, s8);
-                    s0 = s1;
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
   function peg$parsePoolSpec() {
     var s0, s1, s2, s3;
 
@@ -5723,7 +5625,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c223(s1, s2, s3);
+          s1 = peg$c218(s1, s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5742,7 +5644,7 @@ function peg$parse(input, options) {
       s1 = peg$parsePoolMeta();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c224(s1);
+        s1 = peg$c219(s1);
       }
       s0 = s1;
     }
@@ -5755,17 +5657,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 64) {
-      s1 = peg$c225;
+      s1 = peg$c220;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c226); }
+      if (peg$silentFails === 0) { peg$fail(peg$c221); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsePoolNameString();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c227(s2);
+        s1 = peg$c222(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5794,7 +5696,7 @@ function peg$parse(input, options) {
       s2 = peg$parsePoolIdentifier();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c228(s2);
+        s1 = peg$c223(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5834,7 +5736,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c229();
+          s1 = peg$c224();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5851,7 +5753,7 @@ function peg$parse(input, options) {
           s1 = peg$parsePoolNameString();
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c230(s1);
+            s1 = peg$c225(s1);
           }
           s0 = s1;
         }
@@ -5916,7 +5818,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c231();
+        s1 = peg$c226();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5936,12 +5838,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c232) {
-        s2 = peg$c232;
+      if (input.substr(peg$currPos, 5) === peg$c227) {
+        s2 = peg$c227;
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c233); }
+        if (peg$silentFails === 0) { peg$fail(peg$c228); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5951,7 +5853,7 @@ function peg$parse(input, options) {
             s5 = peg$parseOrderSuffix();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c234(s4, s5);
+              s1 = peg$c229(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5983,12 +5885,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c235) {
-        s2 = peg$c235;
+      if (input.substr(peg$currPos, 6) === peg$c230) {
+        s2 = peg$c230;
         peg$currPos += 6;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c236); }
+        if (peg$silentFails === 0) { peg$fail(peg$c231); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5996,7 +5898,7 @@ function peg$parse(input, options) {
           s4 = peg$parseIdentifierName();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c237(s4);
+            s1 = peg$c232(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6022,30 +5924,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c238) {
-      s1 = peg$c238;
+    if (input.substr(peg$currPos, 4) === peg$c233) {
+      s1 = peg$c233;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c239); }
+      if (peg$silentFails === 0) { peg$fail(peg$c234); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c240();
+      s1 = peg$c235();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c241) {
-        s1 = peg$c241;
+      if (input.substr(peg$currPos, 5) === peg$c236) {
+        s1 = peg$c236;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c242); }
+        if (peg$silentFails === 0) { peg$fail(peg$c237); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c243();
+        s1 = peg$c238();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -6053,98 +5955,9 @@ function peg$parse(input, options) {
         s1 = peg$c98;
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c240();
+          s1 = peg$c235();
         }
         s0 = s1;
-      }
-    }
-
-    return s0;
-  }
-
-  function peg$parseOrderArg() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$currPos;
-    s1 = peg$parse_();
-    if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c232) {
-        s2 = peg$c232;
-        peg$currPos += 5;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c233); }
-      }
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parse_();
-        if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c244) {
-            s4 = peg$c244;
-            peg$currPos += 3;
-          } else {
-            s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c245); }
-          }
-          if (s4 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c240();
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$parse_();
-      if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c232) {
-          s2 = peg$c232;
-          peg$currPos += 5;
-        } else {
-          s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c233); }
-        }
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parse_();
-          if (s3 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c246) {
-              s4 = peg$c246;
-              peg$currPos += 4;
-            } else {
-              s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c247); }
-            }
-            if (s4 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c243();
-              s0 = s1;
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
       }
     }
 
@@ -6155,12 +5968,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c248) {
-      s1 = peg$c248;
+    if (input.substr(peg$currPos, 4) === peg$c243) {
+      s1 = peg$c243;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c249); }
+      if (peg$silentFails === 0) { peg$fail(peg$c244); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -6175,7 +5988,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c250();
+        s1 = peg$c245();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6193,12 +6006,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 7) === peg$c251) {
-      s1 = peg$c251;
+    if (input.substr(peg$currPos, 7) === peg$c246) {
+      s1 = peg$c246;
       peg$currPos += 7;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c252); }
+      if (peg$silentFails === 0) { peg$fail(peg$c247); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6213,7 +6026,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c253(s3, s4, s5);
+              s1 = peg$c248(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6243,12 +6056,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c254) {
-      s1 = peg$c254;
+    if (input.substr(peg$currPos, 5) === peg$c249) {
+      s1 = peg$c249;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c255); }
+      if (peg$silentFails === 0) { peg$fail(peg$c250); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6256,7 +6069,7 @@ function peg$parse(input, options) {
         s3 = peg$parseConditionalExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c256(s3);
+          s1 = peg$c251(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6278,12 +6091,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c257) {
-      s1 = peg$c257;
+    if (input.substr(peg$currPos, 4) === peg$c252) {
+      s1 = peg$c252;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c258); }
+      if (peg$silentFails === 0) { peg$fail(peg$c253); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6301,7 +6114,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c259(s3, s4, s5);
+              s1 = peg$c254(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6366,7 +6179,7 @@ function peg$parse(input, options) {
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c260(s6);
+                    s1 = peg$c255(s6);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -6439,7 +6252,7 @@ function peg$parse(input, options) {
                   s10 = peg$parseLocalsAssignment();
                   if (s10 !== peg$FAILED) {
                     peg$savedPos = s6;
-                    s7 = peg$c261(s4, s10);
+                    s7 = peg$c256(s4, s10);
                     s6 = s7;
                   } else {
                     peg$currPos = s6;
@@ -6475,7 +6288,7 @@ function peg$parse(input, options) {
                     s10 = peg$parseLocalsAssignment();
                     if (s10 !== peg$FAILED) {
                       peg$savedPos = s6;
-                      s7 = peg$c261(s4, s10);
+                      s7 = peg$c256(s4, s10);
                       s6 = s7;
                     } else {
                       peg$currPos = s6;
@@ -6566,7 +6379,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c262(s1, s2);
+        s1 = peg$c257(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6584,12 +6397,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c263) {
-      s1 = peg$c263;
+    if (input.substr(peg$currPos, 5) === peg$c258) {
+      s1 = peg$c258;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c264); }
+      if (peg$silentFails === 0) { peg$fail(peg$c259); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6597,7 +6410,7 @@ function peg$parse(input, options) {
         s3 = peg$parseExprs();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c265(s3);
+          s1 = peg$c260(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6628,7 +6441,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c266(s4);
+            s1 = peg$c261(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6663,7 +6476,7 @@ function peg$parse(input, options) {
           s4 = peg$parseDerefExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c267(s4);
+            s1 = peg$c262(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6763,7 +6576,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c269(s1, s2);
+        s1 = peg$c264(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6800,7 +6613,7 @@ function peg$parse(input, options) {
             s7 = peg$parseAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c261(s1, s7);
+              s4 = peg$c256(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6836,7 +6649,7 @@ function peg$parse(input, options) {
               s7 = peg$parseAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c261(s1, s7);
+                s4 = peg$c256(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6857,7 +6670,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c270(s1, s2);
+        s1 = peg$c265(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6892,7 +6705,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c271(s1, s5);
+              s1 = peg$c266(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6936,11 +6749,11 @@ function peg$parse(input, options) {
       s3 = peg$parse__();
       if (s3 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s4 = peg$c272;
+          s4 = peg$c267;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c273); }
+          if (peg$silentFails === 0) { peg$fail(peg$c268); }
         }
         if (s4 !== peg$FAILED) {
           s5 = peg$parse__();
@@ -7000,7 +6813,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c274(s1, s2);
+        s1 = peg$c269(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7031,7 +6844,7 @@ function peg$parse(input, options) {
             s7 = peg$parseLogicalAndExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c275(s1, s5, s7);
+              s4 = peg$c270(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7061,7 +6874,7 @@ function peg$parse(input, options) {
               s7 = peg$parseLogicalAndExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c275(s1, s5, s7);
+                s4 = peg$c270(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7082,7 +6895,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c276(s1, s2);
+        s1 = peg$c271(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7113,7 +6926,7 @@ function peg$parse(input, options) {
             s7 = peg$parseComparisonExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c275(s1, s5, s7);
+              s4 = peg$c270(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7143,7 +6956,7 @@ function peg$parse(input, options) {
               s7 = peg$parseComparisonExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c275(s1, s5, s7);
+                s4 = peg$c270(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7164,7 +6977,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c276(s1, s2);
+        s1 = peg$c271(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7225,7 +7038,7 @@ function peg$parse(input, options) {
           }
           if (s5 !== peg$FAILED) {
             peg$savedPos = s4;
-            s5 = peg$c277();
+            s5 = peg$c272();
           }
           s4 = s5;
           if (s4 !== peg$FAILED) {
@@ -7257,7 +7070,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c278(s1, s2);
+        s1 = peg$c273(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7288,7 +7101,7 @@ function peg$parse(input, options) {
             s7 = peg$parseMultiplicativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c275(s1, s5, s7);
+              s4 = peg$c270(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7318,7 +7131,7 @@ function peg$parse(input, options) {
               s7 = peg$parseMultiplicativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c275(s1, s5, s7);
+                s4 = peg$c270(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7339,7 +7152,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c276(s1, s2);
+        s1 = peg$c271(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7358,19 +7171,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c279;
+      s1 = peg$c274;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c280); }
+      if (peg$silentFails === 0) { peg$fail(peg$c275); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c281;
+        s1 = peg$c276;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c282); }
+        if (peg$silentFails === 0) { peg$fail(peg$c277); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -7399,7 +7212,7 @@ function peg$parse(input, options) {
             s7 = peg$parseNotExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c275(s1, s5, s7);
+              s4 = peg$c270(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7429,7 +7242,7 @@ function peg$parse(input, options) {
               s7 = peg$parseNotExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c275(s1, s5, s7);
+                s4 = peg$c270(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7450,7 +7263,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c276(s1, s2);
+        s1 = peg$c271(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7477,19 +7290,19 @@ function peg$parse(input, options) {
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c283;
+        s1 = peg$c278;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c284); }
+        if (peg$silentFails === 0) { peg$fail(peg$c279); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 37) {
-          s1 = peg$c285;
+          s1 = peg$c280;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c286); }
+          if (peg$silentFails === 0) { peg$fail(peg$c281); }
         }
       }
     }
@@ -7519,7 +7332,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c287(s3);
+          s1 = peg$c282(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7556,11 +7369,11 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c281;
+        s2 = peg$c276;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c282); }
+        if (peg$silentFails === 0) { peg$fail(peg$c277); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -7568,7 +7381,7 @@ function peg$parse(input, options) {
           s4 = peg$parseFuncExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c288(s4);
+            s1 = peg$c283(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7687,20 +7500,20 @@ function peg$parse(input, options) {
   function peg$parseNotFuncs() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c289) {
-      s0 = peg$c289;
+    if (input.substr(peg$currPos, 3) === peg$c284) {
+      s0 = peg$c284;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c290); }
+      if (peg$silentFails === 0) { peg$fail(peg$c285); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c291) {
-        s0 = peg$c291;
+      if (input.substr(peg$currPos, 6) === peg$c286) {
+        s0 = peg$c286;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c292); }
+        if (peg$silentFails === 0) { peg$fail(peg$c287); }
       }
     }
 
@@ -7741,7 +7554,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c293(s1, s5);
+                  s1 = peg$c288(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7781,12 +7594,12 @@ function peg$parse(input, options) {
     s0 = peg$parseGrep();
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c294) {
-        s1 = peg$c294;
+      if (input.substr(peg$currPos, 6) === peg$c289) {
+        s1 = peg$c289;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c295); }
+        if (peg$silentFails === 0) { peg$fail(peg$c290); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
@@ -7833,7 +7646,7 @@ function peg$parse(input, options) {
                             }
                             if (s12 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c296(s5, s9, s12);
+                              s1 = peg$c291(s5, s9, s12);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -7928,7 +7741,7 @@ function peg$parse(input, options) {
                         }
                         if (s9 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c297(s2, s6, s9);
+                          s1 = peg$c292(s2, s6, s9);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -7979,7 +7792,7 @@ function peg$parse(input, options) {
     s1 = peg$parseOverExpr();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c298(s1);
+      s1 = peg$c293(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -7993,12 +7806,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c299) {
-      s1 = peg$c299;
+    if (input.substr(peg$currPos, 4) === peg$c294) {
+      s1 = peg$c294;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c300); }
+      if (peg$silentFails === 0) { peg$fail(peg$c295); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8066,7 +7879,7 @@ function peg$parse(input, options) {
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c301(s5, s7);
+                    s1 = peg$c296(s5, s7);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -8115,7 +7928,7 @@ function peg$parse(input, options) {
         s1 = peg$parseQuotedString();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c302(s1);
+          s1 = peg$c297(s1);
         }
         s0 = s1;
       }
@@ -8164,7 +7977,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c303(s1, s7);
+              s4 = peg$c298(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -8200,7 +8013,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c303(s1, s7);
+                s4 = peg$c298(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -8310,15 +8123,15 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s7 = peg$c304;
+                  s7 = peg$c299;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c305); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c300); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c306(s2, s6);
+                  s1 = peg$c301(s2, s6);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8373,15 +8186,15 @@ function peg$parse(input, options) {
               s5 = peg$parseAdditiveExpr();
               if (s5 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s6 = peg$c304;
+                  s6 = peg$c299;
                   peg$currPos++;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c305); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c300); }
                 }
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c307(s5);
+                  s1 = peg$c302(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8420,15 +8233,15 @@ function peg$parse(input, options) {
           s2 = peg$parseConditionalExpr();
           if (s2 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s3 = peg$c304;
+              s3 = peg$c299;
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c305); }
+              if (peg$silentFails === 0) { peg$fail(peg$c300); }
             }
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c308(s2);
+              s1 = peg$c303(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8455,7 +8268,7 @@ function peg$parse(input, options) {
             s2 = peg$parseIdentifier();
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c309(s2);
+              s1 = peg$c304(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8592,12 +8405,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c257) {
-      s1 = peg$c257;
+    if (input.substr(peg$currPos, 4) === peg$c252) {
+      s1 = peg$c252;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c258); }
+      if (peg$silentFails === 0) { peg$fail(peg$c253); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -8624,7 +8437,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSequential();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c310(s3, s4, s8);
+                    s1 = peg$c305(s3, s4, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -8681,15 +8494,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c311;
+              s5 = peg$c306;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c312); }
+              if (peg$silentFails === 0) { peg$fail(peg$c307); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c313(s3);
+              s1 = peg$c308(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8729,7 +8542,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c270(s1, s2);
+        s1 = peg$c265(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8771,7 +8584,7 @@ function peg$parse(input, options) {
           s4 = peg$parseRecordElem();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c314(s4);
+            s1 = peg$c309(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8811,12 +8624,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c315) {
-      s1 = peg$c315;
+    if (input.substr(peg$currPos, 3) === peg$c310) {
+      s1 = peg$c310;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c316); }
+      if (peg$silentFails === 0) { peg$fail(peg$c311); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8824,7 +8637,7 @@ function peg$parse(input, options) {
         s3 = peg$parseConditionalExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c317(s3);
+          s1 = peg$c312(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8863,7 +8676,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c318(s1, s5);
+              s1 = peg$c313(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8908,15 +8721,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s5 = peg$c304;
+              s5 = peg$c299;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c305); }
+              if (peg$silentFails === 0) { peg$fail(peg$c300); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c319(s3);
+              s1 = peg$c314(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8946,12 +8759,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c320) {
-      s1 = peg$c320;
+    if (input.substr(peg$currPos, 2) === peg$c315) {
+      s1 = peg$c315;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c321); }
+      if (peg$silentFails === 0) { peg$fail(peg$c316); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8960,16 +8773,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c322) {
-              s5 = peg$c322;
+            if (input.substr(peg$currPos, 2) === peg$c317) {
+              s5 = peg$c317;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c323); }
+              if (peg$silentFails === 0) { peg$fail(peg$c318); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c324(s3);
+              s1 = peg$c319(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9018,7 +8831,7 @@ function peg$parse(input, options) {
             s7 = peg$parseVectorElem();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c303(s1, s7);
+              s4 = peg$c298(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -9054,7 +8867,7 @@ function peg$parse(input, options) {
               s7 = peg$parseVectorElem();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c303(s1, s7);
+                s4 = peg$c298(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -9107,7 +8920,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c325(s1);
+        s1 = peg$c320(s1);
       }
       s0 = s1;
     }
@@ -9119,12 +8932,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c326) {
-      s1 = peg$c326;
+    if (input.substr(peg$currPos, 2) === peg$c321) {
+      s1 = peg$c321;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c327); }
+      if (peg$silentFails === 0) { peg$fail(peg$c322); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -9133,16 +8946,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c328) {
-              s5 = peg$c328;
+            if (input.substr(peg$currPos, 2) === peg$c323) {
+              s5 = peg$c323;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c329); }
+              if (peg$silentFails === 0) { peg$fail(peg$c324); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c330(s3);
+              s1 = peg$c325(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9182,7 +8995,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c270(s1, s2);
+        s1 = peg$c265(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9224,7 +9037,7 @@ function peg$parse(input, options) {
           s4 = peg$parseEntry();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c331(s4);
+            s1 = peg$c326(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9267,7 +9080,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c332(s1, s5);
+              s1 = peg$c327(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9332,7 +9145,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSQLLimit();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c333(s1, s2, s3, s4, s5, s6, s7, s8);
+                    s1 = peg$c328(s1, s2, s3, s4, s5, s6, s7, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -9410,7 +9223,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSQLAssignments();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c334(s3);
+            s1 = peg$c329(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9467,7 +9280,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c335(s1, s2);
+        s1 = peg$c330(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9593,7 +9406,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c336(s4, s5);
+              s1 = peg$c331(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9748,7 +9561,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSQLJoin();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s3;
-        s4 = peg$c337(s1, s4);
+        s4 = peg$c332(s1, s4);
       }
       s3 = s4;
       while (s3 !== peg$FAILED) {
@@ -9757,7 +9570,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSQLJoin();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s3;
-          s4 = peg$c337(s1, s4);
+          s4 = peg$c332(s1, s4);
         }
         s3 = s4;
       }
@@ -9819,7 +9632,7 @@ function peg$parse(input, options) {
                               s14 = peg$parseJoinKey();
                               if (s14 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c338(s1, s5, s6, s10, s14);
+                                s1 = peg$c333(s1, s5, s6, s10, s14);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -9899,7 +9712,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c339(s2);
+        s1 = peg$c334(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10058,7 +9871,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseSQLOrder();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c340(s6, s7);
+                  s1 = peg$c335(s6, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10104,7 +9917,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c341(s2);
+        s1 = peg$c336(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10119,7 +9932,7 @@ function peg$parse(input, options) {
       s1 = peg$c98;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c240();
+        s1 = peg$c235();
       }
       s0 = s1;
     }
@@ -10140,7 +9953,7 @@ function peg$parse(input, options) {
           s4 = peg$parseUInt();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c342(s4);
+            s1 = peg$c337(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10175,16 +9988,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c291) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c286) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c343); }
+      if (peg$silentFails === 0) { peg$fail(peg$c338); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c344();
+      s1 = peg$c339();
     }
     s0 = s1;
 
@@ -10195,16 +10008,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c345) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c340) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c346); }
+      if (peg$silentFails === 0) { peg$fail(peg$c341); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c347();
+      s1 = peg$c342();
     }
     s0 = s1;
 
@@ -10220,11 +10033,11 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c348); }
+      if (peg$silentFails === 0) { peg$fail(peg$c343); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c349();
+      s1 = peg$c344();
     }
     s0 = s1;
 
@@ -10240,11 +10053,11 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c350); }
+      if (peg$silentFails === 0) { peg$fail(peg$c345); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c351();
+      s1 = peg$c346();
     }
     s0 = s1;
 
@@ -10260,11 +10073,11 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c352); }
+      if (peg$silentFails === 0) { peg$fail(peg$c347); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c353();
+      s1 = peg$c348();
     }
     s0 = s1;
 
@@ -10275,16 +10088,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c354) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c349) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c355); }
+      if (peg$silentFails === 0) { peg$fail(peg$c350); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c356();
+      s1 = peg$c351();
     }
     s0 = s1;
 
@@ -10295,9 +10108,49 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c357) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c352) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c353); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c354();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseHAVING() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c355) {
+      s1 = input.substr(peg$currPos, 6);
+      peg$currPos += 6;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c356); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c357();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseORDER() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c227) {
+      s1 = input.substr(peg$currPos, 5);
+      peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c358); }
@@ -10311,13 +10164,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseHAVING() {
+  function peg$parseON() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c360) {
-      s1 = input.substr(peg$currPos, 6);
-      peg$currPos += 6;
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c360) {
+      s1 = input.substr(peg$currPos, 2);
+      peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c361); }
@@ -10331,60 +10184,20 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseORDER() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c232) {
-      s1 = input.substr(peg$currPos, 5);
-      peg$currPos += 5;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c363); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c364();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseON() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c365) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c366); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c367();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
   function peg$parseLIMIT() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c368) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c363) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c369); }
+      if (peg$silentFails === 0) { peg$fail(peg$c364); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c370();
+      s1 = peg$c365();
     }
     s0 = s1;
 
@@ -10395,16 +10208,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c244) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c239) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c371); }
+      if (peg$silentFails === 0) { peg$fail(peg$c366); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c240();
+      s1 = peg$c235();
     }
     s0 = s1;
 
@@ -10415,16 +10228,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c246) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c241) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c372); }
+      if (peg$silentFails === 0) { peg$fail(peg$c367); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c243();
+      s1 = peg$c238();
     }
     s0 = s1;
 
@@ -10440,7 +10253,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c373); }
+      if (peg$silentFails === 0) { peg$fail(peg$c368); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10460,7 +10273,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c374); }
+      if (peg$silentFails === 0) { peg$fail(peg$c369); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10480,7 +10293,7 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c375); }
+      if (peg$silentFails === 0) { peg$fail(peg$c370); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10500,7 +10313,7 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c376); }
+      if (peg$silentFails === 0) { peg$fail(peg$c371); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10602,7 +10415,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c377(s1);
+        s1 = peg$c372(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10617,7 +10430,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP4Net();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c377(s1);
+        s1 = peg$c372(s1);
       }
       s0 = s1;
     }
@@ -10643,7 +10456,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c378(s1);
+        s1 = peg$c373(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10658,7 +10471,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c378(s1);
+        s1 = peg$c373(s1);
       }
       s0 = s1;
     }
@@ -10673,7 +10486,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFloatString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c379(s1);
+      s1 = peg$c374(s1);
     }
     s0 = s1;
 
@@ -10687,7 +10500,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c380(s1);
+      s1 = peg$c375(s1);
     }
     s0 = s1;
 
@@ -10698,30 +10511,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c381) {
-      s1 = peg$c381;
+    if (input.substr(peg$currPos, 4) === peg$c376) {
+      s1 = peg$c376;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c382); }
+      if (peg$silentFails === 0) { peg$fail(peg$c377); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c383();
+      s1 = peg$c378();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c384) {
-        s1 = peg$c384;
+      if (input.substr(peg$currPos, 5) === peg$c379) {
+        s1 = peg$c379;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c385); }
+        if (peg$silentFails === 0) { peg$fail(peg$c380); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c386();
+        s1 = peg$c381();
       }
       s0 = s1;
     }
@@ -10733,16 +10546,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c387) {
-      s1 = peg$c387;
+    if (input.substr(peg$currPos, 4) === peg$c382) {
+      s1 = peg$c382;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c388); }
+      if (peg$silentFails === 0) { peg$fail(peg$c383); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c389();
+      s1 = peg$c384();
     }
     s0 = s1;
 
@@ -10753,12 +10566,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c390) {
-      s1 = peg$c390;
+    if (input.substr(peg$currPos, 2) === peg$c385) {
+      s1 = peg$c385;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c391); }
+      if (peg$silentFails === 0) { peg$fail(peg$c386); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -10769,7 +10582,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c392();
+        s1 = peg$c387();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10806,7 +10619,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c393(s2);
+          s1 = peg$c388(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10833,7 +10646,7 @@ function peg$parse(input, options) {
       s1 = peg$parsePrimitiveType();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c393(s1);
+        s1 = peg$c388(s1);
       }
       s0 = s1;
     }
@@ -10873,7 +10686,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c394(s1);
+        s1 = peg$c389(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10925,7 +10738,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c395(s1, s2);
+          s1 = peg$c390(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10940,7 +10753,7 @@ function peg$parse(input, options) {
         s1 = peg$parseQuotedString();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c396(s1);
+          s1 = peg$c391(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
@@ -10966,7 +10779,7 @@ function peg$parse(input, options) {
                 }
                 if (s4 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c397(s3);
+                  s1 = peg$c392(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10998,7 +10811,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTypeList();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c398(s1);
+      s1 = peg$c393(s1);
     }
     s0 = s1;
 
@@ -11023,7 +10836,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c270(s1, s2);
+        s1 = peg$c265(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11056,7 +10869,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c399(s4);
+            s1 = peg$c394(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11097,15 +10910,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c311;
+              s5 = peg$c306;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c312); }
+              if (peg$silentFails === 0) { peg$fail(peg$c307); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c400(s3);
+              s1 = peg$c395(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11144,15 +10957,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c304;
+                s5 = peg$c299;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c305); }
+                if (peg$silentFails === 0) { peg$fail(peg$c300); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c401(s3);
+                s1 = peg$c396(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -11176,12 +10989,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c320) {
-          s1 = peg$c320;
+        if (input.substr(peg$currPos, 2) === peg$c315) {
+          s1 = peg$c315;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c321); }
+          if (peg$silentFails === 0) { peg$fail(peg$c316); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -11190,16 +11003,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c322) {
-                  s5 = peg$c322;
+                if (input.substr(peg$currPos, 2) === peg$c317) {
+                  s5 = peg$c317;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c323); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c318); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c402(s3);
+                  s1 = peg$c397(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -11223,12 +11036,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c326) {
-            s1 = peg$c326;
+          if (input.substr(peg$currPos, 2) === peg$c321) {
+            s1 = peg$c321;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c327); }
+            if (peg$silentFails === 0) { peg$fail(peg$c322); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -11251,16 +11064,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c328) {
-                            s9 = peg$c328;
+                          if (input.substr(peg$currPos, 2) === peg$c323) {
+                            s9 = peg$c323;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c329); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c324); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c403(s3, s7);
+                            s1 = peg$c398(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -11312,7 +11125,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTemplateLiteralParts();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c404(s1);
+      s1 = peg$c399(s1);
     }
     s0 = s1;
 
@@ -11324,11 +11137,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c405;
+      s1 = peg$c400;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c406); }
+      if (peg$silentFails === 0) { peg$fail(peg$c401); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -11339,11 +11152,11 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c405;
+          s3 = peg$c400;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c406); }
+          if (peg$silentFails === 0) { peg$fail(peg$c401); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
@@ -11364,11 +11177,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c407;
+        s1 = peg$c402;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c408); }
+        if (peg$silentFails === 0) { peg$fail(peg$c403); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -11379,11 +11192,11 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c407;
+            s3 = peg$c402;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c408); }
+            if (peg$silentFails === 0) { peg$fail(peg$c403); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
@@ -11424,7 +11237,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c409(s1);
+        s1 = peg$c404(s1);
       }
       s0 = s1;
     }
@@ -11437,19 +11250,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c410;
+      s1 = peg$c405;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c411); }
+      if (peg$silentFails === 0) { peg$fail(peg$c406); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c412) {
-        s2 = peg$c412;
+      if (input.substr(peg$currPos, 2) === peg$c407) {
+        s2 = peg$c407;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c413); }
+        if (peg$silentFails === 0) { peg$fail(peg$c408); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11467,12 +11280,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c412) {
-        s2 = peg$c412;
+      if (input.substr(peg$currPos, 2) === peg$c407) {
+        s2 = peg$c407;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c413); }
+        if (peg$silentFails === 0) { peg$fail(peg$c408); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -11518,7 +11331,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c409(s1);
+        s1 = peg$c404(s1);
       }
       s0 = s1;
     }
@@ -11531,19 +11344,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c410;
+      s1 = peg$c405;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c411); }
+      if (peg$silentFails === 0) { peg$fail(peg$c406); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c412) {
-        s2 = peg$c412;
+      if (input.substr(peg$currPos, 2) === peg$c407) {
+        s2 = peg$c407;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c413); }
+        if (peg$silentFails === 0) { peg$fail(peg$c408); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11561,12 +11374,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c412) {
-        s2 = peg$c412;
+      if (input.substr(peg$currPos, 2) === peg$c407) {
+        s2 = peg$c407;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c413); }
+        if (peg$silentFails === 0) { peg$fail(peg$c408); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -11598,12 +11411,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c412) {
-      s1 = peg$c412;
+    if (input.substr(peg$currPos, 2) === peg$c407) {
+      s1 = peg$c407;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c413); }
+      if (peg$silentFails === 0) { peg$fail(peg$c408); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -11613,15 +11426,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c311;
+              s5 = peg$c306;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c312); }
+              if (peg$silentFails === 0) { peg$fail(peg$c307); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c414(s3);
+              s1 = peg$c409(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11651,148 +11464,148 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c415) {
-      s1 = peg$c415;
+    if (input.substr(peg$currPos, 5) === peg$c410) {
+      s1 = peg$c410;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c416); }
+      if (peg$silentFails === 0) { peg$fail(peg$c411); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c417) {
-        s1 = peg$c417;
+      if (input.substr(peg$currPos, 6) === peg$c412) {
+        s1 = peg$c412;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c418); }
+        if (peg$silentFails === 0) { peg$fail(peg$c413); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c419) {
-          s1 = peg$c419;
+        if (input.substr(peg$currPos, 6) === peg$c414) {
+          s1 = peg$c414;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c420); }
+          if (peg$silentFails === 0) { peg$fail(peg$c415); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c421) {
-            s1 = peg$c421;
+          if (input.substr(peg$currPos, 6) === peg$c416) {
+            s1 = peg$c416;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c422); }
+            if (peg$silentFails === 0) { peg$fail(peg$c417); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c423) {
-              s1 = peg$c423;
+            if (input.substr(peg$currPos, 4) === peg$c418) {
+              s1 = peg$c418;
               peg$currPos += 4;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c424); }
+              if (peg$silentFails === 0) { peg$fail(peg$c419); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 5) === peg$c425) {
-                s1 = peg$c425;
+              if (input.substr(peg$currPos, 5) === peg$c420) {
+                s1 = peg$c420;
                 peg$currPos += 5;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c426); }
+                if (peg$silentFails === 0) { peg$fail(peg$c421); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c427) {
-                  s1 = peg$c427;
+                if (input.substr(peg$currPos, 5) === peg$c422) {
+                  s1 = peg$c422;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c428); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c423); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c429) {
-                    s1 = peg$c429;
+                  if (input.substr(peg$currPos, 5) === peg$c424) {
+                    s1 = peg$c424;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c430); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c425); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7) === peg$c431) {
-                      s1 = peg$c431;
+                    if (input.substr(peg$currPos, 7) === peg$c426) {
+                      s1 = peg$c426;
                       peg$currPos += 7;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c432); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c427); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 7) === peg$c433) {
-                        s1 = peg$c433;
+                      if (input.substr(peg$currPos, 7) === peg$c428) {
+                        s1 = peg$c428;
                         peg$currPos += 7;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c434); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c429); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 7) === peg$c435) {
-                          s1 = peg$c435;
+                        if (input.substr(peg$currPos, 7) === peg$c430) {
+                          s1 = peg$c430;
                           peg$currPos += 7;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c436); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c431); }
                         }
                         if (s1 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 4) === peg$c437) {
-                            s1 = peg$c437;
+                          if (input.substr(peg$currPos, 4) === peg$c432) {
+                            s1 = peg$c432;
                             peg$currPos += 4;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c438); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c433); }
                           }
                           if (s1 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 6) === peg$c439) {
-                              s1 = peg$c439;
+                            if (input.substr(peg$currPos, 6) === peg$c434) {
+                              s1 = peg$c434;
                               peg$currPos += 6;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c440); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c435); }
                             }
                             if (s1 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 8) === peg$c441) {
-                                s1 = peg$c441;
+                              if (input.substr(peg$currPos, 8) === peg$c436) {
+                                s1 = peg$c436;
                                 peg$currPos += 8;
                               } else {
                                 s1 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c442); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c437); }
                               }
                               if (s1 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 4) === peg$c443) {
-                                  s1 = peg$c443;
+                                if (input.substr(peg$currPos, 4) === peg$c438) {
+                                  s1 = peg$c438;
                                   peg$currPos += 4;
                                 } else {
                                   s1 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c444); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c439); }
                                 }
                                 if (s1 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 5) === peg$c445) {
-                                    s1 = peg$c445;
+                                  if (input.substr(peg$currPos, 5) === peg$c440) {
+                                    s1 = peg$c440;
                                     peg$currPos += 5;
                                   } else {
                                     s1 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c446); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c441); }
                                   }
                                   if (s1 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 2) === peg$c447) {
-                                      s1 = peg$c447;
+                                    if (input.substr(peg$currPos, 2) === peg$c442) {
+                                      s1 = peg$c442;
                                       peg$currPos += 2;
                                     } else {
                                       s1 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c448); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c443); }
                                     }
                                     if (s1 === peg$FAILED) {
-                                      if (input.substr(peg$currPos, 3) === peg$c449) {
-                                        s1 = peg$c449;
+                                      if (input.substr(peg$currPos, 3) === peg$c444) {
+                                        s1 = peg$c444;
                                         peg$currPos += 3;
                                       } else {
                                         s1 = peg$FAILED;
-                                        if (peg$silentFails === 0) { peg$fail(peg$c450); }
+                                        if (peg$silentFails === 0) { peg$fail(peg$c445); }
                                       }
                                       if (s1 === peg$FAILED) {
                                         if (input.substr(peg$currPos, 4) === peg$c10) {
@@ -11803,12 +11616,12 @@ function peg$parse(input, options) {
                                           if (peg$silentFails === 0) { peg$fail(peg$c11); }
                                         }
                                         if (s1 === peg$FAILED) {
-                                          if (input.substr(peg$currPos, 4) === peg$c387) {
-                                            s1 = peg$c387;
+                                          if (input.substr(peg$currPos, 4) === peg$c382) {
+                                            s1 = peg$c382;
                                             peg$currPos += 4;
                                           } else {
                                             s1 = peg$FAILED;
-                                            if (peg$silentFails === 0) { peg$fail(peg$c388); }
+                                            if (peg$silentFails === 0) { peg$fail(peg$c383); }
                                           }
                                         }
                                       }
@@ -11831,7 +11644,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c451();
+      s1 = peg$c446();
     }
     s0 = s1;
 
@@ -11852,7 +11665,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c270(s1, s2);
+        s1 = peg$c265(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11894,7 +11707,7 @@ function peg$parse(input, options) {
           s4 = peg$parseTypeField();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c399(s4);
+            s1 = peg$c394(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11937,7 +11750,7 @@ function peg$parse(input, options) {
             s5 = peg$parseType();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c452(s1, s5);
+              s1 = peg$c447(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11978,17 +11791,64 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c453) {
-      s1 = peg$c453;
+    if (input.substr(peg$currPos, 3) === peg$c448) {
+      s1 = peg$c448;
       peg$currPos += 3;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c449); }
+    }
+    if (s1 === peg$FAILED) {
+      if (input.substr(peg$currPos, 3) === peg$c450) {
+        s1 = peg$c450;
+        peg$currPos += 3;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c451); }
+      }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$currPos;
+      peg$silentFails++;
+      s3 = peg$parseIdentifierRest();
+      peg$silentFails--;
+      if (s3 === peg$FAILED) {
+        s2 = void 0;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c452();
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseOrToken() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2) === peg$c453) {
+      s1 = peg$c453;
+      peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c454); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c455) {
+      if (input.substr(peg$currPos, 2) === peg$c455) {
         s1 = peg$c455;
-        peg$currPos += 3;
+        peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$c456); }
@@ -12021,71 +11881,24 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseOrToken() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c458) {
-      s1 = peg$c458;
-      peg$currPos += 2;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c459); }
-    }
-    if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c460) {
-        s1 = peg$c460;
-        peg$currPos += 2;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c461); }
-      }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      peg$silentFails++;
-      s3 = peg$parseIdentifierRest();
-      peg$silentFails--;
-      if (s3 === peg$FAILED) {
-        s2 = void 0;
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c462();
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
   function peg$parseNotToken() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c289) {
-      s1 = peg$c289;
+    if (input.substr(peg$currPos, 3) === peg$c284) {
+      s1 = peg$c284;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c290); }
+      if (peg$silentFails === 0) { peg$fail(peg$c285); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c464) {
-        s1 = peg$c464;
+      if (input.substr(peg$currPos, 3) === peg$c459) {
+        s1 = peg$c459;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c465); }
+        if (peg$silentFails === 0) { peg$fail(peg$c460); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -12101,7 +11914,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c466();
+        s1 = peg$c461();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12119,12 +11932,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c357) {
-      s1 = peg$c357;
+    if (input.substr(peg$currPos, 2) === peg$c352) {
+      s1 = peg$c352;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c467); }
+      if (peg$silentFails === 0) { peg$fail(peg$c462); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -12139,7 +11952,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c359();
+        s1 = peg$c354();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12156,12 +11969,12 @@ function peg$parse(input, options) {
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c468.test(input.charAt(peg$currPos))) {
+    if (peg$c463.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c469); }
+      if (peg$silentFails === 0) { peg$fail(peg$c464); }
     }
 
     return s0;
@@ -12172,12 +11985,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c470.test(input.charAt(peg$currPos))) {
+      if (peg$c465.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c471); }
+        if (peg$silentFails === 0) { peg$fail(peg$c466); }
       }
     }
 
@@ -12191,7 +12004,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c472(s1);
+      s1 = peg$c467(s1);
     }
     s0 = s1;
 
@@ -12246,7 +12059,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c231();
+          s1 = peg$c226();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -12263,11 +12076,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 36) {
-        s1 = peg$c473;
+        s1 = peg$c468;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c474); }
+        if (peg$silentFails === 0) { peg$fail(peg$c469); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -12277,11 +12090,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c410;
+          s1 = peg$c405;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c411); }
+          if (peg$silentFails === 0) { peg$fail(peg$c406); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseIDGuard();
@@ -12388,7 +12201,7 @@ function peg$parse(input, options) {
             s7 = peg$parseIdentifierName();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c475(s1, s7);
+              s4 = peg$c470(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -12424,7 +12237,7 @@ function peg$parse(input, options) {
               s7 = peg$parseIdentifierName();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c475(s1, s7);
+                s4 = peg$c470(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -12445,7 +12258,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c270(s1, s2);
+        s1 = peg$c265(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12483,17 +12296,17 @@ function peg$parse(input, options) {
     s1 = peg$parseFullDate();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 84) {
-        s2 = peg$c476;
+        s2 = peg$c471;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c477); }
+        if (peg$silentFails === 0) { peg$fail(peg$c472); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseFullTime();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c478();
+          s1 = peg$c473();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -12518,21 +12331,21 @@ function peg$parse(input, options) {
     s1 = peg$parseD4();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c281;
+        s2 = peg$c276;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c282); }
+        if (peg$silentFails === 0) { peg$fail(peg$c277); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseD2();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 45) {
-            s4 = peg$c281;
+            s4 = peg$c276;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c282); }
+            if (peg$silentFails === 0) { peg$fail(peg$c277); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseD2();
@@ -12567,36 +12380,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (peg$c470.test(input.charAt(peg$currPos))) {
+    if (peg$c465.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c471); }
+      if (peg$silentFails === 0) { peg$fail(peg$c466); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c470.test(input.charAt(peg$currPos))) {
+      if (peg$c465.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c471); }
+        if (peg$silentFails === 0) { peg$fail(peg$c466); }
       }
       if (s2 !== peg$FAILED) {
-        if (peg$c470.test(input.charAt(peg$currPos))) {
+        if (peg$c465.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c471); }
+          if (peg$silentFails === 0) { peg$fail(peg$c466); }
         }
         if (s3 !== peg$FAILED) {
-          if (peg$c470.test(input.charAt(peg$currPos))) {
+          if (peg$c465.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c471); }
+            if (peg$silentFails === 0) { peg$fail(peg$c466); }
           }
           if (s4 !== peg$FAILED) {
             s1 = [s1, s2, s3, s4];
@@ -12625,20 +12438,20 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c470.test(input.charAt(peg$currPos))) {
+    if (peg$c465.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c471); }
+      if (peg$silentFails === 0) { peg$fail(peg$c466); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c470.test(input.charAt(peg$currPos))) {
+      if (peg$c465.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c471); }
+        if (peg$silentFails === 0) { peg$fail(peg$c466); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -12713,22 +12526,22 @@ function peg$parse(input, options) {
               }
               if (s7 !== peg$FAILED) {
                 s8 = [];
-                if (peg$c470.test(input.charAt(peg$currPos))) {
+                if (peg$c465.test(input.charAt(peg$currPos))) {
                   s9 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s9 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c471); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c466); }
                 }
                 if (s9 !== peg$FAILED) {
                   while (s9 !== peg$FAILED) {
                     s8.push(s9);
-                    if (peg$c470.test(input.charAt(peg$currPos))) {
+                    if (peg$c465.test(input.charAt(peg$currPos))) {
                       s9 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c471); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c466); }
                     }
                   }
                 } else {
@@ -12783,28 +12596,28 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     if (input.charCodeAt(peg$currPos) === 90) {
-      s0 = peg$c479;
+      s0 = peg$c474;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c480); }
+      if (peg$silentFails === 0) { peg$fail(peg$c475); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 43) {
-        s1 = peg$c279;
+        s1 = peg$c274;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c280); }
+        if (peg$silentFails === 0) { peg$fail(peg$c275); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 45) {
-          s1 = peg$c281;
+          s1 = peg$c276;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c282); }
+          if (peg$silentFails === 0) { peg$fail(peg$c277); }
         }
       }
       if (s1 !== peg$FAILED) {
@@ -12830,22 +12643,22 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 s7 = [];
-                if (peg$c470.test(input.charAt(peg$currPos))) {
+                if (peg$c465.test(input.charAt(peg$currPos))) {
                   s8 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s8 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c471); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c466); }
                 }
                 if (s8 !== peg$FAILED) {
                   while (s8 !== peg$FAILED) {
                     s7.push(s8);
-                    if (peg$c470.test(input.charAt(peg$currPos))) {
+                    if (peg$c465.test(input.charAt(peg$currPos))) {
                       s8 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s8 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c471); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c466); }
                     }
                   }
                 } else {
@@ -12898,11 +12711,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c281;
+      s1 = peg$c276;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c282); }
+      if (peg$silentFails === 0) { peg$fail(peg$c277); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -12948,7 +12761,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c481();
+        s1 = peg$c476();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13010,76 +12823,76 @@ function peg$parse(input, options) {
   function peg$parseTimeUnit() {
     var s0;
 
-    if (input.substr(peg$currPos, 2) === peg$c482) {
-      s0 = peg$c482;
+    if (input.substr(peg$currPos, 2) === peg$c477) {
+      s0 = peg$c477;
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c483); }
+      if (peg$silentFails === 0) { peg$fail(peg$c478); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c484) {
-        s0 = peg$c484;
+      if (input.substr(peg$currPos, 2) === peg$c479) {
+        s0 = peg$c479;
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c485); }
+        if (peg$silentFails === 0) { peg$fail(peg$c480); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c486) {
-          s0 = peg$c486;
+        if (input.substr(peg$currPos, 2) === peg$c481) {
+          s0 = peg$c481;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c487); }
+          if (peg$silentFails === 0) { peg$fail(peg$c482); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 115) {
-            s0 = peg$c488;
+            s0 = peg$c483;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c489); }
+            if (peg$silentFails === 0) { peg$fail(peg$c484); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c490;
+              s0 = peg$c485;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c491); }
+              if (peg$silentFails === 0) { peg$fail(peg$c486); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 104) {
-                s0 = peg$c492;
+                s0 = peg$c487;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c493); }
+                if (peg$silentFails === 0) { peg$fail(peg$c488); }
               }
               if (s0 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 100) {
-                  s0 = peg$c494;
+                  s0 = peg$c489;
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c495); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c490); }
                 }
                 if (s0 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 119) {
-                    s0 = peg$c496;
+                    s0 = peg$c491;
                     peg$currPos++;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c497); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c492); }
                   }
                   if (s0 === peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 121) {
-                      s0 = peg$c498;
+                      s0 = peg$c493;
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c499); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c494); }
                     }
                   }
                 }
@@ -13264,7 +13077,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c500(s1, s2);
+        s1 = peg$c495(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13285,12 +13098,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c501) {
-            s3 = peg$c501;
+          if (input.substr(peg$currPos, 2) === peg$c496) {
+            s3 = peg$c496;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c502); }
+            if (peg$silentFails === 0) { peg$fail(peg$c497); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -13303,7 +13116,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c503(s1, s2, s4, s5);
+                s1 = peg$c498(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -13327,12 +13140,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c501) {
-          s1 = peg$c501;
+        if (input.substr(peg$currPos, 2) === peg$c496) {
+          s1 = peg$c496;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c502); }
+          if (peg$silentFails === 0) { peg$fail(peg$c497); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -13345,7 +13158,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c504(s2, s3);
+              s1 = peg$c499(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13370,16 +13183,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c501) {
-                s3 = peg$c501;
+              if (input.substr(peg$currPos, 2) === peg$c496) {
+                s3 = peg$c496;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c502); }
+                if (peg$silentFails === 0) { peg$fail(peg$c497); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c505(s1, s2);
+                s1 = peg$c500(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -13395,16 +13208,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c501) {
-              s1 = peg$c501;
+            if (input.substr(peg$currPos, 2) === peg$c496) {
+              s1 = peg$c496;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c502); }
+              if (peg$silentFails === 0) { peg$fail(peg$c497); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c506();
+              s1 = peg$c501();
             }
             s0 = s1;
           }
@@ -13441,7 +13254,7 @@ function peg$parse(input, options) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c507(s2);
+        s1 = peg$c502(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13470,7 +13283,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c508(s1);
+        s1 = peg$c503(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13491,17 +13304,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c283;
+        s2 = peg$c278;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c284); }
+        if (peg$silentFails === 0) { peg$fail(peg$c279); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c509(s1, s3);
+          s1 = peg$c504(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13526,17 +13339,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c283;
+        s2 = peg$c278;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c284); }
+        if (peg$silentFails === 0) { peg$fail(peg$c279); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c510(s1, s3);
+          s1 = peg$c505(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13561,7 +13374,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c511(s1);
+      s1 = peg$c506(s1);
     }
     s0 = s1;
 
@@ -13584,22 +13397,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c470.test(input.charAt(peg$currPos))) {
+    if (peg$c465.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c471); }
+      if (peg$silentFails === 0) { peg$fail(peg$c466); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c470.test(input.charAt(peg$currPos))) {
+        if (peg$c465.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c471); }
+          if (peg$silentFails === 0) { peg$fail(peg$c466); }
         }
       }
     } else {
@@ -13619,11 +13432,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c281;
+      s1 = peg$c276;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c282); }
+      if (peg$silentFails === 0) { peg$fail(peg$c277); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseUIntString();
@@ -13648,33 +13461,33 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c281;
+      s1 = peg$c276;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c282); }
+      if (peg$silentFails === 0) { peg$fail(peg$c277); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c470.test(input.charAt(peg$currPos))) {
+      if (peg$c465.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c471); }
+        if (peg$silentFails === 0) { peg$fail(peg$c466); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c470.test(input.charAt(peg$currPos))) {
+          if (peg$c465.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c471); }
+            if (peg$silentFails === 0) { peg$fail(peg$c466); }
           }
         }
       } else {
@@ -13690,21 +13503,21 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c470.test(input.charAt(peg$currPos))) {
+          if (peg$c465.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c471); }
+            if (peg$silentFails === 0) { peg$fail(peg$c466); }
           }
           while (s5 !== peg$FAILED) {
             s4.push(s5);
-            if (peg$c470.test(input.charAt(peg$currPos))) {
+            if (peg$c465.test(input.charAt(peg$currPos))) {
               s5 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c471); }
+              if (peg$silentFails === 0) { peg$fail(peg$c466); }
             }
           }
           if (s4 !== peg$FAILED) {
@@ -13714,7 +13527,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c512();
+              s1 = peg$c507();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13739,11 +13552,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c281;
+        s1 = peg$c276;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c282); }
+        if (peg$silentFails === 0) { peg$fail(peg$c277); }
       }
       if (s1 === peg$FAILED) {
         s1 = null;
@@ -13758,22 +13571,22 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c470.test(input.charAt(peg$currPos))) {
+          if (peg$c465.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c471); }
+            if (peg$silentFails === 0) { peg$fail(peg$c466); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c470.test(input.charAt(peg$currPos))) {
+              if (peg$c465.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c471); }
+                if (peg$silentFails === 0) { peg$fail(peg$c466); }
               }
             }
           } else {
@@ -13786,7 +13599,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c512();
+              s1 = peg$c507();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13825,20 +13638,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c513) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c508) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c514); }
+      if (peg$silentFails === 0) { peg$fail(peg$c509); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c515.test(input.charAt(peg$currPos))) {
+      if (peg$c510.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c516); }
+        if (peg$silentFails === 0) { peg$fail(peg$c511); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -13867,12 +13680,12 @@ function peg$parse(input, options) {
   function peg$parseNaN() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c517) {
-      s0 = peg$c517;
+    if (input.substr(peg$currPos, 3) === peg$c512) {
+      s0 = peg$c512;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c518); }
+      if (peg$silentFails === 0) { peg$fail(peg$c513); }
     }
 
     return s0;
@@ -13883,31 +13696,31 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c281;
+      s1 = peg$c276;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c282); }
+      if (peg$silentFails === 0) { peg$fail(peg$c277); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 43) {
-        s1 = peg$c279;
+        s1 = peg$c274;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c280); }
+        if (peg$silentFails === 0) { peg$fail(peg$c275); }
       }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c519) {
-        s2 = peg$c519;
+      if (input.substr(peg$currPos, 3) === peg$c514) {
+        s2 = peg$c514;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c520); }
+        if (peg$silentFails === 0) { peg$fail(peg$c515); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -13950,12 +13763,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c521.test(input.charAt(peg$currPos))) {
+    if (peg$c516.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c522); }
+      if (peg$silentFails === 0) { peg$fail(peg$c517); }
     }
 
     return s0;
@@ -13966,11 +13779,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c405;
+      s1 = peg$c400;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c406); }
+      if (peg$silentFails === 0) { peg$fail(peg$c401); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -13981,15 +13794,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c405;
+          s3 = peg$c400;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c406); }
+          if (peg$silentFails === 0) { peg$fail(peg$c401); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c523(s2);
+          s1 = peg$c518(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -14006,11 +13819,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c407;
+        s1 = peg$c402;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c408); }
+        if (peg$silentFails === 0) { peg$fail(peg$c403); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -14021,15 +13834,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c407;
+            s3 = peg$c402;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c408); }
+            if (peg$silentFails === 0) { peg$fail(peg$c403); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c523(s2);
+            s1 = peg$c518(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -14055,11 +13868,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c405;
+      s2 = peg$c400;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c406); }
+      if (peg$silentFails === 0) { peg$fail(peg$c401); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -14077,7 +13890,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c524); }
+        if (peg$silentFails === 0) { peg$fail(peg$c519); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14094,11 +13907,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c410;
+        s1 = peg$c405;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c411); }
+        if (peg$silentFails === 0) { peg$fail(peg$c406); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -14133,7 +13946,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c525(s1, s2);
+        s1 = peg$c520(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14162,12 +13975,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (peg$c526.test(input.charAt(peg$currPos))) {
+    if (peg$c521.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c527); }
+      if (peg$silentFails === 0) { peg$fail(peg$c522); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -14183,12 +13996,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseKeyWordStart();
     if (s0 === peg$FAILED) {
-      if (peg$c470.test(input.charAt(peg$currPos))) {
+      if (peg$c465.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c471); }
+        if (peg$silentFails === 0) { peg$fail(peg$c466); }
       }
     }
 
@@ -14200,11 +14013,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c410;
+      s1 = peg$c405;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c411); }
+      if (peg$silentFails === 0) { peg$fail(peg$c406); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseKeywordEscape();
@@ -14263,7 +14076,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c528(s3, s4);
+            s1 = peg$c523(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -14381,7 +14194,7 @@ function peg$parse(input, options) {
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c529();
+          s1 = peg$c524();
         }
         s0 = s1;
       }
@@ -14395,12 +14208,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseGlobStart();
     if (s0 === peg$FAILED) {
-      if (peg$c470.test(input.charAt(peg$currPos))) {
+      if (peg$c465.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c471); }
+        if (peg$silentFails === 0) { peg$fail(peg$c466); }
       }
     }
 
@@ -14412,11 +14225,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c410;
+      s1 = peg$c405;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c411); }
+      if (peg$silentFails === 0) { peg$fail(peg$c406); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseGlobEscape();
@@ -14452,7 +14265,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c530();
+      s1 = peg$c525();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -14466,16 +14279,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c531();
+        s1 = peg$c526();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c515.test(input.charAt(peg$currPos))) {
+        if (peg$c510.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c516); }
+          if (peg$silentFails === 0) { peg$fail(peg$c511); }
         }
       }
     }
@@ -14490,11 +14303,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c407;
+      s2 = peg$c402;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c408); }
+      if (peg$silentFails === 0) { peg$fail(peg$c403); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -14512,7 +14325,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c524); }
+        if (peg$silentFails === 0) { peg$fail(peg$c519); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14529,11 +14342,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c410;
+        s1 = peg$c405;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c411); }
+        if (peg$silentFails === 0) { peg$fail(peg$c406); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -14569,20 +14382,20 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c407;
+      s0 = peg$c402;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c408); }
+      if (peg$silentFails === 0) { peg$fail(peg$c403); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s1 = peg$c405;
+        s1 = peg$c400;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c406); }
+        if (peg$silentFails === 0) { peg$fail(peg$c401); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14591,94 +14404,94 @@ function peg$parse(input, options) {
       s0 = s1;
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c410;
+          s0 = peg$c405;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c411); }
+          if (peg$silentFails === 0) { peg$fail(peg$c406); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c532;
+            s1 = peg$c527;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c533); }
+            if (peg$silentFails === 0) { peg$fail(peg$c528); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c534();
+            s1 = peg$c529();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c535;
+              s1 = peg$c530;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c536); }
+              if (peg$silentFails === 0) { peg$fail(peg$c531); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c537();
+              s1 = peg$c532();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c538;
+                s1 = peg$c533;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c539); }
+                if (peg$silentFails === 0) { peg$fail(peg$c534); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c540();
+                s1 = peg$c535();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c541;
+                  s1 = peg$c536;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c542); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c537); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c543();
+                  s1 = peg$c538();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c544;
+                    s1 = peg$c539;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c545); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c540); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c546();
+                    s1 = peg$c541();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c547;
+                      s1 = peg$c542;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c548); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c543); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c549();
+                      s1 = peg$c544();
                     }
                     s0 = s1;
                   }
@@ -14706,7 +14519,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c530();
+      s1 = peg$c525();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -14720,16 +14533,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c550();
+        s1 = peg$c545();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c515.test(input.charAt(peg$currPos))) {
+        if (peg$c510.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c516); }
+          if (peg$silentFails === 0) { peg$fail(peg$c511); }
         }
       }
     }
@@ -14742,11 +14555,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c551;
+      s1 = peg$c546;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c552); }
+      if (peg$silentFails === 0) { peg$fail(peg$c547); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -14778,7 +14591,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c553(s2);
+        s1 = peg$c548(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14791,11 +14604,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c551;
+        s1 = peg$c546;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c552); }
+        if (peg$silentFails === 0) { peg$fail(peg$c547); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
@@ -14862,15 +14675,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c311;
+              s4 = peg$c306;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c312); }
+              if (peg$silentFails === 0) { peg$fail(peg$c307); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c553(s3);
+              s1 = peg$c548(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -14898,21 +14711,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c283;
+      s1 = peg$c278;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c284); }
+      if (peg$silentFails === 0) { peg$fail(peg$c279); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseRegexpBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c283;
+          s3 = peg$c278;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c284); }
+          if (peg$silentFails === 0) { peg$fail(peg$c279); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$currPos;
@@ -14954,21 +14767,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c554.test(input.charAt(peg$currPos))) {
+    if (peg$c549.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c555); }
+      if (peg$silentFails === 0) { peg$fail(peg$c550); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s3 = peg$c410;
+        s3 = peg$c405;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c411); }
+        if (peg$silentFails === 0) { peg$fail(peg$c406); }
       }
       if (s3 !== peg$FAILED) {
         if (input.length > peg$currPos) {
@@ -14976,7 +14789,7 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c524); }
+          if (peg$silentFails === 0) { peg$fail(peg$c519); }
         }
         if (s4 !== peg$FAILED) {
           s3 = [s3, s4];
@@ -14993,21 +14806,21 @@ function peg$parse(input, options) {
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c554.test(input.charAt(peg$currPos))) {
+        if (peg$c549.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c555); }
+          if (peg$silentFails === 0) { peg$fail(peg$c550); }
         }
         if (s2 === peg$FAILED) {
           s2 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 92) {
-            s3 = peg$c410;
+            s3 = peg$c405;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c411); }
+            if (peg$silentFails === 0) { peg$fail(peg$c406); }
           }
           if (s3 !== peg$FAILED) {
             if (input.length > peg$currPos) {
@@ -15015,7 +14828,7 @@ function peg$parse(input, options) {
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c524); }
+              if (peg$silentFails === 0) { peg$fail(peg$c519); }
             }
             if (s4 !== peg$FAILED) {
               s3 = [s3, s4];
@@ -15045,12 +14858,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c556.test(input.charAt(peg$currPos))) {
+    if (peg$c551.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c557); }
+      if (peg$silentFails === 0) { peg$fail(peg$c552); }
     }
 
     return s0;
@@ -15108,7 +14921,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c524); }
+      if (peg$silentFails === 0) { peg$fail(peg$c519); }
     }
 
     return s0;
@@ -15119,51 +14932,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c559;
+      s0 = peg$c554;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c560); }
+      if (peg$silentFails === 0) { peg$fail(peg$c555); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c561;
+        s0 = peg$c556;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c562); }
+        if (peg$silentFails === 0) { peg$fail(peg$c557); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c563;
+          s0 = peg$c558;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c564); }
+          if (peg$silentFails === 0) { peg$fail(peg$c559); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c565;
+            s0 = peg$c560;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c566); }
+            if (peg$silentFails === 0) { peg$fail(peg$c561); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c567;
+              s0 = peg$c562;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c568); }
+              if (peg$silentFails === 0) { peg$fail(peg$c563); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c569;
+                s0 = peg$c564;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c570); }
+                if (peg$silentFails === 0) { peg$fail(peg$c565); }
               }
             }
           }
@@ -15172,7 +14985,7 @@ function peg$parse(input, options) {
     }
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c558); }
+      if (peg$silentFails === 0) { peg$fail(peg$c553); }
     }
 
     return s0;
@@ -15181,12 +14994,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c571.test(input.charAt(peg$currPos))) {
+    if (peg$c566.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c572); }
+      if (peg$silentFails === 0) { peg$fail(peg$c567); }
     }
 
     return s0;
@@ -15199,7 +15012,7 @@ function peg$parse(input, options) {
     s0 = peg$parseSingleLineComment();
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c573); }
+      if (peg$silentFails === 0) { peg$fail(peg$c568); }
     }
 
     return s0;
@@ -15209,12 +15022,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c578) {
-      s1 = peg$c578;
+    if (input.substr(peg$currPos, 2) === peg$c573) {
+      s1 = peg$c573;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c579); }
+      if (peg$silentFails === 0) { peg$fail(peg$c574); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -15294,7 +15107,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c524); }
+      if (peg$silentFails === 0) { peg$fail(peg$c519); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/compiler/parser/parser.es.js
+++ b/compiler/parser/parser.es.js
@@ -600,49 +600,47 @@ function peg$parse(input, options) {
       peg$c236 = ":desc",
       peg$c237 = peg$literalExpectation(":desc", false),
       peg$c238 = function() { return "desc" },
-      peg$c239 = "asc",
-      peg$c241 = "desc",
-      peg$c243 = "pass",
-      peg$c244 = peg$literalExpectation("pass", false),
-      peg$c245 = function() {
+      peg$c239 = "pass",
+      peg$c240 = peg$literalExpectation("pass", false),
+      peg$c241 = function() {
             return {"kind":"Pass"}
           },
-      peg$c246 = "explode",
-      peg$c247 = peg$literalExpectation("explode", false),
-      peg$c248 = function(args, typ, as) {
+      peg$c242 = "explode",
+      peg$c243 = peg$literalExpectation("explode", false),
+      peg$c244 = function(args, typ, as) {
             return {"kind":"Explode", "args": args, "as": as, "type": typ}
           },
-      peg$c249 = "merge",
-      peg$c250 = peg$literalExpectation("merge", false),
-      peg$c251 = function(expr) {
+      peg$c245 = "merge",
+      peg$c246 = peg$literalExpectation("merge", false),
+      peg$c247 = function(expr) {
       	  return {"kind":"Merge", "expr":expr}
           },
-      peg$c252 = "over",
-      peg$c253 = peg$literalExpectation("over", false),
-      peg$c254 = function(exprs, locals, scope) {
+      peg$c248 = "over",
+      peg$c249 = peg$literalExpectation("over", false),
+      peg$c250 = function(exprs, locals, scope) {
             let over = {"kind": "Over", "exprs": exprs, "scope": scope};
             if (locals) {
               return {"kind": "Let", "locals": locals, "over": over}
             }
             return over
           },
-      peg$c255 = function(seq) { return seq },
-      peg$c256 = function(first, a) { return a },
-      peg$c257 = function(name, opt) {
+      peg$c251 = function(seq) { return seq },
+      peg$c252 = function(first, a) { return a },
+      peg$c253 = function(name, opt) {
             let m = {"name": name, "expr": {"kind": "ID", "name": name}};
             if (opt) {
                m["expr"] = opt[3];
             }
             return m
           },
-      peg$c258 = "yield",
-      peg$c259 = peg$literalExpectation("yield", false),
-      peg$c260 = function(exprs) {
+      peg$c254 = "yield",
+      peg$c255 = peg$literalExpectation("yield", false),
+      peg$c256 = function(exprs) {
       	  return {"kind":"Yield", "exprs":exprs}
           },
-      peg$c261 = function(typ) { return typ},
-      peg$c262 = function(lhs) { return lhs },
-      peg$c264 = function(first, rest) {
+      peg$c257 = function(typ) { return typ},
+      peg$c258 = function(lhs) { return lhs },
+      peg$c260 = function(first, rest) {
             let result = [first];
 
             for(let  r of rest) {
@@ -651,13 +649,13 @@ function peg$parse(input, options) {
 
             return result
           },
-      peg$c265 = function(first, rest) {
+      peg$c261 = function(first, rest) {
           return [first, ... rest]
         },
-      peg$c266 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c267 = "?",
-      peg$c268 = peg$literalExpectation("?", false),
-      peg$c269 = function(cond, opt) {
+      peg$c262 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c263 = "?",
+      peg$c264 = peg$literalExpectation("?", false),
+      peg$c265 = function(cond, opt) {
             if (opt) {
               let Then = opt[3];
               let Else = opt[7];
@@ -665,12 +663,12 @@ function peg$parse(input, options) {
             }
             return cond
           },
-      peg$c270 = function(first, op, expr) { return [op, expr] },
-      peg$c271 = function(first, rest) {
+      peg$c266 = function(first, op, expr) { return [op, expr] },
+      peg$c267 = function(first, rest) {
               return makeBinaryExprChain(first, rest)
           },
-      peg$c272 = function(lhs) { return text() },
-      peg$c273 = function(lhs, opAndRHS) {
+      peg$c268 = function(lhs) { return text() },
+      peg$c269 = function(lhs, opAndRHS) {
             if (!opAndRHS) {
               return lhs
             }
@@ -678,106 +676,106 @@ function peg$parse(input, options) {
             let rhs = opAndRHS[3];
             return {"kind": "BinaryExpr", "op": op, "lhs": lhs, "rhs": rhs}
           },
-      peg$c274 = "+",
-      peg$c275 = peg$literalExpectation("+", false),
-      peg$c276 = "-",
-      peg$c277 = peg$literalExpectation("-", false),
-      peg$c278 = "/",
-      peg$c279 = peg$literalExpectation("/", false),
-      peg$c280 = "%",
-      peg$c281 = peg$literalExpectation("%", false),
-      peg$c282 = function(e) {
+      peg$c270 = "+",
+      peg$c271 = peg$literalExpectation("+", false),
+      peg$c272 = "-",
+      peg$c273 = peg$literalExpectation("-", false),
+      peg$c274 = "/",
+      peg$c275 = peg$literalExpectation("/", false),
+      peg$c276 = "%",
+      peg$c277 = peg$literalExpectation("%", false),
+      peg$c278 = function(e) {
               return {"kind": "UnaryExpr", "op": "!", "operand": e}
           },
-      peg$c283 = function(e) {
+      peg$c279 = function(e) {
               return {"kind": "UnaryExpr", "op": "-", "operand": e}
           },
-      peg$c284 = "not",
-      peg$c285 = peg$literalExpectation("not", false),
-      peg$c286 = "select",
-      peg$c287 = peg$literalExpectation("select", false),
-      peg$c288 = function(typ, expr) {
+      peg$c280 = "not",
+      peg$c281 = peg$literalExpectation("not", false),
+      peg$c282 = "select",
+      peg$c283 = peg$literalExpectation("select", false),
+      peg$c284 = function(typ, expr) {
             return {"kind": "Cast", "expr": expr, "type": typ}
           },
-      peg$c289 = "regexp",
-      peg$c290 = peg$literalExpectation("regexp", false),
-      peg$c291 = function(arg0Text, arg1, where) {
+      peg$c285 = "regexp",
+      peg$c286 = peg$literalExpectation("regexp", false),
+      peg$c287 = function(arg0Text, arg1, where) {
             let arg0 = {"kind": "Primitive", "type": "string", "text": arg0Text};
             return {"kind": "Call", "name": "regexp", "args": [arg0, arg1], "where": where}
           },
-      peg$c292 = function(fn, args, where) {
+      peg$c288 = function(fn, args, where) {
             return {"kind": "Call", "name": fn, "args": args, "where": where}
           },
-      peg$c293 = function(o) { return [o] },
-      peg$c294 = "grep",
-      peg$c295 = peg$literalExpectation("grep", false),
-      peg$c296 = function(pattern, opt) {
+      peg$c289 = function(o) { return [o] },
+      peg$c290 = "grep",
+      peg$c291 = peg$literalExpectation("grep", false),
+      peg$c292 = function(pattern, opt) {
             let m = {"kind": "Grep", "pattern": pattern, "expr": {"kind": "ID", "name": "this"}};
             if (opt) {
               m["expr"] = opt[2];
             }
             return m
           },
-      peg$c297 = function(s) {
+      peg$c293 = function(s) {
             return {"kind": "String", "text": s}
           },
-      peg$c298 = function(first, e) { return e },
-      peg$c299 = "]",
-      peg$c300 = peg$literalExpectation("]", false),
-      peg$c301 = function(from, to) {
+      peg$c294 = function(first, e) { return e },
+      peg$c295 = "]",
+      peg$c296 = peg$literalExpectation("]", false),
+      peg$c297 = function(from, to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs":to}]
           
           },
-      peg$c302 = function(to) {
+      peg$c298 = function(to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs": null, "rhs":to}]
           
           },
-      peg$c303 = function(expr) { return ["[", expr] },
-      peg$c304 = function(id) { return [".", id] },
-      peg$c305 = function(exprs, locals, scope) {
+      peg$c299 = function(expr) { return ["[", expr] },
+      peg$c300 = function(id) { return [".", id] },
+      peg$c301 = function(exprs, locals, scope) {
             return {"kind": "OverExpr", "locals": locals, "exprs": exprs, "scope": scope}
           },
-      peg$c306 = "}",
-      peg$c307 = peg$literalExpectation("}", false),
-      peg$c308 = function(elems) {
+      peg$c302 = "}",
+      peg$c303 = peg$literalExpectation("}", false),
+      peg$c304 = function(elems) {
             return {"kind":"RecordExpr", "elems":elems}
           },
-      peg$c309 = function(elem) { return elem },
-      peg$c310 = "...",
-      peg$c311 = peg$literalExpectation("...", false),
-      peg$c312 = function(expr) {
+      peg$c305 = function(elem) { return elem },
+      peg$c306 = "...",
+      peg$c307 = peg$literalExpectation("...", false),
+      peg$c308 = function(expr) {
             return {"kind":"Spread", "expr": expr}
           },
-      peg$c313 = function(name, value) {
+      peg$c309 = function(name, value) {
             return {"kind":"Field","name": name, "value": value}
           },
-      peg$c314 = function(elems) {
+      peg$c310 = function(elems) {
             return {"kind":"ArrayExpr", "elems":elems }
           },
-      peg$c315 = "|[",
-      peg$c316 = peg$literalExpectation("|[", false),
-      peg$c317 = "]|",
-      peg$c318 = peg$literalExpectation("]|", false),
-      peg$c319 = function(elems) {
+      peg$c311 = "|[",
+      peg$c312 = peg$literalExpectation("|[", false),
+      peg$c313 = "]|",
+      peg$c314 = peg$literalExpectation("]|", false),
+      peg$c315 = function(elems) {
             return {"kind":"SetExpr", "elems":elems }
           },
-      peg$c320 = function(e) { return {"kind":"VectorValue","expr":e} },
-      peg$c321 = "|{",
-      peg$c322 = peg$literalExpectation("|{", false),
-      peg$c323 = "}|",
-      peg$c324 = peg$literalExpectation("}|", false),
-      peg$c325 = function(exprs) {
+      peg$c316 = function(e) { return {"kind":"VectorValue","expr":e} },
+      peg$c317 = "|{",
+      peg$c318 = peg$literalExpectation("|{", false),
+      peg$c319 = "}|",
+      peg$c320 = peg$literalExpectation("}|", false),
+      peg$c321 = function(exprs) {
             return {"kind":"MapExpr", "entries":exprs }
           },
-      peg$c326 = function(e) { return e },
-      peg$c327 = function(key, value) {
+      peg$c322 = function(e) { return e },
+      peg$c323 = function(key, value) {
             return {"key": key, "value": value}
           },
-      peg$c328 = function(selection, from, joins, where, groupby, having, orderby, limit) {
+      peg$c324 = function(selection, from, joins, where, groupby, having, orderby, limit) {
             return {
               
             "kind": "SQLExpr",
@@ -799,19 +797,19 @@ function peg$parse(input, options) {
             "limit": limit }
           
           },
-      peg$c329 = function(assignments) { return assignments },
-      peg$c330 = function(rhs, opt) {
+      peg$c325 = function(assignments) { return assignments },
+      peg$c326 = function(rhs, opt) {
             let m = {"kind": "Assignment", "lhs": null, "rhs": rhs};
             if (opt) {
               m["lhs"] = opt[3];
             }
             return m
           },
-      peg$c331 = function(table, alias) {
+      peg$c327 = function(table, alias) {
             return {"table": table, "alias": alias}
           },
-      peg$c332 = function(first, join) { return join },
-      peg$c333 = function(style, table, alias, leftKey, rightKey) {
+      peg$c328 = function(first, join) { return join },
+      peg$c329 = function(style, table, alias, leftKey, rightKey) {
             return {
               
             "table": table,
@@ -825,120 +823,122 @@ function peg$parse(input, options) {
             "alias": alias}
           
           },
-      peg$c334 = function(style) { return style },
-      peg$c335 = function(keys, order) {
+      peg$c330 = function(style) { return style },
+      peg$c331 = function(keys, order) {
             return {"kind": "SQLOrderBy", "keys": keys, "order":order}
           },
-      peg$c336 = function(dir) { return dir },
-      peg$c337 = function(count) { return count },
-      peg$c338 = peg$literalExpectation("select", true),
-      peg$c339 = function() { return "select" },
-      peg$c340 = "as",
-      peg$c341 = peg$literalExpectation("as", true),
-      peg$c342 = function() { return "as" },
-      peg$c343 = peg$literalExpectation("from", true),
-      peg$c344 = function() { return "from" },
-      peg$c345 = peg$literalExpectation("join", true),
-      peg$c346 = function() { return "join" },
-      peg$c347 = peg$literalExpectation("where", true),
-      peg$c348 = function() { return "where" },
-      peg$c349 = "group",
-      peg$c350 = peg$literalExpectation("group", true),
-      peg$c351 = function() { return "group" },
-      peg$c352 = "by",
-      peg$c353 = peg$literalExpectation("by", true),
-      peg$c354 = function() { return "by" },
-      peg$c355 = "having",
-      peg$c356 = peg$literalExpectation("having", true),
-      peg$c357 = function() { return "having" },
-      peg$c358 = peg$literalExpectation("order", true),
-      peg$c359 = function() { return "order" },
-      peg$c360 = "on",
-      peg$c361 = peg$literalExpectation("on", true),
-      peg$c362 = function() { return "on" },
-      peg$c363 = "limit",
-      peg$c364 = peg$literalExpectation("limit", true),
-      peg$c365 = function() { return "limit" },
-      peg$c366 = peg$literalExpectation("asc", true),
-      peg$c367 = peg$literalExpectation("desc", true),
-      peg$c368 = peg$literalExpectation("anti", true),
-      peg$c369 = peg$literalExpectation("left", true),
-      peg$c370 = peg$literalExpectation("right", true),
-      peg$c371 = peg$literalExpectation("inner", true),
-      peg$c372 = function(v) {
+      peg$c332 = function(dir) { return dir },
+      peg$c333 = function(count) { return count },
+      peg$c334 = peg$literalExpectation("select", true),
+      peg$c335 = function() { return "select" },
+      peg$c336 = "as",
+      peg$c337 = peg$literalExpectation("as", true),
+      peg$c338 = function() { return "as" },
+      peg$c339 = peg$literalExpectation("from", true),
+      peg$c340 = function() { return "from" },
+      peg$c341 = peg$literalExpectation("join", true),
+      peg$c342 = function() { return "join" },
+      peg$c343 = peg$literalExpectation("where", true),
+      peg$c344 = function() { return "where" },
+      peg$c345 = "group",
+      peg$c346 = peg$literalExpectation("group", true),
+      peg$c347 = function() { return "group" },
+      peg$c348 = "by",
+      peg$c349 = peg$literalExpectation("by", true),
+      peg$c350 = function() { return "by" },
+      peg$c351 = "having",
+      peg$c352 = peg$literalExpectation("having", true),
+      peg$c353 = function() { return "having" },
+      peg$c354 = peg$literalExpectation("order", true),
+      peg$c355 = function() { return "order" },
+      peg$c356 = "on",
+      peg$c357 = peg$literalExpectation("on", true),
+      peg$c358 = function() { return "on" },
+      peg$c359 = "limit",
+      peg$c360 = peg$literalExpectation("limit", true),
+      peg$c361 = function() { return "limit" },
+      peg$c362 = "asc",
+      peg$c363 = peg$literalExpectation("asc", true),
+      peg$c364 = "desc",
+      peg$c365 = peg$literalExpectation("desc", true),
+      peg$c366 = peg$literalExpectation("anti", true),
+      peg$c367 = peg$literalExpectation("left", true),
+      peg$c368 = peg$literalExpectation("right", true),
+      peg$c369 = peg$literalExpectation("inner", true),
+      peg$c370 = function(v) {
             return {"kind": "Primitive", "type": "net", "text": v}
           },
-      peg$c373 = function(v) {
+      peg$c371 = function(v) {
             return {"kind": "Primitive", "type": "ip", "text": v}
           },
-      peg$c374 = function(v) {
+      peg$c372 = function(v) {
             return {"kind": "Primitive", "type": "float64", "text": v}
           },
-      peg$c375 = function(v) {
+      peg$c373 = function(v) {
             return {"kind": "Primitive", "type": "int64", "text": v}
           },
-      peg$c376 = "true",
-      peg$c377 = peg$literalExpectation("true", false),
-      peg$c378 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
-      peg$c379 = "false",
-      peg$c380 = peg$literalExpectation("false", false),
-      peg$c381 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
-      peg$c382 = "null",
-      peg$c383 = peg$literalExpectation("null", false),
-      peg$c384 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
-      peg$c385 = "0x",
-      peg$c386 = peg$literalExpectation("0x", false),
-      peg$c387 = function() {
+      peg$c374 = "true",
+      peg$c375 = peg$literalExpectation("true", false),
+      peg$c376 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
+      peg$c377 = "false",
+      peg$c378 = peg$literalExpectation("false", false),
+      peg$c379 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
+      peg$c380 = "null",
+      peg$c381 = peg$literalExpectation("null", false),
+      peg$c382 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
+      peg$c383 = "0x",
+      peg$c384 = peg$literalExpectation("0x", false),
+      peg$c385 = function() {
       	return {"kind": "Primitive", "type": "bytes", "text": text()}
         },
-      peg$c388 = function(typ) {
+      peg$c386 = function(typ) {
             return {"kind": "TypeValue", "value": typ}
           },
-      peg$c389 = function(name) { return name },
-      peg$c390 = function(name, opt) {
+      peg$c387 = function(name) { return name },
+      peg$c388 = function(name, opt) {
             if (opt) {
               return {"kind": "TypeDef", "name": name, "type": opt[3]}
             }
             return {"kind": "TypeName", "name": name}
           },
-      peg$c391 = function(name) {
+      peg$c389 = function(name) {
             return {"kind": "TypeName", "name": name}
           },
-      peg$c392 = function(u) { return u },
-      peg$c393 = function(types) {
+      peg$c390 = function(u) { return u },
+      peg$c391 = function(types) {
             return {"kind": "TypeUnion", "types": types}
           },
-      peg$c394 = function(typ) { return typ },
-      peg$c395 = function(fields) {
+      peg$c392 = function(typ) { return typ },
+      peg$c393 = function(fields) {
             return {"kind":"TypeRecord", "fields":fields}
           },
-      peg$c396 = function(typ) {
+      peg$c394 = function(typ) {
             return {"kind":"TypeArray", "type":typ}
           },
-      peg$c397 = function(typ) {
+      peg$c395 = function(typ) {
             return {"kind":"TypeSet", "type":typ}
           },
-      peg$c398 = function(keyType, valType) {
+      peg$c396 = function(keyType, valType) {
             return {"kind":"TypeMap", "key_type":keyType, "val_type": valType}
           },
-      peg$c399 = function(v) {
+      peg$c397 = function(v) {
             if (v.length == 0) {
               return {"kind": "Primitive", "type": "string", "text": ""}
             }
             return makeTemplateExprChain(v)
           },
-      peg$c400 = "\"",
-      peg$c401 = peg$literalExpectation("\"", false),
-      peg$c402 = "'",
-      peg$c403 = peg$literalExpectation("'", false),
-      peg$c404 = function(v) {
+      peg$c398 = "\"",
+      peg$c399 = peg$literalExpectation("\"", false),
+      peg$c400 = "'",
+      peg$c401 = peg$literalExpectation("'", false),
+      peg$c402 = function(v) {
             return {"kind": "Primitive", "type": "string", "text": joinChars(v)}
           },
-      peg$c405 = "\\",
-      peg$c406 = peg$literalExpectation("\\", false),
-      peg$c407 = "${",
-      peg$c408 = peg$literalExpectation("${", false),
-      peg$c409 = function(e) {
+      peg$c403 = "\\",
+      peg$c404 = peg$literalExpectation("\\", false),
+      peg$c405 = "${",
+      peg$c406 = peg$literalExpectation("${", false),
+      peg$c407 = function(e) {
             return {
               
             "kind": "Cast",
@@ -952,194 +952,194 @@ function peg$parse(input, options) {
             "value": {"kind": "TypePrimitive", "name": "string"}}}
           
           },
-      peg$c410 = "uint8",
-      peg$c411 = peg$literalExpectation("uint8", false),
-      peg$c412 = "uint16",
-      peg$c413 = peg$literalExpectation("uint16", false),
-      peg$c414 = "uint32",
-      peg$c415 = peg$literalExpectation("uint32", false),
-      peg$c416 = "uint64",
-      peg$c417 = peg$literalExpectation("uint64", false),
-      peg$c418 = "int8",
-      peg$c419 = peg$literalExpectation("int8", false),
-      peg$c420 = "int16",
-      peg$c421 = peg$literalExpectation("int16", false),
-      peg$c422 = "int32",
-      peg$c423 = peg$literalExpectation("int32", false),
-      peg$c424 = "int64",
-      peg$c425 = peg$literalExpectation("int64", false),
-      peg$c426 = "float16",
-      peg$c427 = peg$literalExpectation("float16", false),
-      peg$c428 = "float32",
-      peg$c429 = peg$literalExpectation("float32", false),
-      peg$c430 = "float64",
-      peg$c431 = peg$literalExpectation("float64", false),
-      peg$c432 = "bool",
-      peg$c433 = peg$literalExpectation("bool", false),
-      peg$c434 = "string",
-      peg$c435 = peg$literalExpectation("string", false),
-      peg$c436 = "duration",
-      peg$c437 = peg$literalExpectation("duration", false),
-      peg$c438 = "time",
-      peg$c439 = peg$literalExpectation("time", false),
-      peg$c440 = "bytes",
-      peg$c441 = peg$literalExpectation("bytes", false),
-      peg$c442 = "ip",
-      peg$c443 = peg$literalExpectation("ip", false),
-      peg$c444 = "net",
-      peg$c445 = peg$literalExpectation("net", false),
-      peg$c446 = function() {
+      peg$c408 = "uint8",
+      peg$c409 = peg$literalExpectation("uint8", false),
+      peg$c410 = "uint16",
+      peg$c411 = peg$literalExpectation("uint16", false),
+      peg$c412 = "uint32",
+      peg$c413 = peg$literalExpectation("uint32", false),
+      peg$c414 = "uint64",
+      peg$c415 = peg$literalExpectation("uint64", false),
+      peg$c416 = "int8",
+      peg$c417 = peg$literalExpectation("int8", false),
+      peg$c418 = "int16",
+      peg$c419 = peg$literalExpectation("int16", false),
+      peg$c420 = "int32",
+      peg$c421 = peg$literalExpectation("int32", false),
+      peg$c422 = "int64",
+      peg$c423 = peg$literalExpectation("int64", false),
+      peg$c424 = "float16",
+      peg$c425 = peg$literalExpectation("float16", false),
+      peg$c426 = "float32",
+      peg$c427 = peg$literalExpectation("float32", false),
+      peg$c428 = "float64",
+      peg$c429 = peg$literalExpectation("float64", false),
+      peg$c430 = "bool",
+      peg$c431 = peg$literalExpectation("bool", false),
+      peg$c432 = "string",
+      peg$c433 = peg$literalExpectation("string", false),
+      peg$c434 = "duration",
+      peg$c435 = peg$literalExpectation("duration", false),
+      peg$c436 = "time",
+      peg$c437 = peg$literalExpectation("time", false),
+      peg$c438 = "bytes",
+      peg$c439 = peg$literalExpectation("bytes", false),
+      peg$c440 = "ip",
+      peg$c441 = peg$literalExpectation("ip", false),
+      peg$c442 = "net",
+      peg$c443 = peg$literalExpectation("net", false),
+      peg$c444 = function() {
                 return {"kind": "TypePrimitive", "name": text()}
               },
-      peg$c447 = function(name, typ) {
+      peg$c445 = function(name, typ) {
             return {"name": name, "type": typ}
           },
-      peg$c448 = "and",
-      peg$c449 = peg$literalExpectation("and", false),
-      peg$c450 = "AND",
-      peg$c451 = peg$literalExpectation("AND", false),
-      peg$c452 = function() { return "and" },
-      peg$c453 = "or",
-      peg$c454 = peg$literalExpectation("or", false),
-      peg$c455 = "OR",
-      peg$c456 = peg$literalExpectation("OR", false),
-      peg$c457 = function() { return "or" },
-      peg$c459 = "NOT",
-      peg$c460 = peg$literalExpectation("NOT", false),
-      peg$c461 = function() { return "not" },
-      peg$c462 = peg$literalExpectation("by", false),
-      peg$c463 = /^[A-Za-z_$]/,
-      peg$c464 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c465 = /^[0-9]/,
-      peg$c466 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c467 = function(id) { return {"kind": "ID", "name": id} },
-      peg$c468 = "$",
-      peg$c469 = peg$literalExpectation("$", false),
-      peg$c470 = function(first, id) { return id},
-      peg$c471 = "T",
-      peg$c472 = peg$literalExpectation("T", false),
-      peg$c473 = function() {
+      peg$c446 = "and",
+      peg$c447 = peg$literalExpectation("and", false),
+      peg$c448 = "AND",
+      peg$c449 = peg$literalExpectation("AND", false),
+      peg$c450 = function() { return "and" },
+      peg$c451 = "or",
+      peg$c452 = peg$literalExpectation("or", false),
+      peg$c453 = "OR",
+      peg$c454 = peg$literalExpectation("OR", false),
+      peg$c455 = function() { return "or" },
+      peg$c457 = "NOT",
+      peg$c458 = peg$literalExpectation("NOT", false),
+      peg$c459 = function() { return "not" },
+      peg$c460 = peg$literalExpectation("by", false),
+      peg$c461 = /^[A-Za-z_$]/,
+      peg$c462 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c463 = /^[0-9]/,
+      peg$c464 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c465 = function(id) { return {"kind": "ID", "name": id} },
+      peg$c466 = "$",
+      peg$c467 = peg$literalExpectation("$", false),
+      peg$c468 = function(first, id) { return id},
+      peg$c469 = "T",
+      peg$c470 = peg$literalExpectation("T", false),
+      peg$c471 = function() {
             return {"kind": "Primitive", "type": "time", "text": text()}
           },
-      peg$c474 = "Z",
-      peg$c475 = peg$literalExpectation("Z", false),
-      peg$c476 = function() {
+      peg$c472 = "Z",
+      peg$c473 = peg$literalExpectation("Z", false),
+      peg$c474 = function() {
             return {"kind": "Primitive", "type": "duration", "text": text()}
           },
-      peg$c477 = "ns",
-      peg$c478 = peg$literalExpectation("ns", false),
-      peg$c479 = "us",
-      peg$c480 = peg$literalExpectation("us", false),
-      peg$c481 = "ms",
-      peg$c482 = peg$literalExpectation("ms", false),
-      peg$c483 = "s",
-      peg$c484 = peg$literalExpectation("s", false),
-      peg$c485 = "m",
-      peg$c486 = peg$literalExpectation("m", false),
-      peg$c487 = "h",
-      peg$c488 = peg$literalExpectation("h", false),
-      peg$c489 = "d",
-      peg$c490 = peg$literalExpectation("d", false),
-      peg$c491 = "w",
-      peg$c492 = peg$literalExpectation("w", false),
-      peg$c493 = "y",
-      peg$c494 = peg$literalExpectation("y", false),
-      peg$c495 = function(a, b) {
+      peg$c475 = "ns",
+      peg$c476 = peg$literalExpectation("ns", false),
+      peg$c477 = "us",
+      peg$c478 = peg$literalExpectation("us", false),
+      peg$c479 = "ms",
+      peg$c480 = peg$literalExpectation("ms", false),
+      peg$c481 = "s",
+      peg$c482 = peg$literalExpectation("s", false),
+      peg$c483 = "m",
+      peg$c484 = peg$literalExpectation("m", false),
+      peg$c485 = "h",
+      peg$c486 = peg$literalExpectation("h", false),
+      peg$c487 = "d",
+      peg$c488 = peg$literalExpectation("d", false),
+      peg$c489 = "w",
+      peg$c490 = peg$literalExpectation("w", false),
+      peg$c491 = "y",
+      peg$c492 = peg$literalExpectation("y", false),
+      peg$c493 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c496 = "::",
-      peg$c497 = peg$literalExpectation("::", false),
-      peg$c498 = function(a, b, d, e) {
+      peg$c494 = "::",
+      peg$c495 = peg$literalExpectation("::", false),
+      peg$c496 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c499 = function(a, b) {
+      peg$c497 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c500 = function(a, b) {
+      peg$c498 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c501 = function() {
+      peg$c499 = function() {
             return "::"
           },
-      peg$c502 = function(v) { return ":" + v },
-      peg$c503 = function(v) { return v + ":" },
-      peg$c504 = function(a, m) {
+      peg$c500 = function(v) { return ":" + v },
+      peg$c501 = function(v) { return v + ":" },
+      peg$c502 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c505 = function(a, m) {
+      peg$c503 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c506 = function(s) { return parseInt(s) },
-      peg$c507 = function() {
+      peg$c504 = function(s) { return parseInt(s) },
+      peg$c505 = function() {
             return text()
           },
-      peg$c508 = "e",
-      peg$c509 = peg$literalExpectation("e", true),
-      peg$c510 = /^[+\-]/,
-      peg$c511 = peg$classExpectation(["+", "-"], false, false),
-      peg$c512 = "NaN",
-      peg$c513 = peg$literalExpectation("NaN", false),
-      peg$c514 = "Inf",
-      peg$c515 = peg$literalExpectation("Inf", false),
-      peg$c516 = /^[0-9a-fA-F]/,
-      peg$c517 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c518 = function(v) { return joinChars(v) },
-      peg$c519 = peg$anyExpectation(),
-      peg$c520 = function(head, tail) { return head + joinChars(tail) },
-      peg$c521 = /^[a-zA-Z_.:\/%#@~]/,
-      peg$c522 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
-      peg$c523 = function(head, tail) {
+      peg$c506 = "e",
+      peg$c507 = peg$literalExpectation("e", true),
+      peg$c508 = /^[+\-]/,
+      peg$c509 = peg$classExpectation(["+", "-"], false, false),
+      peg$c510 = "NaN",
+      peg$c511 = peg$literalExpectation("NaN", false),
+      peg$c512 = "Inf",
+      peg$c513 = peg$literalExpectation("Inf", false),
+      peg$c514 = /^[0-9a-fA-F]/,
+      peg$c515 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c516 = function(v) { return joinChars(v) },
+      peg$c517 = peg$anyExpectation(),
+      peg$c518 = function(head, tail) { return head + joinChars(tail) },
+      peg$c519 = /^[a-zA-Z_.:\/%#@~]/,
+      peg$c520 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
+      peg$c521 = function(head, tail) {
             return head + joinChars(tail)
           },
-      peg$c524 = function() { return "*"},
-      peg$c525 = function() { return "=" },
-      peg$c526 = function() { return "\\*" },
-      peg$c527 = "b",
-      peg$c528 = peg$literalExpectation("b", false),
-      peg$c529 = function() { return "\b" },
-      peg$c530 = "f",
-      peg$c531 = peg$literalExpectation("f", false),
-      peg$c532 = function() { return "\f" },
-      peg$c533 = "n",
-      peg$c534 = peg$literalExpectation("n", false),
-      peg$c535 = function() { return "\n" },
-      peg$c536 = "r",
-      peg$c537 = peg$literalExpectation("r", false),
-      peg$c538 = function() { return "\r" },
-      peg$c539 = "t",
-      peg$c540 = peg$literalExpectation("t", false),
-      peg$c541 = function() { return "\t" },
-      peg$c542 = "v",
-      peg$c543 = peg$literalExpectation("v", false),
-      peg$c544 = function() { return "\v" },
-      peg$c545 = function() { return "*" },
-      peg$c546 = "u",
-      peg$c547 = peg$literalExpectation("u", false),
-      peg$c548 = function(chars) {
+      peg$c522 = function() { return "*"},
+      peg$c523 = function() { return "=" },
+      peg$c524 = function() { return "\\*" },
+      peg$c525 = "b",
+      peg$c526 = peg$literalExpectation("b", false),
+      peg$c527 = function() { return "\b" },
+      peg$c528 = "f",
+      peg$c529 = peg$literalExpectation("f", false),
+      peg$c530 = function() { return "\f" },
+      peg$c531 = "n",
+      peg$c532 = peg$literalExpectation("n", false),
+      peg$c533 = function() { return "\n" },
+      peg$c534 = "r",
+      peg$c535 = peg$literalExpectation("r", false),
+      peg$c536 = function() { return "\r" },
+      peg$c537 = "t",
+      peg$c538 = peg$literalExpectation("t", false),
+      peg$c539 = function() { return "\t" },
+      peg$c540 = "v",
+      peg$c541 = peg$literalExpectation("v", false),
+      peg$c542 = function() { return "\v" },
+      peg$c543 = function() { return "*" },
+      peg$c544 = "u",
+      peg$c545 = peg$literalExpectation("u", false),
+      peg$c546 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c549 = /^[^\/\\]/,
-      peg$c550 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c551 = /^[\0-\x1F\\]/,
-      peg$c552 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c553 = peg$otherExpectation("whitespace"),
-      peg$c554 = "\t",
-      peg$c555 = peg$literalExpectation("\t", false),
-      peg$c556 = "\x0B",
-      peg$c557 = peg$literalExpectation("\x0B", false),
-      peg$c558 = "\f",
-      peg$c559 = peg$literalExpectation("\f", false),
-      peg$c560 = " ",
-      peg$c561 = peg$literalExpectation(" ", false),
-      peg$c562 = "\xA0",
-      peg$c563 = peg$literalExpectation("\xA0", false),
-      peg$c564 = "\uFEFF",
-      peg$c565 = peg$literalExpectation("\uFEFF", false),
-      peg$c566 = /^[\n\r\u2028\u2029]/,
-      peg$c567 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c568 = peg$otherExpectation("comment"),
-      peg$c573 = "//",
-      peg$c574 = peg$literalExpectation("//", false),
+      peg$c547 = /^[^\/\\]/,
+      peg$c548 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c549 = /^[\0-\x1F\\]/,
+      peg$c550 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c551 = peg$otherExpectation("whitespace"),
+      peg$c552 = "\t",
+      peg$c553 = peg$literalExpectation("\t", false),
+      peg$c554 = "\x0B",
+      peg$c555 = peg$literalExpectation("\x0B", false),
+      peg$c556 = "\f",
+      peg$c557 = peg$literalExpectation("\f", false),
+      peg$c558 = " ",
+      peg$c559 = peg$literalExpectation(" ", false),
+      peg$c560 = "\xA0",
+      peg$c561 = peg$literalExpectation("\xA0", false),
+      peg$c562 = "\uFEFF",
+      peg$c563 = peg$literalExpectation("\uFEFF", false),
+      peg$c564 = /^[\n\r\u2028\u2029]/,
+      peg$c565 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c566 = peg$otherExpectation("comment"),
+      peg$c571 = "//",
+      peg$c572 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -5968,12 +5968,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c243) {
-      s1 = peg$c243;
+    if (input.substr(peg$currPos, 4) === peg$c239) {
+      s1 = peg$c239;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c244); }
+      if (peg$silentFails === 0) { peg$fail(peg$c240); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -5988,7 +5988,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c245();
+        s1 = peg$c241();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6006,12 +6006,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 7) === peg$c246) {
-      s1 = peg$c246;
+    if (input.substr(peg$currPos, 7) === peg$c242) {
+      s1 = peg$c242;
       peg$currPos += 7;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c247); }
+      if (peg$silentFails === 0) { peg$fail(peg$c243); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6026,7 +6026,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c248(s3, s4, s5);
+              s1 = peg$c244(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6056,12 +6056,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c249) {
-      s1 = peg$c249;
+    if (input.substr(peg$currPos, 5) === peg$c245) {
+      s1 = peg$c245;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c250); }
+      if (peg$silentFails === 0) { peg$fail(peg$c246); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6069,7 +6069,7 @@ function peg$parse(input, options) {
         s3 = peg$parseConditionalExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c251(s3);
+          s1 = peg$c247(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6091,12 +6091,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c252) {
-      s1 = peg$c252;
+    if (input.substr(peg$currPos, 4) === peg$c248) {
+      s1 = peg$c248;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c253); }
+      if (peg$silentFails === 0) { peg$fail(peg$c249); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6114,7 +6114,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c254(s3, s4, s5);
+              s1 = peg$c250(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6179,7 +6179,7 @@ function peg$parse(input, options) {
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c255(s6);
+                    s1 = peg$c251(s6);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -6252,7 +6252,7 @@ function peg$parse(input, options) {
                   s10 = peg$parseLocalsAssignment();
                   if (s10 !== peg$FAILED) {
                     peg$savedPos = s6;
-                    s7 = peg$c256(s4, s10);
+                    s7 = peg$c252(s4, s10);
                     s6 = s7;
                   } else {
                     peg$currPos = s6;
@@ -6288,7 +6288,7 @@ function peg$parse(input, options) {
                     s10 = peg$parseLocalsAssignment();
                     if (s10 !== peg$FAILED) {
                       peg$savedPos = s6;
-                      s7 = peg$c256(s4, s10);
+                      s7 = peg$c252(s4, s10);
                       s6 = s7;
                     } else {
                       peg$currPos = s6;
@@ -6379,7 +6379,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c257(s1, s2);
+        s1 = peg$c253(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6397,12 +6397,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c258) {
-      s1 = peg$c258;
+    if (input.substr(peg$currPos, 5) === peg$c254) {
+      s1 = peg$c254;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c259); }
+      if (peg$silentFails === 0) { peg$fail(peg$c255); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6410,7 +6410,7 @@ function peg$parse(input, options) {
         s3 = peg$parseExprs();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c260(s3);
+          s1 = peg$c256(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6441,7 +6441,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c261(s4);
+            s1 = peg$c257(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6476,7 +6476,7 @@ function peg$parse(input, options) {
           s4 = peg$parseDerefExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c262(s4);
+            s1 = peg$c258(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6576,7 +6576,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c264(s1, s2);
+        s1 = peg$c260(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6613,7 +6613,7 @@ function peg$parse(input, options) {
             s7 = peg$parseAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c256(s1, s7);
+              s4 = peg$c252(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6649,7 +6649,7 @@ function peg$parse(input, options) {
               s7 = peg$parseAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c256(s1, s7);
+                s4 = peg$c252(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6670,7 +6670,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c265(s1, s2);
+        s1 = peg$c261(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6705,7 +6705,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c266(s1, s5);
+              s1 = peg$c262(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6749,11 +6749,11 @@ function peg$parse(input, options) {
       s3 = peg$parse__();
       if (s3 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s4 = peg$c267;
+          s4 = peg$c263;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c268); }
+          if (peg$silentFails === 0) { peg$fail(peg$c264); }
         }
         if (s4 !== peg$FAILED) {
           s5 = peg$parse__();
@@ -6813,7 +6813,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c269(s1, s2);
+        s1 = peg$c265(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6844,7 +6844,7 @@ function peg$parse(input, options) {
             s7 = peg$parseLogicalAndExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c270(s1, s5, s7);
+              s4 = peg$c266(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6874,7 +6874,7 @@ function peg$parse(input, options) {
               s7 = peg$parseLogicalAndExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c270(s1, s5, s7);
+                s4 = peg$c266(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6895,7 +6895,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c271(s1, s2);
+        s1 = peg$c267(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6926,7 +6926,7 @@ function peg$parse(input, options) {
             s7 = peg$parseComparisonExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c270(s1, s5, s7);
+              s4 = peg$c266(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6956,7 +6956,7 @@ function peg$parse(input, options) {
               s7 = peg$parseComparisonExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c270(s1, s5, s7);
+                s4 = peg$c266(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6977,7 +6977,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c271(s1, s2);
+        s1 = peg$c267(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7038,7 +7038,7 @@ function peg$parse(input, options) {
           }
           if (s5 !== peg$FAILED) {
             peg$savedPos = s4;
-            s5 = peg$c272();
+            s5 = peg$c268();
           }
           s4 = s5;
           if (s4 !== peg$FAILED) {
@@ -7070,7 +7070,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c273(s1, s2);
+        s1 = peg$c269(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7101,7 +7101,7 @@ function peg$parse(input, options) {
             s7 = peg$parseMultiplicativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c270(s1, s5, s7);
+              s4 = peg$c266(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7131,7 +7131,7 @@ function peg$parse(input, options) {
               s7 = peg$parseMultiplicativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c270(s1, s5, s7);
+                s4 = peg$c266(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7152,7 +7152,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c271(s1, s2);
+        s1 = peg$c267(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7171,19 +7171,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c274;
+      s1 = peg$c270;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c275); }
+      if (peg$silentFails === 0) { peg$fail(peg$c271); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c276;
+        s1 = peg$c272;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c277); }
+        if (peg$silentFails === 0) { peg$fail(peg$c273); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -7212,7 +7212,7 @@ function peg$parse(input, options) {
             s7 = peg$parseNotExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c270(s1, s5, s7);
+              s4 = peg$c266(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7242,7 +7242,7 @@ function peg$parse(input, options) {
               s7 = peg$parseNotExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c270(s1, s5, s7);
+                s4 = peg$c266(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7263,7 +7263,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c271(s1, s2);
+        s1 = peg$c267(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7290,19 +7290,19 @@ function peg$parse(input, options) {
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c278;
+        s1 = peg$c274;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c279); }
+        if (peg$silentFails === 0) { peg$fail(peg$c275); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 37) {
-          s1 = peg$c280;
+          s1 = peg$c276;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c281); }
+          if (peg$silentFails === 0) { peg$fail(peg$c277); }
         }
       }
     }
@@ -7332,7 +7332,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c282(s3);
+          s1 = peg$c278(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7369,11 +7369,11 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c276;
+        s2 = peg$c272;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c277); }
+        if (peg$silentFails === 0) { peg$fail(peg$c273); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -7381,7 +7381,7 @@ function peg$parse(input, options) {
           s4 = peg$parseFuncExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c283(s4);
+            s1 = peg$c279(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7500,20 +7500,20 @@ function peg$parse(input, options) {
   function peg$parseNotFuncs() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c284) {
-      s0 = peg$c284;
+    if (input.substr(peg$currPos, 3) === peg$c280) {
+      s0 = peg$c280;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c285); }
+      if (peg$silentFails === 0) { peg$fail(peg$c281); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c286) {
-        s0 = peg$c286;
+      if (input.substr(peg$currPos, 6) === peg$c282) {
+        s0 = peg$c282;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c287); }
+        if (peg$silentFails === 0) { peg$fail(peg$c283); }
       }
     }
 
@@ -7554,7 +7554,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c288(s1, s5);
+                  s1 = peg$c284(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7594,12 +7594,12 @@ function peg$parse(input, options) {
     s0 = peg$parseGrep();
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c289) {
-        s1 = peg$c289;
+      if (input.substr(peg$currPos, 6) === peg$c285) {
+        s1 = peg$c285;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c290); }
+        if (peg$silentFails === 0) { peg$fail(peg$c286); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
@@ -7646,7 +7646,7 @@ function peg$parse(input, options) {
                             }
                             if (s12 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c291(s5, s9, s12);
+                              s1 = peg$c287(s5, s9, s12);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -7741,7 +7741,7 @@ function peg$parse(input, options) {
                         }
                         if (s9 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c292(s2, s6, s9);
+                          s1 = peg$c288(s2, s6, s9);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -7792,7 +7792,7 @@ function peg$parse(input, options) {
     s1 = peg$parseOverExpr();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c293(s1);
+      s1 = peg$c289(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -7806,12 +7806,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c294) {
-      s1 = peg$c294;
+    if (input.substr(peg$currPos, 4) === peg$c290) {
+      s1 = peg$c290;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c295); }
+      if (peg$silentFails === 0) { peg$fail(peg$c291); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -7879,7 +7879,7 @@ function peg$parse(input, options) {
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c296(s5, s7);
+                    s1 = peg$c292(s5, s7);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -7928,7 +7928,7 @@ function peg$parse(input, options) {
         s1 = peg$parseQuotedString();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c297(s1);
+          s1 = peg$c293(s1);
         }
         s0 = s1;
       }
@@ -7977,7 +7977,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c298(s1, s7);
+              s4 = peg$c294(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -8013,7 +8013,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c298(s1, s7);
+                s4 = peg$c294(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -8123,15 +8123,15 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s7 = peg$c299;
+                  s7 = peg$c295;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c300); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c296); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c301(s2, s6);
+                  s1 = peg$c297(s2, s6);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8186,15 +8186,15 @@ function peg$parse(input, options) {
               s5 = peg$parseAdditiveExpr();
               if (s5 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s6 = peg$c299;
+                  s6 = peg$c295;
                   peg$currPos++;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c300); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c296); }
                 }
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c302(s5);
+                  s1 = peg$c298(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8233,15 +8233,15 @@ function peg$parse(input, options) {
           s2 = peg$parseConditionalExpr();
           if (s2 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s3 = peg$c299;
+              s3 = peg$c295;
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c300); }
+              if (peg$silentFails === 0) { peg$fail(peg$c296); }
             }
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c303(s2);
+              s1 = peg$c299(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8268,7 +8268,7 @@ function peg$parse(input, options) {
             s2 = peg$parseIdentifier();
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c304(s2);
+              s1 = peg$c300(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8405,12 +8405,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c252) {
-      s1 = peg$c252;
+    if (input.substr(peg$currPos, 4) === peg$c248) {
+      s1 = peg$c248;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c253); }
+      if (peg$silentFails === 0) { peg$fail(peg$c249); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -8437,7 +8437,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSequential();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c305(s3, s4, s8);
+                    s1 = peg$c301(s3, s4, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -8494,15 +8494,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c306;
+              s5 = peg$c302;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c307); }
+              if (peg$silentFails === 0) { peg$fail(peg$c303); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c308(s3);
+              s1 = peg$c304(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8542,7 +8542,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c265(s1, s2);
+        s1 = peg$c261(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8584,7 +8584,7 @@ function peg$parse(input, options) {
           s4 = peg$parseRecordElem();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c309(s4);
+            s1 = peg$c305(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8624,12 +8624,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c310) {
-      s1 = peg$c310;
+    if (input.substr(peg$currPos, 3) === peg$c306) {
+      s1 = peg$c306;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c311); }
+      if (peg$silentFails === 0) { peg$fail(peg$c307); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8637,7 +8637,7 @@ function peg$parse(input, options) {
         s3 = peg$parseConditionalExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c312(s3);
+          s1 = peg$c308(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8676,7 +8676,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c313(s1, s5);
+              s1 = peg$c309(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8721,15 +8721,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s5 = peg$c299;
+              s5 = peg$c295;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c300); }
+              if (peg$silentFails === 0) { peg$fail(peg$c296); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c314(s3);
+              s1 = peg$c310(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8759,12 +8759,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c315) {
-      s1 = peg$c315;
+    if (input.substr(peg$currPos, 2) === peg$c311) {
+      s1 = peg$c311;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c316); }
+      if (peg$silentFails === 0) { peg$fail(peg$c312); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8773,16 +8773,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c317) {
-              s5 = peg$c317;
+            if (input.substr(peg$currPos, 2) === peg$c313) {
+              s5 = peg$c313;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c318); }
+              if (peg$silentFails === 0) { peg$fail(peg$c314); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c319(s3);
+              s1 = peg$c315(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8831,7 +8831,7 @@ function peg$parse(input, options) {
             s7 = peg$parseVectorElem();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c298(s1, s7);
+              s4 = peg$c294(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -8867,7 +8867,7 @@ function peg$parse(input, options) {
               s7 = peg$parseVectorElem();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c298(s1, s7);
+                s4 = peg$c294(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -8920,7 +8920,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c320(s1);
+        s1 = peg$c316(s1);
       }
       s0 = s1;
     }
@@ -8932,12 +8932,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c321) {
-      s1 = peg$c321;
+    if (input.substr(peg$currPos, 2) === peg$c317) {
+      s1 = peg$c317;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c322); }
+      if (peg$silentFails === 0) { peg$fail(peg$c318); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8946,16 +8946,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c323) {
-              s5 = peg$c323;
+            if (input.substr(peg$currPos, 2) === peg$c319) {
+              s5 = peg$c319;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c324); }
+              if (peg$silentFails === 0) { peg$fail(peg$c320); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c325(s3);
+              s1 = peg$c321(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8995,7 +8995,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c265(s1, s2);
+        s1 = peg$c261(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9037,7 +9037,7 @@ function peg$parse(input, options) {
           s4 = peg$parseEntry();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c326(s4);
+            s1 = peg$c322(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9080,7 +9080,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c327(s1, s5);
+              s1 = peg$c323(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9145,7 +9145,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSQLLimit();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c328(s1, s2, s3, s4, s5, s6, s7, s8);
+                    s1 = peg$c324(s1, s2, s3, s4, s5, s6, s7, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -9223,7 +9223,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSQLAssignments();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c329(s3);
+            s1 = peg$c325(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9280,7 +9280,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c330(s1, s2);
+        s1 = peg$c326(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9406,7 +9406,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c331(s4, s5);
+              s1 = peg$c327(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9561,7 +9561,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSQLJoin();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s3;
-        s4 = peg$c332(s1, s4);
+        s4 = peg$c328(s1, s4);
       }
       s3 = s4;
       while (s3 !== peg$FAILED) {
@@ -9570,7 +9570,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSQLJoin();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s3;
-          s4 = peg$c332(s1, s4);
+          s4 = peg$c328(s1, s4);
         }
         s3 = s4;
       }
@@ -9632,7 +9632,7 @@ function peg$parse(input, options) {
                               s14 = peg$parseJoinKey();
                               if (s14 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c333(s1, s5, s6, s10, s14);
+                                s1 = peg$c329(s1, s5, s6, s10, s14);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -9712,7 +9712,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c334(s2);
+        s1 = peg$c330(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9871,7 +9871,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseSQLOrder();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c335(s6, s7);
+                  s1 = peg$c331(s6, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -9917,7 +9917,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c336(s2);
+        s1 = peg$c332(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9953,7 +9953,7 @@ function peg$parse(input, options) {
           s4 = peg$parseUInt();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c337(s4);
+            s1 = peg$c333(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9988,16 +9988,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c286) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c282) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c338); }
+      if (peg$silentFails === 0) { peg$fail(peg$c334); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c339();
+      s1 = peg$c335();
     }
     s0 = s1;
 
@@ -10008,16 +10008,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c340) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c336) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c341); }
+      if (peg$silentFails === 0) { peg$fail(peg$c337); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c342();
+      s1 = peg$c338();
     }
     s0 = s1;
 
@@ -10033,11 +10033,11 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c343); }
+      if (peg$silentFails === 0) { peg$fail(peg$c339); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c344();
+      s1 = peg$c340();
     }
     s0 = s1;
 
@@ -10053,11 +10053,11 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c345); }
+      if (peg$silentFails === 0) { peg$fail(peg$c341); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c346();
+      s1 = peg$c342();
     }
     s0 = s1;
 
@@ -10073,11 +10073,11 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c347); }
+      if (peg$silentFails === 0) { peg$fail(peg$c343); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c348();
+      s1 = peg$c344();
     }
     s0 = s1;
 
@@ -10088,16 +10088,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c349) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c345) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c350); }
+      if (peg$silentFails === 0) { peg$fail(peg$c346); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c351();
+      s1 = peg$c347();
     }
     s0 = s1;
 
@@ -10108,16 +10108,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c352) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c348) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c353); }
+      if (peg$silentFails === 0) { peg$fail(peg$c349); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c354();
+      s1 = peg$c350();
     }
     s0 = s1;
 
@@ -10128,16 +10128,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c355) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c351) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c356); }
+      if (peg$silentFails === 0) { peg$fail(peg$c352); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c357();
+      s1 = peg$c353();
     }
     s0 = s1;
 
@@ -10153,11 +10153,11 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c358); }
+      if (peg$silentFails === 0) { peg$fail(peg$c354); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c359();
+      s1 = peg$c355();
     }
     s0 = s1;
 
@@ -10168,16 +10168,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c360) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c356) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c361); }
+      if (peg$silentFails === 0) { peg$fail(peg$c357); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c362();
+      s1 = peg$c358();
     }
     s0 = s1;
 
@@ -10188,16 +10188,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c363) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c359) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c364); }
+      if (peg$silentFails === 0) { peg$fail(peg$c360); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c365();
+      s1 = peg$c361();
     }
     s0 = s1;
 
@@ -10208,12 +10208,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c239) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c362) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c366); }
+      if (peg$silentFails === 0) { peg$fail(peg$c363); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10228,12 +10228,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c241) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c364) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c367); }
+      if (peg$silentFails === 0) { peg$fail(peg$c365); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10253,7 +10253,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c368); }
+      if (peg$silentFails === 0) { peg$fail(peg$c366); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10273,7 +10273,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c369); }
+      if (peg$silentFails === 0) { peg$fail(peg$c367); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10293,7 +10293,7 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c370); }
+      if (peg$silentFails === 0) { peg$fail(peg$c368); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10313,7 +10313,7 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c371); }
+      if (peg$silentFails === 0) { peg$fail(peg$c369); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10415,7 +10415,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c372(s1);
+        s1 = peg$c370(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10430,7 +10430,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP4Net();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c372(s1);
+        s1 = peg$c370(s1);
       }
       s0 = s1;
     }
@@ -10456,7 +10456,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c373(s1);
+        s1 = peg$c371(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10471,7 +10471,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c373(s1);
+        s1 = peg$c371(s1);
       }
       s0 = s1;
     }
@@ -10486,7 +10486,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFloatString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c374(s1);
+      s1 = peg$c372(s1);
     }
     s0 = s1;
 
@@ -10500,7 +10500,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c375(s1);
+      s1 = peg$c373(s1);
     }
     s0 = s1;
 
@@ -10511,30 +10511,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c376) {
-      s1 = peg$c376;
+    if (input.substr(peg$currPos, 4) === peg$c374) {
+      s1 = peg$c374;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c377); }
+      if (peg$silentFails === 0) { peg$fail(peg$c375); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c378();
+      s1 = peg$c376();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c379) {
-        s1 = peg$c379;
+      if (input.substr(peg$currPos, 5) === peg$c377) {
+        s1 = peg$c377;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c380); }
+        if (peg$silentFails === 0) { peg$fail(peg$c378); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c381();
+        s1 = peg$c379();
       }
       s0 = s1;
     }
@@ -10546,16 +10546,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c382) {
-      s1 = peg$c382;
+    if (input.substr(peg$currPos, 4) === peg$c380) {
+      s1 = peg$c380;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c383); }
+      if (peg$silentFails === 0) { peg$fail(peg$c381); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c384();
+      s1 = peg$c382();
     }
     s0 = s1;
 
@@ -10566,12 +10566,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c385) {
-      s1 = peg$c385;
+    if (input.substr(peg$currPos, 2) === peg$c383) {
+      s1 = peg$c383;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c386); }
+      if (peg$silentFails === 0) { peg$fail(peg$c384); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -10582,7 +10582,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c387();
+        s1 = peg$c385();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10619,7 +10619,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c388(s2);
+          s1 = peg$c386(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10646,7 +10646,7 @@ function peg$parse(input, options) {
       s1 = peg$parsePrimitiveType();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c388(s1);
+        s1 = peg$c386(s1);
       }
       s0 = s1;
     }
@@ -10686,7 +10686,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c389(s1);
+        s1 = peg$c387(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10738,7 +10738,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c390(s1, s2);
+          s1 = peg$c388(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10753,7 +10753,7 @@ function peg$parse(input, options) {
         s1 = peg$parseQuotedString();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c391(s1);
+          s1 = peg$c389(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
@@ -10779,7 +10779,7 @@ function peg$parse(input, options) {
                 }
                 if (s4 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c392(s3);
+                  s1 = peg$c390(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10811,7 +10811,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTypeList();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c393(s1);
+      s1 = peg$c391(s1);
     }
     s0 = s1;
 
@@ -10836,7 +10836,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c265(s1, s2);
+        s1 = peg$c261(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10869,7 +10869,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c394(s4);
+            s1 = peg$c392(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10910,15 +10910,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c306;
+              s5 = peg$c302;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c307); }
+              if (peg$silentFails === 0) { peg$fail(peg$c303); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c395(s3);
+              s1 = peg$c393(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -10957,15 +10957,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c299;
+                s5 = peg$c295;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c300); }
+                if (peg$silentFails === 0) { peg$fail(peg$c296); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c396(s3);
+                s1 = peg$c394(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -10989,12 +10989,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c315) {
-          s1 = peg$c315;
+        if (input.substr(peg$currPos, 2) === peg$c311) {
+          s1 = peg$c311;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c316); }
+          if (peg$silentFails === 0) { peg$fail(peg$c312); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -11003,16 +11003,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c317) {
-                  s5 = peg$c317;
+                if (input.substr(peg$currPos, 2) === peg$c313) {
+                  s5 = peg$c313;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c318); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c314); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c397(s3);
+                  s1 = peg$c395(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -11036,12 +11036,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c321) {
-            s1 = peg$c321;
+          if (input.substr(peg$currPos, 2) === peg$c317) {
+            s1 = peg$c317;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c322); }
+            if (peg$silentFails === 0) { peg$fail(peg$c318); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -11064,16 +11064,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c323) {
-                            s9 = peg$c323;
+                          if (input.substr(peg$currPos, 2) === peg$c319) {
+                            s9 = peg$c319;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c324); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c320); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c398(s3, s7);
+                            s1 = peg$c396(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -11125,7 +11125,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTemplateLiteralParts();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c399(s1);
+      s1 = peg$c397(s1);
     }
     s0 = s1;
 
@@ -11137,11 +11137,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c400;
+      s1 = peg$c398;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c401); }
+      if (peg$silentFails === 0) { peg$fail(peg$c399); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -11152,11 +11152,11 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c400;
+          s3 = peg$c398;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c401); }
+          if (peg$silentFails === 0) { peg$fail(peg$c399); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
@@ -11177,11 +11177,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c402;
+        s1 = peg$c400;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c403); }
+        if (peg$silentFails === 0) { peg$fail(peg$c401); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -11192,11 +11192,11 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c402;
+            s3 = peg$c400;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c403); }
+            if (peg$silentFails === 0) { peg$fail(peg$c401); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
@@ -11237,7 +11237,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c404(s1);
+        s1 = peg$c402(s1);
       }
       s0 = s1;
     }
@@ -11250,19 +11250,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c405;
+      s1 = peg$c403;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c406); }
+      if (peg$silentFails === 0) { peg$fail(peg$c404); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c407) {
-        s2 = peg$c407;
+      if (input.substr(peg$currPos, 2) === peg$c405) {
+        s2 = peg$c405;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c408); }
+        if (peg$silentFails === 0) { peg$fail(peg$c406); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11280,12 +11280,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c407) {
-        s2 = peg$c407;
+      if (input.substr(peg$currPos, 2) === peg$c405) {
+        s2 = peg$c405;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c408); }
+        if (peg$silentFails === 0) { peg$fail(peg$c406); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -11331,7 +11331,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c404(s1);
+        s1 = peg$c402(s1);
       }
       s0 = s1;
     }
@@ -11344,19 +11344,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c405;
+      s1 = peg$c403;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c406); }
+      if (peg$silentFails === 0) { peg$fail(peg$c404); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c407) {
-        s2 = peg$c407;
+      if (input.substr(peg$currPos, 2) === peg$c405) {
+        s2 = peg$c405;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c408); }
+        if (peg$silentFails === 0) { peg$fail(peg$c406); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11374,12 +11374,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c407) {
-        s2 = peg$c407;
+      if (input.substr(peg$currPos, 2) === peg$c405) {
+        s2 = peg$c405;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c408); }
+        if (peg$silentFails === 0) { peg$fail(peg$c406); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -11411,12 +11411,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c407) {
-      s1 = peg$c407;
+    if (input.substr(peg$currPos, 2) === peg$c405) {
+      s1 = peg$c405;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c408); }
+      if (peg$silentFails === 0) { peg$fail(peg$c406); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -11426,15 +11426,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c306;
+              s5 = peg$c302;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c307); }
+              if (peg$silentFails === 0) { peg$fail(peg$c303); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c409(s3);
+              s1 = peg$c407(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11464,148 +11464,148 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c410) {
-      s1 = peg$c410;
+    if (input.substr(peg$currPos, 5) === peg$c408) {
+      s1 = peg$c408;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c411); }
+      if (peg$silentFails === 0) { peg$fail(peg$c409); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c412) {
-        s1 = peg$c412;
+      if (input.substr(peg$currPos, 6) === peg$c410) {
+        s1 = peg$c410;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c413); }
+        if (peg$silentFails === 0) { peg$fail(peg$c411); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c414) {
-          s1 = peg$c414;
+        if (input.substr(peg$currPos, 6) === peg$c412) {
+          s1 = peg$c412;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c415); }
+          if (peg$silentFails === 0) { peg$fail(peg$c413); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c416) {
-            s1 = peg$c416;
+          if (input.substr(peg$currPos, 6) === peg$c414) {
+            s1 = peg$c414;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c417); }
+            if (peg$silentFails === 0) { peg$fail(peg$c415); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c418) {
-              s1 = peg$c418;
+            if (input.substr(peg$currPos, 4) === peg$c416) {
+              s1 = peg$c416;
               peg$currPos += 4;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c419); }
+              if (peg$silentFails === 0) { peg$fail(peg$c417); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 5) === peg$c420) {
-                s1 = peg$c420;
+              if (input.substr(peg$currPos, 5) === peg$c418) {
+                s1 = peg$c418;
                 peg$currPos += 5;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c421); }
+                if (peg$silentFails === 0) { peg$fail(peg$c419); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c422) {
-                  s1 = peg$c422;
+                if (input.substr(peg$currPos, 5) === peg$c420) {
+                  s1 = peg$c420;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c423); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c421); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c424) {
-                    s1 = peg$c424;
+                  if (input.substr(peg$currPos, 5) === peg$c422) {
+                    s1 = peg$c422;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c425); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c423); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7) === peg$c426) {
-                      s1 = peg$c426;
+                    if (input.substr(peg$currPos, 7) === peg$c424) {
+                      s1 = peg$c424;
                       peg$currPos += 7;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c427); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c425); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 7) === peg$c428) {
-                        s1 = peg$c428;
+                      if (input.substr(peg$currPos, 7) === peg$c426) {
+                        s1 = peg$c426;
                         peg$currPos += 7;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c429); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c427); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 7) === peg$c430) {
-                          s1 = peg$c430;
+                        if (input.substr(peg$currPos, 7) === peg$c428) {
+                          s1 = peg$c428;
                           peg$currPos += 7;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c431); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c429); }
                         }
                         if (s1 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 4) === peg$c432) {
-                            s1 = peg$c432;
+                          if (input.substr(peg$currPos, 4) === peg$c430) {
+                            s1 = peg$c430;
                             peg$currPos += 4;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c433); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c431); }
                           }
                           if (s1 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 6) === peg$c434) {
-                              s1 = peg$c434;
+                            if (input.substr(peg$currPos, 6) === peg$c432) {
+                              s1 = peg$c432;
                               peg$currPos += 6;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c435); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c433); }
                             }
                             if (s1 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 8) === peg$c436) {
-                                s1 = peg$c436;
+                              if (input.substr(peg$currPos, 8) === peg$c434) {
+                                s1 = peg$c434;
                                 peg$currPos += 8;
                               } else {
                                 s1 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c437); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c435); }
                               }
                               if (s1 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 4) === peg$c438) {
-                                  s1 = peg$c438;
+                                if (input.substr(peg$currPos, 4) === peg$c436) {
+                                  s1 = peg$c436;
                                   peg$currPos += 4;
                                 } else {
                                   s1 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c439); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c437); }
                                 }
                                 if (s1 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 5) === peg$c440) {
-                                    s1 = peg$c440;
+                                  if (input.substr(peg$currPos, 5) === peg$c438) {
+                                    s1 = peg$c438;
                                     peg$currPos += 5;
                                   } else {
                                     s1 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c441); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c439); }
                                   }
                                   if (s1 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 2) === peg$c442) {
-                                      s1 = peg$c442;
+                                    if (input.substr(peg$currPos, 2) === peg$c440) {
+                                      s1 = peg$c440;
                                       peg$currPos += 2;
                                     } else {
                                       s1 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c443); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c441); }
                                     }
                                     if (s1 === peg$FAILED) {
-                                      if (input.substr(peg$currPos, 3) === peg$c444) {
-                                        s1 = peg$c444;
+                                      if (input.substr(peg$currPos, 3) === peg$c442) {
+                                        s1 = peg$c442;
                                         peg$currPos += 3;
                                       } else {
                                         s1 = peg$FAILED;
-                                        if (peg$silentFails === 0) { peg$fail(peg$c445); }
+                                        if (peg$silentFails === 0) { peg$fail(peg$c443); }
                                       }
                                       if (s1 === peg$FAILED) {
                                         if (input.substr(peg$currPos, 4) === peg$c10) {
@@ -11616,12 +11616,12 @@ function peg$parse(input, options) {
                                           if (peg$silentFails === 0) { peg$fail(peg$c11); }
                                         }
                                         if (s1 === peg$FAILED) {
-                                          if (input.substr(peg$currPos, 4) === peg$c382) {
-                                            s1 = peg$c382;
+                                          if (input.substr(peg$currPos, 4) === peg$c380) {
+                                            s1 = peg$c380;
                                             peg$currPos += 4;
                                           } else {
                                             s1 = peg$FAILED;
-                                            if (peg$silentFails === 0) { peg$fail(peg$c383); }
+                                            if (peg$silentFails === 0) { peg$fail(peg$c381); }
                                           }
                                         }
                                       }
@@ -11644,7 +11644,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c446();
+      s1 = peg$c444();
     }
     s0 = s1;
 
@@ -11665,7 +11665,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c265(s1, s2);
+        s1 = peg$c261(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11707,7 +11707,7 @@ function peg$parse(input, options) {
           s4 = peg$parseTypeField();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c394(s4);
+            s1 = peg$c392(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11750,7 +11750,7 @@ function peg$parse(input, options) {
             s5 = peg$parseType();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c447(s1, s5);
+              s1 = peg$c445(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11791,20 +11791,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c448) {
-      s1 = peg$c448;
+    if (input.substr(peg$currPos, 3) === peg$c446) {
+      s1 = peg$c446;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c449); }
+      if (peg$silentFails === 0) { peg$fail(peg$c447); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c450) {
-        s1 = peg$c450;
+      if (input.substr(peg$currPos, 3) === peg$c448) {
+        s1 = peg$c448;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c451); }
+        if (peg$silentFails === 0) { peg$fail(peg$c449); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -11820,7 +11820,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c452();
+        s1 = peg$c450();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11838,20 +11838,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c453) {
-      s1 = peg$c453;
+    if (input.substr(peg$currPos, 2) === peg$c451) {
+      s1 = peg$c451;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c454); }
+      if (peg$silentFails === 0) { peg$fail(peg$c452); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c455) {
-        s1 = peg$c455;
+      if (input.substr(peg$currPos, 2) === peg$c453) {
+        s1 = peg$c453;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c456); }
+        if (peg$silentFails === 0) { peg$fail(peg$c454); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -11867,7 +11867,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c457();
+        s1 = peg$c455();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11885,20 +11885,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c284) {
-      s1 = peg$c284;
+    if (input.substr(peg$currPos, 3) === peg$c280) {
+      s1 = peg$c280;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c285); }
+      if (peg$silentFails === 0) { peg$fail(peg$c281); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c459) {
-        s1 = peg$c459;
+      if (input.substr(peg$currPos, 3) === peg$c457) {
+        s1 = peg$c457;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c460); }
+        if (peg$silentFails === 0) { peg$fail(peg$c458); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -11914,7 +11914,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c461();
+        s1 = peg$c459();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11932,12 +11932,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c352) {
-      s1 = peg$c352;
+    if (input.substr(peg$currPos, 2) === peg$c348) {
+      s1 = peg$c348;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c462); }
+      if (peg$silentFails === 0) { peg$fail(peg$c460); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -11952,7 +11952,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c354();
+        s1 = peg$c350();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11969,12 +11969,12 @@ function peg$parse(input, options) {
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c463.test(input.charAt(peg$currPos))) {
+    if (peg$c461.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c464); }
+      if (peg$silentFails === 0) { peg$fail(peg$c462); }
     }
 
     return s0;
@@ -11985,12 +11985,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c465.test(input.charAt(peg$currPos))) {
+      if (peg$c463.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c466); }
+        if (peg$silentFails === 0) { peg$fail(peg$c464); }
       }
     }
 
@@ -12004,7 +12004,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c467(s1);
+      s1 = peg$c465(s1);
     }
     s0 = s1;
 
@@ -12076,11 +12076,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 36) {
-        s1 = peg$c468;
+        s1 = peg$c466;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c469); }
+        if (peg$silentFails === 0) { peg$fail(peg$c467); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -12090,11 +12090,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c405;
+          s1 = peg$c403;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c406); }
+          if (peg$silentFails === 0) { peg$fail(peg$c404); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseIDGuard();
@@ -12201,7 +12201,7 @@ function peg$parse(input, options) {
             s7 = peg$parseIdentifierName();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c470(s1, s7);
+              s4 = peg$c468(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -12237,7 +12237,7 @@ function peg$parse(input, options) {
               s7 = peg$parseIdentifierName();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c470(s1, s7);
+                s4 = peg$c468(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -12258,7 +12258,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c265(s1, s2);
+        s1 = peg$c261(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12296,17 +12296,17 @@ function peg$parse(input, options) {
     s1 = peg$parseFullDate();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 84) {
-        s2 = peg$c471;
+        s2 = peg$c469;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c472); }
+        if (peg$silentFails === 0) { peg$fail(peg$c470); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseFullTime();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c473();
+          s1 = peg$c471();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -12331,21 +12331,21 @@ function peg$parse(input, options) {
     s1 = peg$parseD4();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c276;
+        s2 = peg$c272;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c277); }
+        if (peg$silentFails === 0) { peg$fail(peg$c273); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseD2();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 45) {
-            s4 = peg$c276;
+            s4 = peg$c272;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c277); }
+            if (peg$silentFails === 0) { peg$fail(peg$c273); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseD2();
@@ -12380,36 +12380,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (peg$c465.test(input.charAt(peg$currPos))) {
+    if (peg$c463.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c466); }
+      if (peg$silentFails === 0) { peg$fail(peg$c464); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c465.test(input.charAt(peg$currPos))) {
+      if (peg$c463.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c466); }
+        if (peg$silentFails === 0) { peg$fail(peg$c464); }
       }
       if (s2 !== peg$FAILED) {
-        if (peg$c465.test(input.charAt(peg$currPos))) {
+        if (peg$c463.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c466); }
+          if (peg$silentFails === 0) { peg$fail(peg$c464); }
         }
         if (s3 !== peg$FAILED) {
-          if (peg$c465.test(input.charAt(peg$currPos))) {
+          if (peg$c463.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c466); }
+            if (peg$silentFails === 0) { peg$fail(peg$c464); }
           }
           if (s4 !== peg$FAILED) {
             s1 = [s1, s2, s3, s4];
@@ -12438,20 +12438,20 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c465.test(input.charAt(peg$currPos))) {
+    if (peg$c463.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c466); }
+      if (peg$silentFails === 0) { peg$fail(peg$c464); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c465.test(input.charAt(peg$currPos))) {
+      if (peg$c463.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c466); }
+        if (peg$silentFails === 0) { peg$fail(peg$c464); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -12526,22 +12526,22 @@ function peg$parse(input, options) {
               }
               if (s7 !== peg$FAILED) {
                 s8 = [];
-                if (peg$c465.test(input.charAt(peg$currPos))) {
+                if (peg$c463.test(input.charAt(peg$currPos))) {
                   s9 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s9 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c466); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c464); }
                 }
                 if (s9 !== peg$FAILED) {
                   while (s9 !== peg$FAILED) {
                     s8.push(s9);
-                    if (peg$c465.test(input.charAt(peg$currPos))) {
+                    if (peg$c463.test(input.charAt(peg$currPos))) {
                       s9 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c466); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c464); }
                     }
                   }
                 } else {
@@ -12596,28 +12596,28 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     if (input.charCodeAt(peg$currPos) === 90) {
-      s0 = peg$c474;
+      s0 = peg$c472;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c475); }
+      if (peg$silentFails === 0) { peg$fail(peg$c473); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 43) {
-        s1 = peg$c274;
+        s1 = peg$c270;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c275); }
+        if (peg$silentFails === 0) { peg$fail(peg$c271); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 45) {
-          s1 = peg$c276;
+          s1 = peg$c272;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c277); }
+          if (peg$silentFails === 0) { peg$fail(peg$c273); }
         }
       }
       if (s1 !== peg$FAILED) {
@@ -12643,22 +12643,22 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 s7 = [];
-                if (peg$c465.test(input.charAt(peg$currPos))) {
+                if (peg$c463.test(input.charAt(peg$currPos))) {
                   s8 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s8 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c466); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c464); }
                 }
                 if (s8 !== peg$FAILED) {
                   while (s8 !== peg$FAILED) {
                     s7.push(s8);
-                    if (peg$c465.test(input.charAt(peg$currPos))) {
+                    if (peg$c463.test(input.charAt(peg$currPos))) {
                       s8 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s8 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c466); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c464); }
                     }
                   }
                 } else {
@@ -12711,11 +12711,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c276;
+      s1 = peg$c272;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c277); }
+      if (peg$silentFails === 0) { peg$fail(peg$c273); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -12761,7 +12761,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c476();
+        s1 = peg$c474();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12823,76 +12823,76 @@ function peg$parse(input, options) {
   function peg$parseTimeUnit() {
     var s0;
 
-    if (input.substr(peg$currPos, 2) === peg$c477) {
-      s0 = peg$c477;
+    if (input.substr(peg$currPos, 2) === peg$c475) {
+      s0 = peg$c475;
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c478); }
+      if (peg$silentFails === 0) { peg$fail(peg$c476); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c479) {
-        s0 = peg$c479;
+      if (input.substr(peg$currPos, 2) === peg$c477) {
+        s0 = peg$c477;
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c480); }
+        if (peg$silentFails === 0) { peg$fail(peg$c478); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c481) {
-          s0 = peg$c481;
+        if (input.substr(peg$currPos, 2) === peg$c479) {
+          s0 = peg$c479;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c482); }
+          if (peg$silentFails === 0) { peg$fail(peg$c480); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 115) {
-            s0 = peg$c483;
+            s0 = peg$c481;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c484); }
+            if (peg$silentFails === 0) { peg$fail(peg$c482); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c485;
+              s0 = peg$c483;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c486); }
+              if (peg$silentFails === 0) { peg$fail(peg$c484); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 104) {
-                s0 = peg$c487;
+                s0 = peg$c485;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c488); }
+                if (peg$silentFails === 0) { peg$fail(peg$c486); }
               }
               if (s0 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 100) {
-                  s0 = peg$c489;
+                  s0 = peg$c487;
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c490); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c488); }
                 }
                 if (s0 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 119) {
-                    s0 = peg$c491;
+                    s0 = peg$c489;
                     peg$currPos++;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c492); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c490); }
                   }
                   if (s0 === peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 121) {
-                      s0 = peg$c493;
+                      s0 = peg$c491;
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c494); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c492); }
                     }
                   }
                 }
@@ -13077,7 +13077,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c495(s1, s2);
+        s1 = peg$c493(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13098,12 +13098,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c496) {
-            s3 = peg$c496;
+          if (input.substr(peg$currPos, 2) === peg$c494) {
+            s3 = peg$c494;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c497); }
+            if (peg$silentFails === 0) { peg$fail(peg$c495); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -13116,7 +13116,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c498(s1, s2, s4, s5);
+                s1 = peg$c496(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -13140,12 +13140,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c496) {
-          s1 = peg$c496;
+        if (input.substr(peg$currPos, 2) === peg$c494) {
+          s1 = peg$c494;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c497); }
+          if (peg$silentFails === 0) { peg$fail(peg$c495); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -13158,7 +13158,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c499(s2, s3);
+              s1 = peg$c497(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13183,16 +13183,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c496) {
-                s3 = peg$c496;
+              if (input.substr(peg$currPos, 2) === peg$c494) {
+                s3 = peg$c494;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c497); }
+                if (peg$silentFails === 0) { peg$fail(peg$c495); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c500(s1, s2);
+                s1 = peg$c498(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -13208,16 +13208,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c496) {
-              s1 = peg$c496;
+            if (input.substr(peg$currPos, 2) === peg$c494) {
+              s1 = peg$c494;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c497); }
+              if (peg$silentFails === 0) { peg$fail(peg$c495); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c501();
+              s1 = peg$c499();
             }
             s0 = s1;
           }
@@ -13254,7 +13254,7 @@ function peg$parse(input, options) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c502(s2);
+        s1 = peg$c500(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13283,7 +13283,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c503(s1);
+        s1 = peg$c501(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13304,17 +13304,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c278;
+        s2 = peg$c274;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c279); }
+        if (peg$silentFails === 0) { peg$fail(peg$c275); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c504(s1, s3);
+          s1 = peg$c502(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13339,17 +13339,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c278;
+        s2 = peg$c274;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c279); }
+        if (peg$silentFails === 0) { peg$fail(peg$c275); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c505(s1, s3);
+          s1 = peg$c503(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13374,7 +13374,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c506(s1);
+      s1 = peg$c504(s1);
     }
     s0 = s1;
 
@@ -13397,22 +13397,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c465.test(input.charAt(peg$currPos))) {
+    if (peg$c463.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c466); }
+      if (peg$silentFails === 0) { peg$fail(peg$c464); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c465.test(input.charAt(peg$currPos))) {
+        if (peg$c463.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c466); }
+          if (peg$silentFails === 0) { peg$fail(peg$c464); }
         }
       }
     } else {
@@ -13432,11 +13432,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c276;
+      s1 = peg$c272;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c277); }
+      if (peg$silentFails === 0) { peg$fail(peg$c273); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseUIntString();
@@ -13461,33 +13461,33 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c276;
+      s1 = peg$c272;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c277); }
+      if (peg$silentFails === 0) { peg$fail(peg$c273); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c465.test(input.charAt(peg$currPos))) {
+      if (peg$c463.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c466); }
+        if (peg$silentFails === 0) { peg$fail(peg$c464); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c465.test(input.charAt(peg$currPos))) {
+          if (peg$c463.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c466); }
+            if (peg$silentFails === 0) { peg$fail(peg$c464); }
           }
         }
       } else {
@@ -13503,21 +13503,21 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c465.test(input.charAt(peg$currPos))) {
+          if (peg$c463.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c466); }
+            if (peg$silentFails === 0) { peg$fail(peg$c464); }
           }
           while (s5 !== peg$FAILED) {
             s4.push(s5);
-            if (peg$c465.test(input.charAt(peg$currPos))) {
+            if (peg$c463.test(input.charAt(peg$currPos))) {
               s5 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c466); }
+              if (peg$silentFails === 0) { peg$fail(peg$c464); }
             }
           }
           if (s4 !== peg$FAILED) {
@@ -13527,7 +13527,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c507();
+              s1 = peg$c505();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13552,11 +13552,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c276;
+        s1 = peg$c272;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c277); }
+        if (peg$silentFails === 0) { peg$fail(peg$c273); }
       }
       if (s1 === peg$FAILED) {
         s1 = null;
@@ -13571,22 +13571,22 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c465.test(input.charAt(peg$currPos))) {
+          if (peg$c463.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c466); }
+            if (peg$silentFails === 0) { peg$fail(peg$c464); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c465.test(input.charAt(peg$currPos))) {
+              if (peg$c463.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c466); }
+                if (peg$silentFails === 0) { peg$fail(peg$c464); }
               }
             }
           } else {
@@ -13599,7 +13599,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c507();
+              s1 = peg$c505();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13638,20 +13638,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c508) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c506) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c509); }
+      if (peg$silentFails === 0) { peg$fail(peg$c507); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c510.test(input.charAt(peg$currPos))) {
+      if (peg$c508.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c511); }
+        if (peg$silentFails === 0) { peg$fail(peg$c509); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -13680,12 +13680,12 @@ function peg$parse(input, options) {
   function peg$parseNaN() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c512) {
-      s0 = peg$c512;
+    if (input.substr(peg$currPos, 3) === peg$c510) {
+      s0 = peg$c510;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c513); }
+      if (peg$silentFails === 0) { peg$fail(peg$c511); }
     }
 
     return s0;
@@ -13696,31 +13696,31 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c276;
+      s1 = peg$c272;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c277); }
+      if (peg$silentFails === 0) { peg$fail(peg$c273); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 43) {
-        s1 = peg$c274;
+        s1 = peg$c270;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c275); }
+        if (peg$silentFails === 0) { peg$fail(peg$c271); }
       }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c514) {
-        s2 = peg$c514;
+      if (input.substr(peg$currPos, 3) === peg$c512) {
+        s2 = peg$c512;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c515); }
+        if (peg$silentFails === 0) { peg$fail(peg$c513); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -13763,12 +13763,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c516.test(input.charAt(peg$currPos))) {
+    if (peg$c514.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c517); }
+      if (peg$silentFails === 0) { peg$fail(peg$c515); }
     }
 
     return s0;
@@ -13779,11 +13779,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c400;
+      s1 = peg$c398;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c401); }
+      if (peg$silentFails === 0) { peg$fail(peg$c399); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -13794,15 +13794,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c400;
+          s3 = peg$c398;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c401); }
+          if (peg$silentFails === 0) { peg$fail(peg$c399); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c518(s2);
+          s1 = peg$c516(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13819,11 +13819,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c402;
+        s1 = peg$c400;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c403); }
+        if (peg$silentFails === 0) { peg$fail(peg$c401); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -13834,15 +13834,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c402;
+            s3 = peg$c400;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c403); }
+            if (peg$silentFails === 0) { peg$fail(peg$c401); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c518(s2);
+            s1 = peg$c516(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -13868,11 +13868,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c400;
+      s2 = peg$c398;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c401); }
+      if (peg$silentFails === 0) { peg$fail(peg$c399); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -13890,7 +13890,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c519); }
+        if (peg$silentFails === 0) { peg$fail(peg$c517); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -13907,11 +13907,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c405;
+        s1 = peg$c403;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c406); }
+        if (peg$silentFails === 0) { peg$fail(peg$c404); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -13946,7 +13946,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c520(s1, s2);
+        s1 = peg$c518(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13975,12 +13975,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (peg$c521.test(input.charAt(peg$currPos))) {
+    if (peg$c519.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c522); }
+      if (peg$silentFails === 0) { peg$fail(peg$c520); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -13996,12 +13996,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseKeyWordStart();
     if (s0 === peg$FAILED) {
-      if (peg$c465.test(input.charAt(peg$currPos))) {
+      if (peg$c463.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c466); }
+        if (peg$silentFails === 0) { peg$fail(peg$c464); }
       }
     }
 
@@ -14013,11 +14013,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c405;
+      s1 = peg$c403;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c406); }
+      if (peg$silentFails === 0) { peg$fail(peg$c404); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseKeywordEscape();
@@ -14076,7 +14076,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c523(s3, s4);
+            s1 = peg$c521(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -14194,7 +14194,7 @@ function peg$parse(input, options) {
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c524();
+          s1 = peg$c522();
         }
         s0 = s1;
       }
@@ -14208,12 +14208,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseGlobStart();
     if (s0 === peg$FAILED) {
-      if (peg$c465.test(input.charAt(peg$currPos))) {
+      if (peg$c463.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c466); }
+        if (peg$silentFails === 0) { peg$fail(peg$c464); }
       }
     }
 
@@ -14225,11 +14225,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c405;
+      s1 = peg$c403;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c406); }
+      if (peg$silentFails === 0) { peg$fail(peg$c404); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseGlobEscape();
@@ -14265,7 +14265,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c525();
+      s1 = peg$c523();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -14279,16 +14279,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c526();
+        s1 = peg$c524();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c510.test(input.charAt(peg$currPos))) {
+        if (peg$c508.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c511); }
+          if (peg$silentFails === 0) { peg$fail(peg$c509); }
         }
       }
     }
@@ -14303,11 +14303,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c402;
+      s2 = peg$c400;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c403); }
+      if (peg$silentFails === 0) { peg$fail(peg$c401); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -14325,7 +14325,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c519); }
+        if (peg$silentFails === 0) { peg$fail(peg$c517); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14342,11 +14342,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c405;
+        s1 = peg$c403;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c406); }
+        if (peg$silentFails === 0) { peg$fail(peg$c404); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -14382,20 +14382,20 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c402;
+      s0 = peg$c400;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c403); }
+      if (peg$silentFails === 0) { peg$fail(peg$c401); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s1 = peg$c400;
+        s1 = peg$c398;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c401); }
+        if (peg$silentFails === 0) { peg$fail(peg$c399); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14404,94 +14404,94 @@ function peg$parse(input, options) {
       s0 = s1;
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c405;
+          s0 = peg$c403;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c406); }
+          if (peg$silentFails === 0) { peg$fail(peg$c404); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c527;
+            s1 = peg$c525;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c528); }
+            if (peg$silentFails === 0) { peg$fail(peg$c526); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c529();
+            s1 = peg$c527();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c530;
+              s1 = peg$c528;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c531); }
+              if (peg$silentFails === 0) { peg$fail(peg$c529); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c532();
+              s1 = peg$c530();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c533;
+                s1 = peg$c531;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c534); }
+                if (peg$silentFails === 0) { peg$fail(peg$c532); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c535();
+                s1 = peg$c533();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c536;
+                  s1 = peg$c534;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c537); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c535); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c538();
+                  s1 = peg$c536();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c539;
+                    s1 = peg$c537;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c540); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c538); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c541();
+                    s1 = peg$c539();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c542;
+                      s1 = peg$c540;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c543); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c541); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c544();
+                      s1 = peg$c542();
                     }
                     s0 = s1;
                   }
@@ -14519,7 +14519,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c525();
+      s1 = peg$c523();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -14533,16 +14533,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c545();
+        s1 = peg$c543();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c510.test(input.charAt(peg$currPos))) {
+        if (peg$c508.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c511); }
+          if (peg$silentFails === 0) { peg$fail(peg$c509); }
         }
       }
     }
@@ -14555,11 +14555,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c546;
+      s1 = peg$c544;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c547); }
+      if (peg$silentFails === 0) { peg$fail(peg$c545); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -14591,7 +14591,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c548(s2);
+        s1 = peg$c546(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14604,11 +14604,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c546;
+        s1 = peg$c544;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c547); }
+        if (peg$silentFails === 0) { peg$fail(peg$c545); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
@@ -14675,15 +14675,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c306;
+              s4 = peg$c302;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c307); }
+              if (peg$silentFails === 0) { peg$fail(peg$c303); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c548(s3);
+              s1 = peg$c546(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -14711,21 +14711,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c278;
+      s1 = peg$c274;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c279); }
+      if (peg$silentFails === 0) { peg$fail(peg$c275); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseRegexpBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c278;
+          s3 = peg$c274;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c279); }
+          if (peg$silentFails === 0) { peg$fail(peg$c275); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$currPos;
@@ -14767,21 +14767,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c549.test(input.charAt(peg$currPos))) {
+    if (peg$c547.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c550); }
+      if (peg$silentFails === 0) { peg$fail(peg$c548); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s3 = peg$c405;
+        s3 = peg$c403;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c406); }
+        if (peg$silentFails === 0) { peg$fail(peg$c404); }
       }
       if (s3 !== peg$FAILED) {
         if (input.length > peg$currPos) {
@@ -14789,7 +14789,7 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c519); }
+          if (peg$silentFails === 0) { peg$fail(peg$c517); }
         }
         if (s4 !== peg$FAILED) {
           s3 = [s3, s4];
@@ -14806,21 +14806,21 @@ function peg$parse(input, options) {
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c549.test(input.charAt(peg$currPos))) {
+        if (peg$c547.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c550); }
+          if (peg$silentFails === 0) { peg$fail(peg$c548); }
         }
         if (s2 === peg$FAILED) {
           s2 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 92) {
-            s3 = peg$c405;
+            s3 = peg$c403;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c406); }
+            if (peg$silentFails === 0) { peg$fail(peg$c404); }
           }
           if (s3 !== peg$FAILED) {
             if (input.length > peg$currPos) {
@@ -14828,7 +14828,7 @@ function peg$parse(input, options) {
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c519); }
+              if (peg$silentFails === 0) { peg$fail(peg$c517); }
             }
             if (s4 !== peg$FAILED) {
               s3 = [s3, s4];
@@ -14858,12 +14858,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c551.test(input.charAt(peg$currPos))) {
+    if (peg$c549.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c552); }
+      if (peg$silentFails === 0) { peg$fail(peg$c550); }
     }
 
     return s0;
@@ -14921,7 +14921,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c519); }
+      if (peg$silentFails === 0) { peg$fail(peg$c517); }
     }
 
     return s0;
@@ -14932,51 +14932,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c554;
+      s0 = peg$c552;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c555); }
+      if (peg$silentFails === 0) { peg$fail(peg$c553); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c556;
+        s0 = peg$c554;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c557); }
+        if (peg$silentFails === 0) { peg$fail(peg$c555); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c558;
+          s0 = peg$c556;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c559); }
+          if (peg$silentFails === 0) { peg$fail(peg$c557); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c560;
+            s0 = peg$c558;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c561); }
+            if (peg$silentFails === 0) { peg$fail(peg$c559); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c562;
+              s0 = peg$c560;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c563); }
+              if (peg$silentFails === 0) { peg$fail(peg$c561); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c564;
+                s0 = peg$c562;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c565); }
+                if (peg$silentFails === 0) { peg$fail(peg$c563); }
               }
             }
           }
@@ -14985,7 +14985,7 @@ function peg$parse(input, options) {
     }
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c553); }
+      if (peg$silentFails === 0) { peg$fail(peg$c551); }
     }
 
     return s0;
@@ -14994,12 +14994,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c566.test(input.charAt(peg$currPos))) {
+    if (peg$c564.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c567); }
+      if (peg$silentFails === 0) { peg$fail(peg$c565); }
     }
 
     return s0;
@@ -15012,7 +15012,7 @@ function peg$parse(input, options) {
     s0 = peg$parseSingleLineComment();
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c568); }
+      if (peg$silentFails === 0) { peg$fail(peg$c566); }
     }
 
     return s0;
@@ -15022,12 +15022,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c573) {
-      s1 = peg$c573;
+    if (input.substr(peg$currPos, 2) === peg$c571) {
+      s1 = peg$c571;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c574); }
+      if (peg$silentFails === 0) { peg$fail(peg$c572); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -15107,7 +15107,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c519); }
+      if (peg$silentFails === 0) { peg$fail(peg$c517); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -3985,86 +3985,23 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "OrderArg",
-			pos:  position{line: 556, col: 1, offset: 16229},
-			expr: &choiceExpr{
-				pos: position{line: 557, col: 5, offset: 16242},
-				alternatives: []interface{}{
-					&actionExpr{
-						pos: position{line: 557, col: 5, offset: 16242},
-						run: (*parser).callonOrderArg2,
-						expr: &seqExpr{
-							pos: position{line: 557, col: 5, offset: 16242},
-							exprs: []interface{}{
-								&ruleRefExpr{
-									pos:  position{line: 557, col: 5, offset: 16242},
-									name: "_",
-								},
-								&litMatcher{
-									pos:        position{line: 557, col: 7, offset: 16244},
-									val:        "order",
-									ignoreCase: false,
-								},
-								&ruleRefExpr{
-									pos:  position{line: 557, col: 15, offset: 16252},
-									name: "_",
-								},
-								&litMatcher{
-									pos:        position{line: 557, col: 17, offset: 16254},
-									val:        "asc",
-									ignoreCase: false,
-								},
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 558, col: 5, offset: 16287},
-						run: (*parser).callonOrderArg8,
-						expr: &seqExpr{
-							pos: position{line: 558, col: 5, offset: 16287},
-							exprs: []interface{}{
-								&ruleRefExpr{
-									pos:  position{line: 558, col: 5, offset: 16287},
-									name: "_",
-								},
-								&litMatcher{
-									pos:        position{line: 558, col: 7, offset: 16289},
-									val:        "order",
-									ignoreCase: false,
-								},
-								&ruleRefExpr{
-									pos:  position{line: 558, col: 15, offset: 16297},
-									name: "_",
-								},
-								&litMatcher{
-									pos:        position{line: 558, col: 17, offset: 16299},
-									val:        "desc",
-									ignoreCase: false,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
 			name: "PassOp",
-			pos:  position{line: 560, col: 1, offset: 16331},
+			pos:  position{line: 556, col: 1, offset: 16229},
 			expr: &actionExpr{
-				pos: position{line: 561, col: 5, offset: 16342},
+				pos: position{line: 557, col: 5, offset: 16240},
 				run: (*parser).callonPassOp1,
 				expr: &seqExpr{
-					pos: position{line: 561, col: 5, offset: 16342},
+					pos: position{line: 557, col: 5, offset: 16240},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 561, col: 5, offset: 16342},
+							pos:        position{line: 557, col: 5, offset: 16240},
 							val:        "pass",
 							ignoreCase: false,
 						},
 						&andExpr{
-							pos: position{line: 561, col: 12, offset: 16349},
+							pos: position{line: 557, col: 12, offset: 16247},
 							expr: &ruleRefExpr{
-								pos:  position{line: 561, col: 13, offset: 16350},
+								pos:  position{line: 557, col: 13, offset: 16248},
 								name: "EOKW",
 							},
 						},
@@ -4074,45 +4011,45 @@ var g = &grammar{
 		},
 		{
 			name: "ExplodeOp",
-			pos:  position{line: 567, col: 1, offset: 16542},
+			pos:  position{line: 563, col: 1, offset: 16440},
 			expr: &actionExpr{
-				pos: position{line: 568, col: 5, offset: 16556},
+				pos: position{line: 564, col: 5, offset: 16454},
 				run: (*parser).callonExplodeOp1,
 				expr: &seqExpr{
-					pos: position{line: 568, col: 5, offset: 16556},
+					pos: position{line: 564, col: 5, offset: 16454},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 568, col: 5, offset: 16556},
+							pos:        position{line: 564, col: 5, offset: 16454},
 							val:        "explode",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 568, col: 15, offset: 16566},
+							pos:  position{line: 564, col: 15, offset: 16464},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 568, col: 17, offset: 16568},
+							pos:   position{line: 564, col: 17, offset: 16466},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 568, col: 22, offset: 16573},
+								pos:  position{line: 564, col: 22, offset: 16471},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 568, col: 28, offset: 16579},
+							pos:   position{line: 564, col: 28, offset: 16477},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 568, col: 32, offset: 16583},
+								pos:  position{line: 564, col: 32, offset: 16481},
 								name: "TypeArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 568, col: 40, offset: 16591},
+							pos:   position{line: 564, col: 40, offset: 16489},
 							label: "as",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 568, col: 43, offset: 16594},
+								pos: position{line: 564, col: 43, offset: 16492},
 								expr: &ruleRefExpr{
-									pos:  position{line: 568, col: 43, offset: 16594},
+									pos:  position{line: 564, col: 43, offset: 16492},
 									name: "AsArg",
 								},
 							},
@@ -4123,27 +4060,27 @@ var g = &grammar{
 		},
 		{
 			name: "MergeOp",
-			pos:  position{line: 572, col: 1, offset: 16706},
+			pos:  position{line: 568, col: 1, offset: 16604},
 			expr: &actionExpr{
-				pos: position{line: 573, col: 5, offset: 16718},
+				pos: position{line: 569, col: 5, offset: 16616},
 				run: (*parser).callonMergeOp1,
 				expr: &seqExpr{
-					pos: position{line: 573, col: 5, offset: 16718},
+					pos: position{line: 569, col: 5, offset: 16616},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 573, col: 5, offset: 16718},
+							pos:        position{line: 569, col: 5, offset: 16616},
 							val:        "merge",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 573, col: 13, offset: 16726},
+							pos:  position{line: 569, col: 13, offset: 16624},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 573, col: 15, offset: 16728},
+							pos:   position{line: 569, col: 15, offset: 16626},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 573, col: 20, offset: 16733},
+								pos:  position{line: 569, col: 20, offset: 16631},
 								name: "Expr",
 							},
 						},
@@ -4153,48 +4090,48 @@ var g = &grammar{
 		},
 		{
 			name: "OverOp",
-			pos:  position{line: 577, col: 1, offset: 16814},
+			pos:  position{line: 573, col: 1, offset: 16712},
 			expr: &actionExpr{
-				pos: position{line: 578, col: 5, offset: 16825},
+				pos: position{line: 574, col: 5, offset: 16723},
 				run: (*parser).callonOverOp1,
 				expr: &seqExpr{
-					pos: position{line: 578, col: 5, offset: 16825},
+					pos: position{line: 574, col: 5, offset: 16723},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 578, col: 5, offset: 16825},
+							pos:        position{line: 574, col: 5, offset: 16723},
 							val:        "over",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 578, col: 12, offset: 16832},
+							pos:  position{line: 574, col: 12, offset: 16730},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 578, col: 14, offset: 16834},
+							pos:   position{line: 574, col: 14, offset: 16732},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 578, col: 20, offset: 16840},
+								pos:  position{line: 574, col: 20, offset: 16738},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 578, col: 26, offset: 16846},
+							pos:   position{line: 574, col: 26, offset: 16744},
 							label: "locals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 578, col: 33, offset: 16853},
+								pos: position{line: 574, col: 33, offset: 16751},
 								expr: &ruleRefExpr{
-									pos:  position{line: 578, col: 33, offset: 16853},
+									pos:  position{line: 574, col: 33, offset: 16751},
 									name: "Locals",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 578, col: 41, offset: 16861},
+							pos:   position{line: 574, col: 41, offset: 16759},
 							label: "scope",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 578, col: 47, offset: 16867},
+								pos: position{line: 574, col: 47, offset: 16765},
 								expr: &ruleRefExpr{
-									pos:  position{line: 578, col: 47, offset: 16867},
+									pos:  position{line: 574, col: 47, offset: 16765},
 									name: "Scope",
 								},
 							},
@@ -4205,49 +4142,49 @@ var g = &grammar{
 		},
 		{
 			name: "Scope",
-			pos:  position{line: 586, col: 1, offset: 17117},
+			pos:  position{line: 582, col: 1, offset: 17015},
 			expr: &actionExpr{
-				pos: position{line: 587, col: 5, offset: 17127},
+				pos: position{line: 583, col: 5, offset: 17025},
 				run: (*parser).callonScope1,
 				expr: &seqExpr{
-					pos: position{line: 587, col: 5, offset: 17127},
+					pos: position{line: 583, col: 5, offset: 17025},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 587, col: 5, offset: 17127},
+							pos:  position{line: 583, col: 5, offset: 17025},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 587, col: 8, offset: 17130},
+							pos:        position{line: 583, col: 8, offset: 17028},
 							val:        "=>",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 587, col: 13, offset: 17135},
+							pos:  position{line: 583, col: 13, offset: 17033},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 587, col: 16, offset: 17138},
+							pos:        position{line: 583, col: 16, offset: 17036},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 587, col: 20, offset: 17142},
+							pos:  position{line: 583, col: 20, offset: 17040},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 587, col: 23, offset: 17145},
+							pos:   position{line: 583, col: 23, offset: 17043},
 							label: "seq",
 							expr: &ruleRefExpr{
-								pos:  position{line: 587, col: 27, offset: 17149},
+								pos:  position{line: 583, col: 27, offset: 17047},
 								name: "Sequential",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 587, col: 38, offset: 17160},
+							pos:  position{line: 583, col: 38, offset: 17058},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 587, col: 41, offset: 17163},
+							pos:        position{line: 583, col: 41, offset: 17061},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -4257,63 +4194,63 @@ var g = &grammar{
 		},
 		{
 			name: "Locals",
-			pos:  position{line: 589, col: 1, offset: 17188},
+			pos:  position{line: 585, col: 1, offset: 17086},
 			expr: &actionExpr{
-				pos: position{line: 590, col: 5, offset: 17199},
+				pos: position{line: 586, col: 5, offset: 17097},
 				run: (*parser).callonLocals1,
 				expr: &seqExpr{
-					pos: position{line: 590, col: 5, offset: 17199},
+					pos: position{line: 586, col: 5, offset: 17097},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 590, col: 5, offset: 17199},
+							pos:  position{line: 586, col: 5, offset: 17097},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 590, col: 7, offset: 17201},
+							pos:        position{line: 586, col: 7, offset: 17099},
 							val:        "with",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 590, col: 14, offset: 17208},
+							pos:  position{line: 586, col: 14, offset: 17106},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 590, col: 16, offset: 17210},
+							pos:   position{line: 586, col: 16, offset: 17108},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 590, col: 22, offset: 17216},
+								pos:  position{line: 586, col: 22, offset: 17114},
 								name: "LocalsAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 590, col: 39, offset: 17233},
+							pos:   position{line: 586, col: 39, offset: 17131},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 590, col: 44, offset: 17238},
+								pos: position{line: 586, col: 44, offset: 17136},
 								expr: &actionExpr{
-									pos: position{line: 590, col: 45, offset: 17239},
+									pos: position{line: 586, col: 45, offset: 17137},
 									run: (*parser).callonLocals10,
 									expr: &seqExpr{
-										pos: position{line: 590, col: 45, offset: 17239},
+										pos: position{line: 586, col: 45, offset: 17137},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 590, col: 45, offset: 17239},
+												pos:  position{line: 586, col: 45, offset: 17137},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 590, col: 48, offset: 17242},
+												pos:        position{line: 586, col: 48, offset: 17140},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 590, col: 52, offset: 17246},
+												pos:  position{line: 586, col: 52, offset: 17144},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 590, col: 55, offset: 17249},
+												pos:   position{line: 586, col: 55, offset: 17147},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 590, col: 57, offset: 17251},
+													pos:  position{line: 586, col: 57, offset: 17149},
 													name: "LocalsAssignment",
 												},
 											},
@@ -4328,44 +4265,44 @@ var g = &grammar{
 		},
 		{
 			name: "LocalsAssignment",
-			pos:  position{line: 594, col: 1, offset: 17372},
+			pos:  position{line: 590, col: 1, offset: 17270},
 			expr: &actionExpr{
-				pos: position{line: 595, col: 5, offset: 17393},
+				pos: position{line: 591, col: 5, offset: 17291},
 				run: (*parser).callonLocalsAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 595, col: 5, offset: 17393},
+					pos: position{line: 591, col: 5, offset: 17291},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 595, col: 5, offset: 17393},
+							pos:   position{line: 591, col: 5, offset: 17291},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 595, col: 10, offset: 17398},
+								pos:  position{line: 591, col: 10, offset: 17296},
 								name: "IdentifierName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 595, col: 25, offset: 17413},
+							pos:   position{line: 591, col: 25, offset: 17311},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 595, col: 29, offset: 17417},
+								pos: position{line: 591, col: 29, offset: 17315},
 								expr: &seqExpr{
-									pos: position{line: 595, col: 30, offset: 17418},
+									pos: position{line: 591, col: 30, offset: 17316},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 595, col: 30, offset: 17418},
+											pos:  position{line: 591, col: 30, offset: 17316},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 595, col: 33, offset: 17421},
+											pos:        position{line: 591, col: 33, offset: 17319},
 											val:        "=",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 595, col: 37, offset: 17425},
+											pos:  position{line: 591, col: 37, offset: 17323},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 595, col: 40, offset: 17428},
+											pos:  position{line: 591, col: 40, offset: 17326},
 											name: "Expr",
 										},
 									},
@@ -4378,27 +4315,27 @@ var g = &grammar{
 		},
 		{
 			name: "YieldOp",
-			pos:  position{line: 603, col: 1, offset: 17649},
+			pos:  position{line: 599, col: 1, offset: 17547},
 			expr: &actionExpr{
-				pos: position{line: 604, col: 5, offset: 17661},
+				pos: position{line: 600, col: 5, offset: 17559},
 				run: (*parser).callonYieldOp1,
 				expr: &seqExpr{
-					pos: position{line: 604, col: 5, offset: 17661},
+					pos: position{line: 600, col: 5, offset: 17559},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 604, col: 5, offset: 17661},
+							pos:        position{line: 600, col: 5, offset: 17559},
 							val:        "yield",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 604, col: 13, offset: 17669},
+							pos:  position{line: 600, col: 13, offset: 17567},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 604, col: 15, offset: 17671},
+							pos:   position{line: 600, col: 15, offset: 17569},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 604, col: 21, offset: 17677},
+								pos:  position{line: 600, col: 21, offset: 17575},
 								name: "Exprs",
 							},
 						},
@@ -4408,30 +4345,30 @@ var g = &grammar{
 		},
 		{
 			name: "TypeArg",
-			pos:  position{line: 608, col: 1, offset: 17761},
+			pos:  position{line: 604, col: 1, offset: 17659},
 			expr: &actionExpr{
-				pos: position{line: 609, col: 5, offset: 17773},
+				pos: position{line: 605, col: 5, offset: 17671},
 				run: (*parser).callonTypeArg1,
 				expr: &seqExpr{
-					pos: position{line: 609, col: 5, offset: 17773},
+					pos: position{line: 605, col: 5, offset: 17671},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 609, col: 5, offset: 17773},
+							pos:  position{line: 605, col: 5, offset: 17671},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 609, col: 7, offset: 17775},
+							pos:  position{line: 605, col: 7, offset: 17673},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 609, col: 10, offset: 17778},
+							pos:  position{line: 605, col: 10, offset: 17676},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 609, col: 12, offset: 17780},
+							pos:   position{line: 605, col: 12, offset: 17678},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 609, col: 16, offset: 17784},
+								pos:  position{line: 605, col: 16, offset: 17682},
 								name: "Type",
 							},
 						},
@@ -4441,30 +4378,30 @@ var g = &grammar{
 		},
 		{
 			name: "AsArg",
-			pos:  position{line: 611, col: 1, offset: 17809},
+			pos:  position{line: 607, col: 1, offset: 17707},
 			expr: &actionExpr{
-				pos: position{line: 612, col: 5, offset: 17819},
+				pos: position{line: 608, col: 5, offset: 17717},
 				run: (*parser).callonAsArg1,
 				expr: &seqExpr{
-					pos: position{line: 612, col: 5, offset: 17819},
+					pos: position{line: 608, col: 5, offset: 17717},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 612, col: 5, offset: 17819},
+							pos:  position{line: 608, col: 5, offset: 17717},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 612, col: 7, offset: 17821},
+							pos:  position{line: 608, col: 7, offset: 17719},
 							name: "AS",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 612, col: 10, offset: 17824},
+							pos:  position{line: 608, col: 10, offset: 17722},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 612, col: 12, offset: 17826},
+							pos:   position{line: 608, col: 12, offset: 17724},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 612, col: 16, offset: 17830},
+								pos:  position{line: 608, col: 16, offset: 17728},
 								name: "Lval",
 							},
 						},
@@ -4474,58 +4411,58 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 616, col: 1, offset: 17881},
+			pos:  position{line: 612, col: 1, offset: 17779},
 			expr: &ruleRefExpr{
-				pos:  position{line: 616, col: 8, offset: 17888},
+				pos:  position{line: 612, col: 8, offset: 17786},
 				name: "DerefExpr",
 			},
 		},
 		{
 			name: "Lvals",
-			pos:  position{line: 618, col: 1, offset: 17899},
+			pos:  position{line: 614, col: 1, offset: 17797},
 			expr: &actionExpr{
-				pos: position{line: 619, col: 5, offset: 17909},
+				pos: position{line: 615, col: 5, offset: 17807},
 				run: (*parser).callonLvals1,
 				expr: &seqExpr{
-					pos: position{line: 619, col: 5, offset: 17909},
+					pos: position{line: 615, col: 5, offset: 17807},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 619, col: 5, offset: 17909},
+							pos:   position{line: 615, col: 5, offset: 17807},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 619, col: 11, offset: 17915},
+								pos:  position{line: 615, col: 11, offset: 17813},
 								name: "Lval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 619, col: 16, offset: 17920},
+							pos:   position{line: 615, col: 16, offset: 17818},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 619, col: 21, offset: 17925},
+								pos: position{line: 615, col: 21, offset: 17823},
 								expr: &actionExpr{
-									pos: position{line: 619, col: 22, offset: 17926},
+									pos: position{line: 615, col: 22, offset: 17824},
 									run: (*parser).callonLvals7,
 									expr: &seqExpr{
-										pos: position{line: 619, col: 22, offset: 17926},
+										pos: position{line: 615, col: 22, offset: 17824},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 619, col: 22, offset: 17926},
+												pos:  position{line: 615, col: 22, offset: 17824},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 619, col: 25, offset: 17929},
+												pos:        position{line: 615, col: 25, offset: 17827},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 619, col: 29, offset: 17933},
+												pos:  position{line: 615, col: 29, offset: 17831},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 619, col: 32, offset: 17936},
+												pos:   position{line: 615, col: 32, offset: 17834},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 619, col: 37, offset: 17941},
+													pos:  position{line: 615, col: 37, offset: 17839},
 													name: "Lval",
 												},
 											},
@@ -4540,52 +4477,52 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 623, col: 1, offset: 18053},
+			pos:  position{line: 619, col: 1, offset: 17951},
 			expr: &ruleRefExpr{
-				pos:  position{line: 623, col: 13, offset: 18065},
+				pos:  position{line: 619, col: 13, offset: 17963},
 				name: "Lval",
 			},
 		},
 		{
 			name: "FieldExprs",
-			pos:  position{line: 625, col: 1, offset: 18071},
+			pos:  position{line: 621, col: 1, offset: 17969},
 			expr: &actionExpr{
-				pos: position{line: 626, col: 5, offset: 18086},
+				pos: position{line: 622, col: 5, offset: 17984},
 				run: (*parser).callonFieldExprs1,
 				expr: &seqExpr{
-					pos: position{line: 626, col: 5, offset: 18086},
+					pos: position{line: 622, col: 5, offset: 17984},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 626, col: 5, offset: 18086},
+							pos:   position{line: 622, col: 5, offset: 17984},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 626, col: 11, offset: 18092},
+								pos:  position{line: 622, col: 11, offset: 17990},
 								name: "FieldExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 626, col: 21, offset: 18102},
+							pos:   position{line: 622, col: 21, offset: 18000},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 626, col: 26, offset: 18107},
+								pos: position{line: 622, col: 26, offset: 18005},
 								expr: &seqExpr{
-									pos: position{line: 626, col: 27, offset: 18108},
+									pos: position{line: 622, col: 27, offset: 18006},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 626, col: 27, offset: 18108},
+											pos:  position{line: 622, col: 27, offset: 18006},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 626, col: 30, offset: 18111},
+											pos:        position{line: 622, col: 30, offset: 18009},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 626, col: 34, offset: 18115},
+											pos:  position{line: 622, col: 34, offset: 18013},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 626, col: 37, offset: 18118},
+											pos:  position{line: 622, col: 37, offset: 18016},
 											name: "FieldExpr",
 										},
 									},
@@ -4598,50 +4535,50 @@ var g = &grammar{
 		},
 		{
 			name: "Assignments",
-			pos:  position{line: 636, col: 1, offset: 18317},
+			pos:  position{line: 632, col: 1, offset: 18215},
 			expr: &actionExpr{
-				pos: position{line: 637, col: 5, offset: 18333},
+				pos: position{line: 633, col: 5, offset: 18231},
 				run: (*parser).callonAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 637, col: 5, offset: 18333},
+					pos: position{line: 633, col: 5, offset: 18231},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 637, col: 5, offset: 18333},
+							pos:   position{line: 633, col: 5, offset: 18231},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 637, col: 11, offset: 18339},
+								pos:  position{line: 633, col: 11, offset: 18237},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 637, col: 22, offset: 18350},
+							pos:   position{line: 633, col: 22, offset: 18248},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 637, col: 27, offset: 18355},
+								pos: position{line: 633, col: 27, offset: 18253},
 								expr: &actionExpr{
-									pos: position{line: 637, col: 28, offset: 18356},
+									pos: position{line: 633, col: 28, offset: 18254},
 									run: (*parser).callonAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 637, col: 28, offset: 18356},
+										pos: position{line: 633, col: 28, offset: 18254},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 637, col: 28, offset: 18356},
+												pos:  position{line: 633, col: 28, offset: 18254},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 637, col: 31, offset: 18359},
+												pos:        position{line: 633, col: 31, offset: 18257},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 637, col: 35, offset: 18363},
+												pos:  position{line: 633, col: 35, offset: 18261},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 637, col: 38, offset: 18366},
+												pos:   position{line: 633, col: 38, offset: 18264},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 637, col: 40, offset: 18368},
+													pos:  position{line: 633, col: 40, offset: 18266},
 													name: "Assignment",
 												},
 											},
@@ -4656,39 +4593,39 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 641, col: 1, offset: 18479},
+			pos:  position{line: 637, col: 1, offset: 18377},
 			expr: &actionExpr{
-				pos: position{line: 642, col: 5, offset: 18494},
+				pos: position{line: 638, col: 5, offset: 18392},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 642, col: 5, offset: 18494},
+					pos: position{line: 638, col: 5, offset: 18392},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 642, col: 5, offset: 18494},
+							pos:   position{line: 638, col: 5, offset: 18392},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 642, col: 9, offset: 18498},
+								pos:  position{line: 638, col: 9, offset: 18396},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 642, col: 14, offset: 18503},
+							pos:  position{line: 638, col: 14, offset: 18401},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 642, col: 17, offset: 18506},
+							pos:        position{line: 638, col: 17, offset: 18404},
 							val:        ":=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 642, col: 22, offset: 18511},
+							pos:  position{line: 638, col: 22, offset: 18409},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 642, col: 25, offset: 18514},
+							pos:   position{line: 638, col: 25, offset: 18412},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 642, col: 29, offset: 18518},
+								pos:  position{line: 638, col: 29, offset: 18416},
 								name: "Expr",
 							},
 						},
@@ -4698,69 +4635,69 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 644, col: 1, offset: 18609},
+			pos:  position{line: 640, col: 1, offset: 18507},
 			expr: &ruleRefExpr{
-				pos:  position{line: 644, col: 8, offset: 18616},
+				pos:  position{line: 640, col: 8, offset: 18514},
 				name: "ConditionalExpr",
 			},
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 646, col: 1, offset: 18633},
+			pos:  position{line: 642, col: 1, offset: 18531},
 			expr: &actionExpr{
-				pos: position{line: 647, col: 5, offset: 18653},
+				pos: position{line: 643, col: 5, offset: 18551},
 				run: (*parser).callonConditionalExpr1,
 				expr: &seqExpr{
-					pos: position{line: 647, col: 5, offset: 18653},
+					pos: position{line: 643, col: 5, offset: 18551},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 647, col: 5, offset: 18653},
+							pos:   position{line: 643, col: 5, offset: 18551},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 647, col: 10, offset: 18658},
+								pos:  position{line: 643, col: 10, offset: 18556},
 								name: "LogicalOrExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 647, col: 24, offset: 18672},
+							pos:   position{line: 643, col: 24, offset: 18570},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 647, col: 28, offset: 18676},
+								pos: position{line: 643, col: 28, offset: 18574},
 								expr: &seqExpr{
-									pos: position{line: 647, col: 29, offset: 18677},
+									pos: position{line: 643, col: 29, offset: 18575},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 647, col: 29, offset: 18677},
+											pos:  position{line: 643, col: 29, offset: 18575},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 647, col: 32, offset: 18680},
+											pos:        position{line: 643, col: 32, offset: 18578},
 											val:        "?",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 647, col: 36, offset: 18684},
+											pos:  position{line: 643, col: 36, offset: 18582},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 647, col: 39, offset: 18687},
+											pos:  position{line: 643, col: 39, offset: 18585},
 											name: "Expr",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 647, col: 44, offset: 18692},
+											pos:  position{line: 643, col: 44, offset: 18590},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 647, col: 47, offset: 18695},
+											pos:        position{line: 643, col: 47, offset: 18593},
 											val:        ":",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 647, col: 51, offset: 18699},
+											pos:  position{line: 643, col: 51, offset: 18597},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 647, col: 54, offset: 18702},
+											pos:  position{line: 643, col: 54, offset: 18600},
 											name: "Expr",
 										},
 									},
@@ -4773,53 +4710,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 656, col: 1, offset: 18963},
+			pos:  position{line: 652, col: 1, offset: 18861},
 			expr: &actionExpr{
-				pos: position{line: 657, col: 5, offset: 18981},
+				pos: position{line: 653, col: 5, offset: 18879},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 657, col: 5, offset: 18981},
+					pos: position{line: 653, col: 5, offset: 18879},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 657, col: 5, offset: 18981},
+							pos:   position{line: 653, col: 5, offset: 18879},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 657, col: 11, offset: 18987},
+								pos:  position{line: 653, col: 11, offset: 18885},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 658, col: 5, offset: 19006},
+							pos:   position{line: 654, col: 5, offset: 18904},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 658, col: 10, offset: 19011},
+								pos: position{line: 654, col: 10, offset: 18909},
 								expr: &actionExpr{
-									pos: position{line: 658, col: 11, offset: 19012},
+									pos: position{line: 654, col: 11, offset: 18910},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 658, col: 11, offset: 19012},
+										pos: position{line: 654, col: 11, offset: 18910},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 658, col: 11, offset: 19012},
+												pos:  position{line: 654, col: 11, offset: 18910},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 658, col: 14, offset: 19015},
+												pos:   position{line: 654, col: 14, offset: 18913},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 658, col: 17, offset: 19018},
+													pos:  position{line: 654, col: 17, offset: 18916},
 													name: "OrToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 658, col: 25, offset: 19026},
+												pos:  position{line: 654, col: 25, offset: 18924},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 658, col: 28, offset: 19029},
+												pos:   position{line: 654, col: 28, offset: 18927},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 658, col: 33, offset: 19034},
+													pos:  position{line: 654, col: 33, offset: 18932},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -4834,53 +4771,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 662, col: 1, offset: 19152},
+			pos:  position{line: 658, col: 1, offset: 19050},
 			expr: &actionExpr{
-				pos: position{line: 663, col: 5, offset: 19171},
+				pos: position{line: 659, col: 5, offset: 19069},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 663, col: 5, offset: 19171},
+					pos: position{line: 659, col: 5, offset: 19069},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 663, col: 5, offset: 19171},
+							pos:   position{line: 659, col: 5, offset: 19069},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 663, col: 11, offset: 19177},
+								pos:  position{line: 659, col: 11, offset: 19075},
 								name: "ComparisonExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 664, col: 5, offset: 19196},
+							pos:   position{line: 660, col: 5, offset: 19094},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 664, col: 10, offset: 19201},
+								pos: position{line: 660, col: 10, offset: 19099},
 								expr: &actionExpr{
-									pos: position{line: 664, col: 11, offset: 19202},
+									pos: position{line: 660, col: 11, offset: 19100},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 664, col: 11, offset: 19202},
+										pos: position{line: 660, col: 11, offset: 19100},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 664, col: 11, offset: 19202},
+												pos:  position{line: 660, col: 11, offset: 19100},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 664, col: 14, offset: 19205},
+												pos:   position{line: 660, col: 14, offset: 19103},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 664, col: 17, offset: 19208},
+													pos:  position{line: 660, col: 17, offset: 19106},
 													name: "AndToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 664, col: 26, offset: 19217},
+												pos:  position{line: 660, col: 26, offset: 19115},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 664, col: 29, offset: 19220},
+												pos:   position{line: 660, col: 29, offset: 19118},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 664, col: 34, offset: 19225},
+													pos:  position{line: 660, col: 34, offset: 19123},
 													name: "ComparisonExpr",
 												},
 											},
@@ -4895,72 +4832,72 @@ var g = &grammar{
 		},
 		{
 			name: "ComparisonExpr",
-			pos:  position{line: 668, col: 1, offset: 19343},
+			pos:  position{line: 664, col: 1, offset: 19241},
 			expr: &actionExpr{
-				pos: position{line: 669, col: 5, offset: 19362},
+				pos: position{line: 665, col: 5, offset: 19260},
 				run: (*parser).callonComparisonExpr1,
 				expr: &seqExpr{
-					pos: position{line: 669, col: 5, offset: 19362},
+					pos: position{line: 665, col: 5, offset: 19260},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 669, col: 5, offset: 19362},
+							pos:   position{line: 665, col: 5, offset: 19260},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 669, col: 9, offset: 19366},
+								pos:  position{line: 665, col: 9, offset: 19264},
 								name: "AdditiveExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 669, col: 22, offset: 19379},
+							pos:   position{line: 665, col: 22, offset: 19277},
 							label: "opAndRHS",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 669, col: 31, offset: 19388},
+								pos: position{line: 665, col: 31, offset: 19286},
 								expr: &choiceExpr{
-									pos: position{line: 669, col: 32, offset: 19389},
+									pos: position{line: 665, col: 32, offset: 19287},
 									alternatives: []interface{}{
 										&seqExpr{
-											pos: position{line: 669, col: 32, offset: 19389},
+											pos: position{line: 665, col: 32, offset: 19287},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 669, col: 32, offset: 19389},
+													pos:  position{line: 665, col: 32, offset: 19287},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 669, col: 35, offset: 19392},
+													pos:  position{line: 665, col: 35, offset: 19290},
 													name: "Comparator",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 669, col: 46, offset: 19403},
+													pos:  position{line: 665, col: 46, offset: 19301},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 669, col: 49, offset: 19406},
+													pos:  position{line: 665, col: 49, offset: 19304},
 													name: "AdditiveExpr",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 669, col: 64, offset: 19421},
+											pos: position{line: 665, col: 64, offset: 19319},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 669, col: 64, offset: 19421},
+													pos:  position{line: 665, col: 64, offset: 19319},
 													name: "__",
 												},
 												&actionExpr{
-													pos: position{line: 669, col: 68, offset: 19425},
+													pos: position{line: 665, col: 68, offset: 19323},
 													run: (*parser).callonComparisonExpr15,
 													expr: &litMatcher{
-														pos:        position{line: 669, col: 68, offset: 19425},
+														pos:        position{line: 665, col: 68, offset: 19323},
 														val:        "~",
 														ignoreCase: false,
 													},
 												},
 												&ruleRefExpr{
-													pos:  position{line: 669, col: 104, offset: 19461},
+													pos:  position{line: 665, col: 104, offset: 19359},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 669, col: 107, offset: 19464},
+													pos:  position{line: 665, col: 107, offset: 19362},
 													name: "Regexp",
 												},
 											},
@@ -4975,53 +4912,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 678, col: 1, offset: 19725},
+			pos:  position{line: 674, col: 1, offset: 19623},
 			expr: &actionExpr{
-				pos: position{line: 679, col: 5, offset: 19742},
+				pos: position{line: 675, col: 5, offset: 19640},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 679, col: 5, offset: 19742},
+					pos: position{line: 675, col: 5, offset: 19640},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 679, col: 5, offset: 19742},
+							pos:   position{line: 675, col: 5, offset: 19640},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 679, col: 11, offset: 19748},
+								pos:  position{line: 675, col: 11, offset: 19646},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 680, col: 5, offset: 19771},
+							pos:   position{line: 676, col: 5, offset: 19669},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 680, col: 10, offset: 19776},
+								pos: position{line: 676, col: 10, offset: 19674},
 								expr: &actionExpr{
-									pos: position{line: 680, col: 11, offset: 19777},
+									pos: position{line: 676, col: 11, offset: 19675},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 680, col: 11, offset: 19777},
+										pos: position{line: 676, col: 11, offset: 19675},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 680, col: 11, offset: 19777},
+												pos:  position{line: 676, col: 11, offset: 19675},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 680, col: 14, offset: 19780},
+												pos:   position{line: 676, col: 14, offset: 19678},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 680, col: 17, offset: 19783},
+													pos:  position{line: 676, col: 17, offset: 19681},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 680, col: 34, offset: 19800},
+												pos:  position{line: 676, col: 34, offset: 19698},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 680, col: 37, offset: 19803},
+												pos:   position{line: 676, col: 37, offset: 19701},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 680, col: 42, offset: 19808},
+													pos:  position{line: 676, col: 42, offset: 19706},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -5036,20 +4973,20 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 684, col: 1, offset: 19930},
+			pos:  position{line: 680, col: 1, offset: 19828},
 			expr: &actionExpr{
-				pos: position{line: 684, col: 20, offset: 19949},
+				pos: position{line: 680, col: 20, offset: 19847},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 684, col: 21, offset: 19950},
+					pos: position{line: 680, col: 21, offset: 19848},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 684, col: 21, offset: 19950},
+							pos:        position{line: 680, col: 21, offset: 19848},
 							val:        "+",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 684, col: 27, offset: 19956},
+							pos:        position{line: 680, col: 27, offset: 19854},
 							val:        "-",
 							ignoreCase: false,
 						},
@@ -5059,53 +4996,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 686, col: 1, offset: 19993},
+			pos:  position{line: 682, col: 1, offset: 19891},
 			expr: &actionExpr{
-				pos: position{line: 687, col: 5, offset: 20016},
+				pos: position{line: 683, col: 5, offset: 19914},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 687, col: 5, offset: 20016},
+					pos: position{line: 683, col: 5, offset: 19914},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 687, col: 5, offset: 20016},
+							pos:   position{line: 683, col: 5, offset: 19914},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 687, col: 11, offset: 20022},
+								pos:  position{line: 683, col: 11, offset: 19920},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 688, col: 5, offset: 20034},
+							pos:   position{line: 684, col: 5, offset: 19932},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 688, col: 10, offset: 20039},
+								pos: position{line: 684, col: 10, offset: 19937},
 								expr: &actionExpr{
-									pos: position{line: 688, col: 11, offset: 20040},
+									pos: position{line: 684, col: 11, offset: 19938},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 688, col: 11, offset: 20040},
+										pos: position{line: 684, col: 11, offset: 19938},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 688, col: 11, offset: 20040},
+												pos:  position{line: 684, col: 11, offset: 19938},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 688, col: 14, offset: 20043},
+												pos:   position{line: 684, col: 14, offset: 19941},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 688, col: 17, offset: 20046},
+													pos:  position{line: 684, col: 17, offset: 19944},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 688, col: 40, offset: 20069},
+												pos:  position{line: 684, col: 40, offset: 19967},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 688, col: 43, offset: 20072},
+												pos:   position{line: 684, col: 43, offset: 19970},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 688, col: 48, offset: 20077},
+													pos:  position{line: 684, col: 48, offset: 19975},
 													name: "NotExpr",
 												},
 											},
@@ -5120,25 +5057,25 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 692, col: 1, offset: 20188},
+			pos:  position{line: 688, col: 1, offset: 20086},
 			expr: &actionExpr{
-				pos: position{line: 692, col: 26, offset: 20213},
+				pos: position{line: 688, col: 26, offset: 20111},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 692, col: 27, offset: 20214},
+					pos: position{line: 688, col: 27, offset: 20112},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 692, col: 27, offset: 20214},
+							pos:        position{line: 688, col: 27, offset: 20112},
 							val:        "*",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 692, col: 33, offset: 20220},
+							pos:        position{line: 688, col: 33, offset: 20118},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 692, col: 39, offset: 20226},
+							pos:        position{line: 688, col: 39, offset: 20124},
 							val:        "%",
 							ignoreCase: false,
 						},
@@ -5148,30 +5085,30 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 694, col: 1, offset: 20263},
+			pos:  position{line: 690, col: 1, offset: 20161},
 			expr: &choiceExpr{
-				pos: position{line: 695, col: 5, offset: 20275},
+				pos: position{line: 691, col: 5, offset: 20173},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 695, col: 5, offset: 20275},
+						pos: position{line: 691, col: 5, offset: 20173},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 695, col: 5, offset: 20275},
+							pos: position{line: 691, col: 5, offset: 20173},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 695, col: 5, offset: 20275},
+									pos:        position{line: 691, col: 5, offset: 20173},
 									val:        "!",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 695, col: 9, offset: 20279},
+									pos:  position{line: 691, col: 9, offset: 20177},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 695, col: 12, offset: 20282},
+									pos:   position{line: 691, col: 12, offset: 20180},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 695, col: 14, offset: 20284},
+										pos:  position{line: 691, col: 14, offset: 20182},
 										name: "NotExpr",
 									},
 								},
@@ -5179,7 +5116,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 698, col: 5, offset: 20393},
+						pos:  position{line: 694, col: 5, offset: 20291},
 						name: "NegationExpr",
 					},
 				},
@@ -5187,37 +5124,37 @@ var g = &grammar{
 		},
 		{
 			name: "NegationExpr",
-			pos:  position{line: 700, col: 1, offset: 20407},
+			pos:  position{line: 696, col: 1, offset: 20305},
 			expr: &choiceExpr{
-				pos: position{line: 701, col: 5, offset: 20424},
+				pos: position{line: 697, col: 5, offset: 20322},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 701, col: 5, offset: 20424},
+						pos: position{line: 697, col: 5, offset: 20322},
 						run: (*parser).callonNegationExpr2,
 						expr: &seqExpr{
-							pos: position{line: 701, col: 5, offset: 20424},
+							pos: position{line: 697, col: 5, offset: 20322},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 701, col: 5, offset: 20424},
+									pos: position{line: 697, col: 5, offset: 20322},
 									expr: &ruleRefExpr{
-										pos:  position{line: 701, col: 6, offset: 20425},
+										pos:  position{line: 697, col: 6, offset: 20323},
 										name: "Literal",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 701, col: 14, offset: 20433},
+									pos:        position{line: 697, col: 14, offset: 20331},
 									val:        "-",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 701, col: 18, offset: 20437},
+									pos:  position{line: 697, col: 18, offset: 20335},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 701, col: 21, offset: 20440},
+									pos:   position{line: 697, col: 21, offset: 20338},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 701, col: 23, offset: 20442},
+										pos:  position{line: 697, col: 23, offset: 20340},
 										name: "FuncExpr",
 									},
 								},
@@ -5225,7 +5162,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 704, col: 5, offset: 20552},
+						pos:  position{line: 700, col: 5, offset: 20450},
 						name: "FuncExpr",
 					},
 				},
@@ -5233,31 +5170,31 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 706, col: 1, offset: 20562},
+			pos:  position{line: 702, col: 1, offset: 20460},
 			expr: &choiceExpr{
-				pos: position{line: 707, col: 5, offset: 20575},
+				pos: position{line: 703, col: 5, offset: 20473},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 707, col: 5, offset: 20575},
+						pos: position{line: 703, col: 5, offset: 20473},
 						run: (*parser).callonFuncExpr2,
 						expr: &seqExpr{
-							pos: position{line: 707, col: 5, offset: 20575},
+							pos: position{line: 703, col: 5, offset: 20473},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 707, col: 5, offset: 20575},
+									pos:   position{line: 703, col: 5, offset: 20473},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 707, col: 11, offset: 20581},
+										pos:  position{line: 703, col: 11, offset: 20479},
 										name: "Cast",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 707, col: 16, offset: 20586},
+									pos:   position{line: 703, col: 16, offset: 20484},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 707, col: 21, offset: 20591},
+										pos: position{line: 703, col: 21, offset: 20489},
 										expr: &ruleRefExpr{
-											pos:  position{line: 707, col: 22, offset: 20592},
+											pos:  position{line: 703, col: 22, offset: 20490},
 											name: "Deref",
 										},
 									},
@@ -5266,26 +5203,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 710, col: 5, offset: 20663},
+						pos: position{line: 706, col: 5, offset: 20561},
 						run: (*parser).callonFuncExpr9,
 						expr: &seqExpr{
-							pos: position{line: 710, col: 5, offset: 20663},
+							pos: position{line: 706, col: 5, offset: 20561},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 710, col: 5, offset: 20663},
+									pos:   position{line: 706, col: 5, offset: 20561},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 710, col: 11, offset: 20669},
+										pos:  position{line: 706, col: 11, offset: 20567},
 										name: "Function",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 710, col: 20, offset: 20678},
+									pos:   position{line: 706, col: 20, offset: 20576},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 710, col: 25, offset: 20683},
+										pos: position{line: 706, col: 25, offset: 20581},
 										expr: &ruleRefExpr{
-											pos:  position{line: 710, col: 26, offset: 20684},
+											pos:  position{line: 706, col: 26, offset: 20582},
 											name: "Deref",
 										},
 									},
@@ -5294,11 +5231,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 713, col: 5, offset: 20755},
+						pos:  position{line: 709, col: 5, offset: 20653},
 						name: "DerefExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 714, col: 5, offset: 20769},
+						pos:  position{line: 710, col: 5, offset: 20667},
 						name: "Primary",
 					},
 				},
@@ -5306,20 +5243,20 @@ var g = &grammar{
 		},
 		{
 			name: "FuncGuard",
-			pos:  position{line: 716, col: 1, offset: 20778},
+			pos:  position{line: 712, col: 1, offset: 20676},
 			expr: &seqExpr{
-				pos: position{line: 716, col: 13, offset: 20790},
+				pos: position{line: 712, col: 13, offset: 20688},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 716, col: 13, offset: 20790},
+						pos:  position{line: 712, col: 13, offset: 20688},
 						name: "NotFuncs",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 716, col: 22, offset: 20799},
+						pos:  position{line: 712, col: 22, offset: 20697},
 						name: "__",
 					},
 					&litMatcher{
-						pos:        position{line: 716, col: 25, offset: 20802},
+						pos:        position{line: 712, col: 25, offset: 20700},
 						val:        "(",
 						ignoreCase: false,
 					},
@@ -5328,17 +5265,17 @@ var g = &grammar{
 		},
 		{
 			name: "NotFuncs",
-			pos:  position{line: 718, col: 1, offset: 20807},
+			pos:  position{line: 714, col: 1, offset: 20705},
 			expr: &choiceExpr{
-				pos: position{line: 719, col: 5, offset: 20820},
+				pos: position{line: 715, col: 5, offset: 20718},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 719, col: 5, offset: 20820},
+						pos:        position{line: 715, col: 5, offset: 20718},
 						val:        "not",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 720, col: 5, offset: 20830},
+						pos:        position{line: 716, col: 5, offset: 20728},
 						val:        "select",
 						ignoreCase: false,
 					},
@@ -5347,57 +5284,57 @@ var g = &grammar{
 		},
 		{
 			name: "Cast",
-			pos:  position{line: 722, col: 1, offset: 20840},
+			pos:  position{line: 718, col: 1, offset: 20738},
 			expr: &actionExpr{
-				pos: position{line: 723, col: 5, offset: 20849},
+				pos: position{line: 719, col: 5, offset: 20747},
 				run: (*parser).callonCast1,
 				expr: &seqExpr{
-					pos: position{line: 723, col: 5, offset: 20849},
+					pos: position{line: 719, col: 5, offset: 20747},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 723, col: 5, offset: 20849},
+							pos:   position{line: 719, col: 5, offset: 20747},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 723, col: 9, offset: 20853},
+								pos:  position{line: 719, col: 9, offset: 20751},
 								name: "CastType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 723, col: 18, offset: 20862},
+							pos:  position{line: 719, col: 18, offset: 20760},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 723, col: 21, offset: 20865},
+							pos:        position{line: 719, col: 21, offset: 20763},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 723, col: 25, offset: 20869},
+							pos:  position{line: 719, col: 25, offset: 20767},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 723, col: 28, offset: 20872},
+							pos:   position{line: 719, col: 28, offset: 20770},
 							label: "expr",
 							expr: &choiceExpr{
-								pos: position{line: 723, col: 34, offset: 20878},
+								pos: position{line: 719, col: 34, offset: 20776},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 723, col: 34, offset: 20878},
+										pos:  position{line: 719, col: 34, offset: 20776},
 										name: "OverExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 723, col: 45, offset: 20889},
+										pos:  position{line: 719, col: 45, offset: 20787},
 										name: "Expr",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 723, col: 51, offset: 20895},
+							pos:  position{line: 719, col: 51, offset: 20793},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 723, col: 54, offset: 20898},
+							pos:        position{line: 719, col: 54, offset: 20796},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -5407,83 +5344,83 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 727, col: 1, offset: 20995},
+			pos:  position{line: 723, col: 1, offset: 20893},
 			expr: &choiceExpr{
-				pos: position{line: 728, col: 5, offset: 21008},
+				pos: position{line: 724, col: 5, offset: 20906},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 728, col: 5, offset: 21008},
+						pos:  position{line: 724, col: 5, offset: 20906},
 						name: "Grep",
 					},
 					&actionExpr{
-						pos: position{line: 730, col: 5, offset: 21063},
+						pos: position{line: 726, col: 5, offset: 20961},
 						run: (*parser).callonFunction3,
 						expr: &seqExpr{
-							pos: position{line: 730, col: 5, offset: 21063},
+							pos: position{line: 726, col: 5, offset: 20961},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 730, col: 5, offset: 21063},
+									pos:        position{line: 726, col: 5, offset: 20961},
 									val:        "regexp",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 730, col: 14, offset: 21072},
+									pos:  position{line: 726, col: 14, offset: 20970},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 730, col: 17, offset: 21075},
+									pos:        position{line: 726, col: 17, offset: 20973},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 730, col: 21, offset: 21079},
+									pos:  position{line: 726, col: 21, offset: 20977},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 730, col: 24, offset: 21082},
+									pos:   position{line: 726, col: 24, offset: 20980},
 									label: "arg0Text",
 									expr: &ruleRefExpr{
-										pos:  position{line: 730, col: 33, offset: 21091},
+										pos:  position{line: 726, col: 33, offset: 20989},
 										name: "RegexpPattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 730, col: 47, offset: 21105},
+									pos:  position{line: 726, col: 47, offset: 21003},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 730, col: 50, offset: 21108},
+									pos:        position{line: 726, col: 50, offset: 21006},
 									val:        ",",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 730, col: 54, offset: 21112},
+									pos:  position{line: 726, col: 54, offset: 21010},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 730, col: 57, offset: 21115},
+									pos:   position{line: 726, col: 57, offset: 21013},
 									label: "arg1",
 									expr: &ruleRefExpr{
-										pos:  position{line: 730, col: 62, offset: 21120},
+										pos:  position{line: 726, col: 62, offset: 21018},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 730, col: 67, offset: 21125},
+									pos:  position{line: 726, col: 67, offset: 21023},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 730, col: 70, offset: 21128},
+									pos:        position{line: 726, col: 70, offset: 21026},
 									val:        ")",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 730, col: 74, offset: 21132},
+									pos:   position{line: 726, col: 74, offset: 21030},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 730, col: 80, offset: 21138},
+										pos: position{line: 726, col: 80, offset: 21036},
 										expr: &ruleRefExpr{
-											pos:  position{line: 730, col: 80, offset: 21138},
+											pos:  position{line: 726, col: 80, offset: 21036},
 											name: "WhereClause",
 										},
 									},
@@ -5492,63 +5429,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 734, col: 5, offset: 21386},
+						pos: position{line: 730, col: 5, offset: 21284},
 						run: (*parser).callonFunction21,
 						expr: &seqExpr{
-							pos: position{line: 734, col: 5, offset: 21386},
+							pos: position{line: 730, col: 5, offset: 21284},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 734, col: 5, offset: 21386},
+									pos: position{line: 730, col: 5, offset: 21284},
 									expr: &ruleRefExpr{
-										pos:  position{line: 734, col: 6, offset: 21387},
+										pos:  position{line: 730, col: 6, offset: 21285},
 										name: "FuncGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 734, col: 16, offset: 21397},
+									pos:   position{line: 730, col: 16, offset: 21295},
 									label: "fn",
 									expr: &ruleRefExpr{
-										pos:  position{line: 734, col: 19, offset: 21400},
+										pos:  position{line: 730, col: 19, offset: 21298},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 734, col: 34, offset: 21415},
+									pos:  position{line: 730, col: 34, offset: 21313},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 734, col: 37, offset: 21418},
+									pos:        position{line: 730, col: 37, offset: 21316},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 734, col: 41, offset: 21422},
+									pos:  position{line: 730, col: 41, offset: 21320},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 734, col: 44, offset: 21425},
+									pos:   position{line: 730, col: 44, offset: 21323},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 734, col: 49, offset: 21430},
+										pos:  position{line: 730, col: 49, offset: 21328},
 										name: "FunctionArgs",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 734, col: 62, offset: 21443},
+									pos:  position{line: 730, col: 62, offset: 21341},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 734, col: 65, offset: 21446},
+									pos:        position{line: 730, col: 65, offset: 21344},
 									val:        ")",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 734, col: 69, offset: 21450},
+									pos:   position{line: 730, col: 69, offset: 21348},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 734, col: 75, offset: 21456},
+										pos: position{line: 730, col: 75, offset: 21354},
 										expr: &ruleRefExpr{
-											pos:  position{line: 734, col: 75, offset: 21456},
+											pos:  position{line: 730, col: 75, offset: 21354},
 											name: "WhereClause",
 										},
 									},
@@ -5561,24 +5498,24 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionArgs",
-			pos:  position{line: 738, col: 1, offset: 21577},
+			pos:  position{line: 734, col: 1, offset: 21475},
 			expr: &choiceExpr{
-				pos: position{line: 739, col: 5, offset: 21594},
+				pos: position{line: 735, col: 5, offset: 21492},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 739, col: 5, offset: 21594},
+						pos: position{line: 735, col: 5, offset: 21492},
 						run: (*parser).callonFunctionArgs2,
 						expr: &labeledExpr{
-							pos:   position{line: 739, col: 5, offset: 21594},
+							pos:   position{line: 735, col: 5, offset: 21492},
 							label: "o",
 							expr: &ruleRefExpr{
-								pos:  position{line: 739, col: 7, offset: 21596},
+								pos:  position{line: 735, col: 7, offset: 21494},
 								name: "OverExpr",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 740, col: 5, offset: 21642},
+						pos:  position{line: 736, col: 5, offset: 21540},
 						name: "OptionalExprs",
 					},
 				},
@@ -5586,75 +5523,75 @@ var g = &grammar{
 		},
 		{
 			name: "Grep",
-			pos:  position{line: 742, col: 1, offset: 21657},
+			pos:  position{line: 738, col: 1, offset: 21555},
 			expr: &actionExpr{
-				pos: position{line: 743, col: 5, offset: 21666},
+				pos: position{line: 739, col: 5, offset: 21564},
 				run: (*parser).callonGrep1,
 				expr: &seqExpr{
-					pos: position{line: 743, col: 5, offset: 21666},
+					pos: position{line: 739, col: 5, offset: 21564},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 743, col: 5, offset: 21666},
+							pos:        position{line: 739, col: 5, offset: 21564},
 							val:        "grep",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 743, col: 12, offset: 21673},
+							pos:  position{line: 739, col: 12, offset: 21571},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 743, col: 15, offset: 21676},
+							pos:        position{line: 739, col: 15, offset: 21574},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 743, col: 19, offset: 21680},
+							pos:  position{line: 739, col: 19, offset: 21578},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 743, col: 22, offset: 21683},
+							pos:   position{line: 739, col: 22, offset: 21581},
 							label: "pattern",
 							expr: &ruleRefExpr{
-								pos:  position{line: 743, col: 30, offset: 21691},
+								pos:  position{line: 739, col: 30, offset: 21589},
 								name: "Pattern",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 743, col: 38, offset: 21699},
+							pos:  position{line: 739, col: 38, offset: 21597},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 743, col: 42, offset: 21703},
+							pos:   position{line: 739, col: 42, offset: 21601},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 743, col: 46, offset: 21707},
+								pos: position{line: 739, col: 46, offset: 21605},
 								expr: &seqExpr{
-									pos: position{line: 743, col: 47, offset: 21708},
+									pos: position{line: 739, col: 47, offset: 21606},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 743, col: 47, offset: 21708},
+											pos:        position{line: 739, col: 47, offset: 21606},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 743, col: 51, offset: 21712},
+											pos:  position{line: 739, col: 51, offset: 21610},
 											name: "__",
 										},
 										&choiceExpr{
-											pos: position{line: 743, col: 56, offset: 21717},
+											pos: position{line: 739, col: 56, offset: 21615},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 743, col: 56, offset: 21717},
+													pos:  position{line: 739, col: 56, offset: 21615},
 													name: "OverExpr",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 743, col: 67, offset: 21728},
+													pos:  position{line: 739, col: 67, offset: 21626},
 													name: "Expr",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 743, col: 73, offset: 21734},
+											pos:  position{line: 739, col: 73, offset: 21632},
 											name: "__",
 										},
 									},
@@ -5662,7 +5599,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 743, col: 78, offset: 21739},
+							pos:        position{line: 739, col: 78, offset: 21637},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -5672,26 +5609,26 @@ var g = &grammar{
 		},
 		{
 			name: "Pattern",
-			pos:  position{line: 751, col: 1, offset: 21980},
+			pos:  position{line: 747, col: 1, offset: 21878},
 			expr: &choiceExpr{
-				pos: position{line: 752, col: 5, offset: 21992},
+				pos: position{line: 748, col: 5, offset: 21890},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 752, col: 5, offset: 21992},
+						pos:  position{line: 748, col: 5, offset: 21890},
 						name: "Regexp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 753, col: 5, offset: 22003},
+						pos:  position{line: 749, col: 5, offset: 21901},
 						name: "Glob",
 					},
 					&actionExpr{
-						pos: position{line: 754, col: 5, offset: 22012},
+						pos: position{line: 750, col: 5, offset: 21910},
 						run: (*parser).callonPattern4,
 						expr: &labeledExpr{
-							pos:   position{line: 754, col: 5, offset: 22012},
+							pos:   position{line: 750, col: 5, offset: 21910},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 754, col: 7, offset: 22014},
+								pos:  position{line: 750, col: 7, offset: 21912},
 								name: "QuotedString",
 							},
 						},
@@ -5701,19 +5638,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptionalExprs",
-			pos:  position{line: 758, col: 1, offset: 22106},
+			pos:  position{line: 754, col: 1, offset: 22004},
 			expr: &choiceExpr{
-				pos: position{line: 759, col: 5, offset: 22124},
+				pos: position{line: 755, col: 5, offset: 22022},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 759, col: 5, offset: 22124},
+						pos:  position{line: 755, col: 5, offset: 22022},
 						name: "Exprs",
 					},
 					&actionExpr{
-						pos: position{line: 760, col: 5, offset: 22134},
+						pos: position{line: 756, col: 5, offset: 22032},
 						run: (*parser).callonOptionalExprs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 760, col: 5, offset: 22134},
+							pos:  position{line: 756, col: 5, offset: 22032},
 							name: "__",
 						},
 					},
@@ -5722,50 +5659,50 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 762, col: 1, offset: 22170},
+			pos:  position{line: 758, col: 1, offset: 22068},
 			expr: &actionExpr{
-				pos: position{line: 763, col: 5, offset: 22180},
+				pos: position{line: 759, col: 5, offset: 22078},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 763, col: 5, offset: 22180},
+					pos: position{line: 759, col: 5, offset: 22078},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 763, col: 5, offset: 22180},
+							pos:   position{line: 759, col: 5, offset: 22078},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 763, col: 11, offset: 22186},
+								pos:  position{line: 759, col: 11, offset: 22084},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 763, col: 16, offset: 22191},
+							pos:   position{line: 759, col: 16, offset: 22089},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 763, col: 21, offset: 22196},
+								pos: position{line: 759, col: 21, offset: 22094},
 								expr: &actionExpr{
-									pos: position{line: 763, col: 22, offset: 22197},
+									pos: position{line: 759, col: 22, offset: 22095},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 763, col: 22, offset: 22197},
+										pos: position{line: 759, col: 22, offset: 22095},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 763, col: 22, offset: 22197},
+												pos:  position{line: 759, col: 22, offset: 22095},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 763, col: 25, offset: 22200},
+												pos:        position{line: 759, col: 25, offset: 22098},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 763, col: 29, offset: 22204},
+												pos:  position{line: 759, col: 29, offset: 22102},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 763, col: 32, offset: 22207},
+												pos:   position{line: 759, col: 32, offset: 22105},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 763, col: 34, offset: 22209},
+													pos:  position{line: 759, col: 34, offset: 22107},
 													name: "Expr",
 												},
 											},
@@ -5780,35 +5717,35 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 767, col: 1, offset: 22318},
+			pos:  position{line: 763, col: 1, offset: 22216},
 			expr: &actionExpr{
-				pos: position{line: 768, col: 5, offset: 22332},
+				pos: position{line: 764, col: 5, offset: 22230},
 				run: (*parser).callonDerefExpr1,
 				expr: &seqExpr{
-					pos: position{line: 768, col: 5, offset: 22332},
+					pos: position{line: 764, col: 5, offset: 22230},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 768, col: 5, offset: 22332},
+							pos: position{line: 764, col: 5, offset: 22230},
 							expr: &ruleRefExpr{
-								pos:  position{line: 768, col: 6, offset: 22333},
+								pos:  position{line: 764, col: 6, offset: 22231},
 								name: "IP6",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 768, col: 10, offset: 22337},
+							pos:   position{line: 764, col: 10, offset: 22235},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 768, col: 16, offset: 22343},
+								pos:  position{line: 764, col: 16, offset: 22241},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 768, col: 27, offset: 22354},
+							pos:   position{line: 764, col: 27, offset: 22252},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 768, col: 32, offset: 22359},
+								pos: position{line: 764, col: 32, offset: 22257},
 								expr: &ruleRefExpr{
-									pos:  position{line: 768, col: 33, offset: 22360},
+									pos:  position{line: 764, col: 33, offset: 22258},
 									name: "Deref",
 								},
 							},
@@ -5819,55 +5756,55 @@ var g = &grammar{
 		},
 		{
 			name: "Deref",
-			pos:  position{line: 772, col: 1, offset: 22428},
+			pos:  position{line: 768, col: 1, offset: 22326},
 			expr: &choiceExpr{
-				pos: position{line: 773, col: 5, offset: 22438},
+				pos: position{line: 769, col: 5, offset: 22336},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 773, col: 5, offset: 22438},
+						pos: position{line: 769, col: 5, offset: 22336},
 						run: (*parser).callonDeref2,
 						expr: &seqExpr{
-							pos: position{line: 773, col: 5, offset: 22438},
+							pos: position{line: 769, col: 5, offset: 22336},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 773, col: 5, offset: 22438},
+									pos:        position{line: 769, col: 5, offset: 22336},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 773, col: 9, offset: 22442},
+									pos:   position{line: 769, col: 9, offset: 22340},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 773, col: 14, offset: 22447},
+										pos:  position{line: 769, col: 14, offset: 22345},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 773, col: 27, offset: 22460},
+									pos:  position{line: 769, col: 27, offset: 22358},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 773, col: 30, offset: 22463},
+									pos:        position{line: 769, col: 30, offset: 22361},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 773, col: 34, offset: 22467},
+									pos:  position{line: 769, col: 34, offset: 22365},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 773, col: 37, offset: 22470},
+									pos:   position{line: 769, col: 37, offset: 22368},
 									label: "to",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 773, col: 40, offset: 22473},
+										pos: position{line: 769, col: 40, offset: 22371},
 										expr: &ruleRefExpr{
-											pos:  position{line: 773, col: 40, offset: 22473},
+											pos:  position{line: 769, col: 40, offset: 22371},
 											name: "AdditiveExpr",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 773, col: 54, offset: 22487},
+									pos:        position{line: 769, col: 54, offset: 22385},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5875,39 +5812,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 779, col: 5, offset: 22658},
+						pos: position{line: 775, col: 5, offset: 22556},
 						run: (*parser).callonDeref14,
 						expr: &seqExpr{
-							pos: position{line: 779, col: 5, offset: 22658},
+							pos: position{line: 775, col: 5, offset: 22556},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 779, col: 5, offset: 22658},
+									pos:        position{line: 775, col: 5, offset: 22556},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 779, col: 9, offset: 22662},
+									pos:  position{line: 775, col: 9, offset: 22560},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 779, col: 12, offset: 22665},
+									pos:        position{line: 775, col: 12, offset: 22563},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 779, col: 16, offset: 22669},
+									pos:  position{line: 775, col: 16, offset: 22567},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 779, col: 19, offset: 22672},
+									pos:   position{line: 775, col: 19, offset: 22570},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 779, col: 22, offset: 22675},
+										pos:  position{line: 775, col: 22, offset: 22573},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 779, col: 35, offset: 22688},
+									pos:        position{line: 775, col: 35, offset: 22586},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5915,26 +5852,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 785, col: 5, offset: 22859},
+						pos: position{line: 781, col: 5, offset: 22757},
 						run: (*parser).callonDeref23,
 						expr: &seqExpr{
-							pos: position{line: 785, col: 5, offset: 22859},
+							pos: position{line: 781, col: 5, offset: 22757},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 785, col: 5, offset: 22859},
+									pos:        position{line: 781, col: 5, offset: 22757},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 785, col: 9, offset: 22863},
+									pos:   position{line: 781, col: 9, offset: 22761},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 785, col: 14, offset: 22868},
+										pos:  position{line: 781, col: 14, offset: 22766},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 785, col: 19, offset: 22873},
+									pos:        position{line: 781, col: 19, offset: 22771},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5942,21 +5879,21 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 786, col: 5, offset: 22922},
+						pos: position{line: 782, col: 5, offset: 22820},
 						run: (*parser).callonDeref29,
 						expr: &seqExpr{
-							pos: position{line: 786, col: 5, offset: 22922},
+							pos: position{line: 782, col: 5, offset: 22820},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 786, col: 5, offset: 22922},
+									pos:        position{line: 782, col: 5, offset: 22820},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 786, col: 9, offset: 22926},
+									pos:   position{line: 782, col: 9, offset: 22824},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 786, col: 12, offset: 22929},
+										pos:  position{line: 782, col: 12, offset: 22827},
 										name: "Identifier",
 									},
 								},
@@ -5968,59 +5905,59 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 788, col: 1, offset: 22980},
+			pos:  position{line: 784, col: 1, offset: 22878},
 			expr: &choiceExpr{
-				pos: position{line: 789, col: 5, offset: 22992},
+				pos: position{line: 785, col: 5, offset: 22890},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 789, col: 5, offset: 22992},
+						pos:  position{line: 785, col: 5, offset: 22890},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 790, col: 5, offset: 23003},
+						pos:  position{line: 786, col: 5, offset: 22901},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 791, col: 5, offset: 23013},
+						pos:  position{line: 787, col: 5, offset: 22911},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 792, col: 5, offset: 23021},
+						pos:  position{line: 788, col: 5, offset: 22919},
 						name: "Map",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 793, col: 5, offset: 23029},
+						pos:  position{line: 789, col: 5, offset: 22927},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 794, col: 5, offset: 23041},
+						pos: position{line: 790, col: 5, offset: 22939},
 						run: (*parser).callonPrimary7,
 						expr: &seqExpr{
-							pos: position{line: 794, col: 5, offset: 23041},
+							pos: position{line: 790, col: 5, offset: 22939},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 794, col: 5, offset: 23041},
+									pos:        position{line: 790, col: 5, offset: 22939},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 794, col: 9, offset: 23045},
+									pos:  position{line: 790, col: 9, offset: 22943},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 794, col: 12, offset: 23048},
+									pos:   position{line: 790, col: 12, offset: 22946},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 794, col: 17, offset: 23053},
+										pos:  position{line: 790, col: 17, offset: 22951},
 										name: "OverExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 794, col: 26, offset: 23062},
+									pos:  position{line: 790, col: 26, offset: 22960},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 794, col: 29, offset: 23065},
+									pos:        position{line: 790, col: 29, offset: 22963},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -6028,34 +5965,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 795, col: 5, offset: 23095},
+						pos: position{line: 791, col: 5, offset: 22993},
 						run: (*parser).callonPrimary15,
 						expr: &seqExpr{
-							pos: position{line: 795, col: 5, offset: 23095},
+							pos: position{line: 791, col: 5, offset: 22993},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 795, col: 5, offset: 23095},
+									pos:        position{line: 791, col: 5, offset: 22993},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 795, col: 9, offset: 23099},
+									pos:  position{line: 791, col: 9, offset: 22997},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 795, col: 12, offset: 23102},
+									pos:   position{line: 791, col: 12, offset: 23000},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 795, col: 17, offset: 23107},
+										pos:  position{line: 791, col: 17, offset: 23005},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 795, col: 22, offset: 23112},
+									pos:  position{line: 791, col: 22, offset: 23010},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 795, col: 25, offset: 23115},
+									pos:        position{line: 791, col: 25, offset: 23013},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -6067,59 +6004,59 @@ var g = &grammar{
 		},
 		{
 			name: "OverExpr",
-			pos:  position{line: 797, col: 1, offset: 23141},
+			pos:  position{line: 793, col: 1, offset: 23039},
 			expr: &actionExpr{
-				pos: position{line: 798, col: 5, offset: 23154},
+				pos: position{line: 794, col: 5, offset: 23052},
 				run: (*parser).callonOverExpr1,
 				expr: &seqExpr{
-					pos: position{line: 798, col: 5, offset: 23154},
+					pos: position{line: 794, col: 5, offset: 23052},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 798, col: 5, offset: 23154},
+							pos:        position{line: 794, col: 5, offset: 23052},
 							val:        "over",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 798, col: 12, offset: 23161},
+							pos:  position{line: 794, col: 12, offset: 23059},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 798, col: 14, offset: 23163},
+							pos:   position{line: 794, col: 14, offset: 23061},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 798, col: 20, offset: 23169},
+								pos:  position{line: 794, col: 20, offset: 23067},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 798, col: 26, offset: 23175},
+							pos:   position{line: 794, col: 26, offset: 23073},
 							label: "locals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 798, col: 33, offset: 23182},
+								pos: position{line: 794, col: 33, offset: 23080},
 								expr: &ruleRefExpr{
-									pos:  position{line: 798, col: 33, offset: 23182},
+									pos:  position{line: 794, col: 33, offset: 23080},
 									name: "Locals",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 798, col: 41, offset: 23190},
+							pos:  position{line: 794, col: 41, offset: 23088},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 798, col: 44, offset: 23193},
+							pos:        position{line: 794, col: 44, offset: 23091},
 							val:        "|",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 798, col: 48, offset: 23197},
+							pos:  position{line: 794, col: 48, offset: 23095},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 798, col: 51, offset: 23200},
+							pos:   position{line: 794, col: 51, offset: 23098},
 							label: "scope",
 							expr: &ruleRefExpr{
-								pos:  position{line: 798, col: 57, offset: 23206},
+								pos:  position{line: 794, col: 57, offset: 23104},
 								name: "Sequential",
 							},
 						},
@@ -6129,36 +6066,36 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 802, col: 1, offset: 23337},
+			pos:  position{line: 798, col: 1, offset: 23235},
 			expr: &actionExpr{
-				pos: position{line: 803, col: 5, offset: 23348},
+				pos: position{line: 799, col: 5, offset: 23246},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 803, col: 5, offset: 23348},
+					pos: position{line: 799, col: 5, offset: 23246},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 803, col: 5, offset: 23348},
+							pos:        position{line: 799, col: 5, offset: 23246},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 803, col: 9, offset: 23352},
+							pos:  position{line: 799, col: 9, offset: 23250},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 803, col: 12, offset: 23355},
+							pos:   position{line: 799, col: 12, offset: 23253},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 803, col: 18, offset: 23361},
+								pos:  position{line: 799, col: 18, offset: 23259},
 								name: "RecordElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 803, col: 30, offset: 23373},
+							pos:  position{line: 799, col: 30, offset: 23271},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 803, col: 33, offset: 23376},
+							pos:        position{line: 799, col: 33, offset: 23274},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -6168,31 +6105,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElems",
-			pos:  position{line: 807, col: 1, offset: 23466},
+			pos:  position{line: 803, col: 1, offset: 23364},
 			expr: &choiceExpr{
-				pos: position{line: 808, col: 5, offset: 23482},
+				pos: position{line: 804, col: 5, offset: 23380},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 808, col: 5, offset: 23482},
+						pos: position{line: 804, col: 5, offset: 23380},
 						run: (*parser).callonRecordElems2,
 						expr: &seqExpr{
-							pos: position{line: 808, col: 5, offset: 23482},
+							pos: position{line: 804, col: 5, offset: 23380},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 808, col: 5, offset: 23482},
+									pos:   position{line: 804, col: 5, offset: 23380},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 808, col: 11, offset: 23488},
+										pos:  position{line: 804, col: 11, offset: 23386},
 										name: "RecordElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 808, col: 22, offset: 23499},
+									pos:   position{line: 804, col: 22, offset: 23397},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 808, col: 27, offset: 23504},
+										pos: position{line: 804, col: 27, offset: 23402},
 										expr: &ruleRefExpr{
-											pos:  position{line: 808, col: 27, offset: 23504},
+											pos:  position{line: 804, col: 27, offset: 23402},
 											name: "RecordElemTail",
 										},
 									},
@@ -6201,10 +6138,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 811, col: 5, offset: 23603},
+						pos: position{line: 807, col: 5, offset: 23501},
 						run: (*parser).callonRecordElems9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 811, col: 5, offset: 23603},
+							pos:  position{line: 807, col: 5, offset: 23501},
 							name: "__",
 						},
 					},
@@ -6213,31 +6150,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElemTail",
-			pos:  position{line: 813, col: 1, offset: 23639},
+			pos:  position{line: 809, col: 1, offset: 23537},
 			expr: &actionExpr{
-				pos: position{line: 813, col: 18, offset: 23656},
+				pos: position{line: 809, col: 18, offset: 23554},
 				run: (*parser).callonRecordElemTail1,
 				expr: &seqExpr{
-					pos: position{line: 813, col: 18, offset: 23656},
+					pos: position{line: 809, col: 18, offset: 23554},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 813, col: 18, offset: 23656},
+							pos:  position{line: 809, col: 18, offset: 23554},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 813, col: 21, offset: 23659},
+							pos:        position{line: 809, col: 21, offset: 23557},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 813, col: 25, offset: 23663},
+							pos:  position{line: 809, col: 25, offset: 23561},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 813, col: 28, offset: 23666},
+							pos:   position{line: 809, col: 28, offset: 23564},
 							label: "elem",
 							expr: &ruleRefExpr{
-								pos:  position{line: 813, col: 33, offset: 23671},
+								pos:  position{line: 809, col: 33, offset: 23569},
 								name: "RecordElem",
 							},
 						},
@@ -6247,20 +6184,20 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElem",
-			pos:  position{line: 815, col: 1, offset: 23704},
+			pos:  position{line: 811, col: 1, offset: 23602},
 			expr: &choiceExpr{
-				pos: position{line: 816, col: 5, offset: 23719},
+				pos: position{line: 812, col: 5, offset: 23617},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 816, col: 5, offset: 23719},
+						pos:  position{line: 812, col: 5, offset: 23617},
 						name: "Spread",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 817, col: 5, offset: 23730},
+						pos:  position{line: 813, col: 5, offset: 23628},
 						name: "Field",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 818, col: 5, offset: 23740},
+						pos:  position{line: 814, col: 5, offset: 23638},
 						name: "Identifier",
 					},
 				},
@@ -6268,27 +6205,27 @@ var g = &grammar{
 		},
 		{
 			name: "Spread",
-			pos:  position{line: 820, col: 1, offset: 23752},
+			pos:  position{line: 816, col: 1, offset: 23650},
 			expr: &actionExpr{
-				pos: position{line: 821, col: 5, offset: 23763},
+				pos: position{line: 817, col: 5, offset: 23661},
 				run: (*parser).callonSpread1,
 				expr: &seqExpr{
-					pos: position{line: 821, col: 5, offset: 23763},
+					pos: position{line: 817, col: 5, offset: 23661},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 821, col: 5, offset: 23763},
+							pos:        position{line: 817, col: 5, offset: 23661},
 							val:        "...",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 821, col: 11, offset: 23769},
+							pos:  position{line: 817, col: 11, offset: 23667},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 821, col: 14, offset: 23772},
+							pos:   position{line: 817, col: 14, offset: 23670},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 821, col: 19, offset: 23777},
+								pos:  position{line: 817, col: 19, offset: 23675},
 								name: "Expr",
 							},
 						},
@@ -6298,39 +6235,39 @@ var g = &grammar{
 		},
 		{
 			name: "Field",
-			pos:  position{line: 825, col: 1, offset: 23863},
+			pos:  position{line: 821, col: 1, offset: 23761},
 			expr: &actionExpr{
-				pos: position{line: 826, col: 5, offset: 23873},
+				pos: position{line: 822, col: 5, offset: 23771},
 				run: (*parser).callonField1,
 				expr: &seqExpr{
-					pos: position{line: 826, col: 5, offset: 23873},
+					pos: position{line: 822, col: 5, offset: 23771},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 826, col: 5, offset: 23873},
+							pos:   position{line: 822, col: 5, offset: 23771},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 826, col: 10, offset: 23878},
+								pos:  position{line: 822, col: 10, offset: 23776},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 826, col: 20, offset: 23888},
+							pos:  position{line: 822, col: 20, offset: 23786},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 826, col: 23, offset: 23891},
+							pos:        position{line: 822, col: 23, offset: 23789},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 826, col: 27, offset: 23895},
+							pos:  position{line: 822, col: 27, offset: 23793},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 826, col: 30, offset: 23898},
+							pos:   position{line: 822, col: 30, offset: 23796},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 826, col: 36, offset: 23904},
+								pos:  position{line: 822, col: 36, offset: 23802},
 								name: "Expr",
 							},
 						},
@@ -6340,36 +6277,36 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 830, col: 1, offset: 24004},
+			pos:  position{line: 826, col: 1, offset: 23902},
 			expr: &actionExpr{
-				pos: position{line: 831, col: 5, offset: 24014},
+				pos: position{line: 827, col: 5, offset: 23912},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 831, col: 5, offset: 24014},
+					pos: position{line: 827, col: 5, offset: 23912},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 831, col: 5, offset: 24014},
+							pos:        position{line: 827, col: 5, offset: 23912},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 831, col: 9, offset: 24018},
+							pos:  position{line: 827, col: 9, offset: 23916},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 831, col: 12, offset: 24021},
+							pos:   position{line: 827, col: 12, offset: 23919},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 831, col: 18, offset: 24027},
+								pos:  position{line: 827, col: 18, offset: 23925},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 831, col: 30, offset: 24039},
+							pos:  position{line: 827, col: 30, offset: 23937},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 831, col: 33, offset: 24042},
+							pos:        position{line: 827, col: 33, offset: 23940},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -6379,36 +6316,36 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 835, col: 1, offset: 24132},
+			pos:  position{line: 831, col: 1, offset: 24030},
 			expr: &actionExpr{
-				pos: position{line: 836, col: 5, offset: 24140},
+				pos: position{line: 832, col: 5, offset: 24038},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 836, col: 5, offset: 24140},
+					pos: position{line: 832, col: 5, offset: 24038},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 836, col: 5, offset: 24140},
+							pos:        position{line: 832, col: 5, offset: 24038},
 							val:        "|[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 836, col: 10, offset: 24145},
+							pos:  position{line: 832, col: 10, offset: 24043},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 836, col: 13, offset: 24148},
+							pos:   position{line: 832, col: 13, offset: 24046},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 836, col: 19, offset: 24154},
+								pos:  position{line: 832, col: 19, offset: 24052},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 836, col: 31, offset: 24166},
+							pos:  position{line: 832, col: 31, offset: 24064},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 836, col: 34, offset: 24169},
+							pos:        position{line: 832, col: 34, offset: 24067},
 							val:        "]|",
 							ignoreCase: false,
 						},
@@ -6418,53 +6355,53 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElems",
-			pos:  position{line: 840, col: 1, offset: 24258},
+			pos:  position{line: 836, col: 1, offset: 24156},
 			expr: &choiceExpr{
-				pos: position{line: 841, col: 5, offset: 24274},
+				pos: position{line: 837, col: 5, offset: 24172},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 841, col: 5, offset: 24274},
+						pos: position{line: 837, col: 5, offset: 24172},
 						run: (*parser).callonVectorElems2,
 						expr: &seqExpr{
-							pos: position{line: 841, col: 5, offset: 24274},
+							pos: position{line: 837, col: 5, offset: 24172},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 841, col: 5, offset: 24274},
+									pos:   position{line: 837, col: 5, offset: 24172},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 841, col: 11, offset: 24280},
+										pos:  position{line: 837, col: 11, offset: 24178},
 										name: "VectorElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 841, col: 22, offset: 24291},
+									pos:   position{line: 837, col: 22, offset: 24189},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 841, col: 27, offset: 24296},
+										pos: position{line: 837, col: 27, offset: 24194},
 										expr: &actionExpr{
-											pos: position{line: 841, col: 28, offset: 24297},
+											pos: position{line: 837, col: 28, offset: 24195},
 											run: (*parser).callonVectorElems8,
 											expr: &seqExpr{
-												pos: position{line: 841, col: 28, offset: 24297},
+												pos: position{line: 837, col: 28, offset: 24195},
 												exprs: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 841, col: 28, offset: 24297},
+														pos:  position{line: 837, col: 28, offset: 24195},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 841, col: 31, offset: 24300},
+														pos:        position{line: 837, col: 31, offset: 24198},
 														val:        ",",
 														ignoreCase: false,
 													},
 													&ruleRefExpr{
-														pos:  position{line: 841, col: 35, offset: 24304},
+														pos:  position{line: 837, col: 35, offset: 24202},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 841, col: 38, offset: 24307},
+														pos:   position{line: 837, col: 38, offset: 24205},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 841, col: 40, offset: 24309},
+															pos:  position{line: 837, col: 40, offset: 24207},
 															name: "VectorElem",
 														},
 													},
@@ -6477,10 +6414,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 844, col: 5, offset: 24427},
+						pos: position{line: 840, col: 5, offset: 24325},
 						run: (*parser).callonVectorElems15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 844, col: 5, offset: 24427},
+							pos:  position{line: 840, col: 5, offset: 24325},
 							name: "__",
 						},
 					},
@@ -6489,22 +6426,22 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElem",
-			pos:  position{line: 846, col: 1, offset: 24463},
+			pos:  position{line: 842, col: 1, offset: 24361},
 			expr: &choiceExpr{
-				pos: position{line: 847, col: 5, offset: 24478},
+				pos: position{line: 843, col: 5, offset: 24376},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 847, col: 5, offset: 24478},
+						pos:  position{line: 843, col: 5, offset: 24376},
 						name: "Spread",
 					},
 					&actionExpr{
-						pos: position{line: 848, col: 5, offset: 24489},
+						pos: position{line: 844, col: 5, offset: 24387},
 						run: (*parser).callonVectorElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 848, col: 5, offset: 24489},
+							pos:   position{line: 844, col: 5, offset: 24387},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 848, col: 7, offset: 24491},
+								pos:  position{line: 844, col: 7, offset: 24389},
 								name: "Expr",
 							},
 						},
@@ -6514,36 +6451,36 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 850, col: 1, offset: 24567},
+			pos:  position{line: 846, col: 1, offset: 24465},
 			expr: &actionExpr{
-				pos: position{line: 851, col: 5, offset: 24575},
+				pos: position{line: 847, col: 5, offset: 24473},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 851, col: 5, offset: 24575},
+					pos: position{line: 847, col: 5, offset: 24473},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 851, col: 5, offset: 24575},
+							pos:        position{line: 847, col: 5, offset: 24473},
 							val:        "|{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 851, col: 10, offset: 24580},
+							pos:  position{line: 847, col: 10, offset: 24478},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 851, col: 13, offset: 24583},
+							pos:   position{line: 847, col: 13, offset: 24481},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 851, col: 19, offset: 24589},
+								pos:  position{line: 847, col: 19, offset: 24487},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 851, col: 27, offset: 24597},
+							pos:  position{line: 847, col: 27, offset: 24495},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 851, col: 30, offset: 24600},
+							pos:        position{line: 847, col: 30, offset: 24498},
 							val:        "}|",
 							ignoreCase: false,
 						},
@@ -6553,31 +6490,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 855, col: 1, offset: 24691},
+			pos:  position{line: 851, col: 1, offset: 24589},
 			expr: &choiceExpr{
-				pos: position{line: 856, col: 5, offset: 24703},
+				pos: position{line: 852, col: 5, offset: 24601},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 856, col: 5, offset: 24703},
+						pos: position{line: 852, col: 5, offset: 24601},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 856, col: 5, offset: 24703},
+							pos: position{line: 852, col: 5, offset: 24601},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 856, col: 5, offset: 24703},
+									pos:   position{line: 852, col: 5, offset: 24601},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 856, col: 11, offset: 24709},
+										pos:  position{line: 852, col: 11, offset: 24607},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 856, col: 17, offset: 24715},
+									pos:   position{line: 852, col: 17, offset: 24613},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 856, col: 22, offset: 24720},
+										pos: position{line: 852, col: 22, offset: 24618},
 										expr: &ruleRefExpr{
-											pos:  position{line: 856, col: 22, offset: 24720},
+											pos:  position{line: 852, col: 22, offset: 24618},
 											name: "EntryTail",
 										},
 									},
@@ -6586,10 +6523,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 859, col: 5, offset: 24814},
+						pos: position{line: 855, col: 5, offset: 24712},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 859, col: 5, offset: 24814},
+							pos:  position{line: 855, col: 5, offset: 24712},
 							name: "__",
 						},
 					},
@@ -6598,31 +6535,31 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 862, col: 1, offset: 24851},
+			pos:  position{line: 858, col: 1, offset: 24749},
 			expr: &actionExpr{
-				pos: position{line: 862, col: 13, offset: 24863},
+				pos: position{line: 858, col: 13, offset: 24761},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 862, col: 13, offset: 24863},
+					pos: position{line: 858, col: 13, offset: 24761},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 862, col: 13, offset: 24863},
+							pos:  position{line: 858, col: 13, offset: 24761},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 862, col: 16, offset: 24866},
+							pos:        position{line: 858, col: 16, offset: 24764},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 862, col: 20, offset: 24870},
+							pos:  position{line: 858, col: 20, offset: 24768},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 862, col: 23, offset: 24873},
+							pos:   position{line: 858, col: 23, offset: 24771},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 862, col: 25, offset: 24875},
+								pos:  position{line: 858, col: 25, offset: 24773},
 								name: "Entry",
 							},
 						},
@@ -6632,39 +6569,39 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 864, col: 1, offset: 24900},
+			pos:  position{line: 860, col: 1, offset: 24798},
 			expr: &actionExpr{
-				pos: position{line: 865, col: 5, offset: 24910},
+				pos: position{line: 861, col: 5, offset: 24808},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 865, col: 5, offset: 24910},
+					pos: position{line: 861, col: 5, offset: 24808},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 865, col: 5, offset: 24910},
+							pos:   position{line: 861, col: 5, offset: 24808},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 865, col: 9, offset: 24914},
+								pos:  position{line: 861, col: 9, offset: 24812},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 865, col: 14, offset: 24919},
+							pos:  position{line: 861, col: 14, offset: 24817},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 865, col: 17, offset: 24922},
+							pos:        position{line: 861, col: 17, offset: 24820},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 865, col: 21, offset: 24926},
+							pos:  position{line: 861, col: 21, offset: 24824},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 865, col: 24, offset: 24929},
+							pos:   position{line: 861, col: 24, offset: 24827},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 865, col: 30, offset: 24935},
+								pos:  position{line: 861, col: 30, offset: 24833},
 								name: "Expr",
 							},
 						},
@@ -6674,92 +6611,92 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOp",
-			pos:  position{line: 871, col: 1, offset: 25042},
+			pos:  position{line: 867, col: 1, offset: 24940},
 			expr: &actionExpr{
-				pos: position{line: 872, col: 5, offset: 25052},
+				pos: position{line: 868, col: 5, offset: 24950},
 				run: (*parser).callonSQLOp1,
 				expr: &seqExpr{
-					pos: position{line: 872, col: 5, offset: 25052},
+					pos: position{line: 868, col: 5, offset: 24950},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 872, col: 5, offset: 25052},
+							pos:   position{line: 868, col: 5, offset: 24950},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 872, col: 15, offset: 25062},
+								pos:  position{line: 868, col: 15, offset: 24960},
 								name: "SQLSelect",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 873, col: 5, offset: 25076},
+							pos:   position{line: 869, col: 5, offset: 24974},
 							label: "from",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 873, col: 10, offset: 25081},
+								pos: position{line: 869, col: 10, offset: 24979},
 								expr: &ruleRefExpr{
-									pos:  position{line: 873, col: 10, offset: 25081},
+									pos:  position{line: 869, col: 10, offset: 24979},
 									name: "SQLFrom",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 874, col: 5, offset: 25094},
+							pos:   position{line: 870, col: 5, offset: 24992},
 							label: "joins",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 874, col: 11, offset: 25100},
+								pos: position{line: 870, col: 11, offset: 24998},
 								expr: &ruleRefExpr{
-									pos:  position{line: 874, col: 11, offset: 25100},
+									pos:  position{line: 870, col: 11, offset: 24998},
 									name: "SQLJoins",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 875, col: 5, offset: 25114},
+							pos:   position{line: 871, col: 5, offset: 25012},
 							label: "where",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 875, col: 11, offset: 25120},
+								pos: position{line: 871, col: 11, offset: 25018},
 								expr: &ruleRefExpr{
-									pos:  position{line: 875, col: 11, offset: 25120},
+									pos:  position{line: 871, col: 11, offset: 25018},
 									name: "SQLWhere",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 876, col: 5, offset: 25134},
+							pos:   position{line: 872, col: 5, offset: 25032},
 							label: "groupby",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 876, col: 13, offset: 25142},
+								pos: position{line: 872, col: 13, offset: 25040},
 								expr: &ruleRefExpr{
-									pos:  position{line: 876, col: 13, offset: 25142},
+									pos:  position{line: 872, col: 13, offset: 25040},
 									name: "SQLGroupBy",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 877, col: 5, offset: 25158},
+							pos:   position{line: 873, col: 5, offset: 25056},
 							label: "having",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 877, col: 12, offset: 25165},
+								pos: position{line: 873, col: 12, offset: 25063},
 								expr: &ruleRefExpr{
-									pos:  position{line: 877, col: 12, offset: 25165},
+									pos:  position{line: 873, col: 12, offset: 25063},
 									name: "SQLHaving",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 878, col: 5, offset: 25180},
+							pos:   position{line: 874, col: 5, offset: 25078},
 							label: "orderby",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 878, col: 13, offset: 25188},
+								pos: position{line: 874, col: 13, offset: 25086},
 								expr: &ruleRefExpr{
-									pos:  position{line: 878, col: 13, offset: 25188},
+									pos:  position{line: 874, col: 13, offset: 25086},
 									name: "SQLOrderBy",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 879, col: 5, offset: 25204},
+							pos:   position{line: 875, col: 5, offset: 25102},
 							label: "limit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 879, col: 11, offset: 25210},
+								pos:  position{line: 875, col: 11, offset: 25108},
 								name: "SQLLimit",
 							},
 						},
@@ -6769,26 +6706,26 @@ var g = &grammar{
 		},
 		{
 			name: "SQLSelect",
-			pos:  position{line: 903, col: 1, offset: 25577},
+			pos:  position{line: 899, col: 1, offset: 25475},
 			expr: &choiceExpr{
-				pos: position{line: 904, col: 5, offset: 25591},
+				pos: position{line: 900, col: 5, offset: 25489},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 904, col: 5, offset: 25591},
+						pos: position{line: 900, col: 5, offset: 25489},
 						run: (*parser).callonSQLSelect2,
 						expr: &seqExpr{
-							pos: position{line: 904, col: 5, offset: 25591},
+							pos: position{line: 900, col: 5, offset: 25489},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 904, col: 5, offset: 25591},
+									pos:  position{line: 900, col: 5, offset: 25489},
 									name: "SELECT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 904, col: 12, offset: 25598},
+									pos:  position{line: 900, col: 12, offset: 25496},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 904, col: 14, offset: 25600},
+									pos:        position{line: 900, col: 14, offset: 25498},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -6796,24 +6733,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 905, col: 5, offset: 25628},
+						pos: position{line: 901, col: 5, offset: 25526},
 						run: (*parser).callonSQLSelect7,
 						expr: &seqExpr{
-							pos: position{line: 905, col: 5, offset: 25628},
+							pos: position{line: 901, col: 5, offset: 25526},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 905, col: 5, offset: 25628},
+									pos:  position{line: 901, col: 5, offset: 25526},
 									name: "SELECT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 905, col: 12, offset: 25635},
+									pos:  position{line: 901, col: 12, offset: 25533},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 905, col: 14, offset: 25637},
+									pos:   position{line: 901, col: 14, offset: 25535},
 									label: "assignments",
 									expr: &ruleRefExpr{
-										pos:  position{line: 905, col: 26, offset: 25649},
+										pos:  position{line: 901, col: 26, offset: 25547},
 										name: "SQLAssignments",
 									},
 								},
@@ -6825,43 +6762,43 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAssignment",
-			pos:  position{line: 907, col: 1, offset: 25693},
+			pos:  position{line: 903, col: 1, offset: 25591},
 			expr: &actionExpr{
-				pos: position{line: 908, col: 5, offset: 25711},
+				pos: position{line: 904, col: 5, offset: 25609},
 				run: (*parser).callonSQLAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 908, col: 5, offset: 25711},
+					pos: position{line: 904, col: 5, offset: 25609},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 908, col: 5, offset: 25711},
+							pos:   position{line: 904, col: 5, offset: 25609},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 908, col: 9, offset: 25715},
+								pos:  position{line: 904, col: 9, offset: 25613},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 908, col: 14, offset: 25720},
+							pos:   position{line: 904, col: 14, offset: 25618},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 908, col: 18, offset: 25724},
+								pos: position{line: 904, col: 18, offset: 25622},
 								expr: &seqExpr{
-									pos: position{line: 908, col: 19, offset: 25725},
+									pos: position{line: 904, col: 19, offset: 25623},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 908, col: 19, offset: 25725},
+											pos:  position{line: 904, col: 19, offset: 25623},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 908, col: 21, offset: 25727},
+											pos:  position{line: 904, col: 21, offset: 25625},
 											name: "AS",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 908, col: 24, offset: 25730},
+											pos:  position{line: 904, col: 24, offset: 25628},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 908, col: 26, offset: 25732},
+											pos:  position{line: 904, col: 26, offset: 25630},
 											name: "Lval",
 										},
 									},
@@ -6874,50 +6811,50 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAssignments",
-			pos:  position{line: 916, col: 1, offset: 25923},
+			pos:  position{line: 912, col: 1, offset: 25821},
 			expr: &actionExpr{
-				pos: position{line: 917, col: 5, offset: 25942},
+				pos: position{line: 913, col: 5, offset: 25840},
 				run: (*parser).callonSQLAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 917, col: 5, offset: 25942},
+					pos: position{line: 913, col: 5, offset: 25840},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 917, col: 5, offset: 25942},
+							pos:   position{line: 913, col: 5, offset: 25840},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 917, col: 11, offset: 25948},
+								pos:  position{line: 913, col: 11, offset: 25846},
 								name: "SQLAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 917, col: 25, offset: 25962},
+							pos:   position{line: 913, col: 25, offset: 25860},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 917, col: 30, offset: 25967},
+								pos: position{line: 913, col: 30, offset: 25865},
 								expr: &actionExpr{
-									pos: position{line: 917, col: 31, offset: 25968},
+									pos: position{line: 913, col: 31, offset: 25866},
 									run: (*parser).callonSQLAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 917, col: 31, offset: 25968},
+										pos: position{line: 913, col: 31, offset: 25866},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 917, col: 31, offset: 25968},
+												pos:  position{line: 913, col: 31, offset: 25866},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 917, col: 34, offset: 25971},
+												pos:        position{line: 913, col: 34, offset: 25869},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 917, col: 38, offset: 25975},
+												pos:  position{line: 913, col: 38, offset: 25873},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 917, col: 41, offset: 25978},
+												pos:   position{line: 913, col: 41, offset: 25876},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 917, col: 46, offset: 25983},
+													pos:  position{line: 913, col: 46, offset: 25881},
 													name: "SQLAssignment",
 												},
 											},
@@ -6932,43 +6869,43 @@ var g = &grammar{
 		},
 		{
 			name: "SQLFrom",
-			pos:  position{line: 921, col: 1, offset: 26104},
+			pos:  position{line: 917, col: 1, offset: 26002},
 			expr: &choiceExpr{
-				pos: position{line: 922, col: 5, offset: 26116},
+				pos: position{line: 918, col: 5, offset: 26014},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 922, col: 5, offset: 26116},
+						pos: position{line: 918, col: 5, offset: 26014},
 						run: (*parser).callonSQLFrom2,
 						expr: &seqExpr{
-							pos: position{line: 922, col: 5, offset: 26116},
+							pos: position{line: 918, col: 5, offset: 26014},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 922, col: 5, offset: 26116},
+									pos:  position{line: 918, col: 5, offset: 26014},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 922, col: 7, offset: 26118},
+									pos:  position{line: 918, col: 7, offset: 26016},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 922, col: 12, offset: 26123},
+									pos:  position{line: 918, col: 12, offset: 26021},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 922, col: 14, offset: 26125},
+									pos:   position{line: 918, col: 14, offset: 26023},
 									label: "table",
 									expr: &ruleRefExpr{
-										pos:  position{line: 922, col: 20, offset: 26131},
+										pos:  position{line: 918, col: 20, offset: 26029},
 										name: "SQLTable",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 922, col: 29, offset: 26140},
+									pos:   position{line: 918, col: 29, offset: 26038},
 									label: "alias",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 922, col: 35, offset: 26146},
+										pos: position{line: 918, col: 35, offset: 26044},
 										expr: &ruleRefExpr{
-											pos:  position{line: 922, col: 35, offset: 26146},
+											pos:  position{line: 918, col: 35, offset: 26044},
 											name: "SQLAlias",
 										},
 									},
@@ -6977,25 +6914,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 925, col: 5, offset: 26241},
+						pos: position{line: 921, col: 5, offset: 26139},
 						run: (*parser).callonSQLFrom12,
 						expr: &seqExpr{
-							pos: position{line: 925, col: 5, offset: 26241},
+							pos: position{line: 921, col: 5, offset: 26139},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 925, col: 5, offset: 26241},
+									pos:  position{line: 921, col: 5, offset: 26139},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 925, col: 7, offset: 26243},
+									pos:  position{line: 921, col: 7, offset: 26141},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 925, col: 12, offset: 26248},
+									pos:  position{line: 921, col: 12, offset: 26146},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 925, col: 14, offset: 26250},
+									pos:        position{line: 921, col: 14, offset: 26148},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -7007,33 +6944,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAlias",
-			pos:  position{line: 927, col: 1, offset: 26275},
+			pos:  position{line: 923, col: 1, offset: 26173},
 			expr: &choiceExpr{
-				pos: position{line: 928, col: 5, offset: 26288},
+				pos: position{line: 924, col: 5, offset: 26186},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 928, col: 5, offset: 26288},
+						pos: position{line: 924, col: 5, offset: 26186},
 						run: (*parser).callonSQLAlias2,
 						expr: &seqExpr{
-							pos: position{line: 928, col: 5, offset: 26288},
+							pos: position{line: 924, col: 5, offset: 26186},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 928, col: 5, offset: 26288},
+									pos:  position{line: 924, col: 5, offset: 26186},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 928, col: 7, offset: 26290},
+									pos:  position{line: 924, col: 7, offset: 26188},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 928, col: 10, offset: 26293},
+									pos:  position{line: 924, col: 10, offset: 26191},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 928, col: 12, offset: 26295},
+									pos:   position{line: 924, col: 12, offset: 26193},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 928, col: 15, offset: 26298},
+										pos:  position{line: 924, col: 15, offset: 26196},
 										name: "Lval",
 									},
 								},
@@ -7041,36 +6978,36 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 929, col: 5, offset: 26326},
+						pos: position{line: 925, col: 5, offset: 26224},
 						run: (*parser).callonSQLAlias9,
 						expr: &seqExpr{
-							pos: position{line: 929, col: 5, offset: 26326},
+							pos: position{line: 925, col: 5, offset: 26224},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 929, col: 5, offset: 26326},
+									pos:  position{line: 925, col: 5, offset: 26224},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 929, col: 7, offset: 26328},
+									pos: position{line: 925, col: 7, offset: 26226},
 									expr: &seqExpr{
-										pos: position{line: 929, col: 9, offset: 26330},
+										pos: position{line: 925, col: 9, offset: 26228},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 929, col: 9, offset: 26330},
+												pos:  position{line: 925, col: 9, offset: 26228},
 												name: "SQLTokenSentinels",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 929, col: 27, offset: 26348},
+												pos:  position{line: 925, col: 27, offset: 26246},
 												name: "_",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 929, col: 30, offset: 26351},
+									pos:   position{line: 925, col: 30, offset: 26249},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 929, col: 33, offset: 26354},
+										pos:  position{line: 925, col: 33, offset: 26252},
 										name: "Lval",
 									},
 								},
@@ -7082,42 +7019,42 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTable",
-			pos:  position{line: 931, col: 1, offset: 26379},
+			pos:  position{line: 927, col: 1, offset: 26277},
 			expr: &ruleRefExpr{
-				pos:  position{line: 932, col: 5, offset: 26392},
+				pos:  position{line: 928, col: 5, offset: 26290},
 				name: "Expr",
 			},
 		},
 		{
 			name: "SQLJoins",
-			pos:  position{line: 934, col: 1, offset: 26398},
+			pos:  position{line: 930, col: 1, offset: 26296},
 			expr: &actionExpr{
-				pos: position{line: 935, col: 5, offset: 26411},
+				pos: position{line: 931, col: 5, offset: 26309},
 				run: (*parser).callonSQLJoins1,
 				expr: &seqExpr{
-					pos: position{line: 935, col: 5, offset: 26411},
+					pos: position{line: 931, col: 5, offset: 26309},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 935, col: 5, offset: 26411},
+							pos:   position{line: 931, col: 5, offset: 26309},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 935, col: 11, offset: 26417},
+								pos:  position{line: 931, col: 11, offset: 26315},
 								name: "SQLJoin",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 935, col: 19, offset: 26425},
+							pos:   position{line: 931, col: 19, offset: 26323},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 935, col: 24, offset: 26430},
+								pos: position{line: 931, col: 24, offset: 26328},
 								expr: &actionExpr{
-									pos: position{line: 935, col: 25, offset: 26431},
+									pos: position{line: 931, col: 25, offset: 26329},
 									run: (*parser).callonSQLJoins7,
 									expr: &labeledExpr{
-										pos:   position{line: 935, col: 25, offset: 26431},
+										pos:   position{line: 931, col: 25, offset: 26329},
 										label: "join",
 										expr: &ruleRefExpr{
-											pos:  position{line: 935, col: 30, offset: 26436},
+											pos:  position{line: 931, col: 30, offset: 26334},
 											name: "SQLJoin",
 										},
 									},
@@ -7130,90 +7067,90 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoin",
-			pos:  position{line: 939, col: 1, offset: 26551},
+			pos:  position{line: 935, col: 1, offset: 26449},
 			expr: &actionExpr{
-				pos: position{line: 940, col: 5, offset: 26563},
+				pos: position{line: 936, col: 5, offset: 26461},
 				run: (*parser).callonSQLJoin1,
 				expr: &seqExpr{
-					pos: position{line: 940, col: 5, offset: 26563},
+					pos: position{line: 936, col: 5, offset: 26461},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 940, col: 5, offset: 26563},
+							pos:   position{line: 936, col: 5, offset: 26461},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 940, col: 11, offset: 26569},
+								pos:  position{line: 936, col: 11, offset: 26467},
 								name: "SQLJoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 940, col: 24, offset: 26582},
+							pos:  position{line: 936, col: 24, offset: 26480},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 940, col: 26, offset: 26584},
+							pos:  position{line: 936, col: 26, offset: 26482},
 							name: "JOIN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 940, col: 31, offset: 26589},
+							pos:  position{line: 936, col: 31, offset: 26487},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 940, col: 33, offset: 26591},
+							pos:   position{line: 936, col: 33, offset: 26489},
 							label: "table",
 							expr: &ruleRefExpr{
-								pos:  position{line: 940, col: 39, offset: 26597},
+								pos:  position{line: 936, col: 39, offset: 26495},
 								name: "SQLTable",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 940, col: 48, offset: 26606},
+							pos:   position{line: 936, col: 48, offset: 26504},
 							label: "alias",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 940, col: 54, offset: 26612},
+								pos: position{line: 936, col: 54, offset: 26510},
 								expr: &ruleRefExpr{
-									pos:  position{line: 940, col: 54, offset: 26612},
+									pos:  position{line: 936, col: 54, offset: 26510},
 									name: "SQLAlias",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 940, col: 64, offset: 26622},
+							pos:  position{line: 936, col: 64, offset: 26520},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 940, col: 66, offset: 26624},
+							pos:  position{line: 936, col: 66, offset: 26522},
 							name: "ON",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 940, col: 69, offset: 26627},
+							pos:  position{line: 936, col: 69, offset: 26525},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 940, col: 71, offset: 26629},
+							pos:   position{line: 936, col: 71, offset: 26527},
 							label: "leftKey",
 							expr: &ruleRefExpr{
-								pos:  position{line: 940, col: 79, offset: 26637},
+								pos:  position{line: 936, col: 79, offset: 26535},
 								name: "JoinKey",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 940, col: 87, offset: 26645},
+							pos:  position{line: 936, col: 87, offset: 26543},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 940, col: 90, offset: 26648},
+							pos:        position{line: 936, col: 90, offset: 26546},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 940, col: 94, offset: 26652},
+							pos:  position{line: 936, col: 94, offset: 26550},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 940, col: 97, offset: 26655},
+							pos:   position{line: 936, col: 97, offset: 26553},
 							label: "rightKey",
 							expr: &ruleRefExpr{
-								pos:  position{line: 940, col: 106, offset: 26664},
+								pos:  position{line: 936, col: 106, offset: 26562},
 								name: "JoinKey",
 							},
 						},
@@ -7223,40 +7160,40 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoinStyle",
-			pos:  position{line: 955, col: 1, offset: 26895},
+			pos:  position{line: 951, col: 1, offset: 26793},
 			expr: &choiceExpr{
-				pos: position{line: 956, col: 5, offset: 26912},
+				pos: position{line: 952, col: 5, offset: 26810},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 956, col: 5, offset: 26912},
+						pos: position{line: 952, col: 5, offset: 26810},
 						run: (*parser).callonSQLJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 956, col: 5, offset: 26912},
+							pos: position{line: 952, col: 5, offset: 26810},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 956, col: 5, offset: 26912},
+									pos:  position{line: 952, col: 5, offset: 26810},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 956, col: 7, offset: 26914},
+									pos:   position{line: 952, col: 7, offset: 26812},
 									label: "style",
 									expr: &choiceExpr{
-										pos: position{line: 956, col: 14, offset: 26921},
+										pos: position{line: 952, col: 14, offset: 26819},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 956, col: 14, offset: 26921},
+												pos:  position{line: 952, col: 14, offset: 26819},
 												name: "ANTI",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 956, col: 21, offset: 26928},
+												pos:  position{line: 952, col: 21, offset: 26826},
 												name: "INNER",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 956, col: 29, offset: 26936},
+												pos:  position{line: 952, col: 29, offset: 26834},
 												name: "LEFT",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 956, col: 36, offset: 26943},
+												pos:  position{line: 952, col: 36, offset: 26841},
 												name: "RIGHT",
 											},
 										},
@@ -7266,10 +7203,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 957, col: 5, offset: 26976},
+						pos: position{line: 953, col: 5, offset: 26874},
 						run: (*parser).callonSQLJoinStyle11,
 						expr: &litMatcher{
-							pos:        position{line: 957, col: 5, offset: 26976},
+							pos:        position{line: 953, col: 5, offset: 26874},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7279,30 +7216,30 @@ var g = &grammar{
 		},
 		{
 			name: "SQLWhere",
-			pos:  position{line: 959, col: 1, offset: 27004},
+			pos:  position{line: 955, col: 1, offset: 26902},
 			expr: &actionExpr{
-				pos: position{line: 960, col: 5, offset: 27017},
+				pos: position{line: 956, col: 5, offset: 26915},
 				run: (*parser).callonSQLWhere1,
 				expr: &seqExpr{
-					pos: position{line: 960, col: 5, offset: 27017},
+					pos: position{line: 956, col: 5, offset: 26915},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 960, col: 5, offset: 27017},
+							pos:  position{line: 956, col: 5, offset: 26915},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 960, col: 7, offset: 27019},
+							pos:  position{line: 956, col: 7, offset: 26917},
 							name: "WHERE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 960, col: 13, offset: 27025},
+							pos:  position{line: 956, col: 13, offset: 26923},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 960, col: 15, offset: 27027},
+							pos:   position{line: 956, col: 15, offset: 26925},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 960, col: 20, offset: 27032},
+								pos:  position{line: 956, col: 20, offset: 26930},
 								name: "LogicalOrExpr",
 							},
 						},
@@ -7312,38 +7249,38 @@ var g = &grammar{
 		},
 		{
 			name: "SQLGroupBy",
-			pos:  position{line: 962, col: 1, offset: 27068},
+			pos:  position{line: 958, col: 1, offset: 26966},
 			expr: &actionExpr{
-				pos: position{line: 963, col: 5, offset: 27083},
+				pos: position{line: 959, col: 5, offset: 26981},
 				run: (*parser).callonSQLGroupBy1,
 				expr: &seqExpr{
-					pos: position{line: 963, col: 5, offset: 27083},
+					pos: position{line: 959, col: 5, offset: 26981},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 963, col: 5, offset: 27083},
+							pos:  position{line: 959, col: 5, offset: 26981},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 963, col: 7, offset: 27085},
+							pos:  position{line: 959, col: 7, offset: 26983},
 							name: "GROUP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 963, col: 13, offset: 27091},
+							pos:  position{line: 959, col: 13, offset: 26989},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 963, col: 15, offset: 27093},
+							pos:  position{line: 959, col: 15, offset: 26991},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 963, col: 18, offset: 27096},
+							pos:  position{line: 959, col: 18, offset: 26994},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 963, col: 20, offset: 27098},
+							pos:   position{line: 959, col: 20, offset: 26996},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 963, col: 28, offset: 27106},
+								pos:  position{line: 959, col: 28, offset: 27004},
 								name: "FieldExprs",
 							},
 						},
@@ -7353,30 +7290,30 @@ var g = &grammar{
 		},
 		{
 			name: "SQLHaving",
-			pos:  position{line: 965, col: 1, offset: 27142},
+			pos:  position{line: 961, col: 1, offset: 27040},
 			expr: &actionExpr{
-				pos: position{line: 966, col: 5, offset: 27156},
+				pos: position{line: 962, col: 5, offset: 27054},
 				run: (*parser).callonSQLHaving1,
 				expr: &seqExpr{
-					pos: position{line: 966, col: 5, offset: 27156},
+					pos: position{line: 962, col: 5, offset: 27054},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 966, col: 5, offset: 27156},
+							pos:  position{line: 962, col: 5, offset: 27054},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 966, col: 7, offset: 27158},
+							pos:  position{line: 962, col: 7, offset: 27056},
 							name: "HAVING",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 966, col: 14, offset: 27165},
+							pos:  position{line: 962, col: 14, offset: 27063},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 966, col: 16, offset: 27167},
+							pos:   position{line: 962, col: 16, offset: 27065},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 966, col: 21, offset: 27172},
+								pos:  position{line: 962, col: 21, offset: 27070},
 								name: "LogicalOrExpr",
 							},
 						},
@@ -7386,46 +7323,46 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOrderBy",
-			pos:  position{line: 968, col: 1, offset: 27208},
+			pos:  position{line: 964, col: 1, offset: 27106},
 			expr: &actionExpr{
-				pos: position{line: 969, col: 5, offset: 27223},
+				pos: position{line: 965, col: 5, offset: 27121},
 				run: (*parser).callonSQLOrderBy1,
 				expr: &seqExpr{
-					pos: position{line: 969, col: 5, offset: 27223},
+					pos: position{line: 965, col: 5, offset: 27121},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 969, col: 5, offset: 27223},
+							pos:  position{line: 965, col: 5, offset: 27121},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 969, col: 7, offset: 27225},
+							pos:  position{line: 965, col: 7, offset: 27123},
 							name: "ORDER",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 969, col: 13, offset: 27231},
+							pos:  position{line: 965, col: 13, offset: 27129},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 969, col: 15, offset: 27233},
+							pos:  position{line: 965, col: 15, offset: 27131},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 969, col: 18, offset: 27236},
+							pos:  position{line: 965, col: 18, offset: 27134},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 969, col: 20, offset: 27238},
+							pos:   position{line: 965, col: 20, offset: 27136},
 							label: "keys",
 							expr: &ruleRefExpr{
-								pos:  position{line: 969, col: 25, offset: 27243},
+								pos:  position{line: 965, col: 25, offset: 27141},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 969, col: 31, offset: 27249},
+							pos:   position{line: 965, col: 31, offset: 27147},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 969, col: 37, offset: 27255},
+								pos:  position{line: 965, col: 37, offset: 27153},
 								name: "SQLOrder",
 							},
 						},
@@ -7435,32 +7372,32 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOrder",
-			pos:  position{line: 973, col: 1, offset: 27365},
+			pos:  position{line: 969, col: 1, offset: 27263},
 			expr: &choiceExpr{
-				pos: position{line: 974, col: 5, offset: 27378},
+				pos: position{line: 970, col: 5, offset: 27276},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 974, col: 5, offset: 27378},
+						pos: position{line: 970, col: 5, offset: 27276},
 						run: (*parser).callonSQLOrder2,
 						expr: &seqExpr{
-							pos: position{line: 974, col: 5, offset: 27378},
+							pos: position{line: 970, col: 5, offset: 27276},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 974, col: 5, offset: 27378},
+									pos:  position{line: 970, col: 5, offset: 27276},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 974, col: 7, offset: 27380},
+									pos:   position{line: 970, col: 7, offset: 27278},
 									label: "dir",
 									expr: &choiceExpr{
-										pos: position{line: 974, col: 12, offset: 27385},
+										pos: position{line: 970, col: 12, offset: 27283},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 974, col: 12, offset: 27385},
+												pos:  position{line: 970, col: 12, offset: 27283},
 												name: "ASC",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 974, col: 18, offset: 27391},
+												pos:  position{line: 970, col: 18, offset: 27289},
 												name: "DESC",
 											},
 										},
@@ -7470,10 +7407,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 975, col: 5, offset: 27421},
+						pos: position{line: 971, col: 5, offset: 27319},
 						run: (*parser).callonSQLOrder9,
 						expr: &litMatcher{
-							pos:        position{line: 975, col: 5, offset: 27421},
+							pos:        position{line: 971, col: 5, offset: 27319},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7483,33 +7420,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLLimit",
-			pos:  position{line: 977, col: 1, offset: 27447},
+			pos:  position{line: 973, col: 1, offset: 27345},
 			expr: &choiceExpr{
-				pos: position{line: 978, col: 5, offset: 27460},
+				pos: position{line: 974, col: 5, offset: 27358},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 978, col: 5, offset: 27460},
+						pos: position{line: 974, col: 5, offset: 27358},
 						run: (*parser).callonSQLLimit2,
 						expr: &seqExpr{
-							pos: position{line: 978, col: 5, offset: 27460},
+							pos: position{line: 974, col: 5, offset: 27358},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 978, col: 5, offset: 27460},
+									pos:  position{line: 974, col: 5, offset: 27358},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 978, col: 7, offset: 27462},
+									pos:  position{line: 974, col: 7, offset: 27360},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 978, col: 13, offset: 27468},
+									pos:  position{line: 974, col: 13, offset: 27366},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 978, col: 15, offset: 27470},
+									pos:   position{line: 974, col: 15, offset: 27368},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 978, col: 21, offset: 27476},
+										pos:  position{line: 974, col: 21, offset: 27374},
 										name: "UInt",
 									},
 								},
@@ -7517,10 +7454,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 979, col: 5, offset: 27507},
+						pos: position{line: 975, col: 5, offset: 27405},
 						run: (*parser).callonSQLLimit9,
 						expr: &litMatcher{
-							pos:        position{line: 979, col: 5, offset: 27507},
+							pos:        position{line: 975, col: 5, offset: 27405},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7530,12 +7467,12 @@ var g = &grammar{
 		},
 		{
 			name: "SELECT",
-			pos:  position{line: 981, col: 1, offset: 27529},
+			pos:  position{line: 977, col: 1, offset: 27427},
 			expr: &actionExpr{
-				pos: position{line: 981, col: 10, offset: 27538},
+				pos: position{line: 977, col: 10, offset: 27436},
 				run: (*parser).callonSELECT1,
 				expr: &litMatcher{
-					pos:        position{line: 981, col: 10, offset: 27538},
+					pos:        position{line: 977, col: 10, offset: 27436},
 					val:        "select",
 					ignoreCase: true,
 				},
@@ -7543,12 +7480,12 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 982, col: 1, offset: 27573},
+			pos:  position{line: 978, col: 1, offset: 27471},
 			expr: &actionExpr{
-				pos: position{line: 982, col: 6, offset: 27578},
+				pos: position{line: 978, col: 6, offset: 27476},
 				run: (*parser).callonAS1,
 				expr: &litMatcher{
-					pos:        position{line: 982, col: 6, offset: 27578},
+					pos:        position{line: 978, col: 6, offset: 27476},
 					val:        "as",
 					ignoreCase: true,
 				},
@@ -7556,12 +7493,12 @@ var g = &grammar{
 		},
 		{
 			name: "FROM",
-			pos:  position{line: 983, col: 1, offset: 27605},
+			pos:  position{line: 979, col: 1, offset: 27503},
 			expr: &actionExpr{
-				pos: position{line: 983, col: 8, offset: 27612},
+				pos: position{line: 979, col: 8, offset: 27510},
 				run: (*parser).callonFROM1,
 				expr: &litMatcher{
-					pos:        position{line: 983, col: 8, offset: 27612},
+					pos:        position{line: 979, col: 8, offset: 27510},
 					val:        "from",
 					ignoreCase: true,
 				},
@@ -7569,12 +7506,12 @@ var g = &grammar{
 		},
 		{
 			name: "JOIN",
-			pos:  position{line: 984, col: 1, offset: 27643},
+			pos:  position{line: 980, col: 1, offset: 27541},
 			expr: &actionExpr{
-				pos: position{line: 984, col: 8, offset: 27650},
+				pos: position{line: 980, col: 8, offset: 27548},
 				run: (*parser).callonJOIN1,
 				expr: &litMatcher{
-					pos:        position{line: 984, col: 8, offset: 27650},
+					pos:        position{line: 980, col: 8, offset: 27548},
 					val:        "join",
 					ignoreCase: true,
 				},
@@ -7582,12 +7519,12 @@ var g = &grammar{
 		},
 		{
 			name: "WHERE",
-			pos:  position{line: 985, col: 1, offset: 27681},
+			pos:  position{line: 981, col: 1, offset: 27579},
 			expr: &actionExpr{
-				pos: position{line: 985, col: 9, offset: 27689},
+				pos: position{line: 981, col: 9, offset: 27587},
 				run: (*parser).callonWHERE1,
 				expr: &litMatcher{
-					pos:        position{line: 985, col: 9, offset: 27689},
+					pos:        position{line: 981, col: 9, offset: 27587},
 					val:        "where",
 					ignoreCase: true,
 				},
@@ -7595,12 +7532,12 @@ var g = &grammar{
 		},
 		{
 			name: "GROUP",
-			pos:  position{line: 986, col: 1, offset: 27722},
+			pos:  position{line: 982, col: 1, offset: 27620},
 			expr: &actionExpr{
-				pos: position{line: 986, col: 9, offset: 27730},
+				pos: position{line: 982, col: 9, offset: 27628},
 				run: (*parser).callonGROUP1,
 				expr: &litMatcher{
-					pos:        position{line: 986, col: 9, offset: 27730},
+					pos:        position{line: 982, col: 9, offset: 27628},
 					val:        "group",
 					ignoreCase: true,
 				},
@@ -7608,12 +7545,12 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 987, col: 1, offset: 27763},
+			pos:  position{line: 983, col: 1, offset: 27661},
 			expr: &actionExpr{
-				pos: position{line: 987, col: 6, offset: 27768},
+				pos: position{line: 983, col: 6, offset: 27666},
 				run: (*parser).callonBY1,
 				expr: &litMatcher{
-					pos:        position{line: 987, col: 6, offset: 27768},
+					pos:        position{line: 983, col: 6, offset: 27666},
 					val:        "by",
 					ignoreCase: true,
 				},
@@ -7621,12 +7558,12 @@ var g = &grammar{
 		},
 		{
 			name: "HAVING",
-			pos:  position{line: 988, col: 1, offset: 27795},
+			pos:  position{line: 984, col: 1, offset: 27693},
 			expr: &actionExpr{
-				pos: position{line: 988, col: 10, offset: 27804},
+				pos: position{line: 984, col: 10, offset: 27702},
 				run: (*parser).callonHAVING1,
 				expr: &litMatcher{
-					pos:        position{line: 988, col: 10, offset: 27804},
+					pos:        position{line: 984, col: 10, offset: 27702},
 					val:        "having",
 					ignoreCase: true,
 				},
@@ -7634,12 +7571,12 @@ var g = &grammar{
 		},
 		{
 			name: "ORDER",
-			pos:  position{line: 989, col: 1, offset: 27839},
+			pos:  position{line: 985, col: 1, offset: 27737},
 			expr: &actionExpr{
-				pos: position{line: 989, col: 9, offset: 27847},
+				pos: position{line: 985, col: 9, offset: 27745},
 				run: (*parser).callonORDER1,
 				expr: &litMatcher{
-					pos:        position{line: 989, col: 9, offset: 27847},
+					pos:        position{line: 985, col: 9, offset: 27745},
 					val:        "order",
 					ignoreCase: true,
 				},
@@ -7647,12 +7584,12 @@ var g = &grammar{
 		},
 		{
 			name: "ON",
-			pos:  position{line: 990, col: 1, offset: 27880},
+			pos:  position{line: 986, col: 1, offset: 27778},
 			expr: &actionExpr{
-				pos: position{line: 990, col: 6, offset: 27885},
+				pos: position{line: 986, col: 6, offset: 27783},
 				run: (*parser).callonON1,
 				expr: &litMatcher{
-					pos:        position{line: 990, col: 6, offset: 27885},
+					pos:        position{line: 986, col: 6, offset: 27783},
 					val:        "on",
 					ignoreCase: true,
 				},
@@ -7660,12 +7597,12 @@ var g = &grammar{
 		},
 		{
 			name: "LIMIT",
-			pos:  position{line: 991, col: 1, offset: 27912},
+			pos:  position{line: 987, col: 1, offset: 27810},
 			expr: &actionExpr{
-				pos: position{line: 991, col: 9, offset: 27920},
+				pos: position{line: 987, col: 9, offset: 27818},
 				run: (*parser).callonLIMIT1,
 				expr: &litMatcher{
-					pos:        position{line: 991, col: 9, offset: 27920},
+					pos:        position{line: 987, col: 9, offset: 27818},
 					val:        "limit",
 					ignoreCase: true,
 				},
@@ -7673,12 +7610,12 @@ var g = &grammar{
 		},
 		{
 			name: "ASC",
-			pos:  position{line: 992, col: 1, offset: 27953},
+			pos:  position{line: 988, col: 1, offset: 27851},
 			expr: &actionExpr{
-				pos: position{line: 992, col: 7, offset: 27959},
+				pos: position{line: 988, col: 7, offset: 27857},
 				run: (*parser).callonASC1,
 				expr: &litMatcher{
-					pos:        position{line: 992, col: 7, offset: 27959},
+					pos:        position{line: 988, col: 7, offset: 27857},
 					val:        "asc",
 					ignoreCase: true,
 				},
@@ -7686,12 +7623,12 @@ var g = &grammar{
 		},
 		{
 			name: "DESC",
-			pos:  position{line: 993, col: 1, offset: 27988},
+			pos:  position{line: 989, col: 1, offset: 27886},
 			expr: &actionExpr{
-				pos: position{line: 993, col: 8, offset: 27995},
+				pos: position{line: 989, col: 8, offset: 27893},
 				run: (*parser).callonDESC1,
 				expr: &litMatcher{
-					pos:        position{line: 993, col: 8, offset: 27995},
+					pos:        position{line: 989, col: 8, offset: 27893},
 					val:        "desc",
 					ignoreCase: true,
 				},
@@ -7699,12 +7636,12 @@ var g = &grammar{
 		},
 		{
 			name: "ANTI",
-			pos:  position{line: 994, col: 1, offset: 28026},
+			pos:  position{line: 990, col: 1, offset: 27924},
 			expr: &actionExpr{
-				pos: position{line: 994, col: 8, offset: 28033},
+				pos: position{line: 990, col: 8, offset: 27931},
 				run: (*parser).callonANTI1,
 				expr: &litMatcher{
-					pos:        position{line: 994, col: 8, offset: 28033},
+					pos:        position{line: 990, col: 8, offset: 27931},
 					val:        "anti",
 					ignoreCase: true,
 				},
@@ -7712,12 +7649,12 @@ var g = &grammar{
 		},
 		{
 			name: "LEFT",
-			pos:  position{line: 995, col: 1, offset: 28064},
+			pos:  position{line: 991, col: 1, offset: 27962},
 			expr: &actionExpr{
-				pos: position{line: 995, col: 8, offset: 28071},
+				pos: position{line: 991, col: 8, offset: 27969},
 				run: (*parser).callonLEFT1,
 				expr: &litMatcher{
-					pos:        position{line: 995, col: 8, offset: 28071},
+					pos:        position{line: 991, col: 8, offset: 27969},
 					val:        "left",
 					ignoreCase: true,
 				},
@@ -7725,12 +7662,12 @@ var g = &grammar{
 		},
 		{
 			name: "RIGHT",
-			pos:  position{line: 996, col: 1, offset: 28102},
+			pos:  position{line: 992, col: 1, offset: 28000},
 			expr: &actionExpr{
-				pos: position{line: 996, col: 9, offset: 28110},
+				pos: position{line: 992, col: 9, offset: 28008},
 				run: (*parser).callonRIGHT1,
 				expr: &litMatcher{
-					pos:        position{line: 996, col: 9, offset: 28110},
+					pos:        position{line: 992, col: 9, offset: 28008},
 					val:        "right",
 					ignoreCase: true,
 				},
@@ -7738,12 +7675,12 @@ var g = &grammar{
 		},
 		{
 			name: "INNER",
-			pos:  position{line: 997, col: 1, offset: 28143},
+			pos:  position{line: 993, col: 1, offset: 28041},
 			expr: &actionExpr{
-				pos: position{line: 997, col: 9, offset: 28151},
+				pos: position{line: 993, col: 9, offset: 28049},
 				run: (*parser).callonINNER1,
 				expr: &litMatcher{
-					pos:        position{line: 997, col: 9, offset: 28151},
+					pos:        position{line: 993, col: 9, offset: 28049},
 					val:        "inner",
 					ignoreCase: true,
 				},
@@ -7751,48 +7688,48 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTokenSentinels",
-			pos:  position{line: 999, col: 1, offset: 28185},
+			pos:  position{line: 995, col: 1, offset: 28083},
 			expr: &choiceExpr{
-				pos: position{line: 1000, col: 5, offset: 28207},
+				pos: position{line: 996, col: 5, offset: 28105},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1000, col: 5, offset: 28207},
+						pos:  position{line: 996, col: 5, offset: 28105},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1000, col: 14, offset: 28216},
+						pos:  position{line: 996, col: 14, offset: 28114},
 						name: "AS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1000, col: 19, offset: 28221},
+						pos:  position{line: 996, col: 19, offset: 28119},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1000, col: 27, offset: 28229},
+						pos:  position{line: 996, col: 27, offset: 28127},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1000, col: 34, offset: 28236},
+						pos:  position{line: 996, col: 34, offset: 28134},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1000, col: 42, offset: 28244},
+						pos:  position{line: 996, col: 42, offset: 28142},
 						name: "GROUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1000, col: 50, offset: 28252},
+						pos:  position{line: 996, col: 50, offset: 28150},
 						name: "HAVING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1000, col: 59, offset: 28261},
+						pos:  position{line: 996, col: 59, offset: 28159},
 						name: "ORDER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1000, col: 67, offset: 28269},
+						pos:  position{line: 996, col: 67, offset: 28167},
 						name: "LIMIT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1000, col: 75, offset: 28277},
+						pos:  position{line: 996, col: 75, offset: 28175},
 						name: "ON",
 					},
 				},
@@ -7800,52 +7737,52 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 1004, col: 1, offset: 28303},
+			pos:  position{line: 1000, col: 1, offset: 28201},
 			expr: &choiceExpr{
-				pos: position{line: 1005, col: 5, offset: 28315},
+				pos: position{line: 1001, col: 5, offset: 28213},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1005, col: 5, offset: 28315},
+						pos:  position{line: 1001, col: 5, offset: 28213},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1006, col: 5, offset: 28331},
+						pos:  position{line: 1002, col: 5, offset: 28229},
 						name: "TemplateLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1007, col: 5, offset: 28351},
+						pos:  position{line: 1003, col: 5, offset: 28249},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1008, col: 5, offset: 28369},
+						pos:  position{line: 1004, col: 5, offset: 28267},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1009, col: 5, offset: 28388},
+						pos:  position{line: 1005, col: 5, offset: 28286},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1010, col: 5, offset: 28405},
+						pos:  position{line: 1006, col: 5, offset: 28303},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1011, col: 5, offset: 28418},
+						pos:  position{line: 1007, col: 5, offset: 28316},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1012, col: 5, offset: 28427},
+						pos:  position{line: 1008, col: 5, offset: 28325},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1013, col: 5, offset: 28444},
+						pos:  position{line: 1009, col: 5, offset: 28342},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1014, col: 5, offset: 28463},
+						pos:  position{line: 1010, col: 5, offset: 28361},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1015, col: 5, offset: 28482},
+						pos:  position{line: 1011, col: 5, offset: 28380},
 						name: "NullLiteral",
 					},
 				},
@@ -7853,28 +7790,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 1017, col: 1, offset: 28495},
+			pos:  position{line: 1013, col: 1, offset: 28393},
 			expr: &choiceExpr{
-				pos: position{line: 1018, col: 5, offset: 28513},
+				pos: position{line: 1014, col: 5, offset: 28411},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1018, col: 5, offset: 28513},
+						pos: position{line: 1014, col: 5, offset: 28411},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1018, col: 5, offset: 28513},
+							pos: position{line: 1014, col: 5, offset: 28411},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1018, col: 5, offset: 28513},
+									pos:   position{line: 1014, col: 5, offset: 28411},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1018, col: 7, offset: 28515},
+										pos:  position{line: 1014, col: 7, offset: 28413},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1018, col: 14, offset: 28522},
+									pos: position{line: 1014, col: 14, offset: 28420},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1018, col: 15, offset: 28523},
+										pos:  position{line: 1014, col: 15, offset: 28421},
 										name: "IdentifierRest",
 									},
 								},
@@ -7882,13 +7819,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1021, col: 5, offset: 28638},
+						pos: position{line: 1017, col: 5, offset: 28536},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1021, col: 5, offset: 28638},
+							pos:   position{line: 1017, col: 5, offset: 28536},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1021, col: 7, offset: 28640},
+								pos:  position{line: 1017, col: 7, offset: 28538},
 								name: "IP4Net",
 							},
 						},
@@ -7898,28 +7835,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 1025, col: 1, offset: 28744},
+			pos:  position{line: 1021, col: 1, offset: 28642},
 			expr: &choiceExpr{
-				pos: position{line: 1026, col: 5, offset: 28763},
+				pos: position{line: 1022, col: 5, offset: 28661},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1026, col: 5, offset: 28763},
+						pos: position{line: 1022, col: 5, offset: 28661},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1026, col: 5, offset: 28763},
+							pos: position{line: 1022, col: 5, offset: 28661},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1026, col: 5, offset: 28763},
+									pos:   position{line: 1022, col: 5, offset: 28661},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1026, col: 7, offset: 28765},
+										pos:  position{line: 1022, col: 7, offset: 28663},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1026, col: 11, offset: 28769},
+									pos: position{line: 1022, col: 11, offset: 28667},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1026, col: 12, offset: 28770},
+										pos:  position{line: 1022, col: 12, offset: 28668},
 										name: "IdentifierRest",
 									},
 								},
@@ -7927,13 +7864,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1029, col: 5, offset: 28884},
+						pos: position{line: 1025, col: 5, offset: 28782},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1029, col: 5, offset: 28884},
+							pos:   position{line: 1025, col: 5, offset: 28782},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1029, col: 7, offset: 28886},
+								pos:  position{line: 1025, col: 7, offset: 28784},
 								name: "IP",
 							},
 						},
@@ -7943,15 +7880,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 1033, col: 1, offset: 28985},
+			pos:  position{line: 1029, col: 1, offset: 28883},
 			expr: &actionExpr{
-				pos: position{line: 1034, col: 5, offset: 29002},
+				pos: position{line: 1030, col: 5, offset: 28900},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1034, col: 5, offset: 29002},
+					pos:   position{line: 1030, col: 5, offset: 28900},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1034, col: 7, offset: 29004},
+						pos:  position{line: 1030, col: 7, offset: 28902},
 						name: "FloatString",
 					},
 				},
@@ -7959,15 +7896,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 1038, col: 1, offset: 29117},
+			pos:  position{line: 1034, col: 1, offset: 29015},
 			expr: &actionExpr{
-				pos: position{line: 1039, col: 5, offset: 29136},
+				pos: position{line: 1035, col: 5, offset: 29034},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1039, col: 5, offset: 29136},
+					pos:   position{line: 1035, col: 5, offset: 29034},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1039, col: 7, offset: 29138},
+						pos:  position{line: 1035, col: 7, offset: 29036},
 						name: "IntString",
 					},
 				},
@@ -7975,24 +7912,24 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 1043, col: 1, offset: 29247},
+			pos:  position{line: 1039, col: 1, offset: 29145},
 			expr: &choiceExpr{
-				pos: position{line: 1044, col: 5, offset: 29266},
+				pos: position{line: 1040, col: 5, offset: 29164},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1044, col: 5, offset: 29266},
+						pos: position{line: 1040, col: 5, offset: 29164},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &litMatcher{
-							pos:        position{line: 1044, col: 5, offset: 29266},
+							pos:        position{line: 1040, col: 5, offset: 29164},
 							val:        "true",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1045, col: 5, offset: 29379},
+						pos: position{line: 1041, col: 5, offset: 29277},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &litMatcher{
-							pos:        position{line: 1045, col: 5, offset: 29379},
+							pos:        position{line: 1041, col: 5, offset: 29277},
 							val:        "false",
 							ignoreCase: false,
 						},
@@ -8002,12 +7939,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 1047, col: 1, offset: 29490},
+			pos:  position{line: 1043, col: 1, offset: 29388},
 			expr: &actionExpr{
-				pos: position{line: 1048, col: 5, offset: 29506},
+				pos: position{line: 1044, col: 5, offset: 29404},
 				run: (*parser).callonNullLiteral1,
 				expr: &litMatcher{
-					pos:        position{line: 1048, col: 5, offset: 29506},
+					pos:        position{line: 1044, col: 5, offset: 29404},
 					val:        "null",
 					ignoreCase: false,
 				},
@@ -8015,22 +7952,22 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 1050, col: 1, offset: 29612},
+			pos:  position{line: 1046, col: 1, offset: 29510},
 			expr: &actionExpr{
-				pos: position{line: 1051, col: 5, offset: 29629},
+				pos: position{line: 1047, col: 5, offset: 29527},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1051, col: 5, offset: 29629},
+					pos: position{line: 1047, col: 5, offset: 29527},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1051, col: 5, offset: 29629},
+							pos:        position{line: 1047, col: 5, offset: 29527},
 							val:        "0x",
 							ignoreCase: false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1051, col: 10, offset: 29634},
+							pos: position{line: 1047, col: 10, offset: 29532},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1051, col: 10, offset: 29634},
+								pos:  position{line: 1047, col: 10, offset: 29532},
 								name: "HexDigit",
 							},
 						},
@@ -8040,28 +7977,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 1055, col: 1, offset: 29749},
+			pos:  position{line: 1051, col: 1, offset: 29647},
 			expr: &actionExpr{
-				pos: position{line: 1056, col: 5, offset: 29765},
+				pos: position{line: 1052, col: 5, offset: 29663},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1056, col: 5, offset: 29765},
+					pos: position{line: 1052, col: 5, offset: 29663},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1056, col: 5, offset: 29765},
+							pos:        position{line: 1052, col: 5, offset: 29663},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1056, col: 9, offset: 29769},
+							pos:   position{line: 1052, col: 9, offset: 29667},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1056, col: 13, offset: 29773},
+								pos:  position{line: 1052, col: 13, offset: 29671},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1056, col: 18, offset: 29778},
+							pos:        position{line: 1052, col: 18, offset: 29676},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -8071,22 +8008,22 @@ var g = &grammar{
 		},
 		{
 			name: "CastType",
-			pos:  position{line: 1060, col: 1, offset: 29867},
+			pos:  position{line: 1056, col: 1, offset: 29765},
 			expr: &choiceExpr{
-				pos: position{line: 1061, col: 5, offset: 29880},
+				pos: position{line: 1057, col: 5, offset: 29778},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1061, col: 5, offset: 29880},
+						pos:  position{line: 1057, col: 5, offset: 29778},
 						name: "TypeLiteral",
 					},
 					&actionExpr{
-						pos: position{line: 1062, col: 5, offset: 29896},
+						pos: position{line: 1058, col: 5, offset: 29794},
 						run: (*parser).callonCastType3,
 						expr: &labeledExpr{
-							pos:   position{line: 1062, col: 5, offset: 29896},
+							pos:   position{line: 1058, col: 5, offset: 29794},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1062, col: 9, offset: 29900},
+								pos:  position{line: 1058, col: 9, offset: 29798},
 								name: "PrimitiveType",
 							},
 						},
@@ -8096,20 +8033,20 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1066, col: 1, offset: 29999},
+			pos:  position{line: 1062, col: 1, offset: 29897},
 			expr: &choiceExpr{
-				pos: position{line: 1067, col: 5, offset: 30008},
+				pos: position{line: 1063, col: 5, offset: 29906},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1067, col: 5, offset: 30008},
+						pos:  position{line: 1063, col: 5, offset: 29906},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1068, col: 5, offset: 30024},
+						pos:  position{line: 1064, col: 5, offset: 29922},
 						name: "AmbiguousType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1069, col: 5, offset: 30042},
+						pos:  position{line: 1065, col: 5, offset: 29940},
 						name: "ComplexType",
 					},
 				},
@@ -8117,28 +8054,28 @@ var g = &grammar{
 		},
 		{
 			name: "AmbiguousType",
-			pos:  position{line: 1071, col: 1, offset: 30055},
+			pos:  position{line: 1067, col: 1, offset: 29953},
 			expr: &choiceExpr{
-				pos: position{line: 1072, col: 5, offset: 30073},
+				pos: position{line: 1068, col: 5, offset: 29971},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1072, col: 5, offset: 30073},
+						pos: position{line: 1068, col: 5, offset: 29971},
 						run: (*parser).callonAmbiguousType2,
 						expr: &seqExpr{
-							pos: position{line: 1072, col: 5, offset: 30073},
+							pos: position{line: 1068, col: 5, offset: 29971},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1072, col: 5, offset: 30073},
+									pos:   position{line: 1068, col: 5, offset: 29971},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1072, col: 10, offset: 30078},
+										pos:  position{line: 1068, col: 10, offset: 29976},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1072, col: 24, offset: 30092},
+									pos: position{line: 1068, col: 24, offset: 29990},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1072, col: 25, offset: 30093},
+										pos:  position{line: 1068, col: 25, offset: 29991},
 										name: "IdentifierRest",
 									},
 								},
@@ -8146,42 +8083,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1073, col: 5, offset: 30133},
+						pos: position{line: 1069, col: 5, offset: 30031},
 						run: (*parser).callonAmbiguousType8,
 						expr: &seqExpr{
-							pos: position{line: 1073, col: 5, offset: 30133},
+							pos: position{line: 1069, col: 5, offset: 30031},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1073, col: 5, offset: 30133},
+									pos:   position{line: 1069, col: 5, offset: 30031},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1073, col: 10, offset: 30138},
+										pos:  position{line: 1069, col: 10, offset: 30036},
 										name: "IdentifierName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1073, col: 25, offset: 30153},
+									pos:   position{line: 1069, col: 25, offset: 30051},
 									label: "opt",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1073, col: 29, offset: 30157},
+										pos: position{line: 1069, col: 29, offset: 30055},
 										expr: &seqExpr{
-											pos: position{line: 1073, col: 30, offset: 30158},
+											pos: position{line: 1069, col: 30, offset: 30056},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 1073, col: 30, offset: 30158},
+													pos:  position{line: 1069, col: 30, offset: 30056},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1073, col: 33, offset: 30161},
+													pos:        position{line: 1069, col: 33, offset: 30059},
 													val:        "=",
 													ignoreCase: false,
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1073, col: 37, offset: 30165},
+													pos:  position{line: 1069, col: 37, offset: 30063},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1073, col: 40, offset: 30168},
+													pos:  position{line: 1069, col: 40, offset: 30066},
 													name: "Type",
 												},
 											},
@@ -8192,42 +8129,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1079, col: 5, offset: 30400},
+						pos: position{line: 1075, col: 5, offset: 30298},
 						run: (*parser).callonAmbiguousType19,
 						expr: &labeledExpr{
-							pos:   position{line: 1079, col: 5, offset: 30400},
+							pos:   position{line: 1075, col: 5, offset: 30298},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1079, col: 10, offset: 30405},
+								pos:  position{line: 1075, col: 10, offset: 30303},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1082, col: 5, offset: 30505},
+						pos: position{line: 1078, col: 5, offset: 30403},
 						run: (*parser).callonAmbiguousType22,
 						expr: &seqExpr{
-							pos: position{line: 1082, col: 5, offset: 30505},
+							pos: position{line: 1078, col: 5, offset: 30403},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1082, col: 5, offset: 30505},
+									pos:        position{line: 1078, col: 5, offset: 30403},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1082, col: 9, offset: 30509},
+									pos:  position{line: 1078, col: 9, offset: 30407},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1082, col: 12, offset: 30512},
+									pos:   position{line: 1078, col: 12, offset: 30410},
 									label: "u",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1082, col: 14, offset: 30514},
+										pos:  position{line: 1078, col: 14, offset: 30412},
 										name: "TypeUnion",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1082, col: 25, offset: 30525},
+									pos:        position{line: 1078, col: 25, offset: 30423},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -8239,15 +8176,15 @@ var g = &grammar{
 		},
 		{
 			name: "TypeUnion",
-			pos:  position{line: 1084, col: 1, offset: 30548},
+			pos:  position{line: 1080, col: 1, offset: 30446},
 			expr: &actionExpr{
-				pos: position{line: 1085, col: 5, offset: 30562},
+				pos: position{line: 1081, col: 5, offset: 30460},
 				run: (*parser).callonTypeUnion1,
 				expr: &labeledExpr{
-					pos:   position{line: 1085, col: 5, offset: 30562},
+					pos:   position{line: 1081, col: 5, offset: 30460},
 					label: "types",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1085, col: 11, offset: 30568},
+						pos:  position{line: 1081, col: 11, offset: 30466},
 						name: "TypeList",
 					},
 				},
@@ -8255,28 +8192,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1089, col: 1, offset: 30664},
+			pos:  position{line: 1085, col: 1, offset: 30562},
 			expr: &actionExpr{
-				pos: position{line: 1090, col: 5, offset: 30677},
+				pos: position{line: 1086, col: 5, offset: 30575},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1090, col: 5, offset: 30677},
+					pos: position{line: 1086, col: 5, offset: 30575},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1090, col: 5, offset: 30677},
+							pos:   position{line: 1086, col: 5, offset: 30575},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1090, col: 11, offset: 30683},
+								pos:  position{line: 1086, col: 11, offset: 30581},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1090, col: 16, offset: 30688},
+							pos:   position{line: 1086, col: 16, offset: 30586},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1090, col: 21, offset: 30693},
+								pos: position{line: 1086, col: 21, offset: 30591},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1090, col: 21, offset: 30693},
+									pos:  position{line: 1086, col: 21, offset: 30591},
 									name: "TypeListTail",
 								},
 							},
@@ -8287,31 +8224,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1094, col: 1, offset: 30787},
+			pos:  position{line: 1090, col: 1, offset: 30685},
 			expr: &actionExpr{
-				pos: position{line: 1094, col: 16, offset: 30802},
+				pos: position{line: 1090, col: 16, offset: 30700},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1094, col: 16, offset: 30802},
+					pos: position{line: 1090, col: 16, offset: 30700},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1094, col: 16, offset: 30802},
+							pos:  position{line: 1090, col: 16, offset: 30700},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1094, col: 19, offset: 30805},
+							pos:        position{line: 1090, col: 19, offset: 30703},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1094, col: 23, offset: 30809},
+							pos:  position{line: 1090, col: 23, offset: 30707},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1094, col: 26, offset: 30812},
+							pos:   position{line: 1090, col: 26, offset: 30710},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1094, col: 30, offset: 30816},
+								pos:  position{line: 1090, col: 30, offset: 30714},
 								name: "Type",
 							},
 						},
@@ -8321,39 +8258,39 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 1096, col: 1, offset: 30842},
+			pos:  position{line: 1092, col: 1, offset: 30740},
 			expr: &choiceExpr{
-				pos: position{line: 1097, col: 5, offset: 30858},
+				pos: position{line: 1093, col: 5, offset: 30756},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1097, col: 5, offset: 30858},
+						pos: position{line: 1093, col: 5, offset: 30756},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 1097, col: 5, offset: 30858},
+							pos: position{line: 1093, col: 5, offset: 30756},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1097, col: 5, offset: 30858},
+									pos:        position{line: 1093, col: 5, offset: 30756},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1097, col: 9, offset: 30862},
+									pos:  position{line: 1093, col: 9, offset: 30760},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1097, col: 12, offset: 30865},
+									pos:   position{line: 1093, col: 12, offset: 30763},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1097, col: 19, offset: 30872},
+										pos:  position{line: 1093, col: 19, offset: 30770},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1097, col: 33, offset: 30886},
+									pos:  position{line: 1093, col: 33, offset: 30784},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1097, col: 36, offset: 30889},
+									pos:        position{line: 1093, col: 36, offset: 30787},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -8361,34 +8298,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1100, col: 5, offset: 30984},
+						pos: position{line: 1096, col: 5, offset: 30882},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 1100, col: 5, offset: 30984},
+							pos: position{line: 1096, col: 5, offset: 30882},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1100, col: 5, offset: 30984},
+									pos:        position{line: 1096, col: 5, offset: 30882},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1100, col: 9, offset: 30988},
+									pos:  position{line: 1096, col: 9, offset: 30886},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1100, col: 12, offset: 30991},
+									pos:   position{line: 1096, col: 12, offset: 30889},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1100, col: 16, offset: 30995},
+										pos:  position{line: 1096, col: 16, offset: 30893},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1100, col: 21, offset: 31000},
+									pos:  position{line: 1096, col: 21, offset: 30898},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1100, col: 24, offset: 31003},
+									pos:        position{line: 1096, col: 24, offset: 30901},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -8396,34 +8333,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1103, col: 5, offset: 31092},
+						pos: position{line: 1099, col: 5, offset: 30990},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 1103, col: 5, offset: 31092},
+							pos: position{line: 1099, col: 5, offset: 30990},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1103, col: 5, offset: 31092},
+									pos:        position{line: 1099, col: 5, offset: 30990},
 									val:        "|[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1103, col: 10, offset: 31097},
+									pos:  position{line: 1099, col: 10, offset: 30995},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1103, col: 14, offset: 31101},
+									pos:   position{line: 1099, col: 14, offset: 30999},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1103, col: 18, offset: 31105},
+										pos:  position{line: 1099, col: 18, offset: 31003},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1103, col: 23, offset: 31110},
+									pos:  position{line: 1099, col: 23, offset: 31008},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1103, col: 26, offset: 31113},
+									pos:        position{line: 1099, col: 26, offset: 31011},
 									val:        "]|",
 									ignoreCase: false,
 								},
@@ -8431,55 +8368,55 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1106, col: 5, offset: 31201},
+						pos: position{line: 1102, col: 5, offset: 31099},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 1106, col: 5, offset: 31201},
+							pos: position{line: 1102, col: 5, offset: 31099},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1106, col: 5, offset: 31201},
+									pos:        position{line: 1102, col: 5, offset: 31099},
 									val:        "|{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1106, col: 10, offset: 31206},
+									pos:  position{line: 1102, col: 10, offset: 31104},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1106, col: 13, offset: 31209},
+									pos:   position{line: 1102, col: 13, offset: 31107},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1106, col: 21, offset: 31217},
+										pos:  position{line: 1102, col: 21, offset: 31115},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1106, col: 26, offset: 31222},
+									pos:  position{line: 1102, col: 26, offset: 31120},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1106, col: 29, offset: 31225},
+									pos:        position{line: 1102, col: 29, offset: 31123},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1106, col: 33, offset: 31229},
+									pos:  position{line: 1102, col: 33, offset: 31127},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1106, col: 36, offset: 31232},
+									pos:   position{line: 1102, col: 36, offset: 31130},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1106, col: 44, offset: 31240},
+										pos:  position{line: 1102, col: 44, offset: 31138},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1106, col: 49, offset: 31245},
+									pos:  position{line: 1102, col: 49, offset: 31143},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1106, col: 52, offset: 31248},
+									pos:        position{line: 1102, col: 52, offset: 31146},
 									val:        "}|",
 									ignoreCase: false,
 								},
@@ -8491,15 +8428,15 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateLiteral",
-			pos:  position{line: 1110, col: 1, offset: 31362},
+			pos:  position{line: 1106, col: 1, offset: 31260},
 			expr: &actionExpr{
-				pos: position{line: 1111, col: 5, offset: 31382},
+				pos: position{line: 1107, col: 5, offset: 31280},
 				run: (*parser).callonTemplateLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1111, col: 5, offset: 31382},
+					pos:   position{line: 1107, col: 5, offset: 31280},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1111, col: 7, offset: 31384},
+						pos:  position{line: 1107, col: 7, offset: 31282},
 						name: "TemplateLiteralParts",
 					},
 				},
@@ -8507,34 +8444,34 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateLiteralParts",
-			pos:  position{line: 1118, col: 1, offset: 31600},
+			pos:  position{line: 1114, col: 1, offset: 31498},
 			expr: &choiceExpr{
-				pos: position{line: 1119, col: 5, offset: 31625},
+				pos: position{line: 1115, col: 5, offset: 31523},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1119, col: 5, offset: 31625},
+						pos: position{line: 1115, col: 5, offset: 31523},
 						run: (*parser).callonTemplateLiteralParts2,
 						expr: &seqExpr{
-							pos: position{line: 1119, col: 5, offset: 31625},
+							pos: position{line: 1115, col: 5, offset: 31523},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1119, col: 5, offset: 31625},
+									pos:        position{line: 1115, col: 5, offset: 31523},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1119, col: 9, offset: 31629},
+									pos:   position{line: 1115, col: 9, offset: 31527},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1119, col: 11, offset: 31631},
+										pos: position{line: 1115, col: 11, offset: 31529},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1119, col: 11, offset: 31631},
+											pos:  position{line: 1115, col: 11, offset: 31529},
 											name: "TemplateDoubleQuotedPart",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1119, col: 37, offset: 31657},
+									pos:        position{line: 1115, col: 37, offset: 31555},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -8542,29 +8479,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1120, col: 5, offset: 31683},
+						pos: position{line: 1116, col: 5, offset: 31581},
 						run: (*parser).callonTemplateLiteralParts9,
 						expr: &seqExpr{
-							pos: position{line: 1120, col: 5, offset: 31683},
+							pos: position{line: 1116, col: 5, offset: 31581},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1120, col: 5, offset: 31683},
+									pos:        position{line: 1116, col: 5, offset: 31581},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1120, col: 9, offset: 31687},
+									pos:   position{line: 1116, col: 9, offset: 31585},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1120, col: 11, offset: 31689},
+										pos: position{line: 1116, col: 11, offset: 31587},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1120, col: 11, offset: 31689},
+											pos:  position{line: 1116, col: 11, offset: 31587},
 											name: "TemplateSingleQuotedPart",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1120, col: 37, offset: 31715},
+									pos:        position{line: 1116, col: 37, offset: 31613},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -8576,24 +8513,24 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateDoubleQuotedPart",
-			pos:  position{line: 1122, col: 1, offset: 31738},
+			pos:  position{line: 1118, col: 1, offset: 31636},
 			expr: &choiceExpr{
-				pos: position{line: 1123, col: 5, offset: 31767},
+				pos: position{line: 1119, col: 5, offset: 31665},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1123, col: 5, offset: 31767},
+						pos:  position{line: 1119, col: 5, offset: 31665},
 						name: "TemplateExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1124, col: 5, offset: 31784},
+						pos: position{line: 1120, col: 5, offset: 31682},
 						run: (*parser).callonTemplateDoubleQuotedPart3,
 						expr: &labeledExpr{
-							pos:   position{line: 1124, col: 5, offset: 31784},
+							pos:   position{line: 1120, col: 5, offset: 31682},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1124, col: 7, offset: 31786},
+								pos: position{line: 1120, col: 7, offset: 31684},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1124, col: 7, offset: 31786},
+									pos:  position{line: 1120, col: 7, offset: 31684},
 									name: "TemplateDoubleQuotedChar",
 								},
 							},
@@ -8604,26 +8541,26 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateDoubleQuotedChar",
-			pos:  position{line: 1128, col: 1, offset: 31923},
+			pos:  position{line: 1124, col: 1, offset: 31821},
 			expr: &choiceExpr{
-				pos: position{line: 1129, col: 5, offset: 31952},
+				pos: position{line: 1125, col: 5, offset: 31850},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1129, col: 5, offset: 31952},
+						pos: position{line: 1125, col: 5, offset: 31850},
 						run: (*parser).callonTemplateDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1129, col: 5, offset: 31952},
+							pos: position{line: 1125, col: 5, offset: 31850},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1129, col: 5, offset: 31952},
+									pos:        position{line: 1125, col: 5, offset: 31850},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1129, col: 10, offset: 31957},
+									pos:   position{line: 1125, col: 10, offset: 31855},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1129, col: 12, offset: 31959},
+										pos:        position{line: 1125, col: 12, offset: 31857},
 										val:        "${",
 										ignoreCase: false,
 									},
@@ -8632,24 +8569,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1130, col: 5, offset: 31986},
+						pos: position{line: 1126, col: 5, offset: 31884},
 						run: (*parser).callonTemplateDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1130, col: 5, offset: 31986},
+							pos: position{line: 1126, col: 5, offset: 31884},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1130, col: 5, offset: 31986},
+									pos: position{line: 1126, col: 5, offset: 31884},
 									expr: &litMatcher{
-										pos:        position{line: 1130, col: 8, offset: 31989},
+										pos:        position{line: 1126, col: 8, offset: 31887},
 										val:        "${",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1130, col: 15, offset: 31996},
+									pos:   position{line: 1126, col: 15, offset: 31894},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1130, col: 17, offset: 31998},
+										pos:  position{line: 1126, col: 17, offset: 31896},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -8661,24 +8598,24 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateSingleQuotedPart",
-			pos:  position{line: 1132, col: 1, offset: 32034},
+			pos:  position{line: 1128, col: 1, offset: 31932},
 			expr: &choiceExpr{
-				pos: position{line: 1133, col: 5, offset: 32063},
+				pos: position{line: 1129, col: 5, offset: 31961},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1133, col: 5, offset: 32063},
+						pos:  position{line: 1129, col: 5, offset: 31961},
 						name: "TemplateExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1134, col: 5, offset: 32080},
+						pos: position{line: 1130, col: 5, offset: 31978},
 						run: (*parser).callonTemplateSingleQuotedPart3,
 						expr: &labeledExpr{
-							pos:   position{line: 1134, col: 5, offset: 32080},
+							pos:   position{line: 1130, col: 5, offset: 31978},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1134, col: 7, offset: 32082},
+								pos: position{line: 1130, col: 7, offset: 31980},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1134, col: 7, offset: 32082},
+									pos:  position{line: 1130, col: 7, offset: 31980},
 									name: "TemplateSingleQuotedChar",
 								},
 							},
@@ -8689,26 +8626,26 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateSingleQuotedChar",
-			pos:  position{line: 1138, col: 1, offset: 32219},
+			pos:  position{line: 1134, col: 1, offset: 32117},
 			expr: &choiceExpr{
-				pos: position{line: 1139, col: 5, offset: 32248},
+				pos: position{line: 1135, col: 5, offset: 32146},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1139, col: 5, offset: 32248},
+						pos: position{line: 1135, col: 5, offset: 32146},
 						run: (*parser).callonTemplateSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1139, col: 5, offset: 32248},
+							pos: position{line: 1135, col: 5, offset: 32146},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1139, col: 5, offset: 32248},
+									pos:        position{line: 1135, col: 5, offset: 32146},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1139, col: 10, offset: 32253},
+									pos:   position{line: 1135, col: 10, offset: 32151},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1139, col: 12, offset: 32255},
+										pos:        position{line: 1135, col: 12, offset: 32153},
 										val:        "${",
 										ignoreCase: false,
 									},
@@ -8717,24 +8654,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1140, col: 5, offset: 32282},
+						pos: position{line: 1136, col: 5, offset: 32180},
 						run: (*parser).callonTemplateSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1140, col: 5, offset: 32282},
+							pos: position{line: 1136, col: 5, offset: 32180},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1140, col: 5, offset: 32282},
+									pos: position{line: 1136, col: 5, offset: 32180},
 									expr: &litMatcher{
-										pos:        position{line: 1140, col: 8, offset: 32285},
+										pos:        position{line: 1136, col: 8, offset: 32183},
 										val:        "${",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1140, col: 15, offset: 32292},
+									pos:   position{line: 1136, col: 15, offset: 32190},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1140, col: 17, offset: 32294},
+										pos:  position{line: 1136, col: 17, offset: 32192},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -8746,36 +8683,36 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateExpr",
-			pos:  position{line: 1142, col: 1, offset: 32330},
+			pos:  position{line: 1138, col: 1, offset: 32228},
 			expr: &actionExpr{
-				pos: position{line: 1143, col: 5, offset: 32347},
+				pos: position{line: 1139, col: 5, offset: 32245},
 				run: (*parser).callonTemplateExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1143, col: 5, offset: 32347},
+					pos: position{line: 1139, col: 5, offset: 32245},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1143, col: 5, offset: 32347},
+							pos:        position{line: 1139, col: 5, offset: 32245},
 							val:        "${",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1143, col: 10, offset: 32352},
+							pos:  position{line: 1139, col: 10, offset: 32250},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1143, col: 13, offset: 32355},
+							pos:   position{line: 1139, col: 13, offset: 32253},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1143, col: 15, offset: 32357},
+								pos:  position{line: 1139, col: 15, offset: 32255},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1143, col: 20, offset: 32362},
+							pos:  position{line: 1139, col: 20, offset: 32260},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1143, col: 23, offset: 32365},
+							pos:        position{line: 1139, col: 23, offset: 32263},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -8785,110 +8722,110 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1158, col: 1, offset: 32661},
+			pos:  position{line: 1154, col: 1, offset: 32559},
 			expr: &actionExpr{
-				pos: position{line: 1159, col: 5, offset: 32679},
+				pos: position{line: 1155, col: 5, offset: 32577},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1159, col: 9, offset: 32683},
+					pos: position{line: 1155, col: 9, offset: 32581},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1159, col: 9, offset: 32683},
+							pos:        position{line: 1155, col: 9, offset: 32581},
 							val:        "uint8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1159, col: 19, offset: 32693},
+							pos:        position{line: 1155, col: 19, offset: 32591},
 							val:        "uint16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1159, col: 30, offset: 32704},
+							pos:        position{line: 1155, col: 30, offset: 32602},
 							val:        "uint32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1159, col: 41, offset: 32715},
+							pos:        position{line: 1155, col: 41, offset: 32613},
 							val:        "uint64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1160, col: 9, offset: 32732},
+							pos:        position{line: 1156, col: 9, offset: 32630},
 							val:        "int8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1160, col: 18, offset: 32741},
+							pos:        position{line: 1156, col: 18, offset: 32639},
 							val:        "int16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1160, col: 28, offset: 32751},
+							pos:        position{line: 1156, col: 28, offset: 32649},
 							val:        "int32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1160, col: 38, offset: 32761},
+							pos:        position{line: 1156, col: 38, offset: 32659},
 							val:        "int64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1161, col: 9, offset: 32777},
+							pos:        position{line: 1157, col: 9, offset: 32675},
 							val:        "float16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1161, col: 21, offset: 32789},
+							pos:        position{line: 1157, col: 21, offset: 32687},
 							val:        "float32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1161, col: 33, offset: 32801},
+							pos:        position{line: 1157, col: 33, offset: 32699},
 							val:        "float64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1162, col: 9, offset: 32819},
+							pos:        position{line: 1158, col: 9, offset: 32717},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1162, col: 18, offset: 32828},
+							pos:        position{line: 1158, col: 18, offset: 32726},
 							val:        "string",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1163, col: 9, offset: 32845},
+							pos:        position{line: 1159, col: 9, offset: 32743},
 							val:        "duration",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1163, col: 22, offset: 32858},
+							pos:        position{line: 1159, col: 22, offset: 32756},
 							val:        "time",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1164, col: 9, offset: 32873},
+							pos:        position{line: 1160, col: 9, offset: 32771},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1165, col: 9, offset: 32889},
+							pos:        position{line: 1161, col: 9, offset: 32787},
 							val:        "ip",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1165, col: 16, offset: 32896},
+							pos:        position{line: 1161, col: 16, offset: 32794},
 							val:        "net",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1166, col: 9, offset: 32910},
+							pos:        position{line: 1162, col: 9, offset: 32808},
 							val:        "type",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1166, col: 18, offset: 32919},
+							pos:        position{line: 1162, col: 18, offset: 32817},
 							val:        "null",
 							ignoreCase: false,
 						},
@@ -8898,31 +8835,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1170, col: 1, offset: 33035},
+			pos:  position{line: 1166, col: 1, offset: 32933},
 			expr: &choiceExpr{
-				pos: position{line: 1171, col: 5, offset: 33053},
+				pos: position{line: 1167, col: 5, offset: 32951},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1171, col: 5, offset: 33053},
+						pos: position{line: 1167, col: 5, offset: 32951},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1171, col: 5, offset: 33053},
+							pos: position{line: 1167, col: 5, offset: 32951},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1171, col: 5, offset: 33053},
+									pos:   position{line: 1167, col: 5, offset: 32951},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1171, col: 11, offset: 33059},
+										pos:  position{line: 1167, col: 11, offset: 32957},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1171, col: 21, offset: 33069},
+									pos:   position{line: 1167, col: 21, offset: 32967},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1171, col: 26, offset: 33074},
+										pos: position{line: 1167, col: 26, offset: 32972},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1171, col: 26, offset: 33074},
+											pos:  position{line: 1167, col: 26, offset: 32972},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -8931,10 +8868,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1174, col: 5, offset: 33176},
+						pos: position{line: 1170, col: 5, offset: 33074},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1174, col: 5, offset: 33176},
+							pos:        position{line: 1170, col: 5, offset: 33074},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -8944,31 +8881,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1176, col: 1, offset: 33200},
+			pos:  position{line: 1172, col: 1, offset: 33098},
 			expr: &actionExpr{
-				pos: position{line: 1176, col: 21, offset: 33220},
+				pos: position{line: 1172, col: 21, offset: 33118},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1176, col: 21, offset: 33220},
+					pos: position{line: 1172, col: 21, offset: 33118},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1176, col: 21, offset: 33220},
+							pos:  position{line: 1172, col: 21, offset: 33118},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1176, col: 24, offset: 33223},
+							pos:        position{line: 1172, col: 24, offset: 33121},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1176, col: 28, offset: 33227},
+							pos:  position{line: 1172, col: 28, offset: 33125},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1176, col: 31, offset: 33230},
+							pos:   position{line: 1172, col: 31, offset: 33128},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1176, col: 35, offset: 33234},
+								pos:  position{line: 1172, col: 35, offset: 33132},
 								name: "TypeField",
 							},
 						},
@@ -8978,39 +8915,39 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1178, col: 1, offset: 33265},
+			pos:  position{line: 1174, col: 1, offset: 33163},
 			expr: &actionExpr{
-				pos: position{line: 1179, col: 5, offset: 33279},
+				pos: position{line: 1175, col: 5, offset: 33177},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1179, col: 5, offset: 33279},
+					pos: position{line: 1175, col: 5, offset: 33177},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1179, col: 5, offset: 33279},
+							pos:   position{line: 1175, col: 5, offset: 33177},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1179, col: 10, offset: 33284},
+								pos:  position{line: 1175, col: 10, offset: 33182},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1179, col: 20, offset: 33294},
+							pos:  position{line: 1175, col: 20, offset: 33192},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1179, col: 23, offset: 33297},
+							pos:        position{line: 1175, col: 23, offset: 33195},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1179, col: 27, offset: 33301},
+							pos:  position{line: 1175, col: 27, offset: 33199},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1179, col: 30, offset: 33304},
+							pos:   position{line: 1175, col: 30, offset: 33202},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1179, col: 34, offset: 33308},
+								pos:  position{line: 1175, col: 34, offset: 33206},
 								name: "Type",
 							},
 						},
@@ -9020,16 +8957,16 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 1183, col: 1, offset: 33390},
+			pos:  position{line: 1179, col: 1, offset: 33288},
 			expr: &choiceExpr{
-				pos: position{line: 1184, col: 5, offset: 33404},
+				pos: position{line: 1180, col: 5, offset: 33302},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1184, col: 5, offset: 33404},
+						pos:  position{line: 1180, col: 5, offset: 33302},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1185, col: 5, offset: 33423},
+						pos:  position{line: 1181, col: 5, offset: 33321},
 						name: "QuotedString",
 					},
 				},
@@ -9037,32 +8974,32 @@ var g = &grammar{
 		},
 		{
 			name: "AndToken",
-			pos:  position{line: 1187, col: 1, offset: 33437},
+			pos:  position{line: 1183, col: 1, offset: 33335},
 			expr: &actionExpr{
-				pos: position{line: 1187, col: 12, offset: 33448},
+				pos: position{line: 1183, col: 12, offset: 33346},
 				run: (*parser).callonAndToken1,
 				expr: &seqExpr{
-					pos: position{line: 1187, col: 12, offset: 33448},
+					pos: position{line: 1183, col: 12, offset: 33346},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 1187, col: 13, offset: 33449},
+							pos: position{line: 1183, col: 13, offset: 33347},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1187, col: 13, offset: 33449},
+									pos:        position{line: 1183, col: 13, offset: 33347},
 									val:        "and",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1187, col: 21, offset: 33457},
+									pos:        position{line: 1183, col: 21, offset: 33355},
 									val:        "AND",
 									ignoreCase: false,
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1187, col: 28, offset: 33464},
+							pos: position{line: 1183, col: 28, offset: 33362},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1187, col: 29, offset: 33465},
+								pos:  position{line: 1183, col: 29, offset: 33363},
 								name: "IdentifierRest",
 							},
 						},
@@ -9072,32 +9009,32 @@ var g = &grammar{
 		},
 		{
 			name: "OrToken",
-			pos:  position{line: 1188, col: 1, offset: 33502},
+			pos:  position{line: 1184, col: 1, offset: 33400},
 			expr: &actionExpr{
-				pos: position{line: 1188, col: 11, offset: 33512},
+				pos: position{line: 1184, col: 11, offset: 33410},
 				run: (*parser).callonOrToken1,
 				expr: &seqExpr{
-					pos: position{line: 1188, col: 11, offset: 33512},
+					pos: position{line: 1184, col: 11, offset: 33410},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 1188, col: 12, offset: 33513},
+							pos: position{line: 1184, col: 12, offset: 33411},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1188, col: 12, offset: 33513},
+									pos:        position{line: 1184, col: 12, offset: 33411},
 									val:        "or",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1188, col: 19, offset: 33520},
+									pos:        position{line: 1184, col: 19, offset: 33418},
 									val:        "OR",
 									ignoreCase: false,
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1188, col: 25, offset: 33526},
+							pos: position{line: 1184, col: 25, offset: 33424},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1188, col: 26, offset: 33527},
+								pos:  position{line: 1184, col: 26, offset: 33425},
 								name: "IdentifierRest",
 							},
 						},
@@ -9107,22 +9044,22 @@ var g = &grammar{
 		},
 		{
 			name: "InToken",
-			pos:  position{line: 1189, col: 1, offset: 33563},
+			pos:  position{line: 1185, col: 1, offset: 33461},
 			expr: &actionExpr{
-				pos: position{line: 1189, col: 11, offset: 33573},
+				pos: position{line: 1185, col: 11, offset: 33471},
 				run: (*parser).callonInToken1,
 				expr: &seqExpr{
-					pos: position{line: 1189, col: 11, offset: 33573},
+					pos: position{line: 1185, col: 11, offset: 33471},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1189, col: 11, offset: 33573},
+							pos:        position{line: 1185, col: 11, offset: 33471},
 							val:        "in",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1189, col: 16, offset: 33578},
+							pos: position{line: 1185, col: 16, offset: 33476},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1189, col: 17, offset: 33579},
+								pos:  position{line: 1185, col: 17, offset: 33477},
 								name: "IdentifierRest",
 							},
 						},
@@ -9132,32 +9069,32 @@ var g = &grammar{
 		},
 		{
 			name: "NotToken",
-			pos:  position{line: 1190, col: 1, offset: 33615},
+			pos:  position{line: 1186, col: 1, offset: 33513},
 			expr: &actionExpr{
-				pos: position{line: 1190, col: 12, offset: 33626},
+				pos: position{line: 1186, col: 12, offset: 33524},
 				run: (*parser).callonNotToken1,
 				expr: &seqExpr{
-					pos: position{line: 1190, col: 12, offset: 33626},
+					pos: position{line: 1186, col: 12, offset: 33524},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 1190, col: 13, offset: 33627},
+							pos: position{line: 1186, col: 13, offset: 33525},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1190, col: 13, offset: 33627},
+									pos:        position{line: 1186, col: 13, offset: 33525},
 									val:        "not",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1190, col: 21, offset: 33635},
+									pos:        position{line: 1186, col: 21, offset: 33533},
 									val:        "NOT",
 									ignoreCase: false,
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1190, col: 28, offset: 33642},
+							pos: position{line: 1186, col: 28, offset: 33540},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1190, col: 29, offset: 33643},
+								pos:  position{line: 1186, col: 29, offset: 33541},
 								name: "IdentifierRest",
 							},
 						},
@@ -9167,22 +9104,22 @@ var g = &grammar{
 		},
 		{
 			name: "ByToken",
-			pos:  position{line: 1191, col: 1, offset: 33680},
+			pos:  position{line: 1187, col: 1, offset: 33578},
 			expr: &actionExpr{
-				pos: position{line: 1191, col: 11, offset: 33690},
+				pos: position{line: 1187, col: 11, offset: 33588},
 				run: (*parser).callonByToken1,
 				expr: &seqExpr{
-					pos: position{line: 1191, col: 11, offset: 33690},
+					pos: position{line: 1187, col: 11, offset: 33588},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1191, col: 11, offset: 33690},
+							pos:        position{line: 1187, col: 11, offset: 33588},
 							val:        "by",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1191, col: 16, offset: 33695},
+							pos: position{line: 1187, col: 16, offset: 33593},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1191, col: 17, offset: 33696},
+								pos:  position{line: 1187, col: 17, offset: 33594},
 								name: "IdentifierRest",
 							},
 						},
@@ -9192,9 +9129,9 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1193, col: 1, offset: 33733},
+			pos:  position{line: 1189, col: 1, offset: 33631},
 			expr: &charClassMatcher{
-				pos:        position{line: 1193, col: 19, offset: 33751},
+				pos:        position{line: 1189, col: 19, offset: 33649},
 				val:        "[A-Za-z_$]",
 				chars:      []rune{'_', '$'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -9204,16 +9141,16 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1195, col: 1, offset: 33763},
+			pos:  position{line: 1191, col: 1, offset: 33661},
 			expr: &choiceExpr{
-				pos: position{line: 1195, col: 18, offset: 33780},
+				pos: position{line: 1191, col: 18, offset: 33678},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1195, col: 18, offset: 33780},
+						pos:  position{line: 1191, col: 18, offset: 33678},
 						name: "IdentifierStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1195, col: 36, offset: 33798},
+						pos:        position{line: 1191, col: 36, offset: 33696},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9224,15 +9161,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1197, col: 1, offset: 33805},
+			pos:  position{line: 1193, col: 1, offset: 33703},
 			expr: &actionExpr{
-				pos: position{line: 1198, col: 5, offset: 33820},
+				pos: position{line: 1194, col: 5, offset: 33718},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1198, col: 5, offset: 33820},
+					pos:   position{line: 1194, col: 5, offset: 33718},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1198, col: 8, offset: 33823},
+						pos:  position{line: 1194, col: 8, offset: 33721},
 						name: "IdentifierName",
 					},
 				},
@@ -9240,29 +9177,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1200, col: 1, offset: 33904},
+			pos:  position{line: 1196, col: 1, offset: 33802},
 			expr: &choiceExpr{
-				pos: position{line: 1201, col: 5, offset: 33923},
+				pos: position{line: 1197, col: 5, offset: 33821},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1201, col: 5, offset: 33923},
+						pos: position{line: 1197, col: 5, offset: 33821},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1201, col: 5, offset: 33923},
+							pos: position{line: 1197, col: 5, offset: 33821},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1201, col: 5, offset: 33923},
+									pos: position{line: 1197, col: 5, offset: 33821},
 									expr: &seqExpr{
-										pos: position{line: 1201, col: 7, offset: 33925},
+										pos: position{line: 1197, col: 7, offset: 33823},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1201, col: 7, offset: 33925},
+												pos:  position{line: 1197, col: 7, offset: 33823},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1201, col: 15, offset: 33933},
+												pos: position{line: 1197, col: 15, offset: 33831},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1201, col: 16, offset: 33934},
+													pos:  position{line: 1197, col: 16, offset: 33832},
 													name: "IdentifierRest",
 												},
 											},
@@ -9270,13 +9207,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1201, col: 32, offset: 33950},
+									pos:  position{line: 1197, col: 32, offset: 33848},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1201, col: 48, offset: 33966},
+									pos: position{line: 1197, col: 48, offset: 33864},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1201, col: 48, offset: 33966},
+										pos:  position{line: 1197, col: 48, offset: 33864},
 										name: "IdentifierRest",
 									},
 								},
@@ -9284,30 +9221,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1202, col: 5, offset: 34018},
+						pos: position{line: 1198, col: 5, offset: 33916},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 1202, col: 5, offset: 34018},
+							pos:        position{line: 1198, col: 5, offset: 33916},
 							val:        "$",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1203, col: 5, offset: 34057},
+						pos: position{line: 1199, col: 5, offset: 33955},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 1203, col: 5, offset: 34057},
+							pos: position{line: 1199, col: 5, offset: 33955},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1203, col: 5, offset: 34057},
+									pos:        position{line: 1199, col: 5, offset: 33955},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1203, col: 10, offset: 34062},
+									pos:   position{line: 1199, col: 10, offset: 33960},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1203, col: 13, offset: 34065},
+										pos:  position{line: 1199, col: 13, offset: 33963},
 										name: "IDGuard",
 									},
 								},
@@ -9315,39 +9252,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1205, col: 5, offset: 34156},
+						pos: position{line: 1201, col: 5, offset: 34054},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 1205, col: 5, offset: 34156},
+							pos:        position{line: 1201, col: 5, offset: 34054},
 							val:        "type",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1206, col: 5, offset: 34198},
+						pos: position{line: 1202, col: 5, offset: 34096},
 						run: (*parser).callonIdentifierName21,
 						expr: &seqExpr{
-							pos: position{line: 1206, col: 5, offset: 34198},
+							pos: position{line: 1202, col: 5, offset: 34096},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1206, col: 5, offset: 34198},
+									pos:   position{line: 1202, col: 5, offset: 34096},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1206, col: 8, offset: 34201},
+										pos:  position{line: 1202, col: 8, offset: 34099},
 										name: "SQLTokenSentinels",
 									},
 								},
 								&andExpr{
-									pos: position{line: 1206, col: 26, offset: 34219},
+									pos: position{line: 1202, col: 26, offset: 34117},
 									expr: &seqExpr{
-										pos: position{line: 1206, col: 28, offset: 34221},
+										pos: position{line: 1202, col: 28, offset: 34119},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1206, col: 28, offset: 34221},
+												pos:  position{line: 1202, col: 28, offset: 34119},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1206, col: 31, offset: 34224},
+												pos:        position{line: 1202, col: 31, offset: 34122},
 												val:        "(",
 												ignoreCase: false,
 											},
@@ -9362,50 +9299,50 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierNames",
-			pos:  position{line: 1208, col: 1, offset: 34249},
+			pos:  position{line: 1204, col: 1, offset: 34147},
 			expr: &actionExpr{
-				pos: position{line: 1209, col: 5, offset: 34269},
+				pos: position{line: 1205, col: 5, offset: 34167},
 				run: (*parser).callonIdentifierNames1,
 				expr: &seqExpr{
-					pos: position{line: 1209, col: 5, offset: 34269},
+					pos: position{line: 1205, col: 5, offset: 34167},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1209, col: 5, offset: 34269},
+							pos:   position{line: 1205, col: 5, offset: 34167},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1209, col: 11, offset: 34275},
+								pos:  position{line: 1205, col: 11, offset: 34173},
 								name: "IdentifierName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1209, col: 26, offset: 34290},
+							pos:   position{line: 1205, col: 26, offset: 34188},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1209, col: 31, offset: 34295},
+								pos: position{line: 1205, col: 31, offset: 34193},
 								expr: &actionExpr{
-									pos: position{line: 1209, col: 32, offset: 34296},
+									pos: position{line: 1205, col: 32, offset: 34194},
 									run: (*parser).callonIdentifierNames7,
 									expr: &seqExpr{
-										pos: position{line: 1209, col: 32, offset: 34296},
+										pos: position{line: 1205, col: 32, offset: 34194},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1209, col: 32, offset: 34296},
+												pos:  position{line: 1205, col: 32, offset: 34194},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1209, col: 35, offset: 34299},
+												pos:        position{line: 1205, col: 35, offset: 34197},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1209, col: 39, offset: 34303},
+												pos:  position{line: 1205, col: 39, offset: 34201},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1209, col: 42, offset: 34306},
+												pos:   position{line: 1205, col: 42, offset: 34204},
 												label: "id",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1209, col: 45, offset: 34309},
+													pos:  position{line: 1205, col: 45, offset: 34207},
 													name: "IdentifierName",
 												},
 											},
@@ -9420,24 +9357,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1213, col: 1, offset: 34424},
+			pos:  position{line: 1209, col: 1, offset: 34322},
 			expr: &choiceExpr{
-				pos: position{line: 1214, col: 5, offset: 34436},
+				pos: position{line: 1210, col: 5, offset: 34334},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1214, col: 5, offset: 34436},
+						pos:  position{line: 1210, col: 5, offset: 34334},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1215, col: 5, offset: 34455},
+						pos:  position{line: 1211, col: 5, offset: 34353},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1216, col: 5, offset: 34471},
+						pos:  position{line: 1212, col: 5, offset: 34369},
 						name: "NaN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1217, col: 5, offset: 34479},
+						pos:  position{line: 1213, col: 5, offset: 34377},
 						name: "Infinity",
 					},
 				},
@@ -9445,24 +9382,24 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1219, col: 1, offset: 34489},
+			pos:  position{line: 1215, col: 1, offset: 34387},
 			expr: &actionExpr{
-				pos: position{line: 1220, col: 5, offset: 34498},
+				pos: position{line: 1216, col: 5, offset: 34396},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1220, col: 5, offset: 34498},
+					pos: position{line: 1216, col: 5, offset: 34396},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1220, col: 5, offset: 34498},
+							pos:  position{line: 1216, col: 5, offset: 34396},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1220, col: 14, offset: 34507},
+							pos:        position{line: 1216, col: 14, offset: 34405},
 							val:        "T",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1220, col: 18, offset: 34511},
+							pos:  position{line: 1216, col: 18, offset: 34409},
 							name: "FullTime",
 						},
 					},
@@ -9471,30 +9408,30 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1224, col: 1, offset: 34631},
+			pos:  position{line: 1220, col: 1, offset: 34529},
 			expr: &seqExpr{
-				pos: position{line: 1224, col: 12, offset: 34642},
+				pos: position{line: 1220, col: 12, offset: 34540},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1224, col: 12, offset: 34642},
+						pos:  position{line: 1220, col: 12, offset: 34540},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1224, col: 15, offset: 34645},
+						pos:        position{line: 1220, col: 15, offset: 34543},
 						val:        "-",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1224, col: 19, offset: 34649},
+						pos:  position{line: 1220, col: 19, offset: 34547},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1224, col: 22, offset: 34652},
+						pos:        position{line: 1220, col: 22, offset: 34550},
 						val:        "-",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1224, col: 26, offset: 34656},
+						pos:  position{line: 1220, col: 26, offset: 34554},
 						name: "D2",
 					},
 				},
@@ -9502,33 +9439,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1226, col: 1, offset: 34660},
+			pos:  position{line: 1222, col: 1, offset: 34558},
 			expr: &seqExpr{
-				pos: position{line: 1226, col: 6, offset: 34665},
+				pos: position{line: 1222, col: 6, offset: 34563},
 				exprs: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1226, col: 6, offset: 34665},
+						pos:        position{line: 1222, col: 6, offset: 34563},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1226, col: 11, offset: 34670},
+						pos:        position{line: 1222, col: 11, offset: 34568},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1226, col: 16, offset: 34675},
+						pos:        position{line: 1222, col: 16, offset: 34573},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1226, col: 21, offset: 34680},
+						pos:        position{line: 1222, col: 21, offset: 34578},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9539,19 +9476,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1227, col: 1, offset: 34686},
+			pos:  position{line: 1223, col: 1, offset: 34584},
 			expr: &seqExpr{
-				pos: position{line: 1227, col: 6, offset: 34691},
+				pos: position{line: 1223, col: 6, offset: 34589},
 				exprs: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1227, col: 6, offset: 34691},
+						pos:        position{line: 1223, col: 6, offset: 34589},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1227, col: 11, offset: 34696},
+						pos:        position{line: 1223, col: 11, offset: 34594},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9562,16 +9499,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1229, col: 1, offset: 34703},
+			pos:  position{line: 1225, col: 1, offset: 34601},
 			expr: &seqExpr{
-				pos: position{line: 1229, col: 12, offset: 34714},
+				pos: position{line: 1225, col: 12, offset: 34612},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1229, col: 12, offset: 34714},
+						pos:  position{line: 1225, col: 12, offset: 34612},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1229, col: 24, offset: 34726},
+						pos:  position{line: 1225, col: 24, offset: 34624},
 						name: "TimeOffset",
 					},
 				},
@@ -9579,46 +9516,46 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1231, col: 1, offset: 34738},
+			pos:  position{line: 1227, col: 1, offset: 34636},
 			expr: &seqExpr{
-				pos: position{line: 1231, col: 15, offset: 34752},
+				pos: position{line: 1227, col: 15, offset: 34650},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1231, col: 15, offset: 34752},
+						pos:  position{line: 1227, col: 15, offset: 34650},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1231, col: 18, offset: 34755},
+						pos:        position{line: 1227, col: 18, offset: 34653},
 						val:        ":",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1231, col: 22, offset: 34759},
+						pos:  position{line: 1227, col: 22, offset: 34657},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1231, col: 25, offset: 34762},
+						pos:        position{line: 1227, col: 25, offset: 34660},
 						val:        ":",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1231, col: 29, offset: 34766},
+						pos:  position{line: 1227, col: 29, offset: 34664},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1231, col: 32, offset: 34769},
+						pos: position{line: 1227, col: 32, offset: 34667},
 						expr: &seqExpr{
-							pos: position{line: 1231, col: 33, offset: 34770},
+							pos: position{line: 1227, col: 33, offset: 34668},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1231, col: 33, offset: 34770},
+									pos:        position{line: 1227, col: 33, offset: 34668},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1231, col: 37, offset: 34774},
+									pos: position{line: 1227, col: 37, offset: 34672},
 									expr: &charClassMatcher{
-										pos:        position{line: 1231, col: 37, offset: 34774},
+										pos:        position{line: 1227, col: 37, offset: 34672},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -9633,60 +9570,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1233, col: 1, offset: 34784},
+			pos:  position{line: 1229, col: 1, offset: 34682},
 			expr: &choiceExpr{
-				pos: position{line: 1234, col: 5, offset: 34799},
+				pos: position{line: 1230, col: 5, offset: 34697},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1234, col: 5, offset: 34799},
+						pos:        position{line: 1230, col: 5, offset: 34697},
 						val:        "Z",
 						ignoreCase: false,
 					},
 					&seqExpr{
-						pos: position{line: 1235, col: 5, offset: 34807},
+						pos: position{line: 1231, col: 5, offset: 34705},
 						exprs: []interface{}{
 							&choiceExpr{
-								pos: position{line: 1235, col: 6, offset: 34808},
+								pos: position{line: 1231, col: 6, offset: 34706},
 								alternatives: []interface{}{
 									&litMatcher{
-										pos:        position{line: 1235, col: 6, offset: 34808},
+										pos:        position{line: 1231, col: 6, offset: 34706},
 										val:        "+",
 										ignoreCase: false,
 									},
 									&litMatcher{
-										pos:        position{line: 1235, col: 12, offset: 34814},
+										pos:        position{line: 1231, col: 12, offset: 34712},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1235, col: 17, offset: 34819},
+								pos:  position{line: 1231, col: 17, offset: 34717},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1235, col: 20, offset: 34822},
+								pos:        position{line: 1231, col: 20, offset: 34720},
 								val:        ":",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1235, col: 24, offset: 34826},
+								pos:  position{line: 1231, col: 24, offset: 34724},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1235, col: 27, offset: 34829},
+								pos: position{line: 1231, col: 27, offset: 34727},
 								expr: &seqExpr{
-									pos: position{line: 1235, col: 28, offset: 34830},
+									pos: position{line: 1231, col: 28, offset: 34728},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1235, col: 28, offset: 34830},
+											pos:        position{line: 1231, col: 28, offset: 34728},
 											val:        ".",
 											ignoreCase: false,
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1235, col: 32, offset: 34834},
+											pos: position{line: 1231, col: 32, offset: 34732},
 											expr: &charClassMatcher{
-												pos:        position{line: 1235, col: 32, offset: 34834},
+												pos:        position{line: 1231, col: 32, offset: 34732},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -9703,32 +9640,32 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1237, col: 1, offset: 34844},
+			pos:  position{line: 1233, col: 1, offset: 34742},
 			expr: &actionExpr{
-				pos: position{line: 1238, col: 5, offset: 34857},
+				pos: position{line: 1234, col: 5, offset: 34755},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1238, col: 5, offset: 34857},
+					pos: position{line: 1234, col: 5, offset: 34755},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 1238, col: 5, offset: 34857},
+							pos: position{line: 1234, col: 5, offset: 34755},
 							expr: &litMatcher{
-								pos:        position{line: 1238, col: 5, offset: 34857},
+								pos:        position{line: 1234, col: 5, offset: 34755},
 								val:        "-",
 								ignoreCase: false,
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1238, col: 10, offset: 34862},
+							pos: position{line: 1234, col: 10, offset: 34760},
 							expr: &seqExpr{
-								pos: position{line: 1238, col: 11, offset: 34863},
+								pos: position{line: 1234, col: 11, offset: 34761},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1238, col: 11, offset: 34863},
+										pos:  position{line: 1234, col: 11, offset: 34761},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1238, col: 19, offset: 34871},
+										pos:  position{line: 1234, col: 19, offset: 34769},
 										name: "TimeUnit",
 									},
 								},
@@ -9740,26 +9677,26 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1242, col: 1, offset: 34997},
+			pos:  position{line: 1238, col: 1, offset: 34895},
 			expr: &seqExpr{
-				pos: position{line: 1242, col: 11, offset: 35007},
+				pos: position{line: 1238, col: 11, offset: 34905},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1242, col: 11, offset: 35007},
+						pos:  position{line: 1238, col: 11, offset: 34905},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1242, col: 16, offset: 35012},
+						pos: position{line: 1238, col: 16, offset: 34910},
 						expr: &seqExpr{
-							pos: position{line: 1242, col: 17, offset: 35013},
+							pos: position{line: 1238, col: 17, offset: 34911},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1242, col: 17, offset: 35013},
+									pos:        position{line: 1238, col: 17, offset: 34911},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1242, col: 21, offset: 35017},
+									pos:  position{line: 1238, col: 21, offset: 34915},
 									name: "UInt",
 								},
 							},
@@ -9770,52 +9707,52 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1244, col: 1, offset: 35025},
+			pos:  position{line: 1240, col: 1, offset: 34923},
 			expr: &choiceExpr{
-				pos: position{line: 1245, col: 5, offset: 35038},
+				pos: position{line: 1241, col: 5, offset: 34936},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1245, col: 5, offset: 35038},
+						pos:        position{line: 1241, col: 5, offset: 34936},
 						val:        "ns",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1246, col: 5, offset: 35047},
+						pos:        position{line: 1242, col: 5, offset: 34945},
 						val:        "us",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1247, col: 5, offset: 35056},
+						pos:        position{line: 1243, col: 5, offset: 34954},
 						val:        "ms",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1248, col: 5, offset: 35065},
+						pos:        position{line: 1244, col: 5, offset: 34963},
 						val:        "s",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1249, col: 5, offset: 35073},
+						pos:        position{line: 1245, col: 5, offset: 34971},
 						val:        "m",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1250, col: 5, offset: 35081},
+						pos:        position{line: 1246, col: 5, offset: 34979},
 						val:        "h",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1251, col: 5, offset: 35089},
+						pos:        position{line: 1247, col: 5, offset: 34987},
 						val:        "d",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1252, col: 5, offset: 35097},
+						pos:        position{line: 1248, col: 5, offset: 34995},
 						val:        "w",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1253, col: 5, offset: 35105},
+						pos:        position{line: 1249, col: 5, offset: 35003},
 						val:        "y",
 						ignoreCase: false,
 					},
@@ -9824,42 +9761,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1255, col: 1, offset: 35110},
+			pos:  position{line: 1251, col: 1, offset: 35008},
 			expr: &actionExpr{
-				pos: position{line: 1256, col: 5, offset: 35117},
+				pos: position{line: 1252, col: 5, offset: 35015},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1256, col: 5, offset: 35117},
+					pos: position{line: 1252, col: 5, offset: 35015},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1256, col: 5, offset: 35117},
+							pos:  position{line: 1252, col: 5, offset: 35015},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1256, col: 10, offset: 35122},
+							pos:        position{line: 1252, col: 10, offset: 35020},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1256, col: 14, offset: 35126},
+							pos:  position{line: 1252, col: 14, offset: 35024},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1256, col: 19, offset: 35131},
+							pos:        position{line: 1252, col: 19, offset: 35029},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1256, col: 23, offset: 35135},
+							pos:  position{line: 1252, col: 23, offset: 35033},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1256, col: 28, offset: 35140},
+							pos:        position{line: 1252, col: 28, offset: 35038},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1256, col: 32, offset: 35144},
+							pos:  position{line: 1252, col: 32, offset: 35042},
 							name: "UInt",
 						},
 					},
@@ -9868,42 +9805,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1258, col: 1, offset: 35181},
+			pos:  position{line: 1254, col: 1, offset: 35079},
 			expr: &actionExpr{
-				pos: position{line: 1259, col: 5, offset: 35189},
+				pos: position{line: 1255, col: 5, offset: 35087},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1259, col: 5, offset: 35189},
+					pos: position{line: 1255, col: 5, offset: 35087},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1259, col: 5, offset: 35189},
+							pos: position{line: 1255, col: 5, offset: 35087},
 							expr: &seqExpr{
-								pos: position{line: 1259, col: 8, offset: 35192},
+								pos: position{line: 1255, col: 8, offset: 35090},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1259, col: 8, offset: 35192},
+										pos:  position{line: 1255, col: 8, offset: 35090},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1259, col: 12, offset: 35196},
+										pos:        position{line: 1255, col: 12, offset: 35094},
 										val:        ":",
 										ignoreCase: false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1259, col: 16, offset: 35200},
+										pos:  position{line: 1255, col: 16, offset: 35098},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1259, col: 20, offset: 35204},
+										pos: position{line: 1255, col: 20, offset: 35102},
 										expr: &choiceExpr{
-											pos: position{line: 1259, col: 22, offset: 35206},
+											pos: position{line: 1255, col: 22, offset: 35104},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 1259, col: 22, offset: 35206},
+													pos:  position{line: 1255, col: 22, offset: 35104},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1259, col: 33, offset: 35217},
+													pos:        position{line: 1255, col: 33, offset: 35115},
 													val:        ":",
 													ignoreCase: false,
 												},
@@ -9914,10 +9851,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1259, col: 39, offset: 35223},
+							pos:   position{line: 1255, col: 39, offset: 35121},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1259, col: 41, offset: 35225},
+								pos:  position{line: 1255, col: 41, offset: 35123},
 								name: "IP6Variations",
 							},
 						},
@@ -9927,32 +9864,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1263, col: 1, offset: 35389},
+			pos:  position{line: 1259, col: 1, offset: 35287},
 			expr: &choiceExpr{
-				pos: position{line: 1264, col: 5, offset: 35407},
+				pos: position{line: 1260, col: 5, offset: 35305},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1264, col: 5, offset: 35407},
+						pos: position{line: 1260, col: 5, offset: 35305},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1264, col: 5, offset: 35407},
+							pos: position{line: 1260, col: 5, offset: 35305},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1264, col: 5, offset: 35407},
+									pos:   position{line: 1260, col: 5, offset: 35305},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1264, col: 7, offset: 35409},
+										pos: position{line: 1260, col: 7, offset: 35307},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1264, col: 7, offset: 35409},
+											pos:  position{line: 1260, col: 7, offset: 35307},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1264, col: 17, offset: 35419},
+									pos:   position{line: 1260, col: 17, offset: 35317},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1264, col: 19, offset: 35421},
+										pos:  position{line: 1260, col: 19, offset: 35319},
 										name: "IP6Tail",
 									},
 								},
@@ -9960,51 +9897,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1267, col: 5, offset: 35485},
+						pos: position{line: 1263, col: 5, offset: 35383},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1267, col: 5, offset: 35485},
+							pos: position{line: 1263, col: 5, offset: 35383},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1267, col: 5, offset: 35485},
+									pos:   position{line: 1263, col: 5, offset: 35383},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1267, col: 7, offset: 35487},
+										pos:  position{line: 1263, col: 7, offset: 35385},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1267, col: 11, offset: 35491},
+									pos:   position{line: 1263, col: 11, offset: 35389},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1267, col: 13, offset: 35493},
+										pos: position{line: 1263, col: 13, offset: 35391},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1267, col: 13, offset: 35493},
+											pos:  position{line: 1263, col: 13, offset: 35391},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1267, col: 23, offset: 35503},
+									pos:        position{line: 1263, col: 23, offset: 35401},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1267, col: 28, offset: 35508},
+									pos:   position{line: 1263, col: 28, offset: 35406},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1267, col: 30, offset: 35510},
+										pos: position{line: 1263, col: 30, offset: 35408},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1267, col: 30, offset: 35510},
+											pos:  position{line: 1263, col: 30, offset: 35408},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1267, col: 40, offset: 35520},
+									pos:   position{line: 1263, col: 40, offset: 35418},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1267, col: 42, offset: 35522},
+										pos:  position{line: 1263, col: 42, offset: 35420},
 										name: "IP6Tail",
 									},
 								},
@@ -10012,32 +9949,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1270, col: 5, offset: 35621},
+						pos: position{line: 1266, col: 5, offset: 35519},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1270, col: 5, offset: 35621},
+							pos: position{line: 1266, col: 5, offset: 35519},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1270, col: 5, offset: 35621},
+									pos:        position{line: 1266, col: 5, offset: 35519},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1270, col: 10, offset: 35626},
+									pos:   position{line: 1266, col: 10, offset: 35524},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1270, col: 12, offset: 35628},
+										pos: position{line: 1266, col: 12, offset: 35526},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1270, col: 12, offset: 35628},
+											pos:  position{line: 1266, col: 12, offset: 35526},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1270, col: 22, offset: 35638},
+									pos:   position{line: 1266, col: 22, offset: 35536},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1270, col: 24, offset: 35640},
+										pos:  position{line: 1266, col: 24, offset: 35538},
 										name: "IP6Tail",
 									},
 								},
@@ -10045,32 +9982,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1273, col: 5, offset: 35711},
+						pos: position{line: 1269, col: 5, offset: 35609},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1273, col: 5, offset: 35711},
+							pos: position{line: 1269, col: 5, offset: 35609},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1273, col: 5, offset: 35711},
+									pos:   position{line: 1269, col: 5, offset: 35609},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1273, col: 7, offset: 35713},
+										pos:  position{line: 1269, col: 7, offset: 35611},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1273, col: 11, offset: 35717},
+									pos:   position{line: 1269, col: 11, offset: 35615},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1273, col: 13, offset: 35719},
+										pos: position{line: 1269, col: 13, offset: 35617},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1273, col: 13, offset: 35719},
+											pos:  position{line: 1269, col: 13, offset: 35617},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1273, col: 23, offset: 35729},
+									pos:        position{line: 1269, col: 23, offset: 35627},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -10078,10 +10015,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1276, col: 5, offset: 35797},
+						pos: position{line: 1272, col: 5, offset: 35695},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 1276, col: 5, offset: 35797},
+							pos:        position{line: 1272, col: 5, offset: 35695},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -10091,16 +10028,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1280, col: 1, offset: 35834},
+			pos:  position{line: 1276, col: 1, offset: 35732},
 			expr: &choiceExpr{
-				pos: position{line: 1281, col: 5, offset: 35846},
+				pos: position{line: 1277, col: 5, offset: 35744},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1281, col: 5, offset: 35846},
+						pos:  position{line: 1277, col: 5, offset: 35744},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1282, col: 5, offset: 35853},
+						pos:  position{line: 1278, col: 5, offset: 35751},
 						name: "Hex",
 					},
 				},
@@ -10108,23 +10045,23 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1284, col: 1, offset: 35858},
+			pos:  position{line: 1280, col: 1, offset: 35756},
 			expr: &actionExpr{
-				pos: position{line: 1284, col: 12, offset: 35869},
+				pos: position{line: 1280, col: 12, offset: 35767},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1284, col: 12, offset: 35869},
+					pos: position{line: 1280, col: 12, offset: 35767},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1284, col: 12, offset: 35869},
+							pos:        position{line: 1280, col: 12, offset: 35767},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1284, col: 16, offset: 35873},
+							pos:   position{line: 1280, col: 16, offset: 35771},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1284, col: 18, offset: 35875},
+								pos:  position{line: 1280, col: 18, offset: 35773},
 								name: "Hex",
 							},
 						},
@@ -10134,23 +10071,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1286, col: 1, offset: 35913},
+			pos:  position{line: 1282, col: 1, offset: 35811},
 			expr: &actionExpr{
-				pos: position{line: 1286, col: 12, offset: 35924},
+				pos: position{line: 1282, col: 12, offset: 35822},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1286, col: 12, offset: 35924},
+					pos: position{line: 1282, col: 12, offset: 35822},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1286, col: 12, offset: 35924},
+							pos:   position{line: 1282, col: 12, offset: 35822},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1286, col: 14, offset: 35926},
+								pos:  position{line: 1282, col: 14, offset: 35824},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1286, col: 18, offset: 35930},
+							pos:        position{line: 1282, col: 18, offset: 35828},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -10160,31 +10097,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1288, col: 1, offset: 35968},
+			pos:  position{line: 1284, col: 1, offset: 35866},
 			expr: &actionExpr{
-				pos: position{line: 1289, col: 5, offset: 35979},
+				pos: position{line: 1285, col: 5, offset: 35877},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1289, col: 5, offset: 35979},
+					pos: position{line: 1285, col: 5, offset: 35877},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1289, col: 5, offset: 35979},
+							pos:   position{line: 1285, col: 5, offset: 35877},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1289, col: 7, offset: 35981},
+								pos:  position{line: 1285, col: 7, offset: 35879},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1289, col: 10, offset: 35984},
+							pos:        position{line: 1285, col: 10, offset: 35882},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1289, col: 14, offset: 35988},
+							pos:   position{line: 1285, col: 14, offset: 35886},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1289, col: 16, offset: 35990},
+								pos:  position{line: 1285, col: 16, offset: 35888},
 								name: "UInt",
 							},
 						},
@@ -10194,31 +10131,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1293, col: 1, offset: 36063},
+			pos:  position{line: 1289, col: 1, offset: 35961},
 			expr: &actionExpr{
-				pos: position{line: 1294, col: 5, offset: 36074},
+				pos: position{line: 1290, col: 5, offset: 35972},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1294, col: 5, offset: 36074},
+					pos: position{line: 1290, col: 5, offset: 35972},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1294, col: 5, offset: 36074},
+							pos:   position{line: 1290, col: 5, offset: 35972},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1294, col: 7, offset: 36076},
+								pos:  position{line: 1290, col: 7, offset: 35974},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1294, col: 11, offset: 36080},
+							pos:        position{line: 1290, col: 11, offset: 35978},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1294, col: 15, offset: 36084},
+							pos:   position{line: 1290, col: 15, offset: 35982},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1294, col: 17, offset: 36086},
+								pos:  position{line: 1290, col: 17, offset: 35984},
 								name: "UInt",
 							},
 						},
@@ -10228,15 +10165,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1298, col: 1, offset: 36149},
+			pos:  position{line: 1294, col: 1, offset: 36047},
 			expr: &actionExpr{
-				pos: position{line: 1299, col: 4, offset: 36157},
+				pos: position{line: 1295, col: 4, offset: 36055},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1299, col: 4, offset: 36157},
+					pos:   position{line: 1295, col: 4, offset: 36055},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1299, col: 6, offset: 36159},
+						pos:  position{line: 1295, col: 6, offset: 36057},
 						name: "UIntString",
 					},
 				},
@@ -10244,16 +10181,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1301, col: 1, offset: 36199},
+			pos:  position{line: 1297, col: 1, offset: 36097},
 			expr: &choiceExpr{
-				pos: position{line: 1302, col: 5, offset: 36213},
+				pos: position{line: 1298, col: 5, offset: 36111},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1302, col: 5, offset: 36213},
+						pos:  position{line: 1298, col: 5, offset: 36111},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1303, col: 5, offset: 36228},
+						pos:  position{line: 1299, col: 5, offset: 36126},
 						name: "MinusIntString",
 					},
 				},
@@ -10261,14 +10198,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1305, col: 1, offset: 36244},
+			pos:  position{line: 1301, col: 1, offset: 36142},
 			expr: &actionExpr{
-				pos: position{line: 1305, col: 14, offset: 36257},
+				pos: position{line: 1301, col: 14, offset: 36155},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1305, col: 14, offset: 36257},
+					pos: position{line: 1301, col: 14, offset: 36155},
 					expr: &charClassMatcher{
-						pos:        position{line: 1305, col: 14, offset: 36257},
+						pos:        position{line: 1301, col: 14, offset: 36155},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10279,20 +10216,20 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1307, col: 1, offset: 36296},
+			pos:  position{line: 1303, col: 1, offset: 36194},
 			expr: &actionExpr{
-				pos: position{line: 1308, col: 5, offset: 36315},
+				pos: position{line: 1304, col: 5, offset: 36213},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1308, col: 5, offset: 36315},
+					pos: position{line: 1304, col: 5, offset: 36213},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1308, col: 5, offset: 36315},
+							pos:        position{line: 1304, col: 5, offset: 36213},
 							val:        "-",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1308, col: 9, offset: 36319},
+							pos:  position{line: 1304, col: 9, offset: 36217},
 							name: "UIntString",
 						},
 					},
@@ -10301,28 +10238,28 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1310, col: 1, offset: 36362},
+			pos:  position{line: 1306, col: 1, offset: 36260},
 			expr: &choiceExpr{
-				pos: position{line: 1311, col: 5, offset: 36378},
+				pos: position{line: 1307, col: 5, offset: 36276},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1311, col: 5, offset: 36378},
+						pos: position{line: 1307, col: 5, offset: 36276},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1311, col: 5, offset: 36378},
+							pos: position{line: 1307, col: 5, offset: 36276},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1311, col: 5, offset: 36378},
+									pos: position{line: 1307, col: 5, offset: 36276},
 									expr: &litMatcher{
-										pos:        position{line: 1311, col: 5, offset: 36378},
+										pos:        position{line: 1307, col: 5, offset: 36276},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1311, col: 10, offset: 36383},
+									pos: position{line: 1307, col: 10, offset: 36281},
 									expr: &charClassMatcher{
-										pos:        position{line: 1311, col: 10, offset: 36383},
+										pos:        position{line: 1307, col: 10, offset: 36281},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10330,14 +10267,14 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1311, col: 17, offset: 36390},
+									pos:        position{line: 1307, col: 17, offset: 36288},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1311, col: 21, offset: 36394},
+									pos: position{line: 1307, col: 21, offset: 36292},
 									expr: &charClassMatcher{
-										pos:        position{line: 1311, col: 21, offset: 36394},
+										pos:        position{line: 1307, col: 21, offset: 36292},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10345,9 +10282,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1311, col: 28, offset: 36401},
+									pos: position{line: 1307, col: 28, offset: 36299},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1311, col: 28, offset: 36401},
+										pos:  position{line: 1307, col: 28, offset: 36299},
 										name: "ExponentPart",
 									},
 								},
@@ -10355,28 +10292,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1314, col: 5, offset: 36460},
+						pos: position{line: 1310, col: 5, offset: 36358},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1314, col: 5, offset: 36460},
+							pos: position{line: 1310, col: 5, offset: 36358},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1314, col: 5, offset: 36460},
+									pos: position{line: 1310, col: 5, offset: 36358},
 									expr: &litMatcher{
-										pos:        position{line: 1314, col: 5, offset: 36460},
+										pos:        position{line: 1310, col: 5, offset: 36358},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1314, col: 10, offset: 36465},
+									pos:        position{line: 1310, col: 10, offset: 36363},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1314, col: 14, offset: 36469},
+									pos: position{line: 1310, col: 14, offset: 36367},
 									expr: &charClassMatcher{
-										pos:        position{line: 1314, col: 14, offset: 36469},
+										pos:        position{line: 1310, col: 14, offset: 36367},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10384,9 +10321,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1314, col: 21, offset: 36476},
+									pos: position{line: 1310, col: 21, offset: 36374},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1314, col: 21, offset: 36476},
+										pos:  position{line: 1310, col: 21, offset: 36374},
 										name: "ExponentPart",
 									},
 								},
@@ -10394,17 +10331,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1317, col: 5, offset: 36535},
+						pos: position{line: 1313, col: 5, offset: 36433},
 						run: (*parser).callonFloatString22,
 						expr: &choiceExpr{
-							pos: position{line: 1317, col: 7, offset: 36537},
+							pos: position{line: 1313, col: 7, offset: 36435},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1317, col: 7, offset: 36537},
+									pos:  position{line: 1313, col: 7, offset: 36435},
 									name: "NaN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1317, col: 13, offset: 36543},
+									pos:  position{line: 1313, col: 13, offset: 36441},
 									name: "Infinity",
 								},
 							},
@@ -10415,19 +10352,19 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1320, col: 1, offset: 36587},
+			pos:  position{line: 1316, col: 1, offset: 36485},
 			expr: &seqExpr{
-				pos: position{line: 1320, col: 16, offset: 36602},
+				pos: position{line: 1316, col: 16, offset: 36500},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1320, col: 16, offset: 36602},
+						pos:        position{line: 1316, col: 16, offset: 36500},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1320, col: 21, offset: 36607},
+						pos: position{line: 1316, col: 21, offset: 36505},
 						expr: &charClassMatcher{
-							pos:        position{line: 1320, col: 21, offset: 36607},
+							pos:        position{line: 1316, col: 21, offset: 36505},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -10435,7 +10372,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1320, col: 27, offset: 36613},
+						pos:  position{line: 1316, col: 27, offset: 36511},
 						name: "UIntString",
 					},
 				},
@@ -10443,31 +10380,31 @@ var g = &grammar{
 		},
 		{
 			name: "NaN",
-			pos:  position{line: 1322, col: 1, offset: 36625},
+			pos:  position{line: 1318, col: 1, offset: 36523},
 			expr: &litMatcher{
-				pos:        position{line: 1322, col: 7, offset: 36631},
+				pos:        position{line: 1318, col: 7, offset: 36529},
 				val:        "NaN",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "Infinity",
-			pos:  position{line: 1324, col: 1, offset: 36638},
+			pos:  position{line: 1320, col: 1, offset: 36536},
 			expr: &seqExpr{
-				pos: position{line: 1324, col: 12, offset: 36649},
+				pos: position{line: 1320, col: 12, offset: 36547},
 				exprs: []interface{}{
 					&zeroOrOneExpr{
-						pos: position{line: 1324, col: 12, offset: 36649},
+						pos: position{line: 1320, col: 12, offset: 36547},
 						expr: &choiceExpr{
-							pos: position{line: 1324, col: 13, offset: 36650},
+							pos: position{line: 1320, col: 13, offset: 36548},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1324, col: 13, offset: 36650},
+									pos:        position{line: 1320, col: 13, offset: 36548},
 									val:        "-",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1324, col: 19, offset: 36656},
+									pos:        position{line: 1320, col: 19, offset: 36554},
 									val:        "+",
 									ignoreCase: false,
 								},
@@ -10475,7 +10412,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1324, col: 25, offset: 36662},
+						pos:        position{line: 1320, col: 25, offset: 36560},
 						val:        "Inf",
 						ignoreCase: false,
 					},
@@ -10484,14 +10421,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1326, col: 1, offset: 36669},
+			pos:  position{line: 1322, col: 1, offset: 36567},
 			expr: &actionExpr{
-				pos: position{line: 1326, col: 7, offset: 36675},
+				pos: position{line: 1322, col: 7, offset: 36573},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1326, col: 7, offset: 36675},
+					pos: position{line: 1322, col: 7, offset: 36573},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1326, col: 7, offset: 36675},
+						pos:  position{line: 1322, col: 7, offset: 36573},
 						name: "HexDigit",
 					},
 				},
@@ -10499,9 +10436,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1328, col: 1, offset: 36717},
+			pos:  position{line: 1324, col: 1, offset: 36615},
 			expr: &charClassMatcher{
-				pos:        position{line: 1328, col: 12, offset: 36728},
+				pos:        position{line: 1324, col: 12, offset: 36626},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -10510,34 +10447,34 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1330, col: 1, offset: 36741},
+			pos:  position{line: 1326, col: 1, offset: 36639},
 			expr: &choiceExpr{
-				pos: position{line: 1331, col: 5, offset: 36758},
+				pos: position{line: 1327, col: 5, offset: 36656},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1331, col: 5, offset: 36758},
+						pos: position{line: 1327, col: 5, offset: 36656},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 1331, col: 5, offset: 36758},
+							pos: position{line: 1327, col: 5, offset: 36656},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1331, col: 5, offset: 36758},
+									pos:        position{line: 1327, col: 5, offset: 36656},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1331, col: 9, offset: 36762},
+									pos:   position{line: 1327, col: 9, offset: 36660},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1331, col: 11, offset: 36764},
+										pos: position{line: 1327, col: 11, offset: 36662},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1331, col: 11, offset: 36764},
+											pos:  position{line: 1327, col: 11, offset: 36662},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1331, col: 29, offset: 36782},
+									pos:        position{line: 1327, col: 29, offset: 36680},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -10545,29 +10482,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1332, col: 5, offset: 36819},
+						pos: position{line: 1328, col: 5, offset: 36717},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 1332, col: 5, offset: 36819},
+							pos: position{line: 1328, col: 5, offset: 36717},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1332, col: 5, offset: 36819},
+									pos:        position{line: 1328, col: 5, offset: 36717},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1332, col: 9, offset: 36823},
+									pos:   position{line: 1328, col: 9, offset: 36721},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1332, col: 11, offset: 36825},
+										pos: position{line: 1328, col: 11, offset: 36723},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1332, col: 11, offset: 36825},
+											pos:  position{line: 1328, col: 11, offset: 36723},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1332, col: 29, offset: 36843},
+									pos:        position{line: 1328, col: 29, offset: 36741},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -10579,55 +10516,55 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1334, col: 1, offset: 36877},
+			pos:  position{line: 1330, col: 1, offset: 36775},
 			expr: &choiceExpr{
-				pos: position{line: 1335, col: 5, offset: 36898},
+				pos: position{line: 1331, col: 5, offset: 36796},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1335, col: 5, offset: 36898},
+						pos: position{line: 1331, col: 5, offset: 36796},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1335, col: 5, offset: 36898},
+							pos: position{line: 1331, col: 5, offset: 36796},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1335, col: 5, offset: 36898},
+									pos: position{line: 1331, col: 5, offset: 36796},
 									expr: &choiceExpr{
-										pos: position{line: 1335, col: 7, offset: 36900},
+										pos: position{line: 1331, col: 7, offset: 36798},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1335, col: 7, offset: 36900},
+												pos:        position{line: 1331, col: 7, offset: 36798},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1335, col: 13, offset: 36906},
+												pos:  position{line: 1331, col: 13, offset: 36804},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1335, col: 26, offset: 36919,
+									line: 1331, col: 26, offset: 36817,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1336, col: 5, offset: 36956},
+						pos: position{line: 1332, col: 5, offset: 36854},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1336, col: 5, offset: 36956},
+							pos: position{line: 1332, col: 5, offset: 36854},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1336, col: 5, offset: 36956},
+									pos:        position{line: 1332, col: 5, offset: 36854},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1336, col: 10, offset: 36961},
+									pos:   position{line: 1332, col: 10, offset: 36859},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1336, col: 12, offset: 36963},
+										pos:  position{line: 1332, col: 12, offset: 36861},
 										name: "EscapeSequence",
 									},
 								},
@@ -10639,28 +10576,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1338, col: 1, offset: 36997},
+			pos:  position{line: 1334, col: 1, offset: 36895},
 			expr: &actionExpr{
-				pos: position{line: 1339, col: 5, offset: 37009},
+				pos: position{line: 1335, col: 5, offset: 36907},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1339, col: 5, offset: 37009},
+					pos: position{line: 1335, col: 5, offset: 36907},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1339, col: 5, offset: 37009},
+							pos:   position{line: 1335, col: 5, offset: 36907},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1339, col: 10, offset: 37014},
+								pos:  position{line: 1335, col: 10, offset: 36912},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1339, col: 23, offset: 37027},
+							pos:   position{line: 1335, col: 23, offset: 36925},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1339, col: 28, offset: 37032},
+								pos: position{line: 1335, col: 28, offset: 36930},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1339, col: 28, offset: 37032},
+									pos:  position{line: 1335, col: 28, offset: 36930},
 									name: "KeyWordRest",
 								},
 							},
@@ -10671,16 +10608,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1341, col: 1, offset: 37094},
+			pos:  position{line: 1337, col: 1, offset: 36992},
 			expr: &choiceExpr{
-				pos: position{line: 1342, col: 5, offset: 37111},
+				pos: position{line: 1338, col: 5, offset: 37009},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1342, col: 5, offset: 37111},
+						pos:  position{line: 1338, col: 5, offset: 37009},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1343, col: 5, offset: 37128},
+						pos:  position{line: 1339, col: 5, offset: 37026},
 						name: "KeyWordEsc",
 					},
 				},
@@ -10688,12 +10625,12 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1345, col: 1, offset: 37140},
+			pos:  position{line: 1341, col: 1, offset: 37038},
 			expr: &actionExpr{
-				pos: position{line: 1345, col: 16, offset: 37155},
+				pos: position{line: 1341, col: 16, offset: 37053},
 				run: (*parser).callonKeyWordChars1,
 				expr: &charClassMatcher{
-					pos:        position{line: 1345, col: 16, offset: 37155},
+					pos:        position{line: 1341, col: 16, offset: 37053},
 					val:        "[a-zA-Z_.:/%#@~]",
 					chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 					ranges:     []rune{'a', 'z', 'A', 'Z'},
@@ -10704,16 +10641,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1347, col: 1, offset: 37204},
+			pos:  position{line: 1343, col: 1, offset: 37102},
 			expr: &choiceExpr{
-				pos: position{line: 1348, col: 5, offset: 37220},
+				pos: position{line: 1344, col: 5, offset: 37118},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1348, col: 5, offset: 37220},
+						pos:  position{line: 1344, col: 5, offset: 37118},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1349, col: 5, offset: 37237},
+						pos:        position{line: 1345, col: 5, offset: 37135},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10724,30 +10661,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1351, col: 1, offset: 37244},
+			pos:  position{line: 1347, col: 1, offset: 37142},
 			expr: &actionExpr{
-				pos: position{line: 1351, col: 14, offset: 37257},
+				pos: position{line: 1347, col: 14, offset: 37155},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1351, col: 14, offset: 37257},
+					pos: position{line: 1347, col: 14, offset: 37155},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1351, col: 14, offset: 37257},
+							pos:        position{line: 1347, col: 14, offset: 37155},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1351, col: 19, offset: 37262},
+							pos:   position{line: 1347, col: 19, offset: 37160},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1351, col: 22, offset: 37265},
+								pos: position{line: 1347, col: 22, offset: 37163},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1351, col: 22, offset: 37265},
+										pos:  position{line: 1347, col: 22, offset: 37163},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1351, col: 38, offset: 37281},
+										pos:  position{line: 1347, col: 38, offset: 37179},
 										name: "EscapeSequence",
 									},
 								},
@@ -10759,42 +10696,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1353, col: 1, offset: 37317},
+			pos:  position{line: 1349, col: 1, offset: 37215},
 			expr: &actionExpr{
-				pos: position{line: 1354, col: 5, offset: 37333},
+				pos: position{line: 1350, col: 5, offset: 37231},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1354, col: 5, offset: 37333},
+					pos: position{line: 1350, col: 5, offset: 37231},
 					exprs: []interface{}{
 						&andExpr{
-							pos: position{line: 1354, col: 5, offset: 37333},
+							pos: position{line: 1350, col: 5, offset: 37231},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1354, col: 6, offset: 37334},
+								pos:  position{line: 1350, col: 6, offset: 37232},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1354, col: 22, offset: 37350},
+							pos: position{line: 1350, col: 22, offset: 37248},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1354, col: 23, offset: 37351},
+								pos:  position{line: 1350, col: 23, offset: 37249},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1354, col: 35, offset: 37363},
+							pos:   position{line: 1350, col: 35, offset: 37261},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1354, col: 40, offset: 37368},
+								pos:  position{line: 1350, col: 40, offset: 37266},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1354, col: 50, offset: 37378},
+							pos:   position{line: 1350, col: 50, offset: 37276},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1354, col: 55, offset: 37383},
+								pos: position{line: 1350, col: 55, offset: 37281},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1354, col: 55, offset: 37383},
+									pos:  position{line: 1350, col: 55, offset: 37281},
 									name: "GlobRest",
 								},
 							},
@@ -10805,27 +10742,27 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1358, col: 1, offset: 37452},
+			pos:  position{line: 1354, col: 1, offset: 37350},
 			expr: &choiceExpr{
-				pos: position{line: 1358, col: 19, offset: 37470},
+				pos: position{line: 1354, col: 19, offset: 37368},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1358, col: 19, offset: 37470},
+						pos:  position{line: 1354, col: 19, offset: 37368},
 						name: "KeyWordStart",
 					},
 					&seqExpr{
-						pos: position{line: 1358, col: 34, offset: 37485},
+						pos: position{line: 1354, col: 34, offset: 37383},
 						exprs: []interface{}{
 							&oneOrMoreExpr{
-								pos: position{line: 1358, col: 34, offset: 37485},
+								pos: position{line: 1354, col: 34, offset: 37383},
 								expr: &litMatcher{
-									pos:        position{line: 1358, col: 34, offset: 37485},
+									pos:        position{line: 1354, col: 34, offset: 37383},
 									val:        "*",
 									ignoreCase: false,
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1358, col: 39, offset: 37490},
+								pos:  position{line: 1354, col: 39, offset: 37388},
 								name: "KeyWordRest",
 							},
 						},
@@ -10835,19 +10772,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1359, col: 1, offset: 37502},
+			pos:  position{line: 1355, col: 1, offset: 37400},
 			expr: &seqExpr{
-				pos: position{line: 1359, col: 15, offset: 37516},
+				pos: position{line: 1355, col: 15, offset: 37414},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1359, col: 15, offset: 37516},
+						pos: position{line: 1355, col: 15, offset: 37414},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1359, col: 15, offset: 37516},
+							pos:  position{line: 1355, col: 15, offset: 37414},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1359, col: 28, offset: 37529},
+						pos:        position{line: 1355, col: 28, offset: 37427},
 						val:        "*",
 						ignoreCase: false,
 					},
@@ -10856,23 +10793,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1361, col: 1, offset: 37534},
+			pos:  position{line: 1357, col: 1, offset: 37432},
 			expr: &choiceExpr{
-				pos: position{line: 1362, col: 5, offset: 37548},
+				pos: position{line: 1358, col: 5, offset: 37446},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1362, col: 5, offset: 37548},
+						pos:  position{line: 1358, col: 5, offset: 37446},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1363, col: 5, offset: 37565},
+						pos:  position{line: 1359, col: 5, offset: 37463},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1364, col: 5, offset: 37577},
+						pos: position{line: 1360, col: 5, offset: 37475},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1364, col: 5, offset: 37577},
+							pos:        position{line: 1360, col: 5, offset: 37475},
 							val:        "*",
 							ignoreCase: false,
 						},
@@ -10882,16 +10819,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1366, col: 1, offset: 37601},
+			pos:  position{line: 1362, col: 1, offset: 37499},
 			expr: &choiceExpr{
-				pos: position{line: 1367, col: 5, offset: 37614},
+				pos: position{line: 1363, col: 5, offset: 37512},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1367, col: 5, offset: 37614},
+						pos:  position{line: 1363, col: 5, offset: 37512},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1368, col: 5, offset: 37628},
+						pos:        position{line: 1364, col: 5, offset: 37526},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10902,30 +10839,30 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1370, col: 1, offset: 37635},
+			pos:  position{line: 1366, col: 1, offset: 37533},
 			expr: &actionExpr{
-				pos: position{line: 1370, col: 11, offset: 37645},
+				pos: position{line: 1366, col: 11, offset: 37543},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1370, col: 11, offset: 37645},
+					pos: position{line: 1366, col: 11, offset: 37543},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1370, col: 11, offset: 37645},
+							pos:        position{line: 1366, col: 11, offset: 37543},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1370, col: 16, offset: 37650},
+							pos:   position{line: 1366, col: 16, offset: 37548},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1370, col: 19, offset: 37653},
+								pos: position{line: 1366, col: 19, offset: 37551},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1370, col: 19, offset: 37653},
+										pos:  position{line: 1366, col: 19, offset: 37551},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1370, col: 32, offset: 37666},
+										pos:  position{line: 1366, col: 32, offset: 37564},
 										name: "EscapeSequence",
 									},
 								},
@@ -10937,30 +10874,30 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1372, col: 1, offset: 37702},
+			pos:  position{line: 1368, col: 1, offset: 37600},
 			expr: &choiceExpr{
-				pos: position{line: 1373, col: 5, offset: 37717},
+				pos: position{line: 1369, col: 5, offset: 37615},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1373, col: 5, offset: 37717},
+						pos: position{line: 1369, col: 5, offset: 37615},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1373, col: 5, offset: 37717},
+							pos:        position{line: 1369, col: 5, offset: 37615},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1374, col: 5, offset: 37745},
+						pos: position{line: 1370, col: 5, offset: 37643},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1374, col: 5, offset: 37745},
+							pos:        position{line: 1370, col: 5, offset: 37643},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1375, col: 5, offset: 37775},
+						pos:        position{line: 1371, col: 5, offset: 37673},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -10971,55 +10908,55 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1378, col: 1, offset: 37782},
+			pos:  position{line: 1374, col: 1, offset: 37680},
 			expr: &choiceExpr{
-				pos: position{line: 1379, col: 5, offset: 37803},
+				pos: position{line: 1375, col: 5, offset: 37701},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1379, col: 5, offset: 37803},
+						pos: position{line: 1375, col: 5, offset: 37701},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1379, col: 5, offset: 37803},
+							pos: position{line: 1375, col: 5, offset: 37701},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1379, col: 5, offset: 37803},
+									pos: position{line: 1375, col: 5, offset: 37701},
 									expr: &choiceExpr{
-										pos: position{line: 1379, col: 7, offset: 37805},
+										pos: position{line: 1375, col: 7, offset: 37703},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1379, col: 7, offset: 37805},
+												pos:        position{line: 1375, col: 7, offset: 37703},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1379, col: 13, offset: 37811},
+												pos:  position{line: 1375, col: 13, offset: 37709},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1379, col: 26, offset: 37824,
+									line: 1375, col: 26, offset: 37722,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1380, col: 5, offset: 37861},
+						pos: position{line: 1376, col: 5, offset: 37759},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1380, col: 5, offset: 37861},
+							pos: position{line: 1376, col: 5, offset: 37759},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1380, col: 5, offset: 37861},
+									pos:        position{line: 1376, col: 5, offset: 37759},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1380, col: 10, offset: 37866},
+									pos:   position{line: 1376, col: 10, offset: 37764},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1380, col: 12, offset: 37868},
+										pos:  position{line: 1376, col: 12, offset: 37766},
 										name: "EscapeSequence",
 									},
 								},
@@ -11031,16 +10968,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1382, col: 1, offset: 37902},
+			pos:  position{line: 1378, col: 1, offset: 37800},
 			expr: &choiceExpr{
-				pos: position{line: 1383, col: 5, offset: 37921},
+				pos: position{line: 1379, col: 5, offset: 37819},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1383, col: 5, offset: 37921},
+						pos:  position{line: 1379, col: 5, offset: 37819},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1384, col: 5, offset: 37942},
+						pos:  position{line: 1380, col: 5, offset: 37840},
 						name: "UnicodeEscape",
 					},
 				},
@@ -11048,79 +10985,79 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1386, col: 1, offset: 37957},
+			pos:  position{line: 1382, col: 1, offset: 37855},
 			expr: &choiceExpr{
-				pos: position{line: 1387, col: 5, offset: 37978},
+				pos: position{line: 1383, col: 5, offset: 37876},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1387, col: 5, offset: 37978},
+						pos:        position{line: 1383, col: 5, offset: 37876},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1388, col: 5, offset: 37986},
+						pos: position{line: 1384, col: 5, offset: 37884},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1388, col: 5, offset: 37986},
+							pos:        position{line: 1384, col: 5, offset: 37884},
 							val:        "\"",
 							ignoreCase: false,
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1389, col: 5, offset: 38026},
+						pos:        position{line: 1385, col: 5, offset: 37924},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1390, col: 5, offset: 38035},
+						pos: position{line: 1386, col: 5, offset: 37933},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1390, col: 5, offset: 38035},
+							pos:        position{line: 1386, col: 5, offset: 37933},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1391, col: 5, offset: 38064},
+						pos: position{line: 1387, col: 5, offset: 37962},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1391, col: 5, offset: 38064},
+							pos:        position{line: 1387, col: 5, offset: 37962},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1392, col: 5, offset: 38093},
+						pos: position{line: 1388, col: 5, offset: 37991},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1392, col: 5, offset: 38093},
+							pos:        position{line: 1388, col: 5, offset: 37991},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1393, col: 5, offset: 38122},
+						pos: position{line: 1389, col: 5, offset: 38020},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1393, col: 5, offset: 38122},
+							pos:        position{line: 1389, col: 5, offset: 38020},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1394, col: 5, offset: 38151},
+						pos: position{line: 1390, col: 5, offset: 38049},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1394, col: 5, offset: 38151},
+							pos:        position{line: 1390, col: 5, offset: 38049},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1395, col: 5, offset: 38180},
+						pos: position{line: 1391, col: 5, offset: 38078},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1395, col: 5, offset: 38180},
+							pos:        position{line: 1391, col: 5, offset: 38078},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -11130,30 +11067,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1397, col: 1, offset: 38206},
+			pos:  position{line: 1393, col: 1, offset: 38104},
 			expr: &choiceExpr{
-				pos: position{line: 1398, col: 5, offset: 38224},
+				pos: position{line: 1394, col: 5, offset: 38122},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1398, col: 5, offset: 38224},
+						pos: position{line: 1394, col: 5, offset: 38122},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1398, col: 5, offset: 38224},
+							pos:        position{line: 1394, col: 5, offset: 38122},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1399, col: 5, offset: 38252},
+						pos: position{line: 1395, col: 5, offset: 38150},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1399, col: 5, offset: 38252},
+							pos:        position{line: 1395, col: 5, offset: 38150},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1400, col: 5, offset: 38280},
+						pos:        position{line: 1396, col: 5, offset: 38178},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -11164,41 +11101,41 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1402, col: 1, offset: 38286},
+			pos:  position{line: 1398, col: 1, offset: 38184},
 			expr: &choiceExpr{
-				pos: position{line: 1403, col: 5, offset: 38304},
+				pos: position{line: 1399, col: 5, offset: 38202},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1403, col: 5, offset: 38304},
+						pos: position{line: 1399, col: 5, offset: 38202},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1403, col: 5, offset: 38304},
+							pos: position{line: 1399, col: 5, offset: 38202},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1403, col: 5, offset: 38304},
+									pos:        position{line: 1399, col: 5, offset: 38202},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1403, col: 9, offset: 38308},
+									pos:   position{line: 1399, col: 9, offset: 38206},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1403, col: 16, offset: 38315},
+										pos: position{line: 1399, col: 16, offset: 38213},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1403, col: 16, offset: 38315},
+												pos:  position{line: 1399, col: 16, offset: 38213},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1403, col: 25, offset: 38324},
+												pos:  position{line: 1399, col: 25, offset: 38222},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1403, col: 34, offset: 38333},
+												pos:  position{line: 1399, col: 34, offset: 38231},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1403, col: 43, offset: 38342},
+												pos:  position{line: 1399, col: 43, offset: 38240},
 												name: "HexDigit",
 											},
 										},
@@ -11208,63 +11145,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1406, col: 5, offset: 38405},
+						pos: position{line: 1402, col: 5, offset: 38303},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1406, col: 5, offset: 38405},
+							pos: position{line: 1402, col: 5, offset: 38303},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1406, col: 5, offset: 38405},
+									pos:        position{line: 1402, col: 5, offset: 38303},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1406, col: 9, offset: 38409},
+									pos:        position{line: 1402, col: 9, offset: 38307},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1406, col: 13, offset: 38413},
+									pos:   position{line: 1402, col: 13, offset: 38311},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1406, col: 20, offset: 38420},
+										pos: position{line: 1402, col: 20, offset: 38318},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1406, col: 20, offset: 38420},
+												pos:  position{line: 1402, col: 20, offset: 38318},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1406, col: 29, offset: 38429},
+												pos: position{line: 1402, col: 29, offset: 38327},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1406, col: 29, offset: 38429},
+													pos:  position{line: 1402, col: 29, offset: 38327},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1406, col: 39, offset: 38439},
+												pos: position{line: 1402, col: 39, offset: 38337},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1406, col: 39, offset: 38439},
+													pos:  position{line: 1402, col: 39, offset: 38337},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1406, col: 49, offset: 38449},
+												pos: position{line: 1402, col: 49, offset: 38347},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1406, col: 49, offset: 38449},
+													pos:  position{line: 1402, col: 49, offset: 38347},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1406, col: 59, offset: 38459},
+												pos: position{line: 1402, col: 59, offset: 38357},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1406, col: 59, offset: 38459},
+													pos:  position{line: 1402, col: 59, offset: 38357},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1406, col: 69, offset: 38469},
+												pos: position{line: 1402, col: 69, offset: 38367},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1406, col: 69, offset: 38469},
+													pos:  position{line: 1402, col: 69, offset: 38367},
 													name: "HexDigit",
 												},
 											},
@@ -11272,7 +11209,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1406, col: 80, offset: 38480},
+									pos:        position{line: 1402, col: 80, offset: 38378},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -11284,35 +11221,35 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPattern",
-			pos:  position{line: 1410, col: 1, offset: 38534},
+			pos:  position{line: 1406, col: 1, offset: 38432},
 			expr: &actionExpr{
-				pos: position{line: 1411, col: 5, offset: 38552},
+				pos: position{line: 1407, col: 5, offset: 38450},
 				run: (*parser).callonRegexpPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1411, col: 5, offset: 38552},
+					pos: position{line: 1407, col: 5, offset: 38450},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1411, col: 5, offset: 38552},
+							pos:        position{line: 1407, col: 5, offset: 38450},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1411, col: 9, offset: 38556},
+							pos:   position{line: 1407, col: 9, offset: 38454},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1411, col: 14, offset: 38561},
+								pos:  position{line: 1407, col: 14, offset: 38459},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1411, col: 25, offset: 38572},
+							pos:        position{line: 1407, col: 25, offset: 38470},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1411, col: 29, offset: 38576},
+							pos: position{line: 1407, col: 29, offset: 38474},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1411, col: 30, offset: 38577},
+								pos:  position{line: 1407, col: 30, offset: 38475},
 								name: "KeyWordStart",
 							},
 						},
@@ -11322,32 +11259,32 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1413, col: 1, offset: 38612},
+			pos:  position{line: 1409, col: 1, offset: 38510},
 			expr: &actionExpr{
-				pos: position{line: 1414, col: 5, offset: 38627},
+				pos: position{line: 1410, col: 5, offset: 38525},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1414, col: 5, offset: 38627},
+					pos: position{line: 1410, col: 5, offset: 38525},
 					expr: &choiceExpr{
-						pos: position{line: 1414, col: 6, offset: 38628},
+						pos: position{line: 1410, col: 6, offset: 38526},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 1414, col: 6, offset: 38628},
+								pos:        position{line: 1410, col: 6, offset: 38526},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&seqExpr{
-								pos: position{line: 1414, col: 15, offset: 38637},
+								pos: position{line: 1410, col: 15, offset: 38535},
 								exprs: []interface{}{
 									&litMatcher{
-										pos:        position{line: 1414, col: 15, offset: 38637},
+										pos:        position{line: 1410, col: 15, offset: 38535},
 										val:        "\\",
 										ignoreCase: false,
 									},
 									&anyMatcher{
-										line: 1414, col: 20, offset: 38642,
+										line: 1410, col: 20, offset: 38540,
 									},
 								},
 							},
@@ -11358,9 +11295,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1416, col: 1, offset: 38678},
+			pos:  position{line: 1412, col: 1, offset: 38576},
 			expr: &charClassMatcher{
-				pos:        position{line: 1417, col: 5, offset: 38694},
+				pos:        position{line: 1413, col: 5, offset: 38592},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -11370,42 +11307,42 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1419, col: 1, offset: 38709},
+			pos:  position{line: 1415, col: 1, offset: 38607},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1419, col: 6, offset: 38714},
+				pos: position{line: 1415, col: 6, offset: 38612},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1419, col: 6, offset: 38714},
+					pos:  position{line: 1415, col: 6, offset: 38612},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 1421, col: 1, offset: 38725},
+			pos:  position{line: 1417, col: 1, offset: 38623},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1421, col: 6, offset: 38730},
+				pos: position{line: 1417, col: 6, offset: 38628},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1421, col: 6, offset: 38730},
+					pos:  position{line: 1417, col: 6, offset: 38628},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1423, col: 1, offset: 38741},
+			pos:  position{line: 1419, col: 1, offset: 38639},
 			expr: &choiceExpr{
-				pos: position{line: 1424, col: 5, offset: 38754},
+				pos: position{line: 1420, col: 5, offset: 38652},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1424, col: 5, offset: 38754},
+						pos:  position{line: 1420, col: 5, offset: 38652},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1425, col: 5, offset: 38769},
+						pos:  position{line: 1421, col: 5, offset: 38667},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1426, col: 5, offset: 38788},
+						pos:  position{line: 1422, col: 5, offset: 38686},
 						name: "Comment",
 					},
 				},
@@ -11413,45 +11350,45 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1428, col: 1, offset: 38797},
+			pos:  position{line: 1424, col: 1, offset: 38695},
 			expr: &anyMatcher{
-				line: 1429, col: 5, offset: 38817,
+				line: 1425, col: 5, offset: 38715,
 			},
 		},
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1431, col: 1, offset: 38820},
+			pos:         position{line: 1427, col: 1, offset: 38718},
 			expr: &choiceExpr{
-				pos: position{line: 1432, col: 5, offset: 38848},
+				pos: position{line: 1428, col: 5, offset: 38746},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1432, col: 5, offset: 38848},
+						pos:        position{line: 1428, col: 5, offset: 38746},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1433, col: 5, offset: 38857},
+						pos:        position{line: 1429, col: 5, offset: 38755},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1434, col: 5, offset: 38866},
+						pos:        position{line: 1430, col: 5, offset: 38764},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1435, col: 5, offset: 38875},
+						pos:        position{line: 1431, col: 5, offset: 38773},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1436, col: 5, offset: 38883},
+						pos:        position{line: 1432, col: 5, offset: 38781},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1437, col: 5, offset: 38896},
+						pos:        position{line: 1433, col: 5, offset: 38794},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -11460,9 +11397,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1439, col: 1, offset: 38906},
+			pos:  position{line: 1435, col: 1, offset: 38804},
 			expr: &charClassMatcher{
-				pos:        position{line: 1440, col: 5, offset: 38925},
+				pos:        position{line: 1436, col: 5, offset: 38823},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -11472,45 +11409,45 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1446, col: 1, offset: 39255},
+			pos:         position{line: 1442, col: 1, offset: 39153},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1449, col: 5, offset: 39326},
+				pos:  position{line: 1445, col: 5, offset: 39224},
 				name: "SingleLineComment",
 			},
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1451, col: 1, offset: 39345},
+			pos:  position{line: 1447, col: 1, offset: 39243},
 			expr: &seqExpr{
-				pos: position{line: 1452, col: 5, offset: 39366},
+				pos: position{line: 1448, col: 5, offset: 39264},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1452, col: 5, offset: 39366},
+						pos:        position{line: 1448, col: 5, offset: 39264},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1452, col: 10, offset: 39371},
+						pos: position{line: 1448, col: 10, offset: 39269},
 						expr: &seqExpr{
-							pos: position{line: 1452, col: 11, offset: 39372},
+							pos: position{line: 1448, col: 11, offset: 39270},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1452, col: 11, offset: 39372},
+									pos: position{line: 1448, col: 11, offset: 39270},
 									expr: &litMatcher{
-										pos:        position{line: 1452, col: 12, offset: 39373},
+										pos:        position{line: 1448, col: 12, offset: 39271},
 										val:        "*/",
 										ignoreCase: false,
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1452, col: 17, offset: 39378},
+									pos:  position{line: 1448, col: 17, offset: 39276},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1452, col: 35, offset: 39396},
+						pos:        position{line: 1448, col: 35, offset: 39294},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -11519,29 +11456,29 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1454, col: 1, offset: 39402},
+			pos:  position{line: 1450, col: 1, offset: 39300},
 			expr: &seqExpr{
-				pos: position{line: 1455, col: 5, offset: 39424},
+				pos: position{line: 1451, col: 5, offset: 39322},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1455, col: 5, offset: 39424},
+						pos:        position{line: 1451, col: 5, offset: 39322},
 						val:        "//",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1455, col: 10, offset: 39429},
+						pos: position{line: 1451, col: 10, offset: 39327},
 						expr: &seqExpr{
-							pos: position{line: 1455, col: 11, offset: 39430},
+							pos: position{line: 1451, col: 11, offset: 39328},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1455, col: 11, offset: 39430},
+									pos: position{line: 1451, col: 11, offset: 39328},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1455, col: 12, offset: 39431},
+										pos:  position{line: 1451, col: 12, offset: 39329},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1455, col: 27, offset: 39446},
+									pos:  position{line: 1451, col: 27, offset: 39344},
 									name: "SourceCharacter",
 								},
 							},
@@ -11552,19 +11489,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1457, col: 1, offset: 39465},
+			pos:  position{line: 1453, col: 1, offset: 39363},
 			expr: &seqExpr{
-				pos: position{line: 1457, col: 7, offset: 39471},
+				pos: position{line: 1453, col: 7, offset: 39369},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1457, col: 7, offset: 39471},
+						pos: position{line: 1453, col: 7, offset: 39369},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1457, col: 7, offset: 39471},
+							pos:  position{line: 1453, col: 7, offset: 39369},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1457, col: 19, offset: 39483},
+						pos:  position{line: 1453, col: 19, offset: 39381},
 						name: "LineTerminator",
 					},
 				},
@@ -11572,16 +11509,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1459, col: 1, offset: 39499},
+			pos:  position{line: 1455, col: 1, offset: 39397},
 			expr: &choiceExpr{
-				pos: position{line: 1459, col: 7, offset: 39505},
+				pos: position{line: 1455, col: 7, offset: 39403},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1459, col: 7, offset: 39505},
+						pos:  position{line: 1455, col: 7, offset: 39403},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1459, col: 11, offset: 39509},
+						pos:  position{line: 1455, col: 11, offset: 39407},
 						name: "EOF",
 					},
 				},
@@ -11589,21 +11526,21 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1461, col: 1, offset: 39514},
+			pos:  position{line: 1457, col: 1, offset: 39412},
 			expr: &notExpr{
-				pos: position{line: 1461, col: 7, offset: 39520},
+				pos: position{line: 1457, col: 7, offset: 39418},
 				expr: &anyMatcher{
-					line: 1461, col: 8, offset: 39521,
+					line: 1457, col: 8, offset: 39419,
 				},
 			},
 		},
 		{
 			name: "EOKW",
-			pos:  position{line: 1463, col: 1, offset: 39524},
+			pos:  position{line: 1459, col: 1, offset: 39422},
 			expr: &notExpr{
-				pos: position{line: 1463, col: 8, offset: 39531},
+				pos: position{line: 1459, col: 8, offset: 39429},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1463, col: 9, offset: 39532},
+					pos:  position{line: 1459, col: 9, offset: 39430},
 					name: "KeyWordChars",
 				},
 			},
@@ -12882,26 +12819,6 @@ func (p *parser) callonOrderSuffix6() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onOrderSuffix6()
-}
-
-func (c *current) onOrderArg2() (interface{}, error) {
-	return "asc", nil
-}
-
-func (p *parser) callonOrderArg2() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onOrderArg2()
-}
-
-func (c *current) onOrderArg8() (interface{}, error) {
-	return "desc", nil
-}
-
-func (p *parser) callonOrderArg8() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onOrderArg8()
 }
 
 func (c *current) onPassOp1() (interface{}, error) {

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -3469,76 +3469,54 @@ var g = &grammar{
 								},
 							},
 						},
-						&labeledExpr{
-							pos:   position{line: 493, col: 30, offset: 14501},
-							label: "over",
-							expr: &zeroOrOneExpr{
-								pos: position{line: 493, col: 35, offset: 14506},
-								expr: &ruleRefExpr{
-									pos:  position{line: 493, col: 35, offset: 14506},
-									name: "PoolRange",
-								},
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 493, col: 46, offset: 14517},
-							label: "order",
-							expr: &zeroOrOneExpr{
-								pos: position{line: 493, col: 52, offset: 14523},
-								expr: &ruleRefExpr{
-									pos:  position{line: 493, col: 52, offset: 14523},
-									name: "OrderArg",
-								},
-							},
-						},
 					},
 				},
 			},
 		},
 		{
 			name: "Get",
-			pos:  position{line: 497, col: 1, offset: 14659},
+			pos:  position{line: 497, col: 1, offset: 14591},
 			expr: &actionExpr{
-				pos: position{line: 498, col: 5, offset: 14667},
+				pos: position{line: 498, col: 5, offset: 14599},
 				run: (*parser).callonGet1,
 				expr: &seqExpr{
-					pos: position{line: 498, col: 5, offset: 14667},
+					pos: position{line: 498, col: 5, offset: 14599},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 498, col: 5, offset: 14667},
+							pos:        position{line: 498, col: 5, offset: 14599},
 							val:        "get",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 498, col: 11, offset: 14673},
+							pos:  position{line: 498, col: 11, offset: 14605},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 498, col: 13, offset: 14675},
+							pos:   position{line: 498, col: 13, offset: 14607},
 							label: "url",
 							expr: &ruleRefExpr{
-								pos:  position{line: 498, col: 17, offset: 14679},
+								pos:  position{line: 498, col: 17, offset: 14611},
 								name: "URL",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 498, col: 21, offset: 14683},
+							pos:   position{line: 498, col: 21, offset: 14615},
 							label: "format",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 498, col: 28, offset: 14690},
+								pos: position{line: 498, col: 28, offset: 14622},
 								expr: &ruleRefExpr{
-									pos:  position{line: 498, col: 28, offset: 14690},
+									pos:  position{line: 498, col: 28, offset: 14622},
 									name: "FormatArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 498, col: 39, offset: 14701},
+							pos:   position{line: 498, col: 39, offset: 14633},
 							label: "layout",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 498, col: 46, offset: 14708},
+								pos: position{line: 498, col: 46, offset: 14640},
 								expr: &ruleRefExpr{
-									pos:  position{line: 498, col: 46, offset: 14708},
+									pos:  position{line: 498, col: 46, offset: 14640},
 									name: "LayoutArg",
 								},
 							},
@@ -3549,30 +3527,30 @@ var g = &grammar{
 		},
 		{
 			name: "URL",
-			pos:  position{line: 502, col: 1, offset: 14834},
+			pos:  position{line: 502, col: 1, offset: 14766},
 			expr: &actionExpr{
-				pos: position{line: 502, col: 7, offset: 14840},
+				pos: position{line: 502, col: 7, offset: 14772},
 				run: (*parser).callonURL1,
 				expr: &seqExpr{
-					pos: position{line: 502, col: 7, offset: 14840},
+					pos: position{line: 502, col: 7, offset: 14772},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 502, col: 8, offset: 14841},
+							pos: position{line: 502, col: 8, offset: 14773},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 502, col: 8, offset: 14841},
+									pos:        position{line: 502, col: 8, offset: 14773},
 									val:        "http:",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 502, col: 18, offset: 14851},
+									pos:        position{line: 502, col: 18, offset: 14783},
 									val:        "https:",
 									ignoreCase: false,
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 502, col: 28, offset: 14861},
+							pos:  position{line: 502, col: 28, offset: 14793},
 							name: "Path",
 						},
 					},
@@ -3581,29 +3559,29 @@ var g = &grammar{
 		},
 		{
 			name: "Path",
-			pos:  position{line: 504, col: 1, offset: 14898},
+			pos:  position{line: 504, col: 1, offset: 14830},
 			expr: &choiceExpr{
-				pos: position{line: 505, col: 5, offset: 14907},
+				pos: position{line: 505, col: 5, offset: 14839},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 505, col: 5, offset: 14907},
+						pos: position{line: 505, col: 5, offset: 14839},
 						run: (*parser).callonPath2,
 						expr: &labeledExpr{
-							pos:   position{line: 505, col: 5, offset: 14907},
+							pos:   position{line: 505, col: 5, offset: 14839},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 505, col: 7, offset: 14909},
+								pos:  position{line: 505, col: 7, offset: 14841},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 506, col: 5, offset: 14944},
+						pos: position{line: 506, col: 5, offset: 14876},
 						run: (*parser).callonPath5,
 						expr: &oneOrMoreExpr{
-							pos: position{line: 506, col: 5, offset: 14944},
+							pos: position{line: 506, col: 5, offset: 14876},
 							expr: &charClassMatcher{
-								pos:        position{line: 506, col: 5, offset: 14944},
+								pos:        position{line: 506, col: 5, offset: 14876},
 								val:        "[0-9a-zA-Z!@$%^&*()_=<>,./?:[\\]{}~|+-]",
 								chars:      []rune{'!', '@', '$', '%', '^', '&', '*', '(', ')', '_', '=', '<', '>', ',', '.', '/', '?', ':', '[', ']', '{', '}', '~', '|', '+', '-'},
 								ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
@@ -3617,31 +3595,31 @@ var g = &grammar{
 		},
 		{
 			name: "PoolAt",
-			pos:  position{line: 509, col: 1, offset: 15049},
+			pos:  position{line: 509, col: 1, offset: 14981},
 			expr: &actionExpr{
-				pos: position{line: 510, col: 5, offset: 15060},
+				pos: position{line: 510, col: 5, offset: 14992},
 				run: (*parser).callonPoolAt1,
 				expr: &seqExpr{
-					pos: position{line: 510, col: 5, offset: 15060},
+					pos: position{line: 510, col: 5, offset: 14992},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 510, col: 5, offset: 15060},
+							pos:  position{line: 510, col: 5, offset: 14992},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 510, col: 7, offset: 15062},
+							pos:        position{line: 510, col: 7, offset: 14994},
 							val:        "at",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 510, col: 12, offset: 15067},
+							pos:  position{line: 510, col: 12, offset: 14999},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 510, col: 14, offset: 15069},
+							pos:   position{line: 510, col: 14, offset: 15001},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 510, col: 17, offset: 15072},
+								pos:  position{line: 510, col: 17, offset: 15004},
 								name: "KSUID",
 							},
 						},
@@ -3651,14 +3629,14 @@ var g = &grammar{
 		},
 		{
 			name: "KSUID",
-			pos:  position{line: 513, col: 1, offset: 15138},
+			pos:  position{line: 513, col: 1, offset: 15070},
 			expr: &actionExpr{
-				pos: position{line: 513, col: 9, offset: 15146},
+				pos: position{line: 513, col: 9, offset: 15078},
 				run: (*parser).callonKSUID1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 513, col: 9, offset: 15146},
+					pos: position{line: 513, col: 9, offset: 15078},
 					expr: &charClassMatcher{
-						pos:        position{line: 513, col: 10, offset: 15147},
+						pos:        position{line: 513, col: 10, offset: 15079},
 						val:        "[0-9a-zA-Z]",
 						ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
 						ignoreCase: false,
@@ -3668,98 +3646,43 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "PoolRange",
-			pos:  position{line: 515, col: 1, offset: 15193},
-			expr: &actionExpr{
-				pos: position{line: 516, col: 5, offset: 15207},
-				run: (*parser).callonPoolRange1,
-				expr: &seqExpr{
-					pos: position{line: 516, col: 5, offset: 15207},
-					exprs: []interface{}{
-						&ruleRefExpr{
-							pos:  position{line: 516, col: 5, offset: 15207},
-							name: "_",
-						},
-						&litMatcher{
-							pos:        position{line: 516, col: 7, offset: 15209},
-							val:        "range",
-							ignoreCase: false,
-						},
-						&ruleRefExpr{
-							pos:  position{line: 516, col: 15, offset: 15217},
-							name: "_",
-						},
-						&labeledExpr{
-							pos:   position{line: 516, col: 17, offset: 15219},
-							label: "lower",
-							expr: &ruleRefExpr{
-								pos:  position{line: 516, col: 23, offset: 15225},
-								name: "Literal",
-							},
-						},
-						&ruleRefExpr{
-							pos:  position{line: 516, col: 31, offset: 15233},
-							name: "_",
-						},
-						&litMatcher{
-							pos:        position{line: 516, col: 33, offset: 15235},
-							val:        "to",
-							ignoreCase: false,
-						},
-						&ruleRefExpr{
-							pos:  position{line: 516, col: 38, offset: 15240},
-							name: "_",
-						},
-						&labeledExpr{
-							pos:   position{line: 516, col: 40, offset: 15242},
-							label: "upper",
-							expr: &ruleRefExpr{
-								pos:  position{line: 516, col: 46, offset: 15248},
-								name: "Literal",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
 			name: "PoolSpec",
-			pos:  position{line: 520, col: 1, offset: 15353},
+			pos:  position{line: 515, col: 1, offset: 15125},
 			expr: &choiceExpr{
-				pos: position{line: 521, col: 5, offset: 15366},
+				pos: position{line: 516, col: 5, offset: 15138},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 521, col: 5, offset: 15366},
+						pos: position{line: 516, col: 5, offset: 15138},
 						run: (*parser).callonPoolSpec2,
 						expr: &seqExpr{
-							pos: position{line: 521, col: 5, offset: 15366},
+							pos: position{line: 516, col: 5, offset: 15138},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 521, col: 5, offset: 15366},
+									pos:   position{line: 516, col: 5, offset: 15138},
 									label: "pool",
 									expr: &ruleRefExpr{
-										pos:  position{line: 521, col: 10, offset: 15371},
+										pos:  position{line: 516, col: 10, offset: 15143},
 										name: "PoolName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 521, col: 19, offset: 15380},
+									pos:   position{line: 516, col: 19, offset: 15152},
 									label: "commit",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 521, col: 26, offset: 15387},
+										pos: position{line: 516, col: 26, offset: 15159},
 										expr: &ruleRefExpr{
-											pos:  position{line: 521, col: 26, offset: 15387},
+											pos:  position{line: 516, col: 26, offset: 15159},
 											name: "PoolCommit",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 521, col: 38, offset: 15399},
+									pos:   position{line: 516, col: 38, offset: 15171},
 									label: "meta",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 521, col: 43, offset: 15404},
+										pos: position{line: 516, col: 43, offset: 15176},
 										expr: &ruleRefExpr{
-											pos:  position{line: 521, col: 43, offset: 15404},
+											pos:  position{line: 516, col: 43, offset: 15176},
 											name: "PoolMeta",
 										},
 									},
@@ -3768,13 +3691,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 524, col: 5, offset: 15513},
+						pos: position{line: 519, col: 5, offset: 15285},
 						run: (*parser).callonPoolSpec12,
 						expr: &labeledExpr{
-							pos:   position{line: 524, col: 5, offset: 15513},
+							pos:   position{line: 519, col: 5, offset: 15285},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 524, col: 10, offset: 15518},
+								pos:  position{line: 519, col: 10, offset: 15290},
 								name: "PoolMeta",
 							},
 						},
@@ -3784,23 +3707,23 @@ var g = &grammar{
 		},
 		{
 			name: "PoolCommit",
-			pos:  position{line: 528, col: 1, offset: 15619},
+			pos:  position{line: 523, col: 1, offset: 15391},
 			expr: &actionExpr{
-				pos: position{line: 529, col: 5, offset: 15634},
+				pos: position{line: 524, col: 5, offset: 15406},
 				run: (*parser).callonPoolCommit1,
 				expr: &seqExpr{
-					pos: position{line: 529, col: 5, offset: 15634},
+					pos: position{line: 524, col: 5, offset: 15406},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 529, col: 5, offset: 15634},
+							pos:        position{line: 524, col: 5, offset: 15406},
 							val:        "@",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 529, col: 9, offset: 15638},
+							pos:   position{line: 524, col: 9, offset: 15410},
 							label: "commit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 529, col: 16, offset: 15645},
+								pos:  position{line: 524, col: 16, offset: 15417},
 								name: "PoolNameString",
 							},
 						},
@@ -3810,23 +3733,23 @@ var g = &grammar{
 		},
 		{
 			name: "PoolMeta",
-			pos:  position{line: 531, col: 1, offset: 15684},
+			pos:  position{line: 526, col: 1, offset: 15456},
 			expr: &actionExpr{
-				pos: position{line: 532, col: 5, offset: 15697},
+				pos: position{line: 527, col: 5, offset: 15469},
 				run: (*parser).callonPoolMeta1,
 				expr: &seqExpr{
-					pos: position{line: 532, col: 5, offset: 15697},
+					pos: position{line: 527, col: 5, offset: 15469},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 532, col: 5, offset: 15697},
+							pos:        position{line: 527, col: 5, offset: 15469},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 532, col: 9, offset: 15701},
+							pos:   position{line: 527, col: 9, offset: 15473},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 532, col: 14, offset: 15706},
+								pos:  position{line: 527, col: 14, offset: 15478},
 								name: "PoolIdentifier",
 							},
 						},
@@ -3836,29 +3759,29 @@ var g = &grammar{
 		},
 		{
 			name: "PoolName",
-			pos:  position{line: 534, col: 1, offset: 15743},
+			pos:  position{line: 529, col: 1, offset: 15515},
 			expr: &choiceExpr{
-				pos: position{line: 535, col: 5, offset: 15756},
+				pos: position{line: 530, col: 5, offset: 15528},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 535, col: 5, offset: 15756},
+						pos:  position{line: 530, col: 5, offset: 15528},
 						name: "Glob",
 					},
 					&actionExpr{
-						pos: position{line: 536, col: 5, offset: 15765},
+						pos: position{line: 531, col: 5, offset: 15537},
 						run: (*parser).callonPoolName3,
 						expr: &seqExpr{
-							pos: position{line: 536, col: 5, offset: 15765},
+							pos: position{line: 531, col: 5, offset: 15537},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 536, col: 5, offset: 15765},
+									pos:        position{line: 531, col: 5, offset: 15537},
 									val:        "*",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 536, col: 9, offset: 15769},
+									pos: position{line: 531, col: 9, offset: 15541},
 									expr: &ruleRefExpr{
-										pos:  position{line: 536, col: 10, offset: 15770},
+										pos:  position{line: 531, col: 10, offset: 15542},
 										name: "ExprGuard",
 									},
 								},
@@ -3866,17 +3789,17 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 537, col: 5, offset: 15855},
+						pos:  position{line: 532, col: 5, offset: 15627},
 						name: "Regexp",
 					},
 					&actionExpr{
-						pos: position{line: 538, col: 5, offset: 15866},
+						pos: position{line: 533, col: 5, offset: 15638},
 						run: (*parser).callonPoolName9,
 						expr: &labeledExpr{
-							pos:   position{line: 538, col: 5, offset: 15866},
+							pos:   position{line: 533, col: 5, offset: 15638},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 538, col: 10, offset: 15871},
+								pos:  position{line: 533, col: 10, offset: 15643},
 								name: "PoolNameString",
 							},
 						},
@@ -3886,20 +3809,20 @@ var g = &grammar{
 		},
 		{
 			name: "PoolNameString",
-			pos:  position{line: 540, col: 1, offset: 15958},
+			pos:  position{line: 535, col: 1, offset: 15730},
 			expr: &choiceExpr{
-				pos: position{line: 541, col: 5, offset: 15977},
+				pos: position{line: 536, col: 5, offset: 15749},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 541, col: 5, offset: 15977},
+						pos:  position{line: 536, col: 5, offset: 15749},
 						name: "PoolIdentifier",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 542, col: 5, offset: 15996},
+						pos:  position{line: 537, col: 5, offset: 15768},
 						name: "KSUID",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 543, col: 5, offset: 16006},
+						pos:  position{line: 538, col: 5, offset: 15778},
 						name: "QuotedString",
 					},
 				},
@@ -3907,38 +3830,38 @@ var g = &grammar{
 		},
 		{
 			name: "PoolIdentifier",
-			pos:  position{line: 545, col: 1, offset: 16020},
+			pos:  position{line: 540, col: 1, offset: 15792},
 			expr: &actionExpr{
-				pos: position{line: 546, col: 5, offset: 16039},
+				pos: position{line: 541, col: 5, offset: 15811},
 				run: (*parser).callonPoolIdentifier1,
 				expr: &seqExpr{
-					pos: position{line: 546, col: 5, offset: 16039},
+					pos: position{line: 541, col: 5, offset: 15811},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 546, col: 6, offset: 16040},
+							pos: position{line: 541, col: 6, offset: 15812},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 546, col: 6, offset: 16040},
+									pos:  position{line: 541, col: 6, offset: 15812},
 									name: "IdentifierStart",
 								},
 								&litMatcher{
-									pos:        position{line: 546, col: 24, offset: 16058},
+									pos:        position{line: 541, col: 24, offset: 15830},
 									val:        ".",
 									ignoreCase: false,
 								},
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 546, col: 29, offset: 16063},
+							pos: position{line: 541, col: 29, offset: 15835},
 							expr: &choiceExpr{
-								pos: position{line: 546, col: 30, offset: 16064},
+								pos: position{line: 541, col: 30, offset: 15836},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 546, col: 30, offset: 16064},
+										pos:  position{line: 541, col: 30, offset: 15836},
 										name: "IdentifierRest",
 									},
 									&litMatcher{
-										pos:        position{line: 546, col: 47, offset: 16081},
+										pos:        position{line: 541, col: 47, offset: 15853},
 										val:        ".",
 										ignoreCase: false,
 									},
@@ -3951,39 +3874,39 @@ var g = &grammar{
 		},
 		{
 			name: "LayoutArg",
-			pos:  position{line: 548, col: 1, offset: 16120},
+			pos:  position{line: 543, col: 1, offset: 15892},
 			expr: &actionExpr{
-				pos: position{line: 549, col: 5, offset: 16134},
+				pos: position{line: 544, col: 5, offset: 15906},
 				run: (*parser).callonLayoutArg1,
 				expr: &seqExpr{
-					pos: position{line: 549, col: 5, offset: 16134},
+					pos: position{line: 544, col: 5, offset: 15906},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 549, col: 5, offset: 16134},
+							pos:  position{line: 544, col: 5, offset: 15906},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 549, col: 7, offset: 16136},
+							pos:        position{line: 544, col: 7, offset: 15908},
 							val:        "order",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 549, col: 15, offset: 16144},
+							pos:  position{line: 544, col: 15, offset: 15916},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 549, col: 17, offset: 16146},
+							pos:   position{line: 544, col: 17, offset: 15918},
 							label: "keys",
 							expr: &ruleRefExpr{
-								pos:  position{line: 549, col: 22, offset: 16151},
+								pos:  position{line: 544, col: 22, offset: 15923},
 								name: "FieldExprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 549, col: 33, offset: 16162},
+							pos:   position{line: 544, col: 33, offset: 15934},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 549, col: 39, offset: 16168},
+								pos:  position{line: 544, col: 39, offset: 15940},
 								name: "OrderSuffix",
 							},
 						},
@@ -3993,31 +3916,31 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArg",
-			pos:  position{line: 553, col: 1, offset: 16278},
+			pos:  position{line: 548, col: 1, offset: 16050},
 			expr: &actionExpr{
-				pos: position{line: 554, col: 5, offset: 16292},
+				pos: position{line: 549, col: 5, offset: 16064},
 				run: (*parser).callonFormatArg1,
 				expr: &seqExpr{
-					pos: position{line: 554, col: 5, offset: 16292},
+					pos: position{line: 549, col: 5, offset: 16064},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 554, col: 5, offset: 16292},
+							pos:  position{line: 549, col: 5, offset: 16064},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 554, col: 7, offset: 16294},
+							pos:        position{line: 549, col: 7, offset: 16066},
 							val:        "format",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 554, col: 16, offset: 16303},
+							pos:  position{line: 549, col: 16, offset: 16075},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 554, col: 18, offset: 16305},
+							pos:   position{line: 549, col: 18, offset: 16077},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 554, col: 22, offset: 16309},
+								pos:  position{line: 549, col: 22, offset: 16081},
 								name: "IdentifierName",
 							},
 						},
@@ -4027,33 +3950,33 @@ var g = &grammar{
 		},
 		{
 			name: "OrderSuffix",
-			pos:  position{line: 556, col: 1, offset: 16345},
+			pos:  position{line: 551, col: 1, offset: 16117},
 			expr: &choiceExpr{
-				pos: position{line: 557, col: 5, offset: 16361},
+				pos: position{line: 552, col: 5, offset: 16133},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 557, col: 5, offset: 16361},
+						pos: position{line: 552, col: 5, offset: 16133},
 						run: (*parser).callonOrderSuffix2,
 						expr: &litMatcher{
-							pos:        position{line: 557, col: 5, offset: 16361},
+							pos:        position{line: 552, col: 5, offset: 16133},
 							val:        ":asc",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 558, col: 5, offset: 16395},
+						pos: position{line: 553, col: 5, offset: 16167},
 						run: (*parser).callonOrderSuffix4,
 						expr: &litMatcher{
-							pos:        position{line: 558, col: 5, offset: 16395},
+							pos:        position{line: 553, col: 5, offset: 16167},
 							val:        ":desc",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 559, col: 5, offset: 16431},
+						pos: position{line: 554, col: 5, offset: 16203},
 						run: (*parser).callonOrderSuffix6,
 						expr: &litMatcher{
-							pos:        position{line: 559, col: 5, offset: 16431},
+							pos:        position{line: 554, col: 5, offset: 16203},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -4063,31 +3986,31 @@ var g = &grammar{
 		},
 		{
 			name: "OrderArg",
-			pos:  position{line: 561, col: 1, offset: 16457},
+			pos:  position{line: 556, col: 1, offset: 16229},
 			expr: &choiceExpr{
-				pos: position{line: 562, col: 5, offset: 16470},
+				pos: position{line: 557, col: 5, offset: 16242},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 562, col: 5, offset: 16470},
+						pos: position{line: 557, col: 5, offset: 16242},
 						run: (*parser).callonOrderArg2,
 						expr: &seqExpr{
-							pos: position{line: 562, col: 5, offset: 16470},
+							pos: position{line: 557, col: 5, offset: 16242},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 562, col: 5, offset: 16470},
+									pos:  position{line: 557, col: 5, offset: 16242},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 562, col: 7, offset: 16472},
+									pos:        position{line: 557, col: 7, offset: 16244},
 									val:        "order",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 562, col: 15, offset: 16480},
+									pos:  position{line: 557, col: 15, offset: 16252},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 562, col: 17, offset: 16482},
+									pos:        position{line: 557, col: 17, offset: 16254},
 									val:        "asc",
 									ignoreCase: false,
 								},
@@ -4095,26 +4018,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 563, col: 5, offset: 16515},
+						pos: position{line: 558, col: 5, offset: 16287},
 						run: (*parser).callonOrderArg8,
 						expr: &seqExpr{
-							pos: position{line: 563, col: 5, offset: 16515},
+							pos: position{line: 558, col: 5, offset: 16287},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 563, col: 5, offset: 16515},
+									pos:  position{line: 558, col: 5, offset: 16287},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 563, col: 7, offset: 16517},
+									pos:        position{line: 558, col: 7, offset: 16289},
 									val:        "order",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 563, col: 15, offset: 16525},
+									pos:  position{line: 558, col: 15, offset: 16297},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 563, col: 17, offset: 16527},
+									pos:        position{line: 558, col: 17, offset: 16299},
 									val:        "desc",
 									ignoreCase: false,
 								},
@@ -4126,22 +4049,22 @@ var g = &grammar{
 		},
 		{
 			name: "PassOp",
-			pos:  position{line: 565, col: 1, offset: 16559},
+			pos:  position{line: 560, col: 1, offset: 16331},
 			expr: &actionExpr{
-				pos: position{line: 566, col: 5, offset: 16570},
+				pos: position{line: 561, col: 5, offset: 16342},
 				run: (*parser).callonPassOp1,
 				expr: &seqExpr{
-					pos: position{line: 566, col: 5, offset: 16570},
+					pos: position{line: 561, col: 5, offset: 16342},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 566, col: 5, offset: 16570},
+							pos:        position{line: 561, col: 5, offset: 16342},
 							val:        "pass",
 							ignoreCase: false,
 						},
 						&andExpr{
-							pos: position{line: 566, col: 12, offset: 16577},
+							pos: position{line: 561, col: 12, offset: 16349},
 							expr: &ruleRefExpr{
-								pos:  position{line: 566, col: 13, offset: 16578},
+								pos:  position{line: 561, col: 13, offset: 16350},
 								name: "EOKW",
 							},
 						},
@@ -4151,45 +4074,45 @@ var g = &grammar{
 		},
 		{
 			name: "ExplodeOp",
-			pos:  position{line: 572, col: 1, offset: 16770},
+			pos:  position{line: 567, col: 1, offset: 16542},
 			expr: &actionExpr{
-				pos: position{line: 573, col: 5, offset: 16784},
+				pos: position{line: 568, col: 5, offset: 16556},
 				run: (*parser).callonExplodeOp1,
 				expr: &seqExpr{
-					pos: position{line: 573, col: 5, offset: 16784},
+					pos: position{line: 568, col: 5, offset: 16556},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 573, col: 5, offset: 16784},
+							pos:        position{line: 568, col: 5, offset: 16556},
 							val:        "explode",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 573, col: 15, offset: 16794},
+							pos:  position{line: 568, col: 15, offset: 16566},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 573, col: 17, offset: 16796},
+							pos:   position{line: 568, col: 17, offset: 16568},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 573, col: 22, offset: 16801},
+								pos:  position{line: 568, col: 22, offset: 16573},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 573, col: 28, offset: 16807},
+							pos:   position{line: 568, col: 28, offset: 16579},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 573, col: 32, offset: 16811},
+								pos:  position{line: 568, col: 32, offset: 16583},
 								name: "TypeArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 573, col: 40, offset: 16819},
+							pos:   position{line: 568, col: 40, offset: 16591},
 							label: "as",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 573, col: 43, offset: 16822},
+								pos: position{line: 568, col: 43, offset: 16594},
 								expr: &ruleRefExpr{
-									pos:  position{line: 573, col: 43, offset: 16822},
+									pos:  position{line: 568, col: 43, offset: 16594},
 									name: "AsArg",
 								},
 							},
@@ -4200,27 +4123,27 @@ var g = &grammar{
 		},
 		{
 			name: "MergeOp",
-			pos:  position{line: 577, col: 1, offset: 16934},
+			pos:  position{line: 572, col: 1, offset: 16706},
 			expr: &actionExpr{
-				pos: position{line: 578, col: 5, offset: 16946},
+				pos: position{line: 573, col: 5, offset: 16718},
 				run: (*parser).callonMergeOp1,
 				expr: &seqExpr{
-					pos: position{line: 578, col: 5, offset: 16946},
+					pos: position{line: 573, col: 5, offset: 16718},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 578, col: 5, offset: 16946},
+							pos:        position{line: 573, col: 5, offset: 16718},
 							val:        "merge",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 578, col: 13, offset: 16954},
+							pos:  position{line: 573, col: 13, offset: 16726},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 578, col: 15, offset: 16956},
+							pos:   position{line: 573, col: 15, offset: 16728},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 578, col: 20, offset: 16961},
+								pos:  position{line: 573, col: 20, offset: 16733},
 								name: "Expr",
 							},
 						},
@@ -4230,48 +4153,48 @@ var g = &grammar{
 		},
 		{
 			name: "OverOp",
-			pos:  position{line: 582, col: 1, offset: 17042},
+			pos:  position{line: 577, col: 1, offset: 16814},
 			expr: &actionExpr{
-				pos: position{line: 583, col: 5, offset: 17053},
+				pos: position{line: 578, col: 5, offset: 16825},
 				run: (*parser).callonOverOp1,
 				expr: &seqExpr{
-					pos: position{line: 583, col: 5, offset: 17053},
+					pos: position{line: 578, col: 5, offset: 16825},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 583, col: 5, offset: 17053},
+							pos:        position{line: 578, col: 5, offset: 16825},
 							val:        "over",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 583, col: 12, offset: 17060},
+							pos:  position{line: 578, col: 12, offset: 16832},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 583, col: 14, offset: 17062},
+							pos:   position{line: 578, col: 14, offset: 16834},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 583, col: 20, offset: 17068},
+								pos:  position{line: 578, col: 20, offset: 16840},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 583, col: 26, offset: 17074},
+							pos:   position{line: 578, col: 26, offset: 16846},
 							label: "locals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 583, col: 33, offset: 17081},
+								pos: position{line: 578, col: 33, offset: 16853},
 								expr: &ruleRefExpr{
-									pos:  position{line: 583, col: 33, offset: 17081},
+									pos:  position{line: 578, col: 33, offset: 16853},
 									name: "Locals",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 583, col: 41, offset: 17089},
+							pos:   position{line: 578, col: 41, offset: 16861},
 							label: "scope",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 583, col: 47, offset: 17095},
+								pos: position{line: 578, col: 47, offset: 16867},
 								expr: &ruleRefExpr{
-									pos:  position{line: 583, col: 47, offset: 17095},
+									pos:  position{line: 578, col: 47, offset: 16867},
 									name: "Scope",
 								},
 							},
@@ -4282,49 +4205,49 @@ var g = &grammar{
 		},
 		{
 			name: "Scope",
-			pos:  position{line: 591, col: 1, offset: 17345},
+			pos:  position{line: 586, col: 1, offset: 17117},
 			expr: &actionExpr{
-				pos: position{line: 592, col: 5, offset: 17355},
+				pos: position{line: 587, col: 5, offset: 17127},
 				run: (*parser).callonScope1,
 				expr: &seqExpr{
-					pos: position{line: 592, col: 5, offset: 17355},
+					pos: position{line: 587, col: 5, offset: 17127},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 592, col: 5, offset: 17355},
+							pos:  position{line: 587, col: 5, offset: 17127},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 592, col: 8, offset: 17358},
+							pos:        position{line: 587, col: 8, offset: 17130},
 							val:        "=>",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 592, col: 13, offset: 17363},
+							pos:  position{line: 587, col: 13, offset: 17135},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 592, col: 16, offset: 17366},
+							pos:        position{line: 587, col: 16, offset: 17138},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 592, col: 20, offset: 17370},
+							pos:  position{line: 587, col: 20, offset: 17142},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 592, col: 23, offset: 17373},
+							pos:   position{line: 587, col: 23, offset: 17145},
 							label: "seq",
 							expr: &ruleRefExpr{
-								pos:  position{line: 592, col: 27, offset: 17377},
+								pos:  position{line: 587, col: 27, offset: 17149},
 								name: "Sequential",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 592, col: 38, offset: 17388},
+							pos:  position{line: 587, col: 38, offset: 17160},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 592, col: 41, offset: 17391},
+							pos:        position{line: 587, col: 41, offset: 17163},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -4334,63 +4257,63 @@ var g = &grammar{
 		},
 		{
 			name: "Locals",
-			pos:  position{line: 594, col: 1, offset: 17416},
+			pos:  position{line: 589, col: 1, offset: 17188},
 			expr: &actionExpr{
-				pos: position{line: 595, col: 5, offset: 17427},
+				pos: position{line: 590, col: 5, offset: 17199},
 				run: (*parser).callonLocals1,
 				expr: &seqExpr{
-					pos: position{line: 595, col: 5, offset: 17427},
+					pos: position{line: 590, col: 5, offset: 17199},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 595, col: 5, offset: 17427},
+							pos:  position{line: 590, col: 5, offset: 17199},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 595, col: 7, offset: 17429},
+							pos:        position{line: 590, col: 7, offset: 17201},
 							val:        "with",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 595, col: 14, offset: 17436},
+							pos:  position{line: 590, col: 14, offset: 17208},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 595, col: 16, offset: 17438},
+							pos:   position{line: 590, col: 16, offset: 17210},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 595, col: 22, offset: 17444},
+								pos:  position{line: 590, col: 22, offset: 17216},
 								name: "LocalsAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 595, col: 39, offset: 17461},
+							pos:   position{line: 590, col: 39, offset: 17233},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 595, col: 44, offset: 17466},
+								pos: position{line: 590, col: 44, offset: 17238},
 								expr: &actionExpr{
-									pos: position{line: 595, col: 45, offset: 17467},
+									pos: position{line: 590, col: 45, offset: 17239},
 									run: (*parser).callonLocals10,
 									expr: &seqExpr{
-										pos: position{line: 595, col: 45, offset: 17467},
+										pos: position{line: 590, col: 45, offset: 17239},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 595, col: 45, offset: 17467},
+												pos:  position{line: 590, col: 45, offset: 17239},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 595, col: 48, offset: 17470},
+												pos:        position{line: 590, col: 48, offset: 17242},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 595, col: 52, offset: 17474},
+												pos:  position{line: 590, col: 52, offset: 17246},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 595, col: 55, offset: 17477},
+												pos:   position{line: 590, col: 55, offset: 17249},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 595, col: 57, offset: 17479},
+													pos:  position{line: 590, col: 57, offset: 17251},
 													name: "LocalsAssignment",
 												},
 											},
@@ -4405,44 +4328,44 @@ var g = &grammar{
 		},
 		{
 			name: "LocalsAssignment",
-			pos:  position{line: 599, col: 1, offset: 17600},
+			pos:  position{line: 594, col: 1, offset: 17372},
 			expr: &actionExpr{
-				pos: position{line: 600, col: 5, offset: 17621},
+				pos: position{line: 595, col: 5, offset: 17393},
 				run: (*parser).callonLocalsAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 600, col: 5, offset: 17621},
+					pos: position{line: 595, col: 5, offset: 17393},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 600, col: 5, offset: 17621},
+							pos:   position{line: 595, col: 5, offset: 17393},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 600, col: 10, offset: 17626},
+								pos:  position{line: 595, col: 10, offset: 17398},
 								name: "IdentifierName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 600, col: 25, offset: 17641},
+							pos:   position{line: 595, col: 25, offset: 17413},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 600, col: 29, offset: 17645},
+								pos: position{line: 595, col: 29, offset: 17417},
 								expr: &seqExpr{
-									pos: position{line: 600, col: 30, offset: 17646},
+									pos: position{line: 595, col: 30, offset: 17418},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 600, col: 30, offset: 17646},
+											pos:  position{line: 595, col: 30, offset: 17418},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 600, col: 33, offset: 17649},
+											pos:        position{line: 595, col: 33, offset: 17421},
 											val:        "=",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 600, col: 37, offset: 17653},
+											pos:  position{line: 595, col: 37, offset: 17425},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 600, col: 40, offset: 17656},
+											pos:  position{line: 595, col: 40, offset: 17428},
 											name: "Expr",
 										},
 									},
@@ -4455,27 +4378,27 @@ var g = &grammar{
 		},
 		{
 			name: "YieldOp",
-			pos:  position{line: 608, col: 1, offset: 17877},
+			pos:  position{line: 603, col: 1, offset: 17649},
 			expr: &actionExpr{
-				pos: position{line: 609, col: 5, offset: 17889},
+				pos: position{line: 604, col: 5, offset: 17661},
 				run: (*parser).callonYieldOp1,
 				expr: &seqExpr{
-					pos: position{line: 609, col: 5, offset: 17889},
+					pos: position{line: 604, col: 5, offset: 17661},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 609, col: 5, offset: 17889},
+							pos:        position{line: 604, col: 5, offset: 17661},
 							val:        "yield",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 609, col: 13, offset: 17897},
+							pos:  position{line: 604, col: 13, offset: 17669},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 609, col: 15, offset: 17899},
+							pos:   position{line: 604, col: 15, offset: 17671},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 609, col: 21, offset: 17905},
+								pos:  position{line: 604, col: 21, offset: 17677},
 								name: "Exprs",
 							},
 						},
@@ -4485,30 +4408,30 @@ var g = &grammar{
 		},
 		{
 			name: "TypeArg",
-			pos:  position{line: 613, col: 1, offset: 17989},
+			pos:  position{line: 608, col: 1, offset: 17761},
 			expr: &actionExpr{
-				pos: position{line: 614, col: 5, offset: 18001},
+				pos: position{line: 609, col: 5, offset: 17773},
 				run: (*parser).callonTypeArg1,
 				expr: &seqExpr{
-					pos: position{line: 614, col: 5, offset: 18001},
+					pos: position{line: 609, col: 5, offset: 17773},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 614, col: 5, offset: 18001},
+							pos:  position{line: 609, col: 5, offset: 17773},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 614, col: 7, offset: 18003},
+							pos:  position{line: 609, col: 7, offset: 17775},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 614, col: 10, offset: 18006},
+							pos:  position{line: 609, col: 10, offset: 17778},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 614, col: 12, offset: 18008},
+							pos:   position{line: 609, col: 12, offset: 17780},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 614, col: 16, offset: 18012},
+								pos:  position{line: 609, col: 16, offset: 17784},
 								name: "Type",
 							},
 						},
@@ -4518,30 +4441,30 @@ var g = &grammar{
 		},
 		{
 			name: "AsArg",
-			pos:  position{line: 616, col: 1, offset: 18037},
+			pos:  position{line: 611, col: 1, offset: 17809},
 			expr: &actionExpr{
-				pos: position{line: 617, col: 5, offset: 18047},
+				pos: position{line: 612, col: 5, offset: 17819},
 				run: (*parser).callonAsArg1,
 				expr: &seqExpr{
-					pos: position{line: 617, col: 5, offset: 18047},
+					pos: position{line: 612, col: 5, offset: 17819},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 617, col: 5, offset: 18047},
+							pos:  position{line: 612, col: 5, offset: 17819},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 617, col: 7, offset: 18049},
+							pos:  position{line: 612, col: 7, offset: 17821},
 							name: "AS",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 617, col: 10, offset: 18052},
+							pos:  position{line: 612, col: 10, offset: 17824},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 617, col: 12, offset: 18054},
+							pos:   position{line: 612, col: 12, offset: 17826},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 617, col: 16, offset: 18058},
+								pos:  position{line: 612, col: 16, offset: 17830},
 								name: "Lval",
 							},
 						},
@@ -4551,58 +4474,58 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 621, col: 1, offset: 18109},
+			pos:  position{line: 616, col: 1, offset: 17881},
 			expr: &ruleRefExpr{
-				pos:  position{line: 621, col: 8, offset: 18116},
+				pos:  position{line: 616, col: 8, offset: 17888},
 				name: "DerefExpr",
 			},
 		},
 		{
 			name: "Lvals",
-			pos:  position{line: 623, col: 1, offset: 18127},
+			pos:  position{line: 618, col: 1, offset: 17899},
 			expr: &actionExpr{
-				pos: position{line: 624, col: 5, offset: 18137},
+				pos: position{line: 619, col: 5, offset: 17909},
 				run: (*parser).callonLvals1,
 				expr: &seqExpr{
-					pos: position{line: 624, col: 5, offset: 18137},
+					pos: position{line: 619, col: 5, offset: 17909},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 624, col: 5, offset: 18137},
+							pos:   position{line: 619, col: 5, offset: 17909},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 624, col: 11, offset: 18143},
+								pos:  position{line: 619, col: 11, offset: 17915},
 								name: "Lval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 624, col: 16, offset: 18148},
+							pos:   position{line: 619, col: 16, offset: 17920},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 624, col: 21, offset: 18153},
+								pos: position{line: 619, col: 21, offset: 17925},
 								expr: &actionExpr{
-									pos: position{line: 624, col: 22, offset: 18154},
+									pos: position{line: 619, col: 22, offset: 17926},
 									run: (*parser).callonLvals7,
 									expr: &seqExpr{
-										pos: position{line: 624, col: 22, offset: 18154},
+										pos: position{line: 619, col: 22, offset: 17926},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 624, col: 22, offset: 18154},
+												pos:  position{line: 619, col: 22, offset: 17926},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 624, col: 25, offset: 18157},
+												pos:        position{line: 619, col: 25, offset: 17929},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 624, col: 29, offset: 18161},
+												pos:  position{line: 619, col: 29, offset: 17933},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 624, col: 32, offset: 18164},
+												pos:   position{line: 619, col: 32, offset: 17936},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 624, col: 37, offset: 18169},
+													pos:  position{line: 619, col: 37, offset: 17941},
 													name: "Lval",
 												},
 											},
@@ -4617,52 +4540,52 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 628, col: 1, offset: 18281},
+			pos:  position{line: 623, col: 1, offset: 18053},
 			expr: &ruleRefExpr{
-				pos:  position{line: 628, col: 13, offset: 18293},
+				pos:  position{line: 623, col: 13, offset: 18065},
 				name: "Lval",
 			},
 		},
 		{
 			name: "FieldExprs",
-			pos:  position{line: 630, col: 1, offset: 18299},
+			pos:  position{line: 625, col: 1, offset: 18071},
 			expr: &actionExpr{
-				pos: position{line: 631, col: 5, offset: 18314},
+				pos: position{line: 626, col: 5, offset: 18086},
 				run: (*parser).callonFieldExprs1,
 				expr: &seqExpr{
-					pos: position{line: 631, col: 5, offset: 18314},
+					pos: position{line: 626, col: 5, offset: 18086},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 631, col: 5, offset: 18314},
+							pos:   position{line: 626, col: 5, offset: 18086},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 631, col: 11, offset: 18320},
+								pos:  position{line: 626, col: 11, offset: 18092},
 								name: "FieldExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 631, col: 21, offset: 18330},
+							pos:   position{line: 626, col: 21, offset: 18102},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 631, col: 26, offset: 18335},
+								pos: position{line: 626, col: 26, offset: 18107},
 								expr: &seqExpr{
-									pos: position{line: 631, col: 27, offset: 18336},
+									pos: position{line: 626, col: 27, offset: 18108},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 631, col: 27, offset: 18336},
+											pos:  position{line: 626, col: 27, offset: 18108},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 631, col: 30, offset: 18339},
+											pos:        position{line: 626, col: 30, offset: 18111},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 631, col: 34, offset: 18343},
+											pos:  position{line: 626, col: 34, offset: 18115},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 631, col: 37, offset: 18346},
+											pos:  position{line: 626, col: 37, offset: 18118},
 											name: "FieldExpr",
 										},
 									},
@@ -4675,50 +4598,50 @@ var g = &grammar{
 		},
 		{
 			name: "Assignments",
-			pos:  position{line: 641, col: 1, offset: 18545},
+			pos:  position{line: 636, col: 1, offset: 18317},
 			expr: &actionExpr{
-				pos: position{line: 642, col: 5, offset: 18561},
+				pos: position{line: 637, col: 5, offset: 18333},
 				run: (*parser).callonAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 642, col: 5, offset: 18561},
+					pos: position{line: 637, col: 5, offset: 18333},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 642, col: 5, offset: 18561},
+							pos:   position{line: 637, col: 5, offset: 18333},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 642, col: 11, offset: 18567},
+								pos:  position{line: 637, col: 11, offset: 18339},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 642, col: 22, offset: 18578},
+							pos:   position{line: 637, col: 22, offset: 18350},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 642, col: 27, offset: 18583},
+								pos: position{line: 637, col: 27, offset: 18355},
 								expr: &actionExpr{
-									pos: position{line: 642, col: 28, offset: 18584},
+									pos: position{line: 637, col: 28, offset: 18356},
 									run: (*parser).callonAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 642, col: 28, offset: 18584},
+										pos: position{line: 637, col: 28, offset: 18356},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 642, col: 28, offset: 18584},
+												pos:  position{line: 637, col: 28, offset: 18356},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 642, col: 31, offset: 18587},
+												pos:        position{line: 637, col: 31, offset: 18359},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 642, col: 35, offset: 18591},
+												pos:  position{line: 637, col: 35, offset: 18363},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 642, col: 38, offset: 18594},
+												pos:   position{line: 637, col: 38, offset: 18366},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 642, col: 40, offset: 18596},
+													pos:  position{line: 637, col: 40, offset: 18368},
 													name: "Assignment",
 												},
 											},
@@ -4733,39 +4656,39 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 646, col: 1, offset: 18707},
+			pos:  position{line: 641, col: 1, offset: 18479},
 			expr: &actionExpr{
-				pos: position{line: 647, col: 5, offset: 18722},
+				pos: position{line: 642, col: 5, offset: 18494},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 647, col: 5, offset: 18722},
+					pos: position{line: 642, col: 5, offset: 18494},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 647, col: 5, offset: 18722},
+							pos:   position{line: 642, col: 5, offset: 18494},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 647, col: 9, offset: 18726},
+								pos:  position{line: 642, col: 9, offset: 18498},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 647, col: 14, offset: 18731},
+							pos:  position{line: 642, col: 14, offset: 18503},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 647, col: 17, offset: 18734},
+							pos:        position{line: 642, col: 17, offset: 18506},
 							val:        ":=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 647, col: 22, offset: 18739},
+							pos:  position{line: 642, col: 22, offset: 18511},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 647, col: 25, offset: 18742},
+							pos:   position{line: 642, col: 25, offset: 18514},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 647, col: 29, offset: 18746},
+								pos:  position{line: 642, col: 29, offset: 18518},
 								name: "Expr",
 							},
 						},
@@ -4775,69 +4698,69 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 649, col: 1, offset: 18837},
+			pos:  position{line: 644, col: 1, offset: 18609},
 			expr: &ruleRefExpr{
-				pos:  position{line: 649, col: 8, offset: 18844},
+				pos:  position{line: 644, col: 8, offset: 18616},
 				name: "ConditionalExpr",
 			},
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 651, col: 1, offset: 18861},
+			pos:  position{line: 646, col: 1, offset: 18633},
 			expr: &actionExpr{
-				pos: position{line: 652, col: 5, offset: 18881},
+				pos: position{line: 647, col: 5, offset: 18653},
 				run: (*parser).callonConditionalExpr1,
 				expr: &seqExpr{
-					pos: position{line: 652, col: 5, offset: 18881},
+					pos: position{line: 647, col: 5, offset: 18653},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 652, col: 5, offset: 18881},
+							pos:   position{line: 647, col: 5, offset: 18653},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 652, col: 10, offset: 18886},
+								pos:  position{line: 647, col: 10, offset: 18658},
 								name: "LogicalOrExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 652, col: 24, offset: 18900},
+							pos:   position{line: 647, col: 24, offset: 18672},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 652, col: 28, offset: 18904},
+								pos: position{line: 647, col: 28, offset: 18676},
 								expr: &seqExpr{
-									pos: position{line: 652, col: 29, offset: 18905},
+									pos: position{line: 647, col: 29, offset: 18677},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 652, col: 29, offset: 18905},
+											pos:  position{line: 647, col: 29, offset: 18677},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 652, col: 32, offset: 18908},
+											pos:        position{line: 647, col: 32, offset: 18680},
 											val:        "?",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 652, col: 36, offset: 18912},
+											pos:  position{line: 647, col: 36, offset: 18684},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 652, col: 39, offset: 18915},
+											pos:  position{line: 647, col: 39, offset: 18687},
 											name: "Expr",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 652, col: 44, offset: 18920},
+											pos:  position{line: 647, col: 44, offset: 18692},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 652, col: 47, offset: 18923},
+											pos:        position{line: 647, col: 47, offset: 18695},
 											val:        ":",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 652, col: 51, offset: 18927},
+											pos:  position{line: 647, col: 51, offset: 18699},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 652, col: 54, offset: 18930},
+											pos:  position{line: 647, col: 54, offset: 18702},
 											name: "Expr",
 										},
 									},
@@ -4850,53 +4773,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 661, col: 1, offset: 19191},
+			pos:  position{line: 656, col: 1, offset: 18963},
 			expr: &actionExpr{
-				pos: position{line: 662, col: 5, offset: 19209},
+				pos: position{line: 657, col: 5, offset: 18981},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 662, col: 5, offset: 19209},
+					pos: position{line: 657, col: 5, offset: 18981},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 662, col: 5, offset: 19209},
+							pos:   position{line: 657, col: 5, offset: 18981},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 662, col: 11, offset: 19215},
+								pos:  position{line: 657, col: 11, offset: 18987},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 663, col: 5, offset: 19234},
+							pos:   position{line: 658, col: 5, offset: 19006},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 663, col: 10, offset: 19239},
+								pos: position{line: 658, col: 10, offset: 19011},
 								expr: &actionExpr{
-									pos: position{line: 663, col: 11, offset: 19240},
+									pos: position{line: 658, col: 11, offset: 19012},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 663, col: 11, offset: 19240},
+										pos: position{line: 658, col: 11, offset: 19012},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 663, col: 11, offset: 19240},
+												pos:  position{line: 658, col: 11, offset: 19012},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 663, col: 14, offset: 19243},
+												pos:   position{line: 658, col: 14, offset: 19015},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 663, col: 17, offset: 19246},
+													pos:  position{line: 658, col: 17, offset: 19018},
 													name: "OrToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 663, col: 25, offset: 19254},
+												pos:  position{line: 658, col: 25, offset: 19026},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 663, col: 28, offset: 19257},
+												pos:   position{line: 658, col: 28, offset: 19029},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 663, col: 33, offset: 19262},
+													pos:  position{line: 658, col: 33, offset: 19034},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -4911,53 +4834,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 667, col: 1, offset: 19380},
+			pos:  position{line: 662, col: 1, offset: 19152},
 			expr: &actionExpr{
-				pos: position{line: 668, col: 5, offset: 19399},
+				pos: position{line: 663, col: 5, offset: 19171},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 668, col: 5, offset: 19399},
+					pos: position{line: 663, col: 5, offset: 19171},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 668, col: 5, offset: 19399},
+							pos:   position{line: 663, col: 5, offset: 19171},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 668, col: 11, offset: 19405},
+								pos:  position{line: 663, col: 11, offset: 19177},
 								name: "ComparisonExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 669, col: 5, offset: 19424},
+							pos:   position{line: 664, col: 5, offset: 19196},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 669, col: 10, offset: 19429},
+								pos: position{line: 664, col: 10, offset: 19201},
 								expr: &actionExpr{
-									pos: position{line: 669, col: 11, offset: 19430},
+									pos: position{line: 664, col: 11, offset: 19202},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 669, col: 11, offset: 19430},
+										pos: position{line: 664, col: 11, offset: 19202},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 669, col: 11, offset: 19430},
+												pos:  position{line: 664, col: 11, offset: 19202},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 669, col: 14, offset: 19433},
+												pos:   position{line: 664, col: 14, offset: 19205},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 669, col: 17, offset: 19436},
+													pos:  position{line: 664, col: 17, offset: 19208},
 													name: "AndToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 669, col: 26, offset: 19445},
+												pos:  position{line: 664, col: 26, offset: 19217},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 669, col: 29, offset: 19448},
+												pos:   position{line: 664, col: 29, offset: 19220},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 669, col: 34, offset: 19453},
+													pos:  position{line: 664, col: 34, offset: 19225},
 													name: "ComparisonExpr",
 												},
 											},
@@ -4972,72 +4895,72 @@ var g = &grammar{
 		},
 		{
 			name: "ComparisonExpr",
-			pos:  position{line: 673, col: 1, offset: 19571},
+			pos:  position{line: 668, col: 1, offset: 19343},
 			expr: &actionExpr{
-				pos: position{line: 674, col: 5, offset: 19590},
+				pos: position{line: 669, col: 5, offset: 19362},
 				run: (*parser).callonComparisonExpr1,
 				expr: &seqExpr{
-					pos: position{line: 674, col: 5, offset: 19590},
+					pos: position{line: 669, col: 5, offset: 19362},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 674, col: 5, offset: 19590},
+							pos:   position{line: 669, col: 5, offset: 19362},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 674, col: 9, offset: 19594},
+								pos:  position{line: 669, col: 9, offset: 19366},
 								name: "AdditiveExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 674, col: 22, offset: 19607},
+							pos:   position{line: 669, col: 22, offset: 19379},
 							label: "opAndRHS",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 674, col: 31, offset: 19616},
+								pos: position{line: 669, col: 31, offset: 19388},
 								expr: &choiceExpr{
-									pos: position{line: 674, col: 32, offset: 19617},
+									pos: position{line: 669, col: 32, offset: 19389},
 									alternatives: []interface{}{
 										&seqExpr{
-											pos: position{line: 674, col: 32, offset: 19617},
+											pos: position{line: 669, col: 32, offset: 19389},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 674, col: 32, offset: 19617},
+													pos:  position{line: 669, col: 32, offset: 19389},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 674, col: 35, offset: 19620},
+													pos:  position{line: 669, col: 35, offset: 19392},
 													name: "Comparator",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 674, col: 46, offset: 19631},
+													pos:  position{line: 669, col: 46, offset: 19403},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 674, col: 49, offset: 19634},
+													pos:  position{line: 669, col: 49, offset: 19406},
 													name: "AdditiveExpr",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 674, col: 64, offset: 19649},
+											pos: position{line: 669, col: 64, offset: 19421},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 674, col: 64, offset: 19649},
+													pos:  position{line: 669, col: 64, offset: 19421},
 													name: "__",
 												},
 												&actionExpr{
-													pos: position{line: 674, col: 68, offset: 19653},
+													pos: position{line: 669, col: 68, offset: 19425},
 													run: (*parser).callonComparisonExpr15,
 													expr: &litMatcher{
-														pos:        position{line: 674, col: 68, offset: 19653},
+														pos:        position{line: 669, col: 68, offset: 19425},
 														val:        "~",
 														ignoreCase: false,
 													},
 												},
 												&ruleRefExpr{
-													pos:  position{line: 674, col: 104, offset: 19689},
+													pos:  position{line: 669, col: 104, offset: 19461},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 674, col: 107, offset: 19692},
+													pos:  position{line: 669, col: 107, offset: 19464},
 													name: "Regexp",
 												},
 											},
@@ -5052,53 +4975,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 683, col: 1, offset: 19953},
+			pos:  position{line: 678, col: 1, offset: 19725},
 			expr: &actionExpr{
-				pos: position{line: 684, col: 5, offset: 19970},
+				pos: position{line: 679, col: 5, offset: 19742},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 684, col: 5, offset: 19970},
+					pos: position{line: 679, col: 5, offset: 19742},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 684, col: 5, offset: 19970},
+							pos:   position{line: 679, col: 5, offset: 19742},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 684, col: 11, offset: 19976},
+								pos:  position{line: 679, col: 11, offset: 19748},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 685, col: 5, offset: 19999},
+							pos:   position{line: 680, col: 5, offset: 19771},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 685, col: 10, offset: 20004},
+								pos: position{line: 680, col: 10, offset: 19776},
 								expr: &actionExpr{
-									pos: position{line: 685, col: 11, offset: 20005},
+									pos: position{line: 680, col: 11, offset: 19777},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 685, col: 11, offset: 20005},
+										pos: position{line: 680, col: 11, offset: 19777},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 685, col: 11, offset: 20005},
+												pos:  position{line: 680, col: 11, offset: 19777},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 685, col: 14, offset: 20008},
+												pos:   position{line: 680, col: 14, offset: 19780},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 685, col: 17, offset: 20011},
+													pos:  position{line: 680, col: 17, offset: 19783},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 685, col: 34, offset: 20028},
+												pos:  position{line: 680, col: 34, offset: 19800},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 685, col: 37, offset: 20031},
+												pos:   position{line: 680, col: 37, offset: 19803},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 685, col: 42, offset: 20036},
+													pos:  position{line: 680, col: 42, offset: 19808},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -5113,20 +5036,20 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 689, col: 1, offset: 20158},
+			pos:  position{line: 684, col: 1, offset: 19930},
 			expr: &actionExpr{
-				pos: position{line: 689, col: 20, offset: 20177},
+				pos: position{line: 684, col: 20, offset: 19949},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 689, col: 21, offset: 20178},
+					pos: position{line: 684, col: 21, offset: 19950},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 689, col: 21, offset: 20178},
+							pos:        position{line: 684, col: 21, offset: 19950},
 							val:        "+",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 689, col: 27, offset: 20184},
+							pos:        position{line: 684, col: 27, offset: 19956},
 							val:        "-",
 							ignoreCase: false,
 						},
@@ -5136,53 +5059,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 691, col: 1, offset: 20221},
+			pos:  position{line: 686, col: 1, offset: 19993},
 			expr: &actionExpr{
-				pos: position{line: 692, col: 5, offset: 20244},
+				pos: position{line: 687, col: 5, offset: 20016},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 692, col: 5, offset: 20244},
+					pos: position{line: 687, col: 5, offset: 20016},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 692, col: 5, offset: 20244},
+							pos:   position{line: 687, col: 5, offset: 20016},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 692, col: 11, offset: 20250},
+								pos:  position{line: 687, col: 11, offset: 20022},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 693, col: 5, offset: 20262},
+							pos:   position{line: 688, col: 5, offset: 20034},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 693, col: 10, offset: 20267},
+								pos: position{line: 688, col: 10, offset: 20039},
 								expr: &actionExpr{
-									pos: position{line: 693, col: 11, offset: 20268},
+									pos: position{line: 688, col: 11, offset: 20040},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 693, col: 11, offset: 20268},
+										pos: position{line: 688, col: 11, offset: 20040},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 693, col: 11, offset: 20268},
+												pos:  position{line: 688, col: 11, offset: 20040},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 693, col: 14, offset: 20271},
+												pos:   position{line: 688, col: 14, offset: 20043},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 693, col: 17, offset: 20274},
+													pos:  position{line: 688, col: 17, offset: 20046},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 693, col: 40, offset: 20297},
+												pos:  position{line: 688, col: 40, offset: 20069},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 693, col: 43, offset: 20300},
+												pos:   position{line: 688, col: 43, offset: 20072},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 693, col: 48, offset: 20305},
+													pos:  position{line: 688, col: 48, offset: 20077},
 													name: "NotExpr",
 												},
 											},
@@ -5197,25 +5120,25 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 697, col: 1, offset: 20416},
+			pos:  position{line: 692, col: 1, offset: 20188},
 			expr: &actionExpr{
-				pos: position{line: 697, col: 26, offset: 20441},
+				pos: position{line: 692, col: 26, offset: 20213},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 697, col: 27, offset: 20442},
+					pos: position{line: 692, col: 27, offset: 20214},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 697, col: 27, offset: 20442},
+							pos:        position{line: 692, col: 27, offset: 20214},
 							val:        "*",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 697, col: 33, offset: 20448},
+							pos:        position{line: 692, col: 33, offset: 20220},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 697, col: 39, offset: 20454},
+							pos:        position{line: 692, col: 39, offset: 20226},
 							val:        "%",
 							ignoreCase: false,
 						},
@@ -5225,30 +5148,30 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 699, col: 1, offset: 20491},
+			pos:  position{line: 694, col: 1, offset: 20263},
 			expr: &choiceExpr{
-				pos: position{line: 700, col: 5, offset: 20503},
+				pos: position{line: 695, col: 5, offset: 20275},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 700, col: 5, offset: 20503},
+						pos: position{line: 695, col: 5, offset: 20275},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 700, col: 5, offset: 20503},
+							pos: position{line: 695, col: 5, offset: 20275},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 700, col: 5, offset: 20503},
+									pos:        position{line: 695, col: 5, offset: 20275},
 									val:        "!",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 700, col: 9, offset: 20507},
+									pos:  position{line: 695, col: 9, offset: 20279},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 700, col: 12, offset: 20510},
+									pos:   position{line: 695, col: 12, offset: 20282},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 700, col: 14, offset: 20512},
+										pos:  position{line: 695, col: 14, offset: 20284},
 										name: "NotExpr",
 									},
 								},
@@ -5256,7 +5179,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 703, col: 5, offset: 20621},
+						pos:  position{line: 698, col: 5, offset: 20393},
 						name: "NegationExpr",
 					},
 				},
@@ -5264,37 +5187,37 @@ var g = &grammar{
 		},
 		{
 			name: "NegationExpr",
-			pos:  position{line: 705, col: 1, offset: 20635},
+			pos:  position{line: 700, col: 1, offset: 20407},
 			expr: &choiceExpr{
-				pos: position{line: 706, col: 5, offset: 20652},
+				pos: position{line: 701, col: 5, offset: 20424},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 706, col: 5, offset: 20652},
+						pos: position{line: 701, col: 5, offset: 20424},
 						run: (*parser).callonNegationExpr2,
 						expr: &seqExpr{
-							pos: position{line: 706, col: 5, offset: 20652},
+							pos: position{line: 701, col: 5, offset: 20424},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 706, col: 5, offset: 20652},
+									pos: position{line: 701, col: 5, offset: 20424},
 									expr: &ruleRefExpr{
-										pos:  position{line: 706, col: 6, offset: 20653},
+										pos:  position{line: 701, col: 6, offset: 20425},
 										name: "Literal",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 706, col: 14, offset: 20661},
+									pos:        position{line: 701, col: 14, offset: 20433},
 									val:        "-",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 706, col: 18, offset: 20665},
+									pos:  position{line: 701, col: 18, offset: 20437},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 706, col: 21, offset: 20668},
+									pos:   position{line: 701, col: 21, offset: 20440},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 706, col: 23, offset: 20670},
+										pos:  position{line: 701, col: 23, offset: 20442},
 										name: "FuncExpr",
 									},
 								},
@@ -5302,7 +5225,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 709, col: 5, offset: 20780},
+						pos:  position{line: 704, col: 5, offset: 20552},
 						name: "FuncExpr",
 					},
 				},
@@ -5310,31 +5233,31 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 711, col: 1, offset: 20790},
+			pos:  position{line: 706, col: 1, offset: 20562},
 			expr: &choiceExpr{
-				pos: position{line: 712, col: 5, offset: 20803},
+				pos: position{line: 707, col: 5, offset: 20575},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 712, col: 5, offset: 20803},
+						pos: position{line: 707, col: 5, offset: 20575},
 						run: (*parser).callonFuncExpr2,
 						expr: &seqExpr{
-							pos: position{line: 712, col: 5, offset: 20803},
+							pos: position{line: 707, col: 5, offset: 20575},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 712, col: 5, offset: 20803},
+									pos:   position{line: 707, col: 5, offset: 20575},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 712, col: 11, offset: 20809},
+										pos:  position{line: 707, col: 11, offset: 20581},
 										name: "Cast",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 712, col: 16, offset: 20814},
+									pos:   position{line: 707, col: 16, offset: 20586},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 712, col: 21, offset: 20819},
+										pos: position{line: 707, col: 21, offset: 20591},
 										expr: &ruleRefExpr{
-											pos:  position{line: 712, col: 22, offset: 20820},
+											pos:  position{line: 707, col: 22, offset: 20592},
 											name: "Deref",
 										},
 									},
@@ -5343,26 +5266,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 715, col: 5, offset: 20891},
+						pos: position{line: 710, col: 5, offset: 20663},
 						run: (*parser).callonFuncExpr9,
 						expr: &seqExpr{
-							pos: position{line: 715, col: 5, offset: 20891},
+							pos: position{line: 710, col: 5, offset: 20663},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 715, col: 5, offset: 20891},
+									pos:   position{line: 710, col: 5, offset: 20663},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 715, col: 11, offset: 20897},
+										pos:  position{line: 710, col: 11, offset: 20669},
 										name: "Function",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 715, col: 20, offset: 20906},
+									pos:   position{line: 710, col: 20, offset: 20678},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 715, col: 25, offset: 20911},
+										pos: position{line: 710, col: 25, offset: 20683},
 										expr: &ruleRefExpr{
-											pos:  position{line: 715, col: 26, offset: 20912},
+											pos:  position{line: 710, col: 26, offset: 20684},
 											name: "Deref",
 										},
 									},
@@ -5371,11 +5294,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 718, col: 5, offset: 20983},
+						pos:  position{line: 713, col: 5, offset: 20755},
 						name: "DerefExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 719, col: 5, offset: 20997},
+						pos:  position{line: 714, col: 5, offset: 20769},
 						name: "Primary",
 					},
 				},
@@ -5383,20 +5306,20 @@ var g = &grammar{
 		},
 		{
 			name: "FuncGuard",
-			pos:  position{line: 721, col: 1, offset: 21006},
+			pos:  position{line: 716, col: 1, offset: 20778},
 			expr: &seqExpr{
-				pos: position{line: 721, col: 13, offset: 21018},
+				pos: position{line: 716, col: 13, offset: 20790},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 721, col: 13, offset: 21018},
+						pos:  position{line: 716, col: 13, offset: 20790},
 						name: "NotFuncs",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 721, col: 22, offset: 21027},
+						pos:  position{line: 716, col: 22, offset: 20799},
 						name: "__",
 					},
 					&litMatcher{
-						pos:        position{line: 721, col: 25, offset: 21030},
+						pos:        position{line: 716, col: 25, offset: 20802},
 						val:        "(",
 						ignoreCase: false,
 					},
@@ -5405,17 +5328,17 @@ var g = &grammar{
 		},
 		{
 			name: "NotFuncs",
-			pos:  position{line: 723, col: 1, offset: 21035},
+			pos:  position{line: 718, col: 1, offset: 20807},
 			expr: &choiceExpr{
-				pos: position{line: 724, col: 5, offset: 21048},
+				pos: position{line: 719, col: 5, offset: 20820},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 724, col: 5, offset: 21048},
+						pos:        position{line: 719, col: 5, offset: 20820},
 						val:        "not",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 725, col: 5, offset: 21058},
+						pos:        position{line: 720, col: 5, offset: 20830},
 						val:        "select",
 						ignoreCase: false,
 					},
@@ -5424,57 +5347,57 @@ var g = &grammar{
 		},
 		{
 			name: "Cast",
-			pos:  position{line: 727, col: 1, offset: 21068},
+			pos:  position{line: 722, col: 1, offset: 20840},
 			expr: &actionExpr{
-				pos: position{line: 728, col: 5, offset: 21077},
+				pos: position{line: 723, col: 5, offset: 20849},
 				run: (*parser).callonCast1,
 				expr: &seqExpr{
-					pos: position{line: 728, col: 5, offset: 21077},
+					pos: position{line: 723, col: 5, offset: 20849},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 728, col: 5, offset: 21077},
+							pos:   position{line: 723, col: 5, offset: 20849},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 728, col: 9, offset: 21081},
+								pos:  position{line: 723, col: 9, offset: 20853},
 								name: "CastType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 728, col: 18, offset: 21090},
+							pos:  position{line: 723, col: 18, offset: 20862},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 728, col: 21, offset: 21093},
+							pos:        position{line: 723, col: 21, offset: 20865},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 728, col: 25, offset: 21097},
+							pos:  position{line: 723, col: 25, offset: 20869},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 728, col: 28, offset: 21100},
+							pos:   position{line: 723, col: 28, offset: 20872},
 							label: "expr",
 							expr: &choiceExpr{
-								pos: position{line: 728, col: 34, offset: 21106},
+								pos: position{line: 723, col: 34, offset: 20878},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 728, col: 34, offset: 21106},
+										pos:  position{line: 723, col: 34, offset: 20878},
 										name: "OverExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 728, col: 45, offset: 21117},
+										pos:  position{line: 723, col: 45, offset: 20889},
 										name: "Expr",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 728, col: 51, offset: 21123},
+							pos:  position{line: 723, col: 51, offset: 20895},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 728, col: 54, offset: 21126},
+							pos:        position{line: 723, col: 54, offset: 20898},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -5484,83 +5407,83 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 732, col: 1, offset: 21223},
+			pos:  position{line: 727, col: 1, offset: 20995},
 			expr: &choiceExpr{
-				pos: position{line: 733, col: 5, offset: 21236},
+				pos: position{line: 728, col: 5, offset: 21008},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 733, col: 5, offset: 21236},
+						pos:  position{line: 728, col: 5, offset: 21008},
 						name: "Grep",
 					},
 					&actionExpr{
-						pos: position{line: 735, col: 5, offset: 21291},
+						pos: position{line: 730, col: 5, offset: 21063},
 						run: (*parser).callonFunction3,
 						expr: &seqExpr{
-							pos: position{line: 735, col: 5, offset: 21291},
+							pos: position{line: 730, col: 5, offset: 21063},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 735, col: 5, offset: 21291},
+									pos:        position{line: 730, col: 5, offset: 21063},
 									val:        "regexp",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 735, col: 14, offset: 21300},
+									pos:  position{line: 730, col: 14, offset: 21072},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 735, col: 17, offset: 21303},
+									pos:        position{line: 730, col: 17, offset: 21075},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 735, col: 21, offset: 21307},
+									pos:  position{line: 730, col: 21, offset: 21079},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 735, col: 24, offset: 21310},
+									pos:   position{line: 730, col: 24, offset: 21082},
 									label: "arg0Text",
 									expr: &ruleRefExpr{
-										pos:  position{line: 735, col: 33, offset: 21319},
+										pos:  position{line: 730, col: 33, offset: 21091},
 										name: "RegexpPattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 735, col: 47, offset: 21333},
+									pos:  position{line: 730, col: 47, offset: 21105},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 735, col: 50, offset: 21336},
+									pos:        position{line: 730, col: 50, offset: 21108},
 									val:        ",",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 735, col: 54, offset: 21340},
+									pos:  position{line: 730, col: 54, offset: 21112},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 735, col: 57, offset: 21343},
+									pos:   position{line: 730, col: 57, offset: 21115},
 									label: "arg1",
 									expr: &ruleRefExpr{
-										pos:  position{line: 735, col: 62, offset: 21348},
+										pos:  position{line: 730, col: 62, offset: 21120},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 735, col: 67, offset: 21353},
+									pos:  position{line: 730, col: 67, offset: 21125},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 735, col: 70, offset: 21356},
+									pos:        position{line: 730, col: 70, offset: 21128},
 									val:        ")",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 735, col: 74, offset: 21360},
+									pos:   position{line: 730, col: 74, offset: 21132},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 735, col: 80, offset: 21366},
+										pos: position{line: 730, col: 80, offset: 21138},
 										expr: &ruleRefExpr{
-											pos:  position{line: 735, col: 80, offset: 21366},
+											pos:  position{line: 730, col: 80, offset: 21138},
 											name: "WhereClause",
 										},
 									},
@@ -5569,63 +5492,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 739, col: 5, offset: 21614},
+						pos: position{line: 734, col: 5, offset: 21386},
 						run: (*parser).callonFunction21,
 						expr: &seqExpr{
-							pos: position{line: 739, col: 5, offset: 21614},
+							pos: position{line: 734, col: 5, offset: 21386},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 739, col: 5, offset: 21614},
+									pos: position{line: 734, col: 5, offset: 21386},
 									expr: &ruleRefExpr{
-										pos:  position{line: 739, col: 6, offset: 21615},
+										pos:  position{line: 734, col: 6, offset: 21387},
 										name: "FuncGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 739, col: 16, offset: 21625},
+									pos:   position{line: 734, col: 16, offset: 21397},
 									label: "fn",
 									expr: &ruleRefExpr{
-										pos:  position{line: 739, col: 19, offset: 21628},
+										pos:  position{line: 734, col: 19, offset: 21400},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 739, col: 34, offset: 21643},
+									pos:  position{line: 734, col: 34, offset: 21415},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 739, col: 37, offset: 21646},
+									pos:        position{line: 734, col: 37, offset: 21418},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 739, col: 41, offset: 21650},
+									pos:  position{line: 734, col: 41, offset: 21422},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 739, col: 44, offset: 21653},
+									pos:   position{line: 734, col: 44, offset: 21425},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 739, col: 49, offset: 21658},
+										pos:  position{line: 734, col: 49, offset: 21430},
 										name: "FunctionArgs",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 739, col: 62, offset: 21671},
+									pos:  position{line: 734, col: 62, offset: 21443},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 739, col: 65, offset: 21674},
+									pos:        position{line: 734, col: 65, offset: 21446},
 									val:        ")",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 739, col: 69, offset: 21678},
+									pos:   position{line: 734, col: 69, offset: 21450},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 739, col: 75, offset: 21684},
+										pos: position{line: 734, col: 75, offset: 21456},
 										expr: &ruleRefExpr{
-											pos:  position{line: 739, col: 75, offset: 21684},
+											pos:  position{line: 734, col: 75, offset: 21456},
 											name: "WhereClause",
 										},
 									},
@@ -5638,24 +5561,24 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionArgs",
-			pos:  position{line: 743, col: 1, offset: 21805},
+			pos:  position{line: 738, col: 1, offset: 21577},
 			expr: &choiceExpr{
-				pos: position{line: 744, col: 5, offset: 21822},
+				pos: position{line: 739, col: 5, offset: 21594},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 744, col: 5, offset: 21822},
+						pos: position{line: 739, col: 5, offset: 21594},
 						run: (*parser).callonFunctionArgs2,
 						expr: &labeledExpr{
-							pos:   position{line: 744, col: 5, offset: 21822},
+							pos:   position{line: 739, col: 5, offset: 21594},
 							label: "o",
 							expr: &ruleRefExpr{
-								pos:  position{line: 744, col: 7, offset: 21824},
+								pos:  position{line: 739, col: 7, offset: 21596},
 								name: "OverExpr",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 745, col: 5, offset: 21870},
+						pos:  position{line: 740, col: 5, offset: 21642},
 						name: "OptionalExprs",
 					},
 				},
@@ -5663,75 +5586,75 @@ var g = &grammar{
 		},
 		{
 			name: "Grep",
-			pos:  position{line: 747, col: 1, offset: 21885},
+			pos:  position{line: 742, col: 1, offset: 21657},
 			expr: &actionExpr{
-				pos: position{line: 748, col: 5, offset: 21894},
+				pos: position{line: 743, col: 5, offset: 21666},
 				run: (*parser).callonGrep1,
 				expr: &seqExpr{
-					pos: position{line: 748, col: 5, offset: 21894},
+					pos: position{line: 743, col: 5, offset: 21666},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 748, col: 5, offset: 21894},
+							pos:        position{line: 743, col: 5, offset: 21666},
 							val:        "grep",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 748, col: 12, offset: 21901},
+							pos:  position{line: 743, col: 12, offset: 21673},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 748, col: 15, offset: 21904},
+							pos:        position{line: 743, col: 15, offset: 21676},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 748, col: 19, offset: 21908},
+							pos:  position{line: 743, col: 19, offset: 21680},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 748, col: 22, offset: 21911},
+							pos:   position{line: 743, col: 22, offset: 21683},
 							label: "pattern",
 							expr: &ruleRefExpr{
-								pos:  position{line: 748, col: 30, offset: 21919},
+								pos:  position{line: 743, col: 30, offset: 21691},
 								name: "Pattern",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 748, col: 38, offset: 21927},
+							pos:  position{line: 743, col: 38, offset: 21699},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 748, col: 42, offset: 21931},
+							pos:   position{line: 743, col: 42, offset: 21703},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 748, col: 46, offset: 21935},
+								pos: position{line: 743, col: 46, offset: 21707},
 								expr: &seqExpr{
-									pos: position{line: 748, col: 47, offset: 21936},
+									pos: position{line: 743, col: 47, offset: 21708},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 748, col: 47, offset: 21936},
+											pos:        position{line: 743, col: 47, offset: 21708},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 748, col: 51, offset: 21940},
+											pos:  position{line: 743, col: 51, offset: 21712},
 											name: "__",
 										},
 										&choiceExpr{
-											pos: position{line: 748, col: 56, offset: 21945},
+											pos: position{line: 743, col: 56, offset: 21717},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 748, col: 56, offset: 21945},
+													pos:  position{line: 743, col: 56, offset: 21717},
 													name: "OverExpr",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 748, col: 67, offset: 21956},
+													pos:  position{line: 743, col: 67, offset: 21728},
 													name: "Expr",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 748, col: 73, offset: 21962},
+											pos:  position{line: 743, col: 73, offset: 21734},
 											name: "__",
 										},
 									},
@@ -5739,7 +5662,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 748, col: 78, offset: 21967},
+							pos:        position{line: 743, col: 78, offset: 21739},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -5749,26 +5672,26 @@ var g = &grammar{
 		},
 		{
 			name: "Pattern",
-			pos:  position{line: 756, col: 1, offset: 22208},
+			pos:  position{line: 751, col: 1, offset: 21980},
 			expr: &choiceExpr{
-				pos: position{line: 757, col: 5, offset: 22220},
+				pos: position{line: 752, col: 5, offset: 21992},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 757, col: 5, offset: 22220},
+						pos:  position{line: 752, col: 5, offset: 21992},
 						name: "Regexp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 758, col: 5, offset: 22231},
+						pos:  position{line: 753, col: 5, offset: 22003},
 						name: "Glob",
 					},
 					&actionExpr{
-						pos: position{line: 759, col: 5, offset: 22240},
+						pos: position{line: 754, col: 5, offset: 22012},
 						run: (*parser).callonPattern4,
 						expr: &labeledExpr{
-							pos:   position{line: 759, col: 5, offset: 22240},
+							pos:   position{line: 754, col: 5, offset: 22012},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 759, col: 7, offset: 22242},
+								pos:  position{line: 754, col: 7, offset: 22014},
 								name: "QuotedString",
 							},
 						},
@@ -5778,19 +5701,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptionalExprs",
-			pos:  position{line: 763, col: 1, offset: 22334},
+			pos:  position{line: 758, col: 1, offset: 22106},
 			expr: &choiceExpr{
-				pos: position{line: 764, col: 5, offset: 22352},
+				pos: position{line: 759, col: 5, offset: 22124},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 764, col: 5, offset: 22352},
+						pos:  position{line: 759, col: 5, offset: 22124},
 						name: "Exprs",
 					},
 					&actionExpr{
-						pos: position{line: 765, col: 5, offset: 22362},
+						pos: position{line: 760, col: 5, offset: 22134},
 						run: (*parser).callonOptionalExprs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 765, col: 5, offset: 22362},
+							pos:  position{line: 760, col: 5, offset: 22134},
 							name: "__",
 						},
 					},
@@ -5799,50 +5722,50 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 767, col: 1, offset: 22398},
+			pos:  position{line: 762, col: 1, offset: 22170},
 			expr: &actionExpr{
-				pos: position{line: 768, col: 5, offset: 22408},
+				pos: position{line: 763, col: 5, offset: 22180},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 768, col: 5, offset: 22408},
+					pos: position{line: 763, col: 5, offset: 22180},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 768, col: 5, offset: 22408},
+							pos:   position{line: 763, col: 5, offset: 22180},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 768, col: 11, offset: 22414},
+								pos:  position{line: 763, col: 11, offset: 22186},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 768, col: 16, offset: 22419},
+							pos:   position{line: 763, col: 16, offset: 22191},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 768, col: 21, offset: 22424},
+								pos: position{line: 763, col: 21, offset: 22196},
 								expr: &actionExpr{
-									pos: position{line: 768, col: 22, offset: 22425},
+									pos: position{line: 763, col: 22, offset: 22197},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 768, col: 22, offset: 22425},
+										pos: position{line: 763, col: 22, offset: 22197},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 768, col: 22, offset: 22425},
+												pos:  position{line: 763, col: 22, offset: 22197},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 768, col: 25, offset: 22428},
+												pos:        position{line: 763, col: 25, offset: 22200},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 768, col: 29, offset: 22432},
+												pos:  position{line: 763, col: 29, offset: 22204},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 768, col: 32, offset: 22435},
+												pos:   position{line: 763, col: 32, offset: 22207},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 768, col: 34, offset: 22437},
+													pos:  position{line: 763, col: 34, offset: 22209},
 													name: "Expr",
 												},
 											},
@@ -5857,35 +5780,35 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 772, col: 1, offset: 22546},
+			pos:  position{line: 767, col: 1, offset: 22318},
 			expr: &actionExpr{
-				pos: position{line: 773, col: 5, offset: 22560},
+				pos: position{line: 768, col: 5, offset: 22332},
 				run: (*parser).callonDerefExpr1,
 				expr: &seqExpr{
-					pos: position{line: 773, col: 5, offset: 22560},
+					pos: position{line: 768, col: 5, offset: 22332},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 773, col: 5, offset: 22560},
+							pos: position{line: 768, col: 5, offset: 22332},
 							expr: &ruleRefExpr{
-								pos:  position{line: 773, col: 6, offset: 22561},
+								pos:  position{line: 768, col: 6, offset: 22333},
 								name: "IP6",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 773, col: 10, offset: 22565},
+							pos:   position{line: 768, col: 10, offset: 22337},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 773, col: 16, offset: 22571},
+								pos:  position{line: 768, col: 16, offset: 22343},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 773, col: 27, offset: 22582},
+							pos:   position{line: 768, col: 27, offset: 22354},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 773, col: 32, offset: 22587},
+								pos: position{line: 768, col: 32, offset: 22359},
 								expr: &ruleRefExpr{
-									pos:  position{line: 773, col: 33, offset: 22588},
+									pos:  position{line: 768, col: 33, offset: 22360},
 									name: "Deref",
 								},
 							},
@@ -5896,55 +5819,55 @@ var g = &grammar{
 		},
 		{
 			name: "Deref",
-			pos:  position{line: 777, col: 1, offset: 22656},
+			pos:  position{line: 772, col: 1, offset: 22428},
 			expr: &choiceExpr{
-				pos: position{line: 778, col: 5, offset: 22666},
+				pos: position{line: 773, col: 5, offset: 22438},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 778, col: 5, offset: 22666},
+						pos: position{line: 773, col: 5, offset: 22438},
 						run: (*parser).callonDeref2,
 						expr: &seqExpr{
-							pos: position{line: 778, col: 5, offset: 22666},
+							pos: position{line: 773, col: 5, offset: 22438},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 778, col: 5, offset: 22666},
+									pos:        position{line: 773, col: 5, offset: 22438},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 778, col: 9, offset: 22670},
+									pos:   position{line: 773, col: 9, offset: 22442},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 778, col: 14, offset: 22675},
+										pos:  position{line: 773, col: 14, offset: 22447},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 778, col: 27, offset: 22688},
+									pos:  position{line: 773, col: 27, offset: 22460},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 778, col: 30, offset: 22691},
+									pos:        position{line: 773, col: 30, offset: 22463},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 778, col: 34, offset: 22695},
+									pos:  position{line: 773, col: 34, offset: 22467},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 778, col: 37, offset: 22698},
+									pos:   position{line: 773, col: 37, offset: 22470},
 									label: "to",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 778, col: 40, offset: 22701},
+										pos: position{line: 773, col: 40, offset: 22473},
 										expr: &ruleRefExpr{
-											pos:  position{line: 778, col: 40, offset: 22701},
+											pos:  position{line: 773, col: 40, offset: 22473},
 											name: "AdditiveExpr",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 778, col: 54, offset: 22715},
+									pos:        position{line: 773, col: 54, offset: 22487},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5952,39 +5875,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 784, col: 5, offset: 22886},
+						pos: position{line: 779, col: 5, offset: 22658},
 						run: (*parser).callonDeref14,
 						expr: &seqExpr{
-							pos: position{line: 784, col: 5, offset: 22886},
+							pos: position{line: 779, col: 5, offset: 22658},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 784, col: 5, offset: 22886},
+									pos:        position{line: 779, col: 5, offset: 22658},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 784, col: 9, offset: 22890},
+									pos:  position{line: 779, col: 9, offset: 22662},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 784, col: 12, offset: 22893},
+									pos:        position{line: 779, col: 12, offset: 22665},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 784, col: 16, offset: 22897},
+									pos:  position{line: 779, col: 16, offset: 22669},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 784, col: 19, offset: 22900},
+									pos:   position{line: 779, col: 19, offset: 22672},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 784, col: 22, offset: 22903},
+										pos:  position{line: 779, col: 22, offset: 22675},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 784, col: 35, offset: 22916},
+									pos:        position{line: 779, col: 35, offset: 22688},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5992,26 +5915,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 790, col: 5, offset: 23087},
+						pos: position{line: 785, col: 5, offset: 22859},
 						run: (*parser).callonDeref23,
 						expr: &seqExpr{
-							pos: position{line: 790, col: 5, offset: 23087},
+							pos: position{line: 785, col: 5, offset: 22859},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 790, col: 5, offset: 23087},
+									pos:        position{line: 785, col: 5, offset: 22859},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 790, col: 9, offset: 23091},
+									pos:   position{line: 785, col: 9, offset: 22863},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 790, col: 14, offset: 23096},
+										pos:  position{line: 785, col: 14, offset: 22868},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 790, col: 19, offset: 23101},
+									pos:        position{line: 785, col: 19, offset: 22873},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -6019,21 +5942,21 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 791, col: 5, offset: 23150},
+						pos: position{line: 786, col: 5, offset: 22922},
 						run: (*parser).callonDeref29,
 						expr: &seqExpr{
-							pos: position{line: 791, col: 5, offset: 23150},
+							pos: position{line: 786, col: 5, offset: 22922},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 791, col: 5, offset: 23150},
+									pos:        position{line: 786, col: 5, offset: 22922},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 791, col: 9, offset: 23154},
+									pos:   position{line: 786, col: 9, offset: 22926},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 791, col: 12, offset: 23157},
+										pos:  position{line: 786, col: 12, offset: 22929},
 										name: "Identifier",
 									},
 								},
@@ -6045,59 +5968,59 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 793, col: 1, offset: 23208},
+			pos:  position{line: 788, col: 1, offset: 22980},
 			expr: &choiceExpr{
-				pos: position{line: 794, col: 5, offset: 23220},
+				pos: position{line: 789, col: 5, offset: 22992},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 794, col: 5, offset: 23220},
+						pos:  position{line: 789, col: 5, offset: 22992},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 795, col: 5, offset: 23231},
+						pos:  position{line: 790, col: 5, offset: 23003},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 796, col: 5, offset: 23241},
+						pos:  position{line: 791, col: 5, offset: 23013},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 797, col: 5, offset: 23249},
+						pos:  position{line: 792, col: 5, offset: 23021},
 						name: "Map",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 798, col: 5, offset: 23257},
+						pos:  position{line: 793, col: 5, offset: 23029},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 799, col: 5, offset: 23269},
+						pos: position{line: 794, col: 5, offset: 23041},
 						run: (*parser).callonPrimary7,
 						expr: &seqExpr{
-							pos: position{line: 799, col: 5, offset: 23269},
+							pos: position{line: 794, col: 5, offset: 23041},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 799, col: 5, offset: 23269},
+									pos:        position{line: 794, col: 5, offset: 23041},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 799, col: 9, offset: 23273},
+									pos:  position{line: 794, col: 9, offset: 23045},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 799, col: 12, offset: 23276},
+									pos:   position{line: 794, col: 12, offset: 23048},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 799, col: 17, offset: 23281},
+										pos:  position{line: 794, col: 17, offset: 23053},
 										name: "OverExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 799, col: 26, offset: 23290},
+									pos:  position{line: 794, col: 26, offset: 23062},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 799, col: 29, offset: 23293},
+									pos:        position{line: 794, col: 29, offset: 23065},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -6105,34 +6028,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 800, col: 5, offset: 23323},
+						pos: position{line: 795, col: 5, offset: 23095},
 						run: (*parser).callonPrimary15,
 						expr: &seqExpr{
-							pos: position{line: 800, col: 5, offset: 23323},
+							pos: position{line: 795, col: 5, offset: 23095},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 800, col: 5, offset: 23323},
+									pos:        position{line: 795, col: 5, offset: 23095},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 800, col: 9, offset: 23327},
+									pos:  position{line: 795, col: 9, offset: 23099},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 800, col: 12, offset: 23330},
+									pos:   position{line: 795, col: 12, offset: 23102},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 800, col: 17, offset: 23335},
+										pos:  position{line: 795, col: 17, offset: 23107},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 800, col: 22, offset: 23340},
+									pos:  position{line: 795, col: 22, offset: 23112},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 800, col: 25, offset: 23343},
+									pos:        position{line: 795, col: 25, offset: 23115},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -6144,59 +6067,59 @@ var g = &grammar{
 		},
 		{
 			name: "OverExpr",
-			pos:  position{line: 802, col: 1, offset: 23369},
+			pos:  position{line: 797, col: 1, offset: 23141},
 			expr: &actionExpr{
-				pos: position{line: 803, col: 5, offset: 23382},
+				pos: position{line: 798, col: 5, offset: 23154},
 				run: (*parser).callonOverExpr1,
 				expr: &seqExpr{
-					pos: position{line: 803, col: 5, offset: 23382},
+					pos: position{line: 798, col: 5, offset: 23154},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 803, col: 5, offset: 23382},
+							pos:        position{line: 798, col: 5, offset: 23154},
 							val:        "over",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 803, col: 12, offset: 23389},
+							pos:  position{line: 798, col: 12, offset: 23161},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 803, col: 14, offset: 23391},
+							pos:   position{line: 798, col: 14, offset: 23163},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 803, col: 20, offset: 23397},
+								pos:  position{line: 798, col: 20, offset: 23169},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 803, col: 26, offset: 23403},
+							pos:   position{line: 798, col: 26, offset: 23175},
 							label: "locals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 803, col: 33, offset: 23410},
+								pos: position{line: 798, col: 33, offset: 23182},
 								expr: &ruleRefExpr{
-									pos:  position{line: 803, col: 33, offset: 23410},
+									pos:  position{line: 798, col: 33, offset: 23182},
 									name: "Locals",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 803, col: 41, offset: 23418},
+							pos:  position{line: 798, col: 41, offset: 23190},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 803, col: 44, offset: 23421},
+							pos:        position{line: 798, col: 44, offset: 23193},
 							val:        "|",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 803, col: 48, offset: 23425},
+							pos:  position{line: 798, col: 48, offset: 23197},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 803, col: 51, offset: 23428},
+							pos:   position{line: 798, col: 51, offset: 23200},
 							label: "scope",
 							expr: &ruleRefExpr{
-								pos:  position{line: 803, col: 57, offset: 23434},
+								pos:  position{line: 798, col: 57, offset: 23206},
 								name: "Sequential",
 							},
 						},
@@ -6206,36 +6129,36 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 807, col: 1, offset: 23565},
+			pos:  position{line: 802, col: 1, offset: 23337},
 			expr: &actionExpr{
-				pos: position{line: 808, col: 5, offset: 23576},
+				pos: position{line: 803, col: 5, offset: 23348},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 808, col: 5, offset: 23576},
+					pos: position{line: 803, col: 5, offset: 23348},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 808, col: 5, offset: 23576},
+							pos:        position{line: 803, col: 5, offset: 23348},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 808, col: 9, offset: 23580},
+							pos:  position{line: 803, col: 9, offset: 23352},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 808, col: 12, offset: 23583},
+							pos:   position{line: 803, col: 12, offset: 23355},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 808, col: 18, offset: 23589},
+								pos:  position{line: 803, col: 18, offset: 23361},
 								name: "RecordElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 808, col: 30, offset: 23601},
+							pos:  position{line: 803, col: 30, offset: 23373},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 808, col: 33, offset: 23604},
+							pos:        position{line: 803, col: 33, offset: 23376},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -6245,31 +6168,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElems",
-			pos:  position{line: 812, col: 1, offset: 23694},
+			pos:  position{line: 807, col: 1, offset: 23466},
 			expr: &choiceExpr{
-				pos: position{line: 813, col: 5, offset: 23710},
+				pos: position{line: 808, col: 5, offset: 23482},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 813, col: 5, offset: 23710},
+						pos: position{line: 808, col: 5, offset: 23482},
 						run: (*parser).callonRecordElems2,
 						expr: &seqExpr{
-							pos: position{line: 813, col: 5, offset: 23710},
+							pos: position{line: 808, col: 5, offset: 23482},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 813, col: 5, offset: 23710},
+									pos:   position{line: 808, col: 5, offset: 23482},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 813, col: 11, offset: 23716},
+										pos:  position{line: 808, col: 11, offset: 23488},
 										name: "RecordElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 813, col: 22, offset: 23727},
+									pos:   position{line: 808, col: 22, offset: 23499},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 813, col: 27, offset: 23732},
+										pos: position{line: 808, col: 27, offset: 23504},
 										expr: &ruleRefExpr{
-											pos:  position{line: 813, col: 27, offset: 23732},
+											pos:  position{line: 808, col: 27, offset: 23504},
 											name: "RecordElemTail",
 										},
 									},
@@ -6278,10 +6201,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 816, col: 5, offset: 23831},
+						pos: position{line: 811, col: 5, offset: 23603},
 						run: (*parser).callonRecordElems9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 816, col: 5, offset: 23831},
+							pos:  position{line: 811, col: 5, offset: 23603},
 							name: "__",
 						},
 					},
@@ -6290,31 +6213,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElemTail",
-			pos:  position{line: 818, col: 1, offset: 23867},
+			pos:  position{line: 813, col: 1, offset: 23639},
 			expr: &actionExpr{
-				pos: position{line: 818, col: 18, offset: 23884},
+				pos: position{line: 813, col: 18, offset: 23656},
 				run: (*parser).callonRecordElemTail1,
 				expr: &seqExpr{
-					pos: position{line: 818, col: 18, offset: 23884},
+					pos: position{line: 813, col: 18, offset: 23656},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 818, col: 18, offset: 23884},
+							pos:  position{line: 813, col: 18, offset: 23656},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 818, col: 21, offset: 23887},
+							pos:        position{line: 813, col: 21, offset: 23659},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 818, col: 25, offset: 23891},
+							pos:  position{line: 813, col: 25, offset: 23663},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 818, col: 28, offset: 23894},
+							pos:   position{line: 813, col: 28, offset: 23666},
 							label: "elem",
 							expr: &ruleRefExpr{
-								pos:  position{line: 818, col: 33, offset: 23899},
+								pos:  position{line: 813, col: 33, offset: 23671},
 								name: "RecordElem",
 							},
 						},
@@ -6324,20 +6247,20 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElem",
-			pos:  position{line: 820, col: 1, offset: 23932},
+			pos:  position{line: 815, col: 1, offset: 23704},
 			expr: &choiceExpr{
-				pos: position{line: 821, col: 5, offset: 23947},
+				pos: position{line: 816, col: 5, offset: 23719},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 821, col: 5, offset: 23947},
+						pos:  position{line: 816, col: 5, offset: 23719},
 						name: "Spread",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 822, col: 5, offset: 23958},
+						pos:  position{line: 817, col: 5, offset: 23730},
 						name: "Field",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 823, col: 5, offset: 23968},
+						pos:  position{line: 818, col: 5, offset: 23740},
 						name: "Identifier",
 					},
 				},
@@ -6345,27 +6268,27 @@ var g = &grammar{
 		},
 		{
 			name: "Spread",
-			pos:  position{line: 825, col: 1, offset: 23980},
+			pos:  position{line: 820, col: 1, offset: 23752},
 			expr: &actionExpr{
-				pos: position{line: 826, col: 5, offset: 23991},
+				pos: position{line: 821, col: 5, offset: 23763},
 				run: (*parser).callonSpread1,
 				expr: &seqExpr{
-					pos: position{line: 826, col: 5, offset: 23991},
+					pos: position{line: 821, col: 5, offset: 23763},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 826, col: 5, offset: 23991},
+							pos:        position{line: 821, col: 5, offset: 23763},
 							val:        "...",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 826, col: 11, offset: 23997},
+							pos:  position{line: 821, col: 11, offset: 23769},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 826, col: 14, offset: 24000},
+							pos:   position{line: 821, col: 14, offset: 23772},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 826, col: 19, offset: 24005},
+								pos:  position{line: 821, col: 19, offset: 23777},
 								name: "Expr",
 							},
 						},
@@ -6375,39 +6298,39 @@ var g = &grammar{
 		},
 		{
 			name: "Field",
-			pos:  position{line: 830, col: 1, offset: 24091},
+			pos:  position{line: 825, col: 1, offset: 23863},
 			expr: &actionExpr{
-				pos: position{line: 831, col: 5, offset: 24101},
+				pos: position{line: 826, col: 5, offset: 23873},
 				run: (*parser).callonField1,
 				expr: &seqExpr{
-					pos: position{line: 831, col: 5, offset: 24101},
+					pos: position{line: 826, col: 5, offset: 23873},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 831, col: 5, offset: 24101},
+							pos:   position{line: 826, col: 5, offset: 23873},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 831, col: 10, offset: 24106},
+								pos:  position{line: 826, col: 10, offset: 23878},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 831, col: 20, offset: 24116},
+							pos:  position{line: 826, col: 20, offset: 23888},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 831, col: 23, offset: 24119},
+							pos:        position{line: 826, col: 23, offset: 23891},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 831, col: 27, offset: 24123},
+							pos:  position{line: 826, col: 27, offset: 23895},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 831, col: 30, offset: 24126},
+							pos:   position{line: 826, col: 30, offset: 23898},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 831, col: 36, offset: 24132},
+								pos:  position{line: 826, col: 36, offset: 23904},
 								name: "Expr",
 							},
 						},
@@ -6417,36 +6340,36 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 835, col: 1, offset: 24232},
+			pos:  position{line: 830, col: 1, offset: 24004},
 			expr: &actionExpr{
-				pos: position{line: 836, col: 5, offset: 24242},
+				pos: position{line: 831, col: 5, offset: 24014},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 836, col: 5, offset: 24242},
+					pos: position{line: 831, col: 5, offset: 24014},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 836, col: 5, offset: 24242},
+							pos:        position{line: 831, col: 5, offset: 24014},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 836, col: 9, offset: 24246},
+							pos:  position{line: 831, col: 9, offset: 24018},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 836, col: 12, offset: 24249},
+							pos:   position{line: 831, col: 12, offset: 24021},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 836, col: 18, offset: 24255},
+								pos:  position{line: 831, col: 18, offset: 24027},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 836, col: 30, offset: 24267},
+							pos:  position{line: 831, col: 30, offset: 24039},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 836, col: 33, offset: 24270},
+							pos:        position{line: 831, col: 33, offset: 24042},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -6456,36 +6379,36 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 840, col: 1, offset: 24360},
+			pos:  position{line: 835, col: 1, offset: 24132},
 			expr: &actionExpr{
-				pos: position{line: 841, col: 5, offset: 24368},
+				pos: position{line: 836, col: 5, offset: 24140},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 841, col: 5, offset: 24368},
+					pos: position{line: 836, col: 5, offset: 24140},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 841, col: 5, offset: 24368},
+							pos:        position{line: 836, col: 5, offset: 24140},
 							val:        "|[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 841, col: 10, offset: 24373},
+							pos:  position{line: 836, col: 10, offset: 24145},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 841, col: 13, offset: 24376},
+							pos:   position{line: 836, col: 13, offset: 24148},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 841, col: 19, offset: 24382},
+								pos:  position{line: 836, col: 19, offset: 24154},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 841, col: 31, offset: 24394},
+							pos:  position{line: 836, col: 31, offset: 24166},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 841, col: 34, offset: 24397},
+							pos:        position{line: 836, col: 34, offset: 24169},
 							val:        "]|",
 							ignoreCase: false,
 						},
@@ -6495,53 +6418,53 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElems",
-			pos:  position{line: 845, col: 1, offset: 24486},
+			pos:  position{line: 840, col: 1, offset: 24258},
 			expr: &choiceExpr{
-				pos: position{line: 846, col: 5, offset: 24502},
+				pos: position{line: 841, col: 5, offset: 24274},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 846, col: 5, offset: 24502},
+						pos: position{line: 841, col: 5, offset: 24274},
 						run: (*parser).callonVectorElems2,
 						expr: &seqExpr{
-							pos: position{line: 846, col: 5, offset: 24502},
+							pos: position{line: 841, col: 5, offset: 24274},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 846, col: 5, offset: 24502},
+									pos:   position{line: 841, col: 5, offset: 24274},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 846, col: 11, offset: 24508},
+										pos:  position{line: 841, col: 11, offset: 24280},
 										name: "VectorElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 846, col: 22, offset: 24519},
+									pos:   position{line: 841, col: 22, offset: 24291},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 846, col: 27, offset: 24524},
+										pos: position{line: 841, col: 27, offset: 24296},
 										expr: &actionExpr{
-											pos: position{line: 846, col: 28, offset: 24525},
+											pos: position{line: 841, col: 28, offset: 24297},
 											run: (*parser).callonVectorElems8,
 											expr: &seqExpr{
-												pos: position{line: 846, col: 28, offset: 24525},
+												pos: position{line: 841, col: 28, offset: 24297},
 												exprs: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 846, col: 28, offset: 24525},
+														pos:  position{line: 841, col: 28, offset: 24297},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 846, col: 31, offset: 24528},
+														pos:        position{line: 841, col: 31, offset: 24300},
 														val:        ",",
 														ignoreCase: false,
 													},
 													&ruleRefExpr{
-														pos:  position{line: 846, col: 35, offset: 24532},
+														pos:  position{line: 841, col: 35, offset: 24304},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 846, col: 38, offset: 24535},
+														pos:   position{line: 841, col: 38, offset: 24307},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 846, col: 40, offset: 24537},
+															pos:  position{line: 841, col: 40, offset: 24309},
 															name: "VectorElem",
 														},
 													},
@@ -6554,10 +6477,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 849, col: 5, offset: 24655},
+						pos: position{line: 844, col: 5, offset: 24427},
 						run: (*parser).callonVectorElems15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 849, col: 5, offset: 24655},
+							pos:  position{line: 844, col: 5, offset: 24427},
 							name: "__",
 						},
 					},
@@ -6566,22 +6489,22 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElem",
-			pos:  position{line: 851, col: 1, offset: 24691},
+			pos:  position{line: 846, col: 1, offset: 24463},
 			expr: &choiceExpr{
-				pos: position{line: 852, col: 5, offset: 24706},
+				pos: position{line: 847, col: 5, offset: 24478},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 852, col: 5, offset: 24706},
+						pos:  position{line: 847, col: 5, offset: 24478},
 						name: "Spread",
 					},
 					&actionExpr{
-						pos: position{line: 853, col: 5, offset: 24717},
+						pos: position{line: 848, col: 5, offset: 24489},
 						run: (*parser).callonVectorElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 853, col: 5, offset: 24717},
+							pos:   position{line: 848, col: 5, offset: 24489},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 853, col: 7, offset: 24719},
+								pos:  position{line: 848, col: 7, offset: 24491},
 								name: "Expr",
 							},
 						},
@@ -6591,36 +6514,36 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 855, col: 1, offset: 24795},
+			pos:  position{line: 850, col: 1, offset: 24567},
 			expr: &actionExpr{
-				pos: position{line: 856, col: 5, offset: 24803},
+				pos: position{line: 851, col: 5, offset: 24575},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 856, col: 5, offset: 24803},
+					pos: position{line: 851, col: 5, offset: 24575},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 856, col: 5, offset: 24803},
+							pos:        position{line: 851, col: 5, offset: 24575},
 							val:        "|{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 856, col: 10, offset: 24808},
+							pos:  position{line: 851, col: 10, offset: 24580},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 856, col: 13, offset: 24811},
+							pos:   position{line: 851, col: 13, offset: 24583},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 856, col: 19, offset: 24817},
+								pos:  position{line: 851, col: 19, offset: 24589},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 856, col: 27, offset: 24825},
+							pos:  position{line: 851, col: 27, offset: 24597},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 856, col: 30, offset: 24828},
+							pos:        position{line: 851, col: 30, offset: 24600},
 							val:        "}|",
 							ignoreCase: false,
 						},
@@ -6630,31 +6553,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 860, col: 1, offset: 24919},
+			pos:  position{line: 855, col: 1, offset: 24691},
 			expr: &choiceExpr{
-				pos: position{line: 861, col: 5, offset: 24931},
+				pos: position{line: 856, col: 5, offset: 24703},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 861, col: 5, offset: 24931},
+						pos: position{line: 856, col: 5, offset: 24703},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 861, col: 5, offset: 24931},
+							pos: position{line: 856, col: 5, offset: 24703},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 861, col: 5, offset: 24931},
+									pos:   position{line: 856, col: 5, offset: 24703},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 861, col: 11, offset: 24937},
+										pos:  position{line: 856, col: 11, offset: 24709},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 861, col: 17, offset: 24943},
+									pos:   position{line: 856, col: 17, offset: 24715},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 861, col: 22, offset: 24948},
+										pos: position{line: 856, col: 22, offset: 24720},
 										expr: &ruleRefExpr{
-											pos:  position{line: 861, col: 22, offset: 24948},
+											pos:  position{line: 856, col: 22, offset: 24720},
 											name: "EntryTail",
 										},
 									},
@@ -6663,10 +6586,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 864, col: 5, offset: 25042},
+						pos: position{line: 859, col: 5, offset: 24814},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 864, col: 5, offset: 25042},
+							pos:  position{line: 859, col: 5, offset: 24814},
 							name: "__",
 						},
 					},
@@ -6675,31 +6598,31 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 867, col: 1, offset: 25079},
+			pos:  position{line: 862, col: 1, offset: 24851},
 			expr: &actionExpr{
-				pos: position{line: 867, col: 13, offset: 25091},
+				pos: position{line: 862, col: 13, offset: 24863},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 867, col: 13, offset: 25091},
+					pos: position{line: 862, col: 13, offset: 24863},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 867, col: 13, offset: 25091},
+							pos:  position{line: 862, col: 13, offset: 24863},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 867, col: 16, offset: 25094},
+							pos:        position{line: 862, col: 16, offset: 24866},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 867, col: 20, offset: 25098},
+							pos:  position{line: 862, col: 20, offset: 24870},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 867, col: 23, offset: 25101},
+							pos:   position{line: 862, col: 23, offset: 24873},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 867, col: 25, offset: 25103},
+								pos:  position{line: 862, col: 25, offset: 24875},
 								name: "Entry",
 							},
 						},
@@ -6709,39 +6632,39 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 869, col: 1, offset: 25128},
+			pos:  position{line: 864, col: 1, offset: 24900},
 			expr: &actionExpr{
-				pos: position{line: 870, col: 5, offset: 25138},
+				pos: position{line: 865, col: 5, offset: 24910},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 870, col: 5, offset: 25138},
+					pos: position{line: 865, col: 5, offset: 24910},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 870, col: 5, offset: 25138},
+							pos:   position{line: 865, col: 5, offset: 24910},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 870, col: 9, offset: 25142},
+								pos:  position{line: 865, col: 9, offset: 24914},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 870, col: 14, offset: 25147},
+							pos:  position{line: 865, col: 14, offset: 24919},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 870, col: 17, offset: 25150},
+							pos:        position{line: 865, col: 17, offset: 24922},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 870, col: 21, offset: 25154},
+							pos:  position{line: 865, col: 21, offset: 24926},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 870, col: 24, offset: 25157},
+							pos:   position{line: 865, col: 24, offset: 24929},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 870, col: 30, offset: 25163},
+								pos:  position{line: 865, col: 30, offset: 24935},
 								name: "Expr",
 							},
 						},
@@ -6751,92 +6674,92 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOp",
-			pos:  position{line: 876, col: 1, offset: 25270},
+			pos:  position{line: 871, col: 1, offset: 25042},
 			expr: &actionExpr{
-				pos: position{line: 877, col: 5, offset: 25280},
+				pos: position{line: 872, col: 5, offset: 25052},
 				run: (*parser).callonSQLOp1,
 				expr: &seqExpr{
-					pos: position{line: 877, col: 5, offset: 25280},
+					pos: position{line: 872, col: 5, offset: 25052},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 877, col: 5, offset: 25280},
+							pos:   position{line: 872, col: 5, offset: 25052},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 877, col: 15, offset: 25290},
+								pos:  position{line: 872, col: 15, offset: 25062},
 								name: "SQLSelect",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 878, col: 5, offset: 25304},
+							pos:   position{line: 873, col: 5, offset: 25076},
 							label: "from",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 878, col: 10, offset: 25309},
+								pos: position{line: 873, col: 10, offset: 25081},
 								expr: &ruleRefExpr{
-									pos:  position{line: 878, col: 10, offset: 25309},
+									pos:  position{line: 873, col: 10, offset: 25081},
 									name: "SQLFrom",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 879, col: 5, offset: 25322},
+							pos:   position{line: 874, col: 5, offset: 25094},
 							label: "joins",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 879, col: 11, offset: 25328},
+								pos: position{line: 874, col: 11, offset: 25100},
 								expr: &ruleRefExpr{
-									pos:  position{line: 879, col: 11, offset: 25328},
+									pos:  position{line: 874, col: 11, offset: 25100},
 									name: "SQLJoins",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 880, col: 5, offset: 25342},
+							pos:   position{line: 875, col: 5, offset: 25114},
 							label: "where",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 880, col: 11, offset: 25348},
+								pos: position{line: 875, col: 11, offset: 25120},
 								expr: &ruleRefExpr{
-									pos:  position{line: 880, col: 11, offset: 25348},
+									pos:  position{line: 875, col: 11, offset: 25120},
 									name: "SQLWhere",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 881, col: 5, offset: 25362},
+							pos:   position{line: 876, col: 5, offset: 25134},
 							label: "groupby",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 881, col: 13, offset: 25370},
+								pos: position{line: 876, col: 13, offset: 25142},
 								expr: &ruleRefExpr{
-									pos:  position{line: 881, col: 13, offset: 25370},
+									pos:  position{line: 876, col: 13, offset: 25142},
 									name: "SQLGroupBy",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 882, col: 5, offset: 25386},
+							pos:   position{line: 877, col: 5, offset: 25158},
 							label: "having",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 882, col: 12, offset: 25393},
+								pos: position{line: 877, col: 12, offset: 25165},
 								expr: &ruleRefExpr{
-									pos:  position{line: 882, col: 12, offset: 25393},
+									pos:  position{line: 877, col: 12, offset: 25165},
 									name: "SQLHaving",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 883, col: 5, offset: 25408},
+							pos:   position{line: 878, col: 5, offset: 25180},
 							label: "orderby",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 883, col: 13, offset: 25416},
+								pos: position{line: 878, col: 13, offset: 25188},
 								expr: &ruleRefExpr{
-									pos:  position{line: 883, col: 13, offset: 25416},
+									pos:  position{line: 878, col: 13, offset: 25188},
 									name: "SQLOrderBy",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 884, col: 5, offset: 25432},
+							pos:   position{line: 879, col: 5, offset: 25204},
 							label: "limit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 884, col: 11, offset: 25438},
+								pos:  position{line: 879, col: 11, offset: 25210},
 								name: "SQLLimit",
 							},
 						},
@@ -6846,26 +6769,26 @@ var g = &grammar{
 		},
 		{
 			name: "SQLSelect",
-			pos:  position{line: 908, col: 1, offset: 25805},
+			pos:  position{line: 903, col: 1, offset: 25577},
 			expr: &choiceExpr{
-				pos: position{line: 909, col: 5, offset: 25819},
+				pos: position{line: 904, col: 5, offset: 25591},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 909, col: 5, offset: 25819},
+						pos: position{line: 904, col: 5, offset: 25591},
 						run: (*parser).callonSQLSelect2,
 						expr: &seqExpr{
-							pos: position{line: 909, col: 5, offset: 25819},
+							pos: position{line: 904, col: 5, offset: 25591},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 909, col: 5, offset: 25819},
+									pos:  position{line: 904, col: 5, offset: 25591},
 									name: "SELECT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 909, col: 12, offset: 25826},
+									pos:  position{line: 904, col: 12, offset: 25598},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 909, col: 14, offset: 25828},
+									pos:        position{line: 904, col: 14, offset: 25600},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -6873,24 +6796,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 910, col: 5, offset: 25856},
+						pos: position{line: 905, col: 5, offset: 25628},
 						run: (*parser).callonSQLSelect7,
 						expr: &seqExpr{
-							pos: position{line: 910, col: 5, offset: 25856},
+							pos: position{line: 905, col: 5, offset: 25628},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 910, col: 5, offset: 25856},
+									pos:  position{line: 905, col: 5, offset: 25628},
 									name: "SELECT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 910, col: 12, offset: 25863},
+									pos:  position{line: 905, col: 12, offset: 25635},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 910, col: 14, offset: 25865},
+									pos:   position{line: 905, col: 14, offset: 25637},
 									label: "assignments",
 									expr: &ruleRefExpr{
-										pos:  position{line: 910, col: 26, offset: 25877},
+										pos:  position{line: 905, col: 26, offset: 25649},
 										name: "SQLAssignments",
 									},
 								},
@@ -6902,43 +6825,43 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAssignment",
-			pos:  position{line: 912, col: 1, offset: 25921},
+			pos:  position{line: 907, col: 1, offset: 25693},
 			expr: &actionExpr{
-				pos: position{line: 913, col: 5, offset: 25939},
+				pos: position{line: 908, col: 5, offset: 25711},
 				run: (*parser).callonSQLAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 913, col: 5, offset: 25939},
+					pos: position{line: 908, col: 5, offset: 25711},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 913, col: 5, offset: 25939},
+							pos:   position{line: 908, col: 5, offset: 25711},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 913, col: 9, offset: 25943},
+								pos:  position{line: 908, col: 9, offset: 25715},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 913, col: 14, offset: 25948},
+							pos:   position{line: 908, col: 14, offset: 25720},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 913, col: 18, offset: 25952},
+								pos: position{line: 908, col: 18, offset: 25724},
 								expr: &seqExpr{
-									pos: position{line: 913, col: 19, offset: 25953},
+									pos: position{line: 908, col: 19, offset: 25725},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 913, col: 19, offset: 25953},
+											pos:  position{line: 908, col: 19, offset: 25725},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 913, col: 21, offset: 25955},
+											pos:  position{line: 908, col: 21, offset: 25727},
 											name: "AS",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 913, col: 24, offset: 25958},
+											pos:  position{line: 908, col: 24, offset: 25730},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 913, col: 26, offset: 25960},
+											pos:  position{line: 908, col: 26, offset: 25732},
 											name: "Lval",
 										},
 									},
@@ -6951,50 +6874,50 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAssignments",
-			pos:  position{line: 921, col: 1, offset: 26151},
+			pos:  position{line: 916, col: 1, offset: 25923},
 			expr: &actionExpr{
-				pos: position{line: 922, col: 5, offset: 26170},
+				pos: position{line: 917, col: 5, offset: 25942},
 				run: (*parser).callonSQLAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 922, col: 5, offset: 26170},
+					pos: position{line: 917, col: 5, offset: 25942},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 922, col: 5, offset: 26170},
+							pos:   position{line: 917, col: 5, offset: 25942},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 922, col: 11, offset: 26176},
+								pos:  position{line: 917, col: 11, offset: 25948},
 								name: "SQLAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 922, col: 25, offset: 26190},
+							pos:   position{line: 917, col: 25, offset: 25962},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 922, col: 30, offset: 26195},
+								pos: position{line: 917, col: 30, offset: 25967},
 								expr: &actionExpr{
-									pos: position{line: 922, col: 31, offset: 26196},
+									pos: position{line: 917, col: 31, offset: 25968},
 									run: (*parser).callonSQLAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 922, col: 31, offset: 26196},
+										pos: position{line: 917, col: 31, offset: 25968},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 922, col: 31, offset: 26196},
+												pos:  position{line: 917, col: 31, offset: 25968},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 922, col: 34, offset: 26199},
+												pos:        position{line: 917, col: 34, offset: 25971},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 922, col: 38, offset: 26203},
+												pos:  position{line: 917, col: 38, offset: 25975},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 922, col: 41, offset: 26206},
+												pos:   position{line: 917, col: 41, offset: 25978},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 922, col: 46, offset: 26211},
+													pos:  position{line: 917, col: 46, offset: 25983},
 													name: "SQLAssignment",
 												},
 											},
@@ -7009,43 +6932,43 @@ var g = &grammar{
 		},
 		{
 			name: "SQLFrom",
-			pos:  position{line: 926, col: 1, offset: 26332},
+			pos:  position{line: 921, col: 1, offset: 26104},
 			expr: &choiceExpr{
-				pos: position{line: 927, col: 5, offset: 26344},
+				pos: position{line: 922, col: 5, offset: 26116},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 927, col: 5, offset: 26344},
+						pos: position{line: 922, col: 5, offset: 26116},
 						run: (*parser).callonSQLFrom2,
 						expr: &seqExpr{
-							pos: position{line: 927, col: 5, offset: 26344},
+							pos: position{line: 922, col: 5, offset: 26116},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 927, col: 5, offset: 26344},
+									pos:  position{line: 922, col: 5, offset: 26116},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 927, col: 7, offset: 26346},
+									pos:  position{line: 922, col: 7, offset: 26118},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 927, col: 12, offset: 26351},
+									pos:  position{line: 922, col: 12, offset: 26123},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 927, col: 14, offset: 26353},
+									pos:   position{line: 922, col: 14, offset: 26125},
 									label: "table",
 									expr: &ruleRefExpr{
-										pos:  position{line: 927, col: 20, offset: 26359},
+										pos:  position{line: 922, col: 20, offset: 26131},
 										name: "SQLTable",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 927, col: 29, offset: 26368},
+									pos:   position{line: 922, col: 29, offset: 26140},
 									label: "alias",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 927, col: 35, offset: 26374},
+										pos: position{line: 922, col: 35, offset: 26146},
 										expr: &ruleRefExpr{
-											pos:  position{line: 927, col: 35, offset: 26374},
+											pos:  position{line: 922, col: 35, offset: 26146},
 											name: "SQLAlias",
 										},
 									},
@@ -7054,25 +6977,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 930, col: 5, offset: 26469},
+						pos: position{line: 925, col: 5, offset: 26241},
 						run: (*parser).callonSQLFrom12,
 						expr: &seqExpr{
-							pos: position{line: 930, col: 5, offset: 26469},
+							pos: position{line: 925, col: 5, offset: 26241},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 930, col: 5, offset: 26469},
+									pos:  position{line: 925, col: 5, offset: 26241},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 930, col: 7, offset: 26471},
+									pos:  position{line: 925, col: 7, offset: 26243},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 930, col: 12, offset: 26476},
+									pos:  position{line: 925, col: 12, offset: 26248},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 930, col: 14, offset: 26478},
+									pos:        position{line: 925, col: 14, offset: 26250},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -7084,33 +7007,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAlias",
-			pos:  position{line: 932, col: 1, offset: 26503},
+			pos:  position{line: 927, col: 1, offset: 26275},
 			expr: &choiceExpr{
-				pos: position{line: 933, col: 5, offset: 26516},
+				pos: position{line: 928, col: 5, offset: 26288},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 933, col: 5, offset: 26516},
+						pos: position{line: 928, col: 5, offset: 26288},
 						run: (*parser).callonSQLAlias2,
 						expr: &seqExpr{
-							pos: position{line: 933, col: 5, offset: 26516},
+							pos: position{line: 928, col: 5, offset: 26288},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 933, col: 5, offset: 26516},
+									pos:  position{line: 928, col: 5, offset: 26288},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 933, col: 7, offset: 26518},
+									pos:  position{line: 928, col: 7, offset: 26290},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 933, col: 10, offset: 26521},
+									pos:  position{line: 928, col: 10, offset: 26293},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 933, col: 12, offset: 26523},
+									pos:   position{line: 928, col: 12, offset: 26295},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 933, col: 15, offset: 26526},
+										pos:  position{line: 928, col: 15, offset: 26298},
 										name: "Lval",
 									},
 								},
@@ -7118,36 +7041,36 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 934, col: 5, offset: 26554},
+						pos: position{line: 929, col: 5, offset: 26326},
 						run: (*parser).callonSQLAlias9,
 						expr: &seqExpr{
-							pos: position{line: 934, col: 5, offset: 26554},
+							pos: position{line: 929, col: 5, offset: 26326},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 934, col: 5, offset: 26554},
+									pos:  position{line: 929, col: 5, offset: 26326},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 934, col: 7, offset: 26556},
+									pos: position{line: 929, col: 7, offset: 26328},
 									expr: &seqExpr{
-										pos: position{line: 934, col: 9, offset: 26558},
+										pos: position{line: 929, col: 9, offset: 26330},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 934, col: 9, offset: 26558},
+												pos:  position{line: 929, col: 9, offset: 26330},
 												name: "SQLTokenSentinels",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 934, col: 27, offset: 26576},
+												pos:  position{line: 929, col: 27, offset: 26348},
 												name: "_",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 934, col: 30, offset: 26579},
+									pos:   position{line: 929, col: 30, offset: 26351},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 934, col: 33, offset: 26582},
+										pos:  position{line: 929, col: 33, offset: 26354},
 										name: "Lval",
 									},
 								},
@@ -7159,42 +7082,42 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTable",
-			pos:  position{line: 936, col: 1, offset: 26607},
+			pos:  position{line: 931, col: 1, offset: 26379},
 			expr: &ruleRefExpr{
-				pos:  position{line: 937, col: 5, offset: 26620},
+				pos:  position{line: 932, col: 5, offset: 26392},
 				name: "Expr",
 			},
 		},
 		{
 			name: "SQLJoins",
-			pos:  position{line: 939, col: 1, offset: 26626},
+			pos:  position{line: 934, col: 1, offset: 26398},
 			expr: &actionExpr{
-				pos: position{line: 940, col: 5, offset: 26639},
+				pos: position{line: 935, col: 5, offset: 26411},
 				run: (*parser).callonSQLJoins1,
 				expr: &seqExpr{
-					pos: position{line: 940, col: 5, offset: 26639},
+					pos: position{line: 935, col: 5, offset: 26411},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 940, col: 5, offset: 26639},
+							pos:   position{line: 935, col: 5, offset: 26411},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 940, col: 11, offset: 26645},
+								pos:  position{line: 935, col: 11, offset: 26417},
 								name: "SQLJoin",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 940, col: 19, offset: 26653},
+							pos:   position{line: 935, col: 19, offset: 26425},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 940, col: 24, offset: 26658},
+								pos: position{line: 935, col: 24, offset: 26430},
 								expr: &actionExpr{
-									pos: position{line: 940, col: 25, offset: 26659},
+									pos: position{line: 935, col: 25, offset: 26431},
 									run: (*parser).callonSQLJoins7,
 									expr: &labeledExpr{
-										pos:   position{line: 940, col: 25, offset: 26659},
+										pos:   position{line: 935, col: 25, offset: 26431},
 										label: "join",
 										expr: &ruleRefExpr{
-											pos:  position{line: 940, col: 30, offset: 26664},
+											pos:  position{line: 935, col: 30, offset: 26436},
 											name: "SQLJoin",
 										},
 									},
@@ -7207,90 +7130,90 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoin",
-			pos:  position{line: 944, col: 1, offset: 26779},
+			pos:  position{line: 939, col: 1, offset: 26551},
 			expr: &actionExpr{
-				pos: position{line: 945, col: 5, offset: 26791},
+				pos: position{line: 940, col: 5, offset: 26563},
 				run: (*parser).callonSQLJoin1,
 				expr: &seqExpr{
-					pos: position{line: 945, col: 5, offset: 26791},
+					pos: position{line: 940, col: 5, offset: 26563},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 945, col: 5, offset: 26791},
+							pos:   position{line: 940, col: 5, offset: 26563},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 945, col: 11, offset: 26797},
+								pos:  position{line: 940, col: 11, offset: 26569},
 								name: "SQLJoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 945, col: 24, offset: 26810},
+							pos:  position{line: 940, col: 24, offset: 26582},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 945, col: 26, offset: 26812},
+							pos:  position{line: 940, col: 26, offset: 26584},
 							name: "JOIN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 945, col: 31, offset: 26817},
+							pos:  position{line: 940, col: 31, offset: 26589},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 945, col: 33, offset: 26819},
+							pos:   position{line: 940, col: 33, offset: 26591},
 							label: "table",
 							expr: &ruleRefExpr{
-								pos:  position{line: 945, col: 39, offset: 26825},
+								pos:  position{line: 940, col: 39, offset: 26597},
 								name: "SQLTable",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 945, col: 48, offset: 26834},
+							pos:   position{line: 940, col: 48, offset: 26606},
 							label: "alias",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 945, col: 54, offset: 26840},
+								pos: position{line: 940, col: 54, offset: 26612},
 								expr: &ruleRefExpr{
-									pos:  position{line: 945, col: 54, offset: 26840},
+									pos:  position{line: 940, col: 54, offset: 26612},
 									name: "SQLAlias",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 945, col: 64, offset: 26850},
+							pos:  position{line: 940, col: 64, offset: 26622},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 945, col: 66, offset: 26852},
+							pos:  position{line: 940, col: 66, offset: 26624},
 							name: "ON",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 945, col: 69, offset: 26855},
+							pos:  position{line: 940, col: 69, offset: 26627},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 945, col: 71, offset: 26857},
+							pos:   position{line: 940, col: 71, offset: 26629},
 							label: "leftKey",
 							expr: &ruleRefExpr{
-								pos:  position{line: 945, col: 79, offset: 26865},
+								pos:  position{line: 940, col: 79, offset: 26637},
 								name: "JoinKey",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 945, col: 87, offset: 26873},
+							pos:  position{line: 940, col: 87, offset: 26645},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 945, col: 90, offset: 26876},
+							pos:        position{line: 940, col: 90, offset: 26648},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 945, col: 94, offset: 26880},
+							pos:  position{line: 940, col: 94, offset: 26652},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 945, col: 97, offset: 26883},
+							pos:   position{line: 940, col: 97, offset: 26655},
 							label: "rightKey",
 							expr: &ruleRefExpr{
-								pos:  position{line: 945, col: 106, offset: 26892},
+								pos:  position{line: 940, col: 106, offset: 26664},
 								name: "JoinKey",
 							},
 						},
@@ -7300,40 +7223,40 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoinStyle",
-			pos:  position{line: 960, col: 1, offset: 27123},
+			pos:  position{line: 955, col: 1, offset: 26895},
 			expr: &choiceExpr{
-				pos: position{line: 961, col: 5, offset: 27140},
+				pos: position{line: 956, col: 5, offset: 26912},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 961, col: 5, offset: 27140},
+						pos: position{line: 956, col: 5, offset: 26912},
 						run: (*parser).callonSQLJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 961, col: 5, offset: 27140},
+							pos: position{line: 956, col: 5, offset: 26912},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 961, col: 5, offset: 27140},
+									pos:  position{line: 956, col: 5, offset: 26912},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 961, col: 7, offset: 27142},
+									pos:   position{line: 956, col: 7, offset: 26914},
 									label: "style",
 									expr: &choiceExpr{
-										pos: position{line: 961, col: 14, offset: 27149},
+										pos: position{line: 956, col: 14, offset: 26921},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 961, col: 14, offset: 27149},
+												pos:  position{line: 956, col: 14, offset: 26921},
 												name: "ANTI",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 961, col: 21, offset: 27156},
+												pos:  position{line: 956, col: 21, offset: 26928},
 												name: "INNER",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 961, col: 29, offset: 27164},
+												pos:  position{line: 956, col: 29, offset: 26936},
 												name: "LEFT",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 961, col: 36, offset: 27171},
+												pos:  position{line: 956, col: 36, offset: 26943},
 												name: "RIGHT",
 											},
 										},
@@ -7343,10 +7266,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 962, col: 5, offset: 27204},
+						pos: position{line: 957, col: 5, offset: 26976},
 						run: (*parser).callonSQLJoinStyle11,
 						expr: &litMatcher{
-							pos:        position{line: 962, col: 5, offset: 27204},
+							pos:        position{line: 957, col: 5, offset: 26976},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7356,30 +7279,30 @@ var g = &grammar{
 		},
 		{
 			name: "SQLWhere",
-			pos:  position{line: 964, col: 1, offset: 27232},
+			pos:  position{line: 959, col: 1, offset: 27004},
 			expr: &actionExpr{
-				pos: position{line: 965, col: 5, offset: 27245},
+				pos: position{line: 960, col: 5, offset: 27017},
 				run: (*parser).callonSQLWhere1,
 				expr: &seqExpr{
-					pos: position{line: 965, col: 5, offset: 27245},
+					pos: position{line: 960, col: 5, offset: 27017},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 965, col: 5, offset: 27245},
+							pos:  position{line: 960, col: 5, offset: 27017},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 965, col: 7, offset: 27247},
+							pos:  position{line: 960, col: 7, offset: 27019},
 							name: "WHERE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 965, col: 13, offset: 27253},
+							pos:  position{line: 960, col: 13, offset: 27025},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 965, col: 15, offset: 27255},
+							pos:   position{line: 960, col: 15, offset: 27027},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 965, col: 20, offset: 27260},
+								pos:  position{line: 960, col: 20, offset: 27032},
 								name: "LogicalOrExpr",
 							},
 						},
@@ -7389,38 +7312,38 @@ var g = &grammar{
 		},
 		{
 			name: "SQLGroupBy",
-			pos:  position{line: 967, col: 1, offset: 27296},
+			pos:  position{line: 962, col: 1, offset: 27068},
 			expr: &actionExpr{
-				pos: position{line: 968, col: 5, offset: 27311},
+				pos: position{line: 963, col: 5, offset: 27083},
 				run: (*parser).callonSQLGroupBy1,
 				expr: &seqExpr{
-					pos: position{line: 968, col: 5, offset: 27311},
+					pos: position{line: 963, col: 5, offset: 27083},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 968, col: 5, offset: 27311},
+							pos:  position{line: 963, col: 5, offset: 27083},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 968, col: 7, offset: 27313},
+							pos:  position{line: 963, col: 7, offset: 27085},
 							name: "GROUP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 968, col: 13, offset: 27319},
+							pos:  position{line: 963, col: 13, offset: 27091},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 968, col: 15, offset: 27321},
+							pos:  position{line: 963, col: 15, offset: 27093},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 968, col: 18, offset: 27324},
+							pos:  position{line: 963, col: 18, offset: 27096},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 968, col: 20, offset: 27326},
+							pos:   position{line: 963, col: 20, offset: 27098},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 968, col: 28, offset: 27334},
+								pos:  position{line: 963, col: 28, offset: 27106},
 								name: "FieldExprs",
 							},
 						},
@@ -7430,30 +7353,30 @@ var g = &grammar{
 		},
 		{
 			name: "SQLHaving",
-			pos:  position{line: 970, col: 1, offset: 27370},
+			pos:  position{line: 965, col: 1, offset: 27142},
 			expr: &actionExpr{
-				pos: position{line: 971, col: 5, offset: 27384},
+				pos: position{line: 966, col: 5, offset: 27156},
 				run: (*parser).callonSQLHaving1,
 				expr: &seqExpr{
-					pos: position{line: 971, col: 5, offset: 27384},
+					pos: position{line: 966, col: 5, offset: 27156},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 971, col: 5, offset: 27384},
+							pos:  position{line: 966, col: 5, offset: 27156},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 971, col: 7, offset: 27386},
+							pos:  position{line: 966, col: 7, offset: 27158},
 							name: "HAVING",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 971, col: 14, offset: 27393},
+							pos:  position{line: 966, col: 14, offset: 27165},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 971, col: 16, offset: 27395},
+							pos:   position{line: 966, col: 16, offset: 27167},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 971, col: 21, offset: 27400},
+								pos:  position{line: 966, col: 21, offset: 27172},
 								name: "LogicalOrExpr",
 							},
 						},
@@ -7463,46 +7386,46 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOrderBy",
-			pos:  position{line: 973, col: 1, offset: 27436},
+			pos:  position{line: 968, col: 1, offset: 27208},
 			expr: &actionExpr{
-				pos: position{line: 974, col: 5, offset: 27451},
+				pos: position{line: 969, col: 5, offset: 27223},
 				run: (*parser).callonSQLOrderBy1,
 				expr: &seqExpr{
-					pos: position{line: 974, col: 5, offset: 27451},
+					pos: position{line: 969, col: 5, offset: 27223},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 974, col: 5, offset: 27451},
+							pos:  position{line: 969, col: 5, offset: 27223},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 974, col: 7, offset: 27453},
+							pos:  position{line: 969, col: 7, offset: 27225},
 							name: "ORDER",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 974, col: 13, offset: 27459},
+							pos:  position{line: 969, col: 13, offset: 27231},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 974, col: 15, offset: 27461},
+							pos:  position{line: 969, col: 15, offset: 27233},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 974, col: 18, offset: 27464},
+							pos:  position{line: 969, col: 18, offset: 27236},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 974, col: 20, offset: 27466},
+							pos:   position{line: 969, col: 20, offset: 27238},
 							label: "keys",
 							expr: &ruleRefExpr{
-								pos:  position{line: 974, col: 25, offset: 27471},
+								pos:  position{line: 969, col: 25, offset: 27243},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 974, col: 31, offset: 27477},
+							pos:   position{line: 969, col: 31, offset: 27249},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 974, col: 37, offset: 27483},
+								pos:  position{line: 969, col: 37, offset: 27255},
 								name: "SQLOrder",
 							},
 						},
@@ -7512,32 +7435,32 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOrder",
-			pos:  position{line: 978, col: 1, offset: 27593},
+			pos:  position{line: 973, col: 1, offset: 27365},
 			expr: &choiceExpr{
-				pos: position{line: 979, col: 5, offset: 27606},
+				pos: position{line: 974, col: 5, offset: 27378},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 979, col: 5, offset: 27606},
+						pos: position{line: 974, col: 5, offset: 27378},
 						run: (*parser).callonSQLOrder2,
 						expr: &seqExpr{
-							pos: position{line: 979, col: 5, offset: 27606},
+							pos: position{line: 974, col: 5, offset: 27378},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 979, col: 5, offset: 27606},
+									pos:  position{line: 974, col: 5, offset: 27378},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 979, col: 7, offset: 27608},
+									pos:   position{line: 974, col: 7, offset: 27380},
 									label: "dir",
 									expr: &choiceExpr{
-										pos: position{line: 979, col: 12, offset: 27613},
+										pos: position{line: 974, col: 12, offset: 27385},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 979, col: 12, offset: 27613},
+												pos:  position{line: 974, col: 12, offset: 27385},
 												name: "ASC",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 979, col: 18, offset: 27619},
+												pos:  position{line: 974, col: 18, offset: 27391},
 												name: "DESC",
 											},
 										},
@@ -7547,10 +7470,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 980, col: 5, offset: 27649},
+						pos: position{line: 975, col: 5, offset: 27421},
 						run: (*parser).callonSQLOrder9,
 						expr: &litMatcher{
-							pos:        position{line: 980, col: 5, offset: 27649},
+							pos:        position{line: 975, col: 5, offset: 27421},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7560,33 +7483,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLLimit",
-			pos:  position{line: 982, col: 1, offset: 27675},
+			pos:  position{line: 977, col: 1, offset: 27447},
 			expr: &choiceExpr{
-				pos: position{line: 983, col: 5, offset: 27688},
+				pos: position{line: 978, col: 5, offset: 27460},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 983, col: 5, offset: 27688},
+						pos: position{line: 978, col: 5, offset: 27460},
 						run: (*parser).callonSQLLimit2,
 						expr: &seqExpr{
-							pos: position{line: 983, col: 5, offset: 27688},
+							pos: position{line: 978, col: 5, offset: 27460},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 983, col: 5, offset: 27688},
+									pos:  position{line: 978, col: 5, offset: 27460},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 983, col: 7, offset: 27690},
+									pos:  position{line: 978, col: 7, offset: 27462},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 983, col: 13, offset: 27696},
+									pos:  position{line: 978, col: 13, offset: 27468},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 983, col: 15, offset: 27698},
+									pos:   position{line: 978, col: 15, offset: 27470},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 983, col: 21, offset: 27704},
+										pos:  position{line: 978, col: 21, offset: 27476},
 										name: "UInt",
 									},
 								},
@@ -7594,10 +7517,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 984, col: 5, offset: 27735},
+						pos: position{line: 979, col: 5, offset: 27507},
 						run: (*parser).callonSQLLimit9,
 						expr: &litMatcher{
-							pos:        position{line: 984, col: 5, offset: 27735},
+							pos:        position{line: 979, col: 5, offset: 27507},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -7607,12 +7530,12 @@ var g = &grammar{
 		},
 		{
 			name: "SELECT",
-			pos:  position{line: 986, col: 1, offset: 27757},
+			pos:  position{line: 981, col: 1, offset: 27529},
 			expr: &actionExpr{
-				pos: position{line: 986, col: 10, offset: 27766},
+				pos: position{line: 981, col: 10, offset: 27538},
 				run: (*parser).callonSELECT1,
 				expr: &litMatcher{
-					pos:        position{line: 986, col: 10, offset: 27766},
+					pos:        position{line: 981, col: 10, offset: 27538},
 					val:        "select",
 					ignoreCase: true,
 				},
@@ -7620,12 +7543,12 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 987, col: 1, offset: 27801},
+			pos:  position{line: 982, col: 1, offset: 27573},
 			expr: &actionExpr{
-				pos: position{line: 987, col: 6, offset: 27806},
+				pos: position{line: 982, col: 6, offset: 27578},
 				run: (*parser).callonAS1,
 				expr: &litMatcher{
-					pos:        position{line: 987, col: 6, offset: 27806},
+					pos:        position{line: 982, col: 6, offset: 27578},
 					val:        "as",
 					ignoreCase: true,
 				},
@@ -7633,12 +7556,12 @@ var g = &grammar{
 		},
 		{
 			name: "FROM",
-			pos:  position{line: 988, col: 1, offset: 27833},
+			pos:  position{line: 983, col: 1, offset: 27605},
 			expr: &actionExpr{
-				pos: position{line: 988, col: 8, offset: 27840},
+				pos: position{line: 983, col: 8, offset: 27612},
 				run: (*parser).callonFROM1,
 				expr: &litMatcher{
-					pos:        position{line: 988, col: 8, offset: 27840},
+					pos:        position{line: 983, col: 8, offset: 27612},
 					val:        "from",
 					ignoreCase: true,
 				},
@@ -7646,12 +7569,12 @@ var g = &grammar{
 		},
 		{
 			name: "JOIN",
-			pos:  position{line: 989, col: 1, offset: 27871},
+			pos:  position{line: 984, col: 1, offset: 27643},
 			expr: &actionExpr{
-				pos: position{line: 989, col: 8, offset: 27878},
+				pos: position{line: 984, col: 8, offset: 27650},
 				run: (*parser).callonJOIN1,
 				expr: &litMatcher{
-					pos:        position{line: 989, col: 8, offset: 27878},
+					pos:        position{line: 984, col: 8, offset: 27650},
 					val:        "join",
 					ignoreCase: true,
 				},
@@ -7659,12 +7582,12 @@ var g = &grammar{
 		},
 		{
 			name: "WHERE",
-			pos:  position{line: 990, col: 1, offset: 27909},
+			pos:  position{line: 985, col: 1, offset: 27681},
 			expr: &actionExpr{
-				pos: position{line: 990, col: 9, offset: 27917},
+				pos: position{line: 985, col: 9, offset: 27689},
 				run: (*parser).callonWHERE1,
 				expr: &litMatcher{
-					pos:        position{line: 990, col: 9, offset: 27917},
+					pos:        position{line: 985, col: 9, offset: 27689},
 					val:        "where",
 					ignoreCase: true,
 				},
@@ -7672,12 +7595,12 @@ var g = &grammar{
 		},
 		{
 			name: "GROUP",
-			pos:  position{line: 991, col: 1, offset: 27950},
+			pos:  position{line: 986, col: 1, offset: 27722},
 			expr: &actionExpr{
-				pos: position{line: 991, col: 9, offset: 27958},
+				pos: position{line: 986, col: 9, offset: 27730},
 				run: (*parser).callonGROUP1,
 				expr: &litMatcher{
-					pos:        position{line: 991, col: 9, offset: 27958},
+					pos:        position{line: 986, col: 9, offset: 27730},
 					val:        "group",
 					ignoreCase: true,
 				},
@@ -7685,12 +7608,12 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 992, col: 1, offset: 27991},
+			pos:  position{line: 987, col: 1, offset: 27763},
 			expr: &actionExpr{
-				pos: position{line: 992, col: 6, offset: 27996},
+				pos: position{line: 987, col: 6, offset: 27768},
 				run: (*parser).callonBY1,
 				expr: &litMatcher{
-					pos:        position{line: 992, col: 6, offset: 27996},
+					pos:        position{line: 987, col: 6, offset: 27768},
 					val:        "by",
 					ignoreCase: true,
 				},
@@ -7698,12 +7621,12 @@ var g = &grammar{
 		},
 		{
 			name: "HAVING",
-			pos:  position{line: 993, col: 1, offset: 28023},
+			pos:  position{line: 988, col: 1, offset: 27795},
 			expr: &actionExpr{
-				pos: position{line: 993, col: 10, offset: 28032},
+				pos: position{line: 988, col: 10, offset: 27804},
 				run: (*parser).callonHAVING1,
 				expr: &litMatcher{
-					pos:        position{line: 993, col: 10, offset: 28032},
+					pos:        position{line: 988, col: 10, offset: 27804},
 					val:        "having",
 					ignoreCase: true,
 				},
@@ -7711,12 +7634,12 @@ var g = &grammar{
 		},
 		{
 			name: "ORDER",
-			pos:  position{line: 994, col: 1, offset: 28067},
+			pos:  position{line: 989, col: 1, offset: 27839},
 			expr: &actionExpr{
-				pos: position{line: 994, col: 9, offset: 28075},
+				pos: position{line: 989, col: 9, offset: 27847},
 				run: (*parser).callonORDER1,
 				expr: &litMatcher{
-					pos:        position{line: 994, col: 9, offset: 28075},
+					pos:        position{line: 989, col: 9, offset: 27847},
 					val:        "order",
 					ignoreCase: true,
 				},
@@ -7724,12 +7647,12 @@ var g = &grammar{
 		},
 		{
 			name: "ON",
-			pos:  position{line: 995, col: 1, offset: 28108},
+			pos:  position{line: 990, col: 1, offset: 27880},
 			expr: &actionExpr{
-				pos: position{line: 995, col: 6, offset: 28113},
+				pos: position{line: 990, col: 6, offset: 27885},
 				run: (*parser).callonON1,
 				expr: &litMatcher{
-					pos:        position{line: 995, col: 6, offset: 28113},
+					pos:        position{line: 990, col: 6, offset: 27885},
 					val:        "on",
 					ignoreCase: true,
 				},
@@ -7737,12 +7660,12 @@ var g = &grammar{
 		},
 		{
 			name: "LIMIT",
-			pos:  position{line: 996, col: 1, offset: 28140},
+			pos:  position{line: 991, col: 1, offset: 27912},
 			expr: &actionExpr{
-				pos: position{line: 996, col: 9, offset: 28148},
+				pos: position{line: 991, col: 9, offset: 27920},
 				run: (*parser).callonLIMIT1,
 				expr: &litMatcher{
-					pos:        position{line: 996, col: 9, offset: 28148},
+					pos:        position{line: 991, col: 9, offset: 27920},
 					val:        "limit",
 					ignoreCase: true,
 				},
@@ -7750,12 +7673,12 @@ var g = &grammar{
 		},
 		{
 			name: "ASC",
-			pos:  position{line: 997, col: 1, offset: 28181},
+			pos:  position{line: 992, col: 1, offset: 27953},
 			expr: &actionExpr{
-				pos: position{line: 997, col: 7, offset: 28187},
+				pos: position{line: 992, col: 7, offset: 27959},
 				run: (*parser).callonASC1,
 				expr: &litMatcher{
-					pos:        position{line: 997, col: 7, offset: 28187},
+					pos:        position{line: 992, col: 7, offset: 27959},
 					val:        "asc",
 					ignoreCase: true,
 				},
@@ -7763,12 +7686,12 @@ var g = &grammar{
 		},
 		{
 			name: "DESC",
-			pos:  position{line: 998, col: 1, offset: 28216},
+			pos:  position{line: 993, col: 1, offset: 27988},
 			expr: &actionExpr{
-				pos: position{line: 998, col: 8, offset: 28223},
+				pos: position{line: 993, col: 8, offset: 27995},
 				run: (*parser).callonDESC1,
 				expr: &litMatcher{
-					pos:        position{line: 998, col: 8, offset: 28223},
+					pos:        position{line: 993, col: 8, offset: 27995},
 					val:        "desc",
 					ignoreCase: true,
 				},
@@ -7776,12 +7699,12 @@ var g = &grammar{
 		},
 		{
 			name: "ANTI",
-			pos:  position{line: 999, col: 1, offset: 28254},
+			pos:  position{line: 994, col: 1, offset: 28026},
 			expr: &actionExpr{
-				pos: position{line: 999, col: 8, offset: 28261},
+				pos: position{line: 994, col: 8, offset: 28033},
 				run: (*parser).callonANTI1,
 				expr: &litMatcher{
-					pos:        position{line: 999, col: 8, offset: 28261},
+					pos:        position{line: 994, col: 8, offset: 28033},
 					val:        "anti",
 					ignoreCase: true,
 				},
@@ -7789,12 +7712,12 @@ var g = &grammar{
 		},
 		{
 			name: "LEFT",
-			pos:  position{line: 1000, col: 1, offset: 28292},
+			pos:  position{line: 995, col: 1, offset: 28064},
 			expr: &actionExpr{
-				pos: position{line: 1000, col: 8, offset: 28299},
+				pos: position{line: 995, col: 8, offset: 28071},
 				run: (*parser).callonLEFT1,
 				expr: &litMatcher{
-					pos:        position{line: 1000, col: 8, offset: 28299},
+					pos:        position{line: 995, col: 8, offset: 28071},
 					val:        "left",
 					ignoreCase: true,
 				},
@@ -7802,12 +7725,12 @@ var g = &grammar{
 		},
 		{
 			name: "RIGHT",
-			pos:  position{line: 1001, col: 1, offset: 28330},
+			pos:  position{line: 996, col: 1, offset: 28102},
 			expr: &actionExpr{
-				pos: position{line: 1001, col: 9, offset: 28338},
+				pos: position{line: 996, col: 9, offset: 28110},
 				run: (*parser).callonRIGHT1,
 				expr: &litMatcher{
-					pos:        position{line: 1001, col: 9, offset: 28338},
+					pos:        position{line: 996, col: 9, offset: 28110},
 					val:        "right",
 					ignoreCase: true,
 				},
@@ -7815,12 +7738,12 @@ var g = &grammar{
 		},
 		{
 			name: "INNER",
-			pos:  position{line: 1002, col: 1, offset: 28371},
+			pos:  position{line: 997, col: 1, offset: 28143},
 			expr: &actionExpr{
-				pos: position{line: 1002, col: 9, offset: 28379},
+				pos: position{line: 997, col: 9, offset: 28151},
 				run: (*parser).callonINNER1,
 				expr: &litMatcher{
-					pos:        position{line: 1002, col: 9, offset: 28379},
+					pos:        position{line: 997, col: 9, offset: 28151},
 					val:        "inner",
 					ignoreCase: true,
 				},
@@ -7828,48 +7751,48 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTokenSentinels",
-			pos:  position{line: 1004, col: 1, offset: 28413},
+			pos:  position{line: 999, col: 1, offset: 28185},
 			expr: &choiceExpr{
-				pos: position{line: 1005, col: 5, offset: 28435},
+				pos: position{line: 1000, col: 5, offset: 28207},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1005, col: 5, offset: 28435},
+						pos:  position{line: 1000, col: 5, offset: 28207},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1005, col: 14, offset: 28444},
+						pos:  position{line: 1000, col: 14, offset: 28216},
 						name: "AS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1005, col: 19, offset: 28449},
+						pos:  position{line: 1000, col: 19, offset: 28221},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1005, col: 27, offset: 28457},
+						pos:  position{line: 1000, col: 27, offset: 28229},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1005, col: 34, offset: 28464},
+						pos:  position{line: 1000, col: 34, offset: 28236},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1005, col: 42, offset: 28472},
+						pos:  position{line: 1000, col: 42, offset: 28244},
 						name: "GROUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1005, col: 50, offset: 28480},
+						pos:  position{line: 1000, col: 50, offset: 28252},
 						name: "HAVING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1005, col: 59, offset: 28489},
+						pos:  position{line: 1000, col: 59, offset: 28261},
 						name: "ORDER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1005, col: 67, offset: 28497},
+						pos:  position{line: 1000, col: 67, offset: 28269},
 						name: "LIMIT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1005, col: 75, offset: 28505},
+						pos:  position{line: 1000, col: 75, offset: 28277},
 						name: "ON",
 					},
 				},
@@ -7877,52 +7800,52 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 1009, col: 1, offset: 28531},
+			pos:  position{line: 1004, col: 1, offset: 28303},
 			expr: &choiceExpr{
-				pos: position{line: 1010, col: 5, offset: 28543},
+				pos: position{line: 1005, col: 5, offset: 28315},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1010, col: 5, offset: 28543},
+						pos:  position{line: 1005, col: 5, offset: 28315},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1011, col: 5, offset: 28559},
+						pos:  position{line: 1006, col: 5, offset: 28331},
 						name: "TemplateLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1012, col: 5, offset: 28579},
+						pos:  position{line: 1007, col: 5, offset: 28351},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1013, col: 5, offset: 28597},
+						pos:  position{line: 1008, col: 5, offset: 28369},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1014, col: 5, offset: 28616},
+						pos:  position{line: 1009, col: 5, offset: 28388},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1015, col: 5, offset: 28633},
+						pos:  position{line: 1010, col: 5, offset: 28405},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1016, col: 5, offset: 28646},
+						pos:  position{line: 1011, col: 5, offset: 28418},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1017, col: 5, offset: 28655},
+						pos:  position{line: 1012, col: 5, offset: 28427},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1018, col: 5, offset: 28672},
+						pos:  position{line: 1013, col: 5, offset: 28444},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1019, col: 5, offset: 28691},
+						pos:  position{line: 1014, col: 5, offset: 28463},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1020, col: 5, offset: 28710},
+						pos:  position{line: 1015, col: 5, offset: 28482},
 						name: "NullLiteral",
 					},
 				},
@@ -7930,28 +7853,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 1022, col: 1, offset: 28723},
+			pos:  position{line: 1017, col: 1, offset: 28495},
 			expr: &choiceExpr{
-				pos: position{line: 1023, col: 5, offset: 28741},
+				pos: position{line: 1018, col: 5, offset: 28513},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1023, col: 5, offset: 28741},
+						pos: position{line: 1018, col: 5, offset: 28513},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1023, col: 5, offset: 28741},
+							pos: position{line: 1018, col: 5, offset: 28513},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1023, col: 5, offset: 28741},
+									pos:   position{line: 1018, col: 5, offset: 28513},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1023, col: 7, offset: 28743},
+										pos:  position{line: 1018, col: 7, offset: 28515},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1023, col: 14, offset: 28750},
+									pos: position{line: 1018, col: 14, offset: 28522},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1023, col: 15, offset: 28751},
+										pos:  position{line: 1018, col: 15, offset: 28523},
 										name: "IdentifierRest",
 									},
 								},
@@ -7959,13 +7882,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1026, col: 5, offset: 28866},
+						pos: position{line: 1021, col: 5, offset: 28638},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1026, col: 5, offset: 28866},
+							pos:   position{line: 1021, col: 5, offset: 28638},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1026, col: 7, offset: 28868},
+								pos:  position{line: 1021, col: 7, offset: 28640},
 								name: "IP4Net",
 							},
 						},
@@ -7975,28 +7898,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 1030, col: 1, offset: 28972},
+			pos:  position{line: 1025, col: 1, offset: 28744},
 			expr: &choiceExpr{
-				pos: position{line: 1031, col: 5, offset: 28991},
+				pos: position{line: 1026, col: 5, offset: 28763},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1031, col: 5, offset: 28991},
+						pos: position{line: 1026, col: 5, offset: 28763},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1031, col: 5, offset: 28991},
+							pos: position{line: 1026, col: 5, offset: 28763},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1031, col: 5, offset: 28991},
+									pos:   position{line: 1026, col: 5, offset: 28763},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1031, col: 7, offset: 28993},
+										pos:  position{line: 1026, col: 7, offset: 28765},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1031, col: 11, offset: 28997},
+									pos: position{line: 1026, col: 11, offset: 28769},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1031, col: 12, offset: 28998},
+										pos:  position{line: 1026, col: 12, offset: 28770},
 										name: "IdentifierRest",
 									},
 								},
@@ -8004,13 +7927,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1034, col: 5, offset: 29112},
+						pos: position{line: 1029, col: 5, offset: 28884},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1034, col: 5, offset: 29112},
+							pos:   position{line: 1029, col: 5, offset: 28884},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1034, col: 7, offset: 29114},
+								pos:  position{line: 1029, col: 7, offset: 28886},
 								name: "IP",
 							},
 						},
@@ -8020,15 +7943,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 1038, col: 1, offset: 29213},
+			pos:  position{line: 1033, col: 1, offset: 28985},
 			expr: &actionExpr{
-				pos: position{line: 1039, col: 5, offset: 29230},
+				pos: position{line: 1034, col: 5, offset: 29002},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1039, col: 5, offset: 29230},
+					pos:   position{line: 1034, col: 5, offset: 29002},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1039, col: 7, offset: 29232},
+						pos:  position{line: 1034, col: 7, offset: 29004},
 						name: "FloatString",
 					},
 				},
@@ -8036,15 +7959,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 1043, col: 1, offset: 29345},
+			pos:  position{line: 1038, col: 1, offset: 29117},
 			expr: &actionExpr{
-				pos: position{line: 1044, col: 5, offset: 29364},
+				pos: position{line: 1039, col: 5, offset: 29136},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1044, col: 5, offset: 29364},
+					pos:   position{line: 1039, col: 5, offset: 29136},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1044, col: 7, offset: 29366},
+						pos:  position{line: 1039, col: 7, offset: 29138},
 						name: "IntString",
 					},
 				},
@@ -8052,24 +7975,24 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 1048, col: 1, offset: 29475},
+			pos:  position{line: 1043, col: 1, offset: 29247},
 			expr: &choiceExpr{
-				pos: position{line: 1049, col: 5, offset: 29494},
+				pos: position{line: 1044, col: 5, offset: 29266},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1049, col: 5, offset: 29494},
+						pos: position{line: 1044, col: 5, offset: 29266},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &litMatcher{
-							pos:        position{line: 1049, col: 5, offset: 29494},
+							pos:        position{line: 1044, col: 5, offset: 29266},
 							val:        "true",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1050, col: 5, offset: 29607},
+						pos: position{line: 1045, col: 5, offset: 29379},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &litMatcher{
-							pos:        position{line: 1050, col: 5, offset: 29607},
+							pos:        position{line: 1045, col: 5, offset: 29379},
 							val:        "false",
 							ignoreCase: false,
 						},
@@ -8079,12 +8002,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 1052, col: 1, offset: 29718},
+			pos:  position{line: 1047, col: 1, offset: 29490},
 			expr: &actionExpr{
-				pos: position{line: 1053, col: 5, offset: 29734},
+				pos: position{line: 1048, col: 5, offset: 29506},
 				run: (*parser).callonNullLiteral1,
 				expr: &litMatcher{
-					pos:        position{line: 1053, col: 5, offset: 29734},
+					pos:        position{line: 1048, col: 5, offset: 29506},
 					val:        "null",
 					ignoreCase: false,
 				},
@@ -8092,22 +8015,22 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 1055, col: 1, offset: 29840},
+			pos:  position{line: 1050, col: 1, offset: 29612},
 			expr: &actionExpr{
-				pos: position{line: 1056, col: 5, offset: 29857},
+				pos: position{line: 1051, col: 5, offset: 29629},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1056, col: 5, offset: 29857},
+					pos: position{line: 1051, col: 5, offset: 29629},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1056, col: 5, offset: 29857},
+							pos:        position{line: 1051, col: 5, offset: 29629},
 							val:        "0x",
 							ignoreCase: false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1056, col: 10, offset: 29862},
+							pos: position{line: 1051, col: 10, offset: 29634},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1056, col: 10, offset: 29862},
+								pos:  position{line: 1051, col: 10, offset: 29634},
 								name: "HexDigit",
 							},
 						},
@@ -8117,28 +8040,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 1060, col: 1, offset: 29977},
+			pos:  position{line: 1055, col: 1, offset: 29749},
 			expr: &actionExpr{
-				pos: position{line: 1061, col: 5, offset: 29993},
+				pos: position{line: 1056, col: 5, offset: 29765},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1061, col: 5, offset: 29993},
+					pos: position{line: 1056, col: 5, offset: 29765},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1061, col: 5, offset: 29993},
+							pos:        position{line: 1056, col: 5, offset: 29765},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1061, col: 9, offset: 29997},
+							pos:   position{line: 1056, col: 9, offset: 29769},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1061, col: 13, offset: 30001},
+								pos:  position{line: 1056, col: 13, offset: 29773},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1061, col: 18, offset: 30006},
+							pos:        position{line: 1056, col: 18, offset: 29778},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -8148,22 +8071,22 @@ var g = &grammar{
 		},
 		{
 			name: "CastType",
-			pos:  position{line: 1065, col: 1, offset: 30095},
+			pos:  position{line: 1060, col: 1, offset: 29867},
 			expr: &choiceExpr{
-				pos: position{line: 1066, col: 5, offset: 30108},
+				pos: position{line: 1061, col: 5, offset: 29880},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1066, col: 5, offset: 30108},
+						pos:  position{line: 1061, col: 5, offset: 29880},
 						name: "TypeLiteral",
 					},
 					&actionExpr{
-						pos: position{line: 1067, col: 5, offset: 30124},
+						pos: position{line: 1062, col: 5, offset: 29896},
 						run: (*parser).callonCastType3,
 						expr: &labeledExpr{
-							pos:   position{line: 1067, col: 5, offset: 30124},
+							pos:   position{line: 1062, col: 5, offset: 29896},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1067, col: 9, offset: 30128},
+								pos:  position{line: 1062, col: 9, offset: 29900},
 								name: "PrimitiveType",
 							},
 						},
@@ -8173,20 +8096,20 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1071, col: 1, offset: 30227},
+			pos:  position{line: 1066, col: 1, offset: 29999},
 			expr: &choiceExpr{
-				pos: position{line: 1072, col: 5, offset: 30236},
+				pos: position{line: 1067, col: 5, offset: 30008},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1072, col: 5, offset: 30236},
+						pos:  position{line: 1067, col: 5, offset: 30008},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1073, col: 5, offset: 30252},
+						pos:  position{line: 1068, col: 5, offset: 30024},
 						name: "AmbiguousType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1074, col: 5, offset: 30270},
+						pos:  position{line: 1069, col: 5, offset: 30042},
 						name: "ComplexType",
 					},
 				},
@@ -8194,28 +8117,28 @@ var g = &grammar{
 		},
 		{
 			name: "AmbiguousType",
-			pos:  position{line: 1076, col: 1, offset: 30283},
+			pos:  position{line: 1071, col: 1, offset: 30055},
 			expr: &choiceExpr{
-				pos: position{line: 1077, col: 5, offset: 30301},
+				pos: position{line: 1072, col: 5, offset: 30073},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1077, col: 5, offset: 30301},
+						pos: position{line: 1072, col: 5, offset: 30073},
 						run: (*parser).callonAmbiguousType2,
 						expr: &seqExpr{
-							pos: position{line: 1077, col: 5, offset: 30301},
+							pos: position{line: 1072, col: 5, offset: 30073},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1077, col: 5, offset: 30301},
+									pos:   position{line: 1072, col: 5, offset: 30073},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1077, col: 10, offset: 30306},
+										pos:  position{line: 1072, col: 10, offset: 30078},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1077, col: 24, offset: 30320},
+									pos: position{line: 1072, col: 24, offset: 30092},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1077, col: 25, offset: 30321},
+										pos:  position{line: 1072, col: 25, offset: 30093},
 										name: "IdentifierRest",
 									},
 								},
@@ -8223,42 +8146,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1078, col: 5, offset: 30361},
+						pos: position{line: 1073, col: 5, offset: 30133},
 						run: (*parser).callonAmbiguousType8,
 						expr: &seqExpr{
-							pos: position{line: 1078, col: 5, offset: 30361},
+							pos: position{line: 1073, col: 5, offset: 30133},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1078, col: 5, offset: 30361},
+									pos:   position{line: 1073, col: 5, offset: 30133},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1078, col: 10, offset: 30366},
+										pos:  position{line: 1073, col: 10, offset: 30138},
 										name: "IdentifierName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1078, col: 25, offset: 30381},
+									pos:   position{line: 1073, col: 25, offset: 30153},
 									label: "opt",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1078, col: 29, offset: 30385},
+										pos: position{line: 1073, col: 29, offset: 30157},
 										expr: &seqExpr{
-											pos: position{line: 1078, col: 30, offset: 30386},
+											pos: position{line: 1073, col: 30, offset: 30158},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 1078, col: 30, offset: 30386},
+													pos:  position{line: 1073, col: 30, offset: 30158},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1078, col: 33, offset: 30389},
+													pos:        position{line: 1073, col: 33, offset: 30161},
 													val:        "=",
 													ignoreCase: false,
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1078, col: 37, offset: 30393},
+													pos:  position{line: 1073, col: 37, offset: 30165},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1078, col: 40, offset: 30396},
+													pos:  position{line: 1073, col: 40, offset: 30168},
 													name: "Type",
 												},
 											},
@@ -8269,42 +8192,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1084, col: 5, offset: 30628},
+						pos: position{line: 1079, col: 5, offset: 30400},
 						run: (*parser).callonAmbiguousType19,
 						expr: &labeledExpr{
-							pos:   position{line: 1084, col: 5, offset: 30628},
+							pos:   position{line: 1079, col: 5, offset: 30400},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1084, col: 10, offset: 30633},
+								pos:  position{line: 1079, col: 10, offset: 30405},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1087, col: 5, offset: 30733},
+						pos: position{line: 1082, col: 5, offset: 30505},
 						run: (*parser).callonAmbiguousType22,
 						expr: &seqExpr{
-							pos: position{line: 1087, col: 5, offset: 30733},
+							pos: position{line: 1082, col: 5, offset: 30505},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1087, col: 5, offset: 30733},
+									pos:        position{line: 1082, col: 5, offset: 30505},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1087, col: 9, offset: 30737},
+									pos:  position{line: 1082, col: 9, offset: 30509},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1087, col: 12, offset: 30740},
+									pos:   position{line: 1082, col: 12, offset: 30512},
 									label: "u",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1087, col: 14, offset: 30742},
+										pos:  position{line: 1082, col: 14, offset: 30514},
 										name: "TypeUnion",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1087, col: 25, offset: 30753},
+									pos:        position{line: 1082, col: 25, offset: 30525},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -8316,15 +8239,15 @@ var g = &grammar{
 		},
 		{
 			name: "TypeUnion",
-			pos:  position{line: 1089, col: 1, offset: 30776},
+			pos:  position{line: 1084, col: 1, offset: 30548},
 			expr: &actionExpr{
-				pos: position{line: 1090, col: 5, offset: 30790},
+				pos: position{line: 1085, col: 5, offset: 30562},
 				run: (*parser).callonTypeUnion1,
 				expr: &labeledExpr{
-					pos:   position{line: 1090, col: 5, offset: 30790},
+					pos:   position{line: 1085, col: 5, offset: 30562},
 					label: "types",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1090, col: 11, offset: 30796},
+						pos:  position{line: 1085, col: 11, offset: 30568},
 						name: "TypeList",
 					},
 				},
@@ -8332,28 +8255,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1094, col: 1, offset: 30892},
+			pos:  position{line: 1089, col: 1, offset: 30664},
 			expr: &actionExpr{
-				pos: position{line: 1095, col: 5, offset: 30905},
+				pos: position{line: 1090, col: 5, offset: 30677},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1095, col: 5, offset: 30905},
+					pos: position{line: 1090, col: 5, offset: 30677},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1095, col: 5, offset: 30905},
+							pos:   position{line: 1090, col: 5, offset: 30677},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1095, col: 11, offset: 30911},
+								pos:  position{line: 1090, col: 11, offset: 30683},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1095, col: 16, offset: 30916},
+							pos:   position{line: 1090, col: 16, offset: 30688},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1095, col: 21, offset: 30921},
+								pos: position{line: 1090, col: 21, offset: 30693},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1095, col: 21, offset: 30921},
+									pos:  position{line: 1090, col: 21, offset: 30693},
 									name: "TypeListTail",
 								},
 							},
@@ -8364,31 +8287,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1099, col: 1, offset: 31015},
+			pos:  position{line: 1094, col: 1, offset: 30787},
 			expr: &actionExpr{
-				pos: position{line: 1099, col: 16, offset: 31030},
+				pos: position{line: 1094, col: 16, offset: 30802},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1099, col: 16, offset: 31030},
+					pos: position{line: 1094, col: 16, offset: 30802},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1099, col: 16, offset: 31030},
+							pos:  position{line: 1094, col: 16, offset: 30802},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1099, col: 19, offset: 31033},
+							pos:        position{line: 1094, col: 19, offset: 30805},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1099, col: 23, offset: 31037},
+							pos:  position{line: 1094, col: 23, offset: 30809},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1099, col: 26, offset: 31040},
+							pos:   position{line: 1094, col: 26, offset: 30812},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1099, col: 30, offset: 31044},
+								pos:  position{line: 1094, col: 30, offset: 30816},
 								name: "Type",
 							},
 						},
@@ -8398,39 +8321,39 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 1101, col: 1, offset: 31070},
+			pos:  position{line: 1096, col: 1, offset: 30842},
 			expr: &choiceExpr{
-				pos: position{line: 1102, col: 5, offset: 31086},
+				pos: position{line: 1097, col: 5, offset: 30858},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1102, col: 5, offset: 31086},
+						pos: position{line: 1097, col: 5, offset: 30858},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 1102, col: 5, offset: 31086},
+							pos: position{line: 1097, col: 5, offset: 30858},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1102, col: 5, offset: 31086},
+									pos:        position{line: 1097, col: 5, offset: 30858},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1102, col: 9, offset: 31090},
+									pos:  position{line: 1097, col: 9, offset: 30862},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1102, col: 12, offset: 31093},
+									pos:   position{line: 1097, col: 12, offset: 30865},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1102, col: 19, offset: 31100},
+										pos:  position{line: 1097, col: 19, offset: 30872},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1102, col: 33, offset: 31114},
+									pos:  position{line: 1097, col: 33, offset: 30886},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1102, col: 36, offset: 31117},
+									pos:        position{line: 1097, col: 36, offset: 30889},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -8438,34 +8361,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1105, col: 5, offset: 31212},
+						pos: position{line: 1100, col: 5, offset: 30984},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 1105, col: 5, offset: 31212},
+							pos: position{line: 1100, col: 5, offset: 30984},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1105, col: 5, offset: 31212},
+									pos:        position{line: 1100, col: 5, offset: 30984},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1105, col: 9, offset: 31216},
+									pos:  position{line: 1100, col: 9, offset: 30988},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1105, col: 12, offset: 31219},
+									pos:   position{line: 1100, col: 12, offset: 30991},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1105, col: 16, offset: 31223},
+										pos:  position{line: 1100, col: 16, offset: 30995},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1105, col: 21, offset: 31228},
+									pos:  position{line: 1100, col: 21, offset: 31000},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1105, col: 24, offset: 31231},
+									pos:        position{line: 1100, col: 24, offset: 31003},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -8473,34 +8396,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1108, col: 5, offset: 31320},
+						pos: position{line: 1103, col: 5, offset: 31092},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 1108, col: 5, offset: 31320},
+							pos: position{line: 1103, col: 5, offset: 31092},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1108, col: 5, offset: 31320},
+									pos:        position{line: 1103, col: 5, offset: 31092},
 									val:        "|[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1108, col: 10, offset: 31325},
+									pos:  position{line: 1103, col: 10, offset: 31097},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1108, col: 14, offset: 31329},
+									pos:   position{line: 1103, col: 14, offset: 31101},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1108, col: 18, offset: 31333},
+										pos:  position{line: 1103, col: 18, offset: 31105},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1108, col: 23, offset: 31338},
+									pos:  position{line: 1103, col: 23, offset: 31110},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1108, col: 26, offset: 31341},
+									pos:        position{line: 1103, col: 26, offset: 31113},
 									val:        "]|",
 									ignoreCase: false,
 								},
@@ -8508,55 +8431,55 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1111, col: 5, offset: 31429},
+						pos: position{line: 1106, col: 5, offset: 31201},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 1111, col: 5, offset: 31429},
+							pos: position{line: 1106, col: 5, offset: 31201},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1111, col: 5, offset: 31429},
+									pos:        position{line: 1106, col: 5, offset: 31201},
 									val:        "|{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1111, col: 10, offset: 31434},
+									pos:  position{line: 1106, col: 10, offset: 31206},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1111, col: 13, offset: 31437},
+									pos:   position{line: 1106, col: 13, offset: 31209},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1111, col: 21, offset: 31445},
+										pos:  position{line: 1106, col: 21, offset: 31217},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1111, col: 26, offset: 31450},
+									pos:  position{line: 1106, col: 26, offset: 31222},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1111, col: 29, offset: 31453},
+									pos:        position{line: 1106, col: 29, offset: 31225},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1111, col: 33, offset: 31457},
+									pos:  position{line: 1106, col: 33, offset: 31229},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1111, col: 36, offset: 31460},
+									pos:   position{line: 1106, col: 36, offset: 31232},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1111, col: 44, offset: 31468},
+										pos:  position{line: 1106, col: 44, offset: 31240},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1111, col: 49, offset: 31473},
+									pos:  position{line: 1106, col: 49, offset: 31245},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1111, col: 52, offset: 31476},
+									pos:        position{line: 1106, col: 52, offset: 31248},
 									val:        "}|",
 									ignoreCase: false,
 								},
@@ -8568,15 +8491,15 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateLiteral",
-			pos:  position{line: 1115, col: 1, offset: 31590},
+			pos:  position{line: 1110, col: 1, offset: 31362},
 			expr: &actionExpr{
-				pos: position{line: 1116, col: 5, offset: 31610},
+				pos: position{line: 1111, col: 5, offset: 31382},
 				run: (*parser).callonTemplateLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1116, col: 5, offset: 31610},
+					pos:   position{line: 1111, col: 5, offset: 31382},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1116, col: 7, offset: 31612},
+						pos:  position{line: 1111, col: 7, offset: 31384},
 						name: "TemplateLiteralParts",
 					},
 				},
@@ -8584,34 +8507,34 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateLiteralParts",
-			pos:  position{line: 1123, col: 1, offset: 31828},
+			pos:  position{line: 1118, col: 1, offset: 31600},
 			expr: &choiceExpr{
-				pos: position{line: 1124, col: 5, offset: 31853},
+				pos: position{line: 1119, col: 5, offset: 31625},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1124, col: 5, offset: 31853},
+						pos: position{line: 1119, col: 5, offset: 31625},
 						run: (*parser).callonTemplateLiteralParts2,
 						expr: &seqExpr{
-							pos: position{line: 1124, col: 5, offset: 31853},
+							pos: position{line: 1119, col: 5, offset: 31625},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1124, col: 5, offset: 31853},
+									pos:        position{line: 1119, col: 5, offset: 31625},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1124, col: 9, offset: 31857},
+									pos:   position{line: 1119, col: 9, offset: 31629},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1124, col: 11, offset: 31859},
+										pos: position{line: 1119, col: 11, offset: 31631},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1124, col: 11, offset: 31859},
+											pos:  position{line: 1119, col: 11, offset: 31631},
 											name: "TemplateDoubleQuotedPart",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1124, col: 37, offset: 31885},
+									pos:        position{line: 1119, col: 37, offset: 31657},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -8619,29 +8542,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1125, col: 5, offset: 31911},
+						pos: position{line: 1120, col: 5, offset: 31683},
 						run: (*parser).callonTemplateLiteralParts9,
 						expr: &seqExpr{
-							pos: position{line: 1125, col: 5, offset: 31911},
+							pos: position{line: 1120, col: 5, offset: 31683},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1125, col: 5, offset: 31911},
+									pos:        position{line: 1120, col: 5, offset: 31683},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1125, col: 9, offset: 31915},
+									pos:   position{line: 1120, col: 9, offset: 31687},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1125, col: 11, offset: 31917},
+										pos: position{line: 1120, col: 11, offset: 31689},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1125, col: 11, offset: 31917},
+											pos:  position{line: 1120, col: 11, offset: 31689},
 											name: "TemplateSingleQuotedPart",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1125, col: 37, offset: 31943},
+									pos:        position{line: 1120, col: 37, offset: 31715},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -8653,24 +8576,24 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateDoubleQuotedPart",
-			pos:  position{line: 1127, col: 1, offset: 31966},
+			pos:  position{line: 1122, col: 1, offset: 31738},
 			expr: &choiceExpr{
-				pos: position{line: 1128, col: 5, offset: 31995},
+				pos: position{line: 1123, col: 5, offset: 31767},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1128, col: 5, offset: 31995},
+						pos:  position{line: 1123, col: 5, offset: 31767},
 						name: "TemplateExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1129, col: 5, offset: 32012},
+						pos: position{line: 1124, col: 5, offset: 31784},
 						run: (*parser).callonTemplateDoubleQuotedPart3,
 						expr: &labeledExpr{
-							pos:   position{line: 1129, col: 5, offset: 32012},
+							pos:   position{line: 1124, col: 5, offset: 31784},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1129, col: 7, offset: 32014},
+								pos: position{line: 1124, col: 7, offset: 31786},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1129, col: 7, offset: 32014},
+									pos:  position{line: 1124, col: 7, offset: 31786},
 									name: "TemplateDoubleQuotedChar",
 								},
 							},
@@ -8681,26 +8604,26 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateDoubleQuotedChar",
-			pos:  position{line: 1133, col: 1, offset: 32151},
+			pos:  position{line: 1128, col: 1, offset: 31923},
 			expr: &choiceExpr{
-				pos: position{line: 1134, col: 5, offset: 32180},
+				pos: position{line: 1129, col: 5, offset: 31952},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1134, col: 5, offset: 32180},
+						pos: position{line: 1129, col: 5, offset: 31952},
 						run: (*parser).callonTemplateDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1134, col: 5, offset: 32180},
+							pos: position{line: 1129, col: 5, offset: 31952},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1134, col: 5, offset: 32180},
+									pos:        position{line: 1129, col: 5, offset: 31952},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1134, col: 10, offset: 32185},
+									pos:   position{line: 1129, col: 10, offset: 31957},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1134, col: 12, offset: 32187},
+										pos:        position{line: 1129, col: 12, offset: 31959},
 										val:        "${",
 										ignoreCase: false,
 									},
@@ -8709,24 +8632,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1135, col: 5, offset: 32214},
+						pos: position{line: 1130, col: 5, offset: 31986},
 						run: (*parser).callonTemplateDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1135, col: 5, offset: 32214},
+							pos: position{line: 1130, col: 5, offset: 31986},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1135, col: 5, offset: 32214},
+									pos: position{line: 1130, col: 5, offset: 31986},
 									expr: &litMatcher{
-										pos:        position{line: 1135, col: 8, offset: 32217},
+										pos:        position{line: 1130, col: 8, offset: 31989},
 										val:        "${",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1135, col: 15, offset: 32224},
+									pos:   position{line: 1130, col: 15, offset: 31996},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1135, col: 17, offset: 32226},
+										pos:  position{line: 1130, col: 17, offset: 31998},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -8738,24 +8661,24 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateSingleQuotedPart",
-			pos:  position{line: 1137, col: 1, offset: 32262},
+			pos:  position{line: 1132, col: 1, offset: 32034},
 			expr: &choiceExpr{
-				pos: position{line: 1138, col: 5, offset: 32291},
+				pos: position{line: 1133, col: 5, offset: 32063},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1138, col: 5, offset: 32291},
+						pos:  position{line: 1133, col: 5, offset: 32063},
 						name: "TemplateExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1139, col: 5, offset: 32308},
+						pos: position{line: 1134, col: 5, offset: 32080},
 						run: (*parser).callonTemplateSingleQuotedPart3,
 						expr: &labeledExpr{
-							pos:   position{line: 1139, col: 5, offset: 32308},
+							pos:   position{line: 1134, col: 5, offset: 32080},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1139, col: 7, offset: 32310},
+								pos: position{line: 1134, col: 7, offset: 32082},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1139, col: 7, offset: 32310},
+									pos:  position{line: 1134, col: 7, offset: 32082},
 									name: "TemplateSingleQuotedChar",
 								},
 							},
@@ -8766,26 +8689,26 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateSingleQuotedChar",
-			pos:  position{line: 1143, col: 1, offset: 32447},
+			pos:  position{line: 1138, col: 1, offset: 32219},
 			expr: &choiceExpr{
-				pos: position{line: 1144, col: 5, offset: 32476},
+				pos: position{line: 1139, col: 5, offset: 32248},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1144, col: 5, offset: 32476},
+						pos: position{line: 1139, col: 5, offset: 32248},
 						run: (*parser).callonTemplateSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1144, col: 5, offset: 32476},
+							pos: position{line: 1139, col: 5, offset: 32248},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1144, col: 5, offset: 32476},
+									pos:        position{line: 1139, col: 5, offset: 32248},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1144, col: 10, offset: 32481},
+									pos:   position{line: 1139, col: 10, offset: 32253},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1144, col: 12, offset: 32483},
+										pos:        position{line: 1139, col: 12, offset: 32255},
 										val:        "${",
 										ignoreCase: false,
 									},
@@ -8794,24 +8717,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1145, col: 5, offset: 32510},
+						pos: position{line: 1140, col: 5, offset: 32282},
 						run: (*parser).callonTemplateSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1145, col: 5, offset: 32510},
+							pos: position{line: 1140, col: 5, offset: 32282},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1145, col: 5, offset: 32510},
+									pos: position{line: 1140, col: 5, offset: 32282},
 									expr: &litMatcher{
-										pos:        position{line: 1145, col: 8, offset: 32513},
+										pos:        position{line: 1140, col: 8, offset: 32285},
 										val:        "${",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1145, col: 15, offset: 32520},
+									pos:   position{line: 1140, col: 15, offset: 32292},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1145, col: 17, offset: 32522},
+										pos:  position{line: 1140, col: 17, offset: 32294},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -8823,36 +8746,36 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateExpr",
-			pos:  position{line: 1147, col: 1, offset: 32558},
+			pos:  position{line: 1142, col: 1, offset: 32330},
 			expr: &actionExpr{
-				pos: position{line: 1148, col: 5, offset: 32575},
+				pos: position{line: 1143, col: 5, offset: 32347},
 				run: (*parser).callonTemplateExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1148, col: 5, offset: 32575},
+					pos: position{line: 1143, col: 5, offset: 32347},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1148, col: 5, offset: 32575},
+							pos:        position{line: 1143, col: 5, offset: 32347},
 							val:        "${",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1148, col: 10, offset: 32580},
+							pos:  position{line: 1143, col: 10, offset: 32352},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1148, col: 13, offset: 32583},
+							pos:   position{line: 1143, col: 13, offset: 32355},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1148, col: 15, offset: 32585},
+								pos:  position{line: 1143, col: 15, offset: 32357},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1148, col: 20, offset: 32590},
+							pos:  position{line: 1143, col: 20, offset: 32362},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1148, col: 23, offset: 32593},
+							pos:        position{line: 1143, col: 23, offset: 32365},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -8862,110 +8785,110 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1163, col: 1, offset: 32889},
+			pos:  position{line: 1158, col: 1, offset: 32661},
 			expr: &actionExpr{
-				pos: position{line: 1164, col: 5, offset: 32907},
+				pos: position{line: 1159, col: 5, offset: 32679},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1164, col: 9, offset: 32911},
+					pos: position{line: 1159, col: 9, offset: 32683},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1164, col: 9, offset: 32911},
+							pos:        position{line: 1159, col: 9, offset: 32683},
 							val:        "uint8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1164, col: 19, offset: 32921},
+							pos:        position{line: 1159, col: 19, offset: 32693},
 							val:        "uint16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1164, col: 30, offset: 32932},
+							pos:        position{line: 1159, col: 30, offset: 32704},
 							val:        "uint32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1164, col: 41, offset: 32943},
+							pos:        position{line: 1159, col: 41, offset: 32715},
 							val:        "uint64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1165, col: 9, offset: 32960},
+							pos:        position{line: 1160, col: 9, offset: 32732},
 							val:        "int8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1165, col: 18, offset: 32969},
+							pos:        position{line: 1160, col: 18, offset: 32741},
 							val:        "int16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1165, col: 28, offset: 32979},
+							pos:        position{line: 1160, col: 28, offset: 32751},
 							val:        "int32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1165, col: 38, offset: 32989},
+							pos:        position{line: 1160, col: 38, offset: 32761},
 							val:        "int64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1166, col: 9, offset: 33005},
+							pos:        position{line: 1161, col: 9, offset: 32777},
 							val:        "float16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1166, col: 21, offset: 33017},
+							pos:        position{line: 1161, col: 21, offset: 32789},
 							val:        "float32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1166, col: 33, offset: 33029},
+							pos:        position{line: 1161, col: 33, offset: 32801},
 							val:        "float64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1167, col: 9, offset: 33047},
+							pos:        position{line: 1162, col: 9, offset: 32819},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1167, col: 18, offset: 33056},
+							pos:        position{line: 1162, col: 18, offset: 32828},
 							val:        "string",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1168, col: 9, offset: 33073},
+							pos:        position{line: 1163, col: 9, offset: 32845},
 							val:        "duration",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1168, col: 22, offset: 33086},
+							pos:        position{line: 1163, col: 22, offset: 32858},
 							val:        "time",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1169, col: 9, offset: 33101},
+							pos:        position{line: 1164, col: 9, offset: 32873},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1170, col: 9, offset: 33117},
+							pos:        position{line: 1165, col: 9, offset: 32889},
 							val:        "ip",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1170, col: 16, offset: 33124},
+							pos:        position{line: 1165, col: 16, offset: 32896},
 							val:        "net",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1171, col: 9, offset: 33138},
+							pos:        position{line: 1166, col: 9, offset: 32910},
 							val:        "type",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1171, col: 18, offset: 33147},
+							pos:        position{line: 1166, col: 18, offset: 32919},
 							val:        "null",
 							ignoreCase: false,
 						},
@@ -8975,31 +8898,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1175, col: 1, offset: 33263},
+			pos:  position{line: 1170, col: 1, offset: 33035},
 			expr: &choiceExpr{
-				pos: position{line: 1176, col: 5, offset: 33281},
+				pos: position{line: 1171, col: 5, offset: 33053},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1176, col: 5, offset: 33281},
+						pos: position{line: 1171, col: 5, offset: 33053},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1176, col: 5, offset: 33281},
+							pos: position{line: 1171, col: 5, offset: 33053},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1176, col: 5, offset: 33281},
+									pos:   position{line: 1171, col: 5, offset: 33053},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1176, col: 11, offset: 33287},
+										pos:  position{line: 1171, col: 11, offset: 33059},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1176, col: 21, offset: 33297},
+									pos:   position{line: 1171, col: 21, offset: 33069},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1176, col: 26, offset: 33302},
+										pos: position{line: 1171, col: 26, offset: 33074},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1176, col: 26, offset: 33302},
+											pos:  position{line: 1171, col: 26, offset: 33074},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -9008,10 +8931,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1179, col: 5, offset: 33404},
+						pos: position{line: 1174, col: 5, offset: 33176},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1179, col: 5, offset: 33404},
+							pos:        position{line: 1174, col: 5, offset: 33176},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -9021,31 +8944,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1181, col: 1, offset: 33428},
+			pos:  position{line: 1176, col: 1, offset: 33200},
 			expr: &actionExpr{
-				pos: position{line: 1181, col: 21, offset: 33448},
+				pos: position{line: 1176, col: 21, offset: 33220},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1181, col: 21, offset: 33448},
+					pos: position{line: 1176, col: 21, offset: 33220},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1181, col: 21, offset: 33448},
+							pos:  position{line: 1176, col: 21, offset: 33220},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1181, col: 24, offset: 33451},
+							pos:        position{line: 1176, col: 24, offset: 33223},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1181, col: 28, offset: 33455},
+							pos:  position{line: 1176, col: 28, offset: 33227},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1181, col: 31, offset: 33458},
+							pos:   position{line: 1176, col: 31, offset: 33230},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1181, col: 35, offset: 33462},
+								pos:  position{line: 1176, col: 35, offset: 33234},
 								name: "TypeField",
 							},
 						},
@@ -9055,39 +8978,39 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1183, col: 1, offset: 33493},
+			pos:  position{line: 1178, col: 1, offset: 33265},
 			expr: &actionExpr{
-				pos: position{line: 1184, col: 5, offset: 33507},
+				pos: position{line: 1179, col: 5, offset: 33279},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1184, col: 5, offset: 33507},
+					pos: position{line: 1179, col: 5, offset: 33279},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1184, col: 5, offset: 33507},
+							pos:   position{line: 1179, col: 5, offset: 33279},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1184, col: 10, offset: 33512},
+								pos:  position{line: 1179, col: 10, offset: 33284},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1184, col: 20, offset: 33522},
+							pos:  position{line: 1179, col: 20, offset: 33294},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1184, col: 23, offset: 33525},
+							pos:        position{line: 1179, col: 23, offset: 33297},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1184, col: 27, offset: 33529},
+							pos:  position{line: 1179, col: 27, offset: 33301},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1184, col: 30, offset: 33532},
+							pos:   position{line: 1179, col: 30, offset: 33304},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1184, col: 34, offset: 33536},
+								pos:  position{line: 1179, col: 34, offset: 33308},
 								name: "Type",
 							},
 						},
@@ -9097,16 +9020,16 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 1188, col: 1, offset: 33618},
+			pos:  position{line: 1183, col: 1, offset: 33390},
 			expr: &choiceExpr{
-				pos: position{line: 1189, col: 5, offset: 33632},
+				pos: position{line: 1184, col: 5, offset: 33404},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1189, col: 5, offset: 33632},
+						pos:  position{line: 1184, col: 5, offset: 33404},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1190, col: 5, offset: 33651},
+						pos:  position{line: 1185, col: 5, offset: 33423},
 						name: "QuotedString",
 					},
 				},
@@ -9114,32 +9037,32 @@ var g = &grammar{
 		},
 		{
 			name: "AndToken",
-			pos:  position{line: 1192, col: 1, offset: 33665},
+			pos:  position{line: 1187, col: 1, offset: 33437},
 			expr: &actionExpr{
-				pos: position{line: 1192, col: 12, offset: 33676},
+				pos: position{line: 1187, col: 12, offset: 33448},
 				run: (*parser).callonAndToken1,
 				expr: &seqExpr{
-					pos: position{line: 1192, col: 12, offset: 33676},
+					pos: position{line: 1187, col: 12, offset: 33448},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 1192, col: 13, offset: 33677},
+							pos: position{line: 1187, col: 13, offset: 33449},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1192, col: 13, offset: 33677},
+									pos:        position{line: 1187, col: 13, offset: 33449},
 									val:        "and",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1192, col: 21, offset: 33685},
+									pos:        position{line: 1187, col: 21, offset: 33457},
 									val:        "AND",
 									ignoreCase: false,
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1192, col: 28, offset: 33692},
+							pos: position{line: 1187, col: 28, offset: 33464},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1192, col: 29, offset: 33693},
+								pos:  position{line: 1187, col: 29, offset: 33465},
 								name: "IdentifierRest",
 							},
 						},
@@ -9149,32 +9072,32 @@ var g = &grammar{
 		},
 		{
 			name: "OrToken",
-			pos:  position{line: 1193, col: 1, offset: 33730},
+			pos:  position{line: 1188, col: 1, offset: 33502},
 			expr: &actionExpr{
-				pos: position{line: 1193, col: 11, offset: 33740},
+				pos: position{line: 1188, col: 11, offset: 33512},
 				run: (*parser).callonOrToken1,
 				expr: &seqExpr{
-					pos: position{line: 1193, col: 11, offset: 33740},
+					pos: position{line: 1188, col: 11, offset: 33512},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 1193, col: 12, offset: 33741},
+							pos: position{line: 1188, col: 12, offset: 33513},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1193, col: 12, offset: 33741},
+									pos:        position{line: 1188, col: 12, offset: 33513},
 									val:        "or",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1193, col: 19, offset: 33748},
+									pos:        position{line: 1188, col: 19, offset: 33520},
 									val:        "OR",
 									ignoreCase: false,
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1193, col: 25, offset: 33754},
+							pos: position{line: 1188, col: 25, offset: 33526},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1193, col: 26, offset: 33755},
+								pos:  position{line: 1188, col: 26, offset: 33527},
 								name: "IdentifierRest",
 							},
 						},
@@ -9184,22 +9107,22 @@ var g = &grammar{
 		},
 		{
 			name: "InToken",
-			pos:  position{line: 1194, col: 1, offset: 33791},
+			pos:  position{line: 1189, col: 1, offset: 33563},
 			expr: &actionExpr{
-				pos: position{line: 1194, col: 11, offset: 33801},
+				pos: position{line: 1189, col: 11, offset: 33573},
 				run: (*parser).callonInToken1,
 				expr: &seqExpr{
-					pos: position{line: 1194, col: 11, offset: 33801},
+					pos: position{line: 1189, col: 11, offset: 33573},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1194, col: 11, offset: 33801},
+							pos:        position{line: 1189, col: 11, offset: 33573},
 							val:        "in",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1194, col: 16, offset: 33806},
+							pos: position{line: 1189, col: 16, offset: 33578},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1194, col: 17, offset: 33807},
+								pos:  position{line: 1189, col: 17, offset: 33579},
 								name: "IdentifierRest",
 							},
 						},
@@ -9209,32 +9132,32 @@ var g = &grammar{
 		},
 		{
 			name: "NotToken",
-			pos:  position{line: 1195, col: 1, offset: 33843},
+			pos:  position{line: 1190, col: 1, offset: 33615},
 			expr: &actionExpr{
-				pos: position{line: 1195, col: 12, offset: 33854},
+				pos: position{line: 1190, col: 12, offset: 33626},
 				run: (*parser).callonNotToken1,
 				expr: &seqExpr{
-					pos: position{line: 1195, col: 12, offset: 33854},
+					pos: position{line: 1190, col: 12, offset: 33626},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 1195, col: 13, offset: 33855},
+							pos: position{line: 1190, col: 13, offset: 33627},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1195, col: 13, offset: 33855},
+									pos:        position{line: 1190, col: 13, offset: 33627},
 									val:        "not",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1195, col: 21, offset: 33863},
+									pos:        position{line: 1190, col: 21, offset: 33635},
 									val:        "NOT",
 									ignoreCase: false,
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1195, col: 28, offset: 33870},
+							pos: position{line: 1190, col: 28, offset: 33642},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1195, col: 29, offset: 33871},
+								pos:  position{line: 1190, col: 29, offset: 33643},
 								name: "IdentifierRest",
 							},
 						},
@@ -9244,22 +9167,22 @@ var g = &grammar{
 		},
 		{
 			name: "ByToken",
-			pos:  position{line: 1196, col: 1, offset: 33908},
+			pos:  position{line: 1191, col: 1, offset: 33680},
 			expr: &actionExpr{
-				pos: position{line: 1196, col: 11, offset: 33918},
+				pos: position{line: 1191, col: 11, offset: 33690},
 				run: (*parser).callonByToken1,
 				expr: &seqExpr{
-					pos: position{line: 1196, col: 11, offset: 33918},
+					pos: position{line: 1191, col: 11, offset: 33690},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1196, col: 11, offset: 33918},
+							pos:        position{line: 1191, col: 11, offset: 33690},
 							val:        "by",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1196, col: 16, offset: 33923},
+							pos: position{line: 1191, col: 16, offset: 33695},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1196, col: 17, offset: 33924},
+								pos:  position{line: 1191, col: 17, offset: 33696},
 								name: "IdentifierRest",
 							},
 						},
@@ -9269,9 +9192,9 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1198, col: 1, offset: 33961},
+			pos:  position{line: 1193, col: 1, offset: 33733},
 			expr: &charClassMatcher{
-				pos:        position{line: 1198, col: 19, offset: 33979},
+				pos:        position{line: 1193, col: 19, offset: 33751},
 				val:        "[A-Za-z_$]",
 				chars:      []rune{'_', '$'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -9281,16 +9204,16 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1200, col: 1, offset: 33991},
+			pos:  position{line: 1195, col: 1, offset: 33763},
 			expr: &choiceExpr{
-				pos: position{line: 1200, col: 18, offset: 34008},
+				pos: position{line: 1195, col: 18, offset: 33780},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1200, col: 18, offset: 34008},
+						pos:  position{line: 1195, col: 18, offset: 33780},
 						name: "IdentifierStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1200, col: 36, offset: 34026},
+						pos:        position{line: 1195, col: 36, offset: 33798},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9301,15 +9224,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1202, col: 1, offset: 34033},
+			pos:  position{line: 1197, col: 1, offset: 33805},
 			expr: &actionExpr{
-				pos: position{line: 1203, col: 5, offset: 34048},
+				pos: position{line: 1198, col: 5, offset: 33820},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1203, col: 5, offset: 34048},
+					pos:   position{line: 1198, col: 5, offset: 33820},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1203, col: 8, offset: 34051},
+						pos:  position{line: 1198, col: 8, offset: 33823},
 						name: "IdentifierName",
 					},
 				},
@@ -9317,29 +9240,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1205, col: 1, offset: 34132},
+			pos:  position{line: 1200, col: 1, offset: 33904},
 			expr: &choiceExpr{
-				pos: position{line: 1206, col: 5, offset: 34151},
+				pos: position{line: 1201, col: 5, offset: 33923},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1206, col: 5, offset: 34151},
+						pos: position{line: 1201, col: 5, offset: 33923},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1206, col: 5, offset: 34151},
+							pos: position{line: 1201, col: 5, offset: 33923},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1206, col: 5, offset: 34151},
+									pos: position{line: 1201, col: 5, offset: 33923},
 									expr: &seqExpr{
-										pos: position{line: 1206, col: 7, offset: 34153},
+										pos: position{line: 1201, col: 7, offset: 33925},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1206, col: 7, offset: 34153},
+												pos:  position{line: 1201, col: 7, offset: 33925},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1206, col: 15, offset: 34161},
+												pos: position{line: 1201, col: 15, offset: 33933},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1206, col: 16, offset: 34162},
+													pos:  position{line: 1201, col: 16, offset: 33934},
 													name: "IdentifierRest",
 												},
 											},
@@ -9347,13 +9270,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1206, col: 32, offset: 34178},
+									pos:  position{line: 1201, col: 32, offset: 33950},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1206, col: 48, offset: 34194},
+									pos: position{line: 1201, col: 48, offset: 33966},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1206, col: 48, offset: 34194},
+										pos:  position{line: 1201, col: 48, offset: 33966},
 										name: "IdentifierRest",
 									},
 								},
@@ -9361,30 +9284,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1207, col: 5, offset: 34246},
+						pos: position{line: 1202, col: 5, offset: 34018},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 1207, col: 5, offset: 34246},
+							pos:        position{line: 1202, col: 5, offset: 34018},
 							val:        "$",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1208, col: 5, offset: 34285},
+						pos: position{line: 1203, col: 5, offset: 34057},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 1208, col: 5, offset: 34285},
+							pos: position{line: 1203, col: 5, offset: 34057},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1208, col: 5, offset: 34285},
+									pos:        position{line: 1203, col: 5, offset: 34057},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1208, col: 10, offset: 34290},
+									pos:   position{line: 1203, col: 10, offset: 34062},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1208, col: 13, offset: 34293},
+										pos:  position{line: 1203, col: 13, offset: 34065},
 										name: "IDGuard",
 									},
 								},
@@ -9392,39 +9315,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1210, col: 5, offset: 34384},
+						pos: position{line: 1205, col: 5, offset: 34156},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 1210, col: 5, offset: 34384},
+							pos:        position{line: 1205, col: 5, offset: 34156},
 							val:        "type",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1211, col: 5, offset: 34426},
+						pos: position{line: 1206, col: 5, offset: 34198},
 						run: (*parser).callonIdentifierName21,
 						expr: &seqExpr{
-							pos: position{line: 1211, col: 5, offset: 34426},
+							pos: position{line: 1206, col: 5, offset: 34198},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1211, col: 5, offset: 34426},
+									pos:   position{line: 1206, col: 5, offset: 34198},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1211, col: 8, offset: 34429},
+										pos:  position{line: 1206, col: 8, offset: 34201},
 										name: "SQLTokenSentinels",
 									},
 								},
 								&andExpr{
-									pos: position{line: 1211, col: 26, offset: 34447},
+									pos: position{line: 1206, col: 26, offset: 34219},
 									expr: &seqExpr{
-										pos: position{line: 1211, col: 28, offset: 34449},
+										pos: position{line: 1206, col: 28, offset: 34221},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1211, col: 28, offset: 34449},
+												pos:  position{line: 1206, col: 28, offset: 34221},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1211, col: 31, offset: 34452},
+												pos:        position{line: 1206, col: 31, offset: 34224},
 												val:        "(",
 												ignoreCase: false,
 											},
@@ -9439,50 +9362,50 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierNames",
-			pos:  position{line: 1213, col: 1, offset: 34477},
+			pos:  position{line: 1208, col: 1, offset: 34249},
 			expr: &actionExpr{
-				pos: position{line: 1214, col: 5, offset: 34497},
+				pos: position{line: 1209, col: 5, offset: 34269},
 				run: (*parser).callonIdentifierNames1,
 				expr: &seqExpr{
-					pos: position{line: 1214, col: 5, offset: 34497},
+					pos: position{line: 1209, col: 5, offset: 34269},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1214, col: 5, offset: 34497},
+							pos:   position{line: 1209, col: 5, offset: 34269},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1214, col: 11, offset: 34503},
+								pos:  position{line: 1209, col: 11, offset: 34275},
 								name: "IdentifierName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1214, col: 26, offset: 34518},
+							pos:   position{line: 1209, col: 26, offset: 34290},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1214, col: 31, offset: 34523},
+								pos: position{line: 1209, col: 31, offset: 34295},
 								expr: &actionExpr{
-									pos: position{line: 1214, col: 32, offset: 34524},
+									pos: position{line: 1209, col: 32, offset: 34296},
 									run: (*parser).callonIdentifierNames7,
 									expr: &seqExpr{
-										pos: position{line: 1214, col: 32, offset: 34524},
+										pos: position{line: 1209, col: 32, offset: 34296},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1214, col: 32, offset: 34524},
+												pos:  position{line: 1209, col: 32, offset: 34296},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1214, col: 35, offset: 34527},
+												pos:        position{line: 1209, col: 35, offset: 34299},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1214, col: 39, offset: 34531},
+												pos:  position{line: 1209, col: 39, offset: 34303},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1214, col: 42, offset: 34534},
+												pos:   position{line: 1209, col: 42, offset: 34306},
 												label: "id",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1214, col: 45, offset: 34537},
+													pos:  position{line: 1209, col: 45, offset: 34309},
 													name: "IdentifierName",
 												},
 											},
@@ -9497,24 +9420,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1218, col: 1, offset: 34652},
+			pos:  position{line: 1213, col: 1, offset: 34424},
 			expr: &choiceExpr{
-				pos: position{line: 1219, col: 5, offset: 34664},
+				pos: position{line: 1214, col: 5, offset: 34436},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1219, col: 5, offset: 34664},
+						pos:  position{line: 1214, col: 5, offset: 34436},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1220, col: 5, offset: 34683},
+						pos:  position{line: 1215, col: 5, offset: 34455},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1221, col: 5, offset: 34699},
+						pos:  position{line: 1216, col: 5, offset: 34471},
 						name: "NaN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1222, col: 5, offset: 34707},
+						pos:  position{line: 1217, col: 5, offset: 34479},
 						name: "Infinity",
 					},
 				},
@@ -9522,24 +9445,24 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1224, col: 1, offset: 34717},
+			pos:  position{line: 1219, col: 1, offset: 34489},
 			expr: &actionExpr{
-				pos: position{line: 1225, col: 5, offset: 34726},
+				pos: position{line: 1220, col: 5, offset: 34498},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1225, col: 5, offset: 34726},
+					pos: position{line: 1220, col: 5, offset: 34498},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1225, col: 5, offset: 34726},
+							pos:  position{line: 1220, col: 5, offset: 34498},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1225, col: 14, offset: 34735},
+							pos:        position{line: 1220, col: 14, offset: 34507},
 							val:        "T",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1225, col: 18, offset: 34739},
+							pos:  position{line: 1220, col: 18, offset: 34511},
 							name: "FullTime",
 						},
 					},
@@ -9548,30 +9471,30 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1229, col: 1, offset: 34859},
+			pos:  position{line: 1224, col: 1, offset: 34631},
 			expr: &seqExpr{
-				pos: position{line: 1229, col: 12, offset: 34870},
+				pos: position{line: 1224, col: 12, offset: 34642},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1229, col: 12, offset: 34870},
+						pos:  position{line: 1224, col: 12, offset: 34642},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1229, col: 15, offset: 34873},
+						pos:        position{line: 1224, col: 15, offset: 34645},
 						val:        "-",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1229, col: 19, offset: 34877},
+						pos:  position{line: 1224, col: 19, offset: 34649},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1229, col: 22, offset: 34880},
+						pos:        position{line: 1224, col: 22, offset: 34652},
 						val:        "-",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1229, col: 26, offset: 34884},
+						pos:  position{line: 1224, col: 26, offset: 34656},
 						name: "D2",
 					},
 				},
@@ -9579,33 +9502,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1231, col: 1, offset: 34888},
+			pos:  position{line: 1226, col: 1, offset: 34660},
 			expr: &seqExpr{
-				pos: position{line: 1231, col: 6, offset: 34893},
+				pos: position{line: 1226, col: 6, offset: 34665},
 				exprs: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1231, col: 6, offset: 34893},
+						pos:        position{line: 1226, col: 6, offset: 34665},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1231, col: 11, offset: 34898},
+						pos:        position{line: 1226, col: 11, offset: 34670},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1231, col: 16, offset: 34903},
+						pos:        position{line: 1226, col: 16, offset: 34675},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1231, col: 21, offset: 34908},
+						pos:        position{line: 1226, col: 21, offset: 34680},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9616,19 +9539,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1232, col: 1, offset: 34914},
+			pos:  position{line: 1227, col: 1, offset: 34686},
 			expr: &seqExpr{
-				pos: position{line: 1232, col: 6, offset: 34919},
+				pos: position{line: 1227, col: 6, offset: 34691},
 				exprs: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1232, col: 6, offset: 34919},
+						pos:        position{line: 1227, col: 6, offset: 34691},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1232, col: 11, offset: 34924},
+						pos:        position{line: 1227, col: 11, offset: 34696},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9639,16 +9562,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1234, col: 1, offset: 34931},
+			pos:  position{line: 1229, col: 1, offset: 34703},
 			expr: &seqExpr{
-				pos: position{line: 1234, col: 12, offset: 34942},
+				pos: position{line: 1229, col: 12, offset: 34714},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1234, col: 12, offset: 34942},
+						pos:  position{line: 1229, col: 12, offset: 34714},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1234, col: 24, offset: 34954},
+						pos:  position{line: 1229, col: 24, offset: 34726},
 						name: "TimeOffset",
 					},
 				},
@@ -9656,46 +9579,46 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1236, col: 1, offset: 34966},
+			pos:  position{line: 1231, col: 1, offset: 34738},
 			expr: &seqExpr{
-				pos: position{line: 1236, col: 15, offset: 34980},
+				pos: position{line: 1231, col: 15, offset: 34752},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1236, col: 15, offset: 34980},
+						pos:  position{line: 1231, col: 15, offset: 34752},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1236, col: 18, offset: 34983},
+						pos:        position{line: 1231, col: 18, offset: 34755},
 						val:        ":",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1236, col: 22, offset: 34987},
+						pos:  position{line: 1231, col: 22, offset: 34759},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1236, col: 25, offset: 34990},
+						pos:        position{line: 1231, col: 25, offset: 34762},
 						val:        ":",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1236, col: 29, offset: 34994},
+						pos:  position{line: 1231, col: 29, offset: 34766},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1236, col: 32, offset: 34997},
+						pos: position{line: 1231, col: 32, offset: 34769},
 						expr: &seqExpr{
-							pos: position{line: 1236, col: 33, offset: 34998},
+							pos: position{line: 1231, col: 33, offset: 34770},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1236, col: 33, offset: 34998},
+									pos:        position{line: 1231, col: 33, offset: 34770},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1236, col: 37, offset: 35002},
+									pos: position{line: 1231, col: 37, offset: 34774},
 									expr: &charClassMatcher{
-										pos:        position{line: 1236, col: 37, offset: 35002},
+										pos:        position{line: 1231, col: 37, offset: 34774},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -9710,60 +9633,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1238, col: 1, offset: 35012},
+			pos:  position{line: 1233, col: 1, offset: 34784},
 			expr: &choiceExpr{
-				pos: position{line: 1239, col: 5, offset: 35027},
+				pos: position{line: 1234, col: 5, offset: 34799},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1239, col: 5, offset: 35027},
+						pos:        position{line: 1234, col: 5, offset: 34799},
 						val:        "Z",
 						ignoreCase: false,
 					},
 					&seqExpr{
-						pos: position{line: 1240, col: 5, offset: 35035},
+						pos: position{line: 1235, col: 5, offset: 34807},
 						exprs: []interface{}{
 							&choiceExpr{
-								pos: position{line: 1240, col: 6, offset: 35036},
+								pos: position{line: 1235, col: 6, offset: 34808},
 								alternatives: []interface{}{
 									&litMatcher{
-										pos:        position{line: 1240, col: 6, offset: 35036},
+										pos:        position{line: 1235, col: 6, offset: 34808},
 										val:        "+",
 										ignoreCase: false,
 									},
 									&litMatcher{
-										pos:        position{line: 1240, col: 12, offset: 35042},
+										pos:        position{line: 1235, col: 12, offset: 34814},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1240, col: 17, offset: 35047},
+								pos:  position{line: 1235, col: 17, offset: 34819},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1240, col: 20, offset: 35050},
+								pos:        position{line: 1235, col: 20, offset: 34822},
 								val:        ":",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1240, col: 24, offset: 35054},
+								pos:  position{line: 1235, col: 24, offset: 34826},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1240, col: 27, offset: 35057},
+								pos: position{line: 1235, col: 27, offset: 34829},
 								expr: &seqExpr{
-									pos: position{line: 1240, col: 28, offset: 35058},
+									pos: position{line: 1235, col: 28, offset: 34830},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1240, col: 28, offset: 35058},
+											pos:        position{line: 1235, col: 28, offset: 34830},
 											val:        ".",
 											ignoreCase: false,
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1240, col: 32, offset: 35062},
+											pos: position{line: 1235, col: 32, offset: 34834},
 											expr: &charClassMatcher{
-												pos:        position{line: 1240, col: 32, offset: 35062},
+												pos:        position{line: 1235, col: 32, offset: 34834},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -9780,32 +9703,32 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1242, col: 1, offset: 35072},
+			pos:  position{line: 1237, col: 1, offset: 34844},
 			expr: &actionExpr{
-				pos: position{line: 1243, col: 5, offset: 35085},
+				pos: position{line: 1238, col: 5, offset: 34857},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1243, col: 5, offset: 35085},
+					pos: position{line: 1238, col: 5, offset: 34857},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 1243, col: 5, offset: 35085},
+							pos: position{line: 1238, col: 5, offset: 34857},
 							expr: &litMatcher{
-								pos:        position{line: 1243, col: 5, offset: 35085},
+								pos:        position{line: 1238, col: 5, offset: 34857},
 								val:        "-",
 								ignoreCase: false,
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1243, col: 10, offset: 35090},
+							pos: position{line: 1238, col: 10, offset: 34862},
 							expr: &seqExpr{
-								pos: position{line: 1243, col: 11, offset: 35091},
+								pos: position{line: 1238, col: 11, offset: 34863},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1243, col: 11, offset: 35091},
+										pos:  position{line: 1238, col: 11, offset: 34863},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1243, col: 19, offset: 35099},
+										pos:  position{line: 1238, col: 19, offset: 34871},
 										name: "TimeUnit",
 									},
 								},
@@ -9817,26 +9740,26 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1247, col: 1, offset: 35225},
+			pos:  position{line: 1242, col: 1, offset: 34997},
 			expr: &seqExpr{
-				pos: position{line: 1247, col: 11, offset: 35235},
+				pos: position{line: 1242, col: 11, offset: 35007},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1247, col: 11, offset: 35235},
+						pos:  position{line: 1242, col: 11, offset: 35007},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1247, col: 16, offset: 35240},
+						pos: position{line: 1242, col: 16, offset: 35012},
 						expr: &seqExpr{
-							pos: position{line: 1247, col: 17, offset: 35241},
+							pos: position{line: 1242, col: 17, offset: 35013},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1247, col: 17, offset: 35241},
+									pos:        position{line: 1242, col: 17, offset: 35013},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1247, col: 21, offset: 35245},
+									pos:  position{line: 1242, col: 21, offset: 35017},
 									name: "UInt",
 								},
 							},
@@ -9847,52 +9770,52 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1249, col: 1, offset: 35253},
+			pos:  position{line: 1244, col: 1, offset: 35025},
 			expr: &choiceExpr{
-				pos: position{line: 1250, col: 5, offset: 35266},
+				pos: position{line: 1245, col: 5, offset: 35038},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1250, col: 5, offset: 35266},
+						pos:        position{line: 1245, col: 5, offset: 35038},
 						val:        "ns",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1251, col: 5, offset: 35275},
+						pos:        position{line: 1246, col: 5, offset: 35047},
 						val:        "us",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1252, col: 5, offset: 35284},
+						pos:        position{line: 1247, col: 5, offset: 35056},
 						val:        "ms",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1253, col: 5, offset: 35293},
+						pos:        position{line: 1248, col: 5, offset: 35065},
 						val:        "s",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1254, col: 5, offset: 35301},
+						pos:        position{line: 1249, col: 5, offset: 35073},
 						val:        "m",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1255, col: 5, offset: 35309},
+						pos:        position{line: 1250, col: 5, offset: 35081},
 						val:        "h",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1256, col: 5, offset: 35317},
+						pos:        position{line: 1251, col: 5, offset: 35089},
 						val:        "d",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1257, col: 5, offset: 35325},
+						pos:        position{line: 1252, col: 5, offset: 35097},
 						val:        "w",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1258, col: 5, offset: 35333},
+						pos:        position{line: 1253, col: 5, offset: 35105},
 						val:        "y",
 						ignoreCase: false,
 					},
@@ -9901,42 +9824,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1260, col: 1, offset: 35338},
+			pos:  position{line: 1255, col: 1, offset: 35110},
 			expr: &actionExpr{
-				pos: position{line: 1261, col: 5, offset: 35345},
+				pos: position{line: 1256, col: 5, offset: 35117},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1261, col: 5, offset: 35345},
+					pos: position{line: 1256, col: 5, offset: 35117},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1261, col: 5, offset: 35345},
+							pos:  position{line: 1256, col: 5, offset: 35117},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1261, col: 10, offset: 35350},
+							pos:        position{line: 1256, col: 10, offset: 35122},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1261, col: 14, offset: 35354},
+							pos:  position{line: 1256, col: 14, offset: 35126},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1261, col: 19, offset: 35359},
+							pos:        position{line: 1256, col: 19, offset: 35131},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1261, col: 23, offset: 35363},
+							pos:  position{line: 1256, col: 23, offset: 35135},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1261, col: 28, offset: 35368},
+							pos:        position{line: 1256, col: 28, offset: 35140},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1261, col: 32, offset: 35372},
+							pos:  position{line: 1256, col: 32, offset: 35144},
 							name: "UInt",
 						},
 					},
@@ -9945,42 +9868,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1263, col: 1, offset: 35409},
+			pos:  position{line: 1258, col: 1, offset: 35181},
 			expr: &actionExpr{
-				pos: position{line: 1264, col: 5, offset: 35417},
+				pos: position{line: 1259, col: 5, offset: 35189},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1264, col: 5, offset: 35417},
+					pos: position{line: 1259, col: 5, offset: 35189},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1264, col: 5, offset: 35417},
+							pos: position{line: 1259, col: 5, offset: 35189},
 							expr: &seqExpr{
-								pos: position{line: 1264, col: 8, offset: 35420},
+								pos: position{line: 1259, col: 8, offset: 35192},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1264, col: 8, offset: 35420},
+										pos:  position{line: 1259, col: 8, offset: 35192},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1264, col: 12, offset: 35424},
+										pos:        position{line: 1259, col: 12, offset: 35196},
 										val:        ":",
 										ignoreCase: false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1264, col: 16, offset: 35428},
+										pos:  position{line: 1259, col: 16, offset: 35200},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1264, col: 20, offset: 35432},
+										pos: position{line: 1259, col: 20, offset: 35204},
 										expr: &choiceExpr{
-											pos: position{line: 1264, col: 22, offset: 35434},
+											pos: position{line: 1259, col: 22, offset: 35206},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 1264, col: 22, offset: 35434},
+													pos:  position{line: 1259, col: 22, offset: 35206},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1264, col: 33, offset: 35445},
+													pos:        position{line: 1259, col: 33, offset: 35217},
 													val:        ":",
 													ignoreCase: false,
 												},
@@ -9991,10 +9914,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1264, col: 39, offset: 35451},
+							pos:   position{line: 1259, col: 39, offset: 35223},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1264, col: 41, offset: 35453},
+								pos:  position{line: 1259, col: 41, offset: 35225},
 								name: "IP6Variations",
 							},
 						},
@@ -10004,32 +9927,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1268, col: 1, offset: 35617},
+			pos:  position{line: 1263, col: 1, offset: 35389},
 			expr: &choiceExpr{
-				pos: position{line: 1269, col: 5, offset: 35635},
+				pos: position{line: 1264, col: 5, offset: 35407},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1269, col: 5, offset: 35635},
+						pos: position{line: 1264, col: 5, offset: 35407},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1269, col: 5, offset: 35635},
+							pos: position{line: 1264, col: 5, offset: 35407},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1269, col: 5, offset: 35635},
+									pos:   position{line: 1264, col: 5, offset: 35407},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1269, col: 7, offset: 35637},
+										pos: position{line: 1264, col: 7, offset: 35409},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1269, col: 7, offset: 35637},
+											pos:  position{line: 1264, col: 7, offset: 35409},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1269, col: 17, offset: 35647},
+									pos:   position{line: 1264, col: 17, offset: 35419},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1269, col: 19, offset: 35649},
+										pos:  position{line: 1264, col: 19, offset: 35421},
 										name: "IP6Tail",
 									},
 								},
@@ -10037,51 +9960,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1272, col: 5, offset: 35713},
+						pos: position{line: 1267, col: 5, offset: 35485},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1272, col: 5, offset: 35713},
+							pos: position{line: 1267, col: 5, offset: 35485},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1272, col: 5, offset: 35713},
+									pos:   position{line: 1267, col: 5, offset: 35485},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1272, col: 7, offset: 35715},
+										pos:  position{line: 1267, col: 7, offset: 35487},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1272, col: 11, offset: 35719},
+									pos:   position{line: 1267, col: 11, offset: 35491},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1272, col: 13, offset: 35721},
+										pos: position{line: 1267, col: 13, offset: 35493},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1272, col: 13, offset: 35721},
+											pos:  position{line: 1267, col: 13, offset: 35493},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1272, col: 23, offset: 35731},
+									pos:        position{line: 1267, col: 23, offset: 35503},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1272, col: 28, offset: 35736},
+									pos:   position{line: 1267, col: 28, offset: 35508},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1272, col: 30, offset: 35738},
+										pos: position{line: 1267, col: 30, offset: 35510},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1272, col: 30, offset: 35738},
+											pos:  position{line: 1267, col: 30, offset: 35510},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1272, col: 40, offset: 35748},
+									pos:   position{line: 1267, col: 40, offset: 35520},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1272, col: 42, offset: 35750},
+										pos:  position{line: 1267, col: 42, offset: 35522},
 										name: "IP6Tail",
 									},
 								},
@@ -10089,32 +10012,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1275, col: 5, offset: 35849},
+						pos: position{line: 1270, col: 5, offset: 35621},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1275, col: 5, offset: 35849},
+							pos: position{line: 1270, col: 5, offset: 35621},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1275, col: 5, offset: 35849},
+									pos:        position{line: 1270, col: 5, offset: 35621},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1275, col: 10, offset: 35854},
+									pos:   position{line: 1270, col: 10, offset: 35626},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1275, col: 12, offset: 35856},
+										pos: position{line: 1270, col: 12, offset: 35628},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1275, col: 12, offset: 35856},
+											pos:  position{line: 1270, col: 12, offset: 35628},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1275, col: 22, offset: 35866},
+									pos:   position{line: 1270, col: 22, offset: 35638},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1275, col: 24, offset: 35868},
+										pos:  position{line: 1270, col: 24, offset: 35640},
 										name: "IP6Tail",
 									},
 								},
@@ -10122,32 +10045,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1278, col: 5, offset: 35939},
+						pos: position{line: 1273, col: 5, offset: 35711},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1278, col: 5, offset: 35939},
+							pos: position{line: 1273, col: 5, offset: 35711},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1278, col: 5, offset: 35939},
+									pos:   position{line: 1273, col: 5, offset: 35711},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1278, col: 7, offset: 35941},
+										pos:  position{line: 1273, col: 7, offset: 35713},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1278, col: 11, offset: 35945},
+									pos:   position{line: 1273, col: 11, offset: 35717},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1278, col: 13, offset: 35947},
+										pos: position{line: 1273, col: 13, offset: 35719},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1278, col: 13, offset: 35947},
+											pos:  position{line: 1273, col: 13, offset: 35719},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1278, col: 23, offset: 35957},
+									pos:        position{line: 1273, col: 23, offset: 35729},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -10155,10 +10078,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1281, col: 5, offset: 36025},
+						pos: position{line: 1276, col: 5, offset: 35797},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 1281, col: 5, offset: 36025},
+							pos:        position{line: 1276, col: 5, offset: 35797},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -10168,16 +10091,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1285, col: 1, offset: 36062},
+			pos:  position{line: 1280, col: 1, offset: 35834},
 			expr: &choiceExpr{
-				pos: position{line: 1286, col: 5, offset: 36074},
+				pos: position{line: 1281, col: 5, offset: 35846},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1286, col: 5, offset: 36074},
+						pos:  position{line: 1281, col: 5, offset: 35846},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1287, col: 5, offset: 36081},
+						pos:  position{line: 1282, col: 5, offset: 35853},
 						name: "Hex",
 					},
 				},
@@ -10185,23 +10108,23 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1289, col: 1, offset: 36086},
+			pos:  position{line: 1284, col: 1, offset: 35858},
 			expr: &actionExpr{
-				pos: position{line: 1289, col: 12, offset: 36097},
+				pos: position{line: 1284, col: 12, offset: 35869},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1289, col: 12, offset: 36097},
+					pos: position{line: 1284, col: 12, offset: 35869},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1289, col: 12, offset: 36097},
+							pos:        position{line: 1284, col: 12, offset: 35869},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1289, col: 16, offset: 36101},
+							pos:   position{line: 1284, col: 16, offset: 35873},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1289, col: 18, offset: 36103},
+								pos:  position{line: 1284, col: 18, offset: 35875},
 								name: "Hex",
 							},
 						},
@@ -10211,23 +10134,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1291, col: 1, offset: 36141},
+			pos:  position{line: 1286, col: 1, offset: 35913},
 			expr: &actionExpr{
-				pos: position{line: 1291, col: 12, offset: 36152},
+				pos: position{line: 1286, col: 12, offset: 35924},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1291, col: 12, offset: 36152},
+					pos: position{line: 1286, col: 12, offset: 35924},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1291, col: 12, offset: 36152},
+							pos:   position{line: 1286, col: 12, offset: 35924},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1291, col: 14, offset: 36154},
+								pos:  position{line: 1286, col: 14, offset: 35926},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1291, col: 18, offset: 36158},
+							pos:        position{line: 1286, col: 18, offset: 35930},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -10237,31 +10160,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1293, col: 1, offset: 36196},
+			pos:  position{line: 1288, col: 1, offset: 35968},
 			expr: &actionExpr{
-				pos: position{line: 1294, col: 5, offset: 36207},
+				pos: position{line: 1289, col: 5, offset: 35979},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1294, col: 5, offset: 36207},
+					pos: position{line: 1289, col: 5, offset: 35979},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1294, col: 5, offset: 36207},
+							pos:   position{line: 1289, col: 5, offset: 35979},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1294, col: 7, offset: 36209},
+								pos:  position{line: 1289, col: 7, offset: 35981},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1294, col: 10, offset: 36212},
+							pos:        position{line: 1289, col: 10, offset: 35984},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1294, col: 14, offset: 36216},
+							pos:   position{line: 1289, col: 14, offset: 35988},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1294, col: 16, offset: 36218},
+								pos:  position{line: 1289, col: 16, offset: 35990},
 								name: "UInt",
 							},
 						},
@@ -10271,31 +10194,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1298, col: 1, offset: 36291},
+			pos:  position{line: 1293, col: 1, offset: 36063},
 			expr: &actionExpr{
-				pos: position{line: 1299, col: 5, offset: 36302},
+				pos: position{line: 1294, col: 5, offset: 36074},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1299, col: 5, offset: 36302},
+					pos: position{line: 1294, col: 5, offset: 36074},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1299, col: 5, offset: 36302},
+							pos:   position{line: 1294, col: 5, offset: 36074},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1299, col: 7, offset: 36304},
+								pos:  position{line: 1294, col: 7, offset: 36076},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1299, col: 11, offset: 36308},
+							pos:        position{line: 1294, col: 11, offset: 36080},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1299, col: 15, offset: 36312},
+							pos:   position{line: 1294, col: 15, offset: 36084},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1299, col: 17, offset: 36314},
+								pos:  position{line: 1294, col: 17, offset: 36086},
 								name: "UInt",
 							},
 						},
@@ -10305,15 +10228,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1303, col: 1, offset: 36377},
+			pos:  position{line: 1298, col: 1, offset: 36149},
 			expr: &actionExpr{
-				pos: position{line: 1304, col: 4, offset: 36385},
+				pos: position{line: 1299, col: 4, offset: 36157},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1304, col: 4, offset: 36385},
+					pos:   position{line: 1299, col: 4, offset: 36157},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1304, col: 6, offset: 36387},
+						pos:  position{line: 1299, col: 6, offset: 36159},
 						name: "UIntString",
 					},
 				},
@@ -10321,16 +10244,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1306, col: 1, offset: 36427},
+			pos:  position{line: 1301, col: 1, offset: 36199},
 			expr: &choiceExpr{
-				pos: position{line: 1307, col: 5, offset: 36441},
+				pos: position{line: 1302, col: 5, offset: 36213},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1307, col: 5, offset: 36441},
+						pos:  position{line: 1302, col: 5, offset: 36213},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1308, col: 5, offset: 36456},
+						pos:  position{line: 1303, col: 5, offset: 36228},
 						name: "MinusIntString",
 					},
 				},
@@ -10338,14 +10261,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1310, col: 1, offset: 36472},
+			pos:  position{line: 1305, col: 1, offset: 36244},
 			expr: &actionExpr{
-				pos: position{line: 1310, col: 14, offset: 36485},
+				pos: position{line: 1305, col: 14, offset: 36257},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1310, col: 14, offset: 36485},
+					pos: position{line: 1305, col: 14, offset: 36257},
 					expr: &charClassMatcher{
-						pos:        position{line: 1310, col: 14, offset: 36485},
+						pos:        position{line: 1305, col: 14, offset: 36257},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10356,20 +10279,20 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1312, col: 1, offset: 36524},
+			pos:  position{line: 1307, col: 1, offset: 36296},
 			expr: &actionExpr{
-				pos: position{line: 1313, col: 5, offset: 36543},
+				pos: position{line: 1308, col: 5, offset: 36315},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1313, col: 5, offset: 36543},
+					pos: position{line: 1308, col: 5, offset: 36315},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1313, col: 5, offset: 36543},
+							pos:        position{line: 1308, col: 5, offset: 36315},
 							val:        "-",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1313, col: 9, offset: 36547},
+							pos:  position{line: 1308, col: 9, offset: 36319},
 							name: "UIntString",
 						},
 					},
@@ -10378,28 +10301,28 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1315, col: 1, offset: 36590},
+			pos:  position{line: 1310, col: 1, offset: 36362},
 			expr: &choiceExpr{
-				pos: position{line: 1316, col: 5, offset: 36606},
+				pos: position{line: 1311, col: 5, offset: 36378},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1316, col: 5, offset: 36606},
+						pos: position{line: 1311, col: 5, offset: 36378},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1316, col: 5, offset: 36606},
+							pos: position{line: 1311, col: 5, offset: 36378},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1316, col: 5, offset: 36606},
+									pos: position{line: 1311, col: 5, offset: 36378},
 									expr: &litMatcher{
-										pos:        position{line: 1316, col: 5, offset: 36606},
+										pos:        position{line: 1311, col: 5, offset: 36378},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1316, col: 10, offset: 36611},
+									pos: position{line: 1311, col: 10, offset: 36383},
 									expr: &charClassMatcher{
-										pos:        position{line: 1316, col: 10, offset: 36611},
+										pos:        position{line: 1311, col: 10, offset: 36383},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10407,14 +10330,14 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1316, col: 17, offset: 36618},
+									pos:        position{line: 1311, col: 17, offset: 36390},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1316, col: 21, offset: 36622},
+									pos: position{line: 1311, col: 21, offset: 36394},
 									expr: &charClassMatcher{
-										pos:        position{line: 1316, col: 21, offset: 36622},
+										pos:        position{line: 1311, col: 21, offset: 36394},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10422,9 +10345,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1316, col: 28, offset: 36629},
+									pos: position{line: 1311, col: 28, offset: 36401},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1316, col: 28, offset: 36629},
+										pos:  position{line: 1311, col: 28, offset: 36401},
 										name: "ExponentPart",
 									},
 								},
@@ -10432,28 +10355,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1319, col: 5, offset: 36688},
+						pos: position{line: 1314, col: 5, offset: 36460},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1319, col: 5, offset: 36688},
+							pos: position{line: 1314, col: 5, offset: 36460},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1319, col: 5, offset: 36688},
+									pos: position{line: 1314, col: 5, offset: 36460},
 									expr: &litMatcher{
-										pos:        position{line: 1319, col: 5, offset: 36688},
+										pos:        position{line: 1314, col: 5, offset: 36460},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1319, col: 10, offset: 36693},
+									pos:        position{line: 1314, col: 10, offset: 36465},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1319, col: 14, offset: 36697},
+									pos: position{line: 1314, col: 14, offset: 36469},
 									expr: &charClassMatcher{
-										pos:        position{line: 1319, col: 14, offset: 36697},
+										pos:        position{line: 1314, col: 14, offset: 36469},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10461,9 +10384,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1319, col: 21, offset: 36704},
+									pos: position{line: 1314, col: 21, offset: 36476},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1319, col: 21, offset: 36704},
+										pos:  position{line: 1314, col: 21, offset: 36476},
 										name: "ExponentPart",
 									},
 								},
@@ -10471,17 +10394,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1322, col: 5, offset: 36763},
+						pos: position{line: 1317, col: 5, offset: 36535},
 						run: (*parser).callonFloatString22,
 						expr: &choiceExpr{
-							pos: position{line: 1322, col: 7, offset: 36765},
+							pos: position{line: 1317, col: 7, offset: 36537},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1322, col: 7, offset: 36765},
+									pos:  position{line: 1317, col: 7, offset: 36537},
 									name: "NaN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1322, col: 13, offset: 36771},
+									pos:  position{line: 1317, col: 13, offset: 36543},
 									name: "Infinity",
 								},
 							},
@@ -10492,19 +10415,19 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1325, col: 1, offset: 36815},
+			pos:  position{line: 1320, col: 1, offset: 36587},
 			expr: &seqExpr{
-				pos: position{line: 1325, col: 16, offset: 36830},
+				pos: position{line: 1320, col: 16, offset: 36602},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1325, col: 16, offset: 36830},
+						pos:        position{line: 1320, col: 16, offset: 36602},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1325, col: 21, offset: 36835},
+						pos: position{line: 1320, col: 21, offset: 36607},
 						expr: &charClassMatcher{
-							pos:        position{line: 1325, col: 21, offset: 36835},
+							pos:        position{line: 1320, col: 21, offset: 36607},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -10512,7 +10435,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1325, col: 27, offset: 36841},
+						pos:  position{line: 1320, col: 27, offset: 36613},
 						name: "UIntString",
 					},
 				},
@@ -10520,31 +10443,31 @@ var g = &grammar{
 		},
 		{
 			name: "NaN",
-			pos:  position{line: 1327, col: 1, offset: 36853},
+			pos:  position{line: 1322, col: 1, offset: 36625},
 			expr: &litMatcher{
-				pos:        position{line: 1327, col: 7, offset: 36859},
+				pos:        position{line: 1322, col: 7, offset: 36631},
 				val:        "NaN",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "Infinity",
-			pos:  position{line: 1329, col: 1, offset: 36866},
+			pos:  position{line: 1324, col: 1, offset: 36638},
 			expr: &seqExpr{
-				pos: position{line: 1329, col: 12, offset: 36877},
+				pos: position{line: 1324, col: 12, offset: 36649},
 				exprs: []interface{}{
 					&zeroOrOneExpr{
-						pos: position{line: 1329, col: 12, offset: 36877},
+						pos: position{line: 1324, col: 12, offset: 36649},
 						expr: &choiceExpr{
-							pos: position{line: 1329, col: 13, offset: 36878},
+							pos: position{line: 1324, col: 13, offset: 36650},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1329, col: 13, offset: 36878},
+									pos:        position{line: 1324, col: 13, offset: 36650},
 									val:        "-",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1329, col: 19, offset: 36884},
+									pos:        position{line: 1324, col: 19, offset: 36656},
 									val:        "+",
 									ignoreCase: false,
 								},
@@ -10552,7 +10475,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1329, col: 25, offset: 36890},
+						pos:        position{line: 1324, col: 25, offset: 36662},
 						val:        "Inf",
 						ignoreCase: false,
 					},
@@ -10561,14 +10484,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1331, col: 1, offset: 36897},
+			pos:  position{line: 1326, col: 1, offset: 36669},
 			expr: &actionExpr{
-				pos: position{line: 1331, col: 7, offset: 36903},
+				pos: position{line: 1326, col: 7, offset: 36675},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1331, col: 7, offset: 36903},
+					pos: position{line: 1326, col: 7, offset: 36675},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1331, col: 7, offset: 36903},
+						pos:  position{line: 1326, col: 7, offset: 36675},
 						name: "HexDigit",
 					},
 				},
@@ -10576,9 +10499,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1333, col: 1, offset: 36945},
+			pos:  position{line: 1328, col: 1, offset: 36717},
 			expr: &charClassMatcher{
-				pos:        position{line: 1333, col: 12, offset: 36956},
+				pos:        position{line: 1328, col: 12, offset: 36728},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -10587,34 +10510,34 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1335, col: 1, offset: 36969},
+			pos:  position{line: 1330, col: 1, offset: 36741},
 			expr: &choiceExpr{
-				pos: position{line: 1336, col: 5, offset: 36986},
+				pos: position{line: 1331, col: 5, offset: 36758},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1336, col: 5, offset: 36986},
+						pos: position{line: 1331, col: 5, offset: 36758},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 1336, col: 5, offset: 36986},
+							pos: position{line: 1331, col: 5, offset: 36758},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1336, col: 5, offset: 36986},
+									pos:        position{line: 1331, col: 5, offset: 36758},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1336, col: 9, offset: 36990},
+									pos:   position{line: 1331, col: 9, offset: 36762},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1336, col: 11, offset: 36992},
+										pos: position{line: 1331, col: 11, offset: 36764},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1336, col: 11, offset: 36992},
+											pos:  position{line: 1331, col: 11, offset: 36764},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1336, col: 29, offset: 37010},
+									pos:        position{line: 1331, col: 29, offset: 36782},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -10622,29 +10545,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1337, col: 5, offset: 37047},
+						pos: position{line: 1332, col: 5, offset: 36819},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 1337, col: 5, offset: 37047},
+							pos: position{line: 1332, col: 5, offset: 36819},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1337, col: 5, offset: 37047},
+									pos:        position{line: 1332, col: 5, offset: 36819},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1337, col: 9, offset: 37051},
+									pos:   position{line: 1332, col: 9, offset: 36823},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1337, col: 11, offset: 37053},
+										pos: position{line: 1332, col: 11, offset: 36825},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1337, col: 11, offset: 37053},
+											pos:  position{line: 1332, col: 11, offset: 36825},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1337, col: 29, offset: 37071},
+									pos:        position{line: 1332, col: 29, offset: 36843},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -10656,55 +10579,55 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1339, col: 1, offset: 37105},
+			pos:  position{line: 1334, col: 1, offset: 36877},
 			expr: &choiceExpr{
-				pos: position{line: 1340, col: 5, offset: 37126},
+				pos: position{line: 1335, col: 5, offset: 36898},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1340, col: 5, offset: 37126},
+						pos: position{line: 1335, col: 5, offset: 36898},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1340, col: 5, offset: 37126},
+							pos: position{line: 1335, col: 5, offset: 36898},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1340, col: 5, offset: 37126},
+									pos: position{line: 1335, col: 5, offset: 36898},
 									expr: &choiceExpr{
-										pos: position{line: 1340, col: 7, offset: 37128},
+										pos: position{line: 1335, col: 7, offset: 36900},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1340, col: 7, offset: 37128},
+												pos:        position{line: 1335, col: 7, offset: 36900},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1340, col: 13, offset: 37134},
+												pos:  position{line: 1335, col: 13, offset: 36906},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1340, col: 26, offset: 37147,
+									line: 1335, col: 26, offset: 36919,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1341, col: 5, offset: 37184},
+						pos: position{line: 1336, col: 5, offset: 36956},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1341, col: 5, offset: 37184},
+							pos: position{line: 1336, col: 5, offset: 36956},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1341, col: 5, offset: 37184},
+									pos:        position{line: 1336, col: 5, offset: 36956},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1341, col: 10, offset: 37189},
+									pos:   position{line: 1336, col: 10, offset: 36961},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1341, col: 12, offset: 37191},
+										pos:  position{line: 1336, col: 12, offset: 36963},
 										name: "EscapeSequence",
 									},
 								},
@@ -10716,28 +10639,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1343, col: 1, offset: 37225},
+			pos:  position{line: 1338, col: 1, offset: 36997},
 			expr: &actionExpr{
-				pos: position{line: 1344, col: 5, offset: 37237},
+				pos: position{line: 1339, col: 5, offset: 37009},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1344, col: 5, offset: 37237},
+					pos: position{line: 1339, col: 5, offset: 37009},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1344, col: 5, offset: 37237},
+							pos:   position{line: 1339, col: 5, offset: 37009},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1344, col: 10, offset: 37242},
+								pos:  position{line: 1339, col: 10, offset: 37014},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1344, col: 23, offset: 37255},
+							pos:   position{line: 1339, col: 23, offset: 37027},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1344, col: 28, offset: 37260},
+								pos: position{line: 1339, col: 28, offset: 37032},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1344, col: 28, offset: 37260},
+									pos:  position{line: 1339, col: 28, offset: 37032},
 									name: "KeyWordRest",
 								},
 							},
@@ -10748,16 +10671,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1346, col: 1, offset: 37322},
+			pos:  position{line: 1341, col: 1, offset: 37094},
 			expr: &choiceExpr{
-				pos: position{line: 1347, col: 5, offset: 37339},
+				pos: position{line: 1342, col: 5, offset: 37111},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1347, col: 5, offset: 37339},
+						pos:  position{line: 1342, col: 5, offset: 37111},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1348, col: 5, offset: 37356},
+						pos:  position{line: 1343, col: 5, offset: 37128},
 						name: "KeyWordEsc",
 					},
 				},
@@ -10765,12 +10688,12 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1350, col: 1, offset: 37368},
+			pos:  position{line: 1345, col: 1, offset: 37140},
 			expr: &actionExpr{
-				pos: position{line: 1350, col: 16, offset: 37383},
+				pos: position{line: 1345, col: 16, offset: 37155},
 				run: (*parser).callonKeyWordChars1,
 				expr: &charClassMatcher{
-					pos:        position{line: 1350, col: 16, offset: 37383},
+					pos:        position{line: 1345, col: 16, offset: 37155},
 					val:        "[a-zA-Z_.:/%#@~]",
 					chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 					ranges:     []rune{'a', 'z', 'A', 'Z'},
@@ -10781,16 +10704,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1352, col: 1, offset: 37432},
+			pos:  position{line: 1347, col: 1, offset: 37204},
 			expr: &choiceExpr{
-				pos: position{line: 1353, col: 5, offset: 37448},
+				pos: position{line: 1348, col: 5, offset: 37220},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1353, col: 5, offset: 37448},
+						pos:  position{line: 1348, col: 5, offset: 37220},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1354, col: 5, offset: 37465},
+						pos:        position{line: 1349, col: 5, offset: 37237},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10801,30 +10724,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1356, col: 1, offset: 37472},
+			pos:  position{line: 1351, col: 1, offset: 37244},
 			expr: &actionExpr{
-				pos: position{line: 1356, col: 14, offset: 37485},
+				pos: position{line: 1351, col: 14, offset: 37257},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1356, col: 14, offset: 37485},
+					pos: position{line: 1351, col: 14, offset: 37257},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1356, col: 14, offset: 37485},
+							pos:        position{line: 1351, col: 14, offset: 37257},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1356, col: 19, offset: 37490},
+							pos:   position{line: 1351, col: 19, offset: 37262},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1356, col: 22, offset: 37493},
+								pos: position{line: 1351, col: 22, offset: 37265},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1356, col: 22, offset: 37493},
+										pos:  position{line: 1351, col: 22, offset: 37265},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1356, col: 38, offset: 37509},
+										pos:  position{line: 1351, col: 38, offset: 37281},
 										name: "EscapeSequence",
 									},
 								},
@@ -10836,42 +10759,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1358, col: 1, offset: 37545},
+			pos:  position{line: 1353, col: 1, offset: 37317},
 			expr: &actionExpr{
-				pos: position{line: 1359, col: 5, offset: 37561},
+				pos: position{line: 1354, col: 5, offset: 37333},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1359, col: 5, offset: 37561},
+					pos: position{line: 1354, col: 5, offset: 37333},
 					exprs: []interface{}{
 						&andExpr{
-							pos: position{line: 1359, col: 5, offset: 37561},
+							pos: position{line: 1354, col: 5, offset: 37333},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1359, col: 6, offset: 37562},
+								pos:  position{line: 1354, col: 6, offset: 37334},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1359, col: 22, offset: 37578},
+							pos: position{line: 1354, col: 22, offset: 37350},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1359, col: 23, offset: 37579},
+								pos:  position{line: 1354, col: 23, offset: 37351},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1359, col: 35, offset: 37591},
+							pos:   position{line: 1354, col: 35, offset: 37363},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1359, col: 40, offset: 37596},
+								pos:  position{line: 1354, col: 40, offset: 37368},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1359, col: 50, offset: 37606},
+							pos:   position{line: 1354, col: 50, offset: 37378},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1359, col: 55, offset: 37611},
+								pos: position{line: 1354, col: 55, offset: 37383},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1359, col: 55, offset: 37611},
+									pos:  position{line: 1354, col: 55, offset: 37383},
 									name: "GlobRest",
 								},
 							},
@@ -10882,27 +10805,27 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1363, col: 1, offset: 37680},
+			pos:  position{line: 1358, col: 1, offset: 37452},
 			expr: &choiceExpr{
-				pos: position{line: 1363, col: 19, offset: 37698},
+				pos: position{line: 1358, col: 19, offset: 37470},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1363, col: 19, offset: 37698},
+						pos:  position{line: 1358, col: 19, offset: 37470},
 						name: "KeyWordStart",
 					},
 					&seqExpr{
-						pos: position{line: 1363, col: 34, offset: 37713},
+						pos: position{line: 1358, col: 34, offset: 37485},
 						exprs: []interface{}{
 							&oneOrMoreExpr{
-								pos: position{line: 1363, col: 34, offset: 37713},
+								pos: position{line: 1358, col: 34, offset: 37485},
 								expr: &litMatcher{
-									pos:        position{line: 1363, col: 34, offset: 37713},
+									pos:        position{line: 1358, col: 34, offset: 37485},
 									val:        "*",
 									ignoreCase: false,
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1363, col: 39, offset: 37718},
+								pos:  position{line: 1358, col: 39, offset: 37490},
 								name: "KeyWordRest",
 							},
 						},
@@ -10912,19 +10835,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1364, col: 1, offset: 37730},
+			pos:  position{line: 1359, col: 1, offset: 37502},
 			expr: &seqExpr{
-				pos: position{line: 1364, col: 15, offset: 37744},
+				pos: position{line: 1359, col: 15, offset: 37516},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1364, col: 15, offset: 37744},
+						pos: position{line: 1359, col: 15, offset: 37516},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1364, col: 15, offset: 37744},
+							pos:  position{line: 1359, col: 15, offset: 37516},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1364, col: 28, offset: 37757},
+						pos:        position{line: 1359, col: 28, offset: 37529},
 						val:        "*",
 						ignoreCase: false,
 					},
@@ -10933,23 +10856,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1366, col: 1, offset: 37762},
+			pos:  position{line: 1361, col: 1, offset: 37534},
 			expr: &choiceExpr{
-				pos: position{line: 1367, col: 5, offset: 37776},
+				pos: position{line: 1362, col: 5, offset: 37548},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1367, col: 5, offset: 37776},
+						pos:  position{line: 1362, col: 5, offset: 37548},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1368, col: 5, offset: 37793},
+						pos:  position{line: 1363, col: 5, offset: 37565},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1369, col: 5, offset: 37805},
+						pos: position{line: 1364, col: 5, offset: 37577},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1369, col: 5, offset: 37805},
+							pos:        position{line: 1364, col: 5, offset: 37577},
 							val:        "*",
 							ignoreCase: false,
 						},
@@ -10959,16 +10882,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1371, col: 1, offset: 37829},
+			pos:  position{line: 1366, col: 1, offset: 37601},
 			expr: &choiceExpr{
-				pos: position{line: 1372, col: 5, offset: 37842},
+				pos: position{line: 1367, col: 5, offset: 37614},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1372, col: 5, offset: 37842},
+						pos:  position{line: 1367, col: 5, offset: 37614},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1373, col: 5, offset: 37856},
+						pos:        position{line: 1368, col: 5, offset: 37628},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10979,30 +10902,30 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1375, col: 1, offset: 37863},
+			pos:  position{line: 1370, col: 1, offset: 37635},
 			expr: &actionExpr{
-				pos: position{line: 1375, col: 11, offset: 37873},
+				pos: position{line: 1370, col: 11, offset: 37645},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1375, col: 11, offset: 37873},
+					pos: position{line: 1370, col: 11, offset: 37645},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1375, col: 11, offset: 37873},
+							pos:        position{line: 1370, col: 11, offset: 37645},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1375, col: 16, offset: 37878},
+							pos:   position{line: 1370, col: 16, offset: 37650},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1375, col: 19, offset: 37881},
+								pos: position{line: 1370, col: 19, offset: 37653},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1375, col: 19, offset: 37881},
+										pos:  position{line: 1370, col: 19, offset: 37653},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1375, col: 32, offset: 37894},
+										pos:  position{line: 1370, col: 32, offset: 37666},
 										name: "EscapeSequence",
 									},
 								},
@@ -11014,30 +10937,30 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1377, col: 1, offset: 37930},
+			pos:  position{line: 1372, col: 1, offset: 37702},
 			expr: &choiceExpr{
-				pos: position{line: 1378, col: 5, offset: 37945},
+				pos: position{line: 1373, col: 5, offset: 37717},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1378, col: 5, offset: 37945},
+						pos: position{line: 1373, col: 5, offset: 37717},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1378, col: 5, offset: 37945},
+							pos:        position{line: 1373, col: 5, offset: 37717},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1379, col: 5, offset: 37973},
+						pos: position{line: 1374, col: 5, offset: 37745},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1379, col: 5, offset: 37973},
+							pos:        position{line: 1374, col: 5, offset: 37745},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1380, col: 5, offset: 38003},
+						pos:        position{line: 1375, col: 5, offset: 37775},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -11048,55 +10971,55 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1383, col: 1, offset: 38010},
+			pos:  position{line: 1378, col: 1, offset: 37782},
 			expr: &choiceExpr{
-				pos: position{line: 1384, col: 5, offset: 38031},
+				pos: position{line: 1379, col: 5, offset: 37803},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1384, col: 5, offset: 38031},
+						pos: position{line: 1379, col: 5, offset: 37803},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1384, col: 5, offset: 38031},
+							pos: position{line: 1379, col: 5, offset: 37803},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1384, col: 5, offset: 38031},
+									pos: position{line: 1379, col: 5, offset: 37803},
 									expr: &choiceExpr{
-										pos: position{line: 1384, col: 7, offset: 38033},
+										pos: position{line: 1379, col: 7, offset: 37805},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1384, col: 7, offset: 38033},
+												pos:        position{line: 1379, col: 7, offset: 37805},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1384, col: 13, offset: 38039},
+												pos:  position{line: 1379, col: 13, offset: 37811},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1384, col: 26, offset: 38052,
+									line: 1379, col: 26, offset: 37824,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1385, col: 5, offset: 38089},
+						pos: position{line: 1380, col: 5, offset: 37861},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1385, col: 5, offset: 38089},
+							pos: position{line: 1380, col: 5, offset: 37861},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1385, col: 5, offset: 38089},
+									pos:        position{line: 1380, col: 5, offset: 37861},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1385, col: 10, offset: 38094},
+									pos:   position{line: 1380, col: 10, offset: 37866},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1385, col: 12, offset: 38096},
+										pos:  position{line: 1380, col: 12, offset: 37868},
 										name: "EscapeSequence",
 									},
 								},
@@ -11108,16 +11031,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1387, col: 1, offset: 38130},
+			pos:  position{line: 1382, col: 1, offset: 37902},
 			expr: &choiceExpr{
-				pos: position{line: 1388, col: 5, offset: 38149},
+				pos: position{line: 1383, col: 5, offset: 37921},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1388, col: 5, offset: 38149},
+						pos:  position{line: 1383, col: 5, offset: 37921},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1389, col: 5, offset: 38170},
+						pos:  position{line: 1384, col: 5, offset: 37942},
 						name: "UnicodeEscape",
 					},
 				},
@@ -11125,79 +11048,79 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1391, col: 1, offset: 38185},
+			pos:  position{line: 1386, col: 1, offset: 37957},
 			expr: &choiceExpr{
-				pos: position{line: 1392, col: 5, offset: 38206},
+				pos: position{line: 1387, col: 5, offset: 37978},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1392, col: 5, offset: 38206},
+						pos:        position{line: 1387, col: 5, offset: 37978},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1393, col: 5, offset: 38214},
+						pos: position{line: 1388, col: 5, offset: 37986},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1393, col: 5, offset: 38214},
+							pos:        position{line: 1388, col: 5, offset: 37986},
 							val:        "\"",
 							ignoreCase: false,
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1394, col: 5, offset: 38254},
+						pos:        position{line: 1389, col: 5, offset: 38026},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1395, col: 5, offset: 38263},
+						pos: position{line: 1390, col: 5, offset: 38035},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1395, col: 5, offset: 38263},
+							pos:        position{line: 1390, col: 5, offset: 38035},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1396, col: 5, offset: 38292},
+						pos: position{line: 1391, col: 5, offset: 38064},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1396, col: 5, offset: 38292},
+							pos:        position{line: 1391, col: 5, offset: 38064},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1397, col: 5, offset: 38321},
+						pos: position{line: 1392, col: 5, offset: 38093},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1397, col: 5, offset: 38321},
+							pos:        position{line: 1392, col: 5, offset: 38093},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1398, col: 5, offset: 38350},
+						pos: position{line: 1393, col: 5, offset: 38122},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1398, col: 5, offset: 38350},
+							pos:        position{line: 1393, col: 5, offset: 38122},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1399, col: 5, offset: 38379},
+						pos: position{line: 1394, col: 5, offset: 38151},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1399, col: 5, offset: 38379},
+							pos:        position{line: 1394, col: 5, offset: 38151},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1400, col: 5, offset: 38408},
+						pos: position{line: 1395, col: 5, offset: 38180},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1400, col: 5, offset: 38408},
+							pos:        position{line: 1395, col: 5, offset: 38180},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -11207,30 +11130,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1402, col: 1, offset: 38434},
+			pos:  position{line: 1397, col: 1, offset: 38206},
 			expr: &choiceExpr{
-				pos: position{line: 1403, col: 5, offset: 38452},
+				pos: position{line: 1398, col: 5, offset: 38224},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1403, col: 5, offset: 38452},
+						pos: position{line: 1398, col: 5, offset: 38224},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1403, col: 5, offset: 38452},
+							pos:        position{line: 1398, col: 5, offset: 38224},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1404, col: 5, offset: 38480},
+						pos: position{line: 1399, col: 5, offset: 38252},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1404, col: 5, offset: 38480},
+							pos:        position{line: 1399, col: 5, offset: 38252},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1405, col: 5, offset: 38508},
+						pos:        position{line: 1400, col: 5, offset: 38280},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -11241,41 +11164,41 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1407, col: 1, offset: 38514},
+			pos:  position{line: 1402, col: 1, offset: 38286},
 			expr: &choiceExpr{
-				pos: position{line: 1408, col: 5, offset: 38532},
+				pos: position{line: 1403, col: 5, offset: 38304},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1408, col: 5, offset: 38532},
+						pos: position{line: 1403, col: 5, offset: 38304},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1408, col: 5, offset: 38532},
+							pos: position{line: 1403, col: 5, offset: 38304},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1408, col: 5, offset: 38532},
+									pos:        position{line: 1403, col: 5, offset: 38304},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1408, col: 9, offset: 38536},
+									pos:   position{line: 1403, col: 9, offset: 38308},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1408, col: 16, offset: 38543},
+										pos: position{line: 1403, col: 16, offset: 38315},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1408, col: 16, offset: 38543},
+												pos:  position{line: 1403, col: 16, offset: 38315},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1408, col: 25, offset: 38552},
+												pos:  position{line: 1403, col: 25, offset: 38324},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1408, col: 34, offset: 38561},
+												pos:  position{line: 1403, col: 34, offset: 38333},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1408, col: 43, offset: 38570},
+												pos:  position{line: 1403, col: 43, offset: 38342},
 												name: "HexDigit",
 											},
 										},
@@ -11285,63 +11208,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1411, col: 5, offset: 38633},
+						pos: position{line: 1406, col: 5, offset: 38405},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1411, col: 5, offset: 38633},
+							pos: position{line: 1406, col: 5, offset: 38405},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1411, col: 5, offset: 38633},
+									pos:        position{line: 1406, col: 5, offset: 38405},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1411, col: 9, offset: 38637},
+									pos:        position{line: 1406, col: 9, offset: 38409},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1411, col: 13, offset: 38641},
+									pos:   position{line: 1406, col: 13, offset: 38413},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1411, col: 20, offset: 38648},
+										pos: position{line: 1406, col: 20, offset: 38420},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1411, col: 20, offset: 38648},
+												pos:  position{line: 1406, col: 20, offset: 38420},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1411, col: 29, offset: 38657},
+												pos: position{line: 1406, col: 29, offset: 38429},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1411, col: 29, offset: 38657},
+													pos:  position{line: 1406, col: 29, offset: 38429},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1411, col: 39, offset: 38667},
+												pos: position{line: 1406, col: 39, offset: 38439},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1411, col: 39, offset: 38667},
+													pos:  position{line: 1406, col: 39, offset: 38439},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1411, col: 49, offset: 38677},
+												pos: position{line: 1406, col: 49, offset: 38449},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1411, col: 49, offset: 38677},
+													pos:  position{line: 1406, col: 49, offset: 38449},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1411, col: 59, offset: 38687},
+												pos: position{line: 1406, col: 59, offset: 38459},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1411, col: 59, offset: 38687},
+													pos:  position{line: 1406, col: 59, offset: 38459},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1411, col: 69, offset: 38697},
+												pos: position{line: 1406, col: 69, offset: 38469},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1411, col: 69, offset: 38697},
+													pos:  position{line: 1406, col: 69, offset: 38469},
 													name: "HexDigit",
 												},
 											},
@@ -11349,7 +11272,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1411, col: 80, offset: 38708},
+									pos:        position{line: 1406, col: 80, offset: 38480},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -11361,35 +11284,35 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPattern",
-			pos:  position{line: 1415, col: 1, offset: 38762},
+			pos:  position{line: 1410, col: 1, offset: 38534},
 			expr: &actionExpr{
-				pos: position{line: 1416, col: 5, offset: 38780},
+				pos: position{line: 1411, col: 5, offset: 38552},
 				run: (*parser).callonRegexpPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1416, col: 5, offset: 38780},
+					pos: position{line: 1411, col: 5, offset: 38552},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1416, col: 5, offset: 38780},
+							pos:        position{line: 1411, col: 5, offset: 38552},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1416, col: 9, offset: 38784},
+							pos:   position{line: 1411, col: 9, offset: 38556},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1416, col: 14, offset: 38789},
+								pos:  position{line: 1411, col: 14, offset: 38561},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1416, col: 25, offset: 38800},
+							pos:        position{line: 1411, col: 25, offset: 38572},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1416, col: 29, offset: 38804},
+							pos: position{line: 1411, col: 29, offset: 38576},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1416, col: 30, offset: 38805},
+								pos:  position{line: 1411, col: 30, offset: 38577},
 								name: "KeyWordStart",
 							},
 						},
@@ -11399,32 +11322,32 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1418, col: 1, offset: 38840},
+			pos:  position{line: 1413, col: 1, offset: 38612},
 			expr: &actionExpr{
-				pos: position{line: 1419, col: 5, offset: 38855},
+				pos: position{line: 1414, col: 5, offset: 38627},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1419, col: 5, offset: 38855},
+					pos: position{line: 1414, col: 5, offset: 38627},
 					expr: &choiceExpr{
-						pos: position{line: 1419, col: 6, offset: 38856},
+						pos: position{line: 1414, col: 6, offset: 38628},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 1419, col: 6, offset: 38856},
+								pos:        position{line: 1414, col: 6, offset: 38628},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&seqExpr{
-								pos: position{line: 1419, col: 15, offset: 38865},
+								pos: position{line: 1414, col: 15, offset: 38637},
 								exprs: []interface{}{
 									&litMatcher{
-										pos:        position{line: 1419, col: 15, offset: 38865},
+										pos:        position{line: 1414, col: 15, offset: 38637},
 										val:        "\\",
 										ignoreCase: false,
 									},
 									&anyMatcher{
-										line: 1419, col: 20, offset: 38870,
+										line: 1414, col: 20, offset: 38642,
 									},
 								},
 							},
@@ -11435,9 +11358,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1421, col: 1, offset: 38906},
+			pos:  position{line: 1416, col: 1, offset: 38678},
 			expr: &charClassMatcher{
-				pos:        position{line: 1422, col: 5, offset: 38922},
+				pos:        position{line: 1417, col: 5, offset: 38694},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -11447,42 +11370,42 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1424, col: 1, offset: 38937},
+			pos:  position{line: 1419, col: 1, offset: 38709},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1424, col: 6, offset: 38942},
+				pos: position{line: 1419, col: 6, offset: 38714},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1424, col: 6, offset: 38942},
+					pos:  position{line: 1419, col: 6, offset: 38714},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 1426, col: 1, offset: 38953},
+			pos:  position{line: 1421, col: 1, offset: 38725},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1426, col: 6, offset: 38958},
+				pos: position{line: 1421, col: 6, offset: 38730},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1426, col: 6, offset: 38958},
+					pos:  position{line: 1421, col: 6, offset: 38730},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1428, col: 1, offset: 38969},
+			pos:  position{line: 1423, col: 1, offset: 38741},
 			expr: &choiceExpr{
-				pos: position{line: 1429, col: 5, offset: 38982},
+				pos: position{line: 1424, col: 5, offset: 38754},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1429, col: 5, offset: 38982},
+						pos:  position{line: 1424, col: 5, offset: 38754},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1430, col: 5, offset: 38997},
+						pos:  position{line: 1425, col: 5, offset: 38769},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1431, col: 5, offset: 39016},
+						pos:  position{line: 1426, col: 5, offset: 38788},
 						name: "Comment",
 					},
 				},
@@ -11490,45 +11413,45 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1433, col: 1, offset: 39025},
+			pos:  position{line: 1428, col: 1, offset: 38797},
 			expr: &anyMatcher{
-				line: 1434, col: 5, offset: 39045,
+				line: 1429, col: 5, offset: 38817,
 			},
 		},
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1436, col: 1, offset: 39048},
+			pos:         position{line: 1431, col: 1, offset: 38820},
 			expr: &choiceExpr{
-				pos: position{line: 1437, col: 5, offset: 39076},
+				pos: position{line: 1432, col: 5, offset: 38848},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1437, col: 5, offset: 39076},
+						pos:        position{line: 1432, col: 5, offset: 38848},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1438, col: 5, offset: 39085},
+						pos:        position{line: 1433, col: 5, offset: 38857},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1439, col: 5, offset: 39094},
+						pos:        position{line: 1434, col: 5, offset: 38866},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1440, col: 5, offset: 39103},
+						pos:        position{line: 1435, col: 5, offset: 38875},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1441, col: 5, offset: 39111},
+						pos:        position{line: 1436, col: 5, offset: 38883},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1442, col: 5, offset: 39124},
+						pos:        position{line: 1437, col: 5, offset: 38896},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -11537,9 +11460,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1444, col: 1, offset: 39134},
+			pos:  position{line: 1439, col: 1, offset: 38906},
 			expr: &charClassMatcher{
-				pos:        position{line: 1445, col: 5, offset: 39153},
+				pos:        position{line: 1440, col: 5, offset: 38925},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -11549,45 +11472,45 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1451, col: 1, offset: 39483},
+			pos:         position{line: 1446, col: 1, offset: 39255},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1454, col: 5, offset: 39554},
+				pos:  position{line: 1449, col: 5, offset: 39326},
 				name: "SingleLineComment",
 			},
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1456, col: 1, offset: 39573},
+			pos:  position{line: 1451, col: 1, offset: 39345},
 			expr: &seqExpr{
-				pos: position{line: 1457, col: 5, offset: 39594},
+				pos: position{line: 1452, col: 5, offset: 39366},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1457, col: 5, offset: 39594},
+						pos:        position{line: 1452, col: 5, offset: 39366},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1457, col: 10, offset: 39599},
+						pos: position{line: 1452, col: 10, offset: 39371},
 						expr: &seqExpr{
-							pos: position{line: 1457, col: 11, offset: 39600},
+							pos: position{line: 1452, col: 11, offset: 39372},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1457, col: 11, offset: 39600},
+									pos: position{line: 1452, col: 11, offset: 39372},
 									expr: &litMatcher{
-										pos:        position{line: 1457, col: 12, offset: 39601},
+										pos:        position{line: 1452, col: 12, offset: 39373},
 										val:        "*/",
 										ignoreCase: false,
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1457, col: 17, offset: 39606},
+									pos:  position{line: 1452, col: 17, offset: 39378},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1457, col: 35, offset: 39624},
+						pos:        position{line: 1452, col: 35, offset: 39396},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -11596,29 +11519,29 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1459, col: 1, offset: 39630},
+			pos:  position{line: 1454, col: 1, offset: 39402},
 			expr: &seqExpr{
-				pos: position{line: 1460, col: 5, offset: 39652},
+				pos: position{line: 1455, col: 5, offset: 39424},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1460, col: 5, offset: 39652},
+						pos:        position{line: 1455, col: 5, offset: 39424},
 						val:        "//",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1460, col: 10, offset: 39657},
+						pos: position{line: 1455, col: 10, offset: 39429},
 						expr: &seqExpr{
-							pos: position{line: 1460, col: 11, offset: 39658},
+							pos: position{line: 1455, col: 11, offset: 39430},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1460, col: 11, offset: 39658},
+									pos: position{line: 1455, col: 11, offset: 39430},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1460, col: 12, offset: 39659},
+										pos:  position{line: 1455, col: 12, offset: 39431},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1460, col: 27, offset: 39674},
+									pos:  position{line: 1455, col: 27, offset: 39446},
 									name: "SourceCharacter",
 								},
 							},
@@ -11629,19 +11552,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1462, col: 1, offset: 39693},
+			pos:  position{line: 1457, col: 1, offset: 39465},
 			expr: &seqExpr{
-				pos: position{line: 1462, col: 7, offset: 39699},
+				pos: position{line: 1457, col: 7, offset: 39471},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1462, col: 7, offset: 39699},
+						pos: position{line: 1457, col: 7, offset: 39471},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1462, col: 7, offset: 39699},
+							pos:  position{line: 1457, col: 7, offset: 39471},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1462, col: 19, offset: 39711},
+						pos:  position{line: 1457, col: 19, offset: 39483},
 						name: "LineTerminator",
 					},
 				},
@@ -11649,16 +11572,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1464, col: 1, offset: 39727},
+			pos:  position{line: 1459, col: 1, offset: 39499},
 			expr: &choiceExpr{
-				pos: position{line: 1464, col: 7, offset: 39733},
+				pos: position{line: 1459, col: 7, offset: 39505},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1464, col: 7, offset: 39733},
+						pos:  position{line: 1459, col: 7, offset: 39505},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1464, col: 11, offset: 39737},
+						pos:  position{line: 1459, col: 11, offset: 39509},
 						name: "EOF",
 					},
 				},
@@ -11666,21 +11589,21 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1466, col: 1, offset: 39742},
+			pos:  position{line: 1461, col: 1, offset: 39514},
 			expr: &notExpr{
-				pos: position{line: 1466, col: 7, offset: 39748},
+				pos: position{line: 1461, col: 7, offset: 39520},
 				expr: &anyMatcher{
-					line: 1466, col: 8, offset: 39749,
+					line: 1461, col: 8, offset: 39521,
 				},
 			},
 		},
 		{
 			name: "EOKW",
-			pos:  position{line: 1468, col: 1, offset: 39752},
+			pos:  position{line: 1463, col: 1, offset: 39524},
 			expr: &notExpr{
-				pos: position{line: 1468, col: 8, offset: 39759},
+				pos: position{line: 1463, col: 8, offset: 39531},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1468, col: 9, offset: 39760},
+					pos:  position{line: 1463, col: 9, offset: 39532},
 					name: "KeyWordChars",
 				},
 			},
@@ -12766,15 +12689,15 @@ func (p *parser) callonPool1() (interface{}, error) {
 	return p.cur.onPool1(stack["body"])
 }
 
-func (c *current) onPoolBody1(spec, at, over, order interface{}) (interface{}, error) {
-	return map[string]interface{}{"kind": "Pool", "spec": spec, "at": at, "range": over, "scan_order": order}, nil
+func (c *current) onPoolBody1(spec, at interface{}) (interface{}, error) {
+	return map[string]interface{}{"kind": "Pool", "spec": spec, "at": at}, nil
 
 }
 
 func (p *parser) callonPoolBody1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onPoolBody1(stack["spec"], stack["at"], stack["over"], stack["order"])
+	return p.cur.onPoolBody1(stack["spec"], stack["at"])
 }
 
 func (c *current) onGet1(url, format, layout interface{}) (interface{}, error) {
@@ -12836,17 +12759,6 @@ func (p *parser) callonKSUID1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onKSUID1()
-}
-
-func (c *current) onPoolRange1(lower, upper interface{}) (interface{}, error) {
-	return map[string]interface{}{"kind": "Range", "lower": lower, "upper": upper}, nil
-
-}
-
-func (p *parser) callonPoolRange1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onPoolRange1(stack["lower"], stack["upper"])
 }
 
 func (c *current) onPoolSpec2(pool, commit, meta interface{}) (interface{}, error) {

--- a/compiler/parser/parser.js
+++ b/compiler/parser/parser.js
@@ -562,8 +562,8 @@ function peg$parse(input, options) {
       peg$c200 = function(body) { return body },
       peg$c201 = "pool",
       peg$c202 = peg$literalExpectation("pool", false),
-      peg$c203 = function(spec, at, over, order) {
-            return {"kind": "Pool", "spec": spec, "at": at, "range": over, "scan_order": order}
+      peg$c203 = function(spec, at) {
+            return {"kind": "Pool", "spec": spec, "at": at}
           },
       peg$c204 = "get",
       peg$c205 = peg$literalExpectation("get", false),
@@ -581,86 +581,79 @@ function peg$parse(input, options) {
       peg$c215 = function(id) { return id },
       peg$c216 = /^[0-9a-zA-Z]/,
       peg$c217 = peg$classExpectation([["0", "9"], ["a", "z"], ["A", "Z"]], false, false),
-      peg$c218 = "range",
-      peg$c219 = peg$literalExpectation("range", false),
-      peg$c220 = "to",
-      peg$c221 = peg$literalExpectation("to", false),
-      peg$c222 = function(lower, upper) {
-            return {"kind":"Range","lower": lower, "upper": upper}
-          },
-      peg$c223 = function(pool, commit, meta) {
+      peg$c218 = function(pool, commit, meta) {
             return {"pool": pool, "commit": commit, "meta": meta}
           },
-      peg$c224 = function(meta) {
+      peg$c219 = function(meta) {
             return {"pool": null, "commit": null, "meta": meta}
           },
-      peg$c225 = "@",
-      peg$c226 = peg$literalExpectation("@", false),
-      peg$c227 = function(commit) { return commit },
-      peg$c228 = function(meta) { return meta },
-      peg$c229 = function() { return {"kind": "Glob", "pattern": "*"} },
-      peg$c230 = function(name) { return {"kind": "String", "text": name} },
-      peg$c231 = function() {  return text() },
-      peg$c232 = "order",
-      peg$c233 = peg$literalExpectation("order", false),
-      peg$c234 = function(keys, order) {
+      peg$c220 = "@",
+      peg$c221 = peg$literalExpectation("@", false),
+      peg$c222 = function(commit) { return commit },
+      peg$c223 = function(meta) { return meta },
+      peg$c224 = function() { return {"kind": "Glob", "pattern": "*"} },
+      peg$c225 = function(name) { return {"kind": "String", "text": name} },
+      peg$c226 = function() {  return text() },
+      peg$c227 = "order",
+      peg$c228 = peg$literalExpectation("order", false),
+      peg$c229 = function(keys, order) {
             return {"kind": "Layout", "keys": keys, "order": order}
           },
-      peg$c235 = "format",
-      peg$c236 = peg$literalExpectation("format", false),
-      peg$c237 = function(val) { return val },
-      peg$c238 = ":asc",
-      peg$c239 = peg$literalExpectation(":asc", false),
-      peg$c240 = function() { return "asc" },
-      peg$c241 = ":desc",
-      peg$c242 = peg$literalExpectation(":desc", false),
-      peg$c243 = function() { return "desc" },
-      peg$c244 = "asc",
-      peg$c245 = peg$literalExpectation("asc", false),
-      peg$c246 = "desc",
-      peg$c247 = peg$literalExpectation("desc", false),
-      peg$c248 = "pass",
-      peg$c249 = peg$literalExpectation("pass", false),
-      peg$c250 = function() {
+      peg$c230 = "format",
+      peg$c231 = peg$literalExpectation("format", false),
+      peg$c232 = function(val) { return val },
+      peg$c233 = ":asc",
+      peg$c234 = peg$literalExpectation(":asc", false),
+      peg$c235 = function() { return "asc" },
+      peg$c236 = ":desc",
+      peg$c237 = peg$literalExpectation(":desc", false),
+      peg$c238 = function() { return "desc" },
+      peg$c239 = "asc",
+      peg$c240 = peg$literalExpectation("asc", false),
+      peg$c241 = "desc",
+      peg$c242 = peg$literalExpectation("desc", false),
+      peg$c243 = "pass",
+      peg$c244 = peg$literalExpectation("pass", false),
+      peg$c245 = function() {
             return {"kind":"Pass"}
           },
-      peg$c251 = "explode",
-      peg$c252 = peg$literalExpectation("explode", false),
-      peg$c253 = function(args, typ, as) {
+      peg$c246 = "explode",
+      peg$c247 = peg$literalExpectation("explode", false),
+      peg$c248 = function(args, typ, as) {
             return {"kind":"Explode", "args": args, "as": as, "type": typ}
           },
-      peg$c254 = "merge",
-      peg$c255 = peg$literalExpectation("merge", false),
-      peg$c256 = function(expr) {
+      peg$c249 = "merge",
+      peg$c250 = peg$literalExpectation("merge", false),
+      peg$c251 = function(expr) {
       	  return {"kind":"Merge", "expr":expr}
           },
-      peg$c257 = "over",
-      peg$c258 = peg$literalExpectation("over", false),
-      peg$c259 = function(exprs, locals, scope) {
+      peg$c252 = "over",
+      peg$c253 = peg$literalExpectation("over", false),
+      peg$c254 = function(exprs, locals, scope) {
             let over = {"kind": "Over", "exprs": exprs, "scope": scope}
             if (locals) {
               return {"kind": "Let", "locals": locals, "over": over}
             }
             return over
           },
-      peg$c260 = function(seq) { return seq },
-      peg$c261 = function(first, a) { return a },
-      peg$c262 = function(name, opt) {
+      peg$c255 = function(seq) { return seq },
+      peg$c256 = function(first, a) { return a },
+      peg$c257 = function(name, opt) {
             let m = {"name": name, "expr": {"kind": "ID", "name": name}}
             if (opt) {
                m["expr"] = opt[3]
             }
             return m
           },
-      peg$c263 = "yield",
-      peg$c264 = peg$literalExpectation("yield", false),
-      peg$c265 = function(exprs) {
+      peg$c258 = "yield",
+      peg$c259 = peg$literalExpectation("yield", false),
+      peg$c260 = function(exprs) {
       	  return {"kind":"Yield", "exprs":exprs}
           },
-      peg$c266 = function(typ) { return typ},
-      peg$c267 = function(lhs) { return lhs },
-      peg$c268 = function(first, lval) { return lval },
-      peg$c269 = function(first, rest) {
+      peg$c261 = function(typ) { return typ},
+      peg$c262 = function(lhs) { return lhs },
+      peg$c263 = function(first, lval) { return lval },
+      peg$c264 = function(first, rest) {
             let result = [first]
 
             for(let  r of rest) {
@@ -669,13 +662,13 @@ function peg$parse(input, options) {
 
             return result
           },
-      peg$c270 = function(first, rest) {
+      peg$c265 = function(first, rest) {
           return [first, ... rest]
         },
-      peg$c271 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c272 = "?",
-      peg$c273 = peg$literalExpectation("?", false),
-      peg$c274 = function(cond, opt) {
+      peg$c266 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c267 = "?",
+      peg$c268 = peg$literalExpectation("?", false),
+      peg$c269 = function(cond, opt) {
             if (opt) {
               let Then = opt[3]
               let Else = opt[7]
@@ -683,12 +676,12 @@ function peg$parse(input, options) {
             }
             return cond
           },
-      peg$c275 = function(first, op, expr) { return [op, expr] },
-      peg$c276 = function(first, rest) {
+      peg$c270 = function(first, op, expr) { return [op, expr] },
+      peg$c271 = function(first, rest) {
               return makeBinaryExprChain(first, rest)
           },
-      peg$c277 = function(lhs) { return text() },
-      peg$c278 = function(lhs, opAndRHS) {
+      peg$c272 = function(lhs) { return text() },
+      peg$c273 = function(lhs, opAndRHS) {
             if (!opAndRHS) {
               return lhs
             }
@@ -696,106 +689,106 @@ function peg$parse(input, options) {
             let rhs = opAndRHS[3]
             return {"kind": "BinaryExpr", "op": op, "lhs": lhs, "rhs": rhs}
           },
-      peg$c279 = "+",
-      peg$c280 = peg$literalExpectation("+", false),
-      peg$c281 = "-",
-      peg$c282 = peg$literalExpectation("-", false),
-      peg$c283 = "/",
-      peg$c284 = peg$literalExpectation("/", false),
-      peg$c285 = "%",
-      peg$c286 = peg$literalExpectation("%", false),
-      peg$c287 = function(e) {
+      peg$c274 = "+",
+      peg$c275 = peg$literalExpectation("+", false),
+      peg$c276 = "-",
+      peg$c277 = peg$literalExpectation("-", false),
+      peg$c278 = "/",
+      peg$c279 = peg$literalExpectation("/", false),
+      peg$c280 = "%",
+      peg$c281 = peg$literalExpectation("%", false),
+      peg$c282 = function(e) {
               return {"kind": "UnaryExpr", "op": "!", "operand": e}
           },
-      peg$c288 = function(e) {
+      peg$c283 = function(e) {
               return {"kind": "UnaryExpr", "op": "-", "operand": e}
           },
-      peg$c289 = "not",
-      peg$c290 = peg$literalExpectation("not", false),
-      peg$c291 = "select",
-      peg$c292 = peg$literalExpectation("select", false),
-      peg$c293 = function(typ, expr) {
+      peg$c284 = "not",
+      peg$c285 = peg$literalExpectation("not", false),
+      peg$c286 = "select",
+      peg$c287 = peg$literalExpectation("select", false),
+      peg$c288 = function(typ, expr) {
             return {"kind": "Cast", "expr": expr, "type": typ}
           },
-      peg$c294 = "regexp",
-      peg$c295 = peg$literalExpectation("regexp", false),
-      peg$c296 = function(arg0Text, arg1, where) {
+      peg$c289 = "regexp",
+      peg$c290 = peg$literalExpectation("regexp", false),
+      peg$c291 = function(arg0Text, arg1, where) {
             let arg0 = {"kind": "Primitive", "type": "string", "text": arg0Text}
             return {"kind": "Call", "name": "regexp", "args": [arg0, arg1], "where": where}
           },
-      peg$c297 = function(fn, args, where) {
+      peg$c292 = function(fn, args, where) {
             return {"kind": "Call", "name": fn, "args": args, "where": where}
           },
-      peg$c298 = function(o) { return [o] },
-      peg$c299 = "grep",
-      peg$c300 = peg$literalExpectation("grep", false),
-      peg$c301 = function(pattern, opt) {
+      peg$c293 = function(o) { return [o] },
+      peg$c294 = "grep",
+      peg$c295 = peg$literalExpectation("grep", false),
+      peg$c296 = function(pattern, opt) {
             let m = {"kind": "Grep", "pattern": pattern, "expr": {"kind": "ID", "name": "this"}}
             if (opt) {
               m["expr"] = opt[2]
             }
             return m
           },
-      peg$c302 = function(s) {
+      peg$c297 = function(s) {
             return {"kind": "String", "text": s}
           },
-      peg$c303 = function(first, e) { return e },
-      peg$c304 = "]",
-      peg$c305 = peg$literalExpectation("]", false),
-      peg$c306 = function(from, to) {
+      peg$c298 = function(first, e) { return e },
+      peg$c299 = "]",
+      peg$c300 = peg$literalExpectation("]", false),
+      peg$c301 = function(from, to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs":to}]
           
           },
-      peg$c307 = function(to) {
+      peg$c302 = function(to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs": null, "rhs":to}]
           
           },
-      peg$c308 = function(expr) { return ["[", expr] },
-      peg$c309 = function(id) { return [".", id] },
-      peg$c310 = function(exprs, locals, scope) {
+      peg$c303 = function(expr) { return ["[", expr] },
+      peg$c304 = function(id) { return [".", id] },
+      peg$c305 = function(exprs, locals, scope) {
             return {"kind": "OverExpr", "locals": locals, "exprs": exprs, "scope": scope}
           },
-      peg$c311 = "}",
-      peg$c312 = peg$literalExpectation("}", false),
-      peg$c313 = function(elems) {
+      peg$c306 = "}",
+      peg$c307 = peg$literalExpectation("}", false),
+      peg$c308 = function(elems) {
             return {"kind":"RecordExpr", "elems":elems}
           },
-      peg$c314 = function(elem) { return elem },
-      peg$c315 = "...",
-      peg$c316 = peg$literalExpectation("...", false),
-      peg$c317 = function(expr) {
+      peg$c309 = function(elem) { return elem },
+      peg$c310 = "...",
+      peg$c311 = peg$literalExpectation("...", false),
+      peg$c312 = function(expr) {
             return {"kind":"Spread", "expr": expr}
           },
-      peg$c318 = function(name, value) {
+      peg$c313 = function(name, value) {
             return {"kind":"Field","name": name, "value": value}
           },
-      peg$c319 = function(elems) {
+      peg$c314 = function(elems) {
             return {"kind":"ArrayExpr", "elems":elems }
           },
-      peg$c320 = "|[",
-      peg$c321 = peg$literalExpectation("|[", false),
-      peg$c322 = "]|",
-      peg$c323 = peg$literalExpectation("]|", false),
-      peg$c324 = function(elems) {
+      peg$c315 = "|[",
+      peg$c316 = peg$literalExpectation("|[", false),
+      peg$c317 = "]|",
+      peg$c318 = peg$literalExpectation("]|", false),
+      peg$c319 = function(elems) {
             return {"kind":"SetExpr", "elems":elems }
           },
-      peg$c325 = function(e) { return {"kind":"VectorValue","expr":e} },
-      peg$c326 = "|{",
-      peg$c327 = peg$literalExpectation("|{", false),
-      peg$c328 = "}|",
-      peg$c329 = peg$literalExpectation("}|", false),
-      peg$c330 = function(exprs) {
+      peg$c320 = function(e) { return {"kind":"VectorValue","expr":e} },
+      peg$c321 = "|{",
+      peg$c322 = peg$literalExpectation("|{", false),
+      peg$c323 = "}|",
+      peg$c324 = peg$literalExpectation("}|", false),
+      peg$c325 = function(exprs) {
             return {"kind":"MapExpr", "entries":exprs }
           },
-      peg$c331 = function(e) { return e },
-      peg$c332 = function(key, value) {
+      peg$c326 = function(e) { return e },
+      peg$c327 = function(key, value) {
             return {"key": key, "value": value}
           },
-      peg$c333 = function(selection, from, joins, where, groupby, having, orderby, limit) {
+      peg$c328 = function(selection, from, joins, where, groupby, having, orderby, limit) {
             return {
               
             "kind": "SQLExpr",
@@ -817,19 +810,19 @@ function peg$parse(input, options) {
             "limit": limit }
           
           },
-      peg$c334 = function(assignments) { return assignments },
-      peg$c335 = function(rhs, opt) {
+      peg$c329 = function(assignments) { return assignments },
+      peg$c330 = function(rhs, opt) {
             let m = {"kind": "Assignment", "lhs": null, "rhs": rhs}
             if (opt) {
               m["lhs"] = opt[3]
             }
             return m
           },
-      peg$c336 = function(table, alias) {
+      peg$c331 = function(table, alias) {
             return {"table": table, "alias": alias}
           },
-      peg$c337 = function(first, join) { return join },
-      peg$c338 = function(style, table, alias, leftKey, rightKey) {
+      peg$c332 = function(first, join) { return join },
+      peg$c333 = function(style, table, alias, leftKey, rightKey) {
             return {
               
             "table": table,
@@ -843,120 +836,120 @@ function peg$parse(input, options) {
             "alias": alias}
           
           },
-      peg$c339 = function(style) { return style },
-      peg$c340 = function(keys, order) {
+      peg$c334 = function(style) { return style },
+      peg$c335 = function(keys, order) {
             return {"kind": "SQLOrderBy", "keys": keys, "order":order}
           },
-      peg$c341 = function(dir) { return dir },
-      peg$c342 = function(count) { return count },
-      peg$c343 = peg$literalExpectation("select", true),
-      peg$c344 = function() { return "select" },
-      peg$c345 = "as",
-      peg$c346 = peg$literalExpectation("as", true),
-      peg$c347 = function() { return "as" },
-      peg$c348 = peg$literalExpectation("from", true),
-      peg$c349 = function() { return "from" },
-      peg$c350 = peg$literalExpectation("join", true),
-      peg$c351 = function() { return "join" },
-      peg$c352 = peg$literalExpectation("where", true),
-      peg$c353 = function() { return "where" },
-      peg$c354 = "group",
-      peg$c355 = peg$literalExpectation("group", true),
-      peg$c356 = function() { return "group" },
-      peg$c357 = "by",
-      peg$c358 = peg$literalExpectation("by", true),
-      peg$c359 = function() { return "by" },
-      peg$c360 = "having",
-      peg$c361 = peg$literalExpectation("having", true),
-      peg$c362 = function() { return "having" },
-      peg$c363 = peg$literalExpectation("order", true),
-      peg$c364 = function() { return "order" },
-      peg$c365 = "on",
-      peg$c366 = peg$literalExpectation("on", true),
-      peg$c367 = function() { return "on" },
-      peg$c368 = "limit",
-      peg$c369 = peg$literalExpectation("limit", true),
-      peg$c370 = function() { return "limit" },
-      peg$c371 = peg$literalExpectation("asc", true),
-      peg$c372 = peg$literalExpectation("desc", true),
-      peg$c373 = peg$literalExpectation("anti", true),
-      peg$c374 = peg$literalExpectation("left", true),
-      peg$c375 = peg$literalExpectation("right", true),
-      peg$c376 = peg$literalExpectation("inner", true),
-      peg$c377 = function(v) {
+      peg$c336 = function(dir) { return dir },
+      peg$c337 = function(count) { return count },
+      peg$c338 = peg$literalExpectation("select", true),
+      peg$c339 = function() { return "select" },
+      peg$c340 = "as",
+      peg$c341 = peg$literalExpectation("as", true),
+      peg$c342 = function() { return "as" },
+      peg$c343 = peg$literalExpectation("from", true),
+      peg$c344 = function() { return "from" },
+      peg$c345 = peg$literalExpectation("join", true),
+      peg$c346 = function() { return "join" },
+      peg$c347 = peg$literalExpectation("where", true),
+      peg$c348 = function() { return "where" },
+      peg$c349 = "group",
+      peg$c350 = peg$literalExpectation("group", true),
+      peg$c351 = function() { return "group" },
+      peg$c352 = "by",
+      peg$c353 = peg$literalExpectation("by", true),
+      peg$c354 = function() { return "by" },
+      peg$c355 = "having",
+      peg$c356 = peg$literalExpectation("having", true),
+      peg$c357 = function() { return "having" },
+      peg$c358 = peg$literalExpectation("order", true),
+      peg$c359 = function() { return "order" },
+      peg$c360 = "on",
+      peg$c361 = peg$literalExpectation("on", true),
+      peg$c362 = function() { return "on" },
+      peg$c363 = "limit",
+      peg$c364 = peg$literalExpectation("limit", true),
+      peg$c365 = function() { return "limit" },
+      peg$c366 = peg$literalExpectation("asc", true),
+      peg$c367 = peg$literalExpectation("desc", true),
+      peg$c368 = peg$literalExpectation("anti", true),
+      peg$c369 = peg$literalExpectation("left", true),
+      peg$c370 = peg$literalExpectation("right", true),
+      peg$c371 = peg$literalExpectation("inner", true),
+      peg$c372 = function(v) {
             return {"kind": "Primitive", "type": "net", "text": v}
           },
-      peg$c378 = function(v) {
+      peg$c373 = function(v) {
             return {"kind": "Primitive", "type": "ip", "text": v}
           },
-      peg$c379 = function(v) {
+      peg$c374 = function(v) {
             return {"kind": "Primitive", "type": "float64", "text": v}
           },
-      peg$c380 = function(v) {
+      peg$c375 = function(v) {
             return {"kind": "Primitive", "type": "int64", "text": v}
           },
-      peg$c381 = "true",
-      peg$c382 = peg$literalExpectation("true", false),
-      peg$c383 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
-      peg$c384 = "false",
-      peg$c385 = peg$literalExpectation("false", false),
-      peg$c386 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
-      peg$c387 = "null",
-      peg$c388 = peg$literalExpectation("null", false),
-      peg$c389 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
-      peg$c390 = "0x",
-      peg$c391 = peg$literalExpectation("0x", false),
-      peg$c392 = function() {
+      peg$c376 = "true",
+      peg$c377 = peg$literalExpectation("true", false),
+      peg$c378 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
+      peg$c379 = "false",
+      peg$c380 = peg$literalExpectation("false", false),
+      peg$c381 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
+      peg$c382 = "null",
+      peg$c383 = peg$literalExpectation("null", false),
+      peg$c384 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
+      peg$c385 = "0x",
+      peg$c386 = peg$literalExpectation("0x", false),
+      peg$c387 = function() {
       	return {"kind": "Primitive", "type": "bytes", "text": text()}
         },
-      peg$c393 = function(typ) {
+      peg$c388 = function(typ) {
             return {"kind": "TypeValue", "value": typ}
           },
-      peg$c394 = function(name) { return name },
-      peg$c395 = function(name, opt) {
+      peg$c389 = function(name) { return name },
+      peg$c390 = function(name, opt) {
             if (opt) {
               return {"kind": "TypeDef", "name": name, "type": opt[3]}
             }
             return {"kind": "TypeName", "name": name}
           },
-      peg$c396 = function(name) {
+      peg$c391 = function(name) {
             return {"kind": "TypeName", "name": name}
           },
-      peg$c397 = function(u) { return u },
-      peg$c398 = function(types) {
+      peg$c392 = function(u) { return u },
+      peg$c393 = function(types) {
             return {"kind": "TypeUnion", "types": types}
           },
-      peg$c399 = function(typ) { return typ },
-      peg$c400 = function(fields) {
+      peg$c394 = function(typ) { return typ },
+      peg$c395 = function(fields) {
             return {"kind":"TypeRecord", "fields":fields}
           },
-      peg$c401 = function(typ) {
+      peg$c396 = function(typ) {
             return {"kind":"TypeArray", "type":typ}
           },
-      peg$c402 = function(typ) {
+      peg$c397 = function(typ) {
             return {"kind":"TypeSet", "type":typ}
           },
-      peg$c403 = function(keyType, valType) {
+      peg$c398 = function(keyType, valType) {
             return {"kind":"TypeMap", "key_type":keyType, "val_type": valType}
           },
-      peg$c404 = function(v) {
+      peg$c399 = function(v) {
             if (v.length == 0) {
               return {"kind": "Primitive", "type": "string", "text": ""}
             }
             return makeTemplateExprChain(v)
           },
-      peg$c405 = "\"",
-      peg$c406 = peg$literalExpectation("\"", false),
-      peg$c407 = "'",
-      peg$c408 = peg$literalExpectation("'", false),
-      peg$c409 = function(v) {
+      peg$c400 = "\"",
+      peg$c401 = peg$literalExpectation("\"", false),
+      peg$c402 = "'",
+      peg$c403 = peg$literalExpectation("'", false),
+      peg$c404 = function(v) {
             return {"kind": "Primitive", "type": "string", "text": joinChars(v)}
           },
-      peg$c410 = "\\",
-      peg$c411 = peg$literalExpectation("\\", false),
-      peg$c412 = "${",
-      peg$c413 = peg$literalExpectation("${", false),
-      peg$c414 = function(e) {
+      peg$c405 = "\\",
+      peg$c406 = peg$literalExpectation("\\", false),
+      peg$c407 = "${",
+      peg$c408 = peg$literalExpectation("${", false),
+      peg$c409 = function(e) {
             return {
               
             "kind": "Cast",
@@ -970,199 +963,199 @@ function peg$parse(input, options) {
             "value": {"kind": "TypePrimitive", "name": "string"}}}
           
           },
-      peg$c415 = "uint8",
-      peg$c416 = peg$literalExpectation("uint8", false),
-      peg$c417 = "uint16",
-      peg$c418 = peg$literalExpectation("uint16", false),
-      peg$c419 = "uint32",
-      peg$c420 = peg$literalExpectation("uint32", false),
-      peg$c421 = "uint64",
-      peg$c422 = peg$literalExpectation("uint64", false),
-      peg$c423 = "int8",
-      peg$c424 = peg$literalExpectation("int8", false),
-      peg$c425 = "int16",
-      peg$c426 = peg$literalExpectation("int16", false),
-      peg$c427 = "int32",
-      peg$c428 = peg$literalExpectation("int32", false),
-      peg$c429 = "int64",
-      peg$c430 = peg$literalExpectation("int64", false),
-      peg$c431 = "float16",
-      peg$c432 = peg$literalExpectation("float16", false),
-      peg$c433 = "float32",
-      peg$c434 = peg$literalExpectation("float32", false),
-      peg$c435 = "float64",
-      peg$c436 = peg$literalExpectation("float64", false),
-      peg$c437 = "bool",
-      peg$c438 = peg$literalExpectation("bool", false),
-      peg$c439 = "string",
-      peg$c440 = peg$literalExpectation("string", false),
-      peg$c441 = "duration",
-      peg$c442 = peg$literalExpectation("duration", false),
-      peg$c443 = "time",
-      peg$c444 = peg$literalExpectation("time", false),
-      peg$c445 = "bytes",
-      peg$c446 = peg$literalExpectation("bytes", false),
-      peg$c447 = "ip",
-      peg$c448 = peg$literalExpectation("ip", false),
-      peg$c449 = "net",
-      peg$c450 = peg$literalExpectation("net", false),
-      peg$c451 = function() {
+      peg$c410 = "uint8",
+      peg$c411 = peg$literalExpectation("uint8", false),
+      peg$c412 = "uint16",
+      peg$c413 = peg$literalExpectation("uint16", false),
+      peg$c414 = "uint32",
+      peg$c415 = peg$literalExpectation("uint32", false),
+      peg$c416 = "uint64",
+      peg$c417 = peg$literalExpectation("uint64", false),
+      peg$c418 = "int8",
+      peg$c419 = peg$literalExpectation("int8", false),
+      peg$c420 = "int16",
+      peg$c421 = peg$literalExpectation("int16", false),
+      peg$c422 = "int32",
+      peg$c423 = peg$literalExpectation("int32", false),
+      peg$c424 = "int64",
+      peg$c425 = peg$literalExpectation("int64", false),
+      peg$c426 = "float16",
+      peg$c427 = peg$literalExpectation("float16", false),
+      peg$c428 = "float32",
+      peg$c429 = peg$literalExpectation("float32", false),
+      peg$c430 = "float64",
+      peg$c431 = peg$literalExpectation("float64", false),
+      peg$c432 = "bool",
+      peg$c433 = peg$literalExpectation("bool", false),
+      peg$c434 = "string",
+      peg$c435 = peg$literalExpectation("string", false),
+      peg$c436 = "duration",
+      peg$c437 = peg$literalExpectation("duration", false),
+      peg$c438 = "time",
+      peg$c439 = peg$literalExpectation("time", false),
+      peg$c440 = "bytes",
+      peg$c441 = peg$literalExpectation("bytes", false),
+      peg$c442 = "ip",
+      peg$c443 = peg$literalExpectation("ip", false),
+      peg$c444 = "net",
+      peg$c445 = peg$literalExpectation("net", false),
+      peg$c446 = function() {
                 return {"kind": "TypePrimitive", "name": text()}
               },
-      peg$c452 = function(name, typ) {
+      peg$c447 = function(name, typ) {
             return {"name": name, "type": typ}
           },
-      peg$c453 = "and",
-      peg$c454 = peg$literalExpectation("and", false),
-      peg$c455 = "AND",
-      peg$c456 = peg$literalExpectation("AND", false),
-      peg$c457 = function() { return "and" },
-      peg$c458 = "or",
-      peg$c459 = peg$literalExpectation("or", false),
-      peg$c460 = "OR",
-      peg$c461 = peg$literalExpectation("OR", false),
-      peg$c462 = function() { return "or" },
-      peg$c463 = function() { return "in" },
-      peg$c464 = "NOT",
-      peg$c465 = peg$literalExpectation("NOT", false),
-      peg$c466 = function() { return "not" },
-      peg$c467 = peg$literalExpectation("by", false),
-      peg$c468 = /^[A-Za-z_$]/,
-      peg$c469 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c470 = /^[0-9]/,
-      peg$c471 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c472 = function(id) { return {"kind": "ID", "name": id} },
-      peg$c473 = "$",
-      peg$c474 = peg$literalExpectation("$", false),
-      peg$c475 = function(first, id) { return id},
-      peg$c476 = "T",
-      peg$c477 = peg$literalExpectation("T", false),
-      peg$c478 = function() {
+      peg$c448 = "and",
+      peg$c449 = peg$literalExpectation("and", false),
+      peg$c450 = "AND",
+      peg$c451 = peg$literalExpectation("AND", false),
+      peg$c452 = function() { return "and" },
+      peg$c453 = "or",
+      peg$c454 = peg$literalExpectation("or", false),
+      peg$c455 = "OR",
+      peg$c456 = peg$literalExpectation("OR", false),
+      peg$c457 = function() { return "or" },
+      peg$c458 = function() { return "in" },
+      peg$c459 = "NOT",
+      peg$c460 = peg$literalExpectation("NOT", false),
+      peg$c461 = function() { return "not" },
+      peg$c462 = peg$literalExpectation("by", false),
+      peg$c463 = /^[A-Za-z_$]/,
+      peg$c464 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c465 = /^[0-9]/,
+      peg$c466 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c467 = function(id) { return {"kind": "ID", "name": id} },
+      peg$c468 = "$",
+      peg$c469 = peg$literalExpectation("$", false),
+      peg$c470 = function(first, id) { return id},
+      peg$c471 = "T",
+      peg$c472 = peg$literalExpectation("T", false),
+      peg$c473 = function() {
             return {"kind": "Primitive", "type": "time", "text": text()}
           },
-      peg$c479 = "Z",
-      peg$c480 = peg$literalExpectation("Z", false),
-      peg$c481 = function() {
+      peg$c474 = "Z",
+      peg$c475 = peg$literalExpectation("Z", false),
+      peg$c476 = function() {
             return {"kind": "Primitive", "type": "duration", "text": text()}
           },
-      peg$c482 = "ns",
-      peg$c483 = peg$literalExpectation("ns", false),
-      peg$c484 = "us",
-      peg$c485 = peg$literalExpectation("us", false),
-      peg$c486 = "ms",
-      peg$c487 = peg$literalExpectation("ms", false),
-      peg$c488 = "s",
-      peg$c489 = peg$literalExpectation("s", false),
-      peg$c490 = "m",
-      peg$c491 = peg$literalExpectation("m", false),
-      peg$c492 = "h",
-      peg$c493 = peg$literalExpectation("h", false),
-      peg$c494 = "d",
-      peg$c495 = peg$literalExpectation("d", false),
-      peg$c496 = "w",
-      peg$c497 = peg$literalExpectation("w", false),
-      peg$c498 = "y",
-      peg$c499 = peg$literalExpectation("y", false),
-      peg$c500 = function(a, b) {
+      peg$c477 = "ns",
+      peg$c478 = peg$literalExpectation("ns", false),
+      peg$c479 = "us",
+      peg$c480 = peg$literalExpectation("us", false),
+      peg$c481 = "ms",
+      peg$c482 = peg$literalExpectation("ms", false),
+      peg$c483 = "s",
+      peg$c484 = peg$literalExpectation("s", false),
+      peg$c485 = "m",
+      peg$c486 = peg$literalExpectation("m", false),
+      peg$c487 = "h",
+      peg$c488 = peg$literalExpectation("h", false),
+      peg$c489 = "d",
+      peg$c490 = peg$literalExpectation("d", false),
+      peg$c491 = "w",
+      peg$c492 = peg$literalExpectation("w", false),
+      peg$c493 = "y",
+      peg$c494 = peg$literalExpectation("y", false),
+      peg$c495 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c501 = "::",
-      peg$c502 = peg$literalExpectation("::", false),
-      peg$c503 = function(a, b, d, e) {
+      peg$c496 = "::",
+      peg$c497 = peg$literalExpectation("::", false),
+      peg$c498 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c504 = function(a, b) {
+      peg$c499 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c505 = function(a, b) {
+      peg$c500 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c506 = function() {
+      peg$c501 = function() {
             return "::"
           },
-      peg$c507 = function(v) { return ":" + v },
-      peg$c508 = function(v) { return v + ":" },
-      peg$c509 = function(a, m) {
+      peg$c502 = function(v) { return ":" + v },
+      peg$c503 = function(v) { return v + ":" },
+      peg$c504 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c510 = function(a, m) {
+      peg$c505 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c511 = function(s) { return parseInt(s) },
-      peg$c512 = function() {
+      peg$c506 = function(s) { return parseInt(s) },
+      peg$c507 = function() {
             return text()
           },
-      peg$c513 = "e",
-      peg$c514 = peg$literalExpectation("e", true),
-      peg$c515 = /^[+\-]/,
-      peg$c516 = peg$classExpectation(["+", "-"], false, false),
-      peg$c517 = "NaN",
-      peg$c518 = peg$literalExpectation("NaN", false),
-      peg$c519 = "Inf",
-      peg$c520 = peg$literalExpectation("Inf", false),
-      peg$c521 = /^[0-9a-fA-F]/,
-      peg$c522 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c523 = function(v) { return joinChars(v) },
-      peg$c524 = peg$anyExpectation(),
-      peg$c525 = function(head, tail) { return head + joinChars(tail) },
-      peg$c526 = /^[a-zA-Z_.:\/%#@~]/,
-      peg$c527 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
-      peg$c528 = function(head, tail) {
+      peg$c508 = "e",
+      peg$c509 = peg$literalExpectation("e", true),
+      peg$c510 = /^[+\-]/,
+      peg$c511 = peg$classExpectation(["+", "-"], false, false),
+      peg$c512 = "NaN",
+      peg$c513 = peg$literalExpectation("NaN", false),
+      peg$c514 = "Inf",
+      peg$c515 = peg$literalExpectation("Inf", false),
+      peg$c516 = /^[0-9a-fA-F]/,
+      peg$c517 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c518 = function(v) { return joinChars(v) },
+      peg$c519 = peg$anyExpectation(),
+      peg$c520 = function(head, tail) { return head + joinChars(tail) },
+      peg$c521 = /^[a-zA-Z_.:\/%#@~]/,
+      peg$c522 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
+      peg$c523 = function(head, tail) {
             return head + joinChars(tail)
           },
-      peg$c529 = function() { return "*"},
-      peg$c530 = function() { return "=" },
-      peg$c531 = function() { return "\\*" },
-      peg$c532 = "b",
-      peg$c533 = peg$literalExpectation("b", false),
-      peg$c534 = function() { return "\b" },
-      peg$c535 = "f",
-      peg$c536 = peg$literalExpectation("f", false),
-      peg$c537 = function() { return "\f" },
-      peg$c538 = "n",
-      peg$c539 = peg$literalExpectation("n", false),
-      peg$c540 = function() { return "\n" },
-      peg$c541 = "r",
-      peg$c542 = peg$literalExpectation("r", false),
-      peg$c543 = function() { return "\r" },
-      peg$c544 = "t",
-      peg$c545 = peg$literalExpectation("t", false),
-      peg$c546 = function() { return "\t" },
-      peg$c547 = "v",
-      peg$c548 = peg$literalExpectation("v", false),
-      peg$c549 = function() { return "\v" },
-      peg$c550 = function() { return "*" },
-      peg$c551 = "u",
-      peg$c552 = peg$literalExpectation("u", false),
-      peg$c553 = function(chars) {
+      peg$c524 = function() { return "*"},
+      peg$c525 = function() { return "=" },
+      peg$c526 = function() { return "\\*" },
+      peg$c527 = "b",
+      peg$c528 = peg$literalExpectation("b", false),
+      peg$c529 = function() { return "\b" },
+      peg$c530 = "f",
+      peg$c531 = peg$literalExpectation("f", false),
+      peg$c532 = function() { return "\f" },
+      peg$c533 = "n",
+      peg$c534 = peg$literalExpectation("n", false),
+      peg$c535 = function() { return "\n" },
+      peg$c536 = "r",
+      peg$c537 = peg$literalExpectation("r", false),
+      peg$c538 = function() { return "\r" },
+      peg$c539 = "t",
+      peg$c540 = peg$literalExpectation("t", false),
+      peg$c541 = function() { return "\t" },
+      peg$c542 = "v",
+      peg$c543 = peg$literalExpectation("v", false),
+      peg$c544 = function() { return "\v" },
+      peg$c545 = function() { return "*" },
+      peg$c546 = "u",
+      peg$c547 = peg$literalExpectation("u", false),
+      peg$c548 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c554 = /^[^\/\\]/,
-      peg$c555 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c556 = /^[\0-\x1F\\]/,
-      peg$c557 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c558 = peg$otherExpectation("whitespace"),
-      peg$c559 = "\t",
-      peg$c560 = peg$literalExpectation("\t", false),
-      peg$c561 = "\x0B",
-      peg$c562 = peg$literalExpectation("\x0B", false),
-      peg$c563 = "\f",
-      peg$c564 = peg$literalExpectation("\f", false),
-      peg$c565 = " ",
-      peg$c566 = peg$literalExpectation(" ", false),
-      peg$c567 = "\xA0",
-      peg$c568 = peg$literalExpectation("\xA0", false),
-      peg$c569 = "\uFEFF",
-      peg$c570 = peg$literalExpectation("\uFEFF", false),
-      peg$c571 = /^[\n\r\u2028\u2029]/,
-      peg$c572 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c573 = peg$otherExpectation("comment"),
-      peg$c574 = "/*",
-      peg$c575 = peg$literalExpectation("/*", false),
-      peg$c576 = "*/",
-      peg$c577 = peg$literalExpectation("*/", false),
-      peg$c578 = "//",
-      peg$c579 = peg$literalExpectation("//", false),
+      peg$c549 = /^[^\/\\]/,
+      peg$c550 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c551 = /^[\0-\x1F\\]/,
+      peg$c552 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c553 = peg$otherExpectation("whitespace"),
+      peg$c554 = "\t",
+      peg$c555 = peg$literalExpectation("\t", false),
+      peg$c556 = "\x0B",
+      peg$c557 = peg$literalExpectation("\x0B", false),
+      peg$c558 = "\f",
+      peg$c559 = peg$literalExpectation("\f", false),
+      peg$c560 = " ",
+      peg$c561 = peg$literalExpectation(" ", false),
+      peg$c562 = "\xA0",
+      peg$c563 = peg$literalExpectation("\xA0", false),
+      peg$c564 = "\uFEFF",
+      peg$c565 = peg$literalExpectation("\uFEFF", false),
+      peg$c566 = /^[\n\r\u2028\u2029]/,
+      peg$c567 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c568 = peg$otherExpectation("comment"),
+      peg$c569 = "/*",
+      peg$c570 = peg$literalExpectation("/*", false),
+      peg$c571 = "*/",
+      peg$c572 = peg$literalExpectation("*/", false),
+      peg$c573 = "//",
+      peg$c574 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -5419,7 +5412,7 @@ function peg$parse(input, options) {
   }
 
   function peg$parsePoolBody() {
-    var s0, s1, s2, s3, s4;
+    var s0, s1, s2;
 
     s0 = peg$currPos;
     s1 = peg$parsePoolSpec();
@@ -5429,27 +5422,9 @@ function peg$parse(input, options) {
         s2 = null;
       }
       if (s2 !== peg$FAILED) {
-        s3 = peg$parsePoolRange();
-        if (s3 === peg$FAILED) {
-          s3 = null;
-        }
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parseOrderArg();
-          if (s4 === peg$FAILED) {
-            s4 = null;
-          }
-          if (s4 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c203(s1, s2, s3, s4);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
+        peg$savedPos = s0;
+        s1 = peg$c203(s1, s2);
+        s0 = s1;
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -5673,77 +5648,6 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsePoolRange() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
-
-    s0 = peg$currPos;
-    s1 = peg$parse_();
-    if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c218) {
-        s2 = peg$c218;
-        peg$currPos += 5;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c219); }
-      }
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parse_();
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parseLiteral();
-          if (s4 !== peg$FAILED) {
-            s5 = peg$parse_();
-            if (s5 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c220) {
-                s6 = peg$c220;
-                peg$currPos += 2;
-              } else {
-                s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c221); }
-              }
-              if (s6 !== peg$FAILED) {
-                s7 = peg$parse_();
-                if (s7 !== peg$FAILED) {
-                  s8 = peg$parseLiteral();
-                  if (s8 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c222(s4, s8);
-                    s0 = s1;
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
   function peg$parsePoolSpec() {
     var s0, s1, s2, s3;
 
@@ -5761,7 +5665,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c223(s1, s2, s3);
+          s1 = peg$c218(s1, s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5780,7 +5684,7 @@ function peg$parse(input, options) {
       s1 = peg$parsePoolMeta();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c224(s1);
+        s1 = peg$c219(s1);
       }
       s0 = s1;
     }
@@ -5793,17 +5697,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 64) {
-      s1 = peg$c225;
+      s1 = peg$c220;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c226); }
+      if (peg$silentFails === 0) { peg$fail(peg$c221); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsePoolNameString();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c227(s2);
+        s1 = peg$c222(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5832,7 +5736,7 @@ function peg$parse(input, options) {
       s2 = peg$parsePoolIdentifier();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c228(s2);
+        s1 = peg$c223(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5872,7 +5776,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c229();
+          s1 = peg$c224();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5889,7 +5793,7 @@ function peg$parse(input, options) {
           s1 = peg$parsePoolNameString();
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c230(s1);
+            s1 = peg$c225(s1);
           }
           s0 = s1;
         }
@@ -5954,7 +5858,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c231();
+        s1 = peg$c226();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5974,12 +5878,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c232) {
-        s2 = peg$c232;
+      if (input.substr(peg$currPos, 5) === peg$c227) {
+        s2 = peg$c227;
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c233); }
+        if (peg$silentFails === 0) { peg$fail(peg$c228); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -5989,7 +5893,7 @@ function peg$parse(input, options) {
             s5 = peg$parseOrderSuffix();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c234(s4, s5);
+              s1 = peg$c229(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6021,12 +5925,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c235) {
-        s2 = peg$c235;
+      if (input.substr(peg$currPos, 6) === peg$c230) {
+        s2 = peg$c230;
         peg$currPos += 6;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c236); }
+        if (peg$silentFails === 0) { peg$fail(peg$c231); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -6034,7 +5938,7 @@ function peg$parse(input, options) {
           s4 = peg$parseIdentifierName();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c237(s4);
+            s1 = peg$c232(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6060,30 +5964,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c238) {
-      s1 = peg$c238;
+    if (input.substr(peg$currPos, 4) === peg$c233) {
+      s1 = peg$c233;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c239); }
+      if (peg$silentFails === 0) { peg$fail(peg$c234); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c240();
+      s1 = peg$c235();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c241) {
-        s1 = peg$c241;
+      if (input.substr(peg$currPos, 5) === peg$c236) {
+        s1 = peg$c236;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c242); }
+        if (peg$silentFails === 0) { peg$fail(peg$c237); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c243();
+        s1 = peg$c238();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -6091,7 +5995,7 @@ function peg$parse(input, options) {
         s1 = peg$c98;
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c240();
+          s1 = peg$c235();
         }
         s0 = s1;
       }
@@ -6106,26 +6010,26 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c232) {
-        s2 = peg$c232;
+      if (input.substr(peg$currPos, 5) === peg$c227) {
+        s2 = peg$c227;
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c233); }
+        if (peg$silentFails === 0) { peg$fail(peg$c228); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c244) {
-            s4 = peg$c244;
+          if (input.substr(peg$currPos, 3) === peg$c239) {
+            s4 = peg$c239;
             peg$currPos += 3;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c245); }
+            if (peg$silentFails === 0) { peg$fail(peg$c240); }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c240();
+            s1 = peg$c235();
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6147,26 +6051,26 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$parse_();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c232) {
-          s2 = peg$c232;
+        if (input.substr(peg$currPos, 5) === peg$c227) {
+          s2 = peg$c227;
           peg$currPos += 5;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c233); }
+          if (peg$silentFails === 0) { peg$fail(peg$c228); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c246) {
-              s4 = peg$c246;
+            if (input.substr(peg$currPos, 4) === peg$c241) {
+              s4 = peg$c241;
               peg$currPos += 4;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c247); }
+              if (peg$silentFails === 0) { peg$fail(peg$c242); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c243();
+              s1 = peg$c238();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6193,12 +6097,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c248) {
-      s1 = peg$c248;
+    if (input.substr(peg$currPos, 4) === peg$c243) {
+      s1 = peg$c243;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c249); }
+      if (peg$silentFails === 0) { peg$fail(peg$c244); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -6213,7 +6117,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c250();
+        s1 = peg$c245();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6231,12 +6135,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 7) === peg$c251) {
-      s1 = peg$c251;
+    if (input.substr(peg$currPos, 7) === peg$c246) {
+      s1 = peg$c246;
       peg$currPos += 7;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c252); }
+      if (peg$silentFails === 0) { peg$fail(peg$c247); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6251,7 +6155,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c253(s3, s4, s5);
+              s1 = peg$c248(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6281,12 +6185,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c254) {
-      s1 = peg$c254;
+    if (input.substr(peg$currPos, 5) === peg$c249) {
+      s1 = peg$c249;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c255); }
+      if (peg$silentFails === 0) { peg$fail(peg$c250); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6294,7 +6198,7 @@ function peg$parse(input, options) {
         s3 = peg$parseConditionalExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c256(s3);
+          s1 = peg$c251(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6316,12 +6220,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c257) {
-      s1 = peg$c257;
+    if (input.substr(peg$currPos, 4) === peg$c252) {
+      s1 = peg$c252;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c258); }
+      if (peg$silentFails === 0) { peg$fail(peg$c253); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6339,7 +6243,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c259(s3, s4, s5);
+              s1 = peg$c254(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6404,7 +6308,7 @@ function peg$parse(input, options) {
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c260(s6);
+                    s1 = peg$c255(s6);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -6477,7 +6381,7 @@ function peg$parse(input, options) {
                   s10 = peg$parseLocalsAssignment();
                   if (s10 !== peg$FAILED) {
                     peg$savedPos = s6;
-                    s7 = peg$c261(s4, s10);
+                    s7 = peg$c256(s4, s10);
                     s6 = s7;
                   } else {
                     peg$currPos = s6;
@@ -6513,7 +6417,7 @@ function peg$parse(input, options) {
                     s10 = peg$parseLocalsAssignment();
                     if (s10 !== peg$FAILED) {
                       peg$savedPos = s6;
-                      s7 = peg$c261(s4, s10);
+                      s7 = peg$c256(s4, s10);
                       s6 = s7;
                     } else {
                       peg$currPos = s6;
@@ -6604,7 +6508,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c262(s1, s2);
+        s1 = peg$c257(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6622,12 +6526,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c263) {
-      s1 = peg$c263;
+    if (input.substr(peg$currPos, 5) === peg$c258) {
+      s1 = peg$c258;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c264); }
+      if (peg$silentFails === 0) { peg$fail(peg$c259); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6635,7 +6539,7 @@ function peg$parse(input, options) {
         s3 = peg$parseExprs();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c265(s3);
+          s1 = peg$c260(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6666,7 +6570,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c266(s4);
+            s1 = peg$c261(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6701,7 +6605,7 @@ function peg$parse(input, options) {
           s4 = peg$parseDerefExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c267(s4);
+            s1 = peg$c262(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6746,7 +6650,7 @@ function peg$parse(input, options) {
             s7 = peg$parseDerefExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c268(s1, s7);
+              s4 = peg$c263(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6782,7 +6686,7 @@ function peg$parse(input, options) {
               s7 = peg$parseDerefExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c268(s1, s7);
+                s4 = peg$c263(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6895,7 +6799,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c269(s1, s2);
+        s1 = peg$c264(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6932,7 +6836,7 @@ function peg$parse(input, options) {
             s7 = peg$parseAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c261(s1, s7);
+              s4 = peg$c256(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6968,7 +6872,7 @@ function peg$parse(input, options) {
               s7 = peg$parseAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c261(s1, s7);
+                s4 = peg$c256(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6989,7 +6893,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c270(s1, s2);
+        s1 = peg$c265(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7024,7 +6928,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c271(s1, s5);
+              s1 = peg$c266(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7068,11 +6972,11 @@ function peg$parse(input, options) {
       s3 = peg$parse__();
       if (s3 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s4 = peg$c272;
+          s4 = peg$c267;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c273); }
+          if (peg$silentFails === 0) { peg$fail(peg$c268); }
         }
         if (s4 !== peg$FAILED) {
           s5 = peg$parse__();
@@ -7132,7 +7036,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c274(s1, s2);
+        s1 = peg$c269(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7163,7 +7067,7 @@ function peg$parse(input, options) {
             s7 = peg$parseLogicalAndExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c275(s1, s5, s7);
+              s4 = peg$c270(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7193,7 +7097,7 @@ function peg$parse(input, options) {
               s7 = peg$parseLogicalAndExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c275(s1, s5, s7);
+                s4 = peg$c270(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7214,7 +7118,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c276(s1, s2);
+        s1 = peg$c271(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7245,7 +7149,7 @@ function peg$parse(input, options) {
             s7 = peg$parseComparisonExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c275(s1, s5, s7);
+              s4 = peg$c270(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7275,7 +7179,7 @@ function peg$parse(input, options) {
               s7 = peg$parseComparisonExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c275(s1, s5, s7);
+                s4 = peg$c270(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7296,7 +7200,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c276(s1, s2);
+        s1 = peg$c271(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7357,7 +7261,7 @@ function peg$parse(input, options) {
           }
           if (s5 !== peg$FAILED) {
             peg$savedPos = s4;
-            s5 = peg$c277(s1);
+            s5 = peg$c272(s1);
           }
           s4 = s5;
           if (s4 !== peg$FAILED) {
@@ -7389,7 +7293,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c278(s1, s2);
+        s1 = peg$c273(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7420,7 +7324,7 @@ function peg$parse(input, options) {
             s7 = peg$parseMultiplicativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c275(s1, s5, s7);
+              s4 = peg$c270(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7450,7 +7354,7 @@ function peg$parse(input, options) {
               s7 = peg$parseMultiplicativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c275(s1, s5, s7);
+                s4 = peg$c270(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7471,7 +7375,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c276(s1, s2);
+        s1 = peg$c271(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7490,19 +7394,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c279;
+      s1 = peg$c274;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c280); }
+      if (peg$silentFails === 0) { peg$fail(peg$c275); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c281;
+        s1 = peg$c276;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c282); }
+        if (peg$silentFails === 0) { peg$fail(peg$c277); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -7531,7 +7435,7 @@ function peg$parse(input, options) {
             s7 = peg$parseNotExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c275(s1, s5, s7);
+              s4 = peg$c270(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7561,7 +7465,7 @@ function peg$parse(input, options) {
               s7 = peg$parseNotExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c275(s1, s5, s7);
+                s4 = peg$c270(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7582,7 +7486,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c276(s1, s2);
+        s1 = peg$c271(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7609,19 +7513,19 @@ function peg$parse(input, options) {
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c283;
+        s1 = peg$c278;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c284); }
+        if (peg$silentFails === 0) { peg$fail(peg$c279); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 37) {
-          s1 = peg$c285;
+          s1 = peg$c280;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c286); }
+          if (peg$silentFails === 0) { peg$fail(peg$c281); }
         }
       }
     }
@@ -7651,7 +7555,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c287(s3);
+          s1 = peg$c282(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7688,11 +7592,11 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c281;
+        s2 = peg$c276;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c282); }
+        if (peg$silentFails === 0) { peg$fail(peg$c277); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -7700,7 +7604,7 @@ function peg$parse(input, options) {
           s4 = peg$parseFuncExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c288(s4);
+            s1 = peg$c283(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7819,20 +7723,20 @@ function peg$parse(input, options) {
   function peg$parseNotFuncs() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c289) {
-      s0 = peg$c289;
+    if (input.substr(peg$currPos, 3) === peg$c284) {
+      s0 = peg$c284;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c290); }
+      if (peg$silentFails === 0) { peg$fail(peg$c285); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c291) {
-        s0 = peg$c291;
+      if (input.substr(peg$currPos, 6) === peg$c286) {
+        s0 = peg$c286;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c292); }
+        if (peg$silentFails === 0) { peg$fail(peg$c287); }
       }
     }
 
@@ -7873,7 +7777,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c293(s1, s5);
+                  s1 = peg$c288(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7913,12 +7817,12 @@ function peg$parse(input, options) {
     s0 = peg$parseGrep();
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c294) {
-        s1 = peg$c294;
+      if (input.substr(peg$currPos, 6) === peg$c289) {
+        s1 = peg$c289;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c295); }
+        if (peg$silentFails === 0) { peg$fail(peg$c290); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
@@ -7965,7 +7869,7 @@ function peg$parse(input, options) {
                             }
                             if (s12 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c296(s5, s9, s12);
+                              s1 = peg$c291(s5, s9, s12);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -8060,7 +7964,7 @@ function peg$parse(input, options) {
                         }
                         if (s9 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c297(s2, s6, s9);
+                          s1 = peg$c292(s2, s6, s9);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -8111,7 +8015,7 @@ function peg$parse(input, options) {
     s1 = peg$parseOverExpr();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c298(s1);
+      s1 = peg$c293(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -8125,12 +8029,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c299) {
-      s1 = peg$c299;
+    if (input.substr(peg$currPos, 4) === peg$c294) {
+      s1 = peg$c294;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c300); }
+      if (peg$silentFails === 0) { peg$fail(peg$c295); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8198,7 +8102,7 @@ function peg$parse(input, options) {
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c301(s5, s7);
+                    s1 = peg$c296(s5, s7);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -8247,7 +8151,7 @@ function peg$parse(input, options) {
         s1 = peg$parseQuotedString();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c302(s1);
+          s1 = peg$c297(s1);
         }
         s0 = s1;
       }
@@ -8296,7 +8200,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c303(s1, s7);
+              s4 = peg$c298(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -8332,7 +8236,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c303(s1, s7);
+                s4 = peg$c298(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -8442,15 +8346,15 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s7 = peg$c304;
+                  s7 = peg$c299;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c305); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c300); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c306(s2, s6);
+                  s1 = peg$c301(s2, s6);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8505,15 +8409,15 @@ function peg$parse(input, options) {
               s5 = peg$parseAdditiveExpr();
               if (s5 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s6 = peg$c304;
+                  s6 = peg$c299;
                   peg$currPos++;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c305); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c300); }
                 }
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c307(s5);
+                  s1 = peg$c302(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8552,15 +8456,15 @@ function peg$parse(input, options) {
           s2 = peg$parseConditionalExpr();
           if (s2 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s3 = peg$c304;
+              s3 = peg$c299;
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c305); }
+              if (peg$silentFails === 0) { peg$fail(peg$c300); }
             }
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c308(s2);
+              s1 = peg$c303(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8587,7 +8491,7 @@ function peg$parse(input, options) {
             s2 = peg$parseIdentifier();
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c309(s2);
+              s1 = peg$c304(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8724,12 +8628,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c257) {
-      s1 = peg$c257;
+    if (input.substr(peg$currPos, 4) === peg$c252) {
+      s1 = peg$c252;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c258); }
+      if (peg$silentFails === 0) { peg$fail(peg$c253); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -8756,7 +8660,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSequential();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c310(s3, s4, s8);
+                    s1 = peg$c305(s3, s4, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -8813,15 +8717,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c311;
+              s5 = peg$c306;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c312); }
+              if (peg$silentFails === 0) { peg$fail(peg$c307); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c313(s3);
+              s1 = peg$c308(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8861,7 +8765,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c270(s1, s2);
+        s1 = peg$c265(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8903,7 +8807,7 @@ function peg$parse(input, options) {
           s4 = peg$parseRecordElem();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c314(s4);
+            s1 = peg$c309(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8943,12 +8847,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c315) {
-      s1 = peg$c315;
+    if (input.substr(peg$currPos, 3) === peg$c310) {
+      s1 = peg$c310;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c316); }
+      if (peg$silentFails === 0) { peg$fail(peg$c311); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8956,7 +8860,7 @@ function peg$parse(input, options) {
         s3 = peg$parseConditionalExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c317(s3);
+          s1 = peg$c312(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8995,7 +8899,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c318(s1, s5);
+              s1 = peg$c313(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9040,15 +8944,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s5 = peg$c304;
+              s5 = peg$c299;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c305); }
+              if (peg$silentFails === 0) { peg$fail(peg$c300); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c319(s3);
+              s1 = peg$c314(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9078,12 +8982,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c320) {
-      s1 = peg$c320;
+    if (input.substr(peg$currPos, 2) === peg$c315) {
+      s1 = peg$c315;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c321); }
+      if (peg$silentFails === 0) { peg$fail(peg$c316); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -9092,16 +8996,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c322) {
-              s5 = peg$c322;
+            if (input.substr(peg$currPos, 2) === peg$c317) {
+              s5 = peg$c317;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c323); }
+              if (peg$silentFails === 0) { peg$fail(peg$c318); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c324(s3);
+              s1 = peg$c319(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9150,7 +9054,7 @@ function peg$parse(input, options) {
             s7 = peg$parseVectorElem();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c303(s1, s7);
+              s4 = peg$c298(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -9186,7 +9090,7 @@ function peg$parse(input, options) {
               s7 = peg$parseVectorElem();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c303(s1, s7);
+                s4 = peg$c298(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -9239,7 +9143,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c325(s1);
+        s1 = peg$c320(s1);
       }
       s0 = s1;
     }
@@ -9251,12 +9155,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c326) {
-      s1 = peg$c326;
+    if (input.substr(peg$currPos, 2) === peg$c321) {
+      s1 = peg$c321;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c327); }
+      if (peg$silentFails === 0) { peg$fail(peg$c322); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -9265,16 +9169,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c328) {
-              s5 = peg$c328;
+            if (input.substr(peg$currPos, 2) === peg$c323) {
+              s5 = peg$c323;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c329); }
+              if (peg$silentFails === 0) { peg$fail(peg$c324); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c330(s3);
+              s1 = peg$c325(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9314,7 +9218,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c270(s1, s2);
+        s1 = peg$c265(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9356,7 +9260,7 @@ function peg$parse(input, options) {
           s4 = peg$parseEntry();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c331(s4);
+            s1 = peg$c326(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9399,7 +9303,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c332(s1, s5);
+              s1 = peg$c327(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9464,7 +9368,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSQLLimit();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c333(s1, s2, s3, s4, s5, s6, s7, s8);
+                    s1 = peg$c328(s1, s2, s3, s4, s5, s6, s7, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -9542,7 +9446,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSQLAssignments();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c334(s3);
+            s1 = peg$c329(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9599,7 +9503,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c335(s1, s2);
+        s1 = peg$c330(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9725,7 +9629,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c336(s4, s5);
+              s1 = peg$c331(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9880,7 +9784,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSQLJoin();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s3;
-        s4 = peg$c337(s1, s4);
+        s4 = peg$c332(s1, s4);
       }
       s3 = s4;
       while (s3 !== peg$FAILED) {
@@ -9889,7 +9793,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSQLJoin();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s3;
-          s4 = peg$c337(s1, s4);
+          s4 = peg$c332(s1, s4);
         }
         s3 = s4;
       }
@@ -9951,7 +9855,7 @@ function peg$parse(input, options) {
                               s14 = peg$parseJoinKey();
                               if (s14 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c338(s1, s5, s6, s10, s14);
+                                s1 = peg$c333(s1, s5, s6, s10, s14);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -10031,7 +9935,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c339(s2);
+        s1 = peg$c334(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10190,7 +10094,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseSQLOrder();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c340(s6, s7);
+                  s1 = peg$c335(s6, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10236,7 +10140,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c341(s2);
+        s1 = peg$c336(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10251,7 +10155,7 @@ function peg$parse(input, options) {
       s1 = peg$c98;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c240();
+        s1 = peg$c235();
       }
       s0 = s1;
     }
@@ -10272,7 +10176,7 @@ function peg$parse(input, options) {
           s4 = peg$parseUInt();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c342(s4);
+            s1 = peg$c337(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10307,16 +10211,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c291) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c286) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c343); }
+      if (peg$silentFails === 0) { peg$fail(peg$c338); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c344();
+      s1 = peg$c339();
     }
     s0 = s1;
 
@@ -10327,16 +10231,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c345) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c340) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c346); }
+      if (peg$silentFails === 0) { peg$fail(peg$c341); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c347();
+      s1 = peg$c342();
     }
     s0 = s1;
 
@@ -10352,11 +10256,11 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c348); }
+      if (peg$silentFails === 0) { peg$fail(peg$c343); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c349();
+      s1 = peg$c344();
     }
     s0 = s1;
 
@@ -10372,11 +10276,11 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c350); }
+      if (peg$silentFails === 0) { peg$fail(peg$c345); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c351();
+      s1 = peg$c346();
     }
     s0 = s1;
 
@@ -10392,11 +10296,11 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c352); }
+      if (peg$silentFails === 0) { peg$fail(peg$c347); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c353();
+      s1 = peg$c348();
     }
     s0 = s1;
 
@@ -10407,16 +10311,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c354) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c349) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c355); }
+      if (peg$silentFails === 0) { peg$fail(peg$c350); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c356();
+      s1 = peg$c351();
     }
     s0 = s1;
 
@@ -10427,9 +10331,49 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c357) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c352) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c353); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c354();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseHAVING() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c355) {
+      s1 = input.substr(peg$currPos, 6);
+      peg$currPos += 6;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c356); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c357();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseORDER() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c227) {
+      s1 = input.substr(peg$currPos, 5);
+      peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c358); }
@@ -10443,13 +10387,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseHAVING() {
+  function peg$parseON() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c360) {
-      s1 = input.substr(peg$currPos, 6);
-      peg$currPos += 6;
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c360) {
+      s1 = input.substr(peg$currPos, 2);
+      peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c361); }
@@ -10463,60 +10407,20 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseORDER() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c232) {
-      s1 = input.substr(peg$currPos, 5);
-      peg$currPos += 5;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c363); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c364();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseON() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c365) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c366); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c367();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
   function peg$parseLIMIT() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c368) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c363) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c369); }
+      if (peg$silentFails === 0) { peg$fail(peg$c364); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c370();
+      s1 = peg$c365();
     }
     s0 = s1;
 
@@ -10527,16 +10431,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c244) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c239) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c371); }
+      if (peg$silentFails === 0) { peg$fail(peg$c366); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c240();
+      s1 = peg$c235();
     }
     s0 = s1;
 
@@ -10547,16 +10451,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c246) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c241) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c372); }
+      if (peg$silentFails === 0) { peg$fail(peg$c367); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c243();
+      s1 = peg$c238();
     }
     s0 = s1;
 
@@ -10572,7 +10476,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c373); }
+      if (peg$silentFails === 0) { peg$fail(peg$c368); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10592,7 +10496,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c374); }
+      if (peg$silentFails === 0) { peg$fail(peg$c369); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10612,7 +10516,7 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c375); }
+      if (peg$silentFails === 0) { peg$fail(peg$c370); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10632,7 +10536,7 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c376); }
+      if (peg$silentFails === 0) { peg$fail(peg$c371); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10734,7 +10638,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c377(s1);
+        s1 = peg$c372(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10749,7 +10653,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP4Net();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c377(s1);
+        s1 = peg$c372(s1);
       }
       s0 = s1;
     }
@@ -10775,7 +10679,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c378(s1);
+        s1 = peg$c373(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10790,7 +10694,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c378(s1);
+        s1 = peg$c373(s1);
       }
       s0 = s1;
     }
@@ -10805,7 +10709,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFloatString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c379(s1);
+      s1 = peg$c374(s1);
     }
     s0 = s1;
 
@@ -10819,7 +10723,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c380(s1);
+      s1 = peg$c375(s1);
     }
     s0 = s1;
 
@@ -10830,30 +10734,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c381) {
-      s1 = peg$c381;
+    if (input.substr(peg$currPos, 4) === peg$c376) {
+      s1 = peg$c376;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c382); }
+      if (peg$silentFails === 0) { peg$fail(peg$c377); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c383();
+      s1 = peg$c378();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c384) {
-        s1 = peg$c384;
+      if (input.substr(peg$currPos, 5) === peg$c379) {
+        s1 = peg$c379;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c385); }
+        if (peg$silentFails === 0) { peg$fail(peg$c380); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c386();
+        s1 = peg$c381();
       }
       s0 = s1;
     }
@@ -10865,16 +10769,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c387) {
-      s1 = peg$c387;
+    if (input.substr(peg$currPos, 4) === peg$c382) {
+      s1 = peg$c382;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c388); }
+      if (peg$silentFails === 0) { peg$fail(peg$c383); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c389();
+      s1 = peg$c384();
     }
     s0 = s1;
 
@@ -10885,12 +10789,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c390) {
-      s1 = peg$c390;
+    if (input.substr(peg$currPos, 2) === peg$c385) {
+      s1 = peg$c385;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c391); }
+      if (peg$silentFails === 0) { peg$fail(peg$c386); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -10901,7 +10805,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c392();
+        s1 = peg$c387();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10938,7 +10842,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c393(s2);
+          s1 = peg$c388(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10965,7 +10869,7 @@ function peg$parse(input, options) {
       s1 = peg$parsePrimitiveType();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c393(s1);
+        s1 = peg$c388(s1);
       }
       s0 = s1;
     }
@@ -11005,7 +10909,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c394(s1);
+        s1 = peg$c389(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11057,7 +10961,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c395(s1, s2);
+          s1 = peg$c390(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -11072,7 +10976,7 @@ function peg$parse(input, options) {
         s1 = peg$parseQuotedString();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c396(s1);
+          s1 = peg$c391(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
@@ -11098,7 +11002,7 @@ function peg$parse(input, options) {
                 }
                 if (s4 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c397(s3);
+                  s1 = peg$c392(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -11130,7 +11034,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTypeList();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c398(s1);
+      s1 = peg$c393(s1);
     }
     s0 = s1;
 
@@ -11155,7 +11059,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c270(s1, s2);
+        s1 = peg$c265(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11188,7 +11092,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c399(s4);
+            s1 = peg$c394(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11229,15 +11133,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c311;
+              s5 = peg$c306;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c312); }
+              if (peg$silentFails === 0) { peg$fail(peg$c307); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c400(s3);
+              s1 = peg$c395(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11276,15 +11180,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c304;
+                s5 = peg$c299;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c305); }
+                if (peg$silentFails === 0) { peg$fail(peg$c300); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c401(s3);
+                s1 = peg$c396(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -11308,12 +11212,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c320) {
-          s1 = peg$c320;
+        if (input.substr(peg$currPos, 2) === peg$c315) {
+          s1 = peg$c315;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c321); }
+          if (peg$silentFails === 0) { peg$fail(peg$c316); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -11322,16 +11226,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c322) {
-                  s5 = peg$c322;
+                if (input.substr(peg$currPos, 2) === peg$c317) {
+                  s5 = peg$c317;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c323); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c318); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c402(s3);
+                  s1 = peg$c397(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -11355,12 +11259,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c326) {
-            s1 = peg$c326;
+          if (input.substr(peg$currPos, 2) === peg$c321) {
+            s1 = peg$c321;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c327); }
+            if (peg$silentFails === 0) { peg$fail(peg$c322); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -11383,16 +11287,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c328) {
-                            s9 = peg$c328;
+                          if (input.substr(peg$currPos, 2) === peg$c323) {
+                            s9 = peg$c323;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c329); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c324); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c403(s3, s7);
+                            s1 = peg$c398(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -11444,7 +11348,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTemplateLiteralParts();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c404(s1);
+      s1 = peg$c399(s1);
     }
     s0 = s1;
 
@@ -11456,11 +11360,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c405;
+      s1 = peg$c400;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c406); }
+      if (peg$silentFails === 0) { peg$fail(peg$c401); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -11471,11 +11375,11 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c405;
+          s3 = peg$c400;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c406); }
+          if (peg$silentFails === 0) { peg$fail(peg$c401); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
@@ -11496,11 +11400,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c407;
+        s1 = peg$c402;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c408); }
+        if (peg$silentFails === 0) { peg$fail(peg$c403); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -11511,11 +11415,11 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c407;
+            s3 = peg$c402;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c408); }
+            if (peg$silentFails === 0) { peg$fail(peg$c403); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
@@ -11556,7 +11460,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c409(s1);
+        s1 = peg$c404(s1);
       }
       s0 = s1;
     }
@@ -11569,19 +11473,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c410;
+      s1 = peg$c405;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c411); }
+      if (peg$silentFails === 0) { peg$fail(peg$c406); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c412) {
-        s2 = peg$c412;
+      if (input.substr(peg$currPos, 2) === peg$c407) {
+        s2 = peg$c407;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c413); }
+        if (peg$silentFails === 0) { peg$fail(peg$c408); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11599,12 +11503,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c412) {
-        s2 = peg$c412;
+      if (input.substr(peg$currPos, 2) === peg$c407) {
+        s2 = peg$c407;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c413); }
+        if (peg$silentFails === 0) { peg$fail(peg$c408); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -11650,7 +11554,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c409(s1);
+        s1 = peg$c404(s1);
       }
       s0 = s1;
     }
@@ -11663,19 +11567,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c410;
+      s1 = peg$c405;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c411); }
+      if (peg$silentFails === 0) { peg$fail(peg$c406); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c412) {
-        s2 = peg$c412;
+      if (input.substr(peg$currPos, 2) === peg$c407) {
+        s2 = peg$c407;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c413); }
+        if (peg$silentFails === 0) { peg$fail(peg$c408); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11693,12 +11597,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c412) {
-        s2 = peg$c412;
+      if (input.substr(peg$currPos, 2) === peg$c407) {
+        s2 = peg$c407;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c413); }
+        if (peg$silentFails === 0) { peg$fail(peg$c408); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -11730,12 +11634,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c412) {
-      s1 = peg$c412;
+    if (input.substr(peg$currPos, 2) === peg$c407) {
+      s1 = peg$c407;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c413); }
+      if (peg$silentFails === 0) { peg$fail(peg$c408); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -11745,15 +11649,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c311;
+              s5 = peg$c306;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c312); }
+              if (peg$silentFails === 0) { peg$fail(peg$c307); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c414(s3);
+              s1 = peg$c409(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11783,148 +11687,148 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c415) {
-      s1 = peg$c415;
+    if (input.substr(peg$currPos, 5) === peg$c410) {
+      s1 = peg$c410;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c416); }
+      if (peg$silentFails === 0) { peg$fail(peg$c411); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c417) {
-        s1 = peg$c417;
+      if (input.substr(peg$currPos, 6) === peg$c412) {
+        s1 = peg$c412;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c418); }
+        if (peg$silentFails === 0) { peg$fail(peg$c413); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c419) {
-          s1 = peg$c419;
+        if (input.substr(peg$currPos, 6) === peg$c414) {
+          s1 = peg$c414;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c420); }
+          if (peg$silentFails === 0) { peg$fail(peg$c415); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c421) {
-            s1 = peg$c421;
+          if (input.substr(peg$currPos, 6) === peg$c416) {
+            s1 = peg$c416;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c422); }
+            if (peg$silentFails === 0) { peg$fail(peg$c417); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c423) {
-              s1 = peg$c423;
+            if (input.substr(peg$currPos, 4) === peg$c418) {
+              s1 = peg$c418;
               peg$currPos += 4;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c424); }
+              if (peg$silentFails === 0) { peg$fail(peg$c419); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 5) === peg$c425) {
-                s1 = peg$c425;
+              if (input.substr(peg$currPos, 5) === peg$c420) {
+                s1 = peg$c420;
                 peg$currPos += 5;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c426); }
+                if (peg$silentFails === 0) { peg$fail(peg$c421); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c427) {
-                  s1 = peg$c427;
+                if (input.substr(peg$currPos, 5) === peg$c422) {
+                  s1 = peg$c422;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c428); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c423); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c429) {
-                    s1 = peg$c429;
+                  if (input.substr(peg$currPos, 5) === peg$c424) {
+                    s1 = peg$c424;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c430); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c425); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7) === peg$c431) {
-                      s1 = peg$c431;
+                    if (input.substr(peg$currPos, 7) === peg$c426) {
+                      s1 = peg$c426;
                       peg$currPos += 7;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c432); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c427); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 7) === peg$c433) {
-                        s1 = peg$c433;
+                      if (input.substr(peg$currPos, 7) === peg$c428) {
+                        s1 = peg$c428;
                         peg$currPos += 7;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c434); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c429); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 7) === peg$c435) {
-                          s1 = peg$c435;
+                        if (input.substr(peg$currPos, 7) === peg$c430) {
+                          s1 = peg$c430;
                           peg$currPos += 7;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c436); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c431); }
                         }
                         if (s1 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 4) === peg$c437) {
-                            s1 = peg$c437;
+                          if (input.substr(peg$currPos, 4) === peg$c432) {
+                            s1 = peg$c432;
                             peg$currPos += 4;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c438); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c433); }
                           }
                           if (s1 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 6) === peg$c439) {
-                              s1 = peg$c439;
+                            if (input.substr(peg$currPos, 6) === peg$c434) {
+                              s1 = peg$c434;
                               peg$currPos += 6;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c440); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c435); }
                             }
                             if (s1 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 8) === peg$c441) {
-                                s1 = peg$c441;
+                              if (input.substr(peg$currPos, 8) === peg$c436) {
+                                s1 = peg$c436;
                                 peg$currPos += 8;
                               } else {
                                 s1 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c442); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c437); }
                               }
                               if (s1 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 4) === peg$c443) {
-                                  s1 = peg$c443;
+                                if (input.substr(peg$currPos, 4) === peg$c438) {
+                                  s1 = peg$c438;
                                   peg$currPos += 4;
                                 } else {
                                   s1 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c444); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c439); }
                                 }
                                 if (s1 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 5) === peg$c445) {
-                                    s1 = peg$c445;
+                                  if (input.substr(peg$currPos, 5) === peg$c440) {
+                                    s1 = peg$c440;
                                     peg$currPos += 5;
                                   } else {
                                     s1 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c446); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c441); }
                                   }
                                   if (s1 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 2) === peg$c447) {
-                                      s1 = peg$c447;
+                                    if (input.substr(peg$currPos, 2) === peg$c442) {
+                                      s1 = peg$c442;
                                       peg$currPos += 2;
                                     } else {
                                       s1 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c448); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c443); }
                                     }
                                     if (s1 === peg$FAILED) {
-                                      if (input.substr(peg$currPos, 3) === peg$c449) {
-                                        s1 = peg$c449;
+                                      if (input.substr(peg$currPos, 3) === peg$c444) {
+                                        s1 = peg$c444;
                                         peg$currPos += 3;
                                       } else {
                                         s1 = peg$FAILED;
-                                        if (peg$silentFails === 0) { peg$fail(peg$c450); }
+                                        if (peg$silentFails === 0) { peg$fail(peg$c445); }
                                       }
                                       if (s1 === peg$FAILED) {
                                         if (input.substr(peg$currPos, 4) === peg$c10) {
@@ -11935,12 +11839,12 @@ function peg$parse(input, options) {
                                           if (peg$silentFails === 0) { peg$fail(peg$c11); }
                                         }
                                         if (s1 === peg$FAILED) {
-                                          if (input.substr(peg$currPos, 4) === peg$c387) {
-                                            s1 = peg$c387;
+                                          if (input.substr(peg$currPos, 4) === peg$c382) {
+                                            s1 = peg$c382;
                                             peg$currPos += 4;
                                           } else {
                                             s1 = peg$FAILED;
-                                            if (peg$silentFails === 0) { peg$fail(peg$c388); }
+                                            if (peg$silentFails === 0) { peg$fail(peg$c383); }
                                           }
                                         }
                                       }
@@ -11963,7 +11867,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c451();
+      s1 = peg$c446();
     }
     s0 = s1;
 
@@ -11984,7 +11888,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c270(s1, s2);
+        s1 = peg$c265(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12026,7 +11930,7 @@ function peg$parse(input, options) {
           s4 = peg$parseTypeField();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c399(s4);
+            s1 = peg$c394(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -12069,7 +11973,7 @@ function peg$parse(input, options) {
             s5 = peg$parseType();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c452(s1, s5);
+              s1 = peg$c447(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -12110,17 +12014,64 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c453) {
-      s1 = peg$c453;
+    if (input.substr(peg$currPos, 3) === peg$c448) {
+      s1 = peg$c448;
       peg$currPos += 3;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c449); }
+    }
+    if (s1 === peg$FAILED) {
+      if (input.substr(peg$currPos, 3) === peg$c450) {
+        s1 = peg$c450;
+        peg$currPos += 3;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c451); }
+      }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$currPos;
+      peg$silentFails++;
+      s3 = peg$parseIdentifierRest();
+      peg$silentFails--;
+      if (s3 === peg$FAILED) {
+        s2 = void 0;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c452();
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseOrToken() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2) === peg$c453) {
+      s1 = peg$c453;
+      peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c454); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c455) {
+      if (input.substr(peg$currPos, 2) === peg$c455) {
         s1 = peg$c455;
-        peg$currPos += 3;
+        peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$c456); }
@@ -12140,53 +12091,6 @@ function peg$parse(input, options) {
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
         s1 = peg$c457();
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseOrToken() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c458) {
-      s1 = peg$c458;
-      peg$currPos += 2;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c459); }
-    }
-    if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c460) {
-        s1 = peg$c460;
-        peg$currPos += 2;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c461); }
-      }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      peg$silentFails++;
-      s3 = peg$parseIdentifierRest();
-      peg$silentFails--;
-      if (s3 === peg$FAILED) {
-        s2 = void 0;
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c462();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12224,7 +12128,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c463();
+        s1 = peg$c458();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12242,20 +12146,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c289) {
-      s1 = peg$c289;
+    if (input.substr(peg$currPos, 3) === peg$c284) {
+      s1 = peg$c284;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c290); }
+      if (peg$silentFails === 0) { peg$fail(peg$c285); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c464) {
-        s1 = peg$c464;
+      if (input.substr(peg$currPos, 3) === peg$c459) {
+        s1 = peg$c459;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c465); }
+        if (peg$silentFails === 0) { peg$fail(peg$c460); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -12271,7 +12175,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c466();
+        s1 = peg$c461();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12289,12 +12193,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c357) {
-      s1 = peg$c357;
+    if (input.substr(peg$currPos, 2) === peg$c352) {
+      s1 = peg$c352;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c467); }
+      if (peg$silentFails === 0) { peg$fail(peg$c462); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -12309,7 +12213,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c359();
+        s1 = peg$c354();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12326,12 +12230,12 @@ function peg$parse(input, options) {
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c468.test(input.charAt(peg$currPos))) {
+    if (peg$c463.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c469); }
+      if (peg$silentFails === 0) { peg$fail(peg$c464); }
     }
 
     return s0;
@@ -12342,12 +12246,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c470.test(input.charAt(peg$currPos))) {
+      if (peg$c465.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c471); }
+        if (peg$silentFails === 0) { peg$fail(peg$c466); }
       }
     }
 
@@ -12361,7 +12265,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c472(s1);
+      s1 = peg$c467(s1);
     }
     s0 = s1;
 
@@ -12416,7 +12320,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c231();
+          s1 = peg$c226();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -12433,11 +12337,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 36) {
-        s1 = peg$c473;
+        s1 = peg$c468;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c474); }
+        if (peg$silentFails === 0) { peg$fail(peg$c469); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -12447,11 +12351,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c410;
+          s1 = peg$c405;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c411); }
+          if (peg$silentFails === 0) { peg$fail(peg$c406); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseIDGuard();
@@ -12558,7 +12462,7 @@ function peg$parse(input, options) {
             s7 = peg$parseIdentifierName();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c475(s1, s7);
+              s4 = peg$c470(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -12594,7 +12498,7 @@ function peg$parse(input, options) {
               s7 = peg$parseIdentifierName();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c475(s1, s7);
+                s4 = peg$c470(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -12615,7 +12519,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c270(s1, s2);
+        s1 = peg$c265(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12653,17 +12557,17 @@ function peg$parse(input, options) {
     s1 = peg$parseFullDate();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 84) {
-        s2 = peg$c476;
+        s2 = peg$c471;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c477); }
+        if (peg$silentFails === 0) { peg$fail(peg$c472); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseFullTime();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c478();
+          s1 = peg$c473();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -12688,21 +12592,21 @@ function peg$parse(input, options) {
     s1 = peg$parseD4();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c281;
+        s2 = peg$c276;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c282); }
+        if (peg$silentFails === 0) { peg$fail(peg$c277); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseD2();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 45) {
-            s4 = peg$c281;
+            s4 = peg$c276;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c282); }
+            if (peg$silentFails === 0) { peg$fail(peg$c277); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseD2();
@@ -12737,36 +12641,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (peg$c470.test(input.charAt(peg$currPos))) {
+    if (peg$c465.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c471); }
+      if (peg$silentFails === 0) { peg$fail(peg$c466); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c470.test(input.charAt(peg$currPos))) {
+      if (peg$c465.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c471); }
+        if (peg$silentFails === 0) { peg$fail(peg$c466); }
       }
       if (s2 !== peg$FAILED) {
-        if (peg$c470.test(input.charAt(peg$currPos))) {
+        if (peg$c465.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c471); }
+          if (peg$silentFails === 0) { peg$fail(peg$c466); }
         }
         if (s3 !== peg$FAILED) {
-          if (peg$c470.test(input.charAt(peg$currPos))) {
+          if (peg$c465.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c471); }
+            if (peg$silentFails === 0) { peg$fail(peg$c466); }
           }
           if (s4 !== peg$FAILED) {
             s1 = [s1, s2, s3, s4];
@@ -12795,20 +12699,20 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c470.test(input.charAt(peg$currPos))) {
+    if (peg$c465.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c471); }
+      if (peg$silentFails === 0) { peg$fail(peg$c466); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c470.test(input.charAt(peg$currPos))) {
+      if (peg$c465.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c471); }
+        if (peg$silentFails === 0) { peg$fail(peg$c466); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -12883,22 +12787,22 @@ function peg$parse(input, options) {
               }
               if (s7 !== peg$FAILED) {
                 s8 = [];
-                if (peg$c470.test(input.charAt(peg$currPos))) {
+                if (peg$c465.test(input.charAt(peg$currPos))) {
                   s9 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s9 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c471); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c466); }
                 }
                 if (s9 !== peg$FAILED) {
                   while (s9 !== peg$FAILED) {
                     s8.push(s9);
-                    if (peg$c470.test(input.charAt(peg$currPos))) {
+                    if (peg$c465.test(input.charAt(peg$currPos))) {
                       s9 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c471); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c466); }
                     }
                   }
                 } else {
@@ -12953,28 +12857,28 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     if (input.charCodeAt(peg$currPos) === 90) {
-      s0 = peg$c479;
+      s0 = peg$c474;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c480); }
+      if (peg$silentFails === 0) { peg$fail(peg$c475); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 43) {
-        s1 = peg$c279;
+        s1 = peg$c274;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c280); }
+        if (peg$silentFails === 0) { peg$fail(peg$c275); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 45) {
-          s1 = peg$c281;
+          s1 = peg$c276;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c282); }
+          if (peg$silentFails === 0) { peg$fail(peg$c277); }
         }
       }
       if (s1 !== peg$FAILED) {
@@ -13000,22 +12904,22 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 s7 = [];
-                if (peg$c470.test(input.charAt(peg$currPos))) {
+                if (peg$c465.test(input.charAt(peg$currPos))) {
                   s8 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s8 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c471); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c466); }
                 }
                 if (s8 !== peg$FAILED) {
                   while (s8 !== peg$FAILED) {
                     s7.push(s8);
-                    if (peg$c470.test(input.charAt(peg$currPos))) {
+                    if (peg$c465.test(input.charAt(peg$currPos))) {
                       s8 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s8 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c471); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c466); }
                     }
                   }
                 } else {
@@ -13068,11 +12972,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c281;
+      s1 = peg$c276;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c282); }
+      if (peg$silentFails === 0) { peg$fail(peg$c277); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -13118,7 +13022,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c481();
+        s1 = peg$c476();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13180,76 +13084,76 @@ function peg$parse(input, options) {
   function peg$parseTimeUnit() {
     var s0;
 
-    if (input.substr(peg$currPos, 2) === peg$c482) {
-      s0 = peg$c482;
+    if (input.substr(peg$currPos, 2) === peg$c477) {
+      s0 = peg$c477;
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c483); }
+      if (peg$silentFails === 0) { peg$fail(peg$c478); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c484) {
-        s0 = peg$c484;
+      if (input.substr(peg$currPos, 2) === peg$c479) {
+        s0 = peg$c479;
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c485); }
+        if (peg$silentFails === 0) { peg$fail(peg$c480); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c486) {
-          s0 = peg$c486;
+        if (input.substr(peg$currPos, 2) === peg$c481) {
+          s0 = peg$c481;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c487); }
+          if (peg$silentFails === 0) { peg$fail(peg$c482); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 115) {
-            s0 = peg$c488;
+            s0 = peg$c483;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c489); }
+            if (peg$silentFails === 0) { peg$fail(peg$c484); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c490;
+              s0 = peg$c485;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c491); }
+              if (peg$silentFails === 0) { peg$fail(peg$c486); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 104) {
-                s0 = peg$c492;
+                s0 = peg$c487;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c493); }
+                if (peg$silentFails === 0) { peg$fail(peg$c488); }
               }
               if (s0 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 100) {
-                  s0 = peg$c494;
+                  s0 = peg$c489;
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c495); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c490); }
                 }
                 if (s0 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 119) {
-                    s0 = peg$c496;
+                    s0 = peg$c491;
                     peg$currPos++;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c497); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c492); }
                   }
                   if (s0 === peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 121) {
-                      s0 = peg$c498;
+                      s0 = peg$c493;
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c499); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c494); }
                     }
                   }
                 }
@@ -13434,7 +13338,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c500(s1, s2);
+        s1 = peg$c495(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13455,12 +13359,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c501) {
-            s3 = peg$c501;
+          if (input.substr(peg$currPos, 2) === peg$c496) {
+            s3 = peg$c496;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c502); }
+            if (peg$silentFails === 0) { peg$fail(peg$c497); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -13473,7 +13377,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c503(s1, s2, s4, s5);
+                s1 = peg$c498(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -13497,12 +13401,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c501) {
-          s1 = peg$c501;
+        if (input.substr(peg$currPos, 2) === peg$c496) {
+          s1 = peg$c496;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c502); }
+          if (peg$silentFails === 0) { peg$fail(peg$c497); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -13515,7 +13419,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c504(s2, s3);
+              s1 = peg$c499(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13540,16 +13444,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c501) {
-                s3 = peg$c501;
+              if (input.substr(peg$currPos, 2) === peg$c496) {
+                s3 = peg$c496;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c502); }
+                if (peg$silentFails === 0) { peg$fail(peg$c497); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c505(s1, s2);
+                s1 = peg$c500(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -13565,16 +13469,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c501) {
-              s1 = peg$c501;
+            if (input.substr(peg$currPos, 2) === peg$c496) {
+              s1 = peg$c496;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c502); }
+              if (peg$silentFails === 0) { peg$fail(peg$c497); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c506();
+              s1 = peg$c501();
             }
             s0 = s1;
           }
@@ -13611,7 +13515,7 @@ function peg$parse(input, options) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c507(s2);
+        s1 = peg$c502(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13640,7 +13544,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c508(s1);
+        s1 = peg$c503(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13661,17 +13565,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c283;
+        s2 = peg$c278;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c284); }
+        if (peg$silentFails === 0) { peg$fail(peg$c279); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c509(s1, s3);
+          s1 = peg$c504(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13696,17 +13600,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c283;
+        s2 = peg$c278;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c284); }
+        if (peg$silentFails === 0) { peg$fail(peg$c279); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c510(s1, s3);
+          s1 = peg$c505(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13731,7 +13635,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c511(s1);
+      s1 = peg$c506(s1);
     }
     s0 = s1;
 
@@ -13754,22 +13658,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c470.test(input.charAt(peg$currPos))) {
+    if (peg$c465.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c471); }
+      if (peg$silentFails === 0) { peg$fail(peg$c466); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c470.test(input.charAt(peg$currPos))) {
+        if (peg$c465.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c471); }
+          if (peg$silentFails === 0) { peg$fail(peg$c466); }
         }
       }
     } else {
@@ -13789,11 +13693,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c281;
+      s1 = peg$c276;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c282); }
+      if (peg$silentFails === 0) { peg$fail(peg$c277); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseUIntString();
@@ -13818,33 +13722,33 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c281;
+      s1 = peg$c276;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c282); }
+      if (peg$silentFails === 0) { peg$fail(peg$c277); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c470.test(input.charAt(peg$currPos))) {
+      if (peg$c465.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c471); }
+        if (peg$silentFails === 0) { peg$fail(peg$c466); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c470.test(input.charAt(peg$currPos))) {
+          if (peg$c465.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c471); }
+            if (peg$silentFails === 0) { peg$fail(peg$c466); }
           }
         }
       } else {
@@ -13860,21 +13764,21 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c470.test(input.charAt(peg$currPos))) {
+          if (peg$c465.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c471); }
+            if (peg$silentFails === 0) { peg$fail(peg$c466); }
           }
           while (s5 !== peg$FAILED) {
             s4.push(s5);
-            if (peg$c470.test(input.charAt(peg$currPos))) {
+            if (peg$c465.test(input.charAt(peg$currPos))) {
               s5 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c471); }
+              if (peg$silentFails === 0) { peg$fail(peg$c466); }
             }
           }
           if (s4 !== peg$FAILED) {
@@ -13884,7 +13788,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c512();
+              s1 = peg$c507();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13909,11 +13813,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c281;
+        s1 = peg$c276;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c282); }
+        if (peg$silentFails === 0) { peg$fail(peg$c277); }
       }
       if (s1 === peg$FAILED) {
         s1 = null;
@@ -13928,22 +13832,22 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c470.test(input.charAt(peg$currPos))) {
+          if (peg$c465.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c471); }
+            if (peg$silentFails === 0) { peg$fail(peg$c466); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c470.test(input.charAt(peg$currPos))) {
+              if (peg$c465.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c471); }
+                if (peg$silentFails === 0) { peg$fail(peg$c466); }
               }
             }
           } else {
@@ -13956,7 +13860,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c512();
+              s1 = peg$c507();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13995,20 +13899,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c513) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c508) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c514); }
+      if (peg$silentFails === 0) { peg$fail(peg$c509); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c515.test(input.charAt(peg$currPos))) {
+      if (peg$c510.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c516); }
+        if (peg$silentFails === 0) { peg$fail(peg$c511); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -14037,12 +13941,12 @@ function peg$parse(input, options) {
   function peg$parseNaN() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c517) {
-      s0 = peg$c517;
+    if (input.substr(peg$currPos, 3) === peg$c512) {
+      s0 = peg$c512;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c518); }
+      if (peg$silentFails === 0) { peg$fail(peg$c513); }
     }
 
     return s0;
@@ -14053,31 +13957,31 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c281;
+      s1 = peg$c276;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c282); }
+      if (peg$silentFails === 0) { peg$fail(peg$c277); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 43) {
-        s1 = peg$c279;
+        s1 = peg$c274;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c280); }
+        if (peg$silentFails === 0) { peg$fail(peg$c275); }
       }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c519) {
-        s2 = peg$c519;
+      if (input.substr(peg$currPos, 3) === peg$c514) {
+        s2 = peg$c514;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c520); }
+        if (peg$silentFails === 0) { peg$fail(peg$c515); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -14120,12 +14024,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c521.test(input.charAt(peg$currPos))) {
+    if (peg$c516.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c522); }
+      if (peg$silentFails === 0) { peg$fail(peg$c517); }
     }
 
     return s0;
@@ -14136,11 +14040,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c405;
+      s1 = peg$c400;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c406); }
+      if (peg$silentFails === 0) { peg$fail(peg$c401); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -14151,15 +14055,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c405;
+          s3 = peg$c400;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c406); }
+          if (peg$silentFails === 0) { peg$fail(peg$c401); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c523(s2);
+          s1 = peg$c518(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -14176,11 +14080,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c407;
+        s1 = peg$c402;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c408); }
+        if (peg$silentFails === 0) { peg$fail(peg$c403); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -14191,15 +14095,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c407;
+            s3 = peg$c402;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c408); }
+            if (peg$silentFails === 0) { peg$fail(peg$c403); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c523(s2);
+            s1 = peg$c518(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -14225,11 +14129,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c405;
+      s2 = peg$c400;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c406); }
+      if (peg$silentFails === 0) { peg$fail(peg$c401); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -14247,7 +14151,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c524); }
+        if (peg$silentFails === 0) { peg$fail(peg$c519); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14264,11 +14168,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c410;
+        s1 = peg$c405;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c411); }
+        if (peg$silentFails === 0) { peg$fail(peg$c406); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -14303,7 +14207,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c525(s1, s2);
+        s1 = peg$c520(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14332,12 +14236,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (peg$c526.test(input.charAt(peg$currPos))) {
+    if (peg$c521.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c527); }
+      if (peg$silentFails === 0) { peg$fail(peg$c522); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -14353,12 +14257,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseKeyWordStart();
     if (s0 === peg$FAILED) {
-      if (peg$c470.test(input.charAt(peg$currPos))) {
+      if (peg$c465.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c471); }
+        if (peg$silentFails === 0) { peg$fail(peg$c466); }
       }
     }
 
@@ -14370,11 +14274,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c410;
+      s1 = peg$c405;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c411); }
+      if (peg$silentFails === 0) { peg$fail(peg$c406); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseKeywordEscape();
@@ -14433,7 +14337,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c528(s3, s4);
+            s1 = peg$c523(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -14551,7 +14455,7 @@ function peg$parse(input, options) {
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c529();
+          s1 = peg$c524();
         }
         s0 = s1;
       }
@@ -14565,12 +14469,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseGlobStart();
     if (s0 === peg$FAILED) {
-      if (peg$c470.test(input.charAt(peg$currPos))) {
+      if (peg$c465.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c471); }
+        if (peg$silentFails === 0) { peg$fail(peg$c466); }
       }
     }
 
@@ -14582,11 +14486,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c410;
+      s1 = peg$c405;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c411); }
+      if (peg$silentFails === 0) { peg$fail(peg$c406); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseGlobEscape();
@@ -14622,7 +14526,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c530();
+      s1 = peg$c525();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -14636,16 +14540,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c531();
+        s1 = peg$c526();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c515.test(input.charAt(peg$currPos))) {
+        if (peg$c510.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c516); }
+          if (peg$silentFails === 0) { peg$fail(peg$c511); }
         }
       }
     }
@@ -14660,11 +14564,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c407;
+      s2 = peg$c402;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c408); }
+      if (peg$silentFails === 0) { peg$fail(peg$c403); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -14682,7 +14586,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c524); }
+        if (peg$silentFails === 0) { peg$fail(peg$c519); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14699,11 +14603,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c410;
+        s1 = peg$c405;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c411); }
+        if (peg$silentFails === 0) { peg$fail(peg$c406); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -14739,20 +14643,20 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c407;
+      s0 = peg$c402;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c408); }
+      if (peg$silentFails === 0) { peg$fail(peg$c403); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s1 = peg$c405;
+        s1 = peg$c400;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c406); }
+        if (peg$silentFails === 0) { peg$fail(peg$c401); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14761,94 +14665,94 @@ function peg$parse(input, options) {
       s0 = s1;
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c410;
+          s0 = peg$c405;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c411); }
+          if (peg$silentFails === 0) { peg$fail(peg$c406); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c532;
+            s1 = peg$c527;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c533); }
+            if (peg$silentFails === 0) { peg$fail(peg$c528); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c534();
+            s1 = peg$c529();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c535;
+              s1 = peg$c530;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c536); }
+              if (peg$silentFails === 0) { peg$fail(peg$c531); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c537();
+              s1 = peg$c532();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c538;
+                s1 = peg$c533;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c539); }
+                if (peg$silentFails === 0) { peg$fail(peg$c534); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c540();
+                s1 = peg$c535();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c541;
+                  s1 = peg$c536;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c542); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c537); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c543();
+                  s1 = peg$c538();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c544;
+                    s1 = peg$c539;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c545); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c540); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c546();
+                    s1 = peg$c541();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c547;
+                      s1 = peg$c542;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c548); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c543); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c549();
+                      s1 = peg$c544();
                     }
                     s0 = s1;
                   }
@@ -14876,7 +14780,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c530();
+      s1 = peg$c525();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -14890,16 +14794,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c550();
+        s1 = peg$c545();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c515.test(input.charAt(peg$currPos))) {
+        if (peg$c510.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c516); }
+          if (peg$silentFails === 0) { peg$fail(peg$c511); }
         }
       }
     }
@@ -14912,11 +14816,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c551;
+      s1 = peg$c546;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c552); }
+      if (peg$silentFails === 0) { peg$fail(peg$c547); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -14948,7 +14852,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c553(s2);
+        s1 = peg$c548(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14961,11 +14865,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c551;
+        s1 = peg$c546;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c552); }
+        if (peg$silentFails === 0) { peg$fail(peg$c547); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
@@ -15032,15 +14936,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c311;
+              s4 = peg$c306;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c312); }
+              if (peg$silentFails === 0) { peg$fail(peg$c307); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c553(s3);
+              s1 = peg$c548(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -15068,21 +14972,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c283;
+      s1 = peg$c278;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c284); }
+      if (peg$silentFails === 0) { peg$fail(peg$c279); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseRegexpBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c283;
+          s3 = peg$c278;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c284); }
+          if (peg$silentFails === 0) { peg$fail(peg$c279); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$currPos;
@@ -15124,21 +15028,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c554.test(input.charAt(peg$currPos))) {
+    if (peg$c549.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c555); }
+      if (peg$silentFails === 0) { peg$fail(peg$c550); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s3 = peg$c410;
+        s3 = peg$c405;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c411); }
+        if (peg$silentFails === 0) { peg$fail(peg$c406); }
       }
       if (s3 !== peg$FAILED) {
         if (input.length > peg$currPos) {
@@ -15146,7 +15050,7 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c524); }
+          if (peg$silentFails === 0) { peg$fail(peg$c519); }
         }
         if (s4 !== peg$FAILED) {
           s3 = [s3, s4];
@@ -15163,21 +15067,21 @@ function peg$parse(input, options) {
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c554.test(input.charAt(peg$currPos))) {
+        if (peg$c549.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c555); }
+          if (peg$silentFails === 0) { peg$fail(peg$c550); }
         }
         if (s2 === peg$FAILED) {
           s2 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 92) {
-            s3 = peg$c410;
+            s3 = peg$c405;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c411); }
+            if (peg$silentFails === 0) { peg$fail(peg$c406); }
           }
           if (s3 !== peg$FAILED) {
             if (input.length > peg$currPos) {
@@ -15185,7 +15089,7 @@ function peg$parse(input, options) {
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c524); }
+              if (peg$silentFails === 0) { peg$fail(peg$c519); }
             }
             if (s4 !== peg$FAILED) {
               s3 = [s3, s4];
@@ -15215,12 +15119,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c556.test(input.charAt(peg$currPos))) {
+    if (peg$c551.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c557); }
+      if (peg$silentFails === 0) { peg$fail(peg$c552); }
     }
 
     return s0;
@@ -15278,7 +15182,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c524); }
+      if (peg$silentFails === 0) { peg$fail(peg$c519); }
     }
 
     return s0;
@@ -15289,51 +15193,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c559;
+      s0 = peg$c554;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c560); }
+      if (peg$silentFails === 0) { peg$fail(peg$c555); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c561;
+        s0 = peg$c556;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c562); }
+        if (peg$silentFails === 0) { peg$fail(peg$c557); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c563;
+          s0 = peg$c558;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c564); }
+          if (peg$silentFails === 0) { peg$fail(peg$c559); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c565;
+            s0 = peg$c560;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c566); }
+            if (peg$silentFails === 0) { peg$fail(peg$c561); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c567;
+              s0 = peg$c562;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c568); }
+              if (peg$silentFails === 0) { peg$fail(peg$c563); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c569;
+                s0 = peg$c564;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c570); }
+                if (peg$silentFails === 0) { peg$fail(peg$c565); }
               }
             }
           }
@@ -15343,7 +15247,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c558); }
+      if (peg$silentFails === 0) { peg$fail(peg$c553); }
     }
 
     return s0;
@@ -15352,12 +15256,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c571.test(input.charAt(peg$currPos))) {
+    if (peg$c566.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c572); }
+      if (peg$silentFails === 0) { peg$fail(peg$c567); }
     }
 
     return s0;
@@ -15371,7 +15275,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c573); }
+      if (peg$silentFails === 0) { peg$fail(peg$c568); }
     }
 
     return s0;
@@ -15381,24 +15285,24 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c574) {
-      s1 = peg$c574;
+    if (input.substr(peg$currPos, 2) === peg$c569) {
+      s1 = peg$c569;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c575); }
+      if (peg$silentFails === 0) { peg$fail(peg$c570); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c576) {
-        s5 = peg$c576;
+      if (input.substr(peg$currPos, 2) === peg$c571) {
+        s5 = peg$c571;
         peg$currPos += 2;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c577); }
+        if (peg$silentFails === 0) { peg$fail(peg$c572); }
       }
       peg$silentFails--;
       if (s5 === peg$FAILED) {
@@ -15425,12 +15329,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$currPos;
         peg$silentFails++;
-        if (input.substr(peg$currPos, 2) === peg$c576) {
-          s5 = peg$c576;
+        if (input.substr(peg$currPos, 2) === peg$c571) {
+          s5 = peg$c571;
           peg$currPos += 2;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c577); }
+          if (peg$silentFails === 0) { peg$fail(peg$c572); }
         }
         peg$silentFails--;
         if (s5 === peg$FAILED) {
@@ -15454,12 +15358,12 @@ function peg$parse(input, options) {
         }
       }
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c576) {
-          s3 = peg$c576;
+        if (input.substr(peg$currPos, 2) === peg$c571) {
+          s3 = peg$c571;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c577); }
+          if (peg$silentFails === 0) { peg$fail(peg$c572); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -15484,12 +15388,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c578) {
-      s1 = peg$c578;
+    if (input.substr(peg$currPos, 2) === peg$c573) {
+      s1 = peg$c573;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c579); }
+      if (peg$silentFails === 0) { peg$fail(peg$c574); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -15607,7 +15511,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c524); }
+      if (peg$silentFails === 0) { peg$fail(peg$c519); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/compiler/parser/parser.js
+++ b/compiler/parser/parser.js
@@ -608,52 +608,48 @@ function peg$parse(input, options) {
       peg$c236 = ":desc",
       peg$c237 = peg$literalExpectation(":desc", false),
       peg$c238 = function() { return "desc" },
-      peg$c239 = "asc",
-      peg$c240 = peg$literalExpectation("asc", false),
-      peg$c241 = "desc",
-      peg$c242 = peg$literalExpectation("desc", false),
-      peg$c243 = "pass",
-      peg$c244 = peg$literalExpectation("pass", false),
-      peg$c245 = function() {
+      peg$c239 = "pass",
+      peg$c240 = peg$literalExpectation("pass", false),
+      peg$c241 = function() {
             return {"kind":"Pass"}
           },
-      peg$c246 = "explode",
-      peg$c247 = peg$literalExpectation("explode", false),
-      peg$c248 = function(args, typ, as) {
+      peg$c242 = "explode",
+      peg$c243 = peg$literalExpectation("explode", false),
+      peg$c244 = function(args, typ, as) {
             return {"kind":"Explode", "args": args, "as": as, "type": typ}
           },
-      peg$c249 = "merge",
-      peg$c250 = peg$literalExpectation("merge", false),
-      peg$c251 = function(expr) {
+      peg$c245 = "merge",
+      peg$c246 = peg$literalExpectation("merge", false),
+      peg$c247 = function(expr) {
       	  return {"kind":"Merge", "expr":expr}
           },
-      peg$c252 = "over",
-      peg$c253 = peg$literalExpectation("over", false),
-      peg$c254 = function(exprs, locals, scope) {
+      peg$c248 = "over",
+      peg$c249 = peg$literalExpectation("over", false),
+      peg$c250 = function(exprs, locals, scope) {
             let over = {"kind": "Over", "exprs": exprs, "scope": scope}
             if (locals) {
               return {"kind": "Let", "locals": locals, "over": over}
             }
             return over
           },
-      peg$c255 = function(seq) { return seq },
-      peg$c256 = function(first, a) { return a },
-      peg$c257 = function(name, opt) {
+      peg$c251 = function(seq) { return seq },
+      peg$c252 = function(first, a) { return a },
+      peg$c253 = function(name, opt) {
             let m = {"name": name, "expr": {"kind": "ID", "name": name}}
             if (opt) {
                m["expr"] = opt[3]
             }
             return m
           },
-      peg$c258 = "yield",
-      peg$c259 = peg$literalExpectation("yield", false),
-      peg$c260 = function(exprs) {
+      peg$c254 = "yield",
+      peg$c255 = peg$literalExpectation("yield", false),
+      peg$c256 = function(exprs) {
       	  return {"kind":"Yield", "exprs":exprs}
           },
-      peg$c261 = function(typ) { return typ},
-      peg$c262 = function(lhs) { return lhs },
-      peg$c263 = function(first, lval) { return lval },
-      peg$c264 = function(first, rest) {
+      peg$c257 = function(typ) { return typ},
+      peg$c258 = function(lhs) { return lhs },
+      peg$c259 = function(first, lval) { return lval },
+      peg$c260 = function(first, rest) {
             let result = [first]
 
             for(let  r of rest) {
@@ -662,13 +658,13 @@ function peg$parse(input, options) {
 
             return result
           },
-      peg$c265 = function(first, rest) {
+      peg$c261 = function(first, rest) {
           return [first, ... rest]
         },
-      peg$c266 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c267 = "?",
-      peg$c268 = peg$literalExpectation("?", false),
-      peg$c269 = function(cond, opt) {
+      peg$c262 = function(lhs, rhs) { return {"kind": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c263 = "?",
+      peg$c264 = peg$literalExpectation("?", false),
+      peg$c265 = function(cond, opt) {
             if (opt) {
               let Then = opt[3]
               let Else = opt[7]
@@ -676,12 +672,12 @@ function peg$parse(input, options) {
             }
             return cond
           },
-      peg$c270 = function(first, op, expr) { return [op, expr] },
-      peg$c271 = function(first, rest) {
+      peg$c266 = function(first, op, expr) { return [op, expr] },
+      peg$c267 = function(first, rest) {
               return makeBinaryExprChain(first, rest)
           },
-      peg$c272 = function(lhs) { return text() },
-      peg$c273 = function(lhs, opAndRHS) {
+      peg$c268 = function(lhs) { return text() },
+      peg$c269 = function(lhs, opAndRHS) {
             if (!opAndRHS) {
               return lhs
             }
@@ -689,106 +685,106 @@ function peg$parse(input, options) {
             let rhs = opAndRHS[3]
             return {"kind": "BinaryExpr", "op": op, "lhs": lhs, "rhs": rhs}
           },
-      peg$c274 = "+",
-      peg$c275 = peg$literalExpectation("+", false),
-      peg$c276 = "-",
-      peg$c277 = peg$literalExpectation("-", false),
-      peg$c278 = "/",
-      peg$c279 = peg$literalExpectation("/", false),
-      peg$c280 = "%",
-      peg$c281 = peg$literalExpectation("%", false),
-      peg$c282 = function(e) {
+      peg$c270 = "+",
+      peg$c271 = peg$literalExpectation("+", false),
+      peg$c272 = "-",
+      peg$c273 = peg$literalExpectation("-", false),
+      peg$c274 = "/",
+      peg$c275 = peg$literalExpectation("/", false),
+      peg$c276 = "%",
+      peg$c277 = peg$literalExpectation("%", false),
+      peg$c278 = function(e) {
               return {"kind": "UnaryExpr", "op": "!", "operand": e}
           },
-      peg$c283 = function(e) {
+      peg$c279 = function(e) {
               return {"kind": "UnaryExpr", "op": "-", "operand": e}
           },
-      peg$c284 = "not",
-      peg$c285 = peg$literalExpectation("not", false),
-      peg$c286 = "select",
-      peg$c287 = peg$literalExpectation("select", false),
-      peg$c288 = function(typ, expr) {
+      peg$c280 = "not",
+      peg$c281 = peg$literalExpectation("not", false),
+      peg$c282 = "select",
+      peg$c283 = peg$literalExpectation("select", false),
+      peg$c284 = function(typ, expr) {
             return {"kind": "Cast", "expr": expr, "type": typ}
           },
-      peg$c289 = "regexp",
-      peg$c290 = peg$literalExpectation("regexp", false),
-      peg$c291 = function(arg0Text, arg1, where) {
+      peg$c285 = "regexp",
+      peg$c286 = peg$literalExpectation("regexp", false),
+      peg$c287 = function(arg0Text, arg1, where) {
             let arg0 = {"kind": "Primitive", "type": "string", "text": arg0Text}
             return {"kind": "Call", "name": "regexp", "args": [arg0, arg1], "where": where}
           },
-      peg$c292 = function(fn, args, where) {
+      peg$c288 = function(fn, args, where) {
             return {"kind": "Call", "name": fn, "args": args, "where": where}
           },
-      peg$c293 = function(o) { return [o] },
-      peg$c294 = "grep",
-      peg$c295 = peg$literalExpectation("grep", false),
-      peg$c296 = function(pattern, opt) {
+      peg$c289 = function(o) { return [o] },
+      peg$c290 = "grep",
+      peg$c291 = peg$literalExpectation("grep", false),
+      peg$c292 = function(pattern, opt) {
             let m = {"kind": "Grep", "pattern": pattern, "expr": {"kind": "ID", "name": "this"}}
             if (opt) {
               m["expr"] = opt[2]
             }
             return m
           },
-      peg$c297 = function(s) {
+      peg$c293 = function(s) {
             return {"kind": "String", "text": s}
           },
-      peg$c298 = function(first, e) { return e },
-      peg$c299 = "]",
-      peg$c300 = peg$literalExpectation("]", false),
-      peg$c301 = function(from, to) {
+      peg$c294 = function(first, e) { return e },
+      peg$c295 = "]",
+      peg$c296 = peg$literalExpectation("]", false),
+      peg$c297 = function(from, to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs":from, "rhs":to}]
           
           },
-      peg$c302 = function(to) {
+      peg$c298 = function(to) {
             return ["[", {"kind": "BinaryExpr", "op":":",
                                   
             "lhs": null, "rhs":to}]
           
           },
-      peg$c303 = function(expr) { return ["[", expr] },
-      peg$c304 = function(id) { return [".", id] },
-      peg$c305 = function(exprs, locals, scope) {
+      peg$c299 = function(expr) { return ["[", expr] },
+      peg$c300 = function(id) { return [".", id] },
+      peg$c301 = function(exprs, locals, scope) {
             return {"kind": "OverExpr", "locals": locals, "exprs": exprs, "scope": scope}
           },
-      peg$c306 = "}",
-      peg$c307 = peg$literalExpectation("}", false),
-      peg$c308 = function(elems) {
+      peg$c302 = "}",
+      peg$c303 = peg$literalExpectation("}", false),
+      peg$c304 = function(elems) {
             return {"kind":"RecordExpr", "elems":elems}
           },
-      peg$c309 = function(elem) { return elem },
-      peg$c310 = "...",
-      peg$c311 = peg$literalExpectation("...", false),
-      peg$c312 = function(expr) {
+      peg$c305 = function(elem) { return elem },
+      peg$c306 = "...",
+      peg$c307 = peg$literalExpectation("...", false),
+      peg$c308 = function(expr) {
             return {"kind":"Spread", "expr": expr}
           },
-      peg$c313 = function(name, value) {
+      peg$c309 = function(name, value) {
             return {"kind":"Field","name": name, "value": value}
           },
-      peg$c314 = function(elems) {
+      peg$c310 = function(elems) {
             return {"kind":"ArrayExpr", "elems":elems }
           },
-      peg$c315 = "|[",
-      peg$c316 = peg$literalExpectation("|[", false),
-      peg$c317 = "]|",
-      peg$c318 = peg$literalExpectation("]|", false),
-      peg$c319 = function(elems) {
+      peg$c311 = "|[",
+      peg$c312 = peg$literalExpectation("|[", false),
+      peg$c313 = "]|",
+      peg$c314 = peg$literalExpectation("]|", false),
+      peg$c315 = function(elems) {
             return {"kind":"SetExpr", "elems":elems }
           },
-      peg$c320 = function(e) { return {"kind":"VectorValue","expr":e} },
-      peg$c321 = "|{",
-      peg$c322 = peg$literalExpectation("|{", false),
-      peg$c323 = "}|",
-      peg$c324 = peg$literalExpectation("}|", false),
-      peg$c325 = function(exprs) {
+      peg$c316 = function(e) { return {"kind":"VectorValue","expr":e} },
+      peg$c317 = "|{",
+      peg$c318 = peg$literalExpectation("|{", false),
+      peg$c319 = "}|",
+      peg$c320 = peg$literalExpectation("}|", false),
+      peg$c321 = function(exprs) {
             return {"kind":"MapExpr", "entries":exprs }
           },
-      peg$c326 = function(e) { return e },
-      peg$c327 = function(key, value) {
+      peg$c322 = function(e) { return e },
+      peg$c323 = function(key, value) {
             return {"key": key, "value": value}
           },
-      peg$c328 = function(selection, from, joins, where, groupby, having, orderby, limit) {
+      peg$c324 = function(selection, from, joins, where, groupby, having, orderby, limit) {
             return {
               
             "kind": "SQLExpr",
@@ -810,19 +806,19 @@ function peg$parse(input, options) {
             "limit": limit }
           
           },
-      peg$c329 = function(assignments) { return assignments },
-      peg$c330 = function(rhs, opt) {
+      peg$c325 = function(assignments) { return assignments },
+      peg$c326 = function(rhs, opt) {
             let m = {"kind": "Assignment", "lhs": null, "rhs": rhs}
             if (opt) {
               m["lhs"] = opt[3]
             }
             return m
           },
-      peg$c331 = function(table, alias) {
+      peg$c327 = function(table, alias) {
             return {"table": table, "alias": alias}
           },
-      peg$c332 = function(first, join) { return join },
-      peg$c333 = function(style, table, alias, leftKey, rightKey) {
+      peg$c328 = function(first, join) { return join },
+      peg$c329 = function(style, table, alias, leftKey, rightKey) {
             return {
               
             "table": table,
@@ -836,120 +832,122 @@ function peg$parse(input, options) {
             "alias": alias}
           
           },
-      peg$c334 = function(style) { return style },
-      peg$c335 = function(keys, order) {
+      peg$c330 = function(style) { return style },
+      peg$c331 = function(keys, order) {
             return {"kind": "SQLOrderBy", "keys": keys, "order":order}
           },
-      peg$c336 = function(dir) { return dir },
-      peg$c337 = function(count) { return count },
-      peg$c338 = peg$literalExpectation("select", true),
-      peg$c339 = function() { return "select" },
-      peg$c340 = "as",
-      peg$c341 = peg$literalExpectation("as", true),
-      peg$c342 = function() { return "as" },
-      peg$c343 = peg$literalExpectation("from", true),
-      peg$c344 = function() { return "from" },
-      peg$c345 = peg$literalExpectation("join", true),
-      peg$c346 = function() { return "join" },
-      peg$c347 = peg$literalExpectation("where", true),
-      peg$c348 = function() { return "where" },
-      peg$c349 = "group",
-      peg$c350 = peg$literalExpectation("group", true),
-      peg$c351 = function() { return "group" },
-      peg$c352 = "by",
-      peg$c353 = peg$literalExpectation("by", true),
-      peg$c354 = function() { return "by" },
-      peg$c355 = "having",
-      peg$c356 = peg$literalExpectation("having", true),
-      peg$c357 = function() { return "having" },
-      peg$c358 = peg$literalExpectation("order", true),
-      peg$c359 = function() { return "order" },
-      peg$c360 = "on",
-      peg$c361 = peg$literalExpectation("on", true),
-      peg$c362 = function() { return "on" },
-      peg$c363 = "limit",
-      peg$c364 = peg$literalExpectation("limit", true),
-      peg$c365 = function() { return "limit" },
-      peg$c366 = peg$literalExpectation("asc", true),
-      peg$c367 = peg$literalExpectation("desc", true),
-      peg$c368 = peg$literalExpectation("anti", true),
-      peg$c369 = peg$literalExpectation("left", true),
-      peg$c370 = peg$literalExpectation("right", true),
-      peg$c371 = peg$literalExpectation("inner", true),
-      peg$c372 = function(v) {
+      peg$c332 = function(dir) { return dir },
+      peg$c333 = function(count) { return count },
+      peg$c334 = peg$literalExpectation("select", true),
+      peg$c335 = function() { return "select" },
+      peg$c336 = "as",
+      peg$c337 = peg$literalExpectation("as", true),
+      peg$c338 = function() { return "as" },
+      peg$c339 = peg$literalExpectation("from", true),
+      peg$c340 = function() { return "from" },
+      peg$c341 = peg$literalExpectation("join", true),
+      peg$c342 = function() { return "join" },
+      peg$c343 = peg$literalExpectation("where", true),
+      peg$c344 = function() { return "where" },
+      peg$c345 = "group",
+      peg$c346 = peg$literalExpectation("group", true),
+      peg$c347 = function() { return "group" },
+      peg$c348 = "by",
+      peg$c349 = peg$literalExpectation("by", true),
+      peg$c350 = function() { return "by" },
+      peg$c351 = "having",
+      peg$c352 = peg$literalExpectation("having", true),
+      peg$c353 = function() { return "having" },
+      peg$c354 = peg$literalExpectation("order", true),
+      peg$c355 = function() { return "order" },
+      peg$c356 = "on",
+      peg$c357 = peg$literalExpectation("on", true),
+      peg$c358 = function() { return "on" },
+      peg$c359 = "limit",
+      peg$c360 = peg$literalExpectation("limit", true),
+      peg$c361 = function() { return "limit" },
+      peg$c362 = "asc",
+      peg$c363 = peg$literalExpectation("asc", true),
+      peg$c364 = "desc",
+      peg$c365 = peg$literalExpectation("desc", true),
+      peg$c366 = peg$literalExpectation("anti", true),
+      peg$c367 = peg$literalExpectation("left", true),
+      peg$c368 = peg$literalExpectation("right", true),
+      peg$c369 = peg$literalExpectation("inner", true),
+      peg$c370 = function(v) {
             return {"kind": "Primitive", "type": "net", "text": v}
           },
-      peg$c373 = function(v) {
+      peg$c371 = function(v) {
             return {"kind": "Primitive", "type": "ip", "text": v}
           },
-      peg$c374 = function(v) {
+      peg$c372 = function(v) {
             return {"kind": "Primitive", "type": "float64", "text": v}
           },
-      peg$c375 = function(v) {
+      peg$c373 = function(v) {
             return {"kind": "Primitive", "type": "int64", "text": v}
           },
-      peg$c376 = "true",
-      peg$c377 = peg$literalExpectation("true", false),
-      peg$c378 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
-      peg$c379 = "false",
-      peg$c380 = peg$literalExpectation("false", false),
-      peg$c381 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
-      peg$c382 = "null",
-      peg$c383 = peg$literalExpectation("null", false),
-      peg$c384 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
-      peg$c385 = "0x",
-      peg$c386 = peg$literalExpectation("0x", false),
-      peg$c387 = function() {
+      peg$c374 = "true",
+      peg$c375 = peg$literalExpectation("true", false),
+      peg$c376 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
+      peg$c377 = "false",
+      peg$c378 = peg$literalExpectation("false", false),
+      peg$c379 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
+      peg$c380 = "null",
+      peg$c381 = peg$literalExpectation("null", false),
+      peg$c382 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
+      peg$c383 = "0x",
+      peg$c384 = peg$literalExpectation("0x", false),
+      peg$c385 = function() {
       	return {"kind": "Primitive", "type": "bytes", "text": text()}
         },
-      peg$c388 = function(typ) {
+      peg$c386 = function(typ) {
             return {"kind": "TypeValue", "value": typ}
           },
-      peg$c389 = function(name) { return name },
-      peg$c390 = function(name, opt) {
+      peg$c387 = function(name) { return name },
+      peg$c388 = function(name, opt) {
             if (opt) {
               return {"kind": "TypeDef", "name": name, "type": opt[3]}
             }
             return {"kind": "TypeName", "name": name}
           },
-      peg$c391 = function(name) {
+      peg$c389 = function(name) {
             return {"kind": "TypeName", "name": name}
           },
-      peg$c392 = function(u) { return u },
-      peg$c393 = function(types) {
+      peg$c390 = function(u) { return u },
+      peg$c391 = function(types) {
             return {"kind": "TypeUnion", "types": types}
           },
-      peg$c394 = function(typ) { return typ },
-      peg$c395 = function(fields) {
+      peg$c392 = function(typ) { return typ },
+      peg$c393 = function(fields) {
             return {"kind":"TypeRecord", "fields":fields}
           },
-      peg$c396 = function(typ) {
+      peg$c394 = function(typ) {
             return {"kind":"TypeArray", "type":typ}
           },
-      peg$c397 = function(typ) {
+      peg$c395 = function(typ) {
             return {"kind":"TypeSet", "type":typ}
           },
-      peg$c398 = function(keyType, valType) {
+      peg$c396 = function(keyType, valType) {
             return {"kind":"TypeMap", "key_type":keyType, "val_type": valType}
           },
-      peg$c399 = function(v) {
+      peg$c397 = function(v) {
             if (v.length == 0) {
               return {"kind": "Primitive", "type": "string", "text": ""}
             }
             return makeTemplateExprChain(v)
           },
-      peg$c400 = "\"",
-      peg$c401 = peg$literalExpectation("\"", false),
-      peg$c402 = "'",
-      peg$c403 = peg$literalExpectation("'", false),
-      peg$c404 = function(v) {
+      peg$c398 = "\"",
+      peg$c399 = peg$literalExpectation("\"", false),
+      peg$c400 = "'",
+      peg$c401 = peg$literalExpectation("'", false),
+      peg$c402 = function(v) {
             return {"kind": "Primitive", "type": "string", "text": joinChars(v)}
           },
-      peg$c405 = "\\",
-      peg$c406 = peg$literalExpectation("\\", false),
-      peg$c407 = "${",
-      peg$c408 = peg$literalExpectation("${", false),
-      peg$c409 = function(e) {
+      peg$c403 = "\\",
+      peg$c404 = peg$literalExpectation("\\", false),
+      peg$c405 = "${",
+      peg$c406 = peg$literalExpectation("${", false),
+      peg$c407 = function(e) {
             return {
               
             "kind": "Cast",
@@ -963,199 +961,199 @@ function peg$parse(input, options) {
             "value": {"kind": "TypePrimitive", "name": "string"}}}
           
           },
-      peg$c410 = "uint8",
-      peg$c411 = peg$literalExpectation("uint8", false),
-      peg$c412 = "uint16",
-      peg$c413 = peg$literalExpectation("uint16", false),
-      peg$c414 = "uint32",
-      peg$c415 = peg$literalExpectation("uint32", false),
-      peg$c416 = "uint64",
-      peg$c417 = peg$literalExpectation("uint64", false),
-      peg$c418 = "int8",
-      peg$c419 = peg$literalExpectation("int8", false),
-      peg$c420 = "int16",
-      peg$c421 = peg$literalExpectation("int16", false),
-      peg$c422 = "int32",
-      peg$c423 = peg$literalExpectation("int32", false),
-      peg$c424 = "int64",
-      peg$c425 = peg$literalExpectation("int64", false),
-      peg$c426 = "float16",
-      peg$c427 = peg$literalExpectation("float16", false),
-      peg$c428 = "float32",
-      peg$c429 = peg$literalExpectation("float32", false),
-      peg$c430 = "float64",
-      peg$c431 = peg$literalExpectation("float64", false),
-      peg$c432 = "bool",
-      peg$c433 = peg$literalExpectation("bool", false),
-      peg$c434 = "string",
-      peg$c435 = peg$literalExpectation("string", false),
-      peg$c436 = "duration",
-      peg$c437 = peg$literalExpectation("duration", false),
-      peg$c438 = "time",
-      peg$c439 = peg$literalExpectation("time", false),
-      peg$c440 = "bytes",
-      peg$c441 = peg$literalExpectation("bytes", false),
-      peg$c442 = "ip",
-      peg$c443 = peg$literalExpectation("ip", false),
-      peg$c444 = "net",
-      peg$c445 = peg$literalExpectation("net", false),
-      peg$c446 = function() {
+      peg$c408 = "uint8",
+      peg$c409 = peg$literalExpectation("uint8", false),
+      peg$c410 = "uint16",
+      peg$c411 = peg$literalExpectation("uint16", false),
+      peg$c412 = "uint32",
+      peg$c413 = peg$literalExpectation("uint32", false),
+      peg$c414 = "uint64",
+      peg$c415 = peg$literalExpectation("uint64", false),
+      peg$c416 = "int8",
+      peg$c417 = peg$literalExpectation("int8", false),
+      peg$c418 = "int16",
+      peg$c419 = peg$literalExpectation("int16", false),
+      peg$c420 = "int32",
+      peg$c421 = peg$literalExpectation("int32", false),
+      peg$c422 = "int64",
+      peg$c423 = peg$literalExpectation("int64", false),
+      peg$c424 = "float16",
+      peg$c425 = peg$literalExpectation("float16", false),
+      peg$c426 = "float32",
+      peg$c427 = peg$literalExpectation("float32", false),
+      peg$c428 = "float64",
+      peg$c429 = peg$literalExpectation("float64", false),
+      peg$c430 = "bool",
+      peg$c431 = peg$literalExpectation("bool", false),
+      peg$c432 = "string",
+      peg$c433 = peg$literalExpectation("string", false),
+      peg$c434 = "duration",
+      peg$c435 = peg$literalExpectation("duration", false),
+      peg$c436 = "time",
+      peg$c437 = peg$literalExpectation("time", false),
+      peg$c438 = "bytes",
+      peg$c439 = peg$literalExpectation("bytes", false),
+      peg$c440 = "ip",
+      peg$c441 = peg$literalExpectation("ip", false),
+      peg$c442 = "net",
+      peg$c443 = peg$literalExpectation("net", false),
+      peg$c444 = function() {
                 return {"kind": "TypePrimitive", "name": text()}
               },
-      peg$c447 = function(name, typ) {
+      peg$c445 = function(name, typ) {
             return {"name": name, "type": typ}
           },
-      peg$c448 = "and",
-      peg$c449 = peg$literalExpectation("and", false),
-      peg$c450 = "AND",
-      peg$c451 = peg$literalExpectation("AND", false),
-      peg$c452 = function() { return "and" },
-      peg$c453 = "or",
-      peg$c454 = peg$literalExpectation("or", false),
-      peg$c455 = "OR",
-      peg$c456 = peg$literalExpectation("OR", false),
-      peg$c457 = function() { return "or" },
-      peg$c458 = function() { return "in" },
-      peg$c459 = "NOT",
-      peg$c460 = peg$literalExpectation("NOT", false),
-      peg$c461 = function() { return "not" },
-      peg$c462 = peg$literalExpectation("by", false),
-      peg$c463 = /^[A-Za-z_$]/,
-      peg$c464 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c465 = /^[0-9]/,
-      peg$c466 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c467 = function(id) { return {"kind": "ID", "name": id} },
-      peg$c468 = "$",
-      peg$c469 = peg$literalExpectation("$", false),
-      peg$c470 = function(first, id) { return id},
-      peg$c471 = "T",
-      peg$c472 = peg$literalExpectation("T", false),
-      peg$c473 = function() {
+      peg$c446 = "and",
+      peg$c447 = peg$literalExpectation("and", false),
+      peg$c448 = "AND",
+      peg$c449 = peg$literalExpectation("AND", false),
+      peg$c450 = function() { return "and" },
+      peg$c451 = "or",
+      peg$c452 = peg$literalExpectation("or", false),
+      peg$c453 = "OR",
+      peg$c454 = peg$literalExpectation("OR", false),
+      peg$c455 = function() { return "or" },
+      peg$c456 = function() { return "in" },
+      peg$c457 = "NOT",
+      peg$c458 = peg$literalExpectation("NOT", false),
+      peg$c459 = function() { return "not" },
+      peg$c460 = peg$literalExpectation("by", false),
+      peg$c461 = /^[A-Za-z_$]/,
+      peg$c462 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c463 = /^[0-9]/,
+      peg$c464 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c465 = function(id) { return {"kind": "ID", "name": id} },
+      peg$c466 = "$",
+      peg$c467 = peg$literalExpectation("$", false),
+      peg$c468 = function(first, id) { return id},
+      peg$c469 = "T",
+      peg$c470 = peg$literalExpectation("T", false),
+      peg$c471 = function() {
             return {"kind": "Primitive", "type": "time", "text": text()}
           },
-      peg$c474 = "Z",
-      peg$c475 = peg$literalExpectation("Z", false),
-      peg$c476 = function() {
+      peg$c472 = "Z",
+      peg$c473 = peg$literalExpectation("Z", false),
+      peg$c474 = function() {
             return {"kind": "Primitive", "type": "duration", "text": text()}
           },
-      peg$c477 = "ns",
-      peg$c478 = peg$literalExpectation("ns", false),
-      peg$c479 = "us",
-      peg$c480 = peg$literalExpectation("us", false),
-      peg$c481 = "ms",
-      peg$c482 = peg$literalExpectation("ms", false),
-      peg$c483 = "s",
-      peg$c484 = peg$literalExpectation("s", false),
-      peg$c485 = "m",
-      peg$c486 = peg$literalExpectation("m", false),
-      peg$c487 = "h",
-      peg$c488 = peg$literalExpectation("h", false),
-      peg$c489 = "d",
-      peg$c490 = peg$literalExpectation("d", false),
-      peg$c491 = "w",
-      peg$c492 = peg$literalExpectation("w", false),
-      peg$c493 = "y",
-      peg$c494 = peg$literalExpectation("y", false),
-      peg$c495 = function(a, b) {
+      peg$c475 = "ns",
+      peg$c476 = peg$literalExpectation("ns", false),
+      peg$c477 = "us",
+      peg$c478 = peg$literalExpectation("us", false),
+      peg$c479 = "ms",
+      peg$c480 = peg$literalExpectation("ms", false),
+      peg$c481 = "s",
+      peg$c482 = peg$literalExpectation("s", false),
+      peg$c483 = "m",
+      peg$c484 = peg$literalExpectation("m", false),
+      peg$c485 = "h",
+      peg$c486 = peg$literalExpectation("h", false),
+      peg$c487 = "d",
+      peg$c488 = peg$literalExpectation("d", false),
+      peg$c489 = "w",
+      peg$c490 = peg$literalExpectation("w", false),
+      peg$c491 = "y",
+      peg$c492 = peg$literalExpectation("y", false),
+      peg$c493 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c496 = "::",
-      peg$c497 = peg$literalExpectation("::", false),
-      peg$c498 = function(a, b, d, e) {
+      peg$c494 = "::",
+      peg$c495 = peg$literalExpectation("::", false),
+      peg$c496 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c499 = function(a, b) {
+      peg$c497 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c500 = function(a, b) {
+      peg$c498 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c501 = function() {
+      peg$c499 = function() {
             return "::"
           },
-      peg$c502 = function(v) { return ":" + v },
-      peg$c503 = function(v) { return v + ":" },
-      peg$c504 = function(a, m) {
+      peg$c500 = function(v) { return ":" + v },
+      peg$c501 = function(v) { return v + ":" },
+      peg$c502 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c505 = function(a, m) {
+      peg$c503 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c506 = function(s) { return parseInt(s) },
-      peg$c507 = function() {
+      peg$c504 = function(s) { return parseInt(s) },
+      peg$c505 = function() {
             return text()
           },
-      peg$c508 = "e",
-      peg$c509 = peg$literalExpectation("e", true),
-      peg$c510 = /^[+\-]/,
-      peg$c511 = peg$classExpectation(["+", "-"], false, false),
-      peg$c512 = "NaN",
-      peg$c513 = peg$literalExpectation("NaN", false),
-      peg$c514 = "Inf",
-      peg$c515 = peg$literalExpectation("Inf", false),
-      peg$c516 = /^[0-9a-fA-F]/,
-      peg$c517 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c518 = function(v) { return joinChars(v) },
-      peg$c519 = peg$anyExpectation(),
-      peg$c520 = function(head, tail) { return head + joinChars(tail) },
-      peg$c521 = /^[a-zA-Z_.:\/%#@~]/,
-      peg$c522 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
-      peg$c523 = function(head, tail) {
+      peg$c506 = "e",
+      peg$c507 = peg$literalExpectation("e", true),
+      peg$c508 = /^[+\-]/,
+      peg$c509 = peg$classExpectation(["+", "-"], false, false),
+      peg$c510 = "NaN",
+      peg$c511 = peg$literalExpectation("NaN", false),
+      peg$c512 = "Inf",
+      peg$c513 = peg$literalExpectation("Inf", false),
+      peg$c514 = /^[0-9a-fA-F]/,
+      peg$c515 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c516 = function(v) { return joinChars(v) },
+      peg$c517 = peg$anyExpectation(),
+      peg$c518 = function(head, tail) { return head + joinChars(tail) },
+      peg$c519 = /^[a-zA-Z_.:\/%#@~]/,
+      peg$c520 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
+      peg$c521 = function(head, tail) {
             return head + joinChars(tail)
           },
-      peg$c524 = function() { return "*"},
-      peg$c525 = function() { return "=" },
-      peg$c526 = function() { return "\\*" },
-      peg$c527 = "b",
-      peg$c528 = peg$literalExpectation("b", false),
-      peg$c529 = function() { return "\b" },
-      peg$c530 = "f",
-      peg$c531 = peg$literalExpectation("f", false),
-      peg$c532 = function() { return "\f" },
-      peg$c533 = "n",
-      peg$c534 = peg$literalExpectation("n", false),
-      peg$c535 = function() { return "\n" },
-      peg$c536 = "r",
-      peg$c537 = peg$literalExpectation("r", false),
-      peg$c538 = function() { return "\r" },
-      peg$c539 = "t",
-      peg$c540 = peg$literalExpectation("t", false),
-      peg$c541 = function() { return "\t" },
-      peg$c542 = "v",
-      peg$c543 = peg$literalExpectation("v", false),
-      peg$c544 = function() { return "\v" },
-      peg$c545 = function() { return "*" },
-      peg$c546 = "u",
-      peg$c547 = peg$literalExpectation("u", false),
-      peg$c548 = function(chars) {
+      peg$c522 = function() { return "*"},
+      peg$c523 = function() { return "=" },
+      peg$c524 = function() { return "\\*" },
+      peg$c525 = "b",
+      peg$c526 = peg$literalExpectation("b", false),
+      peg$c527 = function() { return "\b" },
+      peg$c528 = "f",
+      peg$c529 = peg$literalExpectation("f", false),
+      peg$c530 = function() { return "\f" },
+      peg$c531 = "n",
+      peg$c532 = peg$literalExpectation("n", false),
+      peg$c533 = function() { return "\n" },
+      peg$c534 = "r",
+      peg$c535 = peg$literalExpectation("r", false),
+      peg$c536 = function() { return "\r" },
+      peg$c537 = "t",
+      peg$c538 = peg$literalExpectation("t", false),
+      peg$c539 = function() { return "\t" },
+      peg$c540 = "v",
+      peg$c541 = peg$literalExpectation("v", false),
+      peg$c542 = function() { return "\v" },
+      peg$c543 = function() { return "*" },
+      peg$c544 = "u",
+      peg$c545 = peg$literalExpectation("u", false),
+      peg$c546 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c549 = /^[^\/\\]/,
-      peg$c550 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c551 = /^[\0-\x1F\\]/,
-      peg$c552 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c553 = peg$otherExpectation("whitespace"),
-      peg$c554 = "\t",
-      peg$c555 = peg$literalExpectation("\t", false),
-      peg$c556 = "\x0B",
-      peg$c557 = peg$literalExpectation("\x0B", false),
-      peg$c558 = "\f",
-      peg$c559 = peg$literalExpectation("\f", false),
-      peg$c560 = " ",
-      peg$c561 = peg$literalExpectation(" ", false),
-      peg$c562 = "\xA0",
-      peg$c563 = peg$literalExpectation("\xA0", false),
-      peg$c564 = "\uFEFF",
-      peg$c565 = peg$literalExpectation("\uFEFF", false),
-      peg$c566 = /^[\n\r\u2028\u2029]/,
-      peg$c567 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c568 = peg$otherExpectation("comment"),
-      peg$c569 = "/*",
-      peg$c570 = peg$literalExpectation("/*", false),
-      peg$c571 = "*/",
-      peg$c572 = peg$literalExpectation("*/", false),
-      peg$c573 = "//",
-      peg$c574 = peg$literalExpectation("//", false),
+      peg$c547 = /^[^\/\\]/,
+      peg$c548 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c549 = /^[\0-\x1F\\]/,
+      peg$c550 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c551 = peg$otherExpectation("whitespace"),
+      peg$c552 = "\t",
+      peg$c553 = peg$literalExpectation("\t", false),
+      peg$c554 = "\x0B",
+      peg$c555 = peg$literalExpectation("\x0B", false),
+      peg$c556 = "\f",
+      peg$c557 = peg$literalExpectation("\f", false),
+      peg$c558 = " ",
+      peg$c559 = peg$literalExpectation(" ", false),
+      peg$c560 = "\xA0",
+      peg$c561 = peg$literalExpectation("\xA0", false),
+      peg$c562 = "\uFEFF",
+      peg$c563 = peg$literalExpectation("\uFEFF", false),
+      peg$c564 = /^[\n\r\u2028\u2029]/,
+      peg$c565 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c566 = peg$otherExpectation("comment"),
+      peg$c567 = "/*",
+      peg$c568 = peg$literalExpectation("/*", false),
+      peg$c569 = "*/",
+      peg$c570 = peg$literalExpectation("*/", false),
+      peg$c571 = "//",
+      peg$c572 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -6004,105 +6002,16 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseOrderArg() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$currPos;
-    s1 = peg$parse_();
-    if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c227) {
-        s2 = peg$c227;
-        peg$currPos += 5;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c228); }
-      }
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parse_();
-        if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c239) {
-            s4 = peg$c239;
-            peg$currPos += 3;
-          } else {
-            s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c240); }
-          }
-          if (s4 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c235();
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$parse_();
-      if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c227) {
-          s2 = peg$c227;
-          peg$currPos += 5;
-        } else {
-          s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c228); }
-        }
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parse_();
-          if (s3 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c241) {
-              s4 = peg$c241;
-              peg$currPos += 4;
-            } else {
-              s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c242); }
-            }
-            if (s4 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c238();
-              s0 = s1;
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    }
-
-    return s0;
-  }
-
   function peg$parsePassOp() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c243) {
-      s1 = peg$c243;
+    if (input.substr(peg$currPos, 4) === peg$c239) {
+      s1 = peg$c239;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c244); }
+      if (peg$silentFails === 0) { peg$fail(peg$c240); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -6117,7 +6026,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c245();
+        s1 = peg$c241();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6135,12 +6044,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 7) === peg$c246) {
-      s1 = peg$c246;
+    if (input.substr(peg$currPos, 7) === peg$c242) {
+      s1 = peg$c242;
       peg$currPos += 7;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c247); }
+      if (peg$silentFails === 0) { peg$fail(peg$c243); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6155,7 +6064,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c248(s3, s4, s5);
+              s1 = peg$c244(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6185,12 +6094,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c249) {
-      s1 = peg$c249;
+    if (input.substr(peg$currPos, 5) === peg$c245) {
+      s1 = peg$c245;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c250); }
+      if (peg$silentFails === 0) { peg$fail(peg$c246); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6198,7 +6107,7 @@ function peg$parse(input, options) {
         s3 = peg$parseConditionalExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c251(s3);
+          s1 = peg$c247(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6220,12 +6129,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c252) {
-      s1 = peg$c252;
+    if (input.substr(peg$currPos, 4) === peg$c248) {
+      s1 = peg$c248;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c253); }
+      if (peg$silentFails === 0) { peg$fail(peg$c249); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6243,7 +6152,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c254(s3, s4, s5);
+              s1 = peg$c250(s3, s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6308,7 +6217,7 @@ function peg$parse(input, options) {
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c255(s6);
+                    s1 = peg$c251(s6);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -6381,7 +6290,7 @@ function peg$parse(input, options) {
                   s10 = peg$parseLocalsAssignment();
                   if (s10 !== peg$FAILED) {
                     peg$savedPos = s6;
-                    s7 = peg$c256(s4, s10);
+                    s7 = peg$c252(s4, s10);
                     s6 = s7;
                   } else {
                     peg$currPos = s6;
@@ -6417,7 +6326,7 @@ function peg$parse(input, options) {
                     s10 = peg$parseLocalsAssignment();
                     if (s10 !== peg$FAILED) {
                       peg$savedPos = s6;
-                      s7 = peg$c256(s4, s10);
+                      s7 = peg$c252(s4, s10);
                       s6 = s7;
                     } else {
                       peg$currPos = s6;
@@ -6508,7 +6417,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c257(s1, s2);
+        s1 = peg$c253(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6526,12 +6435,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c258) {
-      s1 = peg$c258;
+    if (input.substr(peg$currPos, 5) === peg$c254) {
+      s1 = peg$c254;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c259); }
+      if (peg$silentFails === 0) { peg$fail(peg$c255); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6539,7 +6448,7 @@ function peg$parse(input, options) {
         s3 = peg$parseExprs();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c260(s3);
+          s1 = peg$c256(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6570,7 +6479,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c261(s4);
+            s1 = peg$c257(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6605,7 +6514,7 @@ function peg$parse(input, options) {
           s4 = peg$parseDerefExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c262(s4);
+            s1 = peg$c258(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6650,7 +6559,7 @@ function peg$parse(input, options) {
             s7 = peg$parseDerefExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c263(s1, s7);
+              s4 = peg$c259(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6686,7 +6595,7 @@ function peg$parse(input, options) {
               s7 = peg$parseDerefExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c263(s1, s7);
+                s4 = peg$c259(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6799,7 +6708,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c264(s1, s2);
+        s1 = peg$c260(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6836,7 +6745,7 @@ function peg$parse(input, options) {
             s7 = peg$parseAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c256(s1, s7);
+              s4 = peg$c252(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6872,7 +6781,7 @@ function peg$parse(input, options) {
               s7 = peg$parseAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c256(s1, s7);
+                s4 = peg$c252(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6893,7 +6802,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c265(s1, s2);
+        s1 = peg$c261(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6928,7 +6837,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c266(s1, s5);
+              s1 = peg$c262(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6972,11 +6881,11 @@ function peg$parse(input, options) {
       s3 = peg$parse__();
       if (s3 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s4 = peg$c267;
+          s4 = peg$c263;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c268); }
+          if (peg$silentFails === 0) { peg$fail(peg$c264); }
         }
         if (s4 !== peg$FAILED) {
           s5 = peg$parse__();
@@ -7036,7 +6945,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c269(s1, s2);
+        s1 = peg$c265(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7067,7 +6976,7 @@ function peg$parse(input, options) {
             s7 = peg$parseLogicalAndExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c270(s1, s5, s7);
+              s4 = peg$c266(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7097,7 +7006,7 @@ function peg$parse(input, options) {
               s7 = peg$parseLogicalAndExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c270(s1, s5, s7);
+                s4 = peg$c266(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7118,7 +7027,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c271(s1, s2);
+        s1 = peg$c267(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7149,7 +7058,7 @@ function peg$parse(input, options) {
             s7 = peg$parseComparisonExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c270(s1, s5, s7);
+              s4 = peg$c266(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7179,7 +7088,7 @@ function peg$parse(input, options) {
               s7 = peg$parseComparisonExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c270(s1, s5, s7);
+                s4 = peg$c266(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7200,7 +7109,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c271(s1, s2);
+        s1 = peg$c267(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7261,7 +7170,7 @@ function peg$parse(input, options) {
           }
           if (s5 !== peg$FAILED) {
             peg$savedPos = s4;
-            s5 = peg$c272(s1);
+            s5 = peg$c268(s1);
           }
           s4 = s5;
           if (s4 !== peg$FAILED) {
@@ -7293,7 +7202,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c273(s1, s2);
+        s1 = peg$c269(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7324,7 +7233,7 @@ function peg$parse(input, options) {
             s7 = peg$parseMultiplicativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c270(s1, s5, s7);
+              s4 = peg$c266(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7354,7 +7263,7 @@ function peg$parse(input, options) {
               s7 = peg$parseMultiplicativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c270(s1, s5, s7);
+                s4 = peg$c266(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7375,7 +7284,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c271(s1, s2);
+        s1 = peg$c267(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7394,19 +7303,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c274;
+      s1 = peg$c270;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c275); }
+      if (peg$silentFails === 0) { peg$fail(peg$c271); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c276;
+        s1 = peg$c272;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c277); }
+        if (peg$silentFails === 0) { peg$fail(peg$c273); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -7435,7 +7344,7 @@ function peg$parse(input, options) {
             s7 = peg$parseNotExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c270(s1, s5, s7);
+              s4 = peg$c266(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -7465,7 +7374,7 @@ function peg$parse(input, options) {
               s7 = peg$parseNotExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c270(s1, s5, s7);
+                s4 = peg$c266(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -7486,7 +7395,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c271(s1, s2);
+        s1 = peg$c267(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7513,19 +7422,19 @@ function peg$parse(input, options) {
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c278;
+        s1 = peg$c274;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c279); }
+        if (peg$silentFails === 0) { peg$fail(peg$c275); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 37) {
-          s1 = peg$c280;
+          s1 = peg$c276;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c281); }
+          if (peg$silentFails === 0) { peg$fail(peg$c277); }
         }
       }
     }
@@ -7555,7 +7464,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c282(s3);
+          s1 = peg$c278(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7592,11 +7501,11 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c276;
+        s2 = peg$c272;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c277); }
+        if (peg$silentFails === 0) { peg$fail(peg$c273); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -7604,7 +7513,7 @@ function peg$parse(input, options) {
           s4 = peg$parseFuncExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c283(s4);
+            s1 = peg$c279(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7723,20 +7632,20 @@ function peg$parse(input, options) {
   function peg$parseNotFuncs() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c284) {
-      s0 = peg$c284;
+    if (input.substr(peg$currPos, 3) === peg$c280) {
+      s0 = peg$c280;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c285); }
+      if (peg$silentFails === 0) { peg$fail(peg$c281); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c286) {
-        s0 = peg$c286;
+      if (input.substr(peg$currPos, 6) === peg$c282) {
+        s0 = peg$c282;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c287); }
+        if (peg$silentFails === 0) { peg$fail(peg$c283); }
       }
     }
 
@@ -7777,7 +7686,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c288(s1, s5);
+                  s1 = peg$c284(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7817,12 +7726,12 @@ function peg$parse(input, options) {
     s0 = peg$parseGrep();
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c289) {
-        s1 = peg$c289;
+      if (input.substr(peg$currPos, 6) === peg$c285) {
+        s1 = peg$c285;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c290); }
+        if (peg$silentFails === 0) { peg$fail(peg$c286); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
@@ -7869,7 +7778,7 @@ function peg$parse(input, options) {
                             }
                             if (s12 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c291(s5, s9, s12);
+                              s1 = peg$c287(s5, s9, s12);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -7964,7 +7873,7 @@ function peg$parse(input, options) {
                         }
                         if (s9 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c292(s2, s6, s9);
+                          s1 = peg$c288(s2, s6, s9);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -8015,7 +7924,7 @@ function peg$parse(input, options) {
     s1 = peg$parseOverExpr();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c293(s1);
+      s1 = peg$c289(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -8029,12 +7938,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c294) {
-      s1 = peg$c294;
+    if (input.substr(peg$currPos, 4) === peg$c290) {
+      s1 = peg$c290;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c295); }
+      if (peg$silentFails === 0) { peg$fail(peg$c291); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8102,7 +8011,7 @@ function peg$parse(input, options) {
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c296(s5, s7);
+                    s1 = peg$c292(s5, s7);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -8151,7 +8060,7 @@ function peg$parse(input, options) {
         s1 = peg$parseQuotedString();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c297(s1);
+          s1 = peg$c293(s1);
         }
         s0 = s1;
       }
@@ -8200,7 +8109,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c298(s1, s7);
+              s4 = peg$c294(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -8236,7 +8145,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c298(s1, s7);
+                s4 = peg$c294(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -8346,15 +8255,15 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s7 = peg$c299;
+                  s7 = peg$c295;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c300); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c296); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c301(s2, s6);
+                  s1 = peg$c297(s2, s6);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8409,15 +8318,15 @@ function peg$parse(input, options) {
               s5 = peg$parseAdditiveExpr();
               if (s5 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s6 = peg$c299;
+                  s6 = peg$c295;
                   peg$currPos++;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c300); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c296); }
                 }
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c302(s5);
+                  s1 = peg$c298(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8456,15 +8365,15 @@ function peg$parse(input, options) {
           s2 = peg$parseConditionalExpr();
           if (s2 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s3 = peg$c299;
+              s3 = peg$c295;
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c300); }
+              if (peg$silentFails === 0) { peg$fail(peg$c296); }
             }
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c303(s2);
+              s1 = peg$c299(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8491,7 +8400,7 @@ function peg$parse(input, options) {
             s2 = peg$parseIdentifier();
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c304(s2);
+              s1 = peg$c300(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8628,12 +8537,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c252) {
-      s1 = peg$c252;
+    if (input.substr(peg$currPos, 4) === peg$c248) {
+      s1 = peg$c248;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c253); }
+      if (peg$silentFails === 0) { peg$fail(peg$c249); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -8660,7 +8569,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSequential();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c305(s3, s4, s8);
+                    s1 = peg$c301(s3, s4, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -8717,15 +8626,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c306;
+              s5 = peg$c302;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c307); }
+              if (peg$silentFails === 0) { peg$fail(peg$c303); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c308(s3);
+              s1 = peg$c304(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8765,7 +8674,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c265(s1, s2);
+        s1 = peg$c261(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8807,7 +8716,7 @@ function peg$parse(input, options) {
           s4 = peg$parseRecordElem();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c309(s4);
+            s1 = peg$c305(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8847,12 +8756,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c310) {
-      s1 = peg$c310;
+    if (input.substr(peg$currPos, 3) === peg$c306) {
+      s1 = peg$c306;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c311); }
+      if (peg$silentFails === 0) { peg$fail(peg$c307); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8860,7 +8769,7 @@ function peg$parse(input, options) {
         s3 = peg$parseConditionalExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c312(s3);
+          s1 = peg$c308(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8899,7 +8808,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c313(s1, s5);
+              s1 = peg$c309(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8944,15 +8853,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s5 = peg$c299;
+              s5 = peg$c295;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c300); }
+              if (peg$silentFails === 0) { peg$fail(peg$c296); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c314(s3);
+              s1 = peg$c310(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8982,12 +8891,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c315) {
-      s1 = peg$c315;
+    if (input.substr(peg$currPos, 2) === peg$c311) {
+      s1 = peg$c311;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c316); }
+      if (peg$silentFails === 0) { peg$fail(peg$c312); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -8996,16 +8905,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c317) {
-              s5 = peg$c317;
+            if (input.substr(peg$currPos, 2) === peg$c313) {
+              s5 = peg$c313;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c318); }
+              if (peg$silentFails === 0) { peg$fail(peg$c314); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c319(s3);
+              s1 = peg$c315(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9054,7 +8963,7 @@ function peg$parse(input, options) {
             s7 = peg$parseVectorElem();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c298(s1, s7);
+              s4 = peg$c294(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -9090,7 +8999,7 @@ function peg$parse(input, options) {
               s7 = peg$parseVectorElem();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c298(s1, s7);
+                s4 = peg$c294(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -9143,7 +9052,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c320(s1);
+        s1 = peg$c316(s1);
       }
       s0 = s1;
     }
@@ -9155,12 +9064,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c321) {
-      s1 = peg$c321;
+    if (input.substr(peg$currPos, 2) === peg$c317) {
+      s1 = peg$c317;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c322); }
+      if (peg$silentFails === 0) { peg$fail(peg$c318); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -9169,16 +9078,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c323) {
-              s5 = peg$c323;
+            if (input.substr(peg$currPos, 2) === peg$c319) {
+              s5 = peg$c319;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c324); }
+              if (peg$silentFails === 0) { peg$fail(peg$c320); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c325(s3);
+              s1 = peg$c321(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9218,7 +9127,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c265(s1, s2);
+        s1 = peg$c261(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9260,7 +9169,7 @@ function peg$parse(input, options) {
           s4 = peg$parseEntry();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c326(s4);
+            s1 = peg$c322(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9303,7 +9212,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c327(s1, s5);
+              s1 = peg$c323(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9368,7 +9277,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSQLLimit();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c328(s1, s2, s3, s4, s5, s6, s7, s8);
+                    s1 = peg$c324(s1, s2, s3, s4, s5, s6, s7, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -9446,7 +9355,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSQLAssignments();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c329(s3);
+            s1 = peg$c325(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9503,7 +9412,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c330(s1, s2);
+        s1 = peg$c326(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9629,7 +9538,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c331(s4, s5);
+              s1 = peg$c327(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9784,7 +9693,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSQLJoin();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s3;
-        s4 = peg$c332(s1, s4);
+        s4 = peg$c328(s1, s4);
       }
       s3 = s4;
       while (s3 !== peg$FAILED) {
@@ -9793,7 +9702,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSQLJoin();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s3;
-          s4 = peg$c332(s1, s4);
+          s4 = peg$c328(s1, s4);
         }
         s3 = s4;
       }
@@ -9855,7 +9764,7 @@ function peg$parse(input, options) {
                               s14 = peg$parseJoinKey();
                               if (s14 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c333(s1, s5, s6, s10, s14);
+                                s1 = peg$c329(s1, s5, s6, s10, s14);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -9935,7 +9844,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c334(s2);
+        s1 = peg$c330(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10094,7 +10003,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseSQLOrder();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c335(s6, s7);
+                  s1 = peg$c331(s6, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10140,7 +10049,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c336(s2);
+        s1 = peg$c332(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10176,7 +10085,7 @@ function peg$parse(input, options) {
           s4 = peg$parseUInt();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c337(s4);
+            s1 = peg$c333(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10211,16 +10120,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c286) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c282) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c338); }
+      if (peg$silentFails === 0) { peg$fail(peg$c334); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c339();
+      s1 = peg$c335();
     }
     s0 = s1;
 
@@ -10231,16 +10140,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c340) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c336) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c341); }
+      if (peg$silentFails === 0) { peg$fail(peg$c337); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c342();
+      s1 = peg$c338();
     }
     s0 = s1;
 
@@ -10256,11 +10165,11 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c343); }
+      if (peg$silentFails === 0) { peg$fail(peg$c339); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c344();
+      s1 = peg$c340();
     }
     s0 = s1;
 
@@ -10276,11 +10185,11 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c345); }
+      if (peg$silentFails === 0) { peg$fail(peg$c341); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c346();
+      s1 = peg$c342();
     }
     s0 = s1;
 
@@ -10296,11 +10205,11 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c347); }
+      if (peg$silentFails === 0) { peg$fail(peg$c343); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c348();
+      s1 = peg$c344();
     }
     s0 = s1;
 
@@ -10311,16 +10220,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c349) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c345) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c350); }
+      if (peg$silentFails === 0) { peg$fail(peg$c346); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c351();
+      s1 = peg$c347();
     }
     s0 = s1;
 
@@ -10331,16 +10240,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c352) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c348) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c353); }
+      if (peg$silentFails === 0) { peg$fail(peg$c349); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c354();
+      s1 = peg$c350();
     }
     s0 = s1;
 
@@ -10351,16 +10260,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c355) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c351) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c356); }
+      if (peg$silentFails === 0) { peg$fail(peg$c352); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c357();
+      s1 = peg$c353();
     }
     s0 = s1;
 
@@ -10376,11 +10285,11 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c358); }
+      if (peg$silentFails === 0) { peg$fail(peg$c354); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c359();
+      s1 = peg$c355();
     }
     s0 = s1;
 
@@ -10391,16 +10300,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c360) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c356) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c361); }
+      if (peg$silentFails === 0) { peg$fail(peg$c357); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c362();
+      s1 = peg$c358();
     }
     s0 = s1;
 
@@ -10411,16 +10320,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c363) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c359) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c364); }
+      if (peg$silentFails === 0) { peg$fail(peg$c360); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c365();
+      s1 = peg$c361();
     }
     s0 = s1;
 
@@ -10431,12 +10340,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c239) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c362) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c366); }
+      if (peg$silentFails === 0) { peg$fail(peg$c363); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10451,12 +10360,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c241) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c364) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c367); }
+      if (peg$silentFails === 0) { peg$fail(peg$c365); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10476,7 +10385,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c368); }
+      if (peg$silentFails === 0) { peg$fail(peg$c366); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10496,7 +10405,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c369); }
+      if (peg$silentFails === 0) { peg$fail(peg$c367); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10516,7 +10425,7 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c370); }
+      if (peg$silentFails === 0) { peg$fail(peg$c368); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10536,7 +10445,7 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c371); }
+      if (peg$silentFails === 0) { peg$fail(peg$c369); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10638,7 +10547,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c372(s1);
+        s1 = peg$c370(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10653,7 +10562,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP4Net();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c372(s1);
+        s1 = peg$c370(s1);
       }
       s0 = s1;
     }
@@ -10679,7 +10588,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c373(s1);
+        s1 = peg$c371(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10694,7 +10603,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c373(s1);
+        s1 = peg$c371(s1);
       }
       s0 = s1;
     }
@@ -10709,7 +10618,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFloatString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c374(s1);
+      s1 = peg$c372(s1);
     }
     s0 = s1;
 
@@ -10723,7 +10632,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c375(s1);
+      s1 = peg$c373(s1);
     }
     s0 = s1;
 
@@ -10734,30 +10643,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c376) {
-      s1 = peg$c376;
+    if (input.substr(peg$currPos, 4) === peg$c374) {
+      s1 = peg$c374;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c377); }
+      if (peg$silentFails === 0) { peg$fail(peg$c375); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c378();
+      s1 = peg$c376();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c379) {
-        s1 = peg$c379;
+      if (input.substr(peg$currPos, 5) === peg$c377) {
+        s1 = peg$c377;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c380); }
+        if (peg$silentFails === 0) { peg$fail(peg$c378); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c381();
+        s1 = peg$c379();
       }
       s0 = s1;
     }
@@ -10769,16 +10678,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c382) {
-      s1 = peg$c382;
+    if (input.substr(peg$currPos, 4) === peg$c380) {
+      s1 = peg$c380;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c383); }
+      if (peg$silentFails === 0) { peg$fail(peg$c381); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c384();
+      s1 = peg$c382();
     }
     s0 = s1;
 
@@ -10789,12 +10698,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c385) {
-      s1 = peg$c385;
+    if (input.substr(peg$currPos, 2) === peg$c383) {
+      s1 = peg$c383;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c386); }
+      if (peg$silentFails === 0) { peg$fail(peg$c384); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -10805,7 +10714,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c387();
+        s1 = peg$c385();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10842,7 +10751,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c388(s2);
+          s1 = peg$c386(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10869,7 +10778,7 @@ function peg$parse(input, options) {
       s1 = peg$parsePrimitiveType();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c388(s1);
+        s1 = peg$c386(s1);
       }
       s0 = s1;
     }
@@ -10909,7 +10818,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c389(s1);
+        s1 = peg$c387(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10961,7 +10870,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c390(s1, s2);
+          s1 = peg$c388(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10976,7 +10885,7 @@ function peg$parse(input, options) {
         s1 = peg$parseQuotedString();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c391(s1);
+          s1 = peg$c389(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
@@ -11002,7 +10911,7 @@ function peg$parse(input, options) {
                 }
                 if (s4 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c392(s3);
+                  s1 = peg$c390(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -11034,7 +10943,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTypeList();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c393(s1);
+      s1 = peg$c391(s1);
     }
     s0 = s1;
 
@@ -11059,7 +10968,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c265(s1, s2);
+        s1 = peg$c261(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11092,7 +11001,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c394(s4);
+            s1 = peg$c392(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11133,15 +11042,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c306;
+              s5 = peg$c302;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c307); }
+              if (peg$silentFails === 0) { peg$fail(peg$c303); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c395(s3);
+              s1 = peg$c393(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11180,15 +11089,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c299;
+                s5 = peg$c295;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c300); }
+                if (peg$silentFails === 0) { peg$fail(peg$c296); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c396(s3);
+                s1 = peg$c394(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -11212,12 +11121,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c315) {
-          s1 = peg$c315;
+        if (input.substr(peg$currPos, 2) === peg$c311) {
+          s1 = peg$c311;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c316); }
+          if (peg$silentFails === 0) { peg$fail(peg$c312); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -11226,16 +11135,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c317) {
-                  s5 = peg$c317;
+                if (input.substr(peg$currPos, 2) === peg$c313) {
+                  s5 = peg$c313;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c318); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c314); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c397(s3);
+                  s1 = peg$c395(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -11259,12 +11168,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c321) {
-            s1 = peg$c321;
+          if (input.substr(peg$currPos, 2) === peg$c317) {
+            s1 = peg$c317;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c322); }
+            if (peg$silentFails === 0) { peg$fail(peg$c318); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -11287,16 +11196,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c323) {
-                            s9 = peg$c323;
+                          if (input.substr(peg$currPos, 2) === peg$c319) {
+                            s9 = peg$c319;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c324); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c320); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c398(s3, s7);
+                            s1 = peg$c396(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -11348,7 +11257,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTemplateLiteralParts();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c399(s1);
+      s1 = peg$c397(s1);
     }
     s0 = s1;
 
@@ -11360,11 +11269,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c400;
+      s1 = peg$c398;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c401); }
+      if (peg$silentFails === 0) { peg$fail(peg$c399); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -11375,11 +11284,11 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c400;
+          s3 = peg$c398;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c401); }
+          if (peg$silentFails === 0) { peg$fail(peg$c399); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
@@ -11400,11 +11309,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c402;
+        s1 = peg$c400;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c403); }
+        if (peg$silentFails === 0) { peg$fail(peg$c401); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -11415,11 +11324,11 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c402;
+            s3 = peg$c400;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c403); }
+            if (peg$silentFails === 0) { peg$fail(peg$c401); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
@@ -11460,7 +11369,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c404(s1);
+        s1 = peg$c402(s1);
       }
       s0 = s1;
     }
@@ -11473,19 +11382,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c405;
+      s1 = peg$c403;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c406); }
+      if (peg$silentFails === 0) { peg$fail(peg$c404); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c407) {
-        s2 = peg$c407;
+      if (input.substr(peg$currPos, 2) === peg$c405) {
+        s2 = peg$c405;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c408); }
+        if (peg$silentFails === 0) { peg$fail(peg$c406); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11503,12 +11412,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c407) {
-        s2 = peg$c407;
+      if (input.substr(peg$currPos, 2) === peg$c405) {
+        s2 = peg$c405;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c408); }
+        if (peg$silentFails === 0) { peg$fail(peg$c406); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -11554,7 +11463,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c404(s1);
+        s1 = peg$c402(s1);
       }
       s0 = s1;
     }
@@ -11567,19 +11476,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c405;
+      s1 = peg$c403;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c406); }
+      if (peg$silentFails === 0) { peg$fail(peg$c404); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c407) {
-        s2 = peg$c407;
+      if (input.substr(peg$currPos, 2) === peg$c405) {
+        s2 = peg$c405;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c408); }
+        if (peg$silentFails === 0) { peg$fail(peg$c406); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -11597,12 +11506,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c407) {
-        s2 = peg$c407;
+      if (input.substr(peg$currPos, 2) === peg$c405) {
+        s2 = peg$c405;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c408); }
+        if (peg$silentFails === 0) { peg$fail(peg$c406); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -11634,12 +11543,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c407) {
-      s1 = peg$c407;
+    if (input.substr(peg$currPos, 2) === peg$c405) {
+      s1 = peg$c405;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c408); }
+      if (peg$silentFails === 0) { peg$fail(peg$c406); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -11649,15 +11558,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c306;
+              s5 = peg$c302;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c307); }
+              if (peg$silentFails === 0) { peg$fail(peg$c303); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c409(s3);
+              s1 = peg$c407(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11687,148 +11596,148 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c410) {
-      s1 = peg$c410;
+    if (input.substr(peg$currPos, 5) === peg$c408) {
+      s1 = peg$c408;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c411); }
+      if (peg$silentFails === 0) { peg$fail(peg$c409); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c412) {
-        s1 = peg$c412;
+      if (input.substr(peg$currPos, 6) === peg$c410) {
+        s1 = peg$c410;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c413); }
+        if (peg$silentFails === 0) { peg$fail(peg$c411); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c414) {
-          s1 = peg$c414;
+        if (input.substr(peg$currPos, 6) === peg$c412) {
+          s1 = peg$c412;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c415); }
+          if (peg$silentFails === 0) { peg$fail(peg$c413); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c416) {
-            s1 = peg$c416;
+          if (input.substr(peg$currPos, 6) === peg$c414) {
+            s1 = peg$c414;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c417); }
+            if (peg$silentFails === 0) { peg$fail(peg$c415); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c418) {
-              s1 = peg$c418;
+            if (input.substr(peg$currPos, 4) === peg$c416) {
+              s1 = peg$c416;
               peg$currPos += 4;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c419); }
+              if (peg$silentFails === 0) { peg$fail(peg$c417); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 5) === peg$c420) {
-                s1 = peg$c420;
+              if (input.substr(peg$currPos, 5) === peg$c418) {
+                s1 = peg$c418;
                 peg$currPos += 5;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c421); }
+                if (peg$silentFails === 0) { peg$fail(peg$c419); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c422) {
-                  s1 = peg$c422;
+                if (input.substr(peg$currPos, 5) === peg$c420) {
+                  s1 = peg$c420;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c423); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c421); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c424) {
-                    s1 = peg$c424;
+                  if (input.substr(peg$currPos, 5) === peg$c422) {
+                    s1 = peg$c422;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c425); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c423); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7) === peg$c426) {
-                      s1 = peg$c426;
+                    if (input.substr(peg$currPos, 7) === peg$c424) {
+                      s1 = peg$c424;
                       peg$currPos += 7;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c427); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c425); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 7) === peg$c428) {
-                        s1 = peg$c428;
+                      if (input.substr(peg$currPos, 7) === peg$c426) {
+                        s1 = peg$c426;
                         peg$currPos += 7;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c429); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c427); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 7) === peg$c430) {
-                          s1 = peg$c430;
+                        if (input.substr(peg$currPos, 7) === peg$c428) {
+                          s1 = peg$c428;
                           peg$currPos += 7;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c431); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c429); }
                         }
                         if (s1 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 4) === peg$c432) {
-                            s1 = peg$c432;
+                          if (input.substr(peg$currPos, 4) === peg$c430) {
+                            s1 = peg$c430;
                             peg$currPos += 4;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c433); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c431); }
                           }
                           if (s1 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 6) === peg$c434) {
-                              s1 = peg$c434;
+                            if (input.substr(peg$currPos, 6) === peg$c432) {
+                              s1 = peg$c432;
                               peg$currPos += 6;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c435); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c433); }
                             }
                             if (s1 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 8) === peg$c436) {
-                                s1 = peg$c436;
+                              if (input.substr(peg$currPos, 8) === peg$c434) {
+                                s1 = peg$c434;
                                 peg$currPos += 8;
                               } else {
                                 s1 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c437); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c435); }
                               }
                               if (s1 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 4) === peg$c438) {
-                                  s1 = peg$c438;
+                                if (input.substr(peg$currPos, 4) === peg$c436) {
+                                  s1 = peg$c436;
                                   peg$currPos += 4;
                                 } else {
                                   s1 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c439); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c437); }
                                 }
                                 if (s1 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 5) === peg$c440) {
-                                    s1 = peg$c440;
+                                  if (input.substr(peg$currPos, 5) === peg$c438) {
+                                    s1 = peg$c438;
                                     peg$currPos += 5;
                                   } else {
                                     s1 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c441); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c439); }
                                   }
                                   if (s1 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 2) === peg$c442) {
-                                      s1 = peg$c442;
+                                    if (input.substr(peg$currPos, 2) === peg$c440) {
+                                      s1 = peg$c440;
                                       peg$currPos += 2;
                                     } else {
                                       s1 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c443); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c441); }
                                     }
                                     if (s1 === peg$FAILED) {
-                                      if (input.substr(peg$currPos, 3) === peg$c444) {
-                                        s1 = peg$c444;
+                                      if (input.substr(peg$currPos, 3) === peg$c442) {
+                                        s1 = peg$c442;
                                         peg$currPos += 3;
                                       } else {
                                         s1 = peg$FAILED;
-                                        if (peg$silentFails === 0) { peg$fail(peg$c445); }
+                                        if (peg$silentFails === 0) { peg$fail(peg$c443); }
                                       }
                                       if (s1 === peg$FAILED) {
                                         if (input.substr(peg$currPos, 4) === peg$c10) {
@@ -11839,12 +11748,12 @@ function peg$parse(input, options) {
                                           if (peg$silentFails === 0) { peg$fail(peg$c11); }
                                         }
                                         if (s1 === peg$FAILED) {
-                                          if (input.substr(peg$currPos, 4) === peg$c382) {
-                                            s1 = peg$c382;
+                                          if (input.substr(peg$currPos, 4) === peg$c380) {
+                                            s1 = peg$c380;
                                             peg$currPos += 4;
                                           } else {
                                             s1 = peg$FAILED;
-                                            if (peg$silentFails === 0) { peg$fail(peg$c383); }
+                                            if (peg$silentFails === 0) { peg$fail(peg$c381); }
                                           }
                                         }
                                       }
@@ -11867,7 +11776,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c446();
+      s1 = peg$c444();
     }
     s0 = s1;
 
@@ -11888,7 +11797,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c265(s1, s2);
+        s1 = peg$c261(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11930,7 +11839,7 @@ function peg$parse(input, options) {
           s4 = peg$parseTypeField();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c394(s4);
+            s1 = peg$c392(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11973,7 +11882,7 @@ function peg$parse(input, options) {
             s5 = peg$parseType();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c447(s1, s5);
+              s1 = peg$c445(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -12014,20 +11923,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c448) {
-      s1 = peg$c448;
+    if (input.substr(peg$currPos, 3) === peg$c446) {
+      s1 = peg$c446;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c449); }
+      if (peg$silentFails === 0) { peg$fail(peg$c447); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c450) {
-        s1 = peg$c450;
+      if (input.substr(peg$currPos, 3) === peg$c448) {
+        s1 = peg$c448;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c451); }
+        if (peg$silentFails === 0) { peg$fail(peg$c449); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -12043,7 +11952,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c452();
+        s1 = peg$c450();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12061,20 +11970,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c453) {
-      s1 = peg$c453;
+    if (input.substr(peg$currPos, 2) === peg$c451) {
+      s1 = peg$c451;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c454); }
+      if (peg$silentFails === 0) { peg$fail(peg$c452); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c455) {
-        s1 = peg$c455;
+      if (input.substr(peg$currPos, 2) === peg$c453) {
+        s1 = peg$c453;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c456); }
+        if (peg$silentFails === 0) { peg$fail(peg$c454); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -12090,7 +11999,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c457();
+        s1 = peg$c455();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12128,7 +12037,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c458();
+        s1 = peg$c456();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12146,20 +12055,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c284) {
-      s1 = peg$c284;
+    if (input.substr(peg$currPos, 3) === peg$c280) {
+      s1 = peg$c280;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c285); }
+      if (peg$silentFails === 0) { peg$fail(peg$c281); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c459) {
-        s1 = peg$c459;
+      if (input.substr(peg$currPos, 3) === peg$c457) {
+        s1 = peg$c457;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c460); }
+        if (peg$silentFails === 0) { peg$fail(peg$c458); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -12175,7 +12084,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c461();
+        s1 = peg$c459();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12193,12 +12102,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c352) {
-      s1 = peg$c352;
+    if (input.substr(peg$currPos, 2) === peg$c348) {
+      s1 = peg$c348;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c462); }
+      if (peg$silentFails === 0) { peg$fail(peg$c460); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -12213,7 +12122,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c354();
+        s1 = peg$c350();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12230,12 +12139,12 @@ function peg$parse(input, options) {
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c463.test(input.charAt(peg$currPos))) {
+    if (peg$c461.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c464); }
+      if (peg$silentFails === 0) { peg$fail(peg$c462); }
     }
 
     return s0;
@@ -12246,12 +12155,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c465.test(input.charAt(peg$currPos))) {
+      if (peg$c463.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c466); }
+        if (peg$silentFails === 0) { peg$fail(peg$c464); }
       }
     }
 
@@ -12265,7 +12174,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c467(s1);
+      s1 = peg$c465(s1);
     }
     s0 = s1;
 
@@ -12337,11 +12246,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 36) {
-        s1 = peg$c468;
+        s1 = peg$c466;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c469); }
+        if (peg$silentFails === 0) { peg$fail(peg$c467); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -12351,11 +12260,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c405;
+          s1 = peg$c403;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c406); }
+          if (peg$silentFails === 0) { peg$fail(peg$c404); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseIDGuard();
@@ -12462,7 +12371,7 @@ function peg$parse(input, options) {
             s7 = peg$parseIdentifierName();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c470(s1, s7);
+              s4 = peg$c468(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -12498,7 +12407,7 @@ function peg$parse(input, options) {
               s7 = peg$parseIdentifierName();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c470(s1, s7);
+                s4 = peg$c468(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -12519,7 +12428,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c265(s1, s2);
+        s1 = peg$c261(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12557,17 +12466,17 @@ function peg$parse(input, options) {
     s1 = peg$parseFullDate();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 84) {
-        s2 = peg$c471;
+        s2 = peg$c469;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c472); }
+        if (peg$silentFails === 0) { peg$fail(peg$c470); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseFullTime();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c473();
+          s1 = peg$c471();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -12592,21 +12501,21 @@ function peg$parse(input, options) {
     s1 = peg$parseD4();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c276;
+        s2 = peg$c272;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c277); }
+        if (peg$silentFails === 0) { peg$fail(peg$c273); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseD2();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 45) {
-            s4 = peg$c276;
+            s4 = peg$c272;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c277); }
+            if (peg$silentFails === 0) { peg$fail(peg$c273); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseD2();
@@ -12641,36 +12550,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (peg$c465.test(input.charAt(peg$currPos))) {
+    if (peg$c463.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c466); }
+      if (peg$silentFails === 0) { peg$fail(peg$c464); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c465.test(input.charAt(peg$currPos))) {
+      if (peg$c463.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c466); }
+        if (peg$silentFails === 0) { peg$fail(peg$c464); }
       }
       if (s2 !== peg$FAILED) {
-        if (peg$c465.test(input.charAt(peg$currPos))) {
+        if (peg$c463.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c466); }
+          if (peg$silentFails === 0) { peg$fail(peg$c464); }
         }
         if (s3 !== peg$FAILED) {
-          if (peg$c465.test(input.charAt(peg$currPos))) {
+          if (peg$c463.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c466); }
+            if (peg$silentFails === 0) { peg$fail(peg$c464); }
           }
           if (s4 !== peg$FAILED) {
             s1 = [s1, s2, s3, s4];
@@ -12699,20 +12608,20 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c465.test(input.charAt(peg$currPos))) {
+    if (peg$c463.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c466); }
+      if (peg$silentFails === 0) { peg$fail(peg$c464); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c465.test(input.charAt(peg$currPos))) {
+      if (peg$c463.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c466); }
+        if (peg$silentFails === 0) { peg$fail(peg$c464); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -12787,22 +12696,22 @@ function peg$parse(input, options) {
               }
               if (s7 !== peg$FAILED) {
                 s8 = [];
-                if (peg$c465.test(input.charAt(peg$currPos))) {
+                if (peg$c463.test(input.charAt(peg$currPos))) {
                   s9 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s9 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c466); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c464); }
                 }
                 if (s9 !== peg$FAILED) {
                   while (s9 !== peg$FAILED) {
                     s8.push(s9);
-                    if (peg$c465.test(input.charAt(peg$currPos))) {
+                    if (peg$c463.test(input.charAt(peg$currPos))) {
                       s9 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c466); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c464); }
                     }
                   }
                 } else {
@@ -12857,28 +12766,28 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     if (input.charCodeAt(peg$currPos) === 90) {
-      s0 = peg$c474;
+      s0 = peg$c472;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c475); }
+      if (peg$silentFails === 0) { peg$fail(peg$c473); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 43) {
-        s1 = peg$c274;
+        s1 = peg$c270;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c275); }
+        if (peg$silentFails === 0) { peg$fail(peg$c271); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 45) {
-          s1 = peg$c276;
+          s1 = peg$c272;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c277); }
+          if (peg$silentFails === 0) { peg$fail(peg$c273); }
         }
       }
       if (s1 !== peg$FAILED) {
@@ -12904,22 +12813,22 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 s7 = [];
-                if (peg$c465.test(input.charAt(peg$currPos))) {
+                if (peg$c463.test(input.charAt(peg$currPos))) {
                   s8 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s8 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c466); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c464); }
                 }
                 if (s8 !== peg$FAILED) {
                   while (s8 !== peg$FAILED) {
                     s7.push(s8);
-                    if (peg$c465.test(input.charAt(peg$currPos))) {
+                    if (peg$c463.test(input.charAt(peg$currPos))) {
                       s8 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s8 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c466); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c464); }
                     }
                   }
                 } else {
@@ -12972,11 +12881,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c276;
+      s1 = peg$c272;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c277); }
+      if (peg$silentFails === 0) { peg$fail(peg$c273); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -13022,7 +12931,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c476();
+        s1 = peg$c474();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13084,76 +12993,76 @@ function peg$parse(input, options) {
   function peg$parseTimeUnit() {
     var s0;
 
-    if (input.substr(peg$currPos, 2) === peg$c477) {
-      s0 = peg$c477;
+    if (input.substr(peg$currPos, 2) === peg$c475) {
+      s0 = peg$c475;
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c478); }
+      if (peg$silentFails === 0) { peg$fail(peg$c476); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c479) {
-        s0 = peg$c479;
+      if (input.substr(peg$currPos, 2) === peg$c477) {
+        s0 = peg$c477;
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c480); }
+        if (peg$silentFails === 0) { peg$fail(peg$c478); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c481) {
-          s0 = peg$c481;
+        if (input.substr(peg$currPos, 2) === peg$c479) {
+          s0 = peg$c479;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c482); }
+          if (peg$silentFails === 0) { peg$fail(peg$c480); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 115) {
-            s0 = peg$c483;
+            s0 = peg$c481;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c484); }
+            if (peg$silentFails === 0) { peg$fail(peg$c482); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c485;
+              s0 = peg$c483;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c486); }
+              if (peg$silentFails === 0) { peg$fail(peg$c484); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 104) {
-                s0 = peg$c487;
+                s0 = peg$c485;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c488); }
+                if (peg$silentFails === 0) { peg$fail(peg$c486); }
               }
               if (s0 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 100) {
-                  s0 = peg$c489;
+                  s0 = peg$c487;
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c490); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c488); }
                 }
                 if (s0 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 119) {
-                    s0 = peg$c491;
+                    s0 = peg$c489;
                     peg$currPos++;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c492); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c490); }
                   }
                   if (s0 === peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 121) {
-                      s0 = peg$c493;
+                      s0 = peg$c491;
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c494); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c492); }
                     }
                   }
                 }
@@ -13338,7 +13247,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c495(s1, s2);
+        s1 = peg$c493(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13359,12 +13268,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c496) {
-            s3 = peg$c496;
+          if (input.substr(peg$currPos, 2) === peg$c494) {
+            s3 = peg$c494;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c497); }
+            if (peg$silentFails === 0) { peg$fail(peg$c495); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -13377,7 +13286,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c498(s1, s2, s4, s5);
+                s1 = peg$c496(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -13401,12 +13310,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c496) {
-          s1 = peg$c496;
+        if (input.substr(peg$currPos, 2) === peg$c494) {
+          s1 = peg$c494;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c497); }
+          if (peg$silentFails === 0) { peg$fail(peg$c495); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -13419,7 +13328,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c499(s2, s3);
+              s1 = peg$c497(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13444,16 +13353,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c496) {
-                s3 = peg$c496;
+              if (input.substr(peg$currPos, 2) === peg$c494) {
+                s3 = peg$c494;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c497); }
+                if (peg$silentFails === 0) { peg$fail(peg$c495); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c500(s1, s2);
+                s1 = peg$c498(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -13469,16 +13378,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c496) {
-              s1 = peg$c496;
+            if (input.substr(peg$currPos, 2) === peg$c494) {
+              s1 = peg$c494;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c497); }
+              if (peg$silentFails === 0) { peg$fail(peg$c495); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c501();
+              s1 = peg$c499();
             }
             s0 = s1;
           }
@@ -13515,7 +13424,7 @@ function peg$parse(input, options) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c502(s2);
+        s1 = peg$c500(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13544,7 +13453,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c503(s1);
+        s1 = peg$c501(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13565,17 +13474,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c278;
+        s2 = peg$c274;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c279); }
+        if (peg$silentFails === 0) { peg$fail(peg$c275); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c504(s1, s3);
+          s1 = peg$c502(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13600,17 +13509,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c278;
+        s2 = peg$c274;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c279); }
+        if (peg$silentFails === 0) { peg$fail(peg$c275); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c505(s1, s3);
+          s1 = peg$c503(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13635,7 +13544,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c506(s1);
+      s1 = peg$c504(s1);
     }
     s0 = s1;
 
@@ -13658,22 +13567,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c465.test(input.charAt(peg$currPos))) {
+    if (peg$c463.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c466); }
+      if (peg$silentFails === 0) { peg$fail(peg$c464); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c465.test(input.charAt(peg$currPos))) {
+        if (peg$c463.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c466); }
+          if (peg$silentFails === 0) { peg$fail(peg$c464); }
         }
       }
     } else {
@@ -13693,11 +13602,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c276;
+      s1 = peg$c272;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c277); }
+      if (peg$silentFails === 0) { peg$fail(peg$c273); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseUIntString();
@@ -13722,33 +13631,33 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c276;
+      s1 = peg$c272;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c277); }
+      if (peg$silentFails === 0) { peg$fail(peg$c273); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c465.test(input.charAt(peg$currPos))) {
+      if (peg$c463.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c466); }
+        if (peg$silentFails === 0) { peg$fail(peg$c464); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c465.test(input.charAt(peg$currPos))) {
+          if (peg$c463.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c466); }
+            if (peg$silentFails === 0) { peg$fail(peg$c464); }
           }
         }
       } else {
@@ -13764,21 +13673,21 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c465.test(input.charAt(peg$currPos))) {
+          if (peg$c463.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c466); }
+            if (peg$silentFails === 0) { peg$fail(peg$c464); }
           }
           while (s5 !== peg$FAILED) {
             s4.push(s5);
-            if (peg$c465.test(input.charAt(peg$currPos))) {
+            if (peg$c463.test(input.charAt(peg$currPos))) {
               s5 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c466); }
+              if (peg$silentFails === 0) { peg$fail(peg$c464); }
             }
           }
           if (s4 !== peg$FAILED) {
@@ -13788,7 +13697,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c507();
+              s1 = peg$c505();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13813,11 +13722,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c276;
+        s1 = peg$c272;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c277); }
+        if (peg$silentFails === 0) { peg$fail(peg$c273); }
       }
       if (s1 === peg$FAILED) {
         s1 = null;
@@ -13832,22 +13741,22 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c465.test(input.charAt(peg$currPos))) {
+          if (peg$c463.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c466); }
+            if (peg$silentFails === 0) { peg$fail(peg$c464); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c465.test(input.charAt(peg$currPos))) {
+              if (peg$c463.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c466); }
+                if (peg$silentFails === 0) { peg$fail(peg$c464); }
               }
             }
           } else {
@@ -13860,7 +13769,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c507();
+              s1 = peg$c505();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -13899,20 +13808,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c508) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c506) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c509); }
+      if (peg$silentFails === 0) { peg$fail(peg$c507); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c510.test(input.charAt(peg$currPos))) {
+      if (peg$c508.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c511); }
+        if (peg$silentFails === 0) { peg$fail(peg$c509); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -13941,12 +13850,12 @@ function peg$parse(input, options) {
   function peg$parseNaN() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c512) {
-      s0 = peg$c512;
+    if (input.substr(peg$currPos, 3) === peg$c510) {
+      s0 = peg$c510;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c513); }
+      if (peg$silentFails === 0) { peg$fail(peg$c511); }
     }
 
     return s0;
@@ -13957,31 +13866,31 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c276;
+      s1 = peg$c272;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c277); }
+      if (peg$silentFails === 0) { peg$fail(peg$c273); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 43) {
-        s1 = peg$c274;
+        s1 = peg$c270;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c275); }
+        if (peg$silentFails === 0) { peg$fail(peg$c271); }
       }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c514) {
-        s2 = peg$c514;
+      if (input.substr(peg$currPos, 3) === peg$c512) {
+        s2 = peg$c512;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c515); }
+        if (peg$silentFails === 0) { peg$fail(peg$c513); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -14024,12 +13933,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c516.test(input.charAt(peg$currPos))) {
+    if (peg$c514.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c517); }
+      if (peg$silentFails === 0) { peg$fail(peg$c515); }
     }
 
     return s0;
@@ -14040,11 +13949,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c400;
+      s1 = peg$c398;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c401); }
+      if (peg$silentFails === 0) { peg$fail(peg$c399); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -14055,15 +13964,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c400;
+          s3 = peg$c398;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c401); }
+          if (peg$silentFails === 0) { peg$fail(peg$c399); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c518(s2);
+          s1 = peg$c516(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -14080,11 +13989,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c402;
+        s1 = peg$c400;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c403); }
+        if (peg$silentFails === 0) { peg$fail(peg$c401); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -14095,15 +14004,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c402;
+            s3 = peg$c400;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c403); }
+            if (peg$silentFails === 0) { peg$fail(peg$c401); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c518(s2);
+            s1 = peg$c516(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -14129,11 +14038,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c400;
+      s2 = peg$c398;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c401); }
+      if (peg$silentFails === 0) { peg$fail(peg$c399); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -14151,7 +14060,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c519); }
+        if (peg$silentFails === 0) { peg$fail(peg$c517); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14168,11 +14077,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c405;
+        s1 = peg$c403;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c406); }
+        if (peg$silentFails === 0) { peg$fail(peg$c404); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -14207,7 +14116,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c520(s1, s2);
+        s1 = peg$c518(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14236,12 +14145,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (peg$c521.test(input.charAt(peg$currPos))) {
+    if (peg$c519.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c522); }
+      if (peg$silentFails === 0) { peg$fail(peg$c520); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -14257,12 +14166,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseKeyWordStart();
     if (s0 === peg$FAILED) {
-      if (peg$c465.test(input.charAt(peg$currPos))) {
+      if (peg$c463.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c466); }
+        if (peg$silentFails === 0) { peg$fail(peg$c464); }
       }
     }
 
@@ -14274,11 +14183,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c405;
+      s1 = peg$c403;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c406); }
+      if (peg$silentFails === 0) { peg$fail(peg$c404); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseKeywordEscape();
@@ -14337,7 +14246,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c523(s3, s4);
+            s1 = peg$c521(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -14455,7 +14364,7 @@ function peg$parse(input, options) {
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c524();
+          s1 = peg$c522();
         }
         s0 = s1;
       }
@@ -14469,12 +14378,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseGlobStart();
     if (s0 === peg$FAILED) {
-      if (peg$c465.test(input.charAt(peg$currPos))) {
+      if (peg$c463.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c466); }
+        if (peg$silentFails === 0) { peg$fail(peg$c464); }
       }
     }
 
@@ -14486,11 +14395,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c405;
+      s1 = peg$c403;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c406); }
+      if (peg$silentFails === 0) { peg$fail(peg$c404); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseGlobEscape();
@@ -14526,7 +14435,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c525();
+      s1 = peg$c523();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -14540,16 +14449,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c526();
+        s1 = peg$c524();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c510.test(input.charAt(peg$currPos))) {
+        if (peg$c508.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c511); }
+          if (peg$silentFails === 0) { peg$fail(peg$c509); }
         }
       }
     }
@@ -14564,11 +14473,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c402;
+      s2 = peg$c400;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c403); }
+      if (peg$silentFails === 0) { peg$fail(peg$c401); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -14586,7 +14495,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c519); }
+        if (peg$silentFails === 0) { peg$fail(peg$c517); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14603,11 +14512,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c405;
+        s1 = peg$c403;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c406); }
+        if (peg$silentFails === 0) { peg$fail(peg$c404); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -14643,20 +14552,20 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c402;
+      s0 = peg$c400;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c403); }
+      if (peg$silentFails === 0) { peg$fail(peg$c401); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s1 = peg$c400;
+        s1 = peg$c398;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c401); }
+        if (peg$silentFails === 0) { peg$fail(peg$c399); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14665,94 +14574,94 @@ function peg$parse(input, options) {
       s0 = s1;
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c405;
+          s0 = peg$c403;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c406); }
+          if (peg$silentFails === 0) { peg$fail(peg$c404); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c527;
+            s1 = peg$c525;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c528); }
+            if (peg$silentFails === 0) { peg$fail(peg$c526); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c529();
+            s1 = peg$c527();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c530;
+              s1 = peg$c528;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c531); }
+              if (peg$silentFails === 0) { peg$fail(peg$c529); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c532();
+              s1 = peg$c530();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c533;
+                s1 = peg$c531;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c534); }
+                if (peg$silentFails === 0) { peg$fail(peg$c532); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c535();
+                s1 = peg$c533();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c536;
+                  s1 = peg$c534;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c537); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c535); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c538();
+                  s1 = peg$c536();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c539;
+                    s1 = peg$c537;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c540); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c538); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c541();
+                    s1 = peg$c539();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c542;
+                      s1 = peg$c540;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c543); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c541); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c544();
+                      s1 = peg$c542();
                     }
                     s0 = s1;
                   }
@@ -14780,7 +14689,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c525();
+      s1 = peg$c523();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -14794,16 +14703,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c545();
+        s1 = peg$c543();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c510.test(input.charAt(peg$currPos))) {
+        if (peg$c508.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c511); }
+          if (peg$silentFails === 0) { peg$fail(peg$c509); }
         }
       }
     }
@@ -14816,11 +14725,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c546;
+      s1 = peg$c544;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c547); }
+      if (peg$silentFails === 0) { peg$fail(peg$c545); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -14852,7 +14761,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c548(s2);
+        s1 = peg$c546(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14865,11 +14774,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c546;
+        s1 = peg$c544;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c547); }
+        if (peg$silentFails === 0) { peg$fail(peg$c545); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
@@ -14936,15 +14845,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c306;
+              s4 = peg$c302;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c307); }
+              if (peg$silentFails === 0) { peg$fail(peg$c303); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c548(s3);
+              s1 = peg$c546(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -14972,21 +14881,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c278;
+      s1 = peg$c274;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c279); }
+      if (peg$silentFails === 0) { peg$fail(peg$c275); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseRegexpBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c278;
+          s3 = peg$c274;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c279); }
+          if (peg$silentFails === 0) { peg$fail(peg$c275); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$currPos;
@@ -15028,21 +14937,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c549.test(input.charAt(peg$currPos))) {
+    if (peg$c547.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c550); }
+      if (peg$silentFails === 0) { peg$fail(peg$c548); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s3 = peg$c405;
+        s3 = peg$c403;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c406); }
+        if (peg$silentFails === 0) { peg$fail(peg$c404); }
       }
       if (s3 !== peg$FAILED) {
         if (input.length > peg$currPos) {
@@ -15050,7 +14959,7 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c519); }
+          if (peg$silentFails === 0) { peg$fail(peg$c517); }
         }
         if (s4 !== peg$FAILED) {
           s3 = [s3, s4];
@@ -15067,21 +14976,21 @@ function peg$parse(input, options) {
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c549.test(input.charAt(peg$currPos))) {
+        if (peg$c547.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c550); }
+          if (peg$silentFails === 0) { peg$fail(peg$c548); }
         }
         if (s2 === peg$FAILED) {
           s2 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 92) {
-            s3 = peg$c405;
+            s3 = peg$c403;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c406); }
+            if (peg$silentFails === 0) { peg$fail(peg$c404); }
           }
           if (s3 !== peg$FAILED) {
             if (input.length > peg$currPos) {
@@ -15089,7 +14998,7 @@ function peg$parse(input, options) {
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c519); }
+              if (peg$silentFails === 0) { peg$fail(peg$c517); }
             }
             if (s4 !== peg$FAILED) {
               s3 = [s3, s4];
@@ -15119,12 +15028,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c551.test(input.charAt(peg$currPos))) {
+    if (peg$c549.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c552); }
+      if (peg$silentFails === 0) { peg$fail(peg$c550); }
     }
 
     return s0;
@@ -15182,7 +15091,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c519); }
+      if (peg$silentFails === 0) { peg$fail(peg$c517); }
     }
 
     return s0;
@@ -15193,51 +15102,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c554;
+      s0 = peg$c552;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c555); }
+      if (peg$silentFails === 0) { peg$fail(peg$c553); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c556;
+        s0 = peg$c554;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c557); }
+        if (peg$silentFails === 0) { peg$fail(peg$c555); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c558;
+          s0 = peg$c556;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c559); }
+          if (peg$silentFails === 0) { peg$fail(peg$c557); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c560;
+            s0 = peg$c558;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c561); }
+            if (peg$silentFails === 0) { peg$fail(peg$c559); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c562;
+              s0 = peg$c560;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c563); }
+              if (peg$silentFails === 0) { peg$fail(peg$c561); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c564;
+                s0 = peg$c562;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c565); }
+                if (peg$silentFails === 0) { peg$fail(peg$c563); }
               }
             }
           }
@@ -15247,7 +15156,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c553); }
+      if (peg$silentFails === 0) { peg$fail(peg$c551); }
     }
 
     return s0;
@@ -15256,12 +15165,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c566.test(input.charAt(peg$currPos))) {
+    if (peg$c564.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c567); }
+      if (peg$silentFails === 0) { peg$fail(peg$c565); }
     }
 
     return s0;
@@ -15275,7 +15184,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c568); }
+      if (peg$silentFails === 0) { peg$fail(peg$c566); }
     }
 
     return s0;
@@ -15285,24 +15194,24 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c569) {
-      s1 = peg$c569;
+    if (input.substr(peg$currPos, 2) === peg$c567) {
+      s1 = peg$c567;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c570); }
+      if (peg$silentFails === 0) { peg$fail(peg$c568); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c571) {
-        s5 = peg$c571;
+      if (input.substr(peg$currPos, 2) === peg$c569) {
+        s5 = peg$c569;
         peg$currPos += 2;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c572); }
+        if (peg$silentFails === 0) { peg$fail(peg$c570); }
       }
       peg$silentFails--;
       if (s5 === peg$FAILED) {
@@ -15329,12 +15238,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$currPos;
         peg$silentFails++;
-        if (input.substr(peg$currPos, 2) === peg$c571) {
-          s5 = peg$c571;
+        if (input.substr(peg$currPos, 2) === peg$c569) {
+          s5 = peg$c569;
           peg$currPos += 2;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c572); }
+          if (peg$silentFails === 0) { peg$fail(peg$c570); }
         }
         peg$silentFails--;
         if (s5 === peg$FAILED) {
@@ -15358,12 +15267,12 @@ function peg$parse(input, options) {
         }
       }
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c571) {
-          s3 = peg$c571;
+        if (input.substr(peg$currPos, 2) === peg$c569) {
+          s3 = peg$c569;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c572); }
+          if (peg$silentFails === 0) { peg$fail(peg$c570); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -15388,12 +15297,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c573) {
-      s1 = peg$c573;
+    if (input.substr(peg$currPos, 2) === peg$c571) {
+      s1 = peg$c571;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c574); }
+      if (peg$silentFails === 0) { peg$fail(peg$c572); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -15511,7 +15420,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c519); }
+      if (peg$silentFails === 0) { peg$fail(peg$c517); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -554,10 +554,6 @@ OrderSuffix
   / ":desc"  { RETURN("desc") }
   / "" { RETURN("asc") }
 
-OrderArg
-  = _ "order" _ "asc"  { RETURN("asc") }
-  / _ "order" _ "desc"  { RETURN("desc") }
-
 PassOp
   = "pass" &EOKW {
       RETURN(MAP("kind":"Pass"))

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -491,8 +491,8 @@ Pool
   = "pool" _ body:PoolBody { RETURN(body) }
 
 PoolBody
-  = spec:PoolSpec at:PoolAt? over:PoolRange? order:OrderArg? {
-      RETURN(MAP("kind": "Pool", "spec": spec, "at": at, "range": over, "scan_order": order))
+  = spec:PoolSpec at:PoolAt? {
+      RETURN(MAP("kind": "Pool", "spec": spec, "at": at))
     }
 
 Get
@@ -512,11 +512,6 @@ PoolAt
 
 //XXX this should allow 0x bytes format
 KSUID = ([0-9a-zA-Z])+ { RETURN(TEXT) }
-
-PoolRange
-  = _ "range" _ lower:Literal _ "to" _ upper:Literal {
-      RETURN(MAP("kind":"Range","lower": lower, "upper": upper))
-    }
 
 PoolSpec
   = pool:PoolName commit:PoolCommit? meta:PoolMeta? {

--- a/compiler/semantic/op.go
+++ b/compiler/semantic/op.go
@@ -184,21 +184,6 @@ func semPoolWithName(ctx context.Context, scope *Scope, p *ast.Pool, poolName st
 			return nil, err
 		}
 	}
-	var lower, upper dag.Expr
-	if r := p.Range; r != nil {
-		if r.Lower != nil {
-			lower, err = semExpr(scope, r.Lower)
-			if err != nil {
-				return nil, err
-			}
-		}
-		if r.Upper != nil {
-			upper, err = semExpr(scope, r.Upper)
-			if err != nil {
-				return nil, err
-			}
-		}
-	}
 	if p.At != "" {
 		// XXX
 		// We no longer use "at" to refer to a commit tag, but if there
@@ -221,13 +206,10 @@ func semPoolWithName(ctx context.Context, scope *Scope, p *ast.Pool, poolName st
 	if p.Spec.Meta != "" {
 		if commit != "" {
 			return &dag.CommitMeta{
-				Kind:      "CommitMeta",
-				Meta:      p.Spec.Meta,
-				Pool:      poolID,
-				Commit:    commitID,
-				ScanLower: lower,
-				ScanUpper: upper,
-				ScanOrder: p.ScanOrder,
+				Kind:   "CommitMeta",
+				Meta:   p.Spec.Meta,
+				Pool:   poolID,
+				Commit: commitID,
 			}, nil
 		}
 		return &dag.PoolMeta{
@@ -245,13 +227,10 @@ func semPoolWithName(ctx context.Context, scope *Scope, p *ast.Pool, poolName st
 		}
 	}
 	return &dag.Pool{
-		Kind:      "Pool",
-		ID:        poolID,
-		Commit:    commitID,
-		Delete:    p.Delete,
-		ScanLower: lower,
-		ScanUpper: upper,
-		ScanOrder: p.ScanOrder,
+		Kind:   "Pool",
+		ID:     poolID,
+		Commit: commitID,
+		Delete: p.Delete,
 	}, nil
 }
 

--- a/compiler/ztests/pushdown.yaml
+++ b/compiler/ztests/pushdown.yaml
@@ -10,9 +10,9 @@ script: |
   echo ===
   zc -C -O "from 'pool-ts'| x=='hello' or !(y==2 or y==3)" | sed -e 's/pool .*/pool POOL/'
   echo ===
-  zc -C -O "from 'pool-ts' range 0 to 2" | sed -e 's/pool .*/pool POOL/'
+  zc -C -O "from 'pool-ts' | ts >= 0 and ts <= 2" | sed -e 's/pool .*/pool POOL/'
   echo ===
-  zc -C -O "from 'pool-ts' range 0 to 2 | x=='hello'" | sed -e 's/pool .*/pool POOL/'
+  zc -C -O "from 'pool-ts' | ts >= 0 and ts <= 2 and x=='hello'" | sed -e 's/pool .*/pool POOL/'
 
 outputs:
   - name: stdout


### PR DESCRIPTION
This commit removes the scan range options and scan order options from the DAG (and AST).  Now that we have decent inference of pool key predicates this options are no longer needed.  Furthermore, the scan order was being ignored.  If we want the functionality later, this will be better implemented by the user specifying a sort and the optimizer detecting that a reverse scan can be executed instead of an actual sort.