### PR TITLE
Add note about the multiple join syntaxes

### DIFF
--- a/docs/language/operators/join.md
+++ b/docs/language/operators/join.md
@@ -16,7 +16,7 @@
 
 :::tip Note
 The first `join` syntax shown above was more recently introduced and is in some
-ways similar to other languages such as SQL. The second was the original `join`
+ways similar to other languages such as SQL.  The second was the original `join`
 syntax in Zed.  Most joins can be expressed using either syntax.  See the
 [join tutorial](../../tutorials/join.md)
 for details.

--- a/docs/language/operators/join.md
+++ b/docs/language/operators/join.md
@@ -17,7 +17,7 @@
 :::tip Note
 The first `join` syntax shown above was more recently introduced and is in some
 ways similar to other languages such as SQL. The second was the original `join`
-syntax in Zed. Most joins can be expressed using either syntax. See the
+syntax in Zed.  Most joins can be expressed using either syntax.  See the
 [join tutorial](../../tutorials/join.md)
 for details.
 :::

--- a/docs/language/operators/join.md
+++ b/docs/language/operators/join.md
@@ -13,6 +13,15 @@
 ( => <left-input> => <right-input> )
 | [anti|inner|left|right] join on <left-key>=<right-key> [<field>:=<right-expr>, ...]
 ```
+
+:::tip Note
+The first `join` syntax shown above was more recently introduced and is in some
+ways similar to other languages such as SQL. The second was the original `join`
+syntax in Zed. Most joins can be expressed using either syntax. See the
+[join tutorial](../../tutorials/join.md)
+for details.
+:::
+
 ### Description
 
 The `join` operator combines records from two inputs based on whether


### PR DESCRIPTION
I'm ok with our having multiple `join` syntaxes because:

1. It maintains backward compatibility
2. I know of at least one SQL-centric user that expressed they found our original syntax more intuitive once they got accustomed to it, and they might not be alone
3. As far as I know, the [self join example](https://zed.brimdata.io/docs/next/tutorials/join#self-joins) where a single anonymous stream is input to `zq` is then split & joined can only be expressed with the older syntax, so if we pushed to phase out the old syntax right now we'd be losing functionality

That said, since we don't usually make a habit of having multiple syntaxes, I'm in favor of pointing it out. As I see it, without an explanation an existing Zed user might wonder things like "Why did they introduce a second syntax? Is there a reason to choose one over the other?" and a new user might simply wonder "Why are there two syntaxes?" This is my attempt to proactively & briefly address those questions.

In situations like this, I tend to use a Docusaurus "tip" since it makes it stand out in a way that both makes it obvious and fair game to skip past if the reader is in a hurry. Here's what it looks like rendered:

![image](https://user-images.githubusercontent.com/5934157/233214084-37ab425f-635e-489e-af00-4fad2d95fd6f.png)
