### PR TITLE
Link to pegjs on GitHub

### DIFF
--- a/compiler/parser/README.md
+++ b/compiler/parser/README.md
@@ -4,7 +4,7 @@ This directory contains the Zed parser implemented in PEG.
 
 There is a single PEG input file that works with both
 [pigeon](https://github.com/mna/pigeon), which is Go based, and
-[pegjs](https://pegjs.org/), which is JavaScript based.  This allows us
+[pegjs](https://github.com/pegjs/pegjs), which is JavaScript based.  This allows us
 to embed a Zed compiler into either JavaScript or Go.
 
 The single parser file is run through the C pre-processor allowing


### PR DESCRIPTION
Last night our markdown link checker in CI picked up on https://pegjs.org/ being unreachable, and it's still unreachable now. That may be a temporary outage, but in the same paragraph we link to the GitHub repo for the Go equivalent anyway.