### PR TITLE
Remove Zealot Depedency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,5 @@
   "directories": {
     "bin": "dist"
   },
-  "packageManager": "yarn@3.1.1",
-  "dependencies": {
-    "zealot": "^0.2.0"
-  }
+  "packageManager": "yarn@3.1.1"
 }


### PR DESCRIPTION
This zealot dependency is for a mongodb client!

https://www.npmjs.com/package/zealot