### PR TITLE
update old-style zed.Value variable names

### DIFF
--- a/api/client/request.go
+++ b/api/client/request.go
@@ -95,13 +95,13 @@ func (r *Request) reader() (io.Reader, error) {
 	}
 	m := zson.NewZNGMarshaler()
 	m.Decorate(zson.StylePackage)
-	zv, err := m.Marshal(r.Body)
+	val, err := m.Marshal(r.Body)
 	if err != nil {
 		return nil, err
 	}
 	var buf bytes.Buffer
 	zw := zngio.NewWriter(zio.NopCloser(&buf))
-	if err := zw.Write(zv); err != nil {
+	if err := zw.Write(val); err != nil {
 		return nil, err
 	}
 	if err := zw.Close(); err != nil {

--- a/index/finder.go
+++ b/index/finder.go
@@ -253,11 +253,11 @@ func (f *Finder) ParseKeys(inputs ...string) ([]KeyValue, error) {
 	}
 	kvs := make([]KeyValue, 0, len(inputs))
 	for k, s := range inputs {
-		zv, err := zson.ParseValue(f.zctx, s)
+		val, err := zson.ParseValue(f.zctx, s)
 		if err != nil {
 			return nil, fmt.Errorf("could not parse %q: %w", s, err)
 		}
-		kvs = append(kvs, KeyValue{keys[k], *zv})
+		kvs = append(kvs, KeyValue{keys[k], *val})
 	}
 	return kvs, nil
 }

--- a/lake/branch.go
+++ b/lake/branch.go
@@ -103,11 +103,11 @@ func loadMeta(zctx *zed.Context, meta string) (*zed.Value, error) {
 	if meta == "" {
 		return zed.Null, nil
 	}
-	zv, err := zson.ParseValue(zed.NewContext(), meta)
+	val, err := zson.ParseValue(zed.NewContext(), meta)
 	if err != nil {
-		return zctx.Missing(), fmt.Errorf("%w %s: %v", ErrInvalidCommitMeta, zv, err)
+		return zctx.Missing(), fmt.Errorf("%w %q: %s", ErrInvalidCommitMeta, meta, err)
 	}
-	return zv, nil
+	return val, nil
 }
 
 func (b *Branch) Delete(ctx context.Context, ids []ksuid.KSUID, author, message string) (ksuid.KSUID, error) {

--- a/order/direction.go
+++ b/order/direction.go
@@ -76,8 +76,8 @@ func (d Direction) MarshalZNG(m *zson.MarshalZNGContext) (zed.Type, error) {
 	return m.MarshalValue(d.String())
 }
 
-func (d *Direction) UnmarshalZNG(u *zson.UnmarshalZNGContext, zv *zed.Value) error {
-	dir, err := ParseDirection(string(zv.Bytes))
+func (d *Direction) UnmarshalZNG(u *zson.UnmarshalZNGContext, val *zed.Value) error {
+	dir, err := ParseDirection(string(val.Bytes))
 	if err != nil {
 		return err
 	}

--- a/order/which.go
+++ b/order/which.go
@@ -58,8 +58,8 @@ func (w Which) MarshalZNG(m *zson.MarshalZNGContext) (zed.Type, error) {
 	return m.MarshalValue(w.String())
 }
 
-func (w *Which) UnmarshalZNG(u *zson.UnmarshalZNGContext, zv *zed.Value) error {
-	which, err := Parse(string(zv.Bytes))
+func (w *Which) UnmarshalZNG(u *zson.UnmarshalZNGContext, val *zed.Value) error {
+	which, err := Parse(string(val.Bytes))
 	if err != nil {
 		return err
 	}

--- a/runtime/expr/coerce/coerce.go
+++ b/runtime/expr/coerce/coerce.go
@@ -166,105 +166,105 @@ func (c *Pair) coerceNumbers(aid, bid int) (int, bool) {
 	return id, ok
 }
 
-func ToFloat(zv *zed.Value) (float64, bool) {
-	id := zv.Type.ID()
+func ToFloat(val *zed.Value) (float64, bool) {
+	id := val.Type.ID()
 	if zed.IsFloat(id) {
-		return zed.DecodeFloat(zv.Bytes), true
+		return zed.DecodeFloat(val.Bytes), true
 	}
 	if zed.IsInteger(id) {
 		if zed.IsSigned(id) {
-			return float64(zed.DecodeInt(zv.Bytes)), true
+			return float64(zed.DecodeInt(val.Bytes)), true
 		} else {
-			return float64(zed.DecodeUint(zv.Bytes)), true
+			return float64(zed.DecodeUint(val.Bytes)), true
 		}
 	}
 	if id == zed.IDDuration {
-		return float64(zed.DecodeInt(zv.Bytes)), true
+		return float64(zed.DecodeInt(val.Bytes)), true
 	}
 	if id == zed.IDTime {
-		return float64(zed.DecodeTime(zv.Bytes)), true
+		return float64(zed.DecodeTime(val.Bytes)), true
 	}
 	if id == zed.IDString {
-		v, err := strconv.ParseFloat(string(zv.Bytes), 64)
+		v, err := strconv.ParseFloat(string(val.Bytes), 64)
 		return v, err == nil
 	}
 	return 0, false
 }
 
-func ToUint(zv *zed.Value) (uint64, bool) {
-	id := zv.Type.ID()
+func ToUint(val *zed.Value) (uint64, bool) {
+	id := val.Type.ID()
 	if zed.IsFloat(id) {
-		return uint64(zed.DecodeFloat(zv.Bytes)), true
+		return uint64(zed.DecodeFloat(val.Bytes)), true
 	}
 	if zed.IsInteger(id) {
 		if zed.IsSigned(id) {
-			v := zed.DecodeInt(zv.Bytes)
+			v := zed.DecodeInt(val.Bytes)
 			if v < 0 {
 				return 0, false
 			}
 			return uint64(v), true
 		} else {
-			return uint64(zed.DecodeUint(zv.Bytes)), true
+			return uint64(zed.DecodeUint(val.Bytes)), true
 		}
 	}
 	if id == zed.IDDuration {
-		return uint64(zed.DecodeInt(zv.Bytes)), true
+		return uint64(zed.DecodeInt(val.Bytes)), true
 	}
 	if id == zed.IDTime {
-		return uint64(zed.DecodeTime(zv.Bytes)), true
+		return uint64(zed.DecodeTime(val.Bytes)), true
 	}
 	if id == zed.IDString {
-		v, err := strconv.ParseUint(string(zv.Bytes), 10, 64)
+		v, err := strconv.ParseUint(string(val.Bytes), 10, 64)
 		return v, err == nil
 	}
 	return 0, false
 }
 
-func ToInt(zv *zed.Value) (int64, bool) {
-	id := zv.Type.ID()
+func ToInt(val *zed.Value) (int64, bool) {
+	id := val.Type.ID()
 	if zed.IsFloat(id) {
-		return int64(zed.DecodeFloat(zv.Bytes)), true
+		return int64(zed.DecodeFloat(val.Bytes)), true
 	}
 	if zed.IsInteger(id) {
 		if zed.IsSigned(id) {
 			// XXX check if negative? should -1:uint64 be maxint64 or an error?
-			return int64(zed.DecodeInt(zv.Bytes)), true
+			return int64(zed.DecodeInt(val.Bytes)), true
 		} else {
-			return int64(zed.DecodeUint(zv.Bytes)), true
+			return int64(zed.DecodeUint(val.Bytes)), true
 		}
 	}
 	if id == zed.IDDuration {
-		return int64(zed.DecodeInt(zv.Bytes)), true
+		return int64(zed.DecodeInt(val.Bytes)), true
 	}
 	if id == zed.IDTime {
-		return int64(zed.DecodeTime(zv.Bytes)), true
+		return int64(zed.DecodeTime(val.Bytes)), true
 	}
 	if id == zed.IDString {
-		v, err := strconv.ParseInt(string(zv.Bytes), 10, 64)
+		v, err := strconv.ParseInt(string(val.Bytes), 10, 64)
 		return v, err == nil
 	}
 	return 0, false
 }
 
-func ToBool(zv *zed.Value) (bool, bool) {
-	if zv.IsString() {
-		v, err := strconv.ParseBool(string(zv.Bytes))
+func ToBool(val *zed.Value) (bool, bool) {
+	if val.IsString() {
+		v, err := strconv.ParseBool(string(val.Bytes))
 		return v, err == nil
 	}
-	v, ok := ToInt(zv)
+	v, ok := ToInt(val)
 	return v != 0, ok
 }
 
-func ToTime(zv *zed.Value) (nano.Ts, bool) {
-	id := zv.Type.ID()
+func ToTime(val *zed.Value) (nano.Ts, bool) {
+	id := val.Type.ID()
 	if id == zed.IDTime {
-		return zed.DecodeTime(zv.Bytes), true
+		return zed.DecodeTime(val.Bytes), true
 	}
 	if zed.IsSigned(id) {
-		return nano.Ts(zed.DecodeInt(zv.Bytes)), true
+		return nano.Ts(zed.DecodeInt(val.Bytes)), true
 	}
 	if zed.IsInteger(id) {
-		v := zed.DecodeUint(zv.Bytes)
+		v := zed.DecodeUint(val.Bytes)
 		// check for overflow
 		if v > math.MaxInt64 {
 			return 0, false
@@ -272,7 +272,7 @@ func ToTime(zv *zed.Value) (nano.Ts, bool) {
 		return nano.Ts(v), true
 	}
 	if zed.IsFloat(id) {
-		return nano.Ts(zed.DecodeFloat(zv.Bytes)), true
+		return nano.Ts(zed.DecodeFloat(val.Bytes)), true
 	}
 	return 0, false
 }

--- a/runtime/expr/dropper.go
+++ b/runtime/expr/dropper.go
@@ -22,11 +22,11 @@ func (d *dropper) drop(ectx Context, in *zed.Value) *zed.Value {
 		val := e.Eval(ectx, in)
 		b.Append(val.Bytes)
 	}
-	zv, err := b.Encode()
+	val, err := b.Encode()
 	if err != nil {
 		panic(err)
 	}
-	return zed.NewValue(d.typ, zv)
+	return zed.NewValue(d.typ, val)
 }
 
 type Dropper struct {

--- a/runtime/expr/function/bytes.go
+++ b/runtime/expr/function/bytes.go
@@ -14,24 +14,24 @@ type Base64 struct {
 }
 
 func (b *Base64) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
-	zv := args[0]
-	switch zv.Type.ID() {
+	val := args[0]
+	switch val.Type.ID() {
 	case zed.IDBytes:
-		if zv.Bytes == nil {
+		if val.Bytes == nil {
 			return newErrorf(b.zctx, ctx, "base64: illegal null argument")
 		}
-		return newString(ctx, base64.StdEncoding.EncodeToString(zv.Bytes))
+		return newString(ctx, base64.StdEncoding.EncodeToString(val.Bytes))
 	case zed.IDString:
-		if zv.Bytes == nil {
+		if val.Bytes == nil {
 			return zed.Null
 		}
-		bytes, err := base64.StdEncoding.DecodeString(zed.DecodeString(zv.Bytes))
+		bytes, err := base64.StdEncoding.DecodeString(zed.DecodeString(val.Bytes))
 		if err != nil {
-			return newErrorf(b.zctx, ctx, "base64: string argument is not base64: %q", string(zv.Bytes))
+			return newErrorf(b.zctx, ctx, "base64: string argument is not base64: %q", string(val.Bytes))
 		}
 		return newBytes(ctx, bytes)
 	default:
-		return newErrorf(b.zctx, ctx, "base64: argument must a bytes or string type (bad argument: %s)", zson.String(zv))
+		return newErrorf(b.zctx, ctx, "base64: argument must a bytes or string type (bad argument: %s)", zson.String(val))
 	}
 }
 

--- a/runtime/expr/function/fields.go
+++ b/runtime/expr/function/fields.go
@@ -36,8 +36,8 @@ func buildPath(typ *zed.TypeRecord, b *zcode.Builder, prefix []string) []string 
 }
 
 func (f *Fields) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
-	zvSubject := args[0]
-	typ := f.recordType(zvSubject)
+	subjectVal := args[0]
+	typ := f.recordType(subjectVal)
 	if typ == nil {
 		return f.zctx.Missing()
 	}
@@ -47,12 +47,12 @@ func (f *Fields) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	return ctx.NewValue(f.typ, b.Bytes())
 }
 
-func (f *Fields) recordType(zv zed.Value) *zed.TypeRecord {
-	if typ, ok := zed.TypeUnder(zv.Type).(*zed.TypeRecord); ok {
+func (f *Fields) recordType(val zed.Value) *zed.TypeRecord {
+	if typ, ok := zed.TypeUnder(val.Type).(*zed.TypeRecord); ok {
 		return typ
 	}
-	if zv.Type == zed.TypeType {
-		typ, err := f.zctx.LookupByValue(zv.Bytes)
+	if val.Type == zed.TypeType {
+		typ, err := f.zctx.LookupByValue(val.Bytes)
 		if err != nil {
 			return nil
 		}

--- a/runtime/expr/function/ksuid.go
+++ b/runtime/expr/function/ksuid.go
@@ -15,26 +15,26 @@ func (k *KSUIDToString) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if len(args) == 0 {
 		return newBytes(ctx, ksuid.New().Bytes())
 	}
-	zv := args[0]
-	switch zv.Type.ID() {
+	val := args[0]
+	switch val.Type.ID() {
 	case zed.IDBytes:
-		if zv.Bytes == nil {
+		if val.Bytes == nil {
 			return newErrorf(k.zctx, ctx, "ksuid: illegal null argument")
 		}
 		// XXX GC
-		id, err := ksuid.FromBytes(zv.Bytes)
+		id, err := ksuid.FromBytes(val.Bytes)
 		if err != nil {
 			panic(err)
 		}
 		return newString(ctx, id.String())
 	case zed.IDString:
 		// XXX GC
-		id, err := ksuid.Parse(string(zv.Bytes))
+		id, err := ksuid.Parse(string(val.Bytes))
 		if err != nil {
-			return newErrorf(k.zctx, ctx, "ksuid: %s (bad argument: %s)", err, zson.String(zv))
+			return newErrorf(k.zctx, ctx, "ksuid: %s (bad argument: %s)", err, zson.String(val))
 		}
 		return newBytes(ctx, id.Bytes())
 	default:
-		return newErrorf(k.zctx, ctx, "ksuid: argument must a bytes or string type (bad argument: %s)", zson.String(zv))
+		return newErrorf(k.zctx, ctx, "ksuid: argument must a bytes or string type (bad argument: %s)", zson.String(val))
 	}
 }

--- a/runtime/expr/function/math.go
+++ b/runtime/expr/function/math.go
@@ -115,15 +115,15 @@ type reducer struct {
 }
 
 func (r *reducer) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
-	zv := &args[0]
-	typ := zv.Type
+	val0 := &args[0]
+	typ := val0.Type
 	id := typ.ID()
 	if zed.IsFloat(id) {
 		//XXX this is wrong like math aggregators...
 		// need to be more robust and adjust type as new types encountered
-		result := zed.DecodeFloat(zv.Bytes)
+		result := zed.DecodeFloat(val0.Bytes)
 		for _, val := range args[1:] {
-			v, ok := coerce.ToFloat(zv)
+			v, ok := coerce.ToFloat(&val)
 			if !ok {
 				return newErrorf(r.zctx, ctx, "%s: not a number: %s", r.name, zson.MustFormatValue(&val))
 			}
@@ -132,10 +132,10 @@ func (r *reducer) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		return newFloat64(ctx, result)
 	}
 	if !zed.IsNumber(id) {
-		return newErrorf(r.zctx, ctx, "%s: not a number: %s", r.name, zson.MustFormatValue(zv))
+		return newErrorf(r.zctx, ctx, "%s: not a number: %s", r.name, zson.MustFormatValue(val0))
 	}
 	if zed.IsSigned(id) {
-		result := zed.DecodeInt(zv.Bytes)
+		result := zed.DecodeInt(val0.Bytes)
 		for _, val := range args[1:] {
 			//XXX this is really bad because we silently coerce
 			// floats to ints if we hit a float first
@@ -147,7 +147,7 @@ func (r *reducer) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		}
 		return newInt64(ctx, result)
 	}
-	result := zed.DecodeUint(zv.Bytes)
+	result := zed.DecodeUint(val0.Bytes)
 	for _, val := range args[1:] {
 		v, ok := coerce.ToUint(&val)
 		if !ok {
@@ -164,22 +164,22 @@ type Round struct {
 }
 
 func (r *Round) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
-	zv := &args[0]
-	id := zv.Type.ID()
+	val := &args[0]
+	id := val.Type.ID()
 	if id == zed.IDFloat16 {
-		f := zed.DecodeFloat16(zv.Bytes)
+		f := zed.DecodeFloat16(val.Bytes)
 		return newFloat16(ctx, float32(math.Round(float64(f))))
 	}
 	if id == zed.IDFloat32 {
-		f := zed.DecodeFloat32(zv.Bytes)
+		f := zed.DecodeFloat32(val.Bytes)
 		return newFloat32(ctx, float32(math.Round(float64(f))))
 	}
 	if id == zed.IDFloat64 {
-		f := zed.DecodeFloat64(zv.Bytes)
+		f := zed.DecodeFloat64(val.Bytes)
 		return newFloat64(ctx, math.Round(f))
 	}
 	if !zed.IsNumber(id) {
-		return newErrorf(r.zctx, ctx, "round: not a number: %s", zson.MustFormatValue(zv))
+		return newErrorf(r.zctx, ctx, "round: not a number: %s", zson.MustFormatValue(val))
 	}
 	return ctx.CopyValue(&args[0])
 }

--- a/runtime/expr/function/string.go
+++ b/runtime/expr/function/string.go
@@ -15,21 +15,21 @@ type Replace struct {
 }
 
 func (r *Replace) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
-	zvs := args[0]
-	zvold := args[1]
-	zvnew := args[2]
-	if !zvs.IsString() || !zvold.IsString() || !zvnew.IsString() {
+	sVal := args[0]
+	oldVal := args[1]
+	newVal := args[2]
+	if !sVal.IsString() || !oldVal.IsString() || !newVal.IsString() {
 		return newErrorf(r.zctx, ctx, "replace: string arg required")
 	}
-	if zvs.Bytes == nil {
+	if sVal.Bytes == nil {
 		return zed.Null
 	}
-	if zvold.Bytes == nil || zvnew.Bytes == nil {
+	if oldVal.Bytes == nil || newVal.Bytes == nil {
 		return newErrorf(r.zctx, ctx, "replace: an input arg is null")
 	}
-	s := zed.DecodeString(zvs.Bytes)
-	old := zed.DecodeString(zvold.Bytes)
-	new := zed.DecodeString(zvnew.Bytes)
+	s := zed.DecodeString(sVal.Bytes)
+	old := zed.DecodeString(oldVal.Bytes)
+	new := zed.DecodeString(newVal.Bytes)
 	return newString(ctx, strings.ReplaceAll(s, old, new))
 }
 
@@ -39,14 +39,14 @@ type RuneLen struct {
 }
 
 func (r *RuneLen) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
-	zv := args[0]
-	if !zv.IsString() {
+	val := args[0]
+	if !val.IsString() {
 		return newErrorf(r.zctx, ctx, "rune_len: string arg required")
 	}
-	if zv.Bytes == nil {
+	if val.Bytes == nil {
 		return newInt64(ctx, 0)
 	}
-	s := zed.DecodeString(zv.Bytes)
+	s := zed.DecodeString(val.Bytes)
 	return newInt64(ctx, int64(utf8.RuneCountInString(s)))
 }
 
@@ -56,14 +56,14 @@ type ToLower struct {
 }
 
 func (t *ToLower) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
-	zv := args[0]
-	if !zv.IsString() {
+	val := args[0]
+	if !val.IsString() {
 		return newErrorf(t.zctx, ctx, "lower: string arg required")
 	}
-	if zv.IsNull() {
+	if val.IsNull() {
 		return zed.NullString
 	}
-	s := zed.DecodeString(zv.Bytes)
+	s := zed.DecodeString(val.Bytes)
 	return newString(ctx, strings.ToLower(s))
 }
 
@@ -73,14 +73,14 @@ type ToUpper struct {
 }
 
 func (t *ToUpper) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
-	zv := args[0]
-	if !zv.IsString() {
+	val := args[0]
+	if !val.IsString() {
 		return newErrorf(t.zctx, ctx, "upper: string arg required")
 	}
-	if zv.IsNull() {
+	if val.IsNull() {
 		return zed.NullString
 	}
-	s := zed.DecodeString(zv.Bytes)
+	s := zed.DecodeString(val.Bytes)
 	return newString(ctx, strings.ToUpper(s))
 }
 
@@ -90,14 +90,14 @@ type Trim struct {
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#trim
 func (t *Trim) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
-	zv := args[0]
-	if !zv.IsString() {
+	val := args[0]
+	if !val.IsString() {
 		return newErrorf(t.zctx, ctx, "trim: string arg required")
 	}
-	if zv.IsNull() {
+	if val.IsNull() {
 		return zed.NullString
 	}
-	s := zed.DecodeString(zv.Bytes)
+	s := zed.DecodeString(val.Bytes)
 	return newString(ctx, strings.TrimSpace(s))
 }
 
@@ -115,16 +115,16 @@ func newSplit(zctx *zed.Context) *Split {
 }
 
 func (s *Split) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
-	zs := args[0]
-	zsep := args[1]
-	if !zs.IsString() || !zsep.IsString() {
+	sVal := args[0]
+	sepVal := args[1]
+	if !sVal.IsString() || !sepVal.IsString() {
 		return newErrorf(s.zctx, ctx, "split: string args required")
 	}
-	if zs.IsNull() || zsep.IsNull() {
+	if sVal.IsNull() || sepVal.IsNull() {
 		return ctx.NewValue(s.typ, nil)
 	}
-	str := zed.DecodeString(zs.Bytes)
-	sep := zed.DecodeString(zsep.Bytes)
+	str := zed.DecodeString(sVal.Bytes)
+	sep := zed.DecodeString(sepVal.Bytes)
 	splits := strings.Split(str, sep)
 	var b zcode.Bytes
 	for _, substr := range splits {
@@ -140,8 +140,8 @@ type Join struct {
 }
 
 func (j *Join) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
-	zsplits := args[0]
-	typ, ok := zed.TypeUnder(zsplits.Type).(*zed.TypeArray)
+	splitsVal := args[0]
+	typ, ok := zed.TypeUnder(splitsVal.Type).(*zed.TypeArray)
 	if !ok {
 		return newErrorf(j.zctx, ctx, "join: array of string args required")
 	}
@@ -150,15 +150,15 @@ func (j *Join) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	}
 	var separator string
 	if len(args) == 2 {
-		zsep := args[1]
-		if !zsep.IsString() {
+		sepVal := args[1]
+		if !sepVal.IsString() {
 			return newErrorf(j.zctx, ctx, "join: separator must be string")
 		}
-		separator = zed.DecodeString(zsep.Bytes)
+		separator = zed.DecodeString(sepVal.Bytes)
 	}
 	b := j.builder
 	b.Reset()
-	it := zsplits.Bytes.Iter()
+	it := splitsVal.Bytes.Iter()
 	var sep string
 	for !it.Done() {
 		b.WriteString(sep)

--- a/runtime/expr/slice.go
+++ b/runtime/expr/slice.go
@@ -89,8 +89,8 @@ func sliceIndex(ectx Context, this *zed.Value, slot Evaluator, length int) (int,
 		//XXX
 		return 0, ErrSliceIndexEmpty
 	}
-	zv := slot.Eval(ectx, this)
-	v, ok := coerce.ToInt(zv)
+	val := slot.Eval(ectx, this)
+	v, ok := coerce.ToInt(val)
 	if !ok {
 		return 0, ErrSliceIndex
 	}

--- a/runtime/expr/values.go
+++ b/runtime/expr/values.go
@@ -47,12 +47,12 @@ func (r *recordExpr) Eval(ectx Context, this *zed.Value) *zed.Value {
 	b := r.builder
 	b.Reset()
 	for k, e := range r.exprs {
-		zv := e.Eval(ectx, this)
-		if r.fields[k].Type != zv.Type {
-			r.fields[k].Type = zv.Type
+		val := e.Eval(ectx, this)
+		if r.fields[k].Type != val.Type {
+			r.fields[k].Type = val.Type
 			changed = true
 		}
-		b.Append(zv.Bytes)
+		b.Append(val.Bytes)
 	}
 	if changed {
 		r.typ = r.zctx.MustLookupTypeRecord(r.fields)

--- a/runtime/op/groupby/groupby.go
+++ b/runtime/op/groupby/groupby.go
@@ -386,9 +386,9 @@ func (a *Aggregator) spillTable(eof bool, ref zbuf.Batch) error {
 
 // updateMaxTableKey is called with a volatile zed.Value to update the
 // max value seen in the table for the streaming logic when the input is sorted.
-func (a *Aggregator) updateMaxTableKey(zv *zed.Value) *zed.Value {
-	if a.maxTableKey == nil || a.valueCompare(zv, a.maxTableKey) > 0 {
-		a.maxTableKey = zv.Copy()
+func (a *Aggregator) updateMaxTableKey(val *zed.Value) *zed.Value {
+	if a.maxTableKey == nil || a.valueCompare(val, a.maxTableKey) > 0 {
+		a.maxTableKey = val.Copy()
 	}
 	return a.maxTableKey
 }

--- a/runtime/op/shape/shaper.go
+++ b/runtime/op/shape/shaper.go
@@ -60,8 +60,8 @@ func (a *anchor) mixIn(fields []zed.Field) {
 	}
 }
 
-func (i *integer) check(zv zed.Value) {
-	id := zv.Type.ID()
+func (i *integer) check(val zed.Value) {
+	id := val.Type.ID()
 	if zed.IsInteger(id) || id == zed.IDNull {
 		return
 	}
@@ -70,7 +70,7 @@ func (i *integer) check(zv zed.Value) {
 		i.unsigned = false
 		return
 	}
-	f := zed.DecodeFloat64(zv.Bytes)
+	f := zed.DecodeFloat64(val.Bytes)
 	//XXX We could track signed vs unsigned and overflow,
 	// but for now, we leave it as float64 unless we can
 	// guarantee int64.
@@ -86,8 +86,8 @@ func (i *integer) check(zv zed.Value) {
 func (a *anchor) updateInts(rec *zed.Value) error {
 	it := rec.Bytes.Iter()
 	for k, f := range rec.Fields() {
-		zv := zed.Value{Type: f.Type, Bytes: it.Next()}
-		a.integers[k].check(zv)
+		val := zed.Value{Type: f.Type, Bytes: it.Next()}
+		a.integers[k].check(val)
 	}
 	return nil
 }

--- a/runtime/op/traverse/over.go
+++ b/runtime/op/traverse/over.go
@@ -81,12 +81,12 @@ func (o *Over) over(batch zbuf.Batch, this *zed.Value) zbuf.Batch {
 	return zbuf.NewBatch(batch, vals)
 }
 
-func appendOver(zctx *zed.Context, vals []zed.Value, zv zed.Value) []zed.Value {
-	zv = *zv.Under()
-	switch typ := zed.TypeUnder(zv.Type).(type) {
+func appendOver(zctx *zed.Context, vals []zed.Value, val zed.Value) []zed.Value {
+	val = *val.Under()
+	switch typ := zed.TypeUnder(val.Type).(type) {
 	case *zed.TypeArray, *zed.TypeSet:
 		typ = zed.InnerType(typ)
-		for it := zv.Bytes.Iter(); !it.Done(); {
+		for it := val.Bytes.Iter(); !it.Done(); {
 			// XXX when we do proper expr.Context, we can allocate
 			// this copy through the batch.
 			val := zed.NewValue(typ, it.Next()).Under()
@@ -98,14 +98,14 @@ func appendOver(zctx *zed.Context, vals []zed.Value, zv zed.Value) []zed.Value {
 			zed.NewField("key", typ.KeyType),
 			zed.NewField("value", typ.ValType),
 		})
-		for it := zv.Bytes.Iter(); !it.Done(); {
+		for it := val.Bytes.Iter(); !it.Done(); {
 			bytes := zcode.Append(zcode.Append(nil, it.Next()), it.Next())
 			vals = append(vals, *zed.NewValue(rtyp, bytes))
 		}
 		return vals
 	case *zed.TypeRecord:
 		builder := zcode.NewBuilder()
-		for i, it := 0, zv.Bytes.Iter(); !it.Done(); i++ {
+		for i, it := 0, val.Bytes.Iter(); !it.Done(); i++ {
 			builder.Reset()
 			field := typ.Fields[i]
 			typ := zctx.MustLookupTypeRecord([]zed.Field{
@@ -120,6 +120,6 @@ func appendOver(zctx *zed.Context, vals []zed.Value, zv zed.Value) []zed.Value {
 		}
 		return vals
 	default:
-		return append(vals, zv)
+		return append(vals, val)
 	}
 }

--- a/typevectortable.go
+++ b/typevectortable.go
@@ -50,8 +50,8 @@ func newTypeVector(in []Type) typeVector {
 
 func newTypeVectorFromValues(vals []Value) typeVector {
 	out := make(typeVector, 0, len(vals))
-	for _, zv := range vals {
-		out = append(out, zv.Type)
+	for _, val := range vals {
+		out = append(out, val.Type)
 	}
 	return out
 }

--- a/zio/combiner.go
+++ b/zio/combiner.go
@@ -31,7 +31,7 @@ func NewCombiner(ctx context.Context, readers []Reader) *Combiner {
 type combinerResult struct {
 	err error
 	idx int
-	zv  *zed.Value
+	val *zed.Value
 }
 
 func (c *Combiner) run() {
@@ -77,8 +77,8 @@ func (c *Combiner) Read() (*zed.Value, error) {
 				c.cancel()
 				return nil, r.err
 			}
-			if r.zv != nil {
-				return r.zv, nil
+			if r.val != nil {
+				return r.val, nil
 			}
 			c.done[r.idx] = true
 			if c.finished() {

--- a/zio/zeekio/format.go
+++ b/zio/zeekio/format.go
@@ -15,58 +15,58 @@ import (
 	"github.com/brimdata/zed/zson"
 )
 
-func formatAny(zv *zed.Value, inContainer bool) string {
-	switch t := zv.Type.(type) {
+func formatAny(val *zed.Value, inContainer bool) string {
+	switch t := val.Type.(type) {
 	case *zed.TypeArray:
-		return formatArray(t, zv.Bytes)
+		return formatArray(t, val.Bytes)
 	case *zed.TypeNamed:
-		return formatAny(zed.NewValue(t.Type, zv.Bytes), inContainer)
+		return formatAny(zed.NewValue(t.Type, val.Bytes), inContainer)
 	case *zed.TypeOfBool:
-		if zed.DecodeBool(zv.Bytes) {
+		if zed.DecodeBool(val.Bytes) {
 			return "T"
 		}
 		return "F"
 	case *zed.TypeOfBytes:
-		return base64.StdEncoding.EncodeToString(zv.Bytes)
+		return base64.StdEncoding.EncodeToString(val.Bytes)
 	case *zed.TypeOfDuration:
-		return formatTime(nano.Ts(zed.DecodeDuration(zv.Bytes)))
+		return formatTime(nano.Ts(zed.DecodeDuration(val.Bytes)))
 	case *zed.TypeEnum:
-		return formatAny(zed.NewValue(zed.TypeUint64, zv.Bytes), false)
+		return formatAny(zed.NewValue(zed.TypeUint64, val.Bytes), false)
 	case *zed.TypeOfFloat16:
-		return strconv.FormatFloat(float64(zed.DecodeFloat16(zv.Bytes)), 'f', -1, 32)
+		return strconv.FormatFloat(float64(zed.DecodeFloat16(val.Bytes)), 'f', -1, 32)
 	case *zed.TypeOfFloat32:
-		return strconv.FormatFloat(float64(zed.DecodeFloat32(zv.Bytes)), 'f', -1, 32)
+		return strconv.FormatFloat(float64(zed.DecodeFloat32(val.Bytes)), 'f', -1, 32)
 	case *zed.TypeOfFloat64:
-		return strconv.FormatFloat(zed.DecodeFloat64(zv.Bytes), 'f', -1, 64)
+		return strconv.FormatFloat(zed.DecodeFloat64(val.Bytes), 'f', -1, 64)
 	case *zed.TypeOfInt8, *zed.TypeOfInt16, *zed.TypeOfInt32, *zed.TypeOfInt64:
-		return strconv.FormatInt(zed.DecodeInt(zv.Bytes), 10)
+		return strconv.FormatInt(zed.DecodeInt(val.Bytes), 10)
 	case *zed.TypeOfUint8, *zed.TypeOfUint16, *zed.TypeOfUint32, *zed.TypeOfUint64:
-		return strconv.FormatUint(zed.DecodeUint(zv.Bytes), 10)
+		return strconv.FormatUint(zed.DecodeUint(val.Bytes), 10)
 	case *zed.TypeOfIP:
-		return zed.DecodeIP(zv.Bytes).String()
+		return zed.DecodeIP(val.Bytes).String()
 	case *zed.TypeMap:
-		return formatMap(t, zv.Bytes)
+		return formatMap(t, val.Bytes)
 	case *zed.TypeOfNet:
-		return zed.DecodeNet(zv.Bytes).String()
+		return zed.DecodeNet(val.Bytes).String()
 	case *zed.TypeOfNull:
 		return "-"
 	case *zed.TypeRecord:
-		return formatRecord(t, zv.Bytes)
+		return formatRecord(t, val.Bytes)
 	case *zed.TypeSet:
-		return formatSet(t, zv.Bytes)
+		return formatSet(t, val.Bytes)
 	case *zed.TypeOfString:
-		return formatString(t, zv.Bytes, inContainer)
+		return formatString(t, val.Bytes, inContainer)
 	case *zed.TypeOfTime:
-		return formatTime(zed.DecodeTime(zv.Bytes))
+		return formatTime(zed.DecodeTime(val.Bytes))
 	case *zed.TypeOfType:
-		return zson.String(zv)
+		return zson.String(val)
 	case *zed.TypeUnion:
-		return formatUnion(t, zv.Bytes)
+		return formatUnion(t, val.Bytes)
 	case *zed.TypeError:
 		if zed.TypeUnder(t.Type) == zed.TypeString {
-			return string(zv.Bytes)
+			return string(val.Bytes)
 		}
-		return zson.MustFormatValue(zv)
+		return zson.MustFormatValue(val)
 	default:
 		return fmt.Sprintf("zeekio.StringOf(): unknown type: %T", t)
 	}

--- a/zio/zsonio/reader_test.go
+++ b/zio/zsonio/reader_test.go
@@ -16,7 +16,7 @@ func TestReadOneLineNoEOF(t *testing.T) {
 	const expected = `{msg:"record1"}`
 	type result struct {
 		err error
-		zv  *zed.Value
+		val *zed.Value
 	}
 	done := make(chan result)
 	go func() {
@@ -26,7 +26,7 @@ func TestReadOneLineNoEOF(t *testing.T) {
 		reader <- []byte(expected + "\n" + expected)
 		r := zsonio.NewReader(zed.NewContext(), reader)
 		rec, err := r.Read()
-		done <- result{zv: rec, err: err}
+		done <- result{val: rec, err: err}
 	}()
 	select {
 	// Because this test CAN deadlock fail after 5 seconds.
@@ -34,7 +34,7 @@ func TestReadOneLineNoEOF(t *testing.T) {
 		t.Fatal("testing did not complete in 5 seconds")
 	case res := <-done:
 		require.NoError(t, res.err)
-		rec := res.zv
+		rec := res.val
 		assert.Equal(t, expected, zson.String(rec))
 	}
 }

--- a/zson/formatter.go
+++ b/zson/formatter.go
@@ -81,15 +81,15 @@ func (f *Formatter) FormatRecord(rec *zed.Value) (string, error) {
 	return f.builder.String(), nil
 }
 
-func FormatValue(zv *zed.Value) (string, error) {
+func FormatValue(val *zed.Value) (string, error) {
 	f := NewFormatter(0, nil)
-	return f.Format(zv)
+	return f.Format(val)
 }
 
-func MustFormatValue(zv *zed.Value) string {
-	s, err := FormatValue(zv)
+func MustFormatValue(val *zed.Value) string {
+	s, err := FormatValue(val)
 	if err != nil {
-		panic(fmt.Errorf("ZSON format value failed: type %s, bytes %s", zv.Type, hex.EncodeToString(zv.Bytes)))
+		panic(fmt.Errorf("ZSON format value failed: type %s, bytes %s", val.Type, hex.EncodeToString(val.Bytes)))
 	}
 	return s
 }
@@ -108,9 +108,9 @@ func String(p interface{}) string {
 	}
 }
 
-func (f *Formatter) Format(zv *zed.Value) (string, error) {
+func (f *Formatter) Format(val *zed.Value) (string, error) {
 	f.builder.Reset()
-	if err := f.formatValueAndDecorate(zv.Type, zv.Bytes); err != nil {
+	if err := f.formatValueAndDecorate(val.Type, val.Bytes); err != nil {
 		return "", err
 	}
 	return f.builder.String(), nil
@@ -457,9 +457,9 @@ func (f *Formatter) formatRecord(indent int, typ *zed.TypeRecord, bytes zcode.By
 	return nil
 }
 
-func (f *Formatter) formatVector(indent int, open, close string, inner zed.Type, zv *zed.Value, known, parentImplied bool) (bool, error) {
+func (f *Formatter) formatVector(indent int, open, close string, inner zed.Type, val *zed.Value, known, parentImplied bool) (bool, error) {
 	f.build(open)
-	n, err := zv.ContainerLength()
+	n, err := val.ContainerLength()
 	if err != nil {
 		return true, err
 	}
@@ -469,7 +469,7 @@ func (f *Formatter) formatVector(indent int, open, close string, inner zed.Type,
 	}
 	indent += f.tab
 	sep := f.newline
-	it := zv.Iter()
+	it := val.Iter()
 	elems := newElemBuilder(inner)
 	for !it.Done() {
 		f.build(sep)
@@ -485,7 +485,7 @@ func (f *Formatter) formatVector(indent int, open, close string, inner zed.Type,
 	if elems.needsDecoration() {
 		// If we haven't seen all the types in the union, print the decorator
 		// so the fullness of the union is persevered.
-		f.decorate(zv.Type, false, true)
+		f.decorate(val.Type, false, true)
 	}
 	return false, nil
 }

--- a/zson/marshal_zng_test.go
+++ b/zson/marshal_zng_test.go
@@ -311,9 +311,9 @@ func (m testMarshaler) MarshalZNG(mc *zson.MarshalZNGContext) (zed.Type, error) 
 	return mc.MarshalValue("marshal-" + string(m))
 }
 
-func (m *testMarshaler) UnmarshalZNG(mc *zson.UnmarshalZNGContext, zv *zed.Value) error {
+func (m *testMarshaler) UnmarshalZNG(mc *zson.UnmarshalZNGContext, val *zed.Value) error {
 	var s string
-	if err := mc.Unmarshal(zv, &s); err != nil {
+	if err := mc.Unmarshal(val, &s); err != nil {
 		return err
 	}
 	ss := strings.Split(s, "-")


### PR DESCRIPTION
Our previous conventional name for a zed.Value variable was zv, and the source tree still contains many occurrences (along with a few variations).  Change them to our current conventional name, val.