### PR TITLE
change vam.Puller.PullVec() to Pull()

### DIFF
--- a/cmd/zed/dev/vcache/agg/command.go
+++ b/cmd/zed/dev/vcache/agg/command.go
@@ -73,7 +73,7 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := zio.Copy(writer, zbuf.PullerReader(agg)); err != nil {
+	if err := zio.Copy(writer, zbuf.PullerReader(vam.NewMaterializer(agg))); err != nil {
 		writer.Close()
 		return err
 	}

--- a/runtime/vam/materialize.go
+++ b/runtime/vam/materialize.go
@@ -1,94 +1,43 @@
 package vam
 
 import (
-	"errors"
+	"bytes"
 
-	"github.com/brimdata/zed/vector"
+	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/zbuf"
+	"github.com/brimdata/zed/zcode"
 )
 
+type Materializer struct {
+	parent Puller
+}
+
+var _ zbuf.Puller = (*Materializer)(nil)
+
 func NewMaterializer(p Puller) zbuf.Puller {
-	return p.(zbuf.Puller)
-}
-
-func NewDematerializer(p zbuf.Puller) Puller {
-	return &dematerializer{p}
-}
-
-type dematerializer struct{ zbuf.Puller }
-
-func (*dematerializer) PullVec(_ bool) (vector.Any, error) {
-	return nil, errors.New("internal error: vamPuller.PullVec called")
-}
-
-/* no slots
-func newIntBuilderIndexed(vec *vector.Int, index Index) builder {
-	slots := vec.Slots
-	vals := vec.Vals
-	nulls := vec.Nulls
-	var voff, ioff int
-	return func(b *zcode.Builder) bool {
-		for voff < len(index) && ioff < len(vals) {
-			if slots[voff] < index[ioff] {
-				voff++
-				continue
-			}
-			if slots[voff] > index[ioff] {
-				ioff++
-			}
-			if !nulls.Has(uint32(voff)) {
-				b.Append(zed.EncodeInt(vals[voff]))
-			} else {
-				b.Append(nil)
-			}
-			return true
-
-		}
-		return false
+	return &Materializer{
+		parent: p,
 	}
 }
-*/
 
-/* no slots
-func newUintBuilderIndexed(vec *vector.Uint, index Index) builder {
-	slots := vec.Slots
-	vals := vec.Vals
-	var voff, ioff int
-	return func(b *zcode.Builder) bool {
-		for voff < len(index) && ioff < len(vals) {
-			if slots[voff] < index[ioff] {
-				voff++
-				continue
-			}
-			if slots[voff] > index[ioff] {
-				ioff++
-			}
-			b.Append(zed.EncodeUint(vals[voff]))
-			return true
+func (m *Materializer) Pull(done bool) (zbuf.Batch, error) {
+	vec, err := m.parent.Pull(done)
+	if vec == nil || err != nil {
+		return nil, err
+	}
+	b := vec.NewBuilder()
+	typ := vec.Type()
+	builder := zcode.NewBuilder()
+	var vals []zed.Value
+	for {
+		if !b(builder) {
+			return zbuf.NewArray(vals), nil
 		}
-		return false
+		//XXX Body should only be called for container types, but this
+		// will change soon anyway when we change out vector Builder to a
+		// slot-based indexing approach that isn't based on closures.
+		zv := zed.NewValue(typ, bytes.Clone(builder.Bytes().Body()))
+		vals = append(vals, *zv)
+		builder.Reset()
 	}
 }
-*/
-
-/* no slots
-func newStringBuilderIndexed(vec *vector.String, index Index) builder {
-	slots := vec.Slots
-	vals := vec.Vals
-	var voff, ioff int
-	return func(b *zcode.Builder) bool {
-		for voff < len(index) && ioff < len(vals) {
-			if slots[voff] < index[ioff] {
-				voff++
-				continue
-			}
-			if slots[voff] > index[ioff] {
-				ioff++
-			}
-			b.Append(zed.EncodeString(vals[voff]))
-			return true
-		}
-		return false
-	}
-}
-*/

--- a/runtime/vam/materialize.go
+++ b/runtime/vam/materialize.go
@@ -36,8 +36,8 @@ func (m *Materializer) Pull(done bool) (zbuf.Batch, error) {
 		//XXX Body should only be called for container types, but this
 		// will change soon anyway when we change out vector Builder to a
 		// slot-based indexing approach that isn't based on closures.
-		zv := zed.NewValue(typ, bytes.Clone(builder.Bytes().Body()))
-		vals = append(vals, *zv)
+		val := zed.NewValue(typ, bytes.Clone(builder.Bytes().Body()))
+		vals = append(vals, *val)
 		builder.Reset()
 	}
 }

--- a/runtime/vam/scan.go
+++ b/runtime/vam/scan.go
@@ -18,12 +18,8 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-//XXX change PullVec to Pull and lets partition the dag operators into
-// vecops and ops and have a materlize op that has a vop parent but it
-// an op.
-
 type Puller interface {
-	PullVec(done bool) (vector.Any, error)
+	Pull(done bool) (vector.Any, error)
 }
 
 // XXX need a semaphore pattern here we scanner can run ahead and load objects
@@ -64,12 +60,6 @@ func NewVecScanner(octx *op.Context, cache *vcache.Cache, parent zbuf.Puller, po
 	}
 }
 
-// XXX this is here for the compiler to be ablet o create it as a zbuf.Puller,
-// but we will fix the compiler to understand vops and vam/vector.Puller soon.
-func (v *VecScanner) Pull(done bool) (zbuf.Batch, error) {
-	panic("VecScanner.Pull")
-}
-
 // XXX we need vector scannerstats and means to update them here.
 
 // XXX change this to pull/load vector by each type within an object and
@@ -81,7 +71,7 @@ func (v *VecScanner) Pull(done bool) (zbuf.Batch, error) {
 // a Record vec and let GC reclaim them.  Note if a col is missing, it's a constant
 // vector of error("missing").
 
-func (v *VecScanner) PullVec(done bool) (vector.Any, error) {
+func (v *VecScanner) Pull(done bool) (vector.Any, error) {
 	v.once.Do(func() {
 		// Block p.ctx's cancel function until p.run finishes its
 		// cleanup.


### PR DESCRIPTION
This commit changes PullVec to Pull and adds an explicit materialization step between vector world and sequence world.  We also fixed a bug in the CountByString and Sum hacks introduced by the vector.Nulls wrapper.