### PR TITLE
Change runtime/expr.Function.Call to return by value

### DIFF
--- a/runtime/expr/function/bytes.go
+++ b/runtime/expr/function/bytes.go
@@ -12,25 +12,25 @@ type Base64 struct {
 	zctx *zed.Context
 }
 
-func (b *Base64) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
+func (b *Base64) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	val := args[0]
 	switch val.Type().ID() {
 	case zed.IDBytes:
 		if val.IsNull() {
-			return newErrorf(b.zctx, ctx, "base64: illegal null argument")
+			return *b.zctx.NewErrorf("base64: illegal null argument")
 		}
-		return newString(ctx, base64.StdEncoding.EncodeToString(val.Bytes()))
+		return *zed.NewString(base64.StdEncoding.EncodeToString(val.Bytes()))
 	case zed.IDString:
 		if val.IsNull() {
-			return zed.Null
+			return *zed.Null
 		}
 		bytes, err := base64.StdEncoding.DecodeString(zed.DecodeString(val.Bytes()))
 		if err != nil {
-			return wrapError(b.zctx, ctx, "base64: string argument is not base64", &val)
+			return *b.zctx.WrapError("base64: string argument is not base64", &val)
 		}
-		return newBytes(ctx, bytes)
+		return *zed.NewBytes(bytes)
 	default:
-		return wrapError(b.zctx, ctx, "base64: argument must a bytes or string type", &val)
+		return *b.zctx.WrapError("base64: argument must a bytes or string type", &val)
 	}
 }
 
@@ -39,24 +39,24 @@ type Hex struct {
 	zctx *zed.Context
 }
 
-func (h *Hex) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
+func (h *Hex) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	val := args[0]
 	switch val.Type().ID() {
 	case zed.IDBytes:
 		if val.IsNull() {
-			return newErrorf(h.zctx, ctx, "hex: illegal null argument")
+			return *h.zctx.NewErrorf("hex: illegal null argument")
 		}
-		return newString(ctx, hex.EncodeToString(val.Bytes()))
+		return *zed.NewString(hex.EncodeToString(val.Bytes()))
 	case zed.IDString:
 		if val.IsNull() {
-			return zed.NullString
+			return *zed.NullString
 		}
 		b, err := hex.DecodeString(zed.DecodeString(val.Bytes()))
 		if err != nil {
-			return wrapError(h.zctx, ctx, "hex: string argument is not hexidecimal", &val)
+			return *h.zctx.WrapError("hex: string argument is not hexidecimal", &val)
 		}
-		return newBytes(ctx, b)
+		return *zed.NewBytes(b)
 	default:
-		return wrapError(h.zctx, ctx, "base64: argument must a bytes or string type", &val)
+		return *h.zctx.WrapError("base64: argument must a bytes or string type", &val)
 	}
 }

--- a/runtime/expr/function/coalesce.go
+++ b/runtime/expr/function/coalesce.go
@@ -5,12 +5,12 @@ import "github.com/brimdata/zed"
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#coalesce
 type Coalesce struct{}
 
-func (c *Coalesce) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
+func (c *Coalesce) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	for i := range args {
 		val := &args[i]
 		if !val.IsNull() && !val.IsMissing() && !val.IsQuiet() {
-			return ctx.CopyValue(*val)
+			return *val
 		}
 	}
-	return zed.Null
+	return *zed.Null
 }

--- a/runtime/expr/function/compare.go
+++ b/runtime/expr/function/compare.go
@@ -20,11 +20,11 @@ func NewCompare(zctx *zed.Context) *Compare {
 	}
 }
 
-func (e *Compare) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
+func (e *Compare) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	nullsMax := true
 	if len(args) == 3 {
 		if zed.TypeUnder(args[2].Type()) != zed.TypeBool {
-			return e.zctx.WrapError("compare: nullsMax arg is not bool", &args[2])
+			return *e.zctx.WrapError("compare: nullsMax arg is not bool", &args[2])
 		}
 		nullsMax = args[2].Bool()
 	}
@@ -32,5 +32,5 @@ func (e *Compare) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if !nullsMax {
 		cmp = e.nullsMin
 	}
-	return ctx.CopyValue(*zed.NewInt64(int64(cmp(&args[0], &args[1]))))
+	return *zed.NewInt64(int64(cmp(&args[0], &args[1])))
 }

--- a/runtime/expr/function/fields.go
+++ b/runtime/expr/function/fields.go
@@ -35,16 +35,16 @@ func buildPath(typ *zed.TypeRecord, b *zcode.Builder, prefix []string) []string 
 	return out
 }
 
-func (f *Fields) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
+func (f *Fields) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	subjectVal := args[0]
 	typ := f.recordType(subjectVal)
 	if typ == nil {
-		return f.zctx.Missing()
+		return *f.zctx.Missing()
 	}
 	//XXX should have a way to append into allocator
 	var b zcode.Builder
 	buildPath(typ, &b, nil)
-	return ctx.NewValue(f.typ, b.Bytes())
+	return *zed.NewValue(f.typ, b.Bytes())
 }
 
 func (f *Fields) recordType(val zed.Value) *zed.TypeRecord {

--- a/runtime/expr/function/flatten.go
+++ b/runtime/expr/function/flatten.go
@@ -25,16 +25,16 @@ func NewFlatten(zctx *zed.Context) *Flatten {
 	}
 }
 
-func (n *Flatten) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
+func (n *Flatten) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	val := args[0]
 	typ := zed.TypeRecordOf(val.Type())
 	if typ == nil {
-		return &val
+		return val
 	}
 	inner := n.innerTypeOf(val.Bytes(), typ.Fields)
 	n.Reset()
 	n.encode(typ.Fields, inner, field.Path{}, val.Bytes())
-	return ctx.NewValue(n.zctx.LookupTypeArray(inner), n.Bytes())
+	return *zed.NewValue(n.zctx.LookupTypeArray(inner), n.Bytes())
 }
 
 func (n *Flatten) innerTypeOf(b zcode.Bytes, fields []zed.Field) zed.Type {

--- a/runtime/expr/function/function.go
+++ b/runtime/expr/function/function.go
@@ -193,29 +193,3 @@ func HasBoolResult(name string) bool {
 	}
 	return false
 }
-
-func newFloat64(ctx zed.Allocator, native float64) *zed.Value {
-	return ctx.CopyValue(*zed.NewFloat64(native))
-}
-
-func newString(ctx zed.Allocator, native string) *zed.Value {
-	return ctx.NewValue(zed.TypeString, zed.EncodeString(native))
-}
-
-func newBytes(ctx zed.Allocator, bytes []byte) *zed.Value {
-	return ctx.NewValue(zed.TypeBytes, bytes)
-}
-
-// XXX this should build the error in the allocator's memory but needs
-// zctx for the type
-func newError(zctx *zed.Context, ectx zed.Allocator, err error) *zed.Value {
-	return zctx.NewError(err)
-}
-
-func newErrorf(zctx *zed.Context, ctx zed.Allocator, format string, args ...interface{}) *zed.Value {
-	return zctx.NewErrorf(format, args...)
-}
-
-func wrapError(zctx *zed.Context, ctx zed.Allocator, msg string, val *zed.Value) *zed.Value {
-	return ctx.CopyValue(*zctx.WrapError(msg, val))
-}

--- a/runtime/expr/function/grep.go
+++ b/runtime/expr/function/grep.go
@@ -12,30 +12,23 @@ type Grep struct {
 	zctx    *zed.Context
 }
 
-func (g *Grep) Call(ectx zed.Allocator, vals []zed.Value) *zed.Value {
+func (g *Grep) Call(_ zed.Allocator, vals []zed.Value) zed.Value {
 	patternVal, inputVal := &vals[0], &vals[1]
 	if zed.TypeUnder(patternVal.Type()) != zed.TypeString {
-		return g.error(ectx, "pattern argument must be a string", patternVal)
+		return g.error("pattern argument must be a string", patternVal)
 	}
 	if p := patternVal.AsString(); g.grep == nil || g.pattern != p {
 		g.pattern = p
 		term := norm.NFC.Bytes(patternVal.Bytes())
 		g.grep = expr.NewSearchString(string(term), nil)
 	}
-	return g.grep.Eval(wrapAllocator{ectx}, inputVal)
+	return *g.grep.Eval(expr.NewContext(), inputVal)
 }
 
-// XXX This is gross, any reason function shouldn't just accept an expr.Context?
-type wrapAllocator struct {
-	zed.Allocator
-}
-
-func (wrapAllocator) Vars() []zed.Value { return nil }
-
-func (g *Grep) error(ectx zed.Allocator, msg string, val *zed.Value) *zed.Value {
+func (g *Grep) error(msg string, val *zed.Value) zed.Value {
 	msg = "grep(): " + msg
 	if val == nil {
-		return ectx.CopyValue(*g.zctx.NewErrorf(msg))
+		return *g.zctx.NewErrorf(msg)
 	}
-	return ectx.CopyValue(*g.zctx.WrapError(msg, val))
+	return *g.zctx.WrapError(msg, val)
 }

--- a/runtime/expr/function/has.go
+++ b/runtime/expr/function/has.go
@@ -5,16 +5,16 @@ import "github.com/brimdata/zed"
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#has
 type Has struct{}
 
-func (h *Has) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
+func (h *Has) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	for _, val := range args {
 		if val.IsError() {
 			if val.IsMissing() || val.IsQuiet() {
-				return zed.False
+				return *zed.False
 			}
-			return ctx.CopyValue(val)
+			return val
 		}
 	}
-	return zed.True
+	return *zed.True
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#missing
@@ -22,10 +22,10 @@ type Missing struct {
 	has Has
 }
 
-func (m *Missing) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
-	val := m.has.Call(ctx, args)
+func (m *Missing) Call(ectx zed.Allocator, args []zed.Value) zed.Value {
+	val := m.has.Call(ectx, args)
 	if val.Type() == zed.TypeBool {
-		return ctx.CopyValue(*zed.NewBool(!val.Bool()))
+		return *zed.NewBool(!val.Bool())
 	}
 	return val
 }

--- a/runtime/expr/function/ksuid.go
+++ b/runtime/expr/function/ksuid.go
@@ -10,30 +10,30 @@ type KSUIDToString struct {
 	zctx *zed.Context
 }
 
-func (k *KSUIDToString) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
+func (k *KSUIDToString) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	if len(args) == 0 {
-		return newBytes(ctx, ksuid.New().Bytes())
+		return *zed.NewBytes(ksuid.New().Bytes())
 	}
 	val := args[0]
 	switch val.Type().ID() {
 	case zed.IDBytes:
 		if val.IsNull() {
-			return newErrorf(k.zctx, ctx, "ksuid: illegal null argument")
+			return *k.zctx.NewErrorf("ksuid: illegal null argument")
 		}
 		// XXX GC
 		id, err := ksuid.FromBytes(val.Bytes())
 		if err != nil {
 			panic(err)
 		}
-		return newString(ctx, id.String())
+		return *zed.NewString(id.String())
 	case zed.IDString:
 		// XXX GC
 		id, err := ksuid.Parse(string(val.Bytes()))
 		if err != nil {
-			return wrapError(k.zctx, ctx, "ksuid: "+err.Error(), &val)
+			return *k.zctx.WrapError("ksuid: "+err.Error(), &val)
 		}
-		return newBytes(ctx, id.Bytes())
+		return *zed.NewBytes(id.Bytes())
 	default:
-		return wrapError(k.zctx, ctx, "ksuid: argument must a bytes or string type", &val)
+		return *k.zctx.WrapError("ksuid: argument must a bytes or string type", &val)
 	}
 }

--- a/runtime/expr/function/len.go
+++ b/runtime/expr/function/len.go
@@ -9,7 +9,7 @@ type LenFn struct {
 	zctx *zed.Context
 }
 
-func (l *LenFn) Call(ectx zed.Allocator, args []zed.Value) *zed.Value {
+func (l *LenFn) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	val := args[0]
 	var length int
 	switch typ := zed.TypeUnder(args[0].Type()).(type) {
@@ -25,17 +25,17 @@ func (l *LenFn) Call(ectx zed.Allocator, args []zed.Value) *zed.Value {
 	case *zed.TypeOfBytes, *zed.TypeOfString, *zed.TypeOfIP, *zed.TypeOfNet:
 		length = len(val.Bytes())
 	case *zed.TypeError:
-		return l.zctx.WrapError("len()", &val)
+		return *l.zctx.WrapError("len()", &val)
 	case *zed.TypeOfType:
 		t, err := l.zctx.LookupByValue(val.Bytes())
 		if err != nil {
-			return newError(l.zctx, ectx, err)
+			return *l.zctx.NewError(err)
 		}
 		length = typeLength(t)
 	default:
-		return l.zctx.WrapError("len: bad type", &val)
+		return *l.zctx.WrapError("len: bad type", &val)
 	}
-	return ectx.CopyValue(*zed.NewInt64(int64(length)))
+	return *zed.NewInt64(int64(length))
 }
 
 func typeLength(typ zed.Type) int {

--- a/runtime/expr/function/nestdotted.go
+++ b/runtime/expr/function/nestdotted.go
@@ -55,14 +55,14 @@ func (n *NestDotted) lookupBuilderAndType(in *zed.TypeRecord) (*zed.RecordBuilde
 	return b, typ, nil
 }
 
-func (n *NestDotted) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
+func (n *NestDotted) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	val := &args[len(args)-1]
 	b, typ, err := n.lookupBuilderAndType(zed.TypeRecordOf(val.Type()))
 	if err != nil {
-		return wrapError(n.zctx, ctx, "nest_dotted(): "+err.Error(), val)
+		return *n.zctx.WrapError("nest_dotted(): "+err.Error(), val)
 	}
 	if b == nil {
-		return val
+		return *val
 	}
 	b.Reset()
 	for it := val.Bytes().Iter(); !it.Done(); {
@@ -72,5 +72,5 @@ func (n *NestDotted) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if err != nil {
 		panic(err)
 	}
-	return ctx.NewValue(typ, zbytes)
+	return *zed.NewValue(typ, zbytes)
 }

--- a/runtime/expr/function/parse.go
+++ b/runtime/expr/function/parse.go
@@ -16,15 +16,15 @@ type ParseURI struct {
 	marshaler *zson.MarshalZNGContext
 }
 
-func (p *ParseURI) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
+func (p *ParseURI) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	in := args[0]
 	if !in.IsString() || in.IsNull() {
-		return wrapError(p.zctx, ctx, "parse_uri: non-empty string arg required", &in)
+		return *p.zctx.WrapError("parse_uri: non-empty string arg required", &in)
 	}
 	s := zed.DecodeString(in.Bytes())
 	u, err := url.Parse(s)
 	if err != nil {
-		return wrapError(p.zctx, ctx, "parse_uri: "+err.Error(), &in)
+		return *p.zctx.WrapError("parse_uri: "+err.Error(), &in)
 	}
 	var v struct {
 		Scheme   *string    `zed:"scheme"`
@@ -55,7 +55,7 @@ func (p *ParseURI) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if portString := u.Port(); portString != "" {
 		u64, err := strconv.ParseUint(portString, 10, 16)
 		if err != nil {
-			return wrapError(p.zctx, ctx, "parse_uri: invalid port: "+portString, &in)
+			return *p.zctx.WrapError("parse_uri: invalid port: "+portString, &in)
 		}
 		u16 := uint16(u64)
 		v.Port = &u16
@@ -73,7 +73,7 @@ func (p *ParseURI) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if err != nil {
 		panic(err)
 	}
-	return ctx.CopyValue(*out)
+	return *out
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#parse_zson
@@ -88,21 +88,21 @@ func newParseZSON(zctx *zed.Context) *ParseZSON {
 	return &ParseZSON{zctx, &sr, zsonio.NewReader(zctx, &sr)}
 }
 
-func (p *ParseZSON) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
+func (p *ParseZSON) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	in := args[0]
 	if !in.IsString() {
-		return wrapError(p.zctx, ctx, "parse_zson: string arg required", &in)
+		return *p.zctx.WrapError("parse_zson: string arg required", &in)
 	}
 	if in.IsNull() {
-		return zed.Null
+		return *zed.Null
 	}
 	p.sr.Reset(zed.DecodeString(in.Bytes()))
 	val, err := p.zr.Read()
 	if err != nil {
-		return wrapError(p.zctx, ctx, "parse_zson: "+err.Error(), &in)
+		return *p.zctx.WrapError("parse_zson: "+err.Error(), &in)
 	}
 	if val == nil {
-		return zed.Null
+		return *zed.Null
 	}
-	return ctx.CopyValue(*val)
+	return *val
 }

--- a/runtime/expr/function/regexp.go
+++ b/runtime/expr/function/regexp.go
@@ -17,9 +17,9 @@ type Regexp struct {
 	zctx    *zed.Context
 }
 
-func (r *Regexp) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
+func (r *Regexp) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	if !args[0].IsString() {
-		return wrapError(r.zctx, ctx, "regexp: string required for first arg", &args[0])
+		return *r.zctx.WrapError("regexp: string required for first arg", &args[0])
 	}
 	s := zed.DecodeString(args[0].Bytes())
 	if r.restr != s {
@@ -27,10 +27,10 @@ func (r *Regexp) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		r.re, r.err = regexp.Compile(r.restr)
 	}
 	if r.err != nil {
-		return newErrorf(r.zctx, ctx, "regexp: %s", r.err)
+		return *r.zctx.NewErrorf("regexp: %s", r.err)
 	}
 	if !args[1].IsString() {
-		return wrapError(r.zctx, ctx, "regexp: string required for second arg", &args[1])
+		return *r.zctx.WrapError("regexp: string required for second arg", &args[1])
 	}
 	r.builder.Reset()
 	for _, b := range r.re.FindSubmatch(args[1].Bytes()) {
@@ -39,7 +39,7 @@ func (r *Regexp) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	if r.typ == nil {
 		r.typ = r.zctx.LookupTypeArray(zed.TypeString)
 	}
-	return ctx.NewValue(r.typ, r.builder.Bytes())
+	return *zed.NewValue(r.typ, r.builder.Bytes())
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#regexp_replace
@@ -50,27 +50,27 @@ type RegexpReplace struct {
 	err   error
 }
 
-func (r *RegexpReplace) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
+func (r *RegexpReplace) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	sVal := args[0]
 	reVal := args[1]
 	newVal := args[2]
 	for i := range args {
 		if !args[i].IsString() {
-			return wrapError(r.zctx, ctx, "regexp_replace: string arg required", &args[i])
+			return *r.zctx.WrapError("regexp_replace: string arg required", &args[i])
 		}
 	}
 	if sVal.IsNull() {
-		return zed.Null
+		return *zed.Null
 	}
 	if reVal.IsNull() || newVal.IsNull() {
-		return newErrorf(r.zctx, ctx, "regexp_replace: 2nd and 3rd args cannot be null")
+		return *r.zctx.NewErrorf("regexp_replace: 2nd and 3rd args cannot be null")
 	}
 	if re := zed.DecodeString(reVal.Bytes()); r.restr != re {
 		r.restr = re
 		r.re, r.err = regexp.Compile(re)
 	}
 	if r.err != nil {
-		return newErrorf(r.zctx, ctx, "regexp_replace: %s", r.err)
+		return *r.zctx.NewErrorf("regexp_replace: %s", r.err)
 	}
-	return ctx.NewValue(zed.TypeString, r.re.ReplaceAll(sVal.Bytes(), newVal.Bytes()))
+	return *zed.NewString(string(r.re.ReplaceAll(sVal.Bytes(), newVal.Bytes())))
 }

--- a/runtime/expr/function/string.go
+++ b/runtime/expr/function/string.go
@@ -14,25 +14,25 @@ type Replace struct {
 	zctx *zed.Context
 }
 
-func (r *Replace) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
+func (r *Replace) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	sVal := args[0]
 	oldVal := args[1]
 	newVal := args[2]
 	for i := range args {
 		if !args[i].IsString() {
-			return wrapError(r.zctx, ctx, "replace: string arg required", &args[i])
+			return *r.zctx.WrapError("replace: string arg required", &args[i])
 		}
 	}
 	if sVal.IsNull() {
-		return zed.Null
+		return *zed.Null
 	}
 	if oldVal.IsNull() || newVal.IsNull() {
-		return newErrorf(r.zctx, ctx, "replace: an input arg is null")
+		return *r.zctx.NewErrorf("replace: an input arg is null")
 	}
 	s := zed.DecodeString(sVal.Bytes())
 	old := zed.DecodeString(oldVal.Bytes())
 	new := zed.DecodeString(newVal.Bytes())
-	return newString(ctx, strings.ReplaceAll(s, old, new))
+	return *zed.NewString(strings.ReplaceAll(s, old, new))
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#run_len
@@ -40,16 +40,16 @@ type RuneLen struct {
 	zctx *zed.Context
 }
 
-func (r *RuneLen) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
+func (r *RuneLen) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	val := args[0]
 	if !val.IsString() {
-		return wrapError(r.zctx, ctx, "rune_len: string arg required", &val)
+		return *r.zctx.WrapError("rune_len: string arg required", &val)
 	}
 	if val.IsNull() {
-		return ctx.CopyValue(*zed.NewInt64(0))
+		return *zed.NewInt64(0)
 	}
 	s := zed.DecodeString(val.Bytes())
-	return ctx.CopyValue(*zed.NewInt64(int64(utf8.RuneCountInString(s))))
+	return *zed.NewInt64(int64(utf8.RuneCountInString(s)))
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#lower
@@ -57,16 +57,16 @@ type ToLower struct {
 	zctx *zed.Context
 }
 
-func (t *ToLower) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
+func (t *ToLower) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	val := args[0]
 	if !val.IsString() {
-		return wrapError(t.zctx, ctx, "lower: string arg required", &val)
+		return *t.zctx.WrapError("lower: string arg required", &val)
 	}
 	if val.IsNull() {
-		return zed.NullString
+		return *zed.NullString
 	}
 	s := zed.DecodeString(val.Bytes())
-	return newString(ctx, strings.ToLower(s))
+	return *zed.NewString(strings.ToLower(s))
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#upper
@@ -74,16 +74,16 @@ type ToUpper struct {
 	zctx *zed.Context
 }
 
-func (t *ToUpper) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
+func (t *ToUpper) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	val := args[0]
 	if !val.IsString() {
-		return wrapError(t.zctx, ctx, "upper: string arg required", &val)
+		return *t.zctx.WrapError("upper: string arg required", &val)
 	}
 	if val.IsNull() {
-		return zed.NullString
+		return *zed.NullString
 	}
 	s := zed.DecodeString(val.Bytes())
-	return newString(ctx, strings.ToUpper(s))
+	return *zed.NewString(strings.ToUpper(s))
 }
 
 type Trim struct {
@@ -91,16 +91,16 @@ type Trim struct {
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#trim
-func (t *Trim) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
+func (t *Trim) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	val := args[0]
 	if !val.IsString() {
-		return wrapError(t.zctx, ctx, "trim: string arg required", &val)
+		return *t.zctx.WrapError("trim: string arg required", &val)
 	}
 	if val.IsNull() {
-		return zed.NullString
+		return *zed.NullString
 	}
 	s := zed.DecodeString(val.Bytes())
-	return newString(ctx, strings.TrimSpace(s))
+	return *zed.NewString(strings.TrimSpace(s))
 }
 
 // // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#split
@@ -116,16 +116,16 @@ func newSplit(zctx *zed.Context) *Split {
 	}
 }
 
-func (s *Split) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
+func (s *Split) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	sVal := args[0]
 	sepVal := args[1]
 	for i := range args {
 		if !args[i].IsString() {
-			return wrapError(s.zctx, ctx, "split: string arg required", &args[i])
+			return *s.zctx.WrapError("split: string arg required", &args[i])
 		}
 	}
 	if sVal.IsNull() || sepVal.IsNull() {
-		return ctx.NewValue(s.typ, nil)
+		return *zed.NewValue(s.typ, nil)
 	}
 	str := zed.DecodeString(sVal.Bytes())
 	sep := zed.DecodeString(sepVal.Bytes())
@@ -134,7 +134,7 @@ func (s *Split) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 	for _, substr := range splits {
 		b = zcode.Append(b, zed.EncodeString(substr))
 	}
-	return ctx.NewValue(s.typ, b)
+	return *zed.NewValue(s.typ, b)
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#join
@@ -143,17 +143,17 @@ type Join struct {
 	builder strings.Builder
 }
 
-func (j *Join) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
+func (j *Join) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	splitsVal := args[0]
 	typ, ok := zed.TypeUnder(splitsVal.Type()).(*zed.TypeArray)
 	if !ok || typ.Type.ID() != zed.IDString {
-		return wrapError(j.zctx, ctx, "join: array of string args required", &splitsVal)
+		return *j.zctx.WrapError("join: array of string args required", &splitsVal)
 	}
 	var separator string
 	if len(args) == 2 {
 		sepVal := args[1]
 		if !sepVal.IsString() {
-			return wrapError(j.zctx, ctx, "join: separator must be string", &sepVal)
+			return *j.zctx.WrapError("join: separator must be string", &sepVal)
 		}
 		separator = zed.DecodeString(sepVal.Bytes())
 	}
@@ -166,7 +166,7 @@ func (j *Join) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		b.WriteString(zed.DecodeString(it.Next()))
 		sep = separator
 	}
-	return newString(ctx, b.String())
+	return *zed.NewString(b.String())
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#levenshtein
@@ -174,14 +174,14 @@ type Levenshtein struct {
 	zctx *zed.Context
 }
 
-func (l *Levenshtein) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
+func (l *Levenshtein) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	a, b := &args[0], &args[1]
 	if !a.IsString() {
-		return l.zctx.WrapError("levenshtein: string args required", a)
+		return *l.zctx.WrapError("levenshtein: string args required", a)
 	}
 	if !b.IsString() {
-		return l.zctx.WrapError("levenshtein: string args required", b)
+		return *l.zctx.WrapError("levenshtein: string args required", b)
 	}
 	as, bs := zed.DecodeString(a.Bytes()), zed.DecodeString(b.Bytes())
-	return ctx.CopyValue(*zed.NewInt64(int64(levenshtein.ComputeDistance(as, bs))))
+	return *zed.NewInt64(int64(levenshtein.ComputeDistance(as, bs)))
 }

--- a/runtime/expr/function/under.go
+++ b/runtime/expr/function/under.go
@@ -9,22 +9,22 @@ type Under struct {
 	zctx *zed.Context
 }
 
-func (u *Under) Call(ectx zed.Allocator, args []zed.Value) *zed.Value {
+func (u *Under) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	val := args[0]
 	switch typ := args[0].Type().(type) {
 	case *zed.TypeNamed:
-		return ectx.NewValue(typ.Type, val.Bytes())
+		return *zed.NewValue(typ.Type, val.Bytes())
 	case *zed.TypeError:
-		return ectx.NewValue(typ.Type, val.Bytes())
+		return *zed.NewValue(typ.Type, val.Bytes())
 	case *zed.TypeUnion:
-		return ectx.NewValue(typ.Untag(val.Bytes()))
+		return *zed.NewValue(typ.Untag(val.Bytes()))
 	case *zed.TypeOfType:
 		t, err := u.zctx.LookupByValue(val.Bytes())
 		if err != nil {
-			return newError(u.zctx, ectx, err)
+			return *u.zctx.NewError(err)
 		}
-		return u.zctx.LookupTypeValue(zed.TypeUnder(t))
+		return *u.zctx.LookupTypeValue(zed.TypeUnder(t))
 	default:
-		return &args[0]
+		return val
 	}
 }

--- a/runtime/expr/function/unflatten.go
+++ b/runtime/expr/function/unflatten.go
@@ -28,11 +28,11 @@ func NewUnflatten(zctx *zed.Context) *Unflatten {
 	}
 }
 
-func (u *Unflatten) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
+func (u *Unflatten) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	val := args[0]
 	array, ok := zed.TypeUnder(val.Type()).(*zed.TypeArray)
 	if !ok {
-		return &val
+		return val
 	}
 	u.recordCache.reset()
 	root := u.recordCache.new()
@@ -42,7 +42,7 @@ func (u *Unflatten) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		bytes := it.Next()
 		path, typ, vb, err := u.parseElem(array.Type, bytes)
 		if err != nil {
-			return u.zctx.WrapError(err.Error(), ctx.NewValue(array.Type, bytes))
+			return *u.zctx.WrapError(err.Error(), zed.NewValue(array.Type, bytes))
 		}
 		if typ == nil {
 			continue
@@ -62,9 +62,9 @@ func (u *Unflatten) Call(ctx zed.Allocator, args []zed.Value) *zed.Value {
 		return typ, value
 	})
 	if err != nil {
-		return u.zctx.WrapError(err.Error(), &val)
+		return *u.zctx.WrapError(err.Error(), &val)
 	}
-	return ctx.NewValue(typ, u.builder.Bytes())
+	return *zed.NewValue(typ, u.builder.Bytes())
 }
 
 func (u *Unflatten) parseElem(inner zed.Type, vb zcode.Bytes) (field.Path, zed.Type, zcode.Bytes, error) {

--- a/runtime/expr/udf.go
+++ b/runtime/expr/udf.go
@@ -12,7 +12,7 @@ type UDF struct {
 	Body Evaluator
 }
 
-func (u *UDF) Call(ectx zed.Allocator, args []zed.Value) *zed.Value {
+func (u *UDF) Call(ectx zed.Allocator, args []zed.Value) zed.Value {
 	stack := 1
 	if f, ok := ectx.(*frame); ok {
 		stack += f.stack
@@ -24,7 +24,7 @@ func (u *UDF) Call(ectx zed.Allocator, args []zed.Value) *zed.Value {
 	// recursive calls.
 	f := &frame{stack: stack, vars: slices.Clone(args)}
 	defer f.exit()
-	return u.Body.Eval(f, zed.Null)
+	return *u.Body.Eval(f, zed.Null)
 }
 
 type frame struct {

--- a/value.go
+++ b/value.go
@@ -89,7 +89,7 @@ func NewFloat32(f float32) *Value        { return newNativeValue(TypeFloat32, ma
 func NewFloat64(f float64) *Value        { return newNativeValue(TypeFloat64, math.Float64bits(f)) }
 func NewBool(b bool) *Value              { return newNativeValue(TypeBool, boolToUint64(b)) }
 func NewBytes(b []byte) *Value           { return NewValue(TypeBytes, b) }
-func NewString(s string) *Value          { return &Value{TypeString, unsafe.StringData(s), uint64(len(s))} }
+func NewString(s string) *Value          { return &Value{TypeString, nonNilUnsafeStringData(s), uint64(len(s))} }
 func NewIP(a netip.Addr) *Value          { return NewValue(TypeIP, EncodeIP(a)) }
 func NewNet(p netip.Prefix) *Value       { return NewValue(TypeNet, EncodeNet(p)) }
 func NewTypeValue(t Type) *Value         { return NewValue(TypeNet, EncodeTypeValue(t)) }
@@ -99,6 +99,14 @@ func boolToUint64(b bool) uint64 {
 		return 1
 	}
 	return 0
+}
+
+// nonNilUsafeStringData is like unsafe.StringData but never returns nil.
+func nonNilUnsafeStringData(s string) *byte {
+	if d := unsafe.StringData(s); d != nil {
+		return d
+	}
+	return unsafe.SliceData([]byte{})
 }
 
 // Uint returns v's underlying value.  It panics if v's underlying type is not

--- a/value_test.go
+++ b/value_test.go
@@ -8,6 +8,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestNewStringNotNull(t *testing.T) {
+	assert.NotNil(t, zed.NewString("").Bytes())
+}
+
 func BenchmarkValueUnder(b *testing.B) {
 	var tmpVal zed.Value
 	b.Run("primitive", func(b *testing.B) {


### PR DESCRIPTION
Call returns a *zed.Value.  Change that to a zed.Value, which fits better with planned changes to memory management (and seems to be a little faster, possibly because it elimintes calls to zed.Allocator methods).

Depends on #4966.