### PR TITLE
seek index: fix incorrect entry min/max values

### DIFF
--- a/lake/data/writer.go
+++ b/lake/data/writer.go
@@ -64,17 +64,12 @@ func (o *Object) NewWriter(ctx context.Context, engine storage.Engine, path *sto
 
 func (w *Writer) Write(val *zed.Value) error {
 	w.count++
-	key := val.DerefPath(w.poolKey).MissingAsNull()
-	if w.seekIndex != nil {
-		if err := w.writeIndex(key); err != nil {
-			return err
-		}
-	}
 	if err := w.writer.Write(val); err != nil {
 		return err
 	}
+	key := val.DerefPath(w.poolKey).MissingAsNull()
 	w.object.Max.CopyFrom(key)
-	return nil
+	return w.writeIndex(key)
 }
 
 func (w *Writer) writeIndex(key *zed.Value) error {
@@ -86,7 +81,6 @@ func (w *Writer) writeIndex(key *zed.Value) error {
 	if w.seekMin == nil {
 		w.seekMin = key.Copy()
 	}
-	w.object.Max.CopyFrom(key)
 	if w.seekIndexTrigger < w.seekIndexStride {
 		return nil
 	}

--- a/lake/ztests/consecutive-ts.yaml
+++ b/lake/ztests/consecutive-ts.yaml
@@ -28,9 +28,9 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      {min:1970-01-01T00:00:06Z,max:1970-01-01T00:00:08Z,val_off:0(uint64),val_cnt:3(uint64),offset:0(uint64),length:27(uint64)}
-      {min:1970-01-01T00:00:03Z,max:1970-01-01T00:00:03Z,val_off:3(uint64),val_cnt:3(uint64),offset:27(uint64),length:35(uint64)}
-      {min:1970-01-01T00:00:03Z,max:1970-01-01T00:00:03Z,val_off:6(uint64),val_cnt:3(uint64),offset:62(uint64),length:35(uint64)}
-      {min:1970-01-01T00:00:02Z,max:1970-01-01T00:00:03Z,val_off:9(uint64),val_cnt:3(uint64),offset:97(uint64),length:34(uint64)}
-      {min:1970-01-01T00:00:02Z,max:1970-01-01T00:00:02Z,val_off:12(uint64),val_cnt:3(uint64),offset:131(uint64),length:32(uint64)}
-      {min:1970-01-01T00:00:00Z,max:1970-01-01T00:00:00Z,val_off:15(uint64),val_cnt:1(uint64),offset:163(uint64),length:21(uint64)}
+      {min:1970-01-01T00:00:06Z,max:1970-01-01T00:00:08Z,val_off:0(uint64),val_cnt:3(uint64),offset:0(uint64),length:35(uint64)}
+      {min:1970-01-01T00:00:03Z,max:1970-01-01T00:00:03Z,val_off:3(uint64),val_cnt:3(uint64),offset:35(uint64),length:35(uint64)}
+      {min:1970-01-01T00:00:03Z,max:1970-01-01T00:00:03Z,val_off:6(uint64),val_cnt:3(uint64),offset:70(uint64),length:35(uint64)}
+      {min:1970-01-01T00:00:02Z,max:1970-01-01T00:00:03Z,val_off:9(uint64),val_cnt:3(uint64),offset:105(uint64),length:33(uint64)}
+      {min:1970-01-01T00:00:02Z,max:1970-01-01T00:00:02Z,val_off:12(uint64),val_cnt:3(uint64),offset:138(uint64),length:32(uint64)}
+      {min:1970-01-01T00:00:00Z,max:1970-01-01T00:00:00Z,val_off:15(uint64),val_cnt:1(uint64),offset:170(uint64),length:14(uint64)}

--- a/lake/ztests/seek-index-boundaries.yaml
+++ b/lake/ztests/seek-index-boundaries.yaml
@@ -1,0 +1,73 @@
+script: |
+  export ZED_LAKE=test
+  zed init -q
+  for o in asc desc; do
+    echo // $o | tee /dev/stderr
+    zed create -q -seekstride 1B -orderby ts:$o $o
+    zed use -q $o
+    seq 20 | zq 'yield {ts:this}' - | zed load -q -
+    source query.sh 'ts == 5'
+    source query.sh 'ts < 2'
+    source query.sh 'ts <= 2'
+    source query.sh 'ts > 19'
+    source query.sh 'ts >= 19'
+  done
+
+inputs:
+  - name: query.sh
+    data: |
+      echo // $1 | tee /dev/stderr
+      zed query -z -s "$1"
+outputs:
+  - name: stdout
+    data: |
+      // asc
+      // ts == 5
+      {ts:5}
+      // ts < 2
+      {ts:1}
+      // ts <= 2
+      {ts:1}
+      {ts:2}
+      // ts > 19
+      {ts:20}
+      // ts >= 19
+      {ts:19}
+      {ts:20}
+      // desc
+      // ts == 5
+      {ts:5}
+      // ts < 2
+      {ts:1}
+      // ts <= 2
+      {ts:2}
+      {ts:1}
+      // ts > 19
+      {ts:20}
+      // ts >= 19
+      {ts:20}
+      {ts:19}
+  - name: stderr
+    data: |
+      // asc
+      // ts == 5
+      {bytes_read:2,bytes_matched:2,records_read:1,records_matched:1}
+      // ts < 2
+      {bytes_read:2,bytes_matched:2,records_read:1,records_matched:1}
+      // ts <= 2
+      {bytes_read:4,bytes_matched:4,records_read:2,records_matched:2}
+      // ts > 19
+      {bytes_read:2,bytes_matched:2,records_read:1,records_matched:1}
+      // ts >= 19
+      {bytes_read:4,bytes_matched:4,records_read:2,records_matched:2}
+      // desc
+      // ts == 5
+      {bytes_read:2,bytes_matched:2,records_read:1,records_matched:1}
+      // ts < 2
+      {bytes_read:2,bytes_matched:2,records_read:1,records_matched:1}
+      // ts <= 2
+      {bytes_read:4,bytes_matched:4,records_read:2,records_matched:2}
+      // ts > 19
+      {bytes_read:2,bytes_matched:2,records_read:1,records_matched:1}
+      // ts >= 19
+      {bytes_read:4,bytes_matched:4,records_read:2,records_matched:2}

--- a/lake/ztests/seek-index-null.yaml
+++ b/lake/ztests/seek-index-null.yaml
@@ -29,6 +29,6 @@ outputs:
   - name: stderr
     data: |
       // asc
-      {bytes_read:16401,bytes_matched:87,records_read:500,records_matched:3}
+      {bytes_read:16403,bytes_matched:87,records_read:500,records_matched:3}
       // desc
-      {bytes_read:16404,bytes_matched:87,records_read:500,records_matched:3}
+      {bytes_read:16403,bytes_matched:87,records_read:500,records_matched:3}

--- a/lake/ztests/seek-index-ts.yaml
+++ b/lake/ztests/seek-index-ts.yaml
@@ -45,15 +45,15 @@ outputs:
     data: |
       // asc
       // ts >= 2020-04-21T23:59:26.063Z and ts <= 2020-04-21T23:59:38.069Z
-      {bytes_read:16401,bytes_matched:87,records_read:500,records_matched:3}
+      {bytes_read:16403,bytes_matched:87,records_read:500,records_matched:3}
       // ts == 2020-04-21T23:59:26.06326664Z
-      {bytes_read:8151,bytes_matched:31,records_read:250,records_matched:1}
+      {bytes_read:8141,bytes_matched:31,records_read:250,records_matched:1}
       // ts == 2020-04-21T23:59:26.06326664Z or foo == 'bar'
       {bytes_read:32889,bytes_matched:31,records_read:1000,records_matched:1}
       // desc
       // ts >= 2020-04-21T23:59:26.063Z and ts <= 2020-04-21T23:59:38.069Z
-      {bytes_read:16404,bytes_matched:87,records_read:500,records_matched:3}
+      {bytes_read:16403,bytes_matched:87,records_read:500,records_matched:3}
       // ts == 2020-04-21T23:59:26.06326664Z
-      {bytes_read:8145,bytes_matched:31,records_read:250,records_matched:1}
+      {bytes_read:8141,bytes_matched:31,records_read:250,records_matched:1}
       // ts == 2020-04-21T23:59:26.06326664Z or foo == 'bar'
       {bytes_read:32889,bytes_matched:31,records_read:1000,records_matched:1}

--- a/service/ztests/seek-index-null.yaml
+++ b/service/ztests/seek-index-null.yaml
@@ -29,6 +29,6 @@ outputs:
   - name: stderr
     data: |
       // asc
-      {bytes_read:16401,bytes_matched:87,records_read:500,records_matched:3}
+      {bytes_read:16403,bytes_matched:87,records_read:500,records_matched:3}
       // desc
-      {bytes_read:16404,bytes_matched:87,records_read:500,records_matched:3}
+      {bytes_read:16403,bytes_matched:87,records_read:500,records_matched:3}

--- a/service/ztests/seek-index.yaml
+++ b/service/ztests/seek-index.yaml
@@ -44,15 +44,15 @@ outputs:
     data: |
       // asc
       // ts >= 2020-04-21T23:59:26.063Z and ts <= 2020-04-21T23:59:38.069Z
-      {bytes_read:16401,bytes_matched:87,records_read:500,records_matched:3}
+      {bytes_read:16403,bytes_matched:87,records_read:500,records_matched:3}
       // ts == 2020-04-21T23:59:26.06326664Z
-      {bytes_read:8151,bytes_matched:31,records_read:250,records_matched:1}
+      {bytes_read:8141,bytes_matched:31,records_read:250,records_matched:1}
       // ts == 2020-04-21T23:59:26.06326664Z or foo == 'bar'
       {bytes_read:32889,bytes_matched:31,records_read:1000,records_matched:1}
       // desc
       // ts >= 2020-04-21T23:59:26.063Z and ts <= 2020-04-21T23:59:38.069Z
-      {bytes_read:16404,bytes_matched:87,records_read:500,records_matched:3}
+      {bytes_read:16403,bytes_matched:87,records_read:500,records_matched:3}
       // ts == 2020-04-21T23:59:26.06326664Z
-      {bytes_read:8145,bytes_matched:31,records_read:250,records_matched:1}
+      {bytes_read:8141,bytes_matched:31,records_read:250,records_matched:1}
       // ts == 2020-04-21T23:59:26.06326664Z or foo == 'bar'
       {bytes_read:32889,bytes_matched:31,records_read:1000,records_matched:1}


### PR DESCRIPTION
Fix a bug occurring when seek indexes are generated that produced
incorrect values for the min and max values for seek entries