### PR TITLE
Use native representation for signed integer zed.Value

### DIFF
--- a/runtime/expr/boolean.go
+++ b/runtime/expr/boolean.go
@@ -80,18 +80,14 @@ func CompareInt64(op string, pattern int64) (Boolean, error) {
 	return func(val *zed.Value) bool {
 		zv := val.Bytes()
 		switch val.Type.ID() {
-		case zed.IDInt8, zed.IDInt16, zed.IDInt32, zed.IDInt64:
-			return CompareInt(zed.DecodeInt(zv), pattern)
 		case zed.IDUint8, zed.IDUint16, zed.IDUint32, zed.IDUint64:
 			if v := val.Uint(); v <= math.MaxInt64 {
 				return CompareInt(int64(v), pattern)
 			}
+		case zed.IDInt8, zed.IDInt16, zed.IDInt32, zed.IDInt64, zed.IDTime, zed.IDDuration:
+			return CompareInt(val.Int(), pattern)
 		case zed.IDFloat16, zed.IDFloat32, zed.IDFloat64:
 			return CompareFloat(zed.DecodeFloat(zv), float64(pattern))
-		case zed.IDTime:
-			return CompareInt(int64(zed.DecodeTime(zv)), pattern)
-		case zed.IDDuration:
-			return CompareInt(int64(zed.DecodeDuration(zv)), pattern)
 		}
 		return false
 	}, nil
@@ -144,14 +140,10 @@ func CompareFloat64(op string, pattern float64) (Boolean, error) {
 		// compare with the integer-y field.
 		case zed.IDFloat16, zed.IDFloat32, zed.IDFloat64:
 			return compare(zed.DecodeFloat(zv), pattern)
-		case zed.IDInt8, zed.IDInt16, zed.IDInt32, zed.IDInt64:
-			return compare(float64(zed.DecodeInt(zv)), pattern)
 		case zed.IDUint8, zed.IDUint16, zed.IDUint32, zed.IDUint64:
 			return compare(float64(val.Uint()), pattern)
-		case zed.IDTime:
-			return compare(float64(zed.DecodeTime(zv)), pattern)
-		case zed.IDDuration:
-			return compare(float64(zed.DecodeDuration(zv)), pattern)
+		case zed.IDInt8, zed.IDInt16, zed.IDInt32, zed.IDInt64, zed.IDTime, zed.IDDuration:
+			return compare(float64(val.Int()), pattern)
 		}
 		return false
 	}, nil

--- a/runtime/expr/cast.go
+++ b/runtime/expr/cast.go
@@ -68,7 +68,7 @@ func (c *casterIntN) Eval(ectx Context, val *zed.Value) *zed.Value {
 	if !ok || (c.min != 0 && (v < c.min || v > c.max)) {
 		return c.zctx.WrapError("cannot cast to "+zson.FormatType(c.typ), val)
 	}
-	return ectx.NewValue(c.typ, zed.EncodeInt(v))
+	return ectx.CopyValue(zed.NewInt(c.typ, v))
 }
 
 type casterUintN struct {
@@ -187,18 +187,16 @@ func (c *casterDuration) Eval(ectx Context, val *zed.Value) *zed.Value {
 			}
 			d = nano.Duration(f)
 		}
-		return ectx.NewValue(zed.TypeDuration, zed.EncodeDuration(d))
+		return ectx.CopyValue(zed.NewDuration(d))
 	}
 	if zed.IsFloat(id) {
-		d := nano.Duration(zed.DecodeFloat(val.Bytes()))
-		return ectx.NewValue(zed.TypeDuration, zed.EncodeDuration(d))
+		return ectx.CopyValue(zed.NewDuration(nano.Duration(zed.DecodeFloat(val.Bytes()))))
 	}
 	v, ok := coerce.ToInt(val)
 	if !ok {
 		return c.zctx.WrapError("cannot cast to duration", val)
 	}
-	d := nano.Duration(v)
-	return ectx.NewValue(zed.TypeDuration, zed.EncodeDuration(d))
+	return ectx.CopyValue(zed.NewDuration(nano.Duration(v)))
 }
 
 type casterTime struct {
@@ -234,7 +232,7 @@ func (c *casterTime) Eval(ectx Context, val *zed.Value) *zed.Value {
 	default:
 		return c.zctx.WrapError("cannot cast to time", val)
 	}
-	return ectx.NewValue(zed.TypeTime, zed.EncodeTime(ts))
+	return ectx.CopyValue(zed.NewTime(ts))
 }
 
 type casterString struct {

--- a/runtime/expr/coerce/coerce.go
+++ b/runtime/expr/coerce/coerce.go
@@ -166,13 +166,13 @@ func ToFloat(val *zed.Value) (float64, bool) {
 	}
 	if zed.IsInteger(id) {
 		if zed.IsSigned(id) {
-			return float64(zed.DecodeInt(val.Bytes())), true
+			return float64(val.Int()), true
 		} else {
 			return float64(val.Uint()), true
 		}
 	}
 	if id == zed.IDDuration {
-		return float64(zed.DecodeInt(val.Bytes())), true
+		return float64(val.Int()), true
 	}
 	if id == zed.IDTime {
 		return float64(zed.DecodeTime(val.Bytes())), true
@@ -191,7 +191,7 @@ func ToUint(val *zed.Value) (uint64, bool) {
 	}
 	if zed.IsInteger(id) {
 		if zed.IsSigned(id) {
-			v := zed.DecodeInt(val.Bytes())
+			v := val.Int()
 			if v < 0 {
 				return 0, false
 			}
@@ -201,7 +201,7 @@ func ToUint(val *zed.Value) (uint64, bool) {
 		}
 	}
 	if id == zed.IDDuration {
-		return uint64(zed.DecodeInt(val.Bytes())), true
+		return uint64(val.Int()), true
 	}
 	if id == zed.IDTime {
 		return uint64(zed.DecodeTime(val.Bytes())), true
@@ -221,13 +221,13 @@ func ToInt(val *zed.Value) (int64, bool) {
 	if zed.IsInteger(id) {
 		if zed.IsSigned(id) {
 			// XXX check if negative? should -1:uint64 be maxint64 or an error?
-			return zed.DecodeInt(val.Bytes()), true
+			return val.Int(), true
 		} else {
 			return int64(val.Uint()), true
 		}
 	}
 	if id == zed.IDDuration {
-		return zed.DecodeInt(val.Bytes()), true
+		return val.Int(), true
 	}
 	if id == zed.IDTime {
 		return int64(zed.DecodeTime(val.Bytes())), true
@@ -254,7 +254,7 @@ func ToTime(val *zed.Value) (nano.Ts, bool) {
 		return zed.DecodeTime(val.Bytes()), true
 	}
 	if zed.IsSigned(id) {
-		return nano.Ts(zed.DecodeInt(val.Bytes())), true
+		return nano.Ts(val.Int()), true
 	}
 	if zed.IsInteger(id) {
 		v := val.Uint()
@@ -286,7 +286,7 @@ func ToDuration(in *zed.Value) (nano.Duration, bool) {
 		}
 		return nano.Duration(v) * nano.Second, true
 	case zed.IDInt16, zed.IDInt32, zed.IDInt64:
-		v := zed.DecodeInt(in.Bytes())
+		v := in.Int()
 		//XXX check for overflow here
 		return nano.Duration(v) * nano.Second, true
 	case zed.IDFloat16, zed.IDFloat32, zed.IDFloat64:

--- a/runtime/expr/eval.go
+++ b/runtime/expr/eval.go
@@ -433,7 +433,7 @@ func (a *Add) Eval(ectx Context, this *zed.Value) *zed.Value {
 		return ectx.NewValue(typ, zed.EncodeFloat64(v1+v2))
 	case zed.IsSigned(id):
 		v1, v2 := a.operands.ints()
-		return ectx.NewValue(typ, zed.EncodeInt(v1+v2))
+		return ectx.CopyValue(zed.NewInt(typ, v1+v2))
 	case zed.IsNumber(id):
 		v1, v2 := a.operands.uints()
 		return ectx.CopyValue(zed.NewUint(typ, v1+v2))
@@ -467,7 +467,7 @@ func (s *Subtract) Eval(ectx Context, this *zed.Value) *zed.Value {
 			// Return the difference of two times as a duration.
 			typ = zed.TypeDuration
 		}
-		return ectx.NewValue(typ, zed.EncodeInt(v1-v2))
+		return ectx.CopyValue(zed.NewInt(typ, v1-v2))
 	case zed.IsNumber(id):
 		v1, v2 := s.operands.uints()
 		return ectx.CopyValue(zed.NewUint(typ, v1-v2))
@@ -493,7 +493,7 @@ func (m *Multiply) Eval(ectx Context, this *zed.Value) *zed.Value {
 		return ectx.NewValue(typ, zed.EncodeFloat64(v1*v2))
 	case zed.IsSigned(id):
 		v1, v2 := m.operands.ints()
-		return ectx.NewValue(typ, zed.EncodeInt(v1*v2))
+		return ectx.CopyValue(zed.NewInt(typ, v1*v2))
 	case zed.IsNumber(id):
 		v1, v2 := m.operands.uints()
 		return ectx.CopyValue(zed.NewUint(typ, v1*v2))
@@ -525,7 +525,7 @@ func (d *Divide) Eval(ectx Context, this *zed.Value) *zed.Value {
 		if v2 == 0 {
 			return d.zctx.NewError(DivideByZero)
 		}
-		return ectx.NewValue(typ, zed.EncodeInt(v1/v2))
+		return ectx.CopyValue(zed.NewInt(typ, v1/v2))
 	case zed.IsNumber(id):
 		v1, v2 := d.operands.uints()
 		if v2 == 0 {
@@ -556,7 +556,7 @@ func (m *Modulo) Eval(ectx Context, this *zed.Value) *zed.Value {
 		if y == 0 {
 			return m.zctx.NewError(DivideByZero)
 		}
-		return ectx.NewValue(typ, zed.EncodeInt(x%y))
+		return ectx.CopyValue(zed.NewInt(typ, x%y))
 	}
 	x, y := m.operands.uints()
 	if y == 0 {
@@ -600,38 +600,38 @@ func (u *UnaryMinus) Eval(ectx Context, this *zed.Value) *zed.Value {
 		if val.IsNull() {
 			return val
 		}
-		v := zed.DecodeInt(val.Bytes())
+		v := val.Int()
 		if v == math.MinInt8 {
 			return ectx.CopyValue(u.zctx.NewErrorf("unary '-' underflow: int8(%d)", v))
 		}
-		return ectx.NewValue(typ, zed.EncodeInt(-v))
+		return ectx.CopyValue(zed.NewInt8(int8(-v)))
 	case zed.IDInt16:
 		if val.IsNull() {
 			return val
 		}
-		v := zed.DecodeInt(val.Bytes())
+		v := val.Int()
 		if v == math.MinInt16 {
 			return ectx.CopyValue(u.zctx.NewErrorf("unary '-' underflow: int16(%d)", v))
 		}
-		return ectx.NewValue(typ, zed.EncodeInt(-v))
+		return ectx.CopyValue(zed.NewInt16(int16(-v)))
 	case zed.IDInt32:
 		if val.IsNull() {
 			return val
 		}
-		v := zed.DecodeInt(val.Bytes())
+		v := val.Int()
 		if v == math.MinInt32 {
 			return ectx.CopyValue(u.zctx.NewErrorf("unary '-' underflow: int32(%d)", v))
 		}
-		return ectx.NewValue(typ, zed.EncodeInt(-v))
+		return ectx.CopyValue(zed.NewInt32(int32(-v)))
 	case zed.IDInt64:
 		if val.IsNull() {
 			return val
 		}
-		v := zed.DecodeInt(val.Bytes())
+		v := val.Int()
 		if v == math.MinInt64 {
 			return ectx.CopyValue(u.zctx.NewErrorf("unary '-' underflow: int64(%d)", v))
 		}
-		return ectx.NewValue(typ, zed.EncodeInt(-v))
+		return ectx.CopyValue(zed.NewInt64(-v))
 	case zed.IDUint8:
 		if val.IsNull() {
 			return val
@@ -640,7 +640,7 @@ func (u *UnaryMinus) Eval(ectx Context, this *zed.Value) *zed.Value {
 		if v > math.MaxInt8 {
 			return ectx.CopyValue(u.zctx.NewErrorf("unary '-' overflow: uint8(%d)", v))
 		}
-		return ectx.NewValue(zed.TypeInt8, zed.EncodeInt(-int64(v)))
+		return ectx.CopyValue(zed.NewInt8(int8(-v)))
 	case zed.IDUint16:
 		if val.IsNull() {
 			return val
@@ -649,7 +649,7 @@ func (u *UnaryMinus) Eval(ectx Context, this *zed.Value) *zed.Value {
 		if v > math.MaxInt16 {
 			return ectx.CopyValue(u.zctx.NewErrorf("unary '-' overflow: uint16(%d)", v))
 		}
-		return ectx.NewValue(zed.TypeInt16, zed.EncodeInt(-int64(v)))
+		return ectx.CopyValue(zed.NewInt16(int16(-v)))
 	case zed.IDUint32:
 		if val.IsNull() {
 			return val
@@ -658,7 +658,7 @@ func (u *UnaryMinus) Eval(ectx Context, this *zed.Value) *zed.Value {
 		if v > math.MaxInt32 {
 			return ectx.CopyValue(u.zctx.NewErrorf("unary '-' overflow: uint32(%d)", v))
 		}
-		return ectx.NewValue(zed.TypeInt32, zed.EncodeInt(-int64(v)))
+		return ectx.CopyValue(zed.NewInt32(int32(-v)))
 	case zed.IDUint64:
 		if val.IsNull() {
 			return val
@@ -667,7 +667,7 @@ func (u *UnaryMinus) Eval(ectx Context, this *zed.Value) *zed.Value {
 		if v > math.MaxInt64 {
 			return ectx.CopyValue(u.zctx.NewErrorf("unary '-' overflow: uint64(%d)", v))
 		}
-		return ectx.NewValue(zed.TypeInt64, zed.EncodeInt(-int64(v)))
+		return ectx.CopyValue(zed.NewInt64(int64(-v)))
 	}
 	return u.zctx.WrapError("type incompatible with unary '-' operator", val)
 }
@@ -737,7 +737,7 @@ func indexVector(zctx *zed.Context, ectx Context, inner zed.Type, vector zcode.B
 	}
 	var idx int
 	if zed.IsSigned(id) {
-		idx = int(zed.DecodeInt(index.Bytes()))
+		idx = int(index.Int())
 	} else {
 		idx = int(index.Uint())
 	}

--- a/runtime/expr/function/compare.go
+++ b/runtime/expr/function/compare.go
@@ -32,5 +32,5 @@ func (e *Compare) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if !nullsMax {
 		cmp = e.nullsMin
 	}
-	return newInt64(ctx, int64(cmp(&args[0], &args[1])))
+	return ctx.CopyValue(zed.NewInt64(int64(cmp(&args[0], &args[1]))))
 }

--- a/runtime/expr/function/function.go
+++ b/runtime/expr/function/function.go
@@ -6,7 +6,6 @@ import (
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/pkg/anymath"
 	"github.com/brimdata/zed/pkg/field"
-	"github.com/brimdata/zed/pkg/nano"
 	"github.com/brimdata/zed/runtime/expr"
 	"github.com/brimdata/zed/zson"
 )
@@ -187,16 +186,6 @@ func HasBoolResult(name string) bool {
 	return false
 }
 
-func newInt64(ctx zed.Allocator, native int64) *zed.Value {
-	return newInt(ctx, zed.TypeInt64, native)
-}
-
-func newInt(ctx zed.Allocator, typ zed.Type, native int64) *zed.Value {
-	//XXX we should have an interface to allocator where we can
-	// append into some new bytes; for now, the byte slice goes through GC.
-	return ctx.NewValue(typ, zed.EncodeInt(native))
-}
-
 func newFloat16(ctx zed.Allocator, native float32) *zed.Value {
 	return ctx.NewValue(zed.TypeFloat16, zed.EncodeFloat16(native))
 }
@@ -207,14 +196,6 @@ func newFloat32(ctx zed.Allocator, native float32) *zed.Value {
 
 func newFloat64(ctx zed.Allocator, native float64) *zed.Value {
 	return ctx.NewValue(zed.TypeFloat64, zed.EncodeFloat64(native))
-}
-
-func newDuration(ctx zed.Allocator, native nano.Duration) *zed.Value {
-	return ctx.NewValue(zed.TypeDuration, zed.EncodeDuration(native))
-}
-
-func newTime(ctx zed.Allocator, native nano.Ts) *zed.Value {
-	return ctx.NewValue(zed.TypeTime, zed.EncodeTime(native))
 }
 
 func newString(ctx zed.Allocator, native string) *zed.Value {

--- a/runtime/expr/function/ip.go
+++ b/runtime/expr/function/ip.go
@@ -47,7 +47,7 @@ func (n *NetworkOf) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 			}
 		case zed.IsInteger(id):
 			if zed.IsSigned(id) {
-				bits = int(zed.DecodeInt(body))
+				bits = int(args[1].Int())
 			} else {
 				bits = int(args[1].Uint())
 			}

--- a/runtime/expr/function/len.go
+++ b/runtime/expr/function/len.go
@@ -36,7 +36,7 @@ func (l *LenFn) Call(ectx zed.Allocator, args []zed.Value) *zed.Value {
 	default:
 		return l.zctx.NewErrorf("len: bad type: %s", zson.FormatType(typ))
 	}
-	return newInt64(ectx, int64(length))
+	return ectx.CopyValue(zed.NewInt64(int64(length)))
 }
 
 func typeLength(typ zed.Type) int {

--- a/runtime/expr/function/math.go
+++ b/runtime/expr/function/math.go
@@ -35,11 +35,11 @@ func (a *Abs) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if !zed.IsSigned(id) {
 		return ctx.CopyValue(&args[0])
 	}
-	x := zed.DecodeInt(v.Bytes())
+	x := v.Int()
 	if x < 0 {
 		x = -x
 	}
-	return newInt64(ctx, x)
+	return ctx.CopyValue(zed.NewInt64(x))
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#ceil
@@ -135,7 +135,7 @@ func (r *reducer) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		return newErrorf(r.zctx, ctx, "%s: not a number: %s", r.name, zson.MustFormatValue(val0))
 	}
 	if zed.IsSigned(id) {
-		result := zed.DecodeInt(val0.Bytes())
+		result := val0.Int()
 		for _, val := range args[1:] {
 			//XXX this is really bad because we silently coerce
 			// floats to ints if we hit a float first
@@ -145,7 +145,7 @@ func (r *reducer) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 			}
 			result = r.fn.Int64(result, v)
 		}
-		return newInt64(ctx, result)
+		return ctx.CopyValue(zed.NewInt64(result))
 	}
 	result := val0.Uint()
 	for _, val := range args[1:] {

--- a/runtime/expr/function/string.go
+++ b/runtime/expr/function/string.go
@@ -44,10 +44,10 @@ func (r *RuneLen) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		return newErrorf(r.zctx, ctx, "rune_len: string arg required")
 	}
 	if val.IsNull() {
-		return newInt64(ctx, 0)
+		return ctx.CopyValue(zed.NewInt64(0))
 	}
 	s := zed.DecodeString(val.Bytes())
-	return newInt64(ctx, int64(utf8.RuneCountInString(s)))
+	return ctx.CopyValue(zed.NewInt64(int64(utf8.RuneCountInString(s))))
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#lower
@@ -182,5 +182,5 @@ func (l *Levenshtein) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		return l.zctx.WrapError("levenshtein: string args required", b)
 	}
 	as, bs := zed.DecodeString(a.Bytes()), zed.DecodeString(b.Bytes())
-	return newInt64(ctx, int64(levenshtein.ComputeDistance(as, bs)))
+	return ctx.CopyValue(zed.NewInt64(int64(levenshtein.ComputeDistance(as, bs))))
 }

--- a/runtime/expr/function/time.go
+++ b/runtime/expr/function/time.go
@@ -10,7 +10,7 @@ import (
 type Now struct{}
 
 func (n *Now) Call(ctx zed.Allocator, _ []zed.Value) *zed.Value {
-	return newTime(ctx, nano.Now())
+	return ctx.CopyValue(zed.NewTime(nano.Now()))
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#bucket
@@ -27,7 +27,7 @@ func (b *Bucket) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	}
 	var bin nano.Duration
 	if binArg.Type == zed.TypeDuration {
-		bin = zed.DecodeDuration(binArg.Bytes())
+		bin = nano.Duration(binArg.Int())
 	} else {
 		d, ok := coerce.ToInt(binArg)
 		if !ok {
@@ -36,14 +36,14 @@ func (b *Bucket) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		bin = nano.Duration(d) * nano.Second
 	}
 	if zed.TypeUnder(tsArg.Type) == zed.TypeDuration {
-		dur := zed.DecodeDuration(tsArg.Bytes())
-		return newDuration(ctx, dur.Trunc(bin))
+		dur := nano.Duration(tsArg.Int())
+		return ctx.CopyValue(zed.NewDuration(dur.Trunc(bin)))
 	}
 	ts, ok := coerce.ToTime(tsArg)
 	if !ok {
 		return newErrorf(b.zctx, ctx, "%s: time arg required", b)
 	}
-	return newTime(ctx, ts.Trunc(bin))
+	return ctx.CopyValue(zed.NewTime(ts.Trunc(bin)))
 }
 
 func (b *Bucket) String() string {

--- a/runtime/expr/sort.go
+++ b/runtime/expr/sort.go
@@ -39,7 +39,7 @@ func (c *Comparator) sortStableIndices(vals []zed.Value) []uint32 {
 					i64s[i] = math.MinInt64
 				}
 			} else if zed.IsSigned(id) {
-				i64s[i] = zed.DecodeInt(val.Bytes())
+				i64s[i] = val.Int()
 			} else {
 				v := val.Uint()
 				if v > math.MaxInt64 {

--- a/zio/zeekio/format.go
+++ b/zio/zeekio/format.go
@@ -28,8 +28,8 @@ func formatAny(val *zed.Value, inContainer bool) string {
 		return "F"
 	case *zed.TypeOfBytes:
 		return base64.StdEncoding.EncodeToString(val.Bytes())
-	case *zed.TypeOfDuration:
-		return formatTime(nano.Ts(zed.DecodeDuration(val.Bytes())))
+	case *zed.TypeOfDuration, *zed.TypeOfTime:
+		return formatTime(nano.Ts(val.Int()))
 	case *zed.TypeEnum:
 		return formatAny(zed.NewValue(zed.TypeUint64, val.Bytes()), false)
 	case *zed.TypeOfFloat16:
@@ -39,7 +39,7 @@ func formatAny(val *zed.Value, inContainer bool) string {
 	case *zed.TypeOfFloat64:
 		return strconv.FormatFloat(zed.DecodeFloat64(val.Bytes()), 'f', -1, 64)
 	case *zed.TypeOfInt8, *zed.TypeOfInt16, *zed.TypeOfInt32, *zed.TypeOfInt64:
-		return strconv.FormatInt(zed.DecodeInt(val.Bytes()), 10)
+		return strconv.FormatInt(val.Int(), 10)
 	case *zed.TypeOfUint8, *zed.TypeOfUint16, *zed.TypeOfUint32, *zed.TypeOfUint64:
 		return strconv.FormatUint(val.Uint(), 10)
 	case *zed.TypeOfIP:
@@ -56,8 +56,6 @@ func formatAny(val *zed.Value, inContainer bool) string {
 		return formatSet(t, val.Bytes())
 	case *zed.TypeOfString:
 		return formatString(t, val.Bytes(), inContainer)
-	case *zed.TypeOfTime:
-		return formatTime(zed.DecodeTime(val.Bytes()))
 	case *zed.TypeOfType:
 		return zson.String(val)
 	case *zed.TypeUnion:

--- a/zson/marshal.go
+++ b/zson/marshal.go
@@ -812,7 +812,7 @@ func (u *UnmarshalZNGContext) decodeAny(val *zed.Value, v reflect.Value) error {
 		default:
 			return incompatTypeError(val.Type, v)
 		}
-		v.SetInt(zed.DecodeInt(val.Bytes()))
+		v.SetInt(val.Int())
 		return nil
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		switch zed.TypeUnder(val.Type) {

--- a/zson/marshal_test.go
+++ b/zson/marshal_test.go
@@ -329,7 +329,8 @@ func TestZNGValueField(t *testing.T) {
 	var out ZNGValueField
 	err = u.Unmarshal(zv, &out)
 	require.NoError(t, err)
-	assert.Equal(t, *zngValueField, out)
+	assert.Equal(t, zngValueField.Name, out.Name)
+	assert.True(t, zngValueField.Field.Equal(out.Field))
 	// Include a Zed record inside a Go struct in a zed.Value field.
 	z := `{s:"foo",a:[1,2,3]}`
 	zv2, err := zson.ParseValue(zed.NewContext(), z)


### PR DESCRIPTION
This applies the approach in #4623 to signed integer zed.Values.