### PR TITLE
Fix error reference in docs

### DIFF
--- a/docs/language/data-types.md
+++ b/docs/language/data-types.md
@@ -314,7 +314,7 @@ approach because it lacks first-class errors.
 
 But Zed has first-class errors so
 a reference to something that does not exist is an error of type
-`error<string>` whose value is `error("missing")`.  For example,
+`<error(string)>` whose value is `error("missing")`.  For example,
 ```mdtest-command
 echo "{x:1} {y:2}" | zq -z 'yield x' -
 ```


### PR DESCRIPTION
While reviewing the current docs before opening up #4625, I spotted this apparent glitch in the docs. I confirmed what it should be by tacking on a `typeof(this)` to the example from the doc.

```
$ echo "{x:1} {y:2}" | zq -z 'yield x | yield typeof(this)' - 
<int64>
<error(string)>
```