### PR TITLE
simplify lake version check and improve error message

### DIFF
--- a/lake/ztests/lake-version.yaml
+++ b/lake/ztests/lake-version.yaml
@@ -1,0 +1,12 @@
+script: |
+  export ZED_LAKE=test
+  zed init -q
+  zed create -q test
+  mv test/lake.zng lake-orig.zng
+  zq -o test/lake.zng 'version:=1' lake-orig.zng
+  ! zed serve
+
+outputs:
+  - name: stderr
+    data: |
+      unsupported lake version: found version 1 while expecting 2


### PR DESCRIPTION
This commit simplifies the lake version check and improves the error message when running a new "zed serve" on an old lake. Previously, the server would try to create a new lake when the current lake didn't open and would report file exists for the lake magic.  In this commit, we only try to create a new lake if we get file not exists for the lake magic.

Closes #4387