### PR TITLE
Optimize zed.Value.Under

### DIFF
--- a/value_test.go
+++ b/value_test.go
@@ -8,6 +8,24 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func BenchmarkValueUnder(b *testing.B) {
+	b.Run("primitive", func(b *testing.B) {
+		val := zed.Null
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			val.Under()
+		}
+	})
+	b.Run("named", func(b *testing.B) {
+		typ, _ := zed.NewContext().LookupTypeNamed("name", zed.TypeNull)
+		val := zed.NewValue(typ, nil)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			val.Under()
+		}
+	})
+}
+
 func TestValueValidate(t *testing.T) {
 	recType := zed.NewTypeRecord(0, []zed.Field{
 		zed.NewField("f", zed.NewTypeSet(0, zed.TypeString)),


### PR DESCRIPTION
Move the loop in Value.Under into a separate method, Value.under, so the compiler will inline Under.

goos: darwin
goarch: arm64
pkg: github.com/brimdata/zed
                        |  before.txt  |              after.txt               |
                        |    sec/op    |    sec/op     vs base                |
ValueUnder/primitive-10   2.0560n ± 2%   0.9328n ± 0%  -54.63% (p=0.000 n=10)
ValueUnder/named-10        27.77n ± 0%    27.96n ± 1%   +0.72% (p=0.000 n=10)
geomean                    7.555n         5.107n       -32.40%