### PR TITLE
Fix perf compare by working around zed/4424

### DIFF
--- a/scripts/perf-compare.sh
+++ b/scripts/perf-compare.sh
@@ -45,7 +45,7 @@ declare -a DESCRIPTIONS=(
 declare -a ZED_QUERIES=(
     '*'
     'cut ts'
-    'count()'
+    'count:=count()'
     'count() by quiet(id.orig_h)'
     'id.resp_h==52.85.83.116'
 )


### PR DESCRIPTION
#4424 was found recently by this script. Since I don't think there's a way for Zeek to log non-record outputs, this modifies the script to avoid hitting that repeatedly.