### PR TITLE
Add docs for -log.level option of "zed serve"

### DIFF
--- a/docs/commands/zed.md
+++ b/docs/commands/zed.md
@@ -389,7 +389,7 @@ or [`kubectl`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-co
 commands.
 
 The following sections describe each of the available commands and highlight
-some key options. Built-in help shows the commands and their options:
+some key options.  Built-in help shows the commands and their options:
 
 * `zed -h` with no args displays a list of `zed` commands.
 * `zed command -h`, where `command` is a sub-command, displays help
@@ -862,7 +862,7 @@ specified by the `-l` option, executes the requests, and returns results.
 
 The `-log.level` option controls log verbosity.  Available levels, ordered
 from most to least verbose, are `debug`, `info` (the default), `warn`,
-`error`, `dpanic`, `panic`, and `fatal`. Suggestions for use:
+`error`, `dpanic`, `panic`, and `fatal`.  Suggestions for use:
 
 * As its name implies, `debug` level is likely to only be required when actively debugging issues.
 

--- a/docs/commands/zed.md
+++ b/docs/commands/zed.md
@@ -389,8 +389,7 @@ or [`kubectl`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-co
 commands.
 
 The following sections describe each of the available commands and highlight
-some key options. Built-in help shows all commands and options that can be
-invoked as follows:
+some key options. Built-in help shows the commands and their options:
 
 * `zed -h` with no args displays a list of `zed` commands.
 * `zed command -h`, where `command` is a sub-command, displays help

--- a/docs/commands/zed.md
+++ b/docs/commands/zed.md
@@ -862,12 +862,9 @@ specified by the `-l` option, executes the requests, and returns results.
 
 The `-log.level` option controls log verbosity.  Available levels, ordered
 from most to least verbose, are `debug`, `info` (the default), `warn`,
-`error`, `dpanic`, `panic`, and `fatal`.  Suggestions for use:
-
-* As its name implies, `debug` level is likely to only be required when actively debugging issues.
-
-* If the volume of logging output at the default `info` level seems too
-excessive for production use, `warn` level is recommended.
+`error`, `dpanic`, `panic`, and `fatal`.  If the volume of logging output at
+the default `info` level seems too excessive for production use, `warn` level
+is recommended.
 
 ### 2.14 Use
 ```

--- a/docs/commands/zed.md
+++ b/docs/commands/zed.md
@@ -860,9 +860,9 @@ from instances of Zed's client personality.
 It listens for Zed lake API requests on the interface and port
 specified by the `-l` option, executes the requests, and returns results.
 
-The verbosity of the server's log output can be varied with the `-log.level`
-option. Available levels ordered from most to least verbose are: `debug`, `info` (the
-default), `warn`, `error`, `dpanic`, `panic`, and `fatal`. Suggestions for use:
+The `-log.level` option controls log verbosity.  Available levels, ordered
+from most to least verbose, are `debug`, `info` (the default), `warn`,
+`error`, `dpanic`, `panic`, and `fatal`. Suggestions for use:
 
 * As its name implies, `debug` level is likely to only be required when actively debugging issues.
 

--- a/docs/commands/zed.md
+++ b/docs/commands/zed.md
@@ -384,13 +384,15 @@ case but this design allows different workloads like these to be custom tuned.
 
 The `zed` command is structured as a primary command
 consisting of a large number of interrelated sub-commands, similar to the
-[docker](https://docs.docker.com/engine/reference/commandline/cli/)
-or [kubectl](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands)
+[`docker`](https://docs.docker.com/engine/reference/commandline/cli/)
+or [`kubectl`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands)
 commands.
 
-The following sections describe each of the available commands, but built-in
-help is also available:
-* `zed -h` with no args displays a list of zed commands.
+The following sections describe each of the available commands and highlight
+some key options. Built-in help shows all commands and options that can be
+invoked as follows:
+
+* `zed -h` with no args displays a list of `zed` commands.
 * `zed command -h`, where `command` is a sub-command, displays help
 for that sub-command.
 * `zed command sub-command -h` displays help for a sub-command of a
@@ -854,10 +856,19 @@ pool `<existing>`, which may be referenced by its ID or its previous name.
 ```
 zed serve [options]
 ```
-The serve command implements Zed's server personality to service requests
+The `serve` command implements Zed's server personality to service requests
 from instances of Zed's client personality.
 It listens for Zed lake API requests on the interface and port
 specified by the `-l` option, executes the requests, and returns results.
+
+The verbosity of the server's log output can be varied with the `-log.level`
+option. Available levels ordered from most to least verbose are: `debug`, `info` (the
+default), `warn`, `error`, `dpanic`, `panic`, and `fatal`. Suggestions for use:
+
+* As its name implies, `debug` level is likely to only be required when actively debugging issues.
+
+* If the volume of logging output at the default `info` level seems too
+excessive for production use, `warn` level is recommended.
 
 ### 2.14 Use
 ```


### PR DESCRIPTION
A community zync user reported having looked in the current Zed docs hoping to find guidance on the `zed serve` log levels, but came up empty. While we don't currently try to exhaustively cover each available option at the docs site and instead rely on built-in help for much of that, I figure if a user went looking for it on the docs site and took the time to ask for guidance when nothing came back, that means it's likely to come up again. This PR adds some minimal guidance to cover that for the future.

I've also adjusted some of the top-level "section 2" intro text to be more explicit about the fact that we're only describing highlights of the available options.

Fixes #4448