### PR TITLE
Update CHANGELOG.md for v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## v1.9.0
+* The [Zed Language Overview docs](docs/language/overview.md) have been split into multiple sections (#4576)
+* Add support for [User-Defined Operators](docs/language/statements.md#operator-statements) (#4417, #4635, #4646, #4644, #4663, #4674, #4698, #4702, #4716)
+* Add experimental support to the [`get` operator](https://github.com/brimdata/zed/blob/main/docs/language/operators/get.md) for customized methods, headers, and body (#4572)
+* Allow float decorators on integers in [ZSON](docs/formats/zson.md) (#4654)
+* The [Shaping docs](docs/language/shaping.md) have been expanded with a new section on [error handling](docs/language/shaping.md#error-handling) (#4686)
+* `zq` no longer attaches positional command line file inputs directly to [`join`](docs/language/operators/join.md) inputs (use [`file`](docs/language/operators/file.md) within a Zed program instead) (#4689)
+* [Zeek](https://zeek.org/)-related docs have been moved to the Integrations area of the [Zed docs site](https://zed.brimdata.io/docs) (#4694, #4696)
+* [`zed create`](docs/commands/zed.md#create) now has a `-use` flag to set the newly-created pool as the default pool for future operations (#4656)
+* Fix an issue where the [Zed Python client](docs/libraries/python.md) was incorrectly returning `False` for all `bool` values (#4706)
+* Fix an issue where the `!=` operator was not returning correct results when comparing certain types (#4704)
+
 ## v1.8.1
 * Send an HTTP 400 response instead of HTTP 500 for attempted deletes that find nothing to delete (#4618)
 * Send an HTTP 400 response instead of HTTP 500 for queries that parse ok but fail to compile, such as searches lacking a leading [`from`](docs/language/operators/from.md) (#4620)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v1.9.0
 * The [Zed Language Overview docs](docs/language/overview.md) have been split into multiple sections (#4576)
-* Add support for [User-Defined Operators](docs/language/statements.md#operator-statements) (#4417, #4635, #4646, #4644, #4663, #4674, #4698, #4702, #4716)
+* Add support for [user-defined operators](docs/language/statements.md#operator-statements) (#4417, #4635, #4646, #4644, #4663, #4674, #4698, #4702, #4716)
 * Add experimental support to the [`get` operator](https://github.com/brimdata/zed/blob/main/docs/language/operators/get.md) for customized methods, headers, and body (#4572)
 * Allow float decorators on integers in [ZSON](docs/formats/zson.md) (#4654)
 * The [Shaping docs](docs/language/shaping.md) have been expanded with a new section on [error handling](docs/language/shaping.md#error-handling) (#4686)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Add support for [user-defined operators](docs/language/statements.md#operator-statements) (#4417, #4635, #4646, #4644, #4663, #4674, #4698, #4702, #4716)
 * Add experimental support to the [`get` operator](https://github.com/brimdata/zed/blob/main/docs/language/operators/get.md) for customized methods, headers, and body (#4572)
 * Allow float decorators on integers in [ZSON](docs/formats/zson.md) (#4654)
-* The [Shaping docs](docs/language/shaping.md) have been expanded with a new section on [error handling](docs/language/shaping.md#error-handling) (#4686)
+* The [shaping docs](docs/language/shaping.md) have been expanded with a new section on [error handling](docs/language/shaping.md#error-handling) (#4686)
 * `zq` no longer attaches positional command line file inputs directly to [`join`](docs/language/operators/join.md) inputs (use [`file`](docs/language/operators/file.md) within a Zed program instead) (#4689)
 * [Zeek](https://zeek.org/)-related docs have been moved to the Integrations area of the [Zed docs site](https://zed.brimdata.io/docs) (#4694, #4696)
 * [`zed create`](docs/commands/zed.md#create) now has a `-use` flag to set the newly-created pool as the default pool for future operations (#4656)


### PR DESCRIPTION
https://github.com/brimdata/zed/compare/v1.8.1...b566f6d

Comments on a couple things:

1. I intentionally left out mention of `lake manage` since it doesn't feel like we're not quite ready with compaction or vcache yet. When we've got user-facing docs for those, are running them continuously on Shasta, and maybe have gotten some initial use/feedback from external power testers, then it'll feel appropriate to start pointing the general user base at it.

2. I described Diane's `get` improvements as "experimental" because I felt that the sum of the "opens" I enumerated at https://github.com/brimdata/zed/issues/4225#issuecomment-1585311947 make the newly-added stuff feel a little unfinished. The way it is currently, if a user approaches us on Slack/Issues with a use case for which they needed it, I'd feel ok pointing them at what we've got, disclosing the limitations, and seeing how they fare, kind of like a beta feature. But since it's not yet subject to automated tests, doesn't yet have user-facing docs, etc. makes me want to downplay its readiness a but (but not keep it hidden completely from view).
