### PR TITLE
Mention function-style cast shorthand in functions landing page

### DIFF
--- a/docs/language/functions/README.md
+++ b/docs/language/functions/README.md
@@ -7,7 +7,7 @@ take Zed values as arguments and produce a value as a result.
 
 A function-style syntax is also available for converting values to each of
 Zed's [primitive types](../../formats/zed.md#1-primitive-types), e.g.,
-`uint8()`, `time()`, etc. For details and examples, learn about the
+`uint8()`, `time()`, etc. For details and examples, read about the
 [`cast` function](cast.md) and how it is [used in expressions](../expressions.md#casts).
 
 * [abs](abs.md) - absolute value of a number

--- a/docs/language/functions/README.md
+++ b/docs/language/functions/README.md
@@ -5,6 +5,11 @@
 Functions appear in [expression](../expressions.md) context and
 take Zed values as arguments and produce a value as a result.
 
+A function-style syntax is also available for converting values to each of
+Zed's [primitive types](../../formats/zed.md#1-primitive-types), e.g.,
+`uint8()`, `time()`, etc. For details and examples, learn about the
+[`cast` function](cast.md) and how it is [used in expressions](../expressions.md#casts).
+
 * [abs](abs.md) - absolute value of a number
 * [base64](base64.md) - encode/decode base64 strings
 * [bucket](bucket.md) - quantize a time or duration value into buckets of equal widths


### PR DESCRIPTION
A community zync user recently approached the team with a question about casting, and also noted:

> By the way the function `time()` is not documented.

From our perspective as those that have built & supported the tools, this was a bit surprising to hear, since there's mention of this "function-style syntax" [here](https://zed.brimdata.io/docs/next/language/expressions#casts) and also in the [`cast`](https://zed.brimdata.io/docs/next/language/functions/cast) docs themselves. However, from the perspective of the user, it's also understandable why they may think it's undocumented: `time()` looks like a function call, so upon seeing it used in a Zed program, a user might go looking for it in the left-hand nav of the docs site or in the [functions landing page](https://zed.brimdata.io/docs/next/language/functions), then upon not seeing it mentioned in either spot, consider it undocumented.

We discussed as a group how we might improve here. It certainly would be feasible to add individual entries in both those locations alongside all the built-in functions so they'd be difficult to miss. But considering there's 30 [primitive types](https://zed.brimdata.io/docs/next/formats/zed#1-primitive-types) and hence a shorthand for each, they'd all just be redundant text describing how they're shorthand & point to the same clarifying materials. Their bulk presence in those spots in the docs might also dilute the visibility of the (currently 55) higher-impact built-in functions that each play a unique role.

As a middle path, we reached some consensus around the approach I've proposed in this PR where there's at least some mention of the shorthand syntax in the "functions" landing page. In addition to linking to the clarifying materials, I enumerated a couple specific examples including the `time()` one that tripped up this particular user. That gives at least one more function-related place a reader might find it and what will be a "hit" in the Search tool. I thought briefly about enumerating the function-style syntax for all 30 types in the same paragraph, but once I added the hyperlink to the primitive types, it started to feel bulky again to list 'em all. Happy to switch that around though.

If we merge these changes and another user gets still gets similarly tripped up, we can go ahead and just add all 30 individual references. 😄 