### PR TITLE
Remove "Limitations" section from docs about User Ops

### DIFF
--- a/docs/language/statements.md
+++ b/docs/language/statements.md
@@ -203,17 +203,6 @@ One caveat with nested calls is that calls to other user-defined operators must
 not produce a cycle, i.e., recursive and mutually recursive operators are not
 allowed and will produce an error.
 
-### Limitations
-
-User-defined operators are a new feature in Zed that has been made available
-despite known limitations described in open issues
-[zed/4692](https://github.com/brimdata/zed/issues/4692) and
-[zed/4701](https://github.com/brimdata/zed/issues/4701). If you encounter
-these or other problems when making use of the feature please comment on the
-issues or come talk to us on the [Brim community Slack](https://www.brimdata.io/join-slack/)
-as this will help guide the priority with which these limitations are
-addressed.
-
 ## Type Statements
 
 Named types may be created with the syntax


### PR DESCRIPTION
I'd added this "Limitations" section back when we first released User Ops. I don't make a general habit of trying to disclose all the known bugs in the docs, but at the time it felt we were walking a fine line where it was a good feature if users knew the handful of limitations and stayed within the lines. There were enough of these limitations that I felt it irresponsible to ask users to try the feature without disclosing those gotchas.

Well, over the past couple months @mattnibs has been squashing the bugs one by one and I've been whittling away at the bugs listed in this section after each fix lands. With #4701 now having been verified as fixed, almost all the known limitations have been addressed, so I'm in favor of dropping the section entirely. It does leave us with remaining issue #4692 I'd bumped into at one point, but it's a bit more of a corner case, so I'm happy to revert to the norm.