### PR TITLE
Rename zbuf.PullerBatchSize to PullerBatchValues

### DIFF
--- a/cli/outputflags/flags.go
+++ b/cli/outputflags/flags.go
@@ -116,7 +116,7 @@ func (f *Flags) Init() error {
 		f.ZSON.Pretty = 0
 	}
 	if f.unbuffered {
-		zbuf.PullerBatchSize = 1
+		zbuf.PullerBatchValues = 1
 	}
 	return nil
 }

--- a/runtime/op/groupby/groupby_test.go
+++ b/runtime/op/groupby/groupby_test.go
@@ -84,12 +84,12 @@ func TestGroupbyStreamingSpill(t *testing.T) {
 	// spill before that all records for that key have been
 	// written to the spill.
 	//
-	savedPullerBatchSize := zbuf.PullerBatchSize
-	zbuf.PullerBatchSize = 1
+	savedPullerBatchValues := zbuf.PullerBatchValues
+	zbuf.PullerBatchValues = 1
 	savedBatchSizeGroupByLimit := groupby.DefaultLimit
 	groupby.DefaultLimit = 2
 	defer func() {
-		zbuf.PullerBatchSize = savedPullerBatchSize
+		zbuf.PullerBatchValues = savedPullerBatchValues
 		groupby.DefaultLimit = savedBatchSizeGroupByLimit
 	}()
 

--- a/zbuf/batch.go
+++ b/zbuf/batch.go
@@ -63,12 +63,12 @@ type Puller interface {
 // sense) per batch for a [Puller] created by [NewPuller].
 const PullerBatchBytes = 512 * 1024
 
-// PullerBatchSize is the maximum number of values per batch for a [Puller]
+// PullerBatchValues is the maximum number of values per batch for a [Puller]
 // created by [NewPuller].
-var PullerBatchSize = 100
+var PullerBatchValues = 100
 
 // NewPuller returns a puller for zr that returns batches containing up to
-// [PullerBatchBytes] bytes and [PullerBatchSize] values.
+// [PullerBatchBytes] bytes and [PullerBatchValues] values.
 func NewPuller(zr zio.Reader) Puller {
 	return &puller{zr}
 }
@@ -113,7 +113,7 @@ func newPullerBatch() *pullerBatch {
 	if !ok {
 		b = &pullerBatch{
 			buf:  make([]byte, PullerBatchBytes),
-			vals: make([]zed.Value, PullerBatchSize),
+			vals: make([]zed.Value, PullerBatchValues),
 		}
 	}
 	b.buf = b.buf[:0]


### PR DESCRIPTION
The new name makes it a little clearer that this variable affects the number of values (rather than bytes) per batch.