### PR TITLE
Allow float decorator on integer in ZSON

### DIFF
--- a/zson/analyzer.go
+++ b/zson/analyzer.go
@@ -269,7 +269,7 @@ func stringToEnum(val *astzed.Primitive, cast zed.Type) Value {
 func castType(typ, cast zed.Type) (zed.Type, error) {
 	typID, castID := typ.ID(), cast.ID()
 	if typID == castID || typID == zed.IDNull ||
-		zed.IsInteger(typID) && zed.IsInteger(castID) ||
+		zed.IsInteger(typID) && (zed.IsInteger(castID) || zed.IsFloat(castID)) ||
 		zed.IsFloat(typID) && zed.IsFloat(castID) {
 		return cast, nil
 	}

--- a/zson/ztests/float-cast.yaml
+++ b/zson/ztests/float-cast.yaml
@@ -1,0 +1,17 @@
+zed: '*'
+
+input: |
+  16(float16)
+  -16(float16)
+  32(float32)
+  -32(float32)
+  64(float64)
+  -64(float64)
+
+output: |
+  16.(float16)
+  -16.(float16)
+  32.(float32)
+  -32.(float32)
+  64.
+  -64.


### PR DESCRIPTION
The ZSON parser rejects "1(float64)" with a 'type mismatch: "int64" cannot be used as "float64"' error.  Accept that input instead.

Closes #4604.