### PR TITLE
Eliminate assignments to zed.Value.Type

### DIFF
--- a/runtime/expr/coerce/coerce.go
+++ b/runtime/expr/coerce/coerce.go
@@ -50,12 +50,6 @@ func (c *Pair) Equal() bool {
 func (c *Pair) Coerce(a, b *zed.Value) (int, error) {
 	c.A = a.Bytes()
 	c.B = b.Bytes()
-	if a.Type == nil {
-		a.Type = zed.TypeNull
-	}
-	if b.Type == nil {
-		b.Type = zed.TypeNull
-	}
 	aid := a.Type.ID()
 	bid := b.Type.ID()
 	if aid == bid {

--- a/runtime/expr/expr_test.go
+++ b/runtime/expr/expr_test.go
@@ -416,13 +416,9 @@ func TestArithmetic(t *testing.T) {
 			w = w2
 		}
 		if sign {
-			val := zed.NewInt64(int64(v))
-			val.Type = signed(w)
-			return val
+			return zed.NewInt(signed(w), int64(v))
 		}
-		val := zed.NewUint64(v)
-		val.Type = unsigned(w)
-		return val
+		return zed.NewUint(unsigned(w), v)
 	}
 
 	var intTypes = []string{"int8", "uint8", "int16", "uint16", "int32", "uint32", "int64", "uint64"}

--- a/runtime/expr/shaper.go
+++ b/runtime/expr/shaper.go
@@ -144,16 +144,13 @@ func (c *ConstShaper) Eval(ectx Context, this *zed.Value) *zed.Value {
 	id, shapeToID := val.Type.ID(), c.shapeTo.ID()
 	if id == shapeToID {
 		// Same underlying types but one or both are named.
-		val = ectx.CopyValue(*val)
-		val.Type = c.shapeTo
-		return val
+		return ectx.NewValue(c.shapeTo, val.Bytes())
 	}
 	if c.caster != nil && !zed.IsUnionType(val.Type) {
 		val = c.caster.Eval(ectx, val)
 		if val.Type != c.shapeTo && val.Type.ID() == shapeToID {
 			// Same underlying types but one or both are named.
-			val = ectx.CopyValue(*val)
-			val.Type = c.shapeTo
+			return ectx.NewValue(c.shapeTo, val.Bytes())
 		}
 		return val
 	}

--- a/value.go
+++ b/value.go
@@ -275,9 +275,7 @@ func (v *Value) CopyFrom(from *Value) {
 	} else if _, ok := v.native(); ok || v.IsNull() || v.len < from.len {
 		*v = *NewValue(from.Type, bytes.Clone(from.bytes()))
 	} else {
-		v.Type = from.Type
-		copy(v.bytes(), from.bytes())
-		v.len = from.len
+		*v = *NewValue(from.Type, append(v.bytes()[:0], from.bytes()...))
 	}
 }
 

--- a/zio/mapper.go
+++ b/zio/mapper.go
@@ -32,6 +32,6 @@ func (m *Mapper) Read() (*zed.Value, error) {
 			return nil, err
 		}
 	}
-	rec.Type = sharedType
+	*rec = *zed.NewValue(sharedType, rec.Bytes())
 	return rec, nil
 }


### PR DESCRIPTION
This will simplify a planned conversion of Type from field to method.