### PR TITLE
explode: move "as" check to semantic pass

### DIFF
--- a/compiler/ast/dag/op.go
+++ b/compiler/ast/dag/op.go
@@ -41,7 +41,7 @@ type (
 		Kind string `json:"kind" unpack:""`
 		Args []Expr `json:"args"`
 		Type string `json:"type"`
-		As   Expr   `json:"as"`
+		As   string `json:"as"`
 	}
 	Filter struct {
 		Kind string `json:"kind" unpack:""`

--- a/compiler/kernel/op.go
+++ b/compiler/kernel/op.go
@@ -224,14 +224,7 @@ func (b *Builder) compileLeaf(o dag.Op, parent zbuf.Puller) (zbuf.Puller, error)
 		if err != nil {
 			return nil, err
 		}
-		as, err := compileLval(v.As)
-		if err != nil {
-			return nil, err
-		}
-		if len(as) != 1 {
-			return nil, errors.New("explode field must be a top-level field")
-		}
-		return explode.New(b.octx.Zctx, parent, args, typ, as.Leaf())
+		return explode.New(b.octx.Zctx, parent, args, typ, v.As)
 	case *dag.Over:
 		return b.compileOver(parent, v)
 	case *dag.Yield:


### PR DESCRIPTION
Move the "as" check on explode proc from kernel compilation phase to semantic phase where this belongs.