### PR TITLE
zed: Default app data location

### DIFF
--- a/cli/lakeflags/datadir.go
+++ b/cli/lakeflags/datadir.go
@@ -1,0 +1,36 @@
+package lakeflags
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+var defaultDataDir string
+
+func init() {
+	defaultDataDir = getDefaultDataDir()
+}
+
+// getDefaultDataDir returns the default data directory for the current user.
+// Derived from https://github.com/btcsuite/btcd/blob/master/btcutil/appdata.go
+func getDefaultDataDir() string {
+	// Resolve the XDG data home directory if set.
+	if xdgDataHome := os.Getenv("XDG_DATA_HOME"); xdgDataHome != "" {
+		return filepath.Join(xdgDataHome, "zed")
+	}
+	if runtime.GOOS == "windows" {
+		if appData := os.Getenv("LOCALAPPDATA"); appData != "" {
+			return filepath.Join(appData, "zed")
+		}
+	}
+	if homeDir, _ := os.UserHomeDir(); homeDir != "" {
+		// Follow the XDG spec which states:
+		// If $XDG_DATA_HOME is either not set or empty, a default equal to
+		// $HOME/.local/share should be used.
+		return filepath.Join(homeDir, ".local", "share", "zed")
+	}
+	// Return an empty string which will cause an error if a default data
+	// directory cannot be found.
+	return ""
+}

--- a/cli/lakeflags/datadir.go
+++ b/cli/lakeflags/datadir.go
@@ -6,12 +6,6 @@ import (
 	"runtime"
 )
 
-var defaultDataDir string
-
-func init() {
-	defaultDataDir = getDefaultDataDir()
-}
-
 // getDefaultDataDir returns the default data directory for the current user.
 // Derived from https://github.com/btcsuite/btcd/blob/master/btcutil/appdata.go
 func getDefaultDataDir() string {

--- a/cmd/zed/serve/command.go
+++ b/cmd/zed/serve/command.go
@@ -73,17 +73,12 @@ func (c *Command) Run(args []string) error {
 		return err
 	}
 	defer cleanup()
-	if !c.LakeFlags.LakeSpecified {
-		c.LakeFlags.Lake = ""
-	}
-	uri, err := c.LakeFlags.URI()
-	if err != nil {
+	if c.conf.Root, err = c.LakeFlags.URI(); err != nil {
 		return err
 	}
-	if api.IsLakeService(uri.String()) {
+	if api.IsLakeService(c.conf.Root.String()) {
 		return errors.New("serve command available for local lakes only")
 	}
-	c.conf.Root = uri
 	if c.rootContentFile != "" {
 		f, err := fs.Open(c.rootContentFile)
 		if err != nil {

--- a/cmd/zed/use/command.go
+++ b/cmd/zed/use/command.go
@@ -84,7 +84,7 @@ func (c *Command) Run(args []string) error {
 			return errors.New("default pool and branch unset")
 		}
 		fmt.Printf("HEAD at %s\n", head)
-		if u, err := c.LakeFlags.URI(); err == nil {
+		if u, err := c.LakeFlags.ClientURI(); err == nil {
 			fmt.Printf("Lake at %s\n", u)
 		}
 		return nil

--- a/cmd/zed/ztests/no-lake-location.yaml
+++ b/cmd/zed/ztests/no-lake-location.yaml
@@ -1,6 +1,6 @@
 script: |
   ! zed ls -lake ''
-  ! zed serve
+  ! zed serve -lake ''
 
 outputs:
   - name: stderr

--- a/cmd/zed/ztests/xdg-data-home.yaml
+++ b/cmd/zed/ztests/xdg-data-home.yaml
@@ -1,0 +1,8 @@
+script: |
+  export XDG_DATA_HOME=path/to/lake
+  zed init
+
+outputs:
+  - name: stdout
+    data: |
+      lake created: path/to/lake/zed

--- a/cmd/zed/ztests/xdg-data-home.yaml
+++ b/cmd/zed/ztests/xdg-data-home.yaml
@@ -4,5 +4,5 @@ script: |
 
 outputs:
   - name: stdout
-    data: |
-      lake created: path/to/lake/zed
+    regexp: |
+      lake created: file:.*path/to/lake/zed

--- a/compiler/ztests/from-error.yaml
+++ b/compiler/ztests/from-error.yaml
@@ -1,5 +1,5 @@
 script: |
-  ! zc -C -s 'from p'
+  ! zc -lake='' -C -s 'from p'
   echo === >&2
   export ZED_LAKE=test
   zed init


### PR DESCRIPTION
If no lake location is specified, zed will use a per-os default
location. Also if the default location is used, zed will first check if
there's a service on 9867 and opt to connect to that instead of
operating locally.