### PR TITLE
Modify the cut/coalesce example in Zed language docs

### DIFF
--- a/docs/language/operators/cut.md
+++ b/docs/language/operators/cut.md
@@ -74,3 +74,19 @@ echo '1 {a:1,b:2,c:3}' | zq -z 'cut a,b' -
 {a:error("missing"),b:error("missing")}
 {a:1,b:2}
 ```
+_Invoke a function while cutting to set a default value for a field_
+
+:::tip
+This can be helpful to transform data into a uniform record type, such as if
+the output will be exported in formats such as `csv` or `parquet` (see also:
+[`fuse`](fuse.md)).
+:::
+
+```mdtest-command
+echo '{a:1,b:null}{a:1,b:2}' | zq -z 'cut a,b:=coalesce(b, 0)' -
+```
+=>
+```mdtest-output
+{a:1,b:0}
+{a:1,b:2}
+```


### PR DESCRIPTION
These are additional changes beyond the ones first merged in #4773 (thanks @iloveitaly!).

Traditionally, the docs have taken an approach of trying to show language components mostly in isolation using small examples. The hope is that the user will see them as building blocks such that they'll combine them with other components in useful ways. To the degree that there's specific combinations that enable powerful use cases, we've tried to reveal these through the [tutorials](https://zed.brimdata.io/docs/tutorials), [CLI command walk-throughs](https://zed.brimdata.io/docs/commands), and so forth.

Meanwhile, the docs improvements in #4773 were from a community user that had started from a use case that:

1. Depended on a specific component (the [`cut` operator](https://zed.brimdata.io/docs/language/operators/cut))
2. Combined that with an operation (output as CSV)
3. Hit a common problem (the CSV writer's reliance on data already being of a single record type)
4. Found a particular solution to the problem (using the [`coalesce()` function](https://zed.brimdata.io/docs/language/functions/coalesce) to create that single record type.)

It turns out there's other ways to address the limitation (e.g., using the [`fuse` operator](https://zed.brimdata.io/docs/language/operators/fuse), or specifying the `null` value as `int64` type in the input data) and there's other other use cases that would benefit from this same treatment (e.g., outputting heterogenous records without `cut`, or output in Parquet format). Therefore the original text might benefit from some tweaks.

Here I've tried to make the example a little more widely applicable by noting:

1. This happens to be showing another example of how to invoke functions in the RHS of a field expression (thanks for that suggestion @mattnibs!)
2. It's as applicable to Parquet output as CSV
3. As the CSV writer's error messages also inform the user, `fuse` is yet another available approach

I also used some of the Docusaurus formatting to present the use case context differently.

![image](https://github.com/brimdata/zed/assets/5934157/092f2727-c740-4429-84b5-8375e55944b9)
