### PR TITLE
use json.Unmarshal pattern in unpack

### DIFF
--- a/compiler/ast/dag/unpack.go
+++ b/compiler/ast/dag/unpack.go
@@ -1,7 +1,7 @@
 package dag
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/brimdata/zed/pkg/unpack"
 )
@@ -62,34 +62,11 @@ var unpacker = unpack.New(
 	Yield{},
 )
 
-func UnpackJSON(buf []byte) (interface{}, error) {
-	if len(buf) == 0 {
-		return nil, nil
-	}
-	return unpacker.Unmarshal(buf)
-}
-
-// UnpackJSONAsOp transforms a JSON representation of an operator into an dag.Op.
-func UnpackJSONAsOp(buf []byte) (Op, error) {
-	result, err := UnpackJSON(buf)
-	if result == nil || err != nil {
-		return nil, err
-	}
-	op, ok := result.(Op)
-	if !ok {
-		return nil, errors.New("JSON object is not a DAG operator")
-	}
-	return op, nil
-}
-
-func UnpackMapAsOp(m interface{}) (Op, error) {
-	object, err := unpacker.UnmarshalObject(m)
-	if object == nil || err != nil {
-		return nil, err
-	}
-	op, ok := object.(Op)
-	if !ok {
-		return nil, errors.New("dag.UnpackMapAsOp: not an Op")
+// UnmarshalOp transforms a JSON representation of an operator into an dag.Op.
+func UnmarshalOp(buf []byte) (Op, error) {
+	var op Op
+	if err := unpacker.Unmarshal(buf, &op); err != nil {
+		return nil, fmt.Errorf("system error: JSON object is not a DAG operator: %w", err)
 	}
 	return op, nil
 }

--- a/compiler/ast/dag/unpack.go
+++ b/compiler/ast/dag/unpack.go
@@ -62,11 +62,11 @@ var unpacker = unpack.New(
 	Yield{},
 )
 
-// UnmarshalOp transforms a JSON representation of an operator into an dag.Op.
+// UnmarshalOp transforms a JSON representation of an operator into an Op.
 func UnmarshalOp(buf []byte) (Op, error) {
 	var op Op
 	if err := unpacker.Unmarshal(buf, &op); err != nil {
-		return nil, fmt.Errorf("system error: JSON object is not a DAG operator: %w", err)
+		return nil, fmt.Errorf("internal error: JSON object is not a DAG operator: %w", err)
 	}
 	return op, nil
 }

--- a/compiler/job.go
+++ b/compiler/job.go
@@ -168,7 +168,7 @@ func Parse(src string, filenames ...string) (ast.Seq, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ast.UnpackAsSeq(parsed)
+	return ast.UnmarshalObject(parsed)
 }
 
 // MustParse is like Parse but panics if an error is encountered.

--- a/compiler/optimizer/op.go
+++ b/compiler/optimizer/op.go
@@ -229,7 +229,7 @@ func copyOp(o dag.Op) dag.Op {
 	if err != nil {
 		panic(err)
 	}
-	copy, err := dag.UnpackJSONAsOp(b)
+	copy, err := dag.UnmarshalOp(b)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/unpack/unpack_test.go
+++ b/pkg/unpack/unpack_test.go
@@ -38,7 +38,7 @@ const binaryExprJSON = `
 	"rhs": { "op": "Terminal", "body": "bar" }
 }`
 
-var binaryExprExpected = &BinaryExpr{
+var binaryExprExpected = BinaryExpr{
 	Op:  "BinaryExpr",
 	LHS: &Terminal{Op: "Terminal", Body: "foo"},
 	RHS: &Terminal{Op: "Terminal", Body: "bar"},
@@ -51,7 +51,8 @@ func TestUnpackBinaryExpr(t *testing.T) {
 		Terminal{},
 		List{},
 	)
-	actual, err := reflector.UnmarshalString(binaryExprJSON)
+	var actual BinaryExpr
+	err := reflector.Unmarshal([]byte(binaryExprJSON), &actual)
 	require.NoError(t, err)
 	assert.Equal(t, binaryExprExpected, actual)
 }
@@ -69,7 +70,7 @@ const typeTagJSON = `
 	"rhs": { "op": "Terminal", "body": "bar" }
 }`
 
-var typeTagExpected = &BinaryExpr2{
+var typeTagExpected = BinaryExpr2{
 	Op:  "FooExpr",
 	LHS: &Terminal{Op: "Terminal", Body: "foo"},
 	RHS: &Terminal{Op: "Terminal", Body: "bar"},
@@ -80,7 +81,8 @@ func TestUnpackTypeTag(t *testing.T) {
 		BinaryExpr2{},
 		Terminal{},
 	)
-	actual, err := reflector.UnmarshalString(typeTagJSON)
+	var actual BinaryExpr2
+	err := reflector.Unmarshal([]byte(typeTagJSON), &actual)
 	require.NoError(t, err)
 	assert.Equal(t, typeTagExpected, actual)
 }
@@ -99,7 +101,7 @@ const nestedJSON = `
 	}
 }`
 
-var nestedExpected = &BinaryExpr{
+var nestedExpected = BinaryExpr{
 	Op: "BinaryExpr",
 	LHS: &UnaryExpr{
 		Op:      "UnaryExpr",
@@ -119,7 +121,8 @@ func TestUnpackNested(t *testing.T) {
 		Terminal{},
 		List{},
 	)
-	actual, err := reflector.UnmarshalString(nestedJSON)
+	var actual BinaryExpr
+	err := reflector.Unmarshal([]byte(nestedJSON), &actual)
 	require.NoError(t, err)
 	assert.Equal(t, nestedExpected, actual)
 }
@@ -152,7 +155,7 @@ const embeddedJSON = `
          }
 }`
 
-var embeddedExpected = &Embedded{
+var embeddedExpected = Embedded{
 	Op: "Embedded",
 	Root: Pair{
 		A: &Terminal{"Terminal", "a"},
@@ -172,7 +175,8 @@ func TestUnpackEmbedded(t *testing.T) {
 		List{},
 		Embedded{},
 	)
-	actual, err := reflector.UnmarshalString(embeddedJSON)
+	var actual Embedded
+	err := reflector.Unmarshal([]byte(embeddedJSON), &actual)
 	require.NoError(t, err)
 	assert.Equal(t, embeddedExpected, actual)
 }
@@ -183,7 +187,7 @@ const listJSON = `
 	"exprs": [ { "op": "Terminal", "body": "elem" } ]
 }`
 
-var listExpected = &List{
+var listExpected = List{
 	Op: "List",
 	Exprs: []Expr{
 		&Terminal{Op: "Terminal", Body: "elem"},
@@ -197,7 +201,8 @@ func TestUnpackList(t *testing.T) {
 		Terminal{},
 		List{},
 	)
-	actual, err := reflector.UnmarshalString(listJSON)
+	var actual List
+	err := reflector.Unmarshal([]byte(listJSON), &actual)
 	require.NoError(t, err)
 	assert.Equal(t, listExpected, actual)
 }
@@ -216,7 +221,7 @@ const arrayJSON = `
 	]
 }`
 
-var arrayExpected = &Array{
+var arrayExpected = Array{
 	Op: "Array",
 	Exprs: [2]Expr{
 		&Terminal{Op: "Terminal", Body: "elem0"},
@@ -229,7 +234,8 @@ func TestUnpackArray(t *testing.T) {
 		Terminal{},
 		Array{},
 	)
-	actual, err := reflector.UnmarshalString(arrayJSON)
+	var actual Array
+	err := reflector.Unmarshal([]byte(arrayJSON), &actual)
 	require.NoError(t, err)
 	assert.Equal(t, arrayExpected, actual)
 }
@@ -253,7 +259,7 @@ const pairListJSON = `
 	} ]
 }`
 
-var pairListExpected = &PairList{
+var pairListExpected = PairList{
 	Op: "PairList",
 	Pairs: []Pair{
 		{
@@ -274,7 +280,8 @@ func TestUnpackPairList(t *testing.T) {
 		Terminal{},
 		PairList{},
 	)
-	actual, err := reflector.UnmarshalString(pairListJSON)
+	var actual PairList
+	err := reflector.Unmarshal([]byte(pairListJSON), &actual)
 	require.NoError(t, err)
 	assert.Equal(t, pairListExpected, actual)
 }
@@ -320,7 +327,7 @@ const cutJSON = `
 
 `
 
-var cutExpected = &CutProc{
+var cutExpected = CutProc{
 	Op: "CutProc",
 	Fields: []Assignment{
 		{
@@ -347,7 +354,8 @@ func TestUnpackCut(t *testing.T) {
 		CutProc{},
 		Identifier{},
 	)
-	actual, err := reflector.UnmarshalString(cutJSON)
+	var actual CutProc
+	err := reflector.Unmarshal([]byte(cutJSON), &actual)
 	require.NoError(t, err)
 	assert.Equal(t, cutExpected, actual)
 }
@@ -378,7 +386,8 @@ func TestUnpackSkip(t *testing.T) {
 		BinaryExpr3{},
 		Terminal{},
 	)
-	actual, err := reflector.UnmarshalString(skipJSON)
+	var actual interface{}
+	err := reflector.Unmarshal([]byte(skipJSON), &actual)
 	require.NoError(t, err)
 	assert.Equal(t, skipExpected, actual)
 }
@@ -396,7 +405,8 @@ func TestValueNotAssignableToInterfaceError(t *testing.T) {
 	}
 
 	reflector := unpack.New(S{}, NotAny{})
-	_, err := reflector.UnmarshalString(`{"kind": "S", "value": {"kind": "NotAny"}}`)
+	var dummy interface{}
+	err := reflector.Unmarshal([]byte(`{"kind": "S", "value": {"kind": "NotAny"}}`), &dummy)
 	require.EqualError(t, err,
 		`JSON field "value" in Go struct type "unpack_test.S": value of type "*unpack_test.NotAny" not assignable to type "unpack_test.Any"`)
 }
@@ -429,7 +439,7 @@ const sliceListJSON = `
 	]
 }`
 
-var sliceListExpected = &SliceList{
+var sliceListExpected = SliceList{
 	Op: "SliceList",
 	Slices: [][]Pair{
 		{
@@ -458,14 +468,16 @@ func TestUnpackSliceList(t *testing.T) {
 		Terminal{},
 		SliceList{},
 	)
-	actual, err := reflector.UnmarshalString(sliceListJSON)
+	var actual SliceList
+	err := reflector.Unmarshal([]byte(sliceListJSON), &actual)
 	require.NoError(t, err)
 	assert.Equal(t, sliceListExpected, actual)
 }
 
 func TestEmptyObject(t *testing.T) {
 	reflector := unpack.New()
-	actual, err := reflector.UnmarshalString("{}")
+	var actual map[string]interface{}
+	err := reflector.Unmarshal([]byte("{}"), &actual)
 	require.NoError(t, err)
 	assert.Equal(t, map[string]interface{}{}, actual)
 }
@@ -498,7 +510,7 @@ func TestUnpackOuterPairSlice(t *testing.T) {
 		Terminal{},
 	)
 	var pairs []Pair
-	err := reflector.UnmarshalInto([]byte(outerPairSlice), &pairs)
+	err := reflector.Unmarshal([]byte(outerPairSlice), &pairs)
 	require.NoError(t, err)
 	assert.Equal(t, outerPairSliceExpected, pairs)
 }

--- a/service/ztests/curl-load-error.yaml
+++ b/service/ztests/curl-load-error.yaml
@@ -16,7 +16,7 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      {"type":"Error","kind":"invalid operation","error":"format detection error\n\tarrows: schema message length exceeds 1 MiB\n\tcsv: line 1: EOF\n\tjson: invalid character 'T' looking for beginning of value\n\tline: auto-detection not supported\n\tparquet: auto-detection requires seekable input\n\tvng: auto-detection requires seekable input\n\tzeek: line 1: bad types/fields definition in zeek header\n\tzjson: line 1: malformed ZJSON: bad type object: unpacker error parsing JSON: invalid character 'T' looking for beginning of value (\"This is not a detectable format.\")\n\tzng: malformed zng record\n\tzson: ZSON syntax error"}
+      {"type":"Error","kind":"invalid operation","error":"format detection error\n\tarrows: schema message length exceeds 1 MiB\n\tcsv: line 1: EOF\n\tjson: invalid character 'T' looking for beginning of value\n\tline: auto-detection not supported\n\tparquet: auto-detection requires seekable input\n\tvng: auto-detection requires seekable input\n\tzeek: line 1: bad types/fields definition in zeek header\n\tzjson: line 1: malformed ZJSON: bad type object: \"This is not a detectable format.\": unpacker error parsing JSON: invalid character 'T' looking for beginning of value\n\tzng: malformed zng record\n\tzson: ZSON syntax error"}
       code 400
       {"type":"Error","kind":"invalid operation","error":"unsupported MIME type: unsupported"}
       code 400

--- a/service/ztests/curl-load-error.yaml
+++ b/service/ztests/curl-load-error.yaml
@@ -16,7 +16,7 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      {"type":"Error","kind":"invalid operation","error":"format detection error\n\tarrows: schema message length exceeds 1 MiB\n\tcsv: line 1: EOF\n\tjson: invalid character 'T' looking for beginning of value\n\tline: auto-detection not supported\n\tparquet: auto-detection requires seekable input\n\tvng: auto-detection requires seekable input\n\tzeek: line 1: bad types/fields definition in zeek header\n\tzjson: line 1: invalid character 'T' looking for beginning of value\n\tzng: malformed zng record\n\tzson: ZSON syntax error"}
+      {"type":"Error","kind":"invalid operation","error":"format detection error\n\tarrows: schema message length exceeds 1 MiB\n\tcsv: line 1: EOF\n\tjson: invalid character 'T' looking for beginning of value\n\tline: auto-detection not supported\n\tparquet: auto-detection requires seekable input\n\tvng: auto-detection requires seekable input\n\tzeek: line 1: bad types/fields definition in zeek header\n\tzjson: line 1: malformed ZJSON: bad type object: unpacker error parsing JSON: invalid character 'T' looking for beginning of value (\"This is not a detectable format.\")\n\tzng: malformed zng record\n\tzson: ZSON syntax error"}
       code 400
       {"type":"Error","kind":"invalid operation","error":"unsupported MIME type: unsupported"}
       code 400

--- a/service/ztests/load-garbage.yaml
+++ b/service/ztests/load-garbage.yaml
@@ -20,7 +20,7 @@ outputs:
       	parquet: auto-detection requires seekable input
       	vng: auto-detection requires seekable input
       	zeek: line 1: bad types/fields definition in zeek header
-      	zjson: line 1: invalid character 'T' looking for beginning of value
+      	zjson: line 1: malformed ZJSON: bad type object: unpacker error parsing JSON: invalid character 'T' looking for beginning of value ("This file contains no records.")
       	zng: malformed zng record
       	zson: ZSON syntax error
       status code 400: no records in request

--- a/service/ztests/load-garbage.yaml
+++ b/service/ztests/load-garbage.yaml
@@ -20,7 +20,8 @@ outputs:
       	parquet: auto-detection requires seekable input
       	vng: auto-detection requires seekable input
       	zeek: line 1: bad types/fields definition in zeek header
-      	zjson: line 1: malformed ZJSON: bad type object: unpacker error parsing JSON: invalid character 'T' looking for beginning of value ("This file contains no records.")
+      	zjson: line 1: malformed ZJSON: bad type object: "This file contains no records.": unpacker error parsing JSON: invalid character 'T' looking for beginning of value
       	zng: malformed zng record
       	zson: ZSON syntax error
       status code 400: no records in request
+

--- a/zio/zjsonio/reader.go
+++ b/zio/zjsonio/reader.go
@@ -97,7 +97,7 @@ func (r *Reader) decodeValue(b *zcode.Builder, typ zed.Type, body interface{}) e
 		}
 		var t zType
 		if err := unpacker.UnmarshalObject(body, &t); err != nil {
-			return fmt.Errorf("zjsonio reader:type value is not a valid ZJSON type: %w", err)
+			return fmt.Errorf("type value is not a valid ZJSON type: %w", err)
 		}
 		local, err := r.decoder.decodeType(r.zctx, t)
 		if err != nil {

--- a/zio/zjsonio/reader.go
+++ b/zio/zjsonio/reader.go
@@ -95,13 +95,9 @@ func (r *Reader) decodeValue(b *zcode.Builder, typ zed.Type, body interface{}) e
 			b.Append(nil)
 			return nil
 		}
-		typeObj, err := unpacker.UnmarshalObject(body)
-		if err != nil {
-			return err
-		}
-		t, ok := typeObj.(zType)
-		if !ok {
-			return errors.New("type value is not a valid ZJSON type")
+		var t zType
+		if err := unpacker.UnmarshalObject(body, &t); err != nil {
+			return fmt.Errorf("zjsonio reader:type value is not a valid ZJSON type: %w", err)
 		}
 		local, err := r.decoder.decodeType(r.zctx, t)
 		if err != nil {

--- a/zio/zjsonio/writer.go
+++ b/zio/zjsonio/writer.go
@@ -20,7 +20,7 @@ type Object struct {
 func unmarshal(b []byte) (*Object, error) {
 	var object Object
 	if err := unpacker.Unmarshal(b, &object); err != nil {
-		return nil, fmt.Errorf("malformed ZJSON: bad type object: %w (%q)", err, bytes.TrimSpace(b))
+		return nil, fmt.Errorf("malformed ZJSON: bad type object: %q: %w", bytes.TrimSpace(b), err)
 	}
 	return &object, nil
 }

--- a/zio/zjsonio/writer.go
+++ b/zio/zjsonio/writer.go
@@ -18,33 +18,11 @@ type Object struct {
 }
 
 func unmarshal(b []byte) (*Object, error) {
-	var template struct {
-		Type  interface{} `json:"type"`
-		Value interface{} `json:"value"`
+	var object Object
+	if err := unpacker.Unmarshal(b, &object); err != nil {
+		return nil, fmt.Errorf("malformed ZJSON: bad type object: %w (%q)", err, bytes.TrimSpace(b))
 	}
-	if err := json.Unmarshal(b, &template); err != nil {
-		return nil, err
-	}
-	if template.Type == nil {
-		return nil, fmt.Errorf("malformed ZJSON: no type object in %q", bytes.TrimSpace(b))
-	}
-	// We should enhance the unpacker to take the template struct
-	// here so we don't have to call UnmarshalObject.  But not
-	// a big deal because we only do it for inbound ZJSON (which is
-	// not performance critical and only for typedefs which are
-	// typically infrequent.)  See issue #2702.
-	typeObj, err := unpacker.UnmarshalObject(template.Type)
-	if typeObj == nil || err != nil {
-		return nil, err
-	}
-	typ, ok := typeObj.(zType)
-	if !ok {
-		return nil, fmt.Errorf("ZJSON types object is not a type: %s", string(b))
-	}
-	return &Object{
-		Type:  typ,
-		Value: template.Value,
-	}, nil
+	return &object, nil
 }
 
 type Writer struct {


### PR DESCRIPTION
This commit further simplies the unpacker by adopting the method signature of json.Unmarshal.  Since reworking the packer design, it became apparent that the unpackVal method could be used with an arbitrary destination from the callee thereby providing the same semantics of json.Unmarshal, which simplifies the logic.

This also created an opportunity to simplify the zjson decoder to avoid the ugly workarounds with the previous unpack API.