### PR TITLE
add dictionary encoding to vng

### DIFF
--- a/runtime/vcache/primitive.go
+++ b/runtime/vcache/primitive.go
@@ -36,9 +36,33 @@ func (p *Primitive) NewIter(r io.ReaderAt) (iterator, error) {
 		}
 		p.bytes = data
 	}
+	if dict := p.meta.Dict; dict != nil {
+		bytes := p.bytes
+		return func(b *zcode.Builder) error {
+			pos := bytes[0]
+			bytes = bytes[1:]
+			b.Append(dict[pos].Value.Bytes())
+			return nil
+		}, nil
+	}
 	it := zcode.Iter(p.bytes)
 	return func(b *zcode.Builder) error {
 		b.Append(it.Next())
+		return nil
+	}, nil
+}
+
+type Const struct {
+	bytes zcode.Bytes
+}
+
+func NewConst(meta *vector.Const) *Const {
+	return &Const{bytes: meta.Value.Bytes()}
+}
+
+func (c *Const) NewIter(r io.ReaderAt) (iterator, error) {
+	return func(b *zcode.Builder) error {
+		b.Append(c.bytes)
 		return nil
 	}, nil
 }

--- a/runtime/vcache/vector.go
+++ b/runtime/vcache/vector.go
@@ -43,6 +43,8 @@ func NewVector(meta vector.Metadata, r io.ReaderAt) (Vector, error) {
 			return nil, err
 		}
 		return NewNulls(meta, values, r)
+	case *vector.Const:
+		return NewConst(meta), nil
 	default:
 		return nil, fmt.Errorf("vector cache: type %T not supported", meta)
 	}

--- a/vng/reader.go
+++ b/vng/reader.go
@@ -47,7 +47,7 @@ func (r *Reader) Read() (*zed.Value, error) {
 		return nil, nil
 	}
 	if typeNo < 0 || int(typeNo) >= len(r.readers) {
-		return nil, fmt.Errorf("system error: type number out of range in VNG root metadata")
+		return nil, fmt.Errorf("system error: type number out of range in VNG root metadata: %d out of %d", typeNo, len(r.readers))
 	}
 	tr := r.readers[typeNo]
 	if err := tr.reader.Read(&r.builder); err != nil {

--- a/vng/vector/int.go
+++ b/vng/vector/int.go
@@ -11,7 +11,7 @@ type Int64Writer struct {
 }
 
 func NewInt64Writer(spiller *Spiller) *Int64Writer {
-	return &Int64Writer{*NewPrimitiveWriter(zed.TypeInt64, spiller)}
+	return &Int64Writer{*NewPrimitiveWriter(zed.TypeInt64, spiller, false)}
 }
 
 func (p *Int64Writer) Write(v int64) error {
@@ -23,7 +23,7 @@ type Int64Reader struct {
 }
 
 func NewInt64Reader(segmap []Segment, r io.ReaderAt) *Int64Reader {
-	return &Int64Reader{*NewPrimitiveReader(&Primitive{zed.TypeInt64, segmap}, r)}
+	return &Int64Reader{*NewPrimitiveReader(&Primitive{Typ: zed.TypeInt64, Segmap: segmap}, r)}
 }
 
 func (p *Int64Reader) Read() (int64, error) {

--- a/vng/vector/io.go
+++ b/vng/vector/io.go
@@ -76,7 +76,7 @@ func NewWriter(typ zed.Type, spiller *Spiller) Writer {
 		if !zed.IsPrimitiveType(typ) {
 			panic(fmt.Sprintf("unsupported type in VNG file: %T", typ))
 		}
-		return NewPrimitiveWriter(typ, spiller)
+		return NewPrimitiveWriter(typ, spiller, true)
 	}
 }
 
@@ -116,7 +116,12 @@ func NewReader(meta Metadata, r io.ReaderAt) (Reader, error) {
 	case *Union:
 		return NewUnionReader(meta, r)
 	case *Primitive:
+		if len(meta.Dict) != 0 {
+			return NewDictReader(meta, r), nil
+		}
 		return NewPrimitiveReader(meta, r), nil
+	case *Const:
+		return NewConstReader(meta), nil
 	default:
 		return nil, fmt.Errorf("unknown VNG metadata type: %T", meta)
 	}

--- a/vng/vector/metadata.go
+++ b/vng/vector/metadata.go
@@ -1,8 +1,11 @@
 package vector
 
 import (
+	"sort"
+
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/pkg/field"
+	"github.com/brimdata/zed/runtime/expr"
 )
 
 type Metadata interface {
@@ -118,9 +121,25 @@ func (n *Named) Type(zctx *zed.Context) zed.Type {
 	return t
 }
 
+type DictEntry struct {
+	Value *zed.Value
+	Count uint32
+}
+
+func sortDict(entries []DictEntry, cmp expr.CompareFn) {
+	sort.Slice(entries, func(i, j int) bool {
+		return cmp(entries[i].Value, entries[j].Value) < 0
+	})
+}
+
 type Primitive struct {
 	Typ    zed.Type `zed:"Type"`
 	Segmap []Segment
+	Dict   []DictEntry
+	Min    *zed.Value
+	Max    *zed.Value
+	Count  uint32
+	Nulls  uint32
 }
 
 func (p *Primitive) Type(zctx *zed.Context) zed.Type {
@@ -136,6 +155,15 @@ func (n *Nulls) Type(zctx *zed.Context) zed.Type {
 	return n.Values.Type(zctx)
 }
 
+type Const struct {
+	Value *zed.Value
+	Count uint32
+}
+
+func (c *Const) Type(zctx *zed.Context) zed.Type {
+	return c.Value.Type
+}
+
 var Template = []interface{}{
 	Record{},
 	Array{},
@@ -145,4 +173,5 @@ var Template = []interface{}{
 	Primitive{},
 	Named{},
 	Nulls{},
+	Const{},
 }

--- a/vng/vector/metadata.go
+++ b/vng/vector/metadata.go
@@ -1,11 +1,8 @@
 package vector
 
 import (
-	"sort"
-
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/pkg/field"
-	"github.com/brimdata/zed/runtime/expr"
 )
 
 type Metadata interface {
@@ -124,12 +121,6 @@ func (n *Named) Type(zctx *zed.Context) zed.Type {
 type DictEntry struct {
 	Value *zed.Value
 	Count uint32
-}
-
-func sortDict(entries []DictEntry, cmp expr.CompareFn) {
-	sort.Slice(entries, func(i, j int) bool {
-		return cmp(entries[i].Value, entries[j].Value) < 0
-	})
 }
 
 type Primitive struct {

--- a/vng/vector/primitive.go
+++ b/vng/vector/primitive.go
@@ -2,37 +2,83 @@ package vector
 
 import (
 	"errors"
+	"fmt"
 	"io"
 
 	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/order"
+	"github.com/brimdata/zed/runtime/expr"
 	"github.com/brimdata/zed/zcode"
 	"golang.org/x/exp/slices"
 )
+
+const MaxDictSize = 256
 
 type PrimitiveWriter struct {
 	typ      zed.Type
 	bytes    zcode.Bytes
 	spiller  *Spiller
 	segments []Segment
+	dict     map[string]uint32
+	cmp      expr.CompareFn
+	min      *zed.Value
+	max      *zed.Value
+	count    uint32
+	nulls    uint32
+	hasNull  int
 }
 
-func NewPrimitiveWriter(typ zed.Type, spiller *Spiller) *PrimitiveWriter {
+func NewPrimitiveWriter(typ zed.Type, spiller *Spiller, useDict bool) *PrimitiveWriter {
+	var dict map[string]uint32
+	if useDict {
+		dict = make(map[string]uint32)
+	}
 	return &PrimitiveWriter{
 		typ:     typ,
 		spiller: spiller,
+		dict:    dict,
+		cmp:     expr.NewValueCompareFn(order.Asc, false),
 	}
 }
 
 func (p *PrimitiveWriter) Write(body zcode.Bytes) error {
+	p.update(body)
 	p.bytes = zcode.Append(p.bytes, body)
-	var err error
-	if len(p.bytes) >= p.spiller.Thresh {
-		err = p.Flush(false)
+	return nil
+}
+
+func (p *PrimitiveWriter) update(body zcode.Bytes) {
+	p.count++
+	if body == nil {
+		p.nulls++
+		p.hasNull = 1
+		return
 	}
-	return err
+	if body != nil {
+		val := zed.NewValue(p.typ, body)
+		if p.min == nil || p.cmp(val, p.min) < 0 {
+			p.min = val
+		}
+		if p.max == nil || p.cmp(val, p.max) > 0 {
+			p.max = val
+		}
+	}
+	if p.dict != nil {
+		p.dict[string(body)] += 1
+		if len(p.dict)+p.hasNull > MaxDictSize {
+			p.dict = nil
+		}
+	}
 }
 
 func (p *PrimitiveWriter) Flush(eof bool) error {
+	if !eof {
+		//XXX get rid of this... re-work flush protocol?
+		panic("PrimitiveWriter.Flush")
+	}
+	if p.dict != nil {
+		p.bytes = p.makeDictVector()
+	}
 	var err error
 	if len(p.bytes) > 0 {
 		p.segments, err = p.spiller.Write(p.segments, p.bytes)
@@ -41,15 +87,88 @@ func (p *PrimitiveWriter) Flush(eof bool) error {
 	return err
 }
 
+func (p *PrimitiveWriter) makeDictVector() []byte {
+	dict := p.makeDict()
+	pos := make(map[string]byte)
+	for off, entry := range dict {
+		if bytes := entry.Value.Bytes(); bytes != nil {
+			pos[string(bytes)] = byte(off)
+		}
+	}
+	out := make([]byte, 0, p.count)
+	for it := p.bytes.Iter(); !it.Done(); {
+		bytes := it.Next()
+		if bytes == nil {
+			// null is always the first dict entry if it exists
+			out = append(out, 0)
+			continue
+		}
+		off, ok := pos[string(bytes)]
+		if !ok {
+			panic("bad dict entry") //XXX
+		}
+		out = append(out, off)
+	}
+	return out
+}
+
 func (p *PrimitiveWriter) Segmap() []Segment {
 	return p.segments
 }
 
+func (p *PrimitiveWriter) Const() *Const {
+	if len(p.dict)+p.hasNull != 1 {
+		return nil
+	}
+	var bytes zcode.Bytes
+	if len(p.dict) == 1 {
+		for b := range p.dict {
+			bytes = []byte(b)
+		}
+	}
+	return &Const{
+		Value: zed.NewValue(p.typ, bytes),
+		Count: p.count,
+	}
+}
+
 func (p *PrimitiveWriter) Metadata() Metadata {
+	var dict []DictEntry
+	if p.dict != nil {
+		if cnt := len(p.dict) + p.hasNull; cnt != 0 {
+			if cnt == 1 {
+				return p.Const()
+			}
+			dict = p.makeDict()
+		}
+	}
 	return &Primitive{
 		Typ:    p.typ,
 		Segmap: p.segments,
+		Dict:   dict,
+		Count:  p.count,
+		Nulls:  p.nulls,
+		Min:    p.min,
+		Max:    p.max,
 	}
+}
+
+func (p *PrimitiveWriter) makeDict() []DictEntry {
+	dict := make([]DictEntry, 0, len(p.dict)+p.hasNull)
+	for key, cnt := range p.dict {
+		dict = append(dict, DictEntry{
+			zed.NewValue(p.typ, zcode.Bytes(key)),
+			uint32(cnt),
+		})
+	}
+	if p.nulls != 0 {
+		dict = append(dict, DictEntry{
+			zed.NewValue(p.typ, nil),
+			p.nulls,
+		})
+	}
+	sortDict(dict, expr.NewValueCompareFn(order.Asc, false))
+	return dict
 }
 
 type PrimitiveReader struct {
@@ -91,12 +210,85 @@ func (p *PrimitiveReader) next() error {
 	segment := p.segmap[0]
 	p.segmap = p.segmap[1:]
 	if segment.Length > 2*MaxSegmentThresh {
-		return errors.New("segment too big")
+		return errors.New("corrupt VNG: segment too big")
 	}
 	p.buf = slices.Grow(p.buf[:0], int(segment.MemLength))[:segment.MemLength]
 	if err := segment.Read(p.reader, p.buf); err != nil {
 		return err
 	}
 	p.it = zcode.Iter(p.buf)
+	return nil
+}
+
+type DictReader struct {
+	segmap    []Segment
+	reader    io.ReaderAt
+	dict      []DictEntry
+	selectors []byte
+	off       int
+}
+
+func NewDictReader(primitive *Primitive, reader io.ReaderAt) *DictReader {
+	return &DictReader{
+		reader: reader,
+		segmap: primitive.Segmap,
+		dict:   primitive.Dict,
+	}
+}
+
+func (d *DictReader) Read(b *zcode.Builder) error {
+	bytes, err := d.read()
+	if err == nil {
+		b.Append(bytes)
+	}
+	return err
+}
+
+func (d *DictReader) read() (zcode.Bytes, error) {
+	if d.off >= len(d.selectors) {
+		if len(d.segmap) == 0 {
+			return nil, io.EOF
+		}
+		if err := d.next(); err != nil {
+			return nil, err
+		}
+	}
+	sel := int(d.selectors[d.off])
+	d.off++
+	if sel >= len(d.dict) {
+		return nil, fmt.Errorf("corrupt VNG: selector (%d) out of range (len %d)", sel, len(d.dict))
+	}
+	return d.dict[sel].Value.Bytes(), nil
+}
+
+func (d *DictReader) next() error {
+	segment := d.segmap[0]
+	d.segmap = d.segmap[1:]
+	if segment.Length > 2*MaxSegmentThresh {
+		return errors.New("corrupt VNG: segment too big")
+	}
+	d.selectors = slices.Grow(d.selectors[:0], int(segment.MemLength))[:segment.MemLength]
+	if err := segment.Read(d.reader, d.selectors); err != nil {
+		return err
+	}
+	d.off = 0
+	return nil
+}
+
+type ConstReader struct {
+	bytes zcode.Bytes
+	cnt   uint32
+}
+
+func NewConstReader(c *Const) *ConstReader {
+	return &ConstReader{bytes: c.Value.Bytes(), cnt: c.Count}
+}
+
+func (c *ConstReader) Read(b *zcode.Builder) error {
+	if c.cnt == 0 {
+		return io.EOF
+	}
+	c.cnt--
+	b.Append(c.bytes)
 	return nil
 }

--- a/vng/ztests/const.yaml
+++ b/vng/ztests/const.yaml
@@ -1,0 +1,26 @@
+script: |
+  zq -f vng -o out.vng -
+  zed dev dig section -Z 1 out.vng
+
+inputs:
+  - name: stdin
+    data: |
+      1
+      1
+      1
+
+outputs:
+  - name: stdout
+    data: |
+      [
+          {
+              Offset: 3,
+              Length: 3 (int32),
+              MemLength: 3 (int32),
+              CompressionFormat: 0 (uint8)
+          } (=Segment)
+      ]
+      {
+          Value: 1,
+          Count: 3 (uint32)
+      } (=Const)

--- a/vng/ztests/dict.yaml
+++ b/vng/ztests/dict.yaml
@@ -1,0 +1,33 @@
+script: |
+  zq -f vng -o out.vng -
+  zed dev dig section 1 out.vng | zq -Z "over Fields | yield Values.Dict" -
+
+inputs:
+  - name: stdin
+    data: |
+      {a:"hello",b:1}
+      {a:"world",b:2}
+
+outputs:
+  - name: stdout
+    data: |
+      [
+          {
+              Value: "hello",
+              Count: 1 (uint32)
+          } (=DictEntry),
+          {
+              Value: "world",
+              Count: 1
+          } (DictEntry)
+      ]
+      [
+          {
+              Value: 1,
+              Count: 1 (uint32)
+          } (=DictEntry),
+          {
+              Value: 2,
+              Count: 1
+          } (DictEntry)
+      ]

--- a/vng/ztests/no-dict.yaml
+++ b/vng/ztests/no-dict.yaml
@@ -1,0 +1,8 @@
+script: |
+  seq 1000 | zq -f vng -o out.vng "{x:this}" -
+  zed dev dig section 1 out.vng | zq -Z "over Fields | yield Values.Dict" -
+
+outputs:
+  - name: stdout
+    data: |
+      null ([DictEntry={Value:{Type:null,bytes:Bytes=bytes},Count:uint32}])


### PR DESCRIPTION
This commit adds dictionary encoding to the vng format where primitive vectors are optionally encoded with dictionaries when their cardinality is small.  Currently, the cardinality is limited to 256 values; we will allow larger dictionaries in the future.

When the dictionary has length 1, the vector is simplified into a "constant" vector and the dictionary and stats are omitted.