### PR TITLE
Optimize expr.NewShaper to return ConstShaper when possible

### DIFF
--- a/compiler/kernel/expr.go
+++ b/compiler/kernel/expr.go
@@ -306,7 +306,7 @@ func isShaperFunc(name string) bool {
 	return shaperOps(name) != 0
 }
 
-func (b *Builder) compileShaper(node dag.Call) (*expr.Shaper, error) {
+func (b *Builder) compileShaper(node dag.Call) (expr.Evaluator, error) {
 	args := node.Args
 	if len(args) == 1 {
 		args = append([]dag.Expr{&dag.This{Kind: "This"}}, args...)
@@ -325,10 +325,7 @@ func (b *Builder) compileShaper(node dag.Call) (*expr.Shaper, error) {
 	if err != nil {
 		return nil, err
 	}
-	// XXX When we do constant folding, we should detect when typeExpr is
-	// a constant and allocate a ConstShaper instead of a (dynamic) Shaper.
-	// See issue #2425.
-	return expr.NewShaper(b.zctx(), field, typExpr, shaperOps(node.Name)), nil
+	return expr.NewShaper(b.zctx(), field, typExpr, shaperOps(node.Name))
 }
 
 func (b *Builder) compileCall(call dag.Call) (expr.Evaluator, error) {

--- a/runtime/expr/cast.go
+++ b/runtime/expr/cast.go
@@ -270,3 +270,21 @@ type casterBytes struct{}
 func (c *casterBytes) Eval(ectx Context, val *zed.Value) *zed.Value {
 	return ectx.NewValue(zed.TypeBytes, val.Bytes())
 }
+
+type casterNamedType struct {
+	zctx *zed.Context
+	expr Evaluator
+	name string
+}
+
+func (c *casterNamedType) Eval(ectx Context, this *zed.Value) *zed.Value {
+	val := c.expr.Eval(ectx, this)
+	if val.IsError() {
+		return val
+	}
+	typ, err := c.zctx.LookupTypeNamed(c.name, zed.TypeUnder(val.Type))
+	if err != nil {
+		return ectx.CopyValue(*c.zctx.NewError(err))
+	}
+	return ectx.NewValue(typ, val.Bytes())
+}


### PR DESCRIPTION
In NewShaper, when the type expression passed to the shaper function is know to be constant, return a ConstShaper (or a casterNamedType, added here) instead of a generic Shaper.

Closes #2425.