### PR TITLE
Fix Boolean decoding in Python client

### DIFF
--- a/python/zed/zed.py
+++ b/python/zed/zed.py
@@ -142,7 +142,7 @@ def _decode_value(typ, value):
         if name == 'decimal':
             return decimal.Decimal(value)
         if name == 'bool':
-            return value == 'T'
+            return value == 'true'
         if name == 'bytes':
             return binascii.a2b_hex(value[2:])
         if name == 'string':

--- a/service/ztests/python.yaml
+++ b/service/ztests/python.yaml
@@ -50,7 +50,8 @@ inputs:
         dur: 0s (=myduration),
         tim: 1970-01-01T00:00:00Z (=mytime),
         f64: 0. (=myfloat64),
-        boo: false (=mybool),
+        false: false (=mybool),
+        true: true,
         byt: 0x00 (=mybytes),
         str: "" (=mystring),
         ip: 0.0.0.0 (=myip),
@@ -152,10 +153,10 @@ outputs:
       {'array': [{'a': 1}, {'a': 2}]}
       {'union': 123}
       {'enum': 'bar'}
-      {'u8': 0, 'u16': 0, 'u32': 0, 'u64': 0, 'i8': 0, 'i16': 0, 'i32': 0, 'i64': 0, 'dur': datetime.timedelta(0), 'tim': datetime.datetime(1970, 1, 1, 0, 0, tzinfo=tzutc()), 'f64': 0.0, 'boo': False, 'byt': b'\x00', 'str': '', 'ip': IPv4Address('0.0.0.0'), 'net': IPv4Network('0.0.0.0/0'), 'err': '', 'nul': None}
+      {'u8': 0, 'u16': 0, 'u32': 0, 'u64': 0, 'i8': 0, 'i16': 0, 'i32': 0, 'i64': 0, 'dur': datetime.timedelta(0), 'tim': datetime.datetime(1970, 1, 1, 0, 0, tzinfo=tzutc()), 'f64': 0.0, 'false': False, 'true': True, 'byt': b'\x00', 'str': '', 'ip': IPv4Address('0.0.0.0'), 'net': IPv4Network('0.0.0.0/0'), 'err': '', 'nul': None}
       {'u8': 0, 'u16': 0, 'u32': 0, 'u64': 0, 'i8': 0, 'i16': 0, 'i32': 0, 'i64': 0, 'dur': datetime.timedelta(0), 'tim': datetime.datetime(1970, 1, 1, 0, 0, tzinfo=tzutc()), 'f64': 0.0, 'boo': False, 'byt': b'\x00', 'str': '', 'ip': IPv4Address('0.0.0.0'), 'net': IPv4Network('0.0.0.0/0'), 'err': '', 'nul': None}
       === JSON
-      [{"map":{"a":{"a":1,"b":2},"b":{"a":2,"b":3},"c":{"a":3,"b":4}}},{"set":[1,2,3,4]},{"union":["a","b"]},{"union":[1,2]},{"union":"hello"},{"array":[{"a":1},{"a":2}]},{"union":123},{"enum":"bar"},{"u8":0,"u16":0,"u32":0,"u64":0,"i8":0,"i16":0,"i32":0,"i64":0,"dur":"0s","tim":"1970-01-01T00:00:00Z","f64":0,"boo":false,"byt":"0x00","str":"","ip":"0.0.0.0","net":"0.0.0.0/0","err":{"error":""},"nul":null},{"u8":0,"u16":0,"u32":0,"u64":0,"i8":0,"i16":0,"i32":0,"i64":0,"dur":"0s","tim":"1970-01-01T00:00:00Z","f64":0,"boo":false,"byt":"0x00","str":"","ip":"0.0.0.0","net":"0.0.0.0/0","err":{"error":""},"nul":null}]
+      [{"map":{"a":{"a":1,"b":2},"b":{"a":2,"b":3},"c":{"a":3,"b":4}}},{"set":[1,2,3,4]},{"union":["a","b"]},{"union":[1,2]},{"union":"hello"},{"array":[{"a":1},{"a":2}]},{"union":123},{"enum":"bar"},{"u8":0,"u16":0,"u32":0,"u64":0,"i8":0,"i16":0,"i32":0,"i64":0,"dur":"0s","tim":"1970-01-01T00:00:00Z","f64":0,"false":false,"true":true,"byt":"0x00","str":"","ip":"0.0.0.0","net":"0.0.0.0/0","err":{"error":""},"nul":null},{"u8":0,"u16":0,"u32":0,"u64":0,"i8":0,"i16":0,"i32":0,"i64":0,"dur":"0s","tim":"1970-01-01T00:00:00Z","f64":0,"boo":false,"byt":"0x00","str":"","ip":"0.0.0.0","net":"0.0.0.0/0","err":{"error":""},"nul":null}]
 
       ===
       RequestError('test: pool already exists')


### PR DESCRIPTION
Here's the repro steps from #4705 now running correctly with the fix from this branch.

```
$ zed -version
Version: v1.8.1-60-g8c5955ef

$ zed create -use foo
pool created: foo 2SDxkrEz8RDpnKmrzqIURB8FxXR
Switched to branch "main" on pool "foo"

$ echo '{foo: true, bar: false}' | zed load -
(13/1) 24B 24B/s
2SDxle7NhPthnAKTUTiN4pjWPcj committed

$ zed query 'from foo'
{foo:true,bar:false}

$ pip3 install "git+https://github.com/brimdata/zed@8c5955ef56d5110d934e77a4c6dad2b94e6c120e#subdirectory=python/zed"

$ python3
Python 3.11.4 (main, Jun 20 2023, 16:59:59) [Clang 14.0.3 (clang-1403.0.22.14.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import zed
>>> client = zed.Client()
>>> values = client.query('from foo')
>>> for val in values:
...   print(val)
... 
{'foo': True, 'bar': False}
```

Fixes #4705