### PR TITLE
Remove zed.EncodeError and zed.DecodeError

### DIFF
--- a/complex.go
+++ b/complex.go
@@ -39,17 +39,6 @@ var ErrMissing = errors.New("missing")
 var Missing = zcode.Bytes("missing")
 var Quiet = zcode.Bytes("quiet")
 
-func EncodeError(err error) zcode.Bytes {
-	return zcode.Bytes(err.Error())
-}
-
-func DecodeError(zv zcode.Bytes) error {
-	if zv == nil {
-		return nil
-	}
-	return errors.New(string(zv))
-}
-
 type TypeError struct {
 	id   int
 	Type Type


### PR DESCRIPTION
These functions have been incorrect since structured errors were added to Zed in #3458, allowing a Zed error to contain an arbitrary value rather than just a string.