### PR TITLE
Document "pass" operator and add 3-way "join" example

### DIFF
--- a/docs/language/operators/README.md
+++ b/docs/language/operators/README.md
@@ -17,6 +17,7 @@ and appear as the components of a dataflow pipeline.
 * [head](head.md) - copy leading values of input sequence
 * [join](join.md) - combine data from two inputs using a join predicate
 * [over](over.md) - traverse nested values as a lateral query
+* [pass](pass.md) - copy input values to output
 * [put](put.md) - add or modify fields of records
 * [rename](rename.md) - change the name of record fields
 * [sample](sample.md) - select one value of each shape

--- a/docs/language/operators/pass.md
+++ b/docs/language/operators/pass.md
@@ -1,0 +1,26 @@
+### Operator
+
+&emsp; **pass** &mdash; copy input values to output
+
+### Synopsis
+
+```
+pass
+```
+### Description
+
+The `pass` operator outputs a copy of each input value. It is typically used
+with operators that handle multiple legs of the dataflow path such as
+[`fork`](fork.md) and [`join`](join.md).
+
+### Examples
+
+_Copy input to output_
+```mdtest-command
+echo -e "hello\nworld" | zq -z -i line 'pass' -
+```
+=>
+```mdtest-output
+"hello"
+"world"
+```

--- a/docs/language/operators/pass.md
+++ b/docs/language/operators/pass.md
@@ -17,7 +17,7 @@ with operators that handle multiple legs of the dataflow path such as
 
 _Copy input to output_
 ```mdtest-command
-echo '1 2 3' | zq -z 'pass' -
+echo '1 2 3' | zq -z pass -
 ```
 =>
 ```mdtest-output

--- a/docs/language/operators/pass.md
+++ b/docs/language/operators/pass.md
@@ -17,10 +17,11 @@ with operators that handle multiple legs of the dataflow path such as
 
 _Copy input to output_
 ```mdtest-command
-echo -e "hello\nworld" | zq -z -i line 'pass' -
+echo '1 2 3' | zq -z 'pass' -
 ```
 =>
 ```mdtest-output
-"hello"
-"world"
+1
+2
+3
 ```

--- a/docs/tutorials/join.md
+++ b/docs/tutorials/join.md
@@ -257,6 +257,56 @@ produces
 {name:"strawberry",color:"red",flavor:"sweet",fruitkey:{name:"strawberry",color:"red"},quantity:3000}
 ```
 
+## Joining More Than Two Inputs
+
+While the `join` operator takes only two inputs, more inputs can be joined by
+extending the Zed pipeline.
+
+To illustrate this, we'll introduce some new input data `prices.ndjson`.
+
+```mdtest-input prices.ndjson
+{"name":"apple","price":3.15}
+{"name":"banana","price":4.01}
+{"name":"avocado","price":2.50}
+{"name":"strawberry","price":1.05}
+{"name":"dates","price":6.70}
+{"name":"figs","price": 1.60}
+```
+
+In our Zed script `three-way-join.zed` we'll extend the pipeline we used
+previously for our inner join by piping its output to an additional join
+against the price list. The [`pass` operator](../language/operators/pass.md)
+is used to feed the output of the first `join` into the first input of our
+second `join`.
+
+```mdtest-input three-way-join.zed
+from (
+  file fruit.ndjson => sort flavor
+  file people.ndjson => sort likes
+) | inner join on flavor=likes eater:=name | sort name
+| from (
+  pass
+  file prices.ndjson => sort name
+) | inner join on name=name price:=price
+```
+
+Executing the Zed script:
+
+```mdtest-command
+zq -z -I three-way-join.zed
+```
+
+produces
+
+```mdtest-output
+{name:"apple",color:"red",flavor:"tart",eater:"morgan",price:3.15}
+{name:"apple",color:"red",flavor:"tart",eater:"chris",price:3.15}
+{name:"banana",color:"yellow",flavor:"sweet",eater:"quinn",price:4.01}
+{name:"dates",color:"brown",flavor:"sweet",note:"in season",eater:"quinn",price:6.7}
+{name:"figs",color:"brown",flavor:"plain",eater:"jessie",price:1.6}
+{name:"strawberry",color:"red",flavor:"sweet",eater:"quinn",price:1.05}
+```
+
 ## Embedding the entire opposite record
 
 In the current `join` implementation, explicit entries must be provided in the


### PR DESCRIPTION
A community user recently inquired about how to do `join` with more than two inputs. It's already possible, but the syntax is not super intuitive, so that's added to the `join` tutorial here. Creating the example also highlighted that the `pass` operator, while referenced a couple times in the docs, is not explicitly documented either, so that's covered here as well.