### PR TITLE
add zq -help flag, print help and usage message to stdout instead of stderr

### DIFF
--- a/cmd/zed/ztests/blank-help.yaml
+++ b/cmd/zed/ztests/blank-help.yaml
@@ -2,6 +2,6 @@ script: |
   zed
 
 outputs:
-  - name: stderr
+  - name: stdout
     regexp: |
       run Zed commands

--- a/pkg/charm/help.go
+++ b/pkg/charm/help.go
@@ -65,7 +65,7 @@ func helpDesc(heading, body string) {
 	if len(body) > lineWidth {
 		body = FormatParagraph(body, tab, lineWidth)
 	}
-	fmt.Print(hdr+"\n"+body)
+	fmt.Print(hdr + "\n" + body)
 }
 
 func helpList(heading string, lines []string) {

--- a/pkg/charm/help.go
+++ b/pkg/charm/help.go
@@ -55,7 +55,7 @@ func header(heading string) string {
 func helpItem(heading, body string) {
 	hdr := header(heading)
 	body = hdr + "\n" + tab + body + "\n\n"
-	fmt.Fprint(os.Stderr, body)
+	fmt.Fprint(os.Stdout, body)
 }
 
 func helpDesc(heading, body string) {
@@ -66,14 +66,14 @@ func helpDesc(heading, body string) {
 	if len(body) > lineWidth {
 		body = FormatParagraph(body, tab, lineWidth)
 	}
-	fmt.Fprint(os.Stderr, hdr+"\n"+body)
+	fmt.Fprint(os.Stdout, hdr+"\n"+body)
 }
 
 func helpList(heading string, lines []string) {
 	hdr := header(heading)
 	body := strings.Join(lines, "\n"+tab)
 	body = hdr + "\n" + tab + body + "\n\n"
-	fmt.Fprint(os.Stderr, body)
+	fmt.Fprint(os.Stdout, body)
 }
 
 func getCommands(target *Spec, vflag bool) []string {

--- a/pkg/charm/help.go
+++ b/pkg/charm/help.go
@@ -2,7 +2,6 @@ package charm
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/brimdata/zed/pkg/terminal"
@@ -55,7 +54,7 @@ func header(heading string) string {
 func helpItem(heading, body string) {
 	hdr := header(heading)
 	body = hdr + "\n" + tab + body + "\n\n"
-	fmt.Fprint(os.Stdout, body)
+	fmt.Print(body)
 }
 
 func helpDesc(heading, body string) {
@@ -66,14 +65,14 @@ func helpDesc(heading, body string) {
 	if len(body) > lineWidth {
 		body = FormatParagraph(body, tab, lineWidth)
 	}
-	fmt.Fprint(os.Stdout, hdr+"\n"+body)
+	fmt.Print(hdr+"\n"+body)
 }
 
 func helpList(heading string, lines []string) {
 	hdr := header(heading)
 	body := strings.Join(lines, "\n"+tab)
 	body = hdr + "\n" + tab + body + "\n\n"
-	fmt.Fprint(os.Stdout, body)
+	fmt.Print(body)
 }
 
 func getCommands(target *Spec, vflag bool) []string {

--- a/pkg/charm/instance.go
+++ b/pkg/charm/instance.go
@@ -8,9 +8,9 @@ import (
 )
 
 var (
-	HelpFlag   = "h"
-	HelpLongFlag   = "help"
-	HiddenFlag = "hidden"
+	HelpFlag     = "h"
+	HelpLongFlag = "help"
+	HiddenFlag   = "hidden"
 )
 
 // instance represents a command that has been created but not run.

--- a/pkg/charm/instance.go
+++ b/pkg/charm/instance.go
@@ -9,6 +9,7 @@ import (
 
 var (
 	HelpFlag   = "h"
+	HelpLongFlag   = "help"
 	HiddenFlag = "hidden"
 )
 
@@ -52,6 +53,7 @@ func parse(spec *Spec, args []string, parent Command) (path, []string, bool, err
 	var help, hidden, usage bool
 	flags := flag.NewFlagSet(spec.Name, flag.ContinueOnError)
 	flags.BoolVar(&help, HelpFlag, false, "display help")
+	flags.BoolVar(&help, HelpLongFlag, false, "display help")
 	flags.BoolVar(&hidden, HiddenFlag, false, "show hidden options")
 	flags.Usage = func() {
 		usage = true
@@ -105,6 +107,7 @@ func parseHelp(spec *Spec, args []string) (path, error) {
 	flags := flag.NewFlagSet(spec.Name, flag.ContinueOnError)
 	var b bool
 	flags.BoolVar(&b, HelpFlag, false, "display help")
+	flags.BoolVar(&b, HelpLongFlag, false, "display help")
 	flags.BoolVar(&b, HiddenFlag, false, "show hidden options")
 	flags.Usage = func() {}
 	var parent Command


### PR DESCRIPTION
Handling of `zq -h` is rather convoluted - but the changes are simple once you figure it out. This fixes two problems described in issue #4901 and issue #4774.

1. Help message now prints to stdout instead of stderr
2. `zq --help` and `zq -help` are now recognized and behave exactly like `zq -h`

Closes #4774.
Closes #4901.