### PR TITLE
Change Zealot links & refs to zed-js

### DIFF
--- a/docs/formats/README.md
+++ b/docs/formats/README.md
@@ -274,7 +274,7 @@ values.
 embodies Zed's more general model for heterogeneous and self-describing schemas.
 * [Zed over JSON](zjson.md) defines a JSON format for encapsulating Zed data
 in JSON for easy decoding by JSON-based clients, e.g.,
-the [Zealot JavaScript library](https://github.com/brimdata/zui/tree/main/packages/zealot)
+the [zed-js JavaScript library](https://github.com/brimdata/zealot/tree/main/packages/zed-js)
 and the [Zed Python library](../libraries/python.md).
 
 Because all of the formats conform to the same Zed data model, conversions between

--- a/docs/formats/zjson.md
+++ b/docs/formats/zjson.md
@@ -65,7 +65,7 @@ so appropriate for a [super-structured data model](./README.md#2-zed-a-super-str
 like Zed.  That said, JSON can be used as an encoding format for Zed by mapping Zed data
 onto a JSON-based protocol.  This allows clients like web apps or
 Electron apps to receive and understand Zed and, with the help of client
-libraries like [Zealot](https://github.com/brimdata/zui/tree/main/packages/zealot),
+libraries like [zed-js](https://github.com/brimdata/zealot/tree/main/packages/zed-js),
 to manipulate the rich, structured Zed types that are implemented on top of
 the basic JavaScript types.
 

--- a/docs/libraries/javascript.md
+++ b/docs/libraries/javascript.md
@@ -5,11 +5,11 @@ sidebar_label: JavaScript
 
 # JavaScript
 
-The [Zealot library](https://github.com/brimdata/zui/tree/main/packages/zealot)
+The [zed-js library](https://github.com/brimdata/zealot/tree/main/packages/zed-js)
 provides support for the Zed data model from within
 JavaScript as well as methods for communicating with a Zed lake.
 
-Because JavaScript's native type system is limtied, Zealot provides
+Because JavaScript's native type system is limtied, zed-js provides
 implementations for each of Zed's primitive types as well as
 technique for interpreting and/or constructing arbitrary complex types.
 


### PR DESCRIPTION
https://github.com/brimdata/zui/pull/2759 finalized the move from the JavaScript library being called "Zealot" and living in Zui's `packages/zealot/` directory to it being called "zed-js" and living in https://github.com/brimdata/zealot/tree/main/packages/zed-js in the Zealot mono repo. The library had been referenced in a handful of places in the Zed docs so those links started failing last night because of the merge of https://github.com/brimdata/zui/pull/2759 yesterday.

This PR fixes the markdown link checker failures within the Zed repo. Once this merges, I'll make the same changes to the older tagged Zed docs versions on zed-docs-site since those links break when the other link checker tries to run on the rendered docs site.