### PR TITLE
Replace zed.Value.bytes slice with base and len

### DIFF
--- a/complex.go
+++ b/complex.go
@@ -120,7 +120,7 @@ func (t *TypeMap) Decode(zv zcode.Bytes) (Value, Value, error) {
 		return Value{}, Value{}, nil
 	}
 	it := zv.Iter()
-	return Value{t.KeyType, it.Next()}, Value{t.ValType, it.Next()}, nil
+	return *NewValue(t.KeyType, it.Next()), *NewValue(t.ValType, it.Next()), nil
 }
 
 type keyval struct {

--- a/context.go
+++ b/context.go
@@ -341,7 +341,7 @@ func (c *Context) LookupTypeValue(typ Type) *Value {
 	bytes, ok := c.toValue[typ]
 	c.mu.Unlock()
 	if ok {
-		return &Value{TypeType, bytes}
+		return NewValue(TypeType, bytes)
 	}
 	// In general, this shouldn't happen except for a foreign
 	// type that wasn't initially created in this context.
@@ -535,11 +535,11 @@ func (c *Context) Quiet() *Value {
 // batch/allocator should handle these?
 
 func (c *Context) NewErrorf(format string, args ...interface{}) *Value {
-	return &Value{c.StringTypeError(), zcode.Bytes(fmt.Sprintf(format, args...))}
+	return NewValue(c.StringTypeError(), fmt.Appendf(nil, format, args...))
 }
 
 func (c *Context) NewError(err error) *Value {
-	return &Value{c.StringTypeError(), zcode.Bytes(err.Error())}
+	return NewValue(c.StringTypeError(), []byte(err.Error()))
 }
 
 func (c *Context) StringTypeError() *TypeError {
@@ -558,5 +558,5 @@ func (c *Context) WrapError(msg string, val *Value) *Value {
 	var b zcode.Builder
 	b.Append(EncodeString(msg))
 	b.Append(val.Bytes())
-	return &Value{errType, b.Bytes()}
+	return NewValue(errType, b.Bytes())
 }

--- a/vng/ztests/no-dict.yaml
+++ b/vng/ztests/no-dict.yaml
@@ -5,4 +5,4 @@ script: |
 outputs:
   - name: stdout
     data: |
-      null ([DictEntry={Value:{Type:null,bytes:Bytes=bytes},Count:uint32}])
+      null ([DictEntry={Value:{Type:null,base:uint8,len:uint64},Count:uint32}])

--- a/zbuf/array_test.go
+++ b/zbuf/array_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestArrayWriteCopiesValueBytes(t *testing.T) {
 	var a Array
-	val := zed.NewString("old")
+	val := zed.NewBytes([]byte{0})
 	a.Write(val)
-	copy(val.Bytes(), zed.EncodeString("new"))
-	require.Equal(t, zed.NewString("old"), &a.Values()[0])
+	copy(val.Bytes(), zed.EncodeBytes([]byte{1}))
+	require.Equal(t, zed.NewBytes([]byte{0}), &a.Values()[0])
 }


### PR DESCRIPTION
A zed.Value occupies five words: two for the Type field (an interface) and three for the bytes field (a slice).  Since the slice capacity field is rarely used (only in Value.CopyFrom), shrink Values to four words by replacing the bytes field with base (a pointer) and len (a uint64) fields.  This can reduce maximum RSS by 1.4x when sorting a large input or loading a large input into a lake.