### PR TITLE
Restore a couple aggregate function docs examples

### DIFF
--- a/docs/language/overview.md
+++ b/docs/language/overview.md
@@ -1079,11 +1079,11 @@ produces
 ```
 In contrast, calling aggregate functions within the [`summarize` operator](operators/summarize.md)
 ```mdtest-command
-echo '"foo" "bar" "baz"' | zq -z 'summarize count:=count(),set:=union(this)' -
+echo '"foo" "bar" "baz"' | zq -z 'summarize count(),union(this)' -
 ```
 produces just one output value
 ```mdtest-output
-{count:3(uint64),set:|["bar","baz","foo"]|}
+{count:3(uint64),union:|["bar","baz","foo"]|}
 ```
 
 ### 7.11 Literals

--- a/docs/tutorials/schools.md
+++ b/docs/tutorials/schools.md
@@ -871,7 +871,7 @@ As with SQL, multiple aggregate functions may be invoked at the same time.
 For example, to simultaneously calculate the minimum, maximum, and average of
 the math test scores:
 ```mdtest-command dir=testdata/edu
-zq -f table 'min:=min(AvgScrMath),max:=max(AvgScrMath),avg:=avg(AvgScrMath)' testscores.zson
+zq -f table 'min(AvgScrMath),max(AvgScrMath),avg(AvgScrMath)' testscores.zson
 ```
 produces
 ```mdtest-output


### PR DESCRIPTION
In #4420 there were a couple docs examples that were changed to make the tests pass based on the initial set of changes but based after changes in later commits they could be changed back to how they were before.