### PR TITLE
Fix "zed delete -where" commit message

### DIFF
--- a/lake/branch.go
+++ b/lake/branch.go
@@ -191,7 +191,8 @@ func (b *Branch) DeleteWhere(ctx context.Context, c runtime.Compiler, program as
 			}
 			var added []*data.Object
 			for _, o := range w.Objects() {
-				added = append(added, &o)
+				obj := o
+				added = append(added, &obj)
 			}
 			message = deleteWhereMessage(deletedObjs, added)
 		}


### PR DESCRIPTION
The commit message generated by "zed delete -where" repeats the details of the last added data object.  This happens because lake.Branch.DeleteWhere records the address of a "for" statement's iteration variable, and that address does not change accross iterations.  Fix by creating a new variable on each iteration and recording its address instead.