### PR TITLE
Fix cidr_match() doc

### DIFF
--- a/docs/language/functions/cidr_match.md
+++ b/docs/language/functions/cidr_match.md
@@ -5,14 +5,14 @@
 ### Synopsis
 
 ```
-cidr_match(mask: net, val: any) -> bool
+cidr_match(network: net, val: any) -> bool
 ```
 ### Description
 
 The _cidr_match_ function returns true if `val` contains an IP address that
-falls within the network given by `mask`.  When `val` is a complex type, the
-function traverses its nested structure to find any network values.
-If `mask` is not type `net`, then an error is returned.
+falls within the network given by `network`.  When `val` is a complex type, the
+function traverses its nested structure to find any `ip` values.
+If `network` is not type `net`, then an error is returned.
 
 ### Examples
 
@@ -27,7 +27,7 @@ false
 false
 false
 ```
-It also works for IPs in nested values:
+It also works for IPs in complex values:
 
 ```mdtest-command
 echo '[10.1.2.129,11.1.2.129] {a:10.0.0.1} {a:11.0.0.1}' | zq -z 'yield cidr_match(10.0.0.0/8, this)' -

--- a/docs/language/functions/cidr_match.md
+++ b/docs/language/functions/cidr_match.md
@@ -11,7 +11,7 @@ cidr_match(mask: net, val: any) -> bool
 
 The _cidr_match_ function returns true if `val` contains an IP address that
 falls within the network given by `mask`.  When `val` is a complex type, the
-function traverses its nested structured to find any network values.
+function traverses its nested structure to find any network values.
 If `mask` is not type `net`, then an error is returned.
 
 ### Examples

--- a/docs/language/functions/cidr_match.md
+++ b/docs/language/functions/cidr_match.md
@@ -28,6 +28,8 @@ false
 false
 ```
 It also works for IPs in nested values:
+
+```mdtest-command
 echo '[10.1.2.129,11.1.2.129] {a:10.0.0.1} {a:11.0.0.1}' | zq -z 'yield cidr_match(10.0.0.0/8, this)' -
 ```
 =>
@@ -38,10 +40,10 @@ false
 ```
 
 The first argument must be a network:
-```
+```mdtest-command
 echo '10.0.0.1' | zq -z 'yield cidr_match([1,2,3], this)' -
 ```
 =>
-```
+```mdtest-output
 error("cidr_match: not a net: [1,2,3]")
 ```


### PR DESCRIPTION
I happened to be looking at the `cidr_match()` doc and noticed some of the inline examples were messed up. While correcting those, I corrected some other wording and am also proposing changing the name of the `mask` argument to `network`. I'm accustomed to seeing the word "mask" used as shorthand for "netmask", but the Zed `net` type includes both an address and netmask portion. To me it was a close call between `network` and `subnet`, so, happy to switch over if others have opinions.