### PR TITLE
Convert Value.Bytes to method

### DIFF
--- a/compiler/kernel/bufferfilter.go
+++ b/compiler/kernel/bufferfilter.go
@@ -61,7 +61,7 @@ func CompileBufferFilter(zctx *zed.Context, e dag.Expr) (*expr.BufferFilter, err
 		case zed.TypeNet:
 			return nil, nil
 		case zed.TypeString:
-			pattern := norm.NFC.Bytes(literal.Bytes)
+			pattern := norm.NFC.Bytes(literal.Bytes())
 			left := expr.NewBufferFilterForStringCase(string(pattern))
 			if left == nil {
 				return nil, nil

--- a/compiler/kernel/expr.go
+++ b/compiler/kernel/expr.go
@@ -202,7 +202,7 @@ func (b *Builder) compileSearch(search *dag.Search) (expr.Evaluator, error) {
 	if zed.TypeUnder(val.Type) == zed.TypeString {
 		// Do a grep-style substring search instead of an
 		// exact match on each value.
-		term := norm.NFC.Bytes(val.Bytes)
+		term := norm.NFC.Bytes(val.Bytes())
 		return expr.NewSearchString(string(term), e), nil
 	}
 	return expr.NewSearch(search.Text, val, e)

--- a/compiler/semantic/expr.go
+++ b/compiler/semantic/expr.go
@@ -416,7 +416,7 @@ func (a *analyzer) isIndexOfThis(lhs, rhs dag.Expr) *dag.This {
 func isStringConst(zctx *zed.Context, e dag.Expr) (field string, ok bool) {
 	val, err := kernel.EvalAtCompileTime(zctx, e)
 	if err == nil && !val.IsError() && zed.TypeUnder(val.Type) == zed.TypeString {
-		return string(val.Bytes), true
+		return string(val.Bytes()), true
 	}
 	return "", false
 }

--- a/compiler/semantic/scope.go
+++ b/compiler/semantic/scope.go
@@ -77,7 +77,7 @@ func (s *Scope) DefineConst(zctx *zed.Context, name string, def dag.Expr) error 
 		if val.IsMissing() {
 			return fmt.Errorf("const %q: cannot have variable dependency", name)
 		} else {
-			return fmt.Errorf("const %q: %q", name, string(val.Bytes))
+			return fmt.Errorf("const %q: %q", name, string(val.Bytes()))
 		}
 	}
 	literal := &dag.Literal{

--- a/context.go
+++ b/context.go
@@ -291,7 +291,7 @@ func (c *Context) AddFields(r *Value, newFields []Field, vals []Value) (*Value, 
 		}
 		fields = append(fields, f)
 	}
-	zv := slices.Clone(r.Bytes)
+	zv := slices.Clone(r.Bytes())
 	for _, val := range vals {
 		zv = val.Encode(zv)
 	}
@@ -577,6 +577,6 @@ func (c *Context) WrapError(msg string, val *Value) *Value {
 	errType := c.LookupTypeError(recType)
 	var b zcode.Builder
 	b.Append(EncodeString(msg))
-	b.Append(val.Bytes)
+	b.Append(val.Bytes())
 	return &Value{errType, b.Bytes()}
 }

--- a/lake/data/seekindex.go
+++ b/lake/data/seekindex.go
@@ -35,7 +35,7 @@ func LookupSeekRange(ctx context.Context, engine storage.Engine, path *storage.U
 			return ranges, err
 		}
 		result := pruner.Eval(ectx, val)
-		if result.Type == zed.TypeBool && zed.DecodeBool(result.Bytes) {
+		if result.Type == zed.TypeBool && zed.DecodeBool(result.Bytes()) {
 			rg = nil
 			continue
 		}

--- a/lake/data/writer.go
+++ b/lake/data/writer.go
@@ -73,7 +73,7 @@ func (w *Writer) Write(val *zed.Value) error {
 }
 
 func (w *Writer) writeIndex(key *zed.Value) error {
-	w.seekIndexTrigger += len(key.Bytes)
+	w.seekIndexTrigger += len(key.Bytes())
 	if w.first {
 		w.first = false
 		w.object.Min.CopyFrom(key)

--- a/lake/journal/store.go
+++ b/lake/journal/store.go
@@ -162,7 +162,7 @@ func (s *Store) getSnapshot(ctx context.Context) (ID, map[string]Entry, error) {
 	if val.Type.ID() != zed.IDUint64 {
 		return Nil, table, errors.New("corrupted journal snapshot")
 	}
-	at := ID(zed.DecodeUint(val.Bytes))
+	at := ID(zed.DecodeUint(val.Bytes()))
 	for {
 		val, err := zr.Read()
 		if val == nil || err != nil {

--- a/lake/pool.go
+++ b/lake/pool.go
@@ -182,7 +182,7 @@ func filter(zctx *zed.Context, ectx expr.Context, this *zed.Value, e expr.Evalua
 		return true
 	}
 	val, ok := expr.EvalBool(zctx, ectx, this, e)
-	return ok && zed.DecodeBool(val.Bytes)
+	return ok && zed.DecodeBool(val.Bytes())
 }
 
 type BranchTip struct {

--- a/lake/writer.go
+++ b/lake/writer.go
@@ -85,7 +85,7 @@ func (w *Writer) Write(rec *zed.Value) error {
 	// recycled buffer and keep around an array of ts + byte-slice structs for
 	// sorting.
 	w.vals = append(w.vals, *rec.Copy())
-	w.memBuffered += int64(len(rec.Bytes))
+	w.memBuffered += int64(len(rec.Bytes()))
 	//XXX change name LogSizeThreshold
 	// XXX the previous logic estimated the object size with divide by 2...?!
 	if w.memBuffered >= w.pool.Threshold {

--- a/order/direction.go
+++ b/order/direction.go
@@ -77,7 +77,7 @@ func (d Direction) MarshalZNG(m *zson.MarshalZNGContext) (zed.Type, error) {
 }
 
 func (d *Direction) UnmarshalZNG(u *zson.UnmarshalZNGContext, val *zed.Value) error {
-	dir, err := ParseDirection(string(val.Bytes))
+	dir, err := ParseDirection(string(val.Bytes()))
 	if err != nil {
 		return err
 	}

--- a/order/which.go
+++ b/order/which.go
@@ -59,7 +59,7 @@ func (w Which) MarshalZNG(m *zson.MarshalZNGContext) (zed.Type, error) {
 }
 
 func (w *Which) UnmarshalZNG(u *zson.UnmarshalZNGContext, val *zed.Value) error {
-	which, err := Parse(string(val.Bytes))
+	which, err := Parse(string(val.Bytes()))
 	if err != nil {
 		return err
 	}

--- a/runtime/exec/stats.go
+++ b/runtime/exec/stats.go
@@ -35,8 +35,8 @@ func GetPoolStats(ctx context.Context, p *lake.Pool, snap commits.View) (info Po
 	if poolSpan != nil {
 		min := poolSpan.First()
 		if min.Type == zed.TypeTime {
-			firstTs := zed.DecodeTime(min.Bytes)
-			lastTs := zed.DecodeTime(poolSpan.Last().Bytes)
+			firstTs := zed.DecodeTime(min.Bytes())
+			lastTs := zed.DecodeTime(poolSpan.Last().Bytes())
 			if lastTs < firstTs {
 				firstTs, lastTs = lastTs, firstTs
 			}
@@ -70,8 +70,8 @@ func GetBranchStats(ctx context.Context, b *lake.Branch, snap commits.View) (inf
 	if poolSpan != nil {
 		min := poolSpan.First()
 		if min.Type == zed.TypeTime {
-			firstTs := zed.DecodeTime(min.Bytes)
-			lastTs := zed.DecodeTime(poolSpan.Last().Bytes)
+			firstTs := zed.DecodeTime(min.Bytes())
+			lastTs := zed.DecodeTime(poolSpan.Last().Bytes())
 			if lastTs < firstTs {
 				firstTs, lastTs = lastTs, firstTs
 			}

--- a/runtime/expr/agg.go
+++ b/runtime/expr/agg.go
@@ -34,7 +34,7 @@ func (a *Aggregator) NewFunction() agg.Function {
 
 func (a *Aggregator) Apply(zctx *zed.Context, ectx Context, f agg.Function, this *zed.Value) {
 	if a.where != nil {
-		if val, ok := EvalBool(zctx, ectx, this, a.where); !ok || !zed.DecodeBool(val.Bytes) {
+		if val, ok := EvalBool(zctx, ectx, this, a.where); !ok || !zed.DecodeBool(val.Bytes()) {
 			// XXX Issue #3401: do something with "where" errors.
 			return
 		}

--- a/runtime/expr/agg/avg.go
+++ b/runtime/expr/agg/avg.go
@@ -54,8 +54,8 @@ func (a *Avg) ConsumeAsPartial(partial *zed.Value) {
 	if countVal.Type != zed.TypeUint64 {
 		panic(fmt.Errorf("avg: partial count has bad type: %s", zson.MustFormatValue(countVal)))
 	}
-	a.sum += zed.DecodeFloat64(sumVal.Bytes)
-	a.count += zed.DecodeUint(countVal.Bytes)
+	a.sum += zed.DecodeFloat64(sumVal.Bytes())
+	a.count += zed.DecodeUint(countVal.Bytes())
 }
 
 func (a *Avg) ResultAsPartial(zctx *zed.Context) *zed.Value {

--- a/runtime/expr/agg/collect.go
+++ b/runtime/expr/agg/collect.go
@@ -23,12 +23,12 @@ func (c *Collect) Consume(val *zed.Value) {
 
 func (c *Collect) update(val *zed.Value) {
 	c.values = append(c.values, *val.Copy())
-	c.size += len(val.Bytes)
+	c.size += len(val.Bytes())
 	for c.size > MaxValueSize {
 		// XXX See issue #1813.  For now we silently discard entries
 		// to maintain the size limit.
 		//c.MemExceeded++
-		c.size -= len(c.values[0].Bytes)
+		c.size -= len(c.values[0].Bytes())
 		c.values = c.values[1:]
 	}
 }
@@ -42,11 +42,11 @@ func (c *Collect) Result(zctx *zed.Context) *zed.Value {
 	inner := innerType(zctx, c.values)
 	if union, ok := inner.(*zed.TypeUnion); ok {
 		for _, val := range c.values {
-			zed.BuildUnion(&b, union.TagOf(val.Type), val.Bytes)
+			zed.BuildUnion(&b, union.TagOf(val.Type), val.Bytes())
 		}
 	} else {
 		for _, val := range c.values {
-			b.Append(val.Bytes)
+			b.Append(val.Bytes())
 		}
 	}
 	return zed.NewValue(zctx.LookupTypeArray(inner), b.Bytes())
@@ -66,7 +66,7 @@ func innerType(zctx *zed.Context, vals []zed.Value) zed.Type {
 
 func (c *Collect) ConsumeAsPartial(val *zed.Value) {
 	//XXX These should not be passed in here. See issue #3175
-	if len(val.Bytes) == 0 {
+	if len(val.Bytes()) == 0 {
 		return
 	}
 	arrayType, ok := val.Type.(*zed.TypeArray)

--- a/runtime/expr/agg/count.go
+++ b/runtime/expr/agg/count.go
@@ -20,7 +20,7 @@ func (c *Count) ConsumeAsPartial(partial *zed.Value) {
 	if partial.Type != zed.TypeUint64 {
 		panic("count: partial not uint64")
 	}
-	*c += Count(zed.DecodeUint(partial.Bytes))
+	*c += Count(zed.DecodeUint(partial.Bytes()))
 }
 
 func (c Count) ResultAsPartial(*zed.Context) *zed.Value {

--- a/runtime/expr/agg/dcount.go
+++ b/runtime/expr/agg/dcount.go
@@ -29,7 +29,7 @@ func (d *DCount) Consume(val *zed.Value) {
 	// append type id to vals so we get a unique count where the bytes are same
 	// but the zed.Type is different.
 	d.scratch = zed.AppendInt(d.scratch, int64(val.Type.ID()))
-	d.scratch = append(d.scratch, val.Bytes...)
+	d.scratch = append(d.scratch, val.Bytes()...)
 	d.sketch.Insert(d.scratch)
 }
 
@@ -42,7 +42,7 @@ func (d *DCount) ConsumeAsPartial(partial *zed.Value) {
 		panic(fmt.Errorf("dcount: partial has bad type: %s", zson.MustFormatValue(partial)))
 	}
 	var s hyperloglog.Sketch
-	if err := s.UnmarshalBinary(partial.Bytes); err != nil {
+	if err := s.UnmarshalBinary(partial.Bytes()); err != nil {
 		panic(fmt.Errorf("dcount: unmarshaling partial: %w", err))
 	}
 	d.sketch.Merge(&s)

--- a/runtime/expr/agg/fuse.go
+++ b/runtime/expr/agg/fuse.go
@@ -31,7 +31,7 @@ func (f *fuse) Result(zctx *zed.Context) *zed.Value {
 	}
 	schema := NewSchema(zctx)
 	for _, p := range f.partials {
-		typ, err := zctx.LookupByValue(p.Bytes)
+		typ, err := zctx.LookupByValue(p.Bytes())
 		if err != nil {
 			panic(fmt.Errorf("fuse: invalid partial value: %w", err))
 		}

--- a/runtime/expr/agg/logical.go
+++ b/runtime/expr/agg/logical.go
@@ -18,7 +18,7 @@ func (a *And) Consume(val *zed.Value) {
 		b := true
 		a.val = &b
 	}
-	*a.val = *a.val && zed.DecodeBool(val.Bytes)
+	*a.val = *a.val && zed.DecodeBool(val.Bytes())
 }
 
 func (a *And) Result(*zed.Context) *zed.Value {
@@ -56,7 +56,7 @@ func (o *Or) Consume(val *zed.Value) {
 		b := false
 		o.val = &b
 	}
-	*o.val = *o.val || zed.DecodeBool(val.Bytes)
+	*o.val = *o.val || zed.DecodeBool(val.Bytes())
 }
 
 func (o *Or) Result(*zed.Context) *zed.Value {

--- a/runtime/expr/agg/map.go
+++ b/runtime/expr/agg/map.go
@@ -31,7 +31,7 @@ func (m *Map) Consume(val *zed.Value) {
 		return
 	}
 	// Copy val.Bytes since we're going to keep slices of it.
-	it := zcode.Iter(slices.Clone(val.Bytes))
+	it := zcode.Iter(slices.Clone(val.Bytes()))
 	for !it.Done() {
 		keyTagAndBody := it.NextTagAndBody()
 		key := valueUnder(mtyp.KeyType, keyTagAndBody.Body())
@@ -78,9 +78,9 @@ func (m *Map) ResultAsPartial(zctx *zed.Context) *zed.Value {
 func appendMapVal(b *zcode.Builder, typ zed.Type, val *zed.Value, uniq int) {
 	if uniq > 1 {
 		u := zed.TypeUnder(typ).(*zed.TypeUnion)
-		zed.BuildUnion(b, u.TagOf(val.Type), val.Bytes)
+		zed.BuildUnion(b, u.TagOf(val.Type), val.Bytes())
 	} else {
-		b.Append(val.Bytes)
+		b.Append(val.Bytes())
 	}
 }
 

--- a/runtime/expr/agg/union.go
+++ b/runtime/expr/agg/union.go
@@ -22,7 +22,7 @@ func (u *Union) Consume(val *zed.Value) {
 	if val.IsNull() {
 		return
 	}
-	u.update(val.Type, val.Bytes)
+	u.update(val.Type, val.Bytes())
 }
 
 func (u *Union) update(typ zed.Type, b zcode.Bytes) {

--- a/runtime/expr/boolean.go
+++ b/runtime/expr/boolean.go
@@ -46,7 +46,7 @@ func CompareBool(op string, pattern bool) (Boolean, error) {
 		if val.Type.ID() != zed.IDBool {
 			return false
 		}
-		b := zed.DecodeBool(val.Bytes)
+		b := zed.DecodeBool(val.Bytes())
 		return compare(b, pattern)
 	}, nil
 }
@@ -78,7 +78,7 @@ func CompareInt64(op string, pattern int64) (Boolean, error) {
 	}
 	// many different Zed data types can be compared with integers
 	return func(val *zed.Value) bool {
-		zv := val.Bytes
+		zv := val.Bytes()
 		switch val.Type.ID() {
 		case zed.IDInt8, zed.IDInt16, zed.IDInt32, zed.IDInt64:
 			return CompareInt(zed.DecodeInt(zv), pattern)
@@ -106,7 +106,7 @@ func CompareTime(op string, pattern int64) (Boolean, error) {
 	}
 	// many different Zed data types can be compared with integers
 	return func(val *zed.Value) bool {
-		zv := val.Bytes
+		zv := val.Bytes()
 		switch val.Type.ID() {
 		case zed.IDInt8, zed.IDInt16, zed.IDInt32, zed.IDInt64:
 			return CompareInt(zed.DecodeInt(zv), pattern)
@@ -149,7 +149,7 @@ func CompareIP(op string, pattern netip.Addr) (Boolean, error) {
 		if val.Type.ID() != zed.IDIP {
 			return false
 		}
-		return compare(zed.DecodeIP(val.Bytes), pattern)
+		return compare(zed.DecodeIP(val.Bytes()), pattern)
 	}, nil
 }
 
@@ -163,7 +163,7 @@ func CompareFloat64(op string, pattern float64) (Boolean, error) {
 		return nil, fmt.Errorf("unknown double comparator: %s", op)
 	}
 	return func(val *zed.Value) bool {
-		zv := val.Bytes
+		zv := val.Bytes()
 		switch val.Type.ID() {
 		// We allow comparison of float constant with integer-y
 		// fields and just use typeDouble to parse since it will do
@@ -203,7 +203,7 @@ func CompareString(op string, pattern []byte) (Boolean, error) {
 	s := string(pattern)
 	return func(val *zed.Value) bool {
 		if val.Type.ID() == zed.IDString {
-			return compare(byteconv.UnsafeString(val.Bytes), s)
+			return compare(byteconv.UnsafeString(val.Bytes()), s)
 		}
 		return false
 	}, nil
@@ -226,7 +226,7 @@ func CompareBytes(op string, pattern []byte) (Boolean, error) {
 	return func(val *zed.Value) bool {
 		switch val.Type.ID() {
 		case zed.IDBytes, zed.IDType:
-			return compare(val.Bytes, pattern)
+			return compare(val.Bytes(), pattern)
 		}
 		return false
 	}, nil
@@ -248,7 +248,7 @@ func CompileRegexp(pattern string) (*regexp.Regexp, error) {
 func NewRegexpBoolean(re *regexp.Regexp) Boolean {
 	return func(val *zed.Value) bool {
 		if val.IsString() {
-			return re.Match(val.Bytes)
+			return re.Match(val.Bytes())
 		}
 		return false
 	}
@@ -295,19 +295,19 @@ func Comparison(op string, val *zed.Value) (Boolean, error) {
 	case *zed.TypeOfNull:
 		return CompareNull(op)
 	case *zed.TypeOfIP:
-		return CompareIP(op, zed.DecodeIP(val.Bytes))
+		return CompareIP(op, zed.DecodeIP(val.Bytes()))
 	case *zed.TypeOfBool:
-		return CompareBool(op, zed.DecodeBool(val.Bytes))
+		return CompareBool(op, zed.DecodeBool(val.Bytes()))
 	case *zed.TypeOfFloat64:
-		return CompareFloat64(op, zed.DecodeFloat64(val.Bytes))
+		return CompareFloat64(op, zed.DecodeFloat64(val.Bytes()))
 	case *zed.TypeOfString:
-		return CompareString(op, val.Bytes)
+		return CompareString(op, val.Bytes())
 	case *zed.TypeOfBytes, *zed.TypeOfType:
-		return CompareBytes(op, val.Bytes)
+		return CompareBytes(op, val.Bytes())
 	case *zed.TypeOfInt64:
-		return CompareInt64(op, zed.DecodeInt(val.Bytes))
+		return CompareInt64(op, zed.DecodeInt(val.Bytes()))
 	case *zed.TypeOfTime, *zed.TypeOfDuration:
-		return CompareTime(op, zed.DecodeInt(val.Bytes))
+		return CompareTime(op, zed.DecodeInt(val.Bytes()))
 	default:
 		return nil, fmt.Errorf("literal comparison of type %q unsupported", val.Type)
 	}

--- a/runtime/expr/cast.go
+++ b/runtime/expr/cast.go
@@ -144,7 +144,7 @@ func (c *casterIP) Eval(ectx Context, val *zed.Value) *zed.Value {
 	if !val.IsString() {
 		return c.zctx.WrapError("cannot cast to ip", val)
 	}
-	ip, err := byteconv.ParseIP(val.Bytes)
+	ip, err := byteconv.ParseIP(val.Bytes())
 	if err != nil {
 		return c.zctx.WrapError("cannot cast to ip", val)
 	}
@@ -162,7 +162,7 @@ func (c *casterNet) Eval(ectx Context, val *zed.Value) *zed.Value {
 	if !val.IsString() {
 		return c.zctx.WrapError("cannot cast to net", val)
 	}
-	net, err := netip.ParsePrefix(string(val.Bytes))
+	net, err := netip.ParsePrefix(string(val.Bytes()))
 	if err != nil {
 		return c.zctx.WrapError("cannot cast to net", val)
 	}
@@ -179,9 +179,9 @@ func (c *casterDuration) Eval(ectx Context, val *zed.Value) *zed.Value {
 		return ectx.CopyValue(val)
 	}
 	if id == zed.IDString {
-		d, err := nano.ParseDuration(byteconv.UnsafeString(val.Bytes))
+		d, err := nano.ParseDuration(byteconv.UnsafeString(val.Bytes()))
 		if err != nil {
-			f, ferr := byteconv.ParseFloat64(val.Bytes)
+			f, ferr := byteconv.ParseFloat64(val.Bytes())
 			if ferr != nil {
 				return c.zctx.WrapError("cannot cast to duration", val)
 			}
@@ -190,7 +190,7 @@ func (c *casterDuration) Eval(ectx Context, val *zed.Value) *zed.Value {
 		return ectx.NewValue(zed.TypeDuration, zed.EncodeDuration(d))
 	}
 	if zed.IsFloat(id) {
-		d := nano.Duration(zed.DecodeFloat(val.Bytes))
+		d := nano.Duration(zed.DecodeFloat(val.Bytes()))
 		return ectx.NewValue(zed.TypeDuration, zed.EncodeDuration(d))
 	}
 	v, ok := coerce.ToInt(val)
@@ -214,9 +214,9 @@ func (c *casterTime) Eval(ectx Context, val *zed.Value) *zed.Value {
 	case val.IsNull():
 		// Do nothing. Any nil value is cast to a zero time.
 	case id == zed.IDString:
-		gotime, err := dateparse.ParseAny(byteconv.UnsafeString(val.Bytes))
+		gotime, err := dateparse.ParseAny(byteconv.UnsafeString(val.Bytes()))
 		if err != nil {
-			v, err := byteconv.ParseFloat64(val.Bytes)
+			v, err := byteconv.ParseFloat64(val.Bytes())
 			if err != nil {
 				return c.zctx.WrapError("cannot cast to time", val)
 			}
@@ -244,13 +244,13 @@ type casterString struct {
 func (c *casterString) Eval(ectx Context, val *zed.Value) *zed.Value {
 	id := val.Type.ID()
 	if id == zed.IDBytes {
-		if !utf8.Valid(val.Bytes) {
+		if !utf8.Valid(val.Bytes()) {
 			return c.zctx.WrapError("cannot cast to string: invalid UTF-8", val)
 		}
-		return ectx.NewValue(zed.TypeString, val.Bytes)
+		return ectx.NewValue(zed.TypeString, val.Bytes())
 	}
 	if enum, ok := val.Type.(*zed.TypeEnum); ok {
-		selector := zed.DecodeUint(val.Bytes)
+		selector := zed.DecodeUint(val.Bytes())
 		symbol, err := enum.Symbol(int(selector))
 		if err != nil {
 			return ectx.CopyValue(c.zctx.NewError(err))
@@ -260,7 +260,7 @@ func (c *casterString) Eval(ectx Context, val *zed.Value) *zed.Value {
 	if id == zed.IDString {
 		// If it's already stringy, then the Zed encoding can stay
 		// the same and we just update the stringy type.
-		return ectx.NewValue(zed.TypeString, val.Bytes)
+		return ectx.NewValue(zed.TypeString, val.Bytes())
 	}
 	// Otherwise, we'll use a canonical ZSON value for the string rep
 	// of an arbitrary value cast to a string.
@@ -271,5 +271,5 @@ func (c *casterString) Eval(ectx Context, val *zed.Value) *zed.Value {
 type casterBytes struct{}
 
 func (c *casterBytes) Eval(ectx Context, val *zed.Value) *zed.Value {
-	return ectx.NewValue(zed.TypeBytes, val.Bytes)
+	return ectx.NewValue(zed.TypeBytes, val.Bytes())
 }

--- a/runtime/expr/coerce/coerce.go
+++ b/runtime/expr/coerce/coerce.go
@@ -49,8 +49,8 @@ func (c *Pair) Equal() bool {
 }
 
 func (c *Pair) Coerce(a, b *zed.Value) (int, error) {
-	c.A = a.Bytes
-	c.B = b.Bytes
+	c.A = a.Bytes()
+	c.B = b.Bytes()
 	if a.Type == nil {
 		a.Type = zed.TypeNull
 	}
@@ -162,23 +162,23 @@ func (c *Pair) coerceNumbers(aid, bid int) (int, bool) {
 func ToFloat(val *zed.Value) (float64, bool) {
 	id := val.Type.ID()
 	if zed.IsFloat(id) {
-		return zed.DecodeFloat(val.Bytes), true
+		return zed.DecodeFloat(val.Bytes()), true
 	}
 	if zed.IsInteger(id) {
 		if zed.IsSigned(id) {
-			return float64(zed.DecodeInt(val.Bytes)), true
+			return float64(zed.DecodeInt(val.Bytes())), true
 		} else {
-			return float64(zed.DecodeUint(val.Bytes)), true
+			return float64(zed.DecodeUint(val.Bytes())), true
 		}
 	}
 	if id == zed.IDDuration {
-		return float64(zed.DecodeInt(val.Bytes)), true
+		return float64(zed.DecodeInt(val.Bytes())), true
 	}
 	if id == zed.IDTime {
-		return float64(zed.DecodeTime(val.Bytes)), true
+		return float64(zed.DecodeTime(val.Bytes())), true
 	}
 	if id == zed.IDString {
-		v, err := strconv.ParseFloat(string(val.Bytes), 64)
+		v, err := strconv.ParseFloat(string(val.Bytes()), 64)
 		return v, err == nil
 	}
 	return 0, false
@@ -187,27 +187,27 @@ func ToFloat(val *zed.Value) (float64, bool) {
 func ToUint(val *zed.Value) (uint64, bool) {
 	id := val.Type.ID()
 	if zed.IsFloat(id) {
-		return uint64(zed.DecodeFloat(val.Bytes)), true
+		return uint64(zed.DecodeFloat(val.Bytes())), true
 	}
 	if zed.IsInteger(id) {
 		if zed.IsSigned(id) {
-			v := zed.DecodeInt(val.Bytes)
+			v := zed.DecodeInt(val.Bytes())
 			if v < 0 {
 				return 0, false
 			}
 			return uint64(v), true
 		} else {
-			return zed.DecodeUint(val.Bytes), true
+			return zed.DecodeUint(val.Bytes()), true
 		}
 	}
 	if id == zed.IDDuration {
-		return uint64(zed.DecodeInt(val.Bytes)), true
+		return uint64(zed.DecodeInt(val.Bytes())), true
 	}
 	if id == zed.IDTime {
-		return uint64(zed.DecodeTime(val.Bytes)), true
+		return uint64(zed.DecodeTime(val.Bytes())), true
 	}
 	if id == zed.IDString {
-		v, err := strconv.ParseUint(string(val.Bytes), 10, 64)
+		v, err := strconv.ParseUint(string(val.Bytes()), 10, 64)
 		return v, err == nil
 	}
 	return 0, false
@@ -216,24 +216,24 @@ func ToUint(val *zed.Value) (uint64, bool) {
 func ToInt(val *zed.Value) (int64, bool) {
 	id := val.Type.ID()
 	if zed.IsFloat(id) {
-		return int64(zed.DecodeFloat(val.Bytes)), true
+		return int64(zed.DecodeFloat(val.Bytes())), true
 	}
 	if zed.IsInteger(id) {
 		if zed.IsSigned(id) {
 			// XXX check if negative? should -1:uint64 be maxint64 or an error?
-			return zed.DecodeInt(val.Bytes), true
+			return zed.DecodeInt(val.Bytes()), true
 		} else {
-			return int64(zed.DecodeUint(val.Bytes)), true
+			return int64(zed.DecodeUint(val.Bytes())), true
 		}
 	}
 	if id == zed.IDDuration {
-		return zed.DecodeInt(val.Bytes), true
+		return zed.DecodeInt(val.Bytes()), true
 	}
 	if id == zed.IDTime {
-		return int64(zed.DecodeTime(val.Bytes)), true
+		return int64(zed.DecodeTime(val.Bytes())), true
 	}
 	if id == zed.IDString {
-		v, err := strconv.ParseInt(string(val.Bytes), 10, 64)
+		v, err := strconv.ParseInt(string(val.Bytes()), 10, 64)
 		return v, err == nil
 	}
 	return 0, false
@@ -241,7 +241,7 @@ func ToInt(val *zed.Value) (int64, bool) {
 
 func ToBool(val *zed.Value) (bool, bool) {
 	if val.IsString() {
-		v, err := strconv.ParseBool(string(val.Bytes))
+		v, err := strconv.ParseBool(string(val.Bytes()))
 		return v, err == nil
 	}
 	v, ok := ToInt(val)
@@ -251,13 +251,13 @@ func ToBool(val *zed.Value) (bool, bool) {
 func ToTime(val *zed.Value) (nano.Ts, bool) {
 	id := val.Type.ID()
 	if id == zed.IDTime {
-		return zed.DecodeTime(val.Bytes), true
+		return zed.DecodeTime(val.Bytes()), true
 	}
 	if zed.IsSigned(id) {
-		return nano.Ts(zed.DecodeInt(val.Bytes)), true
+		return nano.Ts(zed.DecodeInt(val.Bytes())), true
 	}
 	if zed.IsInteger(id) {
-		v := zed.DecodeUint(val.Bytes)
+		v := zed.DecodeUint(val.Bytes())
 		// check for overflow
 		if v > math.MaxInt64 {
 			return 0, false
@@ -265,7 +265,7 @@ func ToTime(val *zed.Value) (nano.Ts, bool) {
 		return nano.Ts(v), true
 	}
 	if zed.IsFloat(id) {
-		return nano.Ts(zed.DecodeFloat(val.Bytes)), true
+		return nano.Ts(zed.DecodeFloat(val.Bytes())), true
 	}
 	return 0, false
 }
@@ -277,20 +277,20 @@ func ToTime(val *zed.Value) (nano.Ts, bool) {
 func ToDuration(in *zed.Value) (nano.Duration, bool) {
 	switch in.Type.ID() {
 	case zed.IDDuration:
-		return zed.DecodeDuration(in.Bytes), true
+		return zed.DecodeDuration(in.Bytes()), true
 	case zed.IDUint16, zed.IDUint32, zed.IDUint64:
-		v := zed.DecodeUint(in.Bytes)
+		v := zed.DecodeUint(in.Bytes())
 		// check for overflow
 		if v > math.MaxInt64 {
 			return 0, false
 		}
 		return nano.Duration(v) * nano.Second, true
 	case zed.IDInt16, zed.IDInt32, zed.IDInt64:
-		v := zed.DecodeInt(in.Bytes)
+		v := zed.DecodeInt(in.Bytes())
 		//XXX check for overflow here
 		return nano.Duration(v) * nano.Second, true
 	case zed.IDFloat16, zed.IDFloat32, zed.IDFloat64:
-		return nano.Duration(zed.DecodeFloat(in.Bytes)), true
+		return nano.Duration(zed.DecodeFloat(in.Bytes())), true
 	}
 	return 0, false
 }

--- a/runtime/expr/context.go
+++ b/runtime/expr/context.go
@@ -31,7 +31,7 @@ func (*allocator) NewValue(typ zed.Type, bytes zcode.Bytes) *zed.Value {
 }
 
 func (*allocator) CopyValue(val *zed.Value) *zed.Value {
-	return zed.NewValue(val.Type, val.Bytes)
+	return zed.NewValue(val.Type, val.Bytes())
 }
 
 func (*allocator) Vars() []zed.Value {
@@ -71,7 +71,7 @@ func (r *ResetContext) NewValue(typ zed.Type, b zcode.Bytes) *zed.Value {
 }
 
 func (r *ResetContext) CopyValue(val *zed.Value) *zed.Value {
-	return r.NewValue(val.Type, val.Bytes)
+	return r.NewValue(val.Type, val.Bytes())
 }
 
 func (r *ResetContext) Reset() {

--- a/runtime/expr/context_test.go
+++ b/runtime/expr/context_test.go
@@ -10,21 +10,21 @@ import (
 
 func TestResetContext(t *testing.T) {
 	var ectx ResetContext
-	val := zed.NewBytes(nil)
+	var val *zed.Value
 
 	// Test empty value with ResetContext.buf == nil.
 	require.Nil(t, ectx.buf)
-	val.Bytes = []byte{}
-	assert.Equal(t, val, ectx.NewValue(val.Type, val.Bytes))
+	val = zed.NewBytes([]byte{})
+	assert.Equal(t, val, ectx.NewValue(val.Type, val.Bytes()))
 	assert.Equal(t, val, ectx.CopyValue(val))
 
-	val.Bytes = []byte{'b'}
-	assert.Equal(t, val, ectx.NewValue(val.Type, val.Bytes))
+	val = zed.NewBytes([]byte{'b'})
+	assert.Equal(t, val, ectx.NewValue(val.Type, val.Bytes()))
 	assert.Equal(t, val, ectx.CopyValue(val))
 
 	// Test null value with ResetContext.buf != nil.
 	require.NotNil(t, ectx.buf)
-	val.Bytes = nil
-	assert.Equal(t, val, ectx.NewValue(val.Type, val.Bytes))
+	val = zed.NewBytes(nil)
+	assert.Equal(t, val, ectx.NewValue(val.Type, val.Bytes()))
 	assert.Equal(t, val, ectx.CopyValue(val))
 }

--- a/runtime/expr/cutter.go
+++ b/runtime/expr/cutter.go
@@ -81,11 +81,11 @@ func (c *Cutter) Eval(ectx Context, in *zed.Value) *zed.Value {
 				c.droppers[k] = NewDropper(c.zctx, c.fieldRefs[k:k+1])
 			}
 			droppers = append(droppers, c.droppers[k])
-			b.Append(val.Bytes)
+			b.Append(val.Bytes())
 			types[k] = zed.TypeNull
 			continue
 		}
-		b.Append(val.Bytes)
+		b.Append(val.Bytes())
 		types[k] = val.Type
 	}
 	bytes, err := b.Encode()

--- a/runtime/expr/dot.go
+++ b/runtime/expr/dot.go
@@ -39,10 +39,10 @@ func NewDottedExpr(zctx *zed.Context, f field.Path) Evaluator {
 func (d *DotExpr) Eval(ectx Context, this *zed.Value) *zed.Value {
 	val := d.record.Eval(ectx, this).Under()
 	if _, ok := val.Type.(*zed.TypeOfType); ok {
-		return d.evalTypeOfType(ectx, val.Bytes)
+		return d.evalTypeOfType(ectx, val.Bytes())
 	}
 	if typ, ok := val.Type.(*zed.TypeMap); ok {
-		return indexMap(d.zctx, ectx, typ, val.Bytes, zed.NewString(d.field))
+		return indexMap(d.zctx, ectx, typ, val.Bytes(), zed.NewString(d.field))
 	}
 	recType, ok := val.Type.(*zed.TypeRecord)
 	if !ok {
@@ -58,7 +58,7 @@ func (d *DotExpr) Eval(ectx Context, this *zed.Value) *zed.Value {
 		return ectx.NewValue(typ, nil)
 	}
 	//XXX see PR #1071 to improve this (though we need this for Index anyway)
-	field := getNthFromContainer(val.Bytes, idx)
+	field := getNthFromContainer(val.Bytes(), idx)
 	return ectx.NewValue(recType.Fields[idx].Type, field)
 }
 

--- a/runtime/expr/dropper.go
+++ b/runtime/expr/dropper.go
@@ -20,7 +20,7 @@ func (d *dropper) drop(ectx Context, in *zed.Value) *zed.Value {
 	b.Reset()
 	for _, e := range d.fieldRefs {
 		val := e.Eval(ectx, in)
-		b.Append(val.Bytes)
+		b.Append(val.Bytes())
 	}
 	val, err := b.Encode()
 	if err != nil {

--- a/runtime/expr/eval.go
+++ b/runtime/expr/eval.go
@@ -38,7 +38,7 @@ func (n *Not) Eval(ectx Context, this *zed.Value) *zed.Value {
 	if !ok {
 		return val
 	}
-	if zed.DecodeBool(val.Bytes) {
+	if zed.DecodeBool(val.Bytes()) {
 		return zed.False
 	}
 	return zed.True
@@ -83,14 +83,14 @@ func (a *And) Eval(ectx Context, this *zed.Value) *zed.Value {
 	if !ok {
 		return lhs
 	}
-	if !zed.DecodeBool(lhs.Bytes) {
+	if !zed.DecodeBool(lhs.Bytes()) {
 		return zed.False
 	}
 	rhs, ok := EvalBool(a.zctx, ectx, this, a.rhs)
 	if !ok {
 		return rhs
 	}
-	if !zed.DecodeBool(rhs.Bytes) {
+	if !zed.DecodeBool(rhs.Bytes()) {
 		return zed.False
 	}
 	return zed.True
@@ -98,7 +98,7 @@ func (a *And) Eval(ectx Context, this *zed.Value) *zed.Value {
 
 func (o *Or) Eval(ectx Context, this *zed.Value) *zed.Value {
 	lhs, ok := EvalBool(o.zctx, ectx, this, o.lhs)
-	if ok && zed.DecodeBool(lhs.Bytes) {
+	if ok && zed.DecodeBool(lhs.Bytes()) {
 		return zed.True
 	}
 	if lhs.IsError() && !lhs.IsMissing() {
@@ -106,7 +106,7 @@ func (o *Or) Eval(ectx Context, this *zed.Value) *zed.Value {
 	}
 	rhs, ok := EvalBool(o.zctx, ectx, this, o.rhs)
 	if ok {
-		if zed.DecodeBool(rhs.Bytes) {
+		if zed.DecodeBool(rhs.Bytes()) {
 			return zed.True
 		}
 		return zed.False
@@ -216,7 +216,7 @@ func NewRegexpMatch(re *regexp.Regexp, e Evaluator) *RegexpMatch {
 
 func (r *RegexpMatch) Eval(ectx Context, this *zed.Value) *zed.Value {
 	val := r.expr.Eval(ectx, this)
-	if val.Type.ID() == zed.IDString && r.re.Match(val.Bytes) {
+	if val.Type.ID() == zed.IDString && r.re.Match(val.Bytes()) {
 		return zed.True
 	}
 	return zed.False
@@ -239,7 +239,7 @@ func newNumeric(lhs, rhs Evaluator) numeric {
 func enumify(val *zed.Value) *zed.Value {
 	// automatically convert an enum to its index value when coercing
 	if _, ok := val.Type.(*zed.TypeEnum); ok {
-		return zed.NewValue(zed.TypeUint64, val.Bytes)
+		return zed.NewValue(zed.TypeUint64, val.Bytes())
 	}
 	return val
 }
@@ -585,22 +585,22 @@ func (u *UnaryMinus) Eval(ectx Context, this *zed.Value) *zed.Value {
 		if val.IsNull() {
 			return val
 		}
-		return ectx.NewValue(typ, zed.EncodeFloat16(-zed.DecodeFloat16(val.Bytes)))
+		return ectx.NewValue(typ, zed.EncodeFloat16(-zed.DecodeFloat16(val.Bytes())))
 	case zed.IDFloat32:
 		if val.IsNull() {
 			return val
 		}
-		return ectx.NewValue(typ, zed.EncodeFloat32(-zed.DecodeFloat32(val.Bytes)))
+		return ectx.NewValue(typ, zed.EncodeFloat32(-zed.DecodeFloat32(val.Bytes())))
 	case zed.IDFloat64:
 		if val.IsNull() {
 			return val
 		}
-		return ectx.NewValue(typ, zed.EncodeFloat64(-zed.DecodeFloat64(val.Bytes)))
+		return ectx.NewValue(typ, zed.EncodeFloat64(-zed.DecodeFloat64(val.Bytes())))
 	case zed.IDInt8:
 		if val.IsNull() {
 			return val
 		}
-		v := zed.DecodeInt(val.Bytes)
+		v := zed.DecodeInt(val.Bytes())
 		if v == math.MinInt8 {
 			return ectx.CopyValue(u.zctx.NewErrorf("unary '-' underflow: int8(%d)", v))
 		}
@@ -609,7 +609,7 @@ func (u *UnaryMinus) Eval(ectx Context, this *zed.Value) *zed.Value {
 		if val.IsNull() {
 			return val
 		}
-		v := zed.DecodeInt(val.Bytes)
+		v := zed.DecodeInt(val.Bytes())
 		if v == math.MinInt16 {
 			return ectx.CopyValue(u.zctx.NewErrorf("unary '-' underflow: int16(%d)", v))
 		}
@@ -618,7 +618,7 @@ func (u *UnaryMinus) Eval(ectx Context, this *zed.Value) *zed.Value {
 		if val.IsNull() {
 			return val
 		}
-		v := zed.DecodeInt(val.Bytes)
+		v := zed.DecodeInt(val.Bytes())
 		if v == math.MinInt32 {
 			return ectx.CopyValue(u.zctx.NewErrorf("unary '-' underflow: int32(%d)", v))
 		}
@@ -627,7 +627,7 @@ func (u *UnaryMinus) Eval(ectx Context, this *zed.Value) *zed.Value {
 		if val.IsNull() {
 			return val
 		}
-		v := zed.DecodeInt(val.Bytes)
+		v := zed.DecodeInt(val.Bytes())
 		if v == math.MinInt64 {
 			return ectx.CopyValue(u.zctx.NewErrorf("unary '-' underflow: int64(%d)", v))
 		}
@@ -636,7 +636,7 @@ func (u *UnaryMinus) Eval(ectx Context, this *zed.Value) *zed.Value {
 		if val.IsNull() {
 			return val
 		}
-		v := zed.DecodeUint(val.Bytes)
+		v := zed.DecodeUint(val.Bytes())
 		if v > math.MaxInt8 {
 			return ectx.CopyValue(u.zctx.NewErrorf("unary '-' overflow: uint8(%d)", v))
 		}
@@ -645,7 +645,7 @@ func (u *UnaryMinus) Eval(ectx Context, this *zed.Value) *zed.Value {
 		if val.IsNull() {
 			return val
 		}
-		v := zed.DecodeUint(val.Bytes)
+		v := zed.DecodeUint(val.Bytes())
 		if v > math.MaxInt16 {
 			return ectx.CopyValue(u.zctx.NewErrorf("unary '-' overflow: uint16(%d)", v))
 		}
@@ -654,7 +654,7 @@ func (u *UnaryMinus) Eval(ectx Context, this *zed.Value) *zed.Value {
 		if val.IsNull() {
 			return val
 		}
-		v := zed.DecodeUint(val.Bytes)
+		v := zed.DecodeUint(val.Bytes())
 		if v > math.MaxInt32 {
 			return ectx.CopyValue(u.zctx.NewErrorf("unary '-' overflow: uint32(%d)", v))
 		}
@@ -663,7 +663,7 @@ func (u *UnaryMinus) Eval(ectx Context, this *zed.Value) *zed.Value {
 		if val.IsNull() {
 			return val
 		}
-		v := zed.DecodeUint(val.Bytes)
+		v := zed.DecodeUint(val.Bytes())
 		if v > math.MaxInt64 {
 			return ectx.CopyValue(u.zctx.NewErrorf("unary '-' overflow: uint64(%d)", v))
 		}
@@ -720,11 +720,11 @@ func (i *Index) Eval(ectx Context, this *zed.Value) *zed.Value {
 	index := i.index.Eval(ectx, this)
 	switch typ := zed.TypeUnder(container.Type).(type) {
 	case *zed.TypeArray, *zed.TypeSet:
-		return indexVector(i.zctx, ectx, zed.InnerType(typ), container.Bytes, index)
+		return indexVector(i.zctx, ectx, zed.InnerType(typ), container.Bytes(), index)
 	case *zed.TypeRecord:
-		return indexRecord(i.zctx, ectx, typ, container.Bytes, index)
+		return indexRecord(i.zctx, ectx, typ, container.Bytes(), index)
 	case *zed.TypeMap:
-		return indexMap(i.zctx, ectx, typ, container.Bytes, index)
+		return indexMap(i.zctx, ectx, typ, container.Bytes(), index)
 	default:
 		return i.zctx.Missing()
 	}
@@ -737,9 +737,9 @@ func indexVector(zctx *zed.Context, ectx Context, inner zed.Type, vector zcode.B
 	}
 	var idx int
 	if zed.IsSigned(id) {
-		idx = int(zed.DecodeInt(index.Bytes))
+		idx = int(zed.DecodeInt(index.Bytes()))
 	} else {
-		idx = int(zed.DecodeUint(index.Bytes))
+		idx = int(zed.DecodeUint(index.Bytes()))
 	}
 	zv := getNthFromContainer(vector, idx)
 	if zv == nil {
@@ -753,7 +753,7 @@ func indexRecord(zctx *zed.Context, ectx Context, typ *zed.TypeRecord, record zc
 	if id != zed.IDString {
 		return ectx.CopyValue(zctx.NewErrorf("record index is not a string"))
 	}
-	field := zed.DecodeString(index.Bytes)
+	field := zed.DecodeString(index.Bytes())
 	val := zed.NewValue(typ, record).Deref(field)
 	if val == nil {
 		return zctx.Missing()
@@ -769,7 +769,7 @@ func indexMap(zctx *zed.Context, ectx Context, typ *zed.TypeMap, mapBytes zcode.
 		if union, ok := zed.TypeUnder(typ.KeyType).(*zed.TypeUnion); ok {
 			if tag := union.TagOf(key.Type); tag >= 0 {
 				var b zcode.Builder
-				zed.BuildUnion(&b, union.TagOf(key.Type), key.Bytes)
+				zed.BuildUnion(&b, union.TagOf(key.Type), key.Bytes())
 				if valBytes, ok := lookupKey(mapBytes, b.Bytes().Body()); ok {
 					return deunion(ectx, typ.ValType, valBytes)
 				}
@@ -777,7 +777,7 @@ func indexMap(zctx *zed.Context, ectx Context, typ *zed.TypeMap, mapBytes zcode.
 		}
 		return zctx.Missing()
 	}
-	if valBytes, ok := lookupKey(mapBytes, key.Bytes); ok {
+	if valBytes, ok := lookupKey(mapBytes, key.Bytes()); ok {
 		return deunion(ectx, typ.ValType, valBytes)
 	}
 	return zctx.Missing()
@@ -812,7 +812,7 @@ func (c *Conditional) Eval(ectx Context, this *zed.Value) *zed.Value {
 		val := *c.zctx.NewErrorf("?-operator: bool predicate required")
 		return &val
 	}
-	if zed.DecodeBool(val.Bytes) {
+	if zed.DecodeBool(val.Bytes()) {
 		return c.thenExpr.Eval(ectx, this)
 	}
 	return c.elseExpr.Eval(ectx, this)
@@ -864,7 +864,7 @@ func (c *evalCast) Eval(ectx Context, this *zed.Value) *zed.Value {
 	if val.IsNull() || val.Type == c.typ {
 		// If value is null or the type won't change, just return a
 		// copy of the value.
-		return ectx.NewValue(c.typ, val.Bytes)
+		return ectx.NewValue(c.typ, val.Bytes())
 	}
 	return c.caster.Eval(ectx, val)
 }

--- a/runtime/expr/filter.go
+++ b/runtime/expr/filter.go
@@ -102,8 +102,8 @@ type search struct {
 func NewSearch(searchtext string, searchval *zed.Value, expr Evaluator) (Evaluator, error) {
 	if zed.TypeUnder(searchval.Type) == zed.TypeNet {
 		return &searchCIDR{
-			net:   zed.DecodeNet(searchval.Bytes),
-			bytes: searchval.Bytes,
+			net:   zed.DecodeNet(searchval.Bytes()),
+			bytes: searchval.Bytes(),
 		}, nil
 	}
 	typedCompare, err := Comparison("==", searchval)
@@ -255,7 +255,7 @@ func NewFilterApplier(zctx *zed.Context, e Evaluator) Applier {
 func (f *filterApplier) Eval(ectx Context, this *zed.Value) *zed.Value {
 	val, ok := EvalBool(f.zctx, ectx, this, f.expr)
 	if ok {
-		if zed.DecodeBool(val.Bytes) {
+		if zed.DecodeBool(val.Bytes()) {
 			return this
 		}
 		return f.zctx.Missing()

--- a/runtime/expr/filter_test.go
+++ b/runtime/expr/filter_test.go
@@ -36,7 +36,7 @@ func filter(ectx expr.Context, this *zed.Value, e expr.Evaluator) bool {
 		return true
 	}
 	val := e.Eval(ectx, this)
-	if val.Type == zed.TypeBool && zed.DecodeBool(val.Bytes) {
+	if val.Type == zed.TypeBool && zed.DecodeBool(val.Bytes()) {
 		return true
 	}
 	return false
@@ -77,7 +77,7 @@ func runCasesHelper(t *testing.T, record string, cases []testcase, expectBufferF
 				// hand BufferFilter.Eval a ZNG values frame
 				// containing rec, assembled here.
 				buf := binary.AppendUvarint(nil, uint64(rec.Type.ID()))
-				buf = zcode.Append(buf, rec.Bytes)
+				buf = zcode.Append(buf, rec.Bytes())
 				assert.Equal(t, expected, bf.Eval(zctx, buf),
 					"filter: %q\nvalues:%s\nbuffer:\n%s", c.filter, zson.MustFormatValue(rec), hex.Dump(buf))
 			}

--- a/runtime/expr/flattener.go
+++ b/runtime/expr/flattener.go
@@ -73,7 +73,7 @@ func (f *Flattener) Flatten(r *zed.Value) (*zed.Value, error) {
 	if zed.TypeUnder(r.Type) == flatType {
 		return r, nil
 	}
-	zv, err := recode(nil, zed.TypeRecordOf(r.Type), r.Bytes)
+	zv, err := recode(nil, zed.TypeRecordOf(r.Type), r.Bytes())
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/expr/function/bytes.go
+++ b/runtime/expr/function/bytes.go
@@ -20,14 +20,14 @@ func (b *Base64) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		if val.IsNull() {
 			return newErrorf(b.zctx, ctx, "base64: illegal null argument")
 		}
-		return newString(ctx, base64.StdEncoding.EncodeToString(val.Bytes))
+		return newString(ctx, base64.StdEncoding.EncodeToString(val.Bytes()))
 	case zed.IDString:
 		if val.IsNull() {
 			return zed.Null
 		}
-		bytes, err := base64.StdEncoding.DecodeString(zed.DecodeString(val.Bytes))
+		bytes, err := base64.StdEncoding.DecodeString(zed.DecodeString(val.Bytes()))
 		if err != nil {
-			return newErrorf(b.zctx, ctx, "base64: string argument is not base64: %q", string(val.Bytes))
+			return newErrorf(b.zctx, ctx, "base64: string argument is not base64: %q", string(val.Bytes()))
 		}
 		return newBytes(ctx, bytes)
 	default:
@@ -47,14 +47,14 @@ func (h *Hex) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		if val.IsNull() {
 			return newErrorf(h.zctx, ctx, "hex: illegal null argument")
 		}
-		return newString(ctx, hex.EncodeToString(val.Bytes))
+		return newString(ctx, hex.EncodeToString(val.Bytes()))
 	case zed.IDString:
 		if val.IsNull() {
 			return zed.NullString
 		}
-		b, err := hex.DecodeString(zed.DecodeString(val.Bytes))
+		b, err := hex.DecodeString(zed.DecodeString(val.Bytes()))
 		if err != nil {
-			return newErrorf(h.zctx, ctx, "hex: string argument is not hexidecimal: %q", string(val.Bytes))
+			return newErrorf(h.zctx, ctx, "hex: string argument is not hexidecimal: %q", string(val.Bytes()))
 		}
 		return newBytes(ctx, b)
 	default:

--- a/runtime/expr/function/compare.go
+++ b/runtime/expr/function/compare.go
@@ -26,7 +26,7 @@ func (e *Compare) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		if zed.TypeUnder(args[2].Type) != zed.TypeBool {
 			return e.zctx.WrapError("compare: nullsMax arg is not bool", &args[2])
 		}
-		nullsMax = zed.DecodeBool(args[2].Bytes)
+		nullsMax = zed.DecodeBool(args[2].Bytes())
 	}
 	cmp := e.nullsMax
 	if !nullsMax {

--- a/runtime/expr/function/fields.go
+++ b/runtime/expr/function/fields.go
@@ -52,7 +52,7 @@ func (f *Fields) recordType(val zed.Value) *zed.TypeRecord {
 		return typ
 	}
 	if val.Type == zed.TypeType {
-		typ, err := f.zctx.LookupByValue(val.Bytes)
+		typ, err := f.zctx.LookupByValue(val.Bytes())
 		if err != nil {
 			return nil
 		}

--- a/runtime/expr/function/flatten.go
+++ b/runtime/expr/function/flatten.go
@@ -31,9 +31,9 @@ func (n *Flatten) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if typ == nil {
 		return &val
 	}
-	inner := n.innerTypeOf(val.Bytes, typ.Fields)
+	inner := n.innerTypeOf(val.Bytes(), typ.Fields)
 	n.Reset()
-	n.encode(typ.Fields, inner, field.Path{}, val.Bytes)
+	n.encode(typ.Fields, inner, field.Path{}, val.Bytes())
 	return ctx.NewValue(n.zctx.LookupTypeArray(inner), n.Bytes())
 }
 

--- a/runtime/expr/function/has.go
+++ b/runtime/expr/function/has.go
@@ -25,7 +25,7 @@ type Missing struct {
 func (m *Missing) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	val := m.has.Call(ctx, args)
 	if val.Type == zed.TypeBool {
-		return zed.Not(val.Bytes)
+		return zed.Not(val.Bytes())
 	}
 	return val
 }

--- a/runtime/expr/function/ip.go
+++ b/runtime/expr/function/ip.go
@@ -19,7 +19,7 @@ func (n *NetworkOf) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if id != zed.IDIP {
 		return newErrorf(n.zctx, ctx, "network_of: not an IP")
 	}
-	ip := zed.DecodeIP(args[0].Bytes)
+	ip := zed.DecodeIP(args[0].Bytes())
 	var bits int
 	if len(args) == 1 {
 		switch {
@@ -34,7 +34,7 @@ func (n *NetworkOf) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		}
 	} else {
 		// two args
-		body := args[1].Bytes
+		body := args[1].Bytes()
 		switch id := args[1].Type.ID(); {
 		case id == zed.IDIP:
 			mask := zed.DecodeIP(body)
@@ -75,7 +75,7 @@ func (c *CIDRMatch) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if maskVal.Type.ID() != zed.IDNet {
 		return newErrorf(c.zctx, ctx, "cidr_match: not a net: %s", zson.String(maskVal))
 	}
-	prefix := zed.DecodeNet(maskVal.Bytes)
+	prefix := zed.DecodeNet(maskVal.Bytes())
 	if errMatch == args[1].Walk(func(typ zed.Type, body zcode.Bytes) error {
 		if typ.ID() == zed.IDIP {
 			if prefix.Contains(zed.DecodeIP(body)) {

--- a/runtime/expr/function/ksuid.go
+++ b/runtime/expr/function/ksuid.go
@@ -22,14 +22,14 @@ func (k *KSUIDToString) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 			return newErrorf(k.zctx, ctx, "ksuid: illegal null argument")
 		}
 		// XXX GC
-		id, err := ksuid.FromBytes(val.Bytes)
+		id, err := ksuid.FromBytes(val.Bytes())
 		if err != nil {
 			panic(err)
 		}
 		return newString(ctx, id.String())
 	case zed.IDString:
 		// XXX GC
-		id, err := ksuid.Parse(string(val.Bytes))
+		id, err := ksuid.Parse(string(val.Bytes()))
 		if err != nil {
 			return newErrorf(k.zctx, ctx, "ksuid: %s (bad argument: %s)", err, zson.String(val))
 		}

--- a/runtime/expr/function/len.go
+++ b/runtime/expr/function/len.go
@@ -24,11 +24,11 @@ func (l *LenFn) Call(ectx zed.Allocator, args []zed.Value) *zed.Value {
 			panic(err)
 		}
 	case *zed.TypeOfBytes, *zed.TypeOfString, *zed.TypeOfIP, *zed.TypeOfNet:
-		length = len(val.Bytes)
+		length = len(val.Bytes())
 	case *zed.TypeError:
 		return l.zctx.WrapError("len()", &val)
 	case *zed.TypeOfType:
-		t, err := l.zctx.LookupByValue(val.Bytes)
+		t, err := l.zctx.LookupByValue(val.Bytes())
 		if err != nil {
 			return newError(l.zctx, ectx, err)
 		}

--- a/runtime/expr/function/math.go
+++ b/runtime/expr/function/math.go
@@ -18,15 +18,15 @@ func (a *Abs) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	v := args[0]
 	id := v.Type.ID()
 	if id == zed.IDFloat16 {
-		f := math.Abs(float64(zed.DecodeFloat16(v.Bytes)))
+		f := math.Abs(float64(zed.DecodeFloat16(v.Bytes())))
 		return newFloat16(ctx, float32(f))
 	}
 	if id == zed.IDFloat32 {
-		f := math.Abs(float64(zed.DecodeFloat32(v.Bytes)))
+		f := math.Abs(float64(zed.DecodeFloat32(v.Bytes())))
 		return newFloat32(ctx, float32(f))
 	}
 	if id == zed.IDFloat64 {
-		f := math.Abs(zed.DecodeFloat64(v.Bytes))
+		f := math.Abs(zed.DecodeFloat64(v.Bytes()))
 		return newFloat64(ctx, f)
 	}
 	if !zed.IsInteger(id) {
@@ -35,7 +35,7 @@ func (a *Abs) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if !zed.IsSigned(id) {
 		return ctx.CopyValue(&args[0])
 	}
-	x := zed.DecodeInt(v.Bytes)
+	x := zed.DecodeInt(v.Bytes())
 	if x < 0 {
 		x = -x
 	}
@@ -52,13 +52,13 @@ func (c *Ceil) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	id := v.Type.ID()
 	switch {
 	case id == zed.IDFloat16:
-		f := math.Ceil(float64(zed.DecodeFloat16(v.Bytes)))
+		f := math.Ceil(float64(zed.DecodeFloat16(v.Bytes())))
 		return newFloat16(ctx, float32(f))
 	case id == zed.IDFloat32:
-		f := math.Ceil(float64(zed.DecodeFloat32(v.Bytes)))
+		f := math.Ceil(float64(zed.DecodeFloat32(v.Bytes())))
 		return newFloat32(ctx, float32(f))
 	case id == zed.IDFloat64:
-		f := math.Ceil(zed.DecodeFloat64(v.Bytes))
+		f := math.Ceil(zed.DecodeFloat64(v.Bytes()))
 		return newFloat64(ctx, f)
 	case zed.IsInteger(id):
 		return ctx.CopyValue(&args[0])
@@ -77,13 +77,13 @@ func (f *Floor) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	id := v.Type.ID()
 	switch {
 	case id == zed.IDFloat16:
-		v := math.Floor(float64(zed.DecodeFloat16(v.Bytes)))
+		v := math.Floor(float64(zed.DecodeFloat16(v.Bytes())))
 		return newFloat16(ctx, float32(v))
 	case id == zed.IDFloat32:
-		v := math.Floor(float64(zed.DecodeFloat32(v.Bytes)))
+		v := math.Floor(float64(zed.DecodeFloat32(v.Bytes())))
 		return newFloat32(ctx, float32(v))
 	case id == zed.IDFloat64:
-		v := math.Floor(zed.DecodeFloat64(v.Bytes))
+		v := math.Floor(zed.DecodeFloat64(v.Bytes()))
 		return newFloat64(ctx, v)
 	case zed.IsInteger(id):
 		return ctx.CopyValue(&args[0])
@@ -121,7 +121,7 @@ func (r *reducer) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if zed.IsFloat(id) {
 		//XXX this is wrong like math aggregators...
 		// need to be more robust and adjust type as new types encountered
-		result := zed.DecodeFloat(val0.Bytes)
+		result := zed.DecodeFloat(val0.Bytes())
 		for _, val := range args[1:] {
 			v, ok := coerce.ToFloat(&val)
 			if !ok {
@@ -135,7 +135,7 @@ func (r *reducer) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		return newErrorf(r.zctx, ctx, "%s: not a number: %s", r.name, zson.MustFormatValue(val0))
 	}
 	if zed.IsSigned(id) {
-		result := zed.DecodeInt(val0.Bytes)
+		result := zed.DecodeInt(val0.Bytes())
 		for _, val := range args[1:] {
 			//XXX this is really bad because we silently coerce
 			// floats to ints if we hit a float first
@@ -147,7 +147,7 @@ func (r *reducer) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		}
 		return newInt64(ctx, result)
 	}
-	result := zed.DecodeUint(val0.Bytes)
+	result := zed.DecodeUint(val0.Bytes())
 	for _, val := range args[1:] {
 		v, ok := coerce.ToUint(&val)
 		if !ok {
@@ -167,15 +167,15 @@ func (r *Round) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	val := &args[0]
 	id := val.Type.ID()
 	if id == zed.IDFloat16 {
-		f := zed.DecodeFloat16(val.Bytes)
+		f := zed.DecodeFloat16(val.Bytes())
 		return newFloat16(ctx, float32(math.Round(float64(f))))
 	}
 	if id == zed.IDFloat32 {
-		f := zed.DecodeFloat32(val.Bytes)
+		f := zed.DecodeFloat32(val.Bytes())
 		return newFloat32(ctx, float32(math.Round(float64(f))))
 	}
 	if id == zed.IDFloat64 {
-		f := zed.DecodeFloat64(val.Bytes)
+		f := zed.DecodeFloat64(val.Bytes())
 		return newFloat64(ctx, math.Round(f))
 	}
 	if !zed.IsNumber(id) {

--- a/runtime/expr/function/nestdotted.go
+++ b/runtime/expr/function/nestdotted.go
@@ -65,7 +65,7 @@ func (n *NestDotted) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		return this
 	}
 	b.Reset()
-	for it := this.Bytes.Iter(); !it.Done(); {
+	for it := this.Bytes().Iter(); !it.Done(); {
 		b.Append(it.Next())
 	}
 	zbytes, err := b.Encode()

--- a/runtime/expr/function/parse.go
+++ b/runtime/expr/function/parse.go
@@ -21,7 +21,7 @@ func (p *ParseURI) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if !in.IsString() || in.IsNull() {
 		return newErrorf(p.zctx, ctx, "parse_uri: non-empty string arg required")
 	}
-	s := zed.DecodeString(in.Bytes)
+	s := zed.DecodeString(in.Bytes())
 	u, err := url.Parse(s)
 	if err != nil {
 		return newErrorf(p.zctx, ctx, "parse_uri: %s (%q)", err, s)
@@ -89,7 +89,7 @@ func (p *ParseZSON) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if in.IsNull() {
 		return zed.Null
 	}
-	s := zed.DecodeString(in.Bytes)
+	s := zed.DecodeString(in.Bytes())
 	parser := zson.NewParser(strings.NewReader(s))
 	ast, err := parser.ParseValue()
 	if err != nil {

--- a/runtime/expr/function/regexp.go
+++ b/runtime/expr/function/regexp.go
@@ -21,7 +21,7 @@ func (r *Regexp) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if !args[0].IsString() {
 		return newErrorf(r.zctx, ctx, "regexp: string required for first arg")
 	}
-	s := zed.DecodeString(args[0].Bytes)
+	s := zed.DecodeString(args[0].Bytes())
 	if r.restr != s {
 		r.restr = s
 		r.re, r.err = regexp.Compile(r.restr)
@@ -33,7 +33,7 @@ func (r *Regexp) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		return newErrorf(r.zctx, ctx, "regexp: string required for second arg")
 	}
 	r.builder.Reset()
-	for _, b := range r.re.FindSubmatch(args[1].Bytes) {
+	for _, b := range r.re.FindSubmatch(args[1].Bytes()) {
 		r.builder.Append(b)
 	}
 	if r.typ == nil {
@@ -63,12 +63,12 @@ func (r *RegexpReplace) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if reVal.IsNull() || newVal.IsNull() {
 		return newErrorf(r.zctx, ctx, "regexp_replace: 2nd and 3rd args cannot be null")
 	}
-	if re := zed.DecodeString(reVal.Bytes); r.restr != re {
+	if re := zed.DecodeString(reVal.Bytes()); r.restr != re {
 		r.restr = re
 		r.re, r.err = regexp.Compile(re)
 	}
 	if r.err != nil {
 		return newErrorf(r.zctx, ctx, "regexp_replace: %s", r.err)
 	}
-	return ctx.NewValue(zed.TypeString, r.re.ReplaceAll(sVal.Bytes, newVal.Bytes))
+	return ctx.NewValue(zed.TypeString, r.re.ReplaceAll(sVal.Bytes(), newVal.Bytes()))
 }

--- a/runtime/expr/function/string.go
+++ b/runtime/expr/function/string.go
@@ -27,9 +27,9 @@ func (r *Replace) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if oldVal.IsNull() || newVal.IsNull() {
 		return newErrorf(r.zctx, ctx, "replace: an input arg is null")
 	}
-	s := zed.DecodeString(sVal.Bytes)
-	old := zed.DecodeString(oldVal.Bytes)
-	new := zed.DecodeString(newVal.Bytes)
+	s := zed.DecodeString(sVal.Bytes())
+	old := zed.DecodeString(oldVal.Bytes())
+	new := zed.DecodeString(newVal.Bytes())
 	return newString(ctx, strings.ReplaceAll(s, old, new))
 }
 
@@ -46,7 +46,7 @@ func (r *RuneLen) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if val.IsNull() {
 		return newInt64(ctx, 0)
 	}
-	s := zed.DecodeString(val.Bytes)
+	s := zed.DecodeString(val.Bytes())
 	return newInt64(ctx, int64(utf8.RuneCountInString(s)))
 }
 
@@ -63,7 +63,7 @@ func (t *ToLower) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if val.IsNull() {
 		return zed.NullString
 	}
-	s := zed.DecodeString(val.Bytes)
+	s := zed.DecodeString(val.Bytes())
 	return newString(ctx, strings.ToLower(s))
 }
 
@@ -80,7 +80,7 @@ func (t *ToUpper) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if val.IsNull() {
 		return zed.NullString
 	}
-	s := zed.DecodeString(val.Bytes)
+	s := zed.DecodeString(val.Bytes())
 	return newString(ctx, strings.ToUpper(s))
 }
 
@@ -97,7 +97,7 @@ func (t *Trim) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if val.IsNull() {
 		return zed.NullString
 	}
-	s := zed.DecodeString(val.Bytes)
+	s := zed.DecodeString(val.Bytes())
 	return newString(ctx, strings.TrimSpace(s))
 }
 
@@ -123,8 +123,8 @@ func (s *Split) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if sVal.IsNull() || sepVal.IsNull() {
 		return ctx.NewValue(s.typ, nil)
 	}
-	str := zed.DecodeString(sVal.Bytes)
-	sep := zed.DecodeString(sepVal.Bytes)
+	str := zed.DecodeString(sVal.Bytes())
+	sep := zed.DecodeString(sepVal.Bytes())
 	splits := strings.Split(str, sep)
 	var b zcode.Bytes
 	for _, substr := range splits {
@@ -154,11 +154,11 @@ func (j *Join) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		if !sepVal.IsString() {
 			return newErrorf(j.zctx, ctx, "join: separator must be string")
 		}
-		separator = zed.DecodeString(sepVal.Bytes)
+		separator = zed.DecodeString(sepVal.Bytes())
 	}
 	b := j.builder
 	b.Reset()
-	it := splitsVal.Bytes.Iter()
+	it := splitsVal.Bytes().Iter()
 	var sep string
 	for !it.Done() {
 		b.WriteString(sep)
@@ -181,6 +181,6 @@ func (l *Levenshtein) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if !b.IsString() {
 		return l.zctx.WrapError("levenshtein: string args required", b)
 	}
-	as, bs := zed.DecodeString(a.Bytes), zed.DecodeString(b.Bytes)
+	as, bs := zed.DecodeString(a.Bytes()), zed.DecodeString(b.Bytes())
 	return newInt64(ctx, int64(levenshtein.ComputeDistance(as, bs)))
 }

--- a/runtime/expr/function/time.go
+++ b/runtime/expr/function/time.go
@@ -27,7 +27,7 @@ func (b *Bucket) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	}
 	var bin nano.Duration
 	if binArg.Type == zed.TypeDuration {
-		bin = zed.DecodeDuration(binArg.Bytes)
+		bin = zed.DecodeDuration(binArg.Bytes())
 	} else {
 		d, ok := coerce.ToInt(binArg)
 		if !ok {
@@ -36,7 +36,7 @@ func (b *Bucket) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		bin = nano.Duration(d) * nano.Second
 	}
 	if zed.TypeUnder(tsArg.Type) == zed.TypeDuration {
-		dur := zed.DecodeDuration(tsArg.Bytes)
+		dur := zed.DecodeDuration(tsArg.Bytes())
 		return newDuration(ctx, dur.Trunc(bin))
 	}
 	ts, ok := coerce.ToTime(tsArg)

--- a/runtime/expr/function/types.go
+++ b/runtime/expr/function/types.go
@@ -46,7 +46,7 @@ func (t *typeName) Call(ectx zed.Allocator, args []zed.Value) *zed.Value {
 	if zed.TypeUnder(args[0].Type) != zed.TypeString {
 		return newErrorf(t.zctx, ectx, "typename: first argument not a string")
 	}
-	name := string(args[0].Bytes)
+	name := string(args[0].Bytes())
 	if len(args) == 1 {
 		typ := t.zctx.LookupTypeDef(name)
 		if typ == nil {
@@ -57,7 +57,7 @@ func (t *typeName) Call(ectx zed.Allocator, args []zed.Value) *zed.Value {
 	if zed.TypeUnder(args[1].Type) != zed.TypeType {
 		return newErrorf(t.zctx, ectx, "typename: second argument not a type value")
 	}
-	typ, err := t.zctx.LookupByValue(args[1].Bytes)
+	typ, err := t.zctx.LookupByValue(args[1].Bytes())
 	if err != nil {
 		return newError(t.zctx, ectx, err)
 	}
@@ -70,7 +70,7 @@ type Error struct {
 }
 
 func (e *Error) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
-	return ctx.NewValue(e.zctx.LookupTypeError(args[0].Type), args[0].Bytes)
+	return ctx.NewValue(e.zctx.LookupTypeError(args[0].Type), args[0].Bytes())
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#iserr
@@ -98,9 +98,9 @@ func (i *Is) Call(_ zed.Allocator, args []zed.Value) *zed.Value {
 	var typ zed.Type
 	var err error
 	if zvTypeVal.IsString() {
-		typ, err = zson.ParseType(i.zctx, string(zvTypeVal.Bytes))
+		typ, err = zson.ParseType(i.zctx, string(zvTypeVal.Bytes()))
 	} else {
-		typ, err = i.zctx.LookupByValue(zvTypeVal.Bytes)
+		typ, err = i.zctx.LookupByValue(zvTypeVal.Bytes())
 	}
 	if err == nil && typ == zvSubject.Type {
 		return zed.True
@@ -120,7 +120,7 @@ func NewHasError() *HasError {
 
 func (h *HasError) Call(_ zed.Allocator, args []zed.Value) *zed.Value {
 	v := args[0]
-	if yes, _ := h.hasError(v.Type, v.Bytes); yes {
+	if yes, _ := h.hasError(v.Type, v.Bytes()); yes {
 		return zed.True
 	}
 	return zed.False
@@ -207,7 +207,7 @@ func (k *Kind) Call(ectx zed.Allocator, args []zed.Value) *zed.Value {
 	var typ zed.Type
 	if _, ok := zed.TypeUnder(val.Type).(*zed.TypeOfType); ok {
 		var err error
-		typ, err = k.zctx.LookupByValue(val.Bytes)
+		typ, err = k.zctx.LookupByValue(val.Bytes())
 		if err != nil {
 			panic(err)
 		}

--- a/runtime/expr/function/under.go
+++ b/runtime/expr/function/under.go
@@ -13,13 +13,13 @@ func (u *Under) Call(ectx zed.Allocator, args []zed.Value) *zed.Value {
 	val := args[0]
 	switch typ := args[0].Type.(type) {
 	case *zed.TypeNamed:
-		return ectx.NewValue(typ.Type, val.Bytes)
+		return ectx.NewValue(typ.Type, val.Bytes())
 	case *zed.TypeError:
-		return ectx.NewValue(typ.Type, val.Bytes)
+		return ectx.NewValue(typ.Type, val.Bytes())
 	case *zed.TypeUnion:
-		return ectx.NewValue(typ.Untag(val.Bytes))
+		return ectx.NewValue(typ.Untag(val.Bytes()))
 	case *zed.TypeOfType:
-		t, err := u.zctx.LookupByValue(val.Bytes)
+		t, err := u.zctx.LookupByValue(val.Bytes())
 		if err != nil {
 			return newError(u.zctx, ectx, err)
 		}

--- a/runtime/expr/function/unflatten.go
+++ b/runtime/expr/function/unflatten.go
@@ -38,7 +38,7 @@ func (u *Unflatten) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	root := u.recordCache.new()
 	u.types = u.types[:0]
 	u.values = u.values[:0]
-	for it := val.Bytes.Iter(); !it.Done(); {
+	for it := val.Bytes().Iter(); !it.Done(); {
 		bytes := it.Next()
 		path, typ, vb, err := u.parseElem(array.Type, bytes)
 		if err != nil {

--- a/runtime/expr/putter.go
+++ b/runtime/expr/putter.go
@@ -126,7 +126,7 @@ func (p *putStep) buildRecord(in zcode.Bytes, b *zcode.Builder, vals []zed.Value
 			}
 			b.Append(bytes)
 		case putFromClause:
-			b.Append(vals[step.index].Bytes)
+			b.Append(vals[step.index].Bytes())
 		case putRecord:
 			b.BeginContainer()
 			bytes, err := in, error(nil)
@@ -314,7 +314,7 @@ func (p *Putter) Eval(ectx Context, this *zed.Value) *zed.Value {
 		return this
 	}
 	rule := p.lookupRule(recType, vals, clauses)
-	bytes := rule.step.build(this.Bytes, &p.builder, vals)
+	bytes := rule.step.build(this.Bytes(), &p.builder, vals)
 	return zed.NewValue(rule.typ, bytes)
 }
 

--- a/runtime/expr/renamer.go
+++ b/runtime/expr/renamer.go
@@ -84,7 +84,7 @@ func (r *Renamer) Eval(ectx Context, this *zed.Value) *zed.Value {
 		r.typeMap[id] = typ
 	}
 	out := this.Copy()
-	return ectx.NewValue(typ, out.Bytes)
+	return ectx.NewValue(typ, out.Bytes())
 }
 
 func (*Renamer) String() string { return "rename" }

--- a/runtime/expr/shaper.go
+++ b/runtime/expr/shaper.go
@@ -53,15 +53,15 @@ func (s *Shaper) Eval(ectx Context, this *zed.Value) *zed.Value {
 		return typeVal
 	}
 	if typeVal.Type == zed.TypeString {
-		typ, _ := s.zctx.LookupTypeNamed(string(typeVal.Bytes), this.Type)
-		return ectx.NewValue(typ, this.Bytes)
+		typ, _ := s.zctx.LookupTypeNamed(string(typeVal.Bytes()), this.Type)
+		return ectx.NewValue(typ, this.Bytes())
 	}
 	//XXX TypeUnder?
 	if typeVal.Type != zed.TypeType {
 		return ectx.CopyValue(s.zctx.NewErrorf(
 			"shaper type argument is not a type: %s", zson.MustFormatValue(typeVal)))
 	}
-	shapeTo, err := s.zctx.LookupByValue(typeVal.Bytes)
+	shapeTo, err := s.zctx.LookupByValue(typeVal.Bytes())
 	if err != nil {
 		panic(err)
 	}
@@ -113,10 +113,10 @@ func (c *ConstShaper) Eval(ectx Context, this *zed.Value) *zed.Value {
 		c.shapers[id] = s
 	}
 	if s.typ.ID() == id {
-		return ectx.NewValue(s.typ, val.Bytes)
+		return ectx.NewValue(s.typ, val.Bytes())
 	}
 	c.b.Reset()
-	typ := s.step.build(c.zctx, ectx, val.Bytes, &c.b)
+	typ := s.step.build(c.zctx, ectx, val.Bytes(), &c.b)
 	return ectx.NewValue(typ, c.b.Bytes().Body())
 }
 
@@ -411,7 +411,7 @@ func (s *step) build(zctx *zed.Context, ectx Context, in zcode.Bytes, b *zcode.B
 		// For a successful cast, v.Type == zed.TypeUnder(s.toType).
 		// For a failed cast, v.Type is a zed.TypeError.
 		v := s.caster.Eval(ectx, zed.NewValue(s.fromType, in))
-		b.Append(v.Bytes)
+		b.Append(v.Bytes())
 		if zed.TypeUnder(v.Type) == zed.TypeUnder(s.toType) {
 			// Prefer s.toType in case it's a named type.
 			return s.toType

--- a/runtime/expr/slice.go
+++ b/runtime/expr/slice.go
@@ -36,9 +36,9 @@ func (s *Slice) Eval(ectx Context, this *zed.Value) *zed.Value {
 	var length int
 	switch zed.TypeUnder(elem.Type).(type) {
 	case *zed.TypeOfBytes:
-		length = len(elem.Bytes)
+		length = len(elem.Bytes())
 	case *zed.TypeOfString:
-		length = utf8.RuneCount(elem.Bytes)
+		length = utf8.RuneCount(elem.Bytes())
 	case *zed.TypeArray:
 		n, err := elem.ContainerLength()
 		if err != nil {
@@ -62,7 +62,7 @@ func (s *Slice) Eval(ectx Context, this *zed.Value) *zed.Value {
 		}
 		to = length
 	}
-	bytes := elem.Bytes
+	bytes := elem.Bytes()
 	switch zed.TypeUnder(elem.Type).(type) {
 	case *zed.TypeOfBytes:
 		bytes = bytes[from:to]

--- a/runtime/expr/sort.go
+++ b/runtime/expr/sort.go
@@ -40,9 +40,9 @@ func (c *Comparator) sortStableIndices(vals []zed.Value) []uint32 {
 					i64s[i] = math.MinInt64
 				}
 			} else if zed.IsSigned(id) {
-				i64s[i] = zed.DecodeInt(val.Bytes)
+				i64s[i] = zed.DecodeInt(val.Bytes())
 			} else {
-				v := zed.DecodeUint(val.Bytes)
+				v := zed.DecodeUint(val.Bytes())
 				if v > math.MaxInt64 {
 					v = math.MaxInt64
 				}
@@ -182,7 +182,7 @@ func compareValues(a, b *zed.Value, comparefns map[zed.Type]comparefn, pair *coe
 	}
 
 	typ := a.Type
-	abytes, bbytes := a.Bytes, b.Bytes
+	abytes, bbytes := a.Bytes(), b.Bytes()
 	if a.Type.ID() != b.Type.ID() {
 		id, err := pair.Coerce(a, b)
 		if err == nil {

--- a/runtime/expr/values.go
+++ b/runtime/expr/values.go
@@ -53,7 +53,7 @@ func (r *recordExpr) Eval(ectx Context, this *zed.Value) *zed.Value {
 			r.fields[k].Type = val.Type
 			changed = true
 		}
-		b.Append(val.Bytes)
+		b.Append(val.Bytes())
 	}
 	if changed {
 		r.typ = r.zctx.MustLookupTypeRecord(r.fields)
@@ -151,7 +151,7 @@ func (r *recordSpreadExpr) update(object map[string]fieldValue) {
 			r.invalidate(object)
 			return
 		}
-		r.bytes[field.index] = field.value.Bytes
+		r.bytes[field.index] = field.value.Bytes()
 	}
 }
 
@@ -161,7 +161,7 @@ func (r *recordSpreadExpr) invalidate(object map[string]fieldValue) {
 	r.bytes = slices.Grow(r.bytes[:0], n)[:n]
 	for name, field := range object {
 		r.fields[field.index] = zed.NewField(name, field.value.Type)
-		r.bytes[field.index] = field.value.Bytes
+		r.bytes[field.index] = field.value.Bytes()
 	}
 	r.cache = r.zctx.MustLookupTypeRecord(r.fields)
 }
@@ -200,7 +200,7 @@ func (a *ArrayExpr) Eval(ectx Context, this *zed.Value) *zed.Value {
 			// Treat non-list spread values values like missing.
 			continue
 		}
-		a.collection.appendSpread(inner, val.Bytes)
+		a.collection.appendSpread(inner, val.Bytes())
 	}
 	if len(a.collection.types) == 0 {
 		return ectx.NewValue(a.zctx.LookupTypeArray(zed.TypeNull), []byte{})
@@ -240,7 +240,7 @@ func (a *SetExpr) Eval(ectx Context, this *zed.Value) *zed.Value {
 			// Treat non-list spread values values like missing.
 			continue
 		}
-		a.collection.appendSpread(inner, val.Bytes)
+		a.collection.appendSpread(inner, val.Bytes())
 	}
 	if len(a.collection.types) == 0 {
 		return ectx.NewValue(a.zctx.LookupTypeSet(zed.TypeNull), []byte{})
@@ -308,7 +308,7 @@ func (c *collectionBuilder) reset() {
 
 func (c *collectionBuilder) append(val *zed.Value) {
 	c.types = append(c.types, val.Type)
-	c.bytes = append(c.bytes, val.Bytes)
+	c.bytes = append(c.bytes, val.Bytes())
 }
 
 func (c *collectionBuilder) appendSpread(inner zed.Type, b zcode.Bytes) {

--- a/runtime/op/explode/explode.go
+++ b/runtime/op/explode/explode.go
@@ -45,7 +45,7 @@ func (o *Op) Pull(done bool) (zbuf.Batch, error) {
 					}
 					continue
 				}
-				zed.Walk(val.Type, val.Bytes, func(typ zed.Type, body zcode.Bytes) error {
+				zed.Walk(val.Type, val.Bytes(), func(typ zed.Type, body zcode.Bytes) error {
 					if typ == o.typ && body != nil {
 						bytes := zcode.Append(nil, body)
 						out = append(out, *zed.NewValue(o.outType, bytes))

--- a/runtime/op/exprswitch/exprswitch.go
+++ b/runtime/op/exprswitch/exprswitch.go
@@ -37,7 +37,7 @@ func (s *ExprSwitch) AddCase(val *zed.Value) zbuf.Puller {
 	if val == nil {
 		s.defaultCase = &switchCase{route: route}
 	} else {
-		s.cases[string(val.Bytes)] = &switchCase{route: route}
+		s.cases[string(val.Bytes())] = &switchCase{route: route}
 	}
 	return route
 }
@@ -49,7 +49,7 @@ func (s *ExprSwitch) Forward(router *op.Router, batch zbuf.Batch) bool {
 		if val.IsMissing() {
 			continue
 		}
-		which, ok := s.cases[string(val.Bytes)]
+		which, ok := s.cases[string(val.Bytes())]
 		if !ok {
 			which = s.defaultCase
 		}

--- a/runtime/op/fuse/fuser.go
+++ b/runtime/op/fuse/fuser.go
@@ -61,7 +61,7 @@ func (f *Fuser) Write(rec *zed.Value) error {
 }
 
 func (f *Fuser) stash(rec *zed.Value) error {
-	f.nbytes += len(rec.Bytes)
+	f.nbytes += len(rec.Bytes())
 	if f.nbytes >= f.memMaxBytes {
 		var err error
 		f.spiller, err = spill.NewTempFile()

--- a/runtime/op/groupby/groupby.go
+++ b/runtime/op/groupby/groupby.go
@@ -326,7 +326,7 @@ func (a *Aggregator) Consume(batch zbuf.Batch, this *zed.Value) error {
 		types = append(types, key.Type)
 		// Append each value to the key as a flat value, independent
 		// of whether this is a primitive or container.
-		keyBytes = zcode.Append(keyBytes, key.Bytes)
+		keyBytes = zcode.Append(keyBytes, key.Bytes())
 	}
 	// We conveniently put the key type code at the end of the key string,
 	// so when we recontruct the key values below, we don't have skip over it.
@@ -487,7 +487,7 @@ func (a *Aggregator) nextResultFromSpills(ectx expr.Context) (*zed.Value, error)
 	for _, e := range a.keyRefs {
 		keyVal := e.Eval(ectx, firstRec)
 		types = append(types, keyVal.Type)
-		a.builder.Append(keyVal.Bytes)
+		a.builder.Append(keyVal.Bytes())
 	}
 	for _, f := range row {
 		var v *zed.Value
@@ -497,7 +497,7 @@ func (a *Aggregator) nextResultFromSpills(ectx expr.Context) (*zed.Value, error)
 			v = f.Result(a.zctx)
 		}
 		types = append(types, v.Type)
-		a.builder.Append(v.Bytes)
+		a.builder.Append(v.Bytes())
 	}
 	typ := a.lookupRecordType(types)
 	bytes, err := a.builder.Encode()
@@ -546,7 +546,7 @@ func (a *Aggregator) readTable(flush, partialsOut bool, batch zbuf.Batch) (zbuf.
 				v = f.Result(a.zctx)
 			}
 			types = append(types, v.Type)
-			a.builder.Append(v.Bytes)
+			a.builder.Append(v.Bytes())
 		}
 		typ := a.lookupRecordType(types)
 		zv, err := a.builder.Encode()

--- a/runtime/op/join/join.go
+++ b/runtime/op/join/join.go
@@ -244,9 +244,9 @@ func (o *Op) splice(left, right *zed.Value) (*zed.Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	n := len(left.Bytes)
-	bytes := make([]byte, n+len(right.Bytes))
-	copy(bytes, left.Bytes)
-	copy(bytes[n:], right.Bytes)
+	n := len(left.Bytes())
+	bytes := make([]byte, n+len(right.Bytes()))
+	copy(bytes, left.Bytes())
+	copy(bytes[n:], right.Bytes())
 	return zed.NewValue(typ, bytes), nil
 }

--- a/runtime/op/meta/lister.go
+++ b/runtime/op/meta/lister.go
@@ -113,10 +113,10 @@ func sortObjects(objects []*data.Object, o order.Which) {
 		if cmp(aFrom, bFrom) < 0 {
 			return true
 		}
-		if !bytes.Equal(aFrom.Bytes, bFrom.Bytes) {
+		if !bytes.Equal(aFrom.Bytes(), bFrom.Bytes()) {
 			return false
 		}
-		if bytes.Equal(aTo.Bytes, bTo.Bytes) {
+		if bytes.Equal(aTo.Bytes(), bTo.Bytes()) {
 			// If the pool keys are equal for both the first and last values
 			// in the object, we return false here so that the stable sort preserves
 			// the commit order of the objects in the log. XXX we might want to

--- a/runtime/op/meta/pruner.go
+++ b/runtime/op/meta/pruner.go
@@ -22,5 +22,5 @@ func (p *pruner) prune(val *zed.Value) bool {
 		return false
 	}
 	result := p.pred.Eval(p.ectx, val)
-	return result.Type == zed.TypeBool && zed.DecodeBool(result.Bytes)
+	return result.Type == zed.TypeBool && zed.DecodeBool(result.Bytes())
 }

--- a/runtime/op/shape/shaper.go
+++ b/runtime/op/shape/shaper.go
@@ -69,7 +69,7 @@ func (i *integer) check(val zed.Value) {
 		i.unsigned = false
 		return
 	}
-	f := zed.DecodeFloat64(val.Bytes)
+	f := zed.DecodeFloat64(val.Bytes())
 	//XXX We could track signed vs unsigned and overflow,
 	// but for now, we leave it as float64 unless we can
 	// guarantee int64.
@@ -83,7 +83,7 @@ func (i *integer) check(val zed.Value) {
 }
 
 func (a *anchor) updateInts(rec *zed.Value) error {
-	it := rec.Bytes.Iter()
+	it := rec.Bytes().Iter()
 	for k, f := range rec.Fields() {
 		a.integers[k].check(*zed.NewValue(f.Type, it.Next()))
 	}
@@ -228,7 +228,7 @@ func (s *Shaper) Write(rec *zed.Value) error {
 }
 
 func (s *Shaper) stash(rec *zed.Value) error {
-	s.nbytes += len(rec.Bytes)
+	s.nbytes += len(rec.Bytes())
 	if s.nbytes >= s.memMaxBytes {
 		var err error
 		s.spiller, err = spill.NewTempFile()
@@ -256,7 +256,7 @@ func (s *Shaper) Read() (*zed.Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	bytes := rec.Bytes
+	bytes := rec.Bytes()
 	targetType, err := s.needRecode(rec.Type)
 	if err != nil {
 		return nil, err

--- a/runtime/op/sort/sort.go
+++ b/runtime/op/sort/sort.go
@@ -183,7 +183,7 @@ func (o *Op) append(out []zed.Value, batch zbuf.Batch) ([]zed.Value, int) {
 	vals := batch.Values()
 	for i := range vals {
 		val := &vals[i]
-		nbytes += len(val.Bytes)
+		nbytes += len(val.Bytes())
 		// We're keeping records owned by batch so don't call Unref.
 		out = append(out, *val)
 	}

--- a/runtime/op/switcher/switch.go
+++ b/runtime/op/switcher/switch.go
@@ -52,7 +52,7 @@ func (s *Selector) Forward(router *op.Router, batch zbuf.Batch) bool {
 				//XXX don't break here?
 				//break
 			}
-			if val.Type == zed.TypeBool && zed.DecodeBool(val.Bytes) {
+			if val.Type == zed.TypeBool && zed.DecodeBool(val.Bytes()) {
 				c.vals = append(c.vals, *this)
 				break
 			}

--- a/runtime/op/traverse/eval.go
+++ b/runtime/op/traverse/eval.go
@@ -82,7 +82,7 @@ func (e *Expr) makeArray(ectx expr.Context, vals []zed.Value) *zed.Value {
 	}
 	typ := vals[0].Type
 	if len(vals) == 1 {
-		return ectx.NewValue(typ, vals[0].Bytes)
+		return ectx.NewValue(typ, vals[0].Bytes())
 	}
 	for _, val := range vals[1:] {
 		if typ != val.Type {
@@ -91,7 +91,7 @@ func (e *Expr) makeArray(ectx expr.Context, vals []zed.Value) *zed.Value {
 	}
 	var b zcode.Builder
 	for _, val := range vals {
-		b.Append(val.Bytes)
+		b.Append(val.Bytes())
 	}
 	return ectx.NewValue(e.zctx.LookupTypeArray(typ), b.Bytes())
 }
@@ -108,7 +108,7 @@ func (e *Expr) makeUnionArray(ectx expr.Context, vals []zed.Value) *zed.Value {
 	union := e.zctx.LookupTypeUnion(utypes)
 	var b zcode.Builder
 	for _, val := range vals {
-		zed.BuildUnion(&b, union.TagOf(val.Type), val.Bytes)
+		zed.BuildUnion(&b, union.TagOf(val.Type), val.Bytes())
 	}
 	return ectx.NewValue(e.zctx.LookupTypeArray(union), b.Bytes())
 }

--- a/runtime/op/traverse/over.go
+++ b/runtime/op/traverse/over.go
@@ -86,7 +86,7 @@ func appendOver(zctx *zed.Context, vals []zed.Value, val zed.Value) []zed.Value 
 	switch typ := zed.TypeUnder(val.Type).(type) {
 	case *zed.TypeArray, *zed.TypeSet:
 		typ = zed.InnerType(typ)
-		for it := val.Bytes.Iter(); !it.Done(); {
+		for it := val.Bytes().Iter(); !it.Done(); {
 			// XXX when we do proper expr.Context, we can allocate
 			// this copy through the batch.
 			val := zed.NewValue(typ, it.Next()).Under()
@@ -98,14 +98,14 @@ func appendOver(zctx *zed.Context, vals []zed.Value, val zed.Value) []zed.Value 
 			zed.NewField("key", typ.KeyType),
 			zed.NewField("value", typ.ValType),
 		})
-		for it := val.Bytes.Iter(); !it.Done(); {
+		for it := val.Bytes().Iter(); !it.Done(); {
 			bytes := zcode.Append(zcode.Append(nil, it.Next()), it.Next())
 			vals = append(vals, *zed.NewValue(rtyp, bytes))
 		}
 		return vals
 	case *zed.TypeRecord:
 		builder := zcode.NewBuilder()
-		for i, it := 0, val.Bytes.Iter(); !it.Done(); i++ {
+		for i, it := 0, val.Bytes().Iter(); !it.Done(); i++ {
 			builder.Reset()
 			field := typ.Fields[i]
 			typ := zctx.MustLookupTypeRecord([]zed.Field{

--- a/runtime/op/uniq/uniq.go
+++ b/runtime/op/uniq/uniq.go
@@ -29,7 +29,7 @@ func New(octx *op.Context, parent zbuf.Puller, cflag bool) *Op {
 func (o *Op) wrap(t *zed.Value) *zed.Value {
 	if o.cflag {
 		o.builder.Reset()
-		o.builder.Append(t.Bytes)
+		o.builder.Append(t.Bytes())
 		o.builder.Append(zed.EncodeUint(o.count))
 		typ := o.octx.Zctx.MustLookupTypeRecord([]zed.Field{
 			zed.NewField("value", t.Type),
@@ -45,7 +45,7 @@ func (o *Op) appendUniq(out []zed.Value, t *zed.Value) []zed.Value {
 		o.last = t.Copy()
 		o.count = 1
 		return out
-	} else if bytes.Equal(t.Bytes, o.last.Bytes) {
+	} else if bytes.Equal(t.Bytes(), o.last.Bytes()) {
 		o.count++
 		return out
 	}

--- a/value.go
+++ b/value.go
@@ -75,7 +75,7 @@ func NewIP(a netip.Addr) *Value          { return &Value{TypeIP, EncodeIP(a)} }
 func NewNet(p netip.Prefix) *Value       { return &Value{TypeNet, EncodeNet(p)} }
 func NewTypeValue(t Type) *Value         { return &Value{TypeType, EncodeTypeValue(t)} }
 
-// Bytes returns the ZNG representation for v.
+// Bytes returns v's ZNG representation.
 func (v *Value) Bytes() zcode.Bytes { return v.bytes }
 
 func (v *Value) IsContainer() bool {

--- a/value_test.go
+++ b/value_test.go
@@ -9,11 +9,9 @@ import (
 )
 
 func TestValueValidate(t *testing.T) {
-	r := zed.NewValue(
-		zed.NewTypeRecord(0, []zed.Field{
-			zed.NewField("f", zed.NewTypeSet(0, zed.TypeString)),
-		}),
-		nil)
+	recType := zed.NewTypeRecord(0, []zed.Field{
+		zed.NewField("f", zed.NewTypeSet(0, zed.TypeString)),
+	})
 	t.Run("set/error/duplicate-element", func(t *testing.T) {
 		var b zcode.Builder
 		b.BeginContainer()
@@ -21,8 +19,8 @@ func TestValueValidate(t *testing.T) {
 		b.Append([]byte("dup"))
 		// Don't normalize.
 		b.EndContainer()
-		r.Bytes = b.Bytes()
-		assert.EqualError(t, r.Validate(), "invalid ZNG: duplicate set element")
+		val := zed.NewValue(recType, b.Bytes())
+		assert.EqualError(t, val.Validate(), "invalid ZNG: duplicate set element")
 	})
 	t.Run("set/error/unsorted-elements", func(t *testing.T) {
 		var b zcode.Builder
@@ -32,8 +30,8 @@ func TestValueValidate(t *testing.T) {
 		b.Append([]byte("b"))
 		// Don't normalize.
 		b.EndContainer()
-		r.Bytes = b.Bytes()
-		assert.EqualError(t, r.Validate(), "invalid ZNG: set elements not sorted")
+		val := zed.NewValue(recType, b.Bytes())
+		assert.EqualError(t, val.Validate(), "invalid ZNG: set elements not sorted")
 	})
 	t.Run("set/primitive-elements", func(t *testing.T) {
 		var b zcode.Builder
@@ -44,8 +42,8 @@ func TestValueValidate(t *testing.T) {
 		b.Append([]byte("a"))
 		b.TransformContainer(zed.NormalizeSet)
 		b.EndContainer()
-		r.Bytes = b.Bytes()
-		assert.NoError(t, r.Validate())
+		val := zed.NewValue(recType, b.Bytes())
+		assert.NoError(t, val.Validate())
 	})
 	t.Run("set/complex-elements", func(t *testing.T) {
 		var b zcode.Builder

--- a/vng/writer.go
+++ b/vng/writer.go
@@ -89,10 +89,10 @@ func (w *Writer) Write(val *zed.Value) error {
 	if err := w.root.Write(int64(typeNo)); err != nil {
 		return err
 	}
-	if err := w.writers[typeNo].Write(val.Bytes); err != nil {
+	if err := w.writers[typeNo].Write(val.Bytes()); err != nil {
 		return err
 	}
-	w.footprint += len(val.Bytes)
+	w.footprint += len(val.Bytes())
 	if w.footprint >= w.skewThresh {
 		w.footprint = 0
 		return w.flush(false)

--- a/zbuf/array.go
+++ b/zbuf/array.go
@@ -66,5 +66,5 @@ func (*Array) NewValue(typ zed.Type, bytes zcode.Bytes) *zed.Value {
 
 func (*Array) CopyValue(val *zed.Value) *zed.Value {
 	// XXX can make this more efficient later
-	return zed.NewValue(val.Type, val.Bytes)
+	return zed.NewValue(val.Type, val.Bytes())
 }

--- a/zbuf/array_test.go
+++ b/zbuf/array_test.go
@@ -11,6 +11,6 @@ func TestArrayWriteCopiesValueBytes(t *testing.T) {
 	var a Array
 	val := zed.NewString("old")
 	a.Write(val)
-	copy(val.Bytes, zed.EncodeString("new"))
+	copy(val.Bytes(), zed.EncodeString("new"))
 	require.Equal(t, zed.NewString("old"), &a.Values()[0])
 }

--- a/zbuf/batch.go
+++ b/zbuf/batch.go
@@ -129,15 +129,15 @@ func (b *pullerBatch) appendVal(val *zed.Value) bool {
 	var bytes []byte
 	var bufFull bool
 	if !val.IsNull() {
-		if avail := cap(b.buf) - len(b.buf); avail >= len(val.Bytes) {
+		if avail := cap(b.buf) - len(b.buf); avail >= len(val.Bytes()) {
 			// Append to b.buf since that won't reallocate.
 			start := len(b.buf)
-			b.buf = append(b.buf, val.Bytes...)
+			b.buf = append(b.buf, val.Bytes()...)
 			bytes = b.buf[start:]
-			bufFull = avail == len(val.Bytes)
+			bufFull = avail == len(val.Bytes())
 		} else {
 			// Copy since appending to b.buf would reallocate.
-			bytes = slices.Clone(val.Bytes)
+			bytes = slices.Clone(val.Bytes())
 			bufFull = true
 		}
 	}

--- a/zbuf/merger.go
+++ b/zbuf/merger.go
@@ -31,5 +31,5 @@ func NewComparatorNullsMax(zctx *zed.Context, sortKey order.SortKey) *expr.Compa
 type valueAsBytes struct{}
 
 func (v *valueAsBytes) Eval(ectx expr.Context, val *zed.Value) *zed.Value {
-	return ectx.NewValue(zed.TypeBytes, val.Bytes)
+	return ectx.NewValue(zed.TypeBytes, val.Bytes())
 }

--- a/zbuf/scanner.go
+++ b/zbuf/scanner.go
@@ -131,15 +131,15 @@ func (s *scanner) Read() (*zed.Value, error) {
 		if err != nil || this == nil {
 			return nil, err
 		}
-		atomic.AddInt64(&s.progress.BytesRead, int64(len(this.Bytes)))
+		atomic.AddInt64(&s.progress.BytesRead, int64(len(this.Bytes())))
 		atomic.AddInt64(&s.progress.RecordsRead, 1)
 		if s.filter != nil {
 			val := s.filter.Eval(s.ectx, this)
-			if !(val.Type == zed.TypeBool && zed.DecodeBool(val.Bytes)) {
+			if !(val.Type == zed.TypeBool && zed.DecodeBool(val.Bytes())) {
 				continue
 			}
 		}
-		atomic.AddInt64(&s.progress.BytesMatched, int64(len(this.Bytes)))
+		atomic.AddInt64(&s.progress.BytesMatched, int64(len(this.Bytes())))
 		atomic.AddInt64(&s.progress.RecordsMatched, 1)
 		return this, nil
 	}

--- a/zio/arrowio/writer.go
+++ b/zio/arrowio/writer.go
@@ -97,7 +97,7 @@ func (w *Writer) Write(val *zed.Value) error {
 	} else if w.typ != recType {
 		return fmt.Errorf("%w: %s and %s", ErrMultipleTypes, zson.FormatType(w.typ), zson.FormatType(recType))
 	}
-	it := val.Bytes.Iter()
+	it := val.Bytes().Iter()
 	for i, builder := range w.builder.Fields() {
 		var b zcode.Bytes
 		if it != nil {

--- a/zio/csvio/writer.go
+++ b/zio/csvio/writer.go
@@ -67,17 +67,17 @@ func (w *Writer) Write(rec *zed.Value) error {
 	}
 	w.strings = w.strings[:0]
 	fields := rec.Fields()
-	for i, it := 0, rec.Bytes.Iter(); i < len(fields) && !it.Done(); i++ {
+	for i, it := 0, rec.Bytes().Iter(); i < len(fields) && !it.Done(); i++ {
 		var s string
 		if zb := it.Next(); zb != nil {
 			val := zed.NewValue(fields[i].Type, zb).Under()
 			switch id := val.Type.ID(); {
-			case id == zed.IDBytes && len(val.Bytes) == 0:
+			case id == zed.IDBytes && len(val.Bytes()) == 0:
 				// We want "" instead of "0x" for a zero-length value.
 			case id == zed.IDString:
-				s = string(val.Bytes)
+				s = string(val.Bytes())
 			default:
-				s = formatValue(val.Type, val.Bytes)
+				s = formatValue(val.Type, val.Bytes())
 				if zed.IsFloat(id) && strings.HasSuffix(s, ".") {
 					s = strings.TrimSuffix(s, ".")
 				}

--- a/zio/jsonio/writer.go
+++ b/zio/jsonio/writer.go
@@ -22,5 +22,5 @@ func NewWriter(wc io.WriteCloser) *Writer {
 }
 
 func (w *Writer) Write(val *zed.Value) error {
-	return w.encoder.Encode(marshalAny(val.Type, val.Bytes))
+	return w.encoder.Encode(marshalAny(val.Type, val.Bytes()))
 }

--- a/zio/peeker_test.go
+++ b/zio/peeker_test.go
@@ -29,7 +29,7 @@ func TestPeeker(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if !bytes.Equal(rec1.Bytes, rec2.Bytes) {
+	if !bytes.Equal(rec1.Bytes(), rec2.Bytes()) {
 		t.Error("rec1 != rec2")
 	}
 	rec3, err := peeker.Read()
@@ -37,7 +37,7 @@ func TestPeeker(t *testing.T) {
 		t.Error(err)
 	}
 	rec3 = rec3.Copy()
-	if !bytes.Equal(rec1.Bytes, rec3.Bytes) {
+	if !bytes.Equal(rec1.Bytes(), rec3.Bytes()) {
 		t.Error("rec1 != rec3")
 	}
 	rec4, err := peeker.Peek()
@@ -45,14 +45,14 @@ func TestPeeker(t *testing.T) {
 		t.Error(err)
 	}
 	rec4 = rec4.Copy()
-	if bytes.Equal(rec3.Bytes, rec4.Bytes) {
+	if bytes.Equal(rec3.Bytes(), rec4.Bytes()) {
 		t.Error("rec3 == rec4")
 	}
 	rec5, err := peeker.Read()
 	if err != nil {
 		t.Error(err)
 	}
-	if !bytes.Equal(rec4.Bytes, rec5.Bytes) {
+	if !bytes.Equal(rec4.Bytes(), rec5.Bytes()) {
 		t.Error("rec4 != rec5")
 	}
 }

--- a/zio/tableio/writer.go
+++ b/zio/tableio/writer.go
@@ -61,7 +61,7 @@ func (w *Writer) Write(r *zed.Value) error {
 		value := r.DerefByColumn(k).MissingAsNull()
 		if f.Type == zed.TypeTime {
 			if !value.IsNull() {
-				v = zed.DecodeTime(value.Bytes).Time().Format(time.RFC3339Nano)
+				v = zed.DecodeTime(value.Bytes()).Time().Format(time.RFC3339Nano)
 			}
 		} else {
 			v = zeekio.FormatValue(value)

--- a/zio/textio/writer.go
+++ b/zio/textio/writer.go
@@ -48,7 +48,7 @@ func (w *Writer) writeRecord(rec *zed.Value) error {
 			if value.IsNull() {
 				s = "-"
 			} else {
-				s = zed.DecodeTime(value.Bytes).Time().Format(time.RFC3339Nano)
+				s = zed.DecodeTime(value.Bytes()).Time().Format(time.RFC3339Nano)
 			}
 		} else {
 			s = zeekio.FormatValue(value)

--- a/zio/zeekio/format.go
+++ b/zio/zeekio/format.go
@@ -18,53 +18,53 @@ import (
 func formatAny(val *zed.Value, inContainer bool) string {
 	switch t := val.Type.(type) {
 	case *zed.TypeArray:
-		return formatArray(t, val.Bytes)
+		return formatArray(t, val.Bytes())
 	case *zed.TypeNamed:
-		return formatAny(zed.NewValue(t.Type, val.Bytes), inContainer)
+		return formatAny(zed.NewValue(t.Type, val.Bytes()), inContainer)
 	case *zed.TypeOfBool:
-		if zed.DecodeBool(val.Bytes) {
+		if zed.DecodeBool(val.Bytes()) {
 			return "T"
 		}
 		return "F"
 	case *zed.TypeOfBytes:
-		return base64.StdEncoding.EncodeToString(val.Bytes)
+		return base64.StdEncoding.EncodeToString(val.Bytes())
 	case *zed.TypeOfDuration:
-		return formatTime(nano.Ts(zed.DecodeDuration(val.Bytes)))
+		return formatTime(nano.Ts(zed.DecodeDuration(val.Bytes())))
 	case *zed.TypeEnum:
-		return formatAny(zed.NewValue(zed.TypeUint64, val.Bytes), false)
+		return formatAny(zed.NewValue(zed.TypeUint64, val.Bytes()), false)
 	case *zed.TypeOfFloat16:
-		return strconv.FormatFloat(float64(zed.DecodeFloat16(val.Bytes)), 'f', -1, 32)
+		return strconv.FormatFloat(float64(zed.DecodeFloat16(val.Bytes())), 'f', -1, 32)
 	case *zed.TypeOfFloat32:
-		return strconv.FormatFloat(float64(zed.DecodeFloat32(val.Bytes)), 'f', -1, 32)
+		return strconv.FormatFloat(float64(zed.DecodeFloat32(val.Bytes())), 'f', -1, 32)
 	case *zed.TypeOfFloat64:
-		return strconv.FormatFloat(zed.DecodeFloat64(val.Bytes), 'f', -1, 64)
+		return strconv.FormatFloat(zed.DecodeFloat64(val.Bytes()), 'f', -1, 64)
 	case *zed.TypeOfInt8, *zed.TypeOfInt16, *zed.TypeOfInt32, *zed.TypeOfInt64:
-		return strconv.FormatInt(zed.DecodeInt(val.Bytes), 10)
+		return strconv.FormatInt(zed.DecodeInt(val.Bytes()), 10)
 	case *zed.TypeOfUint8, *zed.TypeOfUint16, *zed.TypeOfUint32, *zed.TypeOfUint64:
-		return strconv.FormatUint(zed.DecodeUint(val.Bytes), 10)
+		return strconv.FormatUint(zed.DecodeUint(val.Bytes()), 10)
 	case *zed.TypeOfIP:
-		return zed.DecodeIP(val.Bytes).String()
+		return zed.DecodeIP(val.Bytes()).String()
 	case *zed.TypeMap:
-		return formatMap(t, val.Bytes)
+		return formatMap(t, val.Bytes())
 	case *zed.TypeOfNet:
-		return zed.DecodeNet(val.Bytes).String()
+		return zed.DecodeNet(val.Bytes()).String()
 	case *zed.TypeOfNull:
 		return "-"
 	case *zed.TypeRecord:
-		return formatRecord(t, val.Bytes)
+		return formatRecord(t, val.Bytes())
 	case *zed.TypeSet:
-		return formatSet(t, val.Bytes)
+		return formatSet(t, val.Bytes())
 	case *zed.TypeOfString:
-		return formatString(t, val.Bytes, inContainer)
+		return formatString(t, val.Bytes(), inContainer)
 	case *zed.TypeOfTime:
-		return formatTime(zed.DecodeTime(val.Bytes))
+		return formatTime(zed.DecodeTime(val.Bytes()))
 	case *zed.TypeOfType:
 		return zson.String(val)
 	case *zed.TypeUnion:
-		return formatUnion(t, val.Bytes)
+		return formatUnion(t, val.Bytes())
 	case *zed.TypeError:
 		if zed.TypeUnder(t.Type) == zed.TypeString {
-			return string(val.Bytes)
+			return string(val.Bytes())
 		}
 		return zson.MustFormatValue(val)
 	default:

--- a/zio/zeekio/writer.go
+++ b/zio/zeekio/writer.go
@@ -43,7 +43,7 @@ func (w *Writer) Write(r *zed.Value) error {
 	}
 	w.buf.Reset()
 	var needSeparator bool
-	it := r.Bytes.Iter()
+	it := r.Bytes().Iter()
 	for _, f := range zed.TypeRecordOf(r.Type).Fields {
 		bytes := it.Next()
 		if f.Name == "_path" {

--- a/zio/zjsonio/reader.go
+++ b/zio/zjsonio/reader.go
@@ -104,7 +104,7 @@ func (r *Reader) decodeValue(b *zcode.Builder, typ zed.Type, body interface{}) e
 			return err
 		}
 		tv := r.zctx.LookupTypeValue(local)
-		b.Append(tv.Bytes)
+		b.Append(tv.Bytes())
 		return nil
 	default:
 		return r.decodePrimitive(b, typ, body)

--- a/zio/zjsonio/writer.go
+++ b/zio/zjsonio/writer.go
@@ -79,7 +79,7 @@ func (w *Writer) Transform(r *zed.Value) (Object, error) {
 	// Encode type before encoding value in case there are type values
 	// in the value.  We want to keep the order consistent.
 	typ := w.encoder.encodeType(local)
-	v, err := w.encodeValue(w.zctx, local, r.Bytes)
+	v, err := w.encodeValue(w.zctx, local, r.Bytes())
 	if err != nil {
 		return Object{}, err
 	}

--- a/zio/zngio/batch.go
+++ b/zio/zngio/batch.go
@@ -51,7 +51,7 @@ func (b *batch) NewValue(typ zed.Type, bytes zcode.Bytes) *zed.Value {
 }
 
 func (b *batch) CopyValue(val *zed.Value) *zed.Value {
-	return zed.NewValue(val.Type, val.Bytes)
+	return zed.NewValue(val.Type, val.Bytes())
 }
 
 func (b *batch) Ref() { atomic.AddInt32(&b.refs, 1) }

--- a/zio/zngio/scanner.go
+++ b/zio/zngio/scanner.go
@@ -320,8 +320,7 @@ func (w *worker) decodeVal(buf *buffer, valRef *zed.Value) error {
 	if typ == nil {
 		return fmt.Errorf("zngio: type ID %d not in context", id)
 	}
-	valRef.Type = typ
-	valRef.Bytes = b
+	*valRef = *zed.NewValue(typ, b)
 	if w.validate {
 		if err := valRef.Validate(); err != nil {
 			return err
@@ -331,7 +330,7 @@ func (w *worker) decodeVal(buf *buffer, valRef *zed.Value) error {
 }
 
 func (w *worker) wantValue(val *zed.Value, progress *zbuf.Progress) bool {
-	progress.BytesRead += int64(len(val.Bytes))
+	progress.BytesRead += int64(len(val.Bytes()))
 	progress.RecordsRead++
 	// It's tempting to call w.bufferFilter.Eval on rec.Bytes here, but that
 	// might call FieldNameFinder.Find, which could explode or return false
@@ -339,7 +338,7 @@ func (w *worker) wantValue(val *zed.Value, progress *zbuf.Progress) bool {
 	// rec.Bytes is just a ZNG value.  (A ZNG value message is a header
 	// indicating a type ID followed by a value of that type.)
 	if w.filter == nil || check(w.ectx, val, w.filter) {
-		progress.BytesMatched += int64(len(val.Bytes))
+		progress.BytesMatched += int64(len(val.Bytes()))
 		progress.RecordsMatched++
 		return true
 	}
@@ -348,5 +347,5 @@ func (w *worker) wantValue(val *zed.Value, progress *zbuf.Progress) bool {
 
 func check(ectx expr.Context, this *zed.Value, filter expr.Evaluator) bool {
 	val := filter.Eval(ectx, this)
-	return val.Type == zed.TypeBool && zed.DecodeBool(val.Bytes)
+	return val.Type == zed.TypeBool && zed.DecodeBool(val.Bytes())
 }

--- a/zio/zngio/writer.go
+++ b/zio/zngio/writer.go
@@ -111,7 +111,7 @@ func (w *Writer) Write(val *zed.Value) error {
 	}
 	id := zed.TypeID(typ)
 	w.values = binary.AppendUvarint(w.values, uint64(id))
-	w.values = zcode.Append(w.values, val.Bytes)
+	w.values = zcode.Append(w.values, val.Bytes())
 	if thresh := w.opts.FrameThresh; len(w.values) >= thresh || len(w.types.bytes) >= thresh {
 		return w.flush()
 	}

--- a/zson/formatter.go
+++ b/zson/formatter.go
@@ -73,7 +73,7 @@ func (f *Formatter) FormatRecord(rec *zed.Value) (string, error) {
 	// by putting a record number/nonce in the map but ZSON
 	// is already intended to be the low performance path.
 	f.typedefs = make(map[string]*zed.TypeNamed)
-	if err := f.formatValueAndDecorate(rec.Type, rec.Bytes); err != nil {
+	if err := f.formatValueAndDecorate(rec.Type, rec.Bytes()); err != nil {
 		return "", err
 	}
 	return f.builder.String(), nil
@@ -87,7 +87,7 @@ func FormatValue(val *zed.Value) (string, error) {
 func MustFormatValue(val *zed.Value) string {
 	s, err := FormatValue(val)
 	if err != nil {
-		panic(fmt.Errorf("ZSON format value failed: type %s, bytes %s", val.Type, hex.EncodeToString(val.Bytes)))
+		panic(fmt.Errorf("ZSON format value failed: type %s, bytes %s", val.Type, hex.EncodeToString(val.Bytes())))
 	}
 	return s
 }
@@ -108,7 +108,7 @@ func String(p interface{}) string {
 
 func (f *Formatter) Format(val *zed.Value) (string, error) {
 	f.builder.Reset()
-	if err := f.formatValueAndDecorate(val.Type, val.Bytes); err != nil {
+	if err := f.formatValueAndDecorate(val.Type, val.Bytes()); err != nil {
 		return "", err
 	}
 	return f.builder.String(), nil

--- a/zson/marshal.go
+++ b/zson/marshal.go
@@ -295,14 +295,14 @@ func (m *MarshalZNGContext) encodeAny(v reflect.Value) (zed.Type, error) {
 		return zed.TypeTime, nil
 	case zed.Type:
 		val := m.Context.LookupTypeValue(v)
-		m.Builder.Append(val.Bytes)
+		m.Builder.Append(val.Bytes())
 		return val.Type, nil
 	case zed.Value:
 		typ, err := m.TranslateType(v.Type)
 		if err != nil {
 			return nil, err
 		}
-		m.Builder.Append(v.Bytes)
+		m.Builder.Append(v.Bytes())
 		return typ, nil
 	}
 	switch v.Kind() {
@@ -712,13 +712,13 @@ func (u *UnmarshalZNGContext) decodeAny(val *zed.Value, v reflect.Value) error {
 		if val.Type != zed.TypeFloat16 {
 			return incompatTypeError(val.Type, v)
 		}
-		v.SetUint(uint64(float16.Fromfloat32(zed.DecodeFloat16(val.Bytes)).Bits()))
+		v.SetUint(uint64(float16.Fromfloat32(zed.DecodeFloat16(val.Bytes())).Bits()))
 		return nil
 	case nano.Ts:
 		if val.Type != zed.TypeTime {
 			return incompatTypeError(val.Type, v)
 		}
-		v.Set(reflect.ValueOf(zed.DecodeTime(val.Bytes)))
+		v.Set(reflect.ValueOf(zed.DecodeTime(val.Bytes())))
 		return nil
 	case zed.Value:
 		// For zed.Values we simply set the reflect value to the
@@ -755,7 +755,7 @@ func (u *UnmarshalZNGContext) decodeAny(val *zed.Value, v reflect.Value) error {
 			if u.zctx == nil {
 				return errors.New("cannot unmarshal type value without type context")
 			}
-			typ, err := u.zctx.LookupByValue(val.Bytes)
+			typ, err := u.zctx.LookupByValue(val.Bytes())
 			if err != nil {
 				return err
 			}
@@ -768,7 +768,7 @@ func (u *UnmarshalZNGContext) decodeAny(val *zed.Value, v reflect.Value) error {
 		if !v.IsNil() {
 			return u.decodeAny(val, v.Elem())
 		}
-		template, err := u.lookupGoType(val.Type, val.Bytes)
+		template, err := u.lookupGoType(val.Type, val.Bytes())
 		if err != nil {
 			return err
 		}
@@ -802,13 +802,13 @@ func (u *UnmarshalZNGContext) decodeAny(val *zed.Value, v reflect.Value) error {
 		default:
 			return incompatTypeError(val.Type, v)
 		}
-		v.SetString(zed.DecodeString(val.Bytes))
+		v.SetString(zed.DecodeString(val.Bytes()))
 		return nil
 	case reflect.Bool:
 		if zed.TypeUnder(val.Type) != zed.TypeBool {
 			return incompatTypeError(val.Type, v)
 		}
-		v.SetBool(zed.DecodeBool(val.Bytes))
+		v.SetBool(zed.DecodeBool(val.Bytes()))
 		return nil
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		switch zed.TypeUnder(val.Type) {
@@ -816,7 +816,7 @@ func (u *UnmarshalZNGContext) decodeAny(val *zed.Value, v reflect.Value) error {
 		default:
 			return incompatTypeError(val.Type, v)
 		}
-		v.SetInt(zed.DecodeInt(val.Bytes))
+		v.SetInt(zed.DecodeInt(val.Bytes()))
 		return nil
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		switch zed.TypeUnder(val.Type) {
@@ -824,19 +824,19 @@ func (u *UnmarshalZNGContext) decodeAny(val *zed.Value, v reflect.Value) error {
 		default:
 			return incompatTypeError(val.Type, v)
 		}
-		v.SetUint(zed.DecodeUint(val.Bytes))
+		v.SetUint(zed.DecodeUint(val.Bytes()))
 		return nil
 	case reflect.Float32:
 		if zed.TypeUnder(val.Type) != zed.TypeFloat32 {
 			return incompatTypeError(val.Type, v)
 		}
-		v.SetFloat(float64(zed.DecodeFloat32(val.Bytes)))
+		v.SetFloat(float64(zed.DecodeFloat32(val.Bytes())))
 		return nil
 	case reflect.Float64:
 		if zed.TypeUnder(val.Type) != zed.TypeFloat64 {
 			return incompatTypeError(val.Type, v)
 		}
-		v.SetFloat(zed.DecodeFloat64(val.Bytes))
+		v.SetFloat(zed.DecodeFloat64(val.Bytes()))
 		return nil
 	default:
 		return fmt.Errorf("unsupported type: %v", v.Kind())
@@ -899,7 +899,7 @@ func (u *UnmarshalZNGContext) decodeNetipAddr(val *zed.Value, v reflect.Value) e
 	if zed.TypeUnder(val.Type) != zed.TypeIP {
 		return incompatTypeError(val.Type, v)
 	}
-	v.Set(reflect.ValueOf(zed.DecodeIP(val.Bytes)))
+	v.Set(reflect.ValueOf(zed.DecodeIP(val.Bytes())))
 	return nil
 }
 
@@ -907,7 +907,7 @@ func (u *UnmarshalZNGContext) decodeNetIP(val *zed.Value, v reflect.Value) error
 	if zed.TypeUnder(val.Type) != zed.TypeIP {
 		return incompatTypeError(val.Type, v)
 	}
-	v.Set(reflect.ValueOf(net.ParseIP(zed.DecodeIP(val.Bytes).String())))
+	v.Set(reflect.ValueOf(net.ParseIP(zed.DecodeIP(val.Bytes()).String())))
 	return nil
 }
 
@@ -942,7 +942,7 @@ func (u *UnmarshalZNGContext) decodeMap(val *zed.Value, mapVal reflect.Value) er
 
 func (u *UnmarshalZNGContext) decodeRecord(val *zed.Value, sval reflect.Value) error {
 	if union, ok := val.Type.(*zed.TypeUnion); ok {
-		typ, bytes := union.Untag(val.Bytes)
+		typ, bytes := union.Untag(val.Bytes())
 		val = zed.NewValue(typ, bytes)
 	}
 	recType, ok := zed.TypeUnder(val.Type).(*zed.TypeRecord)
@@ -983,7 +983,7 @@ func (u *UnmarshalZNGContext) decodeArray(val *zed.Value, arrVal reflect.Value) 
 			return u.decodeArrayBytes(val, arrVal)
 		}
 		// arrVal is a slice here.
-		arrVal.SetBytes(val.Bytes)
+		arrVal.SetBytes(val.Bytes())
 		return nil
 	}
 	arrType, ok := typ.(*zed.TypeArray)
@@ -1024,10 +1024,10 @@ func (u *UnmarshalZNGContext) decodeArray(val *zed.Value, arrVal reflect.Value) 
 }
 
 func (u *UnmarshalZNGContext) decodeArrayBytes(val *zed.Value, arrayVal reflect.Value) error {
-	if len(val.Bytes) != arrayVal.Len() {
+	if len(val.Bytes()) != arrayVal.Len() {
 		return errors.New("ZNG bytes value length differs from Go array")
 	}
-	for k, b := range val.Bytes {
+	for k, b := range val.Bytes() {
 		arrayVal.Index(k).Set(reflect.ValueOf(b))
 	}
 	return nil

--- a/zson/marshal_test.go
+++ b/zson/marshal_test.go
@@ -209,7 +209,7 @@ func TestMixedTypeArrayInsideRecord(t *testing.T) {
 
 	var buffer bytes.Buffer
 	writer := zngio.NewWriter(zio.NopCloser(&buffer))
-	recExpected := zed.NewValue(zv.Type, zv.Bytes)
+	recExpected := zed.NewValue(zv.Type, zv.Bytes())
 	writer.Write(recExpected)
 	writer.Close()
 
@@ -271,7 +271,7 @@ func TestMixedTypeArrayOfStructWithInterface(t *testing.T) {
 
 	var buffer bytes.Buffer
 	writer := zngio.NewWriter(zio.NopCloser(&buffer))
-	recExpected := zed.NewValue(zv.Type, zv.Bytes)
+	recExpected := zed.NewValue(zv.Type, zv.Bytes())
 	writer.Write(recExpected)
 	writer.Close()
 

--- a/zson/marshal_zng_test.go
+++ b/zson/marshal_zng_test.go
@@ -618,8 +618,8 @@ func TestMultipleZedValues(t *testing.T) {
 	var bar zed.Value
 	err = u.Unmarshal(zed.NewValue(zed.TypeString, bytes), &bar)
 	require.NoError(t, err)
-	assert.Equal(t, "foo", string(foo.Bytes))
-	assert.Equal(t, "bar", string(bar.Bytes))
+	assert.Equal(t, "foo", string(foo.Bytes()))
+	assert.Equal(t, "bar", string(bar.Bytes()))
 }
 
 func TestZedValues(t *testing.T) {

--- a/zson/typeval_test.go
+++ b/zson/typeval_test.go
@@ -14,7 +14,7 @@ func TestTypeValue(t *testing.T) {
 	typ, err := zson.ParseType(zed.NewContext(), s)
 	require.NoError(t, err)
 	tv := zctx.LookupTypeValue(typ)
-	require.Exactly(t, s, zson.FormatTypeValue(tv.Bytes))
+	require.Exactly(t, s, zson.FormatTypeValue(tv.Bytes()))
 }
 
 func TestTypeValueCrossContext(t *testing.T) {
@@ -22,5 +22,5 @@ func TestTypeValueCrossContext(t *testing.T) {
 	typ, err := zson.ParseType(zed.NewContext(), s)
 	require.NoError(t, err)
 	tv := zed.NewContext().LookupTypeValue(typ)
-	require.Exactly(t, s, zson.FormatTypeValue(tv.Bytes))
+	require.Exactly(t, s, zson.FormatTypeValue(tv.Bytes()))
 }

--- a/zson/zson_test.go
+++ b/zson/zson_test.go
@@ -54,7 +54,7 @@ func TestZSONBuilder(t *testing.T) {
 	b := zcode.NewBuilder()
 	zv, err := zson.Build(b, val)
 	require.NoError(t, err)
-	rec := zed.NewValue(zv.Type.(*zed.TypeRecord), zv.Bytes)
+	rec := zed.NewValue(zv.Type.(*zed.TypeRecord), zv.Bytes())
 	a := rec.Deref("a")
 	assert.Equal(t, `["1","2","3"]`, zson.String(a))
 }


### PR DESCRIPTION
This is preparation for storing some primitive values natively.  With that change, Value.bytes won't contain the ZNG encoding for native values, so this method will have to create it.  That'll be relatively expensive, but we'll avoid it in most cases by replacing the zed.DecodeXXX(val.Bytes()) pattern with new Value methods that access a native value directly when available.