### PR TITLE
Add docs example of field reorder via record expressions

### DIFF
--- a/docs/language/functions/order.md
+++ b/docs/language/functions/order.md
@@ -27,6 +27,11 @@ the empty record type, i.e.,
 order(val, <{}>)
 ```
 
+:::tip Note
+[Record expressions](../expressions.md#record-expressions) can also be used to
+reorder fields without specifying types ([example](../shaping.md#order)).
+:::
+
 ### Examples
 
 _Order a record_

--- a/docs/language/shaping.md
+++ b/docs/language/shaping.md
@@ -163,6 +163,31 @@ about the `uid` field as it is not in the `connection` type:
 }
 ```
 
+As an alternative to the `order` function,
+[record expressions](expressions.md#record-expressions) can be used to reorder
+fields without specifying types. For example:
+
+```mdtest-command
+zq -Z 'yield {kind,client,server,...this}' sample.json
+```
+
+also produces
+
+```mdtest-output
+{
+    kind: "dns",
+    client: {
+        addr: "10.47.1.100",
+        port: 41772
+    },
+    server: {
+        addr: "10.0.0.100",
+        port: 53
+    },
+    uid: "C2zK5f13SbCtKcyiW5"
+}
+```
+
 ### Shape
 
 The `shape` function brings everything together by applying `cast`,


### PR DESCRIPTION
When discussing the community inquiry in #4900, @nwt reminded us that simple field reordering can be achieved via record expressions. To help users discover this in the future, here I'm proposing calling it out in the docs as a "lite" alternative to the full `order` function.