### PR TITLE
service: Add query status endpoint

### DIFF
--- a/docs/lake/api.md
+++ b/docs/lake/api.md
@@ -440,6 +440,35 @@ curl -X POST \
 {"type":"QueryStats","value":{"start_time":{"sec":1658193276,"ns":964207000},"update_time":{"sec":1658193276,"ns":964592000},"bytes_read":55,"bytes_matched":55,"records_read":3,"records_matched":3}}
 ```
 
+#### Query Status
+
+Retrieve any runtime errors from a specific query. This endpoint only responds
+after the query has exited and is only available for a limited time afterwards.
+
+```
+POST /query/status/{request_id}
+```
+
+**Params**
+
+| Name | Type | In | Description |
+| ---- | ---- | -- | ----------- |
+| request_id | string | path | **Required.** The value of the response header `X-Request-Id` of the target query. |
+
+**Example Request**
+
+```
+curl -X POST \
+     -H 'Accept: application/json' \
+     http://localhost:9867/query/status/2U1oso7btnCXfDenqFOSExOBEIv
+```
+
+**Example Response**
+
+```
+{"error":"parquetio: unsupported type: empty record"}
+```
+
 ---
 
 ### Events

--- a/service/request.go
+++ b/service/request.go
@@ -34,16 +34,13 @@ type Request struct {
 }
 
 func newRequest(w http.ResponseWriter, r *http.Request, c *Core) (*ResponseWriter, *Request, bool) {
-	logger := c.logger.With(zap.String("request_id", api.RequestIDFromContext(r.Context())))
-	req := &Request{
-		Request: r,
-		Logger:  logger,
-	}
+	req := &Request{Request: r}
+	req.Logger = c.logger.With(zap.String("request_id", req.ID()))
 	m := zson.NewZNGMarshaler()
 	m.Decorate(zson.StylePackage)
 	res := &ResponseWriter{
 		ResponseWriter: w,
-		Logger:         logger,
+		Logger:         req.Logger,
 		marshaler:      m,
 	}
 	ss := strings.Split(r.Header.Get("Accept"), ",")
@@ -73,6 +70,10 @@ func (r *Request) openPool(w *ResponseWriter, root *lake.Root) (*lake.Pool, bool
 		return nil, false
 	}
 	return pool, true
+}
+
+func (r *Request) ID() string {
+	return api.RequestIDFromContext(r.Context())
 }
 
 func (r *Request) PoolID(w *ResponseWriter, root *lake.Root) (ksuid.KSUID, bool) {

--- a/service/ztests/query-runtime-error.yaml
+++ b/service/ztests/query-runtime-error.yaml
@@ -1,0 +1,15 @@
+script: |
+  source service.sh
+  zed create -use -q test
+  echo '{}' | zed load -q -
+  curl -D headers.out -s -H 'Accept: application/x-parquet' -d '{"query":"from test"}' $ZED_LAKE/query 
+  rid=$(sed -n 's/^X-Request-Id: \(.\{27\}\).*$/\1/p' headers.out)
+  curl -H 'Accept: application/json' $ZED_LAKE/query/status/$rid
+
+inputs:
+  - name: service.sh
+
+outputs:
+  - name: stdout
+    data: |
+      {"error":"parquetio: unsupported type: empty record"}


### PR DESCRIPTION
This adds a new endpoint to the service that when the query is finished returns any runtime errors that occurred during the query.

Closes #4215