### PR TITLE
Fix != operator for incompatible types

### DIFF
--- a/runtime/expr/eval.go
+++ b/runtime/expr/eval.go
@@ -181,19 +181,15 @@ func (e *Equal) Eval(ectx Context, this *zed.Value) *zed.Value {
 		return zerr
 	}
 	if err != nil {
-		switch {
-		case err == coerce.Overflow:
-			// If there was overflow converting one to the other,
-			// we know they can't be equal.
+		if errors.Is(err, coerce.IncompatibleTypes) || errors.Is(err, coerce.Overflow) {
+			// If the types are incompatible or there was overflow,
+			// then, then we know the values can't be equal.
 			if e.equality {
 				return zed.False
 			}
 			return zed.True
-		case err == coerce.IncompatibleTypes:
-			return zed.False
-		default:
-			return e.zctx.NewError(err)
 		}
+		return e.zctx.NewError(err)
 	}
 	result := e.vals.Equal()
 	if !e.equality {

--- a/runtime/expr/expr_test.go
+++ b/runtime/expr/expr_test.go
@@ -161,21 +161,21 @@ func TestCompareNumbers(t *testing.T) {
 			`{x:%s (%s),s:"hello",i:10.1.1.1,n:10.1.0.0/16} (=0)`, one, typ)
 
 		testSuccessful(t, "x == s", record, ZSON("false"))
-		testSuccessful(t, "x != s", record, ZSON("false"))
+		testSuccessful(t, "x != s", record, ZSON("true"))
 		testSuccessful(t, "x < s", record, ZSON("false"))
 		testSuccessful(t, "x <= s", record, ZSON("false"))
 		testSuccessful(t, "x > s", record, ZSON("false"))
 		testSuccessful(t, "x >= s", record, ZSON("false"))
 
 		testSuccessful(t, "x == i", record, ZSON("false"))
-		testSuccessful(t, "x != i", record, ZSON("false"))
+		testSuccessful(t, "x != i", record, ZSON("true"))
 		testSuccessful(t, "x < i", record, ZSON("false"))
 		testSuccessful(t, "x <= i", record, ZSON("false"))
 		testSuccessful(t, "x > i", record, ZSON("false"))
 		testSuccessful(t, "x >= i", record, ZSON("false"))
 
 		testSuccessful(t, "x == n", record, ZSON("false"))
-		testSuccessful(t, "x != n", record, ZSON("false"))
+		testSuccessful(t, "x != n", record, ZSON("true"))
 		testSuccessful(t, "x < n", record, ZSON("false"))
 		testSuccessful(t, "x <= n", record, ZSON("false"))
 		testSuccessful(t, "x > n", record, ZSON("false"))
@@ -280,7 +280,7 @@ func TestCompareNonNumbers(t *testing.T) {
 				exp := fmt.Sprintf("%s %s %s", t1.field, op, t2.field)
 				// XXX we no longer have a way to
 				// propagate boolean "warnings"...
-				testSuccessful(t, exp, record, ZSON(`false`))
+				testSuccessful(t, exp, record, *zed.NewBool(op == "!="))
 			}
 		}
 	}

--- a/runtime/expr/filter_test.go
+++ b/runtime/expr/filter_test.go
@@ -362,7 +362,7 @@ func TestFilters(t *testing.T) {
 		{"a != 50.1.168.192", true},
 		{"a in 192.168.0.0/16", false},
 		{"a == 10.0.0.0/16", false},
-		{"a != 192.168.0.0/16", false},
+		{"a != 192.168.0.0/16", true},
 	})
 
 	// Test comparisons with a named type


### PR DESCRIPTION
The != operator produces a false value when comparing incompatible types like, e.g., a string and a record.  Fix that by producing true instead.

Closes #4588.