### PR TITLE
Fix vng.Writer.Write panic

### DIFF
--- a/vng/vector/primitive.go
+++ b/vng/vector/primitive.go
@@ -57,10 +57,10 @@ func (p *PrimitiveWriter) update(body zcode.Bytes) {
 	}
 	val := zed.NewValue(p.typ, body)
 	if p.min == nil || p.cmp(val, p.min) < 0 {
-		p.min = val
+		p.min = val.Copy()
 	}
 	if p.max == nil || p.cmp(val, p.max) > 0 {
-		p.max = val
+		p.max = val.Copy()
 	}
 	if p.dict != nil {
 		p.dict[string(body)]++

--- a/zed_test.go
+++ b/zed_test.go
@@ -35,6 +35,7 @@ func TestZed(t *testing.T) {
 		require.NoError(t, err)
 		runAllBoomerangs(t, "arrows", data)
 		runAllBoomerangs(t, "parquet", data)
+		runAllBoomerangs(t, "vng", data)
 		runAllBoomerangs(t, "zson", data)
 	})
 


### PR DESCRIPTION
Add missing zed.Value.Copy calls in vng/vector.PrimitiveWriter.update to fix a vng.Writer.Write panic when running TestZed/boomerang/vng, which is added here.