### PR TITLE
Remove NopCloser from storage.StdioEngine.Put

### DIFF
--- a/pkg/storage/stdio.go
+++ b/pkg/storage/stdio.go
@@ -24,16 +24,14 @@ func (*StdioEngine) Get(_ context.Context, u *URI) (Reader, error) {
 }
 
 func (*StdioEngine) Put(ctx context.Context, u *URI) (io.WriteCloser, error) {
-	var f *os.File
 	switch u.Path {
 	case "stdout", "":
-		f = os.Stdout
+		return os.Stdout, nil
 	case "stderr":
-		f = os.Stderr
+		return os.Stderr, nil
 	default:
 		return nil, fmt.Errorf("cannot write to '%s'", u.Path)
 	}
-	return &NopCloser{f}, nil
 }
 
 func (*StdioEngine) PutIfNotExists(context.Context, *URI, []byte) error {
@@ -58,12 +56,4 @@ func (*StdioEngine) Exists(_ context.Context, u *URI) (bool, error) {
 
 func (*StdioEngine) List(_ context.Context, _ *URI) ([]Info, error) {
 	return nil, errStdioNotSupport
-}
-
-type NopCloser struct {
-	io.Writer
-}
-
-func (*NopCloser) Close() error {
-	return nil
 }

--- a/zio/emitter/file.go
+++ b/zio/emitter/file.go
@@ -24,13 +24,8 @@ func NewFileFromPath(ctx context.Context, engine storage.Engine, path string, un
 }
 
 func IsTerminal(w io.Writer) bool {
-	if f, ok := w.(*os.File); ok {
-		return terminal.IsTerminalFile(f)
-	}
-	if nc, ok := w.(*storage.NopCloser); ok {
-		return IsTerminal(nc.Writer)
-	}
-	return false
+	f, ok := w.(*os.File)
+	return ok && terminal.IsTerminalFile(f)
 }
 
 func NewFileFromURI(ctx context.Context, engine storage.Engine, path *storage.URI, unbuffered bool, opts anyio.WriterOpts) (zio.WriteCloser, error) {


### PR DESCRIPTION
Put wraps os.Stdout and os.Stderr with NopCloser before returning them, but that's unnecessary.