### PR TITLE
compiler: merge filters after lifting into trunks

### DIFF
--- a/compiler/job.go
+++ b/compiler/job.go
@@ -136,7 +136,6 @@ func (j *Job) Entry() dag.Op {
 
 // This must be called before the zbuf.Filter interface will work.
 func (j *Job) Optimize() error {
-	j.optimizer.MergeFilters()
 	return j.optimizer.OptimizeScan()
 }
 

--- a/compiler/optimizer/optimizer.go
+++ b/compiler/optimizer/optimizer.go
@@ -32,12 +32,12 @@ func (o *Optimizer) Entry() *dag.Sequential {
 	return o.entry
 }
 
-// MergeFilters transforms the DAG by merging adjacent filter operators so that,
+// mergeFilters transforms the DAG by merging adjacent filter operators so that,
 // e.g., "where a | where b" becomes "where a and b".
 //
-// Note: MergeFilters does not descend into dag.OverExpr.Scope, so it cannot
+// Note: mergeFilters does not descend into dag.OverExpr.Scope, so it cannot
 // merge filters in "over" expressions like "sum(over a | where b | where c)".
-func (o *Optimizer) MergeFilters() {
+func (o *Optimizer) mergeFilters() {
 	walkOp(o.entry, func(op dag.Op) {
 		if seq, ok := op.(*dag.Sequential); ok {
 			// Start at the next to last element and work toward the first.
@@ -108,6 +108,7 @@ func (o *Optimizer) OptimizeScan() error {
 		}
 		seq.Delete(1, len)
 	}
+	o.mergeFilters()
 	for k := range from.Trunks {
 		trunk := &from.Trunks[k]
 		pushDown(trunk)

--- a/compiler/ztests/merge-filters.yaml
+++ b/compiler/ztests/merge-filters.yaml
@@ -1,7 +1,7 @@
 script: |
   zc -C -O 'where a | where b'
   echo ===
-  zc -C -O 'from ( file a => where b | where c file d => where e | where f )'
+  zc -C -O 'from ( file a => where b | where c file d => where e | where f ) | where g'
   echo ===
   zc -C -O 'over a => ( where b | where c )'
   echo ===
@@ -18,10 +18,10 @@ outputs:
       ===
       from (
         (pushdown
-          where b and c)
+          where b and c and g)
         file a
         (pushdown
-          where e and f)
+          where e and f and g)
         file d
       )
       ===


### PR DESCRIPTION
Merging filters before calling Optimizer.OptimizeScan prevents merging of the filters here:

    from ( file a => b ) | c

Fix that by instead merging filters in OptimizeScan after lifting any splittable path into the trunks.