### PR TITLE
Replace zbuf.Batch.Context with Vars method

### DIFF
--- a/runtime/op/mux.go
+++ b/runtime/op/mux.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/zbuf"
-	"github.com/brimdata/zed/zcode"
 )
 
 type labeled struct {
@@ -147,9 +146,7 @@ type EndOfChannel int
 
 var _ zbuf.Batch = (*EndOfChannel)(nil)
 
-func (*EndOfChannel) Ref()                                      {}
-func (*EndOfChannel) Unref()                                    {}
-func (*EndOfChannel) Values() []zed.Value                       { return nil }
-func (*EndOfChannel) Vars() []zed.Value                         { return nil }
-func (*EndOfChannel) CopyValue(*zed.Value) *zed.Value           { return nil }
-func (*EndOfChannel) NewValue(zed.Type, zcode.Bytes) *zed.Value { return nil }
+func (*EndOfChannel) Ref()                {}
+func (*EndOfChannel) Unref()              {}
+func (*EndOfChannel) Values() []zed.Value { return nil }
+func (*EndOfChannel) Vars() []zed.Value   { return nil }

--- a/zbuf/array.go
+++ b/zbuf/array.go
@@ -2,7 +2,6 @@ package zbuf
 
 import (
 	"github.com/brimdata/zed"
-	"github.com/brimdata/zed/zcode"
 	"github.com/brimdata/zed/zio"
 )
 
@@ -57,14 +56,4 @@ func (a *Array) Read() (*zed.Value, error) {
 		a.values = a.values[1:]
 	}
 	return rec, nil
-}
-
-func (*Array) NewValue(typ zed.Type, bytes zcode.Bytes) *zed.Value {
-	// XXX can make this more efficient later
-	return zed.NewValue(typ, bytes)
-}
-
-func (*Array) CopyValue(val *zed.Value) *zed.Value {
-	// XXX can make this more efficient later
-	return val.Copy()
 }

--- a/zio/zngio/batch.go
+++ b/zio/zngio/batch.go
@@ -5,9 +5,7 @@ import (
 	"sync/atomic"
 
 	"github.com/brimdata/zed"
-	"github.com/brimdata/zed/runtime/expr"
 	"github.com/brimdata/zed/zbuf"
-	"github.com/brimdata/zed/zcode"
 	"golang.org/x/exp/slices"
 )
 
@@ -43,15 +41,6 @@ func (b *batch) unextend() {
 	b.vals = b.vals[:len(b.vals)-1]
 }
 
-func (b *batch) Values() []zed.Value { return b.vals }
-
-// XXX
-func (b *batch) NewValue(typ zed.Type, bytes zcode.Bytes) *zed.Value {
-	return zed.NewValue(typ, bytes)
-}
-
-func (b *batch) CopyValue(val *zed.Value) *zed.Value { return val.Copy() }
-
 func (b *batch) Ref() { atomic.AddInt32(&b.refs, 1) }
 
 func (b *batch) Unref() {
@@ -66,8 +55,8 @@ func (b *batch) Unref() {
 	}
 }
 
+func (b *batch) Values() []zed.Value { return b.vals }
+
 // XXX this should be ok, but we should handle nil receiver in scope so push
 // will do the right thing
 func (*batch) Vars() []zed.Value { return nil }
-
-func (b *batch) Context() expr.Context { return b }


### PR DESCRIPTION
With #4669, zbuf.Batch.Context is unused except for its Vars method. Simplify Batch and its implementations by removing Context and adding a Vars method.