### PR TITLE
Remove runtime/expr.Scope

### DIFF
--- a/runtime/expr/context.go
+++ b/runtime/expr/context.go
@@ -38,20 +38,6 @@ func (*allocator) Vars() []zed.Value {
 	return nil
 }
 
-type Scope []zed.Value
-
-func (s Scope) Frame() []zed.Value {
-	return s
-}
-
-func (s *Scope) Pop(n int) {
-	*s = (*s)[:len(*s)-n]
-}
-
-func (s *Scope) Push(val zed.Value) {
-	*s = append(*s, val)
-}
-
 type ResetContext struct {
 	buf  []byte
 	vals []zed.Value


### PR DESCRIPTION
It's unused.