### PR TITLE
Change runtime/expr/agg.Function to call and return by value

### DIFF
--- a/runtime/expr/agg.go
+++ b/runtime/expr/agg.go
@@ -41,7 +41,7 @@ func (a *Aggregator) Apply(zctx *zed.Context, ectx Context, f agg.Function, this
 	}
 	v := a.expr.Eval(ectx, this)
 	if !v.IsMissing() {
-		f.Consume(v)
+		f.Consume(*v)
 	}
 }
 
@@ -66,5 +66,5 @@ func (s *aggregatorExpr) Eval(ectx Context, val *zed.Value) *zed.Value {
 		s.zctx = zed.NewContext() //XXX
 	}
 	s.agg.Apply(s.zctx, ectx, s.fn, val)
-	return s.fn.Result(s.zctx)
+	return ectx.CopyValue(s.fn.Result(s.zctx))
 }

--- a/runtime/expr/agg/agg.go
+++ b/runtime/expr/agg/agg.go
@@ -17,10 +17,10 @@ var MaxValueSize = 1024 * 1024 * 1024
 type Pattern func() Function
 
 type Function interface {
-	Consume(*zed.Value)
-	ConsumeAsPartial(*zed.Value)
-	Result(*zed.Context) *zed.Value
-	ResultAsPartial(*zed.Context) *zed.Value
+	Consume(zed.Value)
+	ConsumeAsPartial(zed.Value)
+	Result(*zed.Context) zed.Value
+	ResultAsPartial(*zed.Context) zed.Value
 }
 
 func NewPattern(op string, hasarg bool) (Pattern, error) {

--- a/runtime/expr/agg/any.go
+++ b/runtime/expr/agg/any.go
@@ -12,7 +12,7 @@ func NewAny() *Any {
 	return (*Any)(zed.NewValue(zed.TypeNull, nil))
 }
 
-func (a *Any) Consume(val *zed.Value) {
+func (a *Any) Consume(val zed.Value) {
 	// Copy any value from the input while favoring any-typed non-null values
 	// over null values.
 	if (*zed.Value)(a).Type() == nil || (*zed.Value)(a).IsNull() && !val.IsNull() {
@@ -20,17 +20,17 @@ func (a *Any) Consume(val *zed.Value) {
 	}
 }
 
-func (a *Any) Result(*zed.Context) *zed.Value {
+func (a *Any) Result(*zed.Context) zed.Value {
 	if (*zed.Value)(a).Type() == nil {
-		return zed.Null
+		return *zed.Null
 	}
-	return (*zed.Value)(a)
+	return *(*zed.Value)(a)
 }
 
-func (a *Any) ConsumeAsPartial(v *zed.Value) {
+func (a *Any) ConsumeAsPartial(v zed.Value) {
 	a.Consume(v)
 }
 
-func (a *Any) ResultAsPartial(*zed.Context) *zed.Value {
+func (a *Any) ResultAsPartial(*zed.Context) zed.Value {
 	return a.Result(nil)
 }

--- a/runtime/expr/agg/avg.go
+++ b/runtime/expr/agg/avg.go
@@ -17,21 +17,21 @@ type Avg struct {
 
 var _ Function = (*Avg)(nil)
 
-func (a *Avg) Consume(val *zed.Value) {
+func (a *Avg) Consume(val zed.Value) {
 	if val.IsNull() {
 		return
 	}
-	if d, ok := coerce.ToFloat(val); ok {
+	if d, ok := coerce.ToFloat(&val); ok {
 		a.sum += float64(d)
 		a.count++
 	}
 }
 
-func (a *Avg) Result(*zed.Context) *zed.Value {
+func (a *Avg) Result(*zed.Context) zed.Value {
 	if a.count > 0 {
-		return zed.NewFloat64(a.sum / float64(a.count))
+		return *zed.NewFloat64(a.sum / float64(a.count))
 	}
-	return zed.NullFloat64
+	return *zed.NullFloat64
 }
 
 const (
@@ -39,7 +39,7 @@ const (
 	countName = "count"
 )
 
-func (a *Avg) ConsumeAsPartial(partial *zed.Value) {
+func (a *Avg) ConsumeAsPartial(partial zed.Value) {
 	sumVal := partial.Deref(sumName)
 	if sumVal == nil {
 		panic(errors.New("avg: partial sum is missing"))
@@ -58,7 +58,7 @@ func (a *Avg) ConsumeAsPartial(partial *zed.Value) {
 	a.count += countVal.Uint()
 }
 
-func (a *Avg) ResultAsPartial(zctx *zed.Context) *zed.Value {
+func (a *Avg) ResultAsPartial(zctx *zed.Context) zed.Value {
 	var zv zcode.Bytes
 	zv = zed.NewFloat64(a.sum).Encode(zv)
 	zv = zed.NewUint64(a.count).Encode(zv)
@@ -66,5 +66,5 @@ func (a *Avg) ResultAsPartial(zctx *zed.Context) *zed.Value {
 		zed.NewField(sumName, zed.TypeFloat64),
 		zed.NewField(countName, zed.TypeUint64),
 	})
-	return zed.NewValue(typ, zv)
+	return *zed.NewValue(typ, zv)
 }

--- a/runtime/expr/agg/collect.go
+++ b/runtime/expr/agg/collect.go
@@ -15,13 +15,13 @@ type Collect struct {
 
 var _ Function = (*Collect)(nil)
 
-func (c *Collect) Consume(val *zed.Value) {
+func (c *Collect) Consume(val zed.Value) {
 	if !val.IsNull() {
 		c.update(val)
 	}
 }
 
-func (c *Collect) update(val *zed.Value) {
+func (c *Collect) update(val zed.Value) {
 	c.values = append(c.values, *val.Under(&zed.Value{}).Copy())
 	c.size += len(val.Bytes())
 	for c.size > MaxValueSize {
@@ -33,10 +33,10 @@ func (c *Collect) update(val *zed.Value) {
 	}
 }
 
-func (c *Collect) Result(zctx *zed.Context) *zed.Value {
+func (c *Collect) Result(zctx *zed.Context) zed.Value {
 	if len(c.values) == 0 {
 		// no values found
-		return zed.Null
+		return *zed.Null
 	}
 	var b zcode.Builder
 	inner := innerType(zctx, c.values)
@@ -49,7 +49,7 @@ func (c *Collect) Result(zctx *zed.Context) *zed.Value {
 			b.Append(val.Bytes())
 		}
 	}
-	return zed.NewValue(zctx.LookupTypeArray(inner), b.Bytes())
+	return *zed.NewValue(zctx.LookupTypeArray(inner), b.Bytes())
 }
 
 func innerType(zctx *zed.Context, vals []zed.Value) zed.Type {
@@ -64,21 +64,21 @@ func innerType(zctx *zed.Context, vals []zed.Value) zed.Type {
 	return zctx.LookupTypeUnion(types)
 }
 
-func (c *Collect) ConsumeAsPartial(val *zed.Value) {
+func (c *Collect) ConsumeAsPartial(val zed.Value) {
 	//XXX These should not be passed in here. See issue #3175
 	if len(val.Bytes()) == 0 {
 		return
 	}
 	arrayType, ok := val.Type().(*zed.TypeArray)
 	if !ok {
-		panic(fmt.Errorf("collect partial: partial not an array type: %s", zson.FormatValue(val)))
+		panic(fmt.Errorf("collect partial: partial not an array type: %s", zson.FormatValue(&val)))
 	}
 	typ := arrayType.Type
 	for it := val.Iter(); !it.Done(); {
-		c.update(zed.NewValue(typ, it.Next()))
+		c.update(*zed.NewValue(typ, it.Next()))
 	}
 }
 
-func (c *Collect) ResultAsPartial(zctx *zed.Context) *zed.Value {
+func (c *Collect) ResultAsPartial(zctx *zed.Context) zed.Value {
 	return c.Result(zctx)
 }

--- a/runtime/expr/agg/collectmap.go
+++ b/runtime/expr/agg/collectmap.go
@@ -19,11 +19,11 @@ func newCollectMap() *CollectMap {
 var _ Function = (*Collect)(nil)
 
 type mapEntry struct {
-	key *zed.Value
-	val *zed.Value
+	key zed.Value
+	val zed.Value
 }
 
-func (c *CollectMap) Consume(val *zed.Value) {
+func (c *CollectMap) Consume(val zed.Value) {
 	if val.IsNull() {
 		return
 	}
@@ -44,13 +44,13 @@ func (c *CollectMap) Consume(val *zed.Value) {
 	}
 }
 
-func (c *CollectMap) ConsumeAsPartial(val *zed.Value) {
+func (c *CollectMap) ConsumeAsPartial(val zed.Value) {
 	c.Consume(val)
 }
 
-func (c *CollectMap) Result(zctx *zed.Context) *zed.Value {
+func (c *CollectMap) Result(zctx *zed.Context) zed.Value {
 	if len(c.entries) == 0 {
-		return zed.Null
+		return *zed.Null
 	}
 	var ktypes, vtypes []zed.Type
 	for _, e := range c.entries {
@@ -69,14 +69,14 @@ func (c *CollectMap) Result(zctx *zed.Context) *zed.Value {
 	}
 	typ := zctx.LookupTypeMap(ktyp, vtyp)
 	b := zed.NormalizeMap(builder.Bytes())
-	return zed.NewValue(typ, b)
+	return *zed.NewValue(typ, b)
 }
 
-func (c *CollectMap) ResultAsPartial(zctx *zed.Context) *zed.Value {
+func (c *CollectMap) ResultAsPartial(zctx *zed.Context) zed.Value {
 	return c.Result(zctx)
 }
 
-func appendMapVal(b *zcode.Builder, typ zed.Type, val *zed.Value, uniq int) {
+func appendMapVal(b *zcode.Builder, typ zed.Type, val zed.Value, uniq int) {
 	if uniq > 1 {
 		u := zed.TypeUnder(typ).(*zed.TypeUnion)
 		zed.BuildUnion(b, u.TagOf(val.Type()), val.Bytes())
@@ -94,10 +94,10 @@ func unionOf(zctx *zed.Context, types []zed.Type) (zed.Type, int) {
 }
 
 // valueUnder is like zed.(*Value).Under but it preserves non-union named types.
-func valueUnder(typ zed.Type, b zcode.Bytes) *zed.Value {
-	val := zed.NewValue(typ, b)
+func valueUnder(typ zed.Type, b zcode.Bytes) zed.Value {
+	val := *zed.NewValue(typ, b)
 	if _, ok := zed.TypeUnder(typ).(*zed.TypeUnion); !ok {
 		return val
 	}
-	return val.Under(val)
+	return *val.Under(&val)
 }

--- a/runtime/expr/agg/count.go
+++ b/runtime/expr/agg/count.go
@@ -8,21 +8,21 @@ type Count uint64
 
 var _ Function = (*Count)(nil)
 
-func (c *Count) Consume(*zed.Value) {
+func (c *Count) Consume(zed.Value) {
 	*c++
 }
 
-func (c Count) Result(*zed.Context) *zed.Value {
-	return zed.NewUint64(uint64(c))
+func (c Count) Result(*zed.Context) zed.Value {
+	return *zed.NewUint64(uint64(c))
 }
 
-func (c *Count) ConsumeAsPartial(partial *zed.Value) {
+func (c *Count) ConsumeAsPartial(partial zed.Value) {
 	if partial.Type() != zed.TypeUint64 {
 		panic("count: partial not uint64")
 	}
 	*c += Count(partial.Uint())
 }
 
-func (c Count) ResultAsPartial(*zed.Context) *zed.Value {
+func (c Count) ResultAsPartial(*zed.Context) zed.Value {
 	return c.Result(nil)
 }

--- a/runtime/expr/agg/dcount.go
+++ b/runtime/expr/agg/dcount.go
@@ -24,7 +24,7 @@ func NewDCount() *DCount {
 	}
 }
 
-func (d *DCount) Consume(val *zed.Value) {
+func (d *DCount) Consume(val zed.Value) {
 	d.scratch = d.scratch[:0]
 	// append type id to vals so we get a unique count where the bytes are same
 	// but the zed.Type is different.
@@ -33,13 +33,13 @@ func (d *DCount) Consume(val *zed.Value) {
 	d.sketch.Insert(d.scratch)
 }
 
-func (d *DCount) Result(*zed.Context) *zed.Value {
-	return zed.NewUint64(d.sketch.Estimate())
+func (d *DCount) Result(*zed.Context) zed.Value {
+	return *zed.NewUint64(d.sketch.Estimate())
 }
 
-func (d *DCount) ConsumeAsPartial(partial *zed.Value) {
+func (d *DCount) ConsumeAsPartial(partial zed.Value) {
 	if partial.Type() != zed.TypeBytes {
-		panic(fmt.Errorf("dcount: partial has bad type: %s", zson.FormatValue(partial)))
+		panic(fmt.Errorf("dcount: partial has bad type: %s", zson.FormatValue(&partial)))
 	}
 	var s hyperloglog.Sketch
 	if err := s.UnmarshalBinary(partial.Bytes()); err != nil {
@@ -48,10 +48,10 @@ func (d *DCount) ConsumeAsPartial(partial *zed.Value) {
 	d.sketch.Merge(&s)
 }
 
-func (d *DCount) ResultAsPartial(zctx *zed.Context) *zed.Value {
+func (d *DCount) ResultAsPartial(zctx *zed.Context) zed.Value {
 	b, err := d.sketch.MarshalBinary()
 	if err != nil {
 		panic(fmt.Errorf("dcount: marshaling partial: %w", err))
 	}
-	return zed.NewBytes(b)
+	return *zed.NewBytes(b)
 }

--- a/runtime/expr/agg/fuse.go
+++ b/runtime/expr/agg/fuse.go
@@ -19,15 +19,15 @@ func newFuse() *fuse {
 	}
 }
 
-func (f *fuse) Consume(val *zed.Value) {
+func (f *fuse) Consume(val zed.Value) {
 	if _, ok := f.shapes[val.Type()]; !ok {
 		f.shapes[val.Type()] = len(f.shapes)
 	}
 }
 
-func (f *fuse) Result(zctx *zed.Context) *zed.Value {
+func (f *fuse) Result(zctx *zed.Context) zed.Value {
 	if len(f.shapes)+len(f.partials) == 0 {
-		return zed.NullType
+		return *zed.NullType
 	}
 	schema := NewSchema(zctx)
 	for _, p := range f.partials {
@@ -44,16 +44,16 @@ func (f *fuse) Result(zctx *zed.Context) *zed.Value {
 	for _, typ := range shapes {
 		schema.Mixin(typ)
 	}
-	return zctx.LookupTypeValue(schema.Type())
+	return *zctx.LookupTypeValue(schema.Type())
 }
 
-func (f *fuse) ConsumeAsPartial(partial *zed.Value) {
+func (f *fuse) ConsumeAsPartial(partial zed.Value) {
 	if partial.Type() != zed.TypeType {
 		panic("fuse: partial not a type value")
 	}
 	f.partials = append(f.partials, *partial.Copy())
 }
 
-func (f *fuse) ResultAsPartial(zctx *zed.Context) *zed.Value {
+func (f *fuse) ResultAsPartial(zctx *zed.Context) zed.Value {
 	return f.Result(zctx)
 }

--- a/runtime/expr/agg/logical.go
+++ b/runtime/expr/agg/logical.go
@@ -10,7 +10,7 @@ type And struct {
 
 var _ Function = (*And)(nil)
 
-func (a *And) Consume(val *zed.Value) {
+func (a *And) Consume(val zed.Value) {
 	if val.IsNull() || zed.TypeUnder(val.Type()) != zed.TypeBool {
 		return
 	}
@@ -21,24 +21,21 @@ func (a *And) Consume(val *zed.Value) {
 	*a.val = *a.val && val.Bool()
 }
 
-func (a *And) Result(*zed.Context) *zed.Value {
+func (a *And) Result(*zed.Context) zed.Value {
 	if a.val == nil {
-		return zed.NullBool
+		return *zed.NullBool
 	}
-	if *a.val {
-		return zed.True
-	}
-	return zed.False
+	return *zed.NewBool(*a.val)
 }
 
-func (a *And) ConsumeAsPartial(val *zed.Value) {
+func (a *And) ConsumeAsPartial(val zed.Value) {
 	if val.Type() != zed.TypeBool {
 		panic("and: partial not a bool")
 	}
 	a.Consume(val)
 }
 
-func (a *And) ResultAsPartial(*zed.Context) *zed.Value {
+func (a *And) ResultAsPartial(*zed.Context) zed.Value {
 	return a.Result(nil)
 }
 
@@ -48,7 +45,7 @@ type Or struct {
 
 var _ Function = (*Or)(nil)
 
-func (o *Or) Consume(val *zed.Value) {
+func (o *Or) Consume(val zed.Value) {
 	if val.IsNull() || zed.TypeUnder(val.Type()) != zed.TypeBool {
 		return
 	}
@@ -59,23 +56,20 @@ func (o *Or) Consume(val *zed.Value) {
 	*o.val = *o.val || val.Bool()
 }
 
-func (o *Or) Result(*zed.Context) *zed.Value {
+func (o *Or) Result(*zed.Context) zed.Value {
 	if o.val == nil {
-		return zed.NullBool
+		return *zed.NullBool
 	}
-	if *o.val {
-		return zed.True
-	}
-	return zed.False
+	return *zed.NewBool(*o.val)
 }
 
-func (o *Or) ConsumeAsPartial(val *zed.Value) {
+func (o *Or) ConsumeAsPartial(val zed.Value) {
 	if val.Type() != zed.TypeBool {
 		panic("or: partial not a bool")
 	}
 	o.Consume(val)
 }
 
-func (o *Or) ResultAsPartial(*zed.Context) *zed.Value {
+func (o *Or) ResultAsPartial(*zed.Context) zed.Value {
 	return o.Result(nil)
 }

--- a/runtime/expr/agg/math.go
+++ b/runtime/expr/agg/math.go
@@ -11,8 +11,8 @@ import (
 )
 
 type consumer interface {
-	result() *zed.Value
-	consume(*zed.Value)
+	result() zed.Value
+	consume(zed.Value)
 	typ() zed.Type
 }
 
@@ -29,28 +29,28 @@ func newMathReducer(f *anymath.Function) *mathReducer {
 	return &mathReducer{function: f}
 }
 
-func (m *mathReducer) Result(zctx *zed.Context) *zed.Value {
+func (m *mathReducer) Result(zctx *zed.Context) zed.Value {
 	if !m.hasval {
 		if m.math == nil {
-			return zed.Null
+			return *zed.Null
 		}
-		return zed.NewValue(m.math.typ(), nil)
+		return *zed.NewValue(m.math.typ(), nil)
 	}
 	return m.math.result()
 }
 
-func (m *mathReducer) Consume(val *zed.Value) {
+func (m *mathReducer) Consume(val zed.Value) {
 	m.consumeVal(val)
 }
 
-func (m *mathReducer) consumeVal(val *zed.Value) {
+func (m *mathReducer) consumeVal(val zed.Value) {
 	var id int
 	if m.math != nil {
 		var err error
 		// XXX We're not using the value coercion parts of coerce.Pair here.
 		// Would be better if coerce had a function that just compared types
 		// and returned the type to coerce to.
-		id, err = m.pair.Coerce(zed.NewValue(m.math.typ(), nil), val)
+		id, err = m.pair.Coerce(zed.NewValue(m.math.typ(), nil), &val)
 		if err != nil {
 			// Skip invalid values.
 			return
@@ -59,7 +59,7 @@ func (m *mathReducer) consumeVal(val *zed.Value) {
 		id = val.Type().ID()
 	}
 	if m.math == nil || m.math.typ().ID() != id {
-		state := zed.Null
+		state := *zed.Null
 		if m.math != nil {
 			state = m.math.result()
 		}
@@ -86,11 +86,11 @@ func (m *mathReducer) consumeVal(val *zed.Value) {
 	m.math.consume(val)
 }
 
-func (m *mathReducer) ResultAsPartial(*zed.Context) *zed.Value {
+func (m *mathReducer) ResultAsPartial(*zed.Context) zed.Value {
 	return m.Result(nil)
 }
 
-func (m *mathReducer) ConsumeAsPartial(val *zed.Value) {
+func (m *mathReducer) ConsumeAsPartial(val zed.Value) {
 	m.consumeVal(val)
 }
 
@@ -99,11 +99,11 @@ type Float64 struct {
 	function anymath.Float64
 }
 
-func NewFloat64(f *anymath.Function, val *zed.Value) *Float64 {
+func NewFloat64(f *anymath.Function, val zed.Value) *Float64 {
 	state := f.Init.Float64
 	if !val.IsNull() {
 		var ok bool
-		state, ok = coerce.ToFloat(val)
+		state, ok = coerce.ToFloat(&val)
 		if !ok {
 			panicCoercionFail(zed.TypeFloat64, val.Type())
 		}
@@ -114,12 +114,12 @@ func NewFloat64(f *anymath.Function, val *zed.Value) *Float64 {
 	}
 }
 
-func (f *Float64) result() *zed.Value {
-	return zed.NewFloat64(f.state)
+func (f *Float64) result() zed.Value {
+	return *zed.NewFloat64(f.state)
 }
 
-func (f *Float64) consume(val *zed.Value) {
-	if v, ok := coerce.ToFloat(val); ok {
+func (f *Float64) consume(val zed.Value) {
+	if v, ok := coerce.ToFloat(&val); ok {
 		f.state = f.function(f.state, v)
 	}
 }
@@ -131,11 +131,11 @@ type Int64 struct {
 	function anymath.Int64
 }
 
-func NewInt64(f *anymath.Function, val *zed.Value) *Int64 {
+func NewInt64(f *anymath.Function, val zed.Value) *Int64 {
 	state := f.Init.Int64
 	if !val.IsNull() {
 		var ok bool
-		state, ok = coerce.ToInt(val)
+		state, ok = coerce.ToInt(&val)
 		if !ok {
 			panicCoercionFail(zed.TypeInt64, val.Type())
 		}
@@ -146,12 +146,12 @@ func NewInt64(f *anymath.Function, val *zed.Value) *Int64 {
 	}
 }
 
-func (i *Int64) result() *zed.Value {
-	return zed.NewInt64(i.state)
+func (i *Int64) result() zed.Value {
+	return *zed.NewInt64(i.state)
 }
 
-func (i *Int64) consume(val *zed.Value) {
-	if v, ok := coerce.ToInt(val); ok {
+func (i *Int64) consume(val zed.Value) {
+	if v, ok := coerce.ToInt(&val); ok {
 		i.state = i.function(i.state, v)
 	}
 }
@@ -163,11 +163,11 @@ type Uint64 struct {
 	function anymath.Uint64
 }
 
-func NewUint64(f *anymath.Function, val *zed.Value) *Uint64 {
+func NewUint64(f *anymath.Function, val zed.Value) *Uint64 {
 	state := f.Init.Uint64
 	if !val.IsNull() {
 		var ok bool
-		state, ok = coerce.ToUint(val)
+		state, ok = coerce.ToUint(&val)
 		if !ok {
 			panicCoercionFail(zed.TypeUint64, val.Type())
 		}
@@ -178,12 +178,12 @@ func NewUint64(f *anymath.Function, val *zed.Value) *Uint64 {
 	}
 }
 
-func (u *Uint64) result() *zed.Value {
-	return zed.NewUint64(u.state)
+func (u *Uint64) result() zed.Value {
+	return *zed.NewUint64(u.state)
 }
 
-func (u *Uint64) consume(val *zed.Value) {
-	if v, ok := coerce.ToUint(val); ok {
+func (u *Uint64) consume(val zed.Value) {
+	if v, ok := coerce.ToUint(&val); ok {
 		u.state = u.function(u.state, v)
 	}
 }
@@ -195,11 +195,11 @@ type Duration struct {
 	function anymath.Int64
 }
 
-func NewDuration(f *anymath.Function, val *zed.Value) *Duration {
+func NewDuration(f *anymath.Function, val zed.Value) *Duration {
 	state := f.Init.Int64
 	if !val.IsNull() {
 		var ok bool
-		state, ok = coerce.ToInt(val)
+		state, ok = coerce.ToInt(&val)
 		if !ok {
 			panicCoercionFail(zed.TypeDuration, val.Type())
 		}
@@ -210,12 +210,12 @@ func NewDuration(f *anymath.Function, val *zed.Value) *Duration {
 	}
 }
 
-func (d *Duration) result() *zed.Value {
-	return zed.NewDuration(nano.Duration(d.state))
+func (d *Duration) result() zed.Value {
+	return *zed.NewDuration(nano.Duration(d.state))
 }
 
-func (d *Duration) consume(val *zed.Value) {
-	if v, ok := coerce.ToInt(val); ok {
+func (d *Duration) consume(val zed.Value) {
+	if v, ok := coerce.ToInt(&val); ok {
 		d.state = d.function(d.state, v)
 	}
 }
@@ -227,11 +227,11 @@ type Time struct {
 	function anymath.Int64
 }
 
-func NewTime(f *anymath.Function, val *zed.Value) *Time {
+func NewTime(f *anymath.Function, val zed.Value) *Time {
 	state := f.Init.Int64
 	if !val.IsNull() {
 		var ok bool
-		state, ok = coerce.ToInt(val)
+		state, ok = coerce.ToInt(&val)
 		if !ok {
 			panicCoercionFail(zed.TypeTime, val.Type())
 		}
@@ -242,12 +242,12 @@ func NewTime(f *anymath.Function, val *zed.Value) *Time {
 	}
 }
 
-func (t *Time) result() *zed.Value {
-	return zed.NewTime(t.state)
+func (t *Time) result() zed.Value {
+	return *zed.NewTime(t.state)
 }
 
-func (t *Time) consume(val *zed.Value) {
-	if v, ok := coerce.ToInt(val); ok {
+func (t *Time) consume(val zed.Value) {
+	if v, ok := coerce.ToInt(&val); ok {
 		t.state = nano.Ts(t.function(int64(t.state), v))
 	}
 }

--- a/runtime/expr/agg/union.go
+++ b/runtime/expr/agg/union.go
@@ -18,7 +18,7 @@ func newUnion() *Union {
 	}
 }
 
-func (u *Union) Consume(val *zed.Value) {
+func (u *Union) Consume(val zed.Value) {
 	if val.IsNull() {
 		return
 	}
@@ -56,9 +56,9 @@ func (u *Union) deleteOne() {
 	}
 }
 
-func (u *Union) Result(zctx *zed.Context) *zed.Value {
+func (u *Union) Result(zctx *zed.Context) zed.Value {
 	if len(u.types) == 0 {
-		return zed.Null
+		return *zed.Null
 	}
 	types := make([]zed.Type, 0, len(u.types))
 	for typ := range u.types {
@@ -80,10 +80,10 @@ func (u *Union) Result(zctx *zed.Context) *zed.Value {
 			b.Append([]byte(v))
 		}
 	}
-	return zed.NewValue(zctx.LookupTypeSet(inner), zed.NormalizeSet(b.Bytes()))
+	return *zed.NewValue(zctx.LookupTypeSet(inner), zed.NormalizeSet(b.Bytes()))
 }
 
-func (u *Union) ConsumeAsPartial(val *zed.Value) {
+func (u *Union) ConsumeAsPartial(val zed.Value) {
 	if val.IsNull() {
 		return
 	}
@@ -101,6 +101,6 @@ func (u *Union) ConsumeAsPartial(val *zed.Value) {
 	}
 }
 
-func (u *Union) ResultAsPartial(zctx *zed.Context) *zed.Value {
+func (u *Union) ResultAsPartial(zctx *zed.Context) zed.Value {
 	return u.Result(zctx)
 }

--- a/runtime/op/groupby/groupby.go
+++ b/runtime/op/groupby/groupby.go
@@ -497,7 +497,7 @@ func (a *Aggregator) nextResultFromSpills(ectx expr.Context) (*zed.Value, error)
 		a.builder.Append(keyVal.Bytes())
 	}
 	for _, f := range row {
-		var v *zed.Value
+		var v zed.Value
 		if a.partialsOut {
 			v = f.ResultAsPartial(a.zctx)
 		} else {
@@ -546,7 +546,7 @@ func (a *Aggregator) readTable(flush, partialsOut bool, batch zbuf.Batch) (zbuf.
 			types = append(types, typ)
 		}
 		for _, f := range row.reducers {
-			var v *zed.Value
+			var v zed.Value
 			if partialsOut {
 				v = f.ResultAsPartial(a.zctx)
 			} else {

--- a/runtime/op/groupby/row.go
+++ b/runtime/op/groupby/row.go
@@ -34,7 +34,7 @@ func (v valRow) consumeAsPartial(rec *zed.Value, exprs []expr.Evaluator, ectx ex
 		//XXX should do soemthing with errors... they could come from
 		// a worker over the network?
 		if !val.IsError() {
-			r.ConsumeAsPartial(val)
+			r.ConsumeAsPartial(*val)
 		}
 	}
 }


### PR DESCRIPTION
Function's methods pass and return zed.Value parameters by reference. Change them to pass and return zed.Value parameters by value, which fits better with planned changes to memory management.