### PR TITLE
Remove warning from docs now that zed/4651 has been fixed

### DIFF
--- a/docs/language/statements.md
+++ b/docs/language/statements.md
@@ -207,8 +207,7 @@ allowed and will produce an error.
 
 User-defined operators are a new feature in Zed that has been made available
 despite known limitations described in open issues
-[zed/4651](https://github.com/brimdata/zed/issues/4651),
-[zed/4692](https://github.com/brimdata/zed/issues/4692), and
+[zed/4692](https://github.com/brimdata/zed/issues/4692) and
 [zed/4701](https://github.com/brimdata/zed/issues/4701). If you encounter
 these or other problems when making use of the feature please comment on the
 issues or come talk to us on the [Brim community Slack](https://www.brimdata.io/join-slack/)


### PR DESCRIPTION
Per the note-to-self in https://github.com/brimdata/zed/issues/4651#issuecomment-1640608537, since that issue has been fixed, the docs no longer need to caution users to watch out for it.