### PR TITLE
Change "pass" references to "yield this"

### DIFF
--- a/docs/language/operators/combine.md
+++ b/docs/language/operators/combine.md
@@ -21,7 +21,7 @@ and its semantics of undefined merge order.
 
 _Copy input to two paths and combine with the implied operator_
 ```mdtest-command
-echo '1 2' | zq -z 'fork (=>pass =>pass) | sort this' -
+echo '1 2' | zq -z 'fork (=>yield this =>yield this) | sort this' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/operators/fork.md
+++ b/docs/language/operators/fork.md
@@ -24,7 +24,7 @@ merged with an automatically inserted [combine operator](combine.md).
 
 _Copy input to two paths and merge_
 ```mdtest-command
-echo '1 2' | zq -z 'fork (=>pass =>pass) | sort this' -
+echo '1 2' | zq -z 'fork (=>yield this =>yield this) | sort this' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/operators/merge.md
+++ b/docs/language/operators/merge.md
@@ -18,7 +18,7 @@ where the values from the upstream paths are forwarded based on these expression
 
 _Copy input to two paths and combine
 ```mdtest-command
-echo '1 2' | zq -z 'fork (=>pass =>pass) | merge this' -
+echo '1 2' | zq -z 'fork (=>yield this =>yield this) | merge this' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/overview.md
+++ b/docs/language/overview.md
@@ -2143,7 +2143,7 @@ Now, we can turn around and write a "shaper" for data that has the patterns
 we "discovered" above, e.g., if this Zed source text is in `shape.zed`
 ```mdtest-input shape.zed
 switch len(this) (
-    case 1 => pass
+    case 1 => yield this
     case 2 => yield shape(this, <{x:(int64,string),y:string}>)
     default => yield error({kind:"unrecognized shape",value:this})
 )


### PR DESCRIPTION
I recently went to add an example to the `join` tutorial that required the functionality provided by `pass`, which led me to confront that `pass` was not currently documented. That led to the observation that `yield this` is functionally equivalent and not much more verbose, so we could make the language simpler by dropping `pass`. As a prerequisite to putting up the `join` docs PR, here I'm just switching over the references in the docs.