### PR TITLE
compiler/optimizer: always push down filters

### DIFF
--- a/compiler/optimizer/optimizer.go
+++ b/compiler/optimizer/optimizer.go
@@ -104,11 +104,12 @@ func (o *Optimizer) OptimizeScan() error {
 	if len > 0 {
 		chain = chain[:len]
 		for k := range from.Trunks {
-			trunk := &from.Trunks[k]
-			liftInto(trunk, copyOps(chain))
-			pushDown(trunk)
+			liftInto(&from.Trunks[k], copyOps(chain))
 		}
 		seq.Delete(1, len)
+	}
+	for k := range from.Trunks {
+		pushDown(&from.Trunks[k])
 	}
 	return nil
 }

--- a/compiler/ztests/merge-filters.yaml
+++ b/compiler/ztests/merge-filters.yaml
@@ -17,10 +17,12 @@ outputs:
       )
       ===
       from (
-        file a =>
-          where b and c
-        file d =>
-          where e and f
+        (pushdown
+          where b and c)
+        file a
+        (pushdown
+          where e and f)
+        file d
       )
       ===
       from (


### PR DESCRIPTION
Optimizer.OptimizeScan pushes down filters only when it finds a "splittable path".  This means that it pushes down the filter in

    from ( file a ) | b

but not the one in

    from ( file a => b )

Adjust OptimizeScan to push down filters regardless of the presence of a "splittable path".