### PR TITLE
improve UX for metadata queries

### DIFF
--- a/compiler/ast/dag/operator.go
+++ b/compiler/ast/dag/operator.go
@@ -200,6 +200,25 @@ type (
 	}
 )
 
+var LakeMetas = map[string]struct{}{
+	"branches":    {},
+	"index_rules": {},
+	"pools":       {},
+}
+
+var PoolMetas = map[string]struct{}{
+	"branches": {},
+}
+
+var CommitMetas = map[string]struct{}{
+	"indexes":    {},
+	"log":        {},
+	"objects":    {},
+	"partitions": {},
+	"rawlog":     {},
+	"vectors":    {},
+}
+
 type Source interface {
 	Source()
 }

--- a/compiler/optimizer/optimizer.go
+++ b/compiler/optimizer/optimizer.go
@@ -173,8 +173,10 @@ func (o *Optimizer) getLayout(s dag.Source, parent order.Layout) (order.Layout, 
 		return s.Layout, nil
 	case *dag.HTTP:
 		return s.Layout, nil
-	case *dag.Pool, *dag.LakeMeta, *dag.PoolMeta, *dag.CommitMeta:
+	case *dag.Pool:
 		return o.source.Layout(o.ctx, s), nil
+	case *dag.LakeMeta, *dag.PoolMeta, *dag.CommitMeta:
+		return order.Nil, nil
 	case *dag.Pass:
 		return parent, nil
 	case *kernel.Reader:

--- a/lake/ztests/meta.yaml
+++ b/lake/ztests/meta.yaml
@@ -8,7 +8,7 @@ script: |
   zed query -Z 'from :pools | drop id | sort name | drop ts'
   echo ===
   zed query -Z 'from poolA@main:objects | cut nameof(this),meta'
-  zed query -Z 'from poolA@main:log | cut nameof(this) | drop ts'
+  zed query -Z 'from poolA:log | cut nameof(this) | drop ts'
   echo ===
   zed index create -q Rule field a
   zed query -Z 'from :index_rules | nameof:=nameof(this) | drop ts,id'


### PR DESCRIPTION
This commit improves the UX for metadata queries by using the metadata type name to distinguish between commit-level queries and pool-level queries rather than requiring the presence of an @branch commit tag for commit-level queries.  This way you can query the objects on the main branch of a pool without specifying @main.  We also fixed a bug in the optimization logic where the layout of metadata queries was presumed to be the same layout of the pool.  The fix is to presume the layout of metadata queries is unknown.