### PR TITLE
slicer: Parallelize scanning of large partitions

### DIFF
--- a/compiler/kernel/op.go
+++ b/compiler/kernel/op.go
@@ -605,7 +605,7 @@ func (b *Builder) compileTrunk(trunk *dag.Trunk, parent zbuf.Puller) ([]zbuf.Pul
 			if err != nil {
 				return nil, err
 			}
-			slicer = meta.NewSlicer(l, zctx)
+			slicer = meta.NewSlicer(b.octx.Context, l, zctx, pool)
 			b.pools[src] = pool
 			b.slicers[src] = slicer
 		}

--- a/lake/data/seekindex.go
+++ b/lake/data/seekindex.go
@@ -2,7 +2,9 @@ package data
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/lake/seekindex"
@@ -48,5 +50,40 @@ func LookupSeekRange(ctx context.Context, engine storage.Engine, path *storage.U
 			rg = &ranges[len(ranges)-1]
 		}
 		rg.Length += int64(entry.Length)
+	}
+}
+
+func FetchSeekIndex(ctx context.Context, engine storage.Engine, path *storage.URI, obj *Object) ([]seekindex.Entry, error) {
+	r, err := engine.Get(ctx, obj.SeekIndexURI(path))
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			// If there is no seek just return a single entry representing the
+			// entire object.
+			return []seekindex.Entry{{
+				Min:    &obj.Min,
+				Max:    &obj.Max,
+				ValOff: 0,
+				ValCnt: obj.Count,
+				Offset: 0,
+				Length: uint64(obj.Size),
+			}}, nil
+		}
+		return nil, err
+	}
+	defer r.Close()
+	unmarshaler := zson.NewZNGUnmarshaler()
+	reader := zngio.NewReader(zed.NewContext(), r)
+	defer reader.Close()
+	var entries []seekindex.Entry
+	for {
+		val, err := reader.Read()
+		if val == nil || err != nil {
+			return entries, err
+		}
+		var entry seekindex.Entry
+		if err := unmarshaler.Unmarshal(val, &entry); err != nil {
+			return nil, fmt.Errorf("corrupt seek index entry for %q at value: %q (%w)", obj.ID.String(), zson.String(val), err)
+		}
+		entries = append(entries, entry)
 	}
 }

--- a/lake/ztests/break-large-partitions.yaml
+++ b/lake/ztests/break-large-partitions.yaml
@@ -1,0 +1,23 @@
+script: |
+  export ZED_LAKE=test
+  zed init -q
+  for o in asc desc; do
+    echo // $o
+    zed create -q -orderby ts:$o -S 300B -seekstride=1B $o
+    zed use -q $o
+    seq -f "{ts:%1.0f}" 1 20 | zed load -q -
+    seq -f "{ts:%1.0f}" 6 25 | zed load -q -
+    seq -f "{ts:%1.0f}" 11 30 | zed load -q -
+    zed query -Z "from $o:partitions | count()"
+    zed query -Z 'count()'
+  done
+
+outputs:
+  - name: stdout
+    data: |
+      // asc
+      3 (uint64)
+      60 (uint64)
+      // desc
+      3 (uint64)
+      60 (uint64)

--- a/runtime/exec/compact.go
+++ b/runtime/exec/compact.go
@@ -36,7 +36,7 @@ func Compact(ctx context.Context, lk *lake.Root, pool *lake.Pool, branchName str
 	zctx := zed.NewContext()
 	lister := meta.NewSortedListerFromSnap(ctx, zed.NewContext(), lk, pool, compact, nil)
 	octx := op.NewContext(ctx, zctx, nil)
-	slicer := meta.NewSlicer(lister, zctx)
+	slicer := meta.NewSlicer(ctx, lister, zctx, pool)
 	puller := meta.NewSequenceScanner(octx, slicer, pool, nil, nil, nil)
 	w := lake.NewSortedWriter(ctx, pool)
 	if err := zbuf.CopyPuller(w, puller); err != nil {

--- a/runtime/op/meta/scanner.go
+++ b/runtime/op/meta/scanner.go
@@ -88,7 +88,7 @@ func NewCommitMetaScanner(ctx context.Context, zctx *zed.Context, r *lake.Root, 
 		if err != nil {
 			return nil, err
 		}
-		slicer, err := NewSlicer(lister, zctx), nil
+		slicer, err := NewSlicer(ctx, lister, zctx, p), nil
 		if err != nil {
 			return nil, err
 		}

--- a/runtime/op/meta/slicer.go
+++ b/runtime/op/meta/slicer.go
@@ -1,23 +1,30 @@
 package meta
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
 
 	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/lake"
 	"github.com/brimdata/zed/lake/commits"
 	"github.com/brimdata/zed/lake/data"
+	"github.com/brimdata/zed/lake/seekindex"
 	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/runtime/expr"
+	"github.com/brimdata/zed/runtime/expr/extent"
 	"github.com/brimdata/zed/zbuf"
 	"github.com/brimdata/zed/zson"
+	"golang.org/x/exp/slices"
+	"golang.org/x/sync/errgroup"
 )
 
 // Slicer implements an op that pulls data objects and organizes
 // them into overlapping object Slices forming a sequence of
 // non-overlapping Partitions.
 type Slicer struct {
+	ctx         context.Context
 	parent      zbuf.Puller
 	marshaler   *zson.MarshalZNGContext
 	unmarshaler *zson.UnmarshalZNGContext
@@ -26,17 +33,21 @@ type Slicer struct {
 	min         *zed.Value
 	max         *zed.Value
 	mu          sync.Mutex
+	pool        *lake.Pool
+	partitions  []*Partition
 }
 
-func NewSlicer(parent zbuf.Puller, zctx *zed.Context) *Slicer {
+func NewSlicer(ctx context.Context, parent zbuf.Puller, zctx *zed.Context, pool *lake.Pool) *Slicer {
 	m := zson.NewZNGMarshalerWithContext(zctx)
 	m.Decorate(zson.StylePackage)
 	return &Slicer{
+		ctx:         ctx,
 		parent:      parent,
 		marshaler:   m,
 		unmarshaler: zson.NewZNGUnmarshaler(),
 		//XXX check nullsmax is consistent for both dirs in lake ops
-		cmp: expr.NewValueCompareFn(order.Asc, true),
+		cmp:  expr.NewValueCompareFn(order.Asc, true),
+		pool: pool,
 	}
 }
 
@@ -52,6 +63,11 @@ func (s *Slicer) Pull(done bool) (zbuf.Batch, error) {
 	// will be each trunk and the lister parent should run fast in comparison.
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if len(s.partitions) > 0 {
+		p := s.partitions[0]
+		s.partitions = s.partitions[1:]
+		return batchifyPart(s.marshaler, p)
+	}
 	for {
 		batch, err := s.parent.Pull(done)
 		if err != nil {
@@ -84,6 +100,7 @@ func (s *Slicer) nextPartition() (zbuf.Batch, error) {
 	//XXX let's keep this as we go!... need to reorder stuff in stash() to make this work
 	min := &s.objects[0].Min
 	max := &s.objects[0].Max
+	size := s.objects[0].Size
 	for _, o := range s.objects[1:] {
 		if s.cmp(&o.Min, min) < 0 {
 			min = &o.Min
@@ -91,13 +108,35 @@ func (s *Slicer) nextPartition() (zbuf.Batch, error) {
 		if s.cmp(&o.Max, max) > 0 {
 			max = &o.Max
 		}
+		size += o.Size
 	}
-	val, err := s.marshaler.Marshal(&Partition{
-		Min:     min,
-		Max:     max,
-		Objects: s.objects,
-	})
+	var part *Partition
+	if size > s.pool.Threshold*2 {
+		// If size is greater than 2x the pool threshold we need to break things up.
+		// The only way to break to find suitable partitions is by querying
+		// the seek index for all objects in the main partition and find out where
+		// it make sense to break the objects up. Fortunately the seek indexes
+		// should get cached so the io cost of fetching them will only be incurred
+		// once.
+		var err error
+		if s.partitions, err = s.breakup(); err != nil {
+			return nil, err
+		}
+		part = s.partitions[0]
+		s.partitions = s.partitions[1:]
+	} else {
+		part = &Partition{
+			Min:     min,
+			Max:     max,
+			Objects: s.objects,
+		}
+	}
 	s.objects = s.objects[:0]
+	return batchifyPart(s.marshaler, part)
+}
+
+func batchifyPart(marshaler *zson.MarshalZNGContext, part *Partition) (zbuf.Batch, error) {
+	val, err := marshaler.Marshal(part)
 	if err != nil {
 		return nil, err
 	}
@@ -135,13 +174,91 @@ func (s *Slicer) stash(o *data.Object) (zbuf.Batch, error) {
 	return batch, nil
 }
 
+func (s *Slicer) breakup() ([]*Partition, error) {
+	seeks, err := fetchSeeks(s.ctx, s.cmp, s.pool, s.objects)
+	if err != nil {
+		return nil, err
+	}
+	var partitions []*Partition
+	var size int64
+	span := extent.NewGeneric(*s.min, *s.min, s.cmp)
+	for _, seek := range seeks {
+		if size >= s.pool.Threshold && s.cmp(seek.Max, span.Last()) != 0 {
+			// Every partition except for the first partition should be open,
+			// closed.
+			minOpen := len(partitions) > 0
+			p := partitionFromSpan(s.cmp, span, s.objects, minOpen)
+			partitions = append(partitions, p)
+			// Start new span at end of current partition.
+			span = extent.NewGeneric(*p.Max.Copy(), *p.Max.Copy(), s.cmp)
+			size = 0
+		}
+		span.Extend(seek.Max)
+		size += int64(seek.Length)
+	}
+	if p := partitionFromSpan(s.cmp, span, s.objects, len(partitions) > 0); !p.IsZero() {
+		partitions = append(partitions, p)
+	}
+	if s.pool.SortKey.Order == order.Desc {
+		// Reverse partition order for descending.
+		for i, j := 0, len(partitions)-1; i < j; i, j = i+1, j-1 {
+			partitions[i], partitions[j] = partitions[j], partitions[i]
+		}
+	}
+	return partitions, nil
+}
+
+func partitionFromSpan(cmp expr.CompareFn, span *extent.Generic, objects []*data.Object, minOpen bool) *Partition {
+	p := &Partition{
+		Min:     span.First().Copy(),
+		MinOpen: minOpen,
+		Max:     span.Last().Copy(),
+	}
+	// Add objects overlapping objects to the map.
+	for _, o := range objects {
+		if p.Overlaps(cmp, &o.Min, &o.Max) {
+			p.Objects = append(p.Objects, o)
+		}
+	}
+	return p
+}
+
+func fetchSeeks(ctx context.Context, cmp expr.CompareFn, pool *lake.Pool, objects []*data.Object) ([]seekindex.Entry, error) {
+	group, ctx := errgroup.WithContext(ctx)
+	var seeks []seekindex.Entry
+	engine := pool.Storage()
+	var mu sync.Mutex
+	for _, o := range objects {
+		o := o
+		group.Go(func() error {
+			s, err := data.FetchSeekIndex(ctx, engine, pool.DataPath, o)
+			if err != nil {
+				return err
+			}
+			mu.Lock()
+			seeks = append(seeks, s...)
+			mu.Unlock()
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+	slices.SortFunc(seeks, func(a, b seekindex.Entry) bool {
+		return cmp(a.Max, b.Max) < 0
+	})
+	return seeks, nil
+}
+
 // A Partition is a logical view of the records within a pool-key span, stored
 // in one or more data objects.  This provides a way to return the list of
 // objects that should be scanned along with a span to limit the scan
 // to only the span involved.
 type Partition struct {
 	Min     *zed.Value     `zed:"min"`
+	MinOpen bool           `zed:"min_open"`
 	Max     *zed.Value     `zed:"max"`
+	MaxOpen bool           `zed:"max_open"`
 	Objects []*data.Object `zed:"objects"`
 }
 
@@ -156,4 +273,24 @@ func (p Partition) FormatRangeOf(index int) string {
 
 func (p Partition) FormatRange() string {
 	return fmt.Sprintf("[%s-%s]", zson.String(p.Min), zson.String(p.Max))
+}
+
+// In returns true if val is located within the partition.
+func (p *Partition) In(cmp expr.CompareFn, val *zed.Value) bool {
+	if i := cmp(val, p.Min); i < 0 || (p.MinOpen && i == 0) {
+		return false
+	}
+	if i := cmp(val, p.Max); i > 0 || (p.MaxOpen && i == 0) {
+		return false
+	}
+	return true
+}
+
+func (p *Partition) Overlaps(cmp expr.CompareFn, min, max *zed.Value) bool {
+	if i := cmp(min, p.Min); i > 0 || (!p.MinOpen && i == 0) {
+		i = cmp(min, p.Max)
+		return i < 0 || (!p.MaxOpen && i == 0)
+	}
+	i := cmp(max, p.Min)
+	return i > 0 || (!p.MinOpen && i == 0)
 }


### PR DESCRIPTION
When a partition is greater than twice the size of the pool threshold, break the partition into smaller partitions that can then be consumed by parallelized scanners.