### PR TITLE
Replace kernel.Reader with dag.DefaultScan

### DIFF
--- a/compiler/ast/dag/op.go
+++ b/compiler/ast/dag/op.go
@@ -190,6 +190,12 @@ type (
 
 	// Leaf sources
 
+	// DefaultScan scans an input stream provided by the runtime.
+	DefaultScan struct {
+		Kind    string        `json:"kind" unpack:""`
+		Filter  Expr          `json:"filter"`
+		SortKey order.SortKey `json:"sort_key"`
+	}
 	FileScan struct {
 		Kind    string        `json:"kind" unpack:""`
 		Path    string        `json:"path"`
@@ -254,6 +260,7 @@ var CommitMetas = map[string]struct{}{
 	"vectors":    {},
 }
 
+func (*DefaultScan) OpNode()    {}
 func (*FileScan) OpNode()       {}
 func (*HTTPScan) OpNode()       {}
 func (*PoolScan) OpNode()       {}

--- a/compiler/lake.go
+++ b/compiler/lake.go
@@ -36,7 +36,7 @@ func (l *lakeCompiler) NewLakeQuery(octx *op.Context, program ast.Seq, paralleli
 	if err != nil {
 		return nil, err
 	}
-	if job.reader != nil {
+	if _, ok := job.DefaultScan(); ok {
 		return nil, errors.New("query must include a 'from' operator")
 	}
 	if err := job.Optimize(); err != nil {

--- a/compiler/reader.go
+++ b/compiler/reader.go
@@ -30,13 +30,12 @@ func CompileWithSortKey(octx *op.Context, seq ast.Seq, r zio.Reader, sortKey ord
 	if err != nil {
 		return nil, err
 	}
-	reader := job.reader
-	if reader == nil {
+	scan, ok := job.DefaultScan()
+	if !ok {
 		return nil, errors.New("CompileWithSortKey: Zed program expected a reader")
 	}
-	reader.Readers = []zio.Reader{r}
-	reader.SortKey = sortKey
-	return optimizeAndBuild(job)
+	scan.SortKey = sortKey
+	return optimizeAndBuild(job, []zio.Reader{r})
 }
 
 func (*anyCompiler) NewLakeQuery(octx *op.Context, program ast.Seq, parallelism int, head *lakeparse.Commitish) (*runtime.Query, error) {

--- a/compiler/semantic/analyzer.go
+++ b/compiler/semantic/analyzer.go
@@ -7,7 +7,6 @@ import (
 	"github.com/brimdata/zed/compiler/ast"
 	"github.com/brimdata/zed/compiler/ast/dag"
 	"github.com/brimdata/zed/compiler/data"
-	"github.com/brimdata/zed/compiler/kernel"
 	"github.com/brimdata/zed/lakeparse"
 )
 
@@ -76,7 +75,7 @@ func (a *analyzer) addDefaultSource(seq *dag.Seq) error {
 	}
 	// No from so add a source.
 	if a.head == nil {
-		seq.Prepend(&kernel.Reader{})
+		seq.Prepend(&dag.DefaultScan{Kind: "DefaultScan"})
 		return nil
 	}
 	pool := &ast.Pool{

--- a/compiler/semantic/op.go
+++ b/compiler/semantic/op.go
@@ -164,9 +164,6 @@ func (a *analyzer) semSource(source ast.Source) ([]dag.Op, error) {
 	case *ast.Pass:
 		//XXX just connect parent
 		return []dag.Op{dag.PassOp}, nil
-	case *kernel.Reader:
-		// kernel.Reader implements both ast.Source and dag.Op
-		return []dag.Op{p}, nil
 	default:
 		return nil, fmt.Errorf("semantic analyzer: unknown AST source type %T", p)
 	}

--- a/runtime/expr/filter_test.go
+++ b/runtime/expr/filter_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/compiler"
-	"github.com/brimdata/zed/compiler/kernel"
 	"github.com/brimdata/zed/runtime/expr"
 	"github.com/brimdata/zed/runtime/op"
 	"github.com/brimdata/zed/zcode"
@@ -60,9 +59,9 @@ func runCasesHelper(t *testing.T, record string, cases []testcase, expectBufferF
 			require.NoError(t, err, "filter: %q", c.filter)
 			err = job.Build()
 			require.NoError(t, err, "filter: %q", c.filter)
-			seq := job.Entry()
-			reader := seq[0].(*kernel.Reader)
-			filterMaker := job.Builder().PushdownOf(reader.Filter)
+			scan, ok := job.DefaultScan()
+			require.True(t, ok)
+			filterMaker := job.Builder().PushdownOf(scan.Filter)
 			f, err := filterMaker.AsEvaluator()
 			assert.NoError(t, err, "filter: %q", c.filter)
 			if f != nil {

--- a/zfmt/dag.go
+++ b/zfmt/dag.go
@@ -3,7 +3,6 @@ package zfmt
 import (
 	"github.com/brimdata/zed/compiler/ast/dag"
 	astzed "github.com/brimdata/zed/compiler/ast/zed"
-	"github.com/brimdata/zed/compiler/kernel"
 	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/zson"
 )
@@ -472,6 +471,14 @@ func (c *canonDAG) op(p dag.Op) {
 		c.next()
 		c.write("yield ")
 		c.exprs(p.Exprs)
+	case *dag.DefaultScan:
+		c.next()
+		c.write("reader")
+		if p.Filter != nil {
+			c.write(" filter (")
+			c.expr(p.Filter, "")
+			c.write(")")
+		}
 	case *dag.FileScan:
 		c.next()
 		c.write("file %s", p.Path)
@@ -507,14 +514,6 @@ func (c *canonDAG) op(p dag.Op) {
 	case *dag.Pass:
 		c.next()
 		c.write("pass")
-	case *kernel.Reader:
-		c.next()
-		c.write("reader")
-		if p.Filter != nil {
-			c.write(" filter (")
-			c.expr(p.Filter, "")
-			c.write(")")
-		}
 	default:
 		c.next()
 		c.open("unknown proc: %T", p)


### PR DESCRIPTION
compiler/kernel.Reader is a little peculiar both because it's the only compiler/ast/dag.Op implementation outside the dag package and because it holds zio.Readers.  Separately, it forces a dependency in compiler/optimizer on compiler/kernel that's getting in my way on vector work.

Replace it with dag.DefaultScan, which represents the same thing (a scan of an input stream provided by the runtime) but can live in the dag package because it doesn't hold zio.Readers (allowing it to be serialized).  The zio.Readers are instead passed to compiler.Job.Build and then to kernel.Builder.Build.