### PR TITLE
Precount the size of each batch to avoid having to grow the slice. Avoid creating readers in decodeVal.

### DIFF
--- a/zcode/bytes.go
+++ b/zcode/bytes.go
@@ -17,7 +17,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"io"
 )
 
 var ErrNotSingleton = errors.New("value body has more than one encoded value")
@@ -57,17 +56,14 @@ func SizeOfUvarint(u64 uint64) int {
 	return n
 }
 
-func ReadTag(r io.ByteReader) (int, error) {
+// DecodeTag reads a uvarint and interprets it as a tag.
+// Returns the tag and the number of bytes read.
+func DecodeTag(b Bytes) (int, int) {
 	// The tag is zero for a null value; otherwise, it is the value's
 	// length plus one.
-	u64, err := binary.ReadUvarint(r)
-	if err != nil {
-		return 0, err
-	}
-	if tagIsNull(u64) {
-		return -1, nil
-	}
-	return tagLength(u64), nil
+	u64, n := binary.Uvarint(b)
+	// Return -1 for null tags.
+	return int(u64) - 1, n
 }
 
 func DecodeTagLength(b Bytes) int {

--- a/zio/zngio/batch.go
+++ b/zio/zngio/batch.go
@@ -1,7 +1,6 @@
 package zngio
 
 import (
-	"slices"
 	"sync"
 	"sync/atomic"
 
@@ -22,23 +21,12 @@ var batchPool sync.Pool
 func newBatch(buf *buffer) *batch {
 	b, ok := batchPool.Get().(*batch)
 	if !ok {
-		b = &batch{vals: make([]zed.Value, 200)}
+		b = &batch{vals: make([]zed.Value, 0)}
 	}
 	b.buf = buf
 	b.refs = 1
 	b.vals = b.vals[:0]
 	return b
-}
-
-func (b *batch) extend() *zed.Value {
-	n := len(b.vals)
-	b.vals = slices.Grow(b.vals, 1)[:n+1]
-	return &b.vals[n]
-}
-
-// unextend undoes what extend did.
-func (b *batch) unextend() {
-	b.vals = b.vals[:len(b.vals)-1]
 }
 
 func (b *batch) Ref() { atomic.AddInt32(&b.refs, 1) }


### PR DESCRIPTION
I kind of stumbled into this and it seemed worth saving :)

I'd like some help running the autoperf benchmarks before merging, but so far this seems like a fairly big win for queries that touch a lot of small values and don't prune most of them. The downside is that batch.vals can be bigger than needed on queries that prune many values. 

```
> make build && hyperfine --warmup=3 -n old 'dist/zq-main \'max(this)\' ints.zng' -n new 'dist/zq \'max(this)\' ints.zng'
Benchmark 1: old
  Time (mean ± σ):     508.5 ms ±  21.1 ms    [User: 1412.5 ms, System: 221.7 ms]
  Range (min … max):   482.6 ms … 547.7 ms    10 runs

Benchmark 2: new
  Time (mean ± σ):     420.3 ms ±  16.1 ms    [User: 870.2 ms, System: 127.6 ms]
  Range (min … max):   386.4 ms … 436.6 ms    10 runs

Summary
  'new' ran
    1.21 ± 0.07 times faster than 'old'

> make build && hyperfine --warmup=3 -n old 'dist/zq-main \'count() by service | sort service | head 10\' ./wrccdc_mono_10m.zng' -n new 'dist/zq \'count() by service | sort service | head 10\' ./wrccdc_mono_10m.zng'
Benchmark 1: old
  Time (mean ± σ):     755.0 ms ±  12.5 ms    [User: 1461.0 ms, System: 123.5 ms]
  Range (min … max):   737.4 ms … 775.9 ms    10 runs

Benchmark 2: new
  Time (mean ± σ):     629.7 ms ±  13.4 ms    [User: 1323.7 ms, System: 101.6 ms]
  Range (min … max):   604.3 ms … 651.3 ms    10 runs

Summary
  'new' ran
    1.20 ± 0.03 times faster than 'old'

> make build && hyperfine --warmup=3 -n old 'dist/zq-main \'_path=="conn" service!=null | count() by service | sort service | head 10\' ./wrccdc_mono_10m.zng' -n new 'dist/zq \'_path=="conn" service!=null | count() by service | sort service | head 10\' ./wrccdc_mono_10m.zng'
Benchmark 1: old
  Time (mean ± σ):     259.1 ms ±   6.3 ms    [User: 2671.8 ms, System: 112.1 ms]
  Range (min … max):   246.9 ms … 268.4 ms    11 runs

Benchmark 2: new
  Time (mean ± σ):     256.2 ms ±   3.0 ms    [User: 2618.4 ms, System: 108.3 ms]
  Range (min … max):   251.1 ms … 260.8 ms    11 runs

Summary
  'new' ran
    1.01 ± 0.03 times faster than 'old'

> make build && hyperfine --warmup=3 -n old 'dist/zq-main \'count() by every(1w) | sort -r -nulls last ts | head 50\' ./wrccdc_mono_10m.zng' -n new 'dist/zq \'count() by every(1w) | sort -r -nulls last ts | head 50\' ./wrccdc_mono_10m.zng'
Benchmark 1: old
  Time (mean ± σ):      1.025 s ±  0.047 s    [User: 1.765 s, System: 0.119 s]
  Range (min … max):    0.969 s …  1.113 s    10 runs

Benchmark 2: new
  Time (mean ± σ):     951.0 ms ±  14.3 ms    [User: 1646.7 ms, System: 101.6 ms]
  Range (min … max):   927.8 ms … 970.8 ms    10 runs

Summary
  'new' ran
    1.08 ± 0.05 times faster than 'old'

> make build && hyperfine --warmup=3 -n old 'dist/zq-main \'client_addr==10.192.91.91 | count()\' ./wrccdc_mono_10m.zng' -n new 'dist/zq \'client_addr==10.192.91.91 | count()\' ./wrccdc_mono_10m.zng'
Benchmark 1: old
  Time (mean ± σ):     197.6 ms ±   2.0 ms    [User: 977.3 ms, System: 75.2 ms]
  Range (min … max):   193.6 ms … 201.1 ms    15 runs

Benchmark 2: new
  Time (mean ± σ):     195.3 ms ±   2.9 ms    [User: 958.9 ms, System: 71.5 ms]
  Range (min … max):   191.6 ms … 201.1 ms    15 runs

Summary
  'new' ran
    1.01 ± 0.02 times faster than 'old'
```