### PR TITLE
Fix panic in zio/zngio.validStream

### DIFF
--- a/zio/zngio/trailer.go
+++ b/zio/zngio/trailer.go
@@ -146,7 +146,8 @@ func validStream(b []byte, off int) bool {
 			return false
 		}
 		len, ok := decodeLength(b[off:], code)
-		if !ok {
+		if !ok || len < 1 {
+			// len < 1 can loop forever or cause off < 0.
 			return false
 		}
 		off += len


### PR DESCRIPTION
A community zync user is seeing the following panic.  Fix it.

    panic: runtime error: index out of range [-5971847600436493240]

    goroutine 38595 [running]:
    github.com/brimdata/zed/zio/zngio.validStream({0xc056398980, 0x79, 0x79}, 0x112ca80?)
	    /go/pkg/mod/github.com/brimdata/zed@v1.7.0/zio/zngio/trailer.go:135 +0xe5
    github.com/brimdata/zed/zio/zngio.findCandidate({0xc056398980, 0x79, 0x79}, 0xc05cbb61c8?)
	    /go/pkg/mod/github.com/brimdata/zed@v1.7.0/zio/zngio/trailer.go:122 +0x5d
    github.com/brimdata/zed/zio/zngio.findTrailer({0xc056398980, 0x79, 0x79})
	    /go/pkg/mod/github.com/brimdata/zed@v1.7.0/zio/zngio/trailer.go:92 +0x92
    github.com/brimdata/zed/zio/zngio.ReadTrailer({0x7f93e43c4488?, 0xc03f07d970?}, 0x0?)
	    /go/pkg/mod/github.com/brimdata/zed@v1.7.0/zio/zngio/trailer.go:54 +0x45
    github.com/brimdata/zed/vng.readTrailer({0x7f93e43c4488?, 0xc03f07d970?}, 0x0?)
	    /go/pkg/mod/github.com/brimdata/zed@v1.7.0/vng/trailer.go:22 +0x2a
    github.com/brimdata/zed/vng.NewObject(0xc00068e780, {0x7f93e43c4488?, 0xc03f07d970}, 0x79)
	    /go/pkg/mod/github.com/brimdata/zed@v1.7.0/vng/object.go:36 +0x48
    github.com/brimdata/zed/zio/vngio.NewReader(0xc05cbb61c8?, {0x7f93e43c43f8, 0xc03f07d970})
	    /go/pkg/mod/github.com/brimdata/zed@v1.7.0/zio/vngio/reader.go:24 +0xa5
    github.com/brimdata/zed/zio/anyio.NewReaderWithOpts(0xc00068e780, {0x7f93e43c43f8?, 0xc03f07d970}, {{0x1236d88, 0x4}, {0x2c}, {0x0, 0x80000, 0x40000000, 0x0}})
	    /go/pkg/mod/github.com/brimdata/zed@v1.7.0/zio/anyio/reader.go:50 +0x194
    github.com/brimdata/zed/zio/anyio.NewFile(0x0?, {0x7f93e43c43d0?, 0xc03f07d970}, {0x7fff145c3524, 0x2c}, {{0x1236d88, 0x4}, {0x2c}, {0x0, 0x80000, ...}})
	    /go/pkg/mod/github.com/brimdata/zed@v1.7.0/zio/anyio/file.go:48 +0xac
    github.com/brimdata/zed/zio/anyio.Open.func1()
	    /go/pkg/mod/github.com/brimdata/zed@v1.7.0/zio/anyio/file.go:30 +0x17a
    created by github.com/brimdata/zed/zio/anyio.Open
	    /go/pkg/mod/github.com/brimdata/zed@v1.7.0/zio/anyio/file.go:21 +0x28e