### PR TITLE
fix index operator for named complex types

### DIFF
--- a/runtime/expr/eval.go
+++ b/runtime/expr/eval.go
@@ -718,7 +718,7 @@ func NewIndexExpr(zctx *zed.Context, container, index Evaluator) Evaluator {
 func (i *Index) Eval(ectx Context, this *zed.Value) *zed.Value {
 	container := i.container.Eval(ectx, this)
 	index := i.index.Eval(ectx, this)
-	switch typ := container.Type.(type) {
+	switch typ := zed.TypeUnder(container.Type).(type) {
 	case *zed.TypeArray, *zed.TypeSet:
 		return indexVector(i.zctx, ectx, zed.InnerType(typ), container.Bytes, index)
 	case *zed.TypeRecord:

--- a/runtime/expr/ztests/index-named-complex.yaml
+++ b/runtime/expr/ztests/index-named-complex.yaml
@@ -1,0 +1,17 @@
+zed: yield this[1],this["x"]
+
+input: |
+  [1,2,3](=foo)
+  |[4,5,6]|(=bar)
+  |{1:"foo"}|(=baz)
+  {"x":123}(=bap)
+  
+output: |
+  2
+  error("missing")
+  5
+  error("missing")
+  "foo"
+  error("missing")
+  error("record index is not a string")
+  123


### PR DESCRIPTION
This commit fixes a bug where the index operator wasn't looking under named types for arrays, sets, maps, and records.  The fix is to simply call zed.TypeUnder for the type in question.

Closes #4388