### PR TITLE
Don't cancel context on SIGPIPE in "zed serve"

### DIFF
--- a/cmd/zed/root/command.go
+++ b/cmd/zed/root/command.go
@@ -1,7 +1,6 @@
 package root
 
 import (
-	"context"
 	"flag"
 
 	"github.com/brimdata/zed/cli"
@@ -21,23 +20,19 @@ querying, and orchestrating Zed data lakes.`,
 
 type Command struct {
 	charm.Command
+	cli.Flags
 	LakeFlags lakeflags.Flags
-	cli       cli.Flags
 }
 
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{}
-	c.cli.SetFlags(f)
+	c.SetFlags(f)
 	c.LakeFlags.SetFlags(f)
 	return c, nil
 }
 
-func (c *Command) Init(all ...cli.Initializer) (context.Context, func(), error) {
-	return c.cli.Init(all...)
-}
-
 func (c *Command) Run(args []string) error {
-	_, cancel, err := c.cli.Init()
+	_, cancel, err := c.Init()
 	if err != nil {
 		return err
 	}

--- a/cmd/zed/serve/command.go
+++ b/cmd/zed/serve/command.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"syscall"
 
 	"github.com/brimdata/zed/cli"
 	"github.com/brimdata/zed/cli/logflags"
@@ -65,7 +66,9 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 }
 
 func (c *Command) Run(args []string) error {
-	ctx, cleanup, err := c.Init()
+	// Don't include SIGPIPE here or else a write to a closed socket (i.e.,
+	// a broken network connection) will cancel the context on Linux.
+	ctx, cleanup, err := c.InitWithSignals(nil, syscall.SIGINT, syscall.SIGTERM)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
On Linux (but not macOS), "zed serve" exits if it writes to a closed socket (i.e., a broken network connection) because that raises SIGPIPE, canceling the context created by cmd/zed/serve.Command.Init due to the change in #4180.  Fix this by removing SIGPIPE from the list of signal.NotifyContext signals for "zed serve".

Closes #4498.