### PR TITLE
Fix zbuf.Control check in zngio.scanner.Pull

### DIFF
--- a/zio/zngio/scanner.go
+++ b/zio/zngio/scanner.go
@@ -84,9 +84,9 @@ func (s *scanner) Pull(done bool) (zbuf.Batch, error) {
 				continue
 			}
 			if result.Batch == nil || result.Err != nil {
-				if err, ok := result.Err.(*zbuf.Control); !ok {
+				if _, ok := result.Err.(*zbuf.Control); !ok {
 					s.eof = true
-					s.err = err
+					s.err = result.Err
 					s.cancel()
 				}
 			}


### PR DESCRIPTION
scanner.Pull sets scanner.eof to zbuf.Control(nil) instead of result.Err when result.Err isn't a zbuf.Control.  Fix that.

Closes #4459.