### PR TITLE
Remove ZSON formatter error result parameters

### DIFF
--- a/compiler/semantic/expr.go
+++ b/compiler/semantic/expr.go
@@ -40,7 +40,7 @@ func (a *analyzer) semExpr(e ast.Expr) (dag.Expr, error) {
 		}
 		return &dag.Literal{
 			Kind:  "Literal",
-			Value: zson.MustFormatValue(val),
+			Value: zson.FormatValue(val),
 		}, nil
 	case *ast.ID:
 		return a.semID(e)
@@ -52,7 +52,7 @@ func (a *analyzer) semExpr(e ast.Expr) (dag.Expr, error) {
 			if err != nil {
 				return nil, err
 			}
-			val = zson.MustFormatValue(v)
+			val = zson.FormatValue(v)
 		case *astzed.TypeValue:
 			tv, err := a.semType(t.Value)
 			if err != nil {

--- a/compiler/semantic/op.go
+++ b/compiler/semantic/op.go
@@ -488,7 +488,7 @@ func (a *analyzer) semOp(o ast.Op, seq dag.Seq) (dag.Seq, error) {
 			return nil, fmt.Errorf("head: %w", err)
 		}
 		if val.AsInt() < 1 {
-			return nil, fmt.Errorf("head: expression value is not a positive integer: %s", zson.MustFormatValue(val))
+			return nil, fmt.Errorf("head: expression value is not a positive integer: %s", zson.FormatValue(val))
 		}
 		return append(seq, &dag.Head{
 			Kind:  "Head",
@@ -504,7 +504,7 @@ func (a *analyzer) semOp(o ast.Op, seq dag.Seq) (dag.Seq, error) {
 			return nil, fmt.Errorf("tail: %w", err)
 		}
 		if val.AsInt() < 1 {
-			return nil, fmt.Errorf("tail: expression value is not a positive integer: %s", zson.MustFormatValue(val))
+			return nil, fmt.Errorf("tail: expression value is not a positive integer: %s", zson.FormatValue(val))
 		}
 		return append(seq, &dag.Tail{
 			Kind:  "Tail",
@@ -1088,7 +1088,7 @@ func (a *analyzer) maybeConvertUserOp(call *ast.Call, seq dag.Seq) (dag.Op, erro
 			}
 			consts = append(consts, &dag.Literal{
 				Kind:  "Literal",
-				Value: zson.MustFormatValue(val),
+				Value: zson.FormatValue(val),
 			})
 		}
 	}

--- a/compiler/semantic/scope.go
+++ b/compiler/semantic/scope.go
@@ -66,7 +66,7 @@ func (s *Scope) DefineConst(zctx *zed.Context, name string, def dag.Expr) error 
 	}
 	literal := &dag.Literal{
 		Kind:  "Literal",
-		Value: zson.MustFormatValue(val),
+		Value: zson.FormatValue(val),
 	}
 	s.DefineAs(name, literal)
 	return nil

--- a/lake/index/filter.go
+++ b/lake/index/filter.go
@@ -79,10 +79,10 @@ func getSpan(zctx *zed.Context, val *zed.Value, o order.Which) (extent.Span, err
 	max := seekDotMax(zctx).Eval(ectx, val)
 	var err error
 	if min.IsError() {
-		err = errors.New(zson.MustFormatValue(min))
+		err = errors.New(zson.FormatValue(min))
 	}
 	if max.IsError() {
-		err2 := errors.New(zson.MustFormatValue(min))
+		err2 := errors.New(zson.FormatValue(min))
 		err = multierr.Combine(err, err2)
 	}
 	if err != nil {

--- a/runtime/expr/agg/avg.go
+++ b/runtime/expr/agg/avg.go
@@ -45,14 +45,14 @@ func (a *Avg) ConsumeAsPartial(partial *zed.Value) {
 		panic(errors.New("avg: partial sum is missing"))
 	}
 	if sumVal.Type != zed.TypeFloat64 {
-		panic(fmt.Errorf("avg: partial sum has bad type: %s", zson.MustFormatValue(sumVal)))
+		panic(fmt.Errorf("avg: partial sum has bad type: %s", zson.FormatValue(sumVal)))
 	}
 	countVal := partial.Deref(countName)
 	if countVal == nil {
 		panic("avg: partial count is missing")
 	}
 	if countVal.Type != zed.TypeUint64 {
-		panic(fmt.Errorf("avg: partial count has bad type: %s", zson.MustFormatValue(countVal)))
+		panic(fmt.Errorf("avg: partial count has bad type: %s", zson.FormatValue(countVal)))
 	}
 	a.sum += sumVal.Float()
 	a.count += countVal.Uint()

--- a/runtime/expr/agg/collect.go
+++ b/runtime/expr/agg/collect.go
@@ -71,7 +71,7 @@ func (c *Collect) ConsumeAsPartial(val *zed.Value) {
 	}
 	arrayType, ok := val.Type.(*zed.TypeArray)
 	if !ok {
-		panic(fmt.Errorf("collect partial: partial not an array type: %s", zson.MustFormatValue(val)))
+		panic(fmt.Errorf("collect partial: partial not an array type: %s", zson.FormatValue(val)))
 	}
 	typ := arrayType.Type
 	for it := val.Iter(); !it.Done(); {

--- a/runtime/expr/agg/dcount.go
+++ b/runtime/expr/agg/dcount.go
@@ -39,7 +39,7 @@ func (d *DCount) Result(*zed.Context) *zed.Value {
 
 func (d *DCount) ConsumeAsPartial(partial *zed.Value) {
 	if partial.Type != zed.TypeBytes {
-		panic(fmt.Errorf("dcount: partial has bad type: %s", zson.MustFormatValue(partial)))
+		panic(fmt.Errorf("dcount: partial has bad type: %s", zson.FormatValue(partial)))
 	}
 	var s hyperloglog.Sketch
 	if err := s.UnmarshalBinary(partial.Bytes()); err != nil {

--- a/runtime/expr/cast.go
+++ b/runtime/expr/cast.go
@@ -262,8 +262,7 @@ func (c *casterString) Eval(ectx Context, val *zed.Value) *zed.Value {
 	}
 	// Otherwise, we'll use a canonical ZSON value for the string rep
 	// of an arbitrary value cast to a string.
-	result := zson.MustFormatValue(val)
-	return ectx.NewValue(zed.TypeString, zed.EncodeString(result))
+	return ectx.NewValue(zed.TypeString, zed.EncodeString(zson.FormatValue(val)))
 }
 
 type casterBytes struct{}

--- a/runtime/expr/eval.go
+++ b/runtime/expr/eval.go
@@ -75,7 +75,7 @@ func EvalBool(zctx *zed.Context, ectx Context, this *zed.Value, e Evaluator) (*z
 	if val.IsError() {
 		return val, false
 	}
-	return ectx.CopyValue(zctx.NewErrorf("not type bool: %s", zson.MustFormatValue(val))), false
+	return ectx.CopyValue(zctx.NewErrorf("not type bool: %s", zson.FormatValue(val))), false
 }
 
 func (a *And) Eval(ectx Context, this *zed.Value) *zed.Value {

--- a/runtime/expr/expr_test.go
+++ b/runtime/expr/expr_test.go
@@ -17,11 +17,10 @@ func testSuccessful(t *testing.T, e string, input string, expectedVal zed.Value)
 	if input == "" {
 		input = "{}"
 	}
-	expected := zson.MustFormatValue(&expectedVal)
 	runZTest(t, e, &ztest.ZTest{
 		Zed:    fmt.Sprintf("yield %s", e),
 		Input:  input,
-		Output: expected + "\n",
+		Output: zson.FormatValue(&expectedVal) + "\n",
 	})
 }
 

--- a/runtime/expr/extent/span.go
+++ b/runtime/expr/extent/span.go
@@ -102,14 +102,8 @@ func (g *Generic) String() string {
 }
 
 func Format(s Span) string {
-	first, err := zson.FormatValue(s.First())
-	if err != nil {
-		first = fmt.Sprintf("<%s>", err)
-	}
-	last, err := zson.FormatValue(s.Last())
-	if err != nil {
-		last = fmt.Sprintf("<%s>", err)
-	}
+	first := zson.FormatValue(s.First())
+	last := zson.FormatValue(s.Last())
 	return fmt.Sprintf("first %s last %s", first, last)
 }
 

--- a/runtime/expr/filter_test.go
+++ b/runtime/expr/filter_test.go
@@ -67,7 +67,7 @@ func runCasesHelper(t *testing.T, record string, cases []testcase, expectBufferF
 			assert.NoError(t, err, "filter: %q", c.filter)
 			if f != nil {
 				assert.Equal(t, c.expected, filter(expr.NewContext(), rec, f),
-					"filter: %q\nrecord: %s", c.filter, zson.MustFormatValue(rec))
+					"filter: %q\nrecord: %s", c.filter, zson.FormatValue(rec))
 			}
 			bf, err := filterMaker.AsBufferFilter()
 			assert.NoError(t, err, "filter: %q", c.filter)
@@ -79,7 +79,7 @@ func runCasesHelper(t *testing.T, record string, cases []testcase, expectBufferF
 				buf := binary.AppendUvarint(nil, uint64(rec.Type.ID()))
 				buf = zcode.Append(buf, rec.Bytes())
 				assert.Equal(t, expected, bf.Eval(zctx, buf),
-					"filter: %q\nvalues:%s\nbuffer:\n%s", c.filter, zson.MustFormatValue(rec), hex.Dump(buf))
+					"filter: %q\nvalues:%s\nbuffer:\n%s", c.filter, zson.FormatValue(rec), hex.Dump(buf))
 			}
 		})
 	}

--- a/runtime/expr/function/math.go
+++ b/runtime/expr/function/math.go
@@ -30,7 +30,7 @@ func (a *Abs) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		return newFloat64(ctx, f)
 	}
 	if !zed.IsInteger(id) {
-		return newErrorf(a.zctx, ctx, "abs: not a number: %s", zson.MustFormatValue(&args[0]))
+		return newErrorf(a.zctx, ctx, "abs: not a number: %s", zson.FormatValue(&args[0]))
 	}
 	if !zed.IsSigned(id) {
 		return ctx.CopyValue(&args[0])
@@ -103,7 +103,7 @@ func (l *Log) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		return newErrorf(l.zctx, ctx, "log: numeric argument required")
 	}
 	if x <= 0 {
-		return newErrorf(l.zctx, ctx, "log: illegal argument: %s", zson.MustFormatValue(&args[0]))
+		return newErrorf(l.zctx, ctx, "log: illegal argument: %s", zson.FormatValue(&args[0]))
 	}
 	return newFloat64(ctx, math.Log(x))
 }
@@ -125,14 +125,14 @@ func (r *reducer) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		for _, val := range args[1:] {
 			v, ok := coerce.ToFloat(&val)
 			if !ok {
-				return newErrorf(r.zctx, ctx, "%s: not a number: %s", r.name, zson.MustFormatValue(&val))
+				return newErrorf(r.zctx, ctx, "%s: not a number: %s", r.name, zson.FormatValue(&val))
 			}
 			result = r.fn.Float64(result, v)
 		}
 		return newFloat64(ctx, result)
 	}
 	if !zed.IsNumber(id) {
-		return newErrorf(r.zctx, ctx, "%s: not a number: %s", r.name, zson.MustFormatValue(val0))
+		return newErrorf(r.zctx, ctx, "%s: not a number: %s", r.name, zson.FormatValue(val0))
 	}
 	if zed.IsSigned(id) {
 		result := val0.Int()
@@ -141,7 +141,7 @@ func (r *reducer) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 			// floats to ints if we hit a float first
 			v, ok := coerce.ToInt(&val)
 			if !ok {
-				return newErrorf(r.zctx, ctx, "%s: not a number: %s", r.name, zson.MustFormatValue(&val))
+				return newErrorf(r.zctx, ctx, "%s: not a number: %s", r.name, zson.FormatValue(&val))
 			}
 			result = r.fn.Int64(result, v)
 		}
@@ -151,7 +151,7 @@ func (r *reducer) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	for _, val := range args[1:] {
 		v, ok := coerce.ToUint(&val)
 		if !ok {
-			return newErrorf(r.zctx, ctx, "%s: not a number: %s", r.name, zson.MustFormatValue(&val))
+			return newErrorf(r.zctx, ctx, "%s: not a number: %s", r.name, zson.FormatValue(&val))
 		}
 		result = r.fn.Uint64(result, v)
 	}
@@ -176,7 +176,7 @@ func (r *Round) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		return newFloat64(ctx, math.Round(val.Float()))
 	}
 	if !zed.IsNumber(id) {
-		return newErrorf(r.zctx, ctx, "round: not a number: %s", zson.MustFormatValue(val))
+		return newErrorf(r.zctx, ctx, "round: not a number: %s", zson.FormatValue(val))
 	}
 	return ctx.CopyValue(&args[0])
 }
@@ -189,11 +189,11 @@ type Pow struct {
 func (p *Pow) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	x, ok := coerce.ToFloat(&args[0])
 	if !ok {
-		return newErrorf(p.zctx, ctx, "pow: not a number: %s", zson.MustFormatValue(&args[0]))
+		return newErrorf(p.zctx, ctx, "pow: not a number: %s", zson.FormatValue(&args[0]))
 	}
 	y, ok := coerce.ToFloat(&args[1])
 	if !ok {
-		return newErrorf(p.zctx, ctx, "pow: not a number: %s", zson.MustFormatValue(&args[1]))
+		return newErrorf(p.zctx, ctx, "pow: not a number: %s", zson.FormatValue(&args[1]))
 	}
 	return newFloat64(ctx, math.Pow(x, y))
 }
@@ -206,7 +206,7 @@ type Sqrt struct {
 func (s *Sqrt) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	x, ok := coerce.ToFloat(&args[0])
 	if !ok {
-		return newErrorf(s.zctx, ctx, "sqrt: not a number: %s", zson.MustFormatValue(&args[0]))
+		return newErrorf(s.zctx, ctx, "sqrt: not a number: %s", zson.FormatValue(&args[0]))
 	}
 	return newFloat64(ctx, math.Sqrt(x))
 }

--- a/runtime/expr/putter.go
+++ b/runtime/expr/putter.go
@@ -307,7 +307,7 @@ func (p *Putter) Eval(ectx Context, this *zed.Value) *zed.Value {
 			// propagate errors
 			return this
 		}
-		return ectx.CopyValue(p.zctx.NewErrorf("put: not a record: %s", zson.MustFormatValue(this)))
+		return ectx.CopyValue(p.zctx.NewErrorf("put: not a record: %s", zson.FormatValue(this)))
 	}
 	vals, clauses := p.eval(ectx, this)
 	if len(vals) == 0 {

--- a/runtime/expr/shaper.go
+++ b/runtime/expr/shaper.go
@@ -59,7 +59,7 @@ func (s *Shaper) Eval(ectx Context, this *zed.Value) *zed.Value {
 	//XXX TypeUnder?
 	if typeVal.Type != zed.TypeType {
 		return ectx.CopyValue(s.zctx.NewErrorf(
-			"shaper type argument is not a type: %s", zson.MustFormatValue(typeVal)))
+			"shaper type argument is not a type: %s", zson.FormatValue(typeVal)))
 	}
 	shapeTo, err := s.zctx.LookupByValue(typeVal.Bytes())
 	if err != nil {

--- a/runtime/op/groupby/row.go
+++ b/runtime/op/groupby/row.go
@@ -29,7 +29,7 @@ func (v valRow) consumeAsPartial(rec *zed.Value, exprs []expr.Evaluator, ectx ex
 	for k, r := range v {
 		val := exprs[k].Eval(ectx, rec)
 		if val.IsError() {
-			panic(fmt.Errorf("consumeAsPartial: read a Zed error: %s", zson.MustFormatValue(val)))
+			panic(fmt.Errorf("consumeAsPartial: read a Zed error: %s", zson.FormatValue(val)))
 		}
 		//XXX should do soemthing with errors... they could come from
 		// a worker over the network?

--- a/zio/arrowio/writer.go
+++ b/zio/arrowio/writer.go
@@ -79,7 +79,7 @@ const recordBatchSize = 1024
 func (w *Writer) Write(val *zed.Value) error {
 	recType, ok := zed.TypeUnder(val.Type).(*zed.TypeRecord)
 	if !ok {
-		return fmt.Errorf("%w: %s", ErrNotRecord, zson.MustFormatValue(val))
+		return fmt.Errorf("%w: %s", ErrNotRecord, zson.FormatValue(val))
 	}
 	if w.typ == nil {
 		w.typ = recType
@@ -367,7 +367,7 @@ func (w *Writer) buildArrowValue(b array.Builder, typ zed.Type, bytes zcode.Byte
 			}
 			b.Append(s)
 		case *zed.TypeError:
-			b.Append(zson.MustFormatValue(zed.NewValue(typ, bytes)))
+			b.Append(zson.FormatValue(zed.NewValue(typ, bytes)))
 		default:
 			panic(fmt.Sprintf("unexpected Zed type for StringBuilder: %s", zson.FormatType(typ)))
 		}

--- a/zio/csvio/writer.go
+++ b/zio/csvio/writer.go
@@ -47,7 +47,7 @@ func (w *Writer) Flush() error {
 
 func (w *Writer) Write(rec *zed.Value) error {
 	if rec.Type.Kind() != zed.RecordKind {
-		return fmt.Errorf("CSV output encountered non-record value: %s", zson.MustFormatValue(rec))
+		return fmt.Errorf("CSV output encountered non-record value: %s", zson.FormatValue(rec))
 	}
 	rec, err := w.flattener.Flatten(rec)
 	if err != nil {
@@ -93,5 +93,5 @@ func formatValue(typ zed.Type, bytes zcode.Bytes) string {
 	if typ.ID() < zed.IDTypeComplex {
 		return zson.FormatPrimitive(zed.TypeUnder(typ), bytes)
 	}
-	return zson.MustFormatValue(zed.NewValue(typ, bytes))
+	return zson.FormatValue(zed.NewValue(typ, bytes))
 }

--- a/zio/jsonio/marshal.go
+++ b/zio/jsonio/marshal.go
@@ -59,7 +59,7 @@ func marshalAny(typ zed.Type, bytes zcode.Bytes) interface{} {
 	case *zed.TypeError:
 		return map[string]interface{}{"error": marshalAny(typ.Type, bytes)}
 	default:
-		return zson.MustFormatValue(zed.NewValue(typ, bytes))
+		return zson.FormatValue(zed.NewValue(typ, bytes))
 	}
 }
 
@@ -136,11 +136,11 @@ func marshalMap(typ *zed.TypeMap, bytes zcode.Bytes) interface{} {
 			// Untagged, decorated ZSON so
 			// |{0:1,0(uint64):2,0(=t):3,"0":4}| gets unique keys.
 			typ, bytes := keyType.(*zed.TypeUnion).Untag(it.Next())
-			key = zson.MustFormatValue(zed.NewValue(typ, bytes))
+			key = zson.FormatValue(zed.NewValue(typ, bytes))
 		case kind == zed.EnumKind:
 			key = marshalEnum(keyType.(*zed.TypeEnum), it.Next()).(string)
 		default:
-			key = zson.MustFormatValue(zed.NewValue(keyType, it.Next()))
+			key = zson.FormatValue(zed.NewValue(keyType, it.Next()))
 		}
 		val := marshalAny(typ.ValType, it.Next())
 		rec = append(rec, field{key, val})

--- a/zio/lakeio/writer.go
+++ b/zio/lakeio/writer.go
@@ -72,14 +72,10 @@ func (w *Writer) Close() error {
 }
 
 func (w *Writer) WriteZSON(rec *zed.Value) error {
-	s, err := w.zson.FormatRecord(rec)
-	if err != nil {
+	if _, err := io.WriteString(w.writer, w.zson.FormatRecord(rec)); err != nil {
 		return err
 	}
-	if _, err := io.WriteString(w.writer, s); err != nil {
-		return err
-	}
-	_, err = io.WriteString(w.writer, "\n")
+	_, err := io.WriteString(w.writer, "\n")
 	return err
 }
 

--- a/zio/tableio/writer.go
+++ b/zio/tableio/writer.go
@@ -34,7 +34,7 @@ func NewWriter(w io.WriteCloser) *Writer {
 
 func (w *Writer) Write(r *zed.Value) error {
 	if r.Type.Kind() != zed.RecordKind {
-		return fmt.Errorf("table output encountered non-record value: %s", zson.MustFormatValue(r))
+		return fmt.Errorf("table output encountered non-record value: %s", zson.FormatValue(r))
 	}
 	r, err := w.flattener.Flatten(r)
 	if err != nil {

--- a/zio/zeekio/format.go
+++ b/zio/zeekio/format.go
@@ -62,7 +62,7 @@ func formatAny(val *zed.Value, inContainer bool) string {
 		if zed.TypeUnder(t.Type) == zed.TypeString {
 			return string(val.Bytes())
 		}
-		return zson.MustFormatValue(val)
+		return zson.FormatValue(val)
 	default:
 		return fmt.Sprintf("zeekio.StringOf(): unknown type: %T", t)
 	}

--- a/zio/zsonio/writer.go
+++ b/zio/zsonio/writer.go
@@ -30,13 +30,9 @@ func (w *Writer) Close() error {
 }
 
 func (w *Writer) Write(rec *zed.Value) error {
-	s, err := w.formatter.FormatRecord(rec)
-	if err != nil {
+	if _, err := io.WriteString(w.writer, w.formatter.FormatRecord(rec)); err != nil {
 		return err
 	}
-	if _, err := io.WriteString(w.writer, s); err != nil {
-		return err
-	}
-	_, err = w.writer.Write([]byte("\n"))
+	_, err := w.writer.Write([]byte("\n"))
 	return err
 }

--- a/zson/marshal.go
+++ b/zson/marshal.go
@@ -49,7 +49,7 @@ func (m *MarshalContext) Marshal(v interface{}) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return m.formatter.Format(val)
+	return m.formatter.Format(val), nil
 }
 
 func (m *MarshalContext) MarshalCustom(names []string, fields []interface{}) (string, error) {
@@ -57,7 +57,7 @@ func (m *MarshalContext) MarshalCustom(names []string, fields []interface{}) (st
 	if err != nil {
 		return "", err
 	}
-	return m.formatter.FormatRecord(rec)
+	return m.formatter.FormatRecord(rec), nil
 }
 
 type UnmarshalContext struct {

--- a/zson/marshal_test.go
+++ b/zson/marshal_test.go
@@ -216,10 +216,8 @@ func TestMixedTypeArrayInsideRecord(t *testing.T) {
 	reader := zngio.NewReader(zed.NewContext(), &buffer)
 	defer reader.Close()
 	recActual, err := reader.Read()
-	exp, err := zson.FormatValue(recExpected)
-	require.NoError(t, err)
-	actual, err := zson.FormatValue(recActual)
-	require.NoError(t, err)
+	exp := zson.FormatValue(recExpected)
+	actual := zson.FormatValue(recActual)
 	assert.Equal(t, exp, actual)
 	// Double check that all the proper typing made it into the implied union.
 	assert.Equal(t, `{X:"hello",S:[[{MyColor:"red"}(=Plant),{MyColor:"blue"}(=Animal)]]}(=RecordWithInterfaceSlice)`, actual)
@@ -278,10 +276,8 @@ func TestMixedTypeArrayOfStructWithInterface(t *testing.T) {
 	reader := zngio.NewReader(zed.NewContext(), &buffer)
 	defer reader.Close()
 	recActual, err := reader.Read()
-	exp, err := zson.FormatValue(recExpected)
-	require.NoError(t, err)
-	actual, err := zson.FormatValue(recActual)
-	require.NoError(t, err)
+	exp := zson.FormatValue(recExpected)
+	actual := zson.FormatValue(recActual)
 	assert.Equal(t, trim(exp), trim(actual))
 	// Double check that all the proper typing made it into the implied union.
 	assert.Equal(t, `[{Message:"hello",Thing:{MyColor:"red"}(=Plant)}(=MessageThing),{Message:"world",Thing:{MyColor:"blue"}(=Animal)}(=MessageThing)]`, actual)
@@ -322,8 +318,7 @@ func TestZNGValueField(t *testing.T) {
 	zv, err := m.Marshal(zngValueField)
 	require.NoError(t, err)
 	expected := `{Name:"test1",field:123}(=ZNGValueField)`
-	actual, err := zson.FormatValue(zv)
-	require.NoError(t, err)
+	actual := zson.FormatValue(zv)
 	assert.Equal(t, trim(expected), trim(actual))
 	u := zson.NewZNGUnmarshaler()
 	var out ZNGValueField
@@ -344,8 +339,7 @@ func TestZNGValueField(t *testing.T) {
 	zv3, err := m2.Marshal(zngValueField2)
 	require.NoError(t, err)
 	expected2 := `{Name:"test2",field:{s:"foo",a:[1,2,3]}}(=ZNGValueField)`
-	actual2, err := zson.FormatValue(zv3)
-	require.NoError(t, err)
+	actual2 := zson.FormatValue(zv3)
 	assert.Equal(t, trim(expected2), trim(actual2))
 	u2 := zson.NewZNGUnmarshaler()
 	var out2 ZNGValueField

--- a/zson/marshal_zng_test.go
+++ b/zson/marshal_zng_test.go
@@ -630,7 +630,7 @@ func TestZedValues(t *testing.T) {
 			require.NoError(t, err)
 			val, err = zson.MarshalZNG(v)
 			require.NoError(t, err)
-			assert.Equal(t, s, zson.MustFormatValue(val))
+			assert.Equal(t, s, zson.FormatValue(val))
 		})
 	}
 	var testptr struct {


### PR DESCRIPTION
ZSON formatting function and methods, like zson.FormatValue, are cumbersome to use because they return an error.  (For example, MustFormatValue is used far more than FormatValue.)  But the errors those functions and methods return only concern invalid input, which isn't very useful since they validate only a subset of what zed.Value.Validate does.  Remove their error result parameters, and remove MustFormatValue, which is now unneeded.