### PR TITLE
Low-hanging fruit in vector.Read

### DIFF
--- a/runtime/op/meta/vec_sequence.go
+++ b/runtime/op/meta/vec_sequence.go
@@ -120,11 +120,7 @@ func newVecSequenceScanner(ctx context.Context, zctx *zed.Context, pool *lake.Po
 	if err != nil {
 		return nil, ksuid.KSUID{}, err
 	}
-	vngReader, err := vng.NewReader(object)
-	if err != nil {
-		return nil, ksuid.KSUID{}, err
-	}
-	vectorReader := vector.NewReader(vngReader, demandOut)
+	vectorReader := vector.NewReader(object, demandOut)
 	scanner, err := zbuf.NewScanner(ctx, vectorReader, nil)
 	if err != nil {
 		return nil, ksuid.KSUID{}, err

--- a/vector/materializer.go
+++ b/vector/materializer.go
@@ -217,6 +217,15 @@ func (v *constants) newMaterializer() materializer {
 	}
 }
 
+func (v *dict) newMaterializer() materializer {
+	var index int
+	return func(builder *zcode.Builder) {
+		tag := v.tags[index]
+		builder.Append(v.dict[tag].Value.Bytes())
+		index++
+	}
+}
+
 func (v *maps) newMaterializer() materializer {
 	var index int
 	keyMaterializer := v.keys.newMaterializer()
@@ -265,6 +274,20 @@ func (v *records) newMaterializer() materializer {
 			fieldMaterializer(builder)
 		}
 		builder.EndContainer()
+	}
+}
+
+func (v *sets) newMaterializer() materializer {
+	var index int
+	elemMaterializer := v.elems.newMaterializer()
+	return func(builder *zcode.Builder) {
+		length := int(v.lengths[index])
+		builder.BeginContainer()
+		for i := 0; i < length; i++ {
+			elemMaterializer(builder)
+		}
+		builder.EndContainer()
+		index++
 	}
 }
 

--- a/vector/read.go
+++ b/vector/read.go
@@ -573,6 +573,10 @@ func typeAfterDemand(zctx *zed.Context, meta vngvector.Metadata, demandOut deman
 		return typ
 	}
 	switch meta := meta.(type) {
+
+	case *vngvector.Named:
+		return typeAfterDemand(zctx, meta.Values, demandOut, typ.(*zed.TypeNamed).Type)
+
 	case *vngvector.Nulls:
 		return typeAfterDemand(zctx, meta.Values, demandOut, typ)
 

--- a/vector/read.go
+++ b/vector/read.go
@@ -159,7 +159,7 @@ func read(zctx *zed.Context, readerAt io.ReaderAt, meta vngvector.Metadata, dema
 func ReadInt64s(readerAt io.ReaderAt, segmap []vngvector.Segment) ([]int64, error) {
 	var lengthHint int
 	for _, segment := range segmap {
-		// TODO This is likely an underestimate. Store the actual length in segments.
+		// TODO This is likely an overestimate. Store the actual length in segments.
 		lengthHint += int(segment.MemLength)
 	}
 	vector, err := readPrimitive(nil, readerAt, segmap, zed.TypeInt64, lengthHint)

--- a/vector/read.go
+++ b/vector/read.go
@@ -234,17 +234,22 @@ func readPrimitive(zctx *zed.Context, readerAt io.ReaderAt, segmap []vngvector.S
 			}
 			offset += int(segment.MemLength)
 		}
-		offset = 0
+		offsetFrom := 0
+		offsetTo := 0
 		offsets := make([]int, 0, count+1)
-		offsets = append(offsets, offset)
-		for offset < len(data) {
-			dataLenPlusOne, tagLen := binary.Uvarint(data[offset:])
-			if tagLen <= 0 || dataLenPlusOne == 0 {
+		offsets = append(offsets, offsetTo)
+		for offsetFrom < len(data) {
+			tag, tagLen := binary.Uvarint(data[offsetFrom:])
+			if tagLen <= 0 || tag == 0 {
 				return nil, errBadTag
 			}
-			offset += tagLen
-			offsets = append(offsets, offset)
-			offset += int(dataLenPlusOne) - 1
+			dataLen := int(tag - 1)
+			// Shift data over to remove tag.
+			// TODO Don't store tags in the VNG file in the first place.
+			copy(data[offsetTo:offsetTo+dataLen], data[offsetFrom+tagLen:offsetFrom+tagLen+dataLen])
+			offsetFrom += tagLen + dataLen
+			offsetTo += dataLen
+			offsets = append(offsets, offsetTo)
 		}
 		vector := &byteses{
 			data:    data,
@@ -455,17 +460,22 @@ func readPrimitive(zctx *zed.Context, readerAt io.ReaderAt, segmap []vngvector.S
 			}
 			offset += int(segment.MemLength)
 		}
-		offset = 0
+		offsetFrom := 0
+		offsetTo := 0
 		offsets := make([]int, 0, count+1)
-		offsets = append(offsets, offset)
-		for offset < len(data) {
-			dataLenPlusOne, tagLen := binary.Uvarint(data[offset:])
-			if tagLen <= 0 || dataLenPlusOne == 0 {
+		offsets = append(offsets, offsetTo)
+		for offsetFrom < len(data) {
+			tag, tagLen := binary.Uvarint(data[offsetFrom:])
+			if tagLen <= 0 || tag == 0 {
 				return nil, errBadTag
 			}
-			offset += tagLen
-			offsets = append(offsets, offset)
-			offset += int(dataLenPlusOne) - 1
+			dataLen := int(tag - 1)
+			// Shift data over to remove tag.
+			// TODO Don't store tags in the VNG file in the first place.
+			copy(data[offsetTo:offsetTo+dataLen], data[offsetFrom+tagLen:offsetFrom+tagLen+dataLen])
+			offsetFrom += tagLen + dataLen
+			offsetTo += dataLen
+			offsets = append(offsets, offsetTo)
 		}
 		vector := &strings{
 			data:    data,

--- a/vector/read.go
+++ b/vector/read.go
@@ -87,6 +87,9 @@ func read(zctx *zed.Context, readerAt io.ReaderAt, buf *[]byte, meta vngvector.M
 			values:  values,
 		}, nil
 
+	case *vngvector.Named:
+		return read(zctx, readerAt, buf, meta.Values, demandOut)
+
 	case *vngvector.Nulls:
 		runs, err := ReadInt64s(readerAt, buf, meta.Runs)
 		if err != nil {

--- a/vector/reader.go
+++ b/vector/reader.go
@@ -8,23 +8,23 @@ import (
 )
 
 type Reader struct {
-	reader *vng.Reader
+	object *vng.Object
 	// TODO Demand should not be public but currently needed for testing.
 	Demand demand.Demand
 	// Initially nil
 	materializer *Materializer
 }
 
-func NewReader(reader *vng.Reader, demandOut demand.Demand) zio.Reader {
+func NewReader(object *vng.Object, demandOut demand.Demand) zio.Reader {
 	return &Reader{
-		reader: reader,
+		object: object,
 		Demand: demandOut,
 	}
 }
 
 func (r *Reader) Read() (*zed.Value, error) {
 	if r.materializer == nil {
-		vector, err := Read(r.reader, r.Demand)
+		vector, err := Read(r.object, r.Demand)
 		if err != nil {
 			return nil, err
 		}

--- a/vector/types.go
+++ b/vector/types.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/pkg/nano"
+	vngvector "github.com/brimdata/zed/vng/vector"
 )
 
 type vector interface {
@@ -35,9 +36,11 @@ var _ vector = (*uint64s)(nil)
 
 var _ vector = (*arrays)(nil)
 var _ vector = (*constants)(nil)
+var _ vector = (*dict)(nil)
 var _ vector = (*maps)(nil)
 var _ vector = (*nulls)(nil)
 var _ vector = (*records)(nil)
+var _ vector = (*sets)(nil)
 var _ vector = (*unions)(nil)
 
 // TODO Use bitset.
@@ -134,6 +137,11 @@ type constants struct {
 	bytes []byte
 }
 
+type dict struct {
+	dict []vngvector.DictEntry
+	tags []byte
+}
+
 type maps struct {
 	lengths []int64
 	keys    vector
@@ -148,6 +156,11 @@ type nulls struct {
 
 type records struct {
 	fields []vector
+}
+
+type sets struct {
+	lengths []int64
+	elems   vector
 }
 
 type unions struct {

--- a/vector/vector_test.go
+++ b/vector/vector_test.go
@@ -53,7 +53,7 @@ func BenchmarkReadZng(b *testing.B) {
 	rand := rand.New(rand.NewSource(42))
 	valuesIn := make([]zed.Value, N)
 	for i := range valuesIn {
-		valuesIn[i] = *zed.NewValue(zed.TypeInt64, zed.EncodeInt(int64(rand.Intn(N))))
+		valuesIn[i] = *zed.NewInt64(rand.Int63n(N))
 	}
 	var buf bytes.Buffer
 	fuzz.WriteZNG(b, valuesIn, &buf)

--- a/vector/vector_test.go
+++ b/vector/vector_test.go
@@ -2,10 +2,15 @@ package vector_test
 
 import (
 	"bytes"
+	"encoding/binary"
+	"math/rand"
 	"testing"
 
 	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/compiler/optimizer/demand"
 	"github.com/brimdata/zed/fuzz"
+	"github.com/brimdata/zed/vector"
+	"github.com/brimdata/zed/vng"
 	"github.com/brimdata/zed/zio/vngio"
 )
 
@@ -40,4 +45,87 @@ func FuzzQuery(f *testing.F) {
 
 		fuzz.CompareValues(t, resultZNG, resultVNG)
 	})
+}
+
+const N = 10000000
+
+func BenchmarkReadZng(b *testing.B) {
+	rand := rand.New(rand.NewSource(42))
+	valuesIn := make([]zed.Value, N)
+	for i := range valuesIn {
+		valuesIn[i] = *zed.NewValue(zed.TypeInt64, zed.EncodeInt(int64(rand.Intn(N))))
+	}
+	var buf bytes.Buffer
+	fuzz.WriteZNG(b, valuesIn, &buf)
+	bs := buf.Bytes()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		valuesOut, err := fuzz.ReadZNG(bs)
+		if err != nil {
+			panic(err)
+		}
+		if zed.DecodeInt(valuesIn[N-1].Bytes()) != zed.DecodeInt(valuesOut[N-1].Bytes()) {
+			panic("oh no")
+		}
+	}
+}
+
+func BenchmarkReadVng(b *testing.B) {
+	rand := rand.New(rand.NewSource(42))
+	valuesIn := make([]zed.Value, N)
+	for i := range valuesIn {
+		valuesIn[i] = *zed.NewValue(zed.TypeInt64, zed.EncodeInt(int64(rand.Intn(N))))
+	}
+	var buf bytes.Buffer
+	fuzz.WriteVNG(b, valuesIn, &buf, vngio.WriterOpts{
+		SkewThresh:   vngio.DefaultSkewThresh,
+		ColumnThresh: vngio.DefaultColumnThresh,
+	})
+	bs := buf.Bytes()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bytesReader := bytes.NewReader(bs)
+		context := zed.NewContext()
+		object, err := vng.NewObject(context, bytesReader, int64(len(bs)))
+		if err != nil {
+			panic(err)
+		}
+		vector, err := vector.Read(object, demand.All())
+		if err != nil {
+			panic(err)
+		}
+		// TODO Expose a cheap way to get values out of vectors.
+		//if intsIn[N-1] != intsOut[N-1] {
+		//    panic("oh no")
+		//}
+		_ = vector
+	}
+}
+
+func BenchmarkReadVarint(b *testing.B) {
+	rand := rand.New(rand.NewSource(42))
+	intsIn := make([]int64, N)
+	for i := range intsIn {
+		intsIn[i] = int64(rand.Intn(N))
+	}
+	var bs []byte
+	for _, int := range intsIn {
+		bs = binary.AppendVarint(bs, int)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bs := bs
+		intsOut := make([]int64, N)
+		for i := range intsOut {
+			value, n := binary.Varint(bs)
+			if n <= 0 {
+				panic("oh no")
+			}
+			bs = bs[n:]
+			intsOut[i] = value
+		}
+		if intsIn[N-1] != intsOut[N-1] {
+			panic("oh no")
+		}
+	}
 }

--- a/vng/reader.go
+++ b/vng/reader.go
@@ -24,14 +24,14 @@ type TypedReader struct {
 
 // NewReader returns a Reader for o.
 func NewReader(o *Object) (*Reader, error) {
-	root := vector.NewInt64Reader(o.root, o.readerAt)
-	readers := make([]TypedReader, 0, len(o.maps))
-	for _, m := range o.maps {
-		r, err := vector.NewReader(m, o.readerAt)
+	root := vector.NewInt64Reader(o.Root, o.ReaderAt)
+	readers := make([]TypedReader, 0, len(o.Maps))
+	for _, m := range o.Maps {
+		r, err := vector.NewReader(m, o.ReaderAt)
 		if err != nil {
 			return nil, err
 		}
-		readers = append(readers, TypedReader{Type: m.Type(o.zctx), Reader: r})
+		readers = append(readers, TypedReader{Type: m.Type(o.Zctx), Reader: r})
 	}
 	return &Reader{
 		Root:    root,

--- a/vng/vector/primitive.go
+++ b/vng/vector/primitive.go
@@ -15,17 +15,18 @@ import (
 const MaxDictSize = 256
 
 type PrimitiveWriter struct {
-	typ      zed.Type
-	bytes    zcode.Bytes
-	spiller  *Spiller
-	segments []Segment
-	dict     map[string]uint32
-	cmp      expr.CompareFn
-	min      *zed.Value
-	max      *zed.Value
-	count    uint32
-	nulls    uint32
-	hasNull  int
+	typ          zed.Type
+	bytes        zcode.Bytes
+	spiller      *Spiller
+	segments     []Segment
+	dict         map[string]uint32
+	cmp          expr.CompareFn
+	min          *zed.Value
+	max          *zed.Value
+	count        uint32
+	countWritten uint32
+	nulls        uint32
+	hasNull      int
 }
 
 func NewPrimitiveWriter(typ zed.Type, spiller *Spiller, useDict bool) *PrimitiveWriter {
@@ -75,8 +76,9 @@ func (p *PrimitiveWriter) Flush(eof bool) error {
 	}
 	var err error
 	if len(p.bytes) > 0 {
-		p.segments, err = p.spiller.Write(p.segments, p.bytes)
+		p.segments, err = p.spiller.Write(p.segments, p.bytes, p.countWritten-p.count)
 		p.bytes = p.bytes[:0]
+		p.countWritten = p.count
 	}
 	return err
 }

--- a/vng/vector/primitive.go
+++ b/vng/vector/primitive.go
@@ -181,6 +181,14 @@ type PrimitiveReader struct {
 	it  zcode.Iter
 }
 
+// TODO Remove these before merging
+func (p *PrimitiveReader) Segmap() []Segment {
+	return p.segmap
+}
+func (p *PrimitiveReader) Reader() io.ReaderAt {
+	return p.reader
+}
+
 func NewPrimitiveReader(primitive *Primitive, reader io.ReaderAt) *PrimitiveReader {
 	return &PrimitiveReader{
 		Typ:    primitive.Typ,
@@ -232,6 +240,14 @@ type DictReader struct {
 	dict      []DictEntry
 	selectors []byte
 	off       int
+}
+
+// TODO Remove these before merging
+func (p *DictReader) Segmap() []Segment {
+	return p.segmap
+}
+func (p *DictReader) Reader() io.ReaderAt {
+	return p.reader
 }
 
 func NewDictReader(primitive *Primitive, reader io.ReaderAt) *DictReader {

--- a/vng/vector/primitive.go
+++ b/vng/vector/primitive.go
@@ -183,14 +183,6 @@ type PrimitiveReader struct {
 	it  zcode.Iter
 }
 
-// TODO Remove these before merging
-func (p *PrimitiveReader) Segmap() []Segment {
-	return p.segmap
-}
-func (p *PrimitiveReader) Reader() io.ReaderAt {
-	return p.reader
-}
-
 func NewPrimitiveReader(primitive *Primitive, reader io.ReaderAt) *PrimitiveReader {
 	return &PrimitiveReader{
 		Typ:    primitive.Typ,
@@ -242,14 +234,6 @@ type DictReader struct {
 	dict      []DictEntry
 	selectors []byte
 	off       int
-}
-
-// TODO Remove these before merging
-func (p *DictReader) Segmap() []Segment {
-	return p.segmap
-}
-func (p *DictReader) Reader() io.ReaderAt {
-	return p.reader
 }
 
 func NewDictReader(primitive *Primitive, reader io.ReaderAt) *DictReader {

--- a/vng/vector/primitive.go
+++ b/vng/vector/primitive.go
@@ -76,7 +76,7 @@ func (p *PrimitiveWriter) Flush(eof bool) error {
 	}
 	var err error
 	if len(p.bytes) > 0 {
-		p.segments, err = p.spiller.Write(p.segments, p.bytes, p.countWritten-p.count)
+		p.segments, err = p.spiller.Write(p.segments, p.bytes, p.count-p.countWritten)
 		p.bytes = p.bytes[:0]
 		p.countWritten = p.count
 	}

--- a/vng/vector/segment.go
+++ b/vng/vector/segment.go
@@ -16,10 +16,11 @@ const (
 )
 
 type Segment struct {
-	Offset            int64 // Offset relative to start of file
-	Length            int32 // Length in file
-	MemLength         int32 // Length in memory
-	CompressionFormat uint8 // Compression format in file
+	Offset            int64  // Offset relative to start of file
+	Length            int32  // Length in file
+	MemLength         int32  // Length in memory
+	CompressionFormat uint8  // Compression format in file
+	Count             uint32 // Number of values encoded in segment
 }
 
 var zbufPool = sync.Pool{

--- a/vng/vector/spiller.go
+++ b/vng/vector/spiller.go
@@ -27,7 +27,7 @@ func (s *Spiller) Position() int64 {
 	return s.off
 }
 
-func (s *Spiller) Write(segments []Segment, b []byte) ([]Segment, error) {
+func (s *Spiller) Write(segments []Segment, b []byte, count uint32) ([]Segment, error) {
 	cf := CompressionFormatNone
 	contentLen := len(b)
 	// Use contentLen-1 so compression will fail if it doesn't result in
@@ -45,7 +45,7 @@ func (s *Spiller) Write(segments []Segment, b []byte) ([]Segment, error) {
 	if _, err := s.writer.Write(b); err != nil {
 		return nil, err
 	}
-	segment := Segment{s.off, int32(len(b)), int32(contentLen), cf}
+	segment := Segment{s.off, int32(len(b)), int32(contentLen), cf, count}
 	s.off += int64(len(b))
 	return append(segments, segment), nil
 }

--- a/vng/ztests/const.yaml
+++ b/vng/ztests/const.yaml
@@ -17,7 +17,8 @@ outputs:
               Offset: 3,
               Length: 3 (int32),
               MemLength: 3 (int32),
-              CompressionFormat: 0 (uint8)
+              CompressionFormat: 0 (uint8),
+              Count: 3 (uint32)
           } (=Segment)
       ]
       {

--- a/zio/vngio/reader.go
+++ b/zio/vngio/reader.go
@@ -33,11 +33,7 @@ func NewReader(zctx *zed.Context, r io.Reader, demandOut demand.Demand) (zio.Rea
 		if demandOut == nil {
 			demandOut = demand.All()
 		}
-		vngReader, err := vng.NewReader(o)
-		if err != nil {
-			return nil, err
-		}
-		return vector.NewReader(vngReader, demandOut), nil
+		return vector.NewReader(o, demandOut), nil
 	} else {
 		return vng.NewReader(o)
 	}


### PR DESCRIPTION
* Read directly from segmap rather than using `ReadBytes`. 
* Include a count in each segment (this is a breaking change to vng). Use this to pre-size slices.
* Reuse a single buffer across all internal read calls.
* Avoid unnecessary copies for string/bytes vectors.
* Correctly handle dict vectors, now that they're enabled.
* Add a benchmark tracking vng read performance and comparing it to zng and raw varints.

On wrccdc_mono_10m.vng this cuts vector.Read time from 270ms -> 140ms for id.resp_p and 470ms -> 180ms for uid.

Materializer performance is still terrible. I had some success improving it by only exposing a Puller instead of a zio.Reader, but the changes ended up being quite invasive elsewhere so I backed it out. It's probably worth trying again later once we only have one set of code for reading vng.