### PR TITLE
Limit VNG files to a single segment

### DIFF
--- a/vng/writer.go
+++ b/vng/writer.go
@@ -3,6 +3,7 @@ package vng
 import (
 	"fmt"
 	"io"
+	"math"
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/vng/vector"
@@ -12,7 +13,7 @@ import (
 
 const (
 	MaxSegmentThresh = vector.MaxSegmentThresh
-	MaxSkewThresh    = 512 * 1024 * 1024
+	MaxSkewThresh    = math.MaxInt
 )
 
 // Writer implements the zio.Writer interface. A Writer creates a vector
@@ -48,7 +49,7 @@ func NewWriter(w io.WriteCloser, skewThresh, segThresh int) (*Writer, error) {
 		spiller:    spiller,
 		writer:     w,
 		typeMap:    make(map[zed.Type]int),
-		skewThresh: skewThresh,
+		skewThresh: MaxSkewThresh,
 		segThresh:  segThresh,
 		root:       vector.NewInt64Writer(spiller),
 	}, nil

--- a/vng/ztests/skewthresh.yaml
+++ b/vng/ztests/skewthresh.yaml
@@ -1,3 +1,5 @@
+skip: disabled pending either removal of segments or addition of per-segment dictionaries
+
 script: |
   seq 1 100 | zq -f vng -o out.vng -vng.skewthresh 500B "yield 'test'+string(this)" -
   zed dev dig section -Z 1 out.vng | zq -Z 'yield quiet(Segmap)' -


### PR DESCRIPTION
The VNG dictionary representation does not work for multiple segments if the index of a dictionary entry changes after a segment containing that entry is written.  Work around this by limiting VNG files to a single segment.

(We'll fix this permanently either by removing segments entirely or by adding per-segment dictionaries.)