### PR TITLE
lake: log cache object access error and continue

### DIFF
--- a/cli/lakeflags/flags.go
+++ b/cli/lakeflags/flags.go
@@ -14,6 +14,7 @@ import (
 	"github.com/brimdata/zed/lake/api"
 	"github.com/brimdata/zed/lakeparse"
 	"github.com/brimdata/zed/pkg/storage"
+	"go.uber.org/zap"
 )
 
 var ErrNoHEAD = errors.New("HEAD not specified: indicate with -use or run the \"use\" command")
@@ -90,7 +91,7 @@ func (l *Flags) Open(ctx context.Context) (api.Interface, error) {
 		}
 		return api.NewRemoteLake(conn), nil
 	}
-	return api.OpenLocalLake(ctx, uri.String())
+	return api.OpenLocalLake(ctx, zap.Must(zap.NewProduction()), uri.String())
 }
 
 func (l *Flags) AuthStore() *auth0.Store {

--- a/cmd/zed/init/command.go
+++ b/cmd/zed/init/command.go
@@ -8,6 +8,7 @@ import (
 	"github.com/brimdata/zed/cmd/zed/root"
 	"github.com/brimdata/zed/lake/api"
 	"github.com/brimdata/zed/pkg/charm"
+	"go.uber.org/zap"
 )
 
 var Cmd = &charm.Spec{
@@ -46,7 +47,7 @@ func (c *Command) Run(args []string) error {
 	if api.IsLakeService(path) {
 		return fmt.Errorf("init command not valid on remote lake")
 	}
-	if _, err := api.CreateLocalLake(ctx, path); err != nil {
+	if _, err := api.CreateLocalLake(ctx, zap.Must(zap.NewProduction()), path); err != nil {
 		return err
 	}
 	if !c.LakeFlags.Quiet {

--- a/lake/api/api.go
+++ b/lake/api/api.go
@@ -18,6 +18,7 @@ import (
 	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zson"
 	"github.com/segmentio/ksuid"
+	"go.uber.org/zap"
 )
 
 type Interface interface {
@@ -45,11 +46,11 @@ type Interface interface {
 	DeleteVectors(ctx context.Context, pool ksuid.KSUID, branch string, objects []ksuid.KSUID, message api.CommitMessage) (ksuid.KSUID, error)
 }
 
-func OpenLake(ctx context.Context, u string) (Interface, error) {
+func OpenLake(ctx context.Context, logger *zap.Logger, u string) (Interface, error) {
 	if IsLakeService(u) {
 		return NewRemoteLake(client.NewConnectionTo(u)), nil
 	}
-	return OpenLocalLake(ctx, u)
+	return OpenLocalLake(ctx, logger, u)
 }
 
 func IsLakeService(u string) bool {

--- a/lake/api/local.go
+++ b/lake/api/local.go
@@ -17,6 +17,7 @@ import (
 	"github.com/brimdata/zed/zbuf"
 	"github.com/brimdata/zed/zio"
 	"github.com/segmentio/ksuid"
+	"go.uber.org/zap"
 )
 
 type local struct {
@@ -27,13 +28,13 @@ type local struct {
 
 var _ Interface = (*local)(nil)
 
-func OpenLocalLake(ctx context.Context, lakePath string) (Interface, error) {
+func OpenLocalLake(ctx context.Context, logger *zap.Logger, lakePath string) (Interface, error) {
 	uri, err := storage.ParseURI(lakePath)
 	if err != nil {
 		return nil, err
 	}
 	engine := storage.NewLocalEngine()
-	root, err := lake.Open(ctx, engine, uri)
+	root, err := lake.Open(ctx, engine, logger, uri)
 	if err != nil {
 		return nil, err
 	}
@@ -44,13 +45,13 @@ func OpenLocalLake(ctx context.Context, lakePath string) (Interface, error) {
 	}, nil
 }
 
-func CreateLocalLake(ctx context.Context, lakePath string) (Interface, error) {
+func CreateLocalLake(ctx context.Context, logger *zap.Logger, lakePath string) (Interface, error) {
 	uri, err := storage.ParseURI(lakePath)
 	if err != nil {
 		return nil, err
 	}
 	engine := storage.NewLocalEngine()
-	root, err := lake.Create(ctx, engine, uri)
+	root, err := lake.Create(ctx, engine, logger, uri)
 	if err != nil {
 		return nil, err
 	}

--- a/lake/branches/store.go
+++ b/lake/branches/store.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/brimdata/zed/lake/journal"
 	"github.com/brimdata/zed/pkg/storage"
+	"go.uber.org/zap"
 )
 
 var (
@@ -18,16 +19,16 @@ type Store struct {
 	store *journal.Store
 }
 
-func CreateStore(ctx context.Context, engine storage.Engine, path *storage.URI) (*Store, error) {
-	store, err := journal.CreateStore(ctx, engine, path, Config{})
+func CreateStore(ctx context.Context, engine storage.Engine, logger *zap.Logger, path *storage.URI) (*Store, error) {
+	store, err := journal.CreateStore(ctx, engine, logger, path, Config{})
 	if err != nil {
 		return nil, err
 	}
 	return &Store{store}, nil
 }
 
-func OpenStore(ctx context.Context, engine storage.Engine, path *storage.URI) (*Store, error) {
-	store, err := journal.OpenStore(ctx, engine, path, Config{})
+func OpenStore(ctx context.Context, engine storage.Engine, logger *zap.Logger, path *storage.URI) (*Store, error) {
+	store, err := journal.OpenStore(ctx, engine, logger, path, Config{})
 	if err != nil {
 		return nil, err
 	}

--- a/lake/pools/store.go
+++ b/lake/pools/store.go
@@ -8,6 +8,7 @@ import (
 	"github.com/brimdata/zed/lake/journal"
 	"github.com/brimdata/zed/pkg/storage"
 	"github.com/segmentio/ksuid"
+	"go.uber.org/zap"
 )
 
 var (
@@ -19,16 +20,16 @@ type Store struct {
 	store *journal.Store
 }
 
-func CreateStore(ctx context.Context, engine storage.Engine, path *storage.URI) (*Store, error) {
-	store, err := journal.CreateStore(ctx, engine, path, Config{})
+func CreateStore(ctx context.Context, engine storage.Engine, logger *zap.Logger, path *storage.URI) (*Store, error) {
+	store, err := journal.CreateStore(ctx, engine, logger, path, Config{})
 	if err != nil {
 		return nil, err
 	}
 	return &Store{store}, nil
 }
 
-func OpenStore(ctx context.Context, engine storage.Engine, path *storage.URI) (*Store, error) {
-	store, err := journal.OpenStore(ctx, engine, path, Config{})
+func OpenStore(ctx context.Context, engine storage.Engine, logger *zap.Logger, path *storage.URI) (*Store, error) {
+	store, err := journal.OpenStore(ctx, engine, logger, path, Config{})
 	if err != nil {
 		return nil, err
 	}

--- a/service/core.go
+++ b/service/core.go
@@ -107,7 +107,7 @@ func NewCore(ctx context.Context, conf Config) (*Core, error) {
 	default:
 		return nil, fmt.Errorf("root path cannot have scheme %q", path.Scheme)
 	}
-	root, err := lake.CreateOrOpen(ctx, engine, path)
+	root, err := lake.CreateOrOpen(ctx, engine, conf.Logger.Named("lake"), path)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Errors from lake/commits.Store.getSnapshot and putSnapshot and lake/journal.Store.getSnapshot and putSnapshot are unrecoverable even though those methods operate on objects containing only cached information.  Change commits.Store.Snapshot and journal.Store.load to log these errors and continue instead of failing unrecoverably. (Changes elsewhere are just logger plumbing.)

Closes #4328.