### PR TITLE
Prefer zed.NewFloat et al. over zed.NewValue

### DIFF
--- a/runtime/expr/cast.go
+++ b/runtime/expr/cast.go
@@ -106,7 +106,7 @@ func (c *casterFloat16) Eval(ectx Context, val *zed.Value) *zed.Value {
 	if !ok {
 		return c.zctx.WrapError("cannot cast to float16", val)
 	}
-	return ectx.NewValue(zed.TypeFloat16, zed.EncodeFloat16(float32(f)))
+	return ectx.CopyValue(zed.NewFloat16(float32(f)))
 }
 
 type casterFloat32 struct {
@@ -118,7 +118,7 @@ func (c *casterFloat32) Eval(ectx Context, val *zed.Value) *zed.Value {
 	if !ok {
 		return c.zctx.WrapError("cannot cast to float32", val)
 	}
-	return ectx.NewValue(zed.TypeFloat32, zed.EncodeFloat32(float32(f)))
+	return ectx.CopyValue(zed.NewFloat32(float32(f)))
 }
 
 type casterFloat64 struct {
@@ -130,7 +130,7 @@ func (c *casterFloat64) Eval(ectx Context, val *zed.Value) *zed.Value {
 	if !ok {
 		return c.zctx.WrapError("cannot cast to float64", val)
 	}
-	return ectx.NewValue(zed.TypeFloat64, zed.EncodeFloat64(f))
+	return ectx.CopyValue(zed.NewFloat64(f))
 }
 
 type casterIP struct {

--- a/runtime/expr/eval.go
+++ b/runtime/expr/eval.go
@@ -430,7 +430,7 @@ func (a *Add) Eval(ectx Context, this *zed.Value) *zed.Value {
 	switch {
 	case zed.IsFloat(id):
 		v1, v2 := a.operands.floats()
-		return ectx.NewValue(typ, zed.EncodeFloat64(v1+v2))
+		return ectx.CopyValue(zed.NewFloat(typ, v1+v2))
 	case zed.IsSigned(id):
 		v1, v2 := a.operands.ints()
 		return ectx.CopyValue(zed.NewInt(typ, v1+v2))
@@ -460,7 +460,7 @@ func (s *Subtract) Eval(ectx Context, this *zed.Value) *zed.Value {
 	switch {
 	case zed.IsFloat(id):
 		v1, v2 := s.operands.floats()
-		return ectx.NewValue(typ, zed.EncodeFloat64(v1-v2))
+		return ectx.CopyValue(zed.NewFloat(typ, v1-v2))
 	case zed.IsSigned(id):
 		v1, v2 := s.operands.ints()
 		if id == zed.IDTime {
@@ -490,7 +490,7 @@ func (m *Multiply) Eval(ectx Context, this *zed.Value) *zed.Value {
 	switch {
 	case zed.IsFloat(id):
 		v1, v2 := m.operands.floats()
-		return ectx.NewValue(typ, zed.EncodeFloat64(v1*v2))
+		return ectx.CopyValue(zed.NewFloat(typ, v1*v2))
 	case zed.IsSigned(id):
 		v1, v2 := m.operands.ints()
 		return ectx.CopyValue(zed.NewInt(typ, v1*v2))
@@ -519,7 +519,7 @@ func (d *Divide) Eval(ectx Context, this *zed.Value) *zed.Value {
 		if v2 == 0 {
 			return d.zctx.NewError(DivideByZero)
 		}
-		return ectx.NewValue(typ, zed.EncodeFloat64(v1/v2))
+		return ectx.CopyValue(zed.NewFloat(typ, v1/v2))
 	case zed.IsSigned(id):
 		v1, v2 := d.operands.ints()
 		if v2 == 0 {
@@ -585,7 +585,7 @@ func (u *UnaryMinus) Eval(ectx Context, this *zed.Value) *zed.Value {
 	}
 	switch typ.ID() {
 	case zed.IDFloat16, zed.IDFloat32, zed.IDFloat64:
-		return zed.NewFloat(typ, -val.Float())
+		return ectx.CopyValue(zed.NewFloat(typ, -val.Float()))
 	case zed.IDInt8:
 		v := val.Int()
 		if v == math.MinInt8 {

--- a/runtime/expr/function/function.go
+++ b/runtime/expr/function/function.go
@@ -187,15 +187,15 @@ func HasBoolResult(name string) bool {
 }
 
 func newFloat16(ctx zed.Allocator, native float32) *zed.Value {
-	return ctx.NewValue(zed.TypeFloat16, zed.EncodeFloat16(native))
+	return ctx.CopyValue(zed.NewFloat16(native))
 }
 
 func newFloat32(ctx zed.Allocator, native float32) *zed.Value {
-	return ctx.NewValue(zed.TypeFloat32, zed.EncodeFloat32(native))
+	return ctx.CopyValue(zed.NewFloat32(native))
 }
 
 func newFloat64(ctx zed.Allocator, native float64) *zed.Value {
-	return ctx.NewValue(zed.TypeFloat64, zed.EncodeFloat64(native))
+	return ctx.CopyValue(zed.NewFloat64(native))
 }
 
 func newString(ctx zed.Allocator, native string) *zed.Value {


### PR DESCRIPTION
Unlike NewValue, the NewFloat functions all return a zed.Value that uses the native representation.