### PR TITLE
Docs for "zed manage" (i.e., compaction)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -92,7 +92,7 @@ or other third-party services to interpret the lake data.
 Once copied, a new service can be instantiated by pointing a `zed serve`
 at the copy of the lake.
 
-Functionality like data compaction and retention are all API-driven.
+Functionality like [data compaction](commands/zed.md#manage) and retention are all API-driven.
 
 Bite-sized components are unified by the Zed data, usually in the ZNG format:
 * All lake meta-data is available via meta-queries.

--- a/docs/commands/zed.md
+++ b/docs/commands/zed.md
@@ -589,7 +589,7 @@ alternate check frequency in [duration format](../formats/zson.md#23-primitive-v
 If `-monitor` is not specified, a single maintenance pass is performed on the
 lake.
 
-The log output from `manage` provides a per-pool summary of the maintenance
+The output from `manage` provides a per-pool summary of the maintenance
 performed, including a count of `objects_compacted`.
 
 ### Merge

--- a/docs/commands/zed.md
+++ b/docs/commands/zed.md
@@ -577,8 +577,8 @@ zed manage [options]
 The `manage` command performs maintenance tasks on a lake.
 
 Currently the only supported task is _compaction_, which reduces fragmentation
-by reading data objects in a pool and writing them back globally sorted and
-with their contents stored in contiguous large objects.
+by reading data objects in a pool and writing their contents back to large,
+non-overlapping objects.
 
 If the `-monitor` option is specified and the lake is [located](#locating-the-lake)
 via network connection, `zed manage` will run continuously and perform updates

--- a/docs/commands/zed.md
+++ b/docs/commands/zed.md
@@ -574,7 +574,7 @@ API for automation.
 ```
 zed manage [options]
 ```
-Maintenance tasks are performed on a lake with the `manage` command.
+The `manage` command performs maintenance tasks on a lake.
 
 Currently the only supported task is _compaction_, which reduces fragmentation
 by reading data objects in a pool and writing them back globally sorted and


### PR DESCRIPTION
Now that compaction is available via `zed manage` and we have at least one environment where we know it's being used successfully, we're due to reveal it in the docs rather than speaking of it as a planned feature.

Closes #4115
