### PR TITLE
Use native representation for floating point zed.Value

### DIFF
--- a/runtime/expr/agg/avg.go
+++ b/runtime/expr/agg/avg.go
@@ -54,7 +54,7 @@ func (a *Avg) ConsumeAsPartial(partial *zed.Value) {
 	if countVal.Type != zed.TypeUint64 {
 		panic(fmt.Errorf("avg: partial count has bad type: %s", zson.MustFormatValue(countVal)))
 	}
-	a.sum += zed.DecodeFloat64(sumVal.Bytes())
+	a.sum += sumVal.Float()
 	a.count += countVal.Uint()
 }
 

--- a/runtime/expr/cast.go
+++ b/runtime/expr/cast.go
@@ -190,7 +190,7 @@ func (c *casterDuration) Eval(ectx Context, val *zed.Value) *zed.Value {
 		return ectx.CopyValue(zed.NewDuration(d))
 	}
 	if zed.IsFloat(id) {
-		return ectx.CopyValue(zed.NewDuration(nano.Duration(zed.DecodeFloat(val.Bytes()))))
+		return ectx.CopyValue(zed.NewDuration(nano.Duration(val.Float())))
 	}
 	v, ok := coerce.ToInt(val)
 	if !ok {

--- a/runtime/expr/coerce/coerce.go
+++ b/runtime/expr/coerce/coerce.go
@@ -162,7 +162,7 @@ func (c *Pair) coerceNumbers(aid, bid int) (int, bool) {
 func ToFloat(val *zed.Value) (float64, bool) {
 	id := val.Type.ID()
 	if zed.IsFloat(id) {
-		return zed.DecodeFloat(val.Bytes()), true
+		return val.Float(), true
 	}
 	if zed.IsInteger(id) {
 		if zed.IsSigned(id) {
@@ -187,7 +187,7 @@ func ToFloat(val *zed.Value) (float64, bool) {
 func ToUint(val *zed.Value) (uint64, bool) {
 	id := val.Type.ID()
 	if zed.IsFloat(id) {
-		return uint64(zed.DecodeFloat(val.Bytes())), true
+		return uint64(val.Float()), true
 	}
 	if zed.IsInteger(id) {
 		if zed.IsSigned(id) {
@@ -216,7 +216,7 @@ func ToUint(val *zed.Value) (uint64, bool) {
 func ToInt(val *zed.Value) (int64, bool) {
 	id := val.Type.ID()
 	if zed.IsFloat(id) {
-		return int64(zed.DecodeFloat(val.Bytes())), true
+		return int64(val.Float()), true
 	}
 	if zed.IsInteger(id) {
 		if zed.IsSigned(id) {
@@ -290,7 +290,7 @@ func ToDuration(in *zed.Value) (nano.Duration, bool) {
 		//XXX check for overflow here
 		return nano.Duration(v) * nano.Second, true
 	case zed.IDFloat16, zed.IDFloat32, zed.IDFloat64:
-		return nano.Duration(zed.DecodeFloat(in.Bytes())), true
+		return nano.Duration(in.Float()), true
 	}
 	return 0, false
 }

--- a/runtime/expr/eval.go
+++ b/runtime/expr/eval.go
@@ -581,21 +581,11 @@ func (u *UnaryMinus) Eval(ectx Context, this *zed.Value) *zed.Value {
 	val := u.expr.Eval(ectx, this)
 	typ := val.Type
 	switch typ.ID() {
-	case zed.IDFloat16:
+	case zed.IDFloat16, zed.IDFloat32, zed.IDFloat64:
 		if val.IsNull() {
 			return val
 		}
-		return ectx.NewValue(typ, zed.EncodeFloat16(-zed.DecodeFloat16(val.Bytes())))
-	case zed.IDFloat32:
-		if val.IsNull() {
-			return val
-		}
-		return ectx.NewValue(typ, zed.EncodeFloat32(-zed.DecodeFloat32(val.Bytes())))
-	case zed.IDFloat64:
-		if val.IsNull() {
-			return val
-		}
-		return ectx.NewValue(typ, zed.EncodeFloat64(-zed.DecodeFloat64(val.Bytes())))
+		return zed.NewFloat(typ, -val.Float())
 	case zed.IDInt8:
 		if val.IsNull() {
 			return val

--- a/runtime/expr/function/math.go
+++ b/runtime/expr/function/math.go
@@ -18,15 +18,15 @@ func (a *Abs) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	v := args[0]
 	id := v.Type.ID()
 	if id == zed.IDFloat16 {
-		f := math.Abs(float64(zed.DecodeFloat16(v.Bytes())))
+		f := math.Abs(v.Float())
 		return newFloat16(ctx, float32(f))
 	}
 	if id == zed.IDFloat32 {
-		f := math.Abs(float64(zed.DecodeFloat32(v.Bytes())))
+		f := math.Abs(v.Float())
 		return newFloat32(ctx, float32(f))
 	}
 	if id == zed.IDFloat64 {
-		f := math.Abs(zed.DecodeFloat64(v.Bytes()))
+		f := math.Abs(v.Float())
 		return newFloat64(ctx, f)
 	}
 	if !zed.IsInteger(id) {
@@ -52,13 +52,13 @@ func (c *Ceil) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	id := v.Type.ID()
 	switch {
 	case id == zed.IDFloat16:
-		f := math.Ceil(float64(zed.DecodeFloat16(v.Bytes())))
+		f := math.Ceil(v.Float())
 		return newFloat16(ctx, float32(f))
 	case id == zed.IDFloat32:
-		f := math.Ceil(float64(zed.DecodeFloat32(v.Bytes())))
+		f := math.Ceil(v.Float())
 		return newFloat32(ctx, float32(f))
 	case id == zed.IDFloat64:
-		f := math.Ceil(zed.DecodeFloat64(v.Bytes()))
+		f := math.Ceil(v.Float())
 		return newFloat64(ctx, f)
 	case zed.IsInteger(id):
 		return ctx.CopyValue(&args[0])
@@ -77,13 +77,13 @@ func (f *Floor) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	id := v.Type.ID()
 	switch {
 	case id == zed.IDFloat16:
-		v := math.Floor(float64(zed.DecodeFloat16(v.Bytes())))
+		v := math.Floor(v.Float())
 		return newFloat16(ctx, float32(v))
 	case id == zed.IDFloat32:
-		v := math.Floor(float64(zed.DecodeFloat32(v.Bytes())))
+		v := math.Floor(v.Float())
 		return newFloat32(ctx, float32(v))
 	case id == zed.IDFloat64:
-		v := math.Floor(zed.DecodeFloat64(v.Bytes()))
+		v := math.Floor(v.Float())
 		return newFloat64(ctx, v)
 	case zed.IsInteger(id):
 		return ctx.CopyValue(&args[0])
@@ -121,7 +121,7 @@ func (r *reducer) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if zed.IsFloat(id) {
 		//XXX this is wrong like math aggregators...
 		// need to be more robust and adjust type as new types encountered
-		result := zed.DecodeFloat(val0.Bytes())
+		result := val0.Float()
 		for _, val := range args[1:] {
 			v, ok := coerce.ToFloat(&val)
 			if !ok {
@@ -167,16 +167,13 @@ func (r *Round) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	val := &args[0]
 	id := val.Type.ID()
 	if id == zed.IDFloat16 {
-		f := zed.DecodeFloat16(val.Bytes())
-		return newFloat16(ctx, float32(math.Round(float64(f))))
+		return newFloat16(ctx, float32(math.Round(val.Float())))
 	}
 	if id == zed.IDFloat32 {
-		f := zed.DecodeFloat32(val.Bytes())
-		return newFloat32(ctx, float32(math.Round(float64(f))))
+		return newFloat32(ctx, float32(math.Round(val.Float())))
 	}
 	if id == zed.IDFloat64 {
-		f := zed.DecodeFloat64(val.Bytes())
-		return newFloat64(ctx, math.Round(f))
+		return newFloat64(ctx, math.Round(val.Float()))
 	}
 	if !zed.IsNumber(id) {
 		return newErrorf(r.zctx, ctx, "round: not a number: %s", zson.MustFormatValue(val))

--- a/runtime/op/shape/shaper.go
+++ b/runtime/op/shape/shaper.go
@@ -69,7 +69,7 @@ func (i *integer) check(val zed.Value) {
 		i.unsigned = false
 		return
 	}
-	f := zed.DecodeFloat64(val.Bytes())
+	f := val.Float()
 	//XXX We could track signed vs unsigned and overflow,
 	// but for now, we leave it as float64 unless we can
 	// guarantee int64.

--- a/zio/zeekio/format.go
+++ b/zio/zeekio/format.go
@@ -32,12 +32,10 @@ func formatAny(val *zed.Value, inContainer bool) string {
 		return formatTime(nano.Ts(val.Int()))
 	case *zed.TypeEnum:
 		return formatAny(zed.NewValue(zed.TypeUint64, val.Bytes()), false)
-	case *zed.TypeOfFloat16:
-		return strconv.FormatFloat(float64(zed.DecodeFloat16(val.Bytes())), 'f', -1, 32)
-	case *zed.TypeOfFloat32:
-		return strconv.FormatFloat(float64(zed.DecodeFloat32(val.Bytes())), 'f', -1, 32)
+	case *zed.TypeOfFloat16, *zed.TypeOfFloat32:
+		return strconv.FormatFloat(val.Float(), 'f', -1, 32)
 	case *zed.TypeOfFloat64:
-		return strconv.FormatFloat(zed.DecodeFloat64(val.Bytes()), 'f', -1, 64)
+		return strconv.FormatFloat(val.Float(), 'f', -1, 64)
 	case *zed.TypeOfInt8, *zed.TypeOfInt16, *zed.TypeOfInt32, *zed.TypeOfInt64:
 		return strconv.FormatInt(val.Int(), 10)
 	case *zed.TypeOfUint8, *zed.TypeOfUint16, *zed.TypeOfUint32, *zed.TypeOfUint64:

--- a/zson/marshal.go
+++ b/zson/marshal.go
@@ -708,7 +708,7 @@ func (u *UnmarshalZNGContext) decodeAny(val *zed.Value, v reflect.Value) error {
 		if val.Type != zed.TypeFloat16 {
 			return incompatTypeError(val.Type, v)
 		}
-		v.SetUint(uint64(float16.Fromfloat32(zed.DecodeFloat16(val.Bytes())).Bits()))
+		v.SetUint(uint64(float16.Fromfloat32(float32(val.Float()))))
 		return nil
 	case nano.Ts:
 		if val.Type != zed.TypeTime {
@@ -826,13 +826,13 @@ func (u *UnmarshalZNGContext) decodeAny(val *zed.Value, v reflect.Value) error {
 		if zed.TypeUnder(val.Type) != zed.TypeFloat32 {
 			return incompatTypeError(val.Type, v)
 		}
-		v.SetFloat(float64(zed.DecodeFloat32(val.Bytes())))
+		v.SetFloat(val.Float())
 		return nil
 	case reflect.Float64:
 		if zed.TypeUnder(val.Type) != zed.TypeFloat64 {
 			return incompatTypeError(val.Type, v)
 		}
-		v.SetFloat(zed.DecodeFloat64(val.Bytes()))
+		v.SetFloat(val.Float())
 		return nil
 	default:
 		return fmt.Errorf("unsupported type: %v", v.Kind())


### PR DESCRIPTION
This applies the approach in #4623 to floating point zed.Values.