### PR TITLE
Use zed.Value.IsNull where possible

### DIFF
--- a/runtime/expr/agg/any.go
+++ b/runtime/expr/agg/any.go
@@ -15,7 +15,7 @@ func NewAny() *Any {
 func (a *Any) Consume(val *zed.Value) {
 	// Copy any value from the input while favoring any-typed non-null values
 	// over null values.
-	if a.Type == nil || (a.Bytes == nil && val.Bytes != nil) {
+	if a.Type == nil || (*zed.Value)(a).IsNull() && !val.IsNull() {
 		*a = Any(*val.Copy())
 	}
 }

--- a/runtime/expr/agg/math.go
+++ b/runtime/expr/agg/math.go
@@ -101,7 +101,7 @@ type Float64 struct {
 
 func NewFloat64(f *anymath.Function, val *zed.Value) *Float64 {
 	state := f.Init.Float64
-	if val.Bytes != nil {
+	if !val.IsNull() {
 		var ok bool
 		state, ok = coerce.ToFloat(val)
 		if !ok {

--- a/runtime/expr/cast.go
+++ b/runtime/expr/cast.go
@@ -211,7 +211,7 @@ func (c *casterTime) Eval(ectx Context, val *zed.Value) *zed.Value {
 	switch {
 	case id == zed.IDTime:
 		return ectx.CopyValue(val)
-	case val.Bytes == nil:
+	case val.IsNull():
 		// Do nothing. Any nil value is cast to a zero time.
 	case id == zed.IDString:
 		gotime, err := dateparse.ParseAny(byteconv.UnsafeString(val.Bytes))

--- a/runtime/expr/eval.go
+++ b/runtime/expr/eval.go
@@ -582,22 +582,22 @@ func (u *UnaryMinus) Eval(ectx Context, this *zed.Value) *zed.Value {
 	typ := val.Type
 	switch typ.ID() {
 	case zed.IDFloat16:
-		if val.Bytes == nil {
+		if val.IsNull() {
 			return val
 		}
 		return ectx.NewValue(typ, zed.EncodeFloat16(-zed.DecodeFloat16(val.Bytes)))
 	case zed.IDFloat32:
-		if val.Bytes == nil {
+		if val.IsNull() {
 			return val
 		}
 		return ectx.NewValue(typ, zed.EncodeFloat32(-zed.DecodeFloat32(val.Bytes)))
 	case zed.IDFloat64:
-		if val.Bytes == nil {
+		if val.IsNull() {
 			return val
 		}
 		return ectx.NewValue(typ, zed.EncodeFloat64(-zed.DecodeFloat64(val.Bytes)))
 	case zed.IDInt8:
-		if val.Bytes == nil {
+		if val.IsNull() {
 			return val
 		}
 		v := zed.DecodeInt(val.Bytes)
@@ -606,7 +606,7 @@ func (u *UnaryMinus) Eval(ectx Context, this *zed.Value) *zed.Value {
 		}
 		return ectx.NewValue(typ, zed.EncodeInt(-v))
 	case zed.IDInt16:
-		if val.Bytes == nil {
+		if val.IsNull() {
 			return val
 		}
 		v := zed.DecodeInt(val.Bytes)
@@ -615,7 +615,7 @@ func (u *UnaryMinus) Eval(ectx Context, this *zed.Value) *zed.Value {
 		}
 		return ectx.NewValue(typ, zed.EncodeInt(-v))
 	case zed.IDInt32:
-		if val.Bytes == nil {
+		if val.IsNull() {
 			return val
 		}
 		v := zed.DecodeInt(val.Bytes)
@@ -624,7 +624,7 @@ func (u *UnaryMinus) Eval(ectx Context, this *zed.Value) *zed.Value {
 		}
 		return ectx.NewValue(typ, zed.EncodeInt(-v))
 	case zed.IDInt64:
-		if val.Bytes == nil {
+		if val.IsNull() {
 			return val
 		}
 		v := zed.DecodeInt(val.Bytes)
@@ -633,7 +633,7 @@ func (u *UnaryMinus) Eval(ectx Context, this *zed.Value) *zed.Value {
 		}
 		return ectx.NewValue(typ, zed.EncodeInt(-v))
 	case zed.IDUint8:
-		if val.Bytes == nil {
+		if val.IsNull() {
 			return val
 		}
 		v := zed.DecodeUint(val.Bytes)
@@ -642,7 +642,7 @@ func (u *UnaryMinus) Eval(ectx Context, this *zed.Value) *zed.Value {
 		}
 		return ectx.NewValue(zed.TypeInt8, zed.EncodeInt(-int64(v)))
 	case zed.IDUint16:
-		if val.Bytes == nil {
+		if val.IsNull() {
 			return val
 		}
 		v := zed.DecodeUint(val.Bytes)
@@ -651,7 +651,7 @@ func (u *UnaryMinus) Eval(ectx Context, this *zed.Value) *zed.Value {
 		}
 		return ectx.NewValue(zed.TypeInt16, zed.EncodeInt(-int64(v)))
 	case zed.IDUint32:
-		if val.Bytes == nil {
+		if val.IsNull() {
 			return val
 		}
 		v := zed.DecodeUint(val.Bytes)
@@ -660,7 +660,7 @@ func (u *UnaryMinus) Eval(ectx Context, this *zed.Value) *zed.Value {
 		}
 		return ectx.NewValue(zed.TypeInt32, zed.EncodeInt(-int64(v)))
 	case zed.IDUint64:
-		if val.Bytes == nil {
+		if val.IsNull() {
 			return val
 		}
 		v := zed.DecodeUint(val.Bytes)

--- a/runtime/expr/function/bytes.go
+++ b/runtime/expr/function/bytes.go
@@ -17,12 +17,12 @@ func (b *Base64) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	val := args[0]
 	switch val.Type.ID() {
 	case zed.IDBytes:
-		if val.Bytes == nil {
+		if val.IsNull() {
 			return newErrorf(b.zctx, ctx, "base64: illegal null argument")
 		}
 		return newString(ctx, base64.StdEncoding.EncodeToString(val.Bytes))
 	case zed.IDString:
-		if val.Bytes == nil {
+		if val.IsNull() {
 			return zed.Null
 		}
 		bytes, err := base64.StdEncoding.DecodeString(zed.DecodeString(val.Bytes))
@@ -44,12 +44,12 @@ func (h *Hex) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	val := args[0]
 	switch val.Type.ID() {
 	case zed.IDBytes:
-		if val.Bytes == nil {
+		if val.IsNull() {
 			return newErrorf(h.zctx, ctx, "hex: illegal null argument")
 		}
 		return newString(ctx, hex.EncodeToString(val.Bytes))
 	case zed.IDString:
-		if val.Bytes == nil {
+		if val.IsNull() {
 			return zed.NullString
 		}
 		b, err := hex.DecodeString(zed.DecodeString(val.Bytes))

--- a/runtime/expr/function/ksuid.go
+++ b/runtime/expr/function/ksuid.go
@@ -18,7 +18,7 @@ func (k *KSUIDToString) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	val := args[0]
 	switch val.Type.ID() {
 	case zed.IDBytes:
-		if val.Bytes == nil {
+		if val.IsNull() {
 			return newErrorf(k.zctx, ctx, "ksuid: illegal null argument")
 		}
 		// XXX GC

--- a/runtime/expr/function/parse.go
+++ b/runtime/expr/function/parse.go
@@ -18,7 +18,7 @@ type ParseURI struct {
 
 func (p *ParseURI) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	in := args[0]
-	if !in.IsString() || in.Bytes == nil {
+	if !in.IsString() || in.IsNull() {
 		return newErrorf(p.zctx, ctx, "parse_uri: non-empty string arg required")
 	}
 	s := zed.DecodeString(in.Bytes)
@@ -86,7 +86,7 @@ func (p *ParseZSON) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if !in.IsString() {
 		return newErrorf(p.zctx, ctx, "parse_zson: string arg required")
 	}
-	if in.Bytes == nil {
+	if in.IsNull() {
 		return zed.Null
 	}
 	s := zed.DecodeString(in.Bytes)

--- a/runtime/expr/function/regexp.go
+++ b/runtime/expr/function/regexp.go
@@ -57,10 +57,10 @@ func (r *RegexpReplace) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if !sVal.IsString() || !reVal.IsString() || !newVal.IsString() {
 		return newErrorf(r.zctx, ctx, "regexp_replace: string values required for all args")
 	}
-	if sVal.Bytes == nil {
+	if sVal.IsNull() {
 		return zed.Null
 	}
-	if reVal.Bytes == nil || newVal.Bytes == nil {
+	if reVal.IsNull() || newVal.IsNull() {
 		return newErrorf(r.zctx, ctx, "regexp_replace: 2nd and 3rd args cannot be null")
 	}
 	if re := zed.DecodeString(reVal.Bytes); r.restr != re {

--- a/runtime/expr/function/string.go
+++ b/runtime/expr/function/string.go
@@ -21,10 +21,10 @@ func (r *Replace) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if !sVal.IsString() || !oldVal.IsString() || !newVal.IsString() {
 		return newErrorf(r.zctx, ctx, "replace: string arg required")
 	}
-	if sVal.Bytes == nil {
+	if sVal.IsNull() {
 		return zed.Null
 	}
-	if oldVal.Bytes == nil || newVal.Bytes == nil {
+	if oldVal.IsNull() || newVal.IsNull() {
 		return newErrorf(r.zctx, ctx, "replace: an input arg is null")
 	}
 	s := zed.DecodeString(sVal.Bytes)
@@ -43,7 +43,7 @@ func (r *RuneLen) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if !val.IsString() {
 		return newErrorf(r.zctx, ctx, "rune_len: string arg required")
 	}
-	if val.Bytes == nil {
+	if val.IsNull() {
 		return newInt64(ctx, 0)
 	}
 	s := zed.DecodeString(val.Bytes)

--- a/value.go
+++ b/value.go
@@ -146,7 +146,7 @@ func (v *Value) ContainerLength() (int, error) {
 		}
 		return n, nil
 	case *TypeMap:
-		if v.Bytes == nil {
+		if v.IsNull() {
 			return 0, nil
 		}
 		var n int
@@ -176,9 +176,9 @@ func (v *Value) Copy() *Value {
 // to nil if and only if from.Bytes is nil.
 func (v *Value) CopyFrom(from *Value) {
 	v.Type = from.Type
-	if from.Bytes == nil {
+	if from.IsNull() {
 		v.Bytes = nil
-	} else if v.Bytes == nil {
+	} else if v.IsNull() {
 		v.Bytes = slices.Clone(from.Bytes)
 	} else {
 		v.Bytes = append(v.Bytes[:0], from.Bytes...)

--- a/zbuf/batch.go
+++ b/zbuf/batch.go
@@ -128,7 +128,7 @@ func newPullerBatch() *pullerBatch {
 func (b *pullerBatch) appendVal(val *zed.Value) bool {
 	var bytes []byte
 	var bufFull bool
-	if val.Bytes != nil {
+	if !val.IsNull() {
 		if avail := cap(b.buf) - len(b.buf); avail >= len(val.Bytes) {
 			// Append to b.buf since that won't reallocate.
 			start := len(b.buf)

--- a/zio/zeekio/format.go
+++ b/zio/zeekio/format.go
@@ -203,7 +203,7 @@ func formatUnion(t *zed.TypeUnion, zv zcode.Bytes) string {
 }
 
 func FormatValue(v *zed.Value) string {
-	if v.Bytes == nil {
+	if v.IsNull() {
 		return "-"
 	}
 	return formatAny(v, false)

--- a/zson/marshal.go
+++ b/zson/marshal.go
@@ -732,7 +732,7 @@ func (u *UnmarshalZNGContext) decodeAny(val *zed.Value, v reflect.Value) error {
 		v.Set(reflect.Zero(v.Type()))
 		return nil
 	}
-	if v.Kind() == reflect.Pointer && val.Bytes == nil {
+	if v.Kind() == reflect.Pointer && val.IsNull() {
 		return u.decodeNull(val, v)
 	}
 	switch v.Kind() {
@@ -854,7 +854,7 @@ func indirect(v reflect.Value, val *zed.Value) (ZNGUnmarshaler, reflect.Value) {
 	}
 	var nilptr reflect.Value
 	for v.Kind() == reflect.Pointer {
-		if v.CanSet() && val.Bytes == nil {
+		if v.CanSet() && val.IsNull() {
 			// If the reflect value can be set and the zed Value is nil we want
 			// to store this pointer since if destination is not a zed.Value the
 			// pointer will be set to nil.
@@ -916,7 +916,7 @@ func (u *UnmarshalZNGContext) decodeMap(val *zed.Value, mapVal reflect.Value) er
 	if !ok {
 		return errors.New("not a map")
 	}
-	if val.Bytes == nil {
+	if val.IsNull() {
 		// XXX The inner types of the null should be checked.
 		mapVal.Set(reflect.Zero(mapVal.Type()))
 		return nil
@@ -975,7 +975,7 @@ func (u *UnmarshalZNGContext) decodeRecord(val *zed.Value, sval reflect.Value) e
 func (u *UnmarshalZNGContext) decodeArray(val *zed.Value, arrVal reflect.Value) error {
 	typ := zed.TypeUnder(val.Type)
 	if typ == zed.TypeBytes && arrVal.Type().Elem().Kind() == reflect.Uint8 {
-		if val.Bytes == nil {
+		if val.IsNull() {
 			arrVal.Set(reflect.Zero(arrVal.Type()))
 			return nil
 		}
@@ -990,7 +990,7 @@ func (u *UnmarshalZNGContext) decodeArray(val *zed.Value, arrVal reflect.Value) 
 	if !ok {
 		return fmt.Errorf("unmarshaling type %q: not an array", String(typ))
 	}
-	if val.Bytes == nil {
+	if val.IsNull() {
 		// XXX The inner type of the null should be checked.
 		arrVal.Set(reflect.Zero(arrVal.Type()))
 		return nil


### PR DESCRIPTION
This is preparatory to replacing the Value.Bytes field with a method of the same name, which will sometimes (i.e., when a primitive value is stored natively) be substantially more expensive than IsNull.