### PR TITLE
compiler/optimizer: simplify fieldKey

### DIFF
--- a/compiler/optimizer/op.go
+++ b/compiler/optimizer/op.go
@@ -2,6 +2,7 @@ package optimizer
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/brimdata/zed/compiler/ast/dag"
 	"github.com/brimdata/zed/order"
@@ -211,12 +212,7 @@ func analyzeCuts(assignments []dag.Assignment, layout order.Layout) order.Layout
 }
 
 func fieldKey(f field.Path) string {
-	var b []byte
-	for _, s := range f {
-		b = append(b, s...)
-		b = append(b, 0)
-	}
-	return string(b)
+	return strings.Join(f, "\x00")
 }
 
 func fieldOf(e dag.Expr) field.Path {


### PR DESCRIPTION
The behavior of this implementation differs from the original by omitting the trailing zero byte, but that doesn't matter since the function is used solely to generate map keys.