### PR TITLE
Query Status endpoint is GET, not POST (in the example too)

### DIFF
--- a/docs/lake/api.md
+++ b/docs/lake/api.md
@@ -458,7 +458,7 @@ GET /query/status/{request_id}
 **Example Request**
 
 ```
-curl -X POST \
+curl -X GET \
      -H 'Accept: application/json' \
      http://localhost:9867/query/status/2U1oso7btnCXfDenqFOSExOBEIv
 ```


### PR DESCRIPTION
Derp! My fix in #4766 hit only one of two spots that needed to be fixed. 🤦