### PR TITLE
Change type of zed.nativeBase for Go 1.21

### DIFF
--- a/value.go
+++ b/value.go
@@ -157,7 +157,7 @@ func (v *Value) Bytes() zcode.Bytes {
 // nativeBase is the base address for all native Values, which are encoded as a
 // zcode.Bytes with this base address, a length of zero, and capacity set to the
 // bits of the value's native representation.
-var nativeBase struct{}
+var nativeBase uintptr
 
 func encodeNative(x uint64) zcode.Bytes {
 	var b zcode.Bytes


### PR DESCRIPTION
Unlike previous releases, Go 1.21 assigns zed.nativeBase (a struct{} occupying zero bytes) the same address as runtime.zerobase, causing panics because zed.decodeNative now mistakes a zed.Value with a bytes field containing a zero-capacity slice for a native value.  Fix by changing the type of nativeBase to uintptr, which does not occupy zero bytes.

Closes #4764.

To verify, run `make test-unit test-system test-heavy GOFLAGS=-skip=TestZed/boomerang/parque` with Go 1.21.  (The Parquet boomerang tests currently fail for Go 1.21.)