### PR TITLE
regexp_replace doc improvements & test adjustment

### DIFF
--- a/docs/language/functions/regexp_replace.md
+++ b/docs/language/functions/regexp_replace.md
@@ -16,8 +16,8 @@ the string `new`.
 Variables in `new` are replaced with corresponding matches drawn from `s`.
 A variable is a substring of the form `$name` or `${name}`, where `name` is a non-empty
 sequence of letters, digits, and underscores. A purely numeric name like `$1` refers
-to the submatch with the corresponding index; other names refer to parenthesized
-capturing groups named with the `(?P<name>...)` syntax. A reference to an out of range or
+to the submatch with the corresponding index; other names refer to capturing
+parentheses named with the `(?P<name>...)` syntax. A reference to an out of range or
 unmatched index or a name that is not present in the regular expression is replaced
 with an empty string.
 

--- a/docs/language/functions/regexp_replace.md
+++ b/docs/language/functions/regexp_replace.md
@@ -10,28 +10,50 @@ regexp_replace(s: string, re: string|regexp, new: string) -> string
 ### Description
 
 The _regexp_replace_ function substitutes all characters matching the
-[regular expression](../overview.md#regular-expressions) `re` in string `s` with
+[regular expression](../overview.md#811-regular-expressions) `re` in string `s` with
 the string `new`.
 
 Variables in `new` are replaced with corresponding matches drawn from `s`.
-A variable is a substring of the form $name or ${name}, where name is a non-empty
-sequence of letters, digits, and underscores. A purely numeric name like $1 refers
-to the submatch with the corresponding index; other names refer to capturing
-parentheses named with the `(?P<name>...)` syntax. A reference to an out of range or
+A variable is a substring of the form `$name` or `${name}`, where `name` is a non-empty
+sequence of letters, digits, and underscores. A purely numeric name like `$1` refers
+to the submatch with the corresponding index; other names refer to parenthesized
+capturing groups named with the `(?P<name>...)` syntax. A reference to an out of range or
 unmatched index or a name that is not present in the regular expression is replaced
-with an empty slice.
+with an empty string.
 
-In the $name form, name is taken to be as long as possible: $1x is equivalent to
-${1x}, not ${1}x, and, $10 is equivalent to ${10}, not ${1}0.
+In the `$name` form, `name` is taken to be as long as possible: `$1x` is equivalent to
+`${1x}`, not `${1}x`, and, `$10` is equivalent to `${10}`, not `${1}0`.
 
-To insert a literal $ in the output, use $$ in the template.
+To insert a literal `$` in the output, use `$$` in the template.
 
-#### Example:
+#### Examples:
+
+Replace regular expression matches with a letter:
 
 ```mdtest-command
-echo '"-ab-axxb-"' | zq -z 'yield regexp_replace(this, /a(x*)b/, "T")' -
+echo '"-ab-axxb-"' | zq -z 'yield regexp_replace(this, /ax*b/, "T")' -
 ```
 =>
 ```mdtest-output
 "-T-T-"
+```
+
+Replace regular expression matches using numeric references to submatches:
+
+```mdtest-command
+echo '"option: value"' | zq -z 'yield regexp_replace(this,/(\w+):\s+(\w+)$/,"$1=$2")' -
+```
+=>
+```mdtest-output
+"option=value"
+```
+
+Replace regular expression matches using named references:
+
+```mdtest-command
+echo '"option: value"' | zq -z 'yield regexp_replace(this,/(?P<key>\w+):\s+(?P<value>\w+)$/,"$key=$value")' -
+```
+=>
+```mdtest-output
+"option=value"
 ```

--- a/docs/language/overview.md
+++ b/docs/language/overview.md
@@ -1422,8 +1422,8 @@ produces
 {s:"bar"}
 {foo:1}
 ```
-Regular expressions may also appear in the [`grep`](functions/grep.md) and
-[`regexp`](functions/regexp.md) functions:
+Regular expressions may also appear in the [`grep`](functions/grep.md),
+[`regexp`](functions/regexp.md), and [`regexp_replace`](functions/regexp_replace.md) functions:
 ```mdtest-command
 echo '"foo" {s:"bar"} {s:"baz"} {foo:1}' | zq -z 'yield {ba_start:grep(/^ba.*/, s),last_s_char:regexp(/(.)$/,s)[1]}' -
 ```

--- a/runtime/expr/function/ztests/regexp-replace.yaml
+++ b/runtime/expr/function/ztests/regexp-replace.yaml
@@ -1,7 +1,7 @@
 zed: "yield regexp_replace(in, re, new)"
 
 input: |
-  {in:"-ab-axxb-",re:"a(x*)b",new:"T"}
+  {in:"-ab-axxb-",re:"ax*b",new:"T"}
   {in:"-ab-axxb-",re:"a(x*)b",new:"$1"}
   {in:"-ab-axxb-",re:"a(?P<X>x*)b",new:"$X"}
   {in:"Foo bar",re:"Foo",new:"foo"}

--- a/runtime/expr/function/ztests/regexp-replace.yaml
+++ b/runtime/expr/function/ztests/regexp-replace.yaml
@@ -1,7 +1,7 @@
 zed: "yield regexp_replace(in, re, new)"
 
 input: |
-  {in:"-ab-axxb-",re:"ax*b",new:"T"}
+  {in:"-ab-axxb-",re:"a(x*)b",new:"T"}
   {in:"-ab-axxb-",re:"a(x*)b",new:"$1"}
   {in:"-ab-axxb-",re:"a(?P<X>x*)b",new:"$X"}
   {in:"Foo bar",re:"Foo",new:"foo"}

--- a/runtime/expr/function/ztests/regexp-replace.yaml
+++ b/runtime/expr/function/ztests/regexp-replace.yaml
@@ -1,8 +1,9 @@
 zed: "yield regexp_replace(in, re, new)"
 
 input: |
-  {in:"-ab-axxb-",re:"a(x*)b",new:"T"}
+  {in:"-ab-axxb-",re:"ax*b",new:"T"}
   {in:"-ab-axxb-",re:"a(x*)b",new:"$1"}
+  {in:"-ab-axxb-",re:"a(?P<ZeroOrMoreX>x*)b",new:"foo$ZeroOrMoreX bar"}
   {in:"Foo bar",re:"Foo",new:"foo"}
   {in:"seafood fool",re:"foo(.?",new:"food"}
   {in:4,re:5,new:["foo"]}
@@ -11,6 +12,7 @@ input: |
 output: |
   "-T-T-"
   "--xx-"
+  "-foo bar-fooxx bar-"
   "foo bar"
   error("regexp_replace: error parsing regexp: missing closing ): `foo(.?`")
   error("regexp_replace: string values required for all args")

--- a/runtime/expr/function/ztests/regexp-replace.yaml
+++ b/runtime/expr/function/ztests/regexp-replace.yaml
@@ -12,7 +12,7 @@ input: |
 output: |
   "-T-T-"
   "--xx-"
-  "-foo bar-fooxx bar-"
+  "--xx-"
   "foo bar"
   error("regexp_replace: error parsing regexp: missing closing ): `foo(.?`")
   error("regexp_replace: string values required for all args")

--- a/runtime/expr/function/ztests/regexp-replace.yaml
+++ b/runtime/expr/function/ztests/regexp-replace.yaml
@@ -3,7 +3,7 @@ zed: "yield regexp_replace(in, re, new)"
 input: |
   {in:"-ab-axxb-",re:"ax*b",new:"T"}
   {in:"-ab-axxb-",re:"a(x*)b",new:"$1"}
-  {in:"-ab-axxb-",re:"a(?P<ZeroOrMoreX>x*)b",new:"foo$ZeroOrMoreX bar"}
+  {in:"-ab-axxb-",re:"a(?P<X>x*)b",new:"$X"}
   {in:"Foo bar",re:"Foo",new:"foo"}
   {in:"seafood fool",re:"foo(.?",new:"food"}
   {in:4,re:5,new:["foo"]}


### PR DESCRIPTION
While verifying #4296, I tried some of the enhancements that were added late in the #4435 reviews and found a few problems. Strictly speaking even these docs are not 100% safe to follow until #4444 is fixed, but for now it shows an example that's safe to use without the curly braces.

I'll put some comments in-line to explain some of the changes.

Fixes #4296
