### PR TITLE
Fix broken link to Zeek integration doc

### DIFF
--- a/docs/commands/zq.md
+++ b/docs/commands/zq.md
@@ -583,7 +583,7 @@ Next, a JSON file can be converted from ZNG using:
 zq -f json conn.zng > conn.json
 ```
 Note here that we lose information in this conversion because the rich data types
-of Zed (that were [translated from the Zeek format](https://github.com/brimdata/zed/blob/main/zeek/Data-Type-Compatibility.md)) are lost.
+of Zed (that were [translated from the Zeek format](../integrations/zeek/data-type-compatibility.md) are lost.
 
 We'll also make a SQLite database in the file `conn.db` as the table named `conn`.
 One easy way to do this is to install

--- a/performance/README.md
+++ b/performance/README.md
@@ -25,7 +25,7 @@ in `jq`. If there's glaring functional omissions that are limiting your use of
 `zq`, we welcome [contributions](../README.md#contributing).
 
 * For the permutations with `ndjson` input the recommended approach for
-[shaping Zeek NDJSON](https://github.com/brimdata/zed/blob/main/zeek/Shaping-Zeek-NDJSON.md)
+[shaping Zeek NDJSON](https://zed.brimdata.io/docs/next/integrations/zeek/shaping-zeek-ndjson)
 was followed as the input data was being read. In addition to conforming to the
 best practices as described in that article, this also avoids a problem
 described in [a comment in zed/2123](https://github.com/brimdata/zed/pull/2123#issuecomment-859164320).


### PR DESCRIPTION
The broken links in https://github.com/brimdata/zed-docs-site/actions/runs/5449035153/jobs/9912874914 didn't become apparent until after the merge of #4694.

Once this merges, I'll put up another PR to fix the breakages within the older revisions that live within the zed-docs-site repo.