### PR TITLE
Send HTTP 400 response for NOP "delete where"

### DIFF
--- a/service/handlers.go
+++ b/service/handlers.go
@@ -511,7 +511,8 @@ func handleDelete(c *Core, w *ResponseWriter, r *Request) {
 			return
 		}
 		commit, err = branch.DeleteWhere(r.Context(), c.compiler, program, message.Author, message.Body, message.Meta)
-		if errors.Is(err, &compiler.InvalidDeleteWhereQuery{}) {
+		if errors.Is(err, commits.ErrEmptyTransaction) ||
+			errors.Is(err, &compiler.InvalidDeleteWhereQuery{}) {
 			err = srverr.ErrInvalid(err)
 		}
 	}

--- a/service/ztests/curl-delete-where.yaml
+++ b/service/ztests/curl-delete-where.yaml
@@ -7,7 +7,10 @@ script: |
   echo '{x:6}{x:7}{x:8}' | zed load -q -
   curl -s -d '{where:"x <= 4"}' $ZED_LAKE/pool/test/branch/main/delete |
     sed -E 's/0x[0-9a-f]{40}/xxx/'
-  echo ===
+  echo === | tee >(cat >&2)
+  zed query -z '*'
+  echo === | tee >(cat >&2)
+  ! curl --fail --no-progress-meter -d '{where:"x <= 4"}' $ZED_LAKE/pool/test/branch/main/delete
   zed query -z '*'
 
 inputs:
@@ -22,3 +25,13 @@ outputs:
       {x:6}
       {x:7}
       {x:8}
+      ===
+      {x:5}
+      {x:6}
+      {x:7}
+      {x:8}
+  - name: stderr
+    data: |
+      ===
+      ===
+      curl: (22) The requested URL returned error: 400

--- a/service/ztests/curl-delete-where.yaml
+++ b/service/ztests/curl-delete-where.yaml
@@ -7,10 +7,10 @@ script: |
   echo '{x:6}{x:7}{x:8}' | zed load -q -
   curl -s -d '{where:"x <= 4"}' $ZED_LAKE/pool/test/branch/main/delete |
     sed -E 's/0x[0-9a-f]{40}/xxx/'
-  echo === | tee >(cat >&2)
+  echo ===
   zed query -z '*'
-  echo === | tee >(cat >&2)
-  ! curl --fail --no-progress-meter -d '{where:"x <= 4"}' $ZED_LAKE/pool/test/branch/main/delete
+  echo ===
+  curl -w 'code %{response_code}\n' -d '{where:"x <= 4"}' $ZED_LAKE/pool/test/branch/main/delete
   zed query -z '*'
 
 inputs:
@@ -26,12 +26,9 @@ outputs:
       {x:7}
       {x:8}
       ===
+      {"type":"Error","kind":"invalid operation","error":"empty transaction"}
+      code 400
       {x:5}
       {x:6}
       {x:7}
       {x:8}
-  - name: stderr
-    data: |
-      ===
-      ===
-      curl: (22) The requested URL returned error: 400

--- a/service/ztests/delete-where.yaml
+++ b/service/ztests/delete-where.yaml
@@ -1,13 +1,15 @@
 script: |
   source service.sh
   for order in desc asc; do
-    echo === $order ===
+    echo === $order === | tee >(cat >&2)
     zed create -q -S 1KB -orderby ts:$order test
     zed use -q test
     seq 1000 | zq '{ts:this-1,s:"val${this-1}"}' - | zed load -q -
     zed delete -q -where 'ts > 400 and ts <= 500'
     zed query -z 'count()'
     zed delete -q -where 's == "val1" or s == "val999"'
+    zed query -z 'count()'
+    ! zed delete -q -where 's == "val1" or s == "val999"'
     zed query -z 'count()'
     zed drop -f -q test
   done 
@@ -21,6 +23,14 @@ outputs:
       === desc ===
       900(uint64)
       898(uint64)
+      898(uint64)
       === asc ===
       900(uint64)
       898(uint64)
+      898(uint64)
+  - name: stderr
+    data: |
+      === desc ===
+      status code 400: empty transaction
+      === asc ===
+      status code 400: empty transaction


### PR DESCRIPTION
"zed serve" sends a 500 response for a POST
/pool/{pool}/branch/{branch}/delete request whose body contains a "where" filter expression matching no values.  Change that to 400.

Closes #4617.