### PR TITLE
Consistent lake/pools.Config parameter position

### DIFF
--- a/lake/pool.go
+++ b/lake/pool.go
@@ -35,7 +35,7 @@ type Pool struct {
 	commits   *commits.Store
 }
 
-func CreatePool(ctx context.Context, config *pools.Config, engine storage.Engine, logger *zap.Logger, root *storage.URI) error {
+func CreatePool(ctx context.Context, engine storage.Engine, logger *zap.Logger, root *storage.URI, config *pools.Config) error {
 	poolPath := config.Path(root)
 	// branchesPath is the path to the kvs journal of BranchConfigs
 	// for the pool while the commit log is stored in <pool-id>/<branch-id>.
@@ -47,11 +47,11 @@ func CreatePool(ctx context.Context, config *pools.Config, engine storage.Engine
 	}
 	// create the main branch in the branches journal store.  The parent
 	// commit object of the initial main branch is ksuid.Nil.
-	_, err = CreateBranch(ctx, config, engine, logger, root, "main", ksuid.Nil)
+	_, err = CreateBranch(ctx, engine, logger, root, config, "main", ksuid.Nil)
 	return err
 }
 
-func CreateBranch(ctx context.Context, poolConfig *pools.Config, engine storage.Engine, logger *zap.Logger, root *storage.URI, name string, parent ksuid.KSUID) (*branches.Config, error) {
+func CreateBranch(ctx context.Context, engine storage.Engine, logger *zap.Logger, root *storage.URI, poolConfig *pools.Config, name string, parent ksuid.KSUID) (*branches.Config, error) {
 	poolPath := poolConfig.Path(root)
 	branchesPath := poolPath.JoinPath(BranchesTag)
 	store, err := branches.OpenStore(ctx, engine, logger, branchesPath)
@@ -68,7 +68,7 @@ func CreateBranch(ctx context.Context, poolConfig *pools.Config, engine storage.
 	return branchConfig, err
 }
 
-func OpenPool(ctx context.Context, config *pools.Config, engine storage.Engine, logger *zap.Logger, root *storage.URI) (*Pool, error) {
+func OpenPool(ctx context.Context, engine storage.Engine, logger *zap.Logger, root *storage.URI, config *pools.Config) (*Pool, error) {
 	path := config.Path(root)
 	branchesPath := path.JoinPath(BranchesTag)
 	branches, err := branches.OpenStore(ctx, engine, logger, branchesPath)
@@ -91,7 +91,7 @@ func OpenPool(ctx context.Context, config *pools.Config, engine storage.Engine, 
 	}, nil
 }
 
-func RemovePool(ctx context.Context, config *pools.Config, engine storage.Engine, root *storage.URI) error {
+func RemovePool(ctx context.Context, engine storage.Engine, root *storage.URI, config *pools.Config) error {
 	return engine.DeleteByPrefix(ctx, config.Path(root))
 }
 

--- a/lake/root.go
+++ b/lake/root.go
@@ -311,7 +311,7 @@ func (r *Root) openPool(ctx context.Context, config *pools.Config) (*Pool, error
 		p.Config = *config
 		return &p, nil
 	}
-	p, err := OpenPool(ctx, config, r.engine, r.logger, r.path)
+	p, err := OpenPool(ctx, r.engine, r.logger, r.path, config)
 	if err != nil {
 		return nil, err
 	}
@@ -334,16 +334,16 @@ func (r *Root) CreatePool(ctx context.Context, name string, sortKey order.SortKe
 		thresh = data.DefaultThreshold
 	}
 	config := pools.NewConfig(name, sortKey, thresh, seekStride)
-	if err := CreatePool(ctx, config, r.engine, r.logger, r.path); err != nil {
+	if err := CreatePool(ctx, r.engine, r.logger, r.path, config); err != nil {
 		return nil, err
 	}
 	pool, err := r.openPool(ctx, config)
 	if err != nil {
-		RemovePool(ctx, config, r.engine, r.path)
+		RemovePool(ctx, r.engine, r.path, config)
 		return nil, err
 	}
 	if err := r.pools.Add(ctx, config); err != nil {
-		RemovePool(ctx, config, r.engine, r.path)
+		RemovePool(ctx, r.engine, r.path, config)
 		return nil, err
 	}
 	return pool, nil
@@ -363,7 +363,7 @@ func (r *Root) RemovePool(ctx context.Context, id ksuid.KSUID) error {
 	// With no entry in the pool store, it will be inaccessible and
 	// eventually evicted by the cache's LRU algorithm.
 	r.poolCache.Remove(config.ID)
-	return RemovePool(ctx, config, r.engine, r.path)
+	return RemovePool(ctx, r.engine, r.path, config)
 }
 
 func (r *Root) CreateBranch(ctx context.Context, poolID ksuid.KSUID, name string, parent ksuid.KSUID) (*branches.Config, error) {
@@ -371,7 +371,7 @@ func (r *Root) CreateBranch(ctx context.Context, poolID ksuid.KSUID, name string
 	if err != nil {
 		return nil, err
 	}
-	return CreateBranch(ctx, config, r.engine, r.logger, r.path, name, parent)
+	return CreateBranch(ctx, r.engine, r.logger, r.path, config, name, parent)
 }
 
 func (r *Root) RemoveBranch(ctx context.Context, poolID ksuid.KSUID, name string) error {


### PR DESCRIPTION
Move the pool.Config parameter to CreateBranch, CreatePool, OpenPool, and RemovePool so their first four parameters are consistent with other functions that have them.