### PR TITLE
Fix "zed dev vcache copy"

### DIFF
--- a/cmd/zed/dev/vcache/copy/command.go
+++ b/cmd/zed/dev/vcache/copy/command.go
@@ -10,6 +10,7 @@ import (
 	"github.com/brimdata/zed/pkg/charm"
 	"github.com/brimdata/zed/pkg/storage"
 	"github.com/brimdata/zed/runtime/vcache"
+	"github.com/brimdata/zed/zio"
 	"github.com/segmentio/ksuid"
 )
 
@@ -66,11 +67,9 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	/*
-		if err := zio.Copy(writer, object.NewReader()); err != nil {
-			writer.Close()
-			return err
-		}
-	*/
+	if err := zio.Copy(writer, object.NewReader()); err != nil {
+		writer.Close()
+		return err
+	}
 	return writer.Close()
 }

--- a/runtime/vcache/map.go
+++ b/runtime/vcache/map.go
@@ -2,30 +2,34 @@ package vcache
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/pkg/field"
 	"github.com/brimdata/zed/vector"
+	"github.com/brimdata/zed/vng"
 	meta "github.com/brimdata/zed/vng/vector"
 )
 
-func loadMap(any *vector.Any, typ zed.Type, path field.Path, m *meta.Map, r io.ReaderAt) (*vector.Map, error) {
+func (l *loader) loadMap(any *vector.Any, typ zed.Type, path field.Path, m *meta.Map) (*vector.Map, error) {
 	if *any == nil {
 		mapType, ok := typ.(*zed.TypeMap)
 		if !ok {
 			return nil, fmt.Errorf("internal error: vcache.loadMap encountered bad type: %s", typ)
 		}
+		lengths, err := vng.ReadIntVector(m.Lengths, l.r)
+		if err != nil {
+			return nil, err
+		}
 		var keys, values vector.Any
-		_, err := loadVector(&keys, mapType.KeyType, path, m.Keys, r)
+		_, err = l.loadVector(&keys, mapType.KeyType, path, m.Keys)
 		if err != nil {
 			return nil, err
 		}
-		_, err = loadVector(&values, mapType.ValType, path, m.Values, r)
+		_, err = l.loadVector(&values, mapType.ValType, path, m.Values)
 		if err != nil {
 			return nil, err
 		}
-		*any = vector.NewMap(mapType, keys, values)
+		*any = vector.NewMap(mapType, lengths, keys, values)
 	}
 	return (*any).(*vector.Map), nil
 }

--- a/runtime/vcache/object.go
+++ b/runtime/vcache/object.go
@@ -135,7 +135,15 @@ func (o *Object) Len() int {
 // types in the hiearchy).  Load returns a Group for each type and the Group
 // may contain multiple vectors.
 func (o *Object) Load(typeKey uint32, path field.Path) (vector.Any, error) {
+	l := loader{o.local, o.reader}
 	o.mu[typeKey].Lock()
 	defer o.mu[typeKey].Unlock()
-	return loadVector(&o.vectors[typeKey], o.typeDict[typeKey], path, o.metas[typeKey], o.reader)
+	return l.loadVector(&o.vectors[typeKey], o.typeDict[typeKey], path, o.metas[typeKey])
+}
+
+func (o *Object) NewReader() *Reader {
+	return &Reader{
+		object:   o,
+		builders: make([]vector.Builder, len(o.vectors)),
+	}
 }

--- a/runtime/vcache/primitive.go
+++ b/runtime/vcache/primitive.go
@@ -2,7 +2,7 @@ package vcache
 
 import (
 	"fmt"
-	"io"
+	"net/netip"
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/vector"
@@ -10,7 +10,7 @@ import (
 	"github.com/brimdata/zed/zcode"
 )
 
-func loadPrimitive(typ zed.Type, m *meta.Primitive, r io.ReaderAt) (vector.Any, error) {
+func (l *loader) loadPrimitive(typ zed.Type, m *meta.Primitive) (vector.Any, error) {
 	// The VNG primitive columns are stored as one big
 	// list of Zed values.  So we can just read the data in
 	// all at once, compute the byte offsets of each value
@@ -22,7 +22,7 @@ func loadPrimitive(typ zed.Type, m *meta.Primitive, r io.ReaderAt) (vector.Any, 
 	bytes := make([]byte, n)
 	var off int
 	for _, segment := range m.Segmap {
-		if err := segment.Read(r, bytes[off:]); err != nil {
+		if err := segment.Read(l.r, bytes[off:]); err != nil {
 			return nil, err
 		}
 		off += int(segment.MemLength)
@@ -34,103 +34,70 @@ func loadPrimitive(typ zed.Type, m *meta.Primitive, r io.ReaderAt) (vector.Any, 
 		}
 		bytes = b
 	}
+	it := zcode.Iter(bytes)
 	switch typ := typ.(type) {
 	case *zed.TypeOfUint8, *zed.TypeOfUint16, *zed.TypeOfUint32, *zed.TypeOfUint64:
-		//XXX put valcnt in vng meta and use vector allocator
-		var vals []uint64
-		var nullslots []uint32
-		it := zcode.Bytes(bytes).Iter()
+		var values []uint64
 		for !it.Done() {
-			val := it.Next()
-			if val == nil {
-				nullslots = append(nullslots, uint32(len(vals)))
-				vals = append(vals, 0)
-			} else {
-				vals = append(vals, zed.DecodeUint(val))
-			}
+			values = append(values, zed.DecodeUint(it.Next()))
 		}
-		return vector.NewUint(typ, vals, vector.NewNullmask(nullslots, len(vals))), nil
+		return vector.NewUint(typ, values), nil
 	case *zed.TypeOfInt8, *zed.TypeOfInt16, *zed.TypeOfInt32, *zed.TypeOfInt64, *zed.TypeOfDuration, *zed.TypeOfTime:
-		//XXX put valcnt in vng meta and use vector allocator
-		var vals []int64
-		var nullslots []uint32
-		it := zcode.Bytes(bytes).Iter()
+		var values []int64
 		for !it.Done() {
-			val := it.Next()
-			if val == nil {
-				nullslots = append(nullslots, uint32(len(vals)))
-				vals = append(vals, 0)
-			} else {
-				vals = append(vals, zed.DecodeInt(val))
-			}
+			values = append(values, zed.DecodeInt(it.Next()))
 		}
-		return vector.NewInt(typ, vals, vector.NewNullmask(nullslots, len(vals))), nil
-	case *zed.TypeOfFloat16:
-		return nil, fmt.Errorf("vcache.Primitive.Load TBD for %T", typ)
-	case *zed.TypeOfFloat32:
-		return nil, fmt.Errorf("vcache.Primitive.Load TBD for %T", typ)
-	case *zed.TypeOfFloat64:
-		return nil, fmt.Errorf("vcache.Primitive.Load TBD for %T", typ)
+		return vector.NewInt(typ, values), nil
+	case *zed.TypeOfFloat16, *zed.TypeOfFloat32, *zed.TypeOfFloat64:
+		var values []float64
+		for !it.Done() {
+			values = append(values, zed.DecodeFloat(it.Next()))
+		}
+		return vector.NewFloat(typ, values), nil
 	case *zed.TypeOfBool:
-		var vals []bool
-		var nullslots []uint32
-		it := zcode.Bytes(bytes).Iter()
+		var values []bool
 		for !it.Done() {
-			val := it.Next()
-			if val == nil {
-				nullslots = append(nullslots, uint32(len(vals)))
-				vals = append(vals, false)
-			} else {
-				vals = append(vals, zed.DecodeBool(val))
-			}
+			values = append(values, zed.DecodeBool(it.Next()))
 		}
-		return vector.NewBool(typ, vals, vector.NewNullmask(nullslots, len(vals))), nil
+		return vector.NewBool(typ, values), nil
 	case *zed.TypeOfBytes:
-		return nil, fmt.Errorf("vcache.Primitive.Load TBD for %T", typ)
-	case *zed.TypeOfString:
-		var vals []string
-		var nullslots []uint32
-		it := zcode.Bytes(bytes).Iter()
+		var values [][]byte
 		for !it.Done() {
-			val := it.Next()
-			if val == nil {
-				nullslots = append(nullslots, uint32(len(vals)))
-			} else {
-				vals = append(vals, zed.DecodeString(val))
-			}
+			values = append(values, zed.DecodeBytes(it.Next()))
 		}
-		return vector.NewString(typ, vals, vector.NewNullmask(nullslots, len(vals))), nil
+		return vector.NewBytes(typ, values), nil
+	case *zed.TypeOfString:
+		var values []string
+		for !it.Done() {
+			values = append(values, zed.DecodeString(it.Next()))
+		}
+		return vector.NewString(typ, values), nil
 	case *zed.TypeOfIP:
-		return nil, fmt.Errorf("vcache.Primitive.Load TBD for %T", typ)
+		var values []netip.Addr
+		for !it.Done() {
+			values = append(values, zed.DecodeIP(it.Next()))
+		}
+		return vector.NewIP(typ, values), nil
 	case *zed.TypeOfNet:
-		return nil, fmt.Errorf("vcache.Primitive.Load TBD for %T", typ)
-	case *zed.TypeOfNull:
-		return nil, fmt.Errorf("vcache.Primitive.Load TBD for %T", typ)
+		var values []netip.Prefix
+		for !it.Done() {
+			values = append(values, zed.DecodeNet(it.Next()))
+		}
+		return vector.NewNet(typ, values), nil
 	case *zed.TypeOfType:
-		return nil, fmt.Errorf("vcache.Primitive.Load TBD for %T", typ)
+		var values []zed.Type
+		for !it.Done() {
+			t, err := l.zctx.LookupByValue(it.Next())
+			if err != nil {
+				return nil, err
+			}
+			values = append(values, t)
+		}
+		return vector.NewType(typ, values), nil
+	case *zed.TypeOfNull:
+		return vector.NewConst(zed.Null, 0), nil
 	}
-	return nil, nil
-	/*
-	   	 XXX
-	   		if dict := p.meta.Dict; dict != nil {
-	   			bytes := p.bytes
-	   			return func(b *zcode.Builder) error {
-	   				pos := bytes[0]
-	   				bytes = bytes[1:]
-	   				b.Append(dict[pos].Value.Bytes())
-	   				return nil
-	   			}, nil
-	   		}
-	   		it := zcode.Iter(p.bytes)
-	   		return func(b *zcode.Builder) error {
-	   			b.Append(it.Next())
-	   			return nil
-	   		}, nil
-
-	   /* XXX
-
-	   	return nil, fmt.Errorf("internal error: vcache.Primitive.Load uknown type %T", typ)
-	*/
+	return nil, fmt.Errorf("internal error: vcache.loadPrimitive got unknown type %#v", typ)
 }
 
 type Const struct {

--- a/runtime/vcache/vector.go
+++ b/runtime/vcache/vector.go
@@ -11,18 +11,23 @@ import (
 	meta "github.com/brimdata/zed/vng/vector"
 )
 
-func loadVector(any *vector.Any, typ zed.Type, path field.Path, m meta.Metadata, r io.ReaderAt) (vector.Any, error) {
+type loader struct {
+	zctx *zed.Context
+	r    io.ReaderAt
+}
+
+func (l *loader) loadVector(any *vector.Any, typ zed.Type, path field.Path, m meta.Metadata) (vector.Any, error) {
 	switch m := m.(type) {
 	case *meta.Named:
-		return loadVector(any, typ.(*zed.TypeNamed).Type, path, m.Values, r)
+		return l.loadVector(any, typ.(*zed.TypeNamed).Type, path, m.Values)
 	case *meta.Record:
-		return loadRecord(any, typ.(*zed.TypeRecord), path, m, r)
+		return l.loadRecord(any, typ.(*zed.TypeRecord), path, m)
 	case *meta.Primitive:
 		if len(path) != 0 {
 			return nil, fmt.Errorf("internal error: vcache encountered path at primitive element: %q", strings.Join(path, "."))
 		}
 		if *any == nil {
-			v, err := loadPrimitive(typ, m, r)
+			v, err := l.loadPrimitive(typ, m)
 			if err != nil {
 				return nil, err
 			}
@@ -30,18 +35,19 @@ func loadVector(any *vector.Any, typ zed.Type, path field.Path, m meta.Metadata,
 		}
 		return *any, nil
 	case *meta.Array:
-		return loadArray(any, typ, path, m, r)
+		return l.loadArray(any, typ, path, m)
 	case *meta.Set:
 		a := *(*meta.Array)(m)
-		return loadArray(any, typ, path, &a, r)
+		return l.loadArray(any, typ, path, &a)
 	case *meta.Map:
-		return loadMap(any, typ, path, m, r)
+		return l.loadMap(any, typ, path, m)
 	case *meta.Union:
-		return loadUnion(any, typ.(*zed.TypeUnion), path, m, r)
+		return l.loadUnion(any, typ.(*zed.TypeUnion), path, m)
 	case *meta.Nulls:
-		return loadNulls(any, typ, path, m, r)
+		return l.loadNulls(any, typ, path, m)
 	case *meta.Const:
-		return vector.NewConst(m.Value, m.Count), nil
+		*any = vector.NewConst(m.Value, m.Count)
+		return *any, nil
 	default:
 		return nil, fmt.Errorf("vector cache: type %T not supported", m)
 	}

--- a/runtime/vcache/ztests/array-copy.yaml
+++ b/runtime/vcache/ztests/array-copy.yaml
@@ -1,5 +1,3 @@
-skip: disabled until "zed dev vcache copy" is fixed or replaced
-
 # This test simply converts some ZSON to VNG then runs it through 
 # the vector cache to exercise the logic that builds values from 
 # cached vectors.

--- a/runtime/vcache/ztests/map-copy.yaml
+++ b/runtime/vcache/ztests/map-copy.yaml
@@ -1,5 +1,3 @@
-skip: disabled until "zed dev vcache copy" is fixed or replaced
-
 # This test simply converts some ZSON to VNG then runs it through 
 # the vector cache to exercise the logic that builds values from 
 # cached vectors.

--- a/runtime/vcache/ztests/named-copy.yaml
+++ b/runtime/vcache/ztests/named-copy.yaml
@@ -1,5 +1,3 @@
-skip: disabled until "zed dev vcache copy" is fixed or replaced
-
 script: |
   zq -f vng -o test.vng -
   zed dev vcache copy -z test.vng

--- a/runtime/vcache/ztests/primitive-const-copy.yaml
+++ b/runtime/vcache/ztests/primitive-const-copy.yaml
@@ -1,0 +1,33 @@
+# Exercise the logic that builds values from cached constant vectors.
+script: |
+  zq -f vng -o test.vng -
+  zed dev vcache copy -z test.vng
+
+inputs:
+  - name: stdin
+    # One value per type so they'll be encoded as constant vectors.
+    data: &stdin |
+      8(uint8)
+      16(uint16)
+      32(uint32)
+      64(uint64)
+      -8(int8)
+      -16(int16)
+      -32(int32)
+      -64
+      1h2m3s
+      2022-12-04T00:00:00Z
+      16.(float16)
+      32.(float32)
+      64.
+      false
+      0x00
+      "0"
+      1.2.3.4
+      1.2.3.0/24
+      <int64>
+      null
+
+outputs:
+  - name: stdout
+    data: *stdin

--- a/runtime/vcache/ztests/primitive-copy.yaml
+++ b/runtime/vcache/ztests/primitive-copy.yaml
@@ -1,0 +1,53 @@
+# Exercise the logic that builds values from cached non-constant vectors.
+script: |
+  zq -f vng -o test.vng -
+  zed dev vcache copy -z test.vng
+
+inputs:
+  - name: stdin
+    # Two different value per type (except for null) so they won't be encoded as
+    # constant vectors.
+    data: &stdin |
+      8(uint8)
+      80(uint8)
+      16(uint16)
+      1600(uint16)
+      32(uint32)
+      320(uint32)
+      64(uint64)
+      640(uint64)
+      -8(int8)
+      -80(int8)
+      -16(int16)
+      -160(int16)
+      -32(int32)
+      -320(int32)
+      -64
+      -640
+      1h2m3s
+      1h2m30s
+      2022-12-04T00:00:00Z
+      2022-12-04T00:00:01Z
+      16.(float16)
+      160.(float16)
+      32.(float32)
+      320.(float32)
+      64.
+      640.
+      true
+      false
+      0x00
+      0x0000
+      "0"
+      "00"
+      1.2.3.4
+      1.2.3.40
+      1.2.3.0/24
+      1.2.3.0/25
+      <int64>
+      <duration>
+      null
+
+outputs:
+  - name: stdout
+    data: *stdin

--- a/runtime/vcache/ztests/record-copy.yaml
+++ b/runtime/vcache/ztests/record-copy.yaml
@@ -1,5 +1,3 @@
-skip: disabled until "zed dev vcache copy" is fixed or replaced
-
 # This test simply converts some ZSON to VNG then runs it through 
 # the vector cache to exercise the logic that builds values from 
 # cached vectors.

--- a/runtime/vcache/ztests/set-copy.yaml
+++ b/runtime/vcache/ztests/set-copy.yaml
@@ -1,5 +1,3 @@
-skip: disabled until "zed dev vcache copy" is fixed or replaced
-
 # This test simply converts some ZSON to VNG then runs it through 
 # the vector cache to exercise the logic that builds values from 
 # cached vectors.

--- a/runtime/vcache/ztests/union-copy.yaml
+++ b/runtime/vcache/ztests/union-copy.yaml
@@ -1,5 +1,3 @@
-skip: disabled until "zed dev vcache copy" is fixed or replaced
-
 # This test simply converts some ZSON to VNG then runs it through 
 # the vector cache to exercise the logic that builds values from 
 # cached vectors.

--- a/vector/bool.go
+++ b/vector/bool.go
@@ -9,13 +9,12 @@ type Bool struct {
 	mem
 	Typ    zed.Type
 	Values []bool //XXX bit vector
-	Nulls  Nullmask
 }
 
 var _ Any = (*Bool)(nil)
 
-func NewBool(typ zed.Type, vals []bool, nulls Nullmask) *Bool {
-	return &Bool{Typ: typ, Values: vals, Nulls: nulls}
+func NewBool(typ zed.Type, vals []bool) *Bool {
+	return &Bool{Typ: typ, Values: vals}
 }
 
 func (b *Bool) Type() zed.Type {
@@ -24,15 +23,10 @@ func (b *Bool) Type() zed.Type {
 
 func (b *Bool) NewBuilder() Builder {
 	vals := b.Values
-	nulls := b.Nulls
 	var voff int
 	return func(b *zcode.Builder) bool {
 		if voff < len(vals) {
-			if !nulls.Has(uint32(voff)) {
-				b.Append(zed.EncodeBool(vals[voff]))
-			} else {
-				b.Append(nil)
-			}
+			b.Append(zed.EncodeBool(vals[voff]))
 			voff++
 			return true
 

--- a/vector/bytes.go
+++ b/vector/bytes.go
@@ -1,0 +1,34 @@
+package vector
+
+import (
+	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/zcode"
+)
+
+type Bytes struct {
+	mem
+	Typ    zed.Type
+	Values [][]byte
+}
+
+var _ Any = (*Bytes)(nil)
+
+func NewBytes(typ zed.Type, values [][]byte) *Bytes {
+	return &Bytes{Typ: typ, Values: values}
+}
+
+func (b *Bytes) Type() zed.Type {
+	return b.Typ
+}
+
+func (b *Bytes) NewBuilder() Builder {
+	var off int
+	return func(zb *zcode.Builder) bool {
+		if off >= len(b.Values) {
+			return false
+		}
+		zb.Append(zed.EncodeBytes(b.Values[off]))
+		off++
+		return true
+	}
+}

--- a/vector/float.go
+++ b/vector/float.go
@@ -1,0 +1,44 @@
+package vector
+
+import (
+	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/zcode"
+)
+
+type Float struct {
+	mem
+	Typ    zed.Type
+	Values []float64
+}
+
+var _ Any = (*Float)(nil)
+
+func NewFloat(typ zed.Type, values []float64) *Float {
+	return &Float{Typ: typ, Values: values}
+}
+
+func (f *Float) Type() zed.Type {
+	return f.Typ
+}
+
+func (f *Float) NewBuilder() Builder {
+	typeID := f.Typ.ID()
+	var off int
+	return func(b *zcode.Builder) bool {
+		if off >= len(f.Values) {
+			return false
+		}
+		switch typeID {
+		case zed.IDFloat16:
+			b.Append(zed.EncodeFloat16(float32(f.Values[off])))
+		case zed.IDFloat32:
+			b.Append(zed.EncodeFloat32(float32(f.Values[off])))
+		case zed.IDFloat64:
+			b.Append(zed.EncodeFloat64(f.Values[off]))
+		default:
+			panic(f.Typ)
+		}
+		off++
+		return true
+	}
+}

--- a/vector/int.go
+++ b/vector/int.go
@@ -9,13 +9,12 @@ type Int struct {
 	mem
 	Typ    zed.Type
 	Values []int64
-	Nulls  Nullmask
 }
 
 var _ Any = (*Int)(nil)
 
-func NewInt(typ zed.Type, vals []int64, nulls Nullmask) *Int {
-	return &Int{Typ: typ, Values: vals, Nulls: nulls}
+func NewInt(typ zed.Type, values []int64) *Int {
+	return &Int{Typ: typ, Values: values}
 }
 
 func (i *Int) Type() zed.Type {
@@ -24,18 +23,12 @@ func (i *Int) Type() zed.Type {
 
 func (i *Int) NewBuilder() Builder {
 	vals := i.Values
-	nulls := i.Nulls
 	var voff int
 	return func(b *zcode.Builder) bool {
 		if voff < len(vals) {
-			if nulls.Has(uint32(voff)) {
-				b.Append(nil)
-			} else {
-				b.Append(zed.EncodeInt(vals[voff]))
-			}
+			b.Append(zed.EncodeInt(vals[voff]))
 			voff++
 			return true
-
 		}
 		return false
 	}

--- a/vector/ip.go
+++ b/vector/ip.go
@@ -1,0 +1,36 @@
+package vector
+
+import (
+	"net/netip"
+
+	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/zcode"
+)
+
+type IP struct {
+	mem
+	Typ    zed.Type
+	Values []netip.Addr
+}
+
+var _ Any = (*IP)(nil)
+
+func NewIP(typ zed.Type, values []netip.Addr) *IP {
+	return &IP{Typ: typ, Values: values}
+}
+
+func (i *IP) Type() zed.Type {
+	return i.Typ
+}
+
+func (i *IP) NewBuilder() Builder {
+	var off int
+	return func(b *zcode.Builder) bool {
+		if off >= len(i.Values) {
+			return false
+		}
+		b.Append(zed.EncodeIP(i.Values[off]))
+		off++
+		return true
+	}
+}

--- a/vector/net.go
+++ b/vector/net.go
@@ -1,0 +1,36 @@
+package vector
+
+import (
+	"net/netip"
+
+	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/zcode"
+)
+
+type Net struct {
+	mem
+	Typ    zed.Type
+	Values []netip.Prefix
+}
+
+var _ Any = (*Net)(nil)
+
+func NewNet(typ zed.Type, values []netip.Prefix) *Net {
+	return &Net{Typ: typ, Values: values}
+}
+
+func (n *Net) Type() zed.Type {
+	return n.Typ
+}
+
+func (n *Net) NewBuilder() Builder {
+	var off int
+	return func(b *zcode.Builder) bool {
+		if off >= len(n.Values) {
+			return false
+		}
+		b.Append(zed.EncodeNet(n.Values[off]))
+		off++
+		return true
+	}
+}

--- a/vector/string.go
+++ b/vector/string.go
@@ -9,13 +9,12 @@ type String struct {
 	mem
 	Typ    zed.Type
 	Values []string
-	Nulls  Nullmask
 }
 
 var _ Any = (*String)(nil)
 
-func NewString(typ zed.Type, vals []string, nulls Nullmask) *String {
-	return &String{Typ: typ, Values: vals, Nulls: nulls}
+func NewString(typ zed.Type, vals []string) *String {
+	return &String{Typ: typ, Values: vals}
 }
 
 func (s *String) Type() zed.Type {
@@ -24,15 +23,10 @@ func (s *String) Type() zed.Type {
 
 func (s *String) NewBuilder() Builder {
 	vals := s.Values
-	nulls := s.Nulls
 	var voff int
 	return func(b *zcode.Builder) bool {
 		if voff < len(vals) {
-			if !nulls.Has(uint32(voff)) {
-				b.Append(zed.EncodeString(vals[voff]))
-			} else {
-				b.Append(nil)
-			}
+			b.Append(zed.EncodeString(vals[voff]))
 			voff++
 			return true
 

--- a/vector/type.go
+++ b/vector/type.go
@@ -1,0 +1,34 @@
+package vector
+
+import (
+	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/zcode"
+)
+
+type Type struct {
+	mem
+	Typ    zed.Type
+	Values []zed.Type
+}
+
+var _ Any = (*Type)(nil)
+
+func NewType(typ zed.Type, vals []zed.Type) *Type {
+	return &Type{Typ: typ, Values: vals}
+}
+
+func (t *Type) Type() zed.Type {
+	return t.Typ
+}
+
+func (t *Type) NewBuilder() Builder {
+	var off int
+	return func(b *zcode.Builder) bool {
+		if off >= len(t.Values) {
+			return false
+		}
+		b.Append(zed.EncodeTypeValue(t.Values[off]))
+		off++
+		return true
+	}
+}

--- a/vector/uint.go
+++ b/vector/uint.go
@@ -9,13 +9,12 @@ type Uint struct {
 	mem
 	Typ    zed.Type
 	Values []uint64
-	Nulls  Nullmask
 }
 
 var _ Any = (*Uint)(nil)
 
-func NewUint(typ zed.Type, vals []uint64, nulls Nullmask) *Uint {
-	return &Uint{Typ: typ, Values: vals, Nulls: nulls}
+func NewUint(typ zed.Type, values []uint64) *Uint {
+	return &Uint{Typ: typ, Values: values}
 }
 
 func (u *Uint) Type() zed.Type {
@@ -24,18 +23,12 @@ func (u *Uint) Type() zed.Type {
 
 func (u *Uint) NewBuilder() Builder {
 	vals := u.Values
-	nulls := u.Nulls
 	var voff int
 	return func(b *zcode.Builder) bool {
 		if voff < len(vals) {
-			if !nulls.Has(uint32(voff)) {
-				b.Append(zed.EncodeUint(vals[voff]))
-			} else {
-				b.Append(nil)
-			}
+			b.Append(zed.EncodeUint(vals[voff]))
 			voff++
 			return true
-
 		}
 		return false
 	}

--- a/vector/union.go
+++ b/vector/union.go
@@ -2,11 +2,13 @@ package vector
 
 import (
 	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/zcode"
 )
 
 type Union struct {
 	mem
 	Typ    *zed.TypeUnion
+	Tags   []int32
 	Values []Any
 }
 
@@ -21,5 +23,23 @@ func (u *Union) Type() zed.Type {
 }
 
 func (u *Union) NewBuilder() Builder {
-	return nil //XXX
+	var valueBuilders []Builder
+	for _, v := range u.Values {
+		valueBuilders = append(valueBuilders, v.NewBuilder())
+	}
+	var off int
+	return func(b *zcode.Builder) bool {
+		if off >= len(u.Tags) {
+			return false
+		}
+		tag := u.Tags[off]
+		b.BeginContainer()
+		b.Append(zed.EncodeInt(int64(tag)))
+		if !valueBuilders[tag](b) {
+			return false
+		}
+		b.EndContainer()
+		off++
+		return true
+	}
 }


### PR DESCRIPTION
Do that by plugging some holes left by #4925.

* In runtime/vcache/ztests/, re-enable skipped "zed dev vcache copy" tests.

* In cmd/zed/dev/vcache/copy.Command.Run, resurrect the call to zio.Copy.

* In package runtime/vcache:

  * Resurrect the Reader type and update its Read method.

  * Resurrect Object.NewReader.

  * Add loader type to hold the *zed.Context needed when loading a vector of type values.

  * Convert existing loadXXX functions to loader methods.

  * In loadArray, fix bad nil argument to loadVector.

  * In loadMap, load lengths vector.

  * In loadNulls, create slots slice and load values vector.

  * In loadPrimitive, remove null handling (vector.Nulls now does that) and add support for missing Zed types (float16, float32, float64, bytes, ip, net, and type).

  * In loadRecord, load all fields when no specific path is requested.

  * In loadUnion, load tags vector.

  * In loadVector, assign to *any when loading a constant vector.

* In package vector:

  * Add missing Byte, Float, IP, Net, and Type types.

  * Add missing length field to Map type.

  * Add missing tags field to Union type.

  * Implement NewBuilder method for Array, Map, and Union types.

  * Handle nulls for all vector types by replacing the Nullmask type with Nulls, which wraps a vector.Any.