### PR TITLE
fix zson marshaling of unknown interface values

### DIFF
--- a/zson/marshal.go
+++ b/zson/marshal.go
@@ -410,16 +410,9 @@ func (m *MarshalZNGContext) encodeMap(v reflect.Value) (zed.Type, error) {
 }
 
 func (m *MarshalZNGContext) encodeNil(t reflect.Type) (zed.Type, error) {
-	var typ zed.Type
-	if t.Kind() == reflect.Interface {
-		// Encode the nil interface as TypeNull.
-		typ = zed.TypeNull
-	} else {
-		var err error
-		typ, err = m.lookupType(t)
-		if err != nil {
-			return nil, err
-		}
+	typ, err := m.lookupType(t)
+	if err != nil {
+		return nil, err
 	}
 	m.Builder.Append(nil)
 	return typ, nil
@@ -578,6 +571,9 @@ func (m *MarshalZNGContext) lookupType(t reflect.Type) (zed.Type, error) {
 		typ = zed.TypeFloat32
 	case reflect.Float64:
 		typ = zed.TypeFloat64
+	case reflect.Interface:
+		// Encode interfaces when we don't knwo the underlying concrete type as null type.
+		typ = zed.TypeNull
 	default:
 		return nil, fmt.Errorf("unsupported type: %v", t.Kind())
 	}

--- a/zson/marshal.go
+++ b/zson/marshal.go
@@ -572,7 +572,7 @@ func (m *MarshalZNGContext) lookupType(t reflect.Type) (zed.Type, error) {
 	case reflect.Float64:
 		typ = zed.TypeFloat64
 	case reflect.Interface:
-		// Encode interfaces when we don't knwo the underlying concrete type as null type.
+		// Encode interfaces when we don't know the underlying concrete type as null type.
 		typ = zed.TypeNull
 	default:
 		return nil, fmt.Errorf("unsupported type: %v", t.Kind())

--- a/zson/marshal_test.go
+++ b/zson/marshal_test.go
@@ -517,3 +517,12 @@ func TestSimpleUnionUnmarshal(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, i)
 }
+
+func TestEmbeddedNilInterface(t *testing.T) {
+	in := &Record{
+		Fields: nil,
+	}
+	val, err := zson.Marshal(in)
+	require.NoError(t, err)
+	assert.Equal(t, `{Fields:null([{Name:string,Values:null}])}`, val)
+}


### PR DESCRIPTION
This commit changes the logic that determines Zed types from Go native types to always use zed type null for interface types since the underlying concrete type is not known.  Most of the marshaling logic uses values to infer types rather than type lookups but when there is a nil value of a complex type with embedded interfaces, this heuristic is needed.  This still doesn't cover all the possible cases here but it is an improvement over what was here before.