### PR TITLE
zed use: print lake with no args

### DIFF
--- a/cmd/zed/use/command.go
+++ b/cmd/zed/use/command.go
@@ -26,7 +26,8 @@ The use command is like "git checkuout" but there is no local copy of
 the lake data.  Rather, the local HEAD state influences commands as
 they access the lake.
 
-With no argument, use prints the working pool and branch.
+With no argument, use prints the working pool and branch as well as the
+location of the current lake.
 
 With an argument of the form "pool", use sets the working pool as indicated
 and the working branch to "main".
@@ -83,6 +84,9 @@ func (c *Command) Run(args []string) error {
 			return errors.New("default pool and branch unset")
 		}
 		fmt.Printf("HEAD at %s\n", head)
+		if u, err := c.LakeFlags.URI(); err == nil {
+			fmt.Printf("Lake at %s\n", u)
+		}
 		return nil
 	}
 	commitish, err := lakeparse.ParseCommitish(args[0])

--- a/lake/ztests/use.yaml
+++ b/lake/ztests/use.yaml
@@ -7,7 +7,7 @@ script: |
   ! zed use POOL@branch
   echo ===
   zed use POOL
-  zed use
+  zed use > no-args-use.txt
   echo ===
   zed branch -q b1
   zed use @b1
@@ -20,14 +20,16 @@ outputs:
     data: |
       ===
       Switched to branch "main" on pool "POOL"
-      HEAD at POOL@main
       ===
       Switched to branch "b1" on pool "POOL"
       ===
       Switched to branch "b2" on pool "POOL"
-
   - name: stderr
     data: |
       default pool and branch unset
       default pool unset
       "branch": branch not found
+  - name: no-args-use.txt
+    regexp: |
+      HEAD at POOL@main
+      Lake at file.*/test


### PR DESCRIPTION
Change zed use to also print the current lake location if no args are given.