### PR TITLE
Pin markdownlint-cli at 0.35.0 for now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ peg-run: $(PEG_GEN)
 
 .PHONY: markdown-lint
 markdown-lint:
-	@npm install --no-save markdownlint-cli
+	@npm install --no-save markdownlint-cli@0.35.0
 	@npx markdownlint docs
 
 # CI performs these actions individually since that looks nicer in the UI;


### PR DESCRIPTION
Some links in the "schools" tutorial started failing a few days ago. After some digging I found this appears to be due to an issue that's already been reported by someone else (https://github.com/DavidAnson/markdownlint/issues/945). I added details of our own repro at https://github.com/DavidAnson/markdownlint/issues/945#issuecomment-1705638999. To avoid having the failures annoy us each time CI runs, for now it seems appropriate to just pin the markdown CLI checking tool at the prior version before that issue existed. I'll keep an eye on that issue and if it gets fixed we can go back to using the latest tooling.