### PR TITLE
Reference user-defined functions & operators from landing pages

### DIFF
--- a/docs/language/functions/README.md
+++ b/docs/language/functions/README.md
@@ -3,7 +3,9 @@
 ---
 
 Functions appear in [expression](../expressions.md) context and
-take Zed values as arguments and produce a value as a result.
+take Zed values as arguments and produce a value as a result. In addition to
+the built-in functions listed below, Zed also allows for the creation of
+[user-defined functions](../statements.md#func-statements).
 
 * [abs](abs.md) - absolute value of a number
 * [base64](base64.md) - encode/decode base64 strings

--- a/docs/language/operators/README.md
+++ b/docs/language/operators/README.md
@@ -3,7 +3,9 @@
 ---
 
 Dataflow operators process a sequence of input values to create an output sequence
-and appear as the components of a dataflow pipeline.
+and appear as the components of a dataflow pipeline. In addition to the built-in
+operators listed below, Zed also allows for the creation of
+[user-defined operators](../statements.md#operator-statements).
 
 * [assert](assert.md) - evaluate an assertion
 * [combine](combine.md) - combine parallel paths into a single output


### PR DESCRIPTION
In a recent group discussion, it was pointed out that it might be helpful if we point to the sections on user-defined functions & operators from the respective landing pages that currently list off the links & summaries of the built-in ones. I've attempted that here.

In the same conversation we also considered if the titles of the landing pages should change, e.g., "Functions" could become "Built-In Functions", much like in these [Python docs](https://docs.python.org/3/library/). Consensus at the time was that we might as well hold off on this until we have some kind of "modules" concept in Zed.