### PR TITLE
Avoid deprecated goreleaser features

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,6 @@ jobs:
     - run: make test-heavy
     - uses: goreleaser/goreleaser-action@v3
       with:
-        args: release --rm-dist
+        args: release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,7 +40,7 @@ release:
     View [change log](CHANGELOG.md#{{ replace .Tag "." "" }}).
 brews:
   - name: zed
-    tap:
+    repository:
       owner: brimdata
       name: homebrew-tap
     commit_author:
@@ -53,7 +53,7 @@ brews:
     install: |
       bin.install "zed"
   - name: zq
-    tap:
+    repository:
       owner: brimdata
       name: homebrew-tap
     commit_author:


### PR DESCRIPTION
While [prepping the Zed v1.11.0 release](https://github.com/brimdata/zed/actions/runs/6817762308) yesterday, I noticed these deprecation messages at the `goreleaser` stage. I confirmed in a personal fork that the simple changes they suggest are indeed adequate to shut it up.

```
Run goreleaser/goreleaser-action@v3
Downloading https://github.com/goreleaser/goreleaser/releases/download/v1.22.1/goreleaser_Linux_x86_64.tar.gz
Extracting GoReleaser
/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/f9fb4e72-d204-43c2-86db-d820e4745e59 -f /home/runner/work/_temp/780526d4-e542-4062-9a39-fca0c12f8868
GoReleaser latest installed successfully
v1.11.0 tag found for commit 'cd36eaab'
/opt/hostedtoolcache/goreleaser-action/1.22.1/x64/goreleaser release --rm-dist
Flag --rm-dist has been deprecated, please use --clean instead
  • starting release...
  • loading                                          path=.goreleaser.yaml
  • DEPRECATED: --rm-dist was deprecated in favor of --clean, check https://goreleaser.com/deprecations#-rm-dist for more details
  • loading environment variables
    • using token from $GITHUB_TOKEN
  • getting and validating git state
    • git state                                      commit=cd36eaab38d4c0c8a607ef4fa561b0b43f80b1dc branch=HEAD current_tag=v1.11.0 previous_tag=v1.[10](https://github.com/brimdata/zed/actions/runs/6817762308/job/18541946006#step:12:11).0 dirty=false
  • parsing tag
  • setting defaults
    • DEPRECATED: brews.tap should not be used anymore, check https://goreleaser.com/deprecations#brewstap for more info
    • DEPRECATED: brews.tap should not be used anymore, check https://goreleaser.com/deprecations#brewstap for more info
  • checking distribution directory
    • cleaning dist
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/zed_windows_arm64/zed.exe
    • building                                       binary=dist/zed_linux_amd64_v1/zed
    • building                                       binary=dist/zed_windows_amd64_v1/zed.exe
    • building                                       binary=dist/zed_linux_arm64/zed
    • building                                       binary=dist/zed_darwin_amd64_v1/zed
    • building                                       binary=dist/zed_darwin_arm64/zed
    • building                                       binary=dist/zq_linux_amd64_v1/zq
    • building                                       binary=dist/zq_linux_arm64/zq
    • building                                       binary=dist/zq_windows_amd64_v1/zq.exe
    • building                                       binary=dist/zq_windows_arm64/zq.exe
    • building                                       binary=dist/zq_darwin_amd64_v1/zq
    • building                                       binary=dist/zq_darwin_arm64/zq
    • took: 4m21s
  • archives
    • creating                                       archive=dist/zed-v1.[11](https://github.com/brimdata/zed/actions/runs/6817762308/job/18541946006#step:12:12).0.windows-amd64.zip
    • creating                                       archive=dist/zed-v1.11.0.linux-amd64.tar.gz
    • creating                                       archive=dist/zed-v1.11.0.linux-arm64.tar.gz
    • creating                                       archive=dist/zed-v1.11.0.windows-arm64.zip
    • creating                                       archive=dist/zed-v1.11.0.darwin-amd64.tar.gz
    • creating                                       archive=dist/zed-v1.11.0.darwin-arm64.tar.gz
    • took: 17s
  • calculating checksums
  • homebrew tap formula
    • writing                                        formula=dist/homebrew/zed.rb
    • writing                                        formula=dist/homebrew/zq.rb
  • publishing
    • scm releases
      • creating or updating release                 tag=v1.11.0 repo=brimdata/zed
      • refreshing checksums                         file=zed-checksums.txt
      • release created                              name=v1.11.0 release-id=[12](https://github.com/brimdata/zed/actions/runs/6817762308/job/18541946006#step:12:13)881[15](https://github.com/brimdata/zed/actions/runs/6817762308/job/18541946006#step:12:16)78 request-id=4018:2D63:1A5BBD:361571:654D53FC
      • uploading to release                         file=dist/zed-v1.11.0.windows-amd64.zip name=zed-v1.11.0.windows-amd64.zip
      • uploading to release                         file=dist/zed-v1.11.0.linux-arm64.tar.gz name=zed-v1.11.0.linux-arm64.tar.gz
      • uploading to release                         file=dist/zed-v1.11.0.windows-arm64.zip name=zed-v1.11.0.windows-arm64.zip
      • uploading to release                         file=dist/zed-v1.11.0.linux-amd64.tar.gz name=zed-v1.11.0.linux-amd64.tar.gz
      • uploading to release                         file=dist/zed-v1.11.0.darwin-arm64.tar.gz name=zed-v1.11.0.darwin-arm64.tar.gz
      • uploading to release                         file=dist/zed-v1.11.0.darwin-amd64.tar.gz name=zed-v1.11.0.darwin-amd64.tar.gz
      • uploading to release                         file=dist/zed-checksums.txt name=zed-checksums.txt
      • published                                    url=https://github.com/brimdata/zed/releases/tag/v1.11.0
      • took: 3s
    • homebrew tap formula
      • pushing                                      repository=brimdata/homebrew-tap branch= file=zed.rb
      • pushing                                      repository=brimdata/homebrew-tap branch= file=zq.rb
      • took: 1s
  • took: 5s
  • storing release metadata
    • writing                                        file=dist/artifacts.json
    • writing                                        file=dist/metadata.json
  • announcing
  • you are using deprecated options, check the output above for details
  • release succeeded after 4m43s
  • thanks for using goreleaser!
```