### PR TITLE
Extract Zeek shaper from markdown

### DIFF
--- a/scripts/perf-compare.sh
+++ b/scripts/perf-compare.sh
@@ -6,6 +6,9 @@ set -eo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR" || exit 1
 
+SHAPER=$(mktemp)
+sed -e '1,/```mdtest-input shaper.zed/d' ../docs/integrations/zeek/shaping-zeek-ndjson.md | sed -e '/```/,$d' > "$SHAPER"
+
 DATA="../zed-sample-data"
 ln -sfn zeek-default "$DATA/zeek"
 ln -sfn zeek-ndjson "$DATA/ndjson"
@@ -84,7 +87,7 @@ do
         zed=${ZED_QUERIES[$n]}
         echo -n "|\`zq\`|\`$zed\`|$INPUT|$OUTPUT|" | tee -a "$MD"
         case $INPUT in
-          ndjson ) zq_flags="-i json -I ../zeek/shaper.zed" zed="| $zed" ;;
+          ndjson ) zq_flags="-i json -I $SHAPER" zed="| $zed" ;;
           zng-uncompressed ) zq_flags="-i zng" ;;
           * ) zq_flags="-i $INPUT" ;;
         esac

--- a/scripts/perf-compare.sh
+++ b/scripts/perf-compare.sh
@@ -117,3 +117,5 @@ do
 
     echo | tee -a "$MD"
 done
+
+rm -f "$SHAPER"

--- a/scripts/perf-compare.sh
+++ b/scripts/perf-compare.sh
@@ -6,8 +6,8 @@ set -eo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR" || exit 1
 
-SHAPER=$(mktemp)
-sed -e '1,/```mdtest-input shaper.zed/d' ../docs/integrations/zeek/shaping-zeek-ndjson.md | sed -e '/```/,$d' > "$SHAPER"
+shaper=$(mktemp)
+sed -e '1,/```mdtest-input shaper.zed/d' -e '/```/,$d' ../docs/integrations/zeek/shaping-zeek-ndjson.md > "$shaper"
 
 DATA="../zed-sample-data"
 ln -sfn zeek-default "$DATA/zeek"

--- a/scripts/perf-compare.sh
+++ b/scripts/perf-compare.sh
@@ -87,7 +87,7 @@ do
         zed=${ZED_QUERIES[$n]}
         echo -n "|\`zq\`|\`$zed\`|$INPUT|$OUTPUT|" | tee -a "$MD"
         case $INPUT in
-          ndjson ) zq_flags="-i json -I $SHAPER" zed="| $zed" ;;
+          ndjson ) zq_flags="-i json -I $shaper" zed="| $zed" ;;
           zng-uncompressed ) zq_flags="-i zng" ;;
           * ) zq_flags="-i $INPUT" ;;
         esac
@@ -118,4 +118,4 @@ do
     echo | tee -a "$MD"
 done
 
-rm -f "$SHAPER"
+rm -f "$shaper"


### PR DESCRIPTION
After #4694 moved the reference shaper for Zeek into the markdown docs, I realized this performance comparison script was depending on the shaper file at its prior location. This updates the script to extract the shaper from the markdown into a temporary file so it can be used as it was before.