### PR TITLE
Allow script-style ztests to run on Windows

### DIFF
--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -129,7 +129,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -329,11 +328,6 @@ func FromYAMLFile(filename string) (*ZTest, error) {
 
 func (z *ZTest) ShouldSkip(path string) string {
 	switch {
-	case z.Script != "" && runtime.GOOS == "windows":
-		// XXX skip in windows until we figure out the best
-		// way to support script-driven tests across
-		// environments
-		return "script test on Windows"
 	case z.Script != "" && path == "":
 		return "script test on in-process run"
 	case z.Skip != "":

--- a/ztest/ztest_test.go
+++ b/ztest/ztest_test.go
@@ -3,7 +3,6 @@ package ztest
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,19 +10,12 @@ import (
 )
 
 func TestShouldSkip(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		assert.Equal(t, "script test on Windows", (&ZTest{Script: "x"}).ShouldSkip(""))
-	} else {
-		assert.Equal(t, "script test on in-process run", (&ZTest{Script: "x"}).ShouldSkip(""))
-	}
+	assert.Equal(t, "script test on in-process run", (&ZTest{Script: "x"}).ShouldSkip(""))
 	assert.Equal(t, "reason", (&ZTest{Skip: "reason"}).ShouldSkip(""))
 	assert.Equal(t, `tag "x" does not match ZTEST_TAG=""`, (&ZTest{Tag: "x"}).ShouldSkip(""))
 }
 
 func TestRunScript(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on Windows because RunScript uses cmd.exe instead of bash")
-	}
 	t.Run("outputs", func(t *testing.T) {
 		testDir := t.TempDir()
 		require.NoError(t, os.WriteFile(filepath.Join(testDir, "testdirfile"), []byte("testdirfile\n"), 0644))


### PR DESCRIPTION
Script-style ztests require Bash on every OS and run with PATH set to the equivalent of "$ZTEST_PATH:$PATH".  This is a change from the previous value of "/bin:/usr/bin:$ZTEST_PATH".