### PR TITLE
Fix a typo in API doc

### DIFF
--- a/docs/lake/api.md
+++ b/docs/lake/api.md
@@ -143,7 +143,7 @@ POST /pool/{pool}/branch/{branch}
 | branch | string | path | **Required.** Name of branch to which data will be loaded. |
 |   | various | body | **Required.** Contents of the posted data. |
 | Content-Type | string | header | MIME type of the posted content. If undefined, the service will attempt to introspect the data and determine type automatically. |
-| csv.delim | string | query | Exactly one character specifing the field delimiter for CSV data. Defaults to ",". |
+| csv.delim | string | query | Exactly one character specifying the field delimiter for CSV data. Defaults to ",". |
 
 **Example Request**
 


### PR DESCRIPTION
My spell checker spotted a typo on the API doc.