### PR TITLE
api/client/auth0: fix tokenRequest field tags

### DIFF
--- a/api/client/auth0/auth0.go
+++ b/api/client/auth0/auth0.go
@@ -41,9 +41,9 @@ type DeviceCodeResponse struct {
 
 type tokenRequest struct {
 	ClientID     string `json:"client_id"`
-	DeviceCode   string `json:"device_code,-"`
+	DeviceCode   string `json:"device_code,omitempty"`
 	GrantType    string `json:"grant_type"`
-	RefreshToken string `json:"refresh_token,-"`
+	RefreshToken string `json:"refresh_token,omitempty"`
 }
 
 type tokenResponse struct {


### PR DESCRIPTION
The field tags for DeviceCode and RefreshToken contain JSON format strings ending with ",-", which isn't well-formed.  Replace that with ",omitempty", which I suspect was the author's intention as those fields are sometimes empty.