### PR TITLE
Join tutorial: Show up-leveling of fields from embedded record

### DIFF
--- a/docs/tutorials/join.md
+++ b/docs/tutorials/join.md
@@ -379,10 +379,10 @@ left and right data sources. We can account for this by augmenting our Zed into
 a new script `upleveled-opposite.zed`.
 
 ```mdtest-input upleveled-opposite.zed
-from (
-  file fruit.ndjson => sort flavor
-  file people.ndjson => sort likes
-) | inner join on flavor=likes eaterinfo:=this
+file fruit.ndjson | sort flavor
+| inner join (
+  file people.ndjson | sort likes
+) on flavor=likes eaterinfo:=this
 | rename fruit:=name
 | yield {...this,...eaterinfo}
 | drop eaterinfo

--- a/docs/tutorials/join.md
+++ b/docs/tutorials/join.md
@@ -378,7 +378,7 @@ in the example just shown where the `name` field is used differently in the
 left and right inputs. We'll demonstrate this by augmenting `embed-opposite.zed`
 to produce `merge-opposite.zed`.
 
-```mdtest-input upleveled-opposite.zed
+```mdtest-input merge-opposite.zed
 file fruit.ndjson | sort flavor
 | inner join (
   file people.ndjson | sort likes
@@ -391,7 +391,7 @@ file fruit.ndjson | sort flavor
 Executing the Zed script:
 
 ```mdtest-command
-zq -z -I upleveled-opposite.zed
+zq -z -I merge-opposite.zed
 ```
 
 produces

--- a/docs/tutorials/join.md
+++ b/docs/tutorials/join.md
@@ -369,3 +369,38 @@ produces
 {name:"apple",color:"red",flavor:"tart",eaterinfo:{name:"morgan",age:61,likes:"tart"}}
 {name:"apple",color:"red",flavor:"tart",eaterinfo:{name:"chris",age:47,likes:"tart"}}
 ```
+
+If having the data in an embedded record is undesirable, it can easily be
+copied to another location, such as with the
+[spread operator](../language/overview.md#7112-record-expressions). Additional
+processing may be necessary to handle conflicting field names, such as
+in the example just shown where the `name` field is used differently in the
+left and right data sources. We can account for this by augmenting our Zed into
+a new script `upleveled-opposite.zed`.
+
+```mdtest-input upleveled-opposite.zed
+from (
+  file fruit.ndjson => sort flavor
+  file people.ndjson => sort likes
+) | inner join on flavor=likes eaterinfo:=this
+| rename fruit:=name
+| yield {...this,...eaterinfo}
+| drop eaterinfo
+```
+
+Executing the Zed script:
+
+```mdtest-command
+zq -z -I upleveled-opposite.zed
+```
+
+produces
+
+```mdtest-output
+{fruit:"figs",color:"brown",flavor:"plain",name:"jessie",age:30,likes:"plain"}
+{fruit:"banana",color:"yellow",flavor:"sweet",name:"quinn",age:14,likes:"sweet",note:"many kids enjoy sweets"}
+{fruit:"strawberry",color:"red",flavor:"sweet",name:"quinn",age:14,likes:"sweet",note:"many kids enjoy sweets"}
+{fruit:"dates",color:"brown",flavor:"sweet",note:"many kids enjoy sweets",name:"quinn",age:14,likes:"sweet"}
+{fruit:"apple",color:"red",flavor:"tart",name:"morgan",age:61,likes:"tart"}
+{fruit:"apple",color:"red",flavor:"tart",name:"chris",age:47,likes:"tart"}
+```

--- a/docs/tutorials/join.md
+++ b/docs/tutorials/join.md
@@ -375,8 +375,8 @@ records can easily be merged with the
 [spread operator](../language/overview.md#7112-record-expressions). Additional
 processing may be necessary to handle conflicting field names, such as
 in the example just shown where the `name` field is used differently in the
-left and right data sources. We can account for this by augmenting our Zed into
-a new script `upleveled-opposite.zed`.
+left and right inputs. We'll demonstrate this by augmenting `embed-opposite.zed`
+to produce `merge-opposite.zed`.
 
 ```mdtest-input upleveled-opposite.zed
 file fruit.ndjson | sort flavor

--- a/docs/tutorials/join.md
+++ b/docs/tutorials/join.md
@@ -370,8 +370,8 @@ produces
 {name:"apple",color:"red",flavor:"tart",eaterinfo:{name:"chris",age:47,likes:"tart"}}
 ```
 
-If having the data in an embedded record is undesirable, it can easily be
-copied to another location, such as with the
+If embedding the opposite record is undesirable, the left and right
+records can easily be merged with the
 [spread operator](../language/overview.md#7112-record-expressions). Additional
 processing may be necessary to handle conflicting field names, such as
 in the example just shown where the `name` field is used differently in the

--- a/docs/tutorials/join.md
+++ b/docs/tutorials/join.md
@@ -334,7 +334,7 @@ produces
 {name:"strawberry",color:"red",flavor:"sweet",eater:"quinn",price:1.05}
 ```
 
-## Embedding the entire opposite record
+## Including the entire opposite record
 
 In the current `join` implementation, explicit entries must be provided in the
 `[field-list]` in order to copy values from the opposite input into the joined


### PR DESCRIPTION
I was helping a community user recently with a `join` question. They came from a SQL perspective and seemed to be expecting behavior similar to what's described in #2815. While a workaround is already shown [here](https://zed.brimdata.io/docs/tutorials/join#embedding-the-entire-opposite-record) in the join tutorial, I can see that we could take it even further by showing how to move the data from the embedded record "up one level", which I've drafted in this PR.