### PR TITLE
Remove "go mod download" step from .github/workflows/*

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version-file: go.mod
-      - run: go mod download
       - run: make fmt
       - run: make tidy
       - run: make vet

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,6 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version-file: go.mod
-    - run: go mod download
     - run: make fmt
     - run: make tidy
     - run: make vet


### PR DESCRIPTION
It's unnecessary.