### PR TITLE
Use native representation for Boolean zed.Value

### DIFF
--- a/lake/data/seekindex.go
+++ b/lake/data/seekindex.go
@@ -35,7 +35,7 @@ func LookupSeekRange(ctx context.Context, engine storage.Engine, path *storage.U
 			return ranges, err
 		}
 		result := pruner.Eval(ectx, val)
-		if result.Type == zed.TypeBool && zed.DecodeBool(result.Bytes()) {
+		if result.Type == zed.TypeBool && result.Bool() {
 			rg = nil
 			continue
 		}

--- a/lake/pool.go
+++ b/lake/pool.go
@@ -182,7 +182,7 @@ func filter(zctx *zed.Context, ectx expr.Context, this *zed.Value, e expr.Evalua
 		return true
 	}
 	val, ok := expr.EvalBool(zctx, ectx, this, e)
-	return ok && zed.DecodeBool(val.Bytes())
+	return ok && val.Bool()
 }
 
 type BranchTip struct {

--- a/primitive.go
+++ b/primitive.go
@@ -15,17 +15,6 @@ import (
 
 type TypeOfBool struct{}
 
-var False = &Value{TypeBool, []byte{0}}
-var True = &Value{TypeBool, []byte{1}}
-
-// Not returns the inverse Value of the Boolean-typed bytes value of zb.
-func Not(zb zcode.Bytes) *Value {
-	if DecodeBool(zb) {
-		return False
-	}
-	return True
-}
-
 func AppendBool(zb zcode.Bytes, b bool) zcode.Bytes {
 	if b {
 		return append(zb, 1)

--- a/runtime/expr/agg.go
+++ b/runtime/expr/agg.go
@@ -34,7 +34,7 @@ func (a *Aggregator) NewFunction() agg.Function {
 
 func (a *Aggregator) Apply(zctx *zed.Context, ectx Context, f agg.Function, this *zed.Value) {
 	if a.where != nil {
-		if val, ok := EvalBool(zctx, ectx, this, a.where); !ok || !zed.DecodeBool(val.Bytes()) {
+		if val, ok := EvalBool(zctx, ectx, this, a.where); !ok || !val.Bool() {
 			// XXX Issue #3401: do something with "where" errors.
 			return
 		}

--- a/runtime/expr/agg/logical.go
+++ b/runtime/expr/agg/logical.go
@@ -18,7 +18,7 @@ func (a *And) Consume(val *zed.Value) {
 		b := true
 		a.val = &b
 	}
-	*a.val = *a.val && zed.DecodeBool(val.Bytes())
+	*a.val = *a.val && val.Bool()
 }
 
 func (a *And) Result(*zed.Context) *zed.Value {
@@ -56,7 +56,7 @@ func (o *Or) Consume(val *zed.Value) {
 		b := false
 		o.val = &b
 	}
-	*o.val = *o.val || zed.DecodeBool(val.Bytes())
+	*o.val = *o.val || val.Bool()
 }
 
 func (o *Or) Result(*zed.Context) *zed.Value {

--- a/runtime/expr/boolean.go
+++ b/runtime/expr/boolean.go
@@ -46,7 +46,7 @@ func CompareBool(op string, pattern bool) (Boolean, error) {
 		if val.Type.ID() != zed.IDBool {
 			return false
 		}
-		b := zed.DecodeBool(val.Bytes())
+		b := val.Bool()
 		return compare(b, pattern)
 	}, nil
 }
@@ -297,7 +297,7 @@ func Comparison(op string, val *zed.Value) (Boolean, error) {
 	case *zed.TypeOfIP:
 		return CompareIP(op, zed.DecodeIP(val.Bytes()))
 	case *zed.TypeOfBool:
-		return CompareBool(op, zed.DecodeBool(val.Bytes()))
+		return CompareBool(op, val.Bool())
 	case *zed.TypeOfFloat64:
 		return CompareFloat64(op, zed.DecodeFloat64(val.Bytes()))
 	case *zed.TypeOfString:

--- a/runtime/expr/cast.go
+++ b/runtime/expr/cast.go
@@ -94,7 +94,7 @@ func (c *casterBool) Eval(ectx Context, val *zed.Value) *zed.Value {
 	if !ok {
 		return c.zctx.WrapError("cannot cast to bool", val)
 	}
-	return ectx.NewValue(zed.TypeBool, zed.EncodeBool(b))
+	return ectx.CopyValue(zed.NewBool(b))
 }
 
 type casterFloat16 struct {

--- a/runtime/expr/context.go
+++ b/runtime/expr/context.go
@@ -30,9 +30,7 @@ func (*allocator) NewValue(typ zed.Type, bytes zcode.Bytes) *zed.Value {
 	return zed.NewValue(typ, bytes)
 }
 
-func (*allocator) CopyValue(val *zed.Value) *zed.Value {
-	return zed.NewValue(val.Type, val.Bytes())
-}
+func (*allocator) CopyValue(val *zed.Value) *zed.Value { return val.Copy() }
 
 func (*allocator) Vars() []zed.Value {
 	return nil
@@ -57,7 +55,9 @@ func (r *ResetContext) NewValue(typ zed.Type, b zcode.Bytes) *zed.Value {
 }
 
 func (r *ResetContext) CopyValue(val *zed.Value) *zed.Value {
-	return r.NewValue(val.Type, val.Bytes())
+	val2 := r.NewValue(nil, nil)
+	*val2 = *val
+	return val2
 }
 
 func (r *ResetContext) Reset() {

--- a/runtime/expr/eval.go
+++ b/runtime/expr/eval.go
@@ -38,7 +38,7 @@ func (n *Not) Eval(ectx Context, this *zed.Value) *zed.Value {
 	if !ok {
 		return val
 	}
-	if zed.DecodeBool(val.Bytes()) {
+	if val.Bool() {
 		return zed.False
 	}
 	return zed.True
@@ -83,14 +83,14 @@ func (a *And) Eval(ectx Context, this *zed.Value) *zed.Value {
 	if !ok {
 		return lhs
 	}
-	if !zed.DecodeBool(lhs.Bytes()) {
+	if !lhs.Bool() {
 		return zed.False
 	}
 	rhs, ok := EvalBool(a.zctx, ectx, this, a.rhs)
 	if !ok {
 		return rhs
 	}
-	if !zed.DecodeBool(rhs.Bytes()) {
+	if !rhs.Bool() {
 		return zed.False
 	}
 	return zed.True
@@ -98,7 +98,7 @@ func (a *And) Eval(ectx Context, this *zed.Value) *zed.Value {
 
 func (o *Or) Eval(ectx Context, this *zed.Value) *zed.Value {
 	lhs, ok := EvalBool(o.zctx, ectx, this, o.lhs)
-	if ok && zed.DecodeBool(lhs.Bytes()) {
+	if ok && lhs.Bool() {
 		return zed.True
 	}
 	if lhs.IsError() && !lhs.IsMissing() {
@@ -106,7 +106,7 @@ func (o *Or) Eval(ectx Context, this *zed.Value) *zed.Value {
 	}
 	rhs, ok := EvalBool(o.zctx, ectx, this, o.rhs)
 	if ok {
-		if zed.DecodeBool(rhs.Bytes()) {
+		if rhs.Bool() {
 			return zed.True
 		}
 		return zed.False
@@ -812,7 +812,7 @@ func (c *Conditional) Eval(ectx Context, this *zed.Value) *zed.Value {
 		val := *c.zctx.NewErrorf("?-operator: bool predicate required")
 		return &val
 	}
-	if zed.DecodeBool(val.Bytes()) {
+	if val.Bool() {
 		return c.thenExpr.Eval(ectx, this)
 	}
 	return c.elseExpr.Eval(ectx, this)

--- a/runtime/expr/filter.go
+++ b/runtime/expr/filter.go
@@ -255,7 +255,7 @@ func NewFilterApplier(zctx *zed.Context, e Evaluator) Applier {
 func (f *filterApplier) Eval(ectx Context, this *zed.Value) *zed.Value {
 	val, ok := EvalBool(f.zctx, ectx, this, f.expr)
 	if ok {
-		if zed.DecodeBool(val.Bytes()) {
+		if val.Bool() {
 			return this
 		}
 		return f.zctx.Missing()

--- a/runtime/expr/filter_test.go
+++ b/runtime/expr/filter_test.go
@@ -36,7 +36,7 @@ func filter(ectx expr.Context, this *zed.Value, e expr.Evaluator) bool {
 		return true
 	}
 	val := e.Eval(ectx, this)
-	if val.Type == zed.TypeBool && zed.DecodeBool(val.Bytes()) {
+	if val.Type == zed.TypeBool && val.Bool() {
 		return true
 	}
 	return false

--- a/runtime/expr/function/compare.go
+++ b/runtime/expr/function/compare.go
@@ -26,7 +26,7 @@ func (e *Compare) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		if zed.TypeUnder(args[2].Type) != zed.TypeBool {
 			return e.zctx.WrapError("compare: nullsMax arg is not bool", &args[2])
 		}
-		nullsMax = zed.DecodeBool(args[2].Bytes())
+		nullsMax = args[2].Bool()
 	}
 	cmp := e.nullsMax
 	if !nullsMax {

--- a/runtime/expr/function/has.go
+++ b/runtime/expr/function/has.go
@@ -25,7 +25,7 @@ type Missing struct {
 func (m *Missing) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	val := m.has.Call(ctx, args)
 	if val.Type == zed.TypeBool {
-		return zed.Not(val.Bytes())
+		return ctx.CopyValue(zed.NewBool(!val.Bool()))
 	}
 	return val
 }

--- a/runtime/op/meta/pruner.go
+++ b/runtime/op/meta/pruner.go
@@ -22,5 +22,5 @@ func (p *pruner) prune(val *zed.Value) bool {
 		return false
 	}
 	result := p.pred.Eval(p.ectx, val)
-	return result.Type == zed.TypeBool && zed.DecodeBool(result.Bytes())
+	return result.Type == zed.TypeBool && result.Bool()
 }

--- a/runtime/op/switcher/switch.go
+++ b/runtime/op/switcher/switch.go
@@ -52,7 +52,7 @@ func (s *Selector) Forward(router *op.Router, batch zbuf.Batch) bool {
 				//XXX don't break here?
 				//break
 			}
-			if val.Type == zed.TypeBool && zed.DecodeBool(val.Bytes()) {
+			if val.Type == zed.TypeBool && val.Bool() {
 				c.vals = append(c.vals, *this)
 				break
 			}

--- a/value.go
+++ b/value.go
@@ -86,18 +86,18 @@ func (v *Value) Bool() bool {
 	if v.Type.ID() != IDBool {
 		panic(fmt.Sprintf("zed.Value.Bool called on %T", v.Type))
 	}
-	if n, ok := decodeNative(v.bytes); ok {
-		return n != 0
+	if x, ok := decodeNative(v.bytes); ok {
+		return x != 0
 	}
 	return DecodeBool(v.bytes)
 }
 
 // Bytes returns v's ZNG representation.
 func (v *Value) Bytes() zcode.Bytes {
-	if n, ok := decodeNative(v.bytes); ok {
+	if x, ok := decodeNative(v.bytes); ok {
 		switch v.Type.ID() {
 		case IDBool:
-			return EncodeBool(n != 0)
+			return EncodeBool(x != 0)
 		}
 		panic(v.Type)
 	}
@@ -109,11 +109,11 @@ func (v *Value) Bytes() zcode.Bytes {
 // bits of the value's native representation.
 var nativeBase struct{}
 
-func encodeNative(n uint64) zcode.Bytes {
+func encodeNative(x uint64) zcode.Bytes {
 	var b zcode.Bytes
 	s := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 	s.Data = uintptr(unsafe.Pointer(&nativeBase))
-	s.Cap = int(n)
+	s.Cap = int(x)
 	return b
 }
 
@@ -275,9 +275,9 @@ func (v *Value) Equal(p Value) bool {
 	if v.Type != p.Type {
 		return false
 	}
-	if n1, ok := decodeNative(v.bytes); ok {
-		if n2, ok := decodeNative(p.bytes); ok {
-			return n1 == n2
+	if x, ok := decodeNative(v.bytes); ok {
+		if y, ok := decodeNative(p.bytes); ok {
+			return x == y
 		}
 	}
 	return bytes.Equal(v.Bytes(), p.Bytes())

--- a/value.go
+++ b/value.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"net/netip"
+	"reflect"
 	"runtime/debug"
+	"unsafe"
 
 	"github.com/brimdata/zed/pkg/field"
 	"github.com/brimdata/zed/pkg/nano"
@@ -39,6 +41,9 @@ var (
 	NullNet      = &Value{Type: TypeNet}
 	NullType     = &Value{Type: TypeType}
 	Null         = &Value{Type: TypeNull}
+
+	False = NewBool(false)
+	True  = NewBool(true)
 )
 
 type Allocator interface {
@@ -68,15 +73,61 @@ func NewTime(ts nano.Ts) *Value          { return &Value{TypeTime, EncodeTime(ts
 func NewFloat16(f float32) *Value        { return &Value{TypeFloat16, EncodeFloat16(f)} }
 func NewFloat32(f float32) *Value        { return &Value{TypeFloat32, EncodeFloat32(f)} }
 func NewFloat64(f float64) *Value        { return &Value{TypeFloat64, EncodeFloat64(f)} }
-func NewBool(b bool) *Value              { return &Value{TypeBool, EncodeBool(b)} }
+func NewBool(b bool) *Value              { return &Value{TypeBool, encodeNative(boolToUint64(b))} }
 func NewBytes(b []byte) *Value           { return &Value{TypeBytes, EncodeBytes(b)} }
 func NewString(s string) *Value          { return &Value{TypeString, EncodeString(s)} }
 func NewIP(a netip.Addr) *Value          { return &Value{TypeIP, EncodeIP(a)} }
 func NewNet(p netip.Prefix) *Value       { return &Value{TypeNet, EncodeNet(p)} }
 func NewTypeValue(t Type) *Value         { return &Value{TypeType, EncodeTypeValue(t)} }
 
+// Bool returns v's underlying value.  It panics if v's underlying type is not
+// TypeBool.
+func (v *Value) Bool() bool {
+	if v.Type.ID() != IDBool {
+		panic(fmt.Sprintf("zed.Value.Bool called on %T", v.Type))
+	}
+	if n, ok := decodeNative(v.bytes); ok {
+		return n != 0
+	}
+	return DecodeBool(v.bytes)
+}
+
 // Bytes returns v's ZNG representation.
-func (v *Value) Bytes() zcode.Bytes { return v.bytes }
+func (v *Value) Bytes() zcode.Bytes {
+	if n, ok := decodeNative(v.bytes); ok {
+		switch v.Type.ID() {
+		case IDBool:
+			return EncodeBool(n != 0)
+		}
+		panic(v.Type)
+	}
+	return v.bytes
+}
+
+// nativeBase is the base address for all native Values, which are encoded as a
+// zcode.Bytes with this base address, a length of zero, and capacity set to the
+// bits of the value's native representation.
+var nativeBase struct{}
+
+func encodeNative(n uint64) zcode.Bytes {
+	var b zcode.Bytes
+	s := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	s.Data = uintptr(unsafe.Pointer(&nativeBase))
+	s.Cap = int(n)
+	return b
+}
+
+func decodeNative(b zcode.Bytes) (uint64, bool) {
+	s := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	return uint64(s.Cap), s.Data == uintptr(unsafe.Pointer(&nativeBase))
+}
+
+func boolToUint64(b bool) uint64 {
+	if b {
+		return 1
+	}
+	return 0
+}
 
 func (v *Value) IsContainer() bool {
 	return IsContainerType(v.Type)
@@ -169,17 +220,20 @@ func (v *Value) IsNull() bool {
 	return v.bytes == nil
 }
 
-// Copy returns a copy of v that does not share v.Bytes.  The copy's Bytes field
-// is nil if and only if v.Bytes is nil.
+// Copy returns a copy of v that shares no storage.
 func (v *Value) Copy() *Value {
-	return &Value{v.Type, slices.Clone(v.Bytes())}
+	if _, ok := decodeNative(v.bytes); ok {
+		return &Value{v.Type, v.bytes}
+	}
+	return &Value{v.Type, slices.Clone(v.bytes)}
 }
 
-// CopyFrom copies from into v, reusing v.Bytes if possible and setting v.Bytes
-// to nil if and only if from.Bytes is nil.
+// CopyFrom copies from into v, reusing v's storage if possible.
 func (v *Value) CopyFrom(from *Value) {
 	v.Type = from.Type
-	if from.IsNull() {
+	if _, ok := decodeNative(from.bytes); ok {
+		v.bytes = from.bytes
+	} else if from.IsNull() {
 		v.bytes = nil
 	} else if v.IsNull() {
 		v.bytes = slices.Clone(from.bytes)
@@ -215,8 +269,18 @@ func (v *Value) IsQuiet() bool {
 	return false
 }
 
+// Equal reports whether p and v have the same type and the same ZNG
+// representation.
 func (v *Value) Equal(p Value) bool {
-	return v.Type == p.Type && bytes.Equal(v.Bytes(), p.Bytes())
+	if v.Type != p.Type {
+		return false
+	}
+	if n1, ok := decodeNative(v.bytes); ok {
+		if n2, ok := decodeNative(p.bytes); ok {
+			return n1 == n2
+		}
+	}
+	return bytes.Equal(v.Bytes(), p.Bytes())
 }
 
 func (r *Value) HasField(field string) bool {
@@ -288,9 +352,11 @@ func (v *Value) AsString() string {
 	return ""
 }
 
+// AsBool returns v's underlying value.  It returns false if v is nil or v's
+// underlying type is not TypeBool.
 func (v *Value) AsBool() bool {
 	if v != nil && TypeUnder(v.Type) == TypeBool {
-		return DecodeBool(v.Bytes())
+		return v.Bool()
 	}
 	return false
 }

--- a/zbuf/array.go
+++ b/zbuf/array.go
@@ -66,5 +66,5 @@ func (*Array) NewValue(typ zed.Type, bytes zcode.Bytes) *zed.Value {
 
 func (*Array) CopyValue(val *zed.Value) *zed.Value {
 	// XXX can make this more efficient later
-	return zed.NewValue(val.Type, val.Bytes())
+	return val.Copy()
 }

--- a/zbuf/scanner.go
+++ b/zbuf/scanner.go
@@ -135,7 +135,7 @@ func (s *scanner) Read() (*zed.Value, error) {
 		atomic.AddInt64(&s.progress.RecordsRead, 1)
 		if s.filter != nil {
 			val := s.filter.Eval(s.ectx, this)
-			if !(val.Type == zed.TypeBool && zed.DecodeBool(val.Bytes())) {
+			if !(val.Type == zed.TypeBool && val.Bool()) {
 				continue
 			}
 		}

--- a/zio/zeekio/format.go
+++ b/zio/zeekio/format.go
@@ -22,7 +22,7 @@ func formatAny(val *zed.Value, inContainer bool) string {
 	case *zed.TypeNamed:
 		return formatAny(zed.NewValue(t.Type, val.Bytes()), inContainer)
 	case *zed.TypeOfBool:
-		if zed.DecodeBool(val.Bytes()) {
+		if val.Bool() {
 			return "T"
 		}
 		return "F"

--- a/zio/zngio/batch.go
+++ b/zio/zngio/batch.go
@@ -50,9 +50,7 @@ func (b *batch) NewValue(typ zed.Type, bytes zcode.Bytes) *zed.Value {
 	return zed.NewValue(typ, bytes)
 }
 
-func (b *batch) CopyValue(val *zed.Value) *zed.Value {
-	return zed.NewValue(val.Type, val.Bytes())
-}
+func (b *batch) CopyValue(val *zed.Value) *zed.Value { return val.Copy() }
 
 func (b *batch) Ref() { atomic.AddInt32(&b.refs, 1) }
 

--- a/zio/zngio/scanner.go
+++ b/zio/zngio/scanner.go
@@ -347,5 +347,5 @@ func (w *worker) wantValue(val *zed.Value, progress *zbuf.Progress) bool {
 
 func check(ectx expr.Context, this *zed.Value, filter expr.Evaluator) bool {
 	val := filter.Eval(ectx, this)
-	return val.Type == zed.TypeBool && zed.DecodeBool(val.Bytes())
+	return val.Type == zed.TypeBool && val.Bool()
 }

--- a/zson/marshal.go
+++ b/zson/marshal.go
@@ -808,7 +808,7 @@ func (u *UnmarshalZNGContext) decodeAny(val *zed.Value, v reflect.Value) error {
 		if zed.TypeUnder(val.Type) != zed.TypeBool {
 			return incompatTypeError(val.Type, v)
 		}
-		v.SetBool(zed.DecodeBool(val.Bytes()))
+		v.SetBool(val.Bool())
 		return nil
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		switch zed.TypeUnder(val.Type) {


### PR DESCRIPTION
The bytes field of a non-null zed.Value always contains the value's ZNG representation.  This is wasteful for primitive types with a fixed-length native representation like Booleans and numeric types because it consumes memory and requires work to convert between the native and ZNG representations.  To address that waste, this change introduces a native representation for Boolean zed.Values.  (Subsequent changes will extend it to numeric types.)

The basic idea here is to use the unsafe package to store the bits of a fixed-length native value in the capacity field of Value.bytes's slice header.  Additionally, a sentinal address (belonging to the package variable called nativeBase) is stored in the base address field of Value.byte's slice header to distinguish native Values from ZNG Values. When the ZNG representation for a native Value is needed, the Value.Bytes method creates it.

Note that changes to the Go runtime may break this implementation!