### PR TITLE
Mention collect() with "zq -j"

### DIFF
--- a/docs/tutorials/zq.md
+++ b/docs/tutorials/zq.md
@@ -65,7 +65,7 @@ echo '"hello" "world"' | zq -j 'collect(this)' -
 
 which produces
 
-```
+```mdtest-output
 ["hello","world"]
 ```
 

--- a/docs/tutorials/zq.md
+++ b/docs/tutorials/zq.md
@@ -42,32 +42,14 @@ than `jq`.
 
 To this end, if you want full JSON compatibility without having to delve into the
 details of Zed, just use the `-j` option with `zq` and this will tell `zq` to
-expect JSON input and produce JSON output. For example:
+expect JSON values as input and produce JSON values as output, much like `jq`.
 
-```mdtest-command
-echo '"hello" "world"' | zq -j -
-```
-
-produces
-
-```mdtest-output
-"hello"
-"world"
-```
-
-If your downstream JSON tooling expects only a single JSON value, we can
-[`collect()`](../language/aggregates/collect.md) the sequence of values into
-an array via
-
-```mdtest-command
-echo '"hello" "world"' | zq -j 'collect(this)' -
-```
-
-which produces
-
-```mdtest-output
-["hello","world"]
-```
+:::tip
+If your downstream JSON tooling expects only a single JSON value, we can use
+`-j` along with [`collect()`](../language/aggregates/collect.md) to aggregate
+multiple input values into an array. A `collect()` example is shown
+[later in this tutorial](#running-analytics).
+:::
 
 ## `this` vs `.`
 

--- a/docs/tutorials/zq.md
+++ b/docs/tutorials/zq.md
@@ -42,7 +42,32 @@ than `jq`.
 
 To this end, if you want full JSON compatibility without having to delve into the
 details of Zed, just use the `-j` option with `zq` and this will tell `zq` to
-expect JSON input and produce JSON output.
+expect JSON input and produce JSON output. For example:
+
+```mdtest-command
+echo '"hello" "world"' | zq -j -
+```
+
+produces
+
+```mdtest-output
+"hello"
+"world"
+```
+
+If your downstream JSON tooling expects only a single JSON value, we can
+[`collect()`](../language/aggregates/collect.md) the sequence of values into
+an array via
+
+```mdtest-command
+echo '"hello" "world"' | zq -j 'collect(this)' -
+```
+
+which produces
+
+```
+["hello","world"]
+```
 
 ## `this` vs `.`
 


### PR DESCRIPTION
In #3875 a community user was tripped up by the subtle differences between the sequence of JSON values the Zed tooling outputs with `-j` vs. the single JSON values expected by much downstream tooling. Here I've attempted to clarify by emphasizing "values" (plural) and referencing `collect()`.

Closes #3875