### PR TITLE
Use PEP 440 version in python/zed/setup.py

### DIFF
--- a/python/zed/setup.py
+++ b/python/zed/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     python_requires='>=3.3',
     setup_requires=['setuptools_scm'],
     use_scm_version={
-        'fallback_version': 'unknown',
+        'fallback_version': '0+unknown',
         'root': '../..',
         'version_scheme': 'post-release',
     },


### PR DESCRIPTION
service/ztests/python.yaml and service/ztests/python-auth.yaml fail with Python 3.10 or better because setuptools now requires a package version that is valid according to PEP 440.  Fix that.