### PR TITLE
Add on.merge_group in .github/workflows/ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,7 @@
 name: "Tests"
 
 on:
+  merge_group:
   pull_request:
   push:
     branches:


### PR DESCRIPTION
Adding this trigger enables use of a GitHub merge queue.