### PR TITLE
zed manage: Change default behavior

### DIFF
--- a/cmd/zed/manage/command.go
+++ b/cmd/zed/manage/command.go
@@ -15,15 +15,15 @@ import (
 var Cmd = &charm.Spec{
 	Name:  "manage",
 	Usage: "manage",
-	Short: "continuously run compaction and other maintenance tasks on a lake",
+	Short: "run compaction and other maintenance tasks on a lake",
 	New:   New,
 }
 
 type Command struct {
 	*root.Command
 	logFlags logflags.Flags
-	once     bool
 	config   lakemanage.Config
+	monitor  bool
 }
 
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
@@ -38,8 +38,8 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 		d.KnownFields(true) // returns error for unknown fields
 		return d.Decode(&c.config)
 	})
-	c.config.Interval = f.Duration("interval", lakemanage.DefaultInterval, "interval between updates")
-	f.BoolVar(&c.once, "once", false, "run once and exit")
+	c.config.Interval = f.Duration("interval", lakemanage.DefaultInterval, "interval between updates (only applicable with -monitor")
+	f.BoolVar(&c.monitor, "monitor", false, "continuously monitor the lake for updates")
 	return c, nil
 }
 
@@ -54,16 +54,16 @@ func (c *Command) Run(args []string) error {
 		return err
 	}
 	defer logger.Sync()
-	if c.once {
-		lk, err := c.LakeFlags.Open(ctx)
+	if c.monitor {
+		conn, err := c.LakeFlags.Connection()
 		if err != nil {
 			return err
 		}
-		return lakemanage.Update(ctx, lk, c.config, logger)
+		return lakemanage.Monitor(ctx, conn, c.config, logger)
 	}
-	conn, err := c.LakeFlags.Connection()
+	lk, err := c.LakeFlags.Open(ctx)
 	if err != nil {
 		return err
 	}
-	return lakemanage.Monitor(ctx, conn, c.config, logger)
+	return lakemanage.Update(ctx, lk, c.config, logger)
 }

--- a/cmd/zed/manage/ztests/compact.yaml
+++ b/cmd/zed/manage/ztests/compact.yaml
@@ -6,7 +6,7 @@ script: |
   for i in {1..10}; do
     seq 200 | zq '{ts:this}' - | zed load -q -
   done
-  zed manage -q -once
+  zed manage -q
   zed query -z 'from test@main:objects | drop id'
 
 outputs:

--- a/cmd/zed/manage/ztests/config.yaml
+++ b/cmd/zed/manage/ztests/config.yaml
@@ -5,7 +5,7 @@ script: |
   zed create -q test2
   zed create -q test3
   zed branch -use test2 -q live
-  zed manage -once -config=inherit.yaml -log.path=inherit.log
+  zed manage -config=inherit.yaml -log.path=inherit.log
   zq -Z 'msg == "updating pool" | cut name, branch, interval | sort name' inherit.log > inherit.zson
 
 inputs:


### PR DESCRIPTION
Change default behavior of zed manage so the default behavior runs compact once and exits. The -monitor flag can be used to continuously monitor and update pools.