### PR TITLE
Add an "Error Handling" section to Shaping docs

### DIFF
--- a/docs/language/shaping.md
+++ b/docs/language/shaping.md
@@ -358,7 +358,6 @@ error({
 })
 ```
 
-
 ## Type Fusion
 
 Type fusion is another important building block of data shaping.

--- a/docs/language/shaping.md
+++ b/docs/language/shaping.md
@@ -262,7 +262,7 @@ Since these error values are nested inside an otherwise healthy record, adding
 [`has_error(this)`](functions/has_error.md) downstream in our Zed pipeline
 could help find or exclude such records.  If the failure to shape _any_ single
 field is considered severe enough to render the entire input record unhealthy,
-[conditional logic](expressions.md#conditional)
+[a conditional expression](expressions.md#conditional)
 could be applied to wrap the input record as an error while including detail
 to debug the problem, e.g.,
 

--- a/docs/language/shaping.md
+++ b/docs/language/shaping.md
@@ -313,7 +313,7 @@ error({
 }) (error({msg:string,original:{kind:string,server:{addr:string,port:int64},client:{addr:string,port:int64},vlan:string},shaped:{kind:string,client:{addr:error({message:string,on:string}),port:port=uint16},server:socket={addr:ip,port:port},vlan:error({message:string,on:string})}}))
 ```
 
-If you require awareness about changes made by the core shaping functions that
+If you require awareness about changes made by the shaping functions that
 aren't surfaced as errors, a similar wrapping approach can be used with a
 general check for equality. For example, to treat cropped fields as an error,
 we can execute

--- a/docs/language/shaping.md
+++ b/docs/language/shaping.md
@@ -225,7 +225,7 @@ file `malformed.json`.
     "addr": "39 Elm Street",
     "port": 41772
   },
-  vlan: "available"
+  "vlan": "available"
 }
 ```
 


### PR DESCRIPTION
I recently spent some quality time with Zed's shaping features and found I was pretty happy with how things have improved. In particular the improvements in error handling (such as highlighted in the [recent blog post](https://www.brimdata.io/blog/debugging-data-first-class-errors/) from @jameskerr) definitely help plug some remaining UX gaps. To that end, I went back through some old issues to see if it's appropriate to close some, and #2776 definitely looked like fair game. However, I figured it's worthwhile to augment the docs with some examples that show how to catch shaping errors, hence this PR.

Fixes #2776