### PR TITLE
Change destination of Zui links

### DIFF
--- a/docs/language/dataflow-model.md
+++ b/docs/language/dataflow-model.md
@@ -201,7 +201,7 @@ in later expressions.
 
 ## Implied Operators
 
-When Zed is run in an application like [Zui](https://github.com/brimdata/zui),
+When Zed is run in an application like [Zui](https://zui.brimdata.io),
 queries are often composed interactively in a "search bar" experience.
 The language design here attempts to support both this "lean forward" pattern of usage
 along with a "coding style" of query writing where the queries might be large

--- a/docs/libraries/python.md
+++ b/docs/libraries/python.md
@@ -36,7 +36,7 @@ To run this example, first start a Zed lake service from your shell:
 zed init -lake scratch
 zed serve -lake scratch
 ```
-> Or you can launch the [Zui app](https://github.com/brimdata/zui) and it will run a Zed lake service
+> Or you can launch the [Zui app](https://zui.brimdata.io) and it will run a Zed lake service
 > on the default port at `http://localhost:9867`.
 
 Then, in another shell, use Python to create a pool, load some data,


### PR DESCRIPTION
https://zui.brimdata.io has become the more user-friendly link destination when referencing Zui.