### PR TITLE
Replace coerece.ToDuration and ToTime with ToInt

### DIFF
--- a/runtime/expr/agg/math.go
+++ b/runtime/expr/agg/math.go
@@ -215,8 +215,8 @@ func (d *Duration) result() *zed.Value {
 }
 
 func (d *Duration) consume(val *zed.Value) {
-	if v, ok := coerce.ToDuration(val); ok {
-		d.state = d.function(d.state, int64(v))
+	if v, ok := coerce.ToInt(val); ok {
+		d.state = d.function(d.state, v)
 	}
 }
 
@@ -247,8 +247,8 @@ func (t *Time) result() *zed.Value {
 }
 
 func (t *Time) consume(val *zed.Value) {
-	if v, ok := coerce.ToTime(val); ok {
-		t.state = nano.Ts(t.function(int64(t.state), int64(v)))
+	if v, ok := coerce.ToInt(val); ok {
+		t.state = nano.Ts(t.function(int64(t.state), v))
 	}
 }
 

--- a/runtime/expr/coerce/coerce.go
+++ b/runtime/expr/coerce/coerce.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 
 	"github.com/brimdata/zed"
-	"github.com/brimdata/zed/pkg/nano"
 	"github.com/brimdata/zed/runtime/expr/result"
 	"github.com/brimdata/zed/zcode"
 )
@@ -246,51 +245,4 @@ func ToBool(val *zed.Value) (bool, bool) {
 	}
 	v, ok := ToInt(val)
 	return v != 0, ok
-}
-
-func ToTime(val *zed.Value) (nano.Ts, bool) {
-	id := val.Type.ID()
-	if id == zed.IDTime {
-		return zed.DecodeTime(val.Bytes()), true
-	}
-	if zed.IsSigned(id) {
-		return nano.Ts(val.Int()), true
-	}
-	if zed.IsInteger(id) {
-		v := val.Uint()
-		// check for overflow
-		if v > math.MaxInt64 {
-			return 0, false
-		}
-		return nano.Ts(v), true
-	}
-	if zed.IsFloat(id) {
-		return nano.Ts(zed.DecodeFloat(val.Bytes())), true
-	}
-	return 0, false
-}
-
-// ToDuration attempts to convert a value to a duration.  Int
-// and Double are converted as seconds. The resulting coerced value is
-// written to out, and true is returned. If the value cannot be
-// coerced, then false is returned.
-func ToDuration(in *zed.Value) (nano.Duration, bool) {
-	switch in.Type.ID() {
-	case zed.IDDuration:
-		return zed.DecodeDuration(in.Bytes()), true
-	case zed.IDUint16, zed.IDUint32, zed.IDUint64:
-		v := in.Uint()
-		// check for overflow
-		if v > math.MaxInt64 {
-			return 0, false
-		}
-		return nano.Duration(v) * nano.Second, true
-	case zed.IDInt16, zed.IDInt32, zed.IDInt64:
-		v := in.Int()
-		//XXX check for overflow here
-		return nano.Duration(v) * nano.Second, true
-	case zed.IDFloat16, zed.IDFloat32, zed.IDFloat64:
-		return nano.Duration(zed.DecodeFloat(in.Bytes())), true
-	}
-	return 0, false
 }

--- a/runtime/expr/function/time.go
+++ b/runtime/expr/function/time.go
@@ -39,11 +39,11 @@ func (b *Bucket) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		dur := nano.Duration(tsArg.Int())
 		return ctx.CopyValue(zed.NewDuration(dur.Trunc(bin)))
 	}
-	ts, ok := coerce.ToTime(tsArg)
+	v, ok := coerce.ToInt(tsArg)
 	if !ok {
 		return newErrorf(b.zctx, ctx, "%s: time arg required", b)
 	}
-	return ctx.CopyValue(zed.NewTime(ts.Trunc(bin)))
+	return ctx.CopyValue(zed.NewTime(nano.Ts(v).Trunc(bin)))
 }
 
 func (b *Bucket) String() string {


### PR DESCRIPTION
ToDuration and ToTime are nearly identical to ToInt, with two exceptions: They don't handle strings (ToInt does), and ToDuration scales to seconds, which we don't want.  Replace both with ToInt.