### PR TITLE
Change links for NDJSON info

### DIFF
--- a/docs/formats/README.md
+++ b/docs/formats/README.md
@@ -54,7 +54,7 @@ Each JSON value is self-describing in terms of its
 structure and types, though the JSON type system is limited.
 
 When a sequence of JSON objects is organized into a stream
-(perhaps [separated by newlines](http://ndjson.org/))
+(perhaps [separated by newlines](https://en.wikipedia.org/wiki/JSON_streaming#Newline-Delimited_JSON))
 each value can take on any form.
 When all the values have the same form, the JSON sequence
 begins to look like a relational table, but the lack of a comprehensive type system,

--- a/docs/formats/zjson.md
+++ b/docs/formats/zjson.md
@@ -268,7 +268,7 @@ and an array of union of string, and float64 --- might have a value that looks l
 ## 3. Object Framing
 
 A ZJSON file is composed of ZJSON objects formatted as
-[newline delimited JSON (NDJSON)](http://ndjson.org/).
+[newline delimited JSON (NDJSON)](https://en.wikipedia.org/wiki/JSON_streaming#Newline-Delimited_JSON).
 e.g., the [zq](../commands/zq.md) CLI command
 writes its ZJSON output as lines of NDJSON.
 

--- a/docs/integrations/zeek/reading-zeek-log-formats.md
+++ b/docs/integrations/zeek/reading-zeek-log-formats.md
@@ -79,7 +79,7 @@ equivalent [rich types in Zed](../../formats/zson.md#23-primitive-values).
 ## Zeek NDJSON
 
 As an alternative to the default TSV format, there are two common ways that
-Zeek may instead generate logs in [NDJSON](http://ndjson.org/) format.
+Zeek may instead generate logs in [NDJSON](https://en.wikipedia.org/wiki/JSON_streaming#Newline-Delimited_JSON) format.
 
 1. Using the [JSON Streaming Logs](https://github.com/corelight/json-streaming-logs)
    package (recommended for use with Zed)


### PR DESCRIPTION
The ndjson.org site was offline for a while, so when the website's link checker recently picked up on that I'd started pointing to this wikipedia destination instead. When a link checker happened to run today in the Zed repo (which has had its own links to ndjson.org all this time), I've now learned that ndjson.org is back, but for some reason the markdown link checker gets an HTTP 520 when it tries to crawl it. Rather than fuss with it, I'm just pointing these at the wikipedia destination as wel.