### PR TITLE
Use zio.NopCloser when possible

### DIFF
--- a/runtime/op/groupby/groupby_test.go
+++ b/runtime/op/groupby/groupby_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"sort"
 	"strings"
 	"sync"
@@ -296,7 +295,7 @@ func TestGroupbyStreamingSpill(t *testing.T) {
 		zr := zsonio.NewReader(zctx, strings.NewReader(strings.Join(data, "\n")))
 		cr := &countReader{r: zr}
 		var outbuf bytes.Buffer
-		zw := zsonio.NewWriter(&nopCloser{&outbuf}, zsonio.WriterOpts{})
+		zw := zsonio.NewWriter(zio.NopCloser(&outbuf), zsonio.WriterOpts{})
 		checker := &testGroupByWriter{
 			writer: zw,
 			cb: func(n int) {
@@ -322,10 +321,6 @@ func TestGroupbyStreamingSpill(t *testing.T) {
 	resStreaming := runOne("ts")
 	require.Equal(t, res, resStreaming)
 }
-
-type nopCloser struct{ io.Writer }
-
-func (*nopCloser) Close() error { return nil }
 
 func newQueryOnOrderedReader(ctx context.Context, zctx *zed.Context, program ast.Op, reader zio.Reader, sortKey order.SortKey) (*runtime.Query, error) {
 	octx := op.NewContext(ctx, zctx, nil)

--- a/zio/emitter/split_test.go
+++ b/zio/emitter/split_test.go
@@ -29,9 +29,9 @@ func TestDirS3Source(t *testing.T) {
 	engine := storagemock.NewMockEngine(ctrl)
 
 	engine.EXPECT().Put(context.Background(), uri.JoinPath("conn.zson")).
-		Return(&nopCloser{bytes.NewBuffer(nil)}, nil)
+		Return(zio.NopCloser(bytes.NewBuffer(nil)), nil)
 	engine.EXPECT().Put(context.Background(), uri.JoinPath("http.zson")).
-		Return(&nopCloser{bytes.NewBuffer(nil)}, nil)
+		Return(zio.NopCloser(bytes.NewBuffer(nil)), nil)
 
 	r := zsonio.NewReader(zed.NewContext(), strings.NewReader(input))
 	require.NoError(t, err)
@@ -39,7 +39,3 @@ func TestDirS3Source(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, zio.Copy(w, r))
 }
-
-type nopCloser struct{ *bytes.Buffer }
-
-func (nopCloser) Close() error { return nil }

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -511,7 +511,7 @@ func runzq(path, zedProgram, input string, outputFlags []string, inputFlags []st
 	if err := flags.Parse(outputFlags); err != nil {
 		return "", "", err
 	}
-	zw, err := anyio.NewWriter(&nopCloser{&outbuf}, outflags.Options())
+	zw, err := anyio.NewWriter(zio.NopCloser(&outbuf), outflags.Options())
 	if err != nil {
 		return "", "", err
 	}
@@ -542,7 +542,3 @@ func lookupzq(path string) (string, error) {
 	}
 	return "", err
 }
-
-type nopCloser struct{ io.Writer }
-
-func (*nopCloser) Close() error { return nil }


### PR DESCRIPTION
Replace a few types that duplicate the functionality of zio.NopCloser with calls to the latter.