### PR TITLE
Remove runtime/expr.Sorter

### DIFF
--- a/lake/writer.go
+++ b/lake/writer.go
@@ -34,7 +34,6 @@ type Writer struct {
 	// data efficiently in one big backing store.
 	buffer      chan []zed.Value
 	comparator  *expr.Comparator
-	sorter      expr.Sorter
 	memBuffered int64
 	stats       ImportStats
 }
@@ -128,7 +127,7 @@ func (w *Writer) writeObject(object *data.Object, recs []zed.Value) error {
 	if !w.inputSorted {
 		done := make(chan struct{})
 		go func() {
-			w.sorter.SortStable(recs, w.comparator)
+			w.comparator.SortStable(recs)
 			close(done)
 		}()
 		select {

--- a/runtime/expr/sort.go
+++ b/runtime/expr/sort.go
@@ -14,87 +14,76 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-type Sorter struct {
-	indices []uint32
-	i64s    []int64
-	vals    []*zed.Value
-	tmp     []zed.Value
-}
-
-func (s *Sorter) SortStable(vals []zed.Value, cmp *Comparator) {
-	if len(cmp.exprs) == 0 {
+func (c *Comparator) SortStable(vals []zed.Value) {
+	if len(c.exprs) == 0 {
 		return
 	}
 	n := len(vals)
 	if max := math.MaxUint32; n > max {
 		panic(fmt.Sprintf("number of values exceeds %d", max))
 	}
-	if cap(s.indices) < n {
-		indices := make([]uint32, n)
-		s.indices = indices[:cap(indices)]
-		s.i64s = make([]int64, cap(indices))
-		s.vals = make([]*zed.Value, cap(indices))
-		s.tmp = make([]zed.Value, cap(indices))
-	}
-	s.indices = s.indices[:n]
+	indices := make([]uint32, n)
+	i64s := make([]int64, n)
+	val0s := make([]*zed.Value, n)
 	ectx := NewContext()
 	native := true
-	for i := range s.indices {
-		s.indices[i] = uint32(i)
-		val := cmp.exprs[0].Eval(ectx, &vals[i])
-		s.vals[i] = val
+	for i := range indices {
+		indices[i] = uint32(i)
+		val := c.exprs[0].Eval(ectx, &vals[i])
+		val0s[i] = val
 		if id := val.Type.ID(); id <= zed.IDTime {
 			if val.IsNull() {
-				if cmp.nullsMax {
-					s.i64s[i] = math.MaxInt64
+				if c.nullsMax {
+					i64s[i] = math.MaxInt64
 				} else {
-					s.i64s[i] = math.MinInt64
+					i64s[i] = math.MinInt64
 				}
 			} else if zed.IsSigned(id) {
-				s.i64s[i] = zed.DecodeInt(val.Bytes)
+				i64s[i] = zed.DecodeInt(val.Bytes)
 			} else {
 				v := zed.DecodeUint(val.Bytes)
 				if v > math.MaxInt64 {
 					v = math.MaxInt64
 				}
-				s.i64s[i] = int64(v)
+				i64s[i] = int64(v)
 			}
 		} else {
 			native = false
 		}
 	}
-	sort.SliceStable(s.indices, func(i, j int) bool {
-		if cmp.reverse {
+	sort.SliceStable(indices, func(i, j int) bool {
+		if c.reverse {
 			i, j = j, i
 		}
-		iidx, jidx := s.indices[i], s.indices[j]
-		for k, expr := range cmp.exprs {
+		iidx, jidx := indices[i], indices[j]
+		for k, expr := range c.exprs {
 			var ival, jval *zed.Value
 			if k == 0 {
 				if native {
-					if i64, j64 := s.i64s[iidx], s.i64s[jidx]; i64 != j64 {
+					if i64, j64 := i64s[iidx], i64s[jidx]; i64 != j64 {
 						return i64 < j64
 					} else if i64 != math.MaxInt64 && i64 != math.MinInt64 {
 						continue
 					}
 				}
-				ival, jval = s.vals[iidx], s.vals[jidx]
+				ival, jval = val0s[iidx], val0s[jidx]
 			} else {
 				ival = expr.Eval(ectx, &vals[iidx])
 				jval = expr.Eval(ectx, &vals[jidx])
 			}
-			if v := compareValues(ival, jval, cmp.comparefns, &cmp.pair, cmp.nullsMax); v != 0 {
+			if v := compareValues(ival, jval, c.comparefns, &c.pair, c.nullsMax); v != 0 {
 				return v < 0
 			}
 		}
 		return false
 	})
-	for i, index := range s.indices {
-		s.tmp[i] = vals[i]
+	tmp := make([]zed.Value, n)
+	for i, index := range indices {
+		tmp[i] = vals[i]
 		if j := int(index); i < j {
 			vals[i] = vals[j]
 		} else if i > int(index) {
-			vals[i] = s.tmp[j]
+			vals[i] = tmp[j]
 		}
 	}
 }

--- a/runtime/expr/sort_test.go
+++ b/runtime/expr/sort_test.go
@@ -24,14 +24,13 @@ func BenchmarkSort(b *testing.B) {
 		b.Run(zson.FormatType(c.typ), func(b *testing.B) {
 			cmp := NewComparator(false, false, &This{})
 			vals := make([]zed.Value, 1048576)
-			var sorter Sorter
 			for i := 0; i < b.N; i++ {
 				b.StopTimer()
 				for i := range vals {
 					vals[i] = *zed.NewValue(c.typ, c.bytes())
 				}
 				b.StartTimer()
-				sorter.SortStable(vals, cmp)
+				cmp.SortStable(vals)
 			}
 		})
 	}

--- a/runtime/op/sort/sort.go
+++ b/runtime/op/sort/sort.go
@@ -29,7 +29,6 @@ type Op struct {
 	comparator     *expr.Comparator
 	ectx           expr.Context
 	eof            bool
-	sorter         expr.Sorter
 }
 
 func New(octx *op.Context, parent zbuf.Puller, fields []expr.Evaluator, order order.Which, nullsFirst bool) (*Op, error) {
@@ -150,7 +149,7 @@ func (o *Op) run() {
 
 // send sorts vals in memory and sends the result downstream.
 func (o *Op) send(vals []zed.Value) bool {
-	o.sorter.SortStable(vals, o.comparator)
+	o.comparator.SortStable(vals)
 	out := zbuf.NewBatch(o.lastBatch, vals)
 	return o.sendResult(out, nil)
 }

--- a/runtime/op/spill/merge.go
+++ b/runtime/op/spill/merge.go
@@ -20,7 +20,6 @@ type MergeSort struct {
 	nspill     int
 	runs       []*peeker
 	tempDir    string
-	sorter     expr.Sorter
 	spillSize  int64
 	zctx       *zed.Context
 }
@@ -64,7 +63,7 @@ func (r *MergeSort) Cleanup() {
 func (r *MergeSort) Spill(ctx context.Context, vals []zed.Value) error {
 	// Sorting can be slow, so check for cancellation.
 	if err := goWithContext(ctx, func() {
-		r.sorter.SortStable(vals, r.comparator)
+		r.comparator.SortStable(vals)
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
In retrospect, this thing was a bad idea.  Removing it modestly reduces running time and peak memory footprint for both "zed load" and the sort operator on multi-GB inputs.

Closes #4121