### PR TITLE
Use native representation for unsigned integer zed.Value

### DIFF
--- a/lake/journal/store.go
+++ b/lake/journal/store.go
@@ -162,7 +162,7 @@ func (s *Store) getSnapshot(ctx context.Context) (ID, map[string]Entry, error) {
 	if val.Type.ID() != zed.IDUint64 {
 		return Nil, table, errors.New("corrupted journal snapshot")
 	}
-	at := ID(zed.DecodeUint(val.Bytes()))
+	at := ID(val.Uint())
 	for {
 		val, err := zr.Read()
 		if val == nil || err != nil {

--- a/runtime/expr/agg/avg.go
+++ b/runtime/expr/agg/avg.go
@@ -55,7 +55,7 @@ func (a *Avg) ConsumeAsPartial(partial *zed.Value) {
 		panic(fmt.Errorf("avg: partial count has bad type: %s", zson.MustFormatValue(countVal)))
 	}
 	a.sum += zed.DecodeFloat64(sumVal.Bytes())
-	a.count += zed.DecodeUint(countVal.Bytes())
+	a.count += countVal.Uint()
 }
 
 func (a *Avg) ResultAsPartial(zctx *zed.Context) *zed.Value {

--- a/runtime/expr/agg/count.go
+++ b/runtime/expr/agg/count.go
@@ -20,7 +20,7 @@ func (c *Count) ConsumeAsPartial(partial *zed.Value) {
 	if partial.Type != zed.TypeUint64 {
 		panic("count: partial not uint64")
 	}
-	*c += Count(zed.DecodeUint(partial.Bytes()))
+	*c += Count(partial.Uint())
 }
 
 func (c Count) ResultAsPartial(*zed.Context) *zed.Value {

--- a/runtime/expr/boolean.go
+++ b/runtime/expr/boolean.go
@@ -83,8 +83,7 @@ func CompareInt64(op string, pattern int64) (Boolean, error) {
 		case zed.IDInt8, zed.IDInt16, zed.IDInt32, zed.IDInt64:
 			return CompareInt(zed.DecodeInt(zv), pattern)
 		case zed.IDUint8, zed.IDUint16, zed.IDUint32, zed.IDUint64:
-			v := zed.DecodeUint(zv)
-			if v <= math.MaxInt64 {
+			if v := val.Uint(); v <= math.MaxInt64 {
 				return CompareInt(int64(v), pattern)
 			}
 		case zed.IDFloat16, zed.IDFloat32, zed.IDFloat64:
@@ -148,7 +147,7 @@ func CompareFloat64(op string, pattern float64) (Boolean, error) {
 		case zed.IDInt8, zed.IDInt16, zed.IDInt32, zed.IDInt64:
 			return compare(float64(zed.DecodeInt(zv)), pattern)
 		case zed.IDUint8, zed.IDUint16, zed.IDUint32, zed.IDUint64:
-			return compare(float64(zed.DecodeUint(zv)), pattern)
+			return compare(float64(val.Uint()), pattern)
 		case zed.IDTime:
 			return compare(float64(zed.DecodeTime(zv)), pattern)
 		case zed.IDDuration:

--- a/runtime/expr/cast.go
+++ b/runtime/expr/cast.go
@@ -82,7 +82,7 @@ func (c *casterUintN) Eval(ectx Context, val *zed.Value) *zed.Value {
 	if !ok || (c.max != 0 && v > c.max) {
 		return c.zctx.WrapError("cannot cast to "+zson.FormatType(c.typ), val)
 	}
-	return ectx.NewValue(c.typ, zed.EncodeUint(v))
+	return ectx.CopyValue(zed.NewUint(c.typ, v))
 }
 
 type casterBool struct {

--- a/runtime/expr/coerce/coerce.go
+++ b/runtime/expr/coerce/coerce.go
@@ -168,7 +168,7 @@ func ToFloat(val *zed.Value) (float64, bool) {
 		if zed.IsSigned(id) {
 			return float64(zed.DecodeInt(val.Bytes())), true
 		} else {
-			return float64(zed.DecodeUint(val.Bytes())), true
+			return float64(val.Uint()), true
 		}
 	}
 	if id == zed.IDDuration {
@@ -197,7 +197,7 @@ func ToUint(val *zed.Value) (uint64, bool) {
 			}
 			return uint64(v), true
 		} else {
-			return zed.DecodeUint(val.Bytes()), true
+			return val.Uint(), true
 		}
 	}
 	if id == zed.IDDuration {
@@ -223,7 +223,7 @@ func ToInt(val *zed.Value) (int64, bool) {
 			// XXX check if negative? should -1:uint64 be maxint64 or an error?
 			return zed.DecodeInt(val.Bytes()), true
 		} else {
-			return int64(zed.DecodeUint(val.Bytes())), true
+			return int64(val.Uint()), true
 		}
 	}
 	if id == zed.IDDuration {
@@ -257,7 +257,7 @@ func ToTime(val *zed.Value) (nano.Ts, bool) {
 		return nano.Ts(zed.DecodeInt(val.Bytes())), true
 	}
 	if zed.IsInteger(id) {
-		v := zed.DecodeUint(val.Bytes())
+		v := val.Uint()
 		// check for overflow
 		if v > math.MaxInt64 {
 			return 0, false
@@ -279,7 +279,7 @@ func ToDuration(in *zed.Value) (nano.Duration, bool) {
 	case zed.IDDuration:
 		return zed.DecodeDuration(in.Bytes()), true
 	case zed.IDUint16, zed.IDUint32, zed.IDUint64:
-		v := zed.DecodeUint(in.Bytes())
+		v := in.Uint()
 		// check for overflow
 		if v > math.MaxInt64 {
 			return 0, false

--- a/runtime/expr/eval.go
+++ b/runtime/expr/eval.go
@@ -436,7 +436,7 @@ func (a *Add) Eval(ectx Context, this *zed.Value) *zed.Value {
 		return ectx.NewValue(typ, zed.EncodeInt(v1+v2))
 	case zed.IsNumber(id):
 		v1, v2 := a.operands.uints()
-		return ectx.NewValue(typ, zed.EncodeUint(v1+v2))
+		return ectx.CopyValue(zed.NewUint(typ, v1+v2))
 	case id == zed.IDString:
 		v1, v2 := zed.DecodeString(a.operands.vals.A), zed.DecodeString(a.operands.vals.B)
 		// XXX GC
@@ -470,7 +470,7 @@ func (s *Subtract) Eval(ectx Context, this *zed.Value) *zed.Value {
 		return ectx.NewValue(typ, zed.EncodeInt(v1-v2))
 	case zed.IsNumber(id):
 		v1, v2 := s.operands.uints()
-		return ectx.NewValue(typ, zed.EncodeUint(v1-v2))
+		return ectx.CopyValue(zed.NewUint(typ, v1-v2))
 	}
 	return ectx.CopyValue(s.zctx.NewErrorf("type %s incompatible with '-' operator", zson.FormatType(typ)))
 }
@@ -496,7 +496,7 @@ func (m *Multiply) Eval(ectx Context, this *zed.Value) *zed.Value {
 		return ectx.NewValue(typ, zed.EncodeInt(v1*v2))
 	case zed.IsNumber(id):
 		v1, v2 := m.operands.uints()
-		return ectx.NewValue(typ, zed.EncodeUint(v1*v2))
+		return ectx.CopyValue(zed.NewUint(typ, v1*v2))
 	}
 	return ectx.CopyValue(m.zctx.NewErrorf("type %s incompatible with '*' operator", zson.FormatType(typ)))
 }
@@ -531,7 +531,7 @@ func (d *Divide) Eval(ectx Context, this *zed.Value) *zed.Value {
 		if v2 == 0 {
 			return d.zctx.NewError(DivideByZero)
 		}
-		return ectx.NewValue(typ, zed.EncodeUint(v1/v2))
+		return ectx.CopyValue(zed.NewUint(typ, v1/v2))
 	}
 	return ectx.CopyValue(d.zctx.NewErrorf("type %s incompatible with '/' operator", zson.FormatType(typ)))
 }
@@ -562,7 +562,7 @@ func (m *Modulo) Eval(ectx Context, this *zed.Value) *zed.Value {
 	if y == 0 {
 		return m.zctx.NewError(DivideByZero)
 	}
-	return ectx.NewValue(typ, zed.EncodeUint(x%y))
+	return ectx.CopyValue(zed.NewUint(typ, x%y))
 }
 
 type UnaryMinus struct {
@@ -636,7 +636,7 @@ func (u *UnaryMinus) Eval(ectx Context, this *zed.Value) *zed.Value {
 		if val.IsNull() {
 			return val
 		}
-		v := zed.DecodeUint(val.Bytes())
+		v := val.Uint()
 		if v > math.MaxInt8 {
 			return ectx.CopyValue(u.zctx.NewErrorf("unary '-' overflow: uint8(%d)", v))
 		}
@@ -645,7 +645,7 @@ func (u *UnaryMinus) Eval(ectx Context, this *zed.Value) *zed.Value {
 		if val.IsNull() {
 			return val
 		}
-		v := zed.DecodeUint(val.Bytes())
+		v := val.Uint()
 		if v > math.MaxInt16 {
 			return ectx.CopyValue(u.zctx.NewErrorf("unary '-' overflow: uint16(%d)", v))
 		}
@@ -654,7 +654,7 @@ func (u *UnaryMinus) Eval(ectx Context, this *zed.Value) *zed.Value {
 		if val.IsNull() {
 			return val
 		}
-		v := zed.DecodeUint(val.Bytes())
+		v := val.Uint()
 		if v > math.MaxInt32 {
 			return ectx.CopyValue(u.zctx.NewErrorf("unary '-' overflow: uint32(%d)", v))
 		}
@@ -663,7 +663,7 @@ func (u *UnaryMinus) Eval(ectx Context, this *zed.Value) *zed.Value {
 		if val.IsNull() {
 			return val
 		}
-		v := zed.DecodeUint(val.Bytes())
+		v := val.Uint()
 		if v > math.MaxInt64 {
 			return ectx.CopyValue(u.zctx.NewErrorf("unary '-' overflow: uint64(%d)", v))
 		}
@@ -739,7 +739,7 @@ func indexVector(zctx *zed.Context, ectx Context, inner zed.Type, vector zcode.B
 	if zed.IsSigned(id) {
 		idx = int(zed.DecodeInt(index.Bytes()))
 	} else {
-		idx = int(zed.DecodeUint(index.Bytes()))
+		idx = int(index.Uint())
 	}
 	zv := getNthFromContainer(vector, idx)
 	if zv == nil {

--- a/runtime/expr/function/function.go
+++ b/runtime/expr/function/function.go
@@ -197,14 +197,6 @@ func newInt(ctx zed.Allocator, typ zed.Type, native int64) *zed.Value {
 	return ctx.NewValue(typ, zed.EncodeInt(native))
 }
 
-func newUint64(ctx zed.Allocator, native uint64) *zed.Value {
-	return newUint(ctx, zed.TypeUint64, native)
-}
-
-func newUint(ctx zed.Allocator, typ zed.Type, native uint64) *zed.Value {
-	return ctx.NewValue(typ, zed.EncodeUint(native))
-}
-
 func newFloat16(ctx zed.Allocator, native float32) *zed.Value {
 	return ctx.NewValue(zed.TypeFloat16, zed.EncodeFloat16(native))
 }

--- a/runtime/expr/function/ip.go
+++ b/runtime/expr/function/ip.go
@@ -49,7 +49,7 @@ func (n *NetworkOf) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 			if zed.IsSigned(id) {
 				bits = int(zed.DecodeInt(body))
 			} else {
-				bits = int(zed.DecodeUint(body))
+				bits = int(args[1].Uint())
 			}
 			if bits > 128 || bits > 32 && ip.Is4() {
 				return newErrorf(n.zctx, ctx, "network_of: cidr bit count out of range")

--- a/runtime/expr/function/math.go
+++ b/runtime/expr/function/math.go
@@ -147,7 +147,7 @@ func (r *reducer) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		}
 		return newInt64(ctx, result)
 	}
-	result := zed.DecodeUint(val0.Bytes())
+	result := val0.Uint()
 	for _, val := range args[1:] {
 		v, ok := coerce.ToUint(&val)
 		if !ok {
@@ -155,7 +155,7 @@ func (r *reducer) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		}
 		result = r.fn.Uint64(result, v)
 	}
-	return newUint64(ctx, result)
+	return ctx.CopyValue(zed.NewUint64(result))
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#round

--- a/runtime/expr/sort.go
+++ b/runtime/expr/sort.go
@@ -41,7 +41,7 @@ func (c *Comparator) sortStableIndices(vals []zed.Value) []uint32 {
 			} else if zed.IsSigned(id) {
 				i64s[i] = zed.DecodeInt(val.Bytes())
 			} else {
-				v := zed.DecodeUint(val.Bytes())
+				v := val.Uint()
 				if v > math.MaxInt64 {
 					v = math.MaxInt64
 				}

--- a/zio/zeekio/format.go
+++ b/zio/zeekio/format.go
@@ -41,7 +41,7 @@ func formatAny(val *zed.Value, inContainer bool) string {
 	case *zed.TypeOfInt8, *zed.TypeOfInt16, *zed.TypeOfInt32, *zed.TypeOfInt64:
 		return strconv.FormatInt(zed.DecodeInt(val.Bytes()), 10)
 	case *zed.TypeOfUint8, *zed.TypeOfUint16, *zed.TypeOfUint32, *zed.TypeOfUint64:
-		return strconv.FormatUint(zed.DecodeUint(val.Bytes()), 10)
+		return strconv.FormatUint(val.Uint(), 10)
 	case *zed.TypeOfIP:
 		return zed.DecodeIP(val.Bytes()).String()
 	case *zed.TypeMap:

--- a/zson/marshal.go
+++ b/zson/marshal.go
@@ -824,7 +824,7 @@ func (u *UnmarshalZNGContext) decodeAny(val *zed.Value, v reflect.Value) error {
 		default:
 			return incompatTypeError(val.Type, v)
 		}
-		v.SetUint(zed.DecodeUint(val.Bytes()))
+		v.SetUint(val.Uint())
 		return nil
 	case reflect.Float32:
 		if zed.TypeUnder(val.Type) != zed.TypeFloat32 {


### PR DESCRIPTION
This applies the approach in #4623 to unsigned integer zed.Values.