### PR TITLE
improve zio/vngio.Writer constructor ergonomics

### DIFF
--- a/api/queryio/writer.go
+++ b/api/queryio/writer.go
@@ -10,7 +10,6 @@ import (
 	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zio/anyio"
 	"github.com/brimdata/zed/zio/jsonio"
-	"github.com/brimdata/zed/zio/vngio"
 )
 
 type controlWriter interface {
@@ -47,10 +46,6 @@ func NewWriter(w io.WriteCloser, format string, flusher http.Flusher, ctrl bool)
 	default:
 		d.writer, err = anyio.NewWriter(zio.NopCloser(w), anyio.WriterOpts{
 			Format: format,
-			VNG: vngio.WriterOpts{
-				ColumnThresh: vngio.DefaultColumnThresh,
-				SkewThresh:   vngio.DefaultSkewThresh,
-			},
 		})
 	}
 	return d, err

--- a/cli/outputflags/flags.go
+++ b/cli/outputflags/flags.go
@@ -42,6 +42,12 @@ func (f *Flags) Options() anyio.WriterOpts {
 func (f *Flags) setFlags(fs *flag.FlagSet) {
 	// zio stuff
 	fs.BoolVar(&f.color, "color", true, "enable/disable color formatting for -Z and lake text output")
+	f.VNG = &vngio.WriterOpts{
+		ColumnThresh: vngio.DefaultColumnThresh,
+		SkewThresh:   vngio.DefaultSkewThresh,
+	}
+	fs.Var(&f.VNG.ColumnThresh, "vng.colthresh", "minimum VNG frame size")
+	fs.Var(&f.VNG.SkewThresh, "vng.skewthresh", "minimum VNG skew size")
 	f.ZNG = &zngio.WriterOpts{}
 	fs.BoolVar(&f.ZNG.Compress, "zng.compress", true, "compress ZNG frames")
 	fs.IntVar(&f.ZNG.FrameThresh, "zng.framethresh", zngio.DefaultFrameThresh,
@@ -50,10 +56,6 @@ func (f *Flags) setFlags(fs *flag.FlagSet) {
 		"tab size to pretty print ZSON output (0 for newline-delimited ZSON")
 	fs.StringVar(&f.zsonPersist, "persist", "",
 		"regular expression to persist type definitions across the stream")
-	f.VNG.ColumnThresh = vngio.DefaultColumnThresh
-	fs.Var(&f.VNG.ColumnThresh, "vng.colthresh", "minimum frame size (MiB) used for VNG columns")
-	f.VNG.SkewThresh = vngio.DefaultSkewThresh
-	fs.Var(&f.VNG.SkewThresh, "vng.skewthresh", "minimum skew size (MiB) used to group VNG columns")
 
 	// emitter stuff
 	fs.StringVar(&f.split, "split", "",

--- a/lake/data/vector.go
+++ b/lake/data/vector.go
@@ -67,10 +67,7 @@ func NewVectorWriter(ctx context.Context, engine storage.Engine, path *storage.U
 	delete := func() {
 		DeleteVector(context.Background(), engine, path, id)
 	}
-	writer, err := vngio.NewWriter(bufwriter.New(put), vngio.WriterOpts{
-		ColumnThresh: vngio.DefaultColumnThresh,
-		SkewThresh:   vngio.DefaultSkewThresh,
-	})
+	writer, err := vngio.NewWriter(bufwriter.New(put))
 	if err != nil {
 		delete()
 		return nil, err

--- a/zio/anyio/writer.go
+++ b/zio/anyio/writer.go
@@ -23,7 +23,7 @@ import (
 type WriterOpts struct {
 	Format string
 	Lake   lakeio.WriterOpts
-	VNG    vngio.WriterOpts
+	VNG    *vngio.WriterOpts
 	ZNG    *zngio.WriterOpts // Nil means use defaults via zngio.NewWriter.
 	ZSON   zsonio.WriterOpts
 }
@@ -47,7 +47,10 @@ func NewWriter(w io.WriteCloser, opts WriterOpts) (zio.WriteCloser, error) {
 	case "text":
 		return textio.NewWriter(w), nil
 	case "vng":
-		return vngio.NewWriter(w, opts.VNG)
+		if opts.VNG == nil {
+			return vngio.NewWriter(w)
+		}
+		return vngio.NewWriterWithOpts(w, *opts.VNG)
 	case "zeek":
 		return zeekio.NewWriter(w), nil
 	case "zjson":

--- a/zio/anyio/writer.go
+++ b/zio/anyio/writer.go
@@ -23,7 +23,7 @@ import (
 type WriterOpts struct {
 	Format string
 	Lake   lakeio.WriterOpts
-	VNG    *vngio.WriterOpts
+	VNG    *vngio.WriterOpts // Nil means use defaults via vngio.NewWriter.
 	ZNG    *zngio.WriterOpts // Nil means use defaults via zngio.NewWriter.
 	ZSON   zsonio.WriterOpts
 }

--- a/zio/vngio/writer.go
+++ b/zio/vngio/writer.go
@@ -17,6 +17,14 @@ type WriterOpts struct {
 	SkewThresh   units.Bytes
 }
 
-func NewWriter(w io.WriteCloser, opts WriterOpts) (*vng.Writer, error) {
+// NewWriter returns a writer to w with reasonable default options.
+func NewWriter(w io.WriteCloser) (*vng.Writer, error) {
+	return NewWriterWithOpts(w, WriterOpts{
+		ColumnThresh: DefaultColumnThresh,
+		SkewThresh:   DefaultSkewThresh,
+	})
+}
+
+func NewWriterWithOpts(w io.WriteCloser, opts WriterOpts) (*vng.Writer, error) {
 	return vng.NewWriter(w, int(opts.SkewThresh), int(opts.ColumnThresh))
 }


### PR DESCRIPTION
Creating a zio/vngio.Writer with reasonable default options is cumbersome.  Make it easier by renaming the current constructor, NewWriter, to NewWriterWithOpts and adding a new version of NewWriter that calls NewWriterWithOpts with reasonable default options.  (This is the model used in zio/zngio.)