### PR TITLE
Small fixes related to merge docs

### DIFF
--- a/docs/language/operators/README.md
+++ b/docs/language/operators/README.md
@@ -10,12 +10,13 @@ and appear as the components of a dataflow pipeline.
 * [cut](cut.md) - extract subsets of record fields into new records
 * [drop](drop.md) - drop fields from record values
 * [file](from.md) - source data from a file
-* [from](from.md) - source data from pools, files, or URIs
 * [fork](fork.md) - copy values to parallel paths
+* [from](from.md) - source data from pools, files, or URIs
 * [fuse](fuse.md) - coerce all input values into a merged type
 * [get](from.md) - source data from a URI
 * [head](head.md) - copy leading values of input sequence
 * [join](join.md) - combine data from two inputs using a join predicate
+* [merge](merge.md) - combine parallel paths into a single, ordered output
 * [over](over.md) - traverse nested values as a lateral query
 * [pass](pass.md) - copy input values to output
 * [put](put.md) - add or modify fields of records

--- a/docs/language/operators/merge.md
+++ b/docs/language/operators/merge.md
@@ -16,7 +16,7 @@ where the values from the upstream paths are forwarded based on these expression
 
 ### Examples
 
-_Copy input to two paths and combine
+_Copy input to two paths and combine_
 ```mdtest-command
 echo '1 2' | zq -z 'fork (=>pass =>pass) | merge this' -
 ```


### PR DESCRIPTION
I noticed a small formatting glitch in the `merge` doc. Then I noticed it was missing from the operators list. Then I noticed some `from` was out of order in the list. 🤪 