### PR TITLE
grep: accept variables as pattern arguments

### DIFF
--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -84,9 +84,9 @@ type Cast struct {
 }
 
 type Grep struct {
-	Kind    string  `json:"kind" unpack:""`
-	Pattern Pattern `json:"pattern"`
-	Expr    Expr    `json:"expr"`
+	Kind    string `json:"kind" unpack:""`
+	Pattern Expr   `json:"pattern"`
+	Expr    Expr   `json:"expr"`
 }
 
 type Glob struct {

--- a/compiler/parser/parser.es.js
+++ b/compiler/parser/parser.es.js
@@ -729,67 +729,64 @@ function peg$parse(input, options) {
             }
             return m
           },
-      peg$c316 = function(s) {
-            return {"kind": "String", "text": s}
-          },
-      peg$c317 = function() { return [] },
-      peg$c318 = function(first, e) { return e },
-      peg$c319 = "]",
-      peg$c320 = peg$literalExpectation("]", false),
-      peg$c321 = function(from, to) {
+      peg$c316 = function() { return [] },
+      peg$c317 = function(first, e) { return e },
+      peg$c318 = "]",
+      peg$c319 = peg$literalExpectation("]", false),
+      peg$c320 = function(from, to) {
             return ["[", {"kind": "BinaryExpr", "op": ":",
                                   
             "lhs": from, "rhs": to}]
           
           },
-      peg$c322 = function(to) {
+      peg$c321 = function(to) {
             return ["[", {"kind": "BinaryExpr", "op": ":",
                                   
             "lhs": null, "rhs": to}]
           
           },
-      peg$c323 = function(expr) { return ["[", expr] },
-      peg$c324 = function(id) { return [".", id] },
-      peg$c325 = function(exprs, locals, body) {
+      peg$c322 = function(expr) { return ["[", expr] },
+      peg$c323 = function(id) { return [".", id] },
+      peg$c324 = function(exprs, locals, body) {
             return {"kind": "OverExpr", "locals": locals, "exprs": exprs, "body": body}
           },
-      peg$c326 = "}",
-      peg$c327 = peg$literalExpectation("}", false),
-      peg$c328 = function(elems) {
+      peg$c325 = "}",
+      peg$c326 = peg$literalExpectation("}", false),
+      peg$c327 = function(elems) {
             return {"kind": "RecordExpr", "elems": elems}
           },
-      peg$c329 = function(elem) { return elem },
-      peg$c330 = "...",
-      peg$c331 = peg$literalExpectation("...", false),
-      peg$c332 = function(expr) {
+      peg$c328 = function(elem) { return elem },
+      peg$c329 = "...",
+      peg$c330 = peg$literalExpectation("...", false),
+      peg$c331 = function(expr) {
             return {"kind": "Spread", "expr": expr}
           },
-      peg$c333 = function(name, value) {
+      peg$c332 = function(name, value) {
             return {"kind": "Field", "name": name, "value": value}
           },
-      peg$c334 = function(elems) {
+      peg$c333 = function(elems) {
             return {"kind": "ArrayExpr", "elems": elems}
           },
-      peg$c335 = "|[",
-      peg$c336 = peg$literalExpectation("|[", false),
-      peg$c337 = "]|",
-      peg$c338 = peg$literalExpectation("]|", false),
-      peg$c339 = function(elems) {
+      peg$c334 = "|[",
+      peg$c335 = peg$literalExpectation("|[", false),
+      peg$c336 = "]|",
+      peg$c337 = peg$literalExpectation("]|", false),
+      peg$c338 = function(elems) {
             return {"kind": "SetExpr", "elems": elems}
           },
-      peg$c340 = function(e) { return {"kind": "VectorValue", "expr": e} },
-      peg$c341 = "|{",
-      peg$c342 = peg$literalExpectation("|{", false),
-      peg$c343 = "}|",
-      peg$c344 = peg$literalExpectation("}|", false),
-      peg$c345 = function(exprs) {
+      peg$c339 = function(e) { return {"kind": "VectorValue", "expr": e} },
+      peg$c340 = "|{",
+      peg$c341 = peg$literalExpectation("|{", false),
+      peg$c342 = "}|",
+      peg$c343 = peg$literalExpectation("}|", false),
+      peg$c344 = function(exprs) {
             return {"kind": "MapExpr", "entries": exprs}
           },
-      peg$c346 = function(e) { return e },
-      peg$c347 = function(key, value) {
+      peg$c345 = function(e) { return e },
+      peg$c346 = function(key, value) {
             return {"key": key, "value": value}
           },
-      peg$c348 = function(selection, from, joins, where, groupby, having, orderby, limit) {
+      peg$c347 = function(selection, from, joins, where, groupby, having, orderby, limit) {
             return {
               
             "kind": "SQLExpr",
@@ -811,19 +808,19 @@ function peg$parse(input, options) {
             "limit": limit}
           
           },
-      peg$c349 = function(assignments) { return assignments },
-      peg$c350 = function(rhs, opt) {
+      peg$c348 = function(assignments) { return assignments },
+      peg$c349 = function(rhs, opt) {
             let m = {"kind": "Assignment", "lhs": null, "rhs": rhs};
             if (opt) {
               m["lhs"] = opt[3];
             }
             return m
           },
-      peg$c351 = function(table, alias) {
+      peg$c350 = function(table, alias) {
             return {"table": table, "alias": alias}
           },
-      peg$c352 = function(first, join) { return join },
-      peg$c353 = function(style, table, alias, leftKey, rightKey) {
+      peg$c351 = function(first, join) { return join },
+      peg$c352 = function(style, table, alias, leftKey, rightKey) {
             return {
               
             "table": table,
@@ -837,115 +834,115 @@ function peg$parse(input, options) {
             "alias": alias}
           
           },
-      peg$c354 = function(style) { return style },
-      peg$c355 = function(keys, order) {
+      peg$c353 = function(style) { return style },
+      peg$c354 = function(keys, order) {
             return {"kind": "SQLOrderBy", "keys": keys, "order": order}
           },
-      peg$c356 = function(dir) { return dir },
-      peg$c357 = function(count) { return count },
-      peg$c358 = peg$literalExpectation("select", true),
-      peg$c359 = function() { return "select" },
-      peg$c360 = "as",
-      peg$c361 = peg$literalExpectation("as", true),
-      peg$c362 = function() { return "as" },
-      peg$c363 = peg$literalExpectation("from", true),
-      peg$c364 = function() { return "from" },
-      peg$c365 = peg$literalExpectation("join", true),
-      peg$c366 = function() { return "join" },
-      peg$c367 = peg$literalExpectation("where", true),
-      peg$c368 = function() { return "where" },
-      peg$c369 = "group",
-      peg$c370 = peg$literalExpectation("group", true),
-      peg$c371 = function() { return "group" },
-      peg$c372 = "by",
-      peg$c373 = peg$literalExpectation("by", true),
-      peg$c374 = function() { return "by" },
-      peg$c375 = "having",
-      peg$c376 = peg$literalExpectation("having", true),
-      peg$c377 = function() { return "having" },
-      peg$c378 = peg$literalExpectation("order", true),
-      peg$c379 = function() { return "order" },
-      peg$c380 = "on",
-      peg$c381 = peg$literalExpectation("on", true),
-      peg$c382 = function() { return "on" },
-      peg$c383 = "limit",
-      peg$c384 = peg$literalExpectation("limit", true),
-      peg$c385 = function() { return "limit" },
-      peg$c386 = "asc",
-      peg$c387 = peg$literalExpectation("asc", true),
-      peg$c388 = "desc",
-      peg$c389 = peg$literalExpectation("desc", true),
-      peg$c390 = peg$literalExpectation("anti", true),
-      peg$c391 = peg$literalExpectation("left", true),
-      peg$c392 = peg$literalExpectation("right", true),
-      peg$c393 = peg$literalExpectation("inner", true),
-      peg$c394 = function(v) {
+      peg$c355 = function(dir) { return dir },
+      peg$c356 = function(count) { return count },
+      peg$c357 = peg$literalExpectation("select", true),
+      peg$c358 = function() { return "select" },
+      peg$c359 = "as",
+      peg$c360 = peg$literalExpectation("as", true),
+      peg$c361 = function() { return "as" },
+      peg$c362 = peg$literalExpectation("from", true),
+      peg$c363 = function() { return "from" },
+      peg$c364 = peg$literalExpectation("join", true),
+      peg$c365 = function() { return "join" },
+      peg$c366 = peg$literalExpectation("where", true),
+      peg$c367 = function() { return "where" },
+      peg$c368 = "group",
+      peg$c369 = peg$literalExpectation("group", true),
+      peg$c370 = function() { return "group" },
+      peg$c371 = "by",
+      peg$c372 = peg$literalExpectation("by", true),
+      peg$c373 = function() { return "by" },
+      peg$c374 = "having",
+      peg$c375 = peg$literalExpectation("having", true),
+      peg$c376 = function() { return "having" },
+      peg$c377 = peg$literalExpectation("order", true),
+      peg$c378 = function() { return "order" },
+      peg$c379 = "on",
+      peg$c380 = peg$literalExpectation("on", true),
+      peg$c381 = function() { return "on" },
+      peg$c382 = "limit",
+      peg$c383 = peg$literalExpectation("limit", true),
+      peg$c384 = function() { return "limit" },
+      peg$c385 = "asc",
+      peg$c386 = peg$literalExpectation("asc", true),
+      peg$c387 = "desc",
+      peg$c388 = peg$literalExpectation("desc", true),
+      peg$c389 = peg$literalExpectation("anti", true),
+      peg$c390 = peg$literalExpectation("left", true),
+      peg$c391 = peg$literalExpectation("right", true),
+      peg$c392 = peg$literalExpectation("inner", true),
+      peg$c393 = function(v) {
             return {"kind": "Primitive", "type": "net", "text": v}
           },
-      peg$c395 = function(v) {
+      peg$c394 = function(v) {
             return {"kind": "Primitive", "type": "ip", "text": v}
           },
-      peg$c396 = function(v) {
+      peg$c395 = function(v) {
             return {"kind": "Primitive", "type": "float64", "text": v}
           },
-      peg$c397 = function(v) {
+      peg$c396 = function(v) {
             return {"kind": "Primitive", "type": "int64", "text": v}
           },
-      peg$c398 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
-      peg$c399 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
-      peg$c400 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
-      peg$c401 = "0x",
-      peg$c402 = peg$literalExpectation("0x", false),
-      peg$c403 = function() {
+      peg$c397 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
+      peg$c398 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
+      peg$c399 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
+      peg$c400 = "0x",
+      peg$c401 = peg$literalExpectation("0x", false),
+      peg$c402 = function() {
       	return {"kind": "Primitive", "type": "bytes", "text": text()}
         },
-      peg$c404 = function(typ) {
+      peg$c403 = function(typ) {
             return {"kind": "TypeValue", "value": typ}
           },
-      peg$c405 = function(name) { return name },
-      peg$c406 = function(name, opt) {
+      peg$c404 = function(name) { return name },
+      peg$c405 = function(name, opt) {
             if (opt) {
               return {"kind": "TypeDef", "name": name, "type": opt[3]}
             }
             return {"kind": "TypeName", "name": name}
           },
-      peg$c407 = function(name) {
+      peg$c406 = function(name) {
             return {"kind": "TypeName", "name": name}
           },
-      peg$c408 = function(u) { return u },
-      peg$c409 = function(types) {
+      peg$c407 = function(u) { return u },
+      peg$c408 = function(types) {
             return {"kind": "TypeUnion", "types": types}
           },
-      peg$c410 = function(fields) {
+      peg$c409 = function(fields) {
             return {"kind": "TypeRecord", "fields": fields}
           },
-      peg$c411 = function(typ) {
+      peg$c410 = function(typ) {
             return {"kind": "TypeArray", "type": typ}
           },
-      peg$c412 = function(typ) {
+      peg$c411 = function(typ) {
             return {"kind": "TypeSet", "type": typ}
           },
-      peg$c413 = function(keyType, valType) {
+      peg$c412 = function(keyType, valType) {
             return {"kind": "TypeMap", "key_type": keyType, "val_type": valType}
           },
-      peg$c414 = function(v) {
+      peg$c413 = function(v) {
             if (v.length == 0) {
               return {"kind": "Primitive", "type": "string", "text": ""}
             }
             return makeTemplateExprChain(v)
           },
-      peg$c415 = "\"",
-      peg$c416 = peg$literalExpectation("\"", false),
-      peg$c417 = "'",
-      peg$c418 = peg$literalExpectation("'", false),
-      peg$c419 = function(v) {
+      peg$c414 = "\"",
+      peg$c415 = peg$literalExpectation("\"", false),
+      peg$c416 = "'",
+      peg$c417 = peg$literalExpectation("'", false),
+      peg$c418 = function(v) {
             return {"kind": "Primitive", "type": "string", "text": joinChars(v)}
           },
-      peg$c420 = "\\",
-      peg$c421 = peg$literalExpectation("\\", false),
-      peg$c422 = "${",
-      peg$c423 = peg$literalExpectation("${", false),
-      peg$c424 = function(e) {
+      peg$c419 = "\\",
+      peg$c420 = peg$literalExpectation("\\", false),
+      peg$c421 = "${",
+      peg$c422 = peg$literalExpectation("${", false),
+      peg$c423 = function(e) {
             return {
               
             "kind": "Cast",
@@ -959,221 +956,221 @@ function peg$parse(input, options) {
             "value": {"kind": "TypePrimitive", "name": "string"}}}
           
           },
-      peg$c425 = "uint8",
-      peg$c426 = peg$literalExpectation("uint8", false),
-      peg$c427 = "uint16",
-      peg$c428 = peg$literalExpectation("uint16", false),
-      peg$c429 = "uint32",
-      peg$c430 = peg$literalExpectation("uint32", false),
-      peg$c431 = "uint64",
-      peg$c432 = peg$literalExpectation("uint64", false),
-      peg$c433 = "int8",
-      peg$c434 = peg$literalExpectation("int8", false),
-      peg$c435 = "int16",
-      peg$c436 = peg$literalExpectation("int16", false),
-      peg$c437 = "int32",
-      peg$c438 = peg$literalExpectation("int32", false),
-      peg$c439 = "int64",
-      peg$c440 = peg$literalExpectation("int64", false),
-      peg$c441 = "float16",
-      peg$c442 = peg$literalExpectation("float16", false),
-      peg$c443 = "float32",
-      peg$c444 = peg$literalExpectation("float32", false),
-      peg$c445 = "float64",
-      peg$c446 = peg$literalExpectation("float64", false),
-      peg$c447 = "bool",
-      peg$c448 = peg$literalExpectation("bool", false),
-      peg$c449 = "string",
-      peg$c450 = peg$literalExpectation("string", false),
-      peg$c451 = "duration",
-      peg$c452 = peg$literalExpectation("duration", false),
-      peg$c453 = "time",
-      peg$c454 = peg$literalExpectation("time", false),
-      peg$c455 = "bytes",
-      peg$c456 = peg$literalExpectation("bytes", false),
-      peg$c457 = "ip",
-      peg$c458 = peg$literalExpectation("ip", false),
-      peg$c459 = "net",
-      peg$c460 = peg$literalExpectation("net", false),
-      peg$c461 = "null",
-      peg$c462 = peg$literalExpectation("null", false),
-      peg$c463 = function() {
+      peg$c424 = "uint8",
+      peg$c425 = peg$literalExpectation("uint8", false),
+      peg$c426 = "uint16",
+      peg$c427 = peg$literalExpectation("uint16", false),
+      peg$c428 = "uint32",
+      peg$c429 = peg$literalExpectation("uint32", false),
+      peg$c430 = "uint64",
+      peg$c431 = peg$literalExpectation("uint64", false),
+      peg$c432 = "int8",
+      peg$c433 = peg$literalExpectation("int8", false),
+      peg$c434 = "int16",
+      peg$c435 = peg$literalExpectation("int16", false),
+      peg$c436 = "int32",
+      peg$c437 = peg$literalExpectation("int32", false),
+      peg$c438 = "int64",
+      peg$c439 = peg$literalExpectation("int64", false),
+      peg$c440 = "float16",
+      peg$c441 = peg$literalExpectation("float16", false),
+      peg$c442 = "float32",
+      peg$c443 = peg$literalExpectation("float32", false),
+      peg$c444 = "float64",
+      peg$c445 = peg$literalExpectation("float64", false),
+      peg$c446 = "bool",
+      peg$c447 = peg$literalExpectation("bool", false),
+      peg$c448 = "string",
+      peg$c449 = peg$literalExpectation("string", false),
+      peg$c450 = "duration",
+      peg$c451 = peg$literalExpectation("duration", false),
+      peg$c452 = "time",
+      peg$c453 = peg$literalExpectation("time", false),
+      peg$c454 = "bytes",
+      peg$c455 = peg$literalExpectation("bytes", false),
+      peg$c456 = "ip",
+      peg$c457 = peg$literalExpectation("ip", false),
+      peg$c458 = "net",
+      peg$c459 = peg$literalExpectation("net", false),
+      peg$c460 = "null",
+      peg$c461 = peg$literalExpectation("null", false),
+      peg$c462 = function() {
                 return {"kind": "TypePrimitive", "name": text()}
               },
-      peg$c464 = function(name, typ) {
+      peg$c463 = function(name, typ) {
             return {"name": name, "type": typ}
           },
-      peg$c465 = "and",
-      peg$c466 = peg$literalExpectation("and", false),
-      peg$c467 = "AND",
-      peg$c468 = peg$literalExpectation("AND", false),
-      peg$c469 = function() { return "and" },
-      peg$c470 = peg$literalExpectation("by", false),
-      peg$c471 = "false",
-      peg$c472 = peg$literalExpectation("false", false),
-      peg$c473 = "NOT",
-      peg$c474 = peg$literalExpectation("NOT", false),
-      peg$c475 = function() { return "not" },
-      peg$c476 = "or",
-      peg$c477 = peg$literalExpectation("or", false),
-      peg$c478 = "OR",
-      peg$c479 = peg$literalExpectation("OR", false),
-      peg$c480 = function() { return "or" },
-      peg$c481 = "true",
-      peg$c482 = peg$literalExpectation("true", false),
-      peg$c483 = function(id) { return {"kind": "ID", "name": id} },
-      peg$c484 = "$",
-      peg$c485 = peg$literalExpectation("$", false),
-      peg$c486 = function(first, id) { return id },
-      peg$c487 = "_",
-      peg$c488 = peg$literalExpectation("_", false),
-      peg$c489 = "T",
-      peg$c490 = peg$literalExpectation("T", false),
-      peg$c491 = function() {
+      peg$c464 = "and",
+      peg$c465 = peg$literalExpectation("and", false),
+      peg$c466 = "AND",
+      peg$c467 = peg$literalExpectation("AND", false),
+      peg$c468 = function() { return "and" },
+      peg$c469 = peg$literalExpectation("by", false),
+      peg$c470 = "false",
+      peg$c471 = peg$literalExpectation("false", false),
+      peg$c472 = "NOT",
+      peg$c473 = peg$literalExpectation("NOT", false),
+      peg$c474 = function() { return "not" },
+      peg$c475 = "or",
+      peg$c476 = peg$literalExpectation("or", false),
+      peg$c477 = "OR",
+      peg$c478 = peg$literalExpectation("OR", false),
+      peg$c479 = function() { return "or" },
+      peg$c480 = "true",
+      peg$c481 = peg$literalExpectation("true", false),
+      peg$c482 = function(id) { return {"kind": "ID", "name": id} },
+      peg$c483 = "$",
+      peg$c484 = peg$literalExpectation("$", false),
+      peg$c485 = function(first, id) { return id },
+      peg$c486 = "_",
+      peg$c487 = peg$literalExpectation("_", false),
+      peg$c488 = "T",
+      peg$c489 = peg$literalExpectation("T", false),
+      peg$c490 = function() {
             return {"kind": "Primitive", "type": "time", "text": text()}
           },
-      peg$c492 = /^[0-9]/,
-      peg$c493 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c494 = "Z",
-      peg$c495 = peg$literalExpectation("Z", false),
-      peg$c496 = function() {
+      peg$c491 = /^[0-9]/,
+      peg$c492 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c493 = "Z",
+      peg$c494 = peg$literalExpectation("Z", false),
+      peg$c495 = function() {
             return {"kind": "Primitive", "type": "duration", "text": text()}
           },
-      peg$c497 = "ns",
-      peg$c498 = peg$literalExpectation("ns", false),
-      peg$c499 = "us",
-      peg$c500 = peg$literalExpectation("us", false),
-      peg$c501 = "ms",
-      peg$c502 = peg$literalExpectation("ms", false),
-      peg$c503 = "s",
-      peg$c504 = peg$literalExpectation("s", false),
-      peg$c505 = "m",
-      peg$c506 = peg$literalExpectation("m", false),
-      peg$c507 = "h",
-      peg$c508 = peg$literalExpectation("h", false),
-      peg$c509 = "d",
-      peg$c510 = peg$literalExpectation("d", false),
-      peg$c511 = "w",
-      peg$c512 = peg$literalExpectation("w", false),
-      peg$c513 = "y",
-      peg$c514 = peg$literalExpectation("y", false),
-      peg$c515 = function(a, b) {
+      peg$c496 = "ns",
+      peg$c497 = peg$literalExpectation("ns", false),
+      peg$c498 = "us",
+      peg$c499 = peg$literalExpectation("us", false),
+      peg$c500 = "ms",
+      peg$c501 = peg$literalExpectation("ms", false),
+      peg$c502 = "s",
+      peg$c503 = peg$literalExpectation("s", false),
+      peg$c504 = "m",
+      peg$c505 = peg$literalExpectation("m", false),
+      peg$c506 = "h",
+      peg$c507 = peg$literalExpectation("h", false),
+      peg$c508 = "d",
+      peg$c509 = peg$literalExpectation("d", false),
+      peg$c510 = "w",
+      peg$c511 = peg$literalExpectation("w", false),
+      peg$c512 = "y",
+      peg$c513 = peg$literalExpectation("y", false),
+      peg$c514 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c516 = "::",
-      peg$c517 = peg$literalExpectation("::", false),
-      peg$c518 = function(a, b, d, e) {
+      peg$c515 = "::",
+      peg$c516 = peg$literalExpectation("::", false),
+      peg$c517 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c519 = function(a, b) {
+      peg$c518 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c520 = function(a, b) {
+      peg$c519 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c521 = function() {
+      peg$c520 = function() {
             return "::"
           },
-      peg$c522 = function(v) { return ":" + v },
-      peg$c523 = function(v) { return v + ":" },
-      peg$c524 = function(a, m) {
+      peg$c521 = function(v) { return ":" + v },
+      peg$c522 = function(v) { return v + ":" },
+      peg$c523 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c525 = function(a, m) {
+      peg$c524 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c526 = function(s) { return parseInt(s) },
-      peg$c527 = function() {
+      peg$c525 = function(s) { return parseInt(s) },
+      peg$c526 = function() {
             return text()
           },
-      peg$c528 = "e",
-      peg$c529 = peg$literalExpectation("e", true),
-      peg$c530 = /^[+\-]/,
-      peg$c531 = peg$classExpectation(["+", "-"], false, false),
-      peg$c532 = "NaN",
-      peg$c533 = peg$literalExpectation("NaN", false),
-      peg$c534 = "Inf",
-      peg$c535 = peg$literalExpectation("Inf", false),
-      peg$c536 = /^[0-9a-fA-F]/,
-      peg$c537 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c538 = function(v) { return joinChars(v) },
-      peg$c539 = peg$anyExpectation(),
-      peg$c540 = function(head, tail) { return head + joinChars(tail) },
-      peg$c541 = /^[_.:\/%#@~]/,
-      peg$c542 = peg$classExpectation(["_", ".", ":", "/", "%", "#", "@", "~"], false, false),
-      peg$c543 = function(head, tail) {
+      peg$c527 = "e",
+      peg$c528 = peg$literalExpectation("e", true),
+      peg$c529 = /^[+\-]/,
+      peg$c530 = peg$classExpectation(["+", "-"], false, false),
+      peg$c531 = "NaN",
+      peg$c532 = peg$literalExpectation("NaN", false),
+      peg$c533 = "Inf",
+      peg$c534 = peg$literalExpectation("Inf", false),
+      peg$c535 = /^[0-9a-fA-F]/,
+      peg$c536 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c537 = function(v) { return joinChars(v) },
+      peg$c538 = peg$anyExpectation(),
+      peg$c539 = function(head, tail) { return head + joinChars(tail) },
+      peg$c540 = /^[_.:\/%#@~]/,
+      peg$c541 = peg$classExpectation(["_", ".", ":", "/", "%", "#", "@", "~"], false, false),
+      peg$c542 = function(head, tail) {
             return head + joinChars(tail)
           },
-      peg$c544 = function() { return "*" },
-      peg$c545 = function() { return "=" },
-      peg$c546 = function() { return "\\*" },
-      peg$c547 = "b",
-      peg$c548 = peg$literalExpectation("b", false),
-      peg$c549 = function() { return "\b" },
-      peg$c550 = "f",
-      peg$c551 = peg$literalExpectation("f", false),
-      peg$c552 = function() { return "\f" },
-      peg$c553 = "n",
-      peg$c554 = peg$literalExpectation("n", false),
-      peg$c555 = function() { return "\n" },
-      peg$c556 = "r",
-      peg$c557 = peg$literalExpectation("r", false),
-      peg$c558 = function() { return "\r" },
-      peg$c559 = "t",
-      peg$c560 = peg$literalExpectation("t", false),
-      peg$c561 = function() { return "\t" },
-      peg$c562 = "v",
-      peg$c563 = peg$literalExpectation("v", false),
-      peg$c564 = function() { return "\v" },
-      peg$c565 = "u",
-      peg$c566 = peg$literalExpectation("u", false),
-      peg$c567 = function(chars) {
+      peg$c543 = function() { return "*" },
+      peg$c544 = function() { return "=" },
+      peg$c545 = function() { return "\\*" },
+      peg$c546 = "b",
+      peg$c547 = peg$literalExpectation("b", false),
+      peg$c548 = function() { return "\b" },
+      peg$c549 = "f",
+      peg$c550 = peg$literalExpectation("f", false),
+      peg$c551 = function() { return "\f" },
+      peg$c552 = "n",
+      peg$c553 = peg$literalExpectation("n", false),
+      peg$c554 = function() { return "\n" },
+      peg$c555 = "r",
+      peg$c556 = peg$literalExpectation("r", false),
+      peg$c557 = function() { return "\r" },
+      peg$c558 = "t",
+      peg$c559 = peg$literalExpectation("t", false),
+      peg$c560 = function() { return "\t" },
+      peg$c561 = "v",
+      peg$c562 = peg$literalExpectation("v", false),
+      peg$c563 = function() { return "\v" },
+      peg$c564 = "u",
+      peg$c565 = peg$literalExpectation("u", false),
+      peg$c566 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c568 = /^[^\/\\]/,
-      peg$c569 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c570 = /^[\0-\x1F\\]/,
-      peg$c571 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c572 = /^[a-z\xB5\xDF-\xF6\xF8-\xFF\u0101\u0103\u0105\u0107\u0109\u010B\u010D\u010F\u0111\u0113\u0115\u0117\u0119\u011B\u011D\u011F\u0121\u0123\u0125\u0127\u0129\u012B\u012D\u012F\u0131\u0133\u0135\u0137-\u0138\u013A\u013C\u013E\u0140\u0142\u0144\u0146\u0148-\u0149\u014B\u014D\u014F\u0151\u0153\u0155\u0157\u0159\u015B\u015D\u015F\u0161\u0163\u0165\u0167\u0169\u016B\u016D\u016F\u0171\u0173\u0175\u0177\u017A\u017C\u017E-\u0180\u0183\u0185\u0188\u018C-\u018D\u0192\u0195\u0199-\u019B\u019E\u01A1\u01A3\u01A5\u01A8\u01AA-\u01AB\u01AD\u01B0\u01B4\u01B6\u01B9-\u01BA\u01BD-\u01BF\u01C6\u01C9\u01CC\u01CE\u01D0\u01D2\u01D4\u01D6\u01D8\u01DA\u01DC-\u01DD\u01DF\u01E1\u01E3\u01E5\u01E7\u01E9\u01EB\u01ED\u01EF-\u01F0\u01F3\u01F5\u01F9\u01FB\u01FD\u01FF\u0201\u0203\u0205\u0207\u0209\u020B\u020D\u020F\u0211\u0213\u0215\u0217\u0219\u021B\u021D\u021F\u0221\u0223\u0225\u0227\u0229\u022B\u022D\u022F\u0231\u0233-\u0239\u023C\u023F-\u0240\u0242\u0247\u0249\u024B\u024D\u024F-\u0293\u0295-\u02AF\u0371\u0373\u0377\u037B-\u037D\u0390\u03AC-\u03CE\u03D0-\u03D1\u03D5-\u03D7\u03D9\u03DB\u03DD\u03DF\u03E1\u03E3\u03E5\u03E7\u03E9\u03EB\u03ED\u03EF-\u03F3\u03F5\u03F8\u03FB-\u03FC\u0430-\u045F\u0461\u0463\u0465\u0467\u0469\u046B\u046D\u046F\u0471\u0473\u0475\u0477\u0479\u047B\u047D\u047F\u0481\u048B\u048D\u048F\u0491\u0493\u0495\u0497\u0499\u049B\u049D\u049F\u04A1\u04A3\u04A5\u04A7\u04A9\u04AB\u04AD\u04AF\u04B1\u04B3\u04B5\u04B7\u04B9\u04BB\u04BD\u04BF\u04C2\u04C4\u04C6\u04C8\u04CA\u04CC\u04CE-\u04CF\u04D1\u04D3\u04D5\u04D7\u04D9\u04DB\u04DD\u04DF\u04E1\u04E3\u04E5\u04E7\u04E9\u04EB\u04ED\u04EF\u04F1\u04F3\u04F5\u04F7\u04F9\u04FB\u04FD\u04FF\u0501\u0503\u0505\u0507\u0509\u050B\u050D\u050F\u0511\u0513\u0515\u0517\u0519\u051B\u051D\u051F\u0521\u0523\u0525\u0527\u0529\u052B\u052D\u052F\u0560-\u0588\u10D0-\u10FA\u10FD-\u10FF\u13F8-\u13FD\u1C80-\u1C88\u1D00-\u1D2B\u1D6B-\u1D77\u1D79-\u1D9A\u1E01\u1E03\u1E05\u1E07\u1E09\u1E0B\u1E0D\u1E0F\u1E11\u1E13\u1E15\u1E17\u1E19\u1E1B\u1E1D\u1E1F\u1E21\u1E23\u1E25\u1E27\u1E29\u1E2B\u1E2D\u1E2F\u1E31\u1E33\u1E35\u1E37\u1E39\u1E3B\u1E3D\u1E3F\u1E41\u1E43\u1E45\u1E47\u1E49\u1E4B\u1E4D\u1E4F\u1E51\u1E53\u1E55\u1E57\u1E59\u1E5B\u1E5D\u1E5F\u1E61\u1E63\u1E65\u1E67\u1E69\u1E6B\u1E6D\u1E6F\u1E71\u1E73\u1E75\u1E77\u1E79\u1E7B\u1E7D\u1E7F\u1E81\u1E83\u1E85\u1E87\u1E89\u1E8B\u1E8D\u1E8F\u1E91\u1E93\u1E95-\u1E9D\u1E9F\u1EA1\u1EA3\u1EA5\u1EA7\u1EA9\u1EAB\u1EAD\u1EAF\u1EB1\u1EB3\u1EB5\u1EB7\u1EB9\u1EBB\u1EBD\u1EBF\u1EC1\u1EC3\u1EC5\u1EC7\u1EC9\u1ECB\u1ECD\u1ECF\u1ED1\u1ED3\u1ED5\u1ED7\u1ED9\u1EDB\u1EDD\u1EDF\u1EE1\u1EE3\u1EE5\u1EE7\u1EE9\u1EEB\u1EED\u1EEF\u1EF1\u1EF3\u1EF5\u1EF7\u1EF9\u1EFB\u1EFD\u1EFF-\u1F07\u1F10-\u1F15\u1F20-\u1F27\u1F30-\u1F37\u1F40-\u1F45\u1F50-\u1F57\u1F60-\u1F67\u1F70-\u1F7D\u1F80-\u1F87\u1F90-\u1F97\u1FA0-\u1FA7\u1FB0-\u1FB4\u1FB6-\u1FB7\u1FBE\u1FC2-\u1FC4\u1FC6-\u1FC7\u1FD0-\u1FD3\u1FD6-\u1FD7\u1FE0-\u1FE7\u1FF2-\u1FF4\u1FF6-\u1FF7\u210A\u210E-\u210F\u2113\u212F\u2134\u2139\u213C-\u213D\u2146-\u2149\u214E\u2184\u2C30-\u2C5E\u2C61\u2C65-\u2C66\u2C68\u2C6A\u2C6C\u2C71\u2C73-\u2C74\u2C76-\u2C7B\u2C81\u2C83\u2C85\u2C87\u2C89\u2C8B\u2C8D\u2C8F\u2C91\u2C93\u2C95\u2C97\u2C99\u2C9B\u2C9D\u2C9F\u2CA1\u2CA3\u2CA5\u2CA7\u2CA9\u2CAB\u2CAD\u2CAF\u2CB1\u2CB3\u2CB5\u2CB7\u2CB9\u2CBB\u2CBD\u2CBF\u2CC1\u2CC3\u2CC5\u2CC7\u2CC9\u2CCB\u2CCD\u2CCF\u2CD1\u2CD3\u2CD5\u2CD7\u2CD9\u2CDB\u2CDD\u2CDF\u2CE1\u2CE3-\u2CE4\u2CEC\u2CEE\u2CF3\u2D00-\u2D25\u2D27\u2D2D\uA641\uA643\uA645\uA647\uA649\uA64B\uA64D\uA64F\uA651\uA653\uA655\uA657\uA659\uA65B\uA65D\uA65F\uA661\uA663\uA665\uA667\uA669\uA66B\uA66D\uA681\uA683\uA685\uA687\uA689\uA68B\uA68D\uA68F\uA691\uA693\uA695\uA697\uA699\uA69B\uA723\uA725\uA727\uA729\uA72B\uA72D\uA72F-\uA731\uA733\uA735\uA737\uA739\uA73B\uA73D\uA73F\uA741\uA743\uA745\uA747\uA749\uA74B\uA74D\uA74F\uA751\uA753\uA755\uA757\uA759\uA75B\uA75D\uA75F\uA761\uA763\uA765\uA767\uA769\uA76B\uA76D\uA76F\uA771-\uA778\uA77A\uA77C\uA77F\uA781\uA783\uA785\uA787\uA78C\uA78E\uA791\uA793-\uA795\uA797\uA799\uA79B\uA79D\uA79F\uA7A1\uA7A3\uA7A5\uA7A7\uA7A9\uA7AF\uA7B5\uA7B7\uA7B9\uA7FA\uAB30-\uAB5A\uAB60-\uAB65\uAB70-\uABBF\uFB00-\uFB06\uFB13-\uFB17\uFF41-\uFF5A]/,
-      peg$c573 = peg$classExpectation([["a", "z"], "\xB5", ["\xDF", "\xF6"], ["\xF8", "\xFF"], "\u0101", "\u0103", "\u0105", "\u0107", "\u0109", "\u010B", "\u010D", "\u010F", "\u0111", "\u0113", "\u0115", "\u0117", "\u0119", "\u011B", "\u011D", "\u011F", "\u0121", "\u0123", "\u0125", "\u0127", "\u0129", "\u012B", "\u012D", "\u012F", "\u0131", "\u0133", "\u0135", ["\u0137", "\u0138"], "\u013A", "\u013C", "\u013E", "\u0140", "\u0142", "\u0144", "\u0146", ["\u0148", "\u0149"], "\u014B", "\u014D", "\u014F", "\u0151", "\u0153", "\u0155", "\u0157", "\u0159", "\u015B", "\u015D", "\u015F", "\u0161", "\u0163", "\u0165", "\u0167", "\u0169", "\u016B", "\u016D", "\u016F", "\u0171", "\u0173", "\u0175", "\u0177", "\u017A", "\u017C", ["\u017E", "\u0180"], "\u0183", "\u0185", "\u0188", ["\u018C", "\u018D"], "\u0192", "\u0195", ["\u0199", "\u019B"], "\u019E", "\u01A1", "\u01A3", "\u01A5", "\u01A8", ["\u01AA", "\u01AB"], "\u01AD", "\u01B0", "\u01B4", "\u01B6", ["\u01B9", "\u01BA"], ["\u01BD", "\u01BF"], "\u01C6", "\u01C9", "\u01CC", "\u01CE", "\u01D0", "\u01D2", "\u01D4", "\u01D6", "\u01D8", "\u01DA", ["\u01DC", "\u01DD"], "\u01DF", "\u01E1", "\u01E3", "\u01E5", "\u01E7", "\u01E9", "\u01EB", "\u01ED", ["\u01EF", "\u01F0"], "\u01F3", "\u01F5", "\u01F9", "\u01FB", "\u01FD", "\u01FF", "\u0201", "\u0203", "\u0205", "\u0207", "\u0209", "\u020B", "\u020D", "\u020F", "\u0211", "\u0213", "\u0215", "\u0217", "\u0219", "\u021B", "\u021D", "\u021F", "\u0221", "\u0223", "\u0225", "\u0227", "\u0229", "\u022B", "\u022D", "\u022F", "\u0231", ["\u0233", "\u0239"], "\u023C", ["\u023F", "\u0240"], "\u0242", "\u0247", "\u0249", "\u024B", "\u024D", ["\u024F", "\u0293"], ["\u0295", "\u02AF"], "\u0371", "\u0373", "\u0377", ["\u037B", "\u037D"], "\u0390", ["\u03AC", "\u03CE"], ["\u03D0", "\u03D1"], ["\u03D5", "\u03D7"], "\u03D9", "\u03DB", "\u03DD", "\u03DF", "\u03E1", "\u03E3", "\u03E5", "\u03E7", "\u03E9", "\u03EB", "\u03ED", ["\u03EF", "\u03F3"], "\u03F5", "\u03F8", ["\u03FB", "\u03FC"], ["\u0430", "\u045F"], "\u0461", "\u0463", "\u0465", "\u0467", "\u0469", "\u046B", "\u046D", "\u046F", "\u0471", "\u0473", "\u0475", "\u0477", "\u0479", "\u047B", "\u047D", "\u047F", "\u0481", "\u048B", "\u048D", "\u048F", "\u0491", "\u0493", "\u0495", "\u0497", "\u0499", "\u049B", "\u049D", "\u049F", "\u04A1", "\u04A3", "\u04A5", "\u04A7", "\u04A9", "\u04AB", "\u04AD", "\u04AF", "\u04B1", "\u04B3", "\u04B5", "\u04B7", "\u04B9", "\u04BB", "\u04BD", "\u04BF", "\u04C2", "\u04C4", "\u04C6", "\u04C8", "\u04CA", "\u04CC", ["\u04CE", "\u04CF"], "\u04D1", "\u04D3", "\u04D5", "\u04D7", "\u04D9", "\u04DB", "\u04DD", "\u04DF", "\u04E1", "\u04E3", "\u04E5", "\u04E7", "\u04E9", "\u04EB", "\u04ED", "\u04EF", "\u04F1", "\u04F3", "\u04F5", "\u04F7", "\u04F9", "\u04FB", "\u04FD", "\u04FF", "\u0501", "\u0503", "\u0505", "\u0507", "\u0509", "\u050B", "\u050D", "\u050F", "\u0511", "\u0513", "\u0515", "\u0517", "\u0519", "\u051B", "\u051D", "\u051F", "\u0521", "\u0523", "\u0525", "\u0527", "\u0529", "\u052B", "\u052D", "\u052F", ["\u0560", "\u0588"], ["\u10D0", "\u10FA"], ["\u10FD", "\u10FF"], ["\u13F8", "\u13FD"], ["\u1C80", "\u1C88"], ["\u1D00", "\u1D2B"], ["\u1D6B", "\u1D77"], ["\u1D79", "\u1D9A"], "\u1E01", "\u1E03", "\u1E05", "\u1E07", "\u1E09", "\u1E0B", "\u1E0D", "\u1E0F", "\u1E11", "\u1E13", "\u1E15", "\u1E17", "\u1E19", "\u1E1B", "\u1E1D", "\u1E1F", "\u1E21", "\u1E23", "\u1E25", "\u1E27", "\u1E29", "\u1E2B", "\u1E2D", "\u1E2F", "\u1E31", "\u1E33", "\u1E35", "\u1E37", "\u1E39", "\u1E3B", "\u1E3D", "\u1E3F", "\u1E41", "\u1E43", "\u1E45", "\u1E47", "\u1E49", "\u1E4B", "\u1E4D", "\u1E4F", "\u1E51", "\u1E53", "\u1E55", "\u1E57", "\u1E59", "\u1E5B", "\u1E5D", "\u1E5F", "\u1E61", "\u1E63", "\u1E65", "\u1E67", "\u1E69", "\u1E6B", "\u1E6D", "\u1E6F", "\u1E71", "\u1E73", "\u1E75", "\u1E77", "\u1E79", "\u1E7B", "\u1E7D", "\u1E7F", "\u1E81", "\u1E83", "\u1E85", "\u1E87", "\u1E89", "\u1E8B", "\u1E8D", "\u1E8F", "\u1E91", "\u1E93", ["\u1E95", "\u1E9D"], "\u1E9F", "\u1EA1", "\u1EA3", "\u1EA5", "\u1EA7", "\u1EA9", "\u1EAB", "\u1EAD", "\u1EAF", "\u1EB1", "\u1EB3", "\u1EB5", "\u1EB7", "\u1EB9", "\u1EBB", "\u1EBD", "\u1EBF", "\u1EC1", "\u1EC3", "\u1EC5", "\u1EC7", "\u1EC9", "\u1ECB", "\u1ECD", "\u1ECF", "\u1ED1", "\u1ED3", "\u1ED5", "\u1ED7", "\u1ED9", "\u1EDB", "\u1EDD", "\u1EDF", "\u1EE1", "\u1EE3", "\u1EE5", "\u1EE7", "\u1EE9", "\u1EEB", "\u1EED", "\u1EEF", "\u1EF1", "\u1EF3", "\u1EF5", "\u1EF7", "\u1EF9", "\u1EFB", "\u1EFD", ["\u1EFF", "\u1F07"], ["\u1F10", "\u1F15"], ["\u1F20", "\u1F27"], ["\u1F30", "\u1F37"], ["\u1F40", "\u1F45"], ["\u1F50", "\u1F57"], ["\u1F60", "\u1F67"], ["\u1F70", "\u1F7D"], ["\u1F80", "\u1F87"], ["\u1F90", "\u1F97"], ["\u1FA0", "\u1FA7"], ["\u1FB0", "\u1FB4"], ["\u1FB6", "\u1FB7"], "\u1FBE", ["\u1FC2", "\u1FC4"], ["\u1FC6", "\u1FC7"], ["\u1FD0", "\u1FD3"], ["\u1FD6", "\u1FD7"], ["\u1FE0", "\u1FE7"], ["\u1FF2", "\u1FF4"], ["\u1FF6", "\u1FF7"], "\u210A", ["\u210E", "\u210F"], "\u2113", "\u212F", "\u2134", "\u2139", ["\u213C", "\u213D"], ["\u2146", "\u2149"], "\u214E", "\u2184", ["\u2C30", "\u2C5E"], "\u2C61", ["\u2C65", "\u2C66"], "\u2C68", "\u2C6A", "\u2C6C", "\u2C71", ["\u2C73", "\u2C74"], ["\u2C76", "\u2C7B"], "\u2C81", "\u2C83", "\u2C85", "\u2C87", "\u2C89", "\u2C8B", "\u2C8D", "\u2C8F", "\u2C91", "\u2C93", "\u2C95", "\u2C97", "\u2C99", "\u2C9B", "\u2C9D", "\u2C9F", "\u2CA1", "\u2CA3", "\u2CA5", "\u2CA7", "\u2CA9", "\u2CAB", "\u2CAD", "\u2CAF", "\u2CB1", "\u2CB3", "\u2CB5", "\u2CB7", "\u2CB9", "\u2CBB", "\u2CBD", "\u2CBF", "\u2CC1", "\u2CC3", "\u2CC5", "\u2CC7", "\u2CC9", "\u2CCB", "\u2CCD", "\u2CCF", "\u2CD1", "\u2CD3", "\u2CD5", "\u2CD7", "\u2CD9", "\u2CDB", "\u2CDD", "\u2CDF", "\u2CE1", ["\u2CE3", "\u2CE4"], "\u2CEC", "\u2CEE", "\u2CF3", ["\u2D00", "\u2D25"], "\u2D27", "\u2D2D", "\uA641", "\uA643", "\uA645", "\uA647", "\uA649", "\uA64B", "\uA64D", "\uA64F", "\uA651", "\uA653", "\uA655", "\uA657", "\uA659", "\uA65B", "\uA65D", "\uA65F", "\uA661", "\uA663", "\uA665", "\uA667", "\uA669", "\uA66B", "\uA66D", "\uA681", "\uA683", "\uA685", "\uA687", "\uA689", "\uA68B", "\uA68D", "\uA68F", "\uA691", "\uA693", "\uA695", "\uA697", "\uA699", "\uA69B", "\uA723", "\uA725", "\uA727", "\uA729", "\uA72B", "\uA72D", ["\uA72F", "\uA731"], "\uA733", "\uA735", "\uA737", "\uA739", "\uA73B", "\uA73D", "\uA73F", "\uA741", "\uA743", "\uA745", "\uA747", "\uA749", "\uA74B", "\uA74D", "\uA74F", "\uA751", "\uA753", "\uA755", "\uA757", "\uA759", "\uA75B", "\uA75D", "\uA75F", "\uA761", "\uA763", "\uA765", "\uA767", "\uA769", "\uA76B", "\uA76D", "\uA76F", ["\uA771", "\uA778"], "\uA77A", "\uA77C", "\uA77F", "\uA781", "\uA783", "\uA785", "\uA787", "\uA78C", "\uA78E", "\uA791", ["\uA793", "\uA795"], "\uA797", "\uA799", "\uA79B", "\uA79D", "\uA79F", "\uA7A1", "\uA7A3", "\uA7A5", "\uA7A7", "\uA7A9", "\uA7AF", "\uA7B5", "\uA7B7", "\uA7B9", "\uA7FA", ["\uAB30", "\uAB5A"], ["\uAB60", "\uAB65"], ["\uAB70", "\uABBF"], ["\uFB00", "\uFB06"], ["\uFB13", "\uFB17"], ["\uFF41", "\uFF5A"]], false, false),
-      peg$c574 = /^[\u02B0-\u02C1\u02C6-\u02D1\u02E0-\u02E4\u02EC\u02EE\u0374\u037A\u0559\u0640\u06E5-\u06E6\u07F4-\u07F5\u07FA\u081A\u0824\u0828\u0971\u0E46\u0EC6\u10FC\u17D7\u1843\u1AA7\u1C78-\u1C7D\u1D2C-\u1D6A\u1D78\u1D9B-\u1DBF\u2071\u207F\u2090-\u209C\u2C7C-\u2C7D\u2D6F\u2E2F\u3005\u3031-\u3035\u303B\u309D-\u309E\u30FC-\u30FE\uA015\uA4F8-\uA4FD\uA60C\uA67F\uA69C-\uA69D\uA717-\uA71F\uA770\uA788\uA7F8-\uA7F9\uA9CF\uA9E6\uAA70\uAADD\uAAF3-\uAAF4\uAB5C-\uAB5F\uFF70\uFF9E-\uFF9F]/,
-      peg$c575 = peg$classExpectation([["\u02B0", "\u02C1"], ["\u02C6", "\u02D1"], ["\u02E0", "\u02E4"], "\u02EC", "\u02EE", "\u0374", "\u037A", "\u0559", "\u0640", ["\u06E5", "\u06E6"], ["\u07F4", "\u07F5"], "\u07FA", "\u081A", "\u0824", "\u0828", "\u0971", "\u0E46", "\u0EC6", "\u10FC", "\u17D7", "\u1843", "\u1AA7", ["\u1C78", "\u1C7D"], ["\u1D2C", "\u1D6A"], "\u1D78", ["\u1D9B", "\u1DBF"], "\u2071", "\u207F", ["\u2090", "\u209C"], ["\u2C7C", "\u2C7D"], "\u2D6F", "\u2E2F", "\u3005", ["\u3031", "\u3035"], "\u303B", ["\u309D", "\u309E"], ["\u30FC", "\u30FE"], "\uA015", ["\uA4F8", "\uA4FD"], "\uA60C", "\uA67F", ["\uA69C", "\uA69D"], ["\uA717", "\uA71F"], "\uA770", "\uA788", ["\uA7F8", "\uA7F9"], "\uA9CF", "\uA9E6", "\uAA70", "\uAADD", ["\uAAF3", "\uAAF4"], ["\uAB5C", "\uAB5F"], "\uFF70", ["\uFF9E", "\uFF9F"]], false, false),
-      peg$c576 = /^[\xAA\xBA\u01BB\u01C0-\u01C3\u0294\u05D0-\u05EA\u05EF-\u05F2\u0620-\u063F\u0641-\u064A\u066E-\u066F\u0671-\u06D3\u06D5\u06EE-\u06EF\u06FA-\u06FC\u06FF\u0710\u0712-\u072F\u074D-\u07A5\u07B1\u07CA-\u07EA\u0800-\u0815\u0840-\u0858\u0860-\u086A\u08A0-\u08B4\u08B6-\u08BD\u0904-\u0939\u093D\u0950\u0958-\u0961\u0972-\u0980\u0985-\u098C\u098F-\u0990\u0993-\u09A8\u09AA-\u09B0\u09B2\u09B6-\u09B9\u09BD\u09CE\u09DC-\u09DD\u09DF-\u09E1\u09F0-\u09F1\u09FC\u0A05-\u0A0A\u0A0F-\u0A10\u0A13-\u0A28\u0A2A-\u0A30\u0A32-\u0A33\u0A35-\u0A36\u0A38-\u0A39\u0A59-\u0A5C\u0A5E\u0A72-\u0A74\u0A85-\u0A8D\u0A8F-\u0A91\u0A93-\u0AA8\u0AAA-\u0AB0\u0AB2-\u0AB3\u0AB5-\u0AB9\u0ABD\u0AD0\u0AE0-\u0AE1\u0AF9\u0B05-\u0B0C\u0B0F-\u0B10\u0B13-\u0B28\u0B2A-\u0B30\u0B32-\u0B33\u0B35-\u0B39\u0B3D\u0B5C-\u0B5D\u0B5F-\u0B61\u0B71\u0B83\u0B85-\u0B8A\u0B8E-\u0B90\u0B92-\u0B95\u0B99-\u0B9A\u0B9C\u0B9E-\u0B9F\u0BA3-\u0BA4\u0BA8-\u0BAA\u0BAE-\u0BB9\u0BD0\u0C05-\u0C0C\u0C0E-\u0C10\u0C12-\u0C28\u0C2A-\u0C39\u0C3D\u0C58-\u0C5A\u0C60-\u0C61\u0C80\u0C85-\u0C8C\u0C8E-\u0C90\u0C92-\u0CA8\u0CAA-\u0CB3\u0CB5-\u0CB9\u0CBD\u0CDE\u0CE0-\u0CE1\u0CF1-\u0CF2\u0D05-\u0D0C\u0D0E-\u0D10\u0D12-\u0D3A\u0D3D\u0D4E\u0D54-\u0D56\u0D5F-\u0D61\u0D7A-\u0D7F\u0D85-\u0D96\u0D9A-\u0DB1\u0DB3-\u0DBB\u0DBD\u0DC0-\u0DC6\u0E01-\u0E30\u0E32-\u0E33\u0E40-\u0E45\u0E81-\u0E82\u0E84\u0E87-\u0E88\u0E8A\u0E8D\u0E94-\u0E97\u0E99-\u0E9F\u0EA1-\u0EA3\u0EA5\u0EA7\u0EAA-\u0EAB\u0EAD-\u0EB0\u0EB2-\u0EB3\u0EBD\u0EC0-\u0EC4\u0EDC-\u0EDF\u0F00\u0F40-\u0F47\u0F49-\u0F6C\u0F88-\u0F8C\u1000-\u102A\u103F\u1050-\u1055\u105A-\u105D\u1061\u1065-\u1066\u106E-\u1070\u1075-\u1081\u108E\u1100-\u1248\u124A-\u124D\u1250-\u1256\u1258\u125A-\u125D\u1260-\u1288\u128A-\u128D\u1290-\u12B0\u12B2-\u12B5\u12B8-\u12BE\u12C0\u12C2-\u12C5\u12C8-\u12D6\u12D8-\u1310\u1312-\u1315\u1318-\u135A\u1380-\u138F\u1401-\u166C\u166F-\u167F\u1681-\u169A\u16A0-\u16EA\u16F1-\u16F8\u1700-\u170C\u170E-\u1711\u1720-\u1731\u1740-\u1751\u1760-\u176C\u176E-\u1770\u1780-\u17B3\u17DC\u1820-\u1842\u1844-\u1878\u1880-\u1884\u1887-\u18A8\u18AA\u18B0-\u18F5\u1900-\u191E\u1950-\u196D\u1970-\u1974\u1980-\u19AB\u19B0-\u19C9\u1A00-\u1A16\u1A20-\u1A54\u1B05-\u1B33\u1B45-\u1B4B\u1B83-\u1BA0\u1BAE-\u1BAF\u1BBA-\u1BE5\u1C00-\u1C23\u1C4D-\u1C4F\u1C5A-\u1C77\u1CE9-\u1CEC\u1CEE-\u1CF1\u1CF5-\u1CF6\u2135-\u2138\u2D30-\u2D67\u2D80-\u2D96\u2DA0-\u2DA6\u2DA8-\u2DAE\u2DB0-\u2DB6\u2DB8-\u2DBE\u2DC0-\u2DC6\u2DC8-\u2DCE\u2DD0-\u2DD6\u2DD8-\u2DDE\u3006\u303C\u3041-\u3096\u309F\u30A1-\u30FA\u30FF\u3105-\u312F\u3131-\u318E\u31A0-\u31BA\u31F0-\u31FF\u3400-\u4DB5\u4E00-\u9FEF\uA000-\uA014\uA016-\uA48C\uA4D0-\uA4F7\uA500-\uA60B\uA610-\uA61F\uA62A-\uA62B\uA66E\uA6A0-\uA6E5\uA78F\uA7F7\uA7FB-\uA801\uA803-\uA805\uA807-\uA80A\uA80C-\uA822\uA840-\uA873\uA882-\uA8B3\uA8F2-\uA8F7\uA8FB\uA8FD-\uA8FE\uA90A-\uA925\uA930-\uA946\uA960-\uA97C\uA984-\uA9B2\uA9E0-\uA9E4\uA9E7-\uA9EF\uA9FA-\uA9FE\uAA00-\uAA28\uAA40-\uAA42\uAA44-\uAA4B\uAA60-\uAA6F\uAA71-\uAA76\uAA7A\uAA7E-\uAAAF\uAAB1\uAAB5-\uAAB6\uAAB9-\uAABD\uAAC0\uAAC2\uAADB-\uAADC\uAAE0-\uAAEA\uAAF2\uAB01-\uAB06\uAB09-\uAB0E\uAB11-\uAB16\uAB20-\uAB26\uAB28-\uAB2E\uABC0-\uABE2\uAC00-\uD7A3\uD7B0-\uD7C6\uD7CB-\uD7FB\uF900-\uFA6D\uFA70-\uFAD9\uFB1D\uFB1F-\uFB28\uFB2A-\uFB36\uFB38-\uFB3C\uFB3E\uFB40-\uFB41\uFB43-\uFB44\uFB46-\uFBB1\uFBD3-\uFD3D\uFD50-\uFD8F\uFD92-\uFDC7\uFDF0-\uFDFB\uFE70-\uFE74\uFE76-\uFEFC\uFF66-\uFF6F\uFF71-\uFF9D\uFFA0-\uFFBE\uFFC2-\uFFC7\uFFCA-\uFFCF\uFFD2-\uFFD7\uFFDA-\uFFDC]/,
-      peg$c577 = peg$classExpectation(["\xAA", "\xBA", "\u01BB", ["\u01C0", "\u01C3"], "\u0294", ["\u05D0", "\u05EA"], ["\u05EF", "\u05F2"], ["\u0620", "\u063F"], ["\u0641", "\u064A"], ["\u066E", "\u066F"], ["\u0671", "\u06D3"], "\u06D5", ["\u06EE", "\u06EF"], ["\u06FA", "\u06FC"], "\u06FF", "\u0710", ["\u0712", "\u072F"], ["\u074D", "\u07A5"], "\u07B1", ["\u07CA", "\u07EA"], ["\u0800", "\u0815"], ["\u0840", "\u0858"], ["\u0860", "\u086A"], ["\u08A0", "\u08B4"], ["\u08B6", "\u08BD"], ["\u0904", "\u0939"], "\u093D", "\u0950", ["\u0958", "\u0961"], ["\u0972", "\u0980"], ["\u0985", "\u098C"], ["\u098F", "\u0990"], ["\u0993", "\u09A8"], ["\u09AA", "\u09B0"], "\u09B2", ["\u09B6", "\u09B9"], "\u09BD", "\u09CE", ["\u09DC", "\u09DD"], ["\u09DF", "\u09E1"], ["\u09F0", "\u09F1"], "\u09FC", ["\u0A05", "\u0A0A"], ["\u0A0F", "\u0A10"], ["\u0A13", "\u0A28"], ["\u0A2A", "\u0A30"], ["\u0A32", "\u0A33"], ["\u0A35", "\u0A36"], ["\u0A38", "\u0A39"], ["\u0A59", "\u0A5C"], "\u0A5E", ["\u0A72", "\u0A74"], ["\u0A85", "\u0A8D"], ["\u0A8F", "\u0A91"], ["\u0A93", "\u0AA8"], ["\u0AAA", "\u0AB0"], ["\u0AB2", "\u0AB3"], ["\u0AB5", "\u0AB9"], "\u0ABD", "\u0AD0", ["\u0AE0", "\u0AE1"], "\u0AF9", ["\u0B05", "\u0B0C"], ["\u0B0F", "\u0B10"], ["\u0B13", "\u0B28"], ["\u0B2A", "\u0B30"], ["\u0B32", "\u0B33"], ["\u0B35", "\u0B39"], "\u0B3D", ["\u0B5C", "\u0B5D"], ["\u0B5F", "\u0B61"], "\u0B71", "\u0B83", ["\u0B85", "\u0B8A"], ["\u0B8E", "\u0B90"], ["\u0B92", "\u0B95"], ["\u0B99", "\u0B9A"], "\u0B9C", ["\u0B9E", "\u0B9F"], ["\u0BA3", "\u0BA4"], ["\u0BA8", "\u0BAA"], ["\u0BAE", "\u0BB9"], "\u0BD0", ["\u0C05", "\u0C0C"], ["\u0C0E", "\u0C10"], ["\u0C12", "\u0C28"], ["\u0C2A", "\u0C39"], "\u0C3D", ["\u0C58", "\u0C5A"], ["\u0C60", "\u0C61"], "\u0C80", ["\u0C85", "\u0C8C"], ["\u0C8E", "\u0C90"], ["\u0C92", "\u0CA8"], ["\u0CAA", "\u0CB3"], ["\u0CB5", "\u0CB9"], "\u0CBD", "\u0CDE", ["\u0CE0", "\u0CE1"], ["\u0CF1", "\u0CF2"], ["\u0D05", "\u0D0C"], ["\u0D0E", "\u0D10"], ["\u0D12", "\u0D3A"], "\u0D3D", "\u0D4E", ["\u0D54", "\u0D56"], ["\u0D5F", "\u0D61"], ["\u0D7A", "\u0D7F"], ["\u0D85", "\u0D96"], ["\u0D9A", "\u0DB1"], ["\u0DB3", "\u0DBB"], "\u0DBD", ["\u0DC0", "\u0DC6"], ["\u0E01", "\u0E30"], ["\u0E32", "\u0E33"], ["\u0E40", "\u0E45"], ["\u0E81", "\u0E82"], "\u0E84", ["\u0E87", "\u0E88"], "\u0E8A", "\u0E8D", ["\u0E94", "\u0E97"], ["\u0E99", "\u0E9F"], ["\u0EA1", "\u0EA3"], "\u0EA5", "\u0EA7", ["\u0EAA", "\u0EAB"], ["\u0EAD", "\u0EB0"], ["\u0EB2", "\u0EB3"], "\u0EBD", ["\u0EC0", "\u0EC4"], ["\u0EDC", "\u0EDF"], "\u0F00", ["\u0F40", "\u0F47"], ["\u0F49", "\u0F6C"], ["\u0F88", "\u0F8C"], ["\u1000", "\u102A"], "\u103F", ["\u1050", "\u1055"], ["\u105A", "\u105D"], "\u1061", ["\u1065", "\u1066"], ["\u106E", "\u1070"], ["\u1075", "\u1081"], "\u108E", ["\u1100", "\u1248"], ["\u124A", "\u124D"], ["\u1250", "\u1256"], "\u1258", ["\u125A", "\u125D"], ["\u1260", "\u1288"], ["\u128A", "\u128D"], ["\u1290", "\u12B0"], ["\u12B2", "\u12B5"], ["\u12B8", "\u12BE"], "\u12C0", ["\u12C2", "\u12C5"], ["\u12C8", "\u12D6"], ["\u12D8", "\u1310"], ["\u1312", "\u1315"], ["\u1318", "\u135A"], ["\u1380", "\u138F"], ["\u1401", "\u166C"], ["\u166F", "\u167F"], ["\u1681", "\u169A"], ["\u16A0", "\u16EA"], ["\u16F1", "\u16F8"], ["\u1700", "\u170C"], ["\u170E", "\u1711"], ["\u1720", "\u1731"], ["\u1740", "\u1751"], ["\u1760", "\u176C"], ["\u176E", "\u1770"], ["\u1780", "\u17B3"], "\u17DC", ["\u1820", "\u1842"], ["\u1844", "\u1878"], ["\u1880", "\u1884"], ["\u1887", "\u18A8"], "\u18AA", ["\u18B0", "\u18F5"], ["\u1900", "\u191E"], ["\u1950", "\u196D"], ["\u1970", "\u1974"], ["\u1980", "\u19AB"], ["\u19B0", "\u19C9"], ["\u1A00", "\u1A16"], ["\u1A20", "\u1A54"], ["\u1B05", "\u1B33"], ["\u1B45", "\u1B4B"], ["\u1B83", "\u1BA0"], ["\u1BAE", "\u1BAF"], ["\u1BBA", "\u1BE5"], ["\u1C00", "\u1C23"], ["\u1C4D", "\u1C4F"], ["\u1C5A", "\u1C77"], ["\u1CE9", "\u1CEC"], ["\u1CEE", "\u1CF1"], ["\u1CF5", "\u1CF6"], ["\u2135", "\u2138"], ["\u2D30", "\u2D67"], ["\u2D80", "\u2D96"], ["\u2DA0", "\u2DA6"], ["\u2DA8", "\u2DAE"], ["\u2DB0", "\u2DB6"], ["\u2DB8", "\u2DBE"], ["\u2DC0", "\u2DC6"], ["\u2DC8", "\u2DCE"], ["\u2DD0", "\u2DD6"], ["\u2DD8", "\u2DDE"], "\u3006", "\u303C", ["\u3041", "\u3096"], "\u309F", ["\u30A1", "\u30FA"], "\u30FF", ["\u3105", "\u312F"], ["\u3131", "\u318E"], ["\u31A0", "\u31BA"], ["\u31F0", "\u31FF"], ["\u3400", "\u4DB5"], ["\u4E00", "\u9FEF"], ["\uA000", "\uA014"], ["\uA016", "\uA48C"], ["\uA4D0", "\uA4F7"], ["\uA500", "\uA60B"], ["\uA610", "\uA61F"], ["\uA62A", "\uA62B"], "\uA66E", ["\uA6A0", "\uA6E5"], "\uA78F", "\uA7F7", ["\uA7FB", "\uA801"], ["\uA803", "\uA805"], ["\uA807", "\uA80A"], ["\uA80C", "\uA822"], ["\uA840", "\uA873"], ["\uA882", "\uA8B3"], ["\uA8F2", "\uA8F7"], "\uA8FB", ["\uA8FD", "\uA8FE"], ["\uA90A", "\uA925"], ["\uA930", "\uA946"], ["\uA960", "\uA97C"], ["\uA984", "\uA9B2"], ["\uA9E0", "\uA9E4"], ["\uA9E7", "\uA9EF"], ["\uA9FA", "\uA9FE"], ["\uAA00", "\uAA28"], ["\uAA40", "\uAA42"], ["\uAA44", "\uAA4B"], ["\uAA60", "\uAA6F"], ["\uAA71", "\uAA76"], "\uAA7A", ["\uAA7E", "\uAAAF"], "\uAAB1", ["\uAAB5", "\uAAB6"], ["\uAAB9", "\uAABD"], "\uAAC0", "\uAAC2", ["\uAADB", "\uAADC"], ["\uAAE0", "\uAAEA"], "\uAAF2", ["\uAB01", "\uAB06"], ["\uAB09", "\uAB0E"], ["\uAB11", "\uAB16"], ["\uAB20", "\uAB26"], ["\uAB28", "\uAB2E"], ["\uABC0", "\uABE2"], ["\uAC00", "\uD7A3"], ["\uD7B0", "\uD7C6"], ["\uD7CB", "\uD7FB"], ["\uF900", "\uFA6D"], ["\uFA70", "\uFAD9"], "\uFB1D", ["\uFB1F", "\uFB28"], ["\uFB2A", "\uFB36"], ["\uFB38", "\uFB3C"], "\uFB3E", ["\uFB40", "\uFB41"], ["\uFB43", "\uFB44"], ["\uFB46", "\uFBB1"], ["\uFBD3", "\uFD3D"], ["\uFD50", "\uFD8F"], ["\uFD92", "\uFDC7"], ["\uFDF0", "\uFDFB"], ["\uFE70", "\uFE74"], ["\uFE76", "\uFEFC"], ["\uFF66", "\uFF6F"], ["\uFF71", "\uFF9D"], ["\uFFA0", "\uFFBE"], ["\uFFC2", "\uFFC7"], ["\uFFCA", "\uFFCF"], ["\uFFD2", "\uFFD7"], ["\uFFDA", "\uFFDC"]], false, false),
-      peg$c578 = /^[\u01C5\u01C8\u01CB\u01F2\u1F88-\u1F8F\u1F98-\u1F9F\u1FA8-\u1FAF\u1FBC\u1FCC\u1FFC]/,
-      peg$c579 = peg$classExpectation(["\u01C5", "\u01C8", "\u01CB", "\u01F2", ["\u1F88", "\u1F8F"], ["\u1F98", "\u1F9F"], ["\u1FA8", "\u1FAF"], "\u1FBC", "\u1FCC", "\u1FFC"], false, false),
-      peg$c580 = /^[A-Z\xC0-\xD6\xD8-\xDE\u0100\u0102\u0104\u0106\u0108\u010A\u010C\u010E\u0110\u0112\u0114\u0116\u0118\u011A\u011C\u011E\u0120\u0122\u0124\u0126\u0128\u012A\u012C\u012E\u0130\u0132\u0134\u0136\u0139\u013B\u013D\u013F\u0141\u0143\u0145\u0147\u014A\u014C\u014E\u0150\u0152\u0154\u0156\u0158\u015A\u015C\u015E\u0160\u0162\u0164\u0166\u0168\u016A\u016C\u016E\u0170\u0172\u0174\u0176\u0178-\u0179\u017B\u017D\u0181-\u0182\u0184\u0186-\u0187\u0189-\u018B\u018E-\u0191\u0193-\u0194\u0196-\u0198\u019C-\u019D\u019F-\u01A0\u01A2\u01A4\u01A6-\u01A7\u01A9\u01AC\u01AE-\u01AF\u01B1-\u01B3\u01B5\u01B7-\u01B8\u01BC\u01C4\u01C7\u01CA\u01CD\u01CF\u01D1\u01D3\u01D5\u01D7\u01D9\u01DB\u01DE\u01E0\u01E2\u01E4\u01E6\u01E8\u01EA\u01EC\u01EE\u01F1\u01F4\u01F6-\u01F8\u01FA\u01FC\u01FE\u0200\u0202\u0204\u0206\u0208\u020A\u020C\u020E\u0210\u0212\u0214\u0216\u0218\u021A\u021C\u021E\u0220\u0222\u0224\u0226\u0228\u022A\u022C\u022E\u0230\u0232\u023A-\u023B\u023D-\u023E\u0241\u0243-\u0246\u0248\u024A\u024C\u024E\u0370\u0372\u0376\u037F\u0386\u0388-\u038A\u038C\u038E-\u038F\u0391-\u03A1\u03A3-\u03AB\u03CF\u03D2-\u03D4\u03D8\u03DA\u03DC\u03DE\u03E0\u03E2\u03E4\u03E6\u03E8\u03EA\u03EC\u03EE\u03F4\u03F7\u03F9-\u03FA\u03FD-\u042F\u0460\u0462\u0464\u0466\u0468\u046A\u046C\u046E\u0470\u0472\u0474\u0476\u0478\u047A\u047C\u047E\u0480\u048A\u048C\u048E\u0490\u0492\u0494\u0496\u0498\u049A\u049C\u049E\u04A0\u04A2\u04A4\u04A6\u04A8\u04AA\u04AC\u04AE\u04B0\u04B2\u04B4\u04B6\u04B8\u04BA\u04BC\u04BE\u04C0-\u04C1\u04C3\u04C5\u04C7\u04C9\u04CB\u04CD\u04D0\u04D2\u04D4\u04D6\u04D8\u04DA\u04DC\u04DE\u04E0\u04E2\u04E4\u04E6\u04E8\u04EA\u04EC\u04EE\u04F0\u04F2\u04F4\u04F6\u04F8\u04FA\u04FC\u04FE\u0500\u0502\u0504\u0506\u0508\u050A\u050C\u050E\u0510\u0512\u0514\u0516\u0518\u051A\u051C\u051E\u0520\u0522\u0524\u0526\u0528\u052A\u052C\u052E\u0531-\u0556\u10A0-\u10C5\u10C7\u10CD\u13A0-\u13F5\u1C90-\u1CBA\u1CBD-\u1CBF\u1E00\u1E02\u1E04\u1E06\u1E08\u1E0A\u1E0C\u1E0E\u1E10\u1E12\u1E14\u1E16\u1E18\u1E1A\u1E1C\u1E1E\u1E20\u1E22\u1E24\u1E26\u1E28\u1E2A\u1E2C\u1E2E\u1E30\u1E32\u1E34\u1E36\u1E38\u1E3A\u1E3C\u1E3E\u1E40\u1E42\u1E44\u1E46\u1E48\u1E4A\u1E4C\u1E4E\u1E50\u1E52\u1E54\u1E56\u1E58\u1E5A\u1E5C\u1E5E\u1E60\u1E62\u1E64\u1E66\u1E68\u1E6A\u1E6C\u1E6E\u1E70\u1E72\u1E74\u1E76\u1E78\u1E7A\u1E7C\u1E7E\u1E80\u1E82\u1E84\u1E86\u1E88\u1E8A\u1E8C\u1E8E\u1E90\u1E92\u1E94\u1E9E\u1EA0\u1EA2\u1EA4\u1EA6\u1EA8\u1EAA\u1EAC\u1EAE\u1EB0\u1EB2\u1EB4\u1EB6\u1EB8\u1EBA\u1EBC\u1EBE\u1EC0\u1EC2\u1EC4\u1EC6\u1EC8\u1ECA\u1ECC\u1ECE\u1ED0\u1ED2\u1ED4\u1ED6\u1ED8\u1EDA\u1EDC\u1EDE\u1EE0\u1EE2\u1EE4\u1EE6\u1EE8\u1EEA\u1EEC\u1EEE\u1EF0\u1EF2\u1EF4\u1EF6\u1EF8\u1EFA\u1EFC\u1EFE\u1F08-\u1F0F\u1F18-\u1F1D\u1F28-\u1F2F\u1F38-\u1F3F\u1F48-\u1F4D\u1F59\u1F5B\u1F5D\u1F5F\u1F68-\u1F6F\u1FB8-\u1FBB\u1FC8-\u1FCB\u1FD8-\u1FDB\u1FE8-\u1FEC\u1FF8-\u1FFB\u2102\u2107\u210B-\u210D\u2110-\u2112\u2115\u2119-\u211D\u2124\u2126\u2128\u212A-\u212D\u2130-\u2133\u213E-\u213F\u2145\u2183\u2C00-\u2C2E\u2C60\u2C62-\u2C64\u2C67\u2C69\u2C6B\u2C6D-\u2C70\u2C72\u2C75\u2C7E-\u2C80\u2C82\u2C84\u2C86\u2C88\u2C8A\u2C8C\u2C8E\u2C90\u2C92\u2C94\u2C96\u2C98\u2C9A\u2C9C\u2C9E\u2CA0\u2CA2\u2CA4\u2CA6\u2CA8\u2CAA\u2CAC\u2CAE\u2CB0\u2CB2\u2CB4\u2CB6\u2CB8\u2CBA\u2CBC\u2CBE\u2CC0\u2CC2\u2CC4\u2CC6\u2CC8\u2CCA\u2CCC\u2CCE\u2CD0\u2CD2\u2CD4\u2CD6\u2CD8\u2CDA\u2CDC\u2CDE\u2CE0\u2CE2\u2CEB\u2CED\u2CF2\uA640\uA642\uA644\uA646\uA648\uA64A\uA64C\uA64E\uA650\uA652\uA654\uA656\uA658\uA65A\uA65C\uA65E\uA660\uA662\uA664\uA666\uA668\uA66A\uA66C\uA680\uA682\uA684\uA686\uA688\uA68A\uA68C\uA68E\uA690\uA692\uA694\uA696\uA698\uA69A\uA722\uA724\uA726\uA728\uA72A\uA72C\uA72E\uA732\uA734\uA736\uA738\uA73A\uA73C\uA73E\uA740\uA742\uA744\uA746\uA748\uA74A\uA74C\uA74E\uA750\uA752\uA754\uA756\uA758\uA75A\uA75C\uA75E\uA760\uA762\uA764\uA766\uA768\uA76A\uA76C\uA76E\uA779\uA77B\uA77D-\uA77E\uA780\uA782\uA784\uA786\uA78B\uA78D\uA790\uA792\uA796\uA798\uA79A\uA79C\uA79E\uA7A0\uA7A2\uA7A4\uA7A6\uA7A8\uA7AA-\uA7AE\uA7B0-\uA7B4\uA7B6\uA7B8\uFF21-\uFF3A]/,
-      peg$c581 = peg$classExpectation([["A", "Z"], ["\xC0", "\xD6"], ["\xD8", "\xDE"], "\u0100", "\u0102", "\u0104", "\u0106", "\u0108", "\u010A", "\u010C", "\u010E", "\u0110", "\u0112", "\u0114", "\u0116", "\u0118", "\u011A", "\u011C", "\u011E", "\u0120", "\u0122", "\u0124", "\u0126", "\u0128", "\u012A", "\u012C", "\u012E", "\u0130", "\u0132", "\u0134", "\u0136", "\u0139", "\u013B", "\u013D", "\u013F", "\u0141", "\u0143", "\u0145", "\u0147", "\u014A", "\u014C", "\u014E", "\u0150", "\u0152", "\u0154", "\u0156", "\u0158", "\u015A", "\u015C", "\u015E", "\u0160", "\u0162", "\u0164", "\u0166", "\u0168", "\u016A", "\u016C", "\u016E", "\u0170", "\u0172", "\u0174", "\u0176", ["\u0178", "\u0179"], "\u017B", "\u017D", ["\u0181", "\u0182"], "\u0184", ["\u0186", "\u0187"], ["\u0189", "\u018B"], ["\u018E", "\u0191"], ["\u0193", "\u0194"], ["\u0196", "\u0198"], ["\u019C", "\u019D"], ["\u019F", "\u01A0"], "\u01A2", "\u01A4", ["\u01A6", "\u01A7"], "\u01A9", "\u01AC", ["\u01AE", "\u01AF"], ["\u01B1", "\u01B3"], "\u01B5", ["\u01B7", "\u01B8"], "\u01BC", "\u01C4", "\u01C7", "\u01CA", "\u01CD", "\u01CF", "\u01D1", "\u01D3", "\u01D5", "\u01D7", "\u01D9", "\u01DB", "\u01DE", "\u01E0", "\u01E2", "\u01E4", "\u01E6", "\u01E8", "\u01EA", "\u01EC", "\u01EE", "\u01F1", "\u01F4", ["\u01F6", "\u01F8"], "\u01FA", "\u01FC", "\u01FE", "\u0200", "\u0202", "\u0204", "\u0206", "\u0208", "\u020A", "\u020C", "\u020E", "\u0210", "\u0212", "\u0214", "\u0216", "\u0218", "\u021A", "\u021C", "\u021E", "\u0220", "\u0222", "\u0224", "\u0226", "\u0228", "\u022A", "\u022C", "\u022E", "\u0230", "\u0232", ["\u023A", "\u023B"], ["\u023D", "\u023E"], "\u0241", ["\u0243", "\u0246"], "\u0248", "\u024A", "\u024C", "\u024E", "\u0370", "\u0372", "\u0376", "\u037F", "\u0386", ["\u0388", "\u038A"], "\u038C", ["\u038E", "\u038F"], ["\u0391", "\u03A1"], ["\u03A3", "\u03AB"], "\u03CF", ["\u03D2", "\u03D4"], "\u03D8", "\u03DA", "\u03DC", "\u03DE", "\u03E0", "\u03E2", "\u03E4", "\u03E6", "\u03E8", "\u03EA", "\u03EC", "\u03EE", "\u03F4", "\u03F7", ["\u03F9", "\u03FA"], ["\u03FD", "\u042F"], "\u0460", "\u0462", "\u0464", "\u0466", "\u0468", "\u046A", "\u046C", "\u046E", "\u0470", "\u0472", "\u0474", "\u0476", "\u0478", "\u047A", "\u047C", "\u047E", "\u0480", "\u048A", "\u048C", "\u048E", "\u0490", "\u0492", "\u0494", "\u0496", "\u0498", "\u049A", "\u049C", "\u049E", "\u04A0", "\u04A2", "\u04A4", "\u04A6", "\u04A8", "\u04AA", "\u04AC", "\u04AE", "\u04B0", "\u04B2", "\u04B4", "\u04B6", "\u04B8", "\u04BA", "\u04BC", "\u04BE", ["\u04C0", "\u04C1"], "\u04C3", "\u04C5", "\u04C7", "\u04C9", "\u04CB", "\u04CD", "\u04D0", "\u04D2", "\u04D4", "\u04D6", "\u04D8", "\u04DA", "\u04DC", "\u04DE", "\u04E0", "\u04E2", "\u04E4", "\u04E6", "\u04E8", "\u04EA", "\u04EC", "\u04EE", "\u04F0", "\u04F2", "\u04F4", "\u04F6", "\u04F8", "\u04FA", "\u04FC", "\u04FE", "\u0500", "\u0502", "\u0504", "\u0506", "\u0508", "\u050A", "\u050C", "\u050E", "\u0510", "\u0512", "\u0514", "\u0516", "\u0518", "\u051A", "\u051C", "\u051E", "\u0520", "\u0522", "\u0524", "\u0526", "\u0528", "\u052A", "\u052C", "\u052E", ["\u0531", "\u0556"], ["\u10A0", "\u10C5"], "\u10C7", "\u10CD", ["\u13A0", "\u13F5"], ["\u1C90", "\u1CBA"], ["\u1CBD", "\u1CBF"], "\u1E00", "\u1E02", "\u1E04", "\u1E06", "\u1E08", "\u1E0A", "\u1E0C", "\u1E0E", "\u1E10", "\u1E12", "\u1E14", "\u1E16", "\u1E18", "\u1E1A", "\u1E1C", "\u1E1E", "\u1E20", "\u1E22", "\u1E24", "\u1E26", "\u1E28", "\u1E2A", "\u1E2C", "\u1E2E", "\u1E30", "\u1E32", "\u1E34", "\u1E36", "\u1E38", "\u1E3A", "\u1E3C", "\u1E3E", "\u1E40", "\u1E42", "\u1E44", "\u1E46", "\u1E48", "\u1E4A", "\u1E4C", "\u1E4E", "\u1E50", "\u1E52", "\u1E54", "\u1E56", "\u1E58", "\u1E5A", "\u1E5C", "\u1E5E", "\u1E60", "\u1E62", "\u1E64", "\u1E66", "\u1E68", "\u1E6A", "\u1E6C", "\u1E6E", "\u1E70", "\u1E72", "\u1E74", "\u1E76", "\u1E78", "\u1E7A", "\u1E7C", "\u1E7E", "\u1E80", "\u1E82", "\u1E84", "\u1E86", "\u1E88", "\u1E8A", "\u1E8C", "\u1E8E", "\u1E90", "\u1E92", "\u1E94", "\u1E9E", "\u1EA0", "\u1EA2", "\u1EA4", "\u1EA6", "\u1EA8", "\u1EAA", "\u1EAC", "\u1EAE", "\u1EB0", "\u1EB2", "\u1EB4", "\u1EB6", "\u1EB8", "\u1EBA", "\u1EBC", "\u1EBE", "\u1EC0", "\u1EC2", "\u1EC4", "\u1EC6", "\u1EC8", "\u1ECA", "\u1ECC", "\u1ECE", "\u1ED0", "\u1ED2", "\u1ED4", "\u1ED6", "\u1ED8", "\u1EDA", "\u1EDC", "\u1EDE", "\u1EE0", "\u1EE2", "\u1EE4", "\u1EE6", "\u1EE8", "\u1EEA", "\u1EEC", "\u1EEE", "\u1EF0", "\u1EF2", "\u1EF4", "\u1EF6", "\u1EF8", "\u1EFA", "\u1EFC", "\u1EFE", ["\u1F08", "\u1F0F"], ["\u1F18", "\u1F1D"], ["\u1F28", "\u1F2F"], ["\u1F38", "\u1F3F"], ["\u1F48", "\u1F4D"], "\u1F59", "\u1F5B", "\u1F5D", "\u1F5F", ["\u1F68", "\u1F6F"], ["\u1FB8", "\u1FBB"], ["\u1FC8", "\u1FCB"], ["\u1FD8", "\u1FDB"], ["\u1FE8", "\u1FEC"], ["\u1FF8", "\u1FFB"], "\u2102", "\u2107", ["\u210B", "\u210D"], ["\u2110", "\u2112"], "\u2115", ["\u2119", "\u211D"], "\u2124", "\u2126", "\u2128", ["\u212A", "\u212D"], ["\u2130", "\u2133"], ["\u213E", "\u213F"], "\u2145", "\u2183", ["\u2C00", "\u2C2E"], "\u2C60", ["\u2C62", "\u2C64"], "\u2C67", "\u2C69", "\u2C6B", ["\u2C6D", "\u2C70"], "\u2C72", "\u2C75", ["\u2C7E", "\u2C80"], "\u2C82", "\u2C84", "\u2C86", "\u2C88", "\u2C8A", "\u2C8C", "\u2C8E", "\u2C90", "\u2C92", "\u2C94", "\u2C96", "\u2C98", "\u2C9A", "\u2C9C", "\u2C9E", "\u2CA0", "\u2CA2", "\u2CA4", "\u2CA6", "\u2CA8", "\u2CAA", "\u2CAC", "\u2CAE", "\u2CB0", "\u2CB2", "\u2CB4", "\u2CB6", "\u2CB8", "\u2CBA", "\u2CBC", "\u2CBE", "\u2CC0", "\u2CC2", "\u2CC4", "\u2CC6", "\u2CC8", "\u2CCA", "\u2CCC", "\u2CCE", "\u2CD0", "\u2CD2", "\u2CD4", "\u2CD6", "\u2CD8", "\u2CDA", "\u2CDC", "\u2CDE", "\u2CE0", "\u2CE2", "\u2CEB", "\u2CED", "\u2CF2", "\uA640", "\uA642", "\uA644", "\uA646", "\uA648", "\uA64A", "\uA64C", "\uA64E", "\uA650", "\uA652", "\uA654", "\uA656", "\uA658", "\uA65A", "\uA65C", "\uA65E", "\uA660", "\uA662", "\uA664", "\uA666", "\uA668", "\uA66A", "\uA66C", "\uA680", "\uA682", "\uA684", "\uA686", "\uA688", "\uA68A", "\uA68C", "\uA68E", "\uA690", "\uA692", "\uA694", "\uA696", "\uA698", "\uA69A", "\uA722", "\uA724", "\uA726", "\uA728", "\uA72A", "\uA72C", "\uA72E", "\uA732", "\uA734", "\uA736", "\uA738", "\uA73A", "\uA73C", "\uA73E", "\uA740", "\uA742", "\uA744", "\uA746", "\uA748", "\uA74A", "\uA74C", "\uA74E", "\uA750", "\uA752", "\uA754", "\uA756", "\uA758", "\uA75A", "\uA75C", "\uA75E", "\uA760", "\uA762", "\uA764", "\uA766", "\uA768", "\uA76A", "\uA76C", "\uA76E", "\uA779", "\uA77B", ["\uA77D", "\uA77E"], "\uA780", "\uA782", "\uA784", "\uA786", "\uA78B", "\uA78D", "\uA790", "\uA792", "\uA796", "\uA798", "\uA79A", "\uA79C", "\uA79E", "\uA7A0", "\uA7A2", "\uA7A4", "\uA7A6", "\uA7A8", ["\uA7AA", "\uA7AE"], ["\uA7B0", "\uA7B4"], "\uA7B6", "\uA7B8", ["\uFF21", "\uFF3A"]], false, false),
-      peg$c582 = /^[\u0903\u093B\u093E-\u0940\u0949-\u094C\u094E-\u094F\u0982-\u0983\u09BE-\u09C0\u09C7-\u09C8\u09CB-\u09CC\u09D7\u0A03\u0A3E-\u0A40\u0A83\u0ABE-\u0AC0\u0AC9\u0ACB-\u0ACC\u0B02-\u0B03\u0B3E\u0B40\u0B47-\u0B48\u0B4B-\u0B4C\u0B57\u0BBE-\u0BBF\u0BC1-\u0BC2\u0BC6-\u0BC8\u0BCA-\u0BCC\u0BD7\u0C01-\u0C03\u0C41-\u0C44\u0C82-\u0C83\u0CBE\u0CC0-\u0CC4\u0CC7-\u0CC8\u0CCA-\u0CCB\u0CD5-\u0CD6\u0D02-\u0D03\u0D3E-\u0D40\u0D46-\u0D48\u0D4A-\u0D4C\u0D57\u0D82-\u0D83\u0DCF-\u0DD1\u0DD8-\u0DDF\u0DF2-\u0DF3\u0F3E-\u0F3F\u0F7F\u102B-\u102C\u1031\u1038\u103B-\u103C\u1056-\u1057\u1062-\u1064\u1067-\u106D\u1083-\u1084\u1087-\u108C\u108F\u109A-\u109C\u17B6\u17BE-\u17C5\u17C7-\u17C8\u1923-\u1926\u1929-\u192B\u1930-\u1931\u1933-\u1938\u1A19-\u1A1A\u1A55\u1A57\u1A61\u1A63-\u1A64\u1A6D-\u1A72\u1B04\u1B35\u1B3B\u1B3D-\u1B41\u1B43-\u1B44\u1B82\u1BA1\u1BA6-\u1BA7\u1BAA\u1BE7\u1BEA-\u1BEC\u1BEE\u1BF2-\u1BF3\u1C24-\u1C2B\u1C34-\u1C35\u1CE1\u1CF2-\u1CF3\u1CF7\u302E-\u302F\uA823-\uA824\uA827\uA880-\uA881\uA8B4-\uA8C3\uA952-\uA953\uA983\uA9B4-\uA9B5\uA9BA-\uA9BB\uA9BD-\uA9C0\uAA2F-\uAA30\uAA33-\uAA34\uAA4D\uAA7B\uAA7D\uAAEB\uAAEE-\uAAEF\uAAF5\uABE3-\uABE4\uABE6-\uABE7\uABE9-\uABEA\uABEC]/,
-      peg$c583 = peg$classExpectation(["\u0903", "\u093B", ["\u093E", "\u0940"], ["\u0949", "\u094C"], ["\u094E", "\u094F"], ["\u0982", "\u0983"], ["\u09BE", "\u09C0"], ["\u09C7", "\u09C8"], ["\u09CB", "\u09CC"], "\u09D7", "\u0A03", ["\u0A3E", "\u0A40"], "\u0A83", ["\u0ABE", "\u0AC0"], "\u0AC9", ["\u0ACB", "\u0ACC"], ["\u0B02", "\u0B03"], "\u0B3E", "\u0B40", ["\u0B47", "\u0B48"], ["\u0B4B", "\u0B4C"], "\u0B57", ["\u0BBE", "\u0BBF"], ["\u0BC1", "\u0BC2"], ["\u0BC6", "\u0BC8"], ["\u0BCA", "\u0BCC"], "\u0BD7", ["\u0C01", "\u0C03"], ["\u0C41", "\u0C44"], ["\u0C82", "\u0C83"], "\u0CBE", ["\u0CC0", "\u0CC4"], ["\u0CC7", "\u0CC8"], ["\u0CCA", "\u0CCB"], ["\u0CD5", "\u0CD6"], ["\u0D02", "\u0D03"], ["\u0D3E", "\u0D40"], ["\u0D46", "\u0D48"], ["\u0D4A", "\u0D4C"], "\u0D57", ["\u0D82", "\u0D83"], ["\u0DCF", "\u0DD1"], ["\u0DD8", "\u0DDF"], ["\u0DF2", "\u0DF3"], ["\u0F3E", "\u0F3F"], "\u0F7F", ["\u102B", "\u102C"], "\u1031", "\u1038", ["\u103B", "\u103C"], ["\u1056", "\u1057"], ["\u1062", "\u1064"], ["\u1067", "\u106D"], ["\u1083", "\u1084"], ["\u1087", "\u108C"], "\u108F", ["\u109A", "\u109C"], "\u17B6", ["\u17BE", "\u17C5"], ["\u17C7", "\u17C8"], ["\u1923", "\u1926"], ["\u1929", "\u192B"], ["\u1930", "\u1931"], ["\u1933", "\u1938"], ["\u1A19", "\u1A1A"], "\u1A55", "\u1A57", "\u1A61", ["\u1A63", "\u1A64"], ["\u1A6D", "\u1A72"], "\u1B04", "\u1B35", "\u1B3B", ["\u1B3D", "\u1B41"], ["\u1B43", "\u1B44"], "\u1B82", "\u1BA1", ["\u1BA6", "\u1BA7"], "\u1BAA", "\u1BE7", ["\u1BEA", "\u1BEC"], "\u1BEE", ["\u1BF2", "\u1BF3"], ["\u1C24", "\u1C2B"], ["\u1C34", "\u1C35"], "\u1CE1", ["\u1CF2", "\u1CF3"], "\u1CF7", ["\u302E", "\u302F"], ["\uA823", "\uA824"], "\uA827", ["\uA880", "\uA881"], ["\uA8B4", "\uA8C3"], ["\uA952", "\uA953"], "\uA983", ["\uA9B4", "\uA9B5"], ["\uA9BA", "\uA9BB"], ["\uA9BD", "\uA9C0"], ["\uAA2F", "\uAA30"], ["\uAA33", "\uAA34"], "\uAA4D", "\uAA7B", "\uAA7D", "\uAAEB", ["\uAAEE", "\uAAEF"], "\uAAF5", ["\uABE3", "\uABE4"], ["\uABE6", "\uABE7"], ["\uABE9", "\uABEA"], "\uABEC"], false, false),
-      peg$c584 = /^[\u0300-\u036F\u0483-\u0487\u0591-\u05BD\u05BF\u05C1-\u05C2\u05C4-\u05C5\u05C7\u0610-\u061A\u064B-\u065F\u0670\u06D6-\u06DC\u06DF-\u06E4\u06E7-\u06E8\u06EA-\u06ED\u0711\u0730-\u074A\u07A6-\u07B0\u07EB-\u07F3\u07FD\u0816-\u0819\u081B-\u0823\u0825-\u0827\u0829-\u082D\u0859-\u085B\u08D3-\u08E1\u08E3-\u0902\u093A\u093C\u0941-\u0948\u094D\u0951-\u0957\u0962-\u0963\u0981\u09BC\u09C1-\u09C4\u09CD\u09E2-\u09E3\u09FE\u0A01-\u0A02\u0A3C\u0A41-\u0A42\u0A47-\u0A48\u0A4B-\u0A4D\u0A51\u0A70-\u0A71\u0A75\u0A81-\u0A82\u0ABC\u0AC1-\u0AC5\u0AC7-\u0AC8\u0ACD\u0AE2-\u0AE3\u0AFA-\u0AFF\u0B01\u0B3C\u0B3F\u0B41-\u0B44\u0B4D\u0B56\u0B62-\u0B63\u0B82\u0BC0\u0BCD\u0C00\u0C04\u0C3E-\u0C40\u0C46-\u0C48\u0C4A-\u0C4D\u0C55-\u0C56\u0C62-\u0C63\u0C81\u0CBC\u0CBF\u0CC6\u0CCC-\u0CCD\u0CE2-\u0CE3\u0D00-\u0D01\u0D3B-\u0D3C\u0D41-\u0D44\u0D4D\u0D62-\u0D63\u0DCA\u0DD2-\u0DD4\u0DD6\u0E31\u0E34-\u0E3A\u0E47-\u0E4E\u0EB1\u0EB4-\u0EB9\u0EBB-\u0EBC\u0EC8-\u0ECD\u0F18-\u0F19\u0F35\u0F37\u0F39\u0F71-\u0F7E\u0F80-\u0F84\u0F86-\u0F87\u0F8D-\u0F97\u0F99-\u0FBC\u0FC6\u102D-\u1030\u1032-\u1037\u1039-\u103A\u103D-\u103E\u1058-\u1059\u105E-\u1060\u1071-\u1074\u1082\u1085-\u1086\u108D\u109D\u135D-\u135F\u1712-\u1714\u1732-\u1734\u1752-\u1753\u1772-\u1773\u17B4-\u17B5\u17B7-\u17BD\u17C6\u17C9-\u17D3\u17DD\u180B-\u180D\u1885-\u1886\u18A9\u1920-\u1922\u1927-\u1928\u1932\u1939-\u193B\u1A17-\u1A18\u1A1B\u1A56\u1A58-\u1A5E\u1A60\u1A62\u1A65-\u1A6C\u1A73-\u1A7C\u1A7F\u1AB0-\u1ABD\u1B00-\u1B03\u1B34\u1B36-\u1B3A\u1B3C\u1B42\u1B6B-\u1B73\u1B80-\u1B81\u1BA2-\u1BA5\u1BA8-\u1BA9\u1BAB-\u1BAD\u1BE6\u1BE8-\u1BE9\u1BED\u1BEF-\u1BF1\u1C2C-\u1C33\u1C36-\u1C37\u1CD0-\u1CD2\u1CD4-\u1CE0\u1CE2-\u1CE8\u1CED\u1CF4\u1CF8-\u1CF9\u1DC0-\u1DF9\u1DFB-\u1DFF\u20D0-\u20DC\u20E1\u20E5-\u20F0\u2CEF-\u2CF1\u2D7F\u2DE0-\u2DFF\u302A-\u302D\u3099-\u309A\uA66F\uA674-\uA67D\uA69E-\uA69F\uA6F0-\uA6F1\uA802\uA806\uA80B\uA825-\uA826\uA8C4-\uA8C5\uA8E0-\uA8F1\uA8FF\uA926-\uA92D\uA947-\uA951\uA980-\uA982\uA9B3\uA9B6-\uA9B9\uA9BC\uA9E5\uAA29-\uAA2E\uAA31-\uAA32\uAA35-\uAA36\uAA43\uAA4C\uAA7C\uAAB0\uAAB2-\uAAB4\uAAB7-\uAAB8\uAABE-\uAABF\uAAC1\uAAEC-\uAAED\uAAF6\uABE5\uABE8\uABED\uFB1E\uFE00-\uFE0F\uFE20-\uFE2F]/,
-      peg$c585 = peg$classExpectation([["\u0300", "\u036F"], ["\u0483", "\u0487"], ["\u0591", "\u05BD"], "\u05BF", ["\u05C1", "\u05C2"], ["\u05C4", "\u05C5"], "\u05C7", ["\u0610", "\u061A"], ["\u064B", "\u065F"], "\u0670", ["\u06D6", "\u06DC"], ["\u06DF", "\u06E4"], ["\u06E7", "\u06E8"], ["\u06EA", "\u06ED"], "\u0711", ["\u0730", "\u074A"], ["\u07A6", "\u07B0"], ["\u07EB", "\u07F3"], "\u07FD", ["\u0816", "\u0819"], ["\u081B", "\u0823"], ["\u0825", "\u0827"], ["\u0829", "\u082D"], ["\u0859", "\u085B"], ["\u08D3", "\u08E1"], ["\u08E3", "\u0902"], "\u093A", "\u093C", ["\u0941", "\u0948"], "\u094D", ["\u0951", "\u0957"], ["\u0962", "\u0963"], "\u0981", "\u09BC", ["\u09C1", "\u09C4"], "\u09CD", ["\u09E2", "\u09E3"], "\u09FE", ["\u0A01", "\u0A02"], "\u0A3C", ["\u0A41", "\u0A42"], ["\u0A47", "\u0A48"], ["\u0A4B", "\u0A4D"], "\u0A51", ["\u0A70", "\u0A71"], "\u0A75", ["\u0A81", "\u0A82"], "\u0ABC", ["\u0AC1", "\u0AC5"], ["\u0AC7", "\u0AC8"], "\u0ACD", ["\u0AE2", "\u0AE3"], ["\u0AFA", "\u0AFF"], "\u0B01", "\u0B3C", "\u0B3F", ["\u0B41", "\u0B44"], "\u0B4D", "\u0B56", ["\u0B62", "\u0B63"], "\u0B82", "\u0BC0", "\u0BCD", "\u0C00", "\u0C04", ["\u0C3E", "\u0C40"], ["\u0C46", "\u0C48"], ["\u0C4A", "\u0C4D"], ["\u0C55", "\u0C56"], ["\u0C62", "\u0C63"], "\u0C81", "\u0CBC", "\u0CBF", "\u0CC6", ["\u0CCC", "\u0CCD"], ["\u0CE2", "\u0CE3"], ["\u0D00", "\u0D01"], ["\u0D3B", "\u0D3C"], ["\u0D41", "\u0D44"], "\u0D4D", ["\u0D62", "\u0D63"], "\u0DCA", ["\u0DD2", "\u0DD4"], "\u0DD6", "\u0E31", ["\u0E34", "\u0E3A"], ["\u0E47", "\u0E4E"], "\u0EB1", ["\u0EB4", "\u0EB9"], ["\u0EBB", "\u0EBC"], ["\u0EC8", "\u0ECD"], ["\u0F18", "\u0F19"], "\u0F35", "\u0F37", "\u0F39", ["\u0F71", "\u0F7E"], ["\u0F80", "\u0F84"], ["\u0F86", "\u0F87"], ["\u0F8D", "\u0F97"], ["\u0F99", "\u0FBC"], "\u0FC6", ["\u102D", "\u1030"], ["\u1032", "\u1037"], ["\u1039", "\u103A"], ["\u103D", "\u103E"], ["\u1058", "\u1059"], ["\u105E", "\u1060"], ["\u1071", "\u1074"], "\u1082", ["\u1085", "\u1086"], "\u108D", "\u109D", ["\u135D", "\u135F"], ["\u1712", "\u1714"], ["\u1732", "\u1734"], ["\u1752", "\u1753"], ["\u1772", "\u1773"], ["\u17B4", "\u17B5"], ["\u17B7", "\u17BD"], "\u17C6", ["\u17C9", "\u17D3"], "\u17DD", ["\u180B", "\u180D"], ["\u1885", "\u1886"], "\u18A9", ["\u1920", "\u1922"], ["\u1927", "\u1928"], "\u1932", ["\u1939", "\u193B"], ["\u1A17", "\u1A18"], "\u1A1B", "\u1A56", ["\u1A58", "\u1A5E"], "\u1A60", "\u1A62", ["\u1A65", "\u1A6C"], ["\u1A73", "\u1A7C"], "\u1A7F", ["\u1AB0", "\u1ABD"], ["\u1B00", "\u1B03"], "\u1B34", ["\u1B36", "\u1B3A"], "\u1B3C", "\u1B42", ["\u1B6B", "\u1B73"], ["\u1B80", "\u1B81"], ["\u1BA2", "\u1BA5"], ["\u1BA8", "\u1BA9"], ["\u1BAB", "\u1BAD"], "\u1BE6", ["\u1BE8", "\u1BE9"], "\u1BED", ["\u1BEF", "\u1BF1"], ["\u1C2C", "\u1C33"], ["\u1C36", "\u1C37"], ["\u1CD0", "\u1CD2"], ["\u1CD4", "\u1CE0"], ["\u1CE2", "\u1CE8"], "\u1CED", "\u1CF4", ["\u1CF8", "\u1CF9"], ["\u1DC0", "\u1DF9"], ["\u1DFB", "\u1DFF"], ["\u20D0", "\u20DC"], "\u20E1", ["\u20E5", "\u20F0"], ["\u2CEF", "\u2CF1"], "\u2D7F", ["\u2DE0", "\u2DFF"], ["\u302A", "\u302D"], ["\u3099", "\u309A"], "\uA66F", ["\uA674", "\uA67D"], ["\uA69E", "\uA69F"], ["\uA6F0", "\uA6F1"], "\uA802", "\uA806", "\uA80B", ["\uA825", "\uA826"], ["\uA8C4", "\uA8C5"], ["\uA8E0", "\uA8F1"], "\uA8FF", ["\uA926", "\uA92D"], ["\uA947", "\uA951"], ["\uA980", "\uA982"], "\uA9B3", ["\uA9B6", "\uA9B9"], "\uA9BC", "\uA9E5", ["\uAA29", "\uAA2E"], ["\uAA31", "\uAA32"], ["\uAA35", "\uAA36"], "\uAA43", "\uAA4C", "\uAA7C", "\uAAB0", ["\uAAB2", "\uAAB4"], ["\uAAB7", "\uAAB8"], ["\uAABE", "\uAABF"], "\uAAC1", ["\uAAEC", "\uAAED"], "\uAAF6", "\uABE5", "\uABE8", "\uABED", "\uFB1E", ["\uFE00", "\uFE0F"], ["\uFE20", "\uFE2F"]], false, false),
-      peg$c586 = /^[0-9\u0660-\u0669\u06F0-\u06F9\u07C0-\u07C9\u0966-\u096F\u09E6-\u09EF\u0A66-\u0A6F\u0AE6-\u0AEF\u0B66-\u0B6F\u0BE6-\u0BEF\u0C66-\u0C6F\u0CE6-\u0CEF\u0D66-\u0D6F\u0DE6-\u0DEF\u0E50-\u0E59\u0ED0-\u0ED9\u0F20-\u0F29\u1040-\u1049\u1090-\u1099\u17E0-\u17E9\u1810-\u1819\u1946-\u194F\u19D0-\u19D9\u1A80-\u1A89\u1A90-\u1A99\u1B50-\u1B59\u1BB0-\u1BB9\u1C40-\u1C49\u1C50-\u1C59\uA620-\uA629\uA8D0-\uA8D9\uA900-\uA909\uA9D0-\uA9D9\uA9F0-\uA9F9\uAA50-\uAA59\uABF0-\uABF9\uFF10-\uFF19]/,
-      peg$c587 = peg$classExpectation([["0", "9"], ["\u0660", "\u0669"], ["\u06F0", "\u06F9"], ["\u07C0", "\u07C9"], ["\u0966", "\u096F"], ["\u09E6", "\u09EF"], ["\u0A66", "\u0A6F"], ["\u0AE6", "\u0AEF"], ["\u0B66", "\u0B6F"], ["\u0BE6", "\u0BEF"], ["\u0C66", "\u0C6F"], ["\u0CE6", "\u0CEF"], ["\u0D66", "\u0D6F"], ["\u0DE6", "\u0DEF"], ["\u0E50", "\u0E59"], ["\u0ED0", "\u0ED9"], ["\u0F20", "\u0F29"], ["\u1040", "\u1049"], ["\u1090", "\u1099"], ["\u17E0", "\u17E9"], ["\u1810", "\u1819"], ["\u1946", "\u194F"], ["\u19D0", "\u19D9"], ["\u1A80", "\u1A89"], ["\u1A90", "\u1A99"], ["\u1B50", "\u1B59"], ["\u1BB0", "\u1BB9"], ["\u1C40", "\u1C49"], ["\u1C50", "\u1C59"], ["\uA620", "\uA629"], ["\uA8D0", "\uA8D9"], ["\uA900", "\uA909"], ["\uA9D0", "\uA9D9"], ["\uA9F0", "\uA9F9"], ["\uAA50", "\uAA59"], ["\uABF0", "\uABF9"], ["\uFF10", "\uFF19"]], false, false),
-      peg$c588 = /^[\u16EE-\u16F0\u2160-\u2182\u2185-\u2188\u3007\u3021-\u3029\u3038-\u303A\uA6E6-\uA6EF]/,
-      peg$c589 = peg$classExpectation([["\u16EE", "\u16F0"], ["\u2160", "\u2182"], ["\u2185", "\u2188"], "\u3007", ["\u3021", "\u3029"], ["\u3038", "\u303A"], ["\uA6E6", "\uA6EF"]], false, false),
-      peg$c590 = /^[_\u203F-\u2040\u2054\uFE33-\uFE34\uFE4D-\uFE4F\uFF3F]/,
-      peg$c591 = peg$classExpectation(["_", ["\u203F", "\u2040"], "\u2054", ["\uFE33", "\uFE34"], ["\uFE4D", "\uFE4F"], "\uFF3F"], false, false),
-      peg$c592 = /^[ \xA0\u1680\u2000-\u200A\u202F\u205F\u3000]/,
-      peg$c593 = peg$classExpectation([" ", "\xA0", "\u1680", ["\u2000", "\u200A"], "\u202F", "\u205F", "\u3000"], false, false),
-      peg$c594 = peg$otherExpectation("whitespace"),
-      peg$c595 = "\t",
-      peg$c596 = peg$literalExpectation("\t", false),
-      peg$c597 = "\x0B",
-      peg$c598 = peg$literalExpectation("\x0B", false),
-      peg$c599 = "\f",
-      peg$c600 = peg$literalExpectation("\f", false),
-      peg$c601 = " ",
-      peg$c602 = peg$literalExpectation(" ", false),
-      peg$c603 = "\xA0",
-      peg$c604 = peg$literalExpectation("\xA0", false),
-      peg$c605 = "\uFEFF",
-      peg$c606 = peg$literalExpectation("\uFEFF", false),
-      peg$c607 = /^[\n\r\u2028\u2029]/,
-      peg$c608 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c609 = peg$otherExpectation("comment"),
-      peg$c614 = "//",
-      peg$c615 = peg$literalExpectation("//", false),
+      peg$c567 = /^[^\/\\]/,
+      peg$c568 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c569 = /^[\0-\x1F\\]/,
+      peg$c570 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c571 = /^[a-z\xB5\xDF-\xF6\xF8-\xFF\u0101\u0103\u0105\u0107\u0109\u010B\u010D\u010F\u0111\u0113\u0115\u0117\u0119\u011B\u011D\u011F\u0121\u0123\u0125\u0127\u0129\u012B\u012D\u012F\u0131\u0133\u0135\u0137-\u0138\u013A\u013C\u013E\u0140\u0142\u0144\u0146\u0148-\u0149\u014B\u014D\u014F\u0151\u0153\u0155\u0157\u0159\u015B\u015D\u015F\u0161\u0163\u0165\u0167\u0169\u016B\u016D\u016F\u0171\u0173\u0175\u0177\u017A\u017C\u017E-\u0180\u0183\u0185\u0188\u018C-\u018D\u0192\u0195\u0199-\u019B\u019E\u01A1\u01A3\u01A5\u01A8\u01AA-\u01AB\u01AD\u01B0\u01B4\u01B6\u01B9-\u01BA\u01BD-\u01BF\u01C6\u01C9\u01CC\u01CE\u01D0\u01D2\u01D4\u01D6\u01D8\u01DA\u01DC-\u01DD\u01DF\u01E1\u01E3\u01E5\u01E7\u01E9\u01EB\u01ED\u01EF-\u01F0\u01F3\u01F5\u01F9\u01FB\u01FD\u01FF\u0201\u0203\u0205\u0207\u0209\u020B\u020D\u020F\u0211\u0213\u0215\u0217\u0219\u021B\u021D\u021F\u0221\u0223\u0225\u0227\u0229\u022B\u022D\u022F\u0231\u0233-\u0239\u023C\u023F-\u0240\u0242\u0247\u0249\u024B\u024D\u024F-\u0293\u0295-\u02AF\u0371\u0373\u0377\u037B-\u037D\u0390\u03AC-\u03CE\u03D0-\u03D1\u03D5-\u03D7\u03D9\u03DB\u03DD\u03DF\u03E1\u03E3\u03E5\u03E7\u03E9\u03EB\u03ED\u03EF-\u03F3\u03F5\u03F8\u03FB-\u03FC\u0430-\u045F\u0461\u0463\u0465\u0467\u0469\u046B\u046D\u046F\u0471\u0473\u0475\u0477\u0479\u047B\u047D\u047F\u0481\u048B\u048D\u048F\u0491\u0493\u0495\u0497\u0499\u049B\u049D\u049F\u04A1\u04A3\u04A5\u04A7\u04A9\u04AB\u04AD\u04AF\u04B1\u04B3\u04B5\u04B7\u04B9\u04BB\u04BD\u04BF\u04C2\u04C4\u04C6\u04C8\u04CA\u04CC\u04CE-\u04CF\u04D1\u04D3\u04D5\u04D7\u04D9\u04DB\u04DD\u04DF\u04E1\u04E3\u04E5\u04E7\u04E9\u04EB\u04ED\u04EF\u04F1\u04F3\u04F5\u04F7\u04F9\u04FB\u04FD\u04FF\u0501\u0503\u0505\u0507\u0509\u050B\u050D\u050F\u0511\u0513\u0515\u0517\u0519\u051B\u051D\u051F\u0521\u0523\u0525\u0527\u0529\u052B\u052D\u052F\u0560-\u0588\u10D0-\u10FA\u10FD-\u10FF\u13F8-\u13FD\u1C80-\u1C88\u1D00-\u1D2B\u1D6B-\u1D77\u1D79-\u1D9A\u1E01\u1E03\u1E05\u1E07\u1E09\u1E0B\u1E0D\u1E0F\u1E11\u1E13\u1E15\u1E17\u1E19\u1E1B\u1E1D\u1E1F\u1E21\u1E23\u1E25\u1E27\u1E29\u1E2B\u1E2D\u1E2F\u1E31\u1E33\u1E35\u1E37\u1E39\u1E3B\u1E3D\u1E3F\u1E41\u1E43\u1E45\u1E47\u1E49\u1E4B\u1E4D\u1E4F\u1E51\u1E53\u1E55\u1E57\u1E59\u1E5B\u1E5D\u1E5F\u1E61\u1E63\u1E65\u1E67\u1E69\u1E6B\u1E6D\u1E6F\u1E71\u1E73\u1E75\u1E77\u1E79\u1E7B\u1E7D\u1E7F\u1E81\u1E83\u1E85\u1E87\u1E89\u1E8B\u1E8D\u1E8F\u1E91\u1E93\u1E95-\u1E9D\u1E9F\u1EA1\u1EA3\u1EA5\u1EA7\u1EA9\u1EAB\u1EAD\u1EAF\u1EB1\u1EB3\u1EB5\u1EB7\u1EB9\u1EBB\u1EBD\u1EBF\u1EC1\u1EC3\u1EC5\u1EC7\u1EC9\u1ECB\u1ECD\u1ECF\u1ED1\u1ED3\u1ED5\u1ED7\u1ED9\u1EDB\u1EDD\u1EDF\u1EE1\u1EE3\u1EE5\u1EE7\u1EE9\u1EEB\u1EED\u1EEF\u1EF1\u1EF3\u1EF5\u1EF7\u1EF9\u1EFB\u1EFD\u1EFF-\u1F07\u1F10-\u1F15\u1F20-\u1F27\u1F30-\u1F37\u1F40-\u1F45\u1F50-\u1F57\u1F60-\u1F67\u1F70-\u1F7D\u1F80-\u1F87\u1F90-\u1F97\u1FA0-\u1FA7\u1FB0-\u1FB4\u1FB6-\u1FB7\u1FBE\u1FC2-\u1FC4\u1FC6-\u1FC7\u1FD0-\u1FD3\u1FD6-\u1FD7\u1FE0-\u1FE7\u1FF2-\u1FF4\u1FF6-\u1FF7\u210A\u210E-\u210F\u2113\u212F\u2134\u2139\u213C-\u213D\u2146-\u2149\u214E\u2184\u2C30-\u2C5E\u2C61\u2C65-\u2C66\u2C68\u2C6A\u2C6C\u2C71\u2C73-\u2C74\u2C76-\u2C7B\u2C81\u2C83\u2C85\u2C87\u2C89\u2C8B\u2C8D\u2C8F\u2C91\u2C93\u2C95\u2C97\u2C99\u2C9B\u2C9D\u2C9F\u2CA1\u2CA3\u2CA5\u2CA7\u2CA9\u2CAB\u2CAD\u2CAF\u2CB1\u2CB3\u2CB5\u2CB7\u2CB9\u2CBB\u2CBD\u2CBF\u2CC1\u2CC3\u2CC5\u2CC7\u2CC9\u2CCB\u2CCD\u2CCF\u2CD1\u2CD3\u2CD5\u2CD7\u2CD9\u2CDB\u2CDD\u2CDF\u2CE1\u2CE3-\u2CE4\u2CEC\u2CEE\u2CF3\u2D00-\u2D25\u2D27\u2D2D\uA641\uA643\uA645\uA647\uA649\uA64B\uA64D\uA64F\uA651\uA653\uA655\uA657\uA659\uA65B\uA65D\uA65F\uA661\uA663\uA665\uA667\uA669\uA66B\uA66D\uA681\uA683\uA685\uA687\uA689\uA68B\uA68D\uA68F\uA691\uA693\uA695\uA697\uA699\uA69B\uA723\uA725\uA727\uA729\uA72B\uA72D\uA72F-\uA731\uA733\uA735\uA737\uA739\uA73B\uA73D\uA73F\uA741\uA743\uA745\uA747\uA749\uA74B\uA74D\uA74F\uA751\uA753\uA755\uA757\uA759\uA75B\uA75D\uA75F\uA761\uA763\uA765\uA767\uA769\uA76B\uA76D\uA76F\uA771-\uA778\uA77A\uA77C\uA77F\uA781\uA783\uA785\uA787\uA78C\uA78E\uA791\uA793-\uA795\uA797\uA799\uA79B\uA79D\uA79F\uA7A1\uA7A3\uA7A5\uA7A7\uA7A9\uA7AF\uA7B5\uA7B7\uA7B9\uA7FA\uAB30-\uAB5A\uAB60-\uAB65\uAB70-\uABBF\uFB00-\uFB06\uFB13-\uFB17\uFF41-\uFF5A]/,
+      peg$c572 = peg$classExpectation([["a", "z"], "\xB5", ["\xDF", "\xF6"], ["\xF8", "\xFF"], "\u0101", "\u0103", "\u0105", "\u0107", "\u0109", "\u010B", "\u010D", "\u010F", "\u0111", "\u0113", "\u0115", "\u0117", "\u0119", "\u011B", "\u011D", "\u011F", "\u0121", "\u0123", "\u0125", "\u0127", "\u0129", "\u012B", "\u012D", "\u012F", "\u0131", "\u0133", "\u0135", ["\u0137", "\u0138"], "\u013A", "\u013C", "\u013E", "\u0140", "\u0142", "\u0144", "\u0146", ["\u0148", "\u0149"], "\u014B", "\u014D", "\u014F", "\u0151", "\u0153", "\u0155", "\u0157", "\u0159", "\u015B", "\u015D", "\u015F", "\u0161", "\u0163", "\u0165", "\u0167", "\u0169", "\u016B", "\u016D", "\u016F", "\u0171", "\u0173", "\u0175", "\u0177", "\u017A", "\u017C", ["\u017E", "\u0180"], "\u0183", "\u0185", "\u0188", ["\u018C", "\u018D"], "\u0192", "\u0195", ["\u0199", "\u019B"], "\u019E", "\u01A1", "\u01A3", "\u01A5", "\u01A8", ["\u01AA", "\u01AB"], "\u01AD", "\u01B0", "\u01B4", "\u01B6", ["\u01B9", "\u01BA"], ["\u01BD", "\u01BF"], "\u01C6", "\u01C9", "\u01CC", "\u01CE", "\u01D0", "\u01D2", "\u01D4", "\u01D6", "\u01D8", "\u01DA", ["\u01DC", "\u01DD"], "\u01DF", "\u01E1", "\u01E3", "\u01E5", "\u01E7", "\u01E9", "\u01EB", "\u01ED", ["\u01EF", "\u01F0"], "\u01F3", "\u01F5", "\u01F9", "\u01FB", "\u01FD", "\u01FF", "\u0201", "\u0203", "\u0205", "\u0207", "\u0209", "\u020B", "\u020D", "\u020F", "\u0211", "\u0213", "\u0215", "\u0217", "\u0219", "\u021B", "\u021D", "\u021F", "\u0221", "\u0223", "\u0225", "\u0227", "\u0229", "\u022B", "\u022D", "\u022F", "\u0231", ["\u0233", "\u0239"], "\u023C", ["\u023F", "\u0240"], "\u0242", "\u0247", "\u0249", "\u024B", "\u024D", ["\u024F", "\u0293"], ["\u0295", "\u02AF"], "\u0371", "\u0373", "\u0377", ["\u037B", "\u037D"], "\u0390", ["\u03AC", "\u03CE"], ["\u03D0", "\u03D1"], ["\u03D5", "\u03D7"], "\u03D9", "\u03DB", "\u03DD", "\u03DF", "\u03E1", "\u03E3", "\u03E5", "\u03E7", "\u03E9", "\u03EB", "\u03ED", ["\u03EF", "\u03F3"], "\u03F5", "\u03F8", ["\u03FB", "\u03FC"], ["\u0430", "\u045F"], "\u0461", "\u0463", "\u0465", "\u0467", "\u0469", "\u046B", "\u046D", "\u046F", "\u0471", "\u0473", "\u0475", "\u0477", "\u0479", "\u047B", "\u047D", "\u047F", "\u0481", "\u048B", "\u048D", "\u048F", "\u0491", "\u0493", "\u0495", "\u0497", "\u0499", "\u049B", "\u049D", "\u049F", "\u04A1", "\u04A3", "\u04A5", "\u04A7", "\u04A9", "\u04AB", "\u04AD", "\u04AF", "\u04B1", "\u04B3", "\u04B5", "\u04B7", "\u04B9", "\u04BB", "\u04BD", "\u04BF", "\u04C2", "\u04C4", "\u04C6", "\u04C8", "\u04CA", "\u04CC", ["\u04CE", "\u04CF"], "\u04D1", "\u04D3", "\u04D5", "\u04D7", "\u04D9", "\u04DB", "\u04DD", "\u04DF", "\u04E1", "\u04E3", "\u04E5", "\u04E7", "\u04E9", "\u04EB", "\u04ED", "\u04EF", "\u04F1", "\u04F3", "\u04F5", "\u04F7", "\u04F9", "\u04FB", "\u04FD", "\u04FF", "\u0501", "\u0503", "\u0505", "\u0507", "\u0509", "\u050B", "\u050D", "\u050F", "\u0511", "\u0513", "\u0515", "\u0517", "\u0519", "\u051B", "\u051D", "\u051F", "\u0521", "\u0523", "\u0525", "\u0527", "\u0529", "\u052B", "\u052D", "\u052F", ["\u0560", "\u0588"], ["\u10D0", "\u10FA"], ["\u10FD", "\u10FF"], ["\u13F8", "\u13FD"], ["\u1C80", "\u1C88"], ["\u1D00", "\u1D2B"], ["\u1D6B", "\u1D77"], ["\u1D79", "\u1D9A"], "\u1E01", "\u1E03", "\u1E05", "\u1E07", "\u1E09", "\u1E0B", "\u1E0D", "\u1E0F", "\u1E11", "\u1E13", "\u1E15", "\u1E17", "\u1E19", "\u1E1B", "\u1E1D", "\u1E1F", "\u1E21", "\u1E23", "\u1E25", "\u1E27", "\u1E29", "\u1E2B", "\u1E2D", "\u1E2F", "\u1E31", "\u1E33", "\u1E35", "\u1E37", "\u1E39", "\u1E3B", "\u1E3D", "\u1E3F", "\u1E41", "\u1E43", "\u1E45", "\u1E47", "\u1E49", "\u1E4B", "\u1E4D", "\u1E4F", "\u1E51", "\u1E53", "\u1E55", "\u1E57", "\u1E59", "\u1E5B", "\u1E5D", "\u1E5F", "\u1E61", "\u1E63", "\u1E65", "\u1E67", "\u1E69", "\u1E6B", "\u1E6D", "\u1E6F", "\u1E71", "\u1E73", "\u1E75", "\u1E77", "\u1E79", "\u1E7B", "\u1E7D", "\u1E7F", "\u1E81", "\u1E83", "\u1E85", "\u1E87", "\u1E89", "\u1E8B", "\u1E8D", "\u1E8F", "\u1E91", "\u1E93", ["\u1E95", "\u1E9D"], "\u1E9F", "\u1EA1", "\u1EA3", "\u1EA5", "\u1EA7", "\u1EA9", "\u1EAB", "\u1EAD", "\u1EAF", "\u1EB1", "\u1EB3", "\u1EB5", "\u1EB7", "\u1EB9", "\u1EBB", "\u1EBD", "\u1EBF", "\u1EC1", "\u1EC3", "\u1EC5", "\u1EC7", "\u1EC9", "\u1ECB", "\u1ECD", "\u1ECF", "\u1ED1", "\u1ED3", "\u1ED5", "\u1ED7", "\u1ED9", "\u1EDB", "\u1EDD", "\u1EDF", "\u1EE1", "\u1EE3", "\u1EE5", "\u1EE7", "\u1EE9", "\u1EEB", "\u1EED", "\u1EEF", "\u1EF1", "\u1EF3", "\u1EF5", "\u1EF7", "\u1EF9", "\u1EFB", "\u1EFD", ["\u1EFF", "\u1F07"], ["\u1F10", "\u1F15"], ["\u1F20", "\u1F27"], ["\u1F30", "\u1F37"], ["\u1F40", "\u1F45"], ["\u1F50", "\u1F57"], ["\u1F60", "\u1F67"], ["\u1F70", "\u1F7D"], ["\u1F80", "\u1F87"], ["\u1F90", "\u1F97"], ["\u1FA0", "\u1FA7"], ["\u1FB0", "\u1FB4"], ["\u1FB6", "\u1FB7"], "\u1FBE", ["\u1FC2", "\u1FC4"], ["\u1FC6", "\u1FC7"], ["\u1FD0", "\u1FD3"], ["\u1FD6", "\u1FD7"], ["\u1FE0", "\u1FE7"], ["\u1FF2", "\u1FF4"], ["\u1FF6", "\u1FF7"], "\u210A", ["\u210E", "\u210F"], "\u2113", "\u212F", "\u2134", "\u2139", ["\u213C", "\u213D"], ["\u2146", "\u2149"], "\u214E", "\u2184", ["\u2C30", "\u2C5E"], "\u2C61", ["\u2C65", "\u2C66"], "\u2C68", "\u2C6A", "\u2C6C", "\u2C71", ["\u2C73", "\u2C74"], ["\u2C76", "\u2C7B"], "\u2C81", "\u2C83", "\u2C85", "\u2C87", "\u2C89", "\u2C8B", "\u2C8D", "\u2C8F", "\u2C91", "\u2C93", "\u2C95", "\u2C97", "\u2C99", "\u2C9B", "\u2C9D", "\u2C9F", "\u2CA1", "\u2CA3", "\u2CA5", "\u2CA7", "\u2CA9", "\u2CAB", "\u2CAD", "\u2CAF", "\u2CB1", "\u2CB3", "\u2CB5", "\u2CB7", "\u2CB9", "\u2CBB", "\u2CBD", "\u2CBF", "\u2CC1", "\u2CC3", "\u2CC5", "\u2CC7", "\u2CC9", "\u2CCB", "\u2CCD", "\u2CCF", "\u2CD1", "\u2CD3", "\u2CD5", "\u2CD7", "\u2CD9", "\u2CDB", "\u2CDD", "\u2CDF", "\u2CE1", ["\u2CE3", "\u2CE4"], "\u2CEC", "\u2CEE", "\u2CF3", ["\u2D00", "\u2D25"], "\u2D27", "\u2D2D", "\uA641", "\uA643", "\uA645", "\uA647", "\uA649", "\uA64B", "\uA64D", "\uA64F", "\uA651", "\uA653", "\uA655", "\uA657", "\uA659", "\uA65B", "\uA65D", "\uA65F", "\uA661", "\uA663", "\uA665", "\uA667", "\uA669", "\uA66B", "\uA66D", "\uA681", "\uA683", "\uA685", "\uA687", "\uA689", "\uA68B", "\uA68D", "\uA68F", "\uA691", "\uA693", "\uA695", "\uA697", "\uA699", "\uA69B", "\uA723", "\uA725", "\uA727", "\uA729", "\uA72B", "\uA72D", ["\uA72F", "\uA731"], "\uA733", "\uA735", "\uA737", "\uA739", "\uA73B", "\uA73D", "\uA73F", "\uA741", "\uA743", "\uA745", "\uA747", "\uA749", "\uA74B", "\uA74D", "\uA74F", "\uA751", "\uA753", "\uA755", "\uA757", "\uA759", "\uA75B", "\uA75D", "\uA75F", "\uA761", "\uA763", "\uA765", "\uA767", "\uA769", "\uA76B", "\uA76D", "\uA76F", ["\uA771", "\uA778"], "\uA77A", "\uA77C", "\uA77F", "\uA781", "\uA783", "\uA785", "\uA787", "\uA78C", "\uA78E", "\uA791", ["\uA793", "\uA795"], "\uA797", "\uA799", "\uA79B", "\uA79D", "\uA79F", "\uA7A1", "\uA7A3", "\uA7A5", "\uA7A7", "\uA7A9", "\uA7AF", "\uA7B5", "\uA7B7", "\uA7B9", "\uA7FA", ["\uAB30", "\uAB5A"], ["\uAB60", "\uAB65"], ["\uAB70", "\uABBF"], ["\uFB00", "\uFB06"], ["\uFB13", "\uFB17"], ["\uFF41", "\uFF5A"]], false, false),
+      peg$c573 = /^[\u02B0-\u02C1\u02C6-\u02D1\u02E0-\u02E4\u02EC\u02EE\u0374\u037A\u0559\u0640\u06E5-\u06E6\u07F4-\u07F5\u07FA\u081A\u0824\u0828\u0971\u0E46\u0EC6\u10FC\u17D7\u1843\u1AA7\u1C78-\u1C7D\u1D2C-\u1D6A\u1D78\u1D9B-\u1DBF\u2071\u207F\u2090-\u209C\u2C7C-\u2C7D\u2D6F\u2E2F\u3005\u3031-\u3035\u303B\u309D-\u309E\u30FC-\u30FE\uA015\uA4F8-\uA4FD\uA60C\uA67F\uA69C-\uA69D\uA717-\uA71F\uA770\uA788\uA7F8-\uA7F9\uA9CF\uA9E6\uAA70\uAADD\uAAF3-\uAAF4\uAB5C-\uAB5F\uFF70\uFF9E-\uFF9F]/,
+      peg$c574 = peg$classExpectation([["\u02B0", "\u02C1"], ["\u02C6", "\u02D1"], ["\u02E0", "\u02E4"], "\u02EC", "\u02EE", "\u0374", "\u037A", "\u0559", "\u0640", ["\u06E5", "\u06E6"], ["\u07F4", "\u07F5"], "\u07FA", "\u081A", "\u0824", "\u0828", "\u0971", "\u0E46", "\u0EC6", "\u10FC", "\u17D7", "\u1843", "\u1AA7", ["\u1C78", "\u1C7D"], ["\u1D2C", "\u1D6A"], "\u1D78", ["\u1D9B", "\u1DBF"], "\u2071", "\u207F", ["\u2090", "\u209C"], ["\u2C7C", "\u2C7D"], "\u2D6F", "\u2E2F", "\u3005", ["\u3031", "\u3035"], "\u303B", ["\u309D", "\u309E"], ["\u30FC", "\u30FE"], "\uA015", ["\uA4F8", "\uA4FD"], "\uA60C", "\uA67F", ["\uA69C", "\uA69D"], ["\uA717", "\uA71F"], "\uA770", "\uA788", ["\uA7F8", "\uA7F9"], "\uA9CF", "\uA9E6", "\uAA70", "\uAADD", ["\uAAF3", "\uAAF4"], ["\uAB5C", "\uAB5F"], "\uFF70", ["\uFF9E", "\uFF9F"]], false, false),
+      peg$c575 = /^[\xAA\xBA\u01BB\u01C0-\u01C3\u0294\u05D0-\u05EA\u05EF-\u05F2\u0620-\u063F\u0641-\u064A\u066E-\u066F\u0671-\u06D3\u06D5\u06EE-\u06EF\u06FA-\u06FC\u06FF\u0710\u0712-\u072F\u074D-\u07A5\u07B1\u07CA-\u07EA\u0800-\u0815\u0840-\u0858\u0860-\u086A\u08A0-\u08B4\u08B6-\u08BD\u0904-\u0939\u093D\u0950\u0958-\u0961\u0972-\u0980\u0985-\u098C\u098F-\u0990\u0993-\u09A8\u09AA-\u09B0\u09B2\u09B6-\u09B9\u09BD\u09CE\u09DC-\u09DD\u09DF-\u09E1\u09F0-\u09F1\u09FC\u0A05-\u0A0A\u0A0F-\u0A10\u0A13-\u0A28\u0A2A-\u0A30\u0A32-\u0A33\u0A35-\u0A36\u0A38-\u0A39\u0A59-\u0A5C\u0A5E\u0A72-\u0A74\u0A85-\u0A8D\u0A8F-\u0A91\u0A93-\u0AA8\u0AAA-\u0AB0\u0AB2-\u0AB3\u0AB5-\u0AB9\u0ABD\u0AD0\u0AE0-\u0AE1\u0AF9\u0B05-\u0B0C\u0B0F-\u0B10\u0B13-\u0B28\u0B2A-\u0B30\u0B32-\u0B33\u0B35-\u0B39\u0B3D\u0B5C-\u0B5D\u0B5F-\u0B61\u0B71\u0B83\u0B85-\u0B8A\u0B8E-\u0B90\u0B92-\u0B95\u0B99-\u0B9A\u0B9C\u0B9E-\u0B9F\u0BA3-\u0BA4\u0BA8-\u0BAA\u0BAE-\u0BB9\u0BD0\u0C05-\u0C0C\u0C0E-\u0C10\u0C12-\u0C28\u0C2A-\u0C39\u0C3D\u0C58-\u0C5A\u0C60-\u0C61\u0C80\u0C85-\u0C8C\u0C8E-\u0C90\u0C92-\u0CA8\u0CAA-\u0CB3\u0CB5-\u0CB9\u0CBD\u0CDE\u0CE0-\u0CE1\u0CF1-\u0CF2\u0D05-\u0D0C\u0D0E-\u0D10\u0D12-\u0D3A\u0D3D\u0D4E\u0D54-\u0D56\u0D5F-\u0D61\u0D7A-\u0D7F\u0D85-\u0D96\u0D9A-\u0DB1\u0DB3-\u0DBB\u0DBD\u0DC0-\u0DC6\u0E01-\u0E30\u0E32-\u0E33\u0E40-\u0E45\u0E81-\u0E82\u0E84\u0E87-\u0E88\u0E8A\u0E8D\u0E94-\u0E97\u0E99-\u0E9F\u0EA1-\u0EA3\u0EA5\u0EA7\u0EAA-\u0EAB\u0EAD-\u0EB0\u0EB2-\u0EB3\u0EBD\u0EC0-\u0EC4\u0EDC-\u0EDF\u0F00\u0F40-\u0F47\u0F49-\u0F6C\u0F88-\u0F8C\u1000-\u102A\u103F\u1050-\u1055\u105A-\u105D\u1061\u1065-\u1066\u106E-\u1070\u1075-\u1081\u108E\u1100-\u1248\u124A-\u124D\u1250-\u1256\u1258\u125A-\u125D\u1260-\u1288\u128A-\u128D\u1290-\u12B0\u12B2-\u12B5\u12B8-\u12BE\u12C0\u12C2-\u12C5\u12C8-\u12D6\u12D8-\u1310\u1312-\u1315\u1318-\u135A\u1380-\u138F\u1401-\u166C\u166F-\u167F\u1681-\u169A\u16A0-\u16EA\u16F1-\u16F8\u1700-\u170C\u170E-\u1711\u1720-\u1731\u1740-\u1751\u1760-\u176C\u176E-\u1770\u1780-\u17B3\u17DC\u1820-\u1842\u1844-\u1878\u1880-\u1884\u1887-\u18A8\u18AA\u18B0-\u18F5\u1900-\u191E\u1950-\u196D\u1970-\u1974\u1980-\u19AB\u19B0-\u19C9\u1A00-\u1A16\u1A20-\u1A54\u1B05-\u1B33\u1B45-\u1B4B\u1B83-\u1BA0\u1BAE-\u1BAF\u1BBA-\u1BE5\u1C00-\u1C23\u1C4D-\u1C4F\u1C5A-\u1C77\u1CE9-\u1CEC\u1CEE-\u1CF1\u1CF5-\u1CF6\u2135-\u2138\u2D30-\u2D67\u2D80-\u2D96\u2DA0-\u2DA6\u2DA8-\u2DAE\u2DB0-\u2DB6\u2DB8-\u2DBE\u2DC0-\u2DC6\u2DC8-\u2DCE\u2DD0-\u2DD6\u2DD8-\u2DDE\u3006\u303C\u3041-\u3096\u309F\u30A1-\u30FA\u30FF\u3105-\u312F\u3131-\u318E\u31A0-\u31BA\u31F0-\u31FF\u3400-\u4DB5\u4E00-\u9FEF\uA000-\uA014\uA016-\uA48C\uA4D0-\uA4F7\uA500-\uA60B\uA610-\uA61F\uA62A-\uA62B\uA66E\uA6A0-\uA6E5\uA78F\uA7F7\uA7FB-\uA801\uA803-\uA805\uA807-\uA80A\uA80C-\uA822\uA840-\uA873\uA882-\uA8B3\uA8F2-\uA8F7\uA8FB\uA8FD-\uA8FE\uA90A-\uA925\uA930-\uA946\uA960-\uA97C\uA984-\uA9B2\uA9E0-\uA9E4\uA9E7-\uA9EF\uA9FA-\uA9FE\uAA00-\uAA28\uAA40-\uAA42\uAA44-\uAA4B\uAA60-\uAA6F\uAA71-\uAA76\uAA7A\uAA7E-\uAAAF\uAAB1\uAAB5-\uAAB6\uAAB9-\uAABD\uAAC0\uAAC2\uAADB-\uAADC\uAAE0-\uAAEA\uAAF2\uAB01-\uAB06\uAB09-\uAB0E\uAB11-\uAB16\uAB20-\uAB26\uAB28-\uAB2E\uABC0-\uABE2\uAC00-\uD7A3\uD7B0-\uD7C6\uD7CB-\uD7FB\uF900-\uFA6D\uFA70-\uFAD9\uFB1D\uFB1F-\uFB28\uFB2A-\uFB36\uFB38-\uFB3C\uFB3E\uFB40-\uFB41\uFB43-\uFB44\uFB46-\uFBB1\uFBD3-\uFD3D\uFD50-\uFD8F\uFD92-\uFDC7\uFDF0-\uFDFB\uFE70-\uFE74\uFE76-\uFEFC\uFF66-\uFF6F\uFF71-\uFF9D\uFFA0-\uFFBE\uFFC2-\uFFC7\uFFCA-\uFFCF\uFFD2-\uFFD7\uFFDA-\uFFDC]/,
+      peg$c576 = peg$classExpectation(["\xAA", "\xBA", "\u01BB", ["\u01C0", "\u01C3"], "\u0294", ["\u05D0", "\u05EA"], ["\u05EF", "\u05F2"], ["\u0620", "\u063F"], ["\u0641", "\u064A"], ["\u066E", "\u066F"], ["\u0671", "\u06D3"], "\u06D5", ["\u06EE", "\u06EF"], ["\u06FA", "\u06FC"], "\u06FF", "\u0710", ["\u0712", "\u072F"], ["\u074D", "\u07A5"], "\u07B1", ["\u07CA", "\u07EA"], ["\u0800", "\u0815"], ["\u0840", "\u0858"], ["\u0860", "\u086A"], ["\u08A0", "\u08B4"], ["\u08B6", "\u08BD"], ["\u0904", "\u0939"], "\u093D", "\u0950", ["\u0958", "\u0961"], ["\u0972", "\u0980"], ["\u0985", "\u098C"], ["\u098F", "\u0990"], ["\u0993", "\u09A8"], ["\u09AA", "\u09B0"], "\u09B2", ["\u09B6", "\u09B9"], "\u09BD", "\u09CE", ["\u09DC", "\u09DD"], ["\u09DF", "\u09E1"], ["\u09F0", "\u09F1"], "\u09FC", ["\u0A05", "\u0A0A"], ["\u0A0F", "\u0A10"], ["\u0A13", "\u0A28"], ["\u0A2A", "\u0A30"], ["\u0A32", "\u0A33"], ["\u0A35", "\u0A36"], ["\u0A38", "\u0A39"], ["\u0A59", "\u0A5C"], "\u0A5E", ["\u0A72", "\u0A74"], ["\u0A85", "\u0A8D"], ["\u0A8F", "\u0A91"], ["\u0A93", "\u0AA8"], ["\u0AAA", "\u0AB0"], ["\u0AB2", "\u0AB3"], ["\u0AB5", "\u0AB9"], "\u0ABD", "\u0AD0", ["\u0AE0", "\u0AE1"], "\u0AF9", ["\u0B05", "\u0B0C"], ["\u0B0F", "\u0B10"], ["\u0B13", "\u0B28"], ["\u0B2A", "\u0B30"], ["\u0B32", "\u0B33"], ["\u0B35", "\u0B39"], "\u0B3D", ["\u0B5C", "\u0B5D"], ["\u0B5F", "\u0B61"], "\u0B71", "\u0B83", ["\u0B85", "\u0B8A"], ["\u0B8E", "\u0B90"], ["\u0B92", "\u0B95"], ["\u0B99", "\u0B9A"], "\u0B9C", ["\u0B9E", "\u0B9F"], ["\u0BA3", "\u0BA4"], ["\u0BA8", "\u0BAA"], ["\u0BAE", "\u0BB9"], "\u0BD0", ["\u0C05", "\u0C0C"], ["\u0C0E", "\u0C10"], ["\u0C12", "\u0C28"], ["\u0C2A", "\u0C39"], "\u0C3D", ["\u0C58", "\u0C5A"], ["\u0C60", "\u0C61"], "\u0C80", ["\u0C85", "\u0C8C"], ["\u0C8E", "\u0C90"], ["\u0C92", "\u0CA8"], ["\u0CAA", "\u0CB3"], ["\u0CB5", "\u0CB9"], "\u0CBD", "\u0CDE", ["\u0CE0", "\u0CE1"], ["\u0CF1", "\u0CF2"], ["\u0D05", "\u0D0C"], ["\u0D0E", "\u0D10"], ["\u0D12", "\u0D3A"], "\u0D3D", "\u0D4E", ["\u0D54", "\u0D56"], ["\u0D5F", "\u0D61"], ["\u0D7A", "\u0D7F"], ["\u0D85", "\u0D96"], ["\u0D9A", "\u0DB1"], ["\u0DB3", "\u0DBB"], "\u0DBD", ["\u0DC0", "\u0DC6"], ["\u0E01", "\u0E30"], ["\u0E32", "\u0E33"], ["\u0E40", "\u0E45"], ["\u0E81", "\u0E82"], "\u0E84", ["\u0E87", "\u0E88"], "\u0E8A", "\u0E8D", ["\u0E94", "\u0E97"], ["\u0E99", "\u0E9F"], ["\u0EA1", "\u0EA3"], "\u0EA5", "\u0EA7", ["\u0EAA", "\u0EAB"], ["\u0EAD", "\u0EB0"], ["\u0EB2", "\u0EB3"], "\u0EBD", ["\u0EC0", "\u0EC4"], ["\u0EDC", "\u0EDF"], "\u0F00", ["\u0F40", "\u0F47"], ["\u0F49", "\u0F6C"], ["\u0F88", "\u0F8C"], ["\u1000", "\u102A"], "\u103F", ["\u1050", "\u1055"], ["\u105A", "\u105D"], "\u1061", ["\u1065", "\u1066"], ["\u106E", "\u1070"], ["\u1075", "\u1081"], "\u108E", ["\u1100", "\u1248"], ["\u124A", "\u124D"], ["\u1250", "\u1256"], "\u1258", ["\u125A", "\u125D"], ["\u1260", "\u1288"], ["\u128A", "\u128D"], ["\u1290", "\u12B0"], ["\u12B2", "\u12B5"], ["\u12B8", "\u12BE"], "\u12C0", ["\u12C2", "\u12C5"], ["\u12C8", "\u12D6"], ["\u12D8", "\u1310"], ["\u1312", "\u1315"], ["\u1318", "\u135A"], ["\u1380", "\u138F"], ["\u1401", "\u166C"], ["\u166F", "\u167F"], ["\u1681", "\u169A"], ["\u16A0", "\u16EA"], ["\u16F1", "\u16F8"], ["\u1700", "\u170C"], ["\u170E", "\u1711"], ["\u1720", "\u1731"], ["\u1740", "\u1751"], ["\u1760", "\u176C"], ["\u176E", "\u1770"], ["\u1780", "\u17B3"], "\u17DC", ["\u1820", "\u1842"], ["\u1844", "\u1878"], ["\u1880", "\u1884"], ["\u1887", "\u18A8"], "\u18AA", ["\u18B0", "\u18F5"], ["\u1900", "\u191E"], ["\u1950", "\u196D"], ["\u1970", "\u1974"], ["\u1980", "\u19AB"], ["\u19B0", "\u19C9"], ["\u1A00", "\u1A16"], ["\u1A20", "\u1A54"], ["\u1B05", "\u1B33"], ["\u1B45", "\u1B4B"], ["\u1B83", "\u1BA0"], ["\u1BAE", "\u1BAF"], ["\u1BBA", "\u1BE5"], ["\u1C00", "\u1C23"], ["\u1C4D", "\u1C4F"], ["\u1C5A", "\u1C77"], ["\u1CE9", "\u1CEC"], ["\u1CEE", "\u1CF1"], ["\u1CF5", "\u1CF6"], ["\u2135", "\u2138"], ["\u2D30", "\u2D67"], ["\u2D80", "\u2D96"], ["\u2DA0", "\u2DA6"], ["\u2DA8", "\u2DAE"], ["\u2DB0", "\u2DB6"], ["\u2DB8", "\u2DBE"], ["\u2DC0", "\u2DC6"], ["\u2DC8", "\u2DCE"], ["\u2DD0", "\u2DD6"], ["\u2DD8", "\u2DDE"], "\u3006", "\u303C", ["\u3041", "\u3096"], "\u309F", ["\u30A1", "\u30FA"], "\u30FF", ["\u3105", "\u312F"], ["\u3131", "\u318E"], ["\u31A0", "\u31BA"], ["\u31F0", "\u31FF"], ["\u3400", "\u4DB5"], ["\u4E00", "\u9FEF"], ["\uA000", "\uA014"], ["\uA016", "\uA48C"], ["\uA4D0", "\uA4F7"], ["\uA500", "\uA60B"], ["\uA610", "\uA61F"], ["\uA62A", "\uA62B"], "\uA66E", ["\uA6A0", "\uA6E5"], "\uA78F", "\uA7F7", ["\uA7FB", "\uA801"], ["\uA803", "\uA805"], ["\uA807", "\uA80A"], ["\uA80C", "\uA822"], ["\uA840", "\uA873"], ["\uA882", "\uA8B3"], ["\uA8F2", "\uA8F7"], "\uA8FB", ["\uA8FD", "\uA8FE"], ["\uA90A", "\uA925"], ["\uA930", "\uA946"], ["\uA960", "\uA97C"], ["\uA984", "\uA9B2"], ["\uA9E0", "\uA9E4"], ["\uA9E7", "\uA9EF"], ["\uA9FA", "\uA9FE"], ["\uAA00", "\uAA28"], ["\uAA40", "\uAA42"], ["\uAA44", "\uAA4B"], ["\uAA60", "\uAA6F"], ["\uAA71", "\uAA76"], "\uAA7A", ["\uAA7E", "\uAAAF"], "\uAAB1", ["\uAAB5", "\uAAB6"], ["\uAAB9", "\uAABD"], "\uAAC0", "\uAAC2", ["\uAADB", "\uAADC"], ["\uAAE0", "\uAAEA"], "\uAAF2", ["\uAB01", "\uAB06"], ["\uAB09", "\uAB0E"], ["\uAB11", "\uAB16"], ["\uAB20", "\uAB26"], ["\uAB28", "\uAB2E"], ["\uABC0", "\uABE2"], ["\uAC00", "\uD7A3"], ["\uD7B0", "\uD7C6"], ["\uD7CB", "\uD7FB"], ["\uF900", "\uFA6D"], ["\uFA70", "\uFAD9"], "\uFB1D", ["\uFB1F", "\uFB28"], ["\uFB2A", "\uFB36"], ["\uFB38", "\uFB3C"], "\uFB3E", ["\uFB40", "\uFB41"], ["\uFB43", "\uFB44"], ["\uFB46", "\uFBB1"], ["\uFBD3", "\uFD3D"], ["\uFD50", "\uFD8F"], ["\uFD92", "\uFDC7"], ["\uFDF0", "\uFDFB"], ["\uFE70", "\uFE74"], ["\uFE76", "\uFEFC"], ["\uFF66", "\uFF6F"], ["\uFF71", "\uFF9D"], ["\uFFA0", "\uFFBE"], ["\uFFC2", "\uFFC7"], ["\uFFCA", "\uFFCF"], ["\uFFD2", "\uFFD7"], ["\uFFDA", "\uFFDC"]], false, false),
+      peg$c577 = /^[\u01C5\u01C8\u01CB\u01F2\u1F88-\u1F8F\u1F98-\u1F9F\u1FA8-\u1FAF\u1FBC\u1FCC\u1FFC]/,
+      peg$c578 = peg$classExpectation(["\u01C5", "\u01C8", "\u01CB", "\u01F2", ["\u1F88", "\u1F8F"], ["\u1F98", "\u1F9F"], ["\u1FA8", "\u1FAF"], "\u1FBC", "\u1FCC", "\u1FFC"], false, false),
+      peg$c579 = /^[A-Z\xC0-\xD6\xD8-\xDE\u0100\u0102\u0104\u0106\u0108\u010A\u010C\u010E\u0110\u0112\u0114\u0116\u0118\u011A\u011C\u011E\u0120\u0122\u0124\u0126\u0128\u012A\u012C\u012E\u0130\u0132\u0134\u0136\u0139\u013B\u013D\u013F\u0141\u0143\u0145\u0147\u014A\u014C\u014E\u0150\u0152\u0154\u0156\u0158\u015A\u015C\u015E\u0160\u0162\u0164\u0166\u0168\u016A\u016C\u016E\u0170\u0172\u0174\u0176\u0178-\u0179\u017B\u017D\u0181-\u0182\u0184\u0186-\u0187\u0189-\u018B\u018E-\u0191\u0193-\u0194\u0196-\u0198\u019C-\u019D\u019F-\u01A0\u01A2\u01A4\u01A6-\u01A7\u01A9\u01AC\u01AE-\u01AF\u01B1-\u01B3\u01B5\u01B7-\u01B8\u01BC\u01C4\u01C7\u01CA\u01CD\u01CF\u01D1\u01D3\u01D5\u01D7\u01D9\u01DB\u01DE\u01E0\u01E2\u01E4\u01E6\u01E8\u01EA\u01EC\u01EE\u01F1\u01F4\u01F6-\u01F8\u01FA\u01FC\u01FE\u0200\u0202\u0204\u0206\u0208\u020A\u020C\u020E\u0210\u0212\u0214\u0216\u0218\u021A\u021C\u021E\u0220\u0222\u0224\u0226\u0228\u022A\u022C\u022E\u0230\u0232\u023A-\u023B\u023D-\u023E\u0241\u0243-\u0246\u0248\u024A\u024C\u024E\u0370\u0372\u0376\u037F\u0386\u0388-\u038A\u038C\u038E-\u038F\u0391-\u03A1\u03A3-\u03AB\u03CF\u03D2-\u03D4\u03D8\u03DA\u03DC\u03DE\u03E0\u03E2\u03E4\u03E6\u03E8\u03EA\u03EC\u03EE\u03F4\u03F7\u03F9-\u03FA\u03FD-\u042F\u0460\u0462\u0464\u0466\u0468\u046A\u046C\u046E\u0470\u0472\u0474\u0476\u0478\u047A\u047C\u047E\u0480\u048A\u048C\u048E\u0490\u0492\u0494\u0496\u0498\u049A\u049C\u049E\u04A0\u04A2\u04A4\u04A6\u04A8\u04AA\u04AC\u04AE\u04B0\u04B2\u04B4\u04B6\u04B8\u04BA\u04BC\u04BE\u04C0-\u04C1\u04C3\u04C5\u04C7\u04C9\u04CB\u04CD\u04D0\u04D2\u04D4\u04D6\u04D8\u04DA\u04DC\u04DE\u04E0\u04E2\u04E4\u04E6\u04E8\u04EA\u04EC\u04EE\u04F0\u04F2\u04F4\u04F6\u04F8\u04FA\u04FC\u04FE\u0500\u0502\u0504\u0506\u0508\u050A\u050C\u050E\u0510\u0512\u0514\u0516\u0518\u051A\u051C\u051E\u0520\u0522\u0524\u0526\u0528\u052A\u052C\u052E\u0531-\u0556\u10A0-\u10C5\u10C7\u10CD\u13A0-\u13F5\u1C90-\u1CBA\u1CBD-\u1CBF\u1E00\u1E02\u1E04\u1E06\u1E08\u1E0A\u1E0C\u1E0E\u1E10\u1E12\u1E14\u1E16\u1E18\u1E1A\u1E1C\u1E1E\u1E20\u1E22\u1E24\u1E26\u1E28\u1E2A\u1E2C\u1E2E\u1E30\u1E32\u1E34\u1E36\u1E38\u1E3A\u1E3C\u1E3E\u1E40\u1E42\u1E44\u1E46\u1E48\u1E4A\u1E4C\u1E4E\u1E50\u1E52\u1E54\u1E56\u1E58\u1E5A\u1E5C\u1E5E\u1E60\u1E62\u1E64\u1E66\u1E68\u1E6A\u1E6C\u1E6E\u1E70\u1E72\u1E74\u1E76\u1E78\u1E7A\u1E7C\u1E7E\u1E80\u1E82\u1E84\u1E86\u1E88\u1E8A\u1E8C\u1E8E\u1E90\u1E92\u1E94\u1E9E\u1EA0\u1EA2\u1EA4\u1EA6\u1EA8\u1EAA\u1EAC\u1EAE\u1EB0\u1EB2\u1EB4\u1EB6\u1EB8\u1EBA\u1EBC\u1EBE\u1EC0\u1EC2\u1EC4\u1EC6\u1EC8\u1ECA\u1ECC\u1ECE\u1ED0\u1ED2\u1ED4\u1ED6\u1ED8\u1EDA\u1EDC\u1EDE\u1EE0\u1EE2\u1EE4\u1EE6\u1EE8\u1EEA\u1EEC\u1EEE\u1EF0\u1EF2\u1EF4\u1EF6\u1EF8\u1EFA\u1EFC\u1EFE\u1F08-\u1F0F\u1F18-\u1F1D\u1F28-\u1F2F\u1F38-\u1F3F\u1F48-\u1F4D\u1F59\u1F5B\u1F5D\u1F5F\u1F68-\u1F6F\u1FB8-\u1FBB\u1FC8-\u1FCB\u1FD8-\u1FDB\u1FE8-\u1FEC\u1FF8-\u1FFB\u2102\u2107\u210B-\u210D\u2110-\u2112\u2115\u2119-\u211D\u2124\u2126\u2128\u212A-\u212D\u2130-\u2133\u213E-\u213F\u2145\u2183\u2C00-\u2C2E\u2C60\u2C62-\u2C64\u2C67\u2C69\u2C6B\u2C6D-\u2C70\u2C72\u2C75\u2C7E-\u2C80\u2C82\u2C84\u2C86\u2C88\u2C8A\u2C8C\u2C8E\u2C90\u2C92\u2C94\u2C96\u2C98\u2C9A\u2C9C\u2C9E\u2CA0\u2CA2\u2CA4\u2CA6\u2CA8\u2CAA\u2CAC\u2CAE\u2CB0\u2CB2\u2CB4\u2CB6\u2CB8\u2CBA\u2CBC\u2CBE\u2CC0\u2CC2\u2CC4\u2CC6\u2CC8\u2CCA\u2CCC\u2CCE\u2CD0\u2CD2\u2CD4\u2CD6\u2CD8\u2CDA\u2CDC\u2CDE\u2CE0\u2CE2\u2CEB\u2CED\u2CF2\uA640\uA642\uA644\uA646\uA648\uA64A\uA64C\uA64E\uA650\uA652\uA654\uA656\uA658\uA65A\uA65C\uA65E\uA660\uA662\uA664\uA666\uA668\uA66A\uA66C\uA680\uA682\uA684\uA686\uA688\uA68A\uA68C\uA68E\uA690\uA692\uA694\uA696\uA698\uA69A\uA722\uA724\uA726\uA728\uA72A\uA72C\uA72E\uA732\uA734\uA736\uA738\uA73A\uA73C\uA73E\uA740\uA742\uA744\uA746\uA748\uA74A\uA74C\uA74E\uA750\uA752\uA754\uA756\uA758\uA75A\uA75C\uA75E\uA760\uA762\uA764\uA766\uA768\uA76A\uA76C\uA76E\uA779\uA77B\uA77D-\uA77E\uA780\uA782\uA784\uA786\uA78B\uA78D\uA790\uA792\uA796\uA798\uA79A\uA79C\uA79E\uA7A0\uA7A2\uA7A4\uA7A6\uA7A8\uA7AA-\uA7AE\uA7B0-\uA7B4\uA7B6\uA7B8\uFF21-\uFF3A]/,
+      peg$c580 = peg$classExpectation([["A", "Z"], ["\xC0", "\xD6"], ["\xD8", "\xDE"], "\u0100", "\u0102", "\u0104", "\u0106", "\u0108", "\u010A", "\u010C", "\u010E", "\u0110", "\u0112", "\u0114", "\u0116", "\u0118", "\u011A", "\u011C", "\u011E", "\u0120", "\u0122", "\u0124", "\u0126", "\u0128", "\u012A", "\u012C", "\u012E", "\u0130", "\u0132", "\u0134", "\u0136", "\u0139", "\u013B", "\u013D", "\u013F", "\u0141", "\u0143", "\u0145", "\u0147", "\u014A", "\u014C", "\u014E", "\u0150", "\u0152", "\u0154", "\u0156", "\u0158", "\u015A", "\u015C", "\u015E", "\u0160", "\u0162", "\u0164", "\u0166", "\u0168", "\u016A", "\u016C", "\u016E", "\u0170", "\u0172", "\u0174", "\u0176", ["\u0178", "\u0179"], "\u017B", "\u017D", ["\u0181", "\u0182"], "\u0184", ["\u0186", "\u0187"], ["\u0189", "\u018B"], ["\u018E", "\u0191"], ["\u0193", "\u0194"], ["\u0196", "\u0198"], ["\u019C", "\u019D"], ["\u019F", "\u01A0"], "\u01A2", "\u01A4", ["\u01A6", "\u01A7"], "\u01A9", "\u01AC", ["\u01AE", "\u01AF"], ["\u01B1", "\u01B3"], "\u01B5", ["\u01B7", "\u01B8"], "\u01BC", "\u01C4", "\u01C7", "\u01CA", "\u01CD", "\u01CF", "\u01D1", "\u01D3", "\u01D5", "\u01D7", "\u01D9", "\u01DB", "\u01DE", "\u01E0", "\u01E2", "\u01E4", "\u01E6", "\u01E8", "\u01EA", "\u01EC", "\u01EE", "\u01F1", "\u01F4", ["\u01F6", "\u01F8"], "\u01FA", "\u01FC", "\u01FE", "\u0200", "\u0202", "\u0204", "\u0206", "\u0208", "\u020A", "\u020C", "\u020E", "\u0210", "\u0212", "\u0214", "\u0216", "\u0218", "\u021A", "\u021C", "\u021E", "\u0220", "\u0222", "\u0224", "\u0226", "\u0228", "\u022A", "\u022C", "\u022E", "\u0230", "\u0232", ["\u023A", "\u023B"], ["\u023D", "\u023E"], "\u0241", ["\u0243", "\u0246"], "\u0248", "\u024A", "\u024C", "\u024E", "\u0370", "\u0372", "\u0376", "\u037F", "\u0386", ["\u0388", "\u038A"], "\u038C", ["\u038E", "\u038F"], ["\u0391", "\u03A1"], ["\u03A3", "\u03AB"], "\u03CF", ["\u03D2", "\u03D4"], "\u03D8", "\u03DA", "\u03DC", "\u03DE", "\u03E0", "\u03E2", "\u03E4", "\u03E6", "\u03E8", "\u03EA", "\u03EC", "\u03EE", "\u03F4", "\u03F7", ["\u03F9", "\u03FA"], ["\u03FD", "\u042F"], "\u0460", "\u0462", "\u0464", "\u0466", "\u0468", "\u046A", "\u046C", "\u046E", "\u0470", "\u0472", "\u0474", "\u0476", "\u0478", "\u047A", "\u047C", "\u047E", "\u0480", "\u048A", "\u048C", "\u048E", "\u0490", "\u0492", "\u0494", "\u0496", "\u0498", "\u049A", "\u049C", "\u049E", "\u04A0", "\u04A2", "\u04A4", "\u04A6", "\u04A8", "\u04AA", "\u04AC", "\u04AE", "\u04B0", "\u04B2", "\u04B4", "\u04B6", "\u04B8", "\u04BA", "\u04BC", "\u04BE", ["\u04C0", "\u04C1"], "\u04C3", "\u04C5", "\u04C7", "\u04C9", "\u04CB", "\u04CD", "\u04D0", "\u04D2", "\u04D4", "\u04D6", "\u04D8", "\u04DA", "\u04DC", "\u04DE", "\u04E0", "\u04E2", "\u04E4", "\u04E6", "\u04E8", "\u04EA", "\u04EC", "\u04EE", "\u04F0", "\u04F2", "\u04F4", "\u04F6", "\u04F8", "\u04FA", "\u04FC", "\u04FE", "\u0500", "\u0502", "\u0504", "\u0506", "\u0508", "\u050A", "\u050C", "\u050E", "\u0510", "\u0512", "\u0514", "\u0516", "\u0518", "\u051A", "\u051C", "\u051E", "\u0520", "\u0522", "\u0524", "\u0526", "\u0528", "\u052A", "\u052C", "\u052E", ["\u0531", "\u0556"], ["\u10A0", "\u10C5"], "\u10C7", "\u10CD", ["\u13A0", "\u13F5"], ["\u1C90", "\u1CBA"], ["\u1CBD", "\u1CBF"], "\u1E00", "\u1E02", "\u1E04", "\u1E06", "\u1E08", "\u1E0A", "\u1E0C", "\u1E0E", "\u1E10", "\u1E12", "\u1E14", "\u1E16", "\u1E18", "\u1E1A", "\u1E1C", "\u1E1E", "\u1E20", "\u1E22", "\u1E24", "\u1E26", "\u1E28", "\u1E2A", "\u1E2C", "\u1E2E", "\u1E30", "\u1E32", "\u1E34", "\u1E36", "\u1E38", "\u1E3A", "\u1E3C", "\u1E3E", "\u1E40", "\u1E42", "\u1E44", "\u1E46", "\u1E48", "\u1E4A", "\u1E4C", "\u1E4E", "\u1E50", "\u1E52", "\u1E54", "\u1E56", "\u1E58", "\u1E5A", "\u1E5C", "\u1E5E", "\u1E60", "\u1E62", "\u1E64", "\u1E66", "\u1E68", "\u1E6A", "\u1E6C", "\u1E6E", "\u1E70", "\u1E72", "\u1E74", "\u1E76", "\u1E78", "\u1E7A", "\u1E7C", "\u1E7E", "\u1E80", "\u1E82", "\u1E84", "\u1E86", "\u1E88", "\u1E8A", "\u1E8C", "\u1E8E", "\u1E90", "\u1E92", "\u1E94", "\u1E9E", "\u1EA0", "\u1EA2", "\u1EA4", "\u1EA6", "\u1EA8", "\u1EAA", "\u1EAC", "\u1EAE", "\u1EB0", "\u1EB2", "\u1EB4", "\u1EB6", "\u1EB8", "\u1EBA", "\u1EBC", "\u1EBE", "\u1EC0", "\u1EC2", "\u1EC4", "\u1EC6", "\u1EC8", "\u1ECA", "\u1ECC", "\u1ECE", "\u1ED0", "\u1ED2", "\u1ED4", "\u1ED6", "\u1ED8", "\u1EDA", "\u1EDC", "\u1EDE", "\u1EE0", "\u1EE2", "\u1EE4", "\u1EE6", "\u1EE8", "\u1EEA", "\u1EEC", "\u1EEE", "\u1EF0", "\u1EF2", "\u1EF4", "\u1EF6", "\u1EF8", "\u1EFA", "\u1EFC", "\u1EFE", ["\u1F08", "\u1F0F"], ["\u1F18", "\u1F1D"], ["\u1F28", "\u1F2F"], ["\u1F38", "\u1F3F"], ["\u1F48", "\u1F4D"], "\u1F59", "\u1F5B", "\u1F5D", "\u1F5F", ["\u1F68", "\u1F6F"], ["\u1FB8", "\u1FBB"], ["\u1FC8", "\u1FCB"], ["\u1FD8", "\u1FDB"], ["\u1FE8", "\u1FEC"], ["\u1FF8", "\u1FFB"], "\u2102", "\u2107", ["\u210B", "\u210D"], ["\u2110", "\u2112"], "\u2115", ["\u2119", "\u211D"], "\u2124", "\u2126", "\u2128", ["\u212A", "\u212D"], ["\u2130", "\u2133"], ["\u213E", "\u213F"], "\u2145", "\u2183", ["\u2C00", "\u2C2E"], "\u2C60", ["\u2C62", "\u2C64"], "\u2C67", "\u2C69", "\u2C6B", ["\u2C6D", "\u2C70"], "\u2C72", "\u2C75", ["\u2C7E", "\u2C80"], "\u2C82", "\u2C84", "\u2C86", "\u2C88", "\u2C8A", "\u2C8C", "\u2C8E", "\u2C90", "\u2C92", "\u2C94", "\u2C96", "\u2C98", "\u2C9A", "\u2C9C", "\u2C9E", "\u2CA0", "\u2CA2", "\u2CA4", "\u2CA6", "\u2CA8", "\u2CAA", "\u2CAC", "\u2CAE", "\u2CB0", "\u2CB2", "\u2CB4", "\u2CB6", "\u2CB8", "\u2CBA", "\u2CBC", "\u2CBE", "\u2CC0", "\u2CC2", "\u2CC4", "\u2CC6", "\u2CC8", "\u2CCA", "\u2CCC", "\u2CCE", "\u2CD0", "\u2CD2", "\u2CD4", "\u2CD6", "\u2CD8", "\u2CDA", "\u2CDC", "\u2CDE", "\u2CE0", "\u2CE2", "\u2CEB", "\u2CED", "\u2CF2", "\uA640", "\uA642", "\uA644", "\uA646", "\uA648", "\uA64A", "\uA64C", "\uA64E", "\uA650", "\uA652", "\uA654", "\uA656", "\uA658", "\uA65A", "\uA65C", "\uA65E", "\uA660", "\uA662", "\uA664", "\uA666", "\uA668", "\uA66A", "\uA66C", "\uA680", "\uA682", "\uA684", "\uA686", "\uA688", "\uA68A", "\uA68C", "\uA68E", "\uA690", "\uA692", "\uA694", "\uA696", "\uA698", "\uA69A", "\uA722", "\uA724", "\uA726", "\uA728", "\uA72A", "\uA72C", "\uA72E", "\uA732", "\uA734", "\uA736", "\uA738", "\uA73A", "\uA73C", "\uA73E", "\uA740", "\uA742", "\uA744", "\uA746", "\uA748", "\uA74A", "\uA74C", "\uA74E", "\uA750", "\uA752", "\uA754", "\uA756", "\uA758", "\uA75A", "\uA75C", "\uA75E", "\uA760", "\uA762", "\uA764", "\uA766", "\uA768", "\uA76A", "\uA76C", "\uA76E", "\uA779", "\uA77B", ["\uA77D", "\uA77E"], "\uA780", "\uA782", "\uA784", "\uA786", "\uA78B", "\uA78D", "\uA790", "\uA792", "\uA796", "\uA798", "\uA79A", "\uA79C", "\uA79E", "\uA7A0", "\uA7A2", "\uA7A4", "\uA7A6", "\uA7A8", ["\uA7AA", "\uA7AE"], ["\uA7B0", "\uA7B4"], "\uA7B6", "\uA7B8", ["\uFF21", "\uFF3A"]], false, false),
+      peg$c581 = /^[\u0903\u093B\u093E-\u0940\u0949-\u094C\u094E-\u094F\u0982-\u0983\u09BE-\u09C0\u09C7-\u09C8\u09CB-\u09CC\u09D7\u0A03\u0A3E-\u0A40\u0A83\u0ABE-\u0AC0\u0AC9\u0ACB-\u0ACC\u0B02-\u0B03\u0B3E\u0B40\u0B47-\u0B48\u0B4B-\u0B4C\u0B57\u0BBE-\u0BBF\u0BC1-\u0BC2\u0BC6-\u0BC8\u0BCA-\u0BCC\u0BD7\u0C01-\u0C03\u0C41-\u0C44\u0C82-\u0C83\u0CBE\u0CC0-\u0CC4\u0CC7-\u0CC8\u0CCA-\u0CCB\u0CD5-\u0CD6\u0D02-\u0D03\u0D3E-\u0D40\u0D46-\u0D48\u0D4A-\u0D4C\u0D57\u0D82-\u0D83\u0DCF-\u0DD1\u0DD8-\u0DDF\u0DF2-\u0DF3\u0F3E-\u0F3F\u0F7F\u102B-\u102C\u1031\u1038\u103B-\u103C\u1056-\u1057\u1062-\u1064\u1067-\u106D\u1083-\u1084\u1087-\u108C\u108F\u109A-\u109C\u17B6\u17BE-\u17C5\u17C7-\u17C8\u1923-\u1926\u1929-\u192B\u1930-\u1931\u1933-\u1938\u1A19-\u1A1A\u1A55\u1A57\u1A61\u1A63-\u1A64\u1A6D-\u1A72\u1B04\u1B35\u1B3B\u1B3D-\u1B41\u1B43-\u1B44\u1B82\u1BA1\u1BA6-\u1BA7\u1BAA\u1BE7\u1BEA-\u1BEC\u1BEE\u1BF2-\u1BF3\u1C24-\u1C2B\u1C34-\u1C35\u1CE1\u1CF2-\u1CF3\u1CF7\u302E-\u302F\uA823-\uA824\uA827\uA880-\uA881\uA8B4-\uA8C3\uA952-\uA953\uA983\uA9B4-\uA9B5\uA9BA-\uA9BB\uA9BD-\uA9C0\uAA2F-\uAA30\uAA33-\uAA34\uAA4D\uAA7B\uAA7D\uAAEB\uAAEE-\uAAEF\uAAF5\uABE3-\uABE4\uABE6-\uABE7\uABE9-\uABEA\uABEC]/,
+      peg$c582 = peg$classExpectation(["\u0903", "\u093B", ["\u093E", "\u0940"], ["\u0949", "\u094C"], ["\u094E", "\u094F"], ["\u0982", "\u0983"], ["\u09BE", "\u09C0"], ["\u09C7", "\u09C8"], ["\u09CB", "\u09CC"], "\u09D7", "\u0A03", ["\u0A3E", "\u0A40"], "\u0A83", ["\u0ABE", "\u0AC0"], "\u0AC9", ["\u0ACB", "\u0ACC"], ["\u0B02", "\u0B03"], "\u0B3E", "\u0B40", ["\u0B47", "\u0B48"], ["\u0B4B", "\u0B4C"], "\u0B57", ["\u0BBE", "\u0BBF"], ["\u0BC1", "\u0BC2"], ["\u0BC6", "\u0BC8"], ["\u0BCA", "\u0BCC"], "\u0BD7", ["\u0C01", "\u0C03"], ["\u0C41", "\u0C44"], ["\u0C82", "\u0C83"], "\u0CBE", ["\u0CC0", "\u0CC4"], ["\u0CC7", "\u0CC8"], ["\u0CCA", "\u0CCB"], ["\u0CD5", "\u0CD6"], ["\u0D02", "\u0D03"], ["\u0D3E", "\u0D40"], ["\u0D46", "\u0D48"], ["\u0D4A", "\u0D4C"], "\u0D57", ["\u0D82", "\u0D83"], ["\u0DCF", "\u0DD1"], ["\u0DD8", "\u0DDF"], ["\u0DF2", "\u0DF3"], ["\u0F3E", "\u0F3F"], "\u0F7F", ["\u102B", "\u102C"], "\u1031", "\u1038", ["\u103B", "\u103C"], ["\u1056", "\u1057"], ["\u1062", "\u1064"], ["\u1067", "\u106D"], ["\u1083", "\u1084"], ["\u1087", "\u108C"], "\u108F", ["\u109A", "\u109C"], "\u17B6", ["\u17BE", "\u17C5"], ["\u17C7", "\u17C8"], ["\u1923", "\u1926"], ["\u1929", "\u192B"], ["\u1930", "\u1931"], ["\u1933", "\u1938"], ["\u1A19", "\u1A1A"], "\u1A55", "\u1A57", "\u1A61", ["\u1A63", "\u1A64"], ["\u1A6D", "\u1A72"], "\u1B04", "\u1B35", "\u1B3B", ["\u1B3D", "\u1B41"], ["\u1B43", "\u1B44"], "\u1B82", "\u1BA1", ["\u1BA6", "\u1BA7"], "\u1BAA", "\u1BE7", ["\u1BEA", "\u1BEC"], "\u1BEE", ["\u1BF2", "\u1BF3"], ["\u1C24", "\u1C2B"], ["\u1C34", "\u1C35"], "\u1CE1", ["\u1CF2", "\u1CF3"], "\u1CF7", ["\u302E", "\u302F"], ["\uA823", "\uA824"], "\uA827", ["\uA880", "\uA881"], ["\uA8B4", "\uA8C3"], ["\uA952", "\uA953"], "\uA983", ["\uA9B4", "\uA9B5"], ["\uA9BA", "\uA9BB"], ["\uA9BD", "\uA9C0"], ["\uAA2F", "\uAA30"], ["\uAA33", "\uAA34"], "\uAA4D", "\uAA7B", "\uAA7D", "\uAAEB", ["\uAAEE", "\uAAEF"], "\uAAF5", ["\uABE3", "\uABE4"], ["\uABE6", "\uABE7"], ["\uABE9", "\uABEA"], "\uABEC"], false, false),
+      peg$c583 = /^[\u0300-\u036F\u0483-\u0487\u0591-\u05BD\u05BF\u05C1-\u05C2\u05C4-\u05C5\u05C7\u0610-\u061A\u064B-\u065F\u0670\u06D6-\u06DC\u06DF-\u06E4\u06E7-\u06E8\u06EA-\u06ED\u0711\u0730-\u074A\u07A6-\u07B0\u07EB-\u07F3\u07FD\u0816-\u0819\u081B-\u0823\u0825-\u0827\u0829-\u082D\u0859-\u085B\u08D3-\u08E1\u08E3-\u0902\u093A\u093C\u0941-\u0948\u094D\u0951-\u0957\u0962-\u0963\u0981\u09BC\u09C1-\u09C4\u09CD\u09E2-\u09E3\u09FE\u0A01-\u0A02\u0A3C\u0A41-\u0A42\u0A47-\u0A48\u0A4B-\u0A4D\u0A51\u0A70-\u0A71\u0A75\u0A81-\u0A82\u0ABC\u0AC1-\u0AC5\u0AC7-\u0AC8\u0ACD\u0AE2-\u0AE3\u0AFA-\u0AFF\u0B01\u0B3C\u0B3F\u0B41-\u0B44\u0B4D\u0B56\u0B62-\u0B63\u0B82\u0BC0\u0BCD\u0C00\u0C04\u0C3E-\u0C40\u0C46-\u0C48\u0C4A-\u0C4D\u0C55-\u0C56\u0C62-\u0C63\u0C81\u0CBC\u0CBF\u0CC6\u0CCC-\u0CCD\u0CE2-\u0CE3\u0D00-\u0D01\u0D3B-\u0D3C\u0D41-\u0D44\u0D4D\u0D62-\u0D63\u0DCA\u0DD2-\u0DD4\u0DD6\u0E31\u0E34-\u0E3A\u0E47-\u0E4E\u0EB1\u0EB4-\u0EB9\u0EBB-\u0EBC\u0EC8-\u0ECD\u0F18-\u0F19\u0F35\u0F37\u0F39\u0F71-\u0F7E\u0F80-\u0F84\u0F86-\u0F87\u0F8D-\u0F97\u0F99-\u0FBC\u0FC6\u102D-\u1030\u1032-\u1037\u1039-\u103A\u103D-\u103E\u1058-\u1059\u105E-\u1060\u1071-\u1074\u1082\u1085-\u1086\u108D\u109D\u135D-\u135F\u1712-\u1714\u1732-\u1734\u1752-\u1753\u1772-\u1773\u17B4-\u17B5\u17B7-\u17BD\u17C6\u17C9-\u17D3\u17DD\u180B-\u180D\u1885-\u1886\u18A9\u1920-\u1922\u1927-\u1928\u1932\u1939-\u193B\u1A17-\u1A18\u1A1B\u1A56\u1A58-\u1A5E\u1A60\u1A62\u1A65-\u1A6C\u1A73-\u1A7C\u1A7F\u1AB0-\u1ABD\u1B00-\u1B03\u1B34\u1B36-\u1B3A\u1B3C\u1B42\u1B6B-\u1B73\u1B80-\u1B81\u1BA2-\u1BA5\u1BA8-\u1BA9\u1BAB-\u1BAD\u1BE6\u1BE8-\u1BE9\u1BED\u1BEF-\u1BF1\u1C2C-\u1C33\u1C36-\u1C37\u1CD0-\u1CD2\u1CD4-\u1CE0\u1CE2-\u1CE8\u1CED\u1CF4\u1CF8-\u1CF9\u1DC0-\u1DF9\u1DFB-\u1DFF\u20D0-\u20DC\u20E1\u20E5-\u20F0\u2CEF-\u2CF1\u2D7F\u2DE0-\u2DFF\u302A-\u302D\u3099-\u309A\uA66F\uA674-\uA67D\uA69E-\uA69F\uA6F0-\uA6F1\uA802\uA806\uA80B\uA825-\uA826\uA8C4-\uA8C5\uA8E0-\uA8F1\uA8FF\uA926-\uA92D\uA947-\uA951\uA980-\uA982\uA9B3\uA9B6-\uA9B9\uA9BC\uA9E5\uAA29-\uAA2E\uAA31-\uAA32\uAA35-\uAA36\uAA43\uAA4C\uAA7C\uAAB0\uAAB2-\uAAB4\uAAB7-\uAAB8\uAABE-\uAABF\uAAC1\uAAEC-\uAAED\uAAF6\uABE5\uABE8\uABED\uFB1E\uFE00-\uFE0F\uFE20-\uFE2F]/,
+      peg$c584 = peg$classExpectation([["\u0300", "\u036F"], ["\u0483", "\u0487"], ["\u0591", "\u05BD"], "\u05BF", ["\u05C1", "\u05C2"], ["\u05C4", "\u05C5"], "\u05C7", ["\u0610", "\u061A"], ["\u064B", "\u065F"], "\u0670", ["\u06D6", "\u06DC"], ["\u06DF", "\u06E4"], ["\u06E7", "\u06E8"], ["\u06EA", "\u06ED"], "\u0711", ["\u0730", "\u074A"], ["\u07A6", "\u07B0"], ["\u07EB", "\u07F3"], "\u07FD", ["\u0816", "\u0819"], ["\u081B", "\u0823"], ["\u0825", "\u0827"], ["\u0829", "\u082D"], ["\u0859", "\u085B"], ["\u08D3", "\u08E1"], ["\u08E3", "\u0902"], "\u093A", "\u093C", ["\u0941", "\u0948"], "\u094D", ["\u0951", "\u0957"], ["\u0962", "\u0963"], "\u0981", "\u09BC", ["\u09C1", "\u09C4"], "\u09CD", ["\u09E2", "\u09E3"], "\u09FE", ["\u0A01", "\u0A02"], "\u0A3C", ["\u0A41", "\u0A42"], ["\u0A47", "\u0A48"], ["\u0A4B", "\u0A4D"], "\u0A51", ["\u0A70", "\u0A71"], "\u0A75", ["\u0A81", "\u0A82"], "\u0ABC", ["\u0AC1", "\u0AC5"], ["\u0AC7", "\u0AC8"], "\u0ACD", ["\u0AE2", "\u0AE3"], ["\u0AFA", "\u0AFF"], "\u0B01", "\u0B3C", "\u0B3F", ["\u0B41", "\u0B44"], "\u0B4D", "\u0B56", ["\u0B62", "\u0B63"], "\u0B82", "\u0BC0", "\u0BCD", "\u0C00", "\u0C04", ["\u0C3E", "\u0C40"], ["\u0C46", "\u0C48"], ["\u0C4A", "\u0C4D"], ["\u0C55", "\u0C56"], ["\u0C62", "\u0C63"], "\u0C81", "\u0CBC", "\u0CBF", "\u0CC6", ["\u0CCC", "\u0CCD"], ["\u0CE2", "\u0CE3"], ["\u0D00", "\u0D01"], ["\u0D3B", "\u0D3C"], ["\u0D41", "\u0D44"], "\u0D4D", ["\u0D62", "\u0D63"], "\u0DCA", ["\u0DD2", "\u0DD4"], "\u0DD6", "\u0E31", ["\u0E34", "\u0E3A"], ["\u0E47", "\u0E4E"], "\u0EB1", ["\u0EB4", "\u0EB9"], ["\u0EBB", "\u0EBC"], ["\u0EC8", "\u0ECD"], ["\u0F18", "\u0F19"], "\u0F35", "\u0F37", "\u0F39", ["\u0F71", "\u0F7E"], ["\u0F80", "\u0F84"], ["\u0F86", "\u0F87"], ["\u0F8D", "\u0F97"], ["\u0F99", "\u0FBC"], "\u0FC6", ["\u102D", "\u1030"], ["\u1032", "\u1037"], ["\u1039", "\u103A"], ["\u103D", "\u103E"], ["\u1058", "\u1059"], ["\u105E", "\u1060"], ["\u1071", "\u1074"], "\u1082", ["\u1085", "\u1086"], "\u108D", "\u109D", ["\u135D", "\u135F"], ["\u1712", "\u1714"], ["\u1732", "\u1734"], ["\u1752", "\u1753"], ["\u1772", "\u1773"], ["\u17B4", "\u17B5"], ["\u17B7", "\u17BD"], "\u17C6", ["\u17C9", "\u17D3"], "\u17DD", ["\u180B", "\u180D"], ["\u1885", "\u1886"], "\u18A9", ["\u1920", "\u1922"], ["\u1927", "\u1928"], "\u1932", ["\u1939", "\u193B"], ["\u1A17", "\u1A18"], "\u1A1B", "\u1A56", ["\u1A58", "\u1A5E"], "\u1A60", "\u1A62", ["\u1A65", "\u1A6C"], ["\u1A73", "\u1A7C"], "\u1A7F", ["\u1AB0", "\u1ABD"], ["\u1B00", "\u1B03"], "\u1B34", ["\u1B36", "\u1B3A"], "\u1B3C", "\u1B42", ["\u1B6B", "\u1B73"], ["\u1B80", "\u1B81"], ["\u1BA2", "\u1BA5"], ["\u1BA8", "\u1BA9"], ["\u1BAB", "\u1BAD"], "\u1BE6", ["\u1BE8", "\u1BE9"], "\u1BED", ["\u1BEF", "\u1BF1"], ["\u1C2C", "\u1C33"], ["\u1C36", "\u1C37"], ["\u1CD0", "\u1CD2"], ["\u1CD4", "\u1CE0"], ["\u1CE2", "\u1CE8"], "\u1CED", "\u1CF4", ["\u1CF8", "\u1CF9"], ["\u1DC0", "\u1DF9"], ["\u1DFB", "\u1DFF"], ["\u20D0", "\u20DC"], "\u20E1", ["\u20E5", "\u20F0"], ["\u2CEF", "\u2CF1"], "\u2D7F", ["\u2DE0", "\u2DFF"], ["\u302A", "\u302D"], ["\u3099", "\u309A"], "\uA66F", ["\uA674", "\uA67D"], ["\uA69E", "\uA69F"], ["\uA6F0", "\uA6F1"], "\uA802", "\uA806", "\uA80B", ["\uA825", "\uA826"], ["\uA8C4", "\uA8C5"], ["\uA8E0", "\uA8F1"], "\uA8FF", ["\uA926", "\uA92D"], ["\uA947", "\uA951"], ["\uA980", "\uA982"], "\uA9B3", ["\uA9B6", "\uA9B9"], "\uA9BC", "\uA9E5", ["\uAA29", "\uAA2E"], ["\uAA31", "\uAA32"], ["\uAA35", "\uAA36"], "\uAA43", "\uAA4C", "\uAA7C", "\uAAB0", ["\uAAB2", "\uAAB4"], ["\uAAB7", "\uAAB8"], ["\uAABE", "\uAABF"], "\uAAC1", ["\uAAEC", "\uAAED"], "\uAAF6", "\uABE5", "\uABE8", "\uABED", "\uFB1E", ["\uFE00", "\uFE0F"], ["\uFE20", "\uFE2F"]], false, false),
+      peg$c585 = /^[0-9\u0660-\u0669\u06F0-\u06F9\u07C0-\u07C9\u0966-\u096F\u09E6-\u09EF\u0A66-\u0A6F\u0AE6-\u0AEF\u0B66-\u0B6F\u0BE6-\u0BEF\u0C66-\u0C6F\u0CE6-\u0CEF\u0D66-\u0D6F\u0DE6-\u0DEF\u0E50-\u0E59\u0ED0-\u0ED9\u0F20-\u0F29\u1040-\u1049\u1090-\u1099\u17E0-\u17E9\u1810-\u1819\u1946-\u194F\u19D0-\u19D9\u1A80-\u1A89\u1A90-\u1A99\u1B50-\u1B59\u1BB0-\u1BB9\u1C40-\u1C49\u1C50-\u1C59\uA620-\uA629\uA8D0-\uA8D9\uA900-\uA909\uA9D0-\uA9D9\uA9F0-\uA9F9\uAA50-\uAA59\uABF0-\uABF9\uFF10-\uFF19]/,
+      peg$c586 = peg$classExpectation([["0", "9"], ["\u0660", "\u0669"], ["\u06F0", "\u06F9"], ["\u07C0", "\u07C9"], ["\u0966", "\u096F"], ["\u09E6", "\u09EF"], ["\u0A66", "\u0A6F"], ["\u0AE6", "\u0AEF"], ["\u0B66", "\u0B6F"], ["\u0BE6", "\u0BEF"], ["\u0C66", "\u0C6F"], ["\u0CE6", "\u0CEF"], ["\u0D66", "\u0D6F"], ["\u0DE6", "\u0DEF"], ["\u0E50", "\u0E59"], ["\u0ED0", "\u0ED9"], ["\u0F20", "\u0F29"], ["\u1040", "\u1049"], ["\u1090", "\u1099"], ["\u17E0", "\u17E9"], ["\u1810", "\u1819"], ["\u1946", "\u194F"], ["\u19D0", "\u19D9"], ["\u1A80", "\u1A89"], ["\u1A90", "\u1A99"], ["\u1B50", "\u1B59"], ["\u1BB0", "\u1BB9"], ["\u1C40", "\u1C49"], ["\u1C50", "\u1C59"], ["\uA620", "\uA629"], ["\uA8D0", "\uA8D9"], ["\uA900", "\uA909"], ["\uA9D0", "\uA9D9"], ["\uA9F0", "\uA9F9"], ["\uAA50", "\uAA59"], ["\uABF0", "\uABF9"], ["\uFF10", "\uFF19"]], false, false),
+      peg$c587 = /^[\u16EE-\u16F0\u2160-\u2182\u2185-\u2188\u3007\u3021-\u3029\u3038-\u303A\uA6E6-\uA6EF]/,
+      peg$c588 = peg$classExpectation([["\u16EE", "\u16F0"], ["\u2160", "\u2182"], ["\u2185", "\u2188"], "\u3007", ["\u3021", "\u3029"], ["\u3038", "\u303A"], ["\uA6E6", "\uA6EF"]], false, false),
+      peg$c589 = /^[_\u203F-\u2040\u2054\uFE33-\uFE34\uFE4D-\uFE4F\uFF3F]/,
+      peg$c590 = peg$classExpectation(["_", ["\u203F", "\u2040"], "\u2054", ["\uFE33", "\uFE34"], ["\uFE4D", "\uFE4F"], "\uFF3F"], false, false),
+      peg$c591 = /^[ \xA0\u1680\u2000-\u200A\u202F\u205F\u3000]/,
+      peg$c592 = peg$classExpectation([" ", "\xA0", "\u1680", ["\u2000", "\u200A"], "\u202F", "\u205F", "\u3000"], false, false),
+      peg$c593 = peg$otherExpectation("whitespace"),
+      peg$c594 = "\t",
+      peg$c595 = peg$literalExpectation("\t", false),
+      peg$c596 = "\x0B",
+      peg$c597 = peg$literalExpectation("\x0B", false),
+      peg$c598 = "\f",
+      peg$c599 = peg$literalExpectation("\f", false),
+      peg$c600 = " ",
+      peg$c601 = peg$literalExpectation(" ", false),
+      peg$c602 = "\xA0",
+      peg$c603 = peg$literalExpectation("\xA0", false),
+      peg$c604 = "\uFEFF",
+      peg$c605 = peg$literalExpectation("\uFEFF", false),
+      peg$c606 = /^[\n\r\u2028\u2029]/,
+      peg$c607 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c608 = peg$otherExpectation("comment"),
+      peg$c613 = "//",
+      peg$c614 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -8802,7 +8799,13 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            s5 = peg$parsePattern();
+            s5 = peg$parseRegexp();
+            if (s5 === peg$FAILED) {
+              s5 = peg$parseGlob();
+              if (s5 === peg$FAILED) {
+                s5 = peg$parseConditionalExpr();
+              }
+            }
             if (s5 !== peg$FAILED) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
@@ -8893,26 +8896,6 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsePattern() {
-    var s0, s1;
-
-    s0 = peg$parseRegexp();
-    if (s0 === peg$FAILED) {
-      s0 = peg$parseGlob();
-      if (s0 === peg$FAILED) {
-        s0 = peg$currPos;
-        s1 = peg$parseQuotedString();
-        if (s1 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c316(s1);
-        }
-        s0 = s1;
-      }
-    }
-
-    return s0;
-  }
-
   function peg$parseOptionalExprs() {
     var s0, s1;
 
@@ -8922,7 +8905,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c317();
+        s1 = peg$c316();
       }
       s0 = s1;
     }
@@ -8953,7 +8936,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c318(s1, s7);
+              s4 = peg$c317(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -8989,7 +8972,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c318(s1, s7);
+                s4 = peg$c317(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -9099,15 +9082,15 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s7 = peg$c319;
+                  s7 = peg$c318;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c320); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c319); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c321(s2, s6);
+                  s1 = peg$c320(s2, s6);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -9162,15 +9145,15 @@ function peg$parse(input, options) {
               s5 = peg$parseAdditiveExpr();
               if (s5 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s6 = peg$c319;
+                  s6 = peg$c318;
                   peg$currPos++;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c320); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c319); }
                 }
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c322(s5);
+                  s1 = peg$c321(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -9209,15 +9192,15 @@ function peg$parse(input, options) {
           s2 = peg$parseConditionalExpr();
           if (s2 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s3 = peg$c319;
+              s3 = peg$c318;
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c320); }
+              if (peg$silentFails === 0) { peg$fail(peg$c319); }
             }
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c323(s2);
+              s1 = peg$c322(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9244,7 +9227,7 @@ function peg$parse(input, options) {
             s2 = peg$parseIdentifier();
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c324(s2);
+              s1 = peg$c323(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9413,7 +9396,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSeq();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c325(s3, s4, s8);
+                    s1 = peg$c324(s3, s4, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -9470,15 +9453,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c326;
+              s5 = peg$c325;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c327); }
+              if (peg$silentFails === 0) { peg$fail(peg$c326); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c328(s3);
+              s1 = peg$c327(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9533,7 +9516,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c317();
+        s1 = peg$c316();
       }
       s0 = s1;
     }
@@ -9560,7 +9543,7 @@ function peg$parse(input, options) {
           s4 = peg$parseRecordElem();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c329(s4);
+            s1 = peg$c328(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9600,12 +9583,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c330) {
-      s1 = peg$c330;
+    if (input.substr(peg$currPos, 3) === peg$c329) {
+      s1 = peg$c329;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c331); }
+      if (peg$silentFails === 0) { peg$fail(peg$c330); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -9613,7 +9596,7 @@ function peg$parse(input, options) {
         s3 = peg$parseConditionalExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c332(s3);
+          s1 = peg$c331(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -9652,7 +9635,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c333(s1, s5);
+              s1 = peg$c332(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9697,15 +9680,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s5 = peg$c319;
+              s5 = peg$c318;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c320); }
+              if (peg$silentFails === 0) { peg$fail(peg$c319); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c334(s3);
+              s1 = peg$c333(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9735,12 +9718,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c335) {
-      s1 = peg$c335;
+    if (input.substr(peg$currPos, 2) === peg$c334) {
+      s1 = peg$c334;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c336); }
+      if (peg$silentFails === 0) { peg$fail(peg$c335); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -9749,16 +9732,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c337) {
-              s5 = peg$c337;
+            if (input.substr(peg$currPos, 2) === peg$c336) {
+              s5 = peg$c336;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c338); }
+              if (peg$silentFails === 0) { peg$fail(peg$c337); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c339(s3);
+              s1 = peg$c338(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9807,7 +9790,7 @@ function peg$parse(input, options) {
             s7 = peg$parseVectorElem();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c318(s1, s7);
+              s4 = peg$c317(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -9843,7 +9826,7 @@ function peg$parse(input, options) {
               s7 = peg$parseVectorElem();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c318(s1, s7);
+                s4 = peg$c317(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -9879,7 +9862,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c317();
+        s1 = peg$c316();
       }
       s0 = s1;
     }
@@ -9896,7 +9879,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c340(s1);
+        s1 = peg$c339(s1);
       }
       s0 = s1;
     }
@@ -9908,12 +9891,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c341) {
-      s1 = peg$c341;
+    if (input.substr(peg$currPos, 2) === peg$c340) {
+      s1 = peg$c340;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c342); }
+      if (peg$silentFails === 0) { peg$fail(peg$c341); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -9922,16 +9905,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c343) {
-              s5 = peg$c343;
+            if (input.substr(peg$currPos, 2) === peg$c342) {
+              s5 = peg$c342;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c344); }
+              if (peg$silentFails === 0) { peg$fail(peg$c343); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c345(s3);
+              s1 = peg$c344(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9986,7 +9969,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c317();
+        s1 = peg$c316();
       }
       s0 = s1;
     }
@@ -10013,7 +9996,7 @@ function peg$parse(input, options) {
           s4 = peg$parseEntry();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c346(s4);
+            s1 = peg$c345(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10056,7 +10039,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c347(s1, s5);
+              s1 = peg$c346(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -10121,7 +10104,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSQLLimit();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c348(s1, s2, s3, s4, s5, s6, s7, s8);
+                    s1 = peg$c347(s1, s2, s3, s4, s5, s6, s7, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -10199,7 +10182,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSQLAssignments();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c349(s3);
+            s1 = peg$c348(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10256,7 +10239,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c350(s1, s2);
+        s1 = peg$c349(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10382,7 +10365,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c351(s4, s5);
+              s1 = peg$c350(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -10537,7 +10520,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSQLJoin();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s3;
-        s4 = peg$c352(s1, s4);
+        s4 = peg$c351(s1, s4);
       }
       s3 = s4;
       while (s3 !== peg$FAILED) {
@@ -10546,7 +10529,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSQLJoin();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s3;
-          s4 = peg$c352(s1, s4);
+          s4 = peg$c351(s1, s4);
         }
         s3 = s4;
       }
@@ -10608,7 +10591,7 @@ function peg$parse(input, options) {
                               s14 = peg$parseJoinKey();
                               if (s14 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c353(s1, s5, s6, s10, s14);
+                                s1 = peg$c352(s1, s5, s6, s10, s14);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -10688,7 +10671,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c354(s2);
+        s1 = peg$c353(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10847,7 +10830,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseSQLOrder();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c355(s6, s7);
+                  s1 = peg$c354(s6, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -10893,7 +10876,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c356(s2);
+        s1 = peg$c355(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10929,7 +10912,7 @@ function peg$parse(input, options) {
           s4 = peg$parseUInt();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c357(s4);
+            s1 = peg$c356(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10969,11 +10952,11 @@ function peg$parse(input, options) {
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c358); }
+      if (peg$silentFails === 0) { peg$fail(peg$c357); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c359();
+      s1 = peg$c358();
     }
     s0 = s1;
 
@@ -10984,16 +10967,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c360) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c359) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c361); }
+      if (peg$silentFails === 0) { peg$fail(peg$c360); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c362();
+      s1 = peg$c361();
     }
     s0 = s1;
 
@@ -11009,11 +10992,11 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c363); }
+      if (peg$silentFails === 0) { peg$fail(peg$c362); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c364();
+      s1 = peg$c363();
     }
     s0 = s1;
 
@@ -11029,11 +11012,11 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c365); }
+      if (peg$silentFails === 0) { peg$fail(peg$c364); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c366();
+      s1 = peg$c365();
     }
     s0 = s1;
 
@@ -11049,11 +11032,11 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c367); }
+      if (peg$silentFails === 0) { peg$fail(peg$c366); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c368();
+      s1 = peg$c367();
     }
     s0 = s1;
 
@@ -11064,16 +11047,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c369) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c368) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c370); }
+      if (peg$silentFails === 0) { peg$fail(peg$c369); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c371();
+      s1 = peg$c370();
     }
     s0 = s1;
 
@@ -11084,16 +11067,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c372) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c371) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c373); }
+      if (peg$silentFails === 0) { peg$fail(peg$c372); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c374();
+      s1 = peg$c373();
     }
     s0 = s1;
 
@@ -11104,16 +11087,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c375) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c374) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c376); }
+      if (peg$silentFails === 0) { peg$fail(peg$c375); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c377();
+      s1 = peg$c376();
     }
     s0 = s1;
 
@@ -11129,11 +11112,11 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c378); }
+      if (peg$silentFails === 0) { peg$fail(peg$c377); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c379();
+      s1 = peg$c378();
     }
     s0 = s1;
 
@@ -11144,16 +11127,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c380) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c379) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c381); }
+      if (peg$silentFails === 0) { peg$fail(peg$c380); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c382();
+      s1 = peg$c381();
     }
     s0 = s1;
 
@@ -11164,16 +11147,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c383) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c382) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c384); }
+      if (peg$silentFails === 0) { peg$fail(peg$c383); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c385();
+      s1 = peg$c384();
     }
     s0 = s1;
 
@@ -11184,12 +11167,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c386) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c385) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c387); }
+      if (peg$silentFails === 0) { peg$fail(peg$c386); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -11204,12 +11187,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c388) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c387) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c389); }
+      if (peg$silentFails === 0) { peg$fail(peg$c388); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -11229,7 +11212,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c390); }
+      if (peg$silentFails === 0) { peg$fail(peg$c389); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -11249,7 +11232,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c391); }
+      if (peg$silentFails === 0) { peg$fail(peg$c390); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -11269,7 +11252,7 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c392); }
+      if (peg$silentFails === 0) { peg$fail(peg$c391); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -11289,7 +11272,7 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c393); }
+      if (peg$silentFails === 0) { peg$fail(peg$c392); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -11391,7 +11374,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c394(s1);
+        s1 = peg$c393(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11406,7 +11389,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP4Net();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c394(s1);
+        s1 = peg$c393(s1);
       }
       s0 = s1;
     }
@@ -11432,7 +11415,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c395(s1);
+        s1 = peg$c394(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11447,7 +11430,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c395(s1);
+        s1 = peg$c394(s1);
       }
       s0 = s1;
     }
@@ -11462,7 +11445,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFloatString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c396(s1);
+      s1 = peg$c395(s1);
     }
     s0 = s1;
 
@@ -11476,7 +11459,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c397(s1);
+      s1 = peg$c396(s1);
     }
     s0 = s1;
 
@@ -11490,7 +11473,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTrueToken();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c398();
+      s1 = peg$c397();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -11498,7 +11481,7 @@ function peg$parse(input, options) {
       s1 = peg$parseFalseToken();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c399();
+        s1 = peg$c398();
       }
       s0 = s1;
     }
@@ -11513,7 +11496,7 @@ function peg$parse(input, options) {
     s1 = peg$parseNullToken();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c400();
+      s1 = peg$c399();
     }
     s0 = s1;
 
@@ -11524,12 +11507,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c401) {
-      s1 = peg$c401;
+    if (input.substr(peg$currPos, 2) === peg$c400) {
+      s1 = peg$c400;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c402); }
+      if (peg$silentFails === 0) { peg$fail(peg$c401); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -11540,7 +11523,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c403();
+        s1 = peg$c402();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11577,7 +11560,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c404(s2);
+          s1 = peg$c403(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -11627,7 +11610,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c405(s1);
+        s1 = peg$c404(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11679,7 +11662,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c406(s1, s2);
+          s1 = peg$c405(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -11694,7 +11677,7 @@ function peg$parse(input, options) {
         s1 = peg$parseQuotedString();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c407(s1);
+          s1 = peg$c406(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
@@ -11720,7 +11703,7 @@ function peg$parse(input, options) {
                 }
                 if (s4 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c408(s3);
+                  s1 = peg$c407(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -11752,7 +11735,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTypeList();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c409(s1);
+      s1 = peg$c408(s1);
     }
     s0 = s1;
 
@@ -11851,15 +11834,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c326;
+              s5 = peg$c325;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c327); }
+              if (peg$silentFails === 0) { peg$fail(peg$c326); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c410(s3);
+              s1 = peg$c409(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -11898,15 +11881,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c319;
+                s5 = peg$c318;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c320); }
+                if (peg$silentFails === 0) { peg$fail(peg$c319); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c411(s3);
+                s1 = peg$c410(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -11930,12 +11913,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c335) {
-          s1 = peg$c335;
+        if (input.substr(peg$currPos, 2) === peg$c334) {
+          s1 = peg$c334;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c336); }
+          if (peg$silentFails === 0) { peg$fail(peg$c335); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -11944,16 +11927,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c337) {
-                  s5 = peg$c337;
+                if (input.substr(peg$currPos, 2) === peg$c336) {
+                  s5 = peg$c336;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c338); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c337); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c412(s3);
+                  s1 = peg$c411(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -11977,12 +11960,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c341) {
-            s1 = peg$c341;
+          if (input.substr(peg$currPos, 2) === peg$c340) {
+            s1 = peg$c340;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c342); }
+            if (peg$silentFails === 0) { peg$fail(peg$c341); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -12005,16 +11988,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c343) {
-                            s9 = peg$c343;
+                          if (input.substr(peg$currPos, 2) === peg$c342) {
+                            s9 = peg$c342;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c344); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c343); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c413(s3, s7);
+                            s1 = peg$c412(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -12066,7 +12049,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTemplateLiteralParts();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c414(s1);
+      s1 = peg$c413(s1);
     }
     s0 = s1;
 
@@ -12078,11 +12061,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c415;
+      s1 = peg$c414;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c416); }
+      if (peg$silentFails === 0) { peg$fail(peg$c415); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -12093,11 +12076,11 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c415;
+          s3 = peg$c414;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c416); }
+          if (peg$silentFails === 0) { peg$fail(peg$c415); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
@@ -12118,11 +12101,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c417;
+        s1 = peg$c416;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c418); }
+        if (peg$silentFails === 0) { peg$fail(peg$c417); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -12133,11 +12116,11 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c417;
+            s3 = peg$c416;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c418); }
+            if (peg$silentFails === 0) { peg$fail(peg$c417); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
@@ -12178,7 +12161,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c419(s1);
+        s1 = peg$c418(s1);
       }
       s0 = s1;
     }
@@ -12191,19 +12174,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c420;
+      s1 = peg$c419;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c421); }
+      if (peg$silentFails === 0) { peg$fail(peg$c420); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c422) {
-        s2 = peg$c422;
+      if (input.substr(peg$currPos, 2) === peg$c421) {
+        s2 = peg$c421;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c423); }
+        if (peg$silentFails === 0) { peg$fail(peg$c422); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -12221,12 +12204,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c422) {
-        s2 = peg$c422;
+      if (input.substr(peg$currPos, 2) === peg$c421) {
+        s2 = peg$c421;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c423); }
+        if (peg$silentFails === 0) { peg$fail(peg$c422); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -12272,7 +12255,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c419(s1);
+        s1 = peg$c418(s1);
       }
       s0 = s1;
     }
@@ -12285,19 +12268,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c420;
+      s1 = peg$c419;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c421); }
+      if (peg$silentFails === 0) { peg$fail(peg$c420); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c422) {
-        s2 = peg$c422;
+      if (input.substr(peg$currPos, 2) === peg$c421) {
+        s2 = peg$c421;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c423); }
+        if (peg$silentFails === 0) { peg$fail(peg$c422); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -12315,12 +12298,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c422) {
-        s2 = peg$c422;
+      if (input.substr(peg$currPos, 2) === peg$c421) {
+        s2 = peg$c421;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c423); }
+        if (peg$silentFails === 0) { peg$fail(peg$c422); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -12352,12 +12335,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c422) {
-      s1 = peg$c422;
+    if (input.substr(peg$currPos, 2) === peg$c421) {
+      s1 = peg$c421;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c423); }
+      if (peg$silentFails === 0) { peg$fail(peg$c422); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -12367,15 +12350,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c326;
+              s5 = peg$c325;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c327); }
+              if (peg$silentFails === 0) { peg$fail(peg$c326); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c424(s3);
+              s1 = peg$c423(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -12405,148 +12388,148 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c425) {
-      s1 = peg$c425;
+    if (input.substr(peg$currPos, 5) === peg$c424) {
+      s1 = peg$c424;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c426); }
+      if (peg$silentFails === 0) { peg$fail(peg$c425); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c427) {
-        s1 = peg$c427;
+      if (input.substr(peg$currPos, 6) === peg$c426) {
+        s1 = peg$c426;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c428); }
+        if (peg$silentFails === 0) { peg$fail(peg$c427); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c429) {
-          s1 = peg$c429;
+        if (input.substr(peg$currPos, 6) === peg$c428) {
+          s1 = peg$c428;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c430); }
+          if (peg$silentFails === 0) { peg$fail(peg$c429); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c431) {
-            s1 = peg$c431;
+          if (input.substr(peg$currPos, 6) === peg$c430) {
+            s1 = peg$c430;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c432); }
+            if (peg$silentFails === 0) { peg$fail(peg$c431); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c433) {
-              s1 = peg$c433;
+            if (input.substr(peg$currPos, 4) === peg$c432) {
+              s1 = peg$c432;
               peg$currPos += 4;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c434); }
+              if (peg$silentFails === 0) { peg$fail(peg$c433); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 5) === peg$c435) {
-                s1 = peg$c435;
+              if (input.substr(peg$currPos, 5) === peg$c434) {
+                s1 = peg$c434;
                 peg$currPos += 5;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c436); }
+                if (peg$silentFails === 0) { peg$fail(peg$c435); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c437) {
-                  s1 = peg$c437;
+                if (input.substr(peg$currPos, 5) === peg$c436) {
+                  s1 = peg$c436;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c438); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c437); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c439) {
-                    s1 = peg$c439;
+                  if (input.substr(peg$currPos, 5) === peg$c438) {
+                    s1 = peg$c438;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c440); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c439); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7) === peg$c441) {
-                      s1 = peg$c441;
+                    if (input.substr(peg$currPos, 7) === peg$c440) {
+                      s1 = peg$c440;
                       peg$currPos += 7;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c442); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c441); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 7) === peg$c443) {
-                        s1 = peg$c443;
+                      if (input.substr(peg$currPos, 7) === peg$c442) {
+                        s1 = peg$c442;
                         peg$currPos += 7;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c444); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c443); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 7) === peg$c445) {
-                          s1 = peg$c445;
+                        if (input.substr(peg$currPos, 7) === peg$c444) {
+                          s1 = peg$c444;
                           peg$currPos += 7;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c446); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c445); }
                         }
                         if (s1 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 4) === peg$c447) {
-                            s1 = peg$c447;
+                          if (input.substr(peg$currPos, 4) === peg$c446) {
+                            s1 = peg$c446;
                             peg$currPos += 4;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c448); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c447); }
                           }
                           if (s1 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 6) === peg$c449) {
-                              s1 = peg$c449;
+                            if (input.substr(peg$currPos, 6) === peg$c448) {
+                              s1 = peg$c448;
                               peg$currPos += 6;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c450); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c449); }
                             }
                             if (s1 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 8) === peg$c451) {
-                                s1 = peg$c451;
+                              if (input.substr(peg$currPos, 8) === peg$c450) {
+                                s1 = peg$c450;
                                 peg$currPos += 8;
                               } else {
                                 s1 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c452); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c451); }
                               }
                               if (s1 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 4) === peg$c453) {
-                                  s1 = peg$c453;
+                                if (input.substr(peg$currPos, 4) === peg$c452) {
+                                  s1 = peg$c452;
                                   peg$currPos += 4;
                                 } else {
                                   s1 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c454); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c453); }
                                 }
                                 if (s1 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 5) === peg$c455) {
-                                    s1 = peg$c455;
+                                  if (input.substr(peg$currPos, 5) === peg$c454) {
+                                    s1 = peg$c454;
                                     peg$currPos += 5;
                                   } else {
                                     s1 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c456); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c455); }
                                   }
                                   if (s1 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 2) === peg$c457) {
-                                      s1 = peg$c457;
+                                    if (input.substr(peg$currPos, 2) === peg$c456) {
+                                      s1 = peg$c456;
                                       peg$currPos += 2;
                                     } else {
                                       s1 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c458); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c457); }
                                     }
                                     if (s1 === peg$FAILED) {
-                                      if (input.substr(peg$currPos, 3) === peg$c459) {
-                                        s1 = peg$c459;
+                                      if (input.substr(peg$currPos, 3) === peg$c458) {
+                                        s1 = peg$c458;
                                         peg$currPos += 3;
                                       } else {
                                         s1 = peg$FAILED;
-                                        if (peg$silentFails === 0) { peg$fail(peg$c460); }
+                                        if (peg$silentFails === 0) { peg$fail(peg$c459); }
                                       }
                                       if (s1 === peg$FAILED) {
                                         if (input.substr(peg$currPos, 4) === peg$c11) {
@@ -12557,12 +12540,12 @@ function peg$parse(input, options) {
                                           if (peg$silentFails === 0) { peg$fail(peg$c12); }
                                         }
                                         if (s1 === peg$FAILED) {
-                                          if (input.substr(peg$currPos, 4) === peg$c461) {
-                                            s1 = peg$c461;
+                                          if (input.substr(peg$currPos, 4) === peg$c460) {
+                                            s1 = peg$c460;
                                             peg$currPos += 4;
                                           } else {
                                             s1 = peg$FAILED;
-                                            if (peg$silentFails === 0) { peg$fail(peg$c462); }
+                                            if (peg$silentFails === 0) { peg$fail(peg$c461); }
                                           }
                                         }
                                       }
@@ -12585,7 +12568,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c463();
+      s1 = peg$c462();
     }
     s0 = s1;
 
@@ -12691,7 +12674,7 @@ function peg$parse(input, options) {
             s5 = peg$parseType();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c464(s1, s5);
+              s1 = peg$c463(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -12732,20 +12715,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c465) {
-      s1 = peg$c465;
+    if (input.substr(peg$currPos, 3) === peg$c464) {
+      s1 = peg$c464;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c466); }
+      if (peg$silentFails === 0) { peg$fail(peg$c465); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c467) {
-        s1 = peg$c467;
+      if (input.substr(peg$currPos, 3) === peg$c466) {
+        s1 = peg$c466;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c468); }
+        if (peg$silentFails === 0) { peg$fail(peg$c467); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -12761,7 +12744,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c469();
+        s1 = peg$c468();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12779,12 +12762,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c372) {
-      s1 = peg$c372;
+    if (input.substr(peg$currPos, 2) === peg$c371) {
+      s1 = peg$c371;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c470); }
+      if (peg$silentFails === 0) { peg$fail(peg$c469); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -12816,12 +12799,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c471) {
-      s1 = peg$c471;
+    if (input.substr(peg$currPos, 5) === peg$c470) {
+      s1 = peg$c470;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c472); }
+      if (peg$silentFails === 0) { peg$fail(peg$c471); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -12861,12 +12844,12 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$c301); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c473) {
-        s1 = peg$c473;
+      if (input.substr(peg$currPos, 3) === peg$c472) {
+        s1 = peg$c472;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c474); }
+        if (peg$silentFails === 0) { peg$fail(peg$c473); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -12882,7 +12865,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c475();
+        s1 = peg$c474();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12900,12 +12883,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c461) {
-      s1 = peg$c461;
+    if (input.substr(peg$currPos, 4) === peg$c460) {
+      s1 = peg$c460;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c462); }
+      if (peg$silentFails === 0) { peg$fail(peg$c461); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -12937,20 +12920,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c476) {
-      s1 = peg$c476;
+    if (input.substr(peg$currPos, 2) === peg$c475) {
+      s1 = peg$c475;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c477); }
+      if (peg$silentFails === 0) { peg$fail(peg$c476); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c478) {
-        s1 = peg$c478;
+      if (input.substr(peg$currPos, 2) === peg$c477) {
+        s1 = peg$c477;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c479); }
+        if (peg$silentFails === 0) { peg$fail(peg$c478); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -12966,7 +12949,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c480();
+        s1 = peg$c479();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12984,12 +12967,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c481) {
-      s1 = peg$c481;
+    if (input.substr(peg$currPos, 4) === peg$c480) {
+      s1 = peg$c480;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c482); }
+      if (peg$silentFails === 0) { peg$fail(peg$c481); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -13024,7 +13007,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c483(s1);
+      s1 = peg$c482(s1);
     }
     s0 = s1;
 
@@ -13096,11 +13079,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 36) {
-        s1 = peg$c484;
+        s1 = peg$c483;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c485); }
+        if (peg$silentFails === 0) { peg$fail(peg$c484); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -13110,11 +13093,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c420;
+          s1 = peg$c419;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c421); }
+          if (peg$silentFails === 0) { peg$fail(peg$c420); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseIDGuard();
@@ -13221,7 +13204,7 @@ function peg$parse(input, options) {
             s7 = peg$parseIdentifierName();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c486(s1, s7);
+              s4 = peg$c485(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -13257,7 +13240,7 @@ function peg$parse(input, options) {
               s7 = peg$parseIdentifierName();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c486(s1, s7);
+                s4 = peg$c485(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -13298,19 +13281,19 @@ function peg$parse(input, options) {
     s0 = peg$parseUnicodeLetter();
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 36) {
-        s0 = peg$c484;
+        s0 = peg$c483;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c485); }
+        if (peg$silentFails === 0) { peg$fail(peg$c484); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 95) {
-          s0 = peg$c487;
+          s0 = peg$c486;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c488); }
+          if (peg$silentFails === 0) { peg$fail(peg$c487); }
         }
       }
     }
@@ -13359,17 +13342,17 @@ function peg$parse(input, options) {
     s1 = peg$parseFullDate();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 84) {
-        s2 = peg$c489;
+        s2 = peg$c488;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c490); }
+        if (peg$silentFails === 0) { peg$fail(peg$c489); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseFullTime();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c491();
+          s1 = peg$c490();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13443,36 +13426,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (peg$c492.test(input.charAt(peg$currPos))) {
+    if (peg$c491.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c493); }
+      if (peg$silentFails === 0) { peg$fail(peg$c492); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c492.test(input.charAt(peg$currPos))) {
+      if (peg$c491.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c493); }
+        if (peg$silentFails === 0) { peg$fail(peg$c492); }
       }
       if (s2 !== peg$FAILED) {
-        if (peg$c492.test(input.charAt(peg$currPos))) {
+        if (peg$c491.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c493); }
+          if (peg$silentFails === 0) { peg$fail(peg$c492); }
         }
         if (s3 !== peg$FAILED) {
-          if (peg$c492.test(input.charAt(peg$currPos))) {
+          if (peg$c491.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c493); }
+            if (peg$silentFails === 0) { peg$fail(peg$c492); }
           }
           if (s4 !== peg$FAILED) {
             s1 = [s1, s2, s3, s4];
@@ -13501,20 +13484,20 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c492.test(input.charAt(peg$currPos))) {
+    if (peg$c491.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c493); }
+      if (peg$silentFails === 0) { peg$fail(peg$c492); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c492.test(input.charAt(peg$currPos))) {
+      if (peg$c491.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c493); }
+        if (peg$silentFails === 0) { peg$fail(peg$c492); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -13589,22 +13572,22 @@ function peg$parse(input, options) {
               }
               if (s7 !== peg$FAILED) {
                 s8 = [];
-                if (peg$c492.test(input.charAt(peg$currPos))) {
+                if (peg$c491.test(input.charAt(peg$currPos))) {
                   s9 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s9 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c493); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c492); }
                 }
                 if (s9 !== peg$FAILED) {
                   while (s9 !== peg$FAILED) {
                     s8.push(s9);
-                    if (peg$c492.test(input.charAt(peg$currPos))) {
+                    if (peg$c491.test(input.charAt(peg$currPos))) {
                       s9 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c493); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c492); }
                     }
                   }
                 } else {
@@ -13659,11 +13642,11 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     if (input.charCodeAt(peg$currPos) === 90) {
-      s0 = peg$c494;
+      s0 = peg$c493;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c495); }
+      if (peg$silentFails === 0) { peg$fail(peg$c494); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
@@ -13706,22 +13689,22 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 s7 = [];
-                if (peg$c492.test(input.charAt(peg$currPos))) {
+                if (peg$c491.test(input.charAt(peg$currPos))) {
                   s8 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s8 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c493); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c492); }
                 }
                 if (s8 !== peg$FAILED) {
                   while (s8 !== peg$FAILED) {
                     s7.push(s8);
-                    if (peg$c492.test(input.charAt(peg$currPos))) {
+                    if (peg$c491.test(input.charAt(peg$currPos))) {
                       s8 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s8 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c493); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c492); }
                     }
                   }
                 } else {
@@ -13824,7 +13807,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c496();
+        s1 = peg$c495();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13886,76 +13869,76 @@ function peg$parse(input, options) {
   function peg$parseTimeUnit() {
     var s0;
 
-    if (input.substr(peg$currPos, 2) === peg$c497) {
-      s0 = peg$c497;
+    if (input.substr(peg$currPos, 2) === peg$c496) {
+      s0 = peg$c496;
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c498); }
+      if (peg$silentFails === 0) { peg$fail(peg$c497); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c499) {
-        s0 = peg$c499;
+      if (input.substr(peg$currPos, 2) === peg$c498) {
+        s0 = peg$c498;
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c500); }
+        if (peg$silentFails === 0) { peg$fail(peg$c499); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c501) {
-          s0 = peg$c501;
+        if (input.substr(peg$currPos, 2) === peg$c500) {
+          s0 = peg$c500;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c502); }
+          if (peg$silentFails === 0) { peg$fail(peg$c501); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 115) {
-            s0 = peg$c503;
+            s0 = peg$c502;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c504); }
+            if (peg$silentFails === 0) { peg$fail(peg$c503); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c505;
+              s0 = peg$c504;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c506); }
+              if (peg$silentFails === 0) { peg$fail(peg$c505); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 104) {
-                s0 = peg$c507;
+                s0 = peg$c506;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c508); }
+                if (peg$silentFails === 0) { peg$fail(peg$c507); }
               }
               if (s0 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 100) {
-                  s0 = peg$c509;
+                  s0 = peg$c508;
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c510); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c509); }
                 }
                 if (s0 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 119) {
-                    s0 = peg$c511;
+                    s0 = peg$c510;
                     peg$currPos++;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c512); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c511); }
                   }
                   if (s0 === peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 121) {
-                      s0 = peg$c513;
+                      s0 = peg$c512;
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c514); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c513); }
                     }
                   }
                 }
@@ -14140,7 +14123,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c515(s1, s2);
+        s1 = peg$c514(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14161,12 +14144,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c516) {
-            s3 = peg$c516;
+          if (input.substr(peg$currPos, 2) === peg$c515) {
+            s3 = peg$c515;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c517); }
+            if (peg$silentFails === 0) { peg$fail(peg$c516); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -14179,7 +14162,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c518(s1, s2, s4, s5);
+                s1 = peg$c517(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -14203,12 +14186,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c516) {
-          s1 = peg$c516;
+        if (input.substr(peg$currPos, 2) === peg$c515) {
+          s1 = peg$c515;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c517); }
+          if (peg$silentFails === 0) { peg$fail(peg$c516); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -14221,7 +14204,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c519(s2, s3);
+              s1 = peg$c518(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -14246,16 +14229,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c516) {
-                s3 = peg$c516;
+              if (input.substr(peg$currPos, 2) === peg$c515) {
+                s3 = peg$c515;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c517); }
+                if (peg$silentFails === 0) { peg$fail(peg$c516); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c520(s1, s2);
+                s1 = peg$c519(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -14271,16 +14254,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c516) {
-              s1 = peg$c516;
+            if (input.substr(peg$currPos, 2) === peg$c515) {
+              s1 = peg$c515;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c517); }
+              if (peg$silentFails === 0) { peg$fail(peg$c516); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c521();
+              s1 = peg$c520();
             }
             s0 = s1;
           }
@@ -14317,7 +14300,7 @@ function peg$parse(input, options) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c522(s2);
+        s1 = peg$c521(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14346,7 +14329,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c523(s1);
+        s1 = peg$c522(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14377,7 +14360,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c524(s1, s3);
+          s1 = peg$c523(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -14412,7 +14395,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c525(s1, s3);
+          s1 = peg$c524(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -14437,7 +14420,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c526(s1);
+      s1 = peg$c525(s1);
     }
     s0 = s1;
 
@@ -14460,22 +14443,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c492.test(input.charAt(peg$currPos))) {
+    if (peg$c491.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c493); }
+      if (peg$silentFails === 0) { peg$fail(peg$c492); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c492.test(input.charAt(peg$currPos))) {
+        if (peg$c491.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c493); }
+          if (peg$silentFails === 0) { peg$fail(peg$c492); }
         }
       }
     } else {
@@ -14535,22 +14518,22 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c492.test(input.charAt(peg$currPos))) {
+      if (peg$c491.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c493); }
+        if (peg$silentFails === 0) { peg$fail(peg$c492); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c492.test(input.charAt(peg$currPos))) {
+          if (peg$c491.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c493); }
+            if (peg$silentFails === 0) { peg$fail(peg$c492); }
           }
         }
       } else {
@@ -14566,21 +14549,21 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c492.test(input.charAt(peg$currPos))) {
+          if (peg$c491.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c493); }
+            if (peg$silentFails === 0) { peg$fail(peg$c492); }
           }
           while (s5 !== peg$FAILED) {
             s4.push(s5);
-            if (peg$c492.test(input.charAt(peg$currPos))) {
+            if (peg$c491.test(input.charAt(peg$currPos))) {
               s5 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c493); }
+              if (peg$silentFails === 0) { peg$fail(peg$c492); }
             }
           }
           if (s4 !== peg$FAILED) {
@@ -14590,7 +14573,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c527();
+              s1 = peg$c526();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -14634,22 +14617,22 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c492.test(input.charAt(peg$currPos))) {
+          if (peg$c491.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c493); }
+            if (peg$silentFails === 0) { peg$fail(peg$c492); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c492.test(input.charAt(peg$currPos))) {
+              if (peg$c491.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c493); }
+                if (peg$silentFails === 0) { peg$fail(peg$c492); }
               }
             }
           } else {
@@ -14662,7 +14645,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c527();
+              s1 = peg$c526();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -14701,20 +14684,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c528) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c527) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c529); }
+      if (peg$silentFails === 0) { peg$fail(peg$c528); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c530.test(input.charAt(peg$currPos))) {
+      if (peg$c529.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c531); }
+        if (peg$silentFails === 0) { peg$fail(peg$c530); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -14743,12 +14726,12 @@ function peg$parse(input, options) {
   function peg$parseNaN() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c532) {
-      s0 = peg$c532;
+    if (input.substr(peg$currPos, 3) === peg$c531) {
+      s0 = peg$c531;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c533); }
+      if (peg$silentFails === 0) { peg$fail(peg$c532); }
     }
 
     return s0;
@@ -14778,12 +14761,12 @@ function peg$parse(input, options) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c534) {
-        s2 = peg$c534;
+      if (input.substr(peg$currPos, 3) === peg$c533) {
+        s2 = peg$c533;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c535); }
+        if (peg$silentFails === 0) { peg$fail(peg$c534); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -14826,12 +14809,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c536.test(input.charAt(peg$currPos))) {
+    if (peg$c535.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c537); }
+      if (peg$silentFails === 0) { peg$fail(peg$c536); }
     }
 
     return s0;
@@ -14842,11 +14825,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c415;
+      s1 = peg$c414;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c416); }
+      if (peg$silentFails === 0) { peg$fail(peg$c415); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -14857,15 +14840,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c415;
+          s3 = peg$c414;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c416); }
+          if (peg$silentFails === 0) { peg$fail(peg$c415); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c538(s2);
+          s1 = peg$c537(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -14882,11 +14865,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c417;
+        s1 = peg$c416;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c418); }
+        if (peg$silentFails === 0) { peg$fail(peg$c417); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -14897,15 +14880,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c417;
+            s3 = peg$c416;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c418); }
+            if (peg$silentFails === 0) { peg$fail(peg$c417); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c538(s2);
+            s1 = peg$c537(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -14931,11 +14914,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c415;
+      s2 = peg$c414;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c416); }
+      if (peg$silentFails === 0) { peg$fail(peg$c415); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -14953,7 +14936,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c539); }
+        if (peg$silentFails === 0) { peg$fail(peg$c538); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -14970,11 +14953,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c420;
+        s1 = peg$c419;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c421); }
+        if (peg$silentFails === 0) { peg$fail(peg$c420); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -15009,7 +14992,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c540(s1, s2);
+        s1 = peg$c539(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -15039,12 +15022,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseKeyWordStart();
     if (s0 === peg$FAILED) {
-      if (peg$c492.test(input.charAt(peg$currPos))) {
+      if (peg$c491.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c493); }
+        if (peg$silentFails === 0) { peg$fail(peg$c492); }
       }
     }
 
@@ -15057,12 +15040,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parseUnicodeLetter();
     if (s1 === peg$FAILED) {
-      if (peg$c541.test(input.charAt(peg$currPos))) {
+      if (peg$c540.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c542); }
+        if (peg$silentFails === 0) { peg$fail(peg$c541); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -15079,11 +15062,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c420;
+      s1 = peg$c419;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c421); }
+      if (peg$silentFails === 0) { peg$fail(peg$c420); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseKeywordEscape();
@@ -15142,7 +15125,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c543(s3, s4);
+            s1 = peg$c542(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -15260,7 +15243,7 @@ function peg$parse(input, options) {
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c544();
+          s1 = peg$c543();
         }
         s0 = s1;
       }
@@ -15274,12 +15257,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseGlobStart();
     if (s0 === peg$FAILED) {
-      if (peg$c492.test(input.charAt(peg$currPos))) {
+      if (peg$c491.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c493); }
+        if (peg$silentFails === 0) { peg$fail(peg$c492); }
       }
     }
 
@@ -15291,11 +15274,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c420;
+      s1 = peg$c419;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c421); }
+      if (peg$silentFails === 0) { peg$fail(peg$c420); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseGlobEscape();
@@ -15331,7 +15314,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c545();
+      s1 = peg$c544();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -15345,16 +15328,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c546();
+        s1 = peg$c545();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c530.test(input.charAt(peg$currPos))) {
+        if (peg$c529.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c531); }
+          if (peg$silentFails === 0) { peg$fail(peg$c530); }
         }
       }
     }
@@ -15369,11 +15352,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c417;
+      s2 = peg$c416;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c418); }
+      if (peg$silentFails === 0) { peg$fail(peg$c417); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -15391,7 +15374,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c539); }
+        if (peg$silentFails === 0) { peg$fail(peg$c538); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -15408,11 +15391,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c420;
+        s1 = peg$c419;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c421); }
+        if (peg$silentFails === 0) { peg$fail(peg$c420); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -15448,20 +15431,20 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c417;
+      s0 = peg$c416;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c418); }
+      if (peg$silentFails === 0) { peg$fail(peg$c417); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s1 = peg$c415;
+        s1 = peg$c414;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c416); }
+        if (peg$silentFails === 0) { peg$fail(peg$c415); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -15470,94 +15453,94 @@ function peg$parse(input, options) {
       s0 = s1;
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c420;
+          s0 = peg$c419;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c421); }
+          if (peg$silentFails === 0) { peg$fail(peg$c420); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c547;
+            s1 = peg$c546;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c548); }
+            if (peg$silentFails === 0) { peg$fail(peg$c547); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c549();
+            s1 = peg$c548();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c550;
+              s1 = peg$c549;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c551); }
+              if (peg$silentFails === 0) { peg$fail(peg$c550); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c552();
+              s1 = peg$c551();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c553;
+                s1 = peg$c552;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c554); }
+                if (peg$silentFails === 0) { peg$fail(peg$c553); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c555();
+                s1 = peg$c554();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c556;
+                  s1 = peg$c555;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c557); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c556); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c558();
+                  s1 = peg$c557();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c559;
+                    s1 = peg$c558;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c560); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c559); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c561();
+                    s1 = peg$c560();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c562;
+                      s1 = peg$c561;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c563); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c562); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c564();
+                      s1 = peg$c563();
                     }
                     s0 = s1;
                   }
@@ -15585,7 +15568,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c545();
+      s1 = peg$c544();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -15599,16 +15582,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c544();
+        s1 = peg$c543();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c530.test(input.charAt(peg$currPos))) {
+        if (peg$c529.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c531); }
+          if (peg$silentFails === 0) { peg$fail(peg$c530); }
         }
       }
     }
@@ -15621,11 +15604,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c565;
+      s1 = peg$c564;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c566); }
+      if (peg$silentFails === 0) { peg$fail(peg$c565); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -15657,7 +15640,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c567(s2);
+        s1 = peg$c566(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -15670,11 +15653,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c565;
+        s1 = peg$c564;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c566); }
+        if (peg$silentFails === 0) { peg$fail(peg$c565); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
@@ -15741,15 +15724,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c326;
+              s4 = peg$c325;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c327); }
+              if (peg$silentFails === 0) { peg$fail(peg$c326); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c567(s3);
+              s1 = peg$c566(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -15833,21 +15816,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c568.test(input.charAt(peg$currPos))) {
+    if (peg$c567.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c569); }
+      if (peg$silentFails === 0) { peg$fail(peg$c568); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s3 = peg$c420;
+        s3 = peg$c419;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c421); }
+        if (peg$silentFails === 0) { peg$fail(peg$c420); }
       }
       if (s3 !== peg$FAILED) {
         if (input.length > peg$currPos) {
@@ -15855,7 +15838,7 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c539); }
+          if (peg$silentFails === 0) { peg$fail(peg$c538); }
         }
         if (s4 !== peg$FAILED) {
           s3 = [s3, s4];
@@ -15872,21 +15855,21 @@ function peg$parse(input, options) {
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c568.test(input.charAt(peg$currPos))) {
+        if (peg$c567.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c569); }
+          if (peg$silentFails === 0) { peg$fail(peg$c568); }
         }
         if (s2 === peg$FAILED) {
           s2 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 92) {
-            s3 = peg$c420;
+            s3 = peg$c419;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c421); }
+            if (peg$silentFails === 0) { peg$fail(peg$c420); }
           }
           if (s3 !== peg$FAILED) {
             if (input.length > peg$currPos) {
@@ -15894,7 +15877,7 @@ function peg$parse(input, options) {
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c539); }
+              if (peg$silentFails === 0) { peg$fail(peg$c538); }
             }
             if (s4 !== peg$FAILED) {
               s3 = [s3, s4];
@@ -15924,12 +15907,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c570.test(input.charAt(peg$currPos))) {
+    if (peg$c569.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c571); }
+      if (peg$silentFails === 0) { peg$fail(peg$c570); }
     }
 
     return s0;
@@ -16016,12 +15999,12 @@ function peg$parse(input, options) {
   function peg$parseLl() {
     var s0;
 
-    if (peg$c572.test(input.charAt(peg$currPos))) {
+    if (peg$c571.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c573); }
+      if (peg$silentFails === 0) { peg$fail(peg$c572); }
     }
 
     return s0;
@@ -16030,12 +16013,12 @@ function peg$parse(input, options) {
   function peg$parseLm() {
     var s0;
 
-    if (peg$c574.test(input.charAt(peg$currPos))) {
+    if (peg$c573.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c575); }
+      if (peg$silentFails === 0) { peg$fail(peg$c574); }
     }
 
     return s0;
@@ -16044,12 +16027,12 @@ function peg$parse(input, options) {
   function peg$parseLo() {
     var s0;
 
-    if (peg$c576.test(input.charAt(peg$currPos))) {
+    if (peg$c575.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c577); }
+      if (peg$silentFails === 0) { peg$fail(peg$c576); }
     }
 
     return s0;
@@ -16058,12 +16041,12 @@ function peg$parse(input, options) {
   function peg$parseLt() {
     var s0;
 
-    if (peg$c578.test(input.charAt(peg$currPos))) {
+    if (peg$c577.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c579); }
+      if (peg$silentFails === 0) { peg$fail(peg$c578); }
     }
 
     return s0;
@@ -16072,12 +16055,12 @@ function peg$parse(input, options) {
   function peg$parseLu() {
     var s0;
 
-    if (peg$c580.test(input.charAt(peg$currPos))) {
+    if (peg$c579.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c581); }
+      if (peg$silentFails === 0) { peg$fail(peg$c580); }
     }
 
     return s0;
@@ -16086,12 +16069,12 @@ function peg$parse(input, options) {
   function peg$parseMc() {
     var s0;
 
-    if (peg$c582.test(input.charAt(peg$currPos))) {
+    if (peg$c581.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c583); }
+      if (peg$silentFails === 0) { peg$fail(peg$c582); }
     }
 
     return s0;
@@ -16100,12 +16083,12 @@ function peg$parse(input, options) {
   function peg$parseMn() {
     var s0;
 
-    if (peg$c584.test(input.charAt(peg$currPos))) {
+    if (peg$c583.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c585); }
+      if (peg$silentFails === 0) { peg$fail(peg$c584); }
     }
 
     return s0;
@@ -16114,12 +16097,12 @@ function peg$parse(input, options) {
   function peg$parseNd() {
     var s0;
 
-    if (peg$c586.test(input.charAt(peg$currPos))) {
+    if (peg$c585.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c587); }
+      if (peg$silentFails === 0) { peg$fail(peg$c586); }
     }
 
     return s0;
@@ -16128,12 +16111,12 @@ function peg$parse(input, options) {
   function peg$parseNl() {
     var s0;
 
-    if (peg$c588.test(input.charAt(peg$currPos))) {
+    if (peg$c587.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c589); }
+      if (peg$silentFails === 0) { peg$fail(peg$c588); }
     }
 
     return s0;
@@ -16142,12 +16125,12 @@ function peg$parse(input, options) {
   function peg$parsePc() {
     var s0;
 
-    if (peg$c590.test(input.charAt(peg$currPos))) {
+    if (peg$c589.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c591); }
+      if (peg$silentFails === 0) { peg$fail(peg$c590); }
     }
 
     return s0;
@@ -16156,12 +16139,12 @@ function peg$parse(input, options) {
   function peg$parseZs() {
     var s0;
 
-    if (peg$c592.test(input.charAt(peg$currPos))) {
+    if (peg$c591.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c593); }
+      if (peg$silentFails === 0) { peg$fail(peg$c592); }
     }
 
     return s0;
@@ -16175,7 +16158,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c539); }
+      if (peg$silentFails === 0) { peg$fail(peg$c538); }
     }
 
     return s0;
@@ -16186,51 +16169,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c595;
+      s0 = peg$c594;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c596); }
+      if (peg$silentFails === 0) { peg$fail(peg$c595); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c597;
+        s0 = peg$c596;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c598); }
+        if (peg$silentFails === 0) { peg$fail(peg$c597); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c599;
+          s0 = peg$c598;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c600); }
+          if (peg$silentFails === 0) { peg$fail(peg$c599); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c601;
+            s0 = peg$c600;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c602); }
+            if (peg$silentFails === 0) { peg$fail(peg$c601); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c603;
+              s0 = peg$c602;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c604); }
+              if (peg$silentFails === 0) { peg$fail(peg$c603); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c605;
+                s0 = peg$c604;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c606); }
+                if (peg$silentFails === 0) { peg$fail(peg$c605); }
               }
               if (s0 === peg$FAILED) {
                 s0 = peg$parseZs();
@@ -16242,7 +16225,7 @@ function peg$parse(input, options) {
     }
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c594); }
+      if (peg$silentFails === 0) { peg$fail(peg$c593); }
     }
 
     return s0;
@@ -16251,12 +16234,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c607.test(input.charAt(peg$currPos))) {
+    if (peg$c606.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c608); }
+      if (peg$silentFails === 0) { peg$fail(peg$c607); }
     }
 
     return s0;
@@ -16269,7 +16252,7 @@ function peg$parse(input, options) {
     s0 = peg$parseSingleLineComment();
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c609); }
+      if (peg$silentFails === 0) { peg$fail(peg$c608); }
     }
 
     return s0;
@@ -16279,12 +16262,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c614) {
-      s1 = peg$c614;
+    if (input.substr(peg$currPos, 2) === peg$c613) {
+      s1 = peg$c613;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c615); }
+      if (peg$silentFails === 0) { peg$fail(peg$c614); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -16364,7 +16347,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c539); }
+      if (peg$silentFails === 0) { peg$fail(peg$c538); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -6355,47 +6355,60 @@ var g = &grammar{
 						&labeledExpr{
 							pos:   position{line: 768, col: 22, offset: 22695},
 							label: "pattern",
-							expr: &ruleRefExpr{
-								pos:  position{line: 768, col: 30, offset: 22703},
-								name: "Pattern",
+							expr: &choiceExpr{
+								pos: position{line: 768, col: 31, offset: 22704},
+								alternatives: []interface{}{
+									&ruleRefExpr{
+										pos:  position{line: 768, col: 31, offset: 22704},
+										name: "Regexp",
+									},
+									&ruleRefExpr{
+										pos:  position{line: 768, col: 40, offset: 22713},
+										name: "Glob",
+									},
+									&ruleRefExpr{
+										pos:  position{line: 768, col: 47, offset: 22720},
+										name: "Expr",
+									},
+								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 768, col: 38, offset: 22711},
+							pos:  position{line: 768, col: 53, offset: 22726},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 768, col: 41, offset: 22714},
+							pos:   position{line: 768, col: 56, offset: 22729},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 768, col: 45, offset: 22718},
+								pos: position{line: 768, col: 60, offset: 22733},
 								expr: &seqExpr{
-									pos: position{line: 768, col: 46, offset: 22719},
+									pos: position{line: 768, col: 61, offset: 22734},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 768, col: 46, offset: 22719},
+											pos:        position{line: 768, col: 61, offset: 22734},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 768, col: 50, offset: 22723},
+											pos:  position{line: 768, col: 65, offset: 22738},
 											name: "__",
 										},
 										&choiceExpr{
-											pos: position{line: 768, col: 54, offset: 22727},
+											pos: position{line: 768, col: 69, offset: 22742},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 768, col: 54, offset: 22727},
+													pos:  position{line: 768, col: 69, offset: 22742},
 													name: "OverExpr",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 768, col: 65, offset: 22738},
+													pos:  position{line: 768, col: 80, offset: 22753},
 													name: "Expr",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 768, col: 71, offset: 22744},
+											pos:  position{line: 768, col: 86, offset: 22759},
 											name: "__",
 										},
 									},
@@ -6403,7 +6416,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 768, col: 76, offset: 22749},
+							pos:        position{line: 768, col: 91, offset: 22764},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -6412,49 +6425,20 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "Pattern",
-			pos:  position{line: 776, col: 1, offset: 22990},
-			expr: &choiceExpr{
-				pos: position{line: 777, col: 5, offset: 23002},
-				alternatives: []interface{}{
-					&ruleRefExpr{
-						pos:  position{line: 777, col: 5, offset: 23002},
-						name: "Regexp",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 778, col: 5, offset: 23013},
-						name: "Glob",
-					},
-					&actionExpr{
-						pos: position{line: 779, col: 5, offset: 23022},
-						run: (*parser).callonPattern4,
-						expr: &labeledExpr{
-							pos:   position{line: 779, col: 5, offset: 23022},
-							label: "s",
-							expr: &ruleRefExpr{
-								pos:  position{line: 779, col: 7, offset: 23024},
-								name: "QuotedString",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
 			name: "OptionalExprs",
-			pos:  position{line: 783, col: 1, offset: 23116},
+			pos:  position{line: 776, col: 1, offset: 23005},
 			expr: &choiceExpr{
-				pos: position{line: 784, col: 5, offset: 23134},
+				pos: position{line: 777, col: 5, offset: 23023},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 784, col: 5, offset: 23134},
+						pos:  position{line: 777, col: 5, offset: 23023},
 						name: "Exprs",
 					},
 					&actionExpr{
-						pos: position{line: 785, col: 5, offset: 23144},
+						pos: position{line: 778, col: 5, offset: 23033},
 						run: (*parser).callonOptionalExprs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 785, col: 5, offset: 23144},
+							pos:  position{line: 778, col: 5, offset: 23033},
 							name: "__",
 						},
 					},
@@ -6463,50 +6447,50 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 787, col: 1, offset: 23180},
+			pos:  position{line: 780, col: 1, offset: 23069},
 			expr: &actionExpr{
-				pos: position{line: 788, col: 5, offset: 23190},
+				pos: position{line: 781, col: 5, offset: 23079},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 788, col: 5, offset: 23190},
+					pos: position{line: 781, col: 5, offset: 23079},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 788, col: 5, offset: 23190},
+							pos:   position{line: 781, col: 5, offset: 23079},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 788, col: 11, offset: 23196},
+								pos:  position{line: 781, col: 11, offset: 23085},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 788, col: 16, offset: 23201},
+							pos:   position{line: 781, col: 16, offset: 23090},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 788, col: 21, offset: 23206},
+								pos: position{line: 781, col: 21, offset: 23095},
 								expr: &actionExpr{
-									pos: position{line: 788, col: 22, offset: 23207},
+									pos: position{line: 781, col: 22, offset: 23096},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 788, col: 22, offset: 23207},
+										pos: position{line: 781, col: 22, offset: 23096},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 788, col: 22, offset: 23207},
+												pos:  position{line: 781, col: 22, offset: 23096},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 788, col: 25, offset: 23210},
+												pos:        position{line: 781, col: 25, offset: 23099},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 788, col: 29, offset: 23214},
+												pos:  position{line: 781, col: 29, offset: 23103},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 788, col: 32, offset: 23217},
+												pos:   position{line: 781, col: 32, offset: 23106},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 788, col: 34, offset: 23219},
+													pos:  position{line: 781, col: 34, offset: 23108},
 													name: "Expr",
 												},
 											},
@@ -6521,35 +6505,35 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 792, col: 1, offset: 23328},
+			pos:  position{line: 785, col: 1, offset: 23217},
 			expr: &actionExpr{
-				pos: position{line: 793, col: 5, offset: 23342},
+				pos: position{line: 786, col: 5, offset: 23231},
 				run: (*parser).callonDerefExpr1,
 				expr: &seqExpr{
-					pos: position{line: 793, col: 5, offset: 23342},
+					pos: position{line: 786, col: 5, offset: 23231},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 793, col: 5, offset: 23342},
+							pos: position{line: 786, col: 5, offset: 23231},
 							expr: &ruleRefExpr{
-								pos:  position{line: 793, col: 6, offset: 23343},
+								pos:  position{line: 786, col: 6, offset: 23232},
 								name: "IP6",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 793, col: 10, offset: 23347},
+							pos:   position{line: 786, col: 10, offset: 23236},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 793, col: 16, offset: 23353},
+								pos:  position{line: 786, col: 16, offset: 23242},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 793, col: 27, offset: 23364},
+							pos:   position{line: 786, col: 27, offset: 23253},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 793, col: 32, offset: 23369},
+								pos: position{line: 786, col: 32, offset: 23258},
 								expr: &ruleRefExpr{
-									pos:  position{line: 793, col: 33, offset: 23370},
+									pos:  position{line: 786, col: 33, offset: 23259},
 									name: "Deref",
 								},
 							},
@@ -6560,55 +6544,55 @@ var g = &grammar{
 		},
 		{
 			name: "Deref",
-			pos:  position{line: 797, col: 1, offset: 23438},
+			pos:  position{line: 790, col: 1, offset: 23327},
 			expr: &choiceExpr{
-				pos: position{line: 798, col: 5, offset: 23448},
+				pos: position{line: 791, col: 5, offset: 23337},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 798, col: 5, offset: 23448},
+						pos: position{line: 791, col: 5, offset: 23337},
 						run: (*parser).callonDeref2,
 						expr: &seqExpr{
-							pos: position{line: 798, col: 5, offset: 23448},
+							pos: position{line: 791, col: 5, offset: 23337},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 798, col: 5, offset: 23448},
+									pos:        position{line: 791, col: 5, offset: 23337},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 798, col: 9, offset: 23452},
+									pos:   position{line: 791, col: 9, offset: 23341},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 798, col: 14, offset: 23457},
+										pos:  position{line: 791, col: 14, offset: 23346},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 798, col: 27, offset: 23470},
+									pos:  position{line: 791, col: 27, offset: 23359},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 798, col: 30, offset: 23473},
+									pos:        position{line: 791, col: 30, offset: 23362},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 798, col: 34, offset: 23477},
+									pos:  position{line: 791, col: 34, offset: 23366},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 798, col: 37, offset: 23480},
+									pos:   position{line: 791, col: 37, offset: 23369},
 									label: "to",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 798, col: 40, offset: 23483},
+										pos: position{line: 791, col: 40, offset: 23372},
 										expr: &ruleRefExpr{
-											pos:  position{line: 798, col: 40, offset: 23483},
+											pos:  position{line: 791, col: 40, offset: 23372},
 											name: "AdditiveExpr",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 798, col: 54, offset: 23497},
+									pos:        position{line: 791, col: 54, offset: 23386},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -6616,39 +6600,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 804, col: 5, offset: 23671},
+						pos: position{line: 797, col: 5, offset: 23560},
 						run: (*parser).callonDeref14,
 						expr: &seqExpr{
-							pos: position{line: 804, col: 5, offset: 23671},
+							pos: position{line: 797, col: 5, offset: 23560},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 804, col: 5, offset: 23671},
+									pos:        position{line: 797, col: 5, offset: 23560},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 804, col: 9, offset: 23675},
+									pos:  position{line: 797, col: 9, offset: 23564},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 804, col: 12, offset: 23678},
+									pos:        position{line: 797, col: 12, offset: 23567},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 804, col: 16, offset: 23682},
+									pos:  position{line: 797, col: 16, offset: 23571},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 804, col: 19, offset: 23685},
+									pos:   position{line: 797, col: 19, offset: 23574},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 804, col: 22, offset: 23688},
+										pos:  position{line: 797, col: 22, offset: 23577},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 804, col: 35, offset: 23701},
+									pos:        position{line: 797, col: 35, offset: 23590},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -6656,26 +6640,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 810, col: 5, offset: 23874},
+						pos: position{line: 803, col: 5, offset: 23763},
 						run: (*parser).callonDeref23,
 						expr: &seqExpr{
-							pos: position{line: 810, col: 5, offset: 23874},
+							pos: position{line: 803, col: 5, offset: 23763},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 810, col: 5, offset: 23874},
+									pos:        position{line: 803, col: 5, offset: 23763},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 810, col: 9, offset: 23878},
+									pos:   position{line: 803, col: 9, offset: 23767},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 810, col: 14, offset: 23883},
+										pos:  position{line: 803, col: 14, offset: 23772},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 810, col: 19, offset: 23888},
+									pos:        position{line: 803, col: 19, offset: 23777},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -6683,21 +6667,21 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 811, col: 5, offset: 23937},
+						pos: position{line: 804, col: 5, offset: 23826},
 						run: (*parser).callonDeref29,
 						expr: &seqExpr{
-							pos: position{line: 811, col: 5, offset: 23937},
+							pos: position{line: 804, col: 5, offset: 23826},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 811, col: 5, offset: 23937},
+									pos:        position{line: 804, col: 5, offset: 23826},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 811, col: 9, offset: 23941},
+									pos:   position{line: 804, col: 9, offset: 23830},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 811, col: 12, offset: 23944},
+										pos:  position{line: 804, col: 12, offset: 23833},
 										name: "Identifier",
 									},
 								},
@@ -6709,59 +6693,59 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 813, col: 1, offset: 23995},
+			pos:  position{line: 806, col: 1, offset: 23884},
 			expr: &choiceExpr{
-				pos: position{line: 814, col: 5, offset: 24007},
+				pos: position{line: 807, col: 5, offset: 23896},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 814, col: 5, offset: 24007},
+						pos:  position{line: 807, col: 5, offset: 23896},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 815, col: 5, offset: 24018},
+						pos:  position{line: 808, col: 5, offset: 23907},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 816, col: 5, offset: 24028},
+						pos:  position{line: 809, col: 5, offset: 23917},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 817, col: 5, offset: 24036},
+						pos:  position{line: 810, col: 5, offset: 23925},
 						name: "Map",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 818, col: 5, offset: 24044},
+						pos:  position{line: 811, col: 5, offset: 23933},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 819, col: 5, offset: 24056},
+						pos: position{line: 812, col: 5, offset: 23945},
 						run: (*parser).callonPrimary7,
 						expr: &seqExpr{
-							pos: position{line: 819, col: 5, offset: 24056},
+							pos: position{line: 812, col: 5, offset: 23945},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 819, col: 5, offset: 24056},
+									pos:        position{line: 812, col: 5, offset: 23945},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 819, col: 9, offset: 24060},
+									pos:  position{line: 812, col: 9, offset: 23949},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 819, col: 12, offset: 24063},
+									pos:   position{line: 812, col: 12, offset: 23952},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 819, col: 17, offset: 24068},
+										pos:  position{line: 812, col: 17, offset: 23957},
 										name: "OverExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 819, col: 26, offset: 24077},
+									pos:  position{line: 812, col: 26, offset: 23966},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 819, col: 29, offset: 24080},
+									pos:        position{line: 812, col: 29, offset: 23969},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -6769,34 +6753,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 820, col: 5, offset: 24109},
+						pos: position{line: 813, col: 5, offset: 23998},
 						run: (*parser).callonPrimary15,
 						expr: &seqExpr{
-							pos: position{line: 820, col: 5, offset: 24109},
+							pos: position{line: 813, col: 5, offset: 23998},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 820, col: 5, offset: 24109},
+									pos:        position{line: 813, col: 5, offset: 23998},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 820, col: 9, offset: 24113},
+									pos:  position{line: 813, col: 9, offset: 24002},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 820, col: 12, offset: 24116},
+									pos:   position{line: 813, col: 12, offset: 24005},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 820, col: 17, offset: 24121},
+										pos:  position{line: 813, col: 17, offset: 24010},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 820, col: 22, offset: 24126},
+									pos:  position{line: 813, col: 22, offset: 24015},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 820, col: 25, offset: 24129},
+									pos:        position{line: 813, col: 25, offset: 24018},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -6808,59 +6792,59 @@ var g = &grammar{
 		},
 		{
 			name: "OverExpr",
-			pos:  position{line: 822, col: 1, offset: 24155},
+			pos:  position{line: 815, col: 1, offset: 24044},
 			expr: &actionExpr{
-				pos: position{line: 823, col: 5, offset: 24168},
+				pos: position{line: 816, col: 5, offset: 24057},
 				run: (*parser).callonOverExpr1,
 				expr: &seqExpr{
-					pos: position{line: 823, col: 5, offset: 24168},
+					pos: position{line: 816, col: 5, offset: 24057},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 823, col: 5, offset: 24168},
+							pos:        position{line: 816, col: 5, offset: 24057},
 							val:        "over",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 823, col: 12, offset: 24175},
+							pos:  position{line: 816, col: 12, offset: 24064},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 823, col: 14, offset: 24177},
+							pos:   position{line: 816, col: 14, offset: 24066},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 823, col: 20, offset: 24183},
+								pos:  position{line: 816, col: 20, offset: 24072},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 823, col: 26, offset: 24189},
+							pos:   position{line: 816, col: 26, offset: 24078},
 							label: "locals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 823, col: 33, offset: 24196},
+								pos: position{line: 816, col: 33, offset: 24085},
 								expr: &ruleRefExpr{
-									pos:  position{line: 823, col: 33, offset: 24196},
+									pos:  position{line: 816, col: 33, offset: 24085},
 									name: "Locals",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 823, col: 41, offset: 24204},
+							pos:  position{line: 816, col: 41, offset: 24093},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 823, col: 44, offset: 24207},
+							pos:        position{line: 816, col: 44, offset: 24096},
 							val:        "|",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 823, col: 48, offset: 24211},
+							pos:  position{line: 816, col: 48, offset: 24100},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 823, col: 51, offset: 24214},
+							pos:   position{line: 816, col: 51, offset: 24103},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 823, col: 56, offset: 24219},
+								pos:  position{line: 816, col: 56, offset: 24108},
 								name: "Seq",
 							},
 						},
@@ -6870,36 +6854,36 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 827, col: 1, offset: 24341},
+			pos:  position{line: 820, col: 1, offset: 24230},
 			expr: &actionExpr{
-				pos: position{line: 828, col: 5, offset: 24352},
+				pos: position{line: 821, col: 5, offset: 24241},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 828, col: 5, offset: 24352},
+					pos: position{line: 821, col: 5, offset: 24241},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 828, col: 5, offset: 24352},
+							pos:        position{line: 821, col: 5, offset: 24241},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 828, col: 9, offset: 24356},
+							pos:  position{line: 821, col: 9, offset: 24245},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 828, col: 12, offset: 24359},
+							pos:   position{line: 821, col: 12, offset: 24248},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 828, col: 18, offset: 24365},
+								pos:  position{line: 821, col: 18, offset: 24254},
 								name: "RecordElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 828, col: 30, offset: 24377},
+							pos:  position{line: 821, col: 30, offset: 24266},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 828, col: 33, offset: 24380},
+							pos:        position{line: 821, col: 33, offset: 24269},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -6909,31 +6893,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElems",
-			pos:  position{line: 832, col: 1, offset: 24472},
+			pos:  position{line: 825, col: 1, offset: 24361},
 			expr: &choiceExpr{
-				pos: position{line: 833, col: 5, offset: 24488},
+				pos: position{line: 826, col: 5, offset: 24377},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 833, col: 5, offset: 24488},
+						pos: position{line: 826, col: 5, offset: 24377},
 						run: (*parser).callonRecordElems2,
 						expr: &seqExpr{
-							pos: position{line: 833, col: 5, offset: 24488},
+							pos: position{line: 826, col: 5, offset: 24377},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 833, col: 5, offset: 24488},
+									pos:   position{line: 826, col: 5, offset: 24377},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 833, col: 11, offset: 24494},
+										pos:  position{line: 826, col: 11, offset: 24383},
 										name: "RecordElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 833, col: 22, offset: 24505},
+									pos:   position{line: 826, col: 22, offset: 24394},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 833, col: 27, offset: 24510},
+										pos: position{line: 826, col: 27, offset: 24399},
 										expr: &ruleRefExpr{
-											pos:  position{line: 833, col: 27, offset: 24510},
+											pos:  position{line: 826, col: 27, offset: 24399},
 											name: "RecordElemTail",
 										},
 									},
@@ -6942,10 +6926,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 836, col: 5, offset: 24609},
+						pos: position{line: 829, col: 5, offset: 24498},
 						run: (*parser).callonRecordElems9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 836, col: 5, offset: 24609},
+							pos:  position{line: 829, col: 5, offset: 24498},
 							name: "__",
 						},
 					},
@@ -6954,31 +6938,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElemTail",
-			pos:  position{line: 838, col: 1, offset: 24645},
+			pos:  position{line: 831, col: 1, offset: 24534},
 			expr: &actionExpr{
-				pos: position{line: 838, col: 18, offset: 24662},
+				pos: position{line: 831, col: 18, offset: 24551},
 				run: (*parser).callonRecordElemTail1,
 				expr: &seqExpr{
-					pos: position{line: 838, col: 18, offset: 24662},
+					pos: position{line: 831, col: 18, offset: 24551},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 838, col: 18, offset: 24662},
+							pos:  position{line: 831, col: 18, offset: 24551},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 838, col: 21, offset: 24665},
+							pos:        position{line: 831, col: 21, offset: 24554},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 838, col: 25, offset: 24669},
+							pos:  position{line: 831, col: 25, offset: 24558},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 838, col: 28, offset: 24672},
+							pos:   position{line: 831, col: 28, offset: 24561},
 							label: "elem",
 							expr: &ruleRefExpr{
-								pos:  position{line: 838, col: 33, offset: 24677},
+								pos:  position{line: 831, col: 33, offset: 24566},
 								name: "RecordElem",
 							},
 						},
@@ -6988,20 +6972,20 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElem",
-			pos:  position{line: 840, col: 1, offset: 24710},
+			pos:  position{line: 833, col: 1, offset: 24599},
 			expr: &choiceExpr{
-				pos: position{line: 841, col: 5, offset: 24725},
+				pos: position{line: 834, col: 5, offset: 24614},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 841, col: 5, offset: 24725},
+						pos:  position{line: 834, col: 5, offset: 24614},
 						name: "Spread",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 842, col: 5, offset: 24736},
+						pos:  position{line: 835, col: 5, offset: 24625},
 						name: "Field",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 843, col: 5, offset: 24746},
+						pos:  position{line: 836, col: 5, offset: 24635},
 						name: "Identifier",
 					},
 				},
@@ -7009,27 +6993,27 @@ var g = &grammar{
 		},
 		{
 			name: "Spread",
-			pos:  position{line: 845, col: 1, offset: 24758},
+			pos:  position{line: 838, col: 1, offset: 24647},
 			expr: &actionExpr{
-				pos: position{line: 846, col: 5, offset: 24769},
+				pos: position{line: 839, col: 5, offset: 24658},
 				run: (*parser).callonSpread1,
 				expr: &seqExpr{
-					pos: position{line: 846, col: 5, offset: 24769},
+					pos: position{line: 839, col: 5, offset: 24658},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 846, col: 5, offset: 24769},
+							pos:        position{line: 839, col: 5, offset: 24658},
 							val:        "...",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 846, col: 11, offset: 24775},
+							pos:  position{line: 839, col: 11, offset: 24664},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 846, col: 14, offset: 24778},
+							pos:   position{line: 839, col: 14, offset: 24667},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 846, col: 19, offset: 24783},
+								pos:  position{line: 839, col: 19, offset: 24672},
 								name: "Expr",
 							},
 						},
@@ -7039,39 +7023,39 @@ var g = &grammar{
 		},
 		{
 			name: "Field",
-			pos:  position{line: 850, col: 1, offset: 24870},
+			pos:  position{line: 843, col: 1, offset: 24759},
 			expr: &actionExpr{
-				pos: position{line: 851, col: 5, offset: 24880},
+				pos: position{line: 844, col: 5, offset: 24769},
 				run: (*parser).callonField1,
 				expr: &seqExpr{
-					pos: position{line: 851, col: 5, offset: 24880},
+					pos: position{line: 844, col: 5, offset: 24769},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 851, col: 5, offset: 24880},
+							pos:   position{line: 844, col: 5, offset: 24769},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 851, col: 10, offset: 24885},
+								pos:  position{line: 844, col: 10, offset: 24774},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 851, col: 20, offset: 24895},
+							pos:  position{line: 844, col: 20, offset: 24784},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 851, col: 23, offset: 24898},
+							pos:        position{line: 844, col: 23, offset: 24787},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 851, col: 27, offset: 24902},
+							pos:  position{line: 844, col: 27, offset: 24791},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 851, col: 30, offset: 24905},
+							pos:   position{line: 844, col: 30, offset: 24794},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 851, col: 36, offset: 24911},
+								pos:  position{line: 844, col: 36, offset: 24800},
 								name: "Expr",
 							},
 						},
@@ -7081,36 +7065,36 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 855, col: 1, offset: 25013},
+			pos:  position{line: 848, col: 1, offset: 24902},
 			expr: &actionExpr{
-				pos: position{line: 856, col: 5, offset: 25023},
+				pos: position{line: 849, col: 5, offset: 24912},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 856, col: 5, offset: 25023},
+					pos: position{line: 849, col: 5, offset: 24912},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 856, col: 5, offset: 25023},
+							pos:        position{line: 849, col: 5, offset: 24912},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 856, col: 9, offset: 25027},
+							pos:  position{line: 849, col: 9, offset: 24916},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 856, col: 12, offset: 25030},
+							pos:   position{line: 849, col: 12, offset: 24919},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 856, col: 18, offset: 25036},
+								pos:  position{line: 849, col: 18, offset: 24925},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 856, col: 30, offset: 25048},
+							pos:  position{line: 849, col: 30, offset: 24937},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 856, col: 33, offset: 25051},
+							pos:        position{line: 849, col: 33, offset: 24940},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -7120,36 +7104,36 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 860, col: 1, offset: 25142},
+			pos:  position{line: 853, col: 1, offset: 25031},
 			expr: &actionExpr{
-				pos: position{line: 861, col: 5, offset: 25150},
+				pos: position{line: 854, col: 5, offset: 25039},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 861, col: 5, offset: 25150},
+					pos: position{line: 854, col: 5, offset: 25039},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 861, col: 5, offset: 25150},
+							pos:        position{line: 854, col: 5, offset: 25039},
 							val:        "|[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 861, col: 10, offset: 25155},
+							pos:  position{line: 854, col: 10, offset: 25044},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 861, col: 13, offset: 25158},
+							pos:   position{line: 854, col: 13, offset: 25047},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 861, col: 19, offset: 25164},
+								pos:  position{line: 854, col: 19, offset: 25053},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 861, col: 31, offset: 25176},
+							pos:  position{line: 854, col: 31, offset: 25065},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 861, col: 34, offset: 25179},
+							pos:        position{line: 854, col: 34, offset: 25068},
 							val:        "]|",
 							ignoreCase: false,
 						},
@@ -7159,53 +7143,53 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElems",
-			pos:  position{line: 865, col: 1, offset: 25269},
+			pos:  position{line: 858, col: 1, offset: 25158},
 			expr: &choiceExpr{
-				pos: position{line: 866, col: 5, offset: 25285},
+				pos: position{line: 859, col: 5, offset: 25174},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 866, col: 5, offset: 25285},
+						pos: position{line: 859, col: 5, offset: 25174},
 						run: (*parser).callonVectorElems2,
 						expr: &seqExpr{
-							pos: position{line: 866, col: 5, offset: 25285},
+							pos: position{line: 859, col: 5, offset: 25174},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 866, col: 5, offset: 25285},
+									pos:   position{line: 859, col: 5, offset: 25174},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 866, col: 11, offset: 25291},
+										pos:  position{line: 859, col: 11, offset: 25180},
 										name: "VectorElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 866, col: 22, offset: 25302},
+									pos:   position{line: 859, col: 22, offset: 25191},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 866, col: 27, offset: 25307},
+										pos: position{line: 859, col: 27, offset: 25196},
 										expr: &actionExpr{
-											pos: position{line: 866, col: 28, offset: 25308},
+											pos: position{line: 859, col: 28, offset: 25197},
 											run: (*parser).callonVectorElems8,
 											expr: &seqExpr{
-												pos: position{line: 866, col: 28, offset: 25308},
+												pos: position{line: 859, col: 28, offset: 25197},
 												exprs: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 866, col: 28, offset: 25308},
+														pos:  position{line: 859, col: 28, offset: 25197},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 866, col: 31, offset: 25311},
+														pos:        position{line: 859, col: 31, offset: 25200},
 														val:        ",",
 														ignoreCase: false,
 													},
 													&ruleRefExpr{
-														pos:  position{line: 866, col: 35, offset: 25315},
+														pos:  position{line: 859, col: 35, offset: 25204},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 866, col: 38, offset: 25318},
+														pos:   position{line: 859, col: 38, offset: 25207},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 866, col: 40, offset: 25320},
+															pos:  position{line: 859, col: 40, offset: 25209},
 															name: "VectorElem",
 														},
 													},
@@ -7218,10 +7202,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 869, col: 5, offset: 25438},
+						pos: position{line: 862, col: 5, offset: 25327},
 						run: (*parser).callonVectorElems15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 869, col: 5, offset: 25438},
+							pos:  position{line: 862, col: 5, offset: 25327},
 							name: "__",
 						},
 					},
@@ -7230,22 +7214,22 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElem",
-			pos:  position{line: 871, col: 1, offset: 25474},
+			pos:  position{line: 864, col: 1, offset: 25363},
 			expr: &choiceExpr{
-				pos: position{line: 872, col: 5, offset: 25489},
+				pos: position{line: 865, col: 5, offset: 25378},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 872, col: 5, offset: 25489},
+						pos:  position{line: 865, col: 5, offset: 25378},
 						name: "Spread",
 					},
 					&actionExpr{
-						pos: position{line: 873, col: 5, offset: 25500},
+						pos: position{line: 866, col: 5, offset: 25389},
 						run: (*parser).callonVectorElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 873, col: 5, offset: 25500},
+							pos:   position{line: 866, col: 5, offset: 25389},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 873, col: 7, offset: 25502},
+								pos:  position{line: 866, col: 7, offset: 25391},
 								name: "Expr",
 							},
 						},
@@ -7255,36 +7239,36 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 875, col: 1, offset: 25581},
+			pos:  position{line: 868, col: 1, offset: 25470},
 			expr: &actionExpr{
-				pos: position{line: 876, col: 5, offset: 25589},
+				pos: position{line: 869, col: 5, offset: 25478},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 876, col: 5, offset: 25589},
+					pos: position{line: 869, col: 5, offset: 25478},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 876, col: 5, offset: 25589},
+							pos:        position{line: 869, col: 5, offset: 25478},
 							val:        "|{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 876, col: 10, offset: 25594},
+							pos:  position{line: 869, col: 10, offset: 25483},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 876, col: 13, offset: 25597},
+							pos:   position{line: 869, col: 13, offset: 25486},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 876, col: 19, offset: 25603},
+								pos:  position{line: 869, col: 19, offset: 25492},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 876, col: 27, offset: 25611},
+							pos:  position{line: 869, col: 27, offset: 25500},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 876, col: 30, offset: 25614},
+							pos:        position{line: 869, col: 30, offset: 25503},
 							val:        "}|",
 							ignoreCase: false,
 						},
@@ -7294,31 +7278,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 880, col: 1, offset: 25706},
+			pos:  position{line: 873, col: 1, offset: 25595},
 			expr: &choiceExpr{
-				pos: position{line: 881, col: 5, offset: 25718},
+				pos: position{line: 874, col: 5, offset: 25607},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 881, col: 5, offset: 25718},
+						pos: position{line: 874, col: 5, offset: 25607},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 881, col: 5, offset: 25718},
+							pos: position{line: 874, col: 5, offset: 25607},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 881, col: 5, offset: 25718},
+									pos:   position{line: 874, col: 5, offset: 25607},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 881, col: 11, offset: 25724},
+										pos:  position{line: 874, col: 11, offset: 25613},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 881, col: 17, offset: 25730},
+									pos:   position{line: 874, col: 17, offset: 25619},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 881, col: 22, offset: 25735},
+										pos: position{line: 874, col: 22, offset: 25624},
 										expr: &ruleRefExpr{
-											pos:  position{line: 881, col: 22, offset: 25735},
+											pos:  position{line: 874, col: 22, offset: 25624},
 											name: "EntryTail",
 										},
 									},
@@ -7327,10 +7311,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 884, col: 5, offset: 25829},
+						pos: position{line: 877, col: 5, offset: 25718},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 884, col: 5, offset: 25829},
+							pos:  position{line: 877, col: 5, offset: 25718},
 							name: "__",
 						},
 					},
@@ -7339,31 +7323,31 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 887, col: 1, offset: 25866},
+			pos:  position{line: 880, col: 1, offset: 25755},
 			expr: &actionExpr{
-				pos: position{line: 887, col: 13, offset: 25878},
+				pos: position{line: 880, col: 13, offset: 25767},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 887, col: 13, offset: 25878},
+					pos: position{line: 880, col: 13, offset: 25767},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 887, col: 13, offset: 25878},
+							pos:  position{line: 880, col: 13, offset: 25767},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 887, col: 16, offset: 25881},
+							pos:        position{line: 880, col: 16, offset: 25770},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 887, col: 20, offset: 25885},
+							pos:  position{line: 880, col: 20, offset: 25774},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 887, col: 23, offset: 25888},
+							pos:   position{line: 880, col: 23, offset: 25777},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 887, col: 25, offset: 25890},
+								pos:  position{line: 880, col: 25, offset: 25779},
 								name: "Entry",
 							},
 						},
@@ -7373,39 +7357,39 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 889, col: 1, offset: 25915},
+			pos:  position{line: 882, col: 1, offset: 25804},
 			expr: &actionExpr{
-				pos: position{line: 890, col: 5, offset: 25925},
+				pos: position{line: 883, col: 5, offset: 25814},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 890, col: 5, offset: 25925},
+					pos: position{line: 883, col: 5, offset: 25814},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 890, col: 5, offset: 25925},
+							pos:   position{line: 883, col: 5, offset: 25814},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 890, col: 9, offset: 25929},
+								pos:  position{line: 883, col: 9, offset: 25818},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 890, col: 14, offset: 25934},
+							pos:  position{line: 883, col: 14, offset: 25823},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 890, col: 17, offset: 25937},
+							pos:        position{line: 883, col: 17, offset: 25826},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 890, col: 21, offset: 25941},
+							pos:  position{line: 883, col: 21, offset: 25830},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 890, col: 24, offset: 25944},
+							pos:   position{line: 883, col: 24, offset: 25833},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 890, col: 30, offset: 25950},
+								pos:  position{line: 883, col: 30, offset: 25839},
 								name: "Expr",
 							},
 						},
@@ -7415,92 +7399,92 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOp",
-			pos:  position{line: 896, col: 1, offset: 26057},
+			pos:  position{line: 889, col: 1, offset: 25946},
 			expr: &actionExpr{
-				pos: position{line: 897, col: 5, offset: 26067},
+				pos: position{line: 890, col: 5, offset: 25956},
 				run: (*parser).callonSQLOp1,
 				expr: &seqExpr{
-					pos: position{line: 897, col: 5, offset: 26067},
+					pos: position{line: 890, col: 5, offset: 25956},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 897, col: 5, offset: 26067},
+							pos:   position{line: 890, col: 5, offset: 25956},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 897, col: 15, offset: 26077},
+								pos:  position{line: 890, col: 15, offset: 25966},
 								name: "SQLSelect",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 898, col: 5, offset: 26091},
+							pos:   position{line: 891, col: 5, offset: 25980},
 							label: "from",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 898, col: 10, offset: 26096},
+								pos: position{line: 891, col: 10, offset: 25985},
 								expr: &ruleRefExpr{
-									pos:  position{line: 898, col: 10, offset: 26096},
+									pos:  position{line: 891, col: 10, offset: 25985},
 									name: "SQLFrom",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 899, col: 5, offset: 26109},
+							pos:   position{line: 892, col: 5, offset: 25998},
 							label: "joins",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 899, col: 11, offset: 26115},
+								pos: position{line: 892, col: 11, offset: 26004},
 								expr: &ruleRefExpr{
-									pos:  position{line: 899, col: 11, offset: 26115},
+									pos:  position{line: 892, col: 11, offset: 26004},
 									name: "SQLJoins",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 900, col: 5, offset: 26129},
+							pos:   position{line: 893, col: 5, offset: 26018},
 							label: "where",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 900, col: 11, offset: 26135},
+								pos: position{line: 893, col: 11, offset: 26024},
 								expr: &ruleRefExpr{
-									pos:  position{line: 900, col: 11, offset: 26135},
+									pos:  position{line: 893, col: 11, offset: 26024},
 									name: "SQLWhere",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 901, col: 5, offset: 26149},
+							pos:   position{line: 894, col: 5, offset: 26038},
 							label: "groupby",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 901, col: 13, offset: 26157},
+								pos: position{line: 894, col: 13, offset: 26046},
 								expr: &ruleRefExpr{
-									pos:  position{line: 901, col: 13, offset: 26157},
+									pos:  position{line: 894, col: 13, offset: 26046},
 									name: "SQLGroupBy",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 902, col: 5, offset: 26173},
+							pos:   position{line: 895, col: 5, offset: 26062},
 							label: "having",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 902, col: 12, offset: 26180},
+								pos: position{line: 895, col: 12, offset: 26069},
 								expr: &ruleRefExpr{
-									pos:  position{line: 902, col: 12, offset: 26180},
+									pos:  position{line: 895, col: 12, offset: 26069},
 									name: "SQLHaving",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 903, col: 5, offset: 26195},
+							pos:   position{line: 896, col: 5, offset: 26084},
 							label: "orderby",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 903, col: 13, offset: 26203},
+								pos: position{line: 896, col: 13, offset: 26092},
 								expr: &ruleRefExpr{
-									pos:  position{line: 903, col: 13, offset: 26203},
+									pos:  position{line: 896, col: 13, offset: 26092},
 									name: "SQLOrderBy",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 904, col: 5, offset: 26219},
+							pos:   position{line: 897, col: 5, offset: 26108},
 							label: "limit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 904, col: 11, offset: 26225},
+								pos:  position{line: 897, col: 11, offset: 26114},
 								name: "SQLLimit",
 							},
 						},
@@ -7510,26 +7494,26 @@ var g = &grammar{
 		},
 		{
 			name: "SQLSelect",
-			pos:  position{line: 928, col: 1, offset: 26591},
+			pos:  position{line: 921, col: 1, offset: 26480},
 			expr: &choiceExpr{
-				pos: position{line: 929, col: 5, offset: 26605},
+				pos: position{line: 922, col: 5, offset: 26494},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 929, col: 5, offset: 26605},
+						pos: position{line: 922, col: 5, offset: 26494},
 						run: (*parser).callonSQLSelect2,
 						expr: &seqExpr{
-							pos: position{line: 929, col: 5, offset: 26605},
+							pos: position{line: 922, col: 5, offset: 26494},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 929, col: 5, offset: 26605},
+									pos:  position{line: 922, col: 5, offset: 26494},
 									name: "SELECT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 929, col: 12, offset: 26612},
+									pos:  position{line: 922, col: 12, offset: 26501},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 929, col: 14, offset: 26614},
+									pos:        position{line: 922, col: 14, offset: 26503},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -7537,24 +7521,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 930, col: 5, offset: 26642},
+						pos: position{line: 923, col: 5, offset: 26531},
 						run: (*parser).callonSQLSelect7,
 						expr: &seqExpr{
-							pos: position{line: 930, col: 5, offset: 26642},
+							pos: position{line: 923, col: 5, offset: 26531},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 930, col: 5, offset: 26642},
+									pos:  position{line: 923, col: 5, offset: 26531},
 									name: "SELECT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 930, col: 12, offset: 26649},
+									pos:  position{line: 923, col: 12, offset: 26538},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 930, col: 14, offset: 26651},
+									pos:   position{line: 923, col: 14, offset: 26540},
 									label: "assignments",
 									expr: &ruleRefExpr{
-										pos:  position{line: 930, col: 26, offset: 26663},
+										pos:  position{line: 923, col: 26, offset: 26552},
 										name: "SQLAssignments",
 									},
 								},
@@ -7566,43 +7550,43 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAssignment",
-			pos:  position{line: 932, col: 1, offset: 26707},
+			pos:  position{line: 925, col: 1, offset: 26596},
 			expr: &actionExpr{
-				pos: position{line: 933, col: 5, offset: 26725},
+				pos: position{line: 926, col: 5, offset: 26614},
 				run: (*parser).callonSQLAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 933, col: 5, offset: 26725},
+					pos: position{line: 926, col: 5, offset: 26614},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 933, col: 5, offset: 26725},
+							pos:   position{line: 926, col: 5, offset: 26614},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 933, col: 9, offset: 26729},
+								pos:  position{line: 926, col: 9, offset: 26618},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 933, col: 14, offset: 26734},
+							pos:   position{line: 926, col: 14, offset: 26623},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 933, col: 18, offset: 26738},
+								pos: position{line: 926, col: 18, offset: 26627},
 								expr: &seqExpr{
-									pos: position{line: 933, col: 19, offset: 26739},
+									pos: position{line: 926, col: 19, offset: 26628},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 933, col: 19, offset: 26739},
+											pos:  position{line: 926, col: 19, offset: 26628},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 933, col: 21, offset: 26741},
+											pos:  position{line: 926, col: 21, offset: 26630},
 											name: "AS",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 933, col: 24, offset: 26744},
+											pos:  position{line: 926, col: 24, offset: 26633},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 933, col: 26, offset: 26746},
+											pos:  position{line: 926, col: 26, offset: 26635},
 											name: "Lval",
 										},
 									},
@@ -7615,50 +7599,50 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAssignments",
-			pos:  position{line: 941, col: 1, offset: 26937},
+			pos:  position{line: 934, col: 1, offset: 26826},
 			expr: &actionExpr{
-				pos: position{line: 942, col: 5, offset: 26956},
+				pos: position{line: 935, col: 5, offset: 26845},
 				run: (*parser).callonSQLAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 942, col: 5, offset: 26956},
+					pos: position{line: 935, col: 5, offset: 26845},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 942, col: 5, offset: 26956},
+							pos:   position{line: 935, col: 5, offset: 26845},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 942, col: 11, offset: 26962},
+								pos:  position{line: 935, col: 11, offset: 26851},
 								name: "SQLAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 942, col: 25, offset: 26976},
+							pos:   position{line: 935, col: 25, offset: 26865},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 942, col: 30, offset: 26981},
+								pos: position{line: 935, col: 30, offset: 26870},
 								expr: &actionExpr{
-									pos: position{line: 942, col: 31, offset: 26982},
+									pos: position{line: 935, col: 31, offset: 26871},
 									run: (*parser).callonSQLAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 942, col: 31, offset: 26982},
+										pos: position{line: 935, col: 31, offset: 26871},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 942, col: 31, offset: 26982},
+												pos:  position{line: 935, col: 31, offset: 26871},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 942, col: 34, offset: 26985},
+												pos:        position{line: 935, col: 34, offset: 26874},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 942, col: 38, offset: 26989},
+												pos:  position{line: 935, col: 38, offset: 26878},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 942, col: 41, offset: 26992},
+												pos:   position{line: 935, col: 41, offset: 26881},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 942, col: 46, offset: 26997},
+													pos:  position{line: 935, col: 46, offset: 26886},
 													name: "SQLAssignment",
 												},
 											},
@@ -7673,43 +7657,43 @@ var g = &grammar{
 		},
 		{
 			name: "SQLFrom",
-			pos:  position{line: 946, col: 1, offset: 27118},
+			pos:  position{line: 939, col: 1, offset: 27007},
 			expr: &choiceExpr{
-				pos: position{line: 947, col: 5, offset: 27130},
+				pos: position{line: 940, col: 5, offset: 27019},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 947, col: 5, offset: 27130},
+						pos: position{line: 940, col: 5, offset: 27019},
 						run: (*parser).callonSQLFrom2,
 						expr: &seqExpr{
-							pos: position{line: 947, col: 5, offset: 27130},
+							pos: position{line: 940, col: 5, offset: 27019},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 947, col: 5, offset: 27130},
+									pos:  position{line: 940, col: 5, offset: 27019},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 947, col: 7, offset: 27132},
+									pos:  position{line: 940, col: 7, offset: 27021},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 947, col: 12, offset: 27137},
+									pos:  position{line: 940, col: 12, offset: 27026},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 947, col: 14, offset: 27139},
+									pos:   position{line: 940, col: 14, offset: 27028},
 									label: "table",
 									expr: &ruleRefExpr{
-										pos:  position{line: 947, col: 20, offset: 27145},
+										pos:  position{line: 940, col: 20, offset: 27034},
 										name: "SQLTable",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 947, col: 29, offset: 27154},
+									pos:   position{line: 940, col: 29, offset: 27043},
 									label: "alias",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 947, col: 35, offset: 27160},
+										pos: position{line: 940, col: 35, offset: 27049},
 										expr: &ruleRefExpr{
-											pos:  position{line: 947, col: 35, offset: 27160},
+											pos:  position{line: 940, col: 35, offset: 27049},
 											name: "SQLAlias",
 										},
 									},
@@ -7718,25 +7702,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 950, col: 5, offset: 27255},
+						pos: position{line: 943, col: 5, offset: 27144},
 						run: (*parser).callonSQLFrom12,
 						expr: &seqExpr{
-							pos: position{line: 950, col: 5, offset: 27255},
+							pos: position{line: 943, col: 5, offset: 27144},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 950, col: 5, offset: 27255},
+									pos:  position{line: 943, col: 5, offset: 27144},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 950, col: 7, offset: 27257},
+									pos:  position{line: 943, col: 7, offset: 27146},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 950, col: 12, offset: 27262},
+									pos:  position{line: 943, col: 12, offset: 27151},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 950, col: 14, offset: 27264},
+									pos:        position{line: 943, col: 14, offset: 27153},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -7748,33 +7732,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLAlias",
-			pos:  position{line: 952, col: 1, offset: 27289},
+			pos:  position{line: 945, col: 1, offset: 27178},
 			expr: &choiceExpr{
-				pos: position{line: 953, col: 5, offset: 27302},
+				pos: position{line: 946, col: 5, offset: 27191},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 953, col: 5, offset: 27302},
+						pos: position{line: 946, col: 5, offset: 27191},
 						run: (*parser).callonSQLAlias2,
 						expr: &seqExpr{
-							pos: position{line: 953, col: 5, offset: 27302},
+							pos: position{line: 946, col: 5, offset: 27191},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 953, col: 5, offset: 27302},
+									pos:  position{line: 946, col: 5, offset: 27191},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 953, col: 7, offset: 27304},
+									pos:  position{line: 946, col: 7, offset: 27193},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 953, col: 10, offset: 27307},
+									pos:  position{line: 946, col: 10, offset: 27196},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 953, col: 12, offset: 27309},
+									pos:   position{line: 946, col: 12, offset: 27198},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 953, col: 15, offset: 27312},
+										pos:  position{line: 946, col: 15, offset: 27201},
 										name: "Lval",
 									},
 								},
@@ -7782,36 +7766,36 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 954, col: 5, offset: 27340},
+						pos: position{line: 947, col: 5, offset: 27229},
 						run: (*parser).callonSQLAlias9,
 						expr: &seqExpr{
-							pos: position{line: 954, col: 5, offset: 27340},
+							pos: position{line: 947, col: 5, offset: 27229},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 954, col: 5, offset: 27340},
+									pos:  position{line: 947, col: 5, offset: 27229},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 954, col: 7, offset: 27342},
+									pos: position{line: 947, col: 7, offset: 27231},
 									expr: &seqExpr{
-										pos: position{line: 954, col: 9, offset: 27344},
+										pos: position{line: 947, col: 9, offset: 27233},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 954, col: 9, offset: 27344},
+												pos:  position{line: 947, col: 9, offset: 27233},
 												name: "SQLTokenSentinels",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 954, col: 27, offset: 27362},
+												pos:  position{line: 947, col: 27, offset: 27251},
 												name: "_",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 954, col: 30, offset: 27365},
+									pos:   position{line: 947, col: 30, offset: 27254},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 954, col: 33, offset: 27368},
+										pos:  position{line: 947, col: 33, offset: 27257},
 										name: "Lval",
 									},
 								},
@@ -7823,42 +7807,42 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTable",
-			pos:  position{line: 956, col: 1, offset: 27393},
+			pos:  position{line: 949, col: 1, offset: 27282},
 			expr: &ruleRefExpr{
-				pos:  position{line: 957, col: 5, offset: 27406},
+				pos:  position{line: 950, col: 5, offset: 27295},
 				name: "Expr",
 			},
 		},
 		{
 			name: "SQLJoins",
-			pos:  position{line: 959, col: 1, offset: 27412},
+			pos:  position{line: 952, col: 1, offset: 27301},
 			expr: &actionExpr{
-				pos: position{line: 960, col: 5, offset: 27425},
+				pos: position{line: 953, col: 5, offset: 27314},
 				run: (*parser).callonSQLJoins1,
 				expr: &seqExpr{
-					pos: position{line: 960, col: 5, offset: 27425},
+					pos: position{line: 953, col: 5, offset: 27314},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 960, col: 5, offset: 27425},
+							pos:   position{line: 953, col: 5, offset: 27314},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 960, col: 11, offset: 27431},
+								pos:  position{line: 953, col: 11, offset: 27320},
 								name: "SQLJoin",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 960, col: 19, offset: 27439},
+							pos:   position{line: 953, col: 19, offset: 27328},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 960, col: 24, offset: 27444},
+								pos: position{line: 953, col: 24, offset: 27333},
 								expr: &actionExpr{
-									pos: position{line: 960, col: 25, offset: 27445},
+									pos: position{line: 953, col: 25, offset: 27334},
 									run: (*parser).callonSQLJoins7,
 									expr: &labeledExpr{
-										pos:   position{line: 960, col: 25, offset: 27445},
+										pos:   position{line: 953, col: 25, offset: 27334},
 										label: "join",
 										expr: &ruleRefExpr{
-											pos:  position{line: 960, col: 30, offset: 27450},
+											pos:  position{line: 953, col: 30, offset: 27339},
 											name: "SQLJoin",
 										},
 									},
@@ -7871,90 +7855,90 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoin",
-			pos:  position{line: 964, col: 1, offset: 27565},
+			pos:  position{line: 957, col: 1, offset: 27454},
 			expr: &actionExpr{
-				pos: position{line: 965, col: 5, offset: 27577},
+				pos: position{line: 958, col: 5, offset: 27466},
 				run: (*parser).callonSQLJoin1,
 				expr: &seqExpr{
-					pos: position{line: 965, col: 5, offset: 27577},
+					pos: position{line: 958, col: 5, offset: 27466},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 965, col: 5, offset: 27577},
+							pos:   position{line: 958, col: 5, offset: 27466},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 965, col: 11, offset: 27583},
+								pos:  position{line: 958, col: 11, offset: 27472},
 								name: "SQLJoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 965, col: 24, offset: 27596},
+							pos:  position{line: 958, col: 24, offset: 27485},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 965, col: 26, offset: 27598},
+							pos:  position{line: 958, col: 26, offset: 27487},
 							name: "JOIN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 965, col: 31, offset: 27603},
+							pos:  position{line: 958, col: 31, offset: 27492},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 965, col: 33, offset: 27605},
+							pos:   position{line: 958, col: 33, offset: 27494},
 							label: "table",
 							expr: &ruleRefExpr{
-								pos:  position{line: 965, col: 39, offset: 27611},
+								pos:  position{line: 958, col: 39, offset: 27500},
 								name: "SQLTable",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 965, col: 48, offset: 27620},
+							pos:   position{line: 958, col: 48, offset: 27509},
 							label: "alias",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 965, col: 54, offset: 27626},
+								pos: position{line: 958, col: 54, offset: 27515},
 								expr: &ruleRefExpr{
-									pos:  position{line: 965, col: 54, offset: 27626},
+									pos:  position{line: 958, col: 54, offset: 27515},
 									name: "SQLAlias",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 965, col: 64, offset: 27636},
+							pos:  position{line: 958, col: 64, offset: 27525},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 965, col: 66, offset: 27638},
+							pos:  position{line: 958, col: 66, offset: 27527},
 							name: "ON",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 965, col: 69, offset: 27641},
+							pos:  position{line: 958, col: 69, offset: 27530},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 965, col: 71, offset: 27643},
+							pos:   position{line: 958, col: 71, offset: 27532},
 							label: "leftKey",
 							expr: &ruleRefExpr{
-								pos:  position{line: 965, col: 79, offset: 27651},
+								pos:  position{line: 958, col: 79, offset: 27540},
 								name: "JoinKey",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 965, col: 87, offset: 27659},
+							pos:  position{line: 958, col: 87, offset: 27548},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 965, col: 90, offset: 27662},
+							pos:        position{line: 958, col: 90, offset: 27551},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 965, col: 94, offset: 27666},
+							pos:  position{line: 958, col: 94, offset: 27555},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 965, col: 97, offset: 27669},
+							pos:   position{line: 958, col: 97, offset: 27558},
 							label: "rightKey",
 							expr: &ruleRefExpr{
-								pos:  position{line: 965, col: 106, offset: 27678},
+								pos:  position{line: 958, col: 106, offset: 27567},
 								name: "JoinKey",
 							},
 						},
@@ -7964,40 +7948,40 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoinStyle",
-			pos:  position{line: 980, col: 1, offset: 27909},
+			pos:  position{line: 973, col: 1, offset: 27798},
 			expr: &choiceExpr{
-				pos: position{line: 981, col: 5, offset: 27926},
+				pos: position{line: 974, col: 5, offset: 27815},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 981, col: 5, offset: 27926},
+						pos: position{line: 974, col: 5, offset: 27815},
 						run: (*parser).callonSQLJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 981, col: 5, offset: 27926},
+							pos: position{line: 974, col: 5, offset: 27815},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 981, col: 5, offset: 27926},
+									pos:  position{line: 974, col: 5, offset: 27815},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 981, col: 7, offset: 27928},
+									pos:   position{line: 974, col: 7, offset: 27817},
 									label: "style",
 									expr: &choiceExpr{
-										pos: position{line: 981, col: 14, offset: 27935},
+										pos: position{line: 974, col: 14, offset: 27824},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 981, col: 14, offset: 27935},
+												pos:  position{line: 974, col: 14, offset: 27824},
 												name: "ANTI",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 981, col: 21, offset: 27942},
+												pos:  position{line: 974, col: 21, offset: 27831},
 												name: "INNER",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 981, col: 29, offset: 27950},
+												pos:  position{line: 974, col: 29, offset: 27839},
 												name: "LEFT",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 981, col: 36, offset: 27957},
+												pos:  position{line: 974, col: 36, offset: 27846},
 												name: "RIGHT",
 											},
 										},
@@ -8007,10 +7991,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 982, col: 5, offset: 27990},
+						pos: position{line: 975, col: 5, offset: 27879},
 						run: (*parser).callonSQLJoinStyle11,
 						expr: &litMatcher{
-							pos:        position{line: 982, col: 5, offset: 27990},
+							pos:        position{line: 975, col: 5, offset: 27879},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -8020,30 +8004,30 @@ var g = &grammar{
 		},
 		{
 			name: "SQLWhere",
-			pos:  position{line: 984, col: 1, offset: 28018},
+			pos:  position{line: 977, col: 1, offset: 27907},
 			expr: &actionExpr{
-				pos: position{line: 985, col: 5, offset: 28031},
+				pos: position{line: 978, col: 5, offset: 27920},
 				run: (*parser).callonSQLWhere1,
 				expr: &seqExpr{
-					pos: position{line: 985, col: 5, offset: 28031},
+					pos: position{line: 978, col: 5, offset: 27920},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 985, col: 5, offset: 28031},
+							pos:  position{line: 978, col: 5, offset: 27920},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 985, col: 7, offset: 28033},
+							pos:  position{line: 978, col: 7, offset: 27922},
 							name: "WHERE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 985, col: 13, offset: 28039},
+							pos:  position{line: 978, col: 13, offset: 27928},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 985, col: 15, offset: 28041},
+							pos:   position{line: 978, col: 15, offset: 27930},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 985, col: 20, offset: 28046},
+								pos:  position{line: 978, col: 20, offset: 27935},
 								name: "LogicalOrExpr",
 							},
 						},
@@ -8053,38 +8037,38 @@ var g = &grammar{
 		},
 		{
 			name: "SQLGroupBy",
-			pos:  position{line: 987, col: 1, offset: 28082},
+			pos:  position{line: 980, col: 1, offset: 27971},
 			expr: &actionExpr{
-				pos: position{line: 988, col: 5, offset: 28097},
+				pos: position{line: 981, col: 5, offset: 27986},
 				run: (*parser).callonSQLGroupBy1,
 				expr: &seqExpr{
-					pos: position{line: 988, col: 5, offset: 28097},
+					pos: position{line: 981, col: 5, offset: 27986},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 988, col: 5, offset: 28097},
+							pos:  position{line: 981, col: 5, offset: 27986},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 988, col: 7, offset: 28099},
+							pos:  position{line: 981, col: 7, offset: 27988},
 							name: "GROUP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 988, col: 13, offset: 28105},
+							pos:  position{line: 981, col: 13, offset: 27994},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 988, col: 15, offset: 28107},
+							pos:  position{line: 981, col: 15, offset: 27996},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 988, col: 18, offset: 28110},
+							pos:  position{line: 981, col: 18, offset: 27999},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 988, col: 20, offset: 28112},
+							pos:   position{line: 981, col: 20, offset: 28001},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 988, col: 28, offset: 28120},
+								pos:  position{line: 981, col: 28, offset: 28009},
 								name: "FieldExprs",
 							},
 						},
@@ -8094,30 +8078,30 @@ var g = &grammar{
 		},
 		{
 			name: "SQLHaving",
-			pos:  position{line: 990, col: 1, offset: 28156},
+			pos:  position{line: 983, col: 1, offset: 28045},
 			expr: &actionExpr{
-				pos: position{line: 991, col: 5, offset: 28170},
+				pos: position{line: 984, col: 5, offset: 28059},
 				run: (*parser).callonSQLHaving1,
 				expr: &seqExpr{
-					pos: position{line: 991, col: 5, offset: 28170},
+					pos: position{line: 984, col: 5, offset: 28059},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 991, col: 5, offset: 28170},
+							pos:  position{line: 984, col: 5, offset: 28059},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 991, col: 7, offset: 28172},
+							pos:  position{line: 984, col: 7, offset: 28061},
 							name: "HAVING",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 991, col: 14, offset: 28179},
+							pos:  position{line: 984, col: 14, offset: 28068},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 991, col: 16, offset: 28181},
+							pos:   position{line: 984, col: 16, offset: 28070},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 991, col: 21, offset: 28186},
+								pos:  position{line: 984, col: 21, offset: 28075},
 								name: "LogicalOrExpr",
 							},
 						},
@@ -8127,46 +8111,46 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOrderBy",
-			pos:  position{line: 993, col: 1, offset: 28222},
+			pos:  position{line: 986, col: 1, offset: 28111},
 			expr: &actionExpr{
-				pos: position{line: 994, col: 5, offset: 28237},
+				pos: position{line: 987, col: 5, offset: 28126},
 				run: (*parser).callonSQLOrderBy1,
 				expr: &seqExpr{
-					pos: position{line: 994, col: 5, offset: 28237},
+					pos: position{line: 987, col: 5, offset: 28126},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 994, col: 5, offset: 28237},
+							pos:  position{line: 987, col: 5, offset: 28126},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 994, col: 7, offset: 28239},
+							pos:  position{line: 987, col: 7, offset: 28128},
 							name: "ORDER",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 994, col: 13, offset: 28245},
+							pos:  position{line: 987, col: 13, offset: 28134},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 994, col: 15, offset: 28247},
+							pos:  position{line: 987, col: 15, offset: 28136},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 994, col: 18, offset: 28250},
+							pos:  position{line: 987, col: 18, offset: 28139},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 994, col: 20, offset: 28252},
+							pos:   position{line: 987, col: 20, offset: 28141},
 							label: "keys",
 							expr: &ruleRefExpr{
-								pos:  position{line: 994, col: 25, offset: 28257},
+								pos:  position{line: 987, col: 25, offset: 28146},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 994, col: 31, offset: 28263},
+							pos:   position{line: 987, col: 31, offset: 28152},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 994, col: 37, offset: 28269},
+								pos:  position{line: 987, col: 37, offset: 28158},
 								name: "SQLOrder",
 							},
 						},
@@ -8176,32 +8160,32 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOrder",
-			pos:  position{line: 998, col: 1, offset: 28380},
+			pos:  position{line: 991, col: 1, offset: 28269},
 			expr: &choiceExpr{
-				pos: position{line: 999, col: 5, offset: 28393},
+				pos: position{line: 992, col: 5, offset: 28282},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 999, col: 5, offset: 28393},
+						pos: position{line: 992, col: 5, offset: 28282},
 						run: (*parser).callonSQLOrder2,
 						expr: &seqExpr{
-							pos: position{line: 999, col: 5, offset: 28393},
+							pos: position{line: 992, col: 5, offset: 28282},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 999, col: 5, offset: 28393},
+									pos:  position{line: 992, col: 5, offset: 28282},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 999, col: 7, offset: 28395},
+									pos:   position{line: 992, col: 7, offset: 28284},
 									label: "dir",
 									expr: &choiceExpr{
-										pos: position{line: 999, col: 12, offset: 28400},
+										pos: position{line: 992, col: 12, offset: 28289},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 999, col: 12, offset: 28400},
+												pos:  position{line: 992, col: 12, offset: 28289},
 												name: "ASC",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 999, col: 18, offset: 28406},
+												pos:  position{line: 992, col: 18, offset: 28295},
 												name: "DESC",
 											},
 										},
@@ -8211,10 +8195,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1000, col: 5, offset: 28436},
+						pos: position{line: 993, col: 5, offset: 28325},
 						run: (*parser).callonSQLOrder9,
 						expr: &litMatcher{
-							pos:        position{line: 1000, col: 5, offset: 28436},
+							pos:        position{line: 993, col: 5, offset: 28325},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -8224,33 +8208,33 @@ var g = &grammar{
 		},
 		{
 			name: "SQLLimit",
-			pos:  position{line: 1002, col: 1, offset: 28462},
+			pos:  position{line: 995, col: 1, offset: 28351},
 			expr: &choiceExpr{
-				pos: position{line: 1003, col: 5, offset: 28475},
+				pos: position{line: 996, col: 5, offset: 28364},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1003, col: 5, offset: 28475},
+						pos: position{line: 996, col: 5, offset: 28364},
 						run: (*parser).callonSQLLimit2,
 						expr: &seqExpr{
-							pos: position{line: 1003, col: 5, offset: 28475},
+							pos: position{line: 996, col: 5, offset: 28364},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1003, col: 5, offset: 28475},
+									pos:  position{line: 996, col: 5, offset: 28364},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1003, col: 7, offset: 28477},
+									pos:  position{line: 996, col: 7, offset: 28366},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1003, col: 13, offset: 28483},
+									pos:  position{line: 996, col: 13, offset: 28372},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1003, col: 15, offset: 28485},
+									pos:   position{line: 996, col: 15, offset: 28374},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1003, col: 21, offset: 28491},
+										pos:  position{line: 996, col: 21, offset: 28380},
 										name: "UInt",
 									},
 								},
@@ -8258,10 +8242,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1004, col: 5, offset: 28522},
+						pos: position{line: 997, col: 5, offset: 28411},
 						run: (*parser).callonSQLLimit9,
 						expr: &litMatcher{
-							pos:        position{line: 1004, col: 5, offset: 28522},
+							pos:        position{line: 997, col: 5, offset: 28411},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -8271,12 +8255,12 @@ var g = &grammar{
 		},
 		{
 			name: "SELECT",
-			pos:  position{line: 1006, col: 1, offset: 28544},
+			pos:  position{line: 999, col: 1, offset: 28433},
 			expr: &actionExpr{
-				pos: position{line: 1006, col: 10, offset: 28553},
+				pos: position{line: 999, col: 10, offset: 28442},
 				run: (*parser).callonSELECT1,
 				expr: &litMatcher{
-					pos:        position{line: 1006, col: 10, offset: 28553},
+					pos:        position{line: 999, col: 10, offset: 28442},
 					val:        "select",
 					ignoreCase: true,
 				},
@@ -8284,12 +8268,12 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 1007, col: 1, offset: 28588},
+			pos:  position{line: 1000, col: 1, offset: 28477},
 			expr: &actionExpr{
-				pos: position{line: 1007, col: 6, offset: 28593},
+				pos: position{line: 1000, col: 6, offset: 28482},
 				run: (*parser).callonAS1,
 				expr: &litMatcher{
-					pos:        position{line: 1007, col: 6, offset: 28593},
+					pos:        position{line: 1000, col: 6, offset: 28482},
 					val:        "as",
 					ignoreCase: true,
 				},
@@ -8297,12 +8281,12 @@ var g = &grammar{
 		},
 		{
 			name: "FROM",
-			pos:  position{line: 1008, col: 1, offset: 28620},
+			pos:  position{line: 1001, col: 1, offset: 28509},
 			expr: &actionExpr{
-				pos: position{line: 1008, col: 8, offset: 28627},
+				pos: position{line: 1001, col: 8, offset: 28516},
 				run: (*parser).callonFROM1,
 				expr: &litMatcher{
-					pos:        position{line: 1008, col: 8, offset: 28627},
+					pos:        position{line: 1001, col: 8, offset: 28516},
 					val:        "from",
 					ignoreCase: true,
 				},
@@ -8310,12 +8294,12 @@ var g = &grammar{
 		},
 		{
 			name: "JOIN",
-			pos:  position{line: 1009, col: 1, offset: 28658},
+			pos:  position{line: 1002, col: 1, offset: 28547},
 			expr: &actionExpr{
-				pos: position{line: 1009, col: 8, offset: 28665},
+				pos: position{line: 1002, col: 8, offset: 28554},
 				run: (*parser).callonJOIN1,
 				expr: &litMatcher{
-					pos:        position{line: 1009, col: 8, offset: 28665},
+					pos:        position{line: 1002, col: 8, offset: 28554},
 					val:        "join",
 					ignoreCase: true,
 				},
@@ -8323,12 +8307,12 @@ var g = &grammar{
 		},
 		{
 			name: "WHERE",
-			pos:  position{line: 1010, col: 1, offset: 28696},
+			pos:  position{line: 1003, col: 1, offset: 28585},
 			expr: &actionExpr{
-				pos: position{line: 1010, col: 9, offset: 28704},
+				pos: position{line: 1003, col: 9, offset: 28593},
 				run: (*parser).callonWHERE1,
 				expr: &litMatcher{
-					pos:        position{line: 1010, col: 9, offset: 28704},
+					pos:        position{line: 1003, col: 9, offset: 28593},
 					val:        "where",
 					ignoreCase: true,
 				},
@@ -8336,12 +8320,12 @@ var g = &grammar{
 		},
 		{
 			name: "GROUP",
-			pos:  position{line: 1011, col: 1, offset: 28737},
+			pos:  position{line: 1004, col: 1, offset: 28626},
 			expr: &actionExpr{
-				pos: position{line: 1011, col: 9, offset: 28745},
+				pos: position{line: 1004, col: 9, offset: 28634},
 				run: (*parser).callonGROUP1,
 				expr: &litMatcher{
-					pos:        position{line: 1011, col: 9, offset: 28745},
+					pos:        position{line: 1004, col: 9, offset: 28634},
 					val:        "group",
 					ignoreCase: true,
 				},
@@ -8349,12 +8333,12 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 1012, col: 1, offset: 28778},
+			pos:  position{line: 1005, col: 1, offset: 28667},
 			expr: &actionExpr{
-				pos: position{line: 1012, col: 6, offset: 28783},
+				pos: position{line: 1005, col: 6, offset: 28672},
 				run: (*parser).callonBY1,
 				expr: &litMatcher{
-					pos:        position{line: 1012, col: 6, offset: 28783},
+					pos:        position{line: 1005, col: 6, offset: 28672},
 					val:        "by",
 					ignoreCase: true,
 				},
@@ -8362,12 +8346,12 @@ var g = &grammar{
 		},
 		{
 			name: "HAVING",
-			pos:  position{line: 1013, col: 1, offset: 28810},
+			pos:  position{line: 1006, col: 1, offset: 28699},
 			expr: &actionExpr{
-				pos: position{line: 1013, col: 10, offset: 28819},
+				pos: position{line: 1006, col: 10, offset: 28708},
 				run: (*parser).callonHAVING1,
 				expr: &litMatcher{
-					pos:        position{line: 1013, col: 10, offset: 28819},
+					pos:        position{line: 1006, col: 10, offset: 28708},
 					val:        "having",
 					ignoreCase: true,
 				},
@@ -8375,12 +8359,12 @@ var g = &grammar{
 		},
 		{
 			name: "ORDER",
-			pos:  position{line: 1014, col: 1, offset: 28854},
+			pos:  position{line: 1007, col: 1, offset: 28743},
 			expr: &actionExpr{
-				pos: position{line: 1014, col: 9, offset: 28862},
+				pos: position{line: 1007, col: 9, offset: 28751},
 				run: (*parser).callonORDER1,
 				expr: &litMatcher{
-					pos:        position{line: 1014, col: 9, offset: 28862},
+					pos:        position{line: 1007, col: 9, offset: 28751},
 					val:        "order",
 					ignoreCase: true,
 				},
@@ -8388,12 +8372,12 @@ var g = &grammar{
 		},
 		{
 			name: "ON",
-			pos:  position{line: 1015, col: 1, offset: 28895},
+			pos:  position{line: 1008, col: 1, offset: 28784},
 			expr: &actionExpr{
-				pos: position{line: 1015, col: 6, offset: 28900},
+				pos: position{line: 1008, col: 6, offset: 28789},
 				run: (*parser).callonON1,
 				expr: &litMatcher{
-					pos:        position{line: 1015, col: 6, offset: 28900},
+					pos:        position{line: 1008, col: 6, offset: 28789},
 					val:        "on",
 					ignoreCase: true,
 				},
@@ -8401,12 +8385,12 @@ var g = &grammar{
 		},
 		{
 			name: "LIMIT",
-			pos:  position{line: 1016, col: 1, offset: 28927},
+			pos:  position{line: 1009, col: 1, offset: 28816},
 			expr: &actionExpr{
-				pos: position{line: 1016, col: 9, offset: 28935},
+				pos: position{line: 1009, col: 9, offset: 28824},
 				run: (*parser).callonLIMIT1,
 				expr: &litMatcher{
-					pos:        position{line: 1016, col: 9, offset: 28935},
+					pos:        position{line: 1009, col: 9, offset: 28824},
 					val:        "limit",
 					ignoreCase: true,
 				},
@@ -8414,12 +8398,12 @@ var g = &grammar{
 		},
 		{
 			name: "ASC",
-			pos:  position{line: 1017, col: 1, offset: 28968},
+			pos:  position{line: 1010, col: 1, offset: 28857},
 			expr: &actionExpr{
-				pos: position{line: 1017, col: 7, offset: 28974},
+				pos: position{line: 1010, col: 7, offset: 28863},
 				run: (*parser).callonASC1,
 				expr: &litMatcher{
-					pos:        position{line: 1017, col: 7, offset: 28974},
+					pos:        position{line: 1010, col: 7, offset: 28863},
 					val:        "asc",
 					ignoreCase: true,
 				},
@@ -8427,12 +8411,12 @@ var g = &grammar{
 		},
 		{
 			name: "DESC",
-			pos:  position{line: 1018, col: 1, offset: 29003},
+			pos:  position{line: 1011, col: 1, offset: 28892},
 			expr: &actionExpr{
-				pos: position{line: 1018, col: 8, offset: 29010},
+				pos: position{line: 1011, col: 8, offset: 28899},
 				run: (*parser).callonDESC1,
 				expr: &litMatcher{
-					pos:        position{line: 1018, col: 8, offset: 29010},
+					pos:        position{line: 1011, col: 8, offset: 28899},
 					val:        "desc",
 					ignoreCase: true,
 				},
@@ -8440,12 +8424,12 @@ var g = &grammar{
 		},
 		{
 			name: "ANTI",
-			pos:  position{line: 1019, col: 1, offset: 29041},
+			pos:  position{line: 1012, col: 1, offset: 28930},
 			expr: &actionExpr{
-				pos: position{line: 1019, col: 8, offset: 29048},
+				pos: position{line: 1012, col: 8, offset: 28937},
 				run: (*parser).callonANTI1,
 				expr: &litMatcher{
-					pos:        position{line: 1019, col: 8, offset: 29048},
+					pos:        position{line: 1012, col: 8, offset: 28937},
 					val:        "anti",
 					ignoreCase: true,
 				},
@@ -8453,12 +8437,12 @@ var g = &grammar{
 		},
 		{
 			name: "LEFT",
-			pos:  position{line: 1020, col: 1, offset: 29079},
+			pos:  position{line: 1013, col: 1, offset: 28968},
 			expr: &actionExpr{
-				pos: position{line: 1020, col: 8, offset: 29086},
+				pos: position{line: 1013, col: 8, offset: 28975},
 				run: (*parser).callonLEFT1,
 				expr: &litMatcher{
-					pos:        position{line: 1020, col: 8, offset: 29086},
+					pos:        position{line: 1013, col: 8, offset: 28975},
 					val:        "left",
 					ignoreCase: true,
 				},
@@ -8466,12 +8450,12 @@ var g = &grammar{
 		},
 		{
 			name: "RIGHT",
-			pos:  position{line: 1021, col: 1, offset: 29117},
+			pos:  position{line: 1014, col: 1, offset: 29006},
 			expr: &actionExpr{
-				pos: position{line: 1021, col: 9, offset: 29125},
+				pos: position{line: 1014, col: 9, offset: 29014},
 				run: (*parser).callonRIGHT1,
 				expr: &litMatcher{
-					pos:        position{line: 1021, col: 9, offset: 29125},
+					pos:        position{line: 1014, col: 9, offset: 29014},
 					val:        "right",
 					ignoreCase: true,
 				},
@@ -8479,12 +8463,12 @@ var g = &grammar{
 		},
 		{
 			name: "INNER",
-			pos:  position{line: 1022, col: 1, offset: 29158},
+			pos:  position{line: 1015, col: 1, offset: 29047},
 			expr: &actionExpr{
-				pos: position{line: 1022, col: 9, offset: 29166},
+				pos: position{line: 1015, col: 9, offset: 29055},
 				run: (*parser).callonINNER1,
 				expr: &litMatcher{
-					pos:        position{line: 1022, col: 9, offset: 29166},
+					pos:        position{line: 1015, col: 9, offset: 29055},
 					val:        "inner",
 					ignoreCase: true,
 				},
@@ -8492,48 +8476,48 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTokenSentinels",
-			pos:  position{line: 1024, col: 1, offset: 29200},
+			pos:  position{line: 1017, col: 1, offset: 29089},
 			expr: &choiceExpr{
-				pos: position{line: 1025, col: 5, offset: 29222},
+				pos: position{line: 1018, col: 5, offset: 29111},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1025, col: 5, offset: 29222},
+						pos:  position{line: 1018, col: 5, offset: 29111},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1025, col: 14, offset: 29231},
+						pos:  position{line: 1018, col: 14, offset: 29120},
 						name: "AS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1025, col: 19, offset: 29236},
+						pos:  position{line: 1018, col: 19, offset: 29125},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1025, col: 26, offset: 29243},
+						pos:  position{line: 1018, col: 26, offset: 29132},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1025, col: 33, offset: 29250},
+						pos:  position{line: 1018, col: 33, offset: 29139},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1025, col: 41, offset: 29258},
+						pos:  position{line: 1018, col: 41, offset: 29147},
 						name: "GROUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1025, col: 49, offset: 29266},
+						pos:  position{line: 1018, col: 49, offset: 29155},
 						name: "HAVING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1025, col: 58, offset: 29275},
+						pos:  position{line: 1018, col: 58, offset: 29164},
 						name: "ORDER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1025, col: 66, offset: 29283},
+						pos:  position{line: 1018, col: 66, offset: 29172},
 						name: "LIMIT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1025, col: 74, offset: 29291},
+						pos:  position{line: 1018, col: 74, offset: 29180},
 						name: "ON",
 					},
 				},
@@ -8541,52 +8525,52 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 1029, col: 1, offset: 29317},
+			pos:  position{line: 1022, col: 1, offset: 29206},
 			expr: &choiceExpr{
-				pos: position{line: 1030, col: 5, offset: 29329},
+				pos: position{line: 1023, col: 5, offset: 29218},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1030, col: 5, offset: 29329},
+						pos:  position{line: 1023, col: 5, offset: 29218},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1031, col: 5, offset: 29345},
+						pos:  position{line: 1024, col: 5, offset: 29234},
 						name: "TemplateLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1032, col: 5, offset: 29365},
+						pos:  position{line: 1025, col: 5, offset: 29254},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1033, col: 5, offset: 29383},
+						pos:  position{line: 1026, col: 5, offset: 29272},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1034, col: 5, offset: 29402},
+						pos:  position{line: 1027, col: 5, offset: 29291},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1035, col: 5, offset: 29419},
+						pos:  position{line: 1028, col: 5, offset: 29308},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1036, col: 5, offset: 29432},
+						pos:  position{line: 1029, col: 5, offset: 29321},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1037, col: 5, offset: 29441},
+						pos:  position{line: 1030, col: 5, offset: 29330},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1038, col: 5, offset: 29458},
+						pos:  position{line: 1031, col: 5, offset: 29347},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1039, col: 5, offset: 29477},
+						pos:  position{line: 1032, col: 5, offset: 29366},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1040, col: 5, offset: 29496},
+						pos:  position{line: 1033, col: 5, offset: 29385},
 						name: "NullLiteral",
 					},
 				},
@@ -8594,28 +8578,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 1042, col: 1, offset: 29509},
+			pos:  position{line: 1035, col: 1, offset: 29398},
 			expr: &choiceExpr{
-				pos: position{line: 1043, col: 5, offset: 29527},
+				pos: position{line: 1036, col: 5, offset: 29416},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1043, col: 5, offset: 29527},
+						pos: position{line: 1036, col: 5, offset: 29416},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1043, col: 5, offset: 29527},
+							pos: position{line: 1036, col: 5, offset: 29416},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1043, col: 5, offset: 29527},
+									pos:   position{line: 1036, col: 5, offset: 29416},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1043, col: 7, offset: 29529},
+										pos:  position{line: 1036, col: 7, offset: 29418},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1043, col: 14, offset: 29536},
+									pos: position{line: 1036, col: 14, offset: 29425},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1043, col: 15, offset: 29537},
+										pos:  position{line: 1036, col: 15, offset: 29426},
 										name: "IdentifierRest",
 									},
 								},
@@ -8623,13 +8607,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1046, col: 5, offset: 29652},
+						pos: position{line: 1039, col: 5, offset: 29541},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1046, col: 5, offset: 29652},
+							pos:   position{line: 1039, col: 5, offset: 29541},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1046, col: 7, offset: 29654},
+								pos:  position{line: 1039, col: 7, offset: 29543},
 								name: "IP4Net",
 							},
 						},
@@ -8639,28 +8623,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 1050, col: 1, offset: 29758},
+			pos:  position{line: 1043, col: 1, offset: 29647},
 			expr: &choiceExpr{
-				pos: position{line: 1051, col: 5, offset: 29777},
+				pos: position{line: 1044, col: 5, offset: 29666},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1051, col: 5, offset: 29777},
+						pos: position{line: 1044, col: 5, offset: 29666},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1051, col: 5, offset: 29777},
+							pos: position{line: 1044, col: 5, offset: 29666},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1051, col: 5, offset: 29777},
+									pos:   position{line: 1044, col: 5, offset: 29666},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1051, col: 7, offset: 29779},
+										pos:  position{line: 1044, col: 7, offset: 29668},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1051, col: 11, offset: 29783},
+									pos: position{line: 1044, col: 11, offset: 29672},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1051, col: 12, offset: 29784},
+										pos:  position{line: 1044, col: 12, offset: 29673},
 										name: "IdentifierRest",
 									},
 								},
@@ -8668,13 +8652,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1054, col: 5, offset: 29898},
+						pos: position{line: 1047, col: 5, offset: 29787},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1054, col: 5, offset: 29898},
+							pos:   position{line: 1047, col: 5, offset: 29787},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1054, col: 7, offset: 29900},
+								pos:  position{line: 1047, col: 7, offset: 29789},
 								name: "IP",
 							},
 						},
@@ -8684,15 +8668,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 1058, col: 1, offset: 29999},
+			pos:  position{line: 1051, col: 1, offset: 29888},
 			expr: &actionExpr{
-				pos: position{line: 1059, col: 5, offset: 30016},
+				pos: position{line: 1052, col: 5, offset: 29905},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1059, col: 5, offset: 30016},
+					pos:   position{line: 1052, col: 5, offset: 29905},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1059, col: 7, offset: 30018},
+						pos:  position{line: 1052, col: 7, offset: 29907},
 						name: "FloatString",
 					},
 				},
@@ -8700,15 +8684,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 1063, col: 1, offset: 30131},
+			pos:  position{line: 1056, col: 1, offset: 30020},
 			expr: &actionExpr{
-				pos: position{line: 1064, col: 5, offset: 30150},
+				pos: position{line: 1057, col: 5, offset: 30039},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1064, col: 5, offset: 30150},
+					pos:   position{line: 1057, col: 5, offset: 30039},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1064, col: 7, offset: 30152},
+						pos:  position{line: 1057, col: 7, offset: 30041},
 						name: "IntString",
 					},
 				},
@@ -8716,23 +8700,23 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 1068, col: 1, offset: 30261},
+			pos:  position{line: 1061, col: 1, offset: 30150},
 			expr: &choiceExpr{
-				pos: position{line: 1069, col: 5, offset: 30280},
+				pos: position{line: 1062, col: 5, offset: 30169},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1069, col: 5, offset: 30280},
+						pos: position{line: 1062, col: 5, offset: 30169},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1069, col: 5, offset: 30280},
+							pos:  position{line: 1062, col: 5, offset: 30169},
 							name: "TrueToken",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1070, col: 5, offset: 30387},
+						pos: position{line: 1063, col: 5, offset: 30276},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1070, col: 5, offset: 30387},
+							pos:  position{line: 1063, col: 5, offset: 30276},
 							name: "FalseToken",
 						},
 					},
@@ -8741,34 +8725,34 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 1072, col: 1, offset: 30492},
+			pos:  position{line: 1065, col: 1, offset: 30381},
 			expr: &actionExpr{
-				pos: position{line: 1073, col: 5, offset: 30508},
+				pos: position{line: 1066, col: 5, offset: 30397},
 				run: (*parser).callonNullLiteral1,
 				expr: &ruleRefExpr{
-					pos:  position{line: 1073, col: 5, offset: 30508},
+					pos:  position{line: 1066, col: 5, offset: 30397},
 					name: "NullToken",
 				},
 			},
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 1075, col: 1, offset: 30607},
+			pos:  position{line: 1068, col: 1, offset: 30496},
 			expr: &actionExpr{
-				pos: position{line: 1076, col: 5, offset: 30624},
+				pos: position{line: 1069, col: 5, offset: 30513},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1076, col: 5, offset: 30624},
+					pos: position{line: 1069, col: 5, offset: 30513},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1076, col: 5, offset: 30624},
+							pos:        position{line: 1069, col: 5, offset: 30513},
 							val:        "0x",
 							ignoreCase: false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1076, col: 10, offset: 30629},
+							pos: position{line: 1069, col: 10, offset: 30518},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1076, col: 10, offset: 30629},
+								pos:  position{line: 1069, col: 10, offset: 30518},
 								name: "HexDigit",
 							},
 						},
@@ -8778,28 +8762,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 1080, col: 1, offset: 30744},
+			pos:  position{line: 1073, col: 1, offset: 30633},
 			expr: &actionExpr{
-				pos: position{line: 1081, col: 5, offset: 30760},
+				pos: position{line: 1074, col: 5, offset: 30649},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1081, col: 5, offset: 30760},
+					pos: position{line: 1074, col: 5, offset: 30649},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1081, col: 5, offset: 30760},
+							pos:        position{line: 1074, col: 5, offset: 30649},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1081, col: 9, offset: 30764},
+							pos:   position{line: 1074, col: 9, offset: 30653},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1081, col: 13, offset: 30768},
+								pos:  position{line: 1074, col: 13, offset: 30657},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1081, col: 18, offset: 30773},
+							pos:        position{line: 1074, col: 18, offset: 30662},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -8809,20 +8793,20 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1085, col: 1, offset: 30862},
+			pos:  position{line: 1078, col: 1, offset: 30751},
 			expr: &choiceExpr{
-				pos: position{line: 1086, col: 5, offset: 30871},
+				pos: position{line: 1079, col: 5, offset: 30760},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1086, col: 5, offset: 30871},
+						pos:  position{line: 1079, col: 5, offset: 30760},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1087, col: 5, offset: 30887},
+						pos:  position{line: 1080, col: 5, offset: 30776},
 						name: "AmbiguousType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1088, col: 5, offset: 30905},
+						pos:  position{line: 1081, col: 5, offset: 30794},
 						name: "ComplexType",
 					},
 				},
@@ -8830,28 +8814,28 @@ var g = &grammar{
 		},
 		{
 			name: "AmbiguousType",
-			pos:  position{line: 1090, col: 1, offset: 30918},
+			pos:  position{line: 1083, col: 1, offset: 30807},
 			expr: &choiceExpr{
-				pos: position{line: 1091, col: 5, offset: 30936},
+				pos: position{line: 1084, col: 5, offset: 30825},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1091, col: 5, offset: 30936},
+						pos: position{line: 1084, col: 5, offset: 30825},
 						run: (*parser).callonAmbiguousType2,
 						expr: &seqExpr{
-							pos: position{line: 1091, col: 5, offset: 30936},
+							pos: position{line: 1084, col: 5, offset: 30825},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1091, col: 5, offset: 30936},
+									pos:   position{line: 1084, col: 5, offset: 30825},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1091, col: 10, offset: 30941},
+										pos:  position{line: 1084, col: 10, offset: 30830},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1091, col: 24, offset: 30955},
+									pos: position{line: 1084, col: 24, offset: 30844},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1091, col: 25, offset: 30956},
+										pos:  position{line: 1084, col: 25, offset: 30845},
 										name: "IdentifierRest",
 									},
 								},
@@ -8859,42 +8843,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1092, col: 5, offset: 30996},
+						pos: position{line: 1085, col: 5, offset: 30885},
 						run: (*parser).callonAmbiguousType8,
 						expr: &seqExpr{
-							pos: position{line: 1092, col: 5, offset: 30996},
+							pos: position{line: 1085, col: 5, offset: 30885},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1092, col: 5, offset: 30996},
+									pos:   position{line: 1085, col: 5, offset: 30885},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1092, col: 10, offset: 31001},
+										pos:  position{line: 1085, col: 10, offset: 30890},
 										name: "IdentifierName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1092, col: 25, offset: 31016},
+									pos:   position{line: 1085, col: 25, offset: 30905},
 									label: "opt",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1092, col: 29, offset: 31020},
+										pos: position{line: 1085, col: 29, offset: 30909},
 										expr: &seqExpr{
-											pos: position{line: 1092, col: 30, offset: 31021},
+											pos: position{line: 1085, col: 30, offset: 30910},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 1092, col: 30, offset: 31021},
+													pos:  position{line: 1085, col: 30, offset: 30910},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1092, col: 33, offset: 31024},
+													pos:        position{line: 1085, col: 33, offset: 30913},
 													val:        "=",
 													ignoreCase: false,
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1092, col: 37, offset: 31028},
+													pos:  position{line: 1085, col: 37, offset: 30917},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1092, col: 40, offset: 31031},
+													pos:  position{line: 1085, col: 40, offset: 30920},
 													name: "Type",
 												},
 											},
@@ -8905,42 +8889,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1098, col: 5, offset: 31263},
+						pos: position{line: 1091, col: 5, offset: 31152},
 						run: (*parser).callonAmbiguousType19,
 						expr: &labeledExpr{
-							pos:   position{line: 1098, col: 5, offset: 31263},
+							pos:   position{line: 1091, col: 5, offset: 31152},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1098, col: 10, offset: 31268},
+								pos:  position{line: 1091, col: 10, offset: 31157},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1101, col: 5, offset: 31368},
+						pos: position{line: 1094, col: 5, offset: 31257},
 						run: (*parser).callonAmbiguousType22,
 						expr: &seqExpr{
-							pos: position{line: 1101, col: 5, offset: 31368},
+							pos: position{line: 1094, col: 5, offset: 31257},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1101, col: 5, offset: 31368},
+									pos:        position{line: 1094, col: 5, offset: 31257},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1101, col: 9, offset: 31372},
+									pos:  position{line: 1094, col: 9, offset: 31261},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1101, col: 12, offset: 31375},
+									pos:   position{line: 1094, col: 12, offset: 31264},
 									label: "u",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1101, col: 14, offset: 31377},
+										pos:  position{line: 1094, col: 14, offset: 31266},
 										name: "TypeUnion",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1101, col: 24, offset: 31387},
+									pos:        position{line: 1094, col: 24, offset: 31276},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -8952,15 +8936,15 @@ var g = &grammar{
 		},
 		{
 			name: "TypeUnion",
-			pos:  position{line: 1103, col: 1, offset: 31410},
+			pos:  position{line: 1096, col: 1, offset: 31299},
 			expr: &actionExpr{
-				pos: position{line: 1104, col: 5, offset: 31424},
+				pos: position{line: 1097, col: 5, offset: 31313},
 				run: (*parser).callonTypeUnion1,
 				expr: &labeledExpr{
-					pos:   position{line: 1104, col: 5, offset: 31424},
+					pos:   position{line: 1097, col: 5, offset: 31313},
 					label: "types",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1104, col: 11, offset: 31430},
+						pos:  position{line: 1097, col: 11, offset: 31319},
 						name: "TypeList",
 					},
 				},
@@ -8968,28 +8952,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1108, col: 1, offset: 31526},
+			pos:  position{line: 1101, col: 1, offset: 31415},
 			expr: &actionExpr{
-				pos: position{line: 1109, col: 5, offset: 31539},
+				pos: position{line: 1102, col: 5, offset: 31428},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1109, col: 5, offset: 31539},
+					pos: position{line: 1102, col: 5, offset: 31428},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1109, col: 5, offset: 31539},
+							pos:   position{line: 1102, col: 5, offset: 31428},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1109, col: 11, offset: 31545},
+								pos:  position{line: 1102, col: 11, offset: 31434},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1109, col: 16, offset: 31550},
+							pos:   position{line: 1102, col: 16, offset: 31439},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1109, col: 21, offset: 31555},
+								pos: position{line: 1102, col: 21, offset: 31444},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1109, col: 21, offset: 31555},
+									pos:  position{line: 1102, col: 21, offset: 31444},
 									name: "TypeListTail",
 								},
 							},
@@ -9000,31 +8984,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1113, col: 1, offset: 31649},
+			pos:  position{line: 1106, col: 1, offset: 31538},
 			expr: &actionExpr{
-				pos: position{line: 1113, col: 16, offset: 31664},
+				pos: position{line: 1106, col: 16, offset: 31553},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1113, col: 16, offset: 31664},
+					pos: position{line: 1106, col: 16, offset: 31553},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1113, col: 16, offset: 31664},
+							pos:  position{line: 1106, col: 16, offset: 31553},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1113, col: 19, offset: 31667},
+							pos:        position{line: 1106, col: 19, offset: 31556},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1113, col: 23, offset: 31671},
+							pos:  position{line: 1106, col: 23, offset: 31560},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1113, col: 26, offset: 31674},
+							pos:   position{line: 1106, col: 26, offset: 31563},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1113, col: 30, offset: 31678},
+								pos:  position{line: 1106, col: 30, offset: 31567},
 								name: "Type",
 							},
 						},
@@ -9034,39 +9018,39 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 1115, col: 1, offset: 31704},
+			pos:  position{line: 1108, col: 1, offset: 31593},
 			expr: &choiceExpr{
-				pos: position{line: 1116, col: 5, offset: 31720},
+				pos: position{line: 1109, col: 5, offset: 31609},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1116, col: 5, offset: 31720},
+						pos: position{line: 1109, col: 5, offset: 31609},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 1116, col: 5, offset: 31720},
+							pos: position{line: 1109, col: 5, offset: 31609},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1116, col: 5, offset: 31720},
+									pos:        position{line: 1109, col: 5, offset: 31609},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1116, col: 9, offset: 31724},
+									pos:  position{line: 1109, col: 9, offset: 31613},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1116, col: 12, offset: 31727},
+									pos:   position{line: 1109, col: 12, offset: 31616},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1116, col: 19, offset: 31734},
+										pos:  position{line: 1109, col: 19, offset: 31623},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1116, col: 33, offset: 31748},
+									pos:  position{line: 1109, col: 33, offset: 31637},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1116, col: 36, offset: 31751},
+									pos:        position{line: 1109, col: 36, offset: 31640},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -9074,34 +9058,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1119, col: 5, offset: 31848},
+						pos: position{line: 1112, col: 5, offset: 31737},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 1119, col: 5, offset: 31848},
+							pos: position{line: 1112, col: 5, offset: 31737},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1119, col: 5, offset: 31848},
+									pos:        position{line: 1112, col: 5, offset: 31737},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1119, col: 9, offset: 31852},
+									pos:  position{line: 1112, col: 9, offset: 31741},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1119, col: 12, offset: 31855},
+									pos:   position{line: 1112, col: 12, offset: 31744},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1119, col: 16, offset: 31859},
+										pos:  position{line: 1112, col: 16, offset: 31748},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1119, col: 21, offset: 31864},
+									pos:  position{line: 1112, col: 21, offset: 31753},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1119, col: 24, offset: 31867},
+									pos:        position{line: 1112, col: 24, offset: 31756},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -9109,34 +9093,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1122, col: 5, offset: 31958},
+						pos: position{line: 1115, col: 5, offset: 31847},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 1122, col: 5, offset: 31958},
+							pos: position{line: 1115, col: 5, offset: 31847},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1122, col: 5, offset: 31958},
+									pos:        position{line: 1115, col: 5, offset: 31847},
 									val:        "|[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1122, col: 10, offset: 31963},
+									pos:  position{line: 1115, col: 10, offset: 31852},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1122, col: 13, offset: 31966},
+									pos:   position{line: 1115, col: 13, offset: 31855},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1122, col: 17, offset: 31970},
+										pos:  position{line: 1115, col: 17, offset: 31859},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1122, col: 22, offset: 31975},
+									pos:  position{line: 1115, col: 22, offset: 31864},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1122, col: 25, offset: 31978},
+									pos:        position{line: 1115, col: 25, offset: 31867},
 									val:        "]|",
 									ignoreCase: false,
 								},
@@ -9144,55 +9128,55 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1125, col: 5, offset: 32068},
+						pos: position{line: 1118, col: 5, offset: 31957},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 1125, col: 5, offset: 32068},
+							pos: position{line: 1118, col: 5, offset: 31957},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1125, col: 5, offset: 32068},
+									pos:        position{line: 1118, col: 5, offset: 31957},
 									val:        "|{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1125, col: 10, offset: 32073},
+									pos:  position{line: 1118, col: 10, offset: 31962},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1125, col: 13, offset: 32076},
+									pos:   position{line: 1118, col: 13, offset: 31965},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1125, col: 21, offset: 32084},
+										pos:  position{line: 1118, col: 21, offset: 31973},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1125, col: 26, offset: 32089},
+									pos:  position{line: 1118, col: 26, offset: 31978},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1125, col: 29, offset: 32092},
+									pos:        position{line: 1118, col: 29, offset: 31981},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1125, col: 33, offset: 32096},
+									pos:  position{line: 1118, col: 33, offset: 31985},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1125, col: 36, offset: 32099},
+									pos:   position{line: 1118, col: 36, offset: 31988},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1125, col: 44, offset: 32107},
+										pos:  position{line: 1118, col: 44, offset: 31996},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1125, col: 49, offset: 32112},
+									pos:  position{line: 1118, col: 49, offset: 32001},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1125, col: 52, offset: 32115},
+									pos:        position{line: 1118, col: 52, offset: 32004},
 									val:        "}|",
 									ignoreCase: false,
 								},
@@ -9204,15 +9188,15 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateLiteral",
-			pos:  position{line: 1129, col: 1, offset: 32231},
+			pos:  position{line: 1122, col: 1, offset: 32120},
 			expr: &actionExpr{
-				pos: position{line: 1130, col: 5, offset: 32251},
+				pos: position{line: 1123, col: 5, offset: 32140},
 				run: (*parser).callonTemplateLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1130, col: 5, offset: 32251},
+					pos:   position{line: 1123, col: 5, offset: 32140},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1130, col: 7, offset: 32253},
+						pos:  position{line: 1123, col: 7, offset: 32142},
 						name: "TemplateLiteralParts",
 					},
 				},
@@ -9220,34 +9204,34 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateLiteralParts",
-			pos:  position{line: 1137, col: 1, offset: 32469},
+			pos:  position{line: 1130, col: 1, offset: 32358},
 			expr: &choiceExpr{
-				pos: position{line: 1138, col: 5, offset: 32494},
+				pos: position{line: 1131, col: 5, offset: 32383},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1138, col: 5, offset: 32494},
+						pos: position{line: 1131, col: 5, offset: 32383},
 						run: (*parser).callonTemplateLiteralParts2,
 						expr: &seqExpr{
-							pos: position{line: 1138, col: 5, offset: 32494},
+							pos: position{line: 1131, col: 5, offset: 32383},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1138, col: 5, offset: 32494},
+									pos:        position{line: 1131, col: 5, offset: 32383},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1138, col: 9, offset: 32498},
+									pos:   position{line: 1131, col: 9, offset: 32387},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1138, col: 11, offset: 32500},
+										pos: position{line: 1131, col: 11, offset: 32389},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1138, col: 11, offset: 32500},
+											pos:  position{line: 1131, col: 11, offset: 32389},
 											name: "TemplateDoubleQuotedPart",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1138, col: 37, offset: 32526},
+									pos:        position{line: 1131, col: 37, offset: 32415},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -9255,29 +9239,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1139, col: 5, offset: 32552},
+						pos: position{line: 1132, col: 5, offset: 32441},
 						run: (*parser).callonTemplateLiteralParts9,
 						expr: &seqExpr{
-							pos: position{line: 1139, col: 5, offset: 32552},
+							pos: position{line: 1132, col: 5, offset: 32441},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1139, col: 5, offset: 32552},
+									pos:        position{line: 1132, col: 5, offset: 32441},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1139, col: 9, offset: 32556},
+									pos:   position{line: 1132, col: 9, offset: 32445},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1139, col: 11, offset: 32558},
+										pos: position{line: 1132, col: 11, offset: 32447},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1139, col: 11, offset: 32558},
+											pos:  position{line: 1132, col: 11, offset: 32447},
 											name: "TemplateSingleQuotedPart",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1139, col: 37, offset: 32584},
+									pos:        position{line: 1132, col: 37, offset: 32473},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -9289,24 +9273,24 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateDoubleQuotedPart",
-			pos:  position{line: 1141, col: 1, offset: 32607},
+			pos:  position{line: 1134, col: 1, offset: 32496},
 			expr: &choiceExpr{
-				pos: position{line: 1142, col: 5, offset: 32636},
+				pos: position{line: 1135, col: 5, offset: 32525},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1142, col: 5, offset: 32636},
+						pos:  position{line: 1135, col: 5, offset: 32525},
 						name: "TemplateExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1143, col: 5, offset: 32653},
+						pos: position{line: 1136, col: 5, offset: 32542},
 						run: (*parser).callonTemplateDoubleQuotedPart3,
 						expr: &labeledExpr{
-							pos:   position{line: 1143, col: 5, offset: 32653},
+							pos:   position{line: 1136, col: 5, offset: 32542},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1143, col: 7, offset: 32655},
+								pos: position{line: 1136, col: 7, offset: 32544},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1143, col: 7, offset: 32655},
+									pos:  position{line: 1136, col: 7, offset: 32544},
 									name: "TemplateDoubleQuotedChar",
 								},
 							},
@@ -9317,26 +9301,26 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateDoubleQuotedChar",
-			pos:  position{line: 1147, col: 1, offset: 32792},
+			pos:  position{line: 1140, col: 1, offset: 32681},
 			expr: &choiceExpr{
-				pos: position{line: 1148, col: 5, offset: 32821},
+				pos: position{line: 1141, col: 5, offset: 32710},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1148, col: 5, offset: 32821},
+						pos: position{line: 1141, col: 5, offset: 32710},
 						run: (*parser).callonTemplateDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1148, col: 5, offset: 32821},
+							pos: position{line: 1141, col: 5, offset: 32710},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1148, col: 5, offset: 32821},
+									pos:        position{line: 1141, col: 5, offset: 32710},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1148, col: 10, offset: 32826},
+									pos:   position{line: 1141, col: 10, offset: 32715},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1148, col: 12, offset: 32828},
+										pos:        position{line: 1141, col: 12, offset: 32717},
 										val:        "${",
 										ignoreCase: false,
 									},
@@ -9345,24 +9329,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1149, col: 5, offset: 32855},
+						pos: position{line: 1142, col: 5, offset: 32744},
 						run: (*parser).callonTemplateDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1149, col: 5, offset: 32855},
+							pos: position{line: 1142, col: 5, offset: 32744},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1149, col: 5, offset: 32855},
+									pos: position{line: 1142, col: 5, offset: 32744},
 									expr: &litMatcher{
-										pos:        position{line: 1149, col: 7, offset: 32857},
+										pos:        position{line: 1142, col: 7, offset: 32746},
 										val:        "${",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1149, col: 13, offset: 32863},
+									pos:   position{line: 1142, col: 13, offset: 32752},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1149, col: 15, offset: 32865},
+										pos:  position{line: 1142, col: 15, offset: 32754},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -9374,24 +9358,24 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateSingleQuotedPart",
-			pos:  position{line: 1151, col: 1, offset: 32901},
+			pos:  position{line: 1144, col: 1, offset: 32790},
 			expr: &choiceExpr{
-				pos: position{line: 1152, col: 5, offset: 32930},
+				pos: position{line: 1145, col: 5, offset: 32819},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1152, col: 5, offset: 32930},
+						pos:  position{line: 1145, col: 5, offset: 32819},
 						name: "TemplateExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1153, col: 5, offset: 32947},
+						pos: position{line: 1146, col: 5, offset: 32836},
 						run: (*parser).callonTemplateSingleQuotedPart3,
 						expr: &labeledExpr{
-							pos:   position{line: 1153, col: 5, offset: 32947},
+							pos:   position{line: 1146, col: 5, offset: 32836},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1153, col: 7, offset: 32949},
+								pos: position{line: 1146, col: 7, offset: 32838},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1153, col: 7, offset: 32949},
+									pos:  position{line: 1146, col: 7, offset: 32838},
 									name: "TemplateSingleQuotedChar",
 								},
 							},
@@ -9402,26 +9386,26 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateSingleQuotedChar",
-			pos:  position{line: 1157, col: 1, offset: 33086},
+			pos:  position{line: 1150, col: 1, offset: 32975},
 			expr: &choiceExpr{
-				pos: position{line: 1158, col: 5, offset: 33115},
+				pos: position{line: 1151, col: 5, offset: 33004},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1158, col: 5, offset: 33115},
+						pos: position{line: 1151, col: 5, offset: 33004},
 						run: (*parser).callonTemplateSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1158, col: 5, offset: 33115},
+							pos: position{line: 1151, col: 5, offset: 33004},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1158, col: 5, offset: 33115},
+									pos:        position{line: 1151, col: 5, offset: 33004},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1158, col: 10, offset: 33120},
+									pos:   position{line: 1151, col: 10, offset: 33009},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1158, col: 12, offset: 33122},
+										pos:        position{line: 1151, col: 12, offset: 33011},
 										val:        "${",
 										ignoreCase: false,
 									},
@@ -9430,24 +9414,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1159, col: 5, offset: 33149},
+						pos: position{line: 1152, col: 5, offset: 33038},
 						run: (*parser).callonTemplateSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1159, col: 5, offset: 33149},
+							pos: position{line: 1152, col: 5, offset: 33038},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1159, col: 5, offset: 33149},
+									pos: position{line: 1152, col: 5, offset: 33038},
 									expr: &litMatcher{
-										pos:        position{line: 1159, col: 7, offset: 33151},
+										pos:        position{line: 1152, col: 7, offset: 33040},
 										val:        "${",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1159, col: 13, offset: 33157},
+									pos:   position{line: 1152, col: 13, offset: 33046},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1159, col: 15, offset: 33159},
+										pos:  position{line: 1152, col: 15, offset: 33048},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -9459,36 +9443,36 @@ var g = &grammar{
 		},
 		{
 			name: "TemplateExpr",
-			pos:  position{line: 1161, col: 1, offset: 33195},
+			pos:  position{line: 1154, col: 1, offset: 33084},
 			expr: &actionExpr{
-				pos: position{line: 1162, col: 5, offset: 33212},
+				pos: position{line: 1155, col: 5, offset: 33101},
 				run: (*parser).callonTemplateExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1162, col: 5, offset: 33212},
+					pos: position{line: 1155, col: 5, offset: 33101},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1162, col: 5, offset: 33212},
+							pos:        position{line: 1155, col: 5, offset: 33101},
 							val:        "${",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1162, col: 10, offset: 33217},
+							pos:  position{line: 1155, col: 10, offset: 33106},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1162, col: 13, offset: 33220},
+							pos:   position{line: 1155, col: 13, offset: 33109},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1162, col: 15, offset: 33222},
+								pos:  position{line: 1155, col: 15, offset: 33111},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1162, col: 20, offset: 33227},
+							pos:  position{line: 1155, col: 20, offset: 33116},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1162, col: 23, offset: 33230},
+							pos:        position{line: 1155, col: 23, offset: 33119},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -9498,110 +9482,110 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1177, col: 1, offset: 33526},
+			pos:  position{line: 1170, col: 1, offset: 33415},
 			expr: &actionExpr{
-				pos: position{line: 1178, col: 5, offset: 33544},
+				pos: position{line: 1171, col: 5, offset: 33433},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1178, col: 9, offset: 33548},
+					pos: position{line: 1171, col: 9, offset: 33437},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1178, col: 9, offset: 33548},
+							pos:        position{line: 1171, col: 9, offset: 33437},
 							val:        "uint8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1178, col: 19, offset: 33558},
+							pos:        position{line: 1171, col: 19, offset: 33447},
 							val:        "uint16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1178, col: 30, offset: 33569},
+							pos:        position{line: 1171, col: 30, offset: 33458},
 							val:        "uint32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1178, col: 41, offset: 33580},
+							pos:        position{line: 1171, col: 41, offset: 33469},
 							val:        "uint64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1179, col: 9, offset: 33597},
+							pos:        position{line: 1172, col: 9, offset: 33486},
 							val:        "int8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1179, col: 18, offset: 33606},
+							pos:        position{line: 1172, col: 18, offset: 33495},
 							val:        "int16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1179, col: 28, offset: 33616},
+							pos:        position{line: 1172, col: 28, offset: 33505},
 							val:        "int32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1179, col: 38, offset: 33626},
+							pos:        position{line: 1172, col: 38, offset: 33515},
 							val:        "int64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1180, col: 9, offset: 33642},
+							pos:        position{line: 1173, col: 9, offset: 33531},
 							val:        "float16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1180, col: 21, offset: 33654},
+							pos:        position{line: 1173, col: 21, offset: 33543},
 							val:        "float32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1180, col: 33, offset: 33666},
+							pos:        position{line: 1173, col: 33, offset: 33555},
 							val:        "float64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1181, col: 9, offset: 33684},
+							pos:        position{line: 1174, col: 9, offset: 33573},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1181, col: 18, offset: 33693},
+							pos:        position{line: 1174, col: 18, offset: 33582},
 							val:        "string",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1182, col: 9, offset: 33710},
+							pos:        position{line: 1175, col: 9, offset: 33599},
 							val:        "duration",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1182, col: 22, offset: 33723},
+							pos:        position{line: 1175, col: 22, offset: 33612},
 							val:        "time",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1183, col: 9, offset: 33738},
+							pos:        position{line: 1176, col: 9, offset: 33627},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1184, col: 9, offset: 33754},
+							pos:        position{line: 1177, col: 9, offset: 33643},
 							val:        "ip",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1184, col: 16, offset: 33761},
+							pos:        position{line: 1177, col: 16, offset: 33650},
 							val:        "net",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1185, col: 9, offset: 33775},
+							pos:        position{line: 1178, col: 9, offset: 33664},
 							val:        "type",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1185, col: 18, offset: 33784},
+							pos:        position{line: 1178, col: 18, offset: 33673},
 							val:        "null",
 							ignoreCase: false,
 						},
@@ -9611,31 +9595,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1189, col: 1, offset: 33899},
+			pos:  position{line: 1182, col: 1, offset: 33788},
 			expr: &choiceExpr{
-				pos: position{line: 1190, col: 5, offset: 33917},
+				pos: position{line: 1183, col: 5, offset: 33806},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1190, col: 5, offset: 33917},
+						pos: position{line: 1183, col: 5, offset: 33806},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1190, col: 5, offset: 33917},
+							pos: position{line: 1183, col: 5, offset: 33806},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1190, col: 5, offset: 33917},
+									pos:   position{line: 1183, col: 5, offset: 33806},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1190, col: 11, offset: 33923},
+										pos:  position{line: 1183, col: 11, offset: 33812},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1190, col: 21, offset: 33933},
+									pos:   position{line: 1183, col: 21, offset: 33822},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1190, col: 26, offset: 33938},
+										pos: position{line: 1183, col: 26, offset: 33827},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1190, col: 26, offset: 33938},
+											pos:  position{line: 1183, col: 26, offset: 33827},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -9644,10 +9628,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1193, col: 5, offset: 34040},
+						pos: position{line: 1186, col: 5, offset: 33929},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1193, col: 5, offset: 34040},
+							pos:        position{line: 1186, col: 5, offset: 33929},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -9657,31 +9641,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1195, col: 1, offset: 34064},
+			pos:  position{line: 1188, col: 1, offset: 33953},
 			expr: &actionExpr{
-				pos: position{line: 1195, col: 21, offset: 34084},
+				pos: position{line: 1188, col: 21, offset: 33973},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1195, col: 21, offset: 34084},
+					pos: position{line: 1188, col: 21, offset: 33973},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1195, col: 21, offset: 34084},
+							pos:  position{line: 1188, col: 21, offset: 33973},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1195, col: 24, offset: 34087},
+							pos:        position{line: 1188, col: 24, offset: 33976},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1195, col: 28, offset: 34091},
+							pos:  position{line: 1188, col: 28, offset: 33980},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1195, col: 31, offset: 34094},
+							pos:   position{line: 1188, col: 31, offset: 33983},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1195, col: 35, offset: 34098},
+								pos:  position{line: 1188, col: 35, offset: 33987},
 								name: "TypeField",
 							},
 						},
@@ -9691,39 +9675,39 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1197, col: 1, offset: 34129},
+			pos:  position{line: 1190, col: 1, offset: 34018},
 			expr: &actionExpr{
-				pos: position{line: 1198, col: 5, offset: 34143},
+				pos: position{line: 1191, col: 5, offset: 34032},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1198, col: 5, offset: 34143},
+					pos: position{line: 1191, col: 5, offset: 34032},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1198, col: 5, offset: 34143},
+							pos:   position{line: 1191, col: 5, offset: 34032},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1198, col: 10, offset: 34148},
+								pos:  position{line: 1191, col: 10, offset: 34037},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1198, col: 20, offset: 34158},
+							pos:  position{line: 1191, col: 20, offset: 34047},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1198, col: 23, offset: 34161},
+							pos:        position{line: 1191, col: 23, offset: 34050},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1198, col: 27, offset: 34165},
+							pos:  position{line: 1191, col: 27, offset: 34054},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1198, col: 30, offset: 34168},
+							pos:   position{line: 1191, col: 30, offset: 34057},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1198, col: 34, offset: 34172},
+								pos:  position{line: 1191, col: 34, offset: 34061},
 								name: "Type",
 							},
 						},
@@ -9733,16 +9717,16 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 1202, col: 1, offset: 34254},
+			pos:  position{line: 1195, col: 1, offset: 34143},
 			expr: &choiceExpr{
-				pos: position{line: 1203, col: 5, offset: 34268},
+				pos: position{line: 1196, col: 5, offset: 34157},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1203, col: 5, offset: 34268},
+						pos:  position{line: 1196, col: 5, offset: 34157},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1204, col: 5, offset: 34287},
+						pos:  position{line: 1197, col: 5, offset: 34176},
 						name: "QuotedString",
 					},
 				},
@@ -9750,32 +9734,32 @@ var g = &grammar{
 		},
 		{
 			name: "AndToken",
-			pos:  position{line: 1206, col: 1, offset: 34301},
+			pos:  position{line: 1199, col: 1, offset: 34190},
 			expr: &actionExpr{
-				pos: position{line: 1206, col: 12, offset: 34312},
+				pos: position{line: 1199, col: 12, offset: 34201},
 				run: (*parser).callonAndToken1,
 				expr: &seqExpr{
-					pos: position{line: 1206, col: 12, offset: 34312},
+					pos: position{line: 1199, col: 12, offset: 34201},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 1206, col: 13, offset: 34313},
+							pos: position{line: 1199, col: 13, offset: 34202},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1206, col: 13, offset: 34313},
+									pos:        position{line: 1199, col: 13, offset: 34202},
 									val:        "and",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1206, col: 21, offset: 34321},
+									pos:        position{line: 1199, col: 21, offset: 34210},
 									val:        "AND",
 									ignoreCase: false,
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1206, col: 28, offset: 34328},
+							pos: position{line: 1199, col: 28, offset: 34217},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1206, col: 29, offset: 34329},
+								pos:  position{line: 1199, col: 29, offset: 34218},
 								name: "IdentifierRest",
 							},
 						},
@@ -9785,19 +9769,19 @@ var g = &grammar{
 		},
 		{
 			name: "ByToken",
-			pos:  position{line: 1207, col: 1, offset: 34366},
+			pos:  position{line: 1200, col: 1, offset: 34255},
 			expr: &seqExpr{
-				pos: position{line: 1207, col: 11, offset: 34376},
+				pos: position{line: 1200, col: 11, offset: 34265},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1207, col: 11, offset: 34376},
+						pos:        position{line: 1200, col: 11, offset: 34265},
 						val:        "by",
 						ignoreCase: false,
 					},
 					&notExpr{
-						pos: position{line: 1207, col: 16, offset: 34381},
+						pos: position{line: 1200, col: 16, offset: 34270},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1207, col: 17, offset: 34382},
+							pos:  position{line: 1200, col: 17, offset: 34271},
 							name: "IdentifierRest",
 						},
 					},
@@ -9806,19 +9790,19 @@ var g = &grammar{
 		},
 		{
 			name: "FalseToken",
-			pos:  position{line: 1208, col: 1, offset: 34397},
+			pos:  position{line: 1201, col: 1, offset: 34286},
 			expr: &seqExpr{
-				pos: position{line: 1208, col: 14, offset: 34410},
+				pos: position{line: 1201, col: 14, offset: 34299},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1208, col: 14, offset: 34410},
+						pos:        position{line: 1201, col: 14, offset: 34299},
 						val:        "false",
 						ignoreCase: false,
 					},
 					&notExpr{
-						pos: position{line: 1208, col: 22, offset: 34418},
+						pos: position{line: 1201, col: 22, offset: 34307},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1208, col: 23, offset: 34419},
+							pos:  position{line: 1201, col: 23, offset: 34308},
 							name: "IdentifierRest",
 						},
 					},
@@ -9827,19 +9811,19 @@ var g = &grammar{
 		},
 		{
 			name: "InToken",
-			pos:  position{line: 1209, col: 1, offset: 34434},
+			pos:  position{line: 1202, col: 1, offset: 34323},
 			expr: &seqExpr{
-				pos: position{line: 1209, col: 11, offset: 34444},
+				pos: position{line: 1202, col: 11, offset: 34333},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1209, col: 11, offset: 34444},
+						pos:        position{line: 1202, col: 11, offset: 34333},
 						val:        "in",
 						ignoreCase: false,
 					},
 					&notExpr{
-						pos: position{line: 1209, col: 16, offset: 34449},
+						pos: position{line: 1202, col: 16, offset: 34338},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1209, col: 17, offset: 34450},
+							pos:  position{line: 1202, col: 17, offset: 34339},
 							name: "IdentifierRest",
 						},
 					},
@@ -9848,32 +9832,32 @@ var g = &grammar{
 		},
 		{
 			name: "NotToken",
-			pos:  position{line: 1210, col: 1, offset: 34465},
+			pos:  position{line: 1203, col: 1, offset: 34354},
 			expr: &actionExpr{
-				pos: position{line: 1210, col: 12, offset: 34476},
+				pos: position{line: 1203, col: 12, offset: 34365},
 				run: (*parser).callonNotToken1,
 				expr: &seqExpr{
-					pos: position{line: 1210, col: 12, offset: 34476},
+					pos: position{line: 1203, col: 12, offset: 34365},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 1210, col: 13, offset: 34477},
+							pos: position{line: 1203, col: 13, offset: 34366},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1210, col: 13, offset: 34477},
+									pos:        position{line: 1203, col: 13, offset: 34366},
 									val:        "not",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1210, col: 21, offset: 34485},
+									pos:        position{line: 1203, col: 21, offset: 34374},
 									val:        "NOT",
 									ignoreCase: false,
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1210, col: 28, offset: 34492},
+							pos: position{line: 1203, col: 28, offset: 34381},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1210, col: 29, offset: 34493},
+								pos:  position{line: 1203, col: 29, offset: 34382},
 								name: "IdentifierRest",
 							},
 						},
@@ -9883,19 +9867,19 @@ var g = &grammar{
 		},
 		{
 			name: "NullToken",
-			pos:  position{line: 1211, col: 1, offset: 34530},
+			pos:  position{line: 1204, col: 1, offset: 34419},
 			expr: &seqExpr{
-				pos: position{line: 1211, col: 13, offset: 34542},
+				pos: position{line: 1204, col: 13, offset: 34431},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1211, col: 13, offset: 34542},
+						pos:        position{line: 1204, col: 13, offset: 34431},
 						val:        "null",
 						ignoreCase: false,
 					},
 					&notExpr{
-						pos: position{line: 1211, col: 20, offset: 34549},
+						pos: position{line: 1204, col: 20, offset: 34438},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1211, col: 21, offset: 34550},
+							pos:  position{line: 1204, col: 21, offset: 34439},
 							name: "IdentifierRest",
 						},
 					},
@@ -9904,32 +9888,32 @@ var g = &grammar{
 		},
 		{
 			name: "OrToken",
-			pos:  position{line: 1212, col: 1, offset: 34565},
+			pos:  position{line: 1205, col: 1, offset: 34454},
 			expr: &actionExpr{
-				pos: position{line: 1212, col: 11, offset: 34575},
+				pos: position{line: 1205, col: 11, offset: 34464},
 				run: (*parser).callonOrToken1,
 				expr: &seqExpr{
-					pos: position{line: 1212, col: 11, offset: 34575},
+					pos: position{line: 1205, col: 11, offset: 34464},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 1212, col: 12, offset: 34576},
+							pos: position{line: 1205, col: 12, offset: 34465},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1212, col: 12, offset: 34576},
+									pos:        position{line: 1205, col: 12, offset: 34465},
 									val:        "or",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1212, col: 19, offset: 34583},
+									pos:        position{line: 1205, col: 19, offset: 34472},
 									val:        "OR",
 									ignoreCase: false,
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1212, col: 25, offset: 34589},
+							pos: position{line: 1205, col: 25, offset: 34478},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1212, col: 26, offset: 34590},
+								pos:  position{line: 1205, col: 26, offset: 34479},
 								name: "IdentifierRest",
 							},
 						},
@@ -9939,19 +9923,19 @@ var g = &grammar{
 		},
 		{
 			name: "TrueToken",
-			pos:  position{line: 1213, col: 1, offset: 34626},
+			pos:  position{line: 1206, col: 1, offset: 34515},
 			expr: &seqExpr{
-				pos: position{line: 1213, col: 13, offset: 34638},
+				pos: position{line: 1206, col: 13, offset: 34527},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1213, col: 13, offset: 34638},
+						pos:        position{line: 1206, col: 13, offset: 34527},
 						val:        "true",
 						ignoreCase: false,
 					},
 					&notExpr{
-						pos: position{line: 1213, col: 20, offset: 34645},
+						pos: position{line: 1206, col: 20, offset: 34534},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1213, col: 21, offset: 34646},
+							pos:  position{line: 1206, col: 21, offset: 34535},
 							name: "IdentifierRest",
 						},
 					},
@@ -9960,15 +9944,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1215, col: 1, offset: 34662},
+			pos:  position{line: 1208, col: 1, offset: 34551},
 			expr: &actionExpr{
-				pos: position{line: 1216, col: 5, offset: 34677},
+				pos: position{line: 1209, col: 5, offset: 34566},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1216, col: 5, offset: 34677},
+					pos:   position{line: 1209, col: 5, offset: 34566},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1216, col: 8, offset: 34680},
+						pos:  position{line: 1209, col: 8, offset: 34569},
 						name: "IdentifierName",
 					},
 				},
@@ -9976,29 +9960,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1218, col: 1, offset: 34761},
+			pos:  position{line: 1211, col: 1, offset: 34650},
 			expr: &choiceExpr{
-				pos: position{line: 1219, col: 5, offset: 34780},
+				pos: position{line: 1212, col: 5, offset: 34669},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1219, col: 5, offset: 34780},
+						pos: position{line: 1212, col: 5, offset: 34669},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1219, col: 5, offset: 34780},
+							pos: position{line: 1212, col: 5, offset: 34669},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1219, col: 5, offset: 34780},
+									pos: position{line: 1212, col: 5, offset: 34669},
 									expr: &seqExpr{
-										pos: position{line: 1219, col: 7, offset: 34782},
+										pos: position{line: 1212, col: 7, offset: 34671},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1219, col: 7, offset: 34782},
+												pos:  position{line: 1212, col: 7, offset: 34671},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1219, col: 15, offset: 34790},
+												pos: position{line: 1212, col: 15, offset: 34679},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1219, col: 16, offset: 34791},
+													pos:  position{line: 1212, col: 16, offset: 34680},
 													name: "IdentifierRest",
 												},
 											},
@@ -10006,13 +9990,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1219, col: 32, offset: 34807},
+									pos:  position{line: 1212, col: 32, offset: 34696},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1219, col: 48, offset: 34823},
+									pos: position{line: 1212, col: 48, offset: 34712},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1219, col: 48, offset: 34823},
+										pos:  position{line: 1212, col: 48, offset: 34712},
 										name: "IdentifierRest",
 									},
 								},
@@ -10020,30 +10004,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1220, col: 5, offset: 34874},
+						pos: position{line: 1213, col: 5, offset: 34763},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 1220, col: 5, offset: 34874},
+							pos:        position{line: 1213, col: 5, offset: 34763},
 							val:        "$",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1221, col: 5, offset: 34913},
+						pos: position{line: 1214, col: 5, offset: 34802},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 1221, col: 5, offset: 34913},
+							pos: position{line: 1214, col: 5, offset: 34802},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1221, col: 5, offset: 34913},
+									pos:        position{line: 1214, col: 5, offset: 34802},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1221, col: 10, offset: 34918},
+									pos:   position{line: 1214, col: 10, offset: 34807},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1221, col: 13, offset: 34921},
+										pos:  position{line: 1214, col: 13, offset: 34810},
 										name: "IDGuard",
 									},
 								},
@@ -10051,39 +10035,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1223, col: 5, offset: 35012},
+						pos: position{line: 1216, col: 5, offset: 34901},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 1223, col: 5, offset: 35012},
+							pos:        position{line: 1216, col: 5, offset: 34901},
 							val:        "type",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1224, col: 5, offset: 35054},
+						pos: position{line: 1217, col: 5, offset: 34943},
 						run: (*parser).callonIdentifierName21,
 						expr: &seqExpr{
-							pos: position{line: 1224, col: 5, offset: 35054},
+							pos: position{line: 1217, col: 5, offset: 34943},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1224, col: 5, offset: 35054},
+									pos:   position{line: 1217, col: 5, offset: 34943},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1224, col: 8, offset: 35057},
+										pos:  position{line: 1217, col: 8, offset: 34946},
 										name: "SQLTokenSentinels",
 									},
 								},
 								&andExpr{
-									pos: position{line: 1224, col: 26, offset: 35075},
+									pos: position{line: 1217, col: 26, offset: 34964},
 									expr: &seqExpr{
-										pos: position{line: 1224, col: 28, offset: 35077},
+										pos: position{line: 1217, col: 28, offset: 34966},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1224, col: 28, offset: 35077},
+												pos:  position{line: 1217, col: 28, offset: 34966},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1224, col: 31, offset: 35080},
+												pos:        position{line: 1217, col: 31, offset: 34969},
 												val:        "(",
 												ignoreCase: false,
 											},
@@ -10098,50 +10082,50 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierNames",
-			pos:  position{line: 1226, col: 1, offset: 35105},
+			pos:  position{line: 1219, col: 1, offset: 34994},
 			expr: &actionExpr{
-				pos: position{line: 1227, col: 5, offset: 35125},
+				pos: position{line: 1220, col: 5, offset: 35014},
 				run: (*parser).callonIdentifierNames1,
 				expr: &seqExpr{
-					pos: position{line: 1227, col: 5, offset: 35125},
+					pos: position{line: 1220, col: 5, offset: 35014},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1227, col: 5, offset: 35125},
+							pos:   position{line: 1220, col: 5, offset: 35014},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1227, col: 11, offset: 35131},
+								pos:  position{line: 1220, col: 11, offset: 35020},
 								name: "IdentifierName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1227, col: 26, offset: 35146},
+							pos:   position{line: 1220, col: 26, offset: 35035},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1227, col: 31, offset: 35151},
+								pos: position{line: 1220, col: 31, offset: 35040},
 								expr: &actionExpr{
-									pos: position{line: 1227, col: 32, offset: 35152},
+									pos: position{line: 1220, col: 32, offset: 35041},
 									run: (*parser).callonIdentifierNames7,
 									expr: &seqExpr{
-										pos: position{line: 1227, col: 32, offset: 35152},
+										pos: position{line: 1220, col: 32, offset: 35041},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1227, col: 32, offset: 35152},
+												pos:  position{line: 1220, col: 32, offset: 35041},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1227, col: 35, offset: 35155},
+												pos:        position{line: 1220, col: 35, offset: 35044},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1227, col: 39, offset: 35159},
+												pos:  position{line: 1220, col: 39, offset: 35048},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1227, col: 42, offset: 35162},
+												pos:   position{line: 1220, col: 42, offset: 35051},
 												label: "id",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1227, col: 45, offset: 35165},
+													pos:  position{line: 1220, col: 45, offset: 35054},
 													name: "IdentifierName",
 												},
 											},
@@ -10156,21 +10140,21 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1231, col: 1, offset: 35281},
+			pos:  position{line: 1224, col: 1, offset: 35170},
 			expr: &choiceExpr{
-				pos: position{line: 1232, col: 5, offset: 35301},
+				pos: position{line: 1225, col: 5, offset: 35190},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1232, col: 5, offset: 35301},
+						pos:  position{line: 1225, col: 5, offset: 35190},
 						name: "UnicodeLetter",
 					},
 					&litMatcher{
-						pos:        position{line: 1233, col: 5, offset: 35319},
+						pos:        position{line: 1226, col: 5, offset: 35208},
 						val:        "$",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1234, col: 5, offset: 35327},
+						pos:        position{line: 1227, col: 5, offset: 35216},
 						val:        "_",
 						ignoreCase: false,
 					},
@@ -10179,24 +10163,24 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1236, col: 1, offset: 35332},
+			pos:  position{line: 1229, col: 1, offset: 35221},
 			expr: &choiceExpr{
-				pos: position{line: 1237, col: 5, offset: 35351},
+				pos: position{line: 1230, col: 5, offset: 35240},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1237, col: 5, offset: 35351},
+						pos:  position{line: 1230, col: 5, offset: 35240},
 						name: "IdentifierStart",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1238, col: 5, offset: 35371},
+						pos:  position{line: 1231, col: 5, offset: 35260},
 						name: "UnicodeCombiningMark",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1239, col: 5, offset: 35396},
+						pos:  position{line: 1232, col: 5, offset: 35285},
 						name: "UnicodeDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1240, col: 5, offset: 35413},
+						pos:  position{line: 1233, col: 5, offset: 35302},
 						name: "UnicodeConnectorPunctuation",
 					},
 				},
@@ -10204,24 +10188,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1242, col: 1, offset: 35442},
+			pos:  position{line: 1235, col: 1, offset: 35331},
 			expr: &choiceExpr{
-				pos: position{line: 1243, col: 5, offset: 35454},
+				pos: position{line: 1236, col: 5, offset: 35343},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1243, col: 5, offset: 35454},
+						pos:  position{line: 1236, col: 5, offset: 35343},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1244, col: 5, offset: 35473},
+						pos:  position{line: 1237, col: 5, offset: 35362},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1245, col: 5, offset: 35489},
+						pos:  position{line: 1238, col: 5, offset: 35378},
 						name: "NaN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1246, col: 5, offset: 35497},
+						pos:  position{line: 1239, col: 5, offset: 35386},
 						name: "Infinity",
 					},
 				},
@@ -10229,24 +10213,24 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1248, col: 1, offset: 35507},
+			pos:  position{line: 1241, col: 1, offset: 35396},
 			expr: &actionExpr{
-				pos: position{line: 1249, col: 5, offset: 35516},
+				pos: position{line: 1242, col: 5, offset: 35405},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1249, col: 5, offset: 35516},
+					pos: position{line: 1242, col: 5, offset: 35405},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1249, col: 5, offset: 35516},
+							pos:  position{line: 1242, col: 5, offset: 35405},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1249, col: 14, offset: 35525},
+							pos:        position{line: 1242, col: 14, offset: 35414},
 							val:        "T",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1249, col: 18, offset: 35529},
+							pos:  position{line: 1242, col: 18, offset: 35418},
 							name: "FullTime",
 						},
 					},
@@ -10255,30 +10239,30 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1253, col: 1, offset: 35649},
+			pos:  position{line: 1246, col: 1, offset: 35538},
 			expr: &seqExpr{
-				pos: position{line: 1253, col: 12, offset: 35660},
+				pos: position{line: 1246, col: 12, offset: 35549},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1253, col: 12, offset: 35660},
+						pos:  position{line: 1246, col: 12, offset: 35549},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1253, col: 15, offset: 35663},
+						pos:        position{line: 1246, col: 15, offset: 35552},
 						val:        "-",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1253, col: 19, offset: 35667},
+						pos:  position{line: 1246, col: 19, offset: 35556},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1253, col: 22, offset: 35670},
+						pos:        position{line: 1246, col: 22, offset: 35559},
 						val:        "-",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1253, col: 26, offset: 35674},
+						pos:  position{line: 1246, col: 26, offset: 35563},
 						name: "D2",
 					},
 				},
@@ -10286,33 +10270,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1255, col: 1, offset: 35678},
+			pos:  position{line: 1248, col: 1, offset: 35567},
 			expr: &seqExpr{
-				pos: position{line: 1255, col: 6, offset: 35683},
+				pos: position{line: 1248, col: 6, offset: 35572},
 				exprs: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1255, col: 6, offset: 35683},
+						pos:        position{line: 1248, col: 6, offset: 35572},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1255, col: 11, offset: 35688},
+						pos:        position{line: 1248, col: 11, offset: 35577},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1255, col: 16, offset: 35693},
+						pos:        position{line: 1248, col: 16, offset: 35582},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1255, col: 21, offset: 35698},
+						pos:        position{line: 1248, col: 21, offset: 35587},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10323,19 +10307,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1256, col: 1, offset: 35704},
+			pos:  position{line: 1249, col: 1, offset: 35593},
 			expr: &seqExpr{
-				pos: position{line: 1256, col: 6, offset: 35709},
+				pos: position{line: 1249, col: 6, offset: 35598},
 				exprs: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1256, col: 6, offset: 35709},
+						pos:        position{line: 1249, col: 6, offset: 35598},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1256, col: 11, offset: 35714},
+						pos:        position{line: 1249, col: 11, offset: 35603},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10346,16 +10330,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1258, col: 1, offset: 35721},
+			pos:  position{line: 1251, col: 1, offset: 35610},
 			expr: &seqExpr{
-				pos: position{line: 1258, col: 12, offset: 35732},
+				pos: position{line: 1251, col: 12, offset: 35621},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1258, col: 12, offset: 35732},
+						pos:  position{line: 1251, col: 12, offset: 35621},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1258, col: 24, offset: 35744},
+						pos:  position{line: 1251, col: 24, offset: 35633},
 						name: "TimeOffset",
 					},
 				},
@@ -10363,46 +10347,46 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1260, col: 1, offset: 35756},
+			pos:  position{line: 1253, col: 1, offset: 35645},
 			expr: &seqExpr{
-				pos: position{line: 1260, col: 15, offset: 35770},
+				pos: position{line: 1253, col: 15, offset: 35659},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1260, col: 15, offset: 35770},
+						pos:  position{line: 1253, col: 15, offset: 35659},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1260, col: 18, offset: 35773},
+						pos:        position{line: 1253, col: 18, offset: 35662},
 						val:        ":",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1260, col: 22, offset: 35777},
+						pos:  position{line: 1253, col: 22, offset: 35666},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1260, col: 25, offset: 35780},
+						pos:        position{line: 1253, col: 25, offset: 35669},
 						val:        ":",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1260, col: 29, offset: 35784},
+						pos:  position{line: 1253, col: 29, offset: 35673},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1260, col: 32, offset: 35787},
+						pos: position{line: 1253, col: 32, offset: 35676},
 						expr: &seqExpr{
-							pos: position{line: 1260, col: 33, offset: 35788},
+							pos: position{line: 1253, col: 33, offset: 35677},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1260, col: 33, offset: 35788},
+									pos:        position{line: 1253, col: 33, offset: 35677},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1260, col: 37, offset: 35792},
+									pos: position{line: 1253, col: 37, offset: 35681},
 									expr: &charClassMatcher{
-										pos:        position{line: 1260, col: 37, offset: 35792},
+										pos:        position{line: 1253, col: 37, offset: 35681},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10417,60 +10401,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1262, col: 1, offset: 35802},
+			pos:  position{line: 1255, col: 1, offset: 35691},
 			expr: &choiceExpr{
-				pos: position{line: 1263, col: 5, offset: 35817},
+				pos: position{line: 1256, col: 5, offset: 35706},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1263, col: 5, offset: 35817},
+						pos:        position{line: 1256, col: 5, offset: 35706},
 						val:        "Z",
 						ignoreCase: false,
 					},
 					&seqExpr{
-						pos: position{line: 1264, col: 5, offset: 35825},
+						pos: position{line: 1257, col: 5, offset: 35714},
 						exprs: []interface{}{
 							&choiceExpr{
-								pos: position{line: 1264, col: 6, offset: 35826},
+								pos: position{line: 1257, col: 6, offset: 35715},
 								alternatives: []interface{}{
 									&litMatcher{
-										pos:        position{line: 1264, col: 6, offset: 35826},
+										pos:        position{line: 1257, col: 6, offset: 35715},
 										val:        "+",
 										ignoreCase: false,
 									},
 									&litMatcher{
-										pos:        position{line: 1264, col: 12, offset: 35832},
+										pos:        position{line: 1257, col: 12, offset: 35721},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1264, col: 17, offset: 35837},
+								pos:  position{line: 1257, col: 17, offset: 35726},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1264, col: 20, offset: 35840},
+								pos:        position{line: 1257, col: 20, offset: 35729},
 								val:        ":",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1264, col: 24, offset: 35844},
+								pos:  position{line: 1257, col: 24, offset: 35733},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1264, col: 27, offset: 35847},
+								pos: position{line: 1257, col: 27, offset: 35736},
 								expr: &seqExpr{
-									pos: position{line: 1264, col: 28, offset: 35848},
+									pos: position{line: 1257, col: 28, offset: 35737},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1264, col: 28, offset: 35848},
+											pos:        position{line: 1257, col: 28, offset: 35737},
 											val:        ".",
 											ignoreCase: false,
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1264, col: 32, offset: 35852},
+											pos: position{line: 1257, col: 32, offset: 35741},
 											expr: &charClassMatcher{
-												pos:        position{line: 1264, col: 32, offset: 35852},
+												pos:        position{line: 1257, col: 32, offset: 35741},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -10487,32 +10471,32 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1266, col: 1, offset: 35862},
+			pos:  position{line: 1259, col: 1, offset: 35751},
 			expr: &actionExpr{
-				pos: position{line: 1267, col: 5, offset: 35875},
+				pos: position{line: 1260, col: 5, offset: 35764},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1267, col: 5, offset: 35875},
+					pos: position{line: 1260, col: 5, offset: 35764},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 1267, col: 5, offset: 35875},
+							pos: position{line: 1260, col: 5, offset: 35764},
 							expr: &litMatcher{
-								pos:        position{line: 1267, col: 5, offset: 35875},
+								pos:        position{line: 1260, col: 5, offset: 35764},
 								val:        "-",
 								ignoreCase: false,
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1267, col: 10, offset: 35880},
+							pos: position{line: 1260, col: 10, offset: 35769},
 							expr: &seqExpr{
-								pos: position{line: 1267, col: 11, offset: 35881},
+								pos: position{line: 1260, col: 11, offset: 35770},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1267, col: 11, offset: 35881},
+										pos:  position{line: 1260, col: 11, offset: 35770},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1267, col: 19, offset: 35889},
+										pos:  position{line: 1260, col: 19, offset: 35778},
 										name: "TimeUnit",
 									},
 								},
@@ -10524,26 +10508,26 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1271, col: 1, offset: 36015},
+			pos:  position{line: 1264, col: 1, offset: 35904},
 			expr: &seqExpr{
-				pos: position{line: 1271, col: 11, offset: 36025},
+				pos: position{line: 1264, col: 11, offset: 35914},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1271, col: 11, offset: 36025},
+						pos:  position{line: 1264, col: 11, offset: 35914},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1271, col: 16, offset: 36030},
+						pos: position{line: 1264, col: 16, offset: 35919},
 						expr: &seqExpr{
-							pos: position{line: 1271, col: 17, offset: 36031},
+							pos: position{line: 1264, col: 17, offset: 35920},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1271, col: 17, offset: 36031},
+									pos:        position{line: 1264, col: 17, offset: 35920},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1271, col: 21, offset: 36035},
+									pos:  position{line: 1264, col: 21, offset: 35924},
 									name: "UInt",
 								},
 							},
@@ -10554,52 +10538,52 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1273, col: 1, offset: 36043},
+			pos:  position{line: 1266, col: 1, offset: 35932},
 			expr: &choiceExpr{
-				pos: position{line: 1274, col: 5, offset: 36056},
+				pos: position{line: 1267, col: 5, offset: 35945},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1274, col: 5, offset: 36056},
+						pos:        position{line: 1267, col: 5, offset: 35945},
 						val:        "ns",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1275, col: 5, offset: 36065},
+						pos:        position{line: 1268, col: 5, offset: 35954},
 						val:        "us",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1276, col: 5, offset: 36074},
+						pos:        position{line: 1269, col: 5, offset: 35963},
 						val:        "ms",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1277, col: 5, offset: 36083},
+						pos:        position{line: 1270, col: 5, offset: 35972},
 						val:        "s",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1278, col: 5, offset: 36091},
+						pos:        position{line: 1271, col: 5, offset: 35980},
 						val:        "m",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1279, col: 5, offset: 36099},
+						pos:        position{line: 1272, col: 5, offset: 35988},
 						val:        "h",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1280, col: 5, offset: 36107},
+						pos:        position{line: 1273, col: 5, offset: 35996},
 						val:        "d",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1281, col: 5, offset: 36115},
+						pos:        position{line: 1274, col: 5, offset: 36004},
 						val:        "w",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1282, col: 5, offset: 36123},
+						pos:        position{line: 1275, col: 5, offset: 36012},
 						val:        "y",
 						ignoreCase: false,
 					},
@@ -10608,42 +10592,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1284, col: 1, offset: 36128},
+			pos:  position{line: 1277, col: 1, offset: 36017},
 			expr: &actionExpr{
-				pos: position{line: 1285, col: 5, offset: 36135},
+				pos: position{line: 1278, col: 5, offset: 36024},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1285, col: 5, offset: 36135},
+					pos: position{line: 1278, col: 5, offset: 36024},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1285, col: 5, offset: 36135},
+							pos:  position{line: 1278, col: 5, offset: 36024},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1285, col: 10, offset: 36140},
+							pos:        position{line: 1278, col: 10, offset: 36029},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1285, col: 14, offset: 36144},
+							pos:  position{line: 1278, col: 14, offset: 36033},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1285, col: 19, offset: 36149},
+							pos:        position{line: 1278, col: 19, offset: 36038},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1285, col: 23, offset: 36153},
+							pos:  position{line: 1278, col: 23, offset: 36042},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1285, col: 28, offset: 36158},
+							pos:        position{line: 1278, col: 28, offset: 36047},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1285, col: 32, offset: 36162},
+							pos:  position{line: 1278, col: 32, offset: 36051},
 							name: "UInt",
 						},
 					},
@@ -10652,42 +10636,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1287, col: 1, offset: 36199},
+			pos:  position{line: 1280, col: 1, offset: 36088},
 			expr: &actionExpr{
-				pos: position{line: 1288, col: 5, offset: 36207},
+				pos: position{line: 1281, col: 5, offset: 36096},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1288, col: 5, offset: 36207},
+					pos: position{line: 1281, col: 5, offset: 36096},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1288, col: 5, offset: 36207},
+							pos: position{line: 1281, col: 5, offset: 36096},
 							expr: &seqExpr{
-								pos: position{line: 1288, col: 7, offset: 36209},
+								pos: position{line: 1281, col: 7, offset: 36098},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1288, col: 7, offset: 36209},
+										pos:  position{line: 1281, col: 7, offset: 36098},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1288, col: 11, offset: 36213},
+										pos:        position{line: 1281, col: 11, offset: 36102},
 										val:        ":",
 										ignoreCase: false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1288, col: 15, offset: 36217},
+										pos:  position{line: 1281, col: 15, offset: 36106},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1288, col: 19, offset: 36221},
+										pos: position{line: 1281, col: 19, offset: 36110},
 										expr: &choiceExpr{
-											pos: position{line: 1288, col: 21, offset: 36223},
+											pos: position{line: 1281, col: 21, offset: 36112},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 1288, col: 21, offset: 36223},
+													pos:  position{line: 1281, col: 21, offset: 36112},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1288, col: 32, offset: 36234},
+													pos:        position{line: 1281, col: 32, offset: 36123},
 													val:        ":",
 													ignoreCase: false,
 												},
@@ -10698,10 +10682,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1288, col: 38, offset: 36240},
+							pos:   position{line: 1281, col: 38, offset: 36129},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1288, col: 40, offset: 36242},
+								pos:  position{line: 1281, col: 40, offset: 36131},
 								name: "IP6Variations",
 							},
 						},
@@ -10711,32 +10695,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1292, col: 1, offset: 36406},
+			pos:  position{line: 1285, col: 1, offset: 36295},
 			expr: &choiceExpr{
-				pos: position{line: 1293, col: 5, offset: 36424},
+				pos: position{line: 1286, col: 5, offset: 36313},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1293, col: 5, offset: 36424},
+						pos: position{line: 1286, col: 5, offset: 36313},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1293, col: 5, offset: 36424},
+							pos: position{line: 1286, col: 5, offset: 36313},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1293, col: 5, offset: 36424},
+									pos:   position{line: 1286, col: 5, offset: 36313},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1293, col: 7, offset: 36426},
+										pos: position{line: 1286, col: 7, offset: 36315},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1293, col: 7, offset: 36426},
+											pos:  position{line: 1286, col: 7, offset: 36315},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1293, col: 17, offset: 36436},
+									pos:   position{line: 1286, col: 17, offset: 36325},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1293, col: 19, offset: 36438},
+										pos:  position{line: 1286, col: 19, offset: 36327},
 										name: "IP6Tail",
 									},
 								},
@@ -10744,51 +10728,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1296, col: 5, offset: 36502},
+						pos: position{line: 1289, col: 5, offset: 36391},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1296, col: 5, offset: 36502},
+							pos: position{line: 1289, col: 5, offset: 36391},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1296, col: 5, offset: 36502},
+									pos:   position{line: 1289, col: 5, offset: 36391},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1296, col: 7, offset: 36504},
+										pos:  position{line: 1289, col: 7, offset: 36393},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1296, col: 11, offset: 36508},
+									pos:   position{line: 1289, col: 11, offset: 36397},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1296, col: 13, offset: 36510},
+										pos: position{line: 1289, col: 13, offset: 36399},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1296, col: 13, offset: 36510},
+											pos:  position{line: 1289, col: 13, offset: 36399},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1296, col: 23, offset: 36520},
+									pos:        position{line: 1289, col: 23, offset: 36409},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1296, col: 28, offset: 36525},
+									pos:   position{line: 1289, col: 28, offset: 36414},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1296, col: 30, offset: 36527},
+										pos: position{line: 1289, col: 30, offset: 36416},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1296, col: 30, offset: 36527},
+											pos:  position{line: 1289, col: 30, offset: 36416},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1296, col: 40, offset: 36537},
+									pos:   position{line: 1289, col: 40, offset: 36426},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1296, col: 42, offset: 36539},
+										pos:  position{line: 1289, col: 42, offset: 36428},
 										name: "IP6Tail",
 									},
 								},
@@ -10796,32 +10780,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1299, col: 5, offset: 36638},
+						pos: position{line: 1292, col: 5, offset: 36527},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1299, col: 5, offset: 36638},
+							pos: position{line: 1292, col: 5, offset: 36527},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1299, col: 5, offset: 36638},
+									pos:        position{line: 1292, col: 5, offset: 36527},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1299, col: 10, offset: 36643},
+									pos:   position{line: 1292, col: 10, offset: 36532},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1299, col: 12, offset: 36645},
+										pos: position{line: 1292, col: 12, offset: 36534},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1299, col: 12, offset: 36645},
+											pos:  position{line: 1292, col: 12, offset: 36534},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1299, col: 22, offset: 36655},
+									pos:   position{line: 1292, col: 22, offset: 36544},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1299, col: 24, offset: 36657},
+										pos:  position{line: 1292, col: 24, offset: 36546},
 										name: "IP6Tail",
 									},
 								},
@@ -10829,32 +10813,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1302, col: 5, offset: 36728},
+						pos: position{line: 1295, col: 5, offset: 36617},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1302, col: 5, offset: 36728},
+							pos: position{line: 1295, col: 5, offset: 36617},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1302, col: 5, offset: 36728},
+									pos:   position{line: 1295, col: 5, offset: 36617},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1302, col: 7, offset: 36730},
+										pos:  position{line: 1295, col: 7, offset: 36619},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1302, col: 11, offset: 36734},
+									pos:   position{line: 1295, col: 11, offset: 36623},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1302, col: 13, offset: 36736},
+										pos: position{line: 1295, col: 13, offset: 36625},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1302, col: 13, offset: 36736},
+											pos:  position{line: 1295, col: 13, offset: 36625},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1302, col: 23, offset: 36746},
+									pos:        position{line: 1295, col: 23, offset: 36635},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -10862,10 +10846,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1305, col: 5, offset: 36814},
+						pos: position{line: 1298, col: 5, offset: 36703},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 1305, col: 5, offset: 36814},
+							pos:        position{line: 1298, col: 5, offset: 36703},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -10875,16 +10859,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1309, col: 1, offset: 36851},
+			pos:  position{line: 1302, col: 1, offset: 36740},
 			expr: &choiceExpr{
-				pos: position{line: 1310, col: 5, offset: 36863},
+				pos: position{line: 1303, col: 5, offset: 36752},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1310, col: 5, offset: 36863},
+						pos:  position{line: 1303, col: 5, offset: 36752},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1311, col: 5, offset: 36870},
+						pos:  position{line: 1304, col: 5, offset: 36759},
 						name: "Hex",
 					},
 				},
@@ -10892,23 +10876,23 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1313, col: 1, offset: 36875},
+			pos:  position{line: 1306, col: 1, offset: 36764},
 			expr: &actionExpr{
-				pos: position{line: 1313, col: 12, offset: 36886},
+				pos: position{line: 1306, col: 12, offset: 36775},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1313, col: 12, offset: 36886},
+					pos: position{line: 1306, col: 12, offset: 36775},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1313, col: 12, offset: 36886},
+							pos:        position{line: 1306, col: 12, offset: 36775},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1313, col: 16, offset: 36890},
+							pos:   position{line: 1306, col: 16, offset: 36779},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1313, col: 18, offset: 36892},
+								pos:  position{line: 1306, col: 18, offset: 36781},
 								name: "Hex",
 							},
 						},
@@ -10918,23 +10902,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1315, col: 1, offset: 36930},
+			pos:  position{line: 1308, col: 1, offset: 36819},
 			expr: &actionExpr{
-				pos: position{line: 1315, col: 12, offset: 36941},
+				pos: position{line: 1308, col: 12, offset: 36830},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1315, col: 12, offset: 36941},
+					pos: position{line: 1308, col: 12, offset: 36830},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1315, col: 12, offset: 36941},
+							pos:   position{line: 1308, col: 12, offset: 36830},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1315, col: 14, offset: 36943},
+								pos:  position{line: 1308, col: 14, offset: 36832},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1315, col: 18, offset: 36947},
+							pos:        position{line: 1308, col: 18, offset: 36836},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -10944,31 +10928,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1317, col: 1, offset: 36985},
+			pos:  position{line: 1310, col: 1, offset: 36874},
 			expr: &actionExpr{
-				pos: position{line: 1318, col: 5, offset: 36996},
+				pos: position{line: 1311, col: 5, offset: 36885},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1318, col: 5, offset: 36996},
+					pos: position{line: 1311, col: 5, offset: 36885},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1318, col: 5, offset: 36996},
+							pos:   position{line: 1311, col: 5, offset: 36885},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1318, col: 7, offset: 36998},
+								pos:  position{line: 1311, col: 7, offset: 36887},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1318, col: 10, offset: 37001},
+							pos:        position{line: 1311, col: 10, offset: 36890},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1318, col: 14, offset: 37005},
+							pos:   position{line: 1311, col: 14, offset: 36894},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1318, col: 16, offset: 37007},
+								pos:  position{line: 1311, col: 16, offset: 36896},
 								name: "UInt",
 							},
 						},
@@ -10978,31 +10962,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1322, col: 1, offset: 37080},
+			pos:  position{line: 1315, col: 1, offset: 36969},
 			expr: &actionExpr{
-				pos: position{line: 1323, col: 5, offset: 37091},
+				pos: position{line: 1316, col: 5, offset: 36980},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1323, col: 5, offset: 37091},
+					pos: position{line: 1316, col: 5, offset: 36980},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1323, col: 5, offset: 37091},
+							pos:   position{line: 1316, col: 5, offset: 36980},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1323, col: 7, offset: 37093},
+								pos:  position{line: 1316, col: 7, offset: 36982},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1323, col: 11, offset: 37097},
+							pos:        position{line: 1316, col: 11, offset: 36986},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1323, col: 15, offset: 37101},
+							pos:   position{line: 1316, col: 15, offset: 36990},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1323, col: 17, offset: 37103},
+								pos:  position{line: 1316, col: 17, offset: 36992},
 								name: "UInt",
 							},
 						},
@@ -11012,15 +10996,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1327, col: 1, offset: 37166},
+			pos:  position{line: 1320, col: 1, offset: 37055},
 			expr: &actionExpr{
-				pos: position{line: 1328, col: 4, offset: 37174},
+				pos: position{line: 1321, col: 4, offset: 37063},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1328, col: 4, offset: 37174},
+					pos:   position{line: 1321, col: 4, offset: 37063},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1328, col: 6, offset: 37176},
+						pos:  position{line: 1321, col: 6, offset: 37065},
 						name: "UIntString",
 					},
 				},
@@ -11028,16 +11012,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1330, col: 1, offset: 37216},
+			pos:  position{line: 1323, col: 1, offset: 37105},
 			expr: &choiceExpr{
-				pos: position{line: 1331, col: 5, offset: 37230},
+				pos: position{line: 1324, col: 5, offset: 37119},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1331, col: 5, offset: 37230},
+						pos:  position{line: 1324, col: 5, offset: 37119},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1332, col: 5, offset: 37245},
+						pos:  position{line: 1325, col: 5, offset: 37134},
 						name: "MinusIntString",
 					},
 				},
@@ -11045,14 +11029,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1334, col: 1, offset: 37261},
+			pos:  position{line: 1327, col: 1, offset: 37150},
 			expr: &actionExpr{
-				pos: position{line: 1334, col: 14, offset: 37274},
+				pos: position{line: 1327, col: 14, offset: 37163},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1334, col: 14, offset: 37274},
+					pos: position{line: 1327, col: 14, offset: 37163},
 					expr: &charClassMatcher{
-						pos:        position{line: 1334, col: 14, offset: 37274},
+						pos:        position{line: 1327, col: 14, offset: 37163},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11063,20 +11047,20 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1336, col: 1, offset: 37313},
+			pos:  position{line: 1329, col: 1, offset: 37202},
 			expr: &actionExpr{
-				pos: position{line: 1337, col: 5, offset: 37332},
+				pos: position{line: 1330, col: 5, offset: 37221},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1337, col: 5, offset: 37332},
+					pos: position{line: 1330, col: 5, offset: 37221},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1337, col: 5, offset: 37332},
+							pos:        position{line: 1330, col: 5, offset: 37221},
 							val:        "-",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1337, col: 9, offset: 37336},
+							pos:  position{line: 1330, col: 9, offset: 37225},
 							name: "UIntString",
 						},
 					},
@@ -11085,28 +11069,28 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1339, col: 1, offset: 37379},
+			pos:  position{line: 1332, col: 1, offset: 37268},
 			expr: &choiceExpr{
-				pos: position{line: 1340, col: 5, offset: 37395},
+				pos: position{line: 1333, col: 5, offset: 37284},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1340, col: 5, offset: 37395},
+						pos: position{line: 1333, col: 5, offset: 37284},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1340, col: 5, offset: 37395},
+							pos: position{line: 1333, col: 5, offset: 37284},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1340, col: 5, offset: 37395},
+									pos: position{line: 1333, col: 5, offset: 37284},
 									expr: &litMatcher{
-										pos:        position{line: 1340, col: 5, offset: 37395},
+										pos:        position{line: 1333, col: 5, offset: 37284},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1340, col: 10, offset: 37400},
+									pos: position{line: 1333, col: 10, offset: 37289},
 									expr: &charClassMatcher{
-										pos:        position{line: 1340, col: 10, offset: 37400},
+										pos:        position{line: 1333, col: 10, offset: 37289},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11114,14 +11098,14 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1340, col: 17, offset: 37407},
+									pos:        position{line: 1333, col: 17, offset: 37296},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1340, col: 21, offset: 37411},
+									pos: position{line: 1333, col: 21, offset: 37300},
 									expr: &charClassMatcher{
-										pos:        position{line: 1340, col: 21, offset: 37411},
+										pos:        position{line: 1333, col: 21, offset: 37300},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11129,9 +11113,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1340, col: 28, offset: 37418},
+									pos: position{line: 1333, col: 28, offset: 37307},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1340, col: 28, offset: 37418},
+										pos:  position{line: 1333, col: 28, offset: 37307},
 										name: "ExponentPart",
 									},
 								},
@@ -11139,28 +11123,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1343, col: 5, offset: 37477},
+						pos: position{line: 1336, col: 5, offset: 37366},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1343, col: 5, offset: 37477},
+							pos: position{line: 1336, col: 5, offset: 37366},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 1343, col: 5, offset: 37477},
+									pos: position{line: 1336, col: 5, offset: 37366},
 									expr: &litMatcher{
-										pos:        position{line: 1343, col: 5, offset: 37477},
+										pos:        position{line: 1336, col: 5, offset: 37366},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1343, col: 10, offset: 37482},
+									pos:        position{line: 1336, col: 10, offset: 37371},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1343, col: 14, offset: 37486},
+									pos: position{line: 1336, col: 14, offset: 37375},
 									expr: &charClassMatcher{
-										pos:        position{line: 1343, col: 14, offset: 37486},
+										pos:        position{line: 1336, col: 14, offset: 37375},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11168,9 +11152,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1343, col: 21, offset: 37493},
+									pos: position{line: 1336, col: 21, offset: 37382},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1343, col: 21, offset: 37493},
+										pos:  position{line: 1336, col: 21, offset: 37382},
 										name: "ExponentPart",
 									},
 								},
@@ -11178,17 +11162,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1346, col: 5, offset: 37552},
+						pos: position{line: 1339, col: 5, offset: 37441},
 						run: (*parser).callonFloatString22,
 						expr: &choiceExpr{
-							pos: position{line: 1346, col: 6, offset: 37553},
+							pos: position{line: 1339, col: 6, offset: 37442},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1346, col: 6, offset: 37553},
+									pos:  position{line: 1339, col: 6, offset: 37442},
 									name: "NaN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1346, col: 12, offset: 37559},
+									pos:  position{line: 1339, col: 12, offset: 37448},
 									name: "Infinity",
 								},
 							},
@@ -11199,19 +11183,19 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1349, col: 1, offset: 37602},
+			pos:  position{line: 1342, col: 1, offset: 37491},
 			expr: &seqExpr{
-				pos: position{line: 1349, col: 16, offset: 37617},
+				pos: position{line: 1342, col: 16, offset: 37506},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1349, col: 16, offset: 37617},
+						pos:        position{line: 1342, col: 16, offset: 37506},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1349, col: 21, offset: 37622},
+						pos: position{line: 1342, col: 21, offset: 37511},
 						expr: &charClassMatcher{
-							pos:        position{line: 1349, col: 21, offset: 37622},
+							pos:        position{line: 1342, col: 21, offset: 37511},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -11219,7 +11203,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1349, col: 27, offset: 37628},
+						pos:  position{line: 1342, col: 27, offset: 37517},
 						name: "UIntString",
 					},
 				},
@@ -11227,31 +11211,31 @@ var g = &grammar{
 		},
 		{
 			name: "NaN",
-			pos:  position{line: 1351, col: 1, offset: 37640},
+			pos:  position{line: 1344, col: 1, offset: 37529},
 			expr: &litMatcher{
-				pos:        position{line: 1351, col: 7, offset: 37646},
+				pos:        position{line: 1344, col: 7, offset: 37535},
 				val:        "NaN",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "Infinity",
-			pos:  position{line: 1353, col: 1, offset: 37653},
+			pos:  position{line: 1346, col: 1, offset: 37542},
 			expr: &seqExpr{
-				pos: position{line: 1353, col: 12, offset: 37664},
+				pos: position{line: 1346, col: 12, offset: 37553},
 				exprs: []interface{}{
 					&zeroOrOneExpr{
-						pos: position{line: 1353, col: 12, offset: 37664},
+						pos: position{line: 1346, col: 12, offset: 37553},
 						expr: &choiceExpr{
-							pos: position{line: 1353, col: 13, offset: 37665},
+							pos: position{line: 1346, col: 13, offset: 37554},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1353, col: 13, offset: 37665},
+									pos:        position{line: 1346, col: 13, offset: 37554},
 									val:        "-",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1353, col: 19, offset: 37671},
+									pos:        position{line: 1346, col: 19, offset: 37560},
 									val:        "+",
 									ignoreCase: false,
 								},
@@ -11259,7 +11243,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1353, col: 25, offset: 37677},
+						pos:        position{line: 1346, col: 25, offset: 37566},
 						val:        "Inf",
 						ignoreCase: false,
 					},
@@ -11268,14 +11252,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1355, col: 1, offset: 37684},
+			pos:  position{line: 1348, col: 1, offset: 37573},
 			expr: &actionExpr{
-				pos: position{line: 1355, col: 7, offset: 37690},
+				pos: position{line: 1348, col: 7, offset: 37579},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1355, col: 7, offset: 37690},
+					pos: position{line: 1348, col: 7, offset: 37579},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1355, col: 7, offset: 37690},
+						pos:  position{line: 1348, col: 7, offset: 37579},
 						name: "HexDigit",
 					},
 				},
@@ -11283,9 +11267,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1357, col: 1, offset: 37732},
+			pos:  position{line: 1350, col: 1, offset: 37621},
 			expr: &charClassMatcher{
-				pos:        position{line: 1357, col: 12, offset: 37743},
+				pos:        position{line: 1350, col: 12, offset: 37632},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -11294,34 +11278,34 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1359, col: 1, offset: 37756},
+			pos:  position{line: 1352, col: 1, offset: 37645},
 			expr: &choiceExpr{
-				pos: position{line: 1360, col: 5, offset: 37773},
+				pos: position{line: 1353, col: 5, offset: 37662},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1360, col: 5, offset: 37773},
+						pos: position{line: 1353, col: 5, offset: 37662},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 1360, col: 5, offset: 37773},
+							pos: position{line: 1353, col: 5, offset: 37662},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1360, col: 5, offset: 37773},
+									pos:        position{line: 1353, col: 5, offset: 37662},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1360, col: 9, offset: 37777},
+									pos:   position{line: 1353, col: 9, offset: 37666},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1360, col: 11, offset: 37779},
+										pos: position{line: 1353, col: 11, offset: 37668},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1360, col: 11, offset: 37779},
+											pos:  position{line: 1353, col: 11, offset: 37668},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1360, col: 29, offset: 37797},
+									pos:        position{line: 1353, col: 29, offset: 37686},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -11329,29 +11313,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1361, col: 5, offset: 37834},
+						pos: position{line: 1354, col: 5, offset: 37723},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 1361, col: 5, offset: 37834},
+							pos: position{line: 1354, col: 5, offset: 37723},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1361, col: 5, offset: 37834},
+									pos:        position{line: 1354, col: 5, offset: 37723},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1361, col: 9, offset: 37838},
+									pos:   position{line: 1354, col: 9, offset: 37727},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1361, col: 11, offset: 37840},
+										pos: position{line: 1354, col: 11, offset: 37729},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1361, col: 11, offset: 37840},
+											pos:  position{line: 1354, col: 11, offset: 37729},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1361, col: 29, offset: 37858},
+									pos:        position{line: 1354, col: 29, offset: 37747},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -11363,55 +11347,55 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1363, col: 1, offset: 37892},
+			pos:  position{line: 1356, col: 1, offset: 37781},
 			expr: &choiceExpr{
-				pos: position{line: 1364, col: 5, offset: 37913},
+				pos: position{line: 1357, col: 5, offset: 37802},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1364, col: 5, offset: 37913},
+						pos: position{line: 1357, col: 5, offset: 37802},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1364, col: 5, offset: 37913},
+							pos: position{line: 1357, col: 5, offset: 37802},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1364, col: 5, offset: 37913},
+									pos: position{line: 1357, col: 5, offset: 37802},
 									expr: &choiceExpr{
-										pos: position{line: 1364, col: 7, offset: 37915},
+										pos: position{line: 1357, col: 7, offset: 37804},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1364, col: 7, offset: 37915},
+												pos:        position{line: 1357, col: 7, offset: 37804},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1364, col: 13, offset: 37921},
+												pos:  position{line: 1357, col: 13, offset: 37810},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1364, col: 26, offset: 37934,
+									line: 1357, col: 26, offset: 37823,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1365, col: 5, offset: 37971},
+						pos: position{line: 1358, col: 5, offset: 37860},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1365, col: 5, offset: 37971},
+							pos: position{line: 1358, col: 5, offset: 37860},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1365, col: 5, offset: 37971},
+									pos:        position{line: 1358, col: 5, offset: 37860},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1365, col: 10, offset: 37976},
+									pos:   position{line: 1358, col: 10, offset: 37865},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1365, col: 12, offset: 37978},
+										pos:  position{line: 1358, col: 12, offset: 37867},
 										name: "EscapeSequence",
 									},
 								},
@@ -11423,28 +11407,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1367, col: 1, offset: 38012},
+			pos:  position{line: 1360, col: 1, offset: 37901},
 			expr: &actionExpr{
-				pos: position{line: 1368, col: 5, offset: 38024},
+				pos: position{line: 1361, col: 5, offset: 37913},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1368, col: 5, offset: 38024},
+					pos: position{line: 1361, col: 5, offset: 37913},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1368, col: 5, offset: 38024},
+							pos:   position{line: 1361, col: 5, offset: 37913},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1368, col: 10, offset: 38029},
+								pos:  position{line: 1361, col: 10, offset: 37918},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1368, col: 23, offset: 38042},
+							pos:   position{line: 1361, col: 23, offset: 37931},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1368, col: 28, offset: 38047},
+								pos: position{line: 1361, col: 28, offset: 37936},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1368, col: 28, offset: 38047},
+									pos:  position{line: 1361, col: 28, offset: 37936},
 									name: "KeyWordRest",
 								},
 							},
@@ -11455,16 +11439,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1370, col: 1, offset: 38109},
+			pos:  position{line: 1363, col: 1, offset: 37998},
 			expr: &choiceExpr{
-				pos: position{line: 1371, col: 5, offset: 38126},
+				pos: position{line: 1364, col: 5, offset: 38015},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1371, col: 5, offset: 38126},
+						pos:  position{line: 1364, col: 5, offset: 38015},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1372, col: 5, offset: 38143},
+						pos:  position{line: 1365, col: 5, offset: 38032},
 						name: "KeyWordEsc",
 					},
 				},
@@ -11472,16 +11456,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1374, col: 1, offset: 38155},
+			pos:  position{line: 1367, col: 1, offset: 38044},
 			expr: &choiceExpr{
-				pos: position{line: 1375, col: 5, offset: 38171},
+				pos: position{line: 1368, col: 5, offset: 38060},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1375, col: 5, offset: 38171},
+						pos:  position{line: 1368, col: 5, offset: 38060},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1376, col: 5, offset: 38188},
+						pos:        position{line: 1369, col: 5, offset: 38077},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11492,19 +11476,19 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1378, col: 1, offset: 38195},
+			pos:  position{line: 1371, col: 1, offset: 38084},
 			expr: &actionExpr{
-				pos: position{line: 1378, col: 16, offset: 38210},
+				pos: position{line: 1371, col: 16, offset: 38099},
 				run: (*parser).callonKeyWordChars1,
 				expr: &choiceExpr{
-					pos: position{line: 1378, col: 17, offset: 38211},
+					pos: position{line: 1371, col: 17, offset: 38100},
 					alternatives: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1378, col: 17, offset: 38211},
+							pos:  position{line: 1371, col: 17, offset: 38100},
 							name: "UnicodeLetter",
 						},
 						&charClassMatcher{
-							pos:        position{line: 1378, col: 33, offset: 38227},
+							pos:        position{line: 1371, col: 33, offset: 38116},
 							val:        "[_.:/%#@~]",
 							chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 							ignoreCase: false,
@@ -11516,30 +11500,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1380, col: 1, offset: 38271},
+			pos:  position{line: 1373, col: 1, offset: 38160},
 			expr: &actionExpr{
-				pos: position{line: 1380, col: 14, offset: 38284},
+				pos: position{line: 1373, col: 14, offset: 38173},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1380, col: 14, offset: 38284},
+					pos: position{line: 1373, col: 14, offset: 38173},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1380, col: 14, offset: 38284},
+							pos:        position{line: 1373, col: 14, offset: 38173},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1380, col: 19, offset: 38289},
+							pos:   position{line: 1373, col: 19, offset: 38178},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1380, col: 22, offset: 38292},
+								pos: position{line: 1373, col: 22, offset: 38181},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1380, col: 22, offset: 38292},
+										pos:  position{line: 1373, col: 22, offset: 38181},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1380, col: 38, offset: 38308},
+										pos:  position{line: 1373, col: 38, offset: 38197},
 										name: "EscapeSequence",
 									},
 								},
@@ -11551,42 +11535,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1382, col: 1, offset: 38343},
+			pos:  position{line: 1375, col: 1, offset: 38232},
 			expr: &actionExpr{
-				pos: position{line: 1383, col: 5, offset: 38359},
+				pos: position{line: 1376, col: 5, offset: 38248},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1383, col: 5, offset: 38359},
+					pos: position{line: 1376, col: 5, offset: 38248},
 					exprs: []interface{}{
 						&andExpr{
-							pos: position{line: 1383, col: 5, offset: 38359},
+							pos: position{line: 1376, col: 5, offset: 38248},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1383, col: 6, offset: 38360},
+								pos:  position{line: 1376, col: 6, offset: 38249},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1383, col: 22, offset: 38376},
+							pos: position{line: 1376, col: 22, offset: 38265},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1383, col: 23, offset: 38377},
+								pos:  position{line: 1376, col: 23, offset: 38266},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1383, col: 35, offset: 38389},
+							pos:   position{line: 1376, col: 35, offset: 38278},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1383, col: 40, offset: 38394},
+								pos:  position{line: 1376, col: 40, offset: 38283},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1383, col: 50, offset: 38404},
+							pos:   position{line: 1376, col: 50, offset: 38293},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1383, col: 55, offset: 38409},
+								pos: position{line: 1376, col: 55, offset: 38298},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1383, col: 55, offset: 38409},
+									pos:  position{line: 1376, col: 55, offset: 38298},
 									name: "GlobRest",
 								},
 							},
@@ -11597,27 +11581,27 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1387, col: 1, offset: 38478},
+			pos:  position{line: 1380, col: 1, offset: 38367},
 			expr: &choiceExpr{
-				pos: position{line: 1387, col: 19, offset: 38496},
+				pos: position{line: 1380, col: 19, offset: 38385},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1387, col: 19, offset: 38496},
+						pos:  position{line: 1380, col: 19, offset: 38385},
 						name: "KeyWordStart",
 					},
 					&seqExpr{
-						pos: position{line: 1387, col: 34, offset: 38511},
+						pos: position{line: 1380, col: 34, offset: 38400},
 						exprs: []interface{}{
 							&oneOrMoreExpr{
-								pos: position{line: 1387, col: 34, offset: 38511},
+								pos: position{line: 1380, col: 34, offset: 38400},
 								expr: &litMatcher{
-									pos:        position{line: 1387, col: 34, offset: 38511},
+									pos:        position{line: 1380, col: 34, offset: 38400},
 									val:        "*",
 									ignoreCase: false,
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1387, col: 39, offset: 38516},
+								pos:  position{line: 1380, col: 39, offset: 38405},
 								name: "KeyWordRest",
 							},
 						},
@@ -11627,19 +11611,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1388, col: 1, offset: 38528},
+			pos:  position{line: 1381, col: 1, offset: 38417},
 			expr: &seqExpr{
-				pos: position{line: 1388, col: 15, offset: 38542},
+				pos: position{line: 1381, col: 15, offset: 38431},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1388, col: 15, offset: 38542},
+						pos: position{line: 1381, col: 15, offset: 38431},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1388, col: 15, offset: 38542},
+							pos:  position{line: 1381, col: 15, offset: 38431},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1388, col: 28, offset: 38555},
+						pos:        position{line: 1381, col: 28, offset: 38444},
 						val:        "*",
 						ignoreCase: false,
 					},
@@ -11648,23 +11632,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1390, col: 1, offset: 38560},
+			pos:  position{line: 1383, col: 1, offset: 38449},
 			expr: &choiceExpr{
-				pos: position{line: 1391, col: 5, offset: 38574},
+				pos: position{line: 1384, col: 5, offset: 38463},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1391, col: 5, offset: 38574},
+						pos:  position{line: 1384, col: 5, offset: 38463},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1392, col: 5, offset: 38591},
+						pos:  position{line: 1385, col: 5, offset: 38480},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1393, col: 5, offset: 38603},
+						pos: position{line: 1386, col: 5, offset: 38492},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1393, col: 5, offset: 38603},
+							pos:        position{line: 1386, col: 5, offset: 38492},
 							val:        "*",
 							ignoreCase: false,
 						},
@@ -11674,16 +11658,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1395, col: 1, offset: 38628},
+			pos:  position{line: 1388, col: 1, offset: 38517},
 			expr: &choiceExpr{
-				pos: position{line: 1396, col: 5, offset: 38641},
+				pos: position{line: 1389, col: 5, offset: 38530},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1396, col: 5, offset: 38641},
+						pos:  position{line: 1389, col: 5, offset: 38530},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1397, col: 5, offset: 38655},
+						pos:        position{line: 1390, col: 5, offset: 38544},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11694,30 +11678,30 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1399, col: 1, offset: 38662},
+			pos:  position{line: 1392, col: 1, offset: 38551},
 			expr: &actionExpr{
-				pos: position{line: 1399, col: 11, offset: 38672},
+				pos: position{line: 1392, col: 11, offset: 38561},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1399, col: 11, offset: 38672},
+					pos: position{line: 1392, col: 11, offset: 38561},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1399, col: 11, offset: 38672},
+							pos:        position{line: 1392, col: 11, offset: 38561},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1399, col: 16, offset: 38677},
+							pos:   position{line: 1392, col: 16, offset: 38566},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1399, col: 19, offset: 38680},
+								pos: position{line: 1392, col: 19, offset: 38569},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1399, col: 19, offset: 38680},
+										pos:  position{line: 1392, col: 19, offset: 38569},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1399, col: 32, offset: 38693},
+										pos:  position{line: 1392, col: 32, offset: 38582},
 										name: "EscapeSequence",
 									},
 								},
@@ -11729,30 +11713,30 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1401, col: 1, offset: 38728},
+			pos:  position{line: 1394, col: 1, offset: 38617},
 			expr: &choiceExpr{
-				pos: position{line: 1402, col: 5, offset: 38743},
+				pos: position{line: 1395, col: 5, offset: 38632},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1402, col: 5, offset: 38743},
+						pos: position{line: 1395, col: 5, offset: 38632},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1402, col: 5, offset: 38743},
+							pos:        position{line: 1395, col: 5, offset: 38632},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1403, col: 5, offset: 38771},
+						pos: position{line: 1396, col: 5, offset: 38660},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1403, col: 5, offset: 38771},
+							pos:        position{line: 1396, col: 5, offset: 38660},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1404, col: 5, offset: 38801},
+						pos:        position{line: 1397, col: 5, offset: 38690},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -11763,55 +11747,55 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1406, col: 1, offset: 38807},
+			pos:  position{line: 1399, col: 1, offset: 38696},
 			expr: &choiceExpr{
-				pos: position{line: 1407, col: 5, offset: 38828},
+				pos: position{line: 1400, col: 5, offset: 38717},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1407, col: 5, offset: 38828},
+						pos: position{line: 1400, col: 5, offset: 38717},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1407, col: 5, offset: 38828},
+							pos: position{line: 1400, col: 5, offset: 38717},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1407, col: 5, offset: 38828},
+									pos: position{line: 1400, col: 5, offset: 38717},
 									expr: &choiceExpr{
-										pos: position{line: 1407, col: 7, offset: 38830},
+										pos: position{line: 1400, col: 7, offset: 38719},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1407, col: 7, offset: 38830},
+												pos:        position{line: 1400, col: 7, offset: 38719},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1407, col: 13, offset: 38836},
+												pos:  position{line: 1400, col: 13, offset: 38725},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1407, col: 26, offset: 38849,
+									line: 1400, col: 26, offset: 38738,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1408, col: 5, offset: 38886},
+						pos: position{line: 1401, col: 5, offset: 38775},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1408, col: 5, offset: 38886},
+							pos: position{line: 1401, col: 5, offset: 38775},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1408, col: 5, offset: 38886},
+									pos:        position{line: 1401, col: 5, offset: 38775},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1408, col: 10, offset: 38891},
+									pos:   position{line: 1401, col: 10, offset: 38780},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1408, col: 12, offset: 38893},
+										pos:  position{line: 1401, col: 12, offset: 38782},
 										name: "EscapeSequence",
 									},
 								},
@@ -11823,16 +11807,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1410, col: 1, offset: 38927},
+			pos:  position{line: 1403, col: 1, offset: 38816},
 			expr: &choiceExpr{
-				pos: position{line: 1411, col: 5, offset: 38946},
+				pos: position{line: 1404, col: 5, offset: 38835},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1411, col: 5, offset: 38946},
+						pos:  position{line: 1404, col: 5, offset: 38835},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1412, col: 5, offset: 38967},
+						pos:  position{line: 1405, col: 5, offset: 38856},
 						name: "UnicodeEscape",
 					},
 				},
@@ -11840,79 +11824,79 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1414, col: 1, offset: 38982},
+			pos:  position{line: 1407, col: 1, offset: 38871},
 			expr: &choiceExpr{
-				pos: position{line: 1415, col: 5, offset: 39003},
+				pos: position{line: 1408, col: 5, offset: 38892},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1415, col: 5, offset: 39003},
+						pos:        position{line: 1408, col: 5, offset: 38892},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1416, col: 5, offset: 39011},
+						pos: position{line: 1409, col: 5, offset: 38900},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1416, col: 5, offset: 39011},
+							pos:        position{line: 1409, col: 5, offset: 38900},
 							val:        "\"",
 							ignoreCase: false,
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1417, col: 5, offset: 39051},
+						pos:        position{line: 1410, col: 5, offset: 38940},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1418, col: 5, offset: 39060},
+						pos: position{line: 1411, col: 5, offset: 38949},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1418, col: 5, offset: 39060},
+							pos:        position{line: 1411, col: 5, offset: 38949},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1419, col: 5, offset: 39089},
+						pos: position{line: 1412, col: 5, offset: 38978},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1419, col: 5, offset: 39089},
+							pos:        position{line: 1412, col: 5, offset: 38978},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1420, col: 5, offset: 39118},
+						pos: position{line: 1413, col: 5, offset: 39007},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1420, col: 5, offset: 39118},
+							pos:        position{line: 1413, col: 5, offset: 39007},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1421, col: 5, offset: 39147},
+						pos: position{line: 1414, col: 5, offset: 39036},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1421, col: 5, offset: 39147},
+							pos:        position{line: 1414, col: 5, offset: 39036},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1422, col: 5, offset: 39176},
+						pos: position{line: 1415, col: 5, offset: 39065},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1422, col: 5, offset: 39176},
+							pos:        position{line: 1415, col: 5, offset: 39065},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1423, col: 5, offset: 39205},
+						pos: position{line: 1416, col: 5, offset: 39094},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1423, col: 5, offset: 39205},
+							pos:        position{line: 1416, col: 5, offset: 39094},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -11922,30 +11906,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1425, col: 1, offset: 39231},
+			pos:  position{line: 1418, col: 1, offset: 39120},
 			expr: &choiceExpr{
-				pos: position{line: 1426, col: 5, offset: 39249},
+				pos: position{line: 1419, col: 5, offset: 39138},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1426, col: 5, offset: 39249},
+						pos: position{line: 1419, col: 5, offset: 39138},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1426, col: 5, offset: 39249},
+							pos:        position{line: 1419, col: 5, offset: 39138},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1427, col: 5, offset: 39277},
+						pos: position{line: 1420, col: 5, offset: 39166},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1427, col: 5, offset: 39277},
+							pos:        position{line: 1420, col: 5, offset: 39166},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1428, col: 5, offset: 39305},
+						pos:        position{line: 1421, col: 5, offset: 39194},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -11956,41 +11940,41 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1430, col: 1, offset: 39311},
+			pos:  position{line: 1423, col: 1, offset: 39200},
 			expr: &choiceExpr{
-				pos: position{line: 1431, col: 5, offset: 39329},
+				pos: position{line: 1424, col: 5, offset: 39218},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1431, col: 5, offset: 39329},
+						pos: position{line: 1424, col: 5, offset: 39218},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1431, col: 5, offset: 39329},
+							pos: position{line: 1424, col: 5, offset: 39218},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1431, col: 5, offset: 39329},
+									pos:        position{line: 1424, col: 5, offset: 39218},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1431, col: 9, offset: 39333},
+									pos:   position{line: 1424, col: 9, offset: 39222},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1431, col: 16, offset: 39340},
+										pos: position{line: 1424, col: 16, offset: 39229},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1431, col: 16, offset: 39340},
+												pos:  position{line: 1424, col: 16, offset: 39229},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1431, col: 25, offset: 39349},
+												pos:  position{line: 1424, col: 25, offset: 39238},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1431, col: 34, offset: 39358},
+												pos:  position{line: 1424, col: 34, offset: 39247},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1431, col: 43, offset: 39367},
+												pos:  position{line: 1424, col: 43, offset: 39256},
 												name: "HexDigit",
 											},
 										},
@@ -12000,63 +11984,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1434, col: 5, offset: 39430},
+						pos: position{line: 1427, col: 5, offset: 39319},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1434, col: 5, offset: 39430},
+							pos: position{line: 1427, col: 5, offset: 39319},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1434, col: 5, offset: 39430},
+									pos:        position{line: 1427, col: 5, offset: 39319},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1434, col: 9, offset: 39434},
+									pos:        position{line: 1427, col: 9, offset: 39323},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1434, col: 13, offset: 39438},
+									pos:   position{line: 1427, col: 13, offset: 39327},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1434, col: 20, offset: 39445},
+										pos: position{line: 1427, col: 20, offset: 39334},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1434, col: 20, offset: 39445},
+												pos:  position{line: 1427, col: 20, offset: 39334},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1434, col: 29, offset: 39454},
+												pos: position{line: 1427, col: 29, offset: 39343},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1434, col: 29, offset: 39454},
+													pos:  position{line: 1427, col: 29, offset: 39343},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1434, col: 39, offset: 39464},
+												pos: position{line: 1427, col: 39, offset: 39353},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1434, col: 39, offset: 39464},
+													pos:  position{line: 1427, col: 39, offset: 39353},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1434, col: 49, offset: 39474},
+												pos: position{line: 1427, col: 49, offset: 39363},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1434, col: 49, offset: 39474},
+													pos:  position{line: 1427, col: 49, offset: 39363},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1434, col: 59, offset: 39484},
+												pos: position{line: 1427, col: 59, offset: 39373},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1434, col: 59, offset: 39484},
+													pos:  position{line: 1427, col: 59, offset: 39373},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1434, col: 69, offset: 39494},
+												pos: position{line: 1427, col: 69, offset: 39383},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1434, col: 69, offset: 39494},
+													pos:  position{line: 1427, col: 69, offset: 39383},
 													name: "HexDigit",
 												},
 											},
@@ -12064,7 +12048,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1434, col: 80, offset: 39505},
+									pos:        position{line: 1427, col: 80, offset: 39394},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -12076,35 +12060,35 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPattern",
-			pos:  position{line: 1438, col: 1, offset: 39559},
+			pos:  position{line: 1431, col: 1, offset: 39448},
 			expr: &actionExpr{
-				pos: position{line: 1439, col: 5, offset: 39577},
+				pos: position{line: 1432, col: 5, offset: 39466},
 				run: (*parser).callonRegexpPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1439, col: 5, offset: 39577},
+					pos: position{line: 1432, col: 5, offset: 39466},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1439, col: 5, offset: 39577},
+							pos:        position{line: 1432, col: 5, offset: 39466},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1439, col: 9, offset: 39581},
+							pos:   position{line: 1432, col: 9, offset: 39470},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1439, col: 14, offset: 39586},
+								pos:  position{line: 1432, col: 14, offset: 39475},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1439, col: 25, offset: 39597},
+							pos:        position{line: 1432, col: 25, offset: 39486},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1439, col: 29, offset: 39601},
+							pos: position{line: 1432, col: 29, offset: 39490},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1439, col: 30, offset: 39602},
+								pos:  position{line: 1432, col: 30, offset: 39491},
 								name: "KeyWordStart",
 							},
 						},
@@ -12114,32 +12098,32 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1441, col: 1, offset: 39637},
+			pos:  position{line: 1434, col: 1, offset: 39526},
 			expr: &actionExpr{
-				pos: position{line: 1442, col: 5, offset: 39652},
+				pos: position{line: 1435, col: 5, offset: 39541},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1442, col: 5, offset: 39652},
+					pos: position{line: 1435, col: 5, offset: 39541},
 					expr: &choiceExpr{
-						pos: position{line: 1442, col: 6, offset: 39653},
+						pos: position{line: 1435, col: 6, offset: 39542},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 1442, col: 6, offset: 39653},
+								pos:        position{line: 1435, col: 6, offset: 39542},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&seqExpr{
-								pos: position{line: 1442, col: 15, offset: 39662},
+								pos: position{line: 1435, col: 15, offset: 39551},
 								exprs: []interface{}{
 									&litMatcher{
-										pos:        position{line: 1442, col: 15, offset: 39662},
+										pos:        position{line: 1435, col: 15, offset: 39551},
 										val:        "\\",
 										ignoreCase: false,
 									},
 									&anyMatcher{
-										line: 1442, col: 20, offset: 39667,
+										line: 1435, col: 20, offset: 39556,
 									},
 								},
 							},
@@ -12150,9 +12134,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1444, col: 1, offset: 39703},
+			pos:  position{line: 1437, col: 1, offset: 39592},
 			expr: &charClassMatcher{
-				pos:        position{line: 1445, col: 5, offset: 39719},
+				pos:        position{line: 1438, col: 5, offset: 39608},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -12162,42 +12146,42 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1447, col: 1, offset: 39734},
+			pos:  position{line: 1440, col: 1, offset: 39623},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1447, col: 5, offset: 39738},
+				pos: position{line: 1440, col: 5, offset: 39627},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1447, col: 5, offset: 39738},
+					pos:  position{line: 1440, col: 5, offset: 39627},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 1449, col: 1, offset: 39749},
+			pos:  position{line: 1442, col: 1, offset: 39638},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1449, col: 6, offset: 39754},
+				pos: position{line: 1442, col: 6, offset: 39643},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1449, col: 6, offset: 39754},
+					pos:  position{line: 1442, col: 6, offset: 39643},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1451, col: 1, offset: 39765},
+			pos:  position{line: 1444, col: 1, offset: 39654},
 			expr: &choiceExpr{
-				pos: position{line: 1452, col: 5, offset: 39778},
+				pos: position{line: 1445, col: 5, offset: 39667},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1452, col: 5, offset: 39778},
+						pos:  position{line: 1445, col: 5, offset: 39667},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1453, col: 5, offset: 39793},
+						pos:  position{line: 1446, col: 5, offset: 39682},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1454, col: 5, offset: 39812},
+						pos:  position{line: 1447, col: 5, offset: 39701},
 						name: "Comment",
 					},
 				},
@@ -12205,32 +12189,32 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeLetter",
-			pos:  position{line: 1456, col: 1, offset: 39821},
+			pos:  position{line: 1449, col: 1, offset: 39710},
 			expr: &choiceExpr{
-				pos: position{line: 1457, col: 5, offset: 39839},
+				pos: position{line: 1450, col: 5, offset: 39728},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1457, col: 5, offset: 39839},
+						pos:  position{line: 1450, col: 5, offset: 39728},
 						name: "Lu",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1458, col: 5, offset: 39846},
+						pos:  position{line: 1451, col: 5, offset: 39735},
 						name: "Ll",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1459, col: 5, offset: 39853},
+						pos:  position{line: 1452, col: 5, offset: 39742},
 						name: "Lt",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1460, col: 5, offset: 39860},
+						pos:  position{line: 1453, col: 5, offset: 39749},
 						name: "Lm",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1461, col: 5, offset: 39867},
+						pos:  position{line: 1454, col: 5, offset: 39756},
 						name: "Lo",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1462, col: 5, offset: 39874},
+						pos:  position{line: 1455, col: 5, offset: 39763},
 						name: "Nl",
 					},
 				},
@@ -12238,16 +12222,16 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeCombiningMark",
-			pos:  position{line: 1464, col: 1, offset: 39878},
+			pos:  position{line: 1457, col: 1, offset: 39767},
 			expr: &choiceExpr{
-				pos: position{line: 1465, col: 5, offset: 39903},
+				pos: position{line: 1458, col: 5, offset: 39792},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1465, col: 5, offset: 39903},
+						pos:  position{line: 1458, col: 5, offset: 39792},
 						name: "Mn",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1466, col: 5, offset: 39910},
+						pos:  position{line: 1459, col: 5, offset: 39799},
 						name: "Mc",
 					},
 				},
@@ -12255,25 +12239,25 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeDigit",
-			pos:  position{line: 1468, col: 1, offset: 39914},
+			pos:  position{line: 1461, col: 1, offset: 39803},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1469, col: 5, offset: 39931},
+				pos:  position{line: 1462, col: 5, offset: 39820},
 				name: "Nd",
 			},
 		},
 		{
 			name: "UnicodeConnectorPunctuation",
-			pos:  position{line: 1471, col: 1, offset: 39935},
+			pos:  position{line: 1464, col: 1, offset: 39824},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1472, col: 5, offset: 39967},
+				pos:  position{line: 1465, col: 5, offset: 39856},
 				name: "Pc",
 			},
 		},
 		{
 			name: "Ll",
-			pos:  position{line: 1478, col: 1, offset: 40148},
+			pos:  position{line: 1471, col: 1, offset: 40037},
 			expr: &charClassMatcher{
-				pos:        position{line: 1478, col: 6, offset: 40153},
+				pos:        position{line: 1471, col: 6, offset: 40042},
 				val:        "[\\u0061-\\u007A\\u00B5\\u00DF-\\u00F6\\u00F8-\\u00FF\\u0101\\u0103\\u0105\\u0107\\u0109\\u010B\\u010D\\u010F\\u0111\\u0113\\u0115\\u0117\\u0119\\u011B\\u011D\\u011F\\u0121\\u0123\\u0125\\u0127\\u0129\\u012B\\u012D\\u012F\\u0131\\u0133\\u0135\\u0137-\\u0138\\u013A\\u013C\\u013E\\u0140\\u0142\\u0144\\u0146\\u0148-\\u0149\\u014B\\u014D\\u014F\\u0151\\u0153\\u0155\\u0157\\u0159\\u015B\\u015D\\u015F\\u0161\\u0163\\u0165\\u0167\\u0169\\u016B\\u016D\\u016F\\u0171\\u0173\\u0175\\u0177\\u017A\\u017C\\u017E-\\u0180\\u0183\\u0185\\u0188\\u018C-\\u018D\\u0192\\u0195\\u0199-\\u019B\\u019E\\u01A1\\u01A3\\u01A5\\u01A8\\u01AA-\\u01AB\\u01AD\\u01B0\\u01B4\\u01B6\\u01B9-\\u01BA\\u01BD-\\u01BF\\u01C6\\u01C9\\u01CC\\u01CE\\u01D0\\u01D2\\u01D4\\u01D6\\u01D8\\u01DA\\u01DC-\\u01DD\\u01DF\\u01E1\\u01E3\\u01E5\\u01E7\\u01E9\\u01EB\\u01ED\\u01EF-\\u01F0\\u01F3\\u01F5\\u01F9\\u01FB\\u01FD\\u01FF\\u0201\\u0203\\u0205\\u0207\\u0209\\u020B\\u020D\\u020F\\u0211\\u0213\\u0215\\u0217\\u0219\\u021B\\u021D\\u021F\\u0221\\u0223\\u0225\\u0227\\u0229\\u022B\\u022D\\u022F\\u0231\\u0233-\\u0239\\u023C\\u023F-\\u0240\\u0242\\u0247\\u0249\\u024B\\u024D\\u024F-\\u0293\\u0295-\\u02AF\\u0371\\u0373\\u0377\\u037B-\\u037D\\u0390\\u03AC-\\u03CE\\u03D0-\\u03D1\\u03D5-\\u03D7\\u03D9\\u03DB\\u03DD\\u03DF\\u03E1\\u03E3\\u03E5\\u03E7\\u03E9\\u03EB\\u03ED\\u03EF-\\u03F3\\u03F5\\u03F8\\u03FB-\\u03FC\\u0430-\\u045F\\u0461\\u0463\\u0465\\u0467\\u0469\\u046B\\u046D\\u046F\\u0471\\u0473\\u0475\\u0477\\u0479\\u047B\\u047D\\u047F\\u0481\\u048B\\u048D\\u048F\\u0491\\u0493\\u0495\\u0497\\u0499\\u049B\\u049D\\u049F\\u04A1\\u04A3\\u04A5\\u04A7\\u04A9\\u04AB\\u04AD\\u04AF\\u04B1\\u04B3\\u04B5\\u04B7\\u04B9\\u04BB\\u04BD\\u04BF\\u04C2\\u04C4\\u04C6\\u04C8\\u04CA\\u04CC\\u04CE-\\u04CF\\u04D1\\u04D3\\u04D5\\u04D7\\u04D9\\u04DB\\u04DD\\u04DF\\u04E1\\u04E3\\u04E5\\u04E7\\u04E9\\u04EB\\u04ED\\u04EF\\u04F1\\u04F3\\u04F5\\u04F7\\u04F9\\u04FB\\u04FD\\u04FF\\u0501\\u0503\\u0505\\u0507\\u0509\\u050B\\u050D\\u050F\\u0511\\u0513\\u0515\\u0517\\u0519\\u051B\\u051D\\u051F\\u0521\\u0523\\u0525\\u0527\\u0529\\u052B\\u052D\\u052F\\u0560-\\u0588\\u10D0-\\u10FA\\u10FD-\\u10FF\\u13F8-\\u13FD\\u1C80-\\u1C88\\u1D00-\\u1D2B\\u1D6B-\\u1D77\\u1D79-\\u1D9A\\u1E01\\u1E03\\u1E05\\u1E07\\u1E09\\u1E0B\\u1E0D\\u1E0F\\u1E11\\u1E13\\u1E15\\u1E17\\u1E19\\u1E1B\\u1E1D\\u1E1F\\u1E21\\u1E23\\u1E25\\u1E27\\u1E29\\u1E2B\\u1E2D\\u1E2F\\u1E31\\u1E33\\u1E35\\u1E37\\u1E39\\u1E3B\\u1E3D\\u1E3F\\u1E41\\u1E43\\u1E45\\u1E47\\u1E49\\u1E4B\\u1E4D\\u1E4F\\u1E51\\u1E53\\u1E55\\u1E57\\u1E59\\u1E5B\\u1E5D\\u1E5F\\u1E61\\u1E63\\u1E65\\u1E67\\u1E69\\u1E6B\\u1E6D\\u1E6F\\u1E71\\u1E73\\u1E75\\u1E77\\u1E79\\u1E7B\\u1E7D\\u1E7F\\u1E81\\u1E83\\u1E85\\u1E87\\u1E89\\u1E8B\\u1E8D\\u1E8F\\u1E91\\u1E93\\u1E95-\\u1E9D\\u1E9F\\u1EA1\\u1EA3\\u1EA5\\u1EA7\\u1EA9\\u1EAB\\u1EAD\\u1EAF\\u1EB1\\u1EB3\\u1EB5\\u1EB7\\u1EB9\\u1EBB\\u1EBD\\u1EBF\\u1EC1\\u1EC3\\u1EC5\\u1EC7\\u1EC9\\u1ECB\\u1ECD\\u1ECF\\u1ED1\\u1ED3\\u1ED5\\u1ED7\\u1ED9\\u1EDB\\u1EDD\\u1EDF\\u1EE1\\u1EE3\\u1EE5\\u1EE7\\u1EE9\\u1EEB\\u1EED\\u1EEF\\u1EF1\\u1EF3\\u1EF5\\u1EF7\\u1EF9\\u1EFB\\u1EFD\\u1EFF-\\u1F07\\u1F10-\\u1F15\\u1F20-\\u1F27\\u1F30-\\u1F37\\u1F40-\\u1F45\\u1F50-\\u1F57\\u1F60-\\u1F67\\u1F70-\\u1F7D\\u1F80-\\u1F87\\u1F90-\\u1F97\\u1FA0-\\u1FA7\\u1FB0-\\u1FB4\\u1FB6-\\u1FB7\\u1FBE\\u1FC2-\\u1FC4\\u1FC6-\\u1FC7\\u1FD0-\\u1FD3\\u1FD6-\\u1FD7\\u1FE0-\\u1FE7\\u1FF2-\\u1FF4\\u1FF6-\\u1FF7\\u210A\\u210E-\\u210F\\u2113\\u212F\\u2134\\u2139\\u213C-\\u213D\\u2146-\\u2149\\u214E\\u2184\\u2C30-\\u2C5E\\u2C61\\u2C65-\\u2C66\\u2C68\\u2C6A\\u2C6C\\u2C71\\u2C73-\\u2C74\\u2C76-\\u2C7B\\u2C81\\u2C83\\u2C85\\u2C87\\u2C89\\u2C8B\\u2C8D\\u2C8F\\u2C91\\u2C93\\u2C95\\u2C97\\u2C99\\u2C9B\\u2C9D\\u2C9F\\u2CA1\\u2CA3\\u2CA5\\u2CA7\\u2CA9\\u2CAB\\u2CAD\\u2CAF\\u2CB1\\u2CB3\\u2CB5\\u2CB7\\u2CB9\\u2CBB\\u2CBD\\u2CBF\\u2CC1\\u2CC3\\u2CC5\\u2CC7\\u2CC9\\u2CCB\\u2CCD\\u2CCF\\u2CD1\\u2CD3\\u2CD5\\u2CD7\\u2CD9\\u2CDB\\u2CDD\\u2CDF\\u2CE1\\u2CE3-\\u2CE4\\u2CEC\\u2CEE\\u2CF3\\u2D00-\\u2D25\\u2D27\\u2D2D\\uA641\\uA643\\uA645\\uA647\\uA649\\uA64B\\uA64D\\uA64F\\uA651\\uA653\\uA655\\uA657\\uA659\\uA65B\\uA65D\\uA65F\\uA661\\uA663\\uA665\\uA667\\uA669\\uA66B\\uA66D\\uA681\\uA683\\uA685\\uA687\\uA689\\uA68B\\uA68D\\uA68F\\uA691\\uA693\\uA695\\uA697\\uA699\\uA69B\\uA723\\uA725\\uA727\\uA729\\uA72B\\uA72D\\uA72F-\\uA731\\uA733\\uA735\\uA737\\uA739\\uA73B\\uA73D\\uA73F\\uA741\\uA743\\uA745\\uA747\\uA749\\uA74B\\uA74D\\uA74F\\uA751\\uA753\\uA755\\uA757\\uA759\\uA75B\\uA75D\\uA75F\\uA761\\uA763\\uA765\\uA767\\uA769\\uA76B\\uA76D\\uA76F\\uA771-\\uA778\\uA77A\\uA77C\\uA77F\\uA781\\uA783\\uA785\\uA787\\uA78C\\uA78E\\uA791\\uA793-\\uA795\\uA797\\uA799\\uA79B\\uA79D\\uA79F\\uA7A1\\uA7A3\\uA7A5\\uA7A7\\uA7A9\\uA7AF\\uA7B5\\uA7B7\\uA7B9\\uA7FA\\uAB30-\\uAB5A\\uAB60-\\uAB65\\uAB70-\\uABBF\\uFB00-\\uFB06\\uFB13-\\uFB17\\uFF41-\\uFF5A]",
 				chars:      []rune{'µ', 'ā', 'ă', 'ą', 'ć', 'ĉ', 'ċ', 'č', 'ď', 'đ', 'ē', 'ĕ', 'ė', 'ę', 'ě', 'ĝ', 'ğ', 'ġ', 'ģ', 'ĥ', 'ħ', 'ĩ', 'ī', 'ĭ', 'į', 'ı', 'ĳ', 'ĵ', 'ĺ', 'ļ', 'ľ', 'ŀ', 'ł', 'ń', 'ņ', 'ŋ', 'ō', 'ŏ', 'ő', 'œ', 'ŕ', 'ŗ', 'ř', 'ś', 'ŝ', 'ş', 'š', 'ţ', 'ť', 'ŧ', 'ũ', 'ū', 'ŭ', 'ů', 'ű', 'ų', 'ŵ', 'ŷ', 'ź', 'ż', 'ƃ', 'ƅ', 'ƈ', 'ƒ', 'ƕ', 'ƞ', 'ơ', 'ƣ', 'ƥ', 'ƨ', 'ƭ', 'ư', 'ƴ', 'ƶ', 'ǆ', 'ǉ', 'ǌ', 'ǎ', 'ǐ', 'ǒ', 'ǔ', 'ǖ', 'ǘ', 'ǚ', 'ǟ', 'ǡ', 'ǣ', 'ǥ', 'ǧ', 'ǩ', 'ǫ', 'ǭ', 'ǳ', 'ǵ', 'ǹ', 'ǻ', 'ǽ', 'ǿ', 'ȁ', 'ȃ', 'ȅ', 'ȇ', 'ȉ', 'ȋ', 'ȍ', 'ȏ', 'ȑ', 'ȓ', 'ȕ', 'ȗ', 'ș', 'ț', 'ȝ', 'ȟ', 'ȡ', 'ȣ', 'ȥ', 'ȧ', 'ȩ', 'ȫ', 'ȭ', 'ȯ', 'ȱ', 'ȼ', 'ɂ', 'ɇ', 'ɉ', 'ɋ', 'ɍ', 'ͱ', 'ͳ', 'ͷ', 'ΐ', 'ϙ', 'ϛ', 'ϝ', 'ϟ', 'ϡ', 'ϣ', 'ϥ', 'ϧ', 'ϩ', 'ϫ', 'ϭ', 'ϵ', 'ϸ', 'ѡ', 'ѣ', 'ѥ', 'ѧ', 'ѩ', 'ѫ', 'ѭ', 'ѯ', 'ѱ', 'ѳ', 'ѵ', 'ѷ', 'ѹ', 'ѻ', 'ѽ', 'ѿ', 'ҁ', 'ҋ', 'ҍ', 'ҏ', 'ґ', 'ғ', 'ҕ', 'җ', 'ҙ', 'қ', 'ҝ', 'ҟ', 'ҡ', 'ң', 'ҥ', 'ҧ', 'ҩ', 'ҫ', 'ҭ', 'ү', 'ұ', 'ҳ', 'ҵ', 'ҷ', 'ҹ', 'һ', 'ҽ', 'ҿ', 'ӂ', 'ӄ', 'ӆ', 'ӈ', 'ӊ', 'ӌ', 'ӑ', 'ӓ', 'ӕ', 'ӗ', 'ә', 'ӛ', 'ӝ', 'ӟ', 'ӡ', 'ӣ', 'ӥ', 'ӧ', 'ө', 'ӫ', 'ӭ', 'ӯ', 'ӱ', 'ӳ', 'ӵ', 'ӷ', 'ӹ', 'ӻ', 'ӽ', 'ӿ', 'ԁ', 'ԃ', 'ԅ', 'ԇ', 'ԉ', 'ԋ', 'ԍ', 'ԏ', 'ԑ', 'ԓ', 'ԕ', 'ԗ', 'ԙ', 'ԛ', 'ԝ', 'ԟ', 'ԡ', 'ԣ', 'ԥ', 'ԧ', 'ԩ', 'ԫ', 'ԭ', 'ԯ', 'ḁ', 'ḃ', 'ḅ', 'ḇ', 'ḉ', 'ḋ', 'ḍ', 'ḏ', 'ḑ', 'ḓ', 'ḕ', 'ḗ', 'ḙ', 'ḛ', 'ḝ', 'ḟ', 'ḡ', 'ḣ', 'ḥ', 'ḧ', 'ḩ', 'ḫ', 'ḭ', 'ḯ', 'ḱ', 'ḳ', 'ḵ', 'ḷ', 'ḹ', 'ḻ', 'ḽ', 'ḿ', 'ṁ', 'ṃ', 'ṅ', 'ṇ', 'ṉ', 'ṋ', 'ṍ', 'ṏ', 'ṑ', 'ṓ', 'ṕ', 'ṗ', 'ṙ', 'ṛ', 'ṝ', 'ṟ', 'ṡ', 'ṣ', 'ṥ', 'ṧ', 'ṩ', 'ṫ', 'ṭ', 'ṯ', 'ṱ', 'ṳ', 'ṵ', 'ṷ', 'ṹ', 'ṻ', 'ṽ', 'ṿ', 'ẁ', 'ẃ', 'ẅ', 'ẇ', 'ẉ', 'ẋ', 'ẍ', 'ẏ', 'ẑ', 'ẓ', 'ẟ', 'ạ', 'ả', 'ấ', 'ầ', 'ẩ', 'ẫ', 'ậ', 'ắ', 'ằ', 'ẳ', 'ẵ', 'ặ', 'ẹ', 'ẻ', 'ẽ', 'ế', 'ề', 'ể', 'ễ', 'ệ', 'ỉ', 'ị', 'ọ', 'ỏ', 'ố', 'ồ', 'ổ', 'ỗ', 'ộ', 'ớ', 'ờ', 'ở', 'ỡ', 'ợ', 'ụ', 'ủ', 'ứ', 'ừ', 'ử', 'ữ', 'ự', 'ỳ', 'ỵ', 'ỷ', 'ỹ', 'ỻ', 'ỽ', 'ι', 'ℊ', 'ℓ', 'ℯ', 'ℴ', 'ℹ', 'ⅎ', 'ↄ', 'ⱡ', 'ⱨ', 'ⱪ', 'ⱬ', 'ⱱ', 'ⲁ', 'ⲃ', 'ⲅ', 'ⲇ', 'ⲉ', 'ⲋ', 'ⲍ', 'ⲏ', 'ⲑ', 'ⲓ', 'ⲕ', 'ⲗ', 'ⲙ', 'ⲛ', 'ⲝ', 'ⲟ', 'ⲡ', 'ⲣ', 'ⲥ', 'ⲧ', 'ⲩ', 'ⲫ', 'ⲭ', 'ⲯ', 'ⲱ', 'ⲳ', 'ⲵ', 'ⲷ', 'ⲹ', 'ⲻ', 'ⲽ', 'ⲿ', 'ⳁ', 'ⳃ', 'ⳅ', 'ⳇ', 'ⳉ', 'ⳋ', 'ⳍ', 'ⳏ', 'ⳑ', 'ⳓ', 'ⳕ', 'ⳗ', 'ⳙ', 'ⳛ', 'ⳝ', 'ⳟ', 'ⳡ', 'ⳬ', 'ⳮ', 'ⳳ', 'ⴧ', 'ⴭ', 'ꙁ', 'ꙃ', 'ꙅ', 'ꙇ', 'ꙉ', 'ꙋ', 'ꙍ', 'ꙏ', 'ꙑ', 'ꙓ', 'ꙕ', 'ꙗ', 'ꙙ', 'ꙛ', 'ꙝ', 'ꙟ', 'ꙡ', 'ꙣ', 'ꙥ', 'ꙧ', 'ꙩ', 'ꙫ', 'ꙭ', 'ꚁ', 'ꚃ', 'ꚅ', 'ꚇ', 'ꚉ', 'ꚋ', 'ꚍ', 'ꚏ', 'ꚑ', 'ꚓ', 'ꚕ', 'ꚗ', 'ꚙ', 'ꚛ', 'ꜣ', 'ꜥ', 'ꜧ', 'ꜩ', 'ꜫ', 'ꜭ', 'ꜳ', 'ꜵ', 'ꜷ', 'ꜹ', 'ꜻ', 'ꜽ', 'ꜿ', 'ꝁ', 'ꝃ', 'ꝅ', 'ꝇ', 'ꝉ', 'ꝋ', 'ꝍ', 'ꝏ', 'ꝑ', 'ꝓ', 'ꝕ', 'ꝗ', 'ꝙ', 'ꝛ', 'ꝝ', 'ꝟ', 'ꝡ', 'ꝣ', 'ꝥ', 'ꝧ', 'ꝩ', 'ꝫ', 'ꝭ', 'ꝯ', 'ꝺ', 'ꝼ', 'ꝿ', 'ꞁ', 'ꞃ', 'ꞅ', 'ꞇ', 'ꞌ', 'ꞎ', 'ꞑ', 'ꞗ', 'ꞙ', 'ꞛ', 'ꞝ', 'ꞟ', 'ꞡ', 'ꞣ', 'ꞥ', 'ꞧ', 'ꞩ', 'ꞯ', 'ꞵ', 'ꞷ', 'ꞹ', 'ꟺ'},
 				ranges:     []rune{'a', 'z', 'ß', 'ö', 'ø', 'ÿ', 'ķ', 'ĸ', 'ň', 'ŉ', 'ž', 'ƀ', 'ƌ', 'ƍ', 'ƙ', 'ƛ', 'ƪ', 'ƫ', 'ƹ', 'ƺ', 'ƽ', 'ƿ', 'ǜ', 'ǝ', 'ǯ', 'ǰ', 'ȳ', 'ȹ', 'ȿ', 'ɀ', 'ɏ', 'ʓ', 'ʕ', 'ʯ', 'ͻ', 'ͽ', 'ά', 'ώ', 'ϐ', 'ϑ', 'ϕ', 'ϗ', 'ϯ', 'ϳ', 'ϻ', 'ϼ', 'а', 'џ', 'ӎ', 'ӏ', 'ՠ', 'ֈ', 'ა', 'ჺ', 'ჽ', 'ჿ', 'ᏸ', 'ᏽ', 'ᲀ', 'ᲈ', 'ᴀ', 'ᴫ', 'ᵫ', 'ᵷ', 'ᵹ', 'ᶚ', 'ẕ', 'ẝ', 'ỿ', 'ἇ', 'ἐ', 'ἕ', 'ἠ', 'ἧ', 'ἰ', 'ἷ', 'ὀ', 'ὅ', 'ὐ', 'ὗ', 'ὠ', 'ὧ', 'ὰ', 'ώ', 'ᾀ', 'ᾇ', 'ᾐ', 'ᾗ', 'ᾠ', 'ᾧ', 'ᾰ', 'ᾴ', 'ᾶ', 'ᾷ', 'ῂ', 'ῄ', 'ῆ', 'ῇ', 'ῐ', 'ΐ', 'ῖ', 'ῗ', 'ῠ', 'ῧ', 'ῲ', 'ῴ', 'ῶ', 'ῷ', 'ℎ', 'ℏ', 'ℼ', 'ℽ', 'ⅆ', 'ⅉ', 'ⰰ', 'ⱞ', 'ⱥ', 'ⱦ', 'ⱳ', 'ⱴ', 'ⱶ', 'ⱻ', 'ⳣ', 'ⳤ', 'ⴀ', 'ⴥ', 'ꜯ', 'ꜱ', 'ꝱ', 'ꝸ', 'ꞓ', 'ꞕ', 'ꬰ', 'ꭚ', 'ꭠ', 'ꭥ', 'ꭰ', 'ꮿ', 'ﬀ', 'ﬆ', 'ﬓ', 'ﬗ', 'ａ', 'ｚ'},
@@ -12283,9 +12267,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lm",
-			pos:  position{line: 1481, col: 1, offset: 44305},
+			pos:  position{line: 1474, col: 1, offset: 44194},
 			expr: &charClassMatcher{
-				pos:        position{line: 1481, col: 6, offset: 44310},
+				pos:        position{line: 1474, col: 6, offset: 44199},
 				val:        "[\\u02B0-\\u02C1\\u02C6-\\u02D1\\u02E0-\\u02E4\\u02EC\\u02EE\\u0374\\u037A\\u0559\\u0640\\u06E5-\\u06E6\\u07F4-\\u07F5\\u07FA\\u081A\\u0824\\u0828\\u0971\\u0E46\\u0EC6\\u10FC\\u17D7\\u1843\\u1AA7\\u1C78-\\u1C7D\\u1D2C-\\u1D6A\\u1D78\\u1D9B-\\u1DBF\\u2071\\u207F\\u2090-\\u209C\\u2C7C-\\u2C7D\\u2D6F\\u2E2F\\u3005\\u3031-\\u3035\\u303B\\u309D-\\u309E\\u30FC-\\u30FE\\uA015\\uA4F8-\\uA4FD\\uA60C\\uA67F\\uA69C-\\uA69D\\uA717-\\uA71F\\uA770\\uA788\\uA7F8-\\uA7F9\\uA9CF\\uA9E6\\uAA70\\uAADD\\uAAF3-\\uAAF4\\uAB5C-\\uAB5F\\uFF70\\uFF9E-\\uFF9F]",
 				chars:      []rune{'ˬ', 'ˮ', 'ʹ', 'ͺ', 'ՙ', 'ـ', 'ߺ', 'ࠚ', 'ࠤ', 'ࠨ', 'ॱ', 'ๆ', 'ໆ', 'ჼ', 'ៗ', 'ᡃ', 'ᪧ', 'ᵸ', 'ⁱ', 'ⁿ', 'ⵯ', 'ⸯ', '々', '〻', 'ꀕ', 'ꘌ', 'ꙿ', 'ꝰ', 'ꞈ', 'ꧏ', 'ꧦ', 'ꩰ', 'ꫝ', 'ｰ'},
 				ranges:     []rune{'ʰ', 'ˁ', 'ˆ', 'ˑ', 'ˠ', 'ˤ', 'ۥ', 'ۦ', 'ߴ', 'ߵ', 'ᱸ', 'ᱽ', 'ᴬ', 'ᵪ', 'ᶛ', 'ᶿ', 'ₐ', 'ₜ', 'ⱼ', 'ⱽ', '〱', '〵', 'ゝ', 'ゞ', 'ー', 'ヾ', 'ꓸ', 'ꓽ', 'ꚜ', 'ꚝ', 'ꜗ', 'ꜟ', 'ꟸ', 'ꟹ', 'ꫳ', 'ꫴ', 'ꭜ', 'ꭟ', 'ﾞ', 'ﾟ'},
@@ -12295,9 +12279,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lo",
-			pos:  position{line: 1484, col: 1, offset: 44795},
+			pos:  position{line: 1477, col: 1, offset: 44684},
 			expr: &charClassMatcher{
-				pos:        position{line: 1484, col: 6, offset: 44800},
+				pos:        position{line: 1477, col: 6, offset: 44689},
 				val:        "[\\u00AA\\u00BA\\u01BB\\u01C0-\\u01C3\\u0294\\u05D0-\\u05EA\\u05EF-\\u05F2\\u0620-\\u063F\\u0641-\\u064A\\u066E-\\u066F\\u0671-\\u06D3\\u06D5\\u06EE-\\u06EF\\u06FA-\\u06FC\\u06FF\\u0710\\u0712-\\u072F\\u074D-\\u07A5\\u07B1\\u07CA-\\u07EA\\u0800-\\u0815\\u0840-\\u0858\\u0860-\\u086A\\u08A0-\\u08B4\\u08B6-\\u08BD\\u0904-\\u0939\\u093D\\u0950\\u0958-\\u0961\\u0972-\\u0980\\u0985-\\u098C\\u098F-\\u0990\\u0993-\\u09A8\\u09AA-\\u09B0\\u09B2\\u09B6-\\u09B9\\u09BD\\u09CE\\u09DC-\\u09DD\\u09DF-\\u09E1\\u09F0-\\u09F1\\u09FC\\u0A05-\\u0A0A\\u0A0F-\\u0A10\\u0A13-\\u0A28\\u0A2A-\\u0A30\\u0A32-\\u0A33\\u0A35-\\u0A36\\u0A38-\\u0A39\\u0A59-\\u0A5C\\u0A5E\\u0A72-\\u0A74\\u0A85-\\u0A8D\\u0A8F-\\u0A91\\u0A93-\\u0AA8\\u0AAA-\\u0AB0\\u0AB2-\\u0AB3\\u0AB5-\\u0AB9\\u0ABD\\u0AD0\\u0AE0-\\u0AE1\\u0AF9\\u0B05-\\u0B0C\\u0B0F-\\u0B10\\u0B13-\\u0B28\\u0B2A-\\u0B30\\u0B32-\\u0B33\\u0B35-\\u0B39\\u0B3D\\u0B5C-\\u0B5D\\u0B5F-\\u0B61\\u0B71\\u0B83\\u0B85-\\u0B8A\\u0B8E-\\u0B90\\u0B92-\\u0B95\\u0B99-\\u0B9A\\u0B9C\\u0B9E-\\u0B9F\\u0BA3-\\u0BA4\\u0BA8-\\u0BAA\\u0BAE-\\u0BB9\\u0BD0\\u0C05-\\u0C0C\\u0C0E-\\u0C10\\u0C12-\\u0C28\\u0C2A-\\u0C39\\u0C3D\\u0C58-\\u0C5A\\u0C60-\\u0C61\\u0C80\\u0C85-\\u0C8C\\u0C8E-\\u0C90\\u0C92-\\u0CA8\\u0CAA-\\u0CB3\\u0CB5-\\u0CB9\\u0CBD\\u0CDE\\u0CE0-\\u0CE1\\u0CF1-\\u0CF2\\u0D05-\\u0D0C\\u0D0E-\\u0D10\\u0D12-\\u0D3A\\u0D3D\\u0D4E\\u0D54-\\u0D56\\u0D5F-\\u0D61\\u0D7A-\\u0D7F\\u0D85-\\u0D96\\u0D9A-\\u0DB1\\u0DB3-\\u0DBB\\u0DBD\\u0DC0-\\u0DC6\\u0E01-\\u0E30\\u0E32-\\u0E33\\u0E40-\\u0E45\\u0E81-\\u0E82\\u0E84\\u0E87-\\u0E88\\u0E8A\\u0E8D\\u0E94-\\u0E97\\u0E99-\\u0E9F\\u0EA1-\\u0EA3\\u0EA5\\u0EA7\\u0EAA-\\u0EAB\\u0EAD-\\u0EB0\\u0EB2-\\u0EB3\\u0EBD\\u0EC0-\\u0EC4\\u0EDC-\\u0EDF\\u0F00\\u0F40-\\u0F47\\u0F49-\\u0F6C\\u0F88-\\u0F8C\\u1000-\\u102A\\u103F\\u1050-\\u1055\\u105A-\\u105D\\u1061\\u1065-\\u1066\\u106E-\\u1070\\u1075-\\u1081\\u108E\\u1100-\\u1248\\u124A-\\u124D\\u1250-\\u1256\\u1258\\u125A-\\u125D\\u1260-\\u1288\\u128A-\\u128D\\u1290-\\u12B0\\u12B2-\\u12B5\\u12B8-\\u12BE\\u12C0\\u12C2-\\u12C5\\u12C8-\\u12D6\\u12D8-\\u1310\\u1312-\\u1315\\u1318-\\u135A\\u1380-\\u138F\\u1401-\\u166C\\u166F-\\u167F\\u1681-\\u169A\\u16A0-\\u16EA\\u16F1-\\u16F8\\u1700-\\u170C\\u170E-\\u1711\\u1720-\\u1731\\u1740-\\u1751\\u1760-\\u176C\\u176E-\\u1770\\u1780-\\u17B3\\u17DC\\u1820-\\u1842\\u1844-\\u1878\\u1880-\\u1884\\u1887-\\u18A8\\u18AA\\u18B0-\\u18F5\\u1900-\\u191E\\u1950-\\u196D\\u1970-\\u1974\\u1980-\\u19AB\\u19B0-\\u19C9\\u1A00-\\u1A16\\u1A20-\\u1A54\\u1B05-\\u1B33\\u1B45-\\u1B4B\\u1B83-\\u1BA0\\u1BAE-\\u1BAF\\u1BBA-\\u1BE5\\u1C00-\\u1C23\\u1C4D-\\u1C4F\\u1C5A-\\u1C77\\u1CE9-\\u1CEC\\u1CEE-\\u1CF1\\u1CF5-\\u1CF6\\u2135-\\u2138\\u2D30-\\u2D67\\u2D80-\\u2D96\\u2DA0-\\u2DA6\\u2DA8-\\u2DAE\\u2DB0-\\u2DB6\\u2DB8-\\u2DBE\\u2DC0-\\u2DC6\\u2DC8-\\u2DCE\\u2DD0-\\u2DD6\\u2DD8-\\u2DDE\\u3006\\u303C\\u3041-\\u3096\\u309F\\u30A1-\\u30FA\\u30FF\\u3105-\\u312F\\u3131-\\u318E\\u31A0-\\u31BA\\u31F0-\\u31FF\\u3400-\\u4DB5\\u4E00-\\u9FEF\\uA000-\\uA014\\uA016-\\uA48C\\uA4D0-\\uA4F7\\uA500-\\uA60B\\uA610-\\uA61F\\uA62A-\\uA62B\\uA66E\\uA6A0-\\uA6E5\\uA78F\\uA7F7\\uA7FB-\\uA801\\uA803-\\uA805\\uA807-\\uA80A\\uA80C-\\uA822\\uA840-\\uA873\\uA882-\\uA8B3\\uA8F2-\\uA8F7\\uA8FB\\uA8FD-\\uA8FE\\uA90A-\\uA925\\uA930-\\uA946\\uA960-\\uA97C\\uA984-\\uA9B2\\uA9E0-\\uA9E4\\uA9E7-\\uA9EF\\uA9FA-\\uA9FE\\uAA00-\\uAA28\\uAA40-\\uAA42\\uAA44-\\uAA4B\\uAA60-\\uAA6F\\uAA71-\\uAA76\\uAA7A\\uAA7E-\\uAAAF\\uAAB1\\uAAB5-\\uAAB6\\uAAB9-\\uAABD\\uAAC0\\uAAC2\\uAADB-\\uAADC\\uAAE0-\\uAAEA\\uAAF2\\uAB01-\\uAB06\\uAB09-\\uAB0E\\uAB11-\\uAB16\\uAB20-\\uAB26\\uAB28-\\uAB2E\\uABC0-\\uABE2\\uAC00-\\uD7A3\\uD7B0-\\uD7C6\\uD7CB-\\uD7FB\\uF900-\\uFA6D\\uFA70-\\uFAD9\\uFB1D\\uFB1F-\\uFB28\\uFB2A-\\uFB36\\uFB38-\\uFB3C\\uFB3E\\uFB40-\\uFB41\\uFB43-\\uFB44\\uFB46-\\uFBB1\\uFBD3-\\uFD3D\\uFD50-\\uFD8F\\uFD92-\\uFDC7\\uFDF0-\\uFDFB\\uFE70-\\uFE74\\uFE76-\\uFEFC\\uFF66-\\uFF6F\\uFF71-\\uFF9D\\uFFA0-\\uFFBE\\uFFC2-\\uFFC7\\uFFCA-\\uFFCF\\uFFD2-\\uFFD7\\uFFDA-\\uFFDC]",
 				chars:      []rune{'ª', 'º', 'ƻ', 'ʔ', 'ە', 'ۿ', 'ܐ', 'ޱ', 'ऽ', 'ॐ', 'ল', 'ঽ', 'ৎ', 'ৼ', 'ਫ਼', 'ઽ', 'ૐ', 'ૹ', 'ଽ', 'ୱ', 'ஃ', 'ஜ', 'ௐ', 'ఽ', 'ಀ', 'ಽ', 'ೞ', 'ഽ', 'ൎ', 'ල', 'ຄ', 'ຊ', 'ຍ', 'ລ', 'ວ', 'ຽ', 'ༀ', 'ဿ', 'ၡ', 'ႎ', 'ቘ', 'ዀ', 'ៜ', 'ᢪ', '〆', '〼', 'ゟ', 'ヿ', 'ꙮ', 'ꞏ', 'ꟷ', 'ꣻ', 'ꩺ', 'ꪱ', 'ꫀ', 'ꫂ', 'ꫲ', 'יִ', 'מּ'},
 				ranges:     []rune{'ǀ', 'ǃ', 'א', 'ת', 'ׯ', 'ײ', 'ؠ', 'ؿ', 'ف', 'ي', 'ٮ', 'ٯ', 'ٱ', 'ۓ', 'ۮ', 'ۯ', 'ۺ', 'ۼ', 'ܒ', 'ܯ', 'ݍ', 'ޥ', 'ߊ', 'ߪ', 'ࠀ', 'ࠕ', 'ࡀ', 'ࡘ', 'ࡠ', 'ࡪ', 'ࢠ', 'ࢴ', 'ࢶ', 'ࢽ', 'ऄ', 'ह', 'क़', 'ॡ', 'ॲ', 'ঀ', 'অ', 'ঌ', 'এ', 'ঐ', 'ও', 'ন', 'প', 'র', 'শ', 'হ', 'ড়', 'ঢ়', 'য়', 'ৡ', 'ৰ', 'ৱ', 'ਅ', 'ਊ', 'ਏ', 'ਐ', 'ਓ', 'ਨ', 'ਪ', 'ਰ', 'ਲ', 'ਲ਼', 'ਵ', 'ਸ਼', 'ਸ', 'ਹ', 'ਖ਼', 'ੜ', 'ੲ', 'ੴ', 'અ', 'ઍ', 'એ', 'ઑ', 'ઓ', 'ન', 'પ', 'ર', 'લ', 'ળ', 'વ', 'હ', 'ૠ', 'ૡ', 'ଅ', 'ଌ', 'ଏ', 'ଐ', 'ଓ', 'ନ', 'ପ', 'ର', 'ଲ', 'ଳ', 'ଵ', 'ହ', 'ଡ଼', 'ଢ଼', 'ୟ', 'ୡ', 'அ', 'ஊ', 'எ', 'ஐ', 'ஒ', 'க', 'ங', 'ச', 'ஞ', 'ட', 'ண', 'த', 'ந', 'ப', 'ம', 'ஹ', 'అ', 'ఌ', 'ఎ', 'ఐ', 'ఒ', 'న', 'ప', 'హ', 'ౘ', 'ౚ', 'ౠ', 'ౡ', 'ಅ', 'ಌ', 'ಎ', 'ಐ', 'ಒ', 'ನ', 'ಪ', 'ಳ', 'ವ', 'ಹ', 'ೠ', 'ೡ', 'ೱ', 'ೲ', 'അ', 'ഌ', 'എ', 'ഐ', 'ഒ', 'ഺ', 'ൔ', 'ൖ', 'ൟ', 'ൡ', 'ൺ', 'ൿ', 'අ', 'ඖ', 'ක', 'න', 'ඳ', 'ර', 'ව', 'ෆ', 'ก', 'ะ', 'า', 'ำ', 'เ', 'ๅ', 'ກ', 'ຂ', 'ງ', 'ຈ', 'ດ', 'ທ', 'ນ', 'ຟ', 'ມ', 'ຣ', 'ສ', 'ຫ', 'ອ', 'ະ', 'າ', 'ຳ', 'ເ', 'ໄ', 'ໜ', 'ໟ', 'ཀ', 'ཇ', 'ཉ', 'ཬ', 'ྈ', 'ྌ', 'က', 'ဪ', 'ၐ', 'ၕ', 'ၚ', 'ၝ', 'ၥ', 'ၦ', 'ၮ', 'ၰ', 'ၵ', 'ႁ', 'ᄀ', 'ቈ', 'ቊ', 'ቍ', 'ቐ', 'ቖ', 'ቚ', 'ቝ', 'በ', 'ኈ', 'ኊ', 'ኍ', 'ነ', 'ኰ', 'ኲ', 'ኵ', 'ኸ', 'ኾ', 'ዂ', 'ዅ', 'ወ', 'ዖ', 'ዘ', 'ጐ', 'ጒ', 'ጕ', 'ጘ', 'ፚ', 'ᎀ', 'ᎏ', 'ᐁ', 'ᙬ', 'ᙯ', 'ᙿ', 'ᚁ', 'ᚚ', 'ᚠ', 'ᛪ', 'ᛱ', 'ᛸ', 'ᜀ', 'ᜌ', 'ᜎ', 'ᜑ', 'ᜠ', 'ᜱ', 'ᝀ', 'ᝑ', 'ᝠ', 'ᝬ', 'ᝮ', 'ᝰ', 'ក', 'ឳ', 'ᠠ', 'ᡂ', 'ᡄ', 'ᡸ', 'ᢀ', 'ᢄ', 'ᢇ', 'ᢨ', 'ᢰ', 'ᣵ', 'ᤀ', 'ᤞ', 'ᥐ', 'ᥭ', 'ᥰ', 'ᥴ', 'ᦀ', 'ᦫ', 'ᦰ', 'ᧉ', 'ᨀ', 'ᨖ', 'ᨠ', 'ᩔ', 'ᬅ', 'ᬳ', 'ᭅ', 'ᭋ', 'ᮃ', 'ᮠ', 'ᮮ', 'ᮯ', 'ᮺ', 'ᯥ', 'ᰀ', 'ᰣ', 'ᱍ', 'ᱏ', 'ᱚ', 'ᱷ', 'ᳩ', 'ᳬ', 'ᳮ', 'ᳱ', 'ᳵ', 'ᳶ', 'ℵ', 'ℸ', 'ⴰ', 'ⵧ', 'ⶀ', 'ⶖ', 'ⶠ', 'ⶦ', 'ⶨ', 'ⶮ', 'ⶰ', 'ⶶ', 'ⶸ', 'ⶾ', 'ⷀ', 'ⷆ', 'ⷈ', 'ⷎ', 'ⷐ', 'ⷖ', 'ⷘ', 'ⷞ', 'ぁ', 'ゖ', 'ァ', 'ヺ', 'ㄅ', 'ㄯ', 'ㄱ', 'ㆎ', 'ㆠ', 'ㆺ', 'ㇰ', 'ㇿ', '㐀', '䶵', '一', '鿯', 'ꀀ', 'ꀔ', 'ꀖ', 'ꒌ', 'ꓐ', 'ꓷ', 'ꔀ', 'ꘋ', 'ꘐ', 'ꘟ', 'ꘪ', 'ꘫ', 'ꚠ', 'ꛥ', 'ꟻ', 'ꠁ', 'ꠃ', 'ꠅ', 'ꠇ', 'ꠊ', 'ꠌ', 'ꠢ', 'ꡀ', 'ꡳ', 'ꢂ', 'ꢳ', 'ꣲ', 'ꣷ', 'ꣽ', 'ꣾ', 'ꤊ', 'ꤥ', 'ꤰ', 'ꥆ', 'ꥠ', 'ꥼ', 'ꦄ', 'ꦲ', 'ꧠ', 'ꧤ', 'ꧧ', 'ꧯ', 'ꧺ', 'ꧾ', 'ꨀ', 'ꨨ', 'ꩀ', 'ꩂ', 'ꩄ', 'ꩋ', 'ꩠ', 'ꩯ', 'ꩱ', 'ꩶ', 'ꩾ', 'ꪯ', 'ꪵ', 'ꪶ', 'ꪹ', 'ꪽ', 'ꫛ', 'ꫜ', 'ꫠ', 'ꫪ', 'ꬁ', 'ꬆ', 'ꬉ', 'ꬎ', 'ꬑ', 'ꬖ', 'ꬠ', 'ꬦ', 'ꬨ', 'ꬮ', 'ꯀ', 'ꯢ', '가', '힣', 'ힰ', 'ퟆ', 'ퟋ', 'ퟻ', '豈', '舘', '並', '龎', 'ײַ', 'ﬨ', 'שׁ', 'זּ', 'טּ', 'לּ', 'נּ', 'סּ', 'ףּ', 'פּ', 'צּ', 'ﮱ', 'ﯓ', 'ﴽ', 'ﵐ', 'ﶏ', 'ﶒ', 'ﷇ', 'ﷰ', 'ﷻ', 'ﹰ', 'ﹴ', 'ﹶ', 'ﻼ', 'ｦ', 'ｯ', 'ｱ', 'ﾝ', 'ﾠ', 'ﾾ', 'ￂ', 'ￇ', 'ￊ', 'ￏ', 'ￒ', 'ￗ', 'ￚ', 'ￜ'},
@@ -12307,9 +12291,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lt",
-			pos:  position{line: 1487, col: 1, offset: 48247},
+			pos:  position{line: 1480, col: 1, offset: 48136},
 			expr: &charClassMatcher{
-				pos:        position{line: 1487, col: 6, offset: 48252},
+				pos:        position{line: 1480, col: 6, offset: 48141},
 				val:        "[\\u01C5\\u01C8\\u01CB\\u01F2\\u1F88-\\u1F8F\\u1F98-\\u1F9F\\u1FA8-\\u1FAF\\u1FBC\\u1FCC\\u1FFC]",
 				chars:      []rune{'ǅ', 'ǈ', 'ǋ', 'ǲ', 'ᾼ', 'ῌ', 'ῼ'},
 				ranges:     []rune{'ᾈ', 'ᾏ', 'ᾘ', 'ᾟ', 'ᾨ', 'ᾯ'},
@@ -12319,9 +12303,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lu",
-			pos:  position{line: 1490, col: 1, offset: 48358},
+			pos:  position{line: 1483, col: 1, offset: 48247},
 			expr: &charClassMatcher{
-				pos:        position{line: 1490, col: 6, offset: 48363},
+				pos:        position{line: 1483, col: 6, offset: 48252},
 				val:        "[\\u0041-\\u005A\\u00C0-\\u00D6\\u00D8-\\u00DE\\u0100\\u0102\\u0104\\u0106\\u0108\\u010A\\u010C\\u010E\\u0110\\u0112\\u0114\\u0116\\u0118\\u011A\\u011C\\u011E\\u0120\\u0122\\u0124\\u0126\\u0128\\u012A\\u012C\\u012E\\u0130\\u0132\\u0134\\u0136\\u0139\\u013B\\u013D\\u013F\\u0141\\u0143\\u0145\\u0147\\u014A\\u014C\\u014E\\u0150\\u0152\\u0154\\u0156\\u0158\\u015A\\u015C\\u015E\\u0160\\u0162\\u0164\\u0166\\u0168\\u016A\\u016C\\u016E\\u0170\\u0172\\u0174\\u0176\\u0178-\\u0179\\u017B\\u017D\\u0181-\\u0182\\u0184\\u0186-\\u0187\\u0189-\\u018B\\u018E-\\u0191\\u0193-\\u0194\\u0196-\\u0198\\u019C-\\u019D\\u019F-\\u01A0\\u01A2\\u01A4\\u01A6-\\u01A7\\u01A9\\u01AC\\u01AE-\\u01AF\\u01B1-\\u01B3\\u01B5\\u01B7-\\u01B8\\u01BC\\u01C4\\u01C7\\u01CA\\u01CD\\u01CF\\u01D1\\u01D3\\u01D5\\u01D7\\u01D9\\u01DB\\u01DE\\u01E0\\u01E2\\u01E4\\u01E6\\u01E8\\u01EA\\u01EC\\u01EE\\u01F1\\u01F4\\u01F6-\\u01F8\\u01FA\\u01FC\\u01FE\\u0200\\u0202\\u0204\\u0206\\u0208\\u020A\\u020C\\u020E\\u0210\\u0212\\u0214\\u0216\\u0218\\u021A\\u021C\\u021E\\u0220\\u0222\\u0224\\u0226\\u0228\\u022A\\u022C\\u022E\\u0230\\u0232\\u023A-\\u023B\\u023D-\\u023E\\u0241\\u0243-\\u0246\\u0248\\u024A\\u024C\\u024E\\u0370\\u0372\\u0376\\u037F\\u0386\\u0388-\\u038A\\u038C\\u038E-\\u038F\\u0391-\\u03A1\\u03A3-\\u03AB\\u03CF\\u03D2-\\u03D4\\u03D8\\u03DA\\u03DC\\u03DE\\u03E0\\u03E2\\u03E4\\u03E6\\u03E8\\u03EA\\u03EC\\u03EE\\u03F4\\u03F7\\u03F9-\\u03FA\\u03FD-\\u042F\\u0460\\u0462\\u0464\\u0466\\u0468\\u046A\\u046C\\u046E\\u0470\\u0472\\u0474\\u0476\\u0478\\u047A\\u047C\\u047E\\u0480\\u048A\\u048C\\u048E\\u0490\\u0492\\u0494\\u0496\\u0498\\u049A\\u049C\\u049E\\u04A0\\u04A2\\u04A4\\u04A6\\u04A8\\u04AA\\u04AC\\u04AE\\u04B0\\u04B2\\u04B4\\u04B6\\u04B8\\u04BA\\u04BC\\u04BE\\u04C0-\\u04C1\\u04C3\\u04C5\\u04C7\\u04C9\\u04CB\\u04CD\\u04D0\\u04D2\\u04D4\\u04D6\\u04D8\\u04DA\\u04DC\\u04DE\\u04E0\\u04E2\\u04E4\\u04E6\\u04E8\\u04EA\\u04EC\\u04EE\\u04F0\\u04F2\\u04F4\\u04F6\\u04F8\\u04FA\\u04FC\\u04FE\\u0500\\u0502\\u0504\\u0506\\u0508\\u050A\\u050C\\u050E\\u0510\\u0512\\u0514\\u0516\\u0518\\u051A\\u051C\\u051E\\u0520\\u0522\\u0524\\u0526\\u0528\\u052A\\u052C\\u052E\\u0531-\\u0556\\u10A0-\\u10C5\\u10C7\\u10CD\\u13A0-\\u13F5\\u1C90-\\u1CBA\\u1CBD-\\u1CBF\\u1E00\\u1E02\\u1E04\\u1E06\\u1E08\\u1E0A\\u1E0C\\u1E0E\\u1E10\\u1E12\\u1E14\\u1E16\\u1E18\\u1E1A\\u1E1C\\u1E1E\\u1E20\\u1E22\\u1E24\\u1E26\\u1E28\\u1E2A\\u1E2C\\u1E2E\\u1E30\\u1E32\\u1E34\\u1E36\\u1E38\\u1E3A\\u1E3C\\u1E3E\\u1E40\\u1E42\\u1E44\\u1E46\\u1E48\\u1E4A\\u1E4C\\u1E4E\\u1E50\\u1E52\\u1E54\\u1E56\\u1E58\\u1E5A\\u1E5C\\u1E5E\\u1E60\\u1E62\\u1E64\\u1E66\\u1E68\\u1E6A\\u1E6C\\u1E6E\\u1E70\\u1E72\\u1E74\\u1E76\\u1E78\\u1E7A\\u1E7C\\u1E7E\\u1E80\\u1E82\\u1E84\\u1E86\\u1E88\\u1E8A\\u1E8C\\u1E8E\\u1E90\\u1E92\\u1E94\\u1E9E\\u1EA0\\u1EA2\\u1EA4\\u1EA6\\u1EA8\\u1EAA\\u1EAC\\u1EAE\\u1EB0\\u1EB2\\u1EB4\\u1EB6\\u1EB8\\u1EBA\\u1EBC\\u1EBE\\u1EC0\\u1EC2\\u1EC4\\u1EC6\\u1EC8\\u1ECA\\u1ECC\\u1ECE\\u1ED0\\u1ED2\\u1ED4\\u1ED6\\u1ED8\\u1EDA\\u1EDC\\u1EDE\\u1EE0\\u1EE2\\u1EE4\\u1EE6\\u1EE8\\u1EEA\\u1EEC\\u1EEE\\u1EF0\\u1EF2\\u1EF4\\u1EF6\\u1EF8\\u1EFA\\u1EFC\\u1EFE\\u1F08-\\u1F0F\\u1F18-\\u1F1D\\u1F28-\\u1F2F\\u1F38-\\u1F3F\\u1F48-\\u1F4D\\u1F59\\u1F5B\\u1F5D\\u1F5F\\u1F68-\\u1F6F\\u1FB8-\\u1FBB\\u1FC8-\\u1FCB\\u1FD8-\\u1FDB\\u1FE8-\\u1FEC\\u1FF8-\\u1FFB\\u2102\\u2107\\u210B-\\u210D\\u2110-\\u2112\\u2115\\u2119-\\u211D\\u2124\\u2126\\u2128\\u212A-\\u212D\\u2130-\\u2133\\u213E-\\u213F\\u2145\\u2183\\u2C00-\\u2C2E\\u2C60\\u2C62-\\u2C64\\u2C67\\u2C69\\u2C6B\\u2C6D-\\u2C70\\u2C72\\u2C75\\u2C7E-\\u2C80\\u2C82\\u2C84\\u2C86\\u2C88\\u2C8A\\u2C8C\\u2C8E\\u2C90\\u2C92\\u2C94\\u2C96\\u2C98\\u2C9A\\u2C9C\\u2C9E\\u2CA0\\u2CA2\\u2CA4\\u2CA6\\u2CA8\\u2CAA\\u2CAC\\u2CAE\\u2CB0\\u2CB2\\u2CB4\\u2CB6\\u2CB8\\u2CBA\\u2CBC\\u2CBE\\u2CC0\\u2CC2\\u2CC4\\u2CC6\\u2CC8\\u2CCA\\u2CCC\\u2CCE\\u2CD0\\u2CD2\\u2CD4\\u2CD6\\u2CD8\\u2CDA\\u2CDC\\u2CDE\\u2CE0\\u2CE2\\u2CEB\\u2CED\\u2CF2\\uA640\\uA642\\uA644\\uA646\\uA648\\uA64A\\uA64C\\uA64E\\uA650\\uA652\\uA654\\uA656\\uA658\\uA65A\\uA65C\\uA65E\\uA660\\uA662\\uA664\\uA666\\uA668\\uA66A\\uA66C\\uA680\\uA682\\uA684\\uA686\\uA688\\uA68A\\uA68C\\uA68E\\uA690\\uA692\\uA694\\uA696\\uA698\\uA69A\\uA722\\uA724\\uA726\\uA728\\uA72A\\uA72C\\uA72E\\uA732\\uA734\\uA736\\uA738\\uA73A\\uA73C\\uA73E\\uA740\\uA742\\uA744\\uA746\\uA748\\uA74A\\uA74C\\uA74E\\uA750\\uA752\\uA754\\uA756\\uA758\\uA75A\\uA75C\\uA75E\\uA760\\uA762\\uA764\\uA766\\uA768\\uA76A\\uA76C\\uA76E\\uA779\\uA77B\\uA77D-\\uA77E\\uA780\\uA782\\uA784\\uA786\\uA78B\\uA78D\\uA790\\uA792\\uA796\\uA798\\uA79A\\uA79C\\uA79E\\uA7A0\\uA7A2\\uA7A4\\uA7A6\\uA7A8\\uA7AA-\\uA7AE\\uA7B0-\\uA7B4\\uA7B6\\uA7B8\\uFF21-\\uFF3A]",
 				chars:      []rune{'Ā', 'Ă', 'Ą', 'Ć', 'Ĉ', 'Ċ', 'Č', 'Ď', 'Đ', 'Ē', 'Ĕ', 'Ė', 'Ę', 'Ě', 'Ĝ', 'Ğ', 'Ġ', 'Ģ', 'Ĥ', 'Ħ', 'Ĩ', 'Ī', 'Ĭ', 'Į', 'İ', 'Ĳ', 'Ĵ', 'Ķ', 'Ĺ', 'Ļ', 'Ľ', 'Ŀ', 'Ł', 'Ń', 'Ņ', 'Ň', 'Ŋ', 'Ō', 'Ŏ', 'Ő', 'Œ', 'Ŕ', 'Ŗ', 'Ř', 'Ś', 'Ŝ', 'Ş', 'Š', 'Ţ', 'Ť', 'Ŧ', 'Ũ', 'Ū', 'Ŭ', 'Ů', 'Ű', 'Ų', 'Ŵ', 'Ŷ', 'Ż', 'Ž', 'Ƅ', 'Ƣ', 'Ƥ', 'Ʃ', 'Ƭ', 'Ƶ', 'Ƽ', 'Ǆ', 'Ǉ', 'Ǌ', 'Ǎ', 'Ǐ', 'Ǒ', 'Ǔ', 'Ǖ', 'Ǘ', 'Ǚ', 'Ǜ', 'Ǟ', 'Ǡ', 'Ǣ', 'Ǥ', 'Ǧ', 'Ǩ', 'Ǫ', 'Ǭ', 'Ǯ', 'Ǳ', 'Ǵ', 'Ǻ', 'Ǽ', 'Ǿ', 'Ȁ', 'Ȃ', 'Ȅ', 'Ȇ', 'Ȉ', 'Ȋ', 'Ȍ', 'Ȏ', 'Ȑ', 'Ȓ', 'Ȕ', 'Ȗ', 'Ș', 'Ț', 'Ȝ', 'Ȟ', 'Ƞ', 'Ȣ', 'Ȥ', 'Ȧ', 'Ȩ', 'Ȫ', 'Ȭ', 'Ȯ', 'Ȱ', 'Ȳ', 'Ɂ', 'Ɉ', 'Ɋ', 'Ɍ', 'Ɏ', 'Ͱ', 'Ͳ', 'Ͷ', 'Ϳ', 'Ά', 'Ό', 'Ϗ', 'Ϙ', 'Ϛ', 'Ϝ', 'Ϟ', 'Ϡ', 'Ϣ', 'Ϥ', 'Ϧ', 'Ϩ', 'Ϫ', 'Ϭ', 'Ϯ', 'ϴ', 'Ϸ', 'Ѡ', 'Ѣ', 'Ѥ', 'Ѧ', 'Ѩ', 'Ѫ', 'Ѭ', 'Ѯ', 'Ѱ', 'Ѳ', 'Ѵ', 'Ѷ', 'Ѹ', 'Ѻ', 'Ѽ', 'Ѿ', 'Ҁ', 'Ҋ', 'Ҍ', 'Ҏ', 'Ґ', 'Ғ', 'Ҕ', 'Җ', 'Ҙ', 'Қ', 'Ҝ', 'Ҟ', 'Ҡ', 'Ң', 'Ҥ', 'Ҧ', 'Ҩ', 'Ҫ', 'Ҭ', 'Ү', 'Ұ', 'Ҳ', 'Ҵ', 'Ҷ', 'Ҹ', 'Һ', 'Ҽ', 'Ҿ', 'Ӄ', 'Ӆ', 'Ӈ', 'Ӊ', 'Ӌ', 'Ӎ', 'Ӑ', 'Ӓ', 'Ӕ', 'Ӗ', 'Ә', 'Ӛ', 'Ӝ', 'Ӟ', 'Ӡ', 'Ӣ', 'Ӥ', 'Ӧ', 'Ө', 'Ӫ', 'Ӭ', 'Ӯ', 'Ӱ', 'Ӳ', 'Ӵ', 'Ӷ', 'Ӹ', 'Ӻ', 'Ӽ', 'Ӿ', 'Ԁ', 'Ԃ', 'Ԅ', 'Ԇ', 'Ԉ', 'Ԋ', 'Ԍ', 'Ԏ', 'Ԑ', 'Ԓ', 'Ԕ', 'Ԗ', 'Ԙ', 'Ԛ', 'Ԝ', 'Ԟ', 'Ԡ', 'Ԣ', 'Ԥ', 'Ԧ', 'Ԩ', 'Ԫ', 'Ԭ', 'Ԯ', 'Ⴧ', 'Ⴭ', 'Ḁ', 'Ḃ', 'Ḅ', 'Ḇ', 'Ḉ', 'Ḋ', 'Ḍ', 'Ḏ', 'Ḑ', 'Ḓ', 'Ḕ', 'Ḗ', 'Ḙ', 'Ḛ', 'Ḝ', 'Ḟ', 'Ḡ', 'Ḣ', 'Ḥ', 'Ḧ', 'Ḩ', 'Ḫ', 'Ḭ', 'Ḯ', 'Ḱ', 'Ḳ', 'Ḵ', 'Ḷ', 'Ḹ', 'Ḻ', 'Ḽ', 'Ḿ', 'Ṁ', 'Ṃ', 'Ṅ', 'Ṇ', 'Ṉ', 'Ṋ', 'Ṍ', 'Ṏ', 'Ṑ', 'Ṓ', 'Ṕ', 'Ṗ', 'Ṙ', 'Ṛ', 'Ṝ', 'Ṟ', 'Ṡ', 'Ṣ', 'Ṥ', 'Ṧ', 'Ṩ', 'Ṫ', 'Ṭ', 'Ṯ', 'Ṱ', 'Ṳ', 'Ṵ', 'Ṷ', 'Ṹ', 'Ṻ', 'Ṽ', 'Ṿ', 'Ẁ', 'Ẃ', 'Ẅ', 'Ẇ', 'Ẉ', 'Ẋ', 'Ẍ', 'Ẏ', 'Ẑ', 'Ẓ', 'Ẕ', 'ẞ', 'Ạ', 'Ả', 'Ấ', 'Ầ', 'Ẩ', 'Ẫ', 'Ậ', 'Ắ', 'Ằ', 'Ẳ', 'Ẵ', 'Ặ', 'Ẹ', 'Ẻ', 'Ẽ', 'Ế', 'Ề', 'Ể', 'Ễ', 'Ệ', 'Ỉ', 'Ị', 'Ọ', 'Ỏ', 'Ố', 'Ồ', 'Ổ', 'Ỗ', 'Ộ', 'Ớ', 'Ờ', 'Ở', 'Ỡ', 'Ợ', 'Ụ', 'Ủ', 'Ứ', 'Ừ', 'Ử', 'Ữ', 'Ự', 'Ỳ', 'Ỵ', 'Ỷ', 'Ỹ', 'Ỻ', 'Ỽ', 'Ỿ', 'Ὑ', 'Ὓ', 'Ὕ', 'Ὗ', 'ℂ', 'ℇ', 'ℕ', 'ℤ', 'Ω', 'ℨ', 'ⅅ', 'Ↄ', 'Ⱡ', 'Ⱨ', 'Ⱪ', 'Ⱬ', 'Ⱳ', 'Ⱶ', 'Ⲃ', 'Ⲅ', 'Ⲇ', 'Ⲉ', 'Ⲋ', 'Ⲍ', 'Ⲏ', 'Ⲑ', 'Ⲓ', 'Ⲕ', 'Ⲗ', 'Ⲙ', 'Ⲛ', 'Ⲝ', 'Ⲟ', 'Ⲡ', 'Ⲣ', 'Ⲥ', 'Ⲧ', 'Ⲩ', 'Ⲫ', 'Ⲭ', 'Ⲯ', 'Ⲱ', 'Ⲳ', 'Ⲵ', 'Ⲷ', 'Ⲹ', 'Ⲻ', 'Ⲽ', 'Ⲿ', 'Ⳁ', 'Ⳃ', 'Ⳅ', 'Ⳇ', 'Ⳉ', 'Ⳋ', 'Ⳍ', 'Ⳏ', 'Ⳑ', 'Ⳓ', 'Ⳕ', 'Ⳗ', 'Ⳙ', 'Ⳛ', 'Ⳝ', 'Ⳟ', 'Ⳡ', 'Ⳣ', 'Ⳬ', 'Ⳮ', 'Ⳳ', 'Ꙁ', 'Ꙃ', 'Ꙅ', 'Ꙇ', 'Ꙉ', 'Ꙋ', 'Ꙍ', 'Ꙏ', 'Ꙑ', 'Ꙓ', 'Ꙕ', 'Ꙗ', 'Ꙙ', 'Ꙛ', 'Ꙝ', 'Ꙟ', 'Ꙡ', 'Ꙣ', 'Ꙥ', 'Ꙧ', 'Ꙩ', 'Ꙫ', 'Ꙭ', 'Ꚁ', 'Ꚃ', 'Ꚅ', 'Ꚇ', 'Ꚉ', 'Ꚋ', 'Ꚍ', 'Ꚏ', 'Ꚑ', 'Ꚓ', 'Ꚕ', 'Ꚗ', 'Ꚙ', 'Ꚛ', 'Ꜣ', 'Ꜥ', 'Ꜧ', 'Ꜩ', 'Ꜫ', 'Ꜭ', 'Ꜯ', 'Ꜳ', 'Ꜵ', 'Ꜷ', 'Ꜹ', 'Ꜻ', 'Ꜽ', 'Ꜿ', 'Ꝁ', 'Ꝃ', 'Ꝅ', 'Ꝇ', 'Ꝉ', 'Ꝋ', 'Ꝍ', 'Ꝏ', 'Ꝑ', 'Ꝓ', 'Ꝕ', 'Ꝗ', 'Ꝙ', 'Ꝛ', 'Ꝝ', 'Ꝟ', 'Ꝡ', 'Ꝣ', 'Ꝥ', 'Ꝧ', 'Ꝩ', 'Ꝫ', 'Ꝭ', 'Ꝯ', 'Ꝺ', 'Ꝼ', 'Ꞁ', 'Ꞃ', 'Ꞅ', 'Ꞇ', 'Ꞌ', 'Ɥ', 'Ꞑ', 'Ꞓ', 'Ꞗ', 'Ꞙ', 'Ꞛ', 'Ꞝ', 'Ꞟ', 'Ꞡ', 'Ꞣ', 'Ꞥ', 'Ꞧ', 'Ꞩ', 'Ꞷ', 'Ꞹ'},
 				ranges:     []rune{'A', 'Z', 'À', 'Ö', 'Ø', 'Þ', 'Ÿ', 'Ź', 'Ɓ', 'Ƃ', 'Ɔ', 'Ƈ', 'Ɖ', 'Ƌ', 'Ǝ', 'Ƒ', 'Ɠ', 'Ɣ', 'Ɩ', 'Ƙ', 'Ɯ', 'Ɲ', 'Ɵ', 'Ơ', 'Ʀ', 'Ƨ', 'Ʈ', 'Ư', 'Ʊ', 'Ƴ', 'Ʒ', 'Ƹ', 'Ƕ', 'Ǹ', 'Ⱥ', 'Ȼ', 'Ƚ', 'Ⱦ', 'Ƀ', 'Ɇ', 'Έ', 'Ί', 'Ύ', 'Ώ', 'Α', 'Ρ', 'Σ', 'Ϋ', 'ϒ', 'ϔ', 'Ϲ', 'Ϻ', 'Ͻ', 'Я', 'Ӏ', 'Ӂ', 'Ա', 'Ֆ', 'Ⴀ', 'Ⴥ', 'Ꭰ', 'Ᏽ', 'Ა', 'Ჺ', 'Ჽ', 'Ჿ', 'Ἀ', 'Ἇ', 'Ἐ', 'Ἕ', 'Ἠ', 'Ἧ', 'Ἰ', 'Ἷ', 'Ὀ', 'Ὅ', 'Ὠ', 'Ὧ', 'Ᾰ', 'Ά', 'Ὲ', 'Ή', 'Ῐ', 'Ί', 'Ῠ', 'Ῥ', 'Ὸ', 'Ώ', 'ℋ', 'ℍ', 'ℐ', 'ℒ', 'ℙ', 'ℝ', 'K', 'ℭ', 'ℰ', 'ℳ', 'ℾ', 'ℿ', 'Ⰰ', 'Ⱞ', 'Ɫ', 'Ɽ', 'Ɑ', 'Ɒ', 'Ȿ', 'Ⲁ', 'Ᵹ', 'Ꝿ', 'Ɦ', 'Ɪ', 'Ʞ', 'Ꞵ', 'Ａ', 'Ｚ'},
@@ -12331,9 +12315,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mc",
-			pos:  position{line: 1493, col: 1, offset: 52364},
+			pos:  position{line: 1486, col: 1, offset: 52253},
 			expr: &charClassMatcher{
-				pos:        position{line: 1493, col: 6, offset: 52369},
+				pos:        position{line: 1486, col: 6, offset: 52258},
 				val:        "[\\u0903\\u093B\\u093E-\\u0940\\u0949-\\u094C\\u094E-\\u094F\\u0982-\\u0983\\u09BE-\\u09C0\\u09C7-\\u09C8\\u09CB-\\u09CC\\u09D7\\u0A03\\u0A3E-\\u0A40\\u0A83\\u0ABE-\\u0AC0\\u0AC9\\u0ACB-\\u0ACC\\u0B02-\\u0B03\\u0B3E\\u0B40\\u0B47-\\u0B48\\u0B4B-\\u0B4C\\u0B57\\u0BBE-\\u0BBF\\u0BC1-\\u0BC2\\u0BC6-\\u0BC8\\u0BCA-\\u0BCC\\u0BD7\\u0C01-\\u0C03\\u0C41-\\u0C44\\u0C82-\\u0C83\\u0CBE\\u0CC0-\\u0CC4\\u0CC7-\\u0CC8\\u0CCA-\\u0CCB\\u0CD5-\\u0CD6\\u0D02-\\u0D03\\u0D3E-\\u0D40\\u0D46-\\u0D48\\u0D4A-\\u0D4C\\u0D57\\u0D82-\\u0D83\\u0DCF-\\u0DD1\\u0DD8-\\u0DDF\\u0DF2-\\u0DF3\\u0F3E-\\u0F3F\\u0F7F\\u102B-\\u102C\\u1031\\u1038\\u103B-\\u103C\\u1056-\\u1057\\u1062-\\u1064\\u1067-\\u106D\\u1083-\\u1084\\u1087-\\u108C\\u108F\\u109A-\\u109C\\u17B6\\u17BE-\\u17C5\\u17C7-\\u17C8\\u1923-\\u1926\\u1929-\\u192B\\u1930-\\u1931\\u1933-\\u1938\\u1A19-\\u1A1A\\u1A55\\u1A57\\u1A61\\u1A63-\\u1A64\\u1A6D-\\u1A72\\u1B04\\u1B35\\u1B3B\\u1B3D-\\u1B41\\u1B43-\\u1B44\\u1B82\\u1BA1\\u1BA6-\\u1BA7\\u1BAA\\u1BE7\\u1BEA-\\u1BEC\\u1BEE\\u1BF2-\\u1BF3\\u1C24-\\u1C2B\\u1C34-\\u1C35\\u1CE1\\u1CF2-\\u1CF3\\u1CF7\\u302E-\\u302F\\uA823-\\uA824\\uA827\\uA880-\\uA881\\uA8B4-\\uA8C3\\uA952-\\uA953\\uA983\\uA9B4-\\uA9B5\\uA9BA-\\uA9BB\\uA9BD-\\uA9C0\\uAA2F-\\uAA30\\uAA33-\\uAA34\\uAA4D\\uAA7B\\uAA7D\\uAAEB\\uAAEE-\\uAAEF\\uAAF5\\uABE3-\\uABE4\\uABE6-\\uABE7\\uABE9-\\uABEA\\uABEC]",
 				chars:      []rune{'ः', 'ऻ', 'ৗ', 'ਃ', 'ઃ', 'ૉ', 'ା', 'ୀ', 'ୗ', 'ௗ', 'ಾ', 'ൗ', 'ཿ', 'ေ', 'း', 'ႏ', 'ា', 'ᩕ', 'ᩗ', 'ᩡ', 'ᬄ', 'ᬵ', 'ᬻ', 'ᮂ', 'ᮡ', '᮪', 'ᯧ', 'ᯮ', '᳡', '᳷', 'ꠧ', 'ꦃ', 'ꩍ', 'ꩻ', 'ꩽ', 'ꫫ', 'ꫵ', '꯬'},
 				ranges:     []rune{'ा', 'ी', 'ॉ', 'ौ', 'ॎ', 'ॏ', 'ং', 'ঃ', 'া', 'ী', 'ে', 'ৈ', 'ো', 'ৌ', 'ਾ', 'ੀ', 'ા', 'ી', 'ો', 'ૌ', 'ଂ', 'ଃ', 'େ', 'ୈ', 'ୋ', 'ୌ', 'ா', 'ி', 'ு', 'ூ', 'ெ', 'ை', 'ொ', 'ௌ', 'ఁ', 'ః', 'ు', 'ౄ', 'ಂ', 'ಃ', 'ೀ', 'ೄ', 'ೇ', 'ೈ', 'ೊ', 'ೋ', 'ೕ', 'ೖ', 'ം', 'ഃ', 'ാ', 'ീ', 'െ', 'ൈ', 'ൊ', 'ൌ', 'ං', 'ඃ', 'ා', 'ෑ', 'ෘ', 'ෟ', 'ෲ', 'ෳ', '༾', '༿', 'ါ', 'ာ', 'ျ', 'ြ', 'ၖ', 'ၗ', 'ၢ', 'ၤ', 'ၧ', 'ၭ', 'ႃ', 'ႄ', 'ႇ', 'ႌ', 'ႚ', 'ႜ', 'ើ', 'ៅ', 'ះ', 'ៈ', 'ᤣ', 'ᤦ', 'ᤩ', 'ᤫ', 'ᤰ', 'ᤱ', 'ᤳ', 'ᤸ', 'ᨙ', 'ᨚ', 'ᩣ', 'ᩤ', 'ᩭ', 'ᩲ', 'ᬽ', 'ᭁ', 'ᭃ', '᭄', 'ᮦ', 'ᮧ', 'ᯪ', 'ᯬ', '᯲', '᯳', 'ᰤ', 'ᰫ', 'ᰴ', 'ᰵ', 'ᳲ', 'ᳳ', '〮', '〯', 'ꠣ', 'ꠤ', 'ꢀ', 'ꢁ', 'ꢴ', 'ꣃ', 'ꥒ', '꥓', 'ꦴ', 'ꦵ', 'ꦺ', 'ꦻ', 'ꦽ', '꧀', 'ꨯ', 'ꨰ', 'ꨳ', 'ꨴ', 'ꫮ', 'ꫯ', 'ꯣ', 'ꯤ', 'ꯦ', 'ꯧ', 'ꯩ', 'ꯪ'},
@@ -12343,9 +12327,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mn",
-			pos:  position{line: 1496, col: 1, offset: 53557},
+			pos:  position{line: 1489, col: 1, offset: 53446},
 			expr: &charClassMatcher{
-				pos:        position{line: 1496, col: 6, offset: 53562},
+				pos:        position{line: 1489, col: 6, offset: 53451},
 				val:        "[\\u0300-\\u036F\\u0483-\\u0487\\u0591-\\u05BD\\u05BF\\u05C1-\\u05C2\\u05C4-\\u05C5\\u05C7\\u0610-\\u061A\\u064B-\\u065F\\u0670\\u06D6-\\u06DC\\u06DF-\\u06E4\\u06E7-\\u06E8\\u06EA-\\u06ED\\u0711\\u0730-\\u074A\\u07A6-\\u07B0\\u07EB-\\u07F3\\u07FD\\u0816-\\u0819\\u081B-\\u0823\\u0825-\\u0827\\u0829-\\u082D\\u0859-\\u085B\\u08D3-\\u08E1\\u08E3-\\u0902\\u093A\\u093C\\u0941-\\u0948\\u094D\\u0951-\\u0957\\u0962-\\u0963\\u0981\\u09BC\\u09C1-\\u09C4\\u09CD\\u09E2-\\u09E3\\u09FE\\u0A01-\\u0A02\\u0A3C\\u0A41-\\u0A42\\u0A47-\\u0A48\\u0A4B-\\u0A4D\\u0A51\\u0A70-\\u0A71\\u0A75\\u0A81-\\u0A82\\u0ABC\\u0AC1-\\u0AC5\\u0AC7-\\u0AC8\\u0ACD\\u0AE2-\\u0AE3\\u0AFA-\\u0AFF\\u0B01\\u0B3C\\u0B3F\\u0B41-\\u0B44\\u0B4D\\u0B56\\u0B62-\\u0B63\\u0B82\\u0BC0\\u0BCD\\u0C00\\u0C04\\u0C3E-\\u0C40\\u0C46-\\u0C48\\u0C4A-\\u0C4D\\u0C55-\\u0C56\\u0C62-\\u0C63\\u0C81\\u0CBC\\u0CBF\\u0CC6\\u0CCC-\\u0CCD\\u0CE2-\\u0CE3\\u0D00-\\u0D01\\u0D3B-\\u0D3C\\u0D41-\\u0D44\\u0D4D\\u0D62-\\u0D63\\u0DCA\\u0DD2-\\u0DD4\\u0DD6\\u0E31\\u0E34-\\u0E3A\\u0E47-\\u0E4E\\u0EB1\\u0EB4-\\u0EB9\\u0EBB-\\u0EBC\\u0EC8-\\u0ECD\\u0F18-\\u0F19\\u0F35\\u0F37\\u0F39\\u0F71-\\u0F7E\\u0F80-\\u0F84\\u0F86-\\u0F87\\u0F8D-\\u0F97\\u0F99-\\u0FBC\\u0FC6\\u102D-\\u1030\\u1032-\\u1037\\u1039-\\u103A\\u103D-\\u103E\\u1058-\\u1059\\u105E-\\u1060\\u1071-\\u1074\\u1082\\u1085-\\u1086\\u108D\\u109D\\u135D-\\u135F\\u1712-\\u1714\\u1732-\\u1734\\u1752-\\u1753\\u1772-\\u1773\\u17B4-\\u17B5\\u17B7-\\u17BD\\u17C6\\u17C9-\\u17D3\\u17DD\\u180B-\\u180D\\u1885-\\u1886\\u18A9\\u1920-\\u1922\\u1927-\\u1928\\u1932\\u1939-\\u193B\\u1A17-\\u1A18\\u1A1B\\u1A56\\u1A58-\\u1A5E\\u1A60\\u1A62\\u1A65-\\u1A6C\\u1A73-\\u1A7C\\u1A7F\\u1AB0-\\u1ABD\\u1B00-\\u1B03\\u1B34\\u1B36-\\u1B3A\\u1B3C\\u1B42\\u1B6B-\\u1B73\\u1B80-\\u1B81\\u1BA2-\\u1BA5\\u1BA8-\\u1BA9\\u1BAB-\\u1BAD\\u1BE6\\u1BE8-\\u1BE9\\u1BED\\u1BEF-\\u1BF1\\u1C2C-\\u1C33\\u1C36-\\u1C37\\u1CD0-\\u1CD2\\u1CD4-\\u1CE0\\u1CE2-\\u1CE8\\u1CED\\u1CF4\\u1CF8-\\u1CF9\\u1DC0-\\u1DF9\\u1DFB-\\u1DFF\\u20D0-\\u20DC\\u20E1\\u20E5-\\u20F0\\u2CEF-\\u2CF1\\u2D7F\\u2DE0-\\u2DFF\\u302A-\\u302D\\u3099-\\u309A\\uA66F\\uA674-\\uA67D\\uA69E-\\uA69F\\uA6F0-\\uA6F1\\uA802\\uA806\\uA80B\\uA825-\\uA826\\uA8C4-\\uA8C5\\uA8E0-\\uA8F1\\uA8FF\\uA926-\\uA92D\\uA947-\\uA951\\uA980-\\uA982\\uA9B3\\uA9B6-\\uA9B9\\uA9BC\\uA9E5\\uAA29-\\uAA2E\\uAA31-\\uAA32\\uAA35-\\uAA36\\uAA43\\uAA4C\\uAA7C\\uAAB0\\uAAB2-\\uAAB4\\uAAB7-\\uAAB8\\uAABE-\\uAABF\\uAAC1\\uAAEC-\\uAAED\\uAAF6\\uABE5\\uABE8\\uABED\\uFB1E\\uFE00-\\uFE0F\\uFE20-\\uFE2F]",
 				chars:      []rune{'ֿ', 'ׇ', 'ٰ', 'ܑ', '߽', 'ऺ', '़', '्', 'ঁ', '়', '্', '৾', '਼', 'ੑ', 'ੵ', '઼', '્', 'ଁ', '଼', 'ି', '୍', 'ୖ', 'ஂ', 'ீ', '்', 'ఀ', 'ఄ', 'ಁ', '಼', 'ಿ', 'ೆ', '്', '්', 'ූ', 'ั', 'ັ', '༵', '༷', '༹', '࿆', 'ႂ', 'ႍ', 'ႝ', 'ំ', '៝', 'ᢩ', 'ᤲ', 'ᨛ', 'ᩖ', '᩠', 'ᩢ', '᩿', '᬴', 'ᬼ', 'ᭂ', '᯦', 'ᯭ', '᳭', '᳴', '⃡', '⵿', '꙯', 'ꠂ', '꠆', 'ꠋ', 'ꣿ', '꦳', 'ꦼ', 'ꧥ', 'ꩃ', 'ꩌ', 'ꩼ', 'ꪰ', '꫁', '꫶', 'ꯥ', 'ꯨ', '꯭', 'ﬞ'},
 				ranges:     []rune{'̀', 'ͯ', '҃', '҇', '֑', 'ֽ', 'ׁ', 'ׂ', 'ׄ', 'ׅ', 'ؐ', 'ؚ', 'ً', 'ٟ', 'ۖ', 'ۜ', '۟', 'ۤ', 'ۧ', 'ۨ', '۪', 'ۭ', 'ܰ', '݊', 'ަ', 'ް', '߫', '߳', 'ࠖ', '࠙', 'ࠛ', 'ࠣ', 'ࠥ', 'ࠧ', 'ࠩ', '࠭', '࡙', '࡛', '࣓', '࣡', 'ࣣ', 'ं', 'ु', 'ै', '॑', 'ॗ', 'ॢ', 'ॣ', 'ু', 'ৄ', 'ৢ', 'ৣ', 'ਁ', 'ਂ', 'ੁ', 'ੂ', 'ੇ', 'ੈ', 'ੋ', '੍', 'ੰ', 'ੱ', 'ઁ', 'ં', 'ુ', 'ૅ', 'ે', 'ૈ', 'ૢ', 'ૣ', 'ૺ', '૿', 'ୁ', 'ୄ', 'ୢ', 'ୣ', 'ా', 'ీ', 'ె', 'ై', 'ొ', '్', 'ౕ', 'ౖ', 'ౢ', 'ౣ', 'ೌ', '್', 'ೢ', 'ೣ', 'ഀ', 'ഁ', '഻', '഼', 'ു', 'ൄ', 'ൢ', 'ൣ', 'ි', 'ු', 'ิ', 'ฺ', '็', '๎', 'ິ', 'ູ', 'ົ', 'ຼ', '່', 'ໍ', '༘', '༙', 'ཱ', 'ཾ', 'ྀ', '྄', '྆', '྇', 'ྍ', 'ྗ', 'ྙ', 'ྼ', 'ိ', 'ူ', 'ဲ', '့', '္', '်', 'ွ', 'ှ', 'ၘ', 'ၙ', 'ၞ', 'ၠ', 'ၱ', 'ၴ', 'ႅ', 'ႆ', '፝', '፟', 'ᜒ', '᜔', 'ᜲ', '᜴', 'ᝒ', 'ᝓ', 'ᝲ', 'ᝳ', '឴', '឵', 'ិ', 'ួ', '៉', '៓', '᠋', '᠍', 'ᢅ', 'ᢆ', 'ᤠ', 'ᤢ', 'ᤧ', 'ᤨ', '᤹', '᤻', 'ᨗ', 'ᨘ', 'ᩘ', 'ᩞ', 'ᩥ', 'ᩬ', 'ᩳ', '᩼', '᪰', '᪽', 'ᬀ', 'ᬃ', 'ᬶ', 'ᬺ', '᭫', '᭳', 'ᮀ', 'ᮁ', 'ᮢ', 'ᮥ', 'ᮨ', 'ᮩ', '᮫', 'ᮭ', 'ᯨ', 'ᯩ', 'ᯯ', 'ᯱ', 'ᰬ', 'ᰳ', 'ᰶ', '᰷', '᳐', '᳒', '᳔', '᳠', '᳢', '᳨', '᳸', '᳹', '᷀', '᷹', '᷻', '᷿', '⃐', '⃜', '⃥', '⃰', '⳯', '⳱', 'ⷠ', 'ⷿ', '〪', '〭', '゙', '゚', 'ꙴ', '꙽', 'ꚞ', 'ꚟ', '꛰', '꛱', 'ꠥ', 'ꠦ', '꣄', 'ꣅ', '꣠', '꣱', 'ꤦ', '꤭', 'ꥇ', 'ꥑ', 'ꦀ', 'ꦂ', 'ꦶ', 'ꦹ', 'ꨩ', 'ꨮ', 'ꨱ', 'ꨲ', 'ꨵ', 'ꨶ', 'ꪲ', 'ꪴ', 'ꪷ', 'ꪸ', 'ꪾ', '꪿', 'ꫬ', 'ꫭ', '︀', '️', '︠', '︯'},
@@ -12355,9 +12339,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nd",
-			pos:  position{line: 1499, col: 1, offset: 55742},
+			pos:  position{line: 1492, col: 1, offset: 55631},
 			expr: &charClassMatcher{
-				pos:        position{line: 1499, col: 6, offset: 55747},
+				pos:        position{line: 1492, col: 6, offset: 55636},
 				val:        "[\\u0030-\\u0039\\u0660-\\u0669\\u06F0-\\u06F9\\u07C0-\\u07C9\\u0966-\\u096F\\u09E6-\\u09EF\\u0A66-\\u0A6F\\u0AE6-\\u0AEF\\u0B66-\\u0B6F\\u0BE6-\\u0BEF\\u0C66-\\u0C6F\\u0CE6-\\u0CEF\\u0D66-\\u0D6F\\u0DE6-\\u0DEF\\u0E50-\\u0E59\\u0ED0-\\u0ED9\\u0F20-\\u0F29\\u1040-\\u1049\\u1090-\\u1099\\u17E0-\\u17E9\\u1810-\\u1819\\u1946-\\u194F\\u19D0-\\u19D9\\u1A80-\\u1A89\\u1A90-\\u1A99\\u1B50-\\u1B59\\u1BB0-\\u1BB9\\u1C40-\\u1C49\\u1C50-\\u1C59\\uA620-\\uA629\\uA8D0-\\uA8D9\\uA900-\\uA909\\uA9D0-\\uA9D9\\uA9F0-\\uA9F9\\uAA50-\\uAA59\\uABF0-\\uABF9\\uFF10-\\uFF19]",
 				ranges:     []rune{'0', '9', '٠', '٩', '۰', '۹', '߀', '߉', '०', '९', '০', '৯', '੦', '੯', '૦', '૯', '୦', '୯', '௦', '௯', '౦', '౯', '೦', '೯', '൦', '൯', '෦', '෯', '๐', '๙', '໐', '໙', '༠', '༩', '၀', '၉', '႐', '႙', '០', '៩', '᠐', '᠙', '᥆', '᥏', '᧐', '᧙', '᪀', '᪉', '᪐', '᪙', '᭐', '᭙', '᮰', '᮹', '᱀', '᱉', '᱐', '᱙', '꘠', '꘩', '꣐', '꣙', '꤀', '꤉', '꧐', '꧙', '꧰', '꧹', '꩐', '꩙', '꯰', '꯹', '０', '９'},
 				ignoreCase: false,
@@ -12366,9 +12350,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nl",
-			pos:  position{line: 1502, col: 1, offset: 56250},
+			pos:  position{line: 1495, col: 1, offset: 56139},
 			expr: &charClassMatcher{
-				pos:        position{line: 1502, col: 6, offset: 56255},
+				pos:        position{line: 1495, col: 6, offset: 56144},
 				val:        "[\\u16EE-\\u16F0\\u2160-\\u2182\\u2185-\\u2188\\u3007\\u3021-\\u3029\\u3038-\\u303A\\uA6E6-\\uA6EF]",
 				chars:      []rune{'〇'},
 				ranges:     []rune{'ᛮ', 'ᛰ', 'Ⅰ', 'ↂ', 'ↅ', 'ↈ', '〡', '〩', '〸', '〺', 'ꛦ', 'ꛯ'},
@@ -12378,9 +12362,9 @@ var g = &grammar{
 		},
 		{
 			name: "Pc",
-			pos:  position{line: 1505, col: 1, offset: 56369},
+			pos:  position{line: 1498, col: 1, offset: 56258},
 			expr: &charClassMatcher{
-				pos:        position{line: 1505, col: 6, offset: 56374},
+				pos:        position{line: 1498, col: 6, offset: 56263},
 				val:        "[\\u005F\\u203F-\\u2040\\u2054\\uFE33-\\uFE34\\uFE4D-\\uFE4F\\uFF3F]",
 				chars:      []rune{'_', '⁔', '＿'},
 				ranges:     []rune{'‿', '⁀', '︳', '︴', '﹍', '﹏'},
@@ -12390,9 +12374,9 @@ var g = &grammar{
 		},
 		{
 			name: "Zs",
-			pos:  position{line: 1508, col: 1, offset: 56455},
+			pos:  position{line: 1501, col: 1, offset: 56344},
 			expr: &charClassMatcher{
-				pos:        position{line: 1508, col: 6, offset: 56460},
+				pos:        position{line: 1501, col: 6, offset: 56349},
 				val:        "[\\u0020\\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000]",
 				chars:      []rune{' ', '\u00a0', '\u1680', '\u202f', '\u205f', '\u3000'},
 				ranges:     []rune{'\u2000', '\u200a'},
@@ -12402,50 +12386,50 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1510, col: 1, offset: 56513},
+			pos:  position{line: 1503, col: 1, offset: 56402},
 			expr: &anyMatcher{
-				line: 1511, col: 5, offset: 56533,
+				line: 1504, col: 5, offset: 56422,
 			},
 		},
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1513, col: 1, offset: 56536},
+			pos:         position{line: 1506, col: 1, offset: 56425},
 			expr: &choiceExpr{
-				pos: position{line: 1514, col: 5, offset: 56564},
+				pos: position{line: 1507, col: 5, offset: 56453},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1514, col: 5, offset: 56564},
+						pos:        position{line: 1507, col: 5, offset: 56453},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1515, col: 5, offset: 56573},
+						pos:        position{line: 1508, col: 5, offset: 56462},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1516, col: 5, offset: 56582},
+						pos:        position{line: 1509, col: 5, offset: 56471},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1517, col: 5, offset: 56591},
+						pos:        position{line: 1510, col: 5, offset: 56480},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1518, col: 5, offset: 56599},
+						pos:        position{line: 1511, col: 5, offset: 56488},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1519, col: 5, offset: 56612},
+						pos:        position{line: 1512, col: 5, offset: 56501},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1520, col: 5, offset: 56625},
+						pos:  position{line: 1513, col: 5, offset: 56514},
 						name: "Zs",
 					},
 				},
@@ -12453,9 +12437,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1522, col: 1, offset: 56629},
+			pos:  position{line: 1515, col: 1, offset: 56518},
 			expr: &charClassMatcher{
-				pos:        position{line: 1523, col: 5, offset: 56648},
+				pos:        position{line: 1516, col: 5, offset: 56537},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -12465,45 +12449,45 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1529, col: 1, offset: 56978},
+			pos:         position{line: 1522, col: 1, offset: 56867},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1532, col: 5, offset: 57049},
+				pos:  position{line: 1525, col: 5, offset: 56938},
 				name: "SingleLineComment",
 			},
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1534, col: 1, offset: 57068},
+			pos:  position{line: 1527, col: 1, offset: 56957},
 			expr: &seqExpr{
-				pos: position{line: 1535, col: 5, offset: 57089},
+				pos: position{line: 1528, col: 5, offset: 56978},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1535, col: 5, offset: 57089},
+						pos:        position{line: 1528, col: 5, offset: 56978},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1535, col: 10, offset: 57094},
+						pos: position{line: 1528, col: 10, offset: 56983},
 						expr: &seqExpr{
-							pos: position{line: 1535, col: 11, offset: 57095},
+							pos: position{line: 1528, col: 11, offset: 56984},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1535, col: 11, offset: 57095},
+									pos: position{line: 1528, col: 11, offset: 56984},
 									expr: &litMatcher{
-										pos:        position{line: 1535, col: 12, offset: 57096},
+										pos:        position{line: 1528, col: 12, offset: 56985},
 										val:        "*/",
 										ignoreCase: false,
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1535, col: 17, offset: 57101},
+									pos:  position{line: 1528, col: 17, offset: 56990},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1535, col: 35, offset: 57119},
+						pos:        position{line: 1528, col: 35, offset: 57008},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -12512,29 +12496,29 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1537, col: 1, offset: 57125},
+			pos:  position{line: 1530, col: 1, offset: 57014},
 			expr: &seqExpr{
-				pos: position{line: 1538, col: 5, offset: 57147},
+				pos: position{line: 1531, col: 5, offset: 57036},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1538, col: 5, offset: 57147},
+						pos:        position{line: 1531, col: 5, offset: 57036},
 						val:        "//",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1538, col: 10, offset: 57152},
+						pos: position{line: 1531, col: 10, offset: 57041},
 						expr: &seqExpr{
-							pos: position{line: 1538, col: 11, offset: 57153},
+							pos: position{line: 1531, col: 11, offset: 57042},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1538, col: 11, offset: 57153},
+									pos: position{line: 1531, col: 11, offset: 57042},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1538, col: 12, offset: 57154},
+										pos:  position{line: 1531, col: 12, offset: 57043},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1538, col: 27, offset: 57169},
+									pos:  position{line: 1531, col: 27, offset: 57058},
 									name: "SourceCharacter",
 								},
 							},
@@ -12545,19 +12529,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1540, col: 1, offset: 57188},
+			pos:  position{line: 1533, col: 1, offset: 57077},
 			expr: &seqExpr{
-				pos: position{line: 1540, col: 7, offset: 57194},
+				pos: position{line: 1533, col: 7, offset: 57083},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1540, col: 7, offset: 57194},
+						pos: position{line: 1533, col: 7, offset: 57083},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1540, col: 7, offset: 57194},
+							pos:  position{line: 1533, col: 7, offset: 57083},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1540, col: 19, offset: 57206},
+						pos:  position{line: 1533, col: 19, offset: 57095},
 						name: "LineTerminator",
 					},
 				},
@@ -12565,16 +12549,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1542, col: 1, offset: 57222},
+			pos:  position{line: 1535, col: 1, offset: 57111},
 			expr: &choiceExpr{
-				pos: position{line: 1542, col: 7, offset: 57228},
+				pos: position{line: 1535, col: 7, offset: 57117},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1542, col: 7, offset: 57228},
+						pos:  position{line: 1535, col: 7, offset: 57117},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1542, col: 11, offset: 57232},
+						pos:  position{line: 1535, col: 11, offset: 57121},
 						name: "EOF",
 					},
 				},
@@ -12582,21 +12566,21 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1544, col: 1, offset: 57237},
+			pos:  position{line: 1537, col: 1, offset: 57126},
 			expr: &notExpr{
-				pos: position{line: 1544, col: 7, offset: 57243},
+				pos: position{line: 1537, col: 7, offset: 57132},
 				expr: &anyMatcher{
-					line: 1544, col: 8, offset: 57244,
+					line: 1537, col: 8, offset: 57133,
 				},
 			},
 		},
 		{
 			name: "EOKW",
-			pos:  position{line: 1546, col: 1, offset: 57247},
+			pos:  position{line: 1539, col: 1, offset: 57136},
 			expr: &notExpr{
-				pos: position{line: 1546, col: 8, offset: 57254},
+				pos: position{line: 1539, col: 8, offset: 57143},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1546, col: 9, offset: 57255},
+					pos:  position{line: 1539, col: 9, offset: 57144},
 					name: "KeyWordChars",
 				},
 			},
@@ -14478,17 +14462,6 @@ func (p *parser) callonGrep1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onGrep1(stack["pattern"], stack["opt"])
-}
-
-func (c *current) onPattern4(s interface{}) (interface{}, error) {
-	return map[string]interface{}{"kind": "String", "text": s}, nil
-
-}
-
-func (p *parser) callonPattern4() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onPattern4(stack["s"])
 }
 
 func (c *current) onOptionalExprs3() (interface{}, error) {

--- a/compiler/parser/parser.js
+++ b/compiler/parser/parser.js
@@ -738,67 +738,64 @@ function peg$parse(input, options) {
             }
             return m
           },
-      peg$c316 = function(s) {
-            return {"kind": "String", "text": s}
-          },
-      peg$c317 = function() { return [] },
-      peg$c318 = function(first, e) { return e },
-      peg$c319 = "]",
-      peg$c320 = peg$literalExpectation("]", false),
-      peg$c321 = function(from, to) {
+      peg$c316 = function() { return [] },
+      peg$c317 = function(first, e) { return e },
+      peg$c318 = "]",
+      peg$c319 = peg$literalExpectation("]", false),
+      peg$c320 = function(from, to) {
             return ["[", {"kind": "BinaryExpr", "op": ":",
                                   
             "lhs": from, "rhs": to}]
           
           },
-      peg$c322 = function(to) {
+      peg$c321 = function(to) {
             return ["[", {"kind": "BinaryExpr", "op": ":",
                                   
             "lhs": null, "rhs": to}]
           
           },
-      peg$c323 = function(expr) { return ["[", expr] },
-      peg$c324 = function(id) { return [".", id] },
-      peg$c325 = function(exprs, locals, body) {
+      peg$c322 = function(expr) { return ["[", expr] },
+      peg$c323 = function(id) { return [".", id] },
+      peg$c324 = function(exprs, locals, body) {
             return {"kind": "OverExpr", "locals": locals, "exprs": exprs, "body": body}
           },
-      peg$c326 = "}",
-      peg$c327 = peg$literalExpectation("}", false),
-      peg$c328 = function(elems) {
+      peg$c325 = "}",
+      peg$c326 = peg$literalExpectation("}", false),
+      peg$c327 = function(elems) {
             return {"kind": "RecordExpr", "elems": elems}
           },
-      peg$c329 = function(elem) { return elem },
-      peg$c330 = "...",
-      peg$c331 = peg$literalExpectation("...", false),
-      peg$c332 = function(expr) {
+      peg$c328 = function(elem) { return elem },
+      peg$c329 = "...",
+      peg$c330 = peg$literalExpectation("...", false),
+      peg$c331 = function(expr) {
             return {"kind": "Spread", "expr": expr}
           },
-      peg$c333 = function(name, value) {
+      peg$c332 = function(name, value) {
             return {"kind": "Field", "name": name, "value": value}
           },
-      peg$c334 = function(elems) {
+      peg$c333 = function(elems) {
             return {"kind": "ArrayExpr", "elems": elems}
           },
-      peg$c335 = "|[",
-      peg$c336 = peg$literalExpectation("|[", false),
-      peg$c337 = "]|",
-      peg$c338 = peg$literalExpectation("]|", false),
-      peg$c339 = function(elems) {
+      peg$c334 = "|[",
+      peg$c335 = peg$literalExpectation("|[", false),
+      peg$c336 = "]|",
+      peg$c337 = peg$literalExpectation("]|", false),
+      peg$c338 = function(elems) {
             return {"kind": "SetExpr", "elems": elems}
           },
-      peg$c340 = function(e) { return {"kind": "VectorValue", "expr": e} },
-      peg$c341 = "|{",
-      peg$c342 = peg$literalExpectation("|{", false),
-      peg$c343 = "}|",
-      peg$c344 = peg$literalExpectation("}|", false),
-      peg$c345 = function(exprs) {
+      peg$c339 = function(e) { return {"kind": "VectorValue", "expr": e} },
+      peg$c340 = "|{",
+      peg$c341 = peg$literalExpectation("|{", false),
+      peg$c342 = "}|",
+      peg$c343 = peg$literalExpectation("}|", false),
+      peg$c344 = function(exprs) {
             return {"kind": "MapExpr", "entries": exprs}
           },
-      peg$c346 = function(e) { return e },
-      peg$c347 = function(key, value) {
+      peg$c345 = function(e) { return e },
+      peg$c346 = function(key, value) {
             return {"key": key, "value": value}
           },
-      peg$c348 = function(selection, from, joins, where, groupby, having, orderby, limit) {
+      peg$c347 = function(selection, from, joins, where, groupby, having, orderby, limit) {
             return {
               
             "kind": "SQLExpr",
@@ -820,19 +817,19 @@ function peg$parse(input, options) {
             "limit": limit}
           
           },
-      peg$c349 = function(assignments) { return assignments },
-      peg$c350 = function(rhs, opt) {
+      peg$c348 = function(assignments) { return assignments },
+      peg$c349 = function(rhs, opt) {
             let m = {"kind": "Assignment", "lhs": null, "rhs": rhs}
             if (opt) {
               m["lhs"] = opt[3]
             }
             return m
           },
-      peg$c351 = function(table, alias) {
+      peg$c350 = function(table, alias) {
             return {"table": table, "alias": alias}
           },
-      peg$c352 = function(first, join) { return join },
-      peg$c353 = function(style, table, alias, leftKey, rightKey) {
+      peg$c351 = function(first, join) { return join },
+      peg$c352 = function(style, table, alias, leftKey, rightKey) {
             return {
               
             "table": table,
@@ -846,115 +843,115 @@ function peg$parse(input, options) {
             "alias": alias}
           
           },
-      peg$c354 = function(style) { return style },
-      peg$c355 = function(keys, order) {
+      peg$c353 = function(style) { return style },
+      peg$c354 = function(keys, order) {
             return {"kind": "SQLOrderBy", "keys": keys, "order": order}
           },
-      peg$c356 = function(dir) { return dir },
-      peg$c357 = function(count) { return count },
-      peg$c358 = peg$literalExpectation("select", true),
-      peg$c359 = function() { return "select" },
-      peg$c360 = "as",
-      peg$c361 = peg$literalExpectation("as", true),
-      peg$c362 = function() { return "as" },
-      peg$c363 = peg$literalExpectation("from", true),
-      peg$c364 = function() { return "from" },
-      peg$c365 = peg$literalExpectation("join", true),
-      peg$c366 = function() { return "join" },
-      peg$c367 = peg$literalExpectation("where", true),
-      peg$c368 = function() { return "where" },
-      peg$c369 = "group",
-      peg$c370 = peg$literalExpectation("group", true),
-      peg$c371 = function() { return "group" },
-      peg$c372 = "by",
-      peg$c373 = peg$literalExpectation("by", true),
-      peg$c374 = function() { return "by" },
-      peg$c375 = "having",
-      peg$c376 = peg$literalExpectation("having", true),
-      peg$c377 = function() { return "having" },
-      peg$c378 = peg$literalExpectation("order", true),
-      peg$c379 = function() { return "order" },
-      peg$c380 = "on",
-      peg$c381 = peg$literalExpectation("on", true),
-      peg$c382 = function() { return "on" },
-      peg$c383 = "limit",
-      peg$c384 = peg$literalExpectation("limit", true),
-      peg$c385 = function() { return "limit" },
-      peg$c386 = "asc",
-      peg$c387 = peg$literalExpectation("asc", true),
-      peg$c388 = "desc",
-      peg$c389 = peg$literalExpectation("desc", true),
-      peg$c390 = peg$literalExpectation("anti", true),
-      peg$c391 = peg$literalExpectation("left", true),
-      peg$c392 = peg$literalExpectation("right", true),
-      peg$c393 = peg$literalExpectation("inner", true),
-      peg$c394 = function(v) {
+      peg$c355 = function(dir) { return dir },
+      peg$c356 = function(count) { return count },
+      peg$c357 = peg$literalExpectation("select", true),
+      peg$c358 = function() { return "select" },
+      peg$c359 = "as",
+      peg$c360 = peg$literalExpectation("as", true),
+      peg$c361 = function() { return "as" },
+      peg$c362 = peg$literalExpectation("from", true),
+      peg$c363 = function() { return "from" },
+      peg$c364 = peg$literalExpectation("join", true),
+      peg$c365 = function() { return "join" },
+      peg$c366 = peg$literalExpectation("where", true),
+      peg$c367 = function() { return "where" },
+      peg$c368 = "group",
+      peg$c369 = peg$literalExpectation("group", true),
+      peg$c370 = function() { return "group" },
+      peg$c371 = "by",
+      peg$c372 = peg$literalExpectation("by", true),
+      peg$c373 = function() { return "by" },
+      peg$c374 = "having",
+      peg$c375 = peg$literalExpectation("having", true),
+      peg$c376 = function() { return "having" },
+      peg$c377 = peg$literalExpectation("order", true),
+      peg$c378 = function() { return "order" },
+      peg$c379 = "on",
+      peg$c380 = peg$literalExpectation("on", true),
+      peg$c381 = function() { return "on" },
+      peg$c382 = "limit",
+      peg$c383 = peg$literalExpectation("limit", true),
+      peg$c384 = function() { return "limit" },
+      peg$c385 = "asc",
+      peg$c386 = peg$literalExpectation("asc", true),
+      peg$c387 = "desc",
+      peg$c388 = peg$literalExpectation("desc", true),
+      peg$c389 = peg$literalExpectation("anti", true),
+      peg$c390 = peg$literalExpectation("left", true),
+      peg$c391 = peg$literalExpectation("right", true),
+      peg$c392 = peg$literalExpectation("inner", true),
+      peg$c393 = function(v) {
             return {"kind": "Primitive", "type": "net", "text": v}
           },
-      peg$c395 = function(v) {
+      peg$c394 = function(v) {
             return {"kind": "Primitive", "type": "ip", "text": v}
           },
-      peg$c396 = function(v) {
+      peg$c395 = function(v) {
             return {"kind": "Primitive", "type": "float64", "text": v}
           },
-      peg$c397 = function(v) {
+      peg$c396 = function(v) {
             return {"kind": "Primitive", "type": "int64", "text": v}
           },
-      peg$c398 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
-      peg$c399 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
-      peg$c400 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
-      peg$c401 = "0x",
-      peg$c402 = peg$literalExpectation("0x", false),
-      peg$c403 = function() {
+      peg$c397 = function() { return {"kind": "Primitive", "type": "bool", "text": "true"} },
+      peg$c398 = function() { return {"kind": "Primitive", "type": "bool", "text": "false"} },
+      peg$c399 = function() { return {"kind": "Primitive", "type": "null", "text": ""} },
+      peg$c400 = "0x",
+      peg$c401 = peg$literalExpectation("0x", false),
+      peg$c402 = function() {
       	return {"kind": "Primitive", "type": "bytes", "text": text()}
         },
-      peg$c404 = function(typ) {
+      peg$c403 = function(typ) {
             return {"kind": "TypeValue", "value": typ}
           },
-      peg$c405 = function(name) { return name },
-      peg$c406 = function(name, opt) {
+      peg$c404 = function(name) { return name },
+      peg$c405 = function(name, opt) {
             if (opt) {
               return {"kind": "TypeDef", "name": name, "type": opt[3]}
             }
             return {"kind": "TypeName", "name": name}
           },
-      peg$c407 = function(name) {
+      peg$c406 = function(name) {
             return {"kind": "TypeName", "name": name}
           },
-      peg$c408 = function(u) { return u },
-      peg$c409 = function(types) {
+      peg$c407 = function(u) { return u },
+      peg$c408 = function(types) {
             return {"kind": "TypeUnion", "types": types}
           },
-      peg$c410 = function(fields) {
+      peg$c409 = function(fields) {
             return {"kind": "TypeRecord", "fields": fields}
           },
-      peg$c411 = function(typ) {
+      peg$c410 = function(typ) {
             return {"kind": "TypeArray", "type": typ}
           },
-      peg$c412 = function(typ) {
+      peg$c411 = function(typ) {
             return {"kind": "TypeSet", "type": typ}
           },
-      peg$c413 = function(keyType, valType) {
+      peg$c412 = function(keyType, valType) {
             return {"kind": "TypeMap", "key_type": keyType, "val_type": valType}
           },
-      peg$c414 = function(v) {
+      peg$c413 = function(v) {
             if (v.length == 0) {
               return {"kind": "Primitive", "type": "string", "text": ""}
             }
             return makeTemplateExprChain(v)
           },
-      peg$c415 = "\"",
-      peg$c416 = peg$literalExpectation("\"", false),
-      peg$c417 = "'",
-      peg$c418 = peg$literalExpectation("'", false),
-      peg$c419 = function(v) {
+      peg$c414 = "\"",
+      peg$c415 = peg$literalExpectation("\"", false),
+      peg$c416 = "'",
+      peg$c417 = peg$literalExpectation("'", false),
+      peg$c418 = function(v) {
             return {"kind": "Primitive", "type": "string", "text": joinChars(v)}
           },
-      peg$c420 = "\\",
-      peg$c421 = peg$literalExpectation("\\", false),
-      peg$c422 = "${",
-      peg$c423 = peg$literalExpectation("${", false),
-      peg$c424 = function(e) {
+      peg$c419 = "\\",
+      peg$c420 = peg$literalExpectation("\\", false),
+      peg$c421 = "${",
+      peg$c422 = peg$literalExpectation("${", false),
+      peg$c423 = function(e) {
             return {
               
             "kind": "Cast",
@@ -968,225 +965,225 @@ function peg$parse(input, options) {
             "value": {"kind": "TypePrimitive", "name": "string"}}}
           
           },
-      peg$c425 = "uint8",
-      peg$c426 = peg$literalExpectation("uint8", false),
-      peg$c427 = "uint16",
-      peg$c428 = peg$literalExpectation("uint16", false),
-      peg$c429 = "uint32",
-      peg$c430 = peg$literalExpectation("uint32", false),
-      peg$c431 = "uint64",
-      peg$c432 = peg$literalExpectation("uint64", false),
-      peg$c433 = "int8",
-      peg$c434 = peg$literalExpectation("int8", false),
-      peg$c435 = "int16",
-      peg$c436 = peg$literalExpectation("int16", false),
-      peg$c437 = "int32",
-      peg$c438 = peg$literalExpectation("int32", false),
-      peg$c439 = "int64",
-      peg$c440 = peg$literalExpectation("int64", false),
-      peg$c441 = "float16",
-      peg$c442 = peg$literalExpectation("float16", false),
-      peg$c443 = "float32",
-      peg$c444 = peg$literalExpectation("float32", false),
-      peg$c445 = "float64",
-      peg$c446 = peg$literalExpectation("float64", false),
-      peg$c447 = "bool",
-      peg$c448 = peg$literalExpectation("bool", false),
-      peg$c449 = "string",
-      peg$c450 = peg$literalExpectation("string", false),
-      peg$c451 = "duration",
-      peg$c452 = peg$literalExpectation("duration", false),
-      peg$c453 = "time",
-      peg$c454 = peg$literalExpectation("time", false),
-      peg$c455 = "bytes",
-      peg$c456 = peg$literalExpectation("bytes", false),
-      peg$c457 = "ip",
-      peg$c458 = peg$literalExpectation("ip", false),
-      peg$c459 = "net",
-      peg$c460 = peg$literalExpectation("net", false),
-      peg$c461 = "null",
-      peg$c462 = peg$literalExpectation("null", false),
-      peg$c463 = function() {
+      peg$c424 = "uint8",
+      peg$c425 = peg$literalExpectation("uint8", false),
+      peg$c426 = "uint16",
+      peg$c427 = peg$literalExpectation("uint16", false),
+      peg$c428 = "uint32",
+      peg$c429 = peg$literalExpectation("uint32", false),
+      peg$c430 = "uint64",
+      peg$c431 = peg$literalExpectation("uint64", false),
+      peg$c432 = "int8",
+      peg$c433 = peg$literalExpectation("int8", false),
+      peg$c434 = "int16",
+      peg$c435 = peg$literalExpectation("int16", false),
+      peg$c436 = "int32",
+      peg$c437 = peg$literalExpectation("int32", false),
+      peg$c438 = "int64",
+      peg$c439 = peg$literalExpectation("int64", false),
+      peg$c440 = "float16",
+      peg$c441 = peg$literalExpectation("float16", false),
+      peg$c442 = "float32",
+      peg$c443 = peg$literalExpectation("float32", false),
+      peg$c444 = "float64",
+      peg$c445 = peg$literalExpectation("float64", false),
+      peg$c446 = "bool",
+      peg$c447 = peg$literalExpectation("bool", false),
+      peg$c448 = "string",
+      peg$c449 = peg$literalExpectation("string", false),
+      peg$c450 = "duration",
+      peg$c451 = peg$literalExpectation("duration", false),
+      peg$c452 = "time",
+      peg$c453 = peg$literalExpectation("time", false),
+      peg$c454 = "bytes",
+      peg$c455 = peg$literalExpectation("bytes", false),
+      peg$c456 = "ip",
+      peg$c457 = peg$literalExpectation("ip", false),
+      peg$c458 = "net",
+      peg$c459 = peg$literalExpectation("net", false),
+      peg$c460 = "null",
+      peg$c461 = peg$literalExpectation("null", false),
+      peg$c462 = function() {
                 return {"kind": "TypePrimitive", "name": text()}
               },
-      peg$c464 = function(name, typ) {
+      peg$c463 = function(name, typ) {
             return {"name": name, "type": typ}
           },
-      peg$c465 = "and",
-      peg$c466 = peg$literalExpectation("and", false),
-      peg$c467 = "AND",
-      peg$c468 = peg$literalExpectation("AND", false),
-      peg$c469 = function() { return "and" },
-      peg$c470 = peg$literalExpectation("by", false),
-      peg$c471 = "false",
-      peg$c472 = peg$literalExpectation("false", false),
-      peg$c473 = "NOT",
-      peg$c474 = peg$literalExpectation("NOT", false),
-      peg$c475 = function() { return "not" },
-      peg$c476 = "or",
-      peg$c477 = peg$literalExpectation("or", false),
-      peg$c478 = "OR",
-      peg$c479 = peg$literalExpectation("OR", false),
-      peg$c480 = function() { return "or" },
-      peg$c481 = "true",
-      peg$c482 = peg$literalExpectation("true", false),
-      peg$c483 = function(id) { return {"kind": "ID", "name": id} },
-      peg$c484 = "$",
-      peg$c485 = peg$literalExpectation("$", false),
-      peg$c486 = function(first, id) { return id },
-      peg$c487 = "_",
-      peg$c488 = peg$literalExpectation("_", false),
-      peg$c489 = "T",
-      peg$c490 = peg$literalExpectation("T", false),
-      peg$c491 = function() {
+      peg$c464 = "and",
+      peg$c465 = peg$literalExpectation("and", false),
+      peg$c466 = "AND",
+      peg$c467 = peg$literalExpectation("AND", false),
+      peg$c468 = function() { return "and" },
+      peg$c469 = peg$literalExpectation("by", false),
+      peg$c470 = "false",
+      peg$c471 = peg$literalExpectation("false", false),
+      peg$c472 = "NOT",
+      peg$c473 = peg$literalExpectation("NOT", false),
+      peg$c474 = function() { return "not" },
+      peg$c475 = "or",
+      peg$c476 = peg$literalExpectation("or", false),
+      peg$c477 = "OR",
+      peg$c478 = peg$literalExpectation("OR", false),
+      peg$c479 = function() { return "or" },
+      peg$c480 = "true",
+      peg$c481 = peg$literalExpectation("true", false),
+      peg$c482 = function(id) { return {"kind": "ID", "name": id} },
+      peg$c483 = "$",
+      peg$c484 = peg$literalExpectation("$", false),
+      peg$c485 = function(first, id) { return id },
+      peg$c486 = "_",
+      peg$c487 = peg$literalExpectation("_", false),
+      peg$c488 = "T",
+      peg$c489 = peg$literalExpectation("T", false),
+      peg$c490 = function() {
             return {"kind": "Primitive", "type": "time", "text": text()}
           },
-      peg$c492 = /^[0-9]/,
-      peg$c493 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c494 = "Z",
-      peg$c495 = peg$literalExpectation("Z", false),
-      peg$c496 = function() {
+      peg$c491 = /^[0-9]/,
+      peg$c492 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c493 = "Z",
+      peg$c494 = peg$literalExpectation("Z", false),
+      peg$c495 = function() {
             return {"kind": "Primitive", "type": "duration", "text": text()}
           },
-      peg$c497 = "ns",
-      peg$c498 = peg$literalExpectation("ns", false),
-      peg$c499 = "us",
-      peg$c500 = peg$literalExpectation("us", false),
-      peg$c501 = "ms",
-      peg$c502 = peg$literalExpectation("ms", false),
-      peg$c503 = "s",
-      peg$c504 = peg$literalExpectation("s", false),
-      peg$c505 = "m",
-      peg$c506 = peg$literalExpectation("m", false),
-      peg$c507 = "h",
-      peg$c508 = peg$literalExpectation("h", false),
-      peg$c509 = "d",
-      peg$c510 = peg$literalExpectation("d", false),
-      peg$c511 = "w",
-      peg$c512 = peg$literalExpectation("w", false),
-      peg$c513 = "y",
-      peg$c514 = peg$literalExpectation("y", false),
-      peg$c515 = function(a, b) {
+      peg$c496 = "ns",
+      peg$c497 = peg$literalExpectation("ns", false),
+      peg$c498 = "us",
+      peg$c499 = peg$literalExpectation("us", false),
+      peg$c500 = "ms",
+      peg$c501 = peg$literalExpectation("ms", false),
+      peg$c502 = "s",
+      peg$c503 = peg$literalExpectation("s", false),
+      peg$c504 = "m",
+      peg$c505 = peg$literalExpectation("m", false),
+      peg$c506 = "h",
+      peg$c507 = peg$literalExpectation("h", false),
+      peg$c508 = "d",
+      peg$c509 = peg$literalExpectation("d", false),
+      peg$c510 = "w",
+      peg$c511 = peg$literalExpectation("w", false),
+      peg$c512 = "y",
+      peg$c513 = peg$literalExpectation("y", false),
+      peg$c514 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c516 = "::",
-      peg$c517 = peg$literalExpectation("::", false),
-      peg$c518 = function(a, b, d, e) {
+      peg$c515 = "::",
+      peg$c516 = peg$literalExpectation("::", false),
+      peg$c517 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c519 = function(a, b) {
+      peg$c518 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c520 = function(a, b) {
+      peg$c519 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c521 = function() {
+      peg$c520 = function() {
             return "::"
           },
-      peg$c522 = function(v) { return ":" + v },
-      peg$c523 = function(v) { return v + ":" },
-      peg$c524 = function(a, m) {
+      peg$c521 = function(v) { return ":" + v },
+      peg$c522 = function(v) { return v + ":" },
+      peg$c523 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c525 = function(a, m) {
+      peg$c524 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c526 = function(s) { return parseInt(s) },
-      peg$c527 = function() {
+      peg$c525 = function(s) { return parseInt(s) },
+      peg$c526 = function() {
             return text()
           },
-      peg$c528 = "e",
-      peg$c529 = peg$literalExpectation("e", true),
-      peg$c530 = /^[+\-]/,
-      peg$c531 = peg$classExpectation(["+", "-"], false, false),
-      peg$c532 = "NaN",
-      peg$c533 = peg$literalExpectation("NaN", false),
-      peg$c534 = "Inf",
-      peg$c535 = peg$literalExpectation("Inf", false),
-      peg$c536 = /^[0-9a-fA-F]/,
-      peg$c537 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c538 = function(v) { return joinChars(v) },
-      peg$c539 = peg$anyExpectation(),
-      peg$c540 = function(head, tail) { return head + joinChars(tail) },
-      peg$c541 = /^[_.:\/%#@~]/,
-      peg$c542 = peg$classExpectation(["_", ".", ":", "/", "%", "#", "@", "~"], false, false),
-      peg$c543 = function(head, tail) {
+      peg$c527 = "e",
+      peg$c528 = peg$literalExpectation("e", true),
+      peg$c529 = /^[+\-]/,
+      peg$c530 = peg$classExpectation(["+", "-"], false, false),
+      peg$c531 = "NaN",
+      peg$c532 = peg$literalExpectation("NaN", false),
+      peg$c533 = "Inf",
+      peg$c534 = peg$literalExpectation("Inf", false),
+      peg$c535 = /^[0-9a-fA-F]/,
+      peg$c536 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c537 = function(v) { return joinChars(v) },
+      peg$c538 = peg$anyExpectation(),
+      peg$c539 = function(head, tail) { return head + joinChars(tail) },
+      peg$c540 = /^[_.:\/%#@~]/,
+      peg$c541 = peg$classExpectation(["_", ".", ":", "/", "%", "#", "@", "~"], false, false),
+      peg$c542 = function(head, tail) {
             return head + joinChars(tail)
           },
-      peg$c544 = function() { return "*" },
-      peg$c545 = function() { return "=" },
-      peg$c546 = function() { return "\\*" },
-      peg$c547 = "b",
-      peg$c548 = peg$literalExpectation("b", false),
-      peg$c549 = function() { return "\b" },
-      peg$c550 = "f",
-      peg$c551 = peg$literalExpectation("f", false),
-      peg$c552 = function() { return "\f" },
-      peg$c553 = "n",
-      peg$c554 = peg$literalExpectation("n", false),
-      peg$c555 = function() { return "\n" },
-      peg$c556 = "r",
-      peg$c557 = peg$literalExpectation("r", false),
-      peg$c558 = function() { return "\r" },
-      peg$c559 = "t",
-      peg$c560 = peg$literalExpectation("t", false),
-      peg$c561 = function() { return "\t" },
-      peg$c562 = "v",
-      peg$c563 = peg$literalExpectation("v", false),
-      peg$c564 = function() { return "\v" },
-      peg$c565 = "u",
-      peg$c566 = peg$literalExpectation("u", false),
-      peg$c567 = function(chars) {
+      peg$c543 = function() { return "*" },
+      peg$c544 = function() { return "=" },
+      peg$c545 = function() { return "\\*" },
+      peg$c546 = "b",
+      peg$c547 = peg$literalExpectation("b", false),
+      peg$c548 = function() { return "\b" },
+      peg$c549 = "f",
+      peg$c550 = peg$literalExpectation("f", false),
+      peg$c551 = function() { return "\f" },
+      peg$c552 = "n",
+      peg$c553 = peg$literalExpectation("n", false),
+      peg$c554 = function() { return "\n" },
+      peg$c555 = "r",
+      peg$c556 = peg$literalExpectation("r", false),
+      peg$c557 = function() { return "\r" },
+      peg$c558 = "t",
+      peg$c559 = peg$literalExpectation("t", false),
+      peg$c560 = function() { return "\t" },
+      peg$c561 = "v",
+      peg$c562 = peg$literalExpectation("v", false),
+      peg$c563 = function() { return "\v" },
+      peg$c564 = "u",
+      peg$c565 = peg$literalExpectation("u", false),
+      peg$c566 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c568 = /^[^\/\\]/,
-      peg$c569 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c570 = /^[\0-\x1F\\]/,
-      peg$c571 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c572 = /^[a-z\xB5\xDF-\xF6\xF8-\xFF\u0101\u0103\u0105\u0107\u0109\u010B\u010D\u010F\u0111\u0113\u0115\u0117\u0119\u011B\u011D\u011F\u0121\u0123\u0125\u0127\u0129\u012B\u012D\u012F\u0131\u0133\u0135\u0137-\u0138\u013A\u013C\u013E\u0140\u0142\u0144\u0146\u0148-\u0149\u014B\u014D\u014F\u0151\u0153\u0155\u0157\u0159\u015B\u015D\u015F\u0161\u0163\u0165\u0167\u0169\u016B\u016D\u016F\u0171\u0173\u0175\u0177\u017A\u017C\u017E-\u0180\u0183\u0185\u0188\u018C-\u018D\u0192\u0195\u0199-\u019B\u019E\u01A1\u01A3\u01A5\u01A8\u01AA-\u01AB\u01AD\u01B0\u01B4\u01B6\u01B9-\u01BA\u01BD-\u01BF\u01C6\u01C9\u01CC\u01CE\u01D0\u01D2\u01D4\u01D6\u01D8\u01DA\u01DC-\u01DD\u01DF\u01E1\u01E3\u01E5\u01E7\u01E9\u01EB\u01ED\u01EF-\u01F0\u01F3\u01F5\u01F9\u01FB\u01FD\u01FF\u0201\u0203\u0205\u0207\u0209\u020B\u020D\u020F\u0211\u0213\u0215\u0217\u0219\u021B\u021D\u021F\u0221\u0223\u0225\u0227\u0229\u022B\u022D\u022F\u0231\u0233-\u0239\u023C\u023F-\u0240\u0242\u0247\u0249\u024B\u024D\u024F-\u0293\u0295-\u02AF\u0371\u0373\u0377\u037B-\u037D\u0390\u03AC-\u03CE\u03D0-\u03D1\u03D5-\u03D7\u03D9\u03DB\u03DD\u03DF\u03E1\u03E3\u03E5\u03E7\u03E9\u03EB\u03ED\u03EF-\u03F3\u03F5\u03F8\u03FB-\u03FC\u0430-\u045F\u0461\u0463\u0465\u0467\u0469\u046B\u046D\u046F\u0471\u0473\u0475\u0477\u0479\u047B\u047D\u047F\u0481\u048B\u048D\u048F\u0491\u0493\u0495\u0497\u0499\u049B\u049D\u049F\u04A1\u04A3\u04A5\u04A7\u04A9\u04AB\u04AD\u04AF\u04B1\u04B3\u04B5\u04B7\u04B9\u04BB\u04BD\u04BF\u04C2\u04C4\u04C6\u04C8\u04CA\u04CC\u04CE-\u04CF\u04D1\u04D3\u04D5\u04D7\u04D9\u04DB\u04DD\u04DF\u04E1\u04E3\u04E5\u04E7\u04E9\u04EB\u04ED\u04EF\u04F1\u04F3\u04F5\u04F7\u04F9\u04FB\u04FD\u04FF\u0501\u0503\u0505\u0507\u0509\u050B\u050D\u050F\u0511\u0513\u0515\u0517\u0519\u051B\u051D\u051F\u0521\u0523\u0525\u0527\u0529\u052B\u052D\u052F\u0560-\u0588\u10D0-\u10FA\u10FD-\u10FF\u13F8-\u13FD\u1C80-\u1C88\u1D00-\u1D2B\u1D6B-\u1D77\u1D79-\u1D9A\u1E01\u1E03\u1E05\u1E07\u1E09\u1E0B\u1E0D\u1E0F\u1E11\u1E13\u1E15\u1E17\u1E19\u1E1B\u1E1D\u1E1F\u1E21\u1E23\u1E25\u1E27\u1E29\u1E2B\u1E2D\u1E2F\u1E31\u1E33\u1E35\u1E37\u1E39\u1E3B\u1E3D\u1E3F\u1E41\u1E43\u1E45\u1E47\u1E49\u1E4B\u1E4D\u1E4F\u1E51\u1E53\u1E55\u1E57\u1E59\u1E5B\u1E5D\u1E5F\u1E61\u1E63\u1E65\u1E67\u1E69\u1E6B\u1E6D\u1E6F\u1E71\u1E73\u1E75\u1E77\u1E79\u1E7B\u1E7D\u1E7F\u1E81\u1E83\u1E85\u1E87\u1E89\u1E8B\u1E8D\u1E8F\u1E91\u1E93\u1E95-\u1E9D\u1E9F\u1EA1\u1EA3\u1EA5\u1EA7\u1EA9\u1EAB\u1EAD\u1EAF\u1EB1\u1EB3\u1EB5\u1EB7\u1EB9\u1EBB\u1EBD\u1EBF\u1EC1\u1EC3\u1EC5\u1EC7\u1EC9\u1ECB\u1ECD\u1ECF\u1ED1\u1ED3\u1ED5\u1ED7\u1ED9\u1EDB\u1EDD\u1EDF\u1EE1\u1EE3\u1EE5\u1EE7\u1EE9\u1EEB\u1EED\u1EEF\u1EF1\u1EF3\u1EF5\u1EF7\u1EF9\u1EFB\u1EFD\u1EFF-\u1F07\u1F10-\u1F15\u1F20-\u1F27\u1F30-\u1F37\u1F40-\u1F45\u1F50-\u1F57\u1F60-\u1F67\u1F70-\u1F7D\u1F80-\u1F87\u1F90-\u1F97\u1FA0-\u1FA7\u1FB0-\u1FB4\u1FB6-\u1FB7\u1FBE\u1FC2-\u1FC4\u1FC6-\u1FC7\u1FD0-\u1FD3\u1FD6-\u1FD7\u1FE0-\u1FE7\u1FF2-\u1FF4\u1FF6-\u1FF7\u210A\u210E-\u210F\u2113\u212F\u2134\u2139\u213C-\u213D\u2146-\u2149\u214E\u2184\u2C30-\u2C5E\u2C61\u2C65-\u2C66\u2C68\u2C6A\u2C6C\u2C71\u2C73-\u2C74\u2C76-\u2C7B\u2C81\u2C83\u2C85\u2C87\u2C89\u2C8B\u2C8D\u2C8F\u2C91\u2C93\u2C95\u2C97\u2C99\u2C9B\u2C9D\u2C9F\u2CA1\u2CA3\u2CA5\u2CA7\u2CA9\u2CAB\u2CAD\u2CAF\u2CB1\u2CB3\u2CB5\u2CB7\u2CB9\u2CBB\u2CBD\u2CBF\u2CC1\u2CC3\u2CC5\u2CC7\u2CC9\u2CCB\u2CCD\u2CCF\u2CD1\u2CD3\u2CD5\u2CD7\u2CD9\u2CDB\u2CDD\u2CDF\u2CE1\u2CE3-\u2CE4\u2CEC\u2CEE\u2CF3\u2D00-\u2D25\u2D27\u2D2D\uA641\uA643\uA645\uA647\uA649\uA64B\uA64D\uA64F\uA651\uA653\uA655\uA657\uA659\uA65B\uA65D\uA65F\uA661\uA663\uA665\uA667\uA669\uA66B\uA66D\uA681\uA683\uA685\uA687\uA689\uA68B\uA68D\uA68F\uA691\uA693\uA695\uA697\uA699\uA69B\uA723\uA725\uA727\uA729\uA72B\uA72D\uA72F-\uA731\uA733\uA735\uA737\uA739\uA73B\uA73D\uA73F\uA741\uA743\uA745\uA747\uA749\uA74B\uA74D\uA74F\uA751\uA753\uA755\uA757\uA759\uA75B\uA75D\uA75F\uA761\uA763\uA765\uA767\uA769\uA76B\uA76D\uA76F\uA771-\uA778\uA77A\uA77C\uA77F\uA781\uA783\uA785\uA787\uA78C\uA78E\uA791\uA793-\uA795\uA797\uA799\uA79B\uA79D\uA79F\uA7A1\uA7A3\uA7A5\uA7A7\uA7A9\uA7AF\uA7B5\uA7B7\uA7B9\uA7FA\uAB30-\uAB5A\uAB60-\uAB65\uAB70-\uABBF\uFB00-\uFB06\uFB13-\uFB17\uFF41-\uFF5A]/,
-      peg$c573 = peg$classExpectation([["a", "z"], "\xB5", ["\xDF", "\xF6"], ["\xF8", "\xFF"], "\u0101", "\u0103", "\u0105", "\u0107", "\u0109", "\u010B", "\u010D", "\u010F", "\u0111", "\u0113", "\u0115", "\u0117", "\u0119", "\u011B", "\u011D", "\u011F", "\u0121", "\u0123", "\u0125", "\u0127", "\u0129", "\u012B", "\u012D", "\u012F", "\u0131", "\u0133", "\u0135", ["\u0137", "\u0138"], "\u013A", "\u013C", "\u013E", "\u0140", "\u0142", "\u0144", "\u0146", ["\u0148", "\u0149"], "\u014B", "\u014D", "\u014F", "\u0151", "\u0153", "\u0155", "\u0157", "\u0159", "\u015B", "\u015D", "\u015F", "\u0161", "\u0163", "\u0165", "\u0167", "\u0169", "\u016B", "\u016D", "\u016F", "\u0171", "\u0173", "\u0175", "\u0177", "\u017A", "\u017C", ["\u017E", "\u0180"], "\u0183", "\u0185", "\u0188", ["\u018C", "\u018D"], "\u0192", "\u0195", ["\u0199", "\u019B"], "\u019E", "\u01A1", "\u01A3", "\u01A5", "\u01A8", ["\u01AA", "\u01AB"], "\u01AD", "\u01B0", "\u01B4", "\u01B6", ["\u01B9", "\u01BA"], ["\u01BD", "\u01BF"], "\u01C6", "\u01C9", "\u01CC", "\u01CE", "\u01D0", "\u01D2", "\u01D4", "\u01D6", "\u01D8", "\u01DA", ["\u01DC", "\u01DD"], "\u01DF", "\u01E1", "\u01E3", "\u01E5", "\u01E7", "\u01E9", "\u01EB", "\u01ED", ["\u01EF", "\u01F0"], "\u01F3", "\u01F5", "\u01F9", "\u01FB", "\u01FD", "\u01FF", "\u0201", "\u0203", "\u0205", "\u0207", "\u0209", "\u020B", "\u020D", "\u020F", "\u0211", "\u0213", "\u0215", "\u0217", "\u0219", "\u021B", "\u021D", "\u021F", "\u0221", "\u0223", "\u0225", "\u0227", "\u0229", "\u022B", "\u022D", "\u022F", "\u0231", ["\u0233", "\u0239"], "\u023C", ["\u023F", "\u0240"], "\u0242", "\u0247", "\u0249", "\u024B", "\u024D", ["\u024F", "\u0293"], ["\u0295", "\u02AF"], "\u0371", "\u0373", "\u0377", ["\u037B", "\u037D"], "\u0390", ["\u03AC", "\u03CE"], ["\u03D0", "\u03D1"], ["\u03D5", "\u03D7"], "\u03D9", "\u03DB", "\u03DD", "\u03DF", "\u03E1", "\u03E3", "\u03E5", "\u03E7", "\u03E9", "\u03EB", "\u03ED", ["\u03EF", "\u03F3"], "\u03F5", "\u03F8", ["\u03FB", "\u03FC"], ["\u0430", "\u045F"], "\u0461", "\u0463", "\u0465", "\u0467", "\u0469", "\u046B", "\u046D", "\u046F", "\u0471", "\u0473", "\u0475", "\u0477", "\u0479", "\u047B", "\u047D", "\u047F", "\u0481", "\u048B", "\u048D", "\u048F", "\u0491", "\u0493", "\u0495", "\u0497", "\u0499", "\u049B", "\u049D", "\u049F", "\u04A1", "\u04A3", "\u04A5", "\u04A7", "\u04A9", "\u04AB", "\u04AD", "\u04AF", "\u04B1", "\u04B3", "\u04B5", "\u04B7", "\u04B9", "\u04BB", "\u04BD", "\u04BF", "\u04C2", "\u04C4", "\u04C6", "\u04C8", "\u04CA", "\u04CC", ["\u04CE", "\u04CF"], "\u04D1", "\u04D3", "\u04D5", "\u04D7", "\u04D9", "\u04DB", "\u04DD", "\u04DF", "\u04E1", "\u04E3", "\u04E5", "\u04E7", "\u04E9", "\u04EB", "\u04ED", "\u04EF", "\u04F1", "\u04F3", "\u04F5", "\u04F7", "\u04F9", "\u04FB", "\u04FD", "\u04FF", "\u0501", "\u0503", "\u0505", "\u0507", "\u0509", "\u050B", "\u050D", "\u050F", "\u0511", "\u0513", "\u0515", "\u0517", "\u0519", "\u051B", "\u051D", "\u051F", "\u0521", "\u0523", "\u0525", "\u0527", "\u0529", "\u052B", "\u052D", "\u052F", ["\u0560", "\u0588"], ["\u10D0", "\u10FA"], ["\u10FD", "\u10FF"], ["\u13F8", "\u13FD"], ["\u1C80", "\u1C88"], ["\u1D00", "\u1D2B"], ["\u1D6B", "\u1D77"], ["\u1D79", "\u1D9A"], "\u1E01", "\u1E03", "\u1E05", "\u1E07", "\u1E09", "\u1E0B", "\u1E0D", "\u1E0F", "\u1E11", "\u1E13", "\u1E15", "\u1E17", "\u1E19", "\u1E1B", "\u1E1D", "\u1E1F", "\u1E21", "\u1E23", "\u1E25", "\u1E27", "\u1E29", "\u1E2B", "\u1E2D", "\u1E2F", "\u1E31", "\u1E33", "\u1E35", "\u1E37", "\u1E39", "\u1E3B", "\u1E3D", "\u1E3F", "\u1E41", "\u1E43", "\u1E45", "\u1E47", "\u1E49", "\u1E4B", "\u1E4D", "\u1E4F", "\u1E51", "\u1E53", "\u1E55", "\u1E57", "\u1E59", "\u1E5B", "\u1E5D", "\u1E5F", "\u1E61", "\u1E63", "\u1E65", "\u1E67", "\u1E69", "\u1E6B", "\u1E6D", "\u1E6F", "\u1E71", "\u1E73", "\u1E75", "\u1E77", "\u1E79", "\u1E7B", "\u1E7D", "\u1E7F", "\u1E81", "\u1E83", "\u1E85", "\u1E87", "\u1E89", "\u1E8B", "\u1E8D", "\u1E8F", "\u1E91", "\u1E93", ["\u1E95", "\u1E9D"], "\u1E9F", "\u1EA1", "\u1EA3", "\u1EA5", "\u1EA7", "\u1EA9", "\u1EAB", "\u1EAD", "\u1EAF", "\u1EB1", "\u1EB3", "\u1EB5", "\u1EB7", "\u1EB9", "\u1EBB", "\u1EBD", "\u1EBF", "\u1EC1", "\u1EC3", "\u1EC5", "\u1EC7", "\u1EC9", "\u1ECB", "\u1ECD", "\u1ECF", "\u1ED1", "\u1ED3", "\u1ED5", "\u1ED7", "\u1ED9", "\u1EDB", "\u1EDD", "\u1EDF", "\u1EE1", "\u1EE3", "\u1EE5", "\u1EE7", "\u1EE9", "\u1EEB", "\u1EED", "\u1EEF", "\u1EF1", "\u1EF3", "\u1EF5", "\u1EF7", "\u1EF9", "\u1EFB", "\u1EFD", ["\u1EFF", "\u1F07"], ["\u1F10", "\u1F15"], ["\u1F20", "\u1F27"], ["\u1F30", "\u1F37"], ["\u1F40", "\u1F45"], ["\u1F50", "\u1F57"], ["\u1F60", "\u1F67"], ["\u1F70", "\u1F7D"], ["\u1F80", "\u1F87"], ["\u1F90", "\u1F97"], ["\u1FA0", "\u1FA7"], ["\u1FB0", "\u1FB4"], ["\u1FB6", "\u1FB7"], "\u1FBE", ["\u1FC2", "\u1FC4"], ["\u1FC6", "\u1FC7"], ["\u1FD0", "\u1FD3"], ["\u1FD6", "\u1FD7"], ["\u1FE0", "\u1FE7"], ["\u1FF2", "\u1FF4"], ["\u1FF6", "\u1FF7"], "\u210A", ["\u210E", "\u210F"], "\u2113", "\u212F", "\u2134", "\u2139", ["\u213C", "\u213D"], ["\u2146", "\u2149"], "\u214E", "\u2184", ["\u2C30", "\u2C5E"], "\u2C61", ["\u2C65", "\u2C66"], "\u2C68", "\u2C6A", "\u2C6C", "\u2C71", ["\u2C73", "\u2C74"], ["\u2C76", "\u2C7B"], "\u2C81", "\u2C83", "\u2C85", "\u2C87", "\u2C89", "\u2C8B", "\u2C8D", "\u2C8F", "\u2C91", "\u2C93", "\u2C95", "\u2C97", "\u2C99", "\u2C9B", "\u2C9D", "\u2C9F", "\u2CA1", "\u2CA3", "\u2CA5", "\u2CA7", "\u2CA9", "\u2CAB", "\u2CAD", "\u2CAF", "\u2CB1", "\u2CB3", "\u2CB5", "\u2CB7", "\u2CB9", "\u2CBB", "\u2CBD", "\u2CBF", "\u2CC1", "\u2CC3", "\u2CC5", "\u2CC7", "\u2CC9", "\u2CCB", "\u2CCD", "\u2CCF", "\u2CD1", "\u2CD3", "\u2CD5", "\u2CD7", "\u2CD9", "\u2CDB", "\u2CDD", "\u2CDF", "\u2CE1", ["\u2CE3", "\u2CE4"], "\u2CEC", "\u2CEE", "\u2CF3", ["\u2D00", "\u2D25"], "\u2D27", "\u2D2D", "\uA641", "\uA643", "\uA645", "\uA647", "\uA649", "\uA64B", "\uA64D", "\uA64F", "\uA651", "\uA653", "\uA655", "\uA657", "\uA659", "\uA65B", "\uA65D", "\uA65F", "\uA661", "\uA663", "\uA665", "\uA667", "\uA669", "\uA66B", "\uA66D", "\uA681", "\uA683", "\uA685", "\uA687", "\uA689", "\uA68B", "\uA68D", "\uA68F", "\uA691", "\uA693", "\uA695", "\uA697", "\uA699", "\uA69B", "\uA723", "\uA725", "\uA727", "\uA729", "\uA72B", "\uA72D", ["\uA72F", "\uA731"], "\uA733", "\uA735", "\uA737", "\uA739", "\uA73B", "\uA73D", "\uA73F", "\uA741", "\uA743", "\uA745", "\uA747", "\uA749", "\uA74B", "\uA74D", "\uA74F", "\uA751", "\uA753", "\uA755", "\uA757", "\uA759", "\uA75B", "\uA75D", "\uA75F", "\uA761", "\uA763", "\uA765", "\uA767", "\uA769", "\uA76B", "\uA76D", "\uA76F", ["\uA771", "\uA778"], "\uA77A", "\uA77C", "\uA77F", "\uA781", "\uA783", "\uA785", "\uA787", "\uA78C", "\uA78E", "\uA791", ["\uA793", "\uA795"], "\uA797", "\uA799", "\uA79B", "\uA79D", "\uA79F", "\uA7A1", "\uA7A3", "\uA7A5", "\uA7A7", "\uA7A9", "\uA7AF", "\uA7B5", "\uA7B7", "\uA7B9", "\uA7FA", ["\uAB30", "\uAB5A"], ["\uAB60", "\uAB65"], ["\uAB70", "\uABBF"], ["\uFB00", "\uFB06"], ["\uFB13", "\uFB17"], ["\uFF41", "\uFF5A"]], false, false),
-      peg$c574 = /^[\u02B0-\u02C1\u02C6-\u02D1\u02E0-\u02E4\u02EC\u02EE\u0374\u037A\u0559\u0640\u06E5-\u06E6\u07F4-\u07F5\u07FA\u081A\u0824\u0828\u0971\u0E46\u0EC6\u10FC\u17D7\u1843\u1AA7\u1C78-\u1C7D\u1D2C-\u1D6A\u1D78\u1D9B-\u1DBF\u2071\u207F\u2090-\u209C\u2C7C-\u2C7D\u2D6F\u2E2F\u3005\u3031-\u3035\u303B\u309D-\u309E\u30FC-\u30FE\uA015\uA4F8-\uA4FD\uA60C\uA67F\uA69C-\uA69D\uA717-\uA71F\uA770\uA788\uA7F8-\uA7F9\uA9CF\uA9E6\uAA70\uAADD\uAAF3-\uAAF4\uAB5C-\uAB5F\uFF70\uFF9E-\uFF9F]/,
-      peg$c575 = peg$classExpectation([["\u02B0", "\u02C1"], ["\u02C6", "\u02D1"], ["\u02E0", "\u02E4"], "\u02EC", "\u02EE", "\u0374", "\u037A", "\u0559", "\u0640", ["\u06E5", "\u06E6"], ["\u07F4", "\u07F5"], "\u07FA", "\u081A", "\u0824", "\u0828", "\u0971", "\u0E46", "\u0EC6", "\u10FC", "\u17D7", "\u1843", "\u1AA7", ["\u1C78", "\u1C7D"], ["\u1D2C", "\u1D6A"], "\u1D78", ["\u1D9B", "\u1DBF"], "\u2071", "\u207F", ["\u2090", "\u209C"], ["\u2C7C", "\u2C7D"], "\u2D6F", "\u2E2F", "\u3005", ["\u3031", "\u3035"], "\u303B", ["\u309D", "\u309E"], ["\u30FC", "\u30FE"], "\uA015", ["\uA4F8", "\uA4FD"], "\uA60C", "\uA67F", ["\uA69C", "\uA69D"], ["\uA717", "\uA71F"], "\uA770", "\uA788", ["\uA7F8", "\uA7F9"], "\uA9CF", "\uA9E6", "\uAA70", "\uAADD", ["\uAAF3", "\uAAF4"], ["\uAB5C", "\uAB5F"], "\uFF70", ["\uFF9E", "\uFF9F"]], false, false),
-      peg$c576 = /^[\xAA\xBA\u01BB\u01C0-\u01C3\u0294\u05D0-\u05EA\u05EF-\u05F2\u0620-\u063F\u0641-\u064A\u066E-\u066F\u0671-\u06D3\u06D5\u06EE-\u06EF\u06FA-\u06FC\u06FF\u0710\u0712-\u072F\u074D-\u07A5\u07B1\u07CA-\u07EA\u0800-\u0815\u0840-\u0858\u0860-\u086A\u08A0-\u08B4\u08B6-\u08BD\u0904-\u0939\u093D\u0950\u0958-\u0961\u0972-\u0980\u0985-\u098C\u098F-\u0990\u0993-\u09A8\u09AA-\u09B0\u09B2\u09B6-\u09B9\u09BD\u09CE\u09DC-\u09DD\u09DF-\u09E1\u09F0-\u09F1\u09FC\u0A05-\u0A0A\u0A0F-\u0A10\u0A13-\u0A28\u0A2A-\u0A30\u0A32-\u0A33\u0A35-\u0A36\u0A38-\u0A39\u0A59-\u0A5C\u0A5E\u0A72-\u0A74\u0A85-\u0A8D\u0A8F-\u0A91\u0A93-\u0AA8\u0AAA-\u0AB0\u0AB2-\u0AB3\u0AB5-\u0AB9\u0ABD\u0AD0\u0AE0-\u0AE1\u0AF9\u0B05-\u0B0C\u0B0F-\u0B10\u0B13-\u0B28\u0B2A-\u0B30\u0B32-\u0B33\u0B35-\u0B39\u0B3D\u0B5C-\u0B5D\u0B5F-\u0B61\u0B71\u0B83\u0B85-\u0B8A\u0B8E-\u0B90\u0B92-\u0B95\u0B99-\u0B9A\u0B9C\u0B9E-\u0B9F\u0BA3-\u0BA4\u0BA8-\u0BAA\u0BAE-\u0BB9\u0BD0\u0C05-\u0C0C\u0C0E-\u0C10\u0C12-\u0C28\u0C2A-\u0C39\u0C3D\u0C58-\u0C5A\u0C60-\u0C61\u0C80\u0C85-\u0C8C\u0C8E-\u0C90\u0C92-\u0CA8\u0CAA-\u0CB3\u0CB5-\u0CB9\u0CBD\u0CDE\u0CE0-\u0CE1\u0CF1-\u0CF2\u0D05-\u0D0C\u0D0E-\u0D10\u0D12-\u0D3A\u0D3D\u0D4E\u0D54-\u0D56\u0D5F-\u0D61\u0D7A-\u0D7F\u0D85-\u0D96\u0D9A-\u0DB1\u0DB3-\u0DBB\u0DBD\u0DC0-\u0DC6\u0E01-\u0E30\u0E32-\u0E33\u0E40-\u0E45\u0E81-\u0E82\u0E84\u0E87-\u0E88\u0E8A\u0E8D\u0E94-\u0E97\u0E99-\u0E9F\u0EA1-\u0EA3\u0EA5\u0EA7\u0EAA-\u0EAB\u0EAD-\u0EB0\u0EB2-\u0EB3\u0EBD\u0EC0-\u0EC4\u0EDC-\u0EDF\u0F00\u0F40-\u0F47\u0F49-\u0F6C\u0F88-\u0F8C\u1000-\u102A\u103F\u1050-\u1055\u105A-\u105D\u1061\u1065-\u1066\u106E-\u1070\u1075-\u1081\u108E\u1100-\u1248\u124A-\u124D\u1250-\u1256\u1258\u125A-\u125D\u1260-\u1288\u128A-\u128D\u1290-\u12B0\u12B2-\u12B5\u12B8-\u12BE\u12C0\u12C2-\u12C5\u12C8-\u12D6\u12D8-\u1310\u1312-\u1315\u1318-\u135A\u1380-\u138F\u1401-\u166C\u166F-\u167F\u1681-\u169A\u16A0-\u16EA\u16F1-\u16F8\u1700-\u170C\u170E-\u1711\u1720-\u1731\u1740-\u1751\u1760-\u176C\u176E-\u1770\u1780-\u17B3\u17DC\u1820-\u1842\u1844-\u1878\u1880-\u1884\u1887-\u18A8\u18AA\u18B0-\u18F5\u1900-\u191E\u1950-\u196D\u1970-\u1974\u1980-\u19AB\u19B0-\u19C9\u1A00-\u1A16\u1A20-\u1A54\u1B05-\u1B33\u1B45-\u1B4B\u1B83-\u1BA0\u1BAE-\u1BAF\u1BBA-\u1BE5\u1C00-\u1C23\u1C4D-\u1C4F\u1C5A-\u1C77\u1CE9-\u1CEC\u1CEE-\u1CF1\u1CF5-\u1CF6\u2135-\u2138\u2D30-\u2D67\u2D80-\u2D96\u2DA0-\u2DA6\u2DA8-\u2DAE\u2DB0-\u2DB6\u2DB8-\u2DBE\u2DC0-\u2DC6\u2DC8-\u2DCE\u2DD0-\u2DD6\u2DD8-\u2DDE\u3006\u303C\u3041-\u3096\u309F\u30A1-\u30FA\u30FF\u3105-\u312F\u3131-\u318E\u31A0-\u31BA\u31F0-\u31FF\u3400-\u4DB5\u4E00-\u9FEF\uA000-\uA014\uA016-\uA48C\uA4D0-\uA4F7\uA500-\uA60B\uA610-\uA61F\uA62A-\uA62B\uA66E\uA6A0-\uA6E5\uA78F\uA7F7\uA7FB-\uA801\uA803-\uA805\uA807-\uA80A\uA80C-\uA822\uA840-\uA873\uA882-\uA8B3\uA8F2-\uA8F7\uA8FB\uA8FD-\uA8FE\uA90A-\uA925\uA930-\uA946\uA960-\uA97C\uA984-\uA9B2\uA9E0-\uA9E4\uA9E7-\uA9EF\uA9FA-\uA9FE\uAA00-\uAA28\uAA40-\uAA42\uAA44-\uAA4B\uAA60-\uAA6F\uAA71-\uAA76\uAA7A\uAA7E-\uAAAF\uAAB1\uAAB5-\uAAB6\uAAB9-\uAABD\uAAC0\uAAC2\uAADB-\uAADC\uAAE0-\uAAEA\uAAF2\uAB01-\uAB06\uAB09-\uAB0E\uAB11-\uAB16\uAB20-\uAB26\uAB28-\uAB2E\uABC0-\uABE2\uAC00-\uD7A3\uD7B0-\uD7C6\uD7CB-\uD7FB\uF900-\uFA6D\uFA70-\uFAD9\uFB1D\uFB1F-\uFB28\uFB2A-\uFB36\uFB38-\uFB3C\uFB3E\uFB40-\uFB41\uFB43-\uFB44\uFB46-\uFBB1\uFBD3-\uFD3D\uFD50-\uFD8F\uFD92-\uFDC7\uFDF0-\uFDFB\uFE70-\uFE74\uFE76-\uFEFC\uFF66-\uFF6F\uFF71-\uFF9D\uFFA0-\uFFBE\uFFC2-\uFFC7\uFFCA-\uFFCF\uFFD2-\uFFD7\uFFDA-\uFFDC]/,
-      peg$c577 = peg$classExpectation(["\xAA", "\xBA", "\u01BB", ["\u01C0", "\u01C3"], "\u0294", ["\u05D0", "\u05EA"], ["\u05EF", "\u05F2"], ["\u0620", "\u063F"], ["\u0641", "\u064A"], ["\u066E", "\u066F"], ["\u0671", "\u06D3"], "\u06D5", ["\u06EE", "\u06EF"], ["\u06FA", "\u06FC"], "\u06FF", "\u0710", ["\u0712", "\u072F"], ["\u074D", "\u07A5"], "\u07B1", ["\u07CA", "\u07EA"], ["\u0800", "\u0815"], ["\u0840", "\u0858"], ["\u0860", "\u086A"], ["\u08A0", "\u08B4"], ["\u08B6", "\u08BD"], ["\u0904", "\u0939"], "\u093D", "\u0950", ["\u0958", "\u0961"], ["\u0972", "\u0980"], ["\u0985", "\u098C"], ["\u098F", "\u0990"], ["\u0993", "\u09A8"], ["\u09AA", "\u09B0"], "\u09B2", ["\u09B6", "\u09B9"], "\u09BD", "\u09CE", ["\u09DC", "\u09DD"], ["\u09DF", "\u09E1"], ["\u09F0", "\u09F1"], "\u09FC", ["\u0A05", "\u0A0A"], ["\u0A0F", "\u0A10"], ["\u0A13", "\u0A28"], ["\u0A2A", "\u0A30"], ["\u0A32", "\u0A33"], ["\u0A35", "\u0A36"], ["\u0A38", "\u0A39"], ["\u0A59", "\u0A5C"], "\u0A5E", ["\u0A72", "\u0A74"], ["\u0A85", "\u0A8D"], ["\u0A8F", "\u0A91"], ["\u0A93", "\u0AA8"], ["\u0AAA", "\u0AB0"], ["\u0AB2", "\u0AB3"], ["\u0AB5", "\u0AB9"], "\u0ABD", "\u0AD0", ["\u0AE0", "\u0AE1"], "\u0AF9", ["\u0B05", "\u0B0C"], ["\u0B0F", "\u0B10"], ["\u0B13", "\u0B28"], ["\u0B2A", "\u0B30"], ["\u0B32", "\u0B33"], ["\u0B35", "\u0B39"], "\u0B3D", ["\u0B5C", "\u0B5D"], ["\u0B5F", "\u0B61"], "\u0B71", "\u0B83", ["\u0B85", "\u0B8A"], ["\u0B8E", "\u0B90"], ["\u0B92", "\u0B95"], ["\u0B99", "\u0B9A"], "\u0B9C", ["\u0B9E", "\u0B9F"], ["\u0BA3", "\u0BA4"], ["\u0BA8", "\u0BAA"], ["\u0BAE", "\u0BB9"], "\u0BD0", ["\u0C05", "\u0C0C"], ["\u0C0E", "\u0C10"], ["\u0C12", "\u0C28"], ["\u0C2A", "\u0C39"], "\u0C3D", ["\u0C58", "\u0C5A"], ["\u0C60", "\u0C61"], "\u0C80", ["\u0C85", "\u0C8C"], ["\u0C8E", "\u0C90"], ["\u0C92", "\u0CA8"], ["\u0CAA", "\u0CB3"], ["\u0CB5", "\u0CB9"], "\u0CBD", "\u0CDE", ["\u0CE0", "\u0CE1"], ["\u0CF1", "\u0CF2"], ["\u0D05", "\u0D0C"], ["\u0D0E", "\u0D10"], ["\u0D12", "\u0D3A"], "\u0D3D", "\u0D4E", ["\u0D54", "\u0D56"], ["\u0D5F", "\u0D61"], ["\u0D7A", "\u0D7F"], ["\u0D85", "\u0D96"], ["\u0D9A", "\u0DB1"], ["\u0DB3", "\u0DBB"], "\u0DBD", ["\u0DC0", "\u0DC6"], ["\u0E01", "\u0E30"], ["\u0E32", "\u0E33"], ["\u0E40", "\u0E45"], ["\u0E81", "\u0E82"], "\u0E84", ["\u0E87", "\u0E88"], "\u0E8A", "\u0E8D", ["\u0E94", "\u0E97"], ["\u0E99", "\u0E9F"], ["\u0EA1", "\u0EA3"], "\u0EA5", "\u0EA7", ["\u0EAA", "\u0EAB"], ["\u0EAD", "\u0EB0"], ["\u0EB2", "\u0EB3"], "\u0EBD", ["\u0EC0", "\u0EC4"], ["\u0EDC", "\u0EDF"], "\u0F00", ["\u0F40", "\u0F47"], ["\u0F49", "\u0F6C"], ["\u0F88", "\u0F8C"], ["\u1000", "\u102A"], "\u103F", ["\u1050", "\u1055"], ["\u105A", "\u105D"], "\u1061", ["\u1065", "\u1066"], ["\u106E", "\u1070"], ["\u1075", "\u1081"], "\u108E", ["\u1100", "\u1248"], ["\u124A", "\u124D"], ["\u1250", "\u1256"], "\u1258", ["\u125A", "\u125D"], ["\u1260", "\u1288"], ["\u128A", "\u128D"], ["\u1290", "\u12B0"], ["\u12B2", "\u12B5"], ["\u12B8", "\u12BE"], "\u12C0", ["\u12C2", "\u12C5"], ["\u12C8", "\u12D6"], ["\u12D8", "\u1310"], ["\u1312", "\u1315"], ["\u1318", "\u135A"], ["\u1380", "\u138F"], ["\u1401", "\u166C"], ["\u166F", "\u167F"], ["\u1681", "\u169A"], ["\u16A0", "\u16EA"], ["\u16F1", "\u16F8"], ["\u1700", "\u170C"], ["\u170E", "\u1711"], ["\u1720", "\u1731"], ["\u1740", "\u1751"], ["\u1760", "\u176C"], ["\u176E", "\u1770"], ["\u1780", "\u17B3"], "\u17DC", ["\u1820", "\u1842"], ["\u1844", "\u1878"], ["\u1880", "\u1884"], ["\u1887", "\u18A8"], "\u18AA", ["\u18B0", "\u18F5"], ["\u1900", "\u191E"], ["\u1950", "\u196D"], ["\u1970", "\u1974"], ["\u1980", "\u19AB"], ["\u19B0", "\u19C9"], ["\u1A00", "\u1A16"], ["\u1A20", "\u1A54"], ["\u1B05", "\u1B33"], ["\u1B45", "\u1B4B"], ["\u1B83", "\u1BA0"], ["\u1BAE", "\u1BAF"], ["\u1BBA", "\u1BE5"], ["\u1C00", "\u1C23"], ["\u1C4D", "\u1C4F"], ["\u1C5A", "\u1C77"], ["\u1CE9", "\u1CEC"], ["\u1CEE", "\u1CF1"], ["\u1CF5", "\u1CF6"], ["\u2135", "\u2138"], ["\u2D30", "\u2D67"], ["\u2D80", "\u2D96"], ["\u2DA0", "\u2DA6"], ["\u2DA8", "\u2DAE"], ["\u2DB0", "\u2DB6"], ["\u2DB8", "\u2DBE"], ["\u2DC0", "\u2DC6"], ["\u2DC8", "\u2DCE"], ["\u2DD0", "\u2DD6"], ["\u2DD8", "\u2DDE"], "\u3006", "\u303C", ["\u3041", "\u3096"], "\u309F", ["\u30A1", "\u30FA"], "\u30FF", ["\u3105", "\u312F"], ["\u3131", "\u318E"], ["\u31A0", "\u31BA"], ["\u31F0", "\u31FF"], ["\u3400", "\u4DB5"], ["\u4E00", "\u9FEF"], ["\uA000", "\uA014"], ["\uA016", "\uA48C"], ["\uA4D0", "\uA4F7"], ["\uA500", "\uA60B"], ["\uA610", "\uA61F"], ["\uA62A", "\uA62B"], "\uA66E", ["\uA6A0", "\uA6E5"], "\uA78F", "\uA7F7", ["\uA7FB", "\uA801"], ["\uA803", "\uA805"], ["\uA807", "\uA80A"], ["\uA80C", "\uA822"], ["\uA840", "\uA873"], ["\uA882", "\uA8B3"], ["\uA8F2", "\uA8F7"], "\uA8FB", ["\uA8FD", "\uA8FE"], ["\uA90A", "\uA925"], ["\uA930", "\uA946"], ["\uA960", "\uA97C"], ["\uA984", "\uA9B2"], ["\uA9E0", "\uA9E4"], ["\uA9E7", "\uA9EF"], ["\uA9FA", "\uA9FE"], ["\uAA00", "\uAA28"], ["\uAA40", "\uAA42"], ["\uAA44", "\uAA4B"], ["\uAA60", "\uAA6F"], ["\uAA71", "\uAA76"], "\uAA7A", ["\uAA7E", "\uAAAF"], "\uAAB1", ["\uAAB5", "\uAAB6"], ["\uAAB9", "\uAABD"], "\uAAC0", "\uAAC2", ["\uAADB", "\uAADC"], ["\uAAE0", "\uAAEA"], "\uAAF2", ["\uAB01", "\uAB06"], ["\uAB09", "\uAB0E"], ["\uAB11", "\uAB16"], ["\uAB20", "\uAB26"], ["\uAB28", "\uAB2E"], ["\uABC0", "\uABE2"], ["\uAC00", "\uD7A3"], ["\uD7B0", "\uD7C6"], ["\uD7CB", "\uD7FB"], ["\uF900", "\uFA6D"], ["\uFA70", "\uFAD9"], "\uFB1D", ["\uFB1F", "\uFB28"], ["\uFB2A", "\uFB36"], ["\uFB38", "\uFB3C"], "\uFB3E", ["\uFB40", "\uFB41"], ["\uFB43", "\uFB44"], ["\uFB46", "\uFBB1"], ["\uFBD3", "\uFD3D"], ["\uFD50", "\uFD8F"], ["\uFD92", "\uFDC7"], ["\uFDF0", "\uFDFB"], ["\uFE70", "\uFE74"], ["\uFE76", "\uFEFC"], ["\uFF66", "\uFF6F"], ["\uFF71", "\uFF9D"], ["\uFFA0", "\uFFBE"], ["\uFFC2", "\uFFC7"], ["\uFFCA", "\uFFCF"], ["\uFFD2", "\uFFD7"], ["\uFFDA", "\uFFDC"]], false, false),
-      peg$c578 = /^[\u01C5\u01C8\u01CB\u01F2\u1F88-\u1F8F\u1F98-\u1F9F\u1FA8-\u1FAF\u1FBC\u1FCC\u1FFC]/,
-      peg$c579 = peg$classExpectation(["\u01C5", "\u01C8", "\u01CB", "\u01F2", ["\u1F88", "\u1F8F"], ["\u1F98", "\u1F9F"], ["\u1FA8", "\u1FAF"], "\u1FBC", "\u1FCC", "\u1FFC"], false, false),
-      peg$c580 = /^[A-Z\xC0-\xD6\xD8-\xDE\u0100\u0102\u0104\u0106\u0108\u010A\u010C\u010E\u0110\u0112\u0114\u0116\u0118\u011A\u011C\u011E\u0120\u0122\u0124\u0126\u0128\u012A\u012C\u012E\u0130\u0132\u0134\u0136\u0139\u013B\u013D\u013F\u0141\u0143\u0145\u0147\u014A\u014C\u014E\u0150\u0152\u0154\u0156\u0158\u015A\u015C\u015E\u0160\u0162\u0164\u0166\u0168\u016A\u016C\u016E\u0170\u0172\u0174\u0176\u0178-\u0179\u017B\u017D\u0181-\u0182\u0184\u0186-\u0187\u0189-\u018B\u018E-\u0191\u0193-\u0194\u0196-\u0198\u019C-\u019D\u019F-\u01A0\u01A2\u01A4\u01A6-\u01A7\u01A9\u01AC\u01AE-\u01AF\u01B1-\u01B3\u01B5\u01B7-\u01B8\u01BC\u01C4\u01C7\u01CA\u01CD\u01CF\u01D1\u01D3\u01D5\u01D7\u01D9\u01DB\u01DE\u01E0\u01E2\u01E4\u01E6\u01E8\u01EA\u01EC\u01EE\u01F1\u01F4\u01F6-\u01F8\u01FA\u01FC\u01FE\u0200\u0202\u0204\u0206\u0208\u020A\u020C\u020E\u0210\u0212\u0214\u0216\u0218\u021A\u021C\u021E\u0220\u0222\u0224\u0226\u0228\u022A\u022C\u022E\u0230\u0232\u023A-\u023B\u023D-\u023E\u0241\u0243-\u0246\u0248\u024A\u024C\u024E\u0370\u0372\u0376\u037F\u0386\u0388-\u038A\u038C\u038E-\u038F\u0391-\u03A1\u03A3-\u03AB\u03CF\u03D2-\u03D4\u03D8\u03DA\u03DC\u03DE\u03E0\u03E2\u03E4\u03E6\u03E8\u03EA\u03EC\u03EE\u03F4\u03F7\u03F9-\u03FA\u03FD-\u042F\u0460\u0462\u0464\u0466\u0468\u046A\u046C\u046E\u0470\u0472\u0474\u0476\u0478\u047A\u047C\u047E\u0480\u048A\u048C\u048E\u0490\u0492\u0494\u0496\u0498\u049A\u049C\u049E\u04A0\u04A2\u04A4\u04A6\u04A8\u04AA\u04AC\u04AE\u04B0\u04B2\u04B4\u04B6\u04B8\u04BA\u04BC\u04BE\u04C0-\u04C1\u04C3\u04C5\u04C7\u04C9\u04CB\u04CD\u04D0\u04D2\u04D4\u04D6\u04D8\u04DA\u04DC\u04DE\u04E0\u04E2\u04E4\u04E6\u04E8\u04EA\u04EC\u04EE\u04F0\u04F2\u04F4\u04F6\u04F8\u04FA\u04FC\u04FE\u0500\u0502\u0504\u0506\u0508\u050A\u050C\u050E\u0510\u0512\u0514\u0516\u0518\u051A\u051C\u051E\u0520\u0522\u0524\u0526\u0528\u052A\u052C\u052E\u0531-\u0556\u10A0-\u10C5\u10C7\u10CD\u13A0-\u13F5\u1C90-\u1CBA\u1CBD-\u1CBF\u1E00\u1E02\u1E04\u1E06\u1E08\u1E0A\u1E0C\u1E0E\u1E10\u1E12\u1E14\u1E16\u1E18\u1E1A\u1E1C\u1E1E\u1E20\u1E22\u1E24\u1E26\u1E28\u1E2A\u1E2C\u1E2E\u1E30\u1E32\u1E34\u1E36\u1E38\u1E3A\u1E3C\u1E3E\u1E40\u1E42\u1E44\u1E46\u1E48\u1E4A\u1E4C\u1E4E\u1E50\u1E52\u1E54\u1E56\u1E58\u1E5A\u1E5C\u1E5E\u1E60\u1E62\u1E64\u1E66\u1E68\u1E6A\u1E6C\u1E6E\u1E70\u1E72\u1E74\u1E76\u1E78\u1E7A\u1E7C\u1E7E\u1E80\u1E82\u1E84\u1E86\u1E88\u1E8A\u1E8C\u1E8E\u1E90\u1E92\u1E94\u1E9E\u1EA0\u1EA2\u1EA4\u1EA6\u1EA8\u1EAA\u1EAC\u1EAE\u1EB0\u1EB2\u1EB4\u1EB6\u1EB8\u1EBA\u1EBC\u1EBE\u1EC0\u1EC2\u1EC4\u1EC6\u1EC8\u1ECA\u1ECC\u1ECE\u1ED0\u1ED2\u1ED4\u1ED6\u1ED8\u1EDA\u1EDC\u1EDE\u1EE0\u1EE2\u1EE4\u1EE6\u1EE8\u1EEA\u1EEC\u1EEE\u1EF0\u1EF2\u1EF4\u1EF6\u1EF8\u1EFA\u1EFC\u1EFE\u1F08-\u1F0F\u1F18-\u1F1D\u1F28-\u1F2F\u1F38-\u1F3F\u1F48-\u1F4D\u1F59\u1F5B\u1F5D\u1F5F\u1F68-\u1F6F\u1FB8-\u1FBB\u1FC8-\u1FCB\u1FD8-\u1FDB\u1FE8-\u1FEC\u1FF8-\u1FFB\u2102\u2107\u210B-\u210D\u2110-\u2112\u2115\u2119-\u211D\u2124\u2126\u2128\u212A-\u212D\u2130-\u2133\u213E-\u213F\u2145\u2183\u2C00-\u2C2E\u2C60\u2C62-\u2C64\u2C67\u2C69\u2C6B\u2C6D-\u2C70\u2C72\u2C75\u2C7E-\u2C80\u2C82\u2C84\u2C86\u2C88\u2C8A\u2C8C\u2C8E\u2C90\u2C92\u2C94\u2C96\u2C98\u2C9A\u2C9C\u2C9E\u2CA0\u2CA2\u2CA4\u2CA6\u2CA8\u2CAA\u2CAC\u2CAE\u2CB0\u2CB2\u2CB4\u2CB6\u2CB8\u2CBA\u2CBC\u2CBE\u2CC0\u2CC2\u2CC4\u2CC6\u2CC8\u2CCA\u2CCC\u2CCE\u2CD0\u2CD2\u2CD4\u2CD6\u2CD8\u2CDA\u2CDC\u2CDE\u2CE0\u2CE2\u2CEB\u2CED\u2CF2\uA640\uA642\uA644\uA646\uA648\uA64A\uA64C\uA64E\uA650\uA652\uA654\uA656\uA658\uA65A\uA65C\uA65E\uA660\uA662\uA664\uA666\uA668\uA66A\uA66C\uA680\uA682\uA684\uA686\uA688\uA68A\uA68C\uA68E\uA690\uA692\uA694\uA696\uA698\uA69A\uA722\uA724\uA726\uA728\uA72A\uA72C\uA72E\uA732\uA734\uA736\uA738\uA73A\uA73C\uA73E\uA740\uA742\uA744\uA746\uA748\uA74A\uA74C\uA74E\uA750\uA752\uA754\uA756\uA758\uA75A\uA75C\uA75E\uA760\uA762\uA764\uA766\uA768\uA76A\uA76C\uA76E\uA779\uA77B\uA77D-\uA77E\uA780\uA782\uA784\uA786\uA78B\uA78D\uA790\uA792\uA796\uA798\uA79A\uA79C\uA79E\uA7A0\uA7A2\uA7A4\uA7A6\uA7A8\uA7AA-\uA7AE\uA7B0-\uA7B4\uA7B6\uA7B8\uFF21-\uFF3A]/,
-      peg$c581 = peg$classExpectation([["A", "Z"], ["\xC0", "\xD6"], ["\xD8", "\xDE"], "\u0100", "\u0102", "\u0104", "\u0106", "\u0108", "\u010A", "\u010C", "\u010E", "\u0110", "\u0112", "\u0114", "\u0116", "\u0118", "\u011A", "\u011C", "\u011E", "\u0120", "\u0122", "\u0124", "\u0126", "\u0128", "\u012A", "\u012C", "\u012E", "\u0130", "\u0132", "\u0134", "\u0136", "\u0139", "\u013B", "\u013D", "\u013F", "\u0141", "\u0143", "\u0145", "\u0147", "\u014A", "\u014C", "\u014E", "\u0150", "\u0152", "\u0154", "\u0156", "\u0158", "\u015A", "\u015C", "\u015E", "\u0160", "\u0162", "\u0164", "\u0166", "\u0168", "\u016A", "\u016C", "\u016E", "\u0170", "\u0172", "\u0174", "\u0176", ["\u0178", "\u0179"], "\u017B", "\u017D", ["\u0181", "\u0182"], "\u0184", ["\u0186", "\u0187"], ["\u0189", "\u018B"], ["\u018E", "\u0191"], ["\u0193", "\u0194"], ["\u0196", "\u0198"], ["\u019C", "\u019D"], ["\u019F", "\u01A0"], "\u01A2", "\u01A4", ["\u01A6", "\u01A7"], "\u01A9", "\u01AC", ["\u01AE", "\u01AF"], ["\u01B1", "\u01B3"], "\u01B5", ["\u01B7", "\u01B8"], "\u01BC", "\u01C4", "\u01C7", "\u01CA", "\u01CD", "\u01CF", "\u01D1", "\u01D3", "\u01D5", "\u01D7", "\u01D9", "\u01DB", "\u01DE", "\u01E0", "\u01E2", "\u01E4", "\u01E6", "\u01E8", "\u01EA", "\u01EC", "\u01EE", "\u01F1", "\u01F4", ["\u01F6", "\u01F8"], "\u01FA", "\u01FC", "\u01FE", "\u0200", "\u0202", "\u0204", "\u0206", "\u0208", "\u020A", "\u020C", "\u020E", "\u0210", "\u0212", "\u0214", "\u0216", "\u0218", "\u021A", "\u021C", "\u021E", "\u0220", "\u0222", "\u0224", "\u0226", "\u0228", "\u022A", "\u022C", "\u022E", "\u0230", "\u0232", ["\u023A", "\u023B"], ["\u023D", "\u023E"], "\u0241", ["\u0243", "\u0246"], "\u0248", "\u024A", "\u024C", "\u024E", "\u0370", "\u0372", "\u0376", "\u037F", "\u0386", ["\u0388", "\u038A"], "\u038C", ["\u038E", "\u038F"], ["\u0391", "\u03A1"], ["\u03A3", "\u03AB"], "\u03CF", ["\u03D2", "\u03D4"], "\u03D8", "\u03DA", "\u03DC", "\u03DE", "\u03E0", "\u03E2", "\u03E4", "\u03E6", "\u03E8", "\u03EA", "\u03EC", "\u03EE", "\u03F4", "\u03F7", ["\u03F9", "\u03FA"], ["\u03FD", "\u042F"], "\u0460", "\u0462", "\u0464", "\u0466", "\u0468", "\u046A", "\u046C", "\u046E", "\u0470", "\u0472", "\u0474", "\u0476", "\u0478", "\u047A", "\u047C", "\u047E", "\u0480", "\u048A", "\u048C", "\u048E", "\u0490", "\u0492", "\u0494", "\u0496", "\u0498", "\u049A", "\u049C", "\u049E", "\u04A0", "\u04A2", "\u04A4", "\u04A6", "\u04A8", "\u04AA", "\u04AC", "\u04AE", "\u04B0", "\u04B2", "\u04B4", "\u04B6", "\u04B8", "\u04BA", "\u04BC", "\u04BE", ["\u04C0", "\u04C1"], "\u04C3", "\u04C5", "\u04C7", "\u04C9", "\u04CB", "\u04CD", "\u04D0", "\u04D2", "\u04D4", "\u04D6", "\u04D8", "\u04DA", "\u04DC", "\u04DE", "\u04E0", "\u04E2", "\u04E4", "\u04E6", "\u04E8", "\u04EA", "\u04EC", "\u04EE", "\u04F0", "\u04F2", "\u04F4", "\u04F6", "\u04F8", "\u04FA", "\u04FC", "\u04FE", "\u0500", "\u0502", "\u0504", "\u0506", "\u0508", "\u050A", "\u050C", "\u050E", "\u0510", "\u0512", "\u0514", "\u0516", "\u0518", "\u051A", "\u051C", "\u051E", "\u0520", "\u0522", "\u0524", "\u0526", "\u0528", "\u052A", "\u052C", "\u052E", ["\u0531", "\u0556"], ["\u10A0", "\u10C5"], "\u10C7", "\u10CD", ["\u13A0", "\u13F5"], ["\u1C90", "\u1CBA"], ["\u1CBD", "\u1CBF"], "\u1E00", "\u1E02", "\u1E04", "\u1E06", "\u1E08", "\u1E0A", "\u1E0C", "\u1E0E", "\u1E10", "\u1E12", "\u1E14", "\u1E16", "\u1E18", "\u1E1A", "\u1E1C", "\u1E1E", "\u1E20", "\u1E22", "\u1E24", "\u1E26", "\u1E28", "\u1E2A", "\u1E2C", "\u1E2E", "\u1E30", "\u1E32", "\u1E34", "\u1E36", "\u1E38", "\u1E3A", "\u1E3C", "\u1E3E", "\u1E40", "\u1E42", "\u1E44", "\u1E46", "\u1E48", "\u1E4A", "\u1E4C", "\u1E4E", "\u1E50", "\u1E52", "\u1E54", "\u1E56", "\u1E58", "\u1E5A", "\u1E5C", "\u1E5E", "\u1E60", "\u1E62", "\u1E64", "\u1E66", "\u1E68", "\u1E6A", "\u1E6C", "\u1E6E", "\u1E70", "\u1E72", "\u1E74", "\u1E76", "\u1E78", "\u1E7A", "\u1E7C", "\u1E7E", "\u1E80", "\u1E82", "\u1E84", "\u1E86", "\u1E88", "\u1E8A", "\u1E8C", "\u1E8E", "\u1E90", "\u1E92", "\u1E94", "\u1E9E", "\u1EA0", "\u1EA2", "\u1EA4", "\u1EA6", "\u1EA8", "\u1EAA", "\u1EAC", "\u1EAE", "\u1EB0", "\u1EB2", "\u1EB4", "\u1EB6", "\u1EB8", "\u1EBA", "\u1EBC", "\u1EBE", "\u1EC0", "\u1EC2", "\u1EC4", "\u1EC6", "\u1EC8", "\u1ECA", "\u1ECC", "\u1ECE", "\u1ED0", "\u1ED2", "\u1ED4", "\u1ED6", "\u1ED8", "\u1EDA", "\u1EDC", "\u1EDE", "\u1EE0", "\u1EE2", "\u1EE4", "\u1EE6", "\u1EE8", "\u1EEA", "\u1EEC", "\u1EEE", "\u1EF0", "\u1EF2", "\u1EF4", "\u1EF6", "\u1EF8", "\u1EFA", "\u1EFC", "\u1EFE", ["\u1F08", "\u1F0F"], ["\u1F18", "\u1F1D"], ["\u1F28", "\u1F2F"], ["\u1F38", "\u1F3F"], ["\u1F48", "\u1F4D"], "\u1F59", "\u1F5B", "\u1F5D", "\u1F5F", ["\u1F68", "\u1F6F"], ["\u1FB8", "\u1FBB"], ["\u1FC8", "\u1FCB"], ["\u1FD8", "\u1FDB"], ["\u1FE8", "\u1FEC"], ["\u1FF8", "\u1FFB"], "\u2102", "\u2107", ["\u210B", "\u210D"], ["\u2110", "\u2112"], "\u2115", ["\u2119", "\u211D"], "\u2124", "\u2126", "\u2128", ["\u212A", "\u212D"], ["\u2130", "\u2133"], ["\u213E", "\u213F"], "\u2145", "\u2183", ["\u2C00", "\u2C2E"], "\u2C60", ["\u2C62", "\u2C64"], "\u2C67", "\u2C69", "\u2C6B", ["\u2C6D", "\u2C70"], "\u2C72", "\u2C75", ["\u2C7E", "\u2C80"], "\u2C82", "\u2C84", "\u2C86", "\u2C88", "\u2C8A", "\u2C8C", "\u2C8E", "\u2C90", "\u2C92", "\u2C94", "\u2C96", "\u2C98", "\u2C9A", "\u2C9C", "\u2C9E", "\u2CA0", "\u2CA2", "\u2CA4", "\u2CA6", "\u2CA8", "\u2CAA", "\u2CAC", "\u2CAE", "\u2CB0", "\u2CB2", "\u2CB4", "\u2CB6", "\u2CB8", "\u2CBA", "\u2CBC", "\u2CBE", "\u2CC0", "\u2CC2", "\u2CC4", "\u2CC6", "\u2CC8", "\u2CCA", "\u2CCC", "\u2CCE", "\u2CD0", "\u2CD2", "\u2CD4", "\u2CD6", "\u2CD8", "\u2CDA", "\u2CDC", "\u2CDE", "\u2CE0", "\u2CE2", "\u2CEB", "\u2CED", "\u2CF2", "\uA640", "\uA642", "\uA644", "\uA646", "\uA648", "\uA64A", "\uA64C", "\uA64E", "\uA650", "\uA652", "\uA654", "\uA656", "\uA658", "\uA65A", "\uA65C", "\uA65E", "\uA660", "\uA662", "\uA664", "\uA666", "\uA668", "\uA66A", "\uA66C", "\uA680", "\uA682", "\uA684", "\uA686", "\uA688", "\uA68A", "\uA68C", "\uA68E", "\uA690", "\uA692", "\uA694", "\uA696", "\uA698", "\uA69A", "\uA722", "\uA724", "\uA726", "\uA728", "\uA72A", "\uA72C", "\uA72E", "\uA732", "\uA734", "\uA736", "\uA738", "\uA73A", "\uA73C", "\uA73E", "\uA740", "\uA742", "\uA744", "\uA746", "\uA748", "\uA74A", "\uA74C", "\uA74E", "\uA750", "\uA752", "\uA754", "\uA756", "\uA758", "\uA75A", "\uA75C", "\uA75E", "\uA760", "\uA762", "\uA764", "\uA766", "\uA768", "\uA76A", "\uA76C", "\uA76E", "\uA779", "\uA77B", ["\uA77D", "\uA77E"], "\uA780", "\uA782", "\uA784", "\uA786", "\uA78B", "\uA78D", "\uA790", "\uA792", "\uA796", "\uA798", "\uA79A", "\uA79C", "\uA79E", "\uA7A0", "\uA7A2", "\uA7A4", "\uA7A6", "\uA7A8", ["\uA7AA", "\uA7AE"], ["\uA7B0", "\uA7B4"], "\uA7B6", "\uA7B8", ["\uFF21", "\uFF3A"]], false, false),
-      peg$c582 = /^[\u0903\u093B\u093E-\u0940\u0949-\u094C\u094E-\u094F\u0982-\u0983\u09BE-\u09C0\u09C7-\u09C8\u09CB-\u09CC\u09D7\u0A03\u0A3E-\u0A40\u0A83\u0ABE-\u0AC0\u0AC9\u0ACB-\u0ACC\u0B02-\u0B03\u0B3E\u0B40\u0B47-\u0B48\u0B4B-\u0B4C\u0B57\u0BBE-\u0BBF\u0BC1-\u0BC2\u0BC6-\u0BC8\u0BCA-\u0BCC\u0BD7\u0C01-\u0C03\u0C41-\u0C44\u0C82-\u0C83\u0CBE\u0CC0-\u0CC4\u0CC7-\u0CC8\u0CCA-\u0CCB\u0CD5-\u0CD6\u0D02-\u0D03\u0D3E-\u0D40\u0D46-\u0D48\u0D4A-\u0D4C\u0D57\u0D82-\u0D83\u0DCF-\u0DD1\u0DD8-\u0DDF\u0DF2-\u0DF3\u0F3E-\u0F3F\u0F7F\u102B-\u102C\u1031\u1038\u103B-\u103C\u1056-\u1057\u1062-\u1064\u1067-\u106D\u1083-\u1084\u1087-\u108C\u108F\u109A-\u109C\u17B6\u17BE-\u17C5\u17C7-\u17C8\u1923-\u1926\u1929-\u192B\u1930-\u1931\u1933-\u1938\u1A19-\u1A1A\u1A55\u1A57\u1A61\u1A63-\u1A64\u1A6D-\u1A72\u1B04\u1B35\u1B3B\u1B3D-\u1B41\u1B43-\u1B44\u1B82\u1BA1\u1BA6-\u1BA7\u1BAA\u1BE7\u1BEA-\u1BEC\u1BEE\u1BF2-\u1BF3\u1C24-\u1C2B\u1C34-\u1C35\u1CE1\u1CF2-\u1CF3\u1CF7\u302E-\u302F\uA823-\uA824\uA827\uA880-\uA881\uA8B4-\uA8C3\uA952-\uA953\uA983\uA9B4-\uA9B5\uA9BA-\uA9BB\uA9BD-\uA9C0\uAA2F-\uAA30\uAA33-\uAA34\uAA4D\uAA7B\uAA7D\uAAEB\uAAEE-\uAAEF\uAAF5\uABE3-\uABE4\uABE6-\uABE7\uABE9-\uABEA\uABEC]/,
-      peg$c583 = peg$classExpectation(["\u0903", "\u093B", ["\u093E", "\u0940"], ["\u0949", "\u094C"], ["\u094E", "\u094F"], ["\u0982", "\u0983"], ["\u09BE", "\u09C0"], ["\u09C7", "\u09C8"], ["\u09CB", "\u09CC"], "\u09D7", "\u0A03", ["\u0A3E", "\u0A40"], "\u0A83", ["\u0ABE", "\u0AC0"], "\u0AC9", ["\u0ACB", "\u0ACC"], ["\u0B02", "\u0B03"], "\u0B3E", "\u0B40", ["\u0B47", "\u0B48"], ["\u0B4B", "\u0B4C"], "\u0B57", ["\u0BBE", "\u0BBF"], ["\u0BC1", "\u0BC2"], ["\u0BC6", "\u0BC8"], ["\u0BCA", "\u0BCC"], "\u0BD7", ["\u0C01", "\u0C03"], ["\u0C41", "\u0C44"], ["\u0C82", "\u0C83"], "\u0CBE", ["\u0CC0", "\u0CC4"], ["\u0CC7", "\u0CC8"], ["\u0CCA", "\u0CCB"], ["\u0CD5", "\u0CD6"], ["\u0D02", "\u0D03"], ["\u0D3E", "\u0D40"], ["\u0D46", "\u0D48"], ["\u0D4A", "\u0D4C"], "\u0D57", ["\u0D82", "\u0D83"], ["\u0DCF", "\u0DD1"], ["\u0DD8", "\u0DDF"], ["\u0DF2", "\u0DF3"], ["\u0F3E", "\u0F3F"], "\u0F7F", ["\u102B", "\u102C"], "\u1031", "\u1038", ["\u103B", "\u103C"], ["\u1056", "\u1057"], ["\u1062", "\u1064"], ["\u1067", "\u106D"], ["\u1083", "\u1084"], ["\u1087", "\u108C"], "\u108F", ["\u109A", "\u109C"], "\u17B6", ["\u17BE", "\u17C5"], ["\u17C7", "\u17C8"], ["\u1923", "\u1926"], ["\u1929", "\u192B"], ["\u1930", "\u1931"], ["\u1933", "\u1938"], ["\u1A19", "\u1A1A"], "\u1A55", "\u1A57", "\u1A61", ["\u1A63", "\u1A64"], ["\u1A6D", "\u1A72"], "\u1B04", "\u1B35", "\u1B3B", ["\u1B3D", "\u1B41"], ["\u1B43", "\u1B44"], "\u1B82", "\u1BA1", ["\u1BA6", "\u1BA7"], "\u1BAA", "\u1BE7", ["\u1BEA", "\u1BEC"], "\u1BEE", ["\u1BF2", "\u1BF3"], ["\u1C24", "\u1C2B"], ["\u1C34", "\u1C35"], "\u1CE1", ["\u1CF2", "\u1CF3"], "\u1CF7", ["\u302E", "\u302F"], ["\uA823", "\uA824"], "\uA827", ["\uA880", "\uA881"], ["\uA8B4", "\uA8C3"], ["\uA952", "\uA953"], "\uA983", ["\uA9B4", "\uA9B5"], ["\uA9BA", "\uA9BB"], ["\uA9BD", "\uA9C0"], ["\uAA2F", "\uAA30"], ["\uAA33", "\uAA34"], "\uAA4D", "\uAA7B", "\uAA7D", "\uAAEB", ["\uAAEE", "\uAAEF"], "\uAAF5", ["\uABE3", "\uABE4"], ["\uABE6", "\uABE7"], ["\uABE9", "\uABEA"], "\uABEC"], false, false),
-      peg$c584 = /^[\u0300-\u036F\u0483-\u0487\u0591-\u05BD\u05BF\u05C1-\u05C2\u05C4-\u05C5\u05C7\u0610-\u061A\u064B-\u065F\u0670\u06D6-\u06DC\u06DF-\u06E4\u06E7-\u06E8\u06EA-\u06ED\u0711\u0730-\u074A\u07A6-\u07B0\u07EB-\u07F3\u07FD\u0816-\u0819\u081B-\u0823\u0825-\u0827\u0829-\u082D\u0859-\u085B\u08D3-\u08E1\u08E3-\u0902\u093A\u093C\u0941-\u0948\u094D\u0951-\u0957\u0962-\u0963\u0981\u09BC\u09C1-\u09C4\u09CD\u09E2-\u09E3\u09FE\u0A01-\u0A02\u0A3C\u0A41-\u0A42\u0A47-\u0A48\u0A4B-\u0A4D\u0A51\u0A70-\u0A71\u0A75\u0A81-\u0A82\u0ABC\u0AC1-\u0AC5\u0AC7-\u0AC8\u0ACD\u0AE2-\u0AE3\u0AFA-\u0AFF\u0B01\u0B3C\u0B3F\u0B41-\u0B44\u0B4D\u0B56\u0B62-\u0B63\u0B82\u0BC0\u0BCD\u0C00\u0C04\u0C3E-\u0C40\u0C46-\u0C48\u0C4A-\u0C4D\u0C55-\u0C56\u0C62-\u0C63\u0C81\u0CBC\u0CBF\u0CC6\u0CCC-\u0CCD\u0CE2-\u0CE3\u0D00-\u0D01\u0D3B-\u0D3C\u0D41-\u0D44\u0D4D\u0D62-\u0D63\u0DCA\u0DD2-\u0DD4\u0DD6\u0E31\u0E34-\u0E3A\u0E47-\u0E4E\u0EB1\u0EB4-\u0EB9\u0EBB-\u0EBC\u0EC8-\u0ECD\u0F18-\u0F19\u0F35\u0F37\u0F39\u0F71-\u0F7E\u0F80-\u0F84\u0F86-\u0F87\u0F8D-\u0F97\u0F99-\u0FBC\u0FC6\u102D-\u1030\u1032-\u1037\u1039-\u103A\u103D-\u103E\u1058-\u1059\u105E-\u1060\u1071-\u1074\u1082\u1085-\u1086\u108D\u109D\u135D-\u135F\u1712-\u1714\u1732-\u1734\u1752-\u1753\u1772-\u1773\u17B4-\u17B5\u17B7-\u17BD\u17C6\u17C9-\u17D3\u17DD\u180B-\u180D\u1885-\u1886\u18A9\u1920-\u1922\u1927-\u1928\u1932\u1939-\u193B\u1A17-\u1A18\u1A1B\u1A56\u1A58-\u1A5E\u1A60\u1A62\u1A65-\u1A6C\u1A73-\u1A7C\u1A7F\u1AB0-\u1ABD\u1B00-\u1B03\u1B34\u1B36-\u1B3A\u1B3C\u1B42\u1B6B-\u1B73\u1B80-\u1B81\u1BA2-\u1BA5\u1BA8-\u1BA9\u1BAB-\u1BAD\u1BE6\u1BE8-\u1BE9\u1BED\u1BEF-\u1BF1\u1C2C-\u1C33\u1C36-\u1C37\u1CD0-\u1CD2\u1CD4-\u1CE0\u1CE2-\u1CE8\u1CED\u1CF4\u1CF8-\u1CF9\u1DC0-\u1DF9\u1DFB-\u1DFF\u20D0-\u20DC\u20E1\u20E5-\u20F0\u2CEF-\u2CF1\u2D7F\u2DE0-\u2DFF\u302A-\u302D\u3099-\u309A\uA66F\uA674-\uA67D\uA69E-\uA69F\uA6F0-\uA6F1\uA802\uA806\uA80B\uA825-\uA826\uA8C4-\uA8C5\uA8E0-\uA8F1\uA8FF\uA926-\uA92D\uA947-\uA951\uA980-\uA982\uA9B3\uA9B6-\uA9B9\uA9BC\uA9E5\uAA29-\uAA2E\uAA31-\uAA32\uAA35-\uAA36\uAA43\uAA4C\uAA7C\uAAB0\uAAB2-\uAAB4\uAAB7-\uAAB8\uAABE-\uAABF\uAAC1\uAAEC-\uAAED\uAAF6\uABE5\uABE8\uABED\uFB1E\uFE00-\uFE0F\uFE20-\uFE2F]/,
-      peg$c585 = peg$classExpectation([["\u0300", "\u036F"], ["\u0483", "\u0487"], ["\u0591", "\u05BD"], "\u05BF", ["\u05C1", "\u05C2"], ["\u05C4", "\u05C5"], "\u05C7", ["\u0610", "\u061A"], ["\u064B", "\u065F"], "\u0670", ["\u06D6", "\u06DC"], ["\u06DF", "\u06E4"], ["\u06E7", "\u06E8"], ["\u06EA", "\u06ED"], "\u0711", ["\u0730", "\u074A"], ["\u07A6", "\u07B0"], ["\u07EB", "\u07F3"], "\u07FD", ["\u0816", "\u0819"], ["\u081B", "\u0823"], ["\u0825", "\u0827"], ["\u0829", "\u082D"], ["\u0859", "\u085B"], ["\u08D3", "\u08E1"], ["\u08E3", "\u0902"], "\u093A", "\u093C", ["\u0941", "\u0948"], "\u094D", ["\u0951", "\u0957"], ["\u0962", "\u0963"], "\u0981", "\u09BC", ["\u09C1", "\u09C4"], "\u09CD", ["\u09E2", "\u09E3"], "\u09FE", ["\u0A01", "\u0A02"], "\u0A3C", ["\u0A41", "\u0A42"], ["\u0A47", "\u0A48"], ["\u0A4B", "\u0A4D"], "\u0A51", ["\u0A70", "\u0A71"], "\u0A75", ["\u0A81", "\u0A82"], "\u0ABC", ["\u0AC1", "\u0AC5"], ["\u0AC7", "\u0AC8"], "\u0ACD", ["\u0AE2", "\u0AE3"], ["\u0AFA", "\u0AFF"], "\u0B01", "\u0B3C", "\u0B3F", ["\u0B41", "\u0B44"], "\u0B4D", "\u0B56", ["\u0B62", "\u0B63"], "\u0B82", "\u0BC0", "\u0BCD", "\u0C00", "\u0C04", ["\u0C3E", "\u0C40"], ["\u0C46", "\u0C48"], ["\u0C4A", "\u0C4D"], ["\u0C55", "\u0C56"], ["\u0C62", "\u0C63"], "\u0C81", "\u0CBC", "\u0CBF", "\u0CC6", ["\u0CCC", "\u0CCD"], ["\u0CE2", "\u0CE3"], ["\u0D00", "\u0D01"], ["\u0D3B", "\u0D3C"], ["\u0D41", "\u0D44"], "\u0D4D", ["\u0D62", "\u0D63"], "\u0DCA", ["\u0DD2", "\u0DD4"], "\u0DD6", "\u0E31", ["\u0E34", "\u0E3A"], ["\u0E47", "\u0E4E"], "\u0EB1", ["\u0EB4", "\u0EB9"], ["\u0EBB", "\u0EBC"], ["\u0EC8", "\u0ECD"], ["\u0F18", "\u0F19"], "\u0F35", "\u0F37", "\u0F39", ["\u0F71", "\u0F7E"], ["\u0F80", "\u0F84"], ["\u0F86", "\u0F87"], ["\u0F8D", "\u0F97"], ["\u0F99", "\u0FBC"], "\u0FC6", ["\u102D", "\u1030"], ["\u1032", "\u1037"], ["\u1039", "\u103A"], ["\u103D", "\u103E"], ["\u1058", "\u1059"], ["\u105E", "\u1060"], ["\u1071", "\u1074"], "\u1082", ["\u1085", "\u1086"], "\u108D", "\u109D", ["\u135D", "\u135F"], ["\u1712", "\u1714"], ["\u1732", "\u1734"], ["\u1752", "\u1753"], ["\u1772", "\u1773"], ["\u17B4", "\u17B5"], ["\u17B7", "\u17BD"], "\u17C6", ["\u17C9", "\u17D3"], "\u17DD", ["\u180B", "\u180D"], ["\u1885", "\u1886"], "\u18A9", ["\u1920", "\u1922"], ["\u1927", "\u1928"], "\u1932", ["\u1939", "\u193B"], ["\u1A17", "\u1A18"], "\u1A1B", "\u1A56", ["\u1A58", "\u1A5E"], "\u1A60", "\u1A62", ["\u1A65", "\u1A6C"], ["\u1A73", "\u1A7C"], "\u1A7F", ["\u1AB0", "\u1ABD"], ["\u1B00", "\u1B03"], "\u1B34", ["\u1B36", "\u1B3A"], "\u1B3C", "\u1B42", ["\u1B6B", "\u1B73"], ["\u1B80", "\u1B81"], ["\u1BA2", "\u1BA5"], ["\u1BA8", "\u1BA9"], ["\u1BAB", "\u1BAD"], "\u1BE6", ["\u1BE8", "\u1BE9"], "\u1BED", ["\u1BEF", "\u1BF1"], ["\u1C2C", "\u1C33"], ["\u1C36", "\u1C37"], ["\u1CD0", "\u1CD2"], ["\u1CD4", "\u1CE0"], ["\u1CE2", "\u1CE8"], "\u1CED", "\u1CF4", ["\u1CF8", "\u1CF9"], ["\u1DC0", "\u1DF9"], ["\u1DFB", "\u1DFF"], ["\u20D0", "\u20DC"], "\u20E1", ["\u20E5", "\u20F0"], ["\u2CEF", "\u2CF1"], "\u2D7F", ["\u2DE0", "\u2DFF"], ["\u302A", "\u302D"], ["\u3099", "\u309A"], "\uA66F", ["\uA674", "\uA67D"], ["\uA69E", "\uA69F"], ["\uA6F0", "\uA6F1"], "\uA802", "\uA806", "\uA80B", ["\uA825", "\uA826"], ["\uA8C4", "\uA8C5"], ["\uA8E0", "\uA8F1"], "\uA8FF", ["\uA926", "\uA92D"], ["\uA947", "\uA951"], ["\uA980", "\uA982"], "\uA9B3", ["\uA9B6", "\uA9B9"], "\uA9BC", "\uA9E5", ["\uAA29", "\uAA2E"], ["\uAA31", "\uAA32"], ["\uAA35", "\uAA36"], "\uAA43", "\uAA4C", "\uAA7C", "\uAAB0", ["\uAAB2", "\uAAB4"], ["\uAAB7", "\uAAB8"], ["\uAABE", "\uAABF"], "\uAAC1", ["\uAAEC", "\uAAED"], "\uAAF6", "\uABE5", "\uABE8", "\uABED", "\uFB1E", ["\uFE00", "\uFE0F"], ["\uFE20", "\uFE2F"]], false, false),
-      peg$c586 = /^[0-9\u0660-\u0669\u06F0-\u06F9\u07C0-\u07C9\u0966-\u096F\u09E6-\u09EF\u0A66-\u0A6F\u0AE6-\u0AEF\u0B66-\u0B6F\u0BE6-\u0BEF\u0C66-\u0C6F\u0CE6-\u0CEF\u0D66-\u0D6F\u0DE6-\u0DEF\u0E50-\u0E59\u0ED0-\u0ED9\u0F20-\u0F29\u1040-\u1049\u1090-\u1099\u17E0-\u17E9\u1810-\u1819\u1946-\u194F\u19D0-\u19D9\u1A80-\u1A89\u1A90-\u1A99\u1B50-\u1B59\u1BB0-\u1BB9\u1C40-\u1C49\u1C50-\u1C59\uA620-\uA629\uA8D0-\uA8D9\uA900-\uA909\uA9D0-\uA9D9\uA9F0-\uA9F9\uAA50-\uAA59\uABF0-\uABF9\uFF10-\uFF19]/,
-      peg$c587 = peg$classExpectation([["0", "9"], ["\u0660", "\u0669"], ["\u06F0", "\u06F9"], ["\u07C0", "\u07C9"], ["\u0966", "\u096F"], ["\u09E6", "\u09EF"], ["\u0A66", "\u0A6F"], ["\u0AE6", "\u0AEF"], ["\u0B66", "\u0B6F"], ["\u0BE6", "\u0BEF"], ["\u0C66", "\u0C6F"], ["\u0CE6", "\u0CEF"], ["\u0D66", "\u0D6F"], ["\u0DE6", "\u0DEF"], ["\u0E50", "\u0E59"], ["\u0ED0", "\u0ED9"], ["\u0F20", "\u0F29"], ["\u1040", "\u1049"], ["\u1090", "\u1099"], ["\u17E0", "\u17E9"], ["\u1810", "\u1819"], ["\u1946", "\u194F"], ["\u19D0", "\u19D9"], ["\u1A80", "\u1A89"], ["\u1A90", "\u1A99"], ["\u1B50", "\u1B59"], ["\u1BB0", "\u1BB9"], ["\u1C40", "\u1C49"], ["\u1C50", "\u1C59"], ["\uA620", "\uA629"], ["\uA8D0", "\uA8D9"], ["\uA900", "\uA909"], ["\uA9D0", "\uA9D9"], ["\uA9F0", "\uA9F9"], ["\uAA50", "\uAA59"], ["\uABF0", "\uABF9"], ["\uFF10", "\uFF19"]], false, false),
-      peg$c588 = /^[\u16EE-\u16F0\u2160-\u2182\u2185-\u2188\u3007\u3021-\u3029\u3038-\u303A\uA6E6-\uA6EF]/,
-      peg$c589 = peg$classExpectation([["\u16EE", "\u16F0"], ["\u2160", "\u2182"], ["\u2185", "\u2188"], "\u3007", ["\u3021", "\u3029"], ["\u3038", "\u303A"], ["\uA6E6", "\uA6EF"]], false, false),
-      peg$c590 = /^[_\u203F-\u2040\u2054\uFE33-\uFE34\uFE4D-\uFE4F\uFF3F]/,
-      peg$c591 = peg$classExpectation(["_", ["\u203F", "\u2040"], "\u2054", ["\uFE33", "\uFE34"], ["\uFE4D", "\uFE4F"], "\uFF3F"], false, false),
-      peg$c592 = /^[ \xA0\u1680\u2000-\u200A\u202F\u205F\u3000]/,
-      peg$c593 = peg$classExpectation([" ", "\xA0", "\u1680", ["\u2000", "\u200A"], "\u202F", "\u205F", "\u3000"], false, false),
-      peg$c594 = peg$otherExpectation("whitespace"),
-      peg$c595 = "\t",
-      peg$c596 = peg$literalExpectation("\t", false),
-      peg$c597 = "\x0B",
-      peg$c598 = peg$literalExpectation("\x0B", false),
-      peg$c599 = "\f",
-      peg$c600 = peg$literalExpectation("\f", false),
-      peg$c601 = " ",
-      peg$c602 = peg$literalExpectation(" ", false),
-      peg$c603 = "\xA0",
-      peg$c604 = peg$literalExpectation("\xA0", false),
-      peg$c605 = "\uFEFF",
-      peg$c606 = peg$literalExpectation("\uFEFF", false),
-      peg$c607 = /^[\n\r\u2028\u2029]/,
-      peg$c608 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c609 = peg$otherExpectation("comment"),
-      peg$c610 = "/*",
-      peg$c611 = peg$literalExpectation("/*", false),
-      peg$c612 = "*/",
-      peg$c613 = peg$literalExpectation("*/", false),
-      peg$c614 = "//",
-      peg$c615 = peg$literalExpectation("//", false),
+      peg$c567 = /^[^\/\\]/,
+      peg$c568 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c569 = /^[\0-\x1F\\]/,
+      peg$c570 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c571 = /^[a-z\xB5\xDF-\xF6\xF8-\xFF\u0101\u0103\u0105\u0107\u0109\u010B\u010D\u010F\u0111\u0113\u0115\u0117\u0119\u011B\u011D\u011F\u0121\u0123\u0125\u0127\u0129\u012B\u012D\u012F\u0131\u0133\u0135\u0137-\u0138\u013A\u013C\u013E\u0140\u0142\u0144\u0146\u0148-\u0149\u014B\u014D\u014F\u0151\u0153\u0155\u0157\u0159\u015B\u015D\u015F\u0161\u0163\u0165\u0167\u0169\u016B\u016D\u016F\u0171\u0173\u0175\u0177\u017A\u017C\u017E-\u0180\u0183\u0185\u0188\u018C-\u018D\u0192\u0195\u0199-\u019B\u019E\u01A1\u01A3\u01A5\u01A8\u01AA-\u01AB\u01AD\u01B0\u01B4\u01B6\u01B9-\u01BA\u01BD-\u01BF\u01C6\u01C9\u01CC\u01CE\u01D0\u01D2\u01D4\u01D6\u01D8\u01DA\u01DC-\u01DD\u01DF\u01E1\u01E3\u01E5\u01E7\u01E9\u01EB\u01ED\u01EF-\u01F0\u01F3\u01F5\u01F9\u01FB\u01FD\u01FF\u0201\u0203\u0205\u0207\u0209\u020B\u020D\u020F\u0211\u0213\u0215\u0217\u0219\u021B\u021D\u021F\u0221\u0223\u0225\u0227\u0229\u022B\u022D\u022F\u0231\u0233-\u0239\u023C\u023F-\u0240\u0242\u0247\u0249\u024B\u024D\u024F-\u0293\u0295-\u02AF\u0371\u0373\u0377\u037B-\u037D\u0390\u03AC-\u03CE\u03D0-\u03D1\u03D5-\u03D7\u03D9\u03DB\u03DD\u03DF\u03E1\u03E3\u03E5\u03E7\u03E9\u03EB\u03ED\u03EF-\u03F3\u03F5\u03F8\u03FB-\u03FC\u0430-\u045F\u0461\u0463\u0465\u0467\u0469\u046B\u046D\u046F\u0471\u0473\u0475\u0477\u0479\u047B\u047D\u047F\u0481\u048B\u048D\u048F\u0491\u0493\u0495\u0497\u0499\u049B\u049D\u049F\u04A1\u04A3\u04A5\u04A7\u04A9\u04AB\u04AD\u04AF\u04B1\u04B3\u04B5\u04B7\u04B9\u04BB\u04BD\u04BF\u04C2\u04C4\u04C6\u04C8\u04CA\u04CC\u04CE-\u04CF\u04D1\u04D3\u04D5\u04D7\u04D9\u04DB\u04DD\u04DF\u04E1\u04E3\u04E5\u04E7\u04E9\u04EB\u04ED\u04EF\u04F1\u04F3\u04F5\u04F7\u04F9\u04FB\u04FD\u04FF\u0501\u0503\u0505\u0507\u0509\u050B\u050D\u050F\u0511\u0513\u0515\u0517\u0519\u051B\u051D\u051F\u0521\u0523\u0525\u0527\u0529\u052B\u052D\u052F\u0560-\u0588\u10D0-\u10FA\u10FD-\u10FF\u13F8-\u13FD\u1C80-\u1C88\u1D00-\u1D2B\u1D6B-\u1D77\u1D79-\u1D9A\u1E01\u1E03\u1E05\u1E07\u1E09\u1E0B\u1E0D\u1E0F\u1E11\u1E13\u1E15\u1E17\u1E19\u1E1B\u1E1D\u1E1F\u1E21\u1E23\u1E25\u1E27\u1E29\u1E2B\u1E2D\u1E2F\u1E31\u1E33\u1E35\u1E37\u1E39\u1E3B\u1E3D\u1E3F\u1E41\u1E43\u1E45\u1E47\u1E49\u1E4B\u1E4D\u1E4F\u1E51\u1E53\u1E55\u1E57\u1E59\u1E5B\u1E5D\u1E5F\u1E61\u1E63\u1E65\u1E67\u1E69\u1E6B\u1E6D\u1E6F\u1E71\u1E73\u1E75\u1E77\u1E79\u1E7B\u1E7D\u1E7F\u1E81\u1E83\u1E85\u1E87\u1E89\u1E8B\u1E8D\u1E8F\u1E91\u1E93\u1E95-\u1E9D\u1E9F\u1EA1\u1EA3\u1EA5\u1EA7\u1EA9\u1EAB\u1EAD\u1EAF\u1EB1\u1EB3\u1EB5\u1EB7\u1EB9\u1EBB\u1EBD\u1EBF\u1EC1\u1EC3\u1EC5\u1EC7\u1EC9\u1ECB\u1ECD\u1ECF\u1ED1\u1ED3\u1ED5\u1ED7\u1ED9\u1EDB\u1EDD\u1EDF\u1EE1\u1EE3\u1EE5\u1EE7\u1EE9\u1EEB\u1EED\u1EEF\u1EF1\u1EF3\u1EF5\u1EF7\u1EF9\u1EFB\u1EFD\u1EFF-\u1F07\u1F10-\u1F15\u1F20-\u1F27\u1F30-\u1F37\u1F40-\u1F45\u1F50-\u1F57\u1F60-\u1F67\u1F70-\u1F7D\u1F80-\u1F87\u1F90-\u1F97\u1FA0-\u1FA7\u1FB0-\u1FB4\u1FB6-\u1FB7\u1FBE\u1FC2-\u1FC4\u1FC6-\u1FC7\u1FD0-\u1FD3\u1FD6-\u1FD7\u1FE0-\u1FE7\u1FF2-\u1FF4\u1FF6-\u1FF7\u210A\u210E-\u210F\u2113\u212F\u2134\u2139\u213C-\u213D\u2146-\u2149\u214E\u2184\u2C30-\u2C5E\u2C61\u2C65-\u2C66\u2C68\u2C6A\u2C6C\u2C71\u2C73-\u2C74\u2C76-\u2C7B\u2C81\u2C83\u2C85\u2C87\u2C89\u2C8B\u2C8D\u2C8F\u2C91\u2C93\u2C95\u2C97\u2C99\u2C9B\u2C9D\u2C9F\u2CA1\u2CA3\u2CA5\u2CA7\u2CA9\u2CAB\u2CAD\u2CAF\u2CB1\u2CB3\u2CB5\u2CB7\u2CB9\u2CBB\u2CBD\u2CBF\u2CC1\u2CC3\u2CC5\u2CC7\u2CC9\u2CCB\u2CCD\u2CCF\u2CD1\u2CD3\u2CD5\u2CD7\u2CD9\u2CDB\u2CDD\u2CDF\u2CE1\u2CE3-\u2CE4\u2CEC\u2CEE\u2CF3\u2D00-\u2D25\u2D27\u2D2D\uA641\uA643\uA645\uA647\uA649\uA64B\uA64D\uA64F\uA651\uA653\uA655\uA657\uA659\uA65B\uA65D\uA65F\uA661\uA663\uA665\uA667\uA669\uA66B\uA66D\uA681\uA683\uA685\uA687\uA689\uA68B\uA68D\uA68F\uA691\uA693\uA695\uA697\uA699\uA69B\uA723\uA725\uA727\uA729\uA72B\uA72D\uA72F-\uA731\uA733\uA735\uA737\uA739\uA73B\uA73D\uA73F\uA741\uA743\uA745\uA747\uA749\uA74B\uA74D\uA74F\uA751\uA753\uA755\uA757\uA759\uA75B\uA75D\uA75F\uA761\uA763\uA765\uA767\uA769\uA76B\uA76D\uA76F\uA771-\uA778\uA77A\uA77C\uA77F\uA781\uA783\uA785\uA787\uA78C\uA78E\uA791\uA793-\uA795\uA797\uA799\uA79B\uA79D\uA79F\uA7A1\uA7A3\uA7A5\uA7A7\uA7A9\uA7AF\uA7B5\uA7B7\uA7B9\uA7FA\uAB30-\uAB5A\uAB60-\uAB65\uAB70-\uABBF\uFB00-\uFB06\uFB13-\uFB17\uFF41-\uFF5A]/,
+      peg$c572 = peg$classExpectation([["a", "z"], "\xB5", ["\xDF", "\xF6"], ["\xF8", "\xFF"], "\u0101", "\u0103", "\u0105", "\u0107", "\u0109", "\u010B", "\u010D", "\u010F", "\u0111", "\u0113", "\u0115", "\u0117", "\u0119", "\u011B", "\u011D", "\u011F", "\u0121", "\u0123", "\u0125", "\u0127", "\u0129", "\u012B", "\u012D", "\u012F", "\u0131", "\u0133", "\u0135", ["\u0137", "\u0138"], "\u013A", "\u013C", "\u013E", "\u0140", "\u0142", "\u0144", "\u0146", ["\u0148", "\u0149"], "\u014B", "\u014D", "\u014F", "\u0151", "\u0153", "\u0155", "\u0157", "\u0159", "\u015B", "\u015D", "\u015F", "\u0161", "\u0163", "\u0165", "\u0167", "\u0169", "\u016B", "\u016D", "\u016F", "\u0171", "\u0173", "\u0175", "\u0177", "\u017A", "\u017C", ["\u017E", "\u0180"], "\u0183", "\u0185", "\u0188", ["\u018C", "\u018D"], "\u0192", "\u0195", ["\u0199", "\u019B"], "\u019E", "\u01A1", "\u01A3", "\u01A5", "\u01A8", ["\u01AA", "\u01AB"], "\u01AD", "\u01B0", "\u01B4", "\u01B6", ["\u01B9", "\u01BA"], ["\u01BD", "\u01BF"], "\u01C6", "\u01C9", "\u01CC", "\u01CE", "\u01D0", "\u01D2", "\u01D4", "\u01D6", "\u01D8", "\u01DA", ["\u01DC", "\u01DD"], "\u01DF", "\u01E1", "\u01E3", "\u01E5", "\u01E7", "\u01E9", "\u01EB", "\u01ED", ["\u01EF", "\u01F0"], "\u01F3", "\u01F5", "\u01F9", "\u01FB", "\u01FD", "\u01FF", "\u0201", "\u0203", "\u0205", "\u0207", "\u0209", "\u020B", "\u020D", "\u020F", "\u0211", "\u0213", "\u0215", "\u0217", "\u0219", "\u021B", "\u021D", "\u021F", "\u0221", "\u0223", "\u0225", "\u0227", "\u0229", "\u022B", "\u022D", "\u022F", "\u0231", ["\u0233", "\u0239"], "\u023C", ["\u023F", "\u0240"], "\u0242", "\u0247", "\u0249", "\u024B", "\u024D", ["\u024F", "\u0293"], ["\u0295", "\u02AF"], "\u0371", "\u0373", "\u0377", ["\u037B", "\u037D"], "\u0390", ["\u03AC", "\u03CE"], ["\u03D0", "\u03D1"], ["\u03D5", "\u03D7"], "\u03D9", "\u03DB", "\u03DD", "\u03DF", "\u03E1", "\u03E3", "\u03E5", "\u03E7", "\u03E9", "\u03EB", "\u03ED", ["\u03EF", "\u03F3"], "\u03F5", "\u03F8", ["\u03FB", "\u03FC"], ["\u0430", "\u045F"], "\u0461", "\u0463", "\u0465", "\u0467", "\u0469", "\u046B", "\u046D", "\u046F", "\u0471", "\u0473", "\u0475", "\u0477", "\u0479", "\u047B", "\u047D", "\u047F", "\u0481", "\u048B", "\u048D", "\u048F", "\u0491", "\u0493", "\u0495", "\u0497", "\u0499", "\u049B", "\u049D", "\u049F", "\u04A1", "\u04A3", "\u04A5", "\u04A7", "\u04A9", "\u04AB", "\u04AD", "\u04AF", "\u04B1", "\u04B3", "\u04B5", "\u04B7", "\u04B9", "\u04BB", "\u04BD", "\u04BF", "\u04C2", "\u04C4", "\u04C6", "\u04C8", "\u04CA", "\u04CC", ["\u04CE", "\u04CF"], "\u04D1", "\u04D3", "\u04D5", "\u04D7", "\u04D9", "\u04DB", "\u04DD", "\u04DF", "\u04E1", "\u04E3", "\u04E5", "\u04E7", "\u04E9", "\u04EB", "\u04ED", "\u04EF", "\u04F1", "\u04F3", "\u04F5", "\u04F7", "\u04F9", "\u04FB", "\u04FD", "\u04FF", "\u0501", "\u0503", "\u0505", "\u0507", "\u0509", "\u050B", "\u050D", "\u050F", "\u0511", "\u0513", "\u0515", "\u0517", "\u0519", "\u051B", "\u051D", "\u051F", "\u0521", "\u0523", "\u0525", "\u0527", "\u0529", "\u052B", "\u052D", "\u052F", ["\u0560", "\u0588"], ["\u10D0", "\u10FA"], ["\u10FD", "\u10FF"], ["\u13F8", "\u13FD"], ["\u1C80", "\u1C88"], ["\u1D00", "\u1D2B"], ["\u1D6B", "\u1D77"], ["\u1D79", "\u1D9A"], "\u1E01", "\u1E03", "\u1E05", "\u1E07", "\u1E09", "\u1E0B", "\u1E0D", "\u1E0F", "\u1E11", "\u1E13", "\u1E15", "\u1E17", "\u1E19", "\u1E1B", "\u1E1D", "\u1E1F", "\u1E21", "\u1E23", "\u1E25", "\u1E27", "\u1E29", "\u1E2B", "\u1E2D", "\u1E2F", "\u1E31", "\u1E33", "\u1E35", "\u1E37", "\u1E39", "\u1E3B", "\u1E3D", "\u1E3F", "\u1E41", "\u1E43", "\u1E45", "\u1E47", "\u1E49", "\u1E4B", "\u1E4D", "\u1E4F", "\u1E51", "\u1E53", "\u1E55", "\u1E57", "\u1E59", "\u1E5B", "\u1E5D", "\u1E5F", "\u1E61", "\u1E63", "\u1E65", "\u1E67", "\u1E69", "\u1E6B", "\u1E6D", "\u1E6F", "\u1E71", "\u1E73", "\u1E75", "\u1E77", "\u1E79", "\u1E7B", "\u1E7D", "\u1E7F", "\u1E81", "\u1E83", "\u1E85", "\u1E87", "\u1E89", "\u1E8B", "\u1E8D", "\u1E8F", "\u1E91", "\u1E93", ["\u1E95", "\u1E9D"], "\u1E9F", "\u1EA1", "\u1EA3", "\u1EA5", "\u1EA7", "\u1EA9", "\u1EAB", "\u1EAD", "\u1EAF", "\u1EB1", "\u1EB3", "\u1EB5", "\u1EB7", "\u1EB9", "\u1EBB", "\u1EBD", "\u1EBF", "\u1EC1", "\u1EC3", "\u1EC5", "\u1EC7", "\u1EC9", "\u1ECB", "\u1ECD", "\u1ECF", "\u1ED1", "\u1ED3", "\u1ED5", "\u1ED7", "\u1ED9", "\u1EDB", "\u1EDD", "\u1EDF", "\u1EE1", "\u1EE3", "\u1EE5", "\u1EE7", "\u1EE9", "\u1EEB", "\u1EED", "\u1EEF", "\u1EF1", "\u1EF3", "\u1EF5", "\u1EF7", "\u1EF9", "\u1EFB", "\u1EFD", ["\u1EFF", "\u1F07"], ["\u1F10", "\u1F15"], ["\u1F20", "\u1F27"], ["\u1F30", "\u1F37"], ["\u1F40", "\u1F45"], ["\u1F50", "\u1F57"], ["\u1F60", "\u1F67"], ["\u1F70", "\u1F7D"], ["\u1F80", "\u1F87"], ["\u1F90", "\u1F97"], ["\u1FA0", "\u1FA7"], ["\u1FB0", "\u1FB4"], ["\u1FB6", "\u1FB7"], "\u1FBE", ["\u1FC2", "\u1FC4"], ["\u1FC6", "\u1FC7"], ["\u1FD0", "\u1FD3"], ["\u1FD6", "\u1FD7"], ["\u1FE0", "\u1FE7"], ["\u1FF2", "\u1FF4"], ["\u1FF6", "\u1FF7"], "\u210A", ["\u210E", "\u210F"], "\u2113", "\u212F", "\u2134", "\u2139", ["\u213C", "\u213D"], ["\u2146", "\u2149"], "\u214E", "\u2184", ["\u2C30", "\u2C5E"], "\u2C61", ["\u2C65", "\u2C66"], "\u2C68", "\u2C6A", "\u2C6C", "\u2C71", ["\u2C73", "\u2C74"], ["\u2C76", "\u2C7B"], "\u2C81", "\u2C83", "\u2C85", "\u2C87", "\u2C89", "\u2C8B", "\u2C8D", "\u2C8F", "\u2C91", "\u2C93", "\u2C95", "\u2C97", "\u2C99", "\u2C9B", "\u2C9D", "\u2C9F", "\u2CA1", "\u2CA3", "\u2CA5", "\u2CA7", "\u2CA9", "\u2CAB", "\u2CAD", "\u2CAF", "\u2CB1", "\u2CB3", "\u2CB5", "\u2CB7", "\u2CB9", "\u2CBB", "\u2CBD", "\u2CBF", "\u2CC1", "\u2CC3", "\u2CC5", "\u2CC7", "\u2CC9", "\u2CCB", "\u2CCD", "\u2CCF", "\u2CD1", "\u2CD3", "\u2CD5", "\u2CD7", "\u2CD9", "\u2CDB", "\u2CDD", "\u2CDF", "\u2CE1", ["\u2CE3", "\u2CE4"], "\u2CEC", "\u2CEE", "\u2CF3", ["\u2D00", "\u2D25"], "\u2D27", "\u2D2D", "\uA641", "\uA643", "\uA645", "\uA647", "\uA649", "\uA64B", "\uA64D", "\uA64F", "\uA651", "\uA653", "\uA655", "\uA657", "\uA659", "\uA65B", "\uA65D", "\uA65F", "\uA661", "\uA663", "\uA665", "\uA667", "\uA669", "\uA66B", "\uA66D", "\uA681", "\uA683", "\uA685", "\uA687", "\uA689", "\uA68B", "\uA68D", "\uA68F", "\uA691", "\uA693", "\uA695", "\uA697", "\uA699", "\uA69B", "\uA723", "\uA725", "\uA727", "\uA729", "\uA72B", "\uA72D", ["\uA72F", "\uA731"], "\uA733", "\uA735", "\uA737", "\uA739", "\uA73B", "\uA73D", "\uA73F", "\uA741", "\uA743", "\uA745", "\uA747", "\uA749", "\uA74B", "\uA74D", "\uA74F", "\uA751", "\uA753", "\uA755", "\uA757", "\uA759", "\uA75B", "\uA75D", "\uA75F", "\uA761", "\uA763", "\uA765", "\uA767", "\uA769", "\uA76B", "\uA76D", "\uA76F", ["\uA771", "\uA778"], "\uA77A", "\uA77C", "\uA77F", "\uA781", "\uA783", "\uA785", "\uA787", "\uA78C", "\uA78E", "\uA791", ["\uA793", "\uA795"], "\uA797", "\uA799", "\uA79B", "\uA79D", "\uA79F", "\uA7A1", "\uA7A3", "\uA7A5", "\uA7A7", "\uA7A9", "\uA7AF", "\uA7B5", "\uA7B7", "\uA7B9", "\uA7FA", ["\uAB30", "\uAB5A"], ["\uAB60", "\uAB65"], ["\uAB70", "\uABBF"], ["\uFB00", "\uFB06"], ["\uFB13", "\uFB17"], ["\uFF41", "\uFF5A"]], false, false),
+      peg$c573 = /^[\u02B0-\u02C1\u02C6-\u02D1\u02E0-\u02E4\u02EC\u02EE\u0374\u037A\u0559\u0640\u06E5-\u06E6\u07F4-\u07F5\u07FA\u081A\u0824\u0828\u0971\u0E46\u0EC6\u10FC\u17D7\u1843\u1AA7\u1C78-\u1C7D\u1D2C-\u1D6A\u1D78\u1D9B-\u1DBF\u2071\u207F\u2090-\u209C\u2C7C-\u2C7D\u2D6F\u2E2F\u3005\u3031-\u3035\u303B\u309D-\u309E\u30FC-\u30FE\uA015\uA4F8-\uA4FD\uA60C\uA67F\uA69C-\uA69D\uA717-\uA71F\uA770\uA788\uA7F8-\uA7F9\uA9CF\uA9E6\uAA70\uAADD\uAAF3-\uAAF4\uAB5C-\uAB5F\uFF70\uFF9E-\uFF9F]/,
+      peg$c574 = peg$classExpectation([["\u02B0", "\u02C1"], ["\u02C6", "\u02D1"], ["\u02E0", "\u02E4"], "\u02EC", "\u02EE", "\u0374", "\u037A", "\u0559", "\u0640", ["\u06E5", "\u06E6"], ["\u07F4", "\u07F5"], "\u07FA", "\u081A", "\u0824", "\u0828", "\u0971", "\u0E46", "\u0EC6", "\u10FC", "\u17D7", "\u1843", "\u1AA7", ["\u1C78", "\u1C7D"], ["\u1D2C", "\u1D6A"], "\u1D78", ["\u1D9B", "\u1DBF"], "\u2071", "\u207F", ["\u2090", "\u209C"], ["\u2C7C", "\u2C7D"], "\u2D6F", "\u2E2F", "\u3005", ["\u3031", "\u3035"], "\u303B", ["\u309D", "\u309E"], ["\u30FC", "\u30FE"], "\uA015", ["\uA4F8", "\uA4FD"], "\uA60C", "\uA67F", ["\uA69C", "\uA69D"], ["\uA717", "\uA71F"], "\uA770", "\uA788", ["\uA7F8", "\uA7F9"], "\uA9CF", "\uA9E6", "\uAA70", "\uAADD", ["\uAAF3", "\uAAF4"], ["\uAB5C", "\uAB5F"], "\uFF70", ["\uFF9E", "\uFF9F"]], false, false),
+      peg$c575 = /^[\xAA\xBA\u01BB\u01C0-\u01C3\u0294\u05D0-\u05EA\u05EF-\u05F2\u0620-\u063F\u0641-\u064A\u066E-\u066F\u0671-\u06D3\u06D5\u06EE-\u06EF\u06FA-\u06FC\u06FF\u0710\u0712-\u072F\u074D-\u07A5\u07B1\u07CA-\u07EA\u0800-\u0815\u0840-\u0858\u0860-\u086A\u08A0-\u08B4\u08B6-\u08BD\u0904-\u0939\u093D\u0950\u0958-\u0961\u0972-\u0980\u0985-\u098C\u098F-\u0990\u0993-\u09A8\u09AA-\u09B0\u09B2\u09B6-\u09B9\u09BD\u09CE\u09DC-\u09DD\u09DF-\u09E1\u09F0-\u09F1\u09FC\u0A05-\u0A0A\u0A0F-\u0A10\u0A13-\u0A28\u0A2A-\u0A30\u0A32-\u0A33\u0A35-\u0A36\u0A38-\u0A39\u0A59-\u0A5C\u0A5E\u0A72-\u0A74\u0A85-\u0A8D\u0A8F-\u0A91\u0A93-\u0AA8\u0AAA-\u0AB0\u0AB2-\u0AB3\u0AB5-\u0AB9\u0ABD\u0AD0\u0AE0-\u0AE1\u0AF9\u0B05-\u0B0C\u0B0F-\u0B10\u0B13-\u0B28\u0B2A-\u0B30\u0B32-\u0B33\u0B35-\u0B39\u0B3D\u0B5C-\u0B5D\u0B5F-\u0B61\u0B71\u0B83\u0B85-\u0B8A\u0B8E-\u0B90\u0B92-\u0B95\u0B99-\u0B9A\u0B9C\u0B9E-\u0B9F\u0BA3-\u0BA4\u0BA8-\u0BAA\u0BAE-\u0BB9\u0BD0\u0C05-\u0C0C\u0C0E-\u0C10\u0C12-\u0C28\u0C2A-\u0C39\u0C3D\u0C58-\u0C5A\u0C60-\u0C61\u0C80\u0C85-\u0C8C\u0C8E-\u0C90\u0C92-\u0CA8\u0CAA-\u0CB3\u0CB5-\u0CB9\u0CBD\u0CDE\u0CE0-\u0CE1\u0CF1-\u0CF2\u0D05-\u0D0C\u0D0E-\u0D10\u0D12-\u0D3A\u0D3D\u0D4E\u0D54-\u0D56\u0D5F-\u0D61\u0D7A-\u0D7F\u0D85-\u0D96\u0D9A-\u0DB1\u0DB3-\u0DBB\u0DBD\u0DC0-\u0DC6\u0E01-\u0E30\u0E32-\u0E33\u0E40-\u0E45\u0E81-\u0E82\u0E84\u0E87-\u0E88\u0E8A\u0E8D\u0E94-\u0E97\u0E99-\u0E9F\u0EA1-\u0EA3\u0EA5\u0EA7\u0EAA-\u0EAB\u0EAD-\u0EB0\u0EB2-\u0EB3\u0EBD\u0EC0-\u0EC4\u0EDC-\u0EDF\u0F00\u0F40-\u0F47\u0F49-\u0F6C\u0F88-\u0F8C\u1000-\u102A\u103F\u1050-\u1055\u105A-\u105D\u1061\u1065-\u1066\u106E-\u1070\u1075-\u1081\u108E\u1100-\u1248\u124A-\u124D\u1250-\u1256\u1258\u125A-\u125D\u1260-\u1288\u128A-\u128D\u1290-\u12B0\u12B2-\u12B5\u12B8-\u12BE\u12C0\u12C2-\u12C5\u12C8-\u12D6\u12D8-\u1310\u1312-\u1315\u1318-\u135A\u1380-\u138F\u1401-\u166C\u166F-\u167F\u1681-\u169A\u16A0-\u16EA\u16F1-\u16F8\u1700-\u170C\u170E-\u1711\u1720-\u1731\u1740-\u1751\u1760-\u176C\u176E-\u1770\u1780-\u17B3\u17DC\u1820-\u1842\u1844-\u1878\u1880-\u1884\u1887-\u18A8\u18AA\u18B0-\u18F5\u1900-\u191E\u1950-\u196D\u1970-\u1974\u1980-\u19AB\u19B0-\u19C9\u1A00-\u1A16\u1A20-\u1A54\u1B05-\u1B33\u1B45-\u1B4B\u1B83-\u1BA0\u1BAE-\u1BAF\u1BBA-\u1BE5\u1C00-\u1C23\u1C4D-\u1C4F\u1C5A-\u1C77\u1CE9-\u1CEC\u1CEE-\u1CF1\u1CF5-\u1CF6\u2135-\u2138\u2D30-\u2D67\u2D80-\u2D96\u2DA0-\u2DA6\u2DA8-\u2DAE\u2DB0-\u2DB6\u2DB8-\u2DBE\u2DC0-\u2DC6\u2DC8-\u2DCE\u2DD0-\u2DD6\u2DD8-\u2DDE\u3006\u303C\u3041-\u3096\u309F\u30A1-\u30FA\u30FF\u3105-\u312F\u3131-\u318E\u31A0-\u31BA\u31F0-\u31FF\u3400-\u4DB5\u4E00-\u9FEF\uA000-\uA014\uA016-\uA48C\uA4D0-\uA4F7\uA500-\uA60B\uA610-\uA61F\uA62A-\uA62B\uA66E\uA6A0-\uA6E5\uA78F\uA7F7\uA7FB-\uA801\uA803-\uA805\uA807-\uA80A\uA80C-\uA822\uA840-\uA873\uA882-\uA8B3\uA8F2-\uA8F7\uA8FB\uA8FD-\uA8FE\uA90A-\uA925\uA930-\uA946\uA960-\uA97C\uA984-\uA9B2\uA9E0-\uA9E4\uA9E7-\uA9EF\uA9FA-\uA9FE\uAA00-\uAA28\uAA40-\uAA42\uAA44-\uAA4B\uAA60-\uAA6F\uAA71-\uAA76\uAA7A\uAA7E-\uAAAF\uAAB1\uAAB5-\uAAB6\uAAB9-\uAABD\uAAC0\uAAC2\uAADB-\uAADC\uAAE0-\uAAEA\uAAF2\uAB01-\uAB06\uAB09-\uAB0E\uAB11-\uAB16\uAB20-\uAB26\uAB28-\uAB2E\uABC0-\uABE2\uAC00-\uD7A3\uD7B0-\uD7C6\uD7CB-\uD7FB\uF900-\uFA6D\uFA70-\uFAD9\uFB1D\uFB1F-\uFB28\uFB2A-\uFB36\uFB38-\uFB3C\uFB3E\uFB40-\uFB41\uFB43-\uFB44\uFB46-\uFBB1\uFBD3-\uFD3D\uFD50-\uFD8F\uFD92-\uFDC7\uFDF0-\uFDFB\uFE70-\uFE74\uFE76-\uFEFC\uFF66-\uFF6F\uFF71-\uFF9D\uFFA0-\uFFBE\uFFC2-\uFFC7\uFFCA-\uFFCF\uFFD2-\uFFD7\uFFDA-\uFFDC]/,
+      peg$c576 = peg$classExpectation(["\xAA", "\xBA", "\u01BB", ["\u01C0", "\u01C3"], "\u0294", ["\u05D0", "\u05EA"], ["\u05EF", "\u05F2"], ["\u0620", "\u063F"], ["\u0641", "\u064A"], ["\u066E", "\u066F"], ["\u0671", "\u06D3"], "\u06D5", ["\u06EE", "\u06EF"], ["\u06FA", "\u06FC"], "\u06FF", "\u0710", ["\u0712", "\u072F"], ["\u074D", "\u07A5"], "\u07B1", ["\u07CA", "\u07EA"], ["\u0800", "\u0815"], ["\u0840", "\u0858"], ["\u0860", "\u086A"], ["\u08A0", "\u08B4"], ["\u08B6", "\u08BD"], ["\u0904", "\u0939"], "\u093D", "\u0950", ["\u0958", "\u0961"], ["\u0972", "\u0980"], ["\u0985", "\u098C"], ["\u098F", "\u0990"], ["\u0993", "\u09A8"], ["\u09AA", "\u09B0"], "\u09B2", ["\u09B6", "\u09B9"], "\u09BD", "\u09CE", ["\u09DC", "\u09DD"], ["\u09DF", "\u09E1"], ["\u09F0", "\u09F1"], "\u09FC", ["\u0A05", "\u0A0A"], ["\u0A0F", "\u0A10"], ["\u0A13", "\u0A28"], ["\u0A2A", "\u0A30"], ["\u0A32", "\u0A33"], ["\u0A35", "\u0A36"], ["\u0A38", "\u0A39"], ["\u0A59", "\u0A5C"], "\u0A5E", ["\u0A72", "\u0A74"], ["\u0A85", "\u0A8D"], ["\u0A8F", "\u0A91"], ["\u0A93", "\u0AA8"], ["\u0AAA", "\u0AB0"], ["\u0AB2", "\u0AB3"], ["\u0AB5", "\u0AB9"], "\u0ABD", "\u0AD0", ["\u0AE0", "\u0AE1"], "\u0AF9", ["\u0B05", "\u0B0C"], ["\u0B0F", "\u0B10"], ["\u0B13", "\u0B28"], ["\u0B2A", "\u0B30"], ["\u0B32", "\u0B33"], ["\u0B35", "\u0B39"], "\u0B3D", ["\u0B5C", "\u0B5D"], ["\u0B5F", "\u0B61"], "\u0B71", "\u0B83", ["\u0B85", "\u0B8A"], ["\u0B8E", "\u0B90"], ["\u0B92", "\u0B95"], ["\u0B99", "\u0B9A"], "\u0B9C", ["\u0B9E", "\u0B9F"], ["\u0BA3", "\u0BA4"], ["\u0BA8", "\u0BAA"], ["\u0BAE", "\u0BB9"], "\u0BD0", ["\u0C05", "\u0C0C"], ["\u0C0E", "\u0C10"], ["\u0C12", "\u0C28"], ["\u0C2A", "\u0C39"], "\u0C3D", ["\u0C58", "\u0C5A"], ["\u0C60", "\u0C61"], "\u0C80", ["\u0C85", "\u0C8C"], ["\u0C8E", "\u0C90"], ["\u0C92", "\u0CA8"], ["\u0CAA", "\u0CB3"], ["\u0CB5", "\u0CB9"], "\u0CBD", "\u0CDE", ["\u0CE0", "\u0CE1"], ["\u0CF1", "\u0CF2"], ["\u0D05", "\u0D0C"], ["\u0D0E", "\u0D10"], ["\u0D12", "\u0D3A"], "\u0D3D", "\u0D4E", ["\u0D54", "\u0D56"], ["\u0D5F", "\u0D61"], ["\u0D7A", "\u0D7F"], ["\u0D85", "\u0D96"], ["\u0D9A", "\u0DB1"], ["\u0DB3", "\u0DBB"], "\u0DBD", ["\u0DC0", "\u0DC6"], ["\u0E01", "\u0E30"], ["\u0E32", "\u0E33"], ["\u0E40", "\u0E45"], ["\u0E81", "\u0E82"], "\u0E84", ["\u0E87", "\u0E88"], "\u0E8A", "\u0E8D", ["\u0E94", "\u0E97"], ["\u0E99", "\u0E9F"], ["\u0EA1", "\u0EA3"], "\u0EA5", "\u0EA7", ["\u0EAA", "\u0EAB"], ["\u0EAD", "\u0EB0"], ["\u0EB2", "\u0EB3"], "\u0EBD", ["\u0EC0", "\u0EC4"], ["\u0EDC", "\u0EDF"], "\u0F00", ["\u0F40", "\u0F47"], ["\u0F49", "\u0F6C"], ["\u0F88", "\u0F8C"], ["\u1000", "\u102A"], "\u103F", ["\u1050", "\u1055"], ["\u105A", "\u105D"], "\u1061", ["\u1065", "\u1066"], ["\u106E", "\u1070"], ["\u1075", "\u1081"], "\u108E", ["\u1100", "\u1248"], ["\u124A", "\u124D"], ["\u1250", "\u1256"], "\u1258", ["\u125A", "\u125D"], ["\u1260", "\u1288"], ["\u128A", "\u128D"], ["\u1290", "\u12B0"], ["\u12B2", "\u12B5"], ["\u12B8", "\u12BE"], "\u12C0", ["\u12C2", "\u12C5"], ["\u12C8", "\u12D6"], ["\u12D8", "\u1310"], ["\u1312", "\u1315"], ["\u1318", "\u135A"], ["\u1380", "\u138F"], ["\u1401", "\u166C"], ["\u166F", "\u167F"], ["\u1681", "\u169A"], ["\u16A0", "\u16EA"], ["\u16F1", "\u16F8"], ["\u1700", "\u170C"], ["\u170E", "\u1711"], ["\u1720", "\u1731"], ["\u1740", "\u1751"], ["\u1760", "\u176C"], ["\u176E", "\u1770"], ["\u1780", "\u17B3"], "\u17DC", ["\u1820", "\u1842"], ["\u1844", "\u1878"], ["\u1880", "\u1884"], ["\u1887", "\u18A8"], "\u18AA", ["\u18B0", "\u18F5"], ["\u1900", "\u191E"], ["\u1950", "\u196D"], ["\u1970", "\u1974"], ["\u1980", "\u19AB"], ["\u19B0", "\u19C9"], ["\u1A00", "\u1A16"], ["\u1A20", "\u1A54"], ["\u1B05", "\u1B33"], ["\u1B45", "\u1B4B"], ["\u1B83", "\u1BA0"], ["\u1BAE", "\u1BAF"], ["\u1BBA", "\u1BE5"], ["\u1C00", "\u1C23"], ["\u1C4D", "\u1C4F"], ["\u1C5A", "\u1C77"], ["\u1CE9", "\u1CEC"], ["\u1CEE", "\u1CF1"], ["\u1CF5", "\u1CF6"], ["\u2135", "\u2138"], ["\u2D30", "\u2D67"], ["\u2D80", "\u2D96"], ["\u2DA0", "\u2DA6"], ["\u2DA8", "\u2DAE"], ["\u2DB0", "\u2DB6"], ["\u2DB8", "\u2DBE"], ["\u2DC0", "\u2DC6"], ["\u2DC8", "\u2DCE"], ["\u2DD0", "\u2DD6"], ["\u2DD8", "\u2DDE"], "\u3006", "\u303C", ["\u3041", "\u3096"], "\u309F", ["\u30A1", "\u30FA"], "\u30FF", ["\u3105", "\u312F"], ["\u3131", "\u318E"], ["\u31A0", "\u31BA"], ["\u31F0", "\u31FF"], ["\u3400", "\u4DB5"], ["\u4E00", "\u9FEF"], ["\uA000", "\uA014"], ["\uA016", "\uA48C"], ["\uA4D0", "\uA4F7"], ["\uA500", "\uA60B"], ["\uA610", "\uA61F"], ["\uA62A", "\uA62B"], "\uA66E", ["\uA6A0", "\uA6E5"], "\uA78F", "\uA7F7", ["\uA7FB", "\uA801"], ["\uA803", "\uA805"], ["\uA807", "\uA80A"], ["\uA80C", "\uA822"], ["\uA840", "\uA873"], ["\uA882", "\uA8B3"], ["\uA8F2", "\uA8F7"], "\uA8FB", ["\uA8FD", "\uA8FE"], ["\uA90A", "\uA925"], ["\uA930", "\uA946"], ["\uA960", "\uA97C"], ["\uA984", "\uA9B2"], ["\uA9E0", "\uA9E4"], ["\uA9E7", "\uA9EF"], ["\uA9FA", "\uA9FE"], ["\uAA00", "\uAA28"], ["\uAA40", "\uAA42"], ["\uAA44", "\uAA4B"], ["\uAA60", "\uAA6F"], ["\uAA71", "\uAA76"], "\uAA7A", ["\uAA7E", "\uAAAF"], "\uAAB1", ["\uAAB5", "\uAAB6"], ["\uAAB9", "\uAABD"], "\uAAC0", "\uAAC2", ["\uAADB", "\uAADC"], ["\uAAE0", "\uAAEA"], "\uAAF2", ["\uAB01", "\uAB06"], ["\uAB09", "\uAB0E"], ["\uAB11", "\uAB16"], ["\uAB20", "\uAB26"], ["\uAB28", "\uAB2E"], ["\uABC0", "\uABE2"], ["\uAC00", "\uD7A3"], ["\uD7B0", "\uD7C6"], ["\uD7CB", "\uD7FB"], ["\uF900", "\uFA6D"], ["\uFA70", "\uFAD9"], "\uFB1D", ["\uFB1F", "\uFB28"], ["\uFB2A", "\uFB36"], ["\uFB38", "\uFB3C"], "\uFB3E", ["\uFB40", "\uFB41"], ["\uFB43", "\uFB44"], ["\uFB46", "\uFBB1"], ["\uFBD3", "\uFD3D"], ["\uFD50", "\uFD8F"], ["\uFD92", "\uFDC7"], ["\uFDF0", "\uFDFB"], ["\uFE70", "\uFE74"], ["\uFE76", "\uFEFC"], ["\uFF66", "\uFF6F"], ["\uFF71", "\uFF9D"], ["\uFFA0", "\uFFBE"], ["\uFFC2", "\uFFC7"], ["\uFFCA", "\uFFCF"], ["\uFFD2", "\uFFD7"], ["\uFFDA", "\uFFDC"]], false, false),
+      peg$c577 = /^[\u01C5\u01C8\u01CB\u01F2\u1F88-\u1F8F\u1F98-\u1F9F\u1FA8-\u1FAF\u1FBC\u1FCC\u1FFC]/,
+      peg$c578 = peg$classExpectation(["\u01C5", "\u01C8", "\u01CB", "\u01F2", ["\u1F88", "\u1F8F"], ["\u1F98", "\u1F9F"], ["\u1FA8", "\u1FAF"], "\u1FBC", "\u1FCC", "\u1FFC"], false, false),
+      peg$c579 = /^[A-Z\xC0-\xD6\xD8-\xDE\u0100\u0102\u0104\u0106\u0108\u010A\u010C\u010E\u0110\u0112\u0114\u0116\u0118\u011A\u011C\u011E\u0120\u0122\u0124\u0126\u0128\u012A\u012C\u012E\u0130\u0132\u0134\u0136\u0139\u013B\u013D\u013F\u0141\u0143\u0145\u0147\u014A\u014C\u014E\u0150\u0152\u0154\u0156\u0158\u015A\u015C\u015E\u0160\u0162\u0164\u0166\u0168\u016A\u016C\u016E\u0170\u0172\u0174\u0176\u0178-\u0179\u017B\u017D\u0181-\u0182\u0184\u0186-\u0187\u0189-\u018B\u018E-\u0191\u0193-\u0194\u0196-\u0198\u019C-\u019D\u019F-\u01A0\u01A2\u01A4\u01A6-\u01A7\u01A9\u01AC\u01AE-\u01AF\u01B1-\u01B3\u01B5\u01B7-\u01B8\u01BC\u01C4\u01C7\u01CA\u01CD\u01CF\u01D1\u01D3\u01D5\u01D7\u01D9\u01DB\u01DE\u01E0\u01E2\u01E4\u01E6\u01E8\u01EA\u01EC\u01EE\u01F1\u01F4\u01F6-\u01F8\u01FA\u01FC\u01FE\u0200\u0202\u0204\u0206\u0208\u020A\u020C\u020E\u0210\u0212\u0214\u0216\u0218\u021A\u021C\u021E\u0220\u0222\u0224\u0226\u0228\u022A\u022C\u022E\u0230\u0232\u023A-\u023B\u023D-\u023E\u0241\u0243-\u0246\u0248\u024A\u024C\u024E\u0370\u0372\u0376\u037F\u0386\u0388-\u038A\u038C\u038E-\u038F\u0391-\u03A1\u03A3-\u03AB\u03CF\u03D2-\u03D4\u03D8\u03DA\u03DC\u03DE\u03E0\u03E2\u03E4\u03E6\u03E8\u03EA\u03EC\u03EE\u03F4\u03F7\u03F9-\u03FA\u03FD-\u042F\u0460\u0462\u0464\u0466\u0468\u046A\u046C\u046E\u0470\u0472\u0474\u0476\u0478\u047A\u047C\u047E\u0480\u048A\u048C\u048E\u0490\u0492\u0494\u0496\u0498\u049A\u049C\u049E\u04A0\u04A2\u04A4\u04A6\u04A8\u04AA\u04AC\u04AE\u04B0\u04B2\u04B4\u04B6\u04B8\u04BA\u04BC\u04BE\u04C0-\u04C1\u04C3\u04C5\u04C7\u04C9\u04CB\u04CD\u04D0\u04D2\u04D4\u04D6\u04D8\u04DA\u04DC\u04DE\u04E0\u04E2\u04E4\u04E6\u04E8\u04EA\u04EC\u04EE\u04F0\u04F2\u04F4\u04F6\u04F8\u04FA\u04FC\u04FE\u0500\u0502\u0504\u0506\u0508\u050A\u050C\u050E\u0510\u0512\u0514\u0516\u0518\u051A\u051C\u051E\u0520\u0522\u0524\u0526\u0528\u052A\u052C\u052E\u0531-\u0556\u10A0-\u10C5\u10C7\u10CD\u13A0-\u13F5\u1C90-\u1CBA\u1CBD-\u1CBF\u1E00\u1E02\u1E04\u1E06\u1E08\u1E0A\u1E0C\u1E0E\u1E10\u1E12\u1E14\u1E16\u1E18\u1E1A\u1E1C\u1E1E\u1E20\u1E22\u1E24\u1E26\u1E28\u1E2A\u1E2C\u1E2E\u1E30\u1E32\u1E34\u1E36\u1E38\u1E3A\u1E3C\u1E3E\u1E40\u1E42\u1E44\u1E46\u1E48\u1E4A\u1E4C\u1E4E\u1E50\u1E52\u1E54\u1E56\u1E58\u1E5A\u1E5C\u1E5E\u1E60\u1E62\u1E64\u1E66\u1E68\u1E6A\u1E6C\u1E6E\u1E70\u1E72\u1E74\u1E76\u1E78\u1E7A\u1E7C\u1E7E\u1E80\u1E82\u1E84\u1E86\u1E88\u1E8A\u1E8C\u1E8E\u1E90\u1E92\u1E94\u1E9E\u1EA0\u1EA2\u1EA4\u1EA6\u1EA8\u1EAA\u1EAC\u1EAE\u1EB0\u1EB2\u1EB4\u1EB6\u1EB8\u1EBA\u1EBC\u1EBE\u1EC0\u1EC2\u1EC4\u1EC6\u1EC8\u1ECA\u1ECC\u1ECE\u1ED0\u1ED2\u1ED4\u1ED6\u1ED8\u1EDA\u1EDC\u1EDE\u1EE0\u1EE2\u1EE4\u1EE6\u1EE8\u1EEA\u1EEC\u1EEE\u1EF0\u1EF2\u1EF4\u1EF6\u1EF8\u1EFA\u1EFC\u1EFE\u1F08-\u1F0F\u1F18-\u1F1D\u1F28-\u1F2F\u1F38-\u1F3F\u1F48-\u1F4D\u1F59\u1F5B\u1F5D\u1F5F\u1F68-\u1F6F\u1FB8-\u1FBB\u1FC8-\u1FCB\u1FD8-\u1FDB\u1FE8-\u1FEC\u1FF8-\u1FFB\u2102\u2107\u210B-\u210D\u2110-\u2112\u2115\u2119-\u211D\u2124\u2126\u2128\u212A-\u212D\u2130-\u2133\u213E-\u213F\u2145\u2183\u2C00-\u2C2E\u2C60\u2C62-\u2C64\u2C67\u2C69\u2C6B\u2C6D-\u2C70\u2C72\u2C75\u2C7E-\u2C80\u2C82\u2C84\u2C86\u2C88\u2C8A\u2C8C\u2C8E\u2C90\u2C92\u2C94\u2C96\u2C98\u2C9A\u2C9C\u2C9E\u2CA0\u2CA2\u2CA4\u2CA6\u2CA8\u2CAA\u2CAC\u2CAE\u2CB0\u2CB2\u2CB4\u2CB6\u2CB8\u2CBA\u2CBC\u2CBE\u2CC0\u2CC2\u2CC4\u2CC6\u2CC8\u2CCA\u2CCC\u2CCE\u2CD0\u2CD2\u2CD4\u2CD6\u2CD8\u2CDA\u2CDC\u2CDE\u2CE0\u2CE2\u2CEB\u2CED\u2CF2\uA640\uA642\uA644\uA646\uA648\uA64A\uA64C\uA64E\uA650\uA652\uA654\uA656\uA658\uA65A\uA65C\uA65E\uA660\uA662\uA664\uA666\uA668\uA66A\uA66C\uA680\uA682\uA684\uA686\uA688\uA68A\uA68C\uA68E\uA690\uA692\uA694\uA696\uA698\uA69A\uA722\uA724\uA726\uA728\uA72A\uA72C\uA72E\uA732\uA734\uA736\uA738\uA73A\uA73C\uA73E\uA740\uA742\uA744\uA746\uA748\uA74A\uA74C\uA74E\uA750\uA752\uA754\uA756\uA758\uA75A\uA75C\uA75E\uA760\uA762\uA764\uA766\uA768\uA76A\uA76C\uA76E\uA779\uA77B\uA77D-\uA77E\uA780\uA782\uA784\uA786\uA78B\uA78D\uA790\uA792\uA796\uA798\uA79A\uA79C\uA79E\uA7A0\uA7A2\uA7A4\uA7A6\uA7A8\uA7AA-\uA7AE\uA7B0-\uA7B4\uA7B6\uA7B8\uFF21-\uFF3A]/,
+      peg$c580 = peg$classExpectation([["A", "Z"], ["\xC0", "\xD6"], ["\xD8", "\xDE"], "\u0100", "\u0102", "\u0104", "\u0106", "\u0108", "\u010A", "\u010C", "\u010E", "\u0110", "\u0112", "\u0114", "\u0116", "\u0118", "\u011A", "\u011C", "\u011E", "\u0120", "\u0122", "\u0124", "\u0126", "\u0128", "\u012A", "\u012C", "\u012E", "\u0130", "\u0132", "\u0134", "\u0136", "\u0139", "\u013B", "\u013D", "\u013F", "\u0141", "\u0143", "\u0145", "\u0147", "\u014A", "\u014C", "\u014E", "\u0150", "\u0152", "\u0154", "\u0156", "\u0158", "\u015A", "\u015C", "\u015E", "\u0160", "\u0162", "\u0164", "\u0166", "\u0168", "\u016A", "\u016C", "\u016E", "\u0170", "\u0172", "\u0174", "\u0176", ["\u0178", "\u0179"], "\u017B", "\u017D", ["\u0181", "\u0182"], "\u0184", ["\u0186", "\u0187"], ["\u0189", "\u018B"], ["\u018E", "\u0191"], ["\u0193", "\u0194"], ["\u0196", "\u0198"], ["\u019C", "\u019D"], ["\u019F", "\u01A0"], "\u01A2", "\u01A4", ["\u01A6", "\u01A7"], "\u01A9", "\u01AC", ["\u01AE", "\u01AF"], ["\u01B1", "\u01B3"], "\u01B5", ["\u01B7", "\u01B8"], "\u01BC", "\u01C4", "\u01C7", "\u01CA", "\u01CD", "\u01CF", "\u01D1", "\u01D3", "\u01D5", "\u01D7", "\u01D9", "\u01DB", "\u01DE", "\u01E0", "\u01E2", "\u01E4", "\u01E6", "\u01E8", "\u01EA", "\u01EC", "\u01EE", "\u01F1", "\u01F4", ["\u01F6", "\u01F8"], "\u01FA", "\u01FC", "\u01FE", "\u0200", "\u0202", "\u0204", "\u0206", "\u0208", "\u020A", "\u020C", "\u020E", "\u0210", "\u0212", "\u0214", "\u0216", "\u0218", "\u021A", "\u021C", "\u021E", "\u0220", "\u0222", "\u0224", "\u0226", "\u0228", "\u022A", "\u022C", "\u022E", "\u0230", "\u0232", ["\u023A", "\u023B"], ["\u023D", "\u023E"], "\u0241", ["\u0243", "\u0246"], "\u0248", "\u024A", "\u024C", "\u024E", "\u0370", "\u0372", "\u0376", "\u037F", "\u0386", ["\u0388", "\u038A"], "\u038C", ["\u038E", "\u038F"], ["\u0391", "\u03A1"], ["\u03A3", "\u03AB"], "\u03CF", ["\u03D2", "\u03D4"], "\u03D8", "\u03DA", "\u03DC", "\u03DE", "\u03E0", "\u03E2", "\u03E4", "\u03E6", "\u03E8", "\u03EA", "\u03EC", "\u03EE", "\u03F4", "\u03F7", ["\u03F9", "\u03FA"], ["\u03FD", "\u042F"], "\u0460", "\u0462", "\u0464", "\u0466", "\u0468", "\u046A", "\u046C", "\u046E", "\u0470", "\u0472", "\u0474", "\u0476", "\u0478", "\u047A", "\u047C", "\u047E", "\u0480", "\u048A", "\u048C", "\u048E", "\u0490", "\u0492", "\u0494", "\u0496", "\u0498", "\u049A", "\u049C", "\u049E", "\u04A0", "\u04A2", "\u04A4", "\u04A6", "\u04A8", "\u04AA", "\u04AC", "\u04AE", "\u04B0", "\u04B2", "\u04B4", "\u04B6", "\u04B8", "\u04BA", "\u04BC", "\u04BE", ["\u04C0", "\u04C1"], "\u04C3", "\u04C5", "\u04C7", "\u04C9", "\u04CB", "\u04CD", "\u04D0", "\u04D2", "\u04D4", "\u04D6", "\u04D8", "\u04DA", "\u04DC", "\u04DE", "\u04E0", "\u04E2", "\u04E4", "\u04E6", "\u04E8", "\u04EA", "\u04EC", "\u04EE", "\u04F0", "\u04F2", "\u04F4", "\u04F6", "\u04F8", "\u04FA", "\u04FC", "\u04FE", "\u0500", "\u0502", "\u0504", "\u0506", "\u0508", "\u050A", "\u050C", "\u050E", "\u0510", "\u0512", "\u0514", "\u0516", "\u0518", "\u051A", "\u051C", "\u051E", "\u0520", "\u0522", "\u0524", "\u0526", "\u0528", "\u052A", "\u052C", "\u052E", ["\u0531", "\u0556"], ["\u10A0", "\u10C5"], "\u10C7", "\u10CD", ["\u13A0", "\u13F5"], ["\u1C90", "\u1CBA"], ["\u1CBD", "\u1CBF"], "\u1E00", "\u1E02", "\u1E04", "\u1E06", "\u1E08", "\u1E0A", "\u1E0C", "\u1E0E", "\u1E10", "\u1E12", "\u1E14", "\u1E16", "\u1E18", "\u1E1A", "\u1E1C", "\u1E1E", "\u1E20", "\u1E22", "\u1E24", "\u1E26", "\u1E28", "\u1E2A", "\u1E2C", "\u1E2E", "\u1E30", "\u1E32", "\u1E34", "\u1E36", "\u1E38", "\u1E3A", "\u1E3C", "\u1E3E", "\u1E40", "\u1E42", "\u1E44", "\u1E46", "\u1E48", "\u1E4A", "\u1E4C", "\u1E4E", "\u1E50", "\u1E52", "\u1E54", "\u1E56", "\u1E58", "\u1E5A", "\u1E5C", "\u1E5E", "\u1E60", "\u1E62", "\u1E64", "\u1E66", "\u1E68", "\u1E6A", "\u1E6C", "\u1E6E", "\u1E70", "\u1E72", "\u1E74", "\u1E76", "\u1E78", "\u1E7A", "\u1E7C", "\u1E7E", "\u1E80", "\u1E82", "\u1E84", "\u1E86", "\u1E88", "\u1E8A", "\u1E8C", "\u1E8E", "\u1E90", "\u1E92", "\u1E94", "\u1E9E", "\u1EA0", "\u1EA2", "\u1EA4", "\u1EA6", "\u1EA8", "\u1EAA", "\u1EAC", "\u1EAE", "\u1EB0", "\u1EB2", "\u1EB4", "\u1EB6", "\u1EB8", "\u1EBA", "\u1EBC", "\u1EBE", "\u1EC0", "\u1EC2", "\u1EC4", "\u1EC6", "\u1EC8", "\u1ECA", "\u1ECC", "\u1ECE", "\u1ED0", "\u1ED2", "\u1ED4", "\u1ED6", "\u1ED8", "\u1EDA", "\u1EDC", "\u1EDE", "\u1EE0", "\u1EE2", "\u1EE4", "\u1EE6", "\u1EE8", "\u1EEA", "\u1EEC", "\u1EEE", "\u1EF0", "\u1EF2", "\u1EF4", "\u1EF6", "\u1EF8", "\u1EFA", "\u1EFC", "\u1EFE", ["\u1F08", "\u1F0F"], ["\u1F18", "\u1F1D"], ["\u1F28", "\u1F2F"], ["\u1F38", "\u1F3F"], ["\u1F48", "\u1F4D"], "\u1F59", "\u1F5B", "\u1F5D", "\u1F5F", ["\u1F68", "\u1F6F"], ["\u1FB8", "\u1FBB"], ["\u1FC8", "\u1FCB"], ["\u1FD8", "\u1FDB"], ["\u1FE8", "\u1FEC"], ["\u1FF8", "\u1FFB"], "\u2102", "\u2107", ["\u210B", "\u210D"], ["\u2110", "\u2112"], "\u2115", ["\u2119", "\u211D"], "\u2124", "\u2126", "\u2128", ["\u212A", "\u212D"], ["\u2130", "\u2133"], ["\u213E", "\u213F"], "\u2145", "\u2183", ["\u2C00", "\u2C2E"], "\u2C60", ["\u2C62", "\u2C64"], "\u2C67", "\u2C69", "\u2C6B", ["\u2C6D", "\u2C70"], "\u2C72", "\u2C75", ["\u2C7E", "\u2C80"], "\u2C82", "\u2C84", "\u2C86", "\u2C88", "\u2C8A", "\u2C8C", "\u2C8E", "\u2C90", "\u2C92", "\u2C94", "\u2C96", "\u2C98", "\u2C9A", "\u2C9C", "\u2C9E", "\u2CA0", "\u2CA2", "\u2CA4", "\u2CA6", "\u2CA8", "\u2CAA", "\u2CAC", "\u2CAE", "\u2CB0", "\u2CB2", "\u2CB4", "\u2CB6", "\u2CB8", "\u2CBA", "\u2CBC", "\u2CBE", "\u2CC0", "\u2CC2", "\u2CC4", "\u2CC6", "\u2CC8", "\u2CCA", "\u2CCC", "\u2CCE", "\u2CD0", "\u2CD2", "\u2CD4", "\u2CD6", "\u2CD8", "\u2CDA", "\u2CDC", "\u2CDE", "\u2CE0", "\u2CE2", "\u2CEB", "\u2CED", "\u2CF2", "\uA640", "\uA642", "\uA644", "\uA646", "\uA648", "\uA64A", "\uA64C", "\uA64E", "\uA650", "\uA652", "\uA654", "\uA656", "\uA658", "\uA65A", "\uA65C", "\uA65E", "\uA660", "\uA662", "\uA664", "\uA666", "\uA668", "\uA66A", "\uA66C", "\uA680", "\uA682", "\uA684", "\uA686", "\uA688", "\uA68A", "\uA68C", "\uA68E", "\uA690", "\uA692", "\uA694", "\uA696", "\uA698", "\uA69A", "\uA722", "\uA724", "\uA726", "\uA728", "\uA72A", "\uA72C", "\uA72E", "\uA732", "\uA734", "\uA736", "\uA738", "\uA73A", "\uA73C", "\uA73E", "\uA740", "\uA742", "\uA744", "\uA746", "\uA748", "\uA74A", "\uA74C", "\uA74E", "\uA750", "\uA752", "\uA754", "\uA756", "\uA758", "\uA75A", "\uA75C", "\uA75E", "\uA760", "\uA762", "\uA764", "\uA766", "\uA768", "\uA76A", "\uA76C", "\uA76E", "\uA779", "\uA77B", ["\uA77D", "\uA77E"], "\uA780", "\uA782", "\uA784", "\uA786", "\uA78B", "\uA78D", "\uA790", "\uA792", "\uA796", "\uA798", "\uA79A", "\uA79C", "\uA79E", "\uA7A0", "\uA7A2", "\uA7A4", "\uA7A6", "\uA7A8", ["\uA7AA", "\uA7AE"], ["\uA7B0", "\uA7B4"], "\uA7B6", "\uA7B8", ["\uFF21", "\uFF3A"]], false, false),
+      peg$c581 = /^[\u0903\u093B\u093E-\u0940\u0949-\u094C\u094E-\u094F\u0982-\u0983\u09BE-\u09C0\u09C7-\u09C8\u09CB-\u09CC\u09D7\u0A03\u0A3E-\u0A40\u0A83\u0ABE-\u0AC0\u0AC9\u0ACB-\u0ACC\u0B02-\u0B03\u0B3E\u0B40\u0B47-\u0B48\u0B4B-\u0B4C\u0B57\u0BBE-\u0BBF\u0BC1-\u0BC2\u0BC6-\u0BC8\u0BCA-\u0BCC\u0BD7\u0C01-\u0C03\u0C41-\u0C44\u0C82-\u0C83\u0CBE\u0CC0-\u0CC4\u0CC7-\u0CC8\u0CCA-\u0CCB\u0CD5-\u0CD6\u0D02-\u0D03\u0D3E-\u0D40\u0D46-\u0D48\u0D4A-\u0D4C\u0D57\u0D82-\u0D83\u0DCF-\u0DD1\u0DD8-\u0DDF\u0DF2-\u0DF3\u0F3E-\u0F3F\u0F7F\u102B-\u102C\u1031\u1038\u103B-\u103C\u1056-\u1057\u1062-\u1064\u1067-\u106D\u1083-\u1084\u1087-\u108C\u108F\u109A-\u109C\u17B6\u17BE-\u17C5\u17C7-\u17C8\u1923-\u1926\u1929-\u192B\u1930-\u1931\u1933-\u1938\u1A19-\u1A1A\u1A55\u1A57\u1A61\u1A63-\u1A64\u1A6D-\u1A72\u1B04\u1B35\u1B3B\u1B3D-\u1B41\u1B43-\u1B44\u1B82\u1BA1\u1BA6-\u1BA7\u1BAA\u1BE7\u1BEA-\u1BEC\u1BEE\u1BF2-\u1BF3\u1C24-\u1C2B\u1C34-\u1C35\u1CE1\u1CF2-\u1CF3\u1CF7\u302E-\u302F\uA823-\uA824\uA827\uA880-\uA881\uA8B4-\uA8C3\uA952-\uA953\uA983\uA9B4-\uA9B5\uA9BA-\uA9BB\uA9BD-\uA9C0\uAA2F-\uAA30\uAA33-\uAA34\uAA4D\uAA7B\uAA7D\uAAEB\uAAEE-\uAAEF\uAAF5\uABE3-\uABE4\uABE6-\uABE7\uABE9-\uABEA\uABEC]/,
+      peg$c582 = peg$classExpectation(["\u0903", "\u093B", ["\u093E", "\u0940"], ["\u0949", "\u094C"], ["\u094E", "\u094F"], ["\u0982", "\u0983"], ["\u09BE", "\u09C0"], ["\u09C7", "\u09C8"], ["\u09CB", "\u09CC"], "\u09D7", "\u0A03", ["\u0A3E", "\u0A40"], "\u0A83", ["\u0ABE", "\u0AC0"], "\u0AC9", ["\u0ACB", "\u0ACC"], ["\u0B02", "\u0B03"], "\u0B3E", "\u0B40", ["\u0B47", "\u0B48"], ["\u0B4B", "\u0B4C"], "\u0B57", ["\u0BBE", "\u0BBF"], ["\u0BC1", "\u0BC2"], ["\u0BC6", "\u0BC8"], ["\u0BCA", "\u0BCC"], "\u0BD7", ["\u0C01", "\u0C03"], ["\u0C41", "\u0C44"], ["\u0C82", "\u0C83"], "\u0CBE", ["\u0CC0", "\u0CC4"], ["\u0CC7", "\u0CC8"], ["\u0CCA", "\u0CCB"], ["\u0CD5", "\u0CD6"], ["\u0D02", "\u0D03"], ["\u0D3E", "\u0D40"], ["\u0D46", "\u0D48"], ["\u0D4A", "\u0D4C"], "\u0D57", ["\u0D82", "\u0D83"], ["\u0DCF", "\u0DD1"], ["\u0DD8", "\u0DDF"], ["\u0DF2", "\u0DF3"], ["\u0F3E", "\u0F3F"], "\u0F7F", ["\u102B", "\u102C"], "\u1031", "\u1038", ["\u103B", "\u103C"], ["\u1056", "\u1057"], ["\u1062", "\u1064"], ["\u1067", "\u106D"], ["\u1083", "\u1084"], ["\u1087", "\u108C"], "\u108F", ["\u109A", "\u109C"], "\u17B6", ["\u17BE", "\u17C5"], ["\u17C7", "\u17C8"], ["\u1923", "\u1926"], ["\u1929", "\u192B"], ["\u1930", "\u1931"], ["\u1933", "\u1938"], ["\u1A19", "\u1A1A"], "\u1A55", "\u1A57", "\u1A61", ["\u1A63", "\u1A64"], ["\u1A6D", "\u1A72"], "\u1B04", "\u1B35", "\u1B3B", ["\u1B3D", "\u1B41"], ["\u1B43", "\u1B44"], "\u1B82", "\u1BA1", ["\u1BA6", "\u1BA7"], "\u1BAA", "\u1BE7", ["\u1BEA", "\u1BEC"], "\u1BEE", ["\u1BF2", "\u1BF3"], ["\u1C24", "\u1C2B"], ["\u1C34", "\u1C35"], "\u1CE1", ["\u1CF2", "\u1CF3"], "\u1CF7", ["\u302E", "\u302F"], ["\uA823", "\uA824"], "\uA827", ["\uA880", "\uA881"], ["\uA8B4", "\uA8C3"], ["\uA952", "\uA953"], "\uA983", ["\uA9B4", "\uA9B5"], ["\uA9BA", "\uA9BB"], ["\uA9BD", "\uA9C0"], ["\uAA2F", "\uAA30"], ["\uAA33", "\uAA34"], "\uAA4D", "\uAA7B", "\uAA7D", "\uAAEB", ["\uAAEE", "\uAAEF"], "\uAAF5", ["\uABE3", "\uABE4"], ["\uABE6", "\uABE7"], ["\uABE9", "\uABEA"], "\uABEC"], false, false),
+      peg$c583 = /^[\u0300-\u036F\u0483-\u0487\u0591-\u05BD\u05BF\u05C1-\u05C2\u05C4-\u05C5\u05C7\u0610-\u061A\u064B-\u065F\u0670\u06D6-\u06DC\u06DF-\u06E4\u06E7-\u06E8\u06EA-\u06ED\u0711\u0730-\u074A\u07A6-\u07B0\u07EB-\u07F3\u07FD\u0816-\u0819\u081B-\u0823\u0825-\u0827\u0829-\u082D\u0859-\u085B\u08D3-\u08E1\u08E3-\u0902\u093A\u093C\u0941-\u0948\u094D\u0951-\u0957\u0962-\u0963\u0981\u09BC\u09C1-\u09C4\u09CD\u09E2-\u09E3\u09FE\u0A01-\u0A02\u0A3C\u0A41-\u0A42\u0A47-\u0A48\u0A4B-\u0A4D\u0A51\u0A70-\u0A71\u0A75\u0A81-\u0A82\u0ABC\u0AC1-\u0AC5\u0AC7-\u0AC8\u0ACD\u0AE2-\u0AE3\u0AFA-\u0AFF\u0B01\u0B3C\u0B3F\u0B41-\u0B44\u0B4D\u0B56\u0B62-\u0B63\u0B82\u0BC0\u0BCD\u0C00\u0C04\u0C3E-\u0C40\u0C46-\u0C48\u0C4A-\u0C4D\u0C55-\u0C56\u0C62-\u0C63\u0C81\u0CBC\u0CBF\u0CC6\u0CCC-\u0CCD\u0CE2-\u0CE3\u0D00-\u0D01\u0D3B-\u0D3C\u0D41-\u0D44\u0D4D\u0D62-\u0D63\u0DCA\u0DD2-\u0DD4\u0DD6\u0E31\u0E34-\u0E3A\u0E47-\u0E4E\u0EB1\u0EB4-\u0EB9\u0EBB-\u0EBC\u0EC8-\u0ECD\u0F18-\u0F19\u0F35\u0F37\u0F39\u0F71-\u0F7E\u0F80-\u0F84\u0F86-\u0F87\u0F8D-\u0F97\u0F99-\u0FBC\u0FC6\u102D-\u1030\u1032-\u1037\u1039-\u103A\u103D-\u103E\u1058-\u1059\u105E-\u1060\u1071-\u1074\u1082\u1085-\u1086\u108D\u109D\u135D-\u135F\u1712-\u1714\u1732-\u1734\u1752-\u1753\u1772-\u1773\u17B4-\u17B5\u17B7-\u17BD\u17C6\u17C9-\u17D3\u17DD\u180B-\u180D\u1885-\u1886\u18A9\u1920-\u1922\u1927-\u1928\u1932\u1939-\u193B\u1A17-\u1A18\u1A1B\u1A56\u1A58-\u1A5E\u1A60\u1A62\u1A65-\u1A6C\u1A73-\u1A7C\u1A7F\u1AB0-\u1ABD\u1B00-\u1B03\u1B34\u1B36-\u1B3A\u1B3C\u1B42\u1B6B-\u1B73\u1B80-\u1B81\u1BA2-\u1BA5\u1BA8-\u1BA9\u1BAB-\u1BAD\u1BE6\u1BE8-\u1BE9\u1BED\u1BEF-\u1BF1\u1C2C-\u1C33\u1C36-\u1C37\u1CD0-\u1CD2\u1CD4-\u1CE0\u1CE2-\u1CE8\u1CED\u1CF4\u1CF8-\u1CF9\u1DC0-\u1DF9\u1DFB-\u1DFF\u20D0-\u20DC\u20E1\u20E5-\u20F0\u2CEF-\u2CF1\u2D7F\u2DE0-\u2DFF\u302A-\u302D\u3099-\u309A\uA66F\uA674-\uA67D\uA69E-\uA69F\uA6F0-\uA6F1\uA802\uA806\uA80B\uA825-\uA826\uA8C4-\uA8C5\uA8E0-\uA8F1\uA8FF\uA926-\uA92D\uA947-\uA951\uA980-\uA982\uA9B3\uA9B6-\uA9B9\uA9BC\uA9E5\uAA29-\uAA2E\uAA31-\uAA32\uAA35-\uAA36\uAA43\uAA4C\uAA7C\uAAB0\uAAB2-\uAAB4\uAAB7-\uAAB8\uAABE-\uAABF\uAAC1\uAAEC-\uAAED\uAAF6\uABE5\uABE8\uABED\uFB1E\uFE00-\uFE0F\uFE20-\uFE2F]/,
+      peg$c584 = peg$classExpectation([["\u0300", "\u036F"], ["\u0483", "\u0487"], ["\u0591", "\u05BD"], "\u05BF", ["\u05C1", "\u05C2"], ["\u05C4", "\u05C5"], "\u05C7", ["\u0610", "\u061A"], ["\u064B", "\u065F"], "\u0670", ["\u06D6", "\u06DC"], ["\u06DF", "\u06E4"], ["\u06E7", "\u06E8"], ["\u06EA", "\u06ED"], "\u0711", ["\u0730", "\u074A"], ["\u07A6", "\u07B0"], ["\u07EB", "\u07F3"], "\u07FD", ["\u0816", "\u0819"], ["\u081B", "\u0823"], ["\u0825", "\u0827"], ["\u0829", "\u082D"], ["\u0859", "\u085B"], ["\u08D3", "\u08E1"], ["\u08E3", "\u0902"], "\u093A", "\u093C", ["\u0941", "\u0948"], "\u094D", ["\u0951", "\u0957"], ["\u0962", "\u0963"], "\u0981", "\u09BC", ["\u09C1", "\u09C4"], "\u09CD", ["\u09E2", "\u09E3"], "\u09FE", ["\u0A01", "\u0A02"], "\u0A3C", ["\u0A41", "\u0A42"], ["\u0A47", "\u0A48"], ["\u0A4B", "\u0A4D"], "\u0A51", ["\u0A70", "\u0A71"], "\u0A75", ["\u0A81", "\u0A82"], "\u0ABC", ["\u0AC1", "\u0AC5"], ["\u0AC7", "\u0AC8"], "\u0ACD", ["\u0AE2", "\u0AE3"], ["\u0AFA", "\u0AFF"], "\u0B01", "\u0B3C", "\u0B3F", ["\u0B41", "\u0B44"], "\u0B4D", "\u0B56", ["\u0B62", "\u0B63"], "\u0B82", "\u0BC0", "\u0BCD", "\u0C00", "\u0C04", ["\u0C3E", "\u0C40"], ["\u0C46", "\u0C48"], ["\u0C4A", "\u0C4D"], ["\u0C55", "\u0C56"], ["\u0C62", "\u0C63"], "\u0C81", "\u0CBC", "\u0CBF", "\u0CC6", ["\u0CCC", "\u0CCD"], ["\u0CE2", "\u0CE3"], ["\u0D00", "\u0D01"], ["\u0D3B", "\u0D3C"], ["\u0D41", "\u0D44"], "\u0D4D", ["\u0D62", "\u0D63"], "\u0DCA", ["\u0DD2", "\u0DD4"], "\u0DD6", "\u0E31", ["\u0E34", "\u0E3A"], ["\u0E47", "\u0E4E"], "\u0EB1", ["\u0EB4", "\u0EB9"], ["\u0EBB", "\u0EBC"], ["\u0EC8", "\u0ECD"], ["\u0F18", "\u0F19"], "\u0F35", "\u0F37", "\u0F39", ["\u0F71", "\u0F7E"], ["\u0F80", "\u0F84"], ["\u0F86", "\u0F87"], ["\u0F8D", "\u0F97"], ["\u0F99", "\u0FBC"], "\u0FC6", ["\u102D", "\u1030"], ["\u1032", "\u1037"], ["\u1039", "\u103A"], ["\u103D", "\u103E"], ["\u1058", "\u1059"], ["\u105E", "\u1060"], ["\u1071", "\u1074"], "\u1082", ["\u1085", "\u1086"], "\u108D", "\u109D", ["\u135D", "\u135F"], ["\u1712", "\u1714"], ["\u1732", "\u1734"], ["\u1752", "\u1753"], ["\u1772", "\u1773"], ["\u17B4", "\u17B5"], ["\u17B7", "\u17BD"], "\u17C6", ["\u17C9", "\u17D3"], "\u17DD", ["\u180B", "\u180D"], ["\u1885", "\u1886"], "\u18A9", ["\u1920", "\u1922"], ["\u1927", "\u1928"], "\u1932", ["\u1939", "\u193B"], ["\u1A17", "\u1A18"], "\u1A1B", "\u1A56", ["\u1A58", "\u1A5E"], "\u1A60", "\u1A62", ["\u1A65", "\u1A6C"], ["\u1A73", "\u1A7C"], "\u1A7F", ["\u1AB0", "\u1ABD"], ["\u1B00", "\u1B03"], "\u1B34", ["\u1B36", "\u1B3A"], "\u1B3C", "\u1B42", ["\u1B6B", "\u1B73"], ["\u1B80", "\u1B81"], ["\u1BA2", "\u1BA5"], ["\u1BA8", "\u1BA9"], ["\u1BAB", "\u1BAD"], "\u1BE6", ["\u1BE8", "\u1BE9"], "\u1BED", ["\u1BEF", "\u1BF1"], ["\u1C2C", "\u1C33"], ["\u1C36", "\u1C37"], ["\u1CD0", "\u1CD2"], ["\u1CD4", "\u1CE0"], ["\u1CE2", "\u1CE8"], "\u1CED", "\u1CF4", ["\u1CF8", "\u1CF9"], ["\u1DC0", "\u1DF9"], ["\u1DFB", "\u1DFF"], ["\u20D0", "\u20DC"], "\u20E1", ["\u20E5", "\u20F0"], ["\u2CEF", "\u2CF1"], "\u2D7F", ["\u2DE0", "\u2DFF"], ["\u302A", "\u302D"], ["\u3099", "\u309A"], "\uA66F", ["\uA674", "\uA67D"], ["\uA69E", "\uA69F"], ["\uA6F0", "\uA6F1"], "\uA802", "\uA806", "\uA80B", ["\uA825", "\uA826"], ["\uA8C4", "\uA8C5"], ["\uA8E0", "\uA8F1"], "\uA8FF", ["\uA926", "\uA92D"], ["\uA947", "\uA951"], ["\uA980", "\uA982"], "\uA9B3", ["\uA9B6", "\uA9B9"], "\uA9BC", "\uA9E5", ["\uAA29", "\uAA2E"], ["\uAA31", "\uAA32"], ["\uAA35", "\uAA36"], "\uAA43", "\uAA4C", "\uAA7C", "\uAAB0", ["\uAAB2", "\uAAB4"], ["\uAAB7", "\uAAB8"], ["\uAABE", "\uAABF"], "\uAAC1", ["\uAAEC", "\uAAED"], "\uAAF6", "\uABE5", "\uABE8", "\uABED", "\uFB1E", ["\uFE00", "\uFE0F"], ["\uFE20", "\uFE2F"]], false, false),
+      peg$c585 = /^[0-9\u0660-\u0669\u06F0-\u06F9\u07C0-\u07C9\u0966-\u096F\u09E6-\u09EF\u0A66-\u0A6F\u0AE6-\u0AEF\u0B66-\u0B6F\u0BE6-\u0BEF\u0C66-\u0C6F\u0CE6-\u0CEF\u0D66-\u0D6F\u0DE6-\u0DEF\u0E50-\u0E59\u0ED0-\u0ED9\u0F20-\u0F29\u1040-\u1049\u1090-\u1099\u17E0-\u17E9\u1810-\u1819\u1946-\u194F\u19D0-\u19D9\u1A80-\u1A89\u1A90-\u1A99\u1B50-\u1B59\u1BB0-\u1BB9\u1C40-\u1C49\u1C50-\u1C59\uA620-\uA629\uA8D0-\uA8D9\uA900-\uA909\uA9D0-\uA9D9\uA9F0-\uA9F9\uAA50-\uAA59\uABF0-\uABF9\uFF10-\uFF19]/,
+      peg$c586 = peg$classExpectation([["0", "9"], ["\u0660", "\u0669"], ["\u06F0", "\u06F9"], ["\u07C0", "\u07C9"], ["\u0966", "\u096F"], ["\u09E6", "\u09EF"], ["\u0A66", "\u0A6F"], ["\u0AE6", "\u0AEF"], ["\u0B66", "\u0B6F"], ["\u0BE6", "\u0BEF"], ["\u0C66", "\u0C6F"], ["\u0CE6", "\u0CEF"], ["\u0D66", "\u0D6F"], ["\u0DE6", "\u0DEF"], ["\u0E50", "\u0E59"], ["\u0ED0", "\u0ED9"], ["\u0F20", "\u0F29"], ["\u1040", "\u1049"], ["\u1090", "\u1099"], ["\u17E0", "\u17E9"], ["\u1810", "\u1819"], ["\u1946", "\u194F"], ["\u19D0", "\u19D9"], ["\u1A80", "\u1A89"], ["\u1A90", "\u1A99"], ["\u1B50", "\u1B59"], ["\u1BB0", "\u1BB9"], ["\u1C40", "\u1C49"], ["\u1C50", "\u1C59"], ["\uA620", "\uA629"], ["\uA8D0", "\uA8D9"], ["\uA900", "\uA909"], ["\uA9D0", "\uA9D9"], ["\uA9F0", "\uA9F9"], ["\uAA50", "\uAA59"], ["\uABF0", "\uABF9"], ["\uFF10", "\uFF19"]], false, false),
+      peg$c587 = /^[\u16EE-\u16F0\u2160-\u2182\u2185-\u2188\u3007\u3021-\u3029\u3038-\u303A\uA6E6-\uA6EF]/,
+      peg$c588 = peg$classExpectation([["\u16EE", "\u16F0"], ["\u2160", "\u2182"], ["\u2185", "\u2188"], "\u3007", ["\u3021", "\u3029"], ["\u3038", "\u303A"], ["\uA6E6", "\uA6EF"]], false, false),
+      peg$c589 = /^[_\u203F-\u2040\u2054\uFE33-\uFE34\uFE4D-\uFE4F\uFF3F]/,
+      peg$c590 = peg$classExpectation(["_", ["\u203F", "\u2040"], "\u2054", ["\uFE33", "\uFE34"], ["\uFE4D", "\uFE4F"], "\uFF3F"], false, false),
+      peg$c591 = /^[ \xA0\u1680\u2000-\u200A\u202F\u205F\u3000]/,
+      peg$c592 = peg$classExpectation([" ", "\xA0", "\u1680", ["\u2000", "\u200A"], "\u202F", "\u205F", "\u3000"], false, false),
+      peg$c593 = peg$otherExpectation("whitespace"),
+      peg$c594 = "\t",
+      peg$c595 = peg$literalExpectation("\t", false),
+      peg$c596 = "\x0B",
+      peg$c597 = peg$literalExpectation("\x0B", false),
+      peg$c598 = "\f",
+      peg$c599 = peg$literalExpectation("\f", false),
+      peg$c600 = " ",
+      peg$c601 = peg$literalExpectation(" ", false),
+      peg$c602 = "\xA0",
+      peg$c603 = peg$literalExpectation("\xA0", false),
+      peg$c604 = "\uFEFF",
+      peg$c605 = peg$literalExpectation("\uFEFF", false),
+      peg$c606 = /^[\n\r\u2028\u2029]/,
+      peg$c607 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c608 = peg$otherExpectation("comment"),
+      peg$c609 = "/*",
+      peg$c610 = peg$literalExpectation("/*", false),
+      peg$c611 = "*/",
+      peg$c612 = peg$literalExpectation("*/", false),
+      peg$c613 = "//",
+      peg$c614 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -8933,7 +8930,13 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            s5 = peg$parsePattern();
+            s5 = peg$parseRegexp();
+            if (s5 === peg$FAILED) {
+              s5 = peg$parseGlob();
+              if (s5 === peg$FAILED) {
+                s5 = peg$parseConditionalExpr();
+              }
+            }
             if (s5 !== peg$FAILED) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
@@ -9024,26 +9027,6 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsePattern() {
-    var s0, s1;
-
-    s0 = peg$parseRegexp();
-    if (s0 === peg$FAILED) {
-      s0 = peg$parseGlob();
-      if (s0 === peg$FAILED) {
-        s0 = peg$currPos;
-        s1 = peg$parseQuotedString();
-        if (s1 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c316(s1);
-        }
-        s0 = s1;
-      }
-    }
-
-    return s0;
-  }
-
   function peg$parseOptionalExprs() {
     var s0, s1;
 
@@ -9053,7 +9036,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c317();
+        s1 = peg$c316();
       }
       s0 = s1;
     }
@@ -9084,7 +9067,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c318(s1, s7);
+              s4 = peg$c317(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -9120,7 +9103,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c318(s1, s7);
+                s4 = peg$c317(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -9230,15 +9213,15 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s7 = peg$c319;
+                  s7 = peg$c318;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c320); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c319); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c321(s2, s6);
+                  s1 = peg$c320(s2, s6);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -9293,15 +9276,15 @@ function peg$parse(input, options) {
               s5 = peg$parseAdditiveExpr();
               if (s5 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s6 = peg$c319;
+                  s6 = peg$c318;
                   peg$currPos++;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c320); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c319); }
                 }
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c322(s5);
+                  s1 = peg$c321(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -9340,15 +9323,15 @@ function peg$parse(input, options) {
           s2 = peg$parseConditionalExpr();
           if (s2 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s3 = peg$c319;
+              s3 = peg$c318;
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c320); }
+              if (peg$silentFails === 0) { peg$fail(peg$c319); }
             }
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c323(s2);
+              s1 = peg$c322(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9375,7 +9358,7 @@ function peg$parse(input, options) {
             s2 = peg$parseIdentifier();
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c324(s2);
+              s1 = peg$c323(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9544,7 +9527,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSeq();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c325(s3, s4, s8);
+                    s1 = peg$c324(s3, s4, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -9601,15 +9584,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c326;
+              s5 = peg$c325;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c327); }
+              if (peg$silentFails === 0) { peg$fail(peg$c326); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c328(s3);
+              s1 = peg$c327(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9664,7 +9647,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c317();
+        s1 = peg$c316();
       }
       s0 = s1;
     }
@@ -9691,7 +9674,7 @@ function peg$parse(input, options) {
           s4 = peg$parseRecordElem();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c329(s4);
+            s1 = peg$c328(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9731,12 +9714,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c330) {
-      s1 = peg$c330;
+    if (input.substr(peg$currPos, 3) === peg$c329) {
+      s1 = peg$c329;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c331); }
+      if (peg$silentFails === 0) { peg$fail(peg$c330); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -9744,7 +9727,7 @@ function peg$parse(input, options) {
         s3 = peg$parseConditionalExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c332(s3);
+          s1 = peg$c331(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -9783,7 +9766,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c333(s1, s5);
+              s1 = peg$c332(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9828,15 +9811,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s5 = peg$c319;
+              s5 = peg$c318;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c320); }
+              if (peg$silentFails === 0) { peg$fail(peg$c319); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c334(s3);
+              s1 = peg$c333(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9866,12 +9849,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c335) {
-      s1 = peg$c335;
+    if (input.substr(peg$currPos, 2) === peg$c334) {
+      s1 = peg$c334;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c336); }
+      if (peg$silentFails === 0) { peg$fail(peg$c335); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -9880,16 +9863,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c337) {
-              s5 = peg$c337;
+            if (input.substr(peg$currPos, 2) === peg$c336) {
+              s5 = peg$c336;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c338); }
+              if (peg$silentFails === 0) { peg$fail(peg$c337); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c339(s3);
+              s1 = peg$c338(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9938,7 +9921,7 @@ function peg$parse(input, options) {
             s7 = peg$parseVectorElem();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c318(s1, s7);
+              s4 = peg$c317(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -9974,7 +9957,7 @@ function peg$parse(input, options) {
               s7 = peg$parseVectorElem();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c318(s1, s7);
+                s4 = peg$c317(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -10010,7 +9993,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c317();
+        s1 = peg$c316();
       }
       s0 = s1;
     }
@@ -10027,7 +10010,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c340(s1);
+        s1 = peg$c339(s1);
       }
       s0 = s1;
     }
@@ -10039,12 +10022,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c341) {
-      s1 = peg$c341;
+    if (input.substr(peg$currPos, 2) === peg$c340) {
+      s1 = peg$c340;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c342); }
+      if (peg$silentFails === 0) { peg$fail(peg$c341); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -10053,16 +10036,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c343) {
-              s5 = peg$c343;
+            if (input.substr(peg$currPos, 2) === peg$c342) {
+              s5 = peg$c342;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c344); }
+              if (peg$silentFails === 0) { peg$fail(peg$c343); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c345(s3);
+              s1 = peg$c344(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -10117,7 +10100,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c317();
+        s1 = peg$c316();
       }
       s0 = s1;
     }
@@ -10144,7 +10127,7 @@ function peg$parse(input, options) {
           s4 = peg$parseEntry();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c346(s4);
+            s1 = peg$c345(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10187,7 +10170,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c347(s1, s5);
+              s1 = peg$c346(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -10252,7 +10235,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseSQLLimit();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c348(s1, s2, s3, s4, s5, s6, s7, s8);
+                    s1 = peg$c347(s1, s2, s3, s4, s5, s6, s7, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -10330,7 +10313,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSQLAssignments();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c349(s3);
+            s1 = peg$c348(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -10387,7 +10370,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c350(s1, s2);
+        s1 = peg$c349(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10513,7 +10496,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c351(s4, s5);
+              s1 = peg$c350(s4, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -10668,7 +10651,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSQLJoin();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s3;
-        s4 = peg$c352(s1, s4);
+        s4 = peg$c351(s1, s4);
       }
       s3 = s4;
       while (s3 !== peg$FAILED) {
@@ -10677,7 +10660,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSQLJoin();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s3;
-          s4 = peg$c352(s1, s4);
+          s4 = peg$c351(s1, s4);
         }
         s3 = s4;
       }
@@ -10739,7 +10722,7 @@ function peg$parse(input, options) {
                               s14 = peg$parseJoinKey();
                               if (s14 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c353(s1, s5, s6, s10, s14);
+                                s1 = peg$c352(s1, s5, s6, s10, s14);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -10819,7 +10802,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c354(s2);
+        s1 = peg$c353(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10978,7 +10961,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseSQLOrder();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c355(s6, s7);
+                  s1 = peg$c354(s6, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -11024,7 +11007,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c356(s2);
+        s1 = peg$c355(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11060,7 +11043,7 @@ function peg$parse(input, options) {
           s4 = peg$parseUInt();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c357(s4);
+            s1 = peg$c356(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -11100,11 +11083,11 @@ function peg$parse(input, options) {
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c358); }
+      if (peg$silentFails === 0) { peg$fail(peg$c357); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c359();
+      s1 = peg$c358();
     }
     s0 = s1;
 
@@ -11115,16 +11098,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c360) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c359) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c361); }
+      if (peg$silentFails === 0) { peg$fail(peg$c360); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c362();
+      s1 = peg$c361();
     }
     s0 = s1;
 
@@ -11140,11 +11123,11 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c363); }
+      if (peg$silentFails === 0) { peg$fail(peg$c362); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c364();
+      s1 = peg$c363();
     }
     s0 = s1;
 
@@ -11160,11 +11143,11 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c365); }
+      if (peg$silentFails === 0) { peg$fail(peg$c364); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c366();
+      s1 = peg$c365();
     }
     s0 = s1;
 
@@ -11180,11 +11163,11 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c367); }
+      if (peg$silentFails === 0) { peg$fail(peg$c366); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c368();
+      s1 = peg$c367();
     }
     s0 = s1;
 
@@ -11195,16 +11178,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c369) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c368) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c370); }
+      if (peg$silentFails === 0) { peg$fail(peg$c369); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c371();
+      s1 = peg$c370();
     }
     s0 = s1;
 
@@ -11215,16 +11198,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c372) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c371) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c373); }
+      if (peg$silentFails === 0) { peg$fail(peg$c372); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c374();
+      s1 = peg$c373();
     }
     s0 = s1;
 
@@ -11235,16 +11218,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c375) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c374) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c376); }
+      if (peg$silentFails === 0) { peg$fail(peg$c375); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c377();
+      s1 = peg$c376();
     }
     s0 = s1;
 
@@ -11260,11 +11243,11 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c378); }
+      if (peg$silentFails === 0) { peg$fail(peg$c377); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c379();
+      s1 = peg$c378();
     }
     s0 = s1;
 
@@ -11275,16 +11258,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c380) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c379) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c381); }
+      if (peg$silentFails === 0) { peg$fail(peg$c380); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c382();
+      s1 = peg$c381();
     }
     s0 = s1;
 
@@ -11295,16 +11278,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c383) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c382) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c384); }
+      if (peg$silentFails === 0) { peg$fail(peg$c383); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c385();
+      s1 = peg$c384();
     }
     s0 = s1;
 
@@ -11315,12 +11298,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c386) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c385) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c387); }
+      if (peg$silentFails === 0) { peg$fail(peg$c386); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -11335,12 +11318,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c388) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c387) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c389); }
+      if (peg$silentFails === 0) { peg$fail(peg$c388); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -11360,7 +11343,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c390); }
+      if (peg$silentFails === 0) { peg$fail(peg$c389); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -11380,7 +11363,7 @@ function peg$parse(input, options) {
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c391); }
+      if (peg$silentFails === 0) { peg$fail(peg$c390); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -11400,7 +11383,7 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c392); }
+      if (peg$silentFails === 0) { peg$fail(peg$c391); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -11420,7 +11403,7 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c393); }
+      if (peg$silentFails === 0) { peg$fail(peg$c392); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -11522,7 +11505,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c394(s1);
+        s1 = peg$c393(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11537,7 +11520,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP4Net();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c394(s1);
+        s1 = peg$c393(s1);
       }
       s0 = s1;
     }
@@ -11563,7 +11546,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c395(s1);
+        s1 = peg$c394(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11578,7 +11561,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c395(s1);
+        s1 = peg$c394(s1);
       }
       s0 = s1;
     }
@@ -11593,7 +11576,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFloatString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c396(s1);
+      s1 = peg$c395(s1);
     }
     s0 = s1;
 
@@ -11607,7 +11590,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c397(s1);
+      s1 = peg$c396(s1);
     }
     s0 = s1;
 
@@ -11621,7 +11604,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTrueToken();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c398();
+      s1 = peg$c397();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -11629,7 +11612,7 @@ function peg$parse(input, options) {
       s1 = peg$parseFalseToken();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c399();
+        s1 = peg$c398();
       }
       s0 = s1;
     }
@@ -11644,7 +11627,7 @@ function peg$parse(input, options) {
     s1 = peg$parseNullToken();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c400();
+      s1 = peg$c399();
     }
     s0 = s1;
 
@@ -11655,12 +11638,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c401) {
-      s1 = peg$c401;
+    if (input.substr(peg$currPos, 2) === peg$c400) {
+      s1 = peg$c400;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c402); }
+      if (peg$silentFails === 0) { peg$fail(peg$c401); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -11671,7 +11654,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c403();
+        s1 = peg$c402();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11708,7 +11691,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c404(s2);
+          s1 = peg$c403(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -11758,7 +11741,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c405(s1);
+        s1 = peg$c404(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -11810,7 +11793,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c406(s1, s2);
+          s1 = peg$c405(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -11825,7 +11808,7 @@ function peg$parse(input, options) {
         s1 = peg$parseQuotedString();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c407(s1);
+          s1 = peg$c406(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
@@ -11851,7 +11834,7 @@ function peg$parse(input, options) {
                 }
                 if (s4 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c408(s3);
+                  s1 = peg$c407(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -11883,7 +11866,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTypeList();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c409(s1);
+      s1 = peg$c408(s1);
     }
     s0 = s1;
 
@@ -11982,15 +11965,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c326;
+              s5 = peg$c325;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c327); }
+              if (peg$silentFails === 0) { peg$fail(peg$c326); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c410(s3);
+              s1 = peg$c409(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -12029,15 +12012,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c319;
+                s5 = peg$c318;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c320); }
+                if (peg$silentFails === 0) { peg$fail(peg$c319); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c411(s3);
+                s1 = peg$c410(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -12061,12 +12044,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c335) {
-          s1 = peg$c335;
+        if (input.substr(peg$currPos, 2) === peg$c334) {
+          s1 = peg$c334;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c336); }
+          if (peg$silentFails === 0) { peg$fail(peg$c335); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -12075,16 +12058,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c337) {
-                  s5 = peg$c337;
+                if (input.substr(peg$currPos, 2) === peg$c336) {
+                  s5 = peg$c336;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c338); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c337); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c412(s3);
+                  s1 = peg$c411(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -12108,12 +12091,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c341) {
-            s1 = peg$c341;
+          if (input.substr(peg$currPos, 2) === peg$c340) {
+            s1 = peg$c340;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c342); }
+            if (peg$silentFails === 0) { peg$fail(peg$c341); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -12136,16 +12119,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c343) {
-                            s9 = peg$c343;
+                          if (input.substr(peg$currPos, 2) === peg$c342) {
+                            s9 = peg$c342;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c344); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c343); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c413(s3, s7);
+                            s1 = peg$c412(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -12197,7 +12180,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTemplateLiteralParts();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c414(s1);
+      s1 = peg$c413(s1);
     }
     s0 = s1;
 
@@ -12209,11 +12192,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c415;
+      s1 = peg$c414;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c416); }
+      if (peg$silentFails === 0) { peg$fail(peg$c415); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -12224,11 +12207,11 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c415;
+          s3 = peg$c414;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c416); }
+          if (peg$silentFails === 0) { peg$fail(peg$c415); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
@@ -12249,11 +12232,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c417;
+        s1 = peg$c416;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c418); }
+        if (peg$silentFails === 0) { peg$fail(peg$c417); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -12264,11 +12247,11 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c417;
+            s3 = peg$c416;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c418); }
+            if (peg$silentFails === 0) { peg$fail(peg$c417); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
@@ -12309,7 +12292,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c419(s1);
+        s1 = peg$c418(s1);
       }
       s0 = s1;
     }
@@ -12322,19 +12305,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c420;
+      s1 = peg$c419;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c421); }
+      if (peg$silentFails === 0) { peg$fail(peg$c420); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c422) {
-        s2 = peg$c422;
+      if (input.substr(peg$currPos, 2) === peg$c421) {
+        s2 = peg$c421;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c423); }
+        if (peg$silentFails === 0) { peg$fail(peg$c422); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -12352,12 +12335,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c422) {
-        s2 = peg$c422;
+      if (input.substr(peg$currPos, 2) === peg$c421) {
+        s2 = peg$c421;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c423); }
+        if (peg$silentFails === 0) { peg$fail(peg$c422); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -12403,7 +12386,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c419(s1);
+        s1 = peg$c418(s1);
       }
       s0 = s1;
     }
@@ -12416,19 +12399,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c420;
+      s1 = peg$c419;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c421); }
+      if (peg$silentFails === 0) { peg$fail(peg$c420); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c422) {
-        s2 = peg$c422;
+      if (input.substr(peg$currPos, 2) === peg$c421) {
+        s2 = peg$c421;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c423); }
+        if (peg$silentFails === 0) { peg$fail(peg$c422); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -12446,12 +12429,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c422) {
-        s2 = peg$c422;
+      if (input.substr(peg$currPos, 2) === peg$c421) {
+        s2 = peg$c421;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c423); }
+        if (peg$silentFails === 0) { peg$fail(peg$c422); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -12483,12 +12466,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c422) {
-      s1 = peg$c422;
+    if (input.substr(peg$currPos, 2) === peg$c421) {
+      s1 = peg$c421;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c423); }
+      if (peg$silentFails === 0) { peg$fail(peg$c422); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -12498,15 +12481,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c326;
+              s5 = peg$c325;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c327); }
+              if (peg$silentFails === 0) { peg$fail(peg$c326); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c424(s3);
+              s1 = peg$c423(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -12536,148 +12519,148 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c425) {
-      s1 = peg$c425;
+    if (input.substr(peg$currPos, 5) === peg$c424) {
+      s1 = peg$c424;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c426); }
+      if (peg$silentFails === 0) { peg$fail(peg$c425); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c427) {
-        s1 = peg$c427;
+      if (input.substr(peg$currPos, 6) === peg$c426) {
+        s1 = peg$c426;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c428); }
+        if (peg$silentFails === 0) { peg$fail(peg$c427); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c429) {
-          s1 = peg$c429;
+        if (input.substr(peg$currPos, 6) === peg$c428) {
+          s1 = peg$c428;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c430); }
+          if (peg$silentFails === 0) { peg$fail(peg$c429); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c431) {
-            s1 = peg$c431;
+          if (input.substr(peg$currPos, 6) === peg$c430) {
+            s1 = peg$c430;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c432); }
+            if (peg$silentFails === 0) { peg$fail(peg$c431); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c433) {
-              s1 = peg$c433;
+            if (input.substr(peg$currPos, 4) === peg$c432) {
+              s1 = peg$c432;
               peg$currPos += 4;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c434); }
+              if (peg$silentFails === 0) { peg$fail(peg$c433); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 5) === peg$c435) {
-                s1 = peg$c435;
+              if (input.substr(peg$currPos, 5) === peg$c434) {
+                s1 = peg$c434;
                 peg$currPos += 5;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c436); }
+                if (peg$silentFails === 0) { peg$fail(peg$c435); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c437) {
-                  s1 = peg$c437;
+                if (input.substr(peg$currPos, 5) === peg$c436) {
+                  s1 = peg$c436;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c438); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c437); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c439) {
-                    s1 = peg$c439;
+                  if (input.substr(peg$currPos, 5) === peg$c438) {
+                    s1 = peg$c438;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c440); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c439); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7) === peg$c441) {
-                      s1 = peg$c441;
+                    if (input.substr(peg$currPos, 7) === peg$c440) {
+                      s1 = peg$c440;
                       peg$currPos += 7;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c442); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c441); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 7) === peg$c443) {
-                        s1 = peg$c443;
+                      if (input.substr(peg$currPos, 7) === peg$c442) {
+                        s1 = peg$c442;
                         peg$currPos += 7;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c444); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c443); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 7) === peg$c445) {
-                          s1 = peg$c445;
+                        if (input.substr(peg$currPos, 7) === peg$c444) {
+                          s1 = peg$c444;
                           peg$currPos += 7;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c446); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c445); }
                         }
                         if (s1 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 4) === peg$c447) {
-                            s1 = peg$c447;
+                          if (input.substr(peg$currPos, 4) === peg$c446) {
+                            s1 = peg$c446;
                             peg$currPos += 4;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c448); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c447); }
                           }
                           if (s1 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 6) === peg$c449) {
-                              s1 = peg$c449;
+                            if (input.substr(peg$currPos, 6) === peg$c448) {
+                              s1 = peg$c448;
                               peg$currPos += 6;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c450); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c449); }
                             }
                             if (s1 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 8) === peg$c451) {
-                                s1 = peg$c451;
+                              if (input.substr(peg$currPos, 8) === peg$c450) {
+                                s1 = peg$c450;
                                 peg$currPos += 8;
                               } else {
                                 s1 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c452); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c451); }
                               }
                               if (s1 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 4) === peg$c453) {
-                                  s1 = peg$c453;
+                                if (input.substr(peg$currPos, 4) === peg$c452) {
+                                  s1 = peg$c452;
                                   peg$currPos += 4;
                                 } else {
                                   s1 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c454); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c453); }
                                 }
                                 if (s1 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 5) === peg$c455) {
-                                    s1 = peg$c455;
+                                  if (input.substr(peg$currPos, 5) === peg$c454) {
+                                    s1 = peg$c454;
                                     peg$currPos += 5;
                                   } else {
                                     s1 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c456); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c455); }
                                   }
                                   if (s1 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 2) === peg$c457) {
-                                      s1 = peg$c457;
+                                    if (input.substr(peg$currPos, 2) === peg$c456) {
+                                      s1 = peg$c456;
                                       peg$currPos += 2;
                                     } else {
                                       s1 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c458); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c457); }
                                     }
                                     if (s1 === peg$FAILED) {
-                                      if (input.substr(peg$currPos, 3) === peg$c459) {
-                                        s1 = peg$c459;
+                                      if (input.substr(peg$currPos, 3) === peg$c458) {
+                                        s1 = peg$c458;
                                         peg$currPos += 3;
                                       } else {
                                         s1 = peg$FAILED;
-                                        if (peg$silentFails === 0) { peg$fail(peg$c460); }
+                                        if (peg$silentFails === 0) { peg$fail(peg$c459); }
                                       }
                                       if (s1 === peg$FAILED) {
                                         if (input.substr(peg$currPos, 4) === peg$c11) {
@@ -12688,12 +12671,12 @@ function peg$parse(input, options) {
                                           if (peg$silentFails === 0) { peg$fail(peg$c12); }
                                         }
                                         if (s1 === peg$FAILED) {
-                                          if (input.substr(peg$currPos, 4) === peg$c461) {
-                                            s1 = peg$c461;
+                                          if (input.substr(peg$currPos, 4) === peg$c460) {
+                                            s1 = peg$c460;
                                             peg$currPos += 4;
                                           } else {
                                             s1 = peg$FAILED;
-                                            if (peg$silentFails === 0) { peg$fail(peg$c462); }
+                                            if (peg$silentFails === 0) { peg$fail(peg$c461); }
                                           }
                                         }
                                       }
@@ -12716,7 +12699,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c463();
+      s1 = peg$c462();
     }
     s0 = s1;
 
@@ -12822,7 +12805,7 @@ function peg$parse(input, options) {
             s5 = peg$parseType();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c464(s1, s5);
+              s1 = peg$c463(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -12863,20 +12846,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c465) {
-      s1 = peg$c465;
+    if (input.substr(peg$currPos, 3) === peg$c464) {
+      s1 = peg$c464;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c466); }
+      if (peg$silentFails === 0) { peg$fail(peg$c465); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c467) {
-        s1 = peg$c467;
+      if (input.substr(peg$currPos, 3) === peg$c466) {
+        s1 = peg$c466;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c468); }
+        if (peg$silentFails === 0) { peg$fail(peg$c467); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -12892,7 +12875,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c469();
+        s1 = peg$c468();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -12910,12 +12893,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c372) {
-      s1 = peg$c372;
+    if (input.substr(peg$currPos, 2) === peg$c371) {
+      s1 = peg$c371;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c470); }
+      if (peg$silentFails === 0) { peg$fail(peg$c469); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -12947,12 +12930,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c471) {
-      s1 = peg$c471;
+    if (input.substr(peg$currPos, 5) === peg$c470) {
+      s1 = peg$c470;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c472); }
+      if (peg$silentFails === 0) { peg$fail(peg$c471); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -13029,12 +13012,12 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$c301); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c473) {
-        s1 = peg$c473;
+      if (input.substr(peg$currPos, 3) === peg$c472) {
+        s1 = peg$c472;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c474); }
+        if (peg$silentFails === 0) { peg$fail(peg$c473); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -13050,7 +13033,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c475();
+        s1 = peg$c474();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13068,12 +13051,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c461) {
-      s1 = peg$c461;
+    if (input.substr(peg$currPos, 4) === peg$c460) {
+      s1 = peg$c460;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c462); }
+      if (peg$silentFails === 0) { peg$fail(peg$c461); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -13105,20 +13088,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c476) {
-      s1 = peg$c476;
+    if (input.substr(peg$currPos, 2) === peg$c475) {
+      s1 = peg$c475;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c477); }
+      if (peg$silentFails === 0) { peg$fail(peg$c476); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c478) {
-        s1 = peg$c478;
+      if (input.substr(peg$currPos, 2) === peg$c477) {
+        s1 = peg$c477;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c479); }
+        if (peg$silentFails === 0) { peg$fail(peg$c478); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -13134,7 +13117,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c480();
+        s1 = peg$c479();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -13152,12 +13135,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c481) {
-      s1 = peg$c481;
+    if (input.substr(peg$currPos, 4) === peg$c480) {
+      s1 = peg$c480;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c482); }
+      if (peg$silentFails === 0) { peg$fail(peg$c481); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -13192,7 +13175,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c483(s1);
+      s1 = peg$c482(s1);
     }
     s0 = s1;
 
@@ -13264,11 +13247,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 36) {
-        s1 = peg$c484;
+        s1 = peg$c483;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c485); }
+        if (peg$silentFails === 0) { peg$fail(peg$c484); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -13278,11 +13261,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c420;
+          s1 = peg$c419;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c421); }
+          if (peg$silentFails === 0) { peg$fail(peg$c420); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseIDGuard();
@@ -13389,7 +13372,7 @@ function peg$parse(input, options) {
             s7 = peg$parseIdentifierName();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c486(s1, s7);
+              s4 = peg$c485(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -13425,7 +13408,7 @@ function peg$parse(input, options) {
               s7 = peg$parseIdentifierName();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c486(s1, s7);
+                s4 = peg$c485(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -13466,19 +13449,19 @@ function peg$parse(input, options) {
     s0 = peg$parseUnicodeLetter();
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 36) {
-        s0 = peg$c484;
+        s0 = peg$c483;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c485); }
+        if (peg$silentFails === 0) { peg$fail(peg$c484); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 95) {
-          s0 = peg$c487;
+          s0 = peg$c486;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c488); }
+          if (peg$silentFails === 0) { peg$fail(peg$c487); }
         }
       }
     }
@@ -13527,17 +13510,17 @@ function peg$parse(input, options) {
     s1 = peg$parseFullDate();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 84) {
-        s2 = peg$c489;
+        s2 = peg$c488;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c490); }
+        if (peg$silentFails === 0) { peg$fail(peg$c489); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseFullTime();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c491();
+          s1 = peg$c490();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -13611,36 +13594,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (peg$c492.test(input.charAt(peg$currPos))) {
+    if (peg$c491.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c493); }
+      if (peg$silentFails === 0) { peg$fail(peg$c492); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c492.test(input.charAt(peg$currPos))) {
+      if (peg$c491.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c493); }
+        if (peg$silentFails === 0) { peg$fail(peg$c492); }
       }
       if (s2 !== peg$FAILED) {
-        if (peg$c492.test(input.charAt(peg$currPos))) {
+        if (peg$c491.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c493); }
+          if (peg$silentFails === 0) { peg$fail(peg$c492); }
         }
         if (s3 !== peg$FAILED) {
-          if (peg$c492.test(input.charAt(peg$currPos))) {
+          if (peg$c491.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c493); }
+            if (peg$silentFails === 0) { peg$fail(peg$c492); }
           }
           if (s4 !== peg$FAILED) {
             s1 = [s1, s2, s3, s4];
@@ -13669,20 +13652,20 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c492.test(input.charAt(peg$currPos))) {
+    if (peg$c491.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c493); }
+      if (peg$silentFails === 0) { peg$fail(peg$c492); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c492.test(input.charAt(peg$currPos))) {
+      if (peg$c491.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c493); }
+        if (peg$silentFails === 0) { peg$fail(peg$c492); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -13757,22 +13740,22 @@ function peg$parse(input, options) {
               }
               if (s7 !== peg$FAILED) {
                 s8 = [];
-                if (peg$c492.test(input.charAt(peg$currPos))) {
+                if (peg$c491.test(input.charAt(peg$currPos))) {
                   s9 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s9 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c493); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c492); }
                 }
                 if (s9 !== peg$FAILED) {
                   while (s9 !== peg$FAILED) {
                     s8.push(s9);
-                    if (peg$c492.test(input.charAt(peg$currPos))) {
+                    if (peg$c491.test(input.charAt(peg$currPos))) {
                       s9 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c493); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c492); }
                     }
                   }
                 } else {
@@ -13827,11 +13810,11 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
     if (input.charCodeAt(peg$currPos) === 90) {
-      s0 = peg$c494;
+      s0 = peg$c493;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c495); }
+      if (peg$silentFails === 0) { peg$fail(peg$c494); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
@@ -13874,22 +13857,22 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 s7 = [];
-                if (peg$c492.test(input.charAt(peg$currPos))) {
+                if (peg$c491.test(input.charAt(peg$currPos))) {
                   s8 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s8 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c493); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c492); }
                 }
                 if (s8 !== peg$FAILED) {
                   while (s8 !== peg$FAILED) {
                     s7.push(s8);
-                    if (peg$c492.test(input.charAt(peg$currPos))) {
+                    if (peg$c491.test(input.charAt(peg$currPos))) {
                       s8 = input.charAt(peg$currPos);
                       peg$currPos++;
                     } else {
                       s8 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c493); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c492); }
                     }
                   }
                 } else {
@@ -13992,7 +13975,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c496();
+        s1 = peg$c495();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14054,76 +14037,76 @@ function peg$parse(input, options) {
   function peg$parseTimeUnit() {
     var s0;
 
-    if (input.substr(peg$currPos, 2) === peg$c497) {
-      s0 = peg$c497;
+    if (input.substr(peg$currPos, 2) === peg$c496) {
+      s0 = peg$c496;
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c498); }
+      if (peg$silentFails === 0) { peg$fail(peg$c497); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c499) {
-        s0 = peg$c499;
+      if (input.substr(peg$currPos, 2) === peg$c498) {
+        s0 = peg$c498;
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c500); }
+        if (peg$silentFails === 0) { peg$fail(peg$c499); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c501) {
-          s0 = peg$c501;
+        if (input.substr(peg$currPos, 2) === peg$c500) {
+          s0 = peg$c500;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c502); }
+          if (peg$silentFails === 0) { peg$fail(peg$c501); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 115) {
-            s0 = peg$c503;
+            s0 = peg$c502;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c504); }
+            if (peg$silentFails === 0) { peg$fail(peg$c503); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c505;
+              s0 = peg$c504;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c506); }
+              if (peg$silentFails === 0) { peg$fail(peg$c505); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 104) {
-                s0 = peg$c507;
+                s0 = peg$c506;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c508); }
+                if (peg$silentFails === 0) { peg$fail(peg$c507); }
               }
               if (s0 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 100) {
-                  s0 = peg$c509;
+                  s0 = peg$c508;
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c510); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c509); }
                 }
                 if (s0 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 119) {
-                    s0 = peg$c511;
+                    s0 = peg$c510;
                     peg$currPos++;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c512); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c511); }
                   }
                   if (s0 === peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 121) {
-                      s0 = peg$c513;
+                      s0 = peg$c512;
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c514); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c513); }
                     }
                   }
                 }
@@ -14308,7 +14291,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c515(s1, s2);
+        s1 = peg$c514(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14329,12 +14312,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c516) {
-            s3 = peg$c516;
+          if (input.substr(peg$currPos, 2) === peg$c515) {
+            s3 = peg$c515;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c517); }
+            if (peg$silentFails === 0) { peg$fail(peg$c516); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -14347,7 +14330,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c518(s1, s2, s4, s5);
+                s1 = peg$c517(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -14371,12 +14354,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c516) {
-          s1 = peg$c516;
+        if (input.substr(peg$currPos, 2) === peg$c515) {
+          s1 = peg$c515;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c517); }
+          if (peg$silentFails === 0) { peg$fail(peg$c516); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -14389,7 +14372,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c519(s2, s3);
+              s1 = peg$c518(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -14414,16 +14397,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c516) {
-                s3 = peg$c516;
+              if (input.substr(peg$currPos, 2) === peg$c515) {
+                s3 = peg$c515;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c517); }
+                if (peg$silentFails === 0) { peg$fail(peg$c516); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c520(s1, s2);
+                s1 = peg$c519(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -14439,16 +14422,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c516) {
-              s1 = peg$c516;
+            if (input.substr(peg$currPos, 2) === peg$c515) {
+              s1 = peg$c515;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c517); }
+              if (peg$silentFails === 0) { peg$fail(peg$c516); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c521();
+              s1 = peg$c520();
             }
             s0 = s1;
           }
@@ -14485,7 +14468,7 @@ function peg$parse(input, options) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c522(s2);
+        s1 = peg$c521(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14514,7 +14497,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c523(s1);
+        s1 = peg$c522(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -14545,7 +14528,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c524(s1, s3);
+          s1 = peg$c523(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -14580,7 +14563,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c525(s1, s3);
+          s1 = peg$c524(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -14605,7 +14588,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c526(s1);
+      s1 = peg$c525(s1);
     }
     s0 = s1;
 
@@ -14628,22 +14611,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c492.test(input.charAt(peg$currPos))) {
+    if (peg$c491.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c493); }
+      if (peg$silentFails === 0) { peg$fail(peg$c492); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c492.test(input.charAt(peg$currPos))) {
+        if (peg$c491.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c493); }
+          if (peg$silentFails === 0) { peg$fail(peg$c492); }
         }
       }
     } else {
@@ -14703,22 +14686,22 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c492.test(input.charAt(peg$currPos))) {
+      if (peg$c491.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c493); }
+        if (peg$silentFails === 0) { peg$fail(peg$c492); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c492.test(input.charAt(peg$currPos))) {
+          if (peg$c491.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c493); }
+            if (peg$silentFails === 0) { peg$fail(peg$c492); }
           }
         }
       } else {
@@ -14734,21 +14717,21 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c492.test(input.charAt(peg$currPos))) {
+          if (peg$c491.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c493); }
+            if (peg$silentFails === 0) { peg$fail(peg$c492); }
           }
           while (s5 !== peg$FAILED) {
             s4.push(s5);
-            if (peg$c492.test(input.charAt(peg$currPos))) {
+            if (peg$c491.test(input.charAt(peg$currPos))) {
               s5 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c493); }
+              if (peg$silentFails === 0) { peg$fail(peg$c492); }
             }
           }
           if (s4 !== peg$FAILED) {
@@ -14758,7 +14741,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c527();
+              s1 = peg$c526();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -14802,22 +14785,22 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c492.test(input.charAt(peg$currPos))) {
+          if (peg$c491.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c493); }
+            if (peg$silentFails === 0) { peg$fail(peg$c492); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c492.test(input.charAt(peg$currPos))) {
+              if (peg$c491.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c493); }
+                if (peg$silentFails === 0) { peg$fail(peg$c492); }
               }
             }
           } else {
@@ -14830,7 +14813,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c527();
+              s1 = peg$c526();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -14869,20 +14852,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c528) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c527) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c529); }
+      if (peg$silentFails === 0) { peg$fail(peg$c528); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c530.test(input.charAt(peg$currPos))) {
+      if (peg$c529.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c531); }
+        if (peg$silentFails === 0) { peg$fail(peg$c530); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -14911,12 +14894,12 @@ function peg$parse(input, options) {
   function peg$parseNaN() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c532) {
-      s0 = peg$c532;
+    if (input.substr(peg$currPos, 3) === peg$c531) {
+      s0 = peg$c531;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c533); }
+      if (peg$silentFails === 0) { peg$fail(peg$c532); }
     }
 
     return s0;
@@ -14946,12 +14929,12 @@ function peg$parse(input, options) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c534) {
-        s2 = peg$c534;
+      if (input.substr(peg$currPos, 3) === peg$c533) {
+        s2 = peg$c533;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c535); }
+        if (peg$silentFails === 0) { peg$fail(peg$c534); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -14994,12 +14977,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c536.test(input.charAt(peg$currPos))) {
+    if (peg$c535.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c537); }
+      if (peg$silentFails === 0) { peg$fail(peg$c536); }
     }
 
     return s0;
@@ -15010,11 +14993,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c415;
+      s1 = peg$c414;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c416); }
+      if (peg$silentFails === 0) { peg$fail(peg$c415); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -15025,15 +15008,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c415;
+          s3 = peg$c414;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c416); }
+          if (peg$silentFails === 0) { peg$fail(peg$c415); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c538(s2);
+          s1 = peg$c537(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -15050,11 +15033,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c417;
+        s1 = peg$c416;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c418); }
+        if (peg$silentFails === 0) { peg$fail(peg$c417); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -15065,15 +15048,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c417;
+            s3 = peg$c416;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c418); }
+            if (peg$silentFails === 0) { peg$fail(peg$c417); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c538(s2);
+            s1 = peg$c537(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -15099,11 +15082,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c415;
+      s2 = peg$c414;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c416); }
+      if (peg$silentFails === 0) { peg$fail(peg$c415); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -15121,7 +15104,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c539); }
+        if (peg$silentFails === 0) { peg$fail(peg$c538); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -15138,11 +15121,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c420;
+        s1 = peg$c419;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c421); }
+        if (peg$silentFails === 0) { peg$fail(peg$c420); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -15177,7 +15160,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c540(s1, s2);
+        s1 = peg$c539(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -15207,12 +15190,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseKeyWordStart();
     if (s0 === peg$FAILED) {
-      if (peg$c492.test(input.charAt(peg$currPos))) {
+      if (peg$c491.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c493); }
+        if (peg$silentFails === 0) { peg$fail(peg$c492); }
       }
     }
 
@@ -15225,12 +15208,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parseUnicodeLetter();
     if (s1 === peg$FAILED) {
-      if (peg$c541.test(input.charAt(peg$currPos))) {
+      if (peg$c540.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c542); }
+        if (peg$silentFails === 0) { peg$fail(peg$c541); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -15247,11 +15230,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c420;
+      s1 = peg$c419;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c421); }
+      if (peg$silentFails === 0) { peg$fail(peg$c420); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseKeywordEscape();
@@ -15310,7 +15293,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c543(s3, s4);
+            s1 = peg$c542(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -15428,7 +15411,7 @@ function peg$parse(input, options) {
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c544();
+          s1 = peg$c543();
         }
         s0 = s1;
       }
@@ -15442,12 +15425,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseGlobStart();
     if (s0 === peg$FAILED) {
-      if (peg$c492.test(input.charAt(peg$currPos))) {
+      if (peg$c491.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c493); }
+        if (peg$silentFails === 0) { peg$fail(peg$c492); }
       }
     }
 
@@ -15459,11 +15442,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c420;
+      s1 = peg$c419;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c421); }
+      if (peg$silentFails === 0) { peg$fail(peg$c420); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseGlobEscape();
@@ -15499,7 +15482,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c545();
+      s1 = peg$c544();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -15513,16 +15496,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c546();
+        s1 = peg$c545();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c530.test(input.charAt(peg$currPos))) {
+        if (peg$c529.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c531); }
+          if (peg$silentFails === 0) { peg$fail(peg$c530); }
         }
       }
     }
@@ -15537,11 +15520,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c417;
+      s2 = peg$c416;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c418); }
+      if (peg$silentFails === 0) { peg$fail(peg$c417); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -15559,7 +15542,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c539); }
+        if (peg$silentFails === 0) { peg$fail(peg$c538); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -15576,11 +15559,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c420;
+        s1 = peg$c419;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c421); }
+        if (peg$silentFails === 0) { peg$fail(peg$c420); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -15616,20 +15599,20 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c417;
+      s0 = peg$c416;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c418); }
+      if (peg$silentFails === 0) { peg$fail(peg$c417); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s1 = peg$c415;
+        s1 = peg$c414;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c416); }
+        if (peg$silentFails === 0) { peg$fail(peg$c415); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -15638,94 +15621,94 @@ function peg$parse(input, options) {
       s0 = s1;
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c420;
+          s0 = peg$c419;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c421); }
+          if (peg$silentFails === 0) { peg$fail(peg$c420); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c547;
+            s1 = peg$c546;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c548); }
+            if (peg$silentFails === 0) { peg$fail(peg$c547); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c549();
+            s1 = peg$c548();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c550;
+              s1 = peg$c549;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c551); }
+              if (peg$silentFails === 0) { peg$fail(peg$c550); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c552();
+              s1 = peg$c551();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c553;
+                s1 = peg$c552;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c554); }
+                if (peg$silentFails === 0) { peg$fail(peg$c553); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c555();
+                s1 = peg$c554();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c556;
+                  s1 = peg$c555;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c557); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c556); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c558();
+                  s1 = peg$c557();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c559;
+                    s1 = peg$c558;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c560); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c559); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c561();
+                    s1 = peg$c560();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c562;
+                      s1 = peg$c561;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c563); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c562); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c564();
+                      s1 = peg$c563();
                     }
                     s0 = s1;
                   }
@@ -15753,7 +15736,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c545();
+      s1 = peg$c544();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -15767,16 +15750,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c544();
+        s1 = peg$c543();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c530.test(input.charAt(peg$currPos))) {
+        if (peg$c529.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c531); }
+          if (peg$silentFails === 0) { peg$fail(peg$c530); }
         }
       }
     }
@@ -15789,11 +15772,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c565;
+      s1 = peg$c564;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c566); }
+      if (peg$silentFails === 0) { peg$fail(peg$c565); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -15825,7 +15808,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c567(s2);
+        s1 = peg$c566(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -15838,11 +15821,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c565;
+        s1 = peg$c564;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c566); }
+        if (peg$silentFails === 0) { peg$fail(peg$c565); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
@@ -15909,15 +15892,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c326;
+              s4 = peg$c325;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c327); }
+              if (peg$silentFails === 0) { peg$fail(peg$c326); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c567(s3);
+              s1 = peg$c566(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -16001,21 +15984,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c568.test(input.charAt(peg$currPos))) {
+    if (peg$c567.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c569); }
+      if (peg$silentFails === 0) { peg$fail(peg$c568); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s3 = peg$c420;
+        s3 = peg$c419;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c421); }
+        if (peg$silentFails === 0) { peg$fail(peg$c420); }
       }
       if (s3 !== peg$FAILED) {
         if (input.length > peg$currPos) {
@@ -16023,7 +16006,7 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c539); }
+          if (peg$silentFails === 0) { peg$fail(peg$c538); }
         }
         if (s4 !== peg$FAILED) {
           s3 = [s3, s4];
@@ -16040,21 +16023,21 @@ function peg$parse(input, options) {
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c568.test(input.charAt(peg$currPos))) {
+        if (peg$c567.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c569); }
+          if (peg$silentFails === 0) { peg$fail(peg$c568); }
         }
         if (s2 === peg$FAILED) {
           s2 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 92) {
-            s3 = peg$c420;
+            s3 = peg$c419;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c421); }
+            if (peg$silentFails === 0) { peg$fail(peg$c420); }
           }
           if (s3 !== peg$FAILED) {
             if (input.length > peg$currPos) {
@@ -16062,7 +16045,7 @@ function peg$parse(input, options) {
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c539); }
+              if (peg$silentFails === 0) { peg$fail(peg$c538); }
             }
             if (s4 !== peg$FAILED) {
               s3 = [s3, s4];
@@ -16092,12 +16075,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c570.test(input.charAt(peg$currPos))) {
+    if (peg$c569.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c571); }
+      if (peg$silentFails === 0) { peg$fail(peg$c570); }
     }
 
     return s0;
@@ -16184,12 +16167,12 @@ function peg$parse(input, options) {
   function peg$parseLl() {
     var s0;
 
-    if (peg$c572.test(input.charAt(peg$currPos))) {
+    if (peg$c571.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c573); }
+      if (peg$silentFails === 0) { peg$fail(peg$c572); }
     }
 
     return s0;
@@ -16198,12 +16181,12 @@ function peg$parse(input, options) {
   function peg$parseLm() {
     var s0;
 
-    if (peg$c574.test(input.charAt(peg$currPos))) {
+    if (peg$c573.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c575); }
+      if (peg$silentFails === 0) { peg$fail(peg$c574); }
     }
 
     return s0;
@@ -16212,12 +16195,12 @@ function peg$parse(input, options) {
   function peg$parseLo() {
     var s0;
 
-    if (peg$c576.test(input.charAt(peg$currPos))) {
+    if (peg$c575.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c577); }
+      if (peg$silentFails === 0) { peg$fail(peg$c576); }
     }
 
     return s0;
@@ -16226,12 +16209,12 @@ function peg$parse(input, options) {
   function peg$parseLt() {
     var s0;
 
-    if (peg$c578.test(input.charAt(peg$currPos))) {
+    if (peg$c577.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c579); }
+      if (peg$silentFails === 0) { peg$fail(peg$c578); }
     }
 
     return s0;
@@ -16240,12 +16223,12 @@ function peg$parse(input, options) {
   function peg$parseLu() {
     var s0;
 
-    if (peg$c580.test(input.charAt(peg$currPos))) {
+    if (peg$c579.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c581); }
+      if (peg$silentFails === 0) { peg$fail(peg$c580); }
     }
 
     return s0;
@@ -16254,12 +16237,12 @@ function peg$parse(input, options) {
   function peg$parseMc() {
     var s0;
 
-    if (peg$c582.test(input.charAt(peg$currPos))) {
+    if (peg$c581.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c583); }
+      if (peg$silentFails === 0) { peg$fail(peg$c582); }
     }
 
     return s0;
@@ -16268,12 +16251,12 @@ function peg$parse(input, options) {
   function peg$parseMn() {
     var s0;
 
-    if (peg$c584.test(input.charAt(peg$currPos))) {
+    if (peg$c583.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c585); }
+      if (peg$silentFails === 0) { peg$fail(peg$c584); }
     }
 
     return s0;
@@ -16282,12 +16265,12 @@ function peg$parse(input, options) {
   function peg$parseNd() {
     var s0;
 
-    if (peg$c586.test(input.charAt(peg$currPos))) {
+    if (peg$c585.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c587); }
+      if (peg$silentFails === 0) { peg$fail(peg$c586); }
     }
 
     return s0;
@@ -16296,12 +16279,12 @@ function peg$parse(input, options) {
   function peg$parseNl() {
     var s0;
 
-    if (peg$c588.test(input.charAt(peg$currPos))) {
+    if (peg$c587.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c589); }
+      if (peg$silentFails === 0) { peg$fail(peg$c588); }
     }
 
     return s0;
@@ -16310,12 +16293,12 @@ function peg$parse(input, options) {
   function peg$parsePc() {
     var s0;
 
-    if (peg$c590.test(input.charAt(peg$currPos))) {
+    if (peg$c589.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c591); }
+      if (peg$silentFails === 0) { peg$fail(peg$c590); }
     }
 
     return s0;
@@ -16324,12 +16307,12 @@ function peg$parse(input, options) {
   function peg$parseZs() {
     var s0;
 
-    if (peg$c592.test(input.charAt(peg$currPos))) {
+    if (peg$c591.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c593); }
+      if (peg$silentFails === 0) { peg$fail(peg$c592); }
     }
 
     return s0;
@@ -16343,7 +16326,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c539); }
+      if (peg$silentFails === 0) { peg$fail(peg$c538); }
     }
 
     return s0;
@@ -16354,51 +16337,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c595;
+      s0 = peg$c594;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c596); }
+      if (peg$silentFails === 0) { peg$fail(peg$c595); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c597;
+        s0 = peg$c596;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c598); }
+        if (peg$silentFails === 0) { peg$fail(peg$c597); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c599;
+          s0 = peg$c598;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c600); }
+          if (peg$silentFails === 0) { peg$fail(peg$c599); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c601;
+            s0 = peg$c600;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c602); }
+            if (peg$silentFails === 0) { peg$fail(peg$c601); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c603;
+              s0 = peg$c602;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c604); }
+              if (peg$silentFails === 0) { peg$fail(peg$c603); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c605;
+                s0 = peg$c604;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c606); }
+                if (peg$silentFails === 0) { peg$fail(peg$c605); }
               }
               if (s0 === peg$FAILED) {
                 s0 = peg$parseZs();
@@ -16411,7 +16394,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c594); }
+      if (peg$silentFails === 0) { peg$fail(peg$c593); }
     }
 
     return s0;
@@ -16420,12 +16403,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c607.test(input.charAt(peg$currPos))) {
+    if (peg$c606.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c608); }
+      if (peg$silentFails === 0) { peg$fail(peg$c607); }
     }
 
     return s0;
@@ -16439,7 +16422,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c609); }
+      if (peg$silentFails === 0) { peg$fail(peg$c608); }
     }
 
     return s0;
@@ -16449,24 +16432,24 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c610) {
-      s1 = peg$c610;
+    if (input.substr(peg$currPos, 2) === peg$c609) {
+      s1 = peg$c609;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c611); }
+      if (peg$silentFails === 0) { peg$fail(peg$c610); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c612) {
-        s5 = peg$c612;
+      if (input.substr(peg$currPos, 2) === peg$c611) {
+        s5 = peg$c611;
         peg$currPos += 2;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c613); }
+        if (peg$silentFails === 0) { peg$fail(peg$c612); }
       }
       peg$silentFails--;
       if (s5 === peg$FAILED) {
@@ -16493,12 +16476,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$currPos;
         peg$silentFails++;
-        if (input.substr(peg$currPos, 2) === peg$c612) {
-          s5 = peg$c612;
+        if (input.substr(peg$currPos, 2) === peg$c611) {
+          s5 = peg$c611;
           peg$currPos += 2;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c613); }
+          if (peg$silentFails === 0) { peg$fail(peg$c612); }
         }
         peg$silentFails--;
         if (s5 === peg$FAILED) {
@@ -16522,12 +16505,12 @@ function peg$parse(input, options) {
         }
       }
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c612) {
-          s3 = peg$c612;
+        if (input.substr(peg$currPos, 2) === peg$c611) {
+          s3 = peg$c611;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c613); }
+          if (peg$silentFails === 0) { peg$fail(peg$c612); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -16552,12 +16535,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c614) {
-      s1 = peg$c614;
+    if (input.substr(peg$currPos, 2) === peg$c613) {
+      s1 = peg$c613;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c615); }
+      if (peg$silentFails === 0) { peg$fail(peg$c614); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -16675,7 +16658,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c539); }
+      if (peg$silentFails === 0) { peg$fail(peg$c538); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -770,19 +770,12 @@ FunctionArgs
   / OptionalExprs
 
 Grep
-  = "grep" __ "(" __ pattern:Pattern __ opt:("," __ (OverExpr / Expr) __)? ")" {
+  = "grep" __ "(" __ pattern:(Regexp / Glob / Expr) __ opt:("," __ (OverExpr / Expr) __)? ")" {
       VAR(m) = MAP("kind": "Grep", "pattern": pattern, "expr": MAP("kind": "ID", "name": "this"))
       if ISNOTNULL(opt) {
         m["expr"] = ASSERT_ARRAY(opt)[2]
       }
       RETURN(m)
-    }
-
-Pattern
-  = Regexp
-  / Glob
-  / s:QuotedString {
-      RETURN(MAP("kind": "String", "text": s))
     }
 
 OptionalExprs

--- a/docs/language/functions/grep.md
+++ b/docs/language/functions/grep.md
@@ -12,9 +12,9 @@ grep(<pattern> [, e: any]) -> bool
 
 The _grep_ function searches all of the strings in its input value `e`
 (or `this` if `e` is not given)
- using the `<pattern>` argument, which must be a
+ using the `<pattern>` argument, which can be a
 [regular expression](../search-expressions.md#regular-expressions),
-[glob pattern](../search-expressions.md#globs), or string literal.
+[glob pattern](../search-expressions.md#globs), or string.
 If the pattern matches for any string, then the result is `true`.  Otherwise, it is `false`.
 
 > Note that string matches are case insensitive while regular expression

--- a/runtime/expr/function/function.go
+++ b/runtime/expr/function/function.go
@@ -29,10 +29,8 @@ func New(zctx *zed.Context, name string, narg int) (expr.Function, field.Path, e
 		argmax = -1
 		f = &Coalesce{}
 	case "grep":
-		// We special case grep here since a syntax error with the
-		// special grep form will make it look like a function call
-		// and we don't want the error to say unknown function.
-		return nil, nil, errors.New("syntax error")
+		argmax = 2
+		f = &Grep{zctx: zctx}
 	case "len":
 		f = &LenFn{zctx: zctx}
 	case "abs":
@@ -187,7 +185,7 @@ func CheckArgCount(narg int, argmin int, argmax int) error {
 // signatures so the return type can be introspected.
 func HasBoolResult(name string) bool {
 	switch name {
-	case "has", "has_error", "is_error", "is", "missing", "cidr_match":
+	case "grep", "has", "has_error", "is_error", "is", "missing", "cidr_match":
 		return true
 	}
 	return false

--- a/runtime/expr/function/grep.go
+++ b/runtime/expr/function/grep.go
@@ -1,0 +1,41 @@
+package function
+
+import (
+	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/runtime/expr"
+	"golang.org/x/text/unicode/norm"
+)
+
+type Grep struct {
+	grep    expr.Evaluator
+	pattern string
+	zctx    *zed.Context
+}
+
+func (g *Grep) Call(ectx zed.Allocator, vals []zed.Value) *zed.Value {
+	patternVal, inputVal := &vals[0], &vals[1]
+	if zed.TypeUnder(patternVal.Type) != zed.TypeString {
+		return g.error(ectx, "pattern argument must be a string", patternVal)
+	}
+	if p := patternVal.AsString(); g.grep == nil || g.pattern != p {
+		g.pattern = p
+		term := norm.NFC.Bytes(patternVal.Bytes())
+		g.grep = expr.NewSearchString(string(term), nil)
+	}
+	return g.grep.Eval(wrapAllocator{ectx}, inputVal)
+}
+
+// XXX This is gross, any reason function shouldn't just accept an expr.Context?
+type wrapAllocator struct {
+	zed.Allocator
+}
+
+func (wrapAllocator) Vars() []zed.Value { return nil }
+
+func (g *Grep) error(ectx zed.Allocator, msg string, val *zed.Value) *zed.Value {
+	msg = "grep(): " + msg
+	if val == nil {
+		return ectx.CopyValue(*g.zctx.NewErrorf(msg))
+	}
+	return ectx.CopyValue(*g.zctx.WrapError(msg, val))
+}

--- a/runtime/expr/function/ztests/grep.yaml
+++ b/runtime/expr/function/ztests/grep.yaml
@@ -1,0 +1,17 @@
+# This test tests grep as a function call which only happens when the pattern
+# arg is not a glob, regular expression, or resolvable to a string at compile
+# time.
+
+script: |
+  echo '{pattern:"hello",input:[{a:{hello:"world"}},{hi:"world"}]}' | 
+    zq -z 'over input with p=pattern => ( grep(p) )' -
+  echo "// ==="
+  echo '{a:{foo:"bar"}} {b:{baz:"foo"}}' |
+    zq -z 'func g(s, e): ( grep(s, e) ) where g("baz", this)' -
+
+outputs:
+  - name: stdout
+    data: |
+      {a:{hello:"world"}}
+      // ===
+      {b:{baz:"foo"}}

--- a/zfmt/ast.go
+++ b/zfmt/ast.go
@@ -132,16 +132,7 @@ func (c *canon) expr(e ast.Expr, parent string) {
 		c.write(e.Pattern)
 	case *ast.Grep:
 		c.write("grep(")
-		switch p := e.Pattern.(type) {
-		case *ast.Regexp:
-			c.write("/%s/", p.Pattern)
-		case *ast.Glob:
-			c.write(p.Pattern)
-		case *ast.String:
-			c.write(zson.QuotedString([]byte(p.Text)))
-		default:
-			c.open("(unknown grep pattern %T)", p)
-		}
+		c.expr(e.Pattern, "")
 		if !isThis(e.Expr) {
 			c.write(",")
 			c.expr(e.Expr, "")


### PR DESCRIPTION
This pr adjusts grep functionality so that it can accept variables for the pattern argument. An additional improvement is that any compile time evaluatable string will get converted into an optimized search.

Closes #4692, closes #4022