### PR TITLE
zbuf.valueAsBytes: use ectx to create new Value

### DIFF
--- a/zbuf/merger.go
+++ b/zbuf/merger.go
@@ -30,6 +30,6 @@ func NewComparatorNullsMax(zctx *zed.Context, sortKey order.SortKey) *expr.Compa
 
 type valueAsBytes struct{}
 
-func (v *valueAsBytes) Eval(_ expr.Context, val *zed.Value) *zed.Value {
-	return zed.NewBytes(val.Bytes)
+func (v *valueAsBytes) Eval(ectx expr.Context, val *zed.Value) *zed.Value {
+	return ectx.NewValue(zed.TypeBytes, val.Bytes)
 }


### PR DESCRIPTION
In zbuf.valueAsBytes use ectx to create new Values. This is important since a expr.ResetContext can then be used and avoid allocating new Values on each eval.