### PR TITLE
zq: Call user-defined op with source

### DIFF
--- a/cmd/zq/ztests/call-user-op-with-src.yaml
+++ b/cmd/zq/ztests/call-user-op-with-src.yaml
@@ -1,0 +1,16 @@
+script: |
+  zq -z -I countfile.zed 'countfile()'
+
+inputs:
+  - name: countfile.zed
+    data: |
+      op countfile(): (
+        file test.zson | count()
+      )
+  - name: test.zson
+    data: '{} {} {} {}'
+
+outputs:
+  - name: stdout
+    data: |
+      4(uint64)

--- a/compiler/job.go
+++ b/compiler/job.go
@@ -40,7 +40,7 @@ func NewJob(octx *op.Context, in ast.Seq, src *data.Source, head *lakeparse.Comm
 	if len(seq) == 0 {
 		return nil, errors.New("internal error: AST seq cannot be empty")
 	}
-	entry, err := semantic.Analyze(octx.Context, seq, src, head)
+	entry, err := semantic.AnalyzeAddSource(octx.Context, seq, src, head)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The change allows zq users to start a query with a call to a user-defined op that contains a source (file) with no additional input sources. Previously attempting to do this would result in error "redundant inputs".

Fixes #4701