### PR TITLE
Vector perf improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/brimdata/zed
 go 1.20
 
 require (
-	github.com/RoaringBitmap/roaring v1.6.0
 	github.com/agnivade/levenshtein v1.1.1
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d
 	github.com/apache/arrow/go/v12 v12.0.0-20230403164247-0e1f5c6c2ce7
@@ -46,7 +45,6 @@ require (
 	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/apache/thrift v0.16.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/bits-and-blooms/bitset v1.2.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc // indirect
@@ -64,7 +62,6 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 // indirect
 	github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 // indirect
-	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/rivo/uniseg v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,6 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c h1:RGWPOewvKIROun94nF7v2cua9qP+thov/7M50KEoeSU=
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/RoaringBitmap/roaring v1.6.0 h1:dc7kRiroETgJcHhWX6BerXkZz2b3JgLGg9nTURJL/og=
-github.com/RoaringBitmap/roaring v1.6.0/go.mod h1:plvDsJQpxOC5bw8LRteu/MLWHsHez/3y6cubLI4/1yE=
 github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=
 github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -66,8 +64,6 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/bits-and-blooms/bitset v1.2.0 h1:Kn4yilvwNtMACtf1eYDlG8H77R07mZSPbMjLyS07ChA=
-github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -237,8 +233,6 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/mschoch/smat v0.2.0 h1:8imxQsjDm8yFEAVBe7azKmKSgzSkZXDuKkSq9374khM=
-github.com/mschoch/smat v0.2.0/go.mod h1:kc9mz7DoBKqDyiRL7VZN8KvXQMWeTaVnttLRXOlotKw=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=

--- a/vector/materializer.go
+++ b/vector/materializer.go
@@ -100,10 +100,34 @@ func (v *float64s) newMaterializer() materializer {
 	}
 }
 
-func (v *ints) newMaterializer() materializer {
+func (v *int8s) newMaterializer() materializer {
 	var index int
 	return func(builder *zcode.Builder) {
-		builder.Append(zed.EncodeInt(v.values[index]))
+		builder.Append(zed.EncodeInt(int64(v.values[index])))
+		index++
+	}
+}
+
+func (v *int16s) newMaterializer() materializer {
+	var index int
+	return func(builder *zcode.Builder) {
+		builder.Append(zed.EncodeInt(int64(v.values[index])))
+		index++
+	}
+}
+
+func (v *int32s) newMaterializer() materializer {
+	var index int
+	return func(builder *zcode.Builder) {
+		builder.Append(zed.EncodeInt(int64(v.values[index])))
+		index++
+	}
+}
+
+func (v *int64s) newMaterializer() materializer {
+	var index int
+	return func(builder *zcode.Builder) {
+		builder.Append(zed.EncodeInt(int64(v.values[index])))
 		index++
 	}
 }
@@ -149,10 +173,34 @@ func (v *times) newMaterializer() materializer {
 	}
 }
 
-func (v *uints) newMaterializer() materializer {
+func (v *uint8s) newMaterializer() materializer {
 	var index int
 	return func(builder *zcode.Builder) {
-		builder.Append(zed.EncodeUint(v.values[index]))
+		builder.Append(zed.EncodeUint(uint64(v.values[index])))
+		index++
+	}
+}
+
+func (v *uint16s) newMaterializer() materializer {
+	var index int
+	return func(builder *zcode.Builder) {
+		builder.Append(zed.EncodeUint(uint64(v.values[index])))
+		index++
+	}
+}
+
+func (v *uint32s) newMaterializer() materializer {
+	var index int
+	return func(builder *zcode.Builder) {
+		builder.Append(zed.EncodeUint(uint64(v.values[index])))
+		index++
+	}
+}
+
+func (v *uint64s) newMaterializer() materializer {
+	var index int
+	return func(builder *zcode.Builder) {
+		builder.Append(zed.EncodeUint(uint64(v.values[index])))
 		index++
 	}
 }

--- a/vector/materializer.go
+++ b/vector/materializer.go
@@ -194,15 +194,22 @@ func (v *maps) newMaterializer() materializer {
 }
 
 func (v *nulls) newMaterializer() materializer {
-	var index int
+	var runIndex int
+	var run int64
+	isNull := true
 	valueMaterializer := v.values.newMaterializer()
 	return func(builder *zcode.Builder) {
-		if v.mask.ContainsInt(index) {
-			valueMaterializer(builder)
-		} else {
-			builder.Append(nil)
+		for run == 0 {
+			isNull = !isNull
+			run = v.runs[runIndex]
+			runIndex++
 		}
-		index++
+		if isNull {
+			builder.Append(nil)
+		} else {
+			valueMaterializer(builder)
+		}
+		run--
 	}
 }
 

--- a/vector/materializer.go
+++ b/vector/materializer.go
@@ -62,7 +62,8 @@ func (v *bools) newMaterializer() materializer {
 func (v *byteses) newMaterializer() materializer {
 	var index int
 	return func(builder *zcode.Builder) {
-		builder.Append(zed.EncodeBytes(v.values[index]))
+		data := v.data[v.offsets[index]:v.offsets[index+1]]
+		builder.Append(zed.EncodeBytes(data))
 		index++
 	}
 }
@@ -126,7 +127,8 @@ func (v *nets) newMaterializer() materializer {
 func (v *strings) newMaterializer() materializer {
 	var index int
 	return func(builder *zcode.Builder) {
-		builder.Append(zed.EncodeString(v.values[index]))
+		data := v.data[v.offsets[index]:v.offsets[index+1]]
+		builder.Append(zed.EncodeBytes(data))
 		index++
 	}
 }

--- a/vector/read.go
+++ b/vector/read.go
@@ -175,7 +175,9 @@ func readPrimitive(context *zed.Context, typ zed.Type, readBytes func() ([]byte,
 		return vector, nil
 
 	case zed.TypeBytes:
-		values := make([][]byte, 0)
+		data := bytes.NewBuffer(nil)
+		offsets := make([]int, 1)
+		offsets[0] = 0
 		for {
 			bs, err := readBytes()
 			if err != nil {
@@ -185,10 +187,13 @@ func readPrimitive(context *zed.Context, typ zed.Type, readBytes func() ([]byte,
 					return nil, err
 				}
 			}
-			values = append(values, zed.DecodeBytes(bytes.Clone(bs)))
+			data.Write(zed.DecodeBytes(bs))
+			offsets = append(offsets, data.Len())
 		}
 		vector := &byteses{
-			values: values,
+			data: data.Bytes(),
+			// TODO truncate offsets
+			offsets: offsets,
 		}
 		return vector, nil
 
@@ -319,7 +324,9 @@ func readPrimitive(context *zed.Context, typ zed.Type, readBytes func() ([]byte,
 		return vector, nil
 
 	case zed.TypeString:
-		values := make([]string, 0)
+		data := bytes.NewBuffer(nil)
+		offsets := make([]int, 1)
+		offsets[0] = 0
 		for {
 			bs, err := readBytes()
 			if err != nil {
@@ -329,10 +336,13 @@ func readPrimitive(context *zed.Context, typ zed.Type, readBytes func() ([]byte,
 					return nil, err
 				}
 			}
-			values = append(values, zed.DecodeString(bytes.Clone(bs)))
+			data.Write(zed.DecodeBytes(bs))
+			offsets = append(offsets, data.Len())
 		}
 		vector := &strings{
-			values: values,
+			data: data.Bytes(),
+			// TODO truncate offsets
+			offsets: offsets,
 		}
 		return vector, nil
 

--- a/vector/read.go
+++ b/vector/read.go
@@ -176,8 +176,7 @@ func readPrimitive(context *zed.Context, typ zed.Type, readBytes func() ([]byte,
 
 	case zed.TypeBytes:
 		data := bytes.NewBuffer(nil)
-		offsets := make([]int, 1)
-		offsets[0] = 0
+		offsets := []int{0}
 		for {
 			bs, err := readBytes()
 			if err != nil {

--- a/vector/read.go
+++ b/vector/read.go
@@ -269,7 +269,61 @@ func readPrimitive(context *zed.Context, typ zed.Type, readBytes func() ([]byte,
 		}
 		return vector, nil
 
-	case zed.TypeInt8, zed.TypeInt16, zed.TypeInt32, zed.TypeInt64:
+	case zed.TypeInt8:
+		values := make([]int8, 0)
+		for {
+			bs, err := readBytes()
+			if err != nil {
+				if err == io.EOF {
+					break
+				} else {
+					return nil, err
+				}
+			}
+			values = append(values, int8(zed.DecodeInt(bs)))
+		}
+		vector := &int8s{
+			values: values,
+		}
+		return vector, nil
+
+	case zed.TypeInt16:
+		values := make([]int16, 0)
+		for {
+			bs, err := readBytes()
+			if err != nil {
+				if err == io.EOF {
+					break
+				} else {
+					return nil, err
+				}
+			}
+			values = append(values, int16(zed.DecodeInt(bs)))
+		}
+		vector := &int16s{
+			values: values,
+		}
+		return vector, nil
+
+	case zed.TypeInt32:
+		values := make([]int32, 0)
+		for {
+			bs, err := readBytes()
+			if err != nil {
+				if err == io.EOF {
+					break
+				} else {
+					return nil, err
+				}
+			}
+			values = append(values, int32(zed.DecodeInt(bs)))
+		}
+		vector := &int32s{
+			values: values,
+		}
+		return vector, nil
+
+	case zed.TypeInt64:
 		values := make([]int64, 0)
 		for {
 			bs, err := readBytes()
@@ -280,9 +334,9 @@ func readPrimitive(context *zed.Context, typ zed.Type, readBytes func() ([]byte,
 					return nil, err
 				}
 			}
-			values = append(values, zed.DecodeInt(bs))
+			values = append(values, int64(zed.DecodeInt(bs)))
 		}
-		vector := &ints{
+		vector := &int64s{
 			values: values,
 		}
 		return vector, nil
@@ -364,7 +418,61 @@ func readPrimitive(context *zed.Context, typ zed.Type, readBytes func() ([]byte,
 		}
 		return vector, nil
 
-	case zed.TypeUint8, zed.TypeUint16, zed.TypeUint32, zed.TypeUint64:
+	case zed.TypeUint8:
+		values := make([]uint8, 0)
+		for {
+			bs, err := readBytes()
+			if err != nil {
+				if err == io.EOF {
+					break
+				} else {
+					return nil, err
+				}
+			}
+			values = append(values, uint8(zed.DecodeUint(bs)))
+		}
+		vector := &uint8s{
+			values: values,
+		}
+		return vector, nil
+
+	case zed.TypeUint16:
+		values := make([]uint16, 0)
+		for {
+			bs, err := readBytes()
+			if err != nil {
+				if err == io.EOF {
+					break
+				} else {
+					return nil, err
+				}
+			}
+			values = append(values, uint16(zed.DecodeUint(bs)))
+		}
+		vector := &uint16s{
+			values: values,
+		}
+		return vector, nil
+
+	case zed.TypeUint32:
+		values := make([]uint32, 0)
+		for {
+			bs, err := readBytes()
+			if err != nil {
+				if err == io.EOF {
+					break
+				} else {
+					return nil, err
+				}
+			}
+			values = append(values, uint32(zed.DecodeUint(bs)))
+		}
+		vector := &uint32s{
+			values: values,
+		}
+		return vector, nil
+
+	case zed.TypeUint64:
 		values := make([]uint64, 0)
 		for {
 			bs, err := readBytes()
@@ -375,9 +483,9 @@ func readPrimitive(context *zed.Context, typ zed.Type, readBytes func() ([]byte,
 					return nil, err
 				}
 			}
-			values = append(values, zed.DecodeUint(bs))
+			values = append(values, uint64(zed.DecodeUint(bs)))
 		}
-		vector := &uints{
+		vector := &uint64s{
 			values: values,
 		}
 		return vector, nil

--- a/vector/read.go
+++ b/vector/read.go
@@ -378,8 +378,7 @@ func readPrimitive(context *zed.Context, typ zed.Type, readBytes func() ([]byte,
 
 	case zed.TypeString:
 		data := bytes.NewBuffer(nil)
-		offsets := make([]int, 1)
-		offsets[0] = 0
+		offsets := []int{0}
 		for {
 			bs, err := readBytes()
 			if err != nil {

--- a/vector/read.go
+++ b/vector/read.go
@@ -157,7 +157,7 @@ func read(context *zed.Context, reader vngvector.Reader) (vector, error) {
 func readPrimitive(context *zed.Context, typ zed.Type, readBytes func() ([]byte, error)) (vector, error) {
 	switch typ {
 	case zed.TypeBool:
-		values := make([]bool, 0)
+		var values []bool
 		for {
 			bs, err := readBytes()
 			if err != nil {
@@ -198,7 +198,7 @@ func readPrimitive(context *zed.Context, typ zed.Type, readBytes func() ([]byte,
 		return vector, nil
 
 	case zed.TypeDuration:
-		values := make([]nano.Duration, 0)
+		var values []nano.Duration
 		for {
 			bs, err := readBytes()
 			if err != nil {
@@ -216,7 +216,7 @@ func readPrimitive(context *zed.Context, typ zed.Type, readBytes func() ([]byte,
 		return vector, nil
 
 	case zed.TypeFloat16:
-		values := make([]float32, 0)
+		var values []float32
 		for {
 			bs, err := readBytes()
 			if err != nil {
@@ -234,7 +234,7 @@ func readPrimitive(context *zed.Context, typ zed.Type, readBytes func() ([]byte,
 		return vector, nil
 
 	case zed.TypeFloat32:
-		values := make([]float32, 0)
+		var values []float32
 		for {
 			bs, err := readBytes()
 			if err != nil {
@@ -252,7 +252,7 @@ func readPrimitive(context *zed.Context, typ zed.Type, readBytes func() ([]byte,
 		return vector, nil
 
 	case zed.TypeFloat64:
-		values := make([]float64, 0)
+		var values []float64
 		for {
 			bs, err := readBytes()
 			if err != nil {
@@ -270,7 +270,7 @@ func readPrimitive(context *zed.Context, typ zed.Type, readBytes func() ([]byte,
 		return vector, nil
 
 	case zed.TypeInt8:
-		values := make([]int8, 0)
+		var values []int8
 		for {
 			bs, err := readBytes()
 			if err != nil {
@@ -288,7 +288,7 @@ func readPrimitive(context *zed.Context, typ zed.Type, readBytes func() ([]byte,
 		return vector, nil
 
 	case zed.TypeInt16:
-		values := make([]int16, 0)
+		var values []int16
 		for {
 			bs, err := readBytes()
 			if err != nil {
@@ -306,7 +306,7 @@ func readPrimitive(context *zed.Context, typ zed.Type, readBytes func() ([]byte,
 		return vector, nil
 
 	case zed.TypeInt32:
-		values := make([]int32, 0)
+		var values []int32
 		for {
 			bs, err := readBytes()
 			if err != nil {
@@ -324,7 +324,7 @@ func readPrimitive(context *zed.Context, typ zed.Type, readBytes func() ([]byte,
 		return vector, nil
 
 	case zed.TypeInt64:
-		values := make([]int64, 0)
+		var values []int64
 		for {
 			bs, err := readBytes()
 			if err != nil {
@@ -342,7 +342,7 @@ func readPrimitive(context *zed.Context, typ zed.Type, readBytes func() ([]byte,
 		return vector, nil
 
 	case zed.TypeIP:
-		values := make([]netip.Addr, 0)
+		var values []netip.Addr
 		for {
 			bs, err := readBytes()
 			if err != nil {
@@ -360,7 +360,7 @@ func readPrimitive(context *zed.Context, typ zed.Type, readBytes func() ([]byte,
 		return vector, nil
 
 	case zed.TypeNet:
-		values := make([]netip.Prefix, 0)
+		var values []netip.Prefix
 		for {
 			bs, err := readBytes()
 			if err != nil {
@@ -401,7 +401,7 @@ func readPrimitive(context *zed.Context, typ zed.Type, readBytes func() ([]byte,
 		return vector, nil
 
 	case zed.TypeTime:
-		values := make([]nano.Ts, 0)
+		var values []nano.Ts
 		for {
 			bs, err := readBytes()
 			if err != nil {
@@ -419,7 +419,7 @@ func readPrimitive(context *zed.Context, typ zed.Type, readBytes func() ([]byte,
 		return vector, nil
 
 	case zed.TypeUint8:
-		values := make([]uint8, 0)
+		var values []uint8
 		for {
 			bs, err := readBytes()
 			if err != nil {
@@ -437,7 +437,7 @@ func readPrimitive(context *zed.Context, typ zed.Type, readBytes func() ([]byte,
 		return vector, nil
 
 	case zed.TypeUint16:
-		values := make([]uint16, 0)
+		var values []uint16
 		for {
 			bs, err := readBytes()
 			if err != nil {
@@ -455,7 +455,7 @@ func readPrimitive(context *zed.Context, typ zed.Type, readBytes func() ([]byte,
 		return vector, nil
 
 	case zed.TypeUint32:
-		values := make([]uint32, 0)
+		var values []uint32
 		for {
 			bs, err := readBytes()
 			if err != nil {
@@ -473,7 +473,7 @@ func readPrimitive(context *zed.Context, typ zed.Type, readBytes func() ([]byte,
 		return vector, nil
 
 	case zed.TypeUint64:
-		values := make([]uint64, 0)
+		var values []uint64
 		for {
 			bs, err := readBytes()
 			if err != nil {
@@ -497,7 +497,7 @@ func readPrimitive(context *zed.Context, typ zed.Type, readBytes func() ([]byte,
 		return vector, nil
 
 	case zed.TypeType:
-		values := make([]zed.Type, 0)
+		var values []zed.Type
 		for {
 			bs, err := readBytes()
 			if err != nil {
@@ -521,7 +521,7 @@ func readPrimitive(context *zed.Context, typ zed.Type, readBytes func() ([]byte,
 }
 
 func readInt64s(reader *vngvector.Int64Reader) ([]int64, error) {
-	ints := make([]int64, 0)
+	var ints []int64
 	for {
 		int, err := reader.Read()
 		if err != nil {

--- a/vector/types.go
+++ b/vector/types.go
@@ -39,9 +39,11 @@ type bools struct {
 	values []bool
 }
 
-// TODO Read entire vector as single []byte.
 type byteses struct {
-	values [][]byte
+	data []byte
+	// offsets[0] == 0
+	// len(offsets) == len(vector) + 1
+	offsets []int
 }
 
 type durations struct {
@@ -74,9 +76,11 @@ type nets struct {
 	values []netip.Prefix
 }
 
-// TODO Read entire vector as single []byte.
 type strings struct {
-	values []string
+	data []byte
+	// offsets[0] == 0
+	// len(offsets) == len(vector) + 1
+	offsets []int
 }
 
 type times struct {

--- a/vector/types.go
+++ b/vector/types.go
@@ -3,7 +3,6 @@ package vector
 import (
 	"net/netip"
 
-	"github.com/RoaringBitmap/roaring"
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/pkg/nano"
 )
@@ -108,7 +107,8 @@ type maps struct {
 }
 
 type nulls struct {
-	mask   *roaring.Bitmap
+	// len(runs) > 0
+	runs   []int64
 	values vector
 }
 

--- a/vector/types.go
+++ b/vector/types.go
@@ -19,13 +19,19 @@ var _ vector = (*durations)(nil)
 var _ vector = (*float16s)(nil)
 var _ vector = (*float32s)(nil)
 var _ vector = (*float64s)(nil)
-var _ vector = (*ints)(nil)
+var _ vector = (*int8s)(nil)
+var _ vector = (*int16s)(nil)
+var _ vector = (*int32s)(nil)
+var _ vector = (*int64s)(nil)
 var _ vector = (*ips)(nil)
 var _ vector = (*nets)(nil)
 var _ vector = (*strings)(nil)
 var _ vector = (*times)(nil)
 var _ vector = (*types)(nil)
-var _ vector = (*uints)(nil)
+var _ vector = (*uint8s)(nil)
+var _ vector = (*uint16s)(nil)
+var _ vector = (*uint32s)(nil)
+var _ vector = (*uint64s)(nil)
 
 var _ vector = (*arrays)(nil)
 var _ vector = (*constants)(nil)
@@ -64,7 +70,19 @@ type float64s struct {
 	values []float64
 }
 
-type ints struct {
+type int8s struct {
+	values []int8
+}
+
+type int16s struct {
+	values []int16
+}
+
+type int32s struct {
+	values []int32
+}
+
+type int64s struct {
 	values []int64
 }
 
@@ -91,7 +109,19 @@ type types struct {
 	values []zed.Type
 }
 
-type uints struct {
+type uint8s struct {
+	values []uint8
+}
+
+type uint16s struct {
+	values []uint16
+}
+
+type uint32s struct {
+	values []uint32
+}
+
+type uint64s struct {
 	values []uint64
 }
 


### PR DESCRIPTION
In this PR:

* @nwt pointed out that roaring is very slow. Replaced that with `runs []int64`. When we need random access we can build a simple index over `runs`.
* Store bytes/strings in a single allocation with an array of offsets.
* Fill out all the int/uint types (saves memory).

Other things I tried:
* Replacing EncodeFoo with AppendFoo. This ends up requiring Begin/EndContainer because we don't know the lengths of the things we're appending. Minimal improvement and gross code.
* Replacing the materializer functions with an explicit switch. Slower.
* Guessing the size of vectors so the slices can be pre-allocated instead of growing. This shaves off ~15% total but the method I used to guess the sizes is not very robust. Probably better deferred to when we figure out vector chunking.

Before:

```
> time ZED_USE_VECTOR=1 zq -f zson '_path=="conn" service!=null | count() by service | sort service | head 10' ~/zed-perf-testing/autoperf/vs-duckdb/wrccdc_mono_10m.vng > /d
ev/null

________________________________________________________
Executed in   31.82 secs    fish           external
   usr time   62.94 secs    1.17 millis   62.94 secs
   sys time    1.13 secs    0.02 millis    1.13 secs
```

After:

```
> time ZED_USE_VECTOR=1 zq -f zson '_path=="conn" service!=null | count() by service | sort service | head 10' ~/zed-perf-testing/autoperf/vs-duckdb/wrccdc_mono_10m.vng

________________________________________________________
Executed in    5.89 secs    fish           external
   usr time    6.96 secs    1.11 millis    6.96 secs
   sys time    0.44 secs    0.02 millis    0.44 secs
```

Compared to existing vng reader:

```
> time zq -f zson '_path=="conn" service!=null | count() by service | sort service | head 10' ~/zed-perf-testing/autoperf/vs-duckdb/wrccdc_mono_10m.vng > /dev/null

________________________________________________________
Executed in    3.26 secs    fish           external
   usr time    3.20 secs  568.00 micros    3.20 secs
   sys time    0.08 secs   88.00 micros    0.08 secs
```