### PR TITLE
Add references to missing built-in functions in landing page

### DIFF
--- a/docs/language/functions/README.md
+++ b/docs/language/functions/README.md
@@ -22,6 +22,7 @@ take Zed values as arguments and produce a value as a result.
 * [floor](floor.md) - floor of a number
 * [grep](grep.md) - search strings inside of values
 * [has](has.md) - test existence of values
+* [hex](hex.md) - encode/decode hexadecimal strings
 * [has_error](has_error.md) - test if a value has an error
 * [is](is.md) - test a value's type
 * [is_error](is_error.md) - test if a value is an error
@@ -34,6 +35,7 @@ take Zed values as arguments and produce a value as a result.
 * [lower](lower.md) - convert a string to lower case
 * [missing](missing.md) - test for the "missing" error
 * [nameof](nameof.md) - the name of a named type
+* [nest_dotted](nest_dotted.md) - transform fields in a record with dotted names to nested records
 * [network_of](network_of.md) - the network of an IP
 * [now](now.md) - the current time
 * [order](order.md) - reorder record fields


### PR DESCRIPTION
While working on #4675 I spotted a couple built-in functions we have docs pages for that weren't yet summarized & linked-to from the landing page.