### PR TITLE
Eliminate some zed.NewValue allocations

### DIFF
--- a/runtime/expr/boolean.go
+++ b/runtime/expr/boolean.go
@@ -233,9 +233,11 @@ func CompareNull(op string) (Boolean, error) {
 // Given a predicate for comparing individual elements, produce a new
 // predicate that implements the "in" comparison.
 func Contains(compare Boolean) Boolean {
+	var tmpVal zed.Value
 	return func(val *zed.Value) bool {
 		return errMatch == val.Walk(func(typ zed.Type, body zcode.Bytes) error {
-			if compare(zed.NewValue(typ, body)) {
+			tmpVal = *zed.NewValue(typ, body)
+			if compare(&tmpVal) {
 				return errMatch
 			}
 			return nil

--- a/runtime/expr/cutter.go
+++ b/runtime/expr/cutter.go
@@ -90,7 +90,7 @@ func (c *Cutter) Eval(ectx Context, in *zed.Value) *zed.Value {
 	if err != nil {
 		panic(err)
 	}
-	rec := zed.NewValue(c.lookupTypeRecord(types), bytes)
+	rec := ectx.NewValue(c.lookupTypeRecord(types), bytes)
 	for _, d := range droppers {
 		rec = d.Eval(ectx, rec)
 	}

--- a/runtime/expr/dropper.go
+++ b/runtime/expr/dropper.go
@@ -26,7 +26,7 @@ func (d *dropper) drop(ectx Context, in *zed.Value) *zed.Value {
 	if err != nil {
 		panic(err)
 	}
-	return zed.NewValue(d.typ, val)
+	return ectx.NewValue(d.typ, val)
 }
 
 type Dropper struct {

--- a/runtime/expr/eval.go
+++ b/runtime/expr/eval.go
@@ -138,8 +138,10 @@ func (i *In) Eval(ectx Context, this *zed.Value) *zed.Value {
 	if container.IsError() {
 		return container
 	}
+	tmpVal := ectx.NewValue(nil, nil)
 	err := container.Walk(func(typ zed.Type, body zcode.Bytes) error {
-		if _, err := i.vals.Coerce(elem, zed.NewValue(typ, body)); err != nil {
+		*tmpVal = *zed.NewValue(typ, body)
+		if _, err := i.vals.Coerce(elem, tmpVal); err != nil {
 			if err != coerce.IncompatibleTypes {
 				return err
 			}
@@ -232,10 +234,10 @@ func newNumeric(lhs, rhs Evaluator) numeric {
 	}
 }
 
-func enumify(val *zed.Value) *zed.Value {
+func enumify(ectx Context, val *zed.Value) *zed.Value {
 	// automatically convert an enum to its index value when coercing
 	if _, ok := val.Type.(*zed.TypeEnum); ok {
-		return zed.NewValue(zed.TypeUint64, val.Bytes())
+		return ectx.NewValue(zed.TypeUint64, val.Bytes())
 	}
 	return val
 }
@@ -245,12 +247,12 @@ func (n *numeric) eval(ectx Context, this *zed.Value) (int, *zed.Value, error) {
 	if lhs.IsError() {
 		return 0, lhs, nil
 	}
-	lhs = enumify(lhs)
+	lhs = enumify(ectx, lhs)
 	rhs := n.rhs.Eval(ectx, this)
 	if rhs.IsError() {
 		return 0, rhs, nil
 	}
-	rhs = enumify(rhs)
+	rhs = enumify(ectx, rhs)
 	id, err := n.vals.Coerce(lhs, rhs)
 	return id, nil, err
 }
@@ -716,7 +718,7 @@ func indexRecord(zctx *zed.Context, ectx Context, typ *zed.TypeRecord, record zc
 		return ectx.CopyValue(*zctx.WrapError("record index is not a string", index))
 	}
 	field := zed.DecodeString(index.Bytes())
-	val := zed.NewValue(typ, record).Deref(field)
+	val := ectx.NewValue(typ, record).Deref(field)
 	if val == nil {
 		return zctx.Missing()
 	}

--- a/runtime/expr/filter.go
+++ b/runtime/expr/filter.go
@@ -32,8 +32,13 @@ func (s *searchByPred) Eval(ectx Context, val *zed.Value) *zed.Value {
 			return zed.False
 		}
 	}
+	tmpVal := ectx.NewValue(nil, nil)
 	if errMatch == val.Walk(func(typ zed.Type, body zcode.Bytes) error {
-		if s.searchType(typ) || s.pred(zed.NewValue(typ, body)) {
+		if s.searchType(typ) {
+			return errMatch
+		}
+		*tmpVal = *zed.NewValue(typ, body)
+		if s.pred(tmpVal) {
 			return errMatch
 		}
 		return nil
@@ -120,12 +125,16 @@ func (s *search) Eval(ectx Context, val *zed.Value) *zed.Value {
 			return zed.False
 		}
 	}
+	tmpVal := ectx.NewValue(nil, nil)
 	if errMatch == val.Walk(func(typ zed.Type, body zcode.Bytes) error {
 		if typ.ID() == zed.IDString {
 			if stringSearch(byteconv.UnsafeString(body), s.text) {
 				return errMatch
 			}
-		} else if s.compare(zed.NewValue(typ, body)) {
+			return nil
+		}
+		*tmpVal = *zed.NewValue(typ, body)
+		if s.compare(tmpVal) {
 			return errMatch
 		}
 		return nil

--- a/runtime/expr/putter.go
+++ b/runtime/expr/putter.go
@@ -309,5 +309,5 @@ func (p *Putter) Eval(ectx Context, this *zed.Value) *zed.Value {
 	}
 	rule := p.lookupRule(recType, vals, clauses)
 	bytes := rule.step.build(this.Bytes(), &p.builder, vals)
-	return zed.NewValue(rule.typ, bytes)
+	return ectx.NewValue(rule.typ, bytes)
 }

--- a/runtime/expr/shaper.go
+++ b/runtime/expr/shaper.go
@@ -397,7 +397,7 @@ func (s *step) build(zctx *zed.Context, ectx Context, in zcode.Bytes, b *zcode.B
 	case castPrimitive:
 		// For a successful cast, v.Type == zed.TypeUnder(s.toType).
 		// For a failed cast, v.Type is a zed.TypeError.
-		v := s.caster.Eval(ectx, zed.NewValue(s.fromType, in))
+		v := s.caster.Eval(ectx, ectx.NewValue(s.fromType, in))
 		b.Append(v.Bytes())
 		if zed.TypeUnder(v.Type) == zed.TypeUnder(s.toType) {
 			// Prefer s.toType in case it's a named type.

--- a/runtime/op/join/join.go
+++ b/runtime/op/join/join.go
@@ -110,7 +110,7 @@ func (o *Op) Pull(done bool) (zbuf.Batch, error) {
 		// release the batch with and bypass GC.
 		for _, rightRec := range rightRecs {
 			cutRec := o.cutter.Eval(ectx.Reset(), rightRec)
-			rec, err := o.splice(leftRec, cutRec)
+			rec, err := o.splice(&ectx, leftRec, cutRec)
 			if err != nil {
 				return nil, err
 			}
@@ -229,7 +229,7 @@ func (o *Op) combinedType(left, right *zed.TypeRecord) (*zed.TypeRecord, error) 
 	return typ, nil
 }
 
-func (o *Op) splice(left, right *zed.Value) (*zed.Value, error) {
+func (o *Op) splice(ectx *expr.ResetContext, left, right *zed.Value) (*zed.Value, error) {
 	if right == nil {
 		// This happens on a simple join, i.e., "join key",
 		// where there are no cut expressions.  For left joins,
@@ -248,5 +248,5 @@ func (o *Op) splice(left, right *zed.Value) (*zed.Value, error) {
 	bytes := make([]byte, n+len(right.Bytes()))
 	copy(bytes, left.Bytes())
 	copy(bytes[n:], right.Bytes())
-	return zed.NewValue(typ, bytes), nil
+	return ectx.NewValue(typ, bytes), nil
 }

--- a/runtime/op/shape/shaper.go
+++ b/runtime/op/shape/shaper.go
@@ -19,6 +19,7 @@ type Shaper struct {
 	recode     map[zed.Type]*zed.TypeRecord
 	spiller    *spill.File
 	hash       maphash.Hash
+	val        zed.Value
 	vals       []*zed.Value
 }
 
@@ -267,7 +268,8 @@ func (s *Shaper) Read() (*zed.Value, error) {
 		}
 		typ = targetType
 	}
-	return zed.NewValue(typ, bytes), nil
+	s.val = *zed.NewValue(typ, bytes)
+	return &s.val, nil
 }
 
 func recode(from, to []zed.Field, bytes zcode.Bytes) (zcode.Bytes, error) {


### PR DESCRIPTION
Replace a number of zed.NewValue calls that allocate memory with alternatives that don't.