### PR TITLE
Remove zbuf.Array.NewReader

### DIFF
--- a/lake/writer.go
+++ b/lake/writer.go
@@ -140,8 +140,8 @@ func (w *Writer) writeObject(object *data.Object, recs []zed.Value) error {
 	if err != nil {
 		return err
 	}
-	r := zbuf.NewArray(recs).NewReader()
-	if err := zio.CopyWithContext(w.ctx, writer, r); err != nil {
+	a := zbuf.NewArray(recs)
+	if err := zio.CopyWithContext(w.ctx, writer, a); err != nil {
 		writer.Abort()
 		return err
 	}

--- a/zbuf/array.go
+++ b/zbuf/array.go
@@ -59,10 +59,6 @@ func (a *Array) Read() (*zed.Value, error) {
 	return rec, nil
 }
 
-func (a Array) NewReader() zio.Reader {
-	return &a
-}
-
 func (*Array) NewValue(typ zed.Type, bytes zcode.Bytes) *zed.Value {
 	// XXX can make this more efficient later
 	return zed.NewValue(typ, bytes)


### PR DESCRIPTION
There's no benefit to "a.NewReader()" over "zio.Reader(a)".