### PR TITLE
Initialize runtime/expr.numeric.zctx

### DIFF
--- a/compiler/kernel/expr.go
+++ b/compiler/kernel/expr.go
@@ -134,7 +134,7 @@ func (b *Builder) compileBinary(e *dag.BinaryExpr) (expr.Evaluator, error) {
 	case "in":
 		return expr.NewIn(b.zctx(), lhs, rhs), nil
 	case "==", "!=":
-		return expr.NewCompareEquality(lhs, rhs, op)
+		return expr.NewCompareEquality(b.zctx(), lhs, rhs, op)
 	case "<", "<=", ">", ">=":
 		return expr.NewCompareRelative(b.zctx(), lhs, rhs, op)
 	case "+", "-", "*", "/", "%":

--- a/runtime/expr/eval.go
+++ b/runtime/expr/eval.go
@@ -163,8 +163,8 @@ type Equal struct {
 	equality bool
 }
 
-func NewCompareEquality(lhs, rhs Evaluator, operator string) (*Equal, error) {
-	e := &Equal{numeric: newNumeric(lhs, rhs)} //XXX
+func NewCompareEquality(zctx *zed.Context, lhs, rhs Evaluator, operator string) (*Equal, error) {
+	e := &Equal{numeric: newNumeric(zctx, lhs, rhs)} //XXX
 	switch operator {
 	case "==":
 		e.equality = true
@@ -225,10 +225,11 @@ type numeric struct {
 	vals coerce.Pair
 }
 
-func newNumeric(lhs, rhs Evaluator) numeric {
+func newNumeric(zctx *zed.Context, lhs, rhs Evaluator) numeric {
 	return numeric{
-		lhs: lhs,
-		rhs: rhs,
+		zctx: zctx,
+		lhs:  lhs,
+		rhs:  rhs,
 	}
 }
 
@@ -274,7 +275,7 @@ type Compare struct {
 }
 
 func NewCompareRelative(zctx *zed.Context, lhs, rhs Evaluator, operator string) (*Compare, error) {
-	c := &Compare{zctx: zctx, numeric: newNumeric(lhs, rhs)}
+	c := &Compare{zctx: zctx, numeric: newNumeric(zctx, lhs, rhs)}
 	switch operator {
 	case "<":
 		c.convert = func(v int) bool { return v < 0 }
@@ -395,7 +396,7 @@ var DivideByZero = errors.New("divide by zero")
 // NewArithmetic compiles an expression of the form "expr1 op expr2"
 // for the arithmetic operators +, -, *, /
 func NewArithmetic(zctx *zed.Context, lhs, rhs Evaluator, op string) (Evaluator, error) {
-	n := newNumeric(lhs, rhs)
+	n := newNumeric(zctx, lhs, rhs)
 	switch op {
 	case "+":
 		return &Add{zctx: zctx, operands: n}, nil


### PR DESCRIPTION
The numeric.zctx field is always nil.  That isn't a problem right now since that field is unused, but I plan to use it later, so initialize it.