### PR TITLE
Unsupported 32-bit architectures

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,8 @@ in [runtime/expr/agg](runtime/expr/agg).
 ## Development
 
 `zed` requires Go 1.19 or later, and uses [Go modules](https://github.com/golang/go/wiki/Modules).
+Compilation for 32-bit target environments is not currently supported
+(see [zed/4044](https://github.com/brimdata/zed/issues/4044)).
 Dependencies are specified in the [`go.mod` file](./go.mod) and fetched
 automatically by commands like `go build` and `go test`.  No explicit
 fetch commands are necessary.  However, you must set the environment

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
 export GO111MODULE=on
 
 VERSION = $(shell git describe --tags --dirty --always)
+GOARCH = $(shell go env GOARCH)
 LDFLAGS = -s -X github.com/brimdata/zed/cli.version=$(VERSION)
 BUILD_COMMANDS = ./cmd/zed ./cmd/zq
+
+ifneq "" "$(filter $(GOARCH), 386 arm mipsle mips wasm)"
+unsupported-32-bit:
+endif
 
 # This enables a shortcut to run a single test from the ./ztests suite, e.g.:
 #  make TEST=TestZed/ztests/suite/cut/cut
@@ -34,7 +39,7 @@ sampledata: $(SAMPLEDATA)
 
 bin/minio: Makefile
 	@curl -o $@ --compressed --create-dirs \
-		https://dl.min.io/server/minio/release/$$(go env GOOS)-$$(go env GOARCH)/archive/minio.RELEASE.2022-05-04T07-45-27Z
+		https://dl.min.io/server/minio/release/$$(go env GOOS)-$(GOARCH)/archive/minio.RELEASE.2022-05-04T07-45-27Z
 	@chmod +x $@
 
 generate:
@@ -107,3 +112,8 @@ clean:
 
 .PHONY: fmt tidy vet test-unit test-system test-heavy sampledata test-ci
 .PHONY: perf-compare build install clean generate test-generate
+
+.PHONY: unsupported-32-bit
+unsupported-32-bit:
+	$(warning unsupported 32-bit architecture detected: $(GOARCH))
+	$(error see https://github.com/brimdata/zed/issues/4044)

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,11 @@
 export GO111MODULE=on
 
 VERSION = $(shell git describe --tags --dirty --always)
-GOARCH = $(shell go env GOARCH)
 LDFLAGS = -s -X github.com/brimdata/zed/cli.version=$(VERSION)
 BUILD_COMMANDS = ./cmd/zed ./cmd/zq
 
-ifneq "" "$(filter $(GOARCH), 386 arm mipsle mips wasm)"
-unsupported-32-bit:
+ifeq "$(filter-out 386 arm mips mipsle, $(shell go env GOARCH))" ""
+$(error 32-bit architectures are unsupported; see https://github.com/brimdata/zed/issues/4044)
 endif
 
 # This enables a shortcut to run a single test from the ./ztests suite, e.g.:
@@ -39,7 +38,7 @@ sampledata: $(SAMPLEDATA)
 
 bin/minio: Makefile
 	@curl -o $@ --compressed --create-dirs \
-		https://dl.min.io/server/minio/release/$$(go env GOOS)-$(GOARCH)/archive/minio.RELEASE.2022-05-04T07-45-27Z
+		https://dl.min.io/server/minio/release/$$(go env GOOS)-$$(go env GOARCH)/archive/minio.RELEASE.2022-05-04T07-45-27Z
 	@chmod +x $@
 
 generate:
@@ -112,8 +111,3 @@ clean:
 
 .PHONY: fmt tidy vet test-unit test-system test-heavy sampledata test-ci
 .PHONY: perf-compare build install clean generate test-generate
-
-.PHONY: unsupported-32-bit
-unsupported-32-bit:
-	$(warning unsupported 32-bit architecture detected: $(GOARCH))
-	$(error see https://github.com/brimdata/zed/issues/4044)


### PR DESCRIPTION
In #4044 a community user reported having tried & failed to compile Zed on a 32-bit architecture. We had some discussion within the Dev team about if we wanted to commit to the ongoing changes/tests/docs to claim support for 32-bit architectures and the conclusion was that for now we intend to say 32-bit is not supported. That may change in the future if enough users find their way to #4044 and express it as a requirement.

To help users find their way in the meantime, in this PR I've added a brief note to the CONTRIBUTING doc and pointed readers at #4044.

In addition, I've added a few lines to the Makefile to detect if the target architecture is one of the known 32-bit ones listed at https://go.dev/doc/install/source and kick back an error message and pointer to the open issue. I happened to mention this idea to @nwt and he already pointed out two ways this is imperfect:

1. More target architectures may be added over time, so the list in the Makefile may need to grow. That said, we already do have a "release checklist" that includes checking if we need to adjust our support statements due to changes in our Dev tools, so this would not be difficult to check at that time.

2. Many users may compile without ever using a Makefile (e.g., if they do `go install`). However, I suspect that if that failed one of the next things a user may do is clone the repo and see/try the Makefile.

Therefore I still think the Makefile change would be a nice thing to do for our users. But if folks don't like the extra lines in the Makefile, I can revert that.

An example of it doing its thing on a 32-bit Linux VM:

```
$ make
Makefile:118: unsupported 32-bit architecture detected: 386
Makefile:119: *** see https://github.com/brimdata/zed/issues/4044.  Stop.
```
