### PR TITLE
Enhanced user ops example

### DIFF
--- a/docs/language/statements.md
+++ b/docs/language/statements.md
@@ -93,14 +93,21 @@ the operator's signature.
 The `this` value of a user-defined operator's sequence is a record value
 comprised of the parameters provided in the operator's signature.
 
-For instance the `this` value of operator
-```
+For instance the program in `myop.zed`
+```mdtest-input myop.zed
 op myop(foo, bar, baz): (
-  ...
+  yield this
 )
-myop("foo", "bar", "baz")
+myop("foo", true, {pi: this})
 ```
-would be `{foo:"foo",bar:"bar",baz:"baz"}`.
+run via
+```mdtest-command
+echo 3.14 | zq -z -I myop.zed -
+```
+produces
+```mdtest-output
+{foo:"foo",bar:true,baz:{pi:3.14}}
+```
 
 ### Spread Parameters
 


### PR DESCRIPTION
When reviewing #4417 I thought this example could maybe be improved. I tried proposing this change via the GitHub Suggestion workflow but the excessive use of triple backticks with mdtest made the Preview look all weird such that I wasn't convinced it was gonna work correctly. 😛 

In summary, with this change:

1. Multiple data types are shown in the record rather than just strings, including a nested record just to make it more obvious that all the usual stuff is fair game
2. `this` is shown working simultaneously in the different scopes
3. The example is now protected with mdtest