### PR TITLE
Fix zed.MapperLookupCache bug

### DIFF
--- a/mapper.go
+++ b/mapper.go
@@ -72,6 +72,7 @@ type MapperLookupCache struct {
 }
 
 func (m *MapperLookupCache) Reset(mapper *Mapper) {
+	clear(m.cache)
 	m.cache = m.cache[:0]
 	m.mapper = mapper
 }


### PR DESCRIPTION
The recent switch in MapperLookupCache.Lookup to slices.Grow in #4864 introduces a bug because Reset truncates the cache without zeroing it, allowing slices.Grow to expose old entries.  This wasn't a problem previously because the method used to grow the cache zeroed old entries before reusing their storage.