### PR TITLE
Avoid recorder for io.ReadSeeker in anyio.NewReaderWithOpts

### DIFF
--- a/zio/anyio/gzip.go
+++ b/zio/anyio/gzip.go
@@ -17,20 +17,18 @@ func GzipReader(r io.Reader) (io.Reader, error) {
 			return rs, nil
 		}
 	}
-	recorder := NewRecorder(r)
-	track := NewTrack(recorder)
+	track := NewTrack(r)
 	// gzip.NewReader blocks until it reads ten bytes.  readGzipID only
 	// reads two bytes.
 	if !readGzipID(track) {
-		return recorder, nil
+		return track.Reader(), nil
 	}
 	track.Reset()
 	_, err := gzip.NewReader(track)
 	if err == nil {
-		// create a new reader from recorder (track keeps a copy of read data)
-		return gzip.NewReader(recorder)
+		return gzip.NewReader(track.Reader())
 	}
-	return recorder, nil
+	return track.Reader(), nil
 }
 
 // RFC 1952, Section 2.3.1

--- a/zio/anyio/track.go
+++ b/zio/anyio/track.go
@@ -1,24 +1,51 @@
 package anyio
 
+import "io"
+
 const TrackSize = InitBufferSize
 
 type Track struct {
+	rs      io.ReadSeeker
+	initial int64
+
 	recorder *Recorder
 	off      int
 }
 
-func NewTrack(r *Recorder) *Track {
+func NewTrack(r io.Reader) *Track {
+	if rs, ok := r.(io.ReadSeeker); ok {
+		if n, err := rs.Seek(0, io.SeekCurrent); err == nil {
+			return &Track{rs: rs, initial: n}
+		}
+	}
 	return &Track{
-		recorder: r,
+		recorder: NewRecorder(r),
 	}
 }
 
 func (t *Track) Reset() {
+	if t.rs != nil {
+		// We ignore errors here under the assumption that a subsequent
+		// call to Read will also fail.
+		t.rs.Seek(t.initial, io.SeekStart)
+		return
+	}
 	t.off = 0
 }
 
 func (t *Track) Read(b []byte) (int, error) {
+	if t.rs != nil {
+		return t.rs.Read(b)
+	}
 	n, err := t.recorder.ReadAt(t.off, b)
 	t.off += n
 	return n, err
+}
+
+func (t *Track) Reader() io.Reader {
+	if t.rs != nil {
+		t.Reset()
+		return t.rs
+	}
+	return t.recorder
 }

--- a/zio/anyio/ztests/huge.yaml
+++ b/zio/anyio/ztests/huge.yaml
@@ -1,0 +1,23 @@
+script: |
+  ! yes ' ' | head -c $((11 * 1024 * 1024)) > huge.zson
+  echo 0 >> huge.zson
+  zq -z huge.zson
+  ! cat huge.zson | zq -z -
+
+outputs:
+  - name: stdout
+    data: |
+      0
+  - name: stderr
+    data: |
+      stdio:stdin: format detection error
+      	arrows: schema message length exceeds 1 MiB
+      	csv: line 1: no comma found
+      	json: buffer exceeded max size trying to infer input format
+      	line: auto-detection not supported
+      	parquet: auto-detection requires seekable input
+      	vng: auto-detection requires seekable input
+      	zeek: line 1: bad types/fields definition in zeek header
+      	zjson: line 1: malformed ZJSON: bad type object: "": unpacker error parsing JSON: unexpected end of JSON input
+      	zng: buffer exceeded max size trying to infer input format
+      	zson: buffer exceeded max size trying to infer input format


### PR DESCRIPTION
NewReaderWithOpts always creates a Recorder, which buffers its input and can cause format detection to fail if the buffer is too small.  Avoid that problem when the passed reader implements io.ReadSeeker by modifying Track to create a Recorder only when the reader cannot seek.

Closes #4586.