### PR TITLE
Improve messaging when port 9867 is accessed directly

### DIFF
--- a/service/core.go
+++ b/service/core.go
@@ -36,9 +36,9 @@ const indexPage = `
   <title>Zed lake service</title>
   <body style="padding:10px">
     <h2>zed serve</h2>
-    <p>A <a href="https://github.com/brimdata/zed/tree/main/cmd/zed/serve">zed service</a> is listening on this host/port.</p>
-    <p>If you're a <a href="https://www.brimdata.io/">Zui</a> user, connect to this host/port from the <a href="https://github.com/brimdata/zui">Zui application</a> in the graphical desktop interface in your operating system (not a web browser).</p>
-    <p>If your goal is to perform command line operations against this Zed lake, use the <a href="https://github.com/brimdata/zed/tree/main/cmd/zed"><code>zed</code></a> command.</p>
+    <p>A <a href="https://zed.brimdata.io/docs/commands/zed#213-serve">zed service</a> is listening on this host/port.</p>
+    <p>If you're a <a href="https://zui.brimdata.io/">Zui</a> user, connect to this host/port from Zui app in the graphical desktop interface in your operating system (not a web browser).</p>
+    <p>If your goal is to perform command line operations against this Zed lake, use the <a href="https://zed.brimdata.io/docs/commands/zed"><code>zed</code></a> command.</p>
   </body>
 </html>`
 

--- a/service/core.go
+++ b/service/core.go
@@ -36,7 +36,7 @@ const indexPage = `
   <title>Zed lake service</title>
   <body style="padding:10px">
     <h2>zed serve</h2>
-    <p>A <a href="https://zed.brimdata.io/docs/commands/zed#213-serve">zed service</a> is listening on this host/port.</p>
+    <p>A <a href="https://zed.brimdata.io/docs/commands/zed#213-serve">Zed lake service</a> is listening on this host/port.</p>
     <p>If you're a <a href="https://zui.brimdata.io/">Zui</a> user, connect to this host/port from Zui app in the graphical desktop interface in your operating system (not a web browser).</p>
     <p>If your goal is to perform command line operations against this Zed lake, use the <a href="https://zed.brimdata.io/docs/commands/zed"><code>zed</code></a> command.</p>
   </body>


### PR DESCRIPTION
It hopefully doesn't come up a lot, but we have guidance if a user happens to try accessing the Zed service port in a browser. The links had been pointing to repo locations rather than the new docs sites, so I've updated them here.