### PR TITLE
lakeapi: Use pool name/reference over pool id

### DIFF
--- a/api/client/connection_test.go
+++ b/api/client/connection_test.go
@@ -58,7 +58,7 @@ func TestClientRedirectReplay(t *testing.T) {
 		Refresh: "98765",
 	})
 	conn.SetAuthStore(store)
-	_, err := conn.Load(context.Background(), ksuid.New(), "main", "", strings.NewReader(expected), api.CommitMessage{})
+	_, err := conn.Load(context.Background(), ksuid.New().String(), "main", "", strings.NewReader(expected), api.CommitMessage{})
 	require.NoError(t, err)
 	assert.Equal(t, expected, body)
 }

--- a/cmd/zed/branch/command.go
+++ b/cmd/zed/branch/command.go
@@ -74,26 +74,19 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	poolName := head.Pool
-	if poolName == "" {
+	pool := head.Pool
+	if pool == "" {
 		return errors.New("a pool name must be included: pool@branch")
-	}
-	poolID, err := lakeparse.ParseID(poolName)
-	if err != nil {
-		poolID, err = lake.PoolID(ctx, poolName)
-		if err != nil {
-			return err
-		}
 	}
 	parentCommit, err := lakeparse.ParseID(head.Branch)
 	if err != nil {
-		parentCommit, err = lake.CommitObject(ctx, poolID, head.Branch)
+		parentCommit, err = lake.CommitObject(ctx, pool, head.Branch)
 		if err != nil {
 			return err
 		}
 	}
 	if c.delete {
-		if err := lake.RemoveBranch(ctx, poolID, branchName); err != nil {
+		if err := lake.RemoveBranch(ctx, pool, branchName); err != nil {
 			return err
 		}
 		if !c.LakeFlags.Quiet {
@@ -101,7 +94,7 @@ func (c *Command) Run(args []string) error {
 		}
 		return nil
 	}
-	if err := lake.CreateBranch(ctx, poolID, branchName, parentCommit); err != nil {
+	if err := lake.CreateBranch(ctx, pool, branchName, parentCommit); err != nil {
 		return err
 	}
 	if !c.LakeFlags.Quiet {

--- a/cmd/zed/compact/command.go
+++ b/cmd/zed/compact/command.go
@@ -55,11 +55,7 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	poolID, err := lake.PoolID(ctx, head.Pool)
-	if err != nil {
-		return err
-	}
-	commit, err := lake.Compact(ctx, poolID, head.Branch, ids, c.writeVectors, c.commitFlags.CommitMessage())
+	commit, err := lake.Compact(ctx, head.Pool, head.Branch, ids, c.writeVectors, c.commitFlags.CommitMessage())
 	if err == nil && !c.LakeFlags.Quiet {
 		fmt.Printf("%s compaction committed\n", commit)
 	}

--- a/cmd/zed/delete/command.go
+++ b/cmd/zed/delete/command.go
@@ -70,22 +70,18 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	poolName := head.Pool
-	if poolName == "" {
+	pool := head.Pool
+	if pool == "" {
 		return lakeflags.ErrNoHEAD
-	}
-	poolID, err := lake.PoolID(ctx, poolName)
-	if err != nil {
-		return err
 	}
 	var commit ksuid.KSUID
 	if c.where != "" {
 		if len(args) > 0 {
 			return errors.New("too many arguments")
 		}
-		commit, err = c.deleteWhere(ctx, lake, poolID, head.Branch)
+		commit, err = c.deleteWhere(ctx, lake, pool, head.Branch)
 	} else {
-		commit, err = c.deleteByIDs(ctx, lake, poolID, head.Branch, args)
+		commit, err = c.deleteByIDs(ctx, lake, pool, head.Branch, args)
 	}
 	if err != nil {
 		return err
@@ -96,7 +92,7 @@ func (c *Command) Run(args []string) error {
 	return nil
 }
 
-func (c *Command) deleteByIDs(ctx context.Context, lake api.Interface, poolID ksuid.KSUID, branchName string, args []string) (ksuid.KSUID, error) {
+func (c *Command) deleteByIDs(ctx context.Context, lake api.Interface, pool, branchName string, args []string) (ksuid.KSUID, error) {
 	ids, err := lakeparse.ParseIDs(args)
 	if err != nil {
 		return ksuid.Nil, err
@@ -104,9 +100,9 @@ func (c *Command) deleteByIDs(ctx context.Context, lake api.Interface, poolID ks
 	if len(ids) == 0 {
 		return ksuid.Nil, errors.New("no data object IDs specified")
 	}
-	return lake.Delete(ctx, poolID, branchName, ids, c.commitFlags.CommitMessage())
+	return lake.Delete(ctx, pool, branchName, ids, c.commitFlags.CommitMessage())
 }
 
-func (c *Command) deleteWhere(ctx context.Context, lake api.Interface, poolID ksuid.KSUID, branchName string) (ksuid.KSUID, error) {
-	return lake.DeleteWhere(ctx, poolID, branchName, c.where, c.commitFlags.CommitMessage())
+func (c *Command) deleteWhere(ctx context.Context, lake api.Interface, pool, branchName string) (ksuid.KSUID, error) {
+	return lake.DeleteWhere(ctx, pool, branchName, c.where, c.commitFlags.CommitMessage())
 }

--- a/cmd/zed/drop/command.go
+++ b/cmd/zed/drop/command.go
@@ -48,19 +48,15 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	poolName := args[0]
-	poolID, err := lake.PoolID(ctx, poolName)
-	if err != nil {
+	pool := args[0]
+	if err := c.confirm(pool); err != nil {
 		return err
 	}
-	if err := c.confirm(poolName); err != nil {
-		return err
-	}
-	if err := lake.RemovePool(ctx, poolID); err != nil {
+	if err := lake.RemovePool(ctx, pool); err != nil {
 		return err
 	}
 	if !c.LakeFlags.Quiet {
-		fmt.Printf("pool deleted: %s\n", poolName)
+		fmt.Printf("pool deleted: %s\n", pool)
 	}
 	return nil
 }

--- a/cmd/zed/index/apply.go
+++ b/cmd/zed/index/apply.go
@@ -64,11 +64,7 @@ func (c *applyCommand) Run(args []string) error {
 	if head.Pool == "" {
 		return lakeflags.ErrNoHEAD
 	}
-	poolID, err := lake.PoolID(ctx, head.Pool)
-	if err != nil {
-		return err
-	}
-	commit, err := lake.ApplyIndexRules(ctx, c.rules, poolID, head.Branch, tags)
+	commit, err := lake.ApplyIndexRules(ctx, c.rules, head.Pool, head.Branch, tags)
 	if err != nil {
 		return err
 	}

--- a/cmd/zed/index/update.go
+++ b/cmd/zed/index/update.go
@@ -49,11 +49,7 @@ func (c *updateCommand) Run(args []string) error {
 	if head.Pool == "" {
 		return lakeflags.ErrNoHEAD
 	}
-	poolID, err := lake.PoolID(ctx, head.Pool)
-	if err != nil {
-		return err
-	}
-	commit, err := lake.UpdateIndex(ctx, args, poolID, head.Branch)
+	commit, err := lake.UpdateIndex(ctx, args, head.Pool, head.Branch)
 	if err != nil {
 		return err
 	}

--- a/cmd/zed/load/command.go
+++ b/cmd/zed/load/command.go
@@ -87,10 +87,6 @@ func (c *Command) Run(args []string) error {
 	if head.Pool == "" {
 		return lakeflags.ErrNoHEAD
 	}
-	poolID, err := lake.PoolID(ctx, head.Pool)
-	if err != nil {
-		return err
-	}
 	var d *display.Display
 	if !c.LakeFlags.Quiet && term.IsTerminal(int(os.Stderr.Fd())) {
 		c.ctx = ctx
@@ -99,7 +95,7 @@ func (c *Command) Run(args []string) error {
 		go d.Run()
 	}
 	message := c.commitFlags.CommitMessage()
-	commitID, err := lake.Load(ctx, zctx, poolID, head.Branch, zio.ConcatReader(readers...), message)
+	commitID, err := lake.Load(ctx, zctx, head.Pool, head.Branch, zio.ConcatReader(readers...), message)
 	if d != nil {
 		d.Close()
 	}

--- a/cmd/zed/manage/lakemanage/branch.go
+++ b/cmd/zed/manage/lakemanage/branch.go
@@ -62,7 +62,7 @@ func (b *branch) run(ctx context.Context) error {
 	var vectors int
 	group.Go(func() error {
 		for run := range runCh {
-			commit, err := b.lake.Compact(ctx, b.pool.ID, b.config.Branch, run, b.config.Vectors, api.CommitMessage{})
+			commit, err := b.lake.Compact(ctx, b.pool.ID.String(), b.config.Branch, run, b.config.Vectors, api.CommitMessage{})
 			if err != nil {
 				return err
 			}

--- a/cmd/zed/merge/command.go
+++ b/cmd/zed/merge/command.go
@@ -65,11 +65,7 @@ func (c *Command) Run(args []string) error {
 	if head.Branch == "main" && !c.force {
 		return errors.New("merging the main branch into another branch is unusual; use -f to force")
 	}
-	poolID, err := lake.PoolID(ctx, head.Pool)
-	if err != nil {
-		return err
-	}
-	if _, err = lake.MergeBranch(ctx, poolID, head.Branch, targetBranch, c.commitFlags.CommitMessage()); err != nil {
+	if _, err = lake.MergeBranch(ctx, head.Pool, head.Branch, targetBranch, c.commitFlags.CommitMessage()); err != nil {
 		return err
 	}
 	if !c.LakeFlags.Quiet {

--- a/cmd/zed/rename/command.go
+++ b/cmd/zed/rename/command.go
@@ -44,15 +44,11 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	poolID, err := lake.PoolID(ctx, oldName)
-	if err != nil {
-		return err
-	}
-	if err := lake.RenamePool(ctx, poolID, newName); err != nil {
+	if err := lake.RenamePool(ctx, oldName, newName); err != nil {
 		return err
 	}
 	if !c.LakeFlags.Quiet {
-		fmt.Printf("pool %s renamed from %s to %s\n", poolID, oldName, newName)
+		fmt.Printf("pool renamed from %s to %s\n", oldName, newName)
 	}
 	return nil
 }

--- a/cmd/zed/revert/command.go
+++ b/cmd/zed/revert/command.go
@@ -59,10 +59,6 @@ func (c *Command) Run(args []string) error {
 	if head.Pool == "" {
 		return lakeflags.ErrNoHEAD
 	}
-	poolID, err := lake.PoolID(ctx, head.Pool)
-	if err != nil {
-		return err
-	}
 	if _, err := lakeparse.ParseID(head.Branch); err == nil {
 		return errors.New("branch must be named")
 	}
@@ -70,7 +66,7 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	revertID, err := lake.Revert(ctx, poolID, head.Branch, commitID, c.commitFlags.CommitMessage())
+	revertID, err := lake.Revert(ctx, head.Pool, head.Branch, commitID, c.commitFlags.CommitMessage())
 	if err != nil {
 		return err
 	}

--- a/cmd/zed/use/command.go
+++ b/cmd/zed/use/command.go
@@ -107,14 +107,7 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	poolID, err := lakeparse.ParseID(commitish.Pool)
-	if err != nil {
-		poolID, err = lake.PoolID(ctx, commitish.Pool)
-		if err != nil {
-			return err
-		}
-	}
-	if _, err = lake.CommitObject(ctx, poolID, commitish.Branch); err != nil {
+	if _, err = lake.CommitObject(ctx, commitish.Pool, commitish.Branch); err != nil {
 		return err
 	}
 	if err := poolflags.WriteHead(commitish.Pool, commitish.Branch); err != nil {

--- a/lake/api/api.go
+++ b/lake/api/api.go
@@ -26,22 +26,22 @@ type Interface interface {
 	Query(ctx context.Context, head *lakeparse.Commitish, src string, srcfiles ...string) (zio.ReadCloser, error)
 	QueryWithControl(ctx context.Context, head *lakeparse.Commitish, src string, srcfiles ...string) (zbuf.ProgressReadCloser, error)
 	PoolID(ctx context.Context, poolName string) (ksuid.KSUID, error)
-	CommitObject(ctx context.Context, poolID ksuid.KSUID, branchName string) (ksuid.KSUID, error)
+	CommitObject(ctx context.Context, pool, branchName string) (ksuid.KSUID, error)
 	CreatePool(context.Context, string, order.SortKey, int, int64) (ksuid.KSUID, error)
-	RemovePool(context.Context, ksuid.KSUID) error
-	RenamePool(context.Context, ksuid.KSUID, string) error
-	CreateBranch(ctx context.Context, pool ksuid.KSUID, name string, parent ksuid.KSUID) error
-	RemoveBranch(ctx context.Context, pool ksuid.KSUID, branchName string) error
-	MergeBranch(ctx context.Context, pool ksuid.KSUID, childBranch, parentBranch string, message api.CommitMessage) (ksuid.KSUID, error)
-	Compact(ctx context.Context, pool ksuid.KSUID, branch string, objects []ksuid.KSUID, writeVectors bool, message api.CommitMessage) (ksuid.KSUID, error)
-	Load(ctx context.Context, zctx *zed.Context, pool ksuid.KSUID, branch string, r zio.Reader, message api.CommitMessage) (ksuid.KSUID, error)
-	Delete(ctx context.Context, poolID ksuid.KSUID, branchName string, tags []ksuid.KSUID, message api.CommitMessage) (ksuid.KSUID, error)
-	DeleteWhere(ctx context.Context, poolID ksuid.KSUID, branchName, src string, commit api.CommitMessage) (ksuid.KSUID, error)
-	Revert(ctx context.Context, poolID ksuid.KSUID, branch string, commitID ksuid.KSUID, commit api.CommitMessage) (ksuid.KSUID, error)
+	RemovePool(ctx context.Context, pool string) error
+	RenamePool(context.Context, string, string) error
+	CreateBranch(ctx context.Context, pool, name string, parent ksuid.KSUID) error
+	RemoveBranch(ctx context.Context, pool, branchName string) error
+	MergeBranch(ctx context.Context, pool, childBranch, parentBranch string, message api.CommitMessage) (ksuid.KSUID, error)
+	Compact(ctx context.Context, pool, branch string, objects []ksuid.KSUID, writeVectors bool, message api.CommitMessage) (ksuid.KSUID, error)
+	Load(ctx context.Context, zctx *zed.Context, pool string, branch string, r zio.Reader, message api.CommitMessage) (ksuid.KSUID, error)
+	Delete(ctx context.Context, pool, branchName string, tags []ksuid.KSUID, message api.CommitMessage) (ksuid.KSUID, error)
+	DeleteWhere(ctx context.Context, pool, branchName, src string, commit api.CommitMessage) (ksuid.KSUID, error)
+	Revert(ctx context.Context, pool, branch string, commitID ksuid.KSUID, commit api.CommitMessage) (ksuid.KSUID, error)
 	AddIndexRules(context.Context, []index.Rule) error
 	DeleteIndexRules(context.Context, []ksuid.KSUID) ([]index.Rule, error)
-	ApplyIndexRules(ctx context.Context, rules []string, pool ksuid.KSUID, branchName string, ids []ksuid.KSUID) (ksuid.KSUID, error)
-	UpdateIndex(ctx context.Context, names []string, pool ksuid.KSUID, branchName string) (ksuid.KSUID, error)
+	ApplyIndexRules(ctx context.Context, rules []string, pool, branchName string, ids []ksuid.KSUID) (ksuid.KSUID, error)
+	UpdateIndex(ctx context.Context, names []string, pool, branchName string) (ksuid.KSUID, error)
 	AddVectors(ctx context.Context, pool, revision string, objects []ksuid.KSUID, message api.CommitMessage) (ksuid.KSUID, error)
 	DeleteVectors(ctx context.Context, pool, revision string, objects []ksuid.KSUID, message api.CommitMessage) (ksuid.KSUID, error)
 	Vacuum(ctx context.Context, pool, revision string, dryrun bool) ([]ksuid.KSUID, error)

--- a/lake/root.go
+++ b/lake/root.go
@@ -246,16 +246,11 @@ func (r *Root) PoolID(ctx context.Context, poolName string) (ksuid.KSUID, error)
 	if poolName == "" {
 		return ksuid.Nil, errors.New("no pool name given")
 	}
-	poolID, err := ksuid.Parse(poolName)
-	var poolRef *pools.Config
-	if err != nil {
-		poolRef = r.pools.LookupByName(ctx, poolName)
-		if poolRef == nil {
-			return ksuid.Nil, fmt.Errorf("%s: %w", poolName, pools.ErrNotFound)
-		}
-		poolID = poolRef.ID
+	poolRef := r.pools.LookupByName(ctx, poolName)
+	if poolRef == nil {
+		return ksuid.Nil, fmt.Errorf("%s: %w", poolName, pools.ErrNotFound)
 	}
-	return poolID, nil
+	return poolRef.ID, nil
 }
 
 func (r *Root) CommitObject(ctx context.Context, poolID ksuid.KSUID, branchName string) (ksuid.KSUID, error) {

--- a/lake/ztests/create-ksuid-name.yaml
+++ b/lake/ztests/create-ksuid-name.yaml
@@ -1,0 +1,12 @@
+# This test that a pool can be given a ksuid name and everything still works.
+script: |
+  export ZED_LAKE=test
+  zed init -q
+  zed create 2WwyVrZdEITo5WkKu1YsJC4dMjU
+  zed use 2WwyVrZdEITo5WkKu1YsJC4dMjU
+
+outputs:
+  - name: stdout
+    regexp: |
+      pool created: 2WwyVrZdEITo5WkKu1YsJC4dMjU \w{27}
+      Switched to branch "main" on pool "2WwyVrZdEITo5WkKu1YsJC4dMjU"

--- a/lake/ztests/rename.yaml
+++ b/lake/ztests/rename.yaml
@@ -15,7 +15,7 @@ script: |
 outputs:
   - name: stdout
     regexp: |
-      pool \w{27} renamed from p2 to p3
+      pool renamed from p2 to p3
       ===
       p1 \w{27} key ts order desc
       p3 \w{27} key ts order desc

--- a/service/client_test.go
+++ b/service/client_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/brimdata/zed/api/client"
 	"github.com/brimdata/zed/lake"
 	lakeapi "github.com/brimdata/zed/lake/api"
-	"github.com/brimdata/zed/lake/branches"
 	"github.com/brimdata/zed/lake/pools"
 	"github.com/brimdata/zed/runtime/exec"
 	"github.com/brimdata/zed/zio"
@@ -27,8 +26,8 @@ type testClient struct {
 	*client.Connection
 }
 
-func (c *testClient) TestPoolStats(id ksuid.KSUID) exec.PoolStats {
-	r, err := c.Connection.PoolStats(context.Background(), id)
+func (c *testClient) TestPoolStats(pool string) exec.PoolStats {
+	r, err := c.Connection.PoolStats(context.Background(), pool)
 	require.NoError(c, err)
 	return r
 }
@@ -73,10 +72,9 @@ func (c *testClient) TestPoolPost(payload api.PoolPostRequest) ksuid.KSUID {
 	return r.Pool.ID
 }
 
-func (c *testClient) TestBranchPost(poolID ksuid.KSUID, payload api.BranchPostRequest) branches.Config {
-	r, err := c.Connection.CreateBranch(context.Background(), poolID, payload)
+func (c *testClient) TestBranchPost(pool string, payload api.BranchPostRequest) {
+	err := c.Connection.CreateBranch(context.Background(), pool, payload)
 	require.NoError(c, err)
-	return r
 }
 
 func (c *testClient) TestQuery(query string) string {
@@ -91,8 +89,8 @@ func (c *testClient) TestQuery(query string) string {
 	return buf.String()
 }
 
-func (c *testClient) TestLoad(poolID ksuid.KSUID, branchName string, r io.Reader) ksuid.KSUID {
-	commit, err := c.Connection.Load(context.Background(), poolID, branchName, "", r, api.CommitMessage{})
+func (c *testClient) TestLoad(pool, branchName string, r io.Reader) ksuid.KSUID {
+	commit, err := c.Connection.Load(context.Background(), pool, branchName, "", r, api.CommitMessage{})
 	require.NoError(c, err)
 	return commit.Commit
 }

--- a/service/ztests/create-ksuid-name.yaml
+++ b/service/ztests/create-ksuid-name.yaml
@@ -1,0 +1,14 @@
+# This test that a pool can be given a ksuid name and everything still works.
+script: |
+  source service.sh
+  zed create 2WwyVrZdEITo5WkKu1YsJC4dMjU
+  zed use 2WwyVrZdEITo5WkKu1YsJC4dMjU
+
+inputs:
+  - name: service.sh
+
+outputs:
+  - name: stdout
+    regexp: |
+      pool created: 2WwyVrZdEITo5WkKu1YsJC4dMjU \w{27}
+      Switched to branch "main" on pool "2WwyVrZdEITo5WkKu1YsJC4dMjU"

--- a/service/ztests/drop.yaml
+++ b/service/ztests/drop.yaml
@@ -7,8 +7,8 @@ script: |
   echo === | tee /dev/stderr
   zed ls -f zng | zq -z "cut name | sort name" -
   echo === | tee /dev/stderr
-  ! zed drop p3
-  ! zed drop -lake http://127.0.0.1:1 p3
+  ! zed drop -f p3
+  ! zed drop -f -lake http://127.0.0.1:1 p3
 
 inputs:
   - name: service.sh
@@ -26,5 +26,5 @@ outputs:
     data: |
       ===
       ===
-      "p3": pool not found
-      Post "http://127.0.0.1:1/query?ctrl=T": dial tcp 127.0.0.1:1: connect: connection refused
+      pool not found
+      Delete "http://127.0.0.1:1/pool/p3": dial tcp 127.0.0.1:1: connect: connection refused


### PR DESCRIPTION
This commit changes the lakeapi to use the pool name (which call also be the string version of the pool ID) over requiring the pool id when operating on a given pool. Apart from reducing the amount of requests needed when operating on a remote lake, this also allows for users to create a pool with ksuid name with Zed knowing how to resolve this correctly.

Closes #4431