### PR TITLE
move ast.Explode definition

### DIFF
--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -260,6 +260,12 @@ type (
 		Kind string `json:"kind" unpack:""`
 		Args []Expr `json:"args"`
 	}
+	Explode struct {
+		Kind string      `json:"kind" unpack:""`
+		Args []Expr      `json:"args"`
+		Type astzed.Type `json:"type"`
+		As   Expr        `json:"as"`
+	}
 	Head struct {
 		Kind  string `json:"kind" unpack:""`
 		Count int    `json:"count"`
@@ -392,12 +398,6 @@ type (
 		Spec   PoolSpec `json:"spec"`
 		At     string   `json:"at"`
 		Delete bool     `json:"delete"`
-	}
-	Explode struct {
-		Kind string      `json:"kind" unpack:""`
-		Args []Expr      `json:"args"`
-		Type astzed.Type `json:"type"`
-		As   Expr        `json:"as"`
 	}
 )
 


### PR DESCRIPTION
This commit moves the ast.Explode type definition so that it's not listed next to the other ast.Source's and is instead next to the regular operators.