### PR TITLE
zq: Remove dual input join

### DIFF
--- a/compiler/lake.go
+++ b/compiler/lake.go
@@ -36,7 +36,7 @@ func (l *lakeCompiler) NewLakeQuery(octx *op.Context, program ast.Seq, paralleli
 	if err != nil {
 		return nil, err
 	}
-	if len(job.readers) != 0 {
+	if job.reader != nil {
 		return nil, errors.New("query must include a 'from' operator")
 	}
 	if err := job.Optimize(); err != nil {

--- a/compiler/reader.go
+++ b/compiler/reader.go
@@ -1,6 +1,7 @@
 package compiler
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/brimdata/zed/compiler/ast"
@@ -29,12 +30,12 @@ func CompileWithSortKey(octx *op.Context, seq ast.Seq, r zio.Reader, sortKey ord
 	if err != nil {
 		return nil, err
 	}
-	readers := job.readers
-	if len(readers) != 1 {
-		return nil, fmt.Errorf("CompileWithSortKey: Zed program expected %d readers", len(readers))
+	reader := job.reader
+	if reader == nil {
+		return nil, errors.New("CompileWithSortKey: Zed program expected a reader")
 	}
-	readers[0].Readers = []zio.Reader{r}
-	readers[0].SortKey = sortKey
+	reader.Readers = []zio.Reader{r}
+	reader.SortKey = sortKey
 	return optimizeAndBuild(job)
 }
 

--- a/runtime/op/join/ztests/empty-inner.yaml
+++ b/runtime/op/join/ztests/empty-inner.yaml
@@ -1,5 +1,5 @@
 script: |
-  zq -z 'left join on a=b hit:=sc | sort a' A.zson C.zson
+  zq -z 'left join (file C.zson) on a=b hit:=sc' A.zson
 
 inputs:
   - name: A.zson

--- a/runtime/op/join/ztests/expr.yaml
+++ b/runtime/op/join/ztests/expr.yaml
@@ -1,11 +1,11 @@
 script: |
-  zq -z 'left join on s b' A.zson B.zson
+  zq -z 'left join (file B.zson) on s b' A.zson
   echo ===
-  zq -z 'left join on s=(lower(s)) b' A.zson B.zson
+  zq -z 'left join (file B.zson) on s=(lower(s)) b' A.zson
   echo ===
-  zq -z 'left join on (lower(s))=(lower(s)) b' A.zson B.zson
+  zq -z 'left join (file B.zson) on (lower(s))=(lower(s)) b' A.zson
   echo ===
-  zq -z 'left join on s' A.zson B.zson
+  zq -z 'left join (file B.zson) on s' A.zson
 
 inputs:
   - name: A.zson

--- a/runtime/op/join/ztests/join-union.yaml
+++ b/runtime/op/join/ztests/join-union.yaml
@@ -1,5 +1,5 @@
 script: |
-  zq -z 'inner join on a=b' a.zson b.zson
+  zq -z 'inner join (file b.zson) on a=b' a.zson
 inputs:
   - name: a.zson
     data: |

--- a/runtime/op/join/ztests/kinds.yaml
+++ b/runtime/op/join/ztests/kinds.yaml
@@ -1,12 +1,12 @@
 script: |
   echo === ANTI ===
-  zq -z 'anti join on a=b | sort a' A.zson B.zson
+  zq -z 'anti join (file B.zson) on a=b | sort a' A.zson
   echo === LEFT ===
-  zq -z 'left join on a=b hit:=sb | sort a' A.zson B.zson
+  zq -z 'left join (file B.zson) on a=b hit:=sb | sort a' A.zson
   echo === INNER ===
-  zq -z 'inner join on a=b hit:=sb | sort a' A.zson B.zson
+  zq -z 'inner join (file B.zson) on a=b hit:=sb | sort a' A.zson
   echo === RIGHT ===
-  zq -z 'right join on b=c hit:=sb | sort c' B.zson C.zson
+  zq -z 'right join (file C.zson) on b=c hit:=sb | sort c' B.zson
 
 inputs:
   - name: A.zson

--- a/runtime/ztests/parallel-err.yaml
+++ b/runtime/ztests/parallel-err.yaml
@@ -11,4 +11,4 @@ inputs:
 outputs:
   - name: stderr
     data: |
-      join operator requires two inputs
+      join requires two upstream parallel query paths

--- a/runtime/ztests/parallel-stdin.yaml
+++ b/runtime/ztests/parallel-stdin.yaml
@@ -1,5 +1,5 @@
 script: |
-  zq -z 'join on a=b b:=b' - B.zson
+  zq -z 'join (file B.zson) on a=b b:=b' -
 
 inputs:
   - name: stdin

--- a/runtime/ztests/parallel.yaml
+++ b/runtime/ztests/parallel.yaml
@@ -1,5 +1,5 @@
 script: |
-  zq -z 'join on a=b b:=b' A.zson B.zson
+  zq -z 'join (file B.zson) on a=b b:=b' A.zson
 
 inputs:
   - name: A.zson

--- a/zfmt/ztests/join.yaml
+++ b/zfmt/ztests/join.yaml
@@ -1,17 +1,22 @@
 script: |
-  zc -C "join on x=x p:=a"
+  zc -C "join (file test.zson) on x=x p:=a"
   echo ===
-  zc -C -s "join on x=x p:=a"
+  zc -C -s "join (file test.zson) on x=x p:=a"
 
 outputs:
   - name: stdout
     data: |
-      join on x=x p:=a
+      join (
+        from (
+          file test.zson
+        )
+      ) on x=x p:=a
       ===
-      fork (
+      reader
+      | fork (
         =>
-          reader
+          pass
         =>
-          reader
+          file test.zson
       )
       | join on x=x p:=a


### PR DESCRIPTION
Remove functionality from zq where if a program starts with a headless join and is run with two inputs, the first file is the left part of the join while the second is the right side.