### PR TITLE
remove snap from scanner

### DIFF
--- a/compiler/kernel/op.go
+++ b/compiler/kernel/op.go
@@ -621,9 +621,9 @@ func (b *Builder) compileTrunk(trunk *dag.Trunk, parent zbuf.Puller) ([]zbuf.Pul
 			if b.deletes == nil {
 				b.deletes = &sync.Map{}
 			}
-			source = meta.NewDeleter(b.octx, slicer, pool, slicer.Snapshot(), filter, pruner, b.progress, b.deletes)
+			source = meta.NewDeleter(b.octx, slicer, pool, filter, pruner, b.progress, b.deletes)
 		} else {
-			source = meta.NewSequenceScanner(b.octx, slicer, pool, slicer.Snapshot(), filter, pruner, b.progress)
+			source = meta.NewSequenceScanner(b.octx, slicer, pool, filter, pruner, b.progress)
 		}
 	case *dag.PoolMeta:
 		scanner, err := meta.NewPoolMetaScanner(b.octx.Context, b.octx.Zctx, b.source.Lake(), src.ID, src.Meta, pushdown)

--- a/runtime/exec/compact.go
+++ b/runtime/exec/compact.go
@@ -37,7 +37,7 @@ func Compact(ctx context.Context, lk *lake.Root, pool *lake.Pool, branchName str
 	lister := meta.NewSortedListerFromSnap(ctx, zed.NewContext(), lk, pool, compact, nil)
 	octx := op.NewContext(ctx, zctx, nil)
 	slicer := meta.NewSlicer(lister, zctx)
-	puller := meta.NewSequenceScanner(octx, slicer, pool, lister.Snapshot(), nil, nil, nil)
+	puller := meta.NewSequenceScanner(octx, slicer, pool, nil, nil, nil)
 	w := lake.NewSortedWriter(ctx, pool)
 	if err := zbuf.CopyPuller(w, puller); err != nil {
 		puller.Pull(true)

--- a/runtime/op/meta/deleter.go
+++ b/runtime/op/meta/deleter.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"github.com/brimdata/zed/lake"
-	"github.com/brimdata/zed/lake/commits"
 	"github.com/brimdata/zed/lake/data"
 	"github.com/brimdata/zed/runtime/expr"
 	"github.com/brimdata/zed/runtime/op"
@@ -24,15 +23,13 @@ type Deleter struct {
 	octx        *op.Context
 	pool        *lake.Pool
 	progress    *zbuf.Progress
-	snap        commits.View
 	unmarshaler *zson.UnmarshalZNGContext
 	done        bool
 	err         error
 	deletes     *sync.Map
 }
 
-// XXX shouldn't pass in snap
-func NewDeleter(octx *op.Context, parent zbuf.Puller, pool *lake.Pool, snap commits.View, filter zbuf.Filter, pruner expr.Evaluator, progress *zbuf.Progress, deletes *sync.Map) *Deleter {
+func NewDeleter(octx *op.Context, parent zbuf.Puller, pool *lake.Pool, filter zbuf.Filter, pruner expr.Evaluator, progress *zbuf.Progress, deletes *sync.Map) *Deleter {
 	return &Deleter{
 		parent:      parent,
 		filter:      filter,
@@ -40,7 +37,6 @@ func NewDeleter(octx *op.Context, parent zbuf.Puller, pool *lake.Pool, snap comm
 		octx:        octx,
 		pool:        pool,
 		progress:    progress,
-		snap:        snap,
 		unmarshaler: zson.NewZNGUnmarshaler(),
 		deletes:     deletes,
 	}

--- a/runtime/op/meta/sequence.go
+++ b/runtime/op/meta/sequence.go
@@ -5,7 +5,6 @@ import (
 	"io"
 
 	"github.com/brimdata/zed/lake"
-	"github.com/brimdata/zed/lake/commits"
 	"github.com/brimdata/zed/lake/data"
 	"github.com/brimdata/zed/runtime/expr"
 	"github.com/brimdata/zed/runtime/op"
@@ -25,13 +24,12 @@ type SequenceScanner struct {
 	octx        *op.Context
 	pool        *lake.Pool
 	progress    *zbuf.Progress
-	snap        commits.View
 	unmarshaler *zson.UnmarshalZNGContext
 	done        bool
 	err         error
 }
 
-func NewSequenceScanner(octx *op.Context, parent zbuf.Puller, pool *lake.Pool, snap commits.View, filter zbuf.Filter, pruner expr.Evaluator, progress *zbuf.Progress) *SequenceScanner {
+func NewSequenceScanner(octx *op.Context, parent zbuf.Puller, pool *lake.Pool, filter zbuf.Filter, pruner expr.Evaluator, progress *zbuf.Progress) *SequenceScanner {
 	return &SequenceScanner{
 		octx:        octx,
 		parent:      parent,
@@ -39,7 +37,6 @@ func NewSequenceScanner(octx *op.Context, parent zbuf.Puller, pool *lake.Pool, s
 		pruner:      pruner,
 		pool:        pool,
 		progress:    progress,
-		snap:        snap,
 		unmarshaler: zson.NewZNGUnmarshaler(),
 	}
 }


### PR DESCRIPTION
This commit removes the unneeded snap argument from meta.SeqScanner and meta.Deleter.