### PR TITLE
Fix bug with nest_dotted argument

### DIFF
--- a/runtime/expr/function/nestdotted.go
+++ b/runtime/expr/function/nestdotted.go
@@ -56,16 +56,19 @@ func (n *NestDotted) lookupBuilderAndType(in *zed.TypeRecord) (*zed.RecordBuilde
 }
 
 func (n *NestDotted) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
-	this := &args[0]
-	b, typ, err := n.lookupBuilderAndType(zed.TypeRecordOf(this.Type))
+	val := &args[0]
+	if len(args) > 1 {
+		val = &args[1]
+	}
+	b, typ, err := n.lookupBuilderAndType(zed.TypeRecordOf(val.Type))
 	if err != nil {
-		return wrapError(n.zctx, ctx, "nest_dotted: "+err.Error(), this)
+		return wrapError(n.zctx, ctx, "nest_dotted(): "+err.Error(), val)
 	}
 	if b == nil {
-		return this
+		return val
 	}
 	b.Reset()
-	for it := this.Bytes().Iter(); !it.Done(); {
+	for it := val.Bytes().Iter(); !it.Done(); {
 		b.Append(it.Next())
 	}
 	zbytes, err := b.Encode()

--- a/runtime/expr/function/nestdotted.go
+++ b/runtime/expr/function/nestdotted.go
@@ -56,10 +56,7 @@ func (n *NestDotted) lookupBuilderAndType(in *zed.TypeRecord) (*zed.RecordBuilde
 }
 
 func (n *NestDotted) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
-	val := &args[0]
-	if len(args) > 1 {
-		val = &args[1]
-	}
+	val := &args[len(args)-1]
 	b, typ, err := n.lookupBuilderAndType(zed.TypeRecordOf(val.Type))
 	if err != nil {
 		return wrapError(n.zctx, ctx, "nest_dotted(): "+err.Error(), val)

--- a/runtime/expr/ztests/nest_dotted.yaml
+++ b/runtime/expr/ztests/nest_dotted.yaml
@@ -1,11 +1,11 @@
-zed: 'yield nest_dotted(this)'
+script: |
+  echo '{a:1,"b.a":2,"b.b":3,"b.c.a":4,c:5}' | zq -z 'yield nest_dotted()' -
+  echo '{a:1,b:{a:2,b:3,c:{a:4}},c:5}' | zq -z 'yield nest_dotted(this)' -
+  echo '{nest:{a:1,"b.a":2}}' | zq -z 'yield nest_dotted(nest)' -
 
-input: |
-  {a:1,"b.a":2,"b.b":3,"b.c.a":4,c:5}
-  {a:1,b:{a:2,b:3,c:{a:4}},c:5}
-  {a:1,"b.a":2}
-
-output: |
-  {a:1,b:{a:2,b:3,c:{a:4}},c:5}
-  {a:1,b:{a:2,b:3,c:{a:4}},c:5}
-  {a:1,b:{a:2}}
+outputs:
+  - name: stdout
+    data: |
+      {a:1,b:{a:2,b:3,c:{a:4}},c:5}
+      {a:1,b:{a:2,b:3,c:{a:4}},c:5}
+      {a:1,b:{a:2}}


### PR DESCRIPTION
The pr fixes an issue with nest_dotted function not using the argument passed into it but instead always using the `this` value.

Closes #4914