### PR TITLE
Fix typo in pip3 git url

### DIFF
--- a/docs/libraries/python.md
+++ b/docs/libraries/python.md
@@ -26,7 +26,7 @@ pip3 install "git+https://github.com/brimdata/zed#subdirectory=python/zed"
 
 Install the version compatible with a local `zed` like this:
 ```sh
-pip3 install "git+https://github.com/brimdata/zed@$(zed -version | cut -d ' ' -f 2)#subdirectory=python/zed"
+pip3 install "git+https://github.com/brimdata/zed@v$(zed -version | cut -d ' ' -f 2)#subdirectory=python/zed"
 ```
 
 ## Example


### PR DESCRIPTION
Command to pip install zed is missing the `v` at the beginning of tags, making it fetch, e.g, `1.10.0` instead of `v1.10.0` - which fails. Adding a v before the local zed version fixes this.