### PR TITLE
Fix peeker.Reader.Peek and Read panic on negative length

### DIFF
--- a/pkg/peeker/reader.go
+++ b/pkg/peeker/reader.go
@@ -60,6 +60,9 @@ func (r *Reader) fill(need int) error {
 }
 
 func (r *Reader) Peek(n int) ([]byte, error) {
+	if n < 0 {
+		return nil, errors.New("peeker: negative length")
+	}
 	if len(r.cursor) == 0 && r.eof {
 		return nil, io.EOF
 	}

--- a/pkg/peeker/reader_test.go
+++ b/pkg/peeker/reader_test.go
@@ -17,3 +17,11 @@ func TestEOFOnEmptyFill(t *testing.T) {
 	assert.ErrorIs(t, err, io.EOF)
 	assert.Len(t, n, 0)
 }
+
+func TestNegativeLength(t *testing.T) {
+	p := NewReader(nil, 0, 0)
+	_, err := p.Read(-1)
+	assert.ErrorContains(t, err, "peeker: negative length")
+	_, err = p.Peek(-1)
+	assert.ErrorContains(t, err, "peeker: negative length")
+}


### PR DESCRIPTION
Peek and Read panics if their length parameter is negative.  Return an error instead.

Closes #4844.