### PR TITLE
Use zed.Value constructors everywhere

### DIFF
--- a/index/writer.go
+++ b/index/writer.go
@@ -345,8 +345,7 @@ func (w *indexWriter) addToParentIndex(key *zed.Value, offset int64) error {
 
 func (w *indexWriter) writeIndexRecord(keys *zed.Value, offset int64) error {
 	fields := []zed.Field{{Name: w.base.childField, Type: zed.TypeInt64}}
-	val := zed.EncodeInt(offset)
-	rec, err := w.base.zctx.AddFields(keys, fields, []zed.Value{{Type: zed.TypeInt64, Bytes: val}})
+	rec, err := w.base.zctx.AddFields(keys, fields, []zed.Value{*zed.NewInt64(offset)})
 	if err != nil {
 		return err
 	}

--- a/runtime/expr/expr_test.go
+++ b/runtime/expr/expr_test.go
@@ -417,9 +417,13 @@ func TestArithmetic(t *testing.T) {
 			w = w2
 		}
 		if sign {
-			return zed.Value{Type: signed(w), Bytes: zed.AppendInt(nil, int64(v))}
+			val := zed.NewInt64(int64(v))
+			val.Type = signed(w)
+			return *val
 		}
-		return zed.Value{Type: unsigned(w), Bytes: zed.AppendUint(nil, v)}
+		val := zed.NewUint64(v)
+		val.Type = unsigned(w)
+		return *val
 	}
 
 	var intTypes = []string{"int8", "uint8", "int16", "uint16", "int32", "uint32", "int64", "uint64"}

--- a/runtime/expr/values.go
+++ b/runtime/expr/values.go
@@ -109,14 +109,10 @@ func (r *recordSpreadExpr) Eval(ectx Context, this *zed.Value) *zed.Value {
 			it := rec.Iter()
 			for _, f := range typ.Fields {
 				fv, ok := object[f.Name]
-				if ok {
-					fv.value = zed.Value{Type: f.Type, Bytes: it.Next()}
-				} else {
-					fv = fieldValue{
-						index: len(object),
-						value: zed.Value{Type: f.Type, Bytes: it.Next()},
-					}
+				if !ok {
+					fv = fieldValue{index: len(object)}
 				}
+				fv.value = *zed.NewValue(f.Type, it.Next())
 				object[f.Name] = fv
 			}
 		} else {

--- a/runtime/op/shape/shaper.go
+++ b/runtime/op/shape/shaper.go
@@ -85,8 +85,7 @@ func (i *integer) check(val zed.Value) {
 func (a *anchor) updateInts(rec *zed.Value) error {
 	it := rec.Bytes.Iter()
 	for k, f := range rec.Fields() {
-		val := zed.Value{Type: f.Type, Bytes: it.Next()}
-		a.integers[k].check(val)
+		a.integers[k].check(*zed.NewValue(f.Type, it.Next()))
 	}
 	return nil
 }

--- a/zio/csvio/writer.go
+++ b/zio/csvio/writer.go
@@ -93,5 +93,5 @@ func formatValue(typ zed.Type, bytes zcode.Bytes) string {
 	if typ.ID() < zed.IDTypeComplex {
 		return zson.FormatPrimitive(zed.TypeUnder(typ), bytes)
 	}
-	return zson.String(zed.Value{Type: typ, Bytes: bytes})
+	return zson.MustFormatValue(zed.NewValue(typ, bytes))
 }


### PR DESCRIPTION
This will make some planned changes to our use of Value.Bytes easier.