### PR TITLE
Remove zed.IsTrue in favor of zed.DecodeBool

### DIFF
--- a/lake/data/seekindex.go
+++ b/lake/data/seekindex.go
@@ -35,7 +35,7 @@ func LookupSeekRange(ctx context.Context, engine storage.Engine, path *storage.U
 			return ranges, err
 		}
 		result := pruner.Eval(ectx, val)
-		if result.Type == zed.TypeBool && zed.IsTrue(result.Bytes) {
+		if result.Type == zed.TypeBool && zed.DecodeBool(result.Bytes) {
 			rg = nil
 			continue
 		}

--- a/lake/pool.go
+++ b/lake/pool.go
@@ -182,7 +182,7 @@ func filter(zctx *zed.Context, ectx expr.Context, this *zed.Value, e expr.Evalua
 		return true
 	}
 	val, ok := expr.EvalBool(zctx, ectx, this, e)
-	return ok && val.Bytes != nil && zed.IsTrue(val.Bytes)
+	return ok && zed.DecodeBool(val.Bytes)
 }
 
 type BranchTip struct {

--- a/primitive.go
+++ b/primitive.go
@@ -18,13 +18,9 @@ type TypeOfBool struct{}
 var False = &Value{TypeBool, []byte{0}}
 var True = &Value{TypeBool, []byte{1}}
 
-func IsTrue(zv zcode.Bytes) bool {
-	return zv[0] != 0
-}
-
 // Not returns the inverse Value of the Boolean-typed bytes value of zb.
 func Not(zb zcode.Bytes) *Value {
-	if IsTrue(zb) {
+	if DecodeBool(zb) {
 		return False
 	}
 	return True

--- a/runtime/expr/agg.go
+++ b/runtime/expr/agg.go
@@ -34,7 +34,7 @@ func (a *Aggregator) NewFunction() agg.Function {
 
 func (a *Aggregator) Apply(zctx *zed.Context, ectx Context, f agg.Function, this *zed.Value) {
 	if a.where != nil {
-		if val, ok := EvalBool(zctx, ectx, this, a.where); !ok || val.Bytes == nil || !zed.IsTrue(val.Bytes) {
+		if val, ok := EvalBool(zctx, ectx, this, a.where); !ok || !zed.DecodeBool(val.Bytes) {
 			// XXX Issue #3401: do something with "where" errors.
 			return
 		}

--- a/runtime/expr/agg/logical.go
+++ b/runtime/expr/agg/logical.go
@@ -18,7 +18,7 @@ func (a *And) Consume(val *zed.Value) {
 		b := true
 		a.val = &b
 	}
-	*a.val = *a.val && zed.IsTrue(val.Bytes)
+	*a.val = *a.val && zed.DecodeBool(val.Bytes)
 }
 
 func (a *And) Result(*zed.Context) *zed.Value {
@@ -56,7 +56,7 @@ func (o *Or) Consume(val *zed.Value) {
 		b := false
 		o.val = &b
 	}
-	*o.val = *o.val || zed.IsTrue(val.Bytes)
+	*o.val = *o.val || zed.DecodeBool(val.Bytes)
 }
 
 func (o *Or) Result(*zed.Context) *zed.Value {

--- a/runtime/expr/eval.go
+++ b/runtime/expr/eval.go
@@ -38,7 +38,7 @@ func (n *Not) Eval(ectx Context, this *zed.Value) *zed.Value {
 	if !ok {
 		return val
 	}
-	if val.Bytes != nil && zed.IsTrue(val.Bytes) {
+	if zed.DecodeBool(val.Bytes) {
 		return zed.False
 	}
 	return zed.True
@@ -83,14 +83,14 @@ func (a *And) Eval(ectx Context, this *zed.Value) *zed.Value {
 	if !ok {
 		return lhs
 	}
-	if lhs.Bytes == nil || !zed.IsTrue(lhs.Bytes) {
+	if !zed.DecodeBool(lhs.Bytes) {
 		return zed.False
 	}
 	rhs, ok := EvalBool(a.zctx, ectx, this, a.rhs)
 	if !ok {
 		return rhs
 	}
-	if rhs.Bytes == nil || !zed.IsTrue(rhs.Bytes) {
+	if !zed.DecodeBool(rhs.Bytes) {
 		return zed.False
 	}
 	return zed.True
@@ -98,7 +98,7 @@ func (a *And) Eval(ectx Context, this *zed.Value) *zed.Value {
 
 func (o *Or) Eval(ectx Context, this *zed.Value) *zed.Value {
 	lhs, ok := EvalBool(o.zctx, ectx, this, o.lhs)
-	if ok && lhs.Bytes != nil && zed.IsTrue(lhs.Bytes) {
+	if ok && zed.DecodeBool(lhs.Bytes) {
 		return zed.True
 	}
 	if lhs.IsError() && !lhs.IsMissing() {
@@ -106,7 +106,7 @@ func (o *Or) Eval(ectx Context, this *zed.Value) *zed.Value {
 	}
 	rhs, ok := EvalBool(o.zctx, ectx, this, o.rhs)
 	if ok {
-		if rhs.Bytes != nil && zed.IsTrue(rhs.Bytes) {
+		if zed.DecodeBool(rhs.Bytes) {
 			return zed.True
 		}
 		return zed.False
@@ -812,7 +812,7 @@ func (c *Conditional) Eval(ectx Context, this *zed.Value) *zed.Value {
 		val := *c.zctx.NewErrorf("?-operator: bool predicate required")
 		return &val
 	}
-	if zed.IsTrue(val.Bytes) {
+	if zed.DecodeBool(val.Bytes) {
 		return c.thenExpr.Eval(ectx, this)
 	}
 	return c.elseExpr.Eval(ectx, this)

--- a/runtime/expr/filter.go
+++ b/runtime/expr/filter.go
@@ -255,7 +255,7 @@ func NewFilterApplier(zctx *zed.Context, e Evaluator) Applier {
 func (f *filterApplier) Eval(ectx Context, this *zed.Value) *zed.Value {
 	val, ok := EvalBool(f.zctx, ectx, this, f.expr)
 	if ok {
-		if zed.IsTrue(val.Bytes) {
+		if zed.DecodeBool(val.Bytes) {
 			return this
 		}
 		return f.zctx.Missing()

--- a/runtime/expr/filter_test.go
+++ b/runtime/expr/filter_test.go
@@ -36,7 +36,7 @@ func filter(ectx expr.Context, this *zed.Value, e expr.Evaluator) bool {
 		return true
 	}
 	val := e.Eval(ectx, this)
-	if val.Type == zed.TypeBool && zed.IsTrue(val.Bytes) {
+	if val.Type == zed.TypeBool && zed.DecodeBool(val.Bytes) {
 		return true
 	}
 	return false

--- a/runtime/op/meta/pruner.go
+++ b/runtime/op/meta/pruner.go
@@ -22,5 +22,5 @@ func (p *pruner) prune(val *zed.Value) bool {
 		return false
 	}
 	result := p.pred.Eval(p.ectx, val)
-	return result.Type == zed.TypeBool && zed.IsTrue(result.Bytes)
+	return result.Type == zed.TypeBool && zed.DecodeBool(result.Bytes)
 }

--- a/runtime/op/switcher/switch.go
+++ b/runtime/op/switcher/switch.go
@@ -52,7 +52,7 @@ func (s *Selector) Forward(router *op.Router, batch zbuf.Batch) bool {
 				//XXX don't break here?
 				//break
 			}
-			if val.Type == zed.TypeBool && val.Bytes != nil && zed.IsTrue(val.Bytes) {
+			if val.Type == zed.TypeBool && zed.DecodeBool(val.Bytes) {
 				c.vals = append(c.vals, *this)
 				break
 			}

--- a/zbuf/scanner.go
+++ b/zbuf/scanner.go
@@ -135,7 +135,7 @@ func (s *scanner) Read() (*zed.Value, error) {
 		atomic.AddInt64(&s.progress.RecordsRead, 1)
 		if s.filter != nil {
 			val := s.filter.Eval(s.ectx, this)
-			if !(val.Type == zed.TypeBool && zed.IsTrue(val.Bytes)) {
+			if !(val.Type == zed.TypeBool && zed.DecodeBool(val.Bytes)) {
 				continue
 			}
 		}

--- a/zio/zngio/scanner.go
+++ b/zio/zngio/scanner.go
@@ -348,5 +348,5 @@ func (w *worker) wantValue(val *zed.Value, progress *zbuf.Progress) bool {
 
 func check(ectx expr.Context, this *zed.Value, filter expr.Evaluator) bool {
 	val := filter.Eval(ectx, this)
-	return val.Type == zed.TypeBool && zed.IsTrue(val.Bytes)
+	return val.Type == zed.TypeBool && zed.DecodeBool(val.Bytes)
 }

--- a/zson/formatter.go
+++ b/zson/formatter.go
@@ -848,7 +848,7 @@ func formatPrimitive(b *strings.Builder, typ zed.Type, bytes zcode.Bytes) {
 			b.WriteString(strconv.FormatFloat(f, 'g', -1, 64))
 		}
 	case *zed.TypeOfBool:
-		if zed.IsTrue(bytes) {
+		if zed.DecodeBool(bytes) {
 			b.WriteString("true")
 		} else {
 			b.WriteString("false")


### PR DESCRIPTION
zed.IsTrue is redundant to zed.DecodeBool, which additionally checks for a nil argument.  That check isn't always necessary, but it never hurts.