### PR TITLE
zed serve: Add -defaultfmt flag

### DIFF
--- a/api/mime.go
+++ b/api/mime.go
@@ -69,31 +69,31 @@ func MediaTypeToFormat(s string, dflt string) (string, error) {
 	return "", &ErrUnsupportedMimeType{typ}
 }
 
-func FormatToMediaType(format string) string {
+func FormatToMediaType(format string) (string, error) {
 	switch format {
 	case "arrows":
-		return MediaTypeArrowStream
+		return MediaTypeArrowStream, nil
 	case "csv":
-		return MediaTypeCSV
+		return MediaTypeCSV, nil
 	case "json":
-		return MediaTypeJSON
+		return MediaTypeJSON, nil
 	case "line":
-		return MediaTypeLine
+		return MediaTypeLine, nil
 	case "ndjson":
-		return MediaTypeNDJSON
+		return MediaTypeNDJSON, nil
 	case "parquet":
-		return MediaTypeParquet
+		return MediaTypeParquet, nil
 	case "vng":
-		return MediaTypeVNG
+		return MediaTypeVNG, nil
 	case "zeek":
-		return MediaTypeZeek
+		return MediaTypeZeek, nil
 	case "zjson":
-		return MediaTypeZJSON
+		return MediaTypeZJSON, nil
 	case "zng":
-		return MediaTypeZNG
+		return MediaTypeZNG, nil
 	case "zson":
-		return MediaTypeZSON
+		return MediaTypeZSON, nil
 	default:
-		panic(fmt.Sprintf("unknown format type: %s", format))
+		return "", fmt.Errorf("unknown format type: %s", format)
 	}
 }

--- a/cmd/zed/serve/command.go
+++ b/cmd/zed/serve/command.go
@@ -57,6 +57,7 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 		c.conf.CORSAllowedOrigins = append(c.conf.CORSAllowedOrigins, s)
 		return nil
 	})
+	f.StringVar(&c.conf.DefaultZedFormat, "defaultfmt", service.DefaultZedFormat, "default zed response format")
 	f.StringVar(&c.listenAddr, "l", ":9867", "[addr]:port to listen on")
 	f.StringVar(&c.portFile, "portfile", "", "write listen port to file")
 	f.StringVar(&c.rootContentFile, "rootcontentfile", "", "file to serve for GET /")

--- a/cmd/zed/serve/command.go
+++ b/cmd/zed/serve/command.go
@@ -57,7 +57,7 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 		c.conf.CORSAllowedOrigins = append(c.conf.CORSAllowedOrigins, s)
 		return nil
 	})
-	f.StringVar(&c.conf.DefaultZedFormat, "defaultfmt", service.DefaultZedFormat, "default zed response format")
+	f.StringVar(&c.conf.DefaultResponseFormat, "defaultfmt", service.DefaultZedFormat, "default response format")
 	f.StringVar(&c.listenAddr, "l", ":9867", "[addr]:port to listen on")
 	f.StringVar(&c.portFile, "portfile", "", "write listen port to file")
 	f.StringVar(&c.rootContentFile, "rootcontentfile", "", "file to serve for GET /")

--- a/service/core.go
+++ b/service/core.go
@@ -43,13 +43,13 @@ const indexPage = `
 </html>`
 
 type Config struct {
-	Auth               AuthConfig
-	CORSAllowedOrigins []string
-	DefaultZedFormat   string
-	Root               *storage.URI
-	RootContent        io.ReadSeeker
-	Version            string
-	Logger             *zap.Logger
+	Auth                  AuthConfig
+	CORSAllowedOrigins    []string
+	DefaultResponseFormat string
+	Root                  *storage.URI
+	RootContent           io.ReadSeeker
+	Version               string
+	Logger                *zap.Logger
 }
 
 type Core struct {
@@ -68,6 +68,12 @@ type Core struct {
 }
 
 func NewCore(ctx context.Context, conf Config) (*Core, error) {
+	if conf.DefaultResponseFormat == "" {
+		conf.DefaultResponseFormat = DefaultZedFormat
+	}
+	if _, err := api.FormatToMediaType(conf.DefaultResponseFormat); err != nil {
+		return nil, fmt.Errorf("invalid default response format: %w", err)
+	}
 	if conf.Logger == nil {
 		conf.Logger = zap.NewNop()
 	}
@@ -76,9 +82,6 @@ func NewCore(ctx context.Context, conf Config) (*Core, error) {
 	}
 	if conf.Version == "" {
 		conf.Version = "unknown"
-	}
-	if conf.DefaultZedFormat == "" {
-		conf.DefaultZedFormat = DefaultZedFormat
 	}
 
 	registry := prometheus.NewRegistry()

--- a/service/core.go
+++ b/service/core.go
@@ -45,6 +45,7 @@ const indexPage = `
 type Config struct {
 	Auth               AuthConfig
 	CORSAllowedOrigins []string
+	DefaultZedFormat   string
 	Root               *storage.URI
 	RootContent        io.ReadSeeker
 	Version            string
@@ -75,6 +76,9 @@ func NewCore(ctx context.Context, conf Config) (*Core, error) {
 	}
 	if conf.Version == "" {
 		conf.Version = "unknown"
+	}
+	if conf.DefaultZedFormat == "" {
+		conf.DefaultZedFormat = DefaultZedFormat
 	}
 
 	registry := prometheus.NewRegistry()
@@ -178,7 +182,7 @@ func (c *Core) addAPIServerRoutes() {
 
 func (c *Core) handler(f func(*Core, *ResponseWriter, *Request)) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if res, req, ok := newRequest(w, r, c.logger); ok {
+		if res, req, ok := newRequest(w, r, c); ok {
 			f(c, res, req)
 		}
 	})

--- a/service/request.go
+++ b/service/request.go
@@ -33,8 +33,8 @@ type Request struct {
 	Logger *zap.Logger
 }
 
-func newRequest(w http.ResponseWriter, r *http.Request, logger *zap.Logger) (*ResponseWriter, *Request, bool) {
-	logger = logger.With(zap.String("request_id", api.RequestIDFromContext(r.Context())))
+func newRequest(w http.ResponseWriter, r *http.Request, c *Core) (*ResponseWriter, *Request, bool) {
+	logger := c.logger.With(zap.String("request_id", api.RequestIDFromContext(r.Context())))
 	req := &Request{
 		Request: r,
 		Logger:  logger,
@@ -51,7 +51,7 @@ func newRequest(w http.ResponseWriter, r *http.Request, logger *zap.Logger) (*Re
 		ss = []string{""}
 	}
 	for _, mime := range ss {
-		format, err := api.MediaTypeToFormat(mime, DefaultZedFormat)
+		format, err := api.MediaTypeToFormat(mime, c.conf.DefaultZedFormat)
 		if err != nil {
 			continue
 		}

--- a/service/ztests/default-format.yaml
+++ b/service/ztests/default-format.yaml
@@ -1,0 +1,15 @@
+script: |
+  export LAKE_EXTRA_FLAGS='-defaultfmt=ndjson'
+  source service.sh
+  zed create -q test
+  zed use -q test
+  echo '{x: 1(uint64)}' | zed load -q -
+  curl -d '{"query": "from test"}' $ZED_LAKE/query
+
+inputs:
+  - name: service.sh
+
+outputs:
+  - name: stdout
+    data: |
+      {"x":1}


### PR DESCRIPTION
Allow users to specify the default zed format response for requests without a specified accept-type header.

Closes #4184