### PR TITLE
Remove zbuf.ReadAll

### DIFF
--- a/zbuf/reader.go
+++ b/zbuf/reader.go
@@ -68,10 +68,3 @@ func (m *meterReadCloser) Read() (*zed.Value, error) {
 	}
 	return val, err
 }
-
-func ReadAll(r zio.Reader) (arr *Array, err error) {
-	if err := zio.Copy(arr, r); err != nil {
-		return nil, err
-	}
-	return
-}


### PR DESCRIPTION
It's unused and broken (it passes a nil *Array to zio.Copy). Furthermore, it does little for clarity since

    a, err := zbuf.ReadAll(zr)
    if err != nil {...}

and

    var a zbuf.Array
    if err := zio.Copy(&a, zr); err != nil {...}

occupy the same number of lines.