### PR TITLE
Resolve named type ordering ambiguities

### DIFF
--- a/docs/formats/zed.md
+++ b/docs/formats/zed.md
@@ -215,7 +215,10 @@ For example, if "port" is a named type for `uint16`, then two values of
 type "port" have the same type but a value of type "port" and a value of type `uint16`
 do not have the same type.
 
-The type order of two named types is the type order of their underlying types.
+The type order of a named type is the type order of its underlying type with two
+exceptions:
+* A named type is ordered after its underlying type.
+* Named types sharing an underlying type are ordered lexicographically by name.
 
 > While the Zed data model does not include explicit support for schema versioning,
 > named types provide a flexible mechanism to implement versioning

--- a/runtime/expr/shaper_test.go
+++ b/runtime/expr/shaper_test.go
@@ -47,5 +47,5 @@ func TestBestUnionTag(t *testing.T) {
 
 	// Type compatible with needle is in haystack.
 	test(u8named1, u8, []zed.Type{u8named1, u8named2, u8named3})
-	test(u8named3, u8named1, []zed.Type{u8named3, u8named2})
+	test(u8named2, u8named1, []zed.Type{u8named3, u8named2})
 }

--- a/runtime/expr/ztests/shape-crop-null.yaml
+++ b/runtime/expr/ztests/shape-crop-null.yaml
@@ -5,6 +5,6 @@ input: &input |
   {f:[1(=int64_named)](=array_named)}(=array_record_named)
   {f:{g:1(=int64_named)}(=record_named)}(=record_record_named)
   {f:|[1(=int64_named)]|(=set_named)}(=set_record_named)
-  {f:1(=int64_named)(union_named=(int64_named,int64))}(=union_record_named)
+  {f:1(=int64_named)(union_named=(int64,int64_named))}(=union_record_named)
 
 output: *input

--- a/runtime/expr/ztests/shape-fill-null.yaml
+++ b/runtime/expr/ztests/shape-fill-null.yaml
@@ -5,6 +5,6 @@ input: &input |
   {f:[1(=int64_named)](=array_named)}(=array_record_named)
   {f:{g:1(=int64_named)}(=record_named)}(=record_record_named)
   {f:|[1(=int64_named)]|(=set_named)}(=set_record_named)
-  {f:1(=int64_named)(union_named=(int64_named,int64))}(=union_record_named)
+  {f:1(=int64_named)(union_named=(int64,int64_named))}(=union_record_named)
 
 output: *input

--- a/runtime/expr/ztests/shape-order-null.yaml
+++ b/runtime/expr/ztests/shape-order-null.yaml
@@ -5,6 +5,6 @@ input: &input |
   {f:[1(=int64_named)](=array_named)}(=array_record_named)
   {f:{g:1(=int64_named)}(=record_named)}(=record_record_named)
   {f:|[1(=int64_named)]|(=set_named)}(=set_record_named)
-  {f:1(=int64_named)(union_named=(int64_named,int64))}(=union_record_named)
+  {f:1(=int64_named)(union_named=(int64,int64_named))}(=union_record_named)
 
 output: *input

--- a/runtime/op/sort/ztests/sort-types.yaml
+++ b/runtime/op/sort/ztests/sort-types.yaml
@@ -18,7 +18,9 @@ input: |
   <{x:int64,y:int64}>
   <{x:string}>
   <{x:uint16}>
-  <named=type>
+  <named2=type>
+  <type>
+  <named1=type>
   <float64>
   <uint16>
   <uint64>
@@ -58,7 +60,9 @@ output: |
   <string>
   <ip>
   <net>
-  <named=type>
+  <type>
+  <named1=type>
+  <named2=type>
   <null>
   <{x:uint16}>
   <{x:string}>

--- a/type.go
+++ b/type.go
@@ -393,13 +393,30 @@ func UniqueTypes(types []Type) []Type {
 }
 
 func CompareTypes(a, b Type) int {
-	a, b = TypeUnder(a), TypeUnder(b)
+	aID, bID := a.ID(), b.ID()
+	if aID == bID {
+		if a, ok := a.(*TypeNamed); ok {
+			if b, ok := b.(*TypeNamed); ok {
+				// Named types sharing an underlying type are
+				// ordered by name.
+				return strings.Compare(a.Name, b.Name)
+			}
+			// Named type a is ordered after its underlying type b.
+			return 1
+		}
+		if _, ok := b.(*TypeNamed); ok {
+			// Named type b is ordered after its underlying type a.
+			return -1
+		}
+		// a == b
+		return 0
+	}
 	if cmp := compareInts(int(a.Kind()), int(b.Kind())); cmp != 0 {
 		return cmp
 	}
 	switch a.Kind() {
 	case PrimitiveKind:
-		return compareInts(a.ID(), b.ID())
+		return compareInts(aID, bID)
 	case RecordKind:
 		ra, rb := TypeRecordOf(a), TypeRecordOf(b)
 		// First compare number of fields.


### PR DESCRIPTION
The Zed data model specifies a total order on types, implemented in zed.CompareTypes.  Neither the specification nor the implementation covers the order of a named type relative to its underlying type or to another named type with the same underlying type.  These ambiguities can produce unexpected behavior when constructing unions or sorting types. Resolve them by updating the specification and implementation as follows:

* A named type is ordered after its underlying type.

* Named types sharing an underlying type are ordered lexicographically by name.