### PR TITLE
Change comment to show something other than a copyright

### DIFF
--- a/docs/language/overview.md
+++ b/docs/language/overview.md
@@ -99,7 +99,7 @@ To further ease the maintenance and readability of source files, comments
 beginning with `//` may appear in Zed.
 
 ```
-// Copyright (C) 2023 Fictional Corp Ultd. - All Rights Reserved
+// This includes a search with boolean logic, an expression, and an aggregation.
 
 search "example.com" AND "urgent"
 | where message_length > 100       // We only care about long messages


### PR DESCRIPTION
This example had tried to mimic how comments are often used for copyrights at the top of files kept in source control. However, @mccanne expressed confusion when he noticed it recently during a docs review, so here I'm changing it to something more generic.