### PR TITLE
Fix lake.SortedWriter

### DIFF
--- a/cmd/zed/manage/ztests/overlap.yaml
+++ b/cmd/zed/manage/ztests/overlap.yaml
@@ -1,0 +1,17 @@
+# Test ensures that zed manage merges objects with the same key into one object 
+# even if the object is greater than pool threshold.
+
+script: |
+  export ZED_LAKE=test
+  zed init -q
+  zed create -q -use -orderby x:asc -S 100B test
+  for i in {1..5}; do
+    seq 100 | zq '{ts:this,x:1}' - | zed load -q -
+  done
+  zed manage -q -once
+  zed query -z 'from test@main:objects | drop id'
+
+outputs:
+  - name: stdout
+    data: |
+      {min:1,max:1,count:500(uint64),size:539}

--- a/lake/data/writer.go
+++ b/lake/data/writer.go
@@ -63,11 +63,15 @@ func (o *Object) NewWriter(ctx context.Context, engine storage.Engine, path *sto
 }
 
 func (w *Writer) Write(val *zed.Value) error {
+	key := val.DerefPath(w.poolKey).MissingAsNull()
+	return w.WriteWithKey(key, val)
+}
+
+func (w *Writer) WriteWithKey(key, val *zed.Value) error {
 	w.count++
 	if err := w.writer.Write(val); err != nil {
 		return err
 	}
-	key := val.DerefPath(w.poolKey).MissingAsNull()
 	w.object.Max.CopyFrom(key)
 	return w.writeIndex(key)
 }

--- a/runtime/exec/compact.go
+++ b/runtime/exec/compact.go
@@ -38,7 +38,7 @@ func Compact(ctx context.Context, lk *lake.Root, pool *lake.Pool, branchName str
 	octx := op.NewContext(ctx, zctx, nil)
 	slicer := meta.NewSlicer(lister, zctx)
 	puller := meta.NewSequenceScanner(octx, slicer, pool, nil, nil, nil)
-	w := lake.NewSortedWriter(ctx, pool)
+	w := lake.NewSortedWriter(ctx, zctx, pool)
 	if err := zbuf.CopyPuller(w, puller); err != nil {
 		puller.Pull(true)
 		w.Abort()


### PR DESCRIPTION
Fix an issue with SortedWriter that would end an object when the next key was equal to the previous key. The net result would be two objects that overlap each other.