### PR TITLE
Use zed.CompareTypes in sort

### DIFF
--- a/compiler/ztests/sql-search-mixed.yaml
+++ b/compiler/ztests/sql-search-mixed.yaml
@@ -15,6 +15,6 @@ input: |
   {name:"jim",likes:null([string]),age:30}(=person)
 
 output: |
-  {flavor:error("missing"),union:|["joe"]|}
   {flavor:"tart",union:|["apple"]|}
   {flavor:"sweet",union:|["strawberry"]|}
+  {flavor:error("missing"),union:|["joe"]|}

--- a/docs/language/functions/cast.md
+++ b/docs/language/functions/cast.md
@@ -81,7 +81,7 @@ echo '{x:1,y:2}{r:3}{x:4,y:5}' | zq -z 'switch ( case has(x) => cast(this, "poin
 ```
 produces
 ```mdtest-output
+{r:3}(=radius)
 {x:1,y:2}(=point)
 {x:4,y:5}(=point)
-{r:3}(=radius)
 ```

--- a/docs/language/operators/sample.md
+++ b/docs/language/operators/sample.md
@@ -28,8 +28,8 @@ echo '1 2 3 "foo" "bar" 10.0.0.1 10.0.0.2' | zq -z 'sample | sort this' -
 =>
 ```mdtest-output
 1
-10.0.0.1
 "foo"
+10.0.0.1
 ```
 
 _Sampling record shapes_

--- a/docs/language/shaping.md
+++ b/docs/language/shaping.md
@@ -318,8 +318,8 @@ echo '{x:1} {x:"foo",y:"foo"} {x:2,y:"bar"} {a:1,b:2,c:3}' | zq -z -I shape.zed 
 ```
 we get
 ```mdtest-output
-{x:1}
+error({kind:"unrecognized shape",value:{a:1,b:2,c:3}})
 {x:"foo"((int64,string)),y:"foo"}
 {x:2((int64,string)),y:"bar"}
-error({kind:"unrecognized shape",value:{a:1,b:2,c:3}})
+{x:1}
 ```

--- a/docs/tutorials/schools.md
+++ b/docs/tutorials/schools.md
@@ -36,6 +36,10 @@ zq -Z 'sample | sort this' schools.zson testscores.zson webaddrs.zson
 displays
 ```mdtest-output
 {
+    Website: "abbott.lynwood.edlioschool.com",
+    addr: 151.101.0.80
+}
+{
     AvgScrMath: null (uint16),
     AvgScrRead: null (uint16),
     AvgScrWrite: null (uint16),
@@ -57,10 +61,6 @@ displays
     Phone: null (string),
     StatusType: "Merged",
     Website: null (string)
-}
-{
-    Website: "abbott.lynwood.edlioschool.com",
-    addr: 151.101.0.80
 }
 ```
 >Note that the `-Z` option tells `zq` to "pretty print" the output in

--- a/runtime/expr/agg/ztests/groupby-missing.yaml
+++ b/runtime/expr/agg/ztests/groupby-missing.yaml
@@ -7,6 +7,6 @@ input: |
   {a:[0],b:{c:1}}
 
 output: |
-  {a:error("missing"),b:error("missing")}
-  {a:error("missing"),b:1}
   {a:0,b:1}
+  {a:error("missing"),b:1}
+  {a:error("missing"),b:error("missing")}

--- a/runtime/expr/function/ztests/nameof-missing.yaml
+++ b/runtime/expr/function/ztests/nameof-missing.yaml
@@ -8,6 +8,6 @@ input: |
   {x:"foo",y:1,z:2}(=bar)
 
 output: |
-  {nameof:error("missing"),count:3(uint64)}
   {nameof:"bar",count:1(uint64)}
   {nameof:"foo",count:1(uint64)}
+  {nameof:error("missing"),count:3(uint64)}

--- a/runtime/expr/sort.go
+++ b/runtime/expr/sort.go
@@ -11,7 +11,6 @@ import (
 	"github.com/brimdata/zed/runtime/expr/coerce"
 	"github.com/brimdata/zed/zcode"
 	"github.com/brimdata/zed/zio"
-	"github.com/brimdata/zed/zson"
 	"golang.org/x/exp/slices"
 )
 
@@ -189,11 +188,7 @@ func compareValues(a, b *zed.Value, comparefns map[zed.Type]comparefn, pair *coe
 			typ, err = zed.LookupPrimitiveByID(id)
 		}
 		if err != nil {
-			// If values cannot be coerced, just compare the native
-			// representation of the type.
-			// XXX This is heavyweight and should probably just compare
-			// the zcode.Bytes.  See issue #2354.
-			return bytes.Compare([]byte(zson.String(a.Type)), []byte(zson.String(b.Type)))
+			return zed.CompareTypes(a.Type, b.Type)
 		}
 		abytes, bbytes = pair.A, pair.B
 	}

--- a/runtime/expr/ztests/type-map.yaml
+++ b/runtime/expr/ztests/type-map.yaml
@@ -18,8 +18,8 @@ input: |
   {y:"has no _path"}
 
 output: |
-  {_path:"unknown",x:"has unknown _path",_UNCLASSIFIED:true}
   {schema:<conn={_path:string,id:{src:ip,dst:ip},etc:string}>}
   {schema:<conn={_path:string,id:{src:ip,dst:ip},etc:string}>}
   {schema:<dns={_path:string,id:{src:ip,dst:ip},query:string,query_size:uint64}>}
   {y:"has no _path",_UNCLASSIFIED:true}
+  {_path:"unknown",x:"has unknown _path",_UNCLASSIFIED:true}

--- a/runtime/op/groupby/groupby_test.go
+++ b/runtime/op/groupby/groupby_test.go
@@ -73,10 +73,10 @@ const differentTypeIn = `
 `
 
 const differentTypeOut = `
-{key1:10.0.0.1,count:2(uint64)}
-{key1:10.0.0.2,count:1(uint64)}
 {key1:"a",count:2(uint64)}
 {key1:"b",count:1(uint64)}
+{key1:10.0.0.1,count:2(uint64)}
+{key1:10.0.0.2,count:1(uint64)}
 `
 
 const reducersOut = `

--- a/runtime/op/groupby/ztests/count-by-this.yaml
+++ b/runtime/op/groupby/ztests/count-by-this.yaml
@@ -8,7 +8,7 @@ input: |
   {y:7}
 
 output: |
-  {val:{x:1(int32),s:"foo"},count:1(uint64)}
-  {val:{x:2(int32),s:"Bar"},count:1(uint64)}
   {val:{y:5},count:2(uint64)}
   {val:{y:7},count:1(uint64)}
+  {val:{x:1(int32),s:"foo"},count:1(uint64)}
+  {val:{x:2(int32),s:"Bar"},count:1(uint64)}

--- a/runtime/op/groupby/ztests/mixed-output-types.yaml
+++ b/runtime/op/groupby/ztests/mixed-output-types.yaml
@@ -5,5 +5,5 @@ input: |
   {addr:fe80::215:17ff:fe84:c13f}
 
 output: |
-  {x:error("network_of: not an IPv4 address")}
   {x:10.0.0.0/8}
+  {x:error("network_of: not an IPv4 address")}

--- a/runtime/op/switcher/ztests/switch-error.yaml
+++ b/runtime/op/switcher/ztests/switch-error.yaml
@@ -9,5 +9,5 @@ input: |
   {a:2,s:"b"}
 
 output: |
-  error("divide by zero")
   {a:1,s:"a",v:"one"}
+  error("divide by zero")


### PR DESCRIPTION
When sorting Zed values, we order values with incomparable types by comparing the types' ZSON representations.  Those are expensive to create, so compare using zed.CompareTypes instead.

Closes #2354.