### PR TITLE
Use "pass" in more docs

### DIFF
--- a/docs/language/operators/from.md
+++ b/docs/language/operators/from.md
@@ -164,10 +164,10 @@ zed -lake example query -f text 'from * | count()'
 _Join the data from multiple pools_
 ```mdtest-command
 zed -lake example query -z '
-  from (
-    pool coinflips => sort flip
-    pool numbers => sort number
-  ) | join on flip=number word'
+  from coinflips | sort flip
+  | join (
+    from numbers | sort number
+  ) on flip=number word'
 ```
 =>
 ```mdtest-output
@@ -178,10 +178,10 @@ zed -lake example query -z '
 _Use `pass` to combine our join output with data from yet another source_
 ```mdtest-command
 zed -lake example query -z '
-  from (
-    pool coinflips => sort flip
-    pool numbers => sort number
-  ) | join on flip=number word
+  from coinflips | sort flip
+  | join (
+    from numbers | sort number
+  ) on flip=number word
   | from (
     pass
     pool coinflips@trial => c:=count() | yield "There were ${int64(c)} trial flips"

--- a/docs/language/operators/from.md
+++ b/docs/language/operators/from.md
@@ -183,13 +183,13 @@ zed -lake example query -z '
     from numbers | sort number
   ) on flip=number word
   | from (
-    pass
-    pool coinflips@trial => c:=count() | yield "There were ${int64(c)} flips"
+      pass
+      pool coinflips@trial => c:=count() | yield "There were ${int64(c)} flips"
   ) | sort this'
 ```
 =>
 ```mdtest-output
-"There were 3 trial flips"
+"There were 3 flips"
 {flip:1,result:"heads",word:"one"}
 {flip:2,result:"tails",word:"two"}
 ```

--- a/docs/language/operators/from.md
+++ b/docs/language/operators/from.md
@@ -184,7 +184,7 @@ zed -lake example query -z '
   ) | join on flip=number word
   | from (
     pass
-    pool coinflips@trial => c:=count() | c:=int64(c) | yield "There were ${c} trial flips"
+    pool coinflips@trial => c:=count() | yield "There were ${int64(c)} trial flips"
   ) | sort this'
 ```
 =>

--- a/docs/language/operators/from.md
+++ b/docs/language/operators/from.md
@@ -183,8 +183,8 @@ zed -lake example query -z '
     from numbers | sort number
   ) on flip=number word
   | from (
-      pass
-      pool coinflips@trial => c:=count() | yield "There were ${int64(c)} flips"
+    pass
+    pool coinflips@trial => c:=count() | yield "There were ${int64(c)} flips"
   ) | sort this'
 ```
 =>

--- a/docs/language/operators/from.md
+++ b/docs/language/operators/from.md
@@ -184,7 +184,7 @@ zed -lake example query -z '
   ) on flip=number word
   | from (
     pass
-    pool coinflips@trial => c:=count() | yield "There were ${int64(c)} trial flips"
+    pool coinflips@trial => c:=count() | yield "There were ${int64(c)} flips"
   ) | sort this'
 ```
 =>

--- a/docs/language/operators/pass.md
+++ b/docs/language/operators/pass.md
@@ -30,9 +30,9 @@ _Copy each input value to three parallel legs and leave the values unmodified on
 ```mdtest-command
 echo '"HeLlo, WoRlD!"' | zq -z '
   fork (
-  => pass
-  => upper(this)
-  => lower(this)
+    => pass
+    => upper(this)
+    => lower(this)
 ) | sort' -
 ```
 =>

--- a/docs/language/operators/pass.md
+++ b/docs/language/operators/pass.md
@@ -25,3 +25,19 @@ echo '1 2 3' | zq -z pass -
 2
 3
 ```
+
+_Copy each input value to three parallel legs and leave the values unmodified on one of them_
+```mdtest-command
+echo '"HeLlo, WoRlD!"' | zq -z '
+  fork (
+  => pass
+  => upper(this)
+  => lower(this)
+) | sort' -
+```
+=>
+```mdtest-output
+"HELLO, WORLD!"
+"HeLlo, WoRlD!"
+"hello, world!"
+```


### PR DESCRIPTION
Some time ago one of our community zync users presented a query challenge for which we had to show them how to use the `pass` operator within `from`. Once educated, they remarked that this had not been clear from the docs, so here I've tried to improve by making sure `pass` is explicitly mentioned in the `from` doc with its own example. I've also enhanced the `pass` doc itself with another example.