### PR TITLE
Fix NaN handling in expr.LookupCompare

### DIFF
--- a/runtime/expr/sort.go
+++ b/runtime/expr/sort.go
@@ -349,9 +349,10 @@ func LookupCompare(typ zed.Type) comparefn {
 	case zed.IDFloat16, zed.IDFloat32, zed.IDFloat64:
 		return func(a, b zcode.Bytes) int {
 			va, vb := zed.DecodeFloat(a), zed.DecodeFloat(b)
-			if va < vb {
+			aNaN, bNaN := math.IsNaN(va), math.IsNaN(vb)
+			if va < vb || aNaN && !bNaN {
 				return -1
-			} else if va > vb {
+			} else if va > vb || bNaN && !aNaN {
 				return 1
 			}
 			return 0

--- a/runtime/expr/sort.go
+++ b/runtime/expr/sort.go
@@ -350,9 +350,18 @@ func LookupCompare(typ zed.Type) comparefn {
 		return func(a, b zcode.Bytes) int {
 			va, vb := zed.DecodeFloat(a), zed.DecodeFloat(b)
 			aNaN, bNaN := math.IsNaN(va), math.IsNaN(vb)
-			if va < vb || aNaN && !bNaN {
+			if aNaN && bNaN {
+				// Order different NaNs so ZNG sets have a canonical form.
+				aBits, bBits := math.Float64bits(va), math.Float64bits(vb)
+				if aBits < bBits {
+					return -1
+				} else if aBits > bBits {
+					return 1
+				}
+				return 0
+			} else if aNaN || va < vb {
 				return -1
-			} else if va > vb || bNaN && !aNaN {
+			} else if bNaN || va > vb {
 				return 1
 			}
 			return 0

--- a/runtime/op/sort/ztests/numbers.yaml
+++ b/runtime/op/sort/ztests/numbers.yaml
@@ -11,8 +11,13 @@ input: |
   32.32(float32)
   -64.64
   64.64
+  -Inf
+  +Inf
+  NaN
 
 output: |
+  NaN
+  -Inf
   -64.64
   -64
   -32.32(float32)
@@ -23,3 +28,4 @@ output: |
   32.32(float32)
   64(uint64)
   64.64
+  +Inf


### PR DESCRIPTION
LookupCompare fails to account for the fact that a floating-point NaN is neither less than, greater than, nor equal to itself or any other floating-point value, leading to unexpected results from the sort operator and other parts of the system that compare values.  A common approach to this quirk is to consider NaN to be equal to itself and either less than or greater than all other floating-point values.  Apply this approach with NaN considered less than all other values, in keeping with the Go standard library.