### PR TITLE
Change most remaining instances of *zed.Value to zed.Value

### DIFF
--- a/api/client/connection.go
+++ b/api/client/connection.go
@@ -148,7 +148,7 @@ func (c *Connection) doAndUnmarshal(req *Request, v interface{}, templates ...in
 	}
 	m := zson.NewZNGUnmarshaler()
 	m.Bind(templates...)
-	return m.Unmarshal(rec, v)
+	return m.Unmarshal(*rec, v)
 }
 
 // parseError parses an error from an http.Response with an error status code. For now the content type of errors is assumed to be JSON.

--- a/api/client/request.go
+++ b/api/client/request.go
@@ -101,7 +101,7 @@ func (r *Request) reader() (io.Reader, error) {
 	}
 	var buf bytes.Buffer
 	zw := zngio.NewWriter(zio.NopCloser(&buf))
-	if err := zw.Write(*val); err != nil {
+	if err := zw.Write(val); err != nil {
 		return nil, err
 	}
 	if err := zw.Close(); err != nil {

--- a/api/queryio/zng.go
+++ b/api/queryio/zng.go
@@ -32,7 +32,7 @@ func (w *ZNGWriter) WriteControl(v interface{}) error {
 		return err
 	}
 	var buf bytes.Buffer
-	err = zsonio.NewWriter(zio.NopCloser(&buf), zsonio.WriterOpts{}).Write(*val)
+	err = zsonio.NewWriter(zio.NopCloser(&buf), zsonio.WriterOpts{}).Write(val)
 	if err != nil {
 		return err
 	}

--- a/cli/zq/command.go
+++ b/cli/zq/command.go
@@ -141,7 +141,7 @@ func (c *Command) Run(args []string) error {
 	local := storage.NewLocalEngine()
 	var readers []zio.Reader
 	if null {
-		readers = []zio.Reader{zbuf.NewArray([]zed.Value{*zed.Null})}
+		readers = []zio.Reader{zbuf.NewArray([]zed.Value{zed.Null})}
 	} else {
 		readers, err = c.inputFlags.Open(ctx, zctx, local, paths, c.stopErr)
 		if err != nil {

--- a/cmd/zed/dev/dig/frames/command.go
+++ b/cmd/zed/dev/dig/frames/command.go
@@ -116,7 +116,8 @@ func (m *metaReader) Read() (*zed.Value, error) {
 	if f == nil || err != nil {
 		return nil, err
 	}
-	return m.marshaler.Marshal(f)
+	val, err := m.marshaler.Marshal(f)
+	return &val, err
 }
 
 func (m *metaReader) nextFrame() (interface{}, error) {

--- a/cmd/zed/manage/lakemanage/scan.go
+++ b/cmd/zed/manage/lakemanage/scan.go
@@ -47,7 +47,7 @@ func scan(ctx context.Context, it *objectIterator, pool *pools.Config, runCh cha
 		if err != nil {
 			return err
 		}
-		if run.overlaps(&o.Min, &o.Max) || run.size+o.Size < pool.Threshold {
+		if run.overlaps(o.Min, o.Max) || run.size+o.Size < pool.Threshold {
 			run.add(o)
 			continue
 		}
@@ -90,10 +90,10 @@ func (r *objectIterator) next() (*object, error) {
 	var o object
 	// XXX Embedded structs currently not supported in zed marshal so unmarshal
 	// embedded object struct separately.
-	if err := r.unmarshaler.Unmarshal(val, &o.Object); err != nil {
+	if err := r.unmarshaler.Unmarshal(*val, &o.Object); err != nil {
 		return nil, err
 	}
-	if err := r.unmarshaler.Unmarshal(val, &o); err != nil {
+	if err := r.unmarshaler.Unmarshal(*val, &o); err != nil {
 		return nil, err
 	}
 	return &o, nil
@@ -119,7 +119,7 @@ func newRunBuilder() *runBuilder {
 	return &runBuilder{cmp: expr.NewValueCompareFn(order.Asc, true)}
 }
 
-func (r *runBuilder) overlaps(first, last *zed.Value) bool {
+func (r *runBuilder) overlaps(first, last zed.Value) bool {
 	if r.span == nil {
 		return false
 	}
@@ -133,8 +133,8 @@ func (r *runBuilder) add(o *object) {
 		r.span = extent.NewGeneric(o.Min, o.Max, r.cmp)
 		return
 	}
-	r.span.Extend(&o.Min)
-	r.span.Extend(&o.Max)
+	r.span.Extend(o.Min)
+	r.span.Extend(o.Max)
 }
 
 func (r *runBuilder) objectIDs() []ksuid.KSUID {

--- a/compiler/kernel/bufferfilter.go
+++ b/compiler/kernel/bufferfilter.go
@@ -21,7 +21,7 @@ func CompileBufferFilter(zctx *zed.Context, e dag.Expr) (*expr.BufferFilter, err
 			return nil, err
 		}
 		if literal != nil {
-			return newBufferFilterForLiteral(literal)
+			return newBufferFilterForLiteral(*literal)
 		}
 		if e.Op == "and" {
 			left, err := CompileBufferFilter(zctx, e.LHS)
@@ -90,7 +90,7 @@ func isFieldEqualOrIn(zctx *zed.Context, e *dag.BinaryExpr) (*zed.Value, error) 
 			if err != nil {
 				return nil, err
 			}
-			return val, nil
+			return &val, nil
 		}
 	} else if dag.IsTopLevelField(e.RHS) && e.Op == "in" {
 		if literal, ok := e.LHS.(*dag.Literal); ok {
@@ -101,13 +101,13 @@ func isFieldEqualOrIn(zctx *zed.Context, e *dag.BinaryExpr) (*zed.Value, error) 
 			if val.Type() == zed.TypeNet {
 				return nil, err
 			}
-			return val, nil
+			return &val, nil
 		}
 	}
 	return nil, nil
 }
 
-func newBufferFilterForLiteral(val *zed.Value) (*expr.BufferFilter, error) {
+func newBufferFilterForLiteral(val zed.Value) (*expr.BufferFilter, error) {
 	if id := val.Type().ID(); zed.IsNumber(id) || id == zed.IDNull {
 		// All numbers are comparable, so they can require up to three
 		// patterns: float, varint, and uvarint.

--- a/compiler/semantic/op.go
+++ b/compiler/semantic/op.go
@@ -169,7 +169,7 @@ func (a *analyzer) semSource(source ast.Source) ([]dag.Op, error) {
 	}
 }
 
-func unmarshalHeaders(val *zed.Value) (map[string][]string, error) {
+func unmarshalHeaders(val zed.Value) (map[string][]string, error) {
 	if !zed.IsRecordType(val.Type()) {
 		return nil, errors.New("headers value must be a record")
 	}

--- a/fuzz/fuzz.go
+++ b/fuzz/fuzz.go
@@ -128,7 +128,7 @@ func RunQuery(t testing.TB, zctx *zed.Context, readers []zio.Reader, querySource
 			break
 		}
 		for _, value := range batch.Values() {
-			valuesOut = append(valuesOut, *(value.Copy()))
+			valuesOut = append(valuesOut, value.Copy())
 		}
 		batch.Unref()
 	}
@@ -167,7 +167,7 @@ func GenValues(b *bytes.Reader, context *zed.Context, types []zed.Type) []zed.Va
 		typ := types[int(GenByte(b))%len(types)]
 		builder.Reset()
 		GenValue(b, context, typ, &builder)
-		values = append(values, *zed.NewValue(typ, builder.Bytes().Body()))
+		values = append(values, zed.NewValue(typ, builder.Bytes().Body()))
 	}
 	return values
 }

--- a/lake/api/api.go
+++ b/lake/api/api.go
@@ -189,7 +189,7 @@ func newBuffer(types ...interface{}) *buffer {
 
 func (b *buffer) Write(val zed.Value) error {
 	var v interface{}
-	if err := b.unmarshaler.Unmarshal(&val, &v); err != nil {
+	if err := b.unmarshaler.Unmarshal(val, &v); err != nil {
 		return err
 	}
 	b.results = append(b.results, v)

--- a/lake/branch.go
+++ b/lake/branch.go
@@ -75,7 +75,7 @@ func (b *Branch) Load(ctx context.Context, zctx *zed.Context, r zio.Reader, auth
 	// with other concurrent writers (except for updating the branch pointer
 	// which is handled by Branch.commit)
 	return b.commit(ctx, func(parent *branches.Config, retries int) (*commits.Object, error) {
-		return commits.NewAddsObject(parent.Commit, retries, author, message, *appMeta, objects), nil
+		return commits.NewAddsObject(parent.Commit, retries, author, message, appMeta, objects), nil
 	})
 }
 
@@ -94,7 +94,7 @@ func loadMessage(objects []data.Object) string {
 	return b.String()
 }
 
-func loadMeta(zctx *zed.Context, meta string) (*zed.Value, error) {
+func loadMeta(zctx *zed.Context, meta string) (zed.Value, error) {
 	if meta == "" {
 		return zed.Null, nil
 	}
@@ -191,7 +191,7 @@ func (b *Branch) DeleteWhere(ctx context.Context, c runtime.Compiler, program as
 			}
 			message = deleteWhereMessage(deletedObjs, added)
 		}
-		return patch.NewCommitObject(parent.Commit, retries, author, message, *appMeta), nil
+		return patch.NewCommitObject(parent.Commit, retries, author, message, appMeta), nil
 	})
 }
 
@@ -274,7 +274,7 @@ func (b *Branch) CommitCompact(ctx context.Context, src, rollup []*data.Object, 
 			printObjects(&b, rollup, maxMessageObjects-len(src))
 			message = b.String()
 		}
-		commit := patch.NewCommitObject(parent.Commit, retries, author, message, *appMeta)
+		commit := patch.NewCommitObject(parent.Commit, retries, author, message, appMeta)
 		return commit, nil
 	})
 }
@@ -336,7 +336,7 @@ func (b *Branch) buildMergeObject(ctx context.Context, parent *branches.Config, 
 	if err != nil {
 		return nil, fmt.Errorf("error merging %q into %q: %w", b.Name, parent.Name, err)
 	}
-	return diff.NewCommitObject(parent.Commit, retries, author, message, *zed.Null), nil
+	return diff.NewCommitObject(parent.Commit, retries, author, message, zed.Null), nil
 }
 
 func commonAncestor(a, b []ksuid.KSUID) ksuid.KSUID {

--- a/lake/commits/object.go
+++ b/lake/commits/object.go
@@ -48,7 +48,7 @@ func NewAddsObject(parent ksuid.KSUID, retries int, author, message string, meta
 }
 
 func NewDeletesObject(parent ksuid.KSUID, retries int, author, message string, ids []ksuid.KSUID) *Object {
-	o := NewObject(parent, author, message, *zed.Null, retries)
+	o := NewObject(parent, author, message, zed.Null, retries)
 	for _, id := range ids {
 		o.appendDelete(id)
 	}
@@ -56,7 +56,7 @@ func NewDeletesObject(parent ksuid.KSUID, retries int, author, message string, i
 }
 
 func NewAddVectorsObject(parent ksuid.KSUID, author, message string, ids []ksuid.KSUID, retries int) *Object {
-	o := NewObject(parent, author, message, *zed.Null, retries)
+	o := NewObject(parent, author, message, zed.Null, retries)
 	for _, id := range ids {
 		o.appendAddVector(id)
 	}
@@ -64,7 +64,7 @@ func NewAddVectorsObject(parent ksuid.KSUID, author, message string, ids []ksuid
 }
 
 func NewDeleteVectorsObject(parent ksuid.KSUID, author, message string, ids []ksuid.KSUID, retries int) *Object {
-	o := NewObject(parent, author, message, *zed.Null, retries)
+	o := NewObject(parent, author, message, zed.Null, retries)
 	for _, id := range ids {
 		o.appendDeleteVector(id)
 	}

--- a/lake/commits/patch.go
+++ b/lake/commits/patch.go
@@ -121,7 +121,7 @@ func (p *Patch) NewCommitObject(parent ksuid.KSUID, retries int, author, message
 }
 
 func (p *Patch) Revert(tip *Snapshot, commit, parent ksuid.KSUID, retries int, author, message string) (*Object, error) {
-	object := NewObject(parent, author, message, *zed.Null, retries)
+	object := NewObject(parent, author, message, zed.Null, retries)
 	// For each data object that is added in the patch and is also in the tip, we do a delete.
 	for _, dataObject := range p.diff.SelectAll() {
 		if Exists(tip, dataObject.ID) {

--- a/lake/commits/reader.go
+++ b/lake/commits/reader.go
@@ -44,5 +44,6 @@ func (r *LogReader) Read() (*zed.Value, error) {
 		next = ksuid.Nil
 	}
 	r.cursor = next
-	return r.marshaler.Marshal(commitObject)
+	val, err := r.marshaler.Marshal(commitObject)
+	return &val, err
 }

--- a/lake/data/seekindex.go
+++ b/lake/data/seekindex.go
@@ -34,13 +34,13 @@ func LookupSeekRange(ctx context.Context, engine storage.Engine, path *storage.U
 		if val == nil || err != nil {
 			return ranges, err
 		}
-		result := pruner.Eval(ectx.Reset(), val)
+		result := pruner.Eval(ectx.Reset(), *val)
 		if result.Type() == zed.TypeBool && result.Bool() {
 			rg = nil
 			continue
 		}
 		var entry seekindex.Entry
-		if err := unmarshaler.Unmarshal(val, &entry); err != nil {
+		if err := unmarshaler.Unmarshal(*val, &entry); err != nil {
 			return nil, fmt.Errorf("corrupt seek index entry for %q at value: %q (%w)", obj.ID.String(), zson.String(val), err)
 		}
 		if rg == nil {

--- a/lake/data/writer.go
+++ b/lake/data/writer.go
@@ -72,7 +72,7 @@ func (w *Writer) WriteWithKey(key, val zed.Value) error {
 	if err := w.writer.Write(val); err != nil {
 		return err
 	}
-	w.object.Max.CopyFrom(&key)
+	w.object.Max.CopyFrom(key)
 	return w.writeIndex(key)
 }
 
@@ -80,10 +80,10 @@ func (w *Writer) writeIndex(key zed.Value) error {
 	w.seekIndexTrigger += len(key.Bytes())
 	if w.first {
 		w.first = false
-		w.object.Min.CopyFrom(&key)
+		w.object.Min.CopyFrom(key)
 	}
 	if w.seekMin == nil {
-		w.seekMin = key.Copy()
+		w.seekMin = key.Copy().Ptr()
 	}
 	if w.seekIndexTrigger < w.seekIndexStride {
 		return nil
@@ -97,7 +97,7 @@ func (w *Writer) writeIndex(key zed.Value) error {
 func (w *Writer) flushSeekIndex() error {
 	if w.seekMin != nil {
 		w.seekIndexTrigger = 0
-		min := w.seekMin
+		min := *w.seekMin
 		max := w.object.Max.Copy()
 		if w.order == order.Desc {
 			min, max = max, min

--- a/lake/data/writer.go
+++ b/lake/data/writer.go
@@ -64,7 +64,7 @@ func (o *Object) NewWriter(ctx context.Context, engine storage.Engine, path *sto
 
 func (w *Writer) Write(val zed.Value) error {
 	key := val.DerefPath(w.poolKey).MissingAsNull()
-	return w.WriteWithKey(*key, val)
+	return w.WriteWithKey(key, val)
 }
 
 func (w *Writer) WriteWithKey(key, val zed.Value) error {

--- a/lake/data/writer_test.go
+++ b/lake/data/writer_test.go
@@ -24,9 +24,9 @@ func TestDataReaderWriterVector(t *testing.T) {
 	w, err := object.NewWriter(ctx, engine, tmp, order.Asc, field.Path{"a"}, 1000)
 	require.NoError(t, err)
 	zctx := zed.NewContext()
-	require.NoError(t, w.Write(*zson.MustParseValue(zctx, "{a:1,b:4}")))
-	require.NoError(t, w.Write(*zson.MustParseValue(zctx, "{a:2,b:5}")))
-	require.NoError(t, w.Write(*zson.MustParseValue(zctx, "{a:3,b:6}")))
+	require.NoError(t, w.Write(zson.MustParseValue(zctx, "{a:1,b:4}")))
+	require.NoError(t, w.Write(zson.MustParseValue(zctx, "{a:2,b:5}")))
+	require.NoError(t, w.Write(zson.MustParseValue(zctx, "{a:3,b:6}")))
 	require.NoError(t, w.Close(ctx))
 	require.NoError(t, data.CreateVector(ctx, engine, tmp, object.ID))
 	// Read back the VNG file and make sure it's the same.

--- a/lake/journal/store.go
+++ b/lake/journal/store.go
@@ -126,7 +126,7 @@ func (s *Store) load(ctx context.Context) error {
 			return nil
 		}
 		var e Entry
-		if err := s.unmarshaler.Unmarshal(val, &e); err != nil {
+		if err := s.unmarshaler.Unmarshal(*val, &e); err != nil {
 			return err
 		}
 		switch e := e.(type) {
@@ -169,7 +169,7 @@ func (s *Store) getSnapshot(ctx context.Context) (ID, map[string]Entry, error) {
 			return at, table, err
 		}
 		var e Entry
-		if err := s.unmarshaler.Unmarshal(val, &e); err != nil {
+		if err := s.unmarshaler.Unmarshal(*val, &e); err != nil {
 			return at, nil, err
 		}
 		table[e.Key()] = e
@@ -184,7 +184,7 @@ func (s *Store) putSnapshot(ctx context.Context, at ID, table map[string]Entry) 
 	}
 	zw := zngio.NewWriter(w)
 	defer zw.Close()
-	if err := zw.Write(*zed.NewUint64(uint64(at))); err != nil {
+	if err := zw.Write(zed.NewUint64(uint64(at))); err != nil {
 		return err
 	}
 	marshaler := zson.NewZNGMarshaler()
@@ -194,7 +194,7 @@ func (s *Store) putSnapshot(ctx context.Context, at ID, table map[string]Entry) 
 		if err != nil {
 			return err
 		}
-		if err := zw.Write(*val); err != nil {
+		if err := zw.Write(val); err != nil {
 			return err
 		}
 	}

--- a/lake/pool.go
+++ b/lake/pool.go
@@ -169,13 +169,13 @@ func (p *Pool) BatchifyBranches(ctx context.Context, zctx *zed.Context, recs []z
 			return nil, err
 		}
 		if filter(zctx, ectx.Reset(), rec, f) {
-			recs = append(recs, *rec)
+			recs = append(recs, rec)
 		}
 	}
 	return recs, nil
 }
 
-func filter(zctx *zed.Context, ectx expr.Context, this *zed.Value, e expr.Evaluator) bool {
+func filter(zctx *zed.Context, ectx expr.Context, this zed.Value, e expr.Evaluator) bool {
 	if e == nil {
 		return true
 	}
@@ -203,7 +203,7 @@ func (p *Pool) BatchifyBranchTips(ctx context.Context, zctx *zed.Context, f expr
 			return nil, err
 		}
 		if filter(zctx, ectx.Reset(), rec, f) {
-			recs = append(recs, *rec)
+			recs = append(recs, rec)
 		}
 	}
 	return recs, nil

--- a/lake/root.go
+++ b/lake/root.go
@@ -166,7 +166,7 @@ func (r *Root) readLakeMagic(ctx context.Context) error {
 		return fmt.Errorf("corrupt lake version file: more than one Zed value at %s", zson.String(last))
 	}
 	var magic LakeMagic
-	if err := zson.UnmarshalZNG(val, &magic); err != nil {
+	if err := zson.UnmarshalZNG(*val, &magic); err != nil {
 		return fmt.Errorf("corrupt lake version file: %w", err)
 	}
 	if magic.Magic != LakeMagicString {
@@ -193,7 +193,7 @@ func (r *Root) BatchifyPools(ctx context.Context, zctx *zed.Context, f expr.Eval
 			return nil, err
 		}
 		if filter(zctx, ectx.Reset(), rec, f) {
-			vals = append(vals, *rec)
+			vals = append(vals, rec)
 		}
 	}
 	return vals, nil

--- a/lake/seekindex/writer.go
+++ b/lake/seekindex/writer.go
@@ -7,12 +7,12 @@ import (
 )
 
 type Entry struct {
-	Min    *zed.Value `zed:"min"`
-	Max    *zed.Value `zed:"max"`
-	ValOff uint64     `zed:"val_off"`
-	ValCnt uint64     `zed:"val_cnt"`
-	Offset uint64     `zed:"offset"`
-	Length uint64     `zed:"length"`
+	Min    zed.Value `zed:"min"`
+	Max    zed.Value `zed:"max"`
+	ValOff uint64    `zed:"val_off"`
+	ValCnt uint64    `zed:"val_cnt"`
+	Offset uint64    `zed:"offset"`
+	Length uint64    `zed:"length"`
 }
 
 type Writer struct {
@@ -29,7 +29,7 @@ func NewWriter(w zio.Writer) *Writer {
 	}
 }
 
-func (w *Writer) Write(min, max *zed.Value, valoff uint64, offset uint64) error {
+func (w *Writer) Write(min, max zed.Value, valoff uint64, offset uint64) error {
 	val, err := w.marshal.Marshal(&Entry{
 		Min:    min,
 		Max:    max,
@@ -43,5 +43,5 @@ func (w *Writer) Write(min, max *zed.Value, valoff uint64, offset uint64) error 
 	if err != nil {
 		return err
 	}
-	return w.writer.Write(*val.Copy())
+	return w.writer.Write(val)
 }

--- a/lake/writer.go
+++ b/lake/writer.go
@@ -185,7 +185,7 @@ func NewSortedWriter(ctx context.Context, zctx *zed.Context, pool *Pool, vectorE
 }
 
 func (w *SortedWriter) Write(val zed.Value) error {
-	key := *val.DerefPath(w.poolKey).MissingAsNull()
+	key := val.DerefPath(w.poolKey).MissingAsNull()
 again:
 	if w.writer == nil {
 		if err := w.newWriter(); err != nil {

--- a/lake/writer.go
+++ b/lake/writer.go
@@ -84,7 +84,7 @@ func (w *Writer) Write(rec zed.Value) error {
 	// and slow down import. We should instead copy the raw record bytes into a
 	// recycled buffer and keep around an array of ts + byte-slice structs for
 	// sorting.
-	w.vals = append(w.vals, *rec.Copy())
+	w.vals = append(w.vals, rec.Copy())
 	w.memBuffered += int64(len(rec.Bytes()))
 	//XXX change name LogSizeThreshold
 	// XXX the previous logic estimated the object size with divide by 2...?!
@@ -167,7 +167,7 @@ type SortedWriter struct {
 	ctx           context.Context
 	pool          *Pool
 	poolKey       field.Path
-	lastKey       *zed.Value
+	lastKey       zed.Value
 	writer        *data.Writer
 	vectorEnabled bool
 	vectorWriter  *data.VectorWriter
@@ -180,13 +180,12 @@ func NewSortedWriter(ctx context.Context, zctx *zed.Context, pool *Pool, vectorE
 		ctx:           ctx,
 		poolKey:       poolKey(pool.SortKey),
 		pool:          pool,
-		lastKey:       &zed.Value{},
 		vectorEnabled: vectorEnabled,
 	}
 }
 
 func (w *SortedWriter) Write(val zed.Value) error {
-	key := val.DerefPath(w.poolKey).MissingAsNull()
+	key := *val.DerefPath(w.poolKey).MissingAsNull()
 again:
 	if w.writer == nil {
 		if err := w.newWriter(); err != nil {
@@ -203,7 +202,7 @@ again:
 		w.writer, w.vectorWriter = nil, nil
 		goto again
 	}
-	if err := w.writer.WriteWithKey(*key, val); err != nil {
+	if err := w.writer.WriteWithKey(key, val); err != nil {
 		w.Abort()
 		return err
 	}

--- a/order/direction.go
+++ b/order/direction.go
@@ -76,7 +76,7 @@ func (d Direction) MarshalZNG(m *zson.MarshalZNGContext) (zed.Type, error) {
 	return m.MarshalValue(d.String())
 }
 
-func (d *Direction) UnmarshalZNG(u *zson.UnmarshalZNGContext, val *zed.Value) error {
+func (d *Direction) UnmarshalZNG(u *zson.UnmarshalZNGContext, val zed.Value) error {
 	dir, err := ParseDirection(string(val.Bytes()))
 	if err != nil {
 		return err

--- a/order/which.go
+++ b/order/which.go
@@ -65,7 +65,7 @@ func (w Which) MarshalZNG(m *zson.MarshalZNGContext) (zed.Type, error) {
 	return m.MarshalValue(w.String())
 }
 
-func (w *Which) UnmarshalZNG(u *zson.UnmarshalZNGContext, val *zed.Value) error {
+func (w *Which) UnmarshalZNG(u *zson.UnmarshalZNGContext, val zed.Value) error {
 	which, err := Parse(string(val.Bytes()))
 	if err != nil {
 		return err

--- a/runtime/exec/stats.go
+++ b/runtime/exec/stats.go
@@ -27,8 +27,8 @@ func GetPoolStats(ctx context.Context, p *lake.Pool, snap commits.View) (info Po
 		if poolSpan == nil {
 			poolSpan = extent.NewGenericFromOrder(object.Min, object.Max, order.Asc)
 		} else {
-			poolSpan.Extend(&object.Min)
-			poolSpan.Extend(&object.Max)
+			poolSpan.Extend(object.Min)
+			poolSpan.Extend(object.Max)
 		}
 	}
 	//XXX need to change API to take return key range
@@ -62,8 +62,8 @@ func GetBranchStats(ctx context.Context, b *lake.Branch, snap commits.View) (inf
 		if poolSpan == nil {
 			poolSpan = extent.NewGenericFromOrder(object.Min, object.Max, order.Asc)
 		} else {
-			poolSpan.Extend(&object.Min)
-			poolSpan.Extend(&object.Max)
+			poolSpan.Extend(object.Min)
+			poolSpan.Extend(object.Max)
 		}
 	}
 	//XXX need to change API to take return key range

--- a/runtime/expr/agg.go
+++ b/runtime/expr/agg.go
@@ -32,7 +32,7 @@ func (a *Aggregator) NewFunction() agg.Function {
 	return a.pattern()
 }
 
-func (a *Aggregator) Apply(zctx *zed.Context, ectx Context, f agg.Function, this *zed.Value) {
+func (a *Aggregator) Apply(zctx *zed.Context, ectx Context, f agg.Function, this zed.Value) {
 	if a.where != nil {
 		if val, ok := EvalBool(zctx, ectx, this, a.where); !ok || !val.Bool() {
 			// XXX Issue #3401: do something with "where" errors.
@@ -41,7 +41,7 @@ func (a *Aggregator) Apply(zctx *zed.Context, ectx Context, f agg.Function, this
 	}
 	v := a.expr.Eval(ectx, this)
 	if !v.IsMissing() {
-		f.Consume(*v)
+		f.Consume(v)
 	}
 }
 
@@ -60,11 +60,11 @@ type aggregatorExpr struct {
 
 var _ Evaluator = (*aggregatorExpr)(nil)
 
-func (s *aggregatorExpr) Eval(ectx Context, val *zed.Value) *zed.Value {
+func (s *aggregatorExpr) Eval(ectx Context, val zed.Value) zed.Value {
 	if s.fn == nil {
 		s.fn = s.agg.NewFunction()
 		s.zctx = zed.NewContext() //XXX
 	}
 	s.agg.Apply(s.zctx, ectx, s.fn, val)
-	return ectx.CopyValue(s.fn.Result(s.zctx))
+	return s.fn.Result(s.zctx)
 }

--- a/runtime/expr/agg/any.go
+++ b/runtime/expr/agg/any.go
@@ -9,20 +9,21 @@ type Any zed.Value
 var _ Function = (*Any)(nil)
 
 func NewAny() *Any {
-	return (*Any)(zed.NewValue(zed.TypeNull, nil))
+	a := (Any)(zed.Null)
+	return &a
 }
 
 func (a *Any) Consume(val zed.Value) {
 	// Copy any value from the input while favoring any-typed non-null values
 	// over null values.
 	if (*zed.Value)(a).Type() == nil || (*zed.Value)(a).IsNull() && !val.IsNull() {
-		*a = Any(*val.Copy())
+		*a = Any(val.Copy())
 	}
 }
 
 func (a *Any) Result(*zed.Context) zed.Value {
 	if (*zed.Value)(a).Type() == nil {
-		return *zed.Null
+		return zed.Null
 	}
 	return *(*zed.Value)(a)
 }

--- a/runtime/expr/agg/avg.go
+++ b/runtime/expr/agg/avg.go
@@ -21,7 +21,7 @@ func (a *Avg) Consume(val zed.Value) {
 	if val.IsNull() {
 		return
 	}
-	if d, ok := coerce.ToFloat(&val); ok {
+	if d, ok := coerce.ToFloat(val); ok {
 		a.sum += float64(d)
 		a.count++
 	}
@@ -29,9 +29,9 @@ func (a *Avg) Consume(val zed.Value) {
 
 func (a *Avg) Result(*zed.Context) zed.Value {
 	if a.count > 0 {
-		return *zed.NewFloat64(a.sum / float64(a.count))
+		return zed.NewFloat64(a.sum / float64(a.count))
 	}
-	return *zed.NullFloat64
+	return zed.NullFloat64
 }
 
 const (
@@ -45,14 +45,14 @@ func (a *Avg) ConsumeAsPartial(partial zed.Value) {
 		panic(errors.New("avg: partial sum is missing"))
 	}
 	if sumVal.Type() != zed.TypeFloat64 {
-		panic(fmt.Errorf("avg: partial sum has bad type: %s", zson.FormatValue(sumVal)))
+		panic(fmt.Errorf("avg: partial sum has bad type: %s", zson.FormatValue(*sumVal)))
 	}
 	countVal := partial.Deref(countName)
 	if countVal == nil {
 		panic("avg: partial count is missing")
 	}
 	if countVal.Type() != zed.TypeUint64 {
-		panic(fmt.Errorf("avg: partial count has bad type: %s", zson.FormatValue(countVal)))
+		panic(fmt.Errorf("avg: partial count has bad type: %s", zson.FormatValue(*countVal)))
 	}
 	a.sum += sumVal.Float()
 	a.count += countVal.Uint()
@@ -66,5 +66,5 @@ func (a *Avg) ResultAsPartial(zctx *zed.Context) zed.Value {
 		zed.NewField(sumName, zed.TypeFloat64),
 		zed.NewField(countName, zed.TypeUint64),
 	})
-	return *zed.NewValue(typ, zv)
+	return zed.NewValue(typ, zv)
 }

--- a/runtime/expr/agg/collect.go
+++ b/runtime/expr/agg/collect.go
@@ -22,7 +22,7 @@ func (c *Collect) Consume(val zed.Value) {
 }
 
 func (c *Collect) update(val zed.Value) {
-	c.values = append(c.values, *val.Under(&zed.Value{}).Copy())
+	c.values = append(c.values, val.Under().Copy())
 	c.size += len(val.Bytes())
 	for c.size > MaxValueSize {
 		// XXX See issue #1813.  For now we silently discard entries
@@ -36,7 +36,7 @@ func (c *Collect) update(val zed.Value) {
 func (c *Collect) Result(zctx *zed.Context) zed.Value {
 	if len(c.values) == 0 {
 		// no values found
-		return *zed.Null
+		return zed.Null
 	}
 	var b zcode.Builder
 	inner := innerType(zctx, c.values)
@@ -49,7 +49,7 @@ func (c *Collect) Result(zctx *zed.Context) zed.Value {
 			b.Append(val.Bytes())
 		}
 	}
-	return *zed.NewValue(zctx.LookupTypeArray(inner), b.Bytes())
+	return zed.NewValue(zctx.LookupTypeArray(inner), b.Bytes())
 }
 
 func innerType(zctx *zed.Context, vals []zed.Value) zed.Type {
@@ -71,11 +71,11 @@ func (c *Collect) ConsumeAsPartial(val zed.Value) {
 	}
 	arrayType, ok := val.Type().(*zed.TypeArray)
 	if !ok {
-		panic(fmt.Errorf("collect partial: partial not an array type: %s", zson.FormatValue(&val)))
+		panic(fmt.Errorf("collect partial: partial not an array type: %s", zson.FormatValue(val)))
 	}
 	typ := arrayType.Type
 	for it := val.Iter(); !it.Done(); {
-		c.update(*zed.NewValue(typ, it.Next()))
+		c.update(zed.NewValue(typ, it.Next()))
 	}
 }
 

--- a/runtime/expr/agg/collectmap.go
+++ b/runtime/expr/agg/collectmap.go
@@ -50,7 +50,7 @@ func (c *CollectMap) ConsumeAsPartial(val zed.Value) {
 
 func (c *CollectMap) Result(zctx *zed.Context) zed.Value {
 	if len(c.entries) == 0 {
-		return *zed.Null
+		return zed.Null
 	}
 	var ktypes, vtypes []zed.Type
 	for _, e := range c.entries {
@@ -69,7 +69,7 @@ func (c *CollectMap) Result(zctx *zed.Context) zed.Value {
 	}
 	typ := zctx.LookupTypeMap(ktyp, vtyp)
 	b := zed.NormalizeMap(builder.Bytes())
-	return *zed.NewValue(typ, b)
+	return zed.NewValue(typ, b)
 }
 
 func (c *CollectMap) ResultAsPartial(zctx *zed.Context) zed.Value {
@@ -95,9 +95,9 @@ func unionOf(zctx *zed.Context, types []zed.Type) (zed.Type, int) {
 
 // valueUnder is like zed.(*Value).Under but it preserves non-union named types.
 func valueUnder(typ zed.Type, b zcode.Bytes) zed.Value {
-	val := *zed.NewValue(typ, b)
+	val := zed.NewValue(typ, b)
 	if _, ok := zed.TypeUnder(typ).(*zed.TypeUnion); !ok {
 		return val
 	}
-	return *val.Under(&val)
+	return val.Under()
 }

--- a/runtime/expr/agg/count.go
+++ b/runtime/expr/agg/count.go
@@ -13,7 +13,7 @@ func (c *Count) Consume(zed.Value) {
 }
 
 func (c Count) Result(*zed.Context) zed.Value {
-	return *zed.NewUint64(uint64(c))
+	return zed.NewUint64(uint64(c))
 }
 
 func (c *Count) ConsumeAsPartial(partial zed.Value) {

--- a/runtime/expr/agg/dcount.go
+++ b/runtime/expr/agg/dcount.go
@@ -34,12 +34,12 @@ func (d *DCount) Consume(val zed.Value) {
 }
 
 func (d *DCount) Result(*zed.Context) zed.Value {
-	return *zed.NewUint64(d.sketch.Estimate())
+	return zed.NewUint64(d.sketch.Estimate())
 }
 
 func (d *DCount) ConsumeAsPartial(partial zed.Value) {
 	if partial.Type() != zed.TypeBytes {
-		panic(fmt.Errorf("dcount: partial has bad type: %s", zson.FormatValue(&partial)))
+		panic(fmt.Errorf("dcount: partial has bad type: %s", zson.FormatValue(partial)))
 	}
 	var s hyperloglog.Sketch
 	if err := s.UnmarshalBinary(partial.Bytes()); err != nil {
@@ -53,5 +53,5 @@ func (d *DCount) ResultAsPartial(zctx *zed.Context) zed.Value {
 	if err != nil {
 		panic(fmt.Errorf("dcount: marshaling partial: %w", err))
 	}
-	return *zed.NewBytes(b)
+	return zed.NewBytes(b)
 }

--- a/runtime/expr/agg/fuse.go
+++ b/runtime/expr/agg/fuse.go
@@ -27,7 +27,7 @@ func (f *fuse) Consume(val zed.Value) {
 
 func (f *fuse) Result(zctx *zed.Context) zed.Value {
 	if len(f.shapes)+len(f.partials) == 0 {
-		return *zed.NullType
+		return zed.NullType
 	}
 	schema := NewSchema(zctx)
 	for _, p := range f.partials {
@@ -44,14 +44,14 @@ func (f *fuse) Result(zctx *zed.Context) zed.Value {
 	for _, typ := range shapes {
 		schema.Mixin(typ)
 	}
-	return *zctx.LookupTypeValue(schema.Type())
+	return zctx.LookupTypeValue(schema.Type())
 }
 
 func (f *fuse) ConsumeAsPartial(partial zed.Value) {
 	if partial.Type() != zed.TypeType {
 		panic("fuse: partial not a type value")
 	}
-	f.partials = append(f.partials, *partial.Copy())
+	f.partials = append(f.partials, partial.Copy())
 }
 
 func (f *fuse) ResultAsPartial(zctx *zed.Context) zed.Value {

--- a/runtime/expr/agg/logical.go
+++ b/runtime/expr/agg/logical.go
@@ -23,9 +23,9 @@ func (a *And) Consume(val zed.Value) {
 
 func (a *And) Result(*zed.Context) zed.Value {
 	if a.val == nil {
-		return *zed.NullBool
+		return zed.NullBool
 	}
-	return *zed.NewBool(*a.val)
+	return zed.NewBool(*a.val)
 }
 
 func (a *And) ConsumeAsPartial(val zed.Value) {
@@ -58,9 +58,9 @@ func (o *Or) Consume(val zed.Value) {
 
 func (o *Or) Result(*zed.Context) zed.Value {
 	if o.val == nil {
-		return *zed.NullBool
+		return zed.NullBool
 	}
-	return *zed.NewBool(*o.val)
+	return zed.NewBool(*o.val)
 }
 
 func (o *Or) ConsumeAsPartial(val zed.Value) {

--- a/runtime/expr/agg/math.go
+++ b/runtime/expr/agg/math.go
@@ -32,9 +32,9 @@ func newMathReducer(f *anymath.Function) *mathReducer {
 func (m *mathReducer) Result(zctx *zed.Context) zed.Value {
 	if !m.hasval {
 		if m.math == nil {
-			return *zed.Null
+			return zed.Null
 		}
-		return *zed.NewValue(m.math.typ(), nil)
+		return zed.NewValue(m.math.typ(), nil)
 	}
 	return m.math.result()
 }
@@ -50,7 +50,7 @@ func (m *mathReducer) consumeVal(val zed.Value) {
 		// XXX We're not using the value coercion parts of coerce.Pair here.
 		// Would be better if coerce had a function that just compared types
 		// and returned the type to coerce to.
-		id, err = m.pair.Coerce(zed.NewValue(m.math.typ(), nil), &val)
+		id, err = m.pair.Coerce(zed.NewValue(m.math.typ(), nil), val)
 		if err != nil {
 			// Skip invalid values.
 			return
@@ -59,7 +59,7 @@ func (m *mathReducer) consumeVal(val zed.Value) {
 		id = val.Type().ID()
 	}
 	if m.math == nil || m.math.typ().ID() != id {
-		state := *zed.Null
+		state := zed.Null
 		if m.math != nil {
 			state = m.math.result()
 		}
@@ -103,7 +103,7 @@ func NewFloat64(f *anymath.Function, val zed.Value) *Float64 {
 	state := f.Init.Float64
 	if !val.IsNull() {
 		var ok bool
-		state, ok = coerce.ToFloat(&val)
+		state, ok = coerce.ToFloat(val)
 		if !ok {
 			panicCoercionFail(zed.TypeFloat64, val.Type())
 		}
@@ -115,11 +115,11 @@ func NewFloat64(f *anymath.Function, val zed.Value) *Float64 {
 }
 
 func (f *Float64) result() zed.Value {
-	return *zed.NewFloat64(f.state)
+	return zed.NewFloat64(f.state)
 }
 
 func (f *Float64) consume(val zed.Value) {
-	if v, ok := coerce.ToFloat(&val); ok {
+	if v, ok := coerce.ToFloat(val); ok {
 		f.state = f.function(f.state, v)
 	}
 }
@@ -135,7 +135,7 @@ func NewInt64(f *anymath.Function, val zed.Value) *Int64 {
 	state := f.Init.Int64
 	if !val.IsNull() {
 		var ok bool
-		state, ok = coerce.ToInt(&val)
+		state, ok = coerce.ToInt(val)
 		if !ok {
 			panicCoercionFail(zed.TypeInt64, val.Type())
 		}
@@ -147,11 +147,11 @@ func NewInt64(f *anymath.Function, val zed.Value) *Int64 {
 }
 
 func (i *Int64) result() zed.Value {
-	return *zed.NewInt64(i.state)
+	return zed.NewInt64(i.state)
 }
 
 func (i *Int64) consume(val zed.Value) {
-	if v, ok := coerce.ToInt(&val); ok {
+	if v, ok := coerce.ToInt(val); ok {
 		i.state = i.function(i.state, v)
 	}
 }
@@ -167,7 +167,7 @@ func NewUint64(f *anymath.Function, val zed.Value) *Uint64 {
 	state := f.Init.Uint64
 	if !val.IsNull() {
 		var ok bool
-		state, ok = coerce.ToUint(&val)
+		state, ok = coerce.ToUint(val)
 		if !ok {
 			panicCoercionFail(zed.TypeUint64, val.Type())
 		}
@@ -179,11 +179,11 @@ func NewUint64(f *anymath.Function, val zed.Value) *Uint64 {
 }
 
 func (u *Uint64) result() zed.Value {
-	return *zed.NewUint64(u.state)
+	return zed.NewUint64(u.state)
 }
 
 func (u *Uint64) consume(val zed.Value) {
-	if v, ok := coerce.ToUint(&val); ok {
+	if v, ok := coerce.ToUint(val); ok {
 		u.state = u.function(u.state, v)
 	}
 }
@@ -199,7 +199,7 @@ func NewDuration(f *anymath.Function, val zed.Value) *Duration {
 	state := f.Init.Int64
 	if !val.IsNull() {
 		var ok bool
-		state, ok = coerce.ToInt(&val)
+		state, ok = coerce.ToInt(val)
 		if !ok {
 			panicCoercionFail(zed.TypeDuration, val.Type())
 		}
@@ -211,11 +211,11 @@ func NewDuration(f *anymath.Function, val zed.Value) *Duration {
 }
 
 func (d *Duration) result() zed.Value {
-	return *zed.NewDuration(nano.Duration(d.state))
+	return zed.NewDuration(nano.Duration(d.state))
 }
 
 func (d *Duration) consume(val zed.Value) {
-	if v, ok := coerce.ToInt(&val); ok {
+	if v, ok := coerce.ToInt(val); ok {
 		d.state = d.function(d.state, v)
 	}
 }
@@ -231,7 +231,7 @@ func NewTime(f *anymath.Function, val zed.Value) *Time {
 	state := f.Init.Int64
 	if !val.IsNull() {
 		var ok bool
-		state, ok = coerce.ToInt(&val)
+		state, ok = coerce.ToInt(val)
 		if !ok {
 			panicCoercionFail(zed.TypeTime, val.Type())
 		}
@@ -243,11 +243,11 @@ func NewTime(f *anymath.Function, val zed.Value) *Time {
 }
 
 func (t *Time) result() zed.Value {
-	return *zed.NewTime(t.state)
+	return zed.NewTime(t.state)
 }
 
 func (t *Time) consume(val zed.Value) {
-	if v, ok := coerce.ToInt(&val); ok {
+	if v, ok := coerce.ToInt(val); ok {
 		t.state = nano.Ts(t.function(int64(t.state), v))
 	}
 }

--- a/runtime/expr/agg/union.go
+++ b/runtime/expr/agg/union.go
@@ -58,7 +58,7 @@ func (u *Union) deleteOne() {
 
 func (u *Union) Result(zctx *zed.Context) zed.Value {
 	if len(u.types) == 0 {
-		return *zed.Null
+		return zed.Null
 	}
 	types := make([]zed.Type, 0, len(u.types))
 	for typ := range u.types {
@@ -80,7 +80,7 @@ func (u *Union) Result(zctx *zed.Context) zed.Value {
 			b.Append([]byte(v))
 		}
 	}
-	return *zed.NewValue(zctx.LookupTypeSet(inner), zed.NormalizeSet(b.Bytes()))
+	return zed.NewValue(zctx.LookupTypeSet(inner), zed.NormalizeSet(b.Bytes()))
 }
 
 func (u *Union) ConsumeAsPartial(val zed.Value) {

--- a/runtime/expr/cast.go
+++ b/runtime/expr/cast.go
@@ -64,12 +64,12 @@ type casterIntN struct {
 	max  int64
 }
 
-func (c *casterIntN) Eval(ectx Context, val *zed.Value) *zed.Value {
+func (c *casterIntN) Eval(ectx Context, val zed.Value) zed.Value {
 	v, ok := coerce.ToInt(val)
 	if !ok || (c.min != 0 && (v < c.min || v > c.max)) {
 		return c.zctx.WrapError("cannot cast to "+zson.FormatType(c.typ), val)
 	}
-	return ectx.CopyValue(*zed.NewInt(c.typ, v))
+	return zed.NewInt(c.typ, v)
 }
 
 type casterUintN struct {
@@ -78,68 +78,68 @@ type casterUintN struct {
 	max  uint64
 }
 
-func (c *casterUintN) Eval(ectx Context, val *zed.Value) *zed.Value {
+func (c *casterUintN) Eval(ectx Context, val zed.Value) zed.Value {
 	v, ok := coerce.ToUint(val)
 	if !ok || (c.max != 0 && v > c.max) {
 		return c.zctx.WrapError("cannot cast to "+zson.FormatType(c.typ), val)
 	}
-	return ectx.CopyValue(*zed.NewUint(c.typ, v))
+	return zed.NewUint(c.typ, v)
 }
 
 type casterBool struct {
 	zctx *zed.Context
 }
 
-func (c *casterBool) Eval(ectx Context, val *zed.Value) *zed.Value {
+func (c *casterBool) Eval(ectx Context, val zed.Value) zed.Value {
 	b, ok := coerce.ToBool(val)
 	if !ok {
 		return c.zctx.WrapError("cannot cast to bool", val)
 	}
-	return ectx.CopyValue(*zed.NewBool(b))
+	return zed.NewBool(b)
 }
 
 type casterFloat16 struct {
 	zctx *zed.Context
 }
 
-func (c *casterFloat16) Eval(ectx Context, val *zed.Value) *zed.Value {
+func (c *casterFloat16) Eval(ectx Context, val zed.Value) zed.Value {
 	f, ok := coerce.ToFloat(val)
 	if !ok {
 		return c.zctx.WrapError("cannot cast to float16", val)
 	}
 	f16 := float16.Fromfloat32(float32(f))
-	return ectx.CopyValue(*zed.NewFloat16(f16.Float32()))
+	return zed.NewFloat16(f16.Float32())
 }
 
 type casterFloat32 struct {
 	zctx *zed.Context
 }
 
-func (c *casterFloat32) Eval(ectx Context, val *zed.Value) *zed.Value {
+func (c *casterFloat32) Eval(ectx Context, val zed.Value) zed.Value {
 	f, ok := coerce.ToFloat(val)
 	if !ok {
 		return c.zctx.WrapError("cannot cast to float32", val)
 	}
-	return ectx.CopyValue(*zed.NewFloat32(float32(f)))
+	return zed.NewFloat32(float32(f))
 }
 
 type casterFloat64 struct {
 	zctx *zed.Context
 }
 
-func (c *casterFloat64) Eval(ectx Context, val *zed.Value) *zed.Value {
+func (c *casterFloat64) Eval(ectx Context, val zed.Value) zed.Value {
 	f, ok := coerce.ToFloat(val)
 	if !ok {
 		return c.zctx.WrapError("cannot cast to float64", val)
 	}
-	return ectx.CopyValue(*zed.NewFloat64(f))
+	return zed.NewFloat64(f)
 }
 
 type casterIP struct {
 	zctx *zed.Context
 }
 
-func (c *casterIP) Eval(ectx Context, val *zed.Value) *zed.Value {
+func (c *casterIP) Eval(ectx Context, val zed.Value) zed.Value {
 	if _, ok := zed.TypeUnder(val.Type()).(*zed.TypeOfIP); ok {
 		return val
 	}
@@ -150,14 +150,14 @@ func (c *casterIP) Eval(ectx Context, val *zed.Value) *zed.Value {
 	if err != nil {
 		return c.zctx.WrapError("cannot cast to ip", val)
 	}
-	return ectx.NewValue(zed.TypeIP, zed.EncodeIP(ip))
+	return zed.NewIP(ip)
 }
 
 type casterNet struct {
 	zctx *zed.Context
 }
 
-func (c *casterNet) Eval(ectx Context, val *zed.Value) *zed.Value {
+func (c *casterNet) Eval(ectx Context, val zed.Value) zed.Value {
 	if val.Type().ID() == zed.IDNet {
 		return val
 	}
@@ -168,14 +168,14 @@ func (c *casterNet) Eval(ectx Context, val *zed.Value) *zed.Value {
 	if err != nil {
 		return c.zctx.WrapError("cannot cast to net", val)
 	}
-	return ectx.NewValue(zed.TypeNet, zed.EncodeNet(net))
+	return zed.NewNet(net)
 }
 
 type casterDuration struct {
 	zctx *zed.Context
 }
 
-func (c *casterDuration) Eval(ectx Context, val *zed.Value) *zed.Value {
+func (c *casterDuration) Eval(ectx Context, val zed.Value) zed.Value {
 	id := val.Type().ID()
 	if id == zed.IDDuration {
 		return val
@@ -189,23 +189,23 @@ func (c *casterDuration) Eval(ectx Context, val *zed.Value) *zed.Value {
 			}
 			d = nano.Duration(f)
 		}
-		return ectx.CopyValue(*zed.NewDuration(d))
+		return zed.NewDuration(d)
 	}
 	if zed.IsFloat(id) {
-		return ectx.CopyValue(*zed.NewDuration(nano.Duration(val.Float())))
+		return zed.NewDuration(nano.Duration(val.Float()))
 	}
 	v, ok := coerce.ToInt(val)
 	if !ok {
 		return c.zctx.WrapError("cannot cast to duration", val)
 	}
-	return ectx.CopyValue(*zed.NewDuration(nano.Duration(v)))
+	return zed.NewDuration(nano.Duration(v))
 }
 
 type casterTime struct {
 	zctx *zed.Context
 }
 
-func (c *casterTime) Eval(ectx Context, val *zed.Value) *zed.Value {
+func (c *casterTime) Eval(ectx Context, val zed.Value) zed.Value {
 	id := val.Type().ID()
 	var ts nano.Ts
 	switch {
@@ -234,43 +234,43 @@ func (c *casterTime) Eval(ectx Context, val *zed.Value) *zed.Value {
 	default:
 		return c.zctx.WrapError("cannot cast to time", val)
 	}
-	return ectx.CopyValue(*zed.NewTime(ts))
+	return zed.NewTime(ts)
 }
 
 type casterString struct {
 	zctx *zed.Context
 }
 
-func (c *casterString) Eval(ectx Context, val *zed.Value) *zed.Value {
+func (c *casterString) Eval(ectx Context, val zed.Value) zed.Value {
 	id := val.Type().ID()
 	if id == zed.IDBytes {
 		if !utf8.Valid(val.Bytes()) {
 			return c.zctx.WrapError("cannot cast to string: invalid UTF-8", val)
 		}
-		return ectx.NewValue(zed.TypeString, val.Bytes())
+		return zed.NewValue(zed.TypeString, val.Bytes())
 	}
 	if enum, ok := val.Type().(*zed.TypeEnum); ok {
 		selector := zed.DecodeUint(val.Bytes())
 		symbol, err := enum.Symbol(int(selector))
 		if err != nil {
-			return ectx.CopyValue(*c.zctx.NewError(err))
+			return c.zctx.NewError(err)
 		}
-		return ectx.NewValue(zed.TypeString, zed.EncodeString(symbol))
+		return zed.NewString(symbol)
 	}
 	if id == zed.IDString {
 		// If it's already stringy, then the Zed encoding can stay
 		// the same and we just update the stringy type.
-		return ectx.NewValue(zed.TypeString, val.Bytes())
+		return zed.NewValue(zed.TypeString, val.Bytes())
 	}
 	// Otherwise, we'll use a canonical ZSON value for the string rep
 	// of an arbitrary value cast to a string.
-	return ectx.NewValue(zed.TypeString, zed.EncodeString(zson.FormatValue(val)))
+	return zed.NewString(zson.FormatValue(val))
 }
 
 type casterBytes struct{}
 
-func (c *casterBytes) Eval(ectx Context, val *zed.Value) *zed.Value {
-	return ectx.NewValue(zed.TypeBytes, val.Bytes())
+func (c *casterBytes) Eval(ectx Context, val zed.Value) zed.Value {
+	return zed.NewBytes(val.Bytes())
 }
 
 type casterNamedType struct {
@@ -279,14 +279,14 @@ type casterNamedType struct {
 	name string
 }
 
-func (c *casterNamedType) Eval(ectx Context, this *zed.Value) *zed.Value {
+func (c *casterNamedType) Eval(ectx Context, this zed.Value) zed.Value {
 	val := c.expr.Eval(ectx, this)
 	if val.IsError() {
 		return val
 	}
 	typ, err := c.zctx.LookupTypeNamed(c.name, zed.TypeUnder(val.Type()))
 	if err != nil {
-		return ectx.CopyValue(*c.zctx.NewError(err))
+		return c.zctx.NewError(err)
 	}
-	return ectx.NewValue(typ, val.Bytes())
+	return zed.NewValue(typ, val.Bytes())
 }

--- a/runtime/expr/coerce/coerce.go
+++ b/runtime/expr/coerce/coerce.go
@@ -47,7 +47,7 @@ func (c *Pair) Equal() bool {
 	return bytes.Equal(c.A, c.B)
 }
 
-func (c *Pair) Coerce(a, b *zed.Value) (int, error) {
+func (c *Pair) Coerce(a, b zed.Value) (int, error) {
 	c.A = a.Bytes()
 	c.B = b.Bytes()
 	aid := a.Type().ID()
@@ -152,7 +152,7 @@ func (c *Pair) coerceNumbers(aid, bid int) (int, bool) {
 	return id, ok
 }
 
-func ToFloat(val *zed.Value) (float64, bool) {
+func ToFloat(val zed.Value) (float64, bool) {
 	switch id := val.Type().ID(); {
 	case zed.IsUnsigned(id):
 		return float64(val.Uint()), true
@@ -167,7 +167,7 @@ func ToFloat(val *zed.Value) (float64, bool) {
 	return 0, false
 }
 
-func ToUint(val *zed.Value) (uint64, bool) {
+func ToUint(val zed.Value) (uint64, bool) {
 	switch id := val.Type().ID(); {
 	case zed.IsUnsigned(id):
 		return val.Uint(), true
@@ -186,7 +186,7 @@ func ToUint(val *zed.Value) (uint64, bool) {
 	return 0, false
 }
 
-func ToInt(val *zed.Value) (int64, bool) {
+func ToInt(val zed.Value) (int64, bool) {
 	switch id := val.Type().ID(); {
 	case zed.IsUnsigned(id):
 		return int64(val.Uint()), true
@@ -202,7 +202,7 @@ func ToInt(val *zed.Value) (int64, bool) {
 	return 0, false
 }
 
-func ToBool(val *zed.Value) (bool, bool) {
+func ToBool(val zed.Value) (bool, bool) {
 	if val.IsString() {
 		v, err := byteconv.ParseBool(val.Bytes())
 		return v, err == nil

--- a/runtime/expr/context.go
+++ b/runtime/expr/context.go
@@ -2,7 +2,6 @@ package expr
 
 import (
 	"github.com/brimdata/zed"
-	"github.com/brimdata/zed/zcode"
 )
 
 // Context is an interface to a scope and value allocator for expressions.
@@ -12,9 +11,6 @@ import (
 type Context interface {
 	// Vars() accesses the variables reachable in the current scope.
 	Vars() []zed.Value
-	//XXX there should be two NewValues: one when bytes is already inside
-	// of the context... another when you need to copy those bytes into
-	// this context.
 	zed.Allocator
 }
 
@@ -26,35 +22,17 @@ func NewContext() *allocator {
 	return &allocator{}
 }
 
-func (*allocator) NewValue(typ zed.Type, bytes zcode.Bytes) *zed.Value {
-	return zed.NewValue(typ, bytes)
-}
-
-func (*allocator) CopyValue(val zed.Value) *zed.Value { return val.Copy() }
-
 func (*allocator) Vars() []zed.Value {
 	return nil
 }
 
 type ResetContext struct {
-	vals []zed.Value
 	vars []zed.Value
 }
 
 var _ Context = (*ResetContext)(nil)
 
-func (r *ResetContext) NewValue(typ zed.Type, b zcode.Bytes) *zed.Value {
-	r.vals = append(r.vals, *zed.NewValue(typ, b))
-	return &r.vals[len(r.vals)-1]
-}
-
-func (r *ResetContext) CopyValue(val zed.Value) *zed.Value {
-	r.vals = append(r.vals, val)
-	return &r.vals[len(r.vals)-1]
-}
-
 func (r *ResetContext) Reset() *ResetContext {
-	r.vals = r.vals[:0]
 	return r
 }
 

--- a/runtime/expr/cutter.go
+++ b/runtime/expr/cutter.go
@@ -53,10 +53,10 @@ func (c *Cutter) FoundCut() bool {
 // Apply returns a new record comprising fields copied from in according to the
 // receiver's configuration.  If the resulting record would be empty, Apply
 // returns zed.Missing.
-func (c *Cutter) Eval(ectx Context, in *zed.Value) *zed.Value {
+func (c *Cutter) Eval(ectx Context, in zed.Value) zed.Value {
 	rb, paths, err := c.lookupBuilder(ectx, in)
 	if err != nil {
-		return ectx.CopyValue(*c.zctx.WrapError(fmt.Sprintf("cut: %s", err), in))
+		return c.zctx.WrapError(fmt.Sprintf("cut: %s", err), in)
 	}
 	types := c.typeCache
 	rb.Reset()
@@ -81,7 +81,7 @@ func (c *Cutter) Eval(ectx Context, in *zed.Value) *zed.Value {
 	if err != nil {
 		panic(err)
 	}
-	rec := ectx.NewValue(rb.Type(c.outTypes.Lookup(types), types), bytes)
+	rec := zed.NewValue(rb.Type(c.outTypes.Lookup(types), types), bytes)
 	for _, d := range droppers {
 		rec = d.Eval(ectx, rec)
 	}
@@ -91,7 +91,7 @@ func (c *Cutter) Eval(ectx Context, in *zed.Value) *zed.Value {
 	return rec
 }
 
-func (c *Cutter) lookupBuilder(ectx Context, in *zed.Value) (*recordBuilderCachedTypes, field.List, error) {
+func (c *Cutter) lookupBuilder(ectx Context, in zed.Value) (*recordBuilderCachedTypes, field.List, error) {
 	paths := c.fieldRefs[:0]
 	for _, p := range c.lvals {
 		path, err := p.Eval(ectx, in)

--- a/runtime/expr/dot.go
+++ b/runtime/expr/dot.go
@@ -11,7 +11,7 @@ import (
 
 type This struct{}
 
-func (*This) Eval(_ Context, this *zed.Value) *zed.Value {
+func (*This) Eval(_ Context, this zed.Value) zed.Value {
 	return this
 }
 
@@ -38,9 +38,8 @@ func NewDottedExpr(zctx *zed.Context, f field.Path) Evaluator {
 	return ret
 }
 
-func (d *DotExpr) Eval(ectx Context, this *zed.Value) *zed.Value {
-	var tmpVal zed.Value
-	val := d.record.Eval(ectx, this).Under(&tmpVal)
+func (d *DotExpr) Eval(ectx Context, this zed.Value) zed.Value {
+	val := d.record.Eval(ectx, this).Under()
 	// Cases are ordered by decreasing expected frequency.
 	switch typ := val.Type().(type) {
 	case *zed.TypeRecord:
@@ -48,7 +47,7 @@ func (d *DotExpr) Eval(ectx Context, this *zed.Value) *zed.Value {
 		if !ok {
 			return d.zctx.Missing()
 		}
-		return ectx.NewValue(typ.Fields[i].Type, getNthFromContainer(val.Bytes(), i))
+		return zed.NewValue(typ.Fields[i].Type, getNthFromContainer(val.Bytes(), i))
 	case *zed.TypeMap:
 		return indexMap(d.zctx, ectx, typ, val.Bytes(), zed.NewString(d.field))
 	case *zed.TypeOfType:
@@ -76,7 +75,7 @@ func (d *DotExpr) fieldIndex(typ *zed.TypeRecord) (int, bool) {
 	return i, ok
 }
 
-func (d *DotExpr) evalTypeOfType(ectx Context, b zcode.Bytes) *zed.Value {
+func (d *DotExpr) evalTypeOfType(ectx Context, b zcode.Bytes) zed.Value {
 	typ, _ := d.zctx.DecodeTypeValue(b)
 	if typ, ok := zed.TypeUnder(typ).(*zed.TypeRecord); ok {
 		if typ, ok := typ.TypeOfField(d.field); ok {

--- a/runtime/expr/dropper.go
+++ b/runtime/expr/dropper.go
@@ -13,7 +13,7 @@ type dropper struct {
 	fieldRefs []Evaluator
 }
 
-func (d *dropper) drop(ectx Context, in *zed.Value) *zed.Value {
+func (d *dropper) drop(ectx Context, in zed.Value) zed.Value {
 	if d.typ == in.Type() {
 		return in
 	}
@@ -27,7 +27,7 @@ func (d *dropper) drop(ectx Context, in *zed.Value) *zed.Value {
 	if err != nil {
 		panic(err)
 	}
-	return ectx.NewValue(d.typ, val)
+	return zed.NewValue(d.typ, val)
 }
 
 type Dropper struct {
@@ -44,7 +44,7 @@ func NewDropper(zctx *zed.Context, fields field.List) *Dropper {
 	}
 }
 
-func (d *Dropper) newDropper(zctx *zed.Context, r *zed.Value) *dropper {
+func (d *Dropper) newDropper(zctx *zed.Context, r zed.Value) *dropper {
 	fields, fieldTypes, match := complementFields(d.fields, nil, zed.TypeRecordOf(r.Type()))
 	if !match {
 		// r.Type contains no fields matching d.fields, so we set
@@ -97,7 +97,7 @@ func complementFields(drops field.List, prefix field.Path, typ *zed.TypeRecord) 
 	return fields, types, match
 }
 
-func (d *Dropper) Eval(ectx Context, in *zed.Value) *zed.Value {
+func (d *Dropper) Eval(ectx Context, in zed.Value) zed.Value {
 	if !zed.IsRecordType(in.Type()) {
 		return in
 	}

--- a/runtime/expr/expr_test.go
+++ b/runtime/expr/expr_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/x448/float16"
 )
 
-func testSuccessful(t *testing.T, e string, input string, expectedVal *zed.Value) {
+func testSuccessful(t *testing.T, e string, input string, expectedVal zed.Value) {
 	if input == "" {
 		input = "{}"
 	}
@@ -400,7 +400,7 @@ func TestArithmetic(t *testing.T) {
 		panic("signed")
 	}
 	// Test arithmetic between integer types
-	iresult := func(t1, t2 string, v uint64) *zed.Value {
+	iresult := func(t1, t2 string, v uint64) zed.Value {
 		typ1 := zed.LookupPrimitive(t1)
 		typ2 := zed.LookupPrimitive(t2)
 		id1 := typ1.ID()

--- a/runtime/expr/extent/span.go
+++ b/runtime/expr/extent/span.go
@@ -17,14 +17,14 @@ import (
 // Span represents the closed interval [first, last] where first is "less than"
 // last with respect to the Span's order.Which.
 type Span interface {
-	First() *zed.Value
-	Last() *zed.Value
-	Before(*zed.Value) bool
-	After(*zed.Value) bool
-	In(*zed.Value) bool
-	Overlaps(*zed.Value, *zed.Value) bool
+	First() zed.Value
+	Last() zed.Value
+	Before(zed.Value) bool
+	After(zed.Value) bool
+	In(zed.Value) bool
+	Overlaps(zed.Value, zed.Value) bool
 	Crop(Span) bool
-	Extend(*zed.Value)
+	Extend(zed.Value)
 	String() string
 }
 
@@ -38,7 +38,7 @@ type Generic struct {
 // to lower and upper.  The range is not sensitive to the absolute order
 // of lower and upper.
 func NewGeneric(lower, upper zed.Value, cmp expr.CompareFn) *Generic {
-	if cmp(&lower, &upper) > 0 {
+	if cmp(lower, upper) > 0 {
 		lower, upper = upper, lower
 	}
 	return &Generic{
@@ -52,48 +52,48 @@ func NewGenericFromOrder(first, last zed.Value, o order.Which) *Generic {
 	return NewGeneric(first, last, expr.NewValueCompareFn(o, o == order.Asc))
 }
 
-func (g *Generic) In(val *zed.Value) bool {
-	return g.cmp(val, &g.first) >= 0 && g.cmp(val, &g.last) <= 0
+func (g *Generic) In(val zed.Value) bool {
+	return g.cmp(val, g.first) >= 0 && g.cmp(val, g.last) <= 0
 }
 
-func (g *Generic) First() *zed.Value {
-	return &g.first
+func (g *Generic) First() zed.Value {
+	return g.first
 }
 
-func (g *Generic) Last() *zed.Value {
-	return &g.last
+func (g *Generic) Last() zed.Value {
+	return g.last
 }
 
-func (g *Generic) After(val *zed.Value) bool {
-	return g.cmp(val, &g.last) > 0
+func (g *Generic) After(val zed.Value) bool {
+	return g.cmp(val, g.last) > 0
 }
 
-func (g *Generic) Before(val *zed.Value) bool {
-	return g.cmp(val, &g.first) < 0
+func (g *Generic) Before(val zed.Value) bool {
+	return g.cmp(val, g.first) < 0
 }
 
-func (g *Generic) Overlaps(first, last *zed.Value) bool {
-	if g.cmp(first, &g.first) >= 0 {
-		return g.cmp(first, &g.last) <= 0
+func (g *Generic) Overlaps(first, last zed.Value) bool {
+	if g.cmp(first, g.first) >= 0 {
+		return g.cmp(first, g.last) <= 0
 	}
-	return g.cmp(last, &g.first) >= 0
+	return g.cmp(last, g.first) >= 0
 }
 
 func (g *Generic) Crop(s Span) bool {
-	if first := s.First(); g.cmp(first, &g.first) > 0 {
-		g.first = *first
+	if first := s.First(); g.cmp(first, g.first) > 0 {
+		g.first = first
 	}
-	if last := s.Last(); g.cmp(last, &g.last) < 0 {
-		g.last = *last
+	if last := s.Last(); g.cmp(last, g.last) < 0 {
+		g.last = last
 	}
-	return g.cmp(&g.first, &g.last) <= 0
+	return g.cmp(g.first, g.last) <= 0
 }
 
-func (g *Generic) Extend(val *zed.Value) {
-	if g.cmp(val, &g.first) < 0 {
-		g.first = *val.Copy()
-	} else if g.cmp(val, &g.last) > 0 {
-		g.last = *val.Copy()
+func (g *Generic) Extend(val zed.Value) {
+	if g.cmp(val, g.first) < 0 {
+		g.first = val.Copy()
+	} else if g.cmp(val, g.last) > 0 {
+		g.last = val.Copy()
 	}
 }
 

--- a/runtime/expr/filter_test.go
+++ b/runtime/expr/filter_test.go
@@ -30,7 +30,7 @@ func runCasesExpectBufferFilterFalsePositives(t *testing.T, record string, cases
 	runCasesHelper(t, record, cases, true)
 }
 
-func filter(ectx expr.Context, this *zed.Value, e expr.Evaluator) bool {
+func filter(ectx expr.Context, this zed.Value, e expr.Evaluator) bool {
 	if e == nil {
 		return true
 	}

--- a/runtime/expr/flattener.go
+++ b/runtime/expr/flattener.go
@@ -75,9 +75,9 @@ func (f *Flattener) Flatten(r zed.Value) (zed.Value, error) {
 	}
 	zv, err := recode(nil, zed.TypeRecordOf(r.Type()), r.Bytes())
 	if err != nil {
-		return *zed.Null, err
+		return zed.Null, err
 	}
-	return *zed.NewValue(flatType.(*zed.TypeRecord), zv), nil
+	return zed.NewValue(flatType.(*zed.TypeRecord), zv), nil
 }
 
 // FlattenFields turns nested records into a series of fields of

--- a/runtime/expr/function/bytes.go
+++ b/runtime/expr/function/bytes.go
@@ -17,20 +17,20 @@ func (b *Base64) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	switch val.Type().ID() {
 	case zed.IDBytes:
 		if val.IsNull() {
-			return *b.zctx.NewErrorf("base64: illegal null argument")
+			return b.zctx.NewErrorf("base64: illegal null argument")
 		}
-		return *zed.NewString(base64.StdEncoding.EncodeToString(val.Bytes()))
+		return zed.NewString(base64.StdEncoding.EncodeToString(val.Bytes()))
 	case zed.IDString:
 		if val.IsNull() {
-			return *zed.Null
+			return zed.Null
 		}
 		bytes, err := base64.StdEncoding.DecodeString(zed.DecodeString(val.Bytes()))
 		if err != nil {
-			return *b.zctx.WrapError("base64: string argument is not base64", &val)
+			return b.zctx.WrapError("base64: string argument is not base64", val)
 		}
-		return *zed.NewBytes(bytes)
+		return zed.NewBytes(bytes)
 	default:
-		return *b.zctx.WrapError("base64: argument must a bytes or string type", &val)
+		return b.zctx.WrapError("base64: argument must a bytes or string type", val)
 	}
 }
 
@@ -44,19 +44,19 @@ func (h *Hex) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	switch val.Type().ID() {
 	case zed.IDBytes:
 		if val.IsNull() {
-			return *h.zctx.NewErrorf("hex: illegal null argument")
+			return h.zctx.NewErrorf("hex: illegal null argument")
 		}
-		return *zed.NewString(hex.EncodeToString(val.Bytes()))
+		return zed.NewString(hex.EncodeToString(val.Bytes()))
 	case zed.IDString:
 		if val.IsNull() {
-			return *zed.NullString
+			return zed.NullString
 		}
 		b, err := hex.DecodeString(zed.DecodeString(val.Bytes()))
 		if err != nil {
-			return *h.zctx.WrapError("hex: string argument is not hexidecimal", &val)
+			return h.zctx.WrapError("hex: string argument is not hexidecimal", val)
 		}
-		return *zed.NewBytes(b)
+		return zed.NewBytes(b)
 	default:
-		return *h.zctx.WrapError("base64: argument must a bytes or string type", &val)
+		return h.zctx.WrapError("base64: argument must a bytes or string type", val)
 	}
 }

--- a/runtime/expr/function/coalesce.go
+++ b/runtime/expr/function/coalesce.go
@@ -12,5 +12,5 @@ func (c *Coalesce) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 			return *val
 		}
 	}
-	return *zed.Null
+	return zed.Null
 }

--- a/runtime/expr/function/compare.go
+++ b/runtime/expr/function/compare.go
@@ -24,7 +24,7 @@ func (e *Compare) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	nullsMax := true
 	if len(args) == 3 {
 		if zed.TypeUnder(args[2].Type()) != zed.TypeBool {
-			return *e.zctx.WrapError("compare: nullsMax arg is not bool", &args[2])
+			return e.zctx.WrapError("compare: nullsMax arg is not bool", args[2])
 		}
 		nullsMax = args[2].Bool()
 	}
@@ -32,5 +32,5 @@ func (e *Compare) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	if !nullsMax {
 		cmp = e.nullsMin
 	}
-	return *zed.NewInt64(int64(cmp(&args[0], &args[1])))
+	return zed.NewInt64(int64(cmp(args[0], args[1])))
 }

--- a/runtime/expr/function/fields.go
+++ b/runtime/expr/function/fields.go
@@ -39,12 +39,12 @@ func (f *Fields) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	subjectVal := args[0]
 	typ := f.recordType(subjectVal)
 	if typ == nil {
-		return *f.zctx.Missing()
+		return f.zctx.Missing()
 	}
 	//XXX should have a way to append into allocator
 	var b zcode.Builder
 	buildPath(typ, &b, nil)
-	return *zed.NewValue(f.typ, b.Bytes())
+	return zed.NewValue(f.typ, b.Bytes())
 }
 
 func (f *Fields) recordType(val zed.Value) *zed.TypeRecord {

--- a/runtime/expr/function/flatten.go
+++ b/runtime/expr/function/flatten.go
@@ -34,7 +34,7 @@ func (n *Flatten) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	inner := n.innerTypeOf(val.Bytes(), typ.Fields)
 	n.Reset()
 	n.encode(typ.Fields, inner, field.Path{}, val.Bytes())
-	return *zed.NewValue(n.zctx.LookupTypeArray(inner), n.Bytes())
+	return zed.NewValue(n.zctx.LookupTypeArray(inner), n.Bytes())
 }
 
 func (n *Flatten) innerTypeOf(b zcode.Bytes, fields []zed.Field) zed.Type {

--- a/runtime/expr/function/grep.go
+++ b/runtime/expr/function/grep.go
@@ -13,22 +13,14 @@ type Grep struct {
 }
 
 func (g *Grep) Call(_ zed.Allocator, vals []zed.Value) zed.Value {
-	patternVal, inputVal := &vals[0], &vals[1]
+	patternVal, inputVal := vals[0], vals[1]
 	if zed.TypeUnder(patternVal.Type()) != zed.TypeString {
-		return g.error("pattern argument must be a string", patternVal)
+		return g.zctx.WrapError("grep(): pattern argument must be a string", patternVal)
 	}
 	if p := patternVal.AsString(); g.grep == nil || g.pattern != p {
 		g.pattern = p
 		term := norm.NFC.Bytes(patternVal.Bytes())
 		g.grep = expr.NewSearchString(string(term), nil)
 	}
-	return *g.grep.Eval(expr.NewContext(), inputVal)
-}
-
-func (g *Grep) error(msg string, val *zed.Value) zed.Value {
-	msg = "grep(): " + msg
-	if val == nil {
-		return *g.zctx.NewErrorf(msg)
-	}
-	return *g.zctx.WrapError(msg, val)
+	return g.grep.Eval(expr.NewContext(), inputVal)
 }

--- a/runtime/expr/function/grok.go
+++ b/runtime/expr/function/grok.go
@@ -1,7 +1,6 @@
 package function
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/brimdata/zed"
@@ -25,15 +24,15 @@ func newGrok(zctx *zed.Context) *Grok {
 func (g *Grok) Call(_ zed.Allocator, vals []zed.Value) zed.Value {
 	patternArg, inputArg, defArg := vals[0], vals[1], zed.NullString
 	if len(vals) == 3 {
-		defArg = &vals[2]
+		defArg = vals[2]
 	}
 	switch {
 	case zed.TypeUnder(defArg.Type()) != zed.TypeString:
 		return g.error("definitions argument must be a string", defArg)
 	case zed.TypeUnder(patternArg.Type()) != zed.TypeString:
-		return g.error("pattern argument must be a string", &patternArg)
+		return g.error("pattern argument must be a string", patternArg)
 	case zed.TypeUnder(inputArg.Type()) != zed.TypeString:
-		return g.error("input argument must be a string", &inputArg)
+		return g.error("input argument must be a string", inputArg)
 	}
 	h, err := g.getHost(defArg.AsString())
 	if err != nil {
@@ -41,25 +40,21 @@ func (g *Grok) Call(_ zed.Allocator, vals []zed.Value) zed.Value {
 	}
 	p, err := h.getPattern(g.zctx, patternArg.AsString())
 	if err != nil {
-		return g.error(err.Error(), &patternArg)
+		return g.error(err.Error(), patternArg)
 	}
 	ss := p.ParseValues(inputArg.AsString())
 	if ss == nil {
-		return g.error("value does not match pattern", &inputArg)
+		return g.error("value does not match pattern", inputArg)
 	}
 	g.builder.Reset()
 	for _, s := range ss {
 		g.builder.Append([]byte(s))
 	}
-	return *zed.NewValue(p.typ, g.builder.Bytes())
+	return zed.NewValue(p.typ, g.builder.Bytes())
 }
 
-func (g *Grok) error(err string, val *zed.Value) zed.Value {
-	err = fmt.Sprintf("grok(): %s", err)
-	if val == nil {
-		return *g.zctx.NewErrorf(err)
-	}
-	return *g.zctx.WrapError(err, val)
+func (g *Grok) error(msg string, val zed.Value) zed.Value {
+	return g.zctx.WrapError("grok(): "+msg, val)
 }
 
 func (g *Grok) getHost(defs string) (*host, error) {

--- a/runtime/expr/function/has.go
+++ b/runtime/expr/function/has.go
@@ -9,12 +9,12 @@ func (h *Has) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	for _, val := range args {
 		if val.IsError() {
 			if val.IsMissing() || val.IsQuiet() {
-				return *zed.False
+				return zed.False
 			}
 			return val
 		}
 	}
-	return *zed.True
+	return zed.True
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#missing
@@ -25,7 +25,7 @@ type Missing struct {
 func (m *Missing) Call(ectx zed.Allocator, args []zed.Value) zed.Value {
 	val := m.has.Call(ectx, args)
 	if val.Type() == zed.TypeBool {
-		return *zed.NewBool(!val.Bool())
+		return zed.NewBool(!val.Bool())
 	}
 	return val
 }

--- a/runtime/expr/function/ksuid.go
+++ b/runtime/expr/function/ksuid.go
@@ -12,28 +12,28 @@ type KSUIDToString struct {
 
 func (k *KSUIDToString) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	if len(args) == 0 {
-		return *zed.NewBytes(ksuid.New().Bytes())
+		return zed.NewBytes(ksuid.New().Bytes())
 	}
 	val := args[0]
 	switch val.Type().ID() {
 	case zed.IDBytes:
 		if val.IsNull() {
-			return *k.zctx.NewErrorf("ksuid: illegal null argument")
+			return k.zctx.NewErrorf("ksuid: illegal null argument")
 		}
 		// XXX GC
 		id, err := ksuid.FromBytes(val.Bytes())
 		if err != nil {
 			panic(err)
 		}
-		return *zed.NewString(id.String())
+		return zed.NewString(id.String())
 	case zed.IDString:
 		// XXX GC
 		id, err := ksuid.Parse(string(val.Bytes()))
 		if err != nil {
-			return *k.zctx.WrapError("ksuid: "+err.Error(), &val)
+			return k.zctx.WrapError("ksuid: "+err.Error(), val)
 		}
-		return *zed.NewBytes(id.Bytes())
+		return zed.NewBytes(id.Bytes())
 	default:
-		return *k.zctx.WrapError("ksuid: argument must a bytes or string type", &val)
+		return k.zctx.WrapError("ksuid: argument must a bytes or string type", val)
 	}
 }

--- a/runtime/expr/function/len.go
+++ b/runtime/expr/function/len.go
@@ -25,17 +25,17 @@ func (l *LenFn) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	case *zed.TypeOfBytes, *zed.TypeOfString, *zed.TypeOfIP, *zed.TypeOfNet:
 		length = len(val.Bytes())
 	case *zed.TypeError:
-		return *l.zctx.WrapError("len()", &val)
+		return l.zctx.WrapError("len()", val)
 	case *zed.TypeOfType:
 		t, err := l.zctx.LookupByValue(val.Bytes())
 		if err != nil {
-			return *l.zctx.NewError(err)
+			return l.zctx.NewError(err)
 		}
 		length = typeLength(t)
 	default:
-		return *l.zctx.WrapError("len: bad type", &val)
+		return l.zctx.WrapError("len: bad type", val)
 	}
-	return *zed.NewInt64(int64(length))
+	return zed.NewInt64(int64(length))
 }
 
 func typeLength(typ zed.Type) int {

--- a/runtime/expr/function/math.go
+++ b/runtime/expr/function/math.go
@@ -14,20 +14,20 @@ type Abs struct {
 }
 
 func (a *Abs) Call(_ zed.Allocator, args []zed.Value) zed.Value {
-	val := &args[0]
+	val := args[0]
 	switch id := val.Type().ID(); {
 	case zed.IsUnsigned(id):
-		return *val
+		return val
 	case zed.IsSigned(id):
 		x := val.Int()
 		if x < 0 {
 			x = -x
 		}
-		return *zed.NewInt(val.Type(), x)
+		return zed.NewInt(val.Type(), x)
 	case zed.IsFloat(id):
-		return *zed.NewFloat(val.Type(), math.Abs(val.Float()))
+		return zed.NewFloat(val.Type(), math.Abs(val.Float()))
 	}
-	return *a.zctx.WrapError("abs: not a number", val)
+	return a.zctx.WrapError("abs: not a number", val)
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#ceil
@@ -36,14 +36,14 @@ type Ceil struct {
 }
 
 func (c *Ceil) Call(_ zed.Allocator, args []zed.Value) zed.Value {
-	val := &args[0]
+	val := args[0]
 	switch id := val.Type().ID(); {
 	case zed.IsUnsigned(id) || zed.IsSigned(id):
-		return *val
+		return val
 	case zed.IsFloat(id):
-		return *zed.NewFloat(val.Type(), math.Ceil(val.Float()))
+		return zed.NewFloat(val.Type(), math.Ceil(val.Float()))
 	}
-	return *c.zctx.WrapError("ceil: not a number", val)
+	return c.zctx.WrapError("ceil: not a number", val)
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#floor
@@ -52,14 +52,14 @@ type Floor struct {
 }
 
 func (f *Floor) Call(_ zed.Allocator, args []zed.Value) zed.Value {
-	val := &args[0]
+	val := args[0]
 	switch id := val.Type().ID(); {
 	case zed.IsUnsigned(id) || zed.IsSigned(id):
-		return *val
+		return val
 	case zed.IsFloat(id):
-		return *zed.NewFloat(val.Type(), math.Floor(val.Float()))
+		return zed.NewFloat(val.Type(), math.Floor(val.Float()))
 	}
-	return *f.zctx.WrapError("floor: not a number", val)
+	return f.zctx.WrapError("floor: not a number", val)
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#log
@@ -68,14 +68,14 @@ type Log struct {
 }
 
 func (l *Log) Call(_ zed.Allocator, args []zed.Value) zed.Value {
-	x, ok := coerce.ToFloat(&args[0])
+	x, ok := coerce.ToFloat(args[0])
 	if !ok {
-		return *l.zctx.WrapError("log: not a number", &args[0])
+		return l.zctx.WrapError("log: not a number", args[0])
 	}
 	if x <= 0 {
-		return *l.zctx.WrapError("log: illegal argument", &args[0])
+		return l.zctx.WrapError("log: illegal argument", args[0])
 	}
-	return *zed.NewFloat64(math.Log(x))
+	return zed.NewFloat64(math.Log(x))
 }
 
 type reducer struct {
@@ -85,44 +85,44 @@ type reducer struct {
 }
 
 func (r *reducer) Call(_ zed.Allocator, args []zed.Value) zed.Value {
-	val0 := &args[0]
+	val0 := args[0]
 	switch id := val0.Type().ID(); {
 	case zed.IsUnsigned(id):
 		result := val0.Uint()
 		for _, val := range args[1:] {
-			v, ok := coerce.ToUint(&val)
+			v, ok := coerce.ToUint(val)
 			if !ok {
-				return *r.zctx.WrapError(r.name+": not a number", &val)
+				return r.zctx.WrapError(r.name+": not a number", val)
 			}
 			result = r.fn.Uint64(result, v)
 		}
-		return *zed.NewUint64(result)
+		return zed.NewUint64(result)
 	case zed.IsSigned(id):
 		result := val0.Int()
 		for _, val := range args[1:] {
 			//XXX this is really bad because we silently coerce
 			// floats to ints if we hit a float first
-			v, ok := coerce.ToInt(&val)
+			v, ok := coerce.ToInt(val)
 			if !ok {
-				return *r.zctx.WrapError(r.name+": not a number", &val)
+				return r.zctx.WrapError(r.name+": not a number", val)
 			}
 			result = r.fn.Int64(result, v)
 		}
-		return *zed.NewInt64(result)
+		return zed.NewInt64(result)
 	case zed.IsFloat(id):
 		//XXX this is wrong like math aggregators...
 		// need to be more robust and adjust type as new types encountered
 		result := val0.Float()
 		for _, val := range args[1:] {
-			v, ok := coerce.ToFloat(&val)
+			v, ok := coerce.ToFloat(val)
 			if !ok {
-				return *r.zctx.WrapError(r.name+": not a number", &val)
+				return r.zctx.WrapError(r.name+": not a number", val)
 			}
 			result = r.fn.Float64(result, v)
 		}
-		return *zed.NewFloat64(result)
+		return zed.NewFloat64(result)
 	}
-	return *r.zctx.WrapError(r.name+": not a number", val0)
+	return r.zctx.WrapError(r.name+": not a number", val0)
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#round
@@ -131,14 +131,14 @@ type Round struct {
 }
 
 func (r *Round) Call(_ zed.Allocator, args []zed.Value) zed.Value {
-	val := &args[0]
+	val := args[0]
 	switch id := val.Type().ID(); {
 	case zed.IsUnsigned(id) || zed.IsSigned(id):
-		return *val
+		return val
 	case zed.IsFloat(id):
-		return *zed.NewFloat(val.Type(), math.Round(val.Float()))
+		return zed.NewFloat(val.Type(), math.Round(val.Float()))
 	}
-	return *r.zctx.WrapError("round: not a number", val)
+	return r.zctx.WrapError("round: not a number", val)
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#pow
@@ -147,15 +147,15 @@ type Pow struct {
 }
 
 func (p *Pow) Call(_ zed.Allocator, args []zed.Value) zed.Value {
-	x, ok := coerce.ToFloat(&args[0])
+	x, ok := coerce.ToFloat(args[0])
 	if !ok {
-		return *p.zctx.WrapError("pow: not a number", &args[0])
+		return p.zctx.WrapError("pow: not a number", args[0])
 	}
-	y, ok := coerce.ToFloat(&args[1])
+	y, ok := coerce.ToFloat(args[1])
 	if !ok {
-		return *p.zctx.WrapError("pow: not a number", &args[1])
+		return p.zctx.WrapError("pow: not a number", args[1])
 	}
-	return *zed.NewFloat64(math.Pow(x, y))
+	return zed.NewFloat64(math.Pow(x, y))
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#sqrt
@@ -164,9 +164,9 @@ type Sqrt struct {
 }
 
 func (s *Sqrt) Call(_ zed.Allocator, args []zed.Value) zed.Value {
-	x, ok := coerce.ToFloat(&args[0])
+	x, ok := coerce.ToFloat(args[0])
 	if !ok {
-		return *s.zctx.WrapError("sqrt: not a number", &args[0])
+		return s.zctx.WrapError("sqrt: not a number", args[0])
 	}
-	return *zed.NewFloat64(math.Sqrt(x))
+	return zed.NewFloat64(math.Sqrt(x))
 }

--- a/runtime/expr/function/nestdotted.go
+++ b/runtime/expr/function/nestdotted.go
@@ -56,13 +56,13 @@ func (n *NestDotted) lookupBuilderAndType(in *zed.TypeRecord) (*zed.RecordBuilde
 }
 
 func (n *NestDotted) Call(_ zed.Allocator, args []zed.Value) zed.Value {
-	val := &args[len(args)-1]
+	val := args[len(args)-1]
 	b, typ, err := n.lookupBuilderAndType(zed.TypeRecordOf(val.Type()))
 	if err != nil {
-		return *n.zctx.WrapError("nest_dotted(): "+err.Error(), val)
+		return n.zctx.WrapError("nest_dotted(): "+err.Error(), val)
 	}
 	if b == nil {
-		return *val
+		return val
 	}
 	b.Reset()
 	for it := val.Bytes().Iter(); !it.Done(); {
@@ -72,5 +72,5 @@ func (n *NestDotted) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	if err != nil {
 		panic(err)
 	}
-	return *zed.NewValue(typ, zbytes)
+	return zed.NewValue(typ, zbytes)
 }

--- a/runtime/expr/function/parse.go
+++ b/runtime/expr/function/parse.go
@@ -19,12 +19,12 @@ type ParseURI struct {
 func (p *ParseURI) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	in := args[0]
 	if !in.IsString() || in.IsNull() {
-		return *p.zctx.WrapError("parse_uri: non-empty string arg required", &in)
+		return p.zctx.WrapError("parse_uri: non-empty string arg required", in)
 	}
 	s := zed.DecodeString(in.Bytes())
 	u, err := url.Parse(s)
 	if err != nil {
-		return *p.zctx.WrapError("parse_uri: "+err.Error(), &in)
+		return p.zctx.WrapError("parse_uri: "+err.Error(), in)
 	}
 	var v struct {
 		Scheme   *string    `zed:"scheme"`
@@ -55,7 +55,7 @@ func (p *ParseURI) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	if portString := u.Port(); portString != "" {
 		u64, err := strconv.ParseUint(portString, 10, 16)
 		if err != nil {
-			return *p.zctx.WrapError("parse_uri: invalid port: "+portString, &in)
+			return p.zctx.WrapError("parse_uri: invalid port: "+portString, in)
 		}
 		u16 := uint16(u64)
 		v.Port = &u16
@@ -73,7 +73,7 @@ func (p *ParseURI) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	if err != nil {
 		panic(err)
 	}
-	return *out
+	return out
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#parse_zson
@@ -91,18 +91,18 @@ func newParseZSON(zctx *zed.Context) *ParseZSON {
 func (p *ParseZSON) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	in := args[0]
 	if !in.IsString() {
-		return *p.zctx.WrapError("parse_zson: string arg required", &in)
+		return p.zctx.WrapError("parse_zson: string arg required", in)
 	}
 	if in.IsNull() {
-		return *zed.Null
+		return zed.Null
 	}
 	p.sr.Reset(zed.DecodeString(in.Bytes()))
 	val, err := p.zr.Read()
 	if err != nil {
-		return *p.zctx.WrapError("parse_zson: "+err.Error(), &in)
+		return p.zctx.WrapError("parse_zson: "+err.Error(), in)
 	}
 	if val == nil {
-		return *zed.Null
+		return zed.Null
 	}
 	return *val
 }

--- a/runtime/expr/function/regexp.go
+++ b/runtime/expr/function/regexp.go
@@ -19,7 +19,7 @@ type Regexp struct {
 
 func (r *Regexp) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	if !args[0].IsString() {
-		return *r.zctx.WrapError("regexp: string required for first arg", &args[0])
+		return r.zctx.WrapError("regexp: string required for first arg", args[0])
 	}
 	s := zed.DecodeString(args[0].Bytes())
 	if r.restr != s {
@@ -27,10 +27,10 @@ func (r *Regexp) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 		r.re, r.err = regexp.Compile(r.restr)
 	}
 	if r.err != nil {
-		return *r.zctx.NewErrorf("regexp: %s", r.err)
+		return r.zctx.NewErrorf("regexp: %s", r.err)
 	}
 	if !args[1].IsString() {
-		return *r.zctx.WrapError("regexp: string required for second arg", &args[1])
+		return r.zctx.WrapError("regexp: string required for second arg", args[1])
 	}
 	r.builder.Reset()
 	for _, b := range r.re.FindSubmatch(args[1].Bytes()) {
@@ -39,7 +39,7 @@ func (r *Regexp) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	if r.typ == nil {
 		r.typ = r.zctx.LookupTypeArray(zed.TypeString)
 	}
-	return *zed.NewValue(r.typ, r.builder.Bytes())
+	return zed.NewValue(r.typ, r.builder.Bytes())
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#regexp_replace
@@ -56,21 +56,21 @@ func (r *RegexpReplace) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	newVal := args[2]
 	for i := range args {
 		if !args[i].IsString() {
-			return *r.zctx.WrapError("regexp_replace: string arg required", &args[i])
+			return r.zctx.WrapError("regexp_replace: string arg required", args[i])
 		}
 	}
 	if sVal.IsNull() {
-		return *zed.Null
+		return zed.Null
 	}
 	if reVal.IsNull() || newVal.IsNull() {
-		return *r.zctx.NewErrorf("regexp_replace: 2nd and 3rd args cannot be null")
+		return r.zctx.NewErrorf("regexp_replace: 2nd and 3rd args cannot be null")
 	}
 	if re := zed.DecodeString(reVal.Bytes()); r.restr != re {
 		r.restr = re
 		r.re, r.err = regexp.Compile(re)
 	}
 	if r.err != nil {
-		return *r.zctx.NewErrorf("regexp_replace: %s", r.err)
+		return r.zctx.NewErrorf("regexp_replace: %s", r.err)
 	}
-	return *zed.NewString(string(r.re.ReplaceAll(sVal.Bytes(), newVal.Bytes())))
+	return zed.NewString(string(r.re.ReplaceAll(sVal.Bytes(), newVal.Bytes())))
 }

--- a/runtime/expr/function/string.go
+++ b/runtime/expr/function/string.go
@@ -20,19 +20,19 @@ func (r *Replace) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	newVal := args[2]
 	for i := range args {
 		if !args[i].IsString() {
-			return *r.zctx.WrapError("replace: string arg required", &args[i])
+			return r.zctx.WrapError("replace: string arg required", args[i])
 		}
 	}
 	if sVal.IsNull() {
-		return *zed.Null
+		return zed.Null
 	}
 	if oldVal.IsNull() || newVal.IsNull() {
-		return *r.zctx.NewErrorf("replace: an input arg is null")
+		return r.zctx.NewErrorf("replace: an input arg is null")
 	}
 	s := zed.DecodeString(sVal.Bytes())
 	old := zed.DecodeString(oldVal.Bytes())
 	new := zed.DecodeString(newVal.Bytes())
-	return *zed.NewString(strings.ReplaceAll(s, old, new))
+	return zed.NewString(strings.ReplaceAll(s, old, new))
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#run_len
@@ -43,13 +43,13 @@ type RuneLen struct {
 func (r *RuneLen) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	val := args[0]
 	if !val.IsString() {
-		return *r.zctx.WrapError("rune_len: string arg required", &val)
+		return r.zctx.WrapError("rune_len: string arg required", val)
 	}
 	if val.IsNull() {
-		return *zed.NewInt64(0)
+		return zed.NewInt64(0)
 	}
 	s := zed.DecodeString(val.Bytes())
-	return *zed.NewInt64(int64(utf8.RuneCountInString(s)))
+	return zed.NewInt64(int64(utf8.RuneCountInString(s)))
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#lower
@@ -60,13 +60,13 @@ type ToLower struct {
 func (t *ToLower) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	val := args[0]
 	if !val.IsString() {
-		return *t.zctx.WrapError("lower: string arg required", &val)
+		return t.zctx.WrapError("lower: string arg required", val)
 	}
 	if val.IsNull() {
-		return *zed.NullString
+		return zed.NullString
 	}
 	s := zed.DecodeString(val.Bytes())
-	return *zed.NewString(strings.ToLower(s))
+	return zed.NewString(strings.ToLower(s))
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#upper
@@ -77,13 +77,13 @@ type ToUpper struct {
 func (t *ToUpper) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	val := args[0]
 	if !val.IsString() {
-		return *t.zctx.WrapError("upper: string arg required", &val)
+		return t.zctx.WrapError("upper: string arg required", val)
 	}
 	if val.IsNull() {
-		return *zed.NullString
+		return zed.NullString
 	}
 	s := zed.DecodeString(val.Bytes())
-	return *zed.NewString(strings.ToUpper(s))
+	return zed.NewString(strings.ToUpper(s))
 }
 
 type Trim struct {
@@ -94,13 +94,13 @@ type Trim struct {
 func (t *Trim) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	val := args[0]
 	if !val.IsString() {
-		return *t.zctx.WrapError("trim: string arg required", &val)
+		return t.zctx.WrapError("trim: string arg required", val)
 	}
 	if val.IsNull() {
-		return *zed.NullString
+		return zed.NullString
 	}
 	s := zed.DecodeString(val.Bytes())
-	return *zed.NewString(strings.TrimSpace(s))
+	return zed.NewString(strings.TrimSpace(s))
 }
 
 // // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#split
@@ -121,11 +121,11 @@ func (s *Split) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	sepVal := args[1]
 	for i := range args {
 		if !args[i].IsString() {
-			return *s.zctx.WrapError("split: string arg required", &args[i])
+			return s.zctx.WrapError("split: string arg required", args[i])
 		}
 	}
 	if sVal.IsNull() || sepVal.IsNull() {
-		return *zed.NewValue(s.typ, nil)
+		return zed.NewValue(s.typ, nil)
 	}
 	str := zed.DecodeString(sVal.Bytes())
 	sep := zed.DecodeString(sepVal.Bytes())
@@ -134,7 +134,7 @@ func (s *Split) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	for _, substr := range splits {
 		b = zcode.Append(b, zed.EncodeString(substr))
 	}
-	return *zed.NewValue(s.typ, b)
+	return zed.NewValue(s.typ, b)
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#join
@@ -147,13 +147,13 @@ func (j *Join) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	splitsVal := args[0]
 	typ, ok := zed.TypeUnder(splitsVal.Type()).(*zed.TypeArray)
 	if !ok || typ.Type.ID() != zed.IDString {
-		return *j.zctx.WrapError("join: array of string args required", &splitsVal)
+		return j.zctx.WrapError("join: array of string args required", splitsVal)
 	}
 	var separator string
 	if len(args) == 2 {
 		sepVal := args[1]
 		if !sepVal.IsString() {
-			return *j.zctx.WrapError("join: separator must be string", &sepVal)
+			return j.zctx.WrapError("join: separator must be string", sepVal)
 		}
 		separator = zed.DecodeString(sepVal.Bytes())
 	}
@@ -166,7 +166,7 @@ func (j *Join) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 		b.WriteString(zed.DecodeString(it.Next()))
 		sep = separator
 	}
-	return *zed.NewString(b.String())
+	return zed.NewString(b.String())
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#levenshtein
@@ -175,13 +175,13 @@ type Levenshtein struct {
 }
 
 func (l *Levenshtein) Call(_ zed.Allocator, args []zed.Value) zed.Value {
-	a, b := &args[0], &args[1]
+	a, b := args[0], args[1]
 	if !a.IsString() {
-		return *l.zctx.WrapError("levenshtein: string args required", a)
+		return l.zctx.WrapError("levenshtein: string args required", a)
 	}
 	if !b.IsString() {
-		return *l.zctx.WrapError("levenshtein: string args required", b)
+		return l.zctx.WrapError("levenshtein: string args required", b)
 	}
 	as, bs := zed.DecodeString(a.Bytes()), zed.DecodeString(b.Bytes())
-	return *zed.NewInt64(int64(levenshtein.ComputeDistance(as, bs)))
+	return zed.NewInt64(int64(levenshtein.ComputeDistance(as, bs)))
 }

--- a/runtime/expr/function/time.go
+++ b/runtime/expr/function/time.go
@@ -10,7 +10,7 @@ import (
 type Now struct{}
 
 func (n *Now) Call(_ zed.Allocator, _ []zed.Value) zed.Value {
-	return *zed.NewTime(nano.Now())
+	return zed.NewTime(nano.Now())
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#bucket
@@ -20,10 +20,10 @@ type Bucket struct {
 }
 
 func (b *Bucket) Call(_ zed.Allocator, args []zed.Value) zed.Value {
-	tsArg := &args[0]
-	binArg := &args[1]
+	tsArg := args[0]
+	binArg := args[1]
 	if tsArg.IsNull() || binArg.IsNull() {
-		return *zed.NullTime
+		return zed.NullTime
 	}
 	var bin nano.Duration
 	if binArg.Type() == zed.TypeDuration {
@@ -31,17 +31,17 @@ func (b *Bucket) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	} else {
 		d, ok := coerce.ToInt(binArg)
 		if !ok {
-			return *b.zctx.WrapError(b.name+": second argument is not a duration or number", binArg)
+			return b.zctx.WrapError(b.name+": second argument is not a duration or number", binArg)
 		}
 		bin = nano.Duration(d) * nano.Second
 	}
 	if zed.TypeUnder(tsArg.Type()) == zed.TypeDuration {
 		dur := nano.Duration(tsArg.Int())
-		return *zed.NewDuration(dur.Trunc(bin))
+		return zed.NewDuration(dur.Trunc(bin))
 	}
 	v, ok := coerce.ToInt(tsArg)
 	if !ok {
-		return *b.zctx.WrapError(b.name+": first argument is not a time", tsArg)
+		return b.zctx.WrapError(b.name+": first argument is not a time", tsArg)
 	}
-	return *zed.NewTime(nano.Ts(v).Trunc(bin))
+	return zed.NewTime(nano.Ts(v).Trunc(bin))
 }

--- a/runtime/expr/function/types.go
+++ b/runtime/expr/function/types.go
@@ -12,7 +12,7 @@ type TypeOf struct {
 }
 
 func (t *TypeOf) Call(_ zed.Allocator, args []zed.Value) zed.Value {
-	return *t.zctx.LookupTypeValue(args[0].Type())
+	return t.zctx.LookupTypeValue(args[0].Type())
 }
 
 type typeUnder struct {
@@ -21,7 +21,7 @@ type typeUnder struct {
 
 func (t *typeUnder) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	typ := zed.TypeUnder(args[0].Type())
-	return *t.zctx.LookupTypeValue(typ)
+	return t.zctx.LookupTypeValue(typ)
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#nameof
@@ -32,9 +32,9 @@ type NameOf struct {
 func (n *NameOf) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	typ := args[0].Type()
 	if named, ok := typ.(*zed.TypeNamed); ok {
-		return *zed.NewString(named.Name)
+		return zed.NewString(named.Name)
 	}
-	return *n.zctx.Missing()
+	return n.zctx.Missing()
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#typename
@@ -44,24 +44,24 @@ type typeName struct {
 
 func (t *typeName) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	if zed.TypeUnder(args[0].Type()) != zed.TypeString {
-		return *t.zctx.WrapError("typename: first argument not a string", &args[0])
+		return t.zctx.WrapError("typename: first argument not a string", args[0])
 	}
 	name := string(args[0].Bytes())
 	if len(args) == 1 {
 		typ := t.zctx.LookupTypeDef(name)
 		if typ == nil {
-			return *t.zctx.Missing()
+			return t.zctx.Missing()
 		}
-		return *t.zctx.LookupTypeValue(typ)
+		return t.zctx.LookupTypeValue(typ)
 	}
 	if zed.TypeUnder(args[1].Type()) != zed.TypeType {
-		return *t.zctx.WrapError("typename: second argument not a type value", &args[1])
+		return t.zctx.WrapError("typename: second argument not a type value", args[1])
 	}
 	typ, err := t.zctx.LookupByValue(args[1].Bytes())
 	if err != nil {
-		return *t.zctx.NewError(err)
+		return t.zctx.NewError(err)
 	}
-	return *t.zctx.LookupTypeValue(typ)
+	return t.zctx.LookupTypeValue(typ)
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#error
@@ -70,14 +70,14 @@ type Error struct {
 }
 
 func (e *Error) Call(_ zed.Allocator, args []zed.Value) zed.Value {
-	return *zed.NewValue(e.zctx.LookupTypeError(args[0].Type()), args[0].Bytes())
+	return zed.NewValue(e.zctx.LookupTypeError(args[0].Type()), args[0].Bytes())
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#iserr
 type IsErr struct{}
 
 func (*IsErr) Call(_ zed.Allocator, args []zed.Value) zed.Value {
-	return *zed.NewBool(args[0].IsError())
+	return zed.NewBool(args[0].IsError())
 }
 
 // https://github.com/brimdata/zed/blob/main/docs/language/functions.md#is
@@ -99,7 +99,7 @@ func (i *Is) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	} else {
 		typ, err = i.zctx.LookupByValue(zvTypeVal.Bytes())
 	}
-	return *zed.NewBool(err == nil && typ == zvSubject.Type())
+	return zed.NewBool(err == nil && typ == zvSubject.Type())
 }
 
 type HasError struct {
@@ -115,7 +115,7 @@ func NewHasError() *HasError {
 func (h *HasError) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	val := args[0]
 	hasError, _ := h.hasError(val.Type(), val.Bytes())
-	return *zed.NewBool(hasError)
+	return zed.NewBool(hasError)
 }
 
 func (h *HasError) hasError(t zed.Type, b zcode.Bytes) (bool, bool) {
@@ -184,7 +184,7 @@ type Quiet struct {
 func (q *Quiet) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	val := args[0]
 	if val.IsMissing() {
-		return *q.zctx.Quiet()
+		return q.zctx.Quiet()
 	}
 	return val
 }
@@ -206,5 +206,5 @@ func (k *Kind) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	} else {
 		typ = val.Type()
 	}
-	return *zed.NewString(typ.Kind().String())
+	return zed.NewString(typ.Kind().String())
 }

--- a/runtime/expr/function/under.go
+++ b/runtime/expr/function/under.go
@@ -13,17 +13,17 @@ func (u *Under) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 	val := args[0]
 	switch typ := args[0].Type().(type) {
 	case *zed.TypeNamed:
-		return *zed.NewValue(typ.Type, val.Bytes())
+		return zed.NewValue(typ.Type, val.Bytes())
 	case *zed.TypeError:
-		return *zed.NewValue(typ.Type, val.Bytes())
+		return zed.NewValue(typ.Type, val.Bytes())
 	case *zed.TypeUnion:
-		return *zed.NewValue(typ.Untag(val.Bytes()))
+		return zed.NewValue(typ.Untag(val.Bytes()))
 	case *zed.TypeOfType:
 		t, err := u.zctx.LookupByValue(val.Bytes())
 		if err != nil {
-			return *u.zctx.NewError(err)
+			return u.zctx.NewError(err)
 		}
-		return *u.zctx.LookupTypeValue(zed.TypeUnder(t))
+		return u.zctx.LookupTypeValue(zed.TypeUnder(t))
 	default:
 		return val
 	}

--- a/runtime/expr/function/unflatten.go
+++ b/runtime/expr/function/unflatten.go
@@ -42,7 +42,7 @@ func (u *Unflatten) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 		bytes := it.Next()
 		path, typ, vb, err := u.parseElem(array.Type, bytes)
 		if err != nil {
-			return *u.zctx.WrapError(err.Error(), zed.NewValue(array.Type, bytes))
+			return u.zctx.WrapError(err.Error(), zed.NewValue(array.Type, bytes))
 		}
 		if typ == nil {
 			continue
@@ -62,9 +62,9 @@ func (u *Unflatten) Call(_ zed.Allocator, args []zed.Value) zed.Value {
 		return typ, value
 	})
 	if err != nil {
-		return *u.zctx.WrapError(err.Error(), &val)
+		return u.zctx.WrapError(err.Error(), val)
 	}
-	return *zed.NewValue(typ, u.builder.Bytes())
+	return zed.NewValue(typ, u.builder.Bytes())
 }
 
 func (u *Unflatten) parseElem(inner zed.Type, vb zcode.Bytes) (field.Path, zed.Type, zcode.Bytes, error) {

--- a/runtime/expr/functions_test.go
+++ b/runtime/expr/functions_test.go
@@ -14,7 +14,7 @@ func TestBadFunction(t *testing.T) {
 	testError(t, "notafunction()", function.ErrNoSuchFunction, "calling nonexistent function")
 }
 
-func ZSON(s string) *zed.Value {
+func ZSON(s string) zed.Value {
 	val, err := zson.ParseValue(zed.NewContext(), s)
 	if err != nil {
 		panic(fmt.Sprintf("zson parse failed compiling: %q (%s)", s, err))

--- a/runtime/expr/literal.go
+++ b/runtime/expr/literal.go
@@ -2,17 +2,16 @@ package expr
 
 import "github.com/brimdata/zed"
 
-// Literal is a pointer so it can point to known Zed singletons.
 type Literal struct {
-	val *zed.Value
+	val zed.Value
 }
 
 var _ Evaluator = (*Literal)(nil)
 
-func NewLiteral(val *zed.Value) *Literal {
+func NewLiteral(val zed.Value) *Literal {
 	return &Literal{val: val}
 }
 
-func (l Literal) Eval(Context, *zed.Value) *zed.Value {
+func (l Literal) Eval(Context, zed.Value) zed.Value {
 	return l.val
 }

--- a/runtime/expr/lval.go
+++ b/runtime/expr/lval.go
@@ -17,9 +17,8 @@ func NewLval(evals []LvalElem) *Lval {
 	return &Lval{Elems: evals}
 }
 
-// Eval returns the path of the lval. If there's an error the returned *zed.Value
-// will not be nill.
-func (l *Lval) Eval(ectx Context, this *zed.Value) (field.Path, error) {
+// Eval returns the path of the lval.
+func (l *Lval) Eval(ectx Context, this zed.Value) (field.Path, error) {
 	l.cache = l.cache[:0]
 	for _, e := range l.Elems {
 		name, err := e.Eval(ectx, this)
@@ -46,14 +45,14 @@ func (l *Lval) Path() (field.Path, bool) {
 }
 
 type LvalElem interface {
-	Eval(ectx Context, this *zed.Value) (string, error)
+	Eval(ectx Context, this zed.Value) (string, error)
 }
 
 type StaticLvalElem struct {
 	Name string
 }
 
-func (l *StaticLvalElem) Eval(_ Context, _ *zed.Value) (string, error) {
+func (l *StaticLvalElem) Eval(_ Context, _ zed.Value) (string, error) {
 	return l.Name, nil
 }
 
@@ -69,7 +68,7 @@ func NewExprLvalElem(zctx *zed.Context, e Evaluator) *ExprLvalElem {
 	}
 }
 
-func (l *ExprLvalElem) Eval(ectx Context, this *zed.Value) (string, error) {
+func (l *ExprLvalElem) Eval(ectx Context, this zed.Value) (string, error) {
 	val := l.eval.Eval(ectx, this)
 	if val.IsError() {
 		return "", lvalErr(ectx, val)
@@ -82,8 +81,8 @@ func (l *ExprLvalElem) Eval(ectx Context, this *zed.Value) (string, error) {
 	return val.AsString(), nil
 }
 
-func lvalErr(ectx Context, errVal *zed.Value) error {
-	val := ectx.NewValue(errVal.Type().(*zed.TypeError).Type, errVal.Bytes())
+func lvalErr(ectx Context, errVal zed.Value) error {
+	val := zed.NewValue(errVal.Type().(*zed.TypeError).Type, errVal.Bytes())
 	if val.IsString() {
 		return errors.New(val.AsString())
 	}

--- a/runtime/expr/renamer.go
+++ b/runtime/expr/renamer.go
@@ -28,13 +28,13 @@ func NewRenamer(zctx *zed.Context, srcs, dsts []*Lval) *Renamer {
 	return &Renamer{zctx, srcs, dsts, make(map[int]map[string]*zed.TypeRecord), nil}
 }
 
-func (r *Renamer) Eval(ectx Context, this *zed.Value) *zed.Value {
+func (r *Renamer) Eval(ectx Context, this zed.Value) zed.Value {
 	if !zed.IsRecordType(this.Type()) {
 		return this
 	}
 	srcs, dsts, err := r.evalFields(ectx, this)
 	if err != nil {
-		return ectx.CopyValue(*r.zctx.WrapError(fmt.Sprintf("rename: %s", err), this))
+		return r.zctx.WrapError(fmt.Sprintf("rename: %s", err), this)
 	}
 	id := this.Type().ID()
 	m, ok := r.typeMap[id]
@@ -48,11 +48,11 @@ func (r *Renamer) Eval(ectx Context, this *zed.Value) *zed.Value {
 		var err error
 		typ, err = r.computeType(zed.TypeRecordOf(this.Type()), srcs, dsts)
 		if err != nil {
-			return ectx.CopyValue(*r.zctx.WrapError(fmt.Sprintf("rename: %s", err), this))
+			return r.zctx.WrapError(fmt.Sprintf("rename: %s", err), this)
 		}
 		m[string(r.fieldsStr)] = typ
 	}
-	return ectx.NewValue(typ, this.Bytes())
+	return zed.NewValue(typ, this.Bytes())
 }
 
 func CheckRenameField(src, dst field.Path) error {
@@ -67,7 +67,7 @@ func CheckRenameField(src, dst field.Path) error {
 	return nil
 }
 
-func (r *Renamer) evalFields(ectx Context, this *zed.Value) (field.List, field.List, error) {
+func (r *Renamer) evalFields(ectx Context, this zed.Value) (field.List, field.List, error) {
 	var srcs, dsts field.List
 	for i := range r.srcs {
 		src, err := r.srcs[i].Eval(ectx, this)

--- a/runtime/expr/slice.go
+++ b/runtime/expr/slice.go
@@ -28,7 +28,7 @@ func NewSlice(zctx *zed.Context, elem, from, to Evaluator) *Slice {
 var ErrSliceIndex = errors.New("slice index is not a number")
 var ErrSliceIndexEmpty = errors.New("slice index is empty")
 
-func (s *Slice) Eval(ectx Context, this *zed.Value) *zed.Value {
+func (s *Slice) Eval(ectx Context, this zed.Value) zed.Value {
 	elem := s.elem.Eval(ectx, this)
 	if elem.IsError() {
 		return elem
@@ -81,10 +81,10 @@ func (s *Slice) Eval(ectx Context, this *zed.Value) *zed.Value {
 	default:
 		panic(elem.Type())
 	}
-	return ectx.NewValue(elem.Type(), bytes)
+	return zed.NewValue(elem.Type(), bytes)
 }
 
-func sliceIndex(ectx Context, this *zed.Value, slot Evaluator, length int) (int, error) {
+func sliceIndex(ectx Context, this zed.Value, slot Evaluator, length int) (int, error) {
 	if slot == nil {
 		//XXX
 		return 0, ErrSliceIndexEmpty

--- a/runtime/expr/sort_test.go
+++ b/runtime/expr/sort_test.go
@@ -27,7 +27,7 @@ func BenchmarkSort(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				b.StopTimer()
 				for i := range vals {
-					vals[i] = *zed.NewValue(c.typ, c.bytes())
+					vals[i] = zed.NewValue(c.typ, c.bytes())
 				}
 				b.StartTimer()
 				cmp.SortStable(vals)

--- a/runtime/expr/udf.go
+++ b/runtime/expr/udf.go
@@ -24,7 +24,7 @@ func (u *UDF) Call(ectx zed.Allocator, args []zed.Value) zed.Value {
 	// recursive calls.
 	f := &frame{stack: stack, vars: slices.Clone(args)}
 	defer f.exit()
-	return *u.Body.Eval(f, zed.Null)
+	return u.Body.Eval(f, zed.Null)
 }
 
 type frame struct {

--- a/runtime/expr/var.go
+++ b/runtime/expr/var.go
@@ -10,6 +10,6 @@ func NewVar(slot int) *Var {
 	return (*Var)(&slot)
 }
 
-func (v Var) Eval(ectx Context, _ *zed.Value) *zed.Value {
-	return &ectx.Vars()[v]
+func (v Var) Eval(ectx Context, _ zed.Value) zed.Value {
+	return ectx.Vars()[v]
 }

--- a/runtime/op/apply.go
+++ b/runtime/op/apply.go
@@ -31,13 +31,13 @@ func (a *applier) Pull(done bool) (zbuf.Batch, error) {
 		vals := batch.Values()
 		out := make([]zed.Value, 0, len(vals))
 		for i := range vals {
-			val := a.expr.Eval(a.ectx.Reset(), &vals[i])
+			val := a.expr.Eval(a.ectx.Reset(), vals[i])
 			if val.IsError() {
 				if val.IsQuiet() || val.IsMissing() {
 					continue
 				}
 			}
-			out = append(out, *val.Copy())
+			out = append(out, val.Copy())
 		}
 		if len(out) > 0 {
 			defer batch.Unref()

--- a/runtime/op/explode/explode.go
+++ b/runtime/op/explode/explode.go
@@ -40,17 +40,17 @@ func (o *Op) Pull(done bool) (zbuf.Batch, error) {
 		out := make([]zed.Value, 0, len(vals))
 		for i := range vals {
 			for _, arg := range o.args {
-				val := arg.Eval(o.ectx.Reset(), &vals[i])
+				val := arg.Eval(o.ectx.Reset(), vals[i])
 				if val.IsError() {
 					if !val.IsMissing() {
-						out = append(out, *val.Copy())
+						out = append(out, val.Copy())
 					}
 					continue
 				}
 				zed.Walk(val.Type(), val.Bytes(), func(typ zed.Type, body zcode.Bytes) error {
 					if typ == o.typ && body != nil {
 						bytes := zcode.Append(nil, body)
-						out = append(out, *zed.NewValue(o.outType, bytes))
+						out = append(out, zed.NewValue(o.outType, bytes))
 						return zed.SkipContainer
 					}
 					return nil

--- a/runtime/op/exprswitch/exprswitch.go
+++ b/runtime/op/exprswitch/exprswitch.go
@@ -47,7 +47,7 @@ func (s *ExprSwitch) Forward(router *op.Router, batch zbuf.Batch) bool {
 	s.ectx.SetVars(batch.Vars())
 	vals := batch.Values()
 	for i := range vals {
-		val := s.expr.Eval(s.ectx.Reset(), &vals[i])
+		val := s.expr.Eval(s.ectx.Reset(), vals[i])
 		if val.IsMissing() {
 			continue
 		}

--- a/runtime/op/fuse/fuser.go
+++ b/runtime/op/fuse/fuser.go
@@ -15,7 +15,7 @@ type Fuser struct {
 	memMaxBytes int
 
 	nbytes  int
-	vals    []*zed.Value
+	vals    []zed.Value
 	spiller *spill.File
 
 	types      map[zed.Type]struct{}
@@ -68,7 +68,7 @@ func (f *Fuser) stash(rec zed.Value) error {
 			return err
 		}
 		for _, rec := range f.vals {
-			if err := f.spiller.Write(*rec); err != nil {
+			if err := f.spiller.Write(rec); err != nil {
 				return err
 			}
 		}
@@ -95,7 +95,7 @@ func (f *Fuser) Read() (*zed.Value, error) {
 	if rec == nil || err != nil {
 		return nil, err
 	}
-	return f.shaper.Eval(f.ectx.Reset(), rec), nil
+	return f.shaper.Eval(f.ectx.Reset(), *rec).Ptr(), nil
 }
 
 func (f *Fuser) next() (*zed.Value, error) {
@@ -104,7 +104,7 @@ func (f *Fuser) next() (*zed.Value, error) {
 	}
 	var rec *zed.Value
 	if len(f.vals) > 0 {
-		rec = f.vals[0]
+		rec = &f.vals[0]
 		f.vals = f.vals[1:]
 	}
 	return rec, nil

--- a/runtime/op/groupby/row.go
+++ b/runtime/op/groupby/row.go
@@ -19,13 +19,13 @@ func newValRow(aggs []*expr.Aggregator) valRow {
 	return row
 }
 
-func (v valRow) apply(zctx *zed.Context, ectx expr.Context, aggs []*expr.Aggregator, this *zed.Value) {
+func (v valRow) apply(zctx *zed.Context, ectx expr.Context, aggs []*expr.Aggregator, this zed.Value) {
 	for k, a := range aggs {
 		a.Apply(zctx, ectx, v[k], this)
 	}
 }
 
-func (v valRow) consumeAsPartial(rec *zed.Value, exprs []expr.Evaluator, ectx expr.Context) {
+func (v valRow) consumeAsPartial(rec zed.Value, exprs []expr.Evaluator, ectx expr.Context) {
 	for k, r := range v {
 		val := exprs[k].Eval(ectx, rec)
 		if val.IsError() {
@@ -34,7 +34,7 @@ func (v valRow) consumeAsPartial(rec *zed.Value, exprs []expr.Evaluator, ectx ex
 		//XXX should do soemthing with errors... they could come from
 		// a worker over the network?
 		if !val.IsError() {
-			r.ConsumeAsPartial(*val)
+			r.ConsumeAsPartial(val)
 		}
 	}
 }

--- a/runtime/op/load/load.go
+++ b/runtime/op/load/load.go
@@ -66,7 +66,6 @@ func (o *Op) Pull(done bool) (zbuf.Batch, error) {
 	if err != nil {
 		return nil, err
 	}
-	commitByte := zed.NewBytes(commitID[:])
-	valueID := []zed.Value{*commitByte}
-	return zbuf.NewArray(valueID), nil
+	val := zed.NewBytes(commitID[:])
+	return zbuf.NewArray([]zed.Value{val}), nil
 }

--- a/runtime/op/merge/merge.go
+++ b/runtime/op/merge/merge.go
@@ -60,7 +60,7 @@ func (o *Op) Pull(done bool) (zbuf.Batch, error) {
 		return nil, o.start()
 	}
 	min := heap.Pop(o).(*puller)
-	if o.Len() == 0 || o.cmp(&min.vals[len(min.vals)-1], &o.hol[0].vals[0]) <= 0 {
+	if o.Len() == 0 || o.cmp(min.vals[len(min.vals)-1], o.hol[0].vals[0]) <= 0 {
 		// Either min is the only upstreams or min's last value is less
 		// than or equal to the next upstream's first value.  Either
 		// way, it's safe to return min's remaining values as a batch.
@@ -158,7 +158,7 @@ func (o *Op) propagateDone() error {
 func (o *Op) Len() int { return len(o.hol) }
 
 func (o *Op) Less(i, j int) bool {
-	return o.cmp(&o.hol[i].vals[0], &o.hol[j].vals[0]) < 0
+	return o.cmp(o.hol[i].vals[0], o.hol[j].vals[0]) < 0
 }
 
 func (o *Op) Swap(i, j int) { o.hol[i], o.hol[j] = o.hol[j], o.hol[i] }

--- a/runtime/op/meta/deleter.go
+++ b/runtime/op/meta/deleter.go
@@ -87,14 +87,14 @@ func (d *Deleter) nextDeletion() (zbuf.Puller, error) {
 			// We currently support only one partition per batch.
 			return nil, errors.New("internal error: meta.Deleter encountered multi-valued batch")
 		}
-		if hasDeletes, err := d.hasDeletes(&vals[0]); err != nil {
+		if hasDeletes, err := d.hasDeletes(vals[0]); err != nil {
 			return nil, err
 		} else if !hasDeletes {
 			continue
 		}
 		// Use a no-op progress so stats are not inflated.
 		var progress zbuf.Progress
-		scanner, object, err := newScanner(d.octx.Context, d.octx.Zctx, d.pool, d.unmarshaler, d.pruner, d.filter, &progress, &vals[0])
+		scanner, object, err := newScanner(d.octx.Context, d.octx.Zctx, d.pool, d.unmarshaler, d.pruner, d.filter, &progress, vals[0])
 		if err != nil {
 			return nil, err
 		}
@@ -103,7 +103,7 @@ func (d *Deleter) nextDeletion() (zbuf.Puller, error) {
 	}
 }
 
-func (d *Deleter) hasDeletes(val *zed.Value) (bool, error) {
+func (d *Deleter) hasDeletes(val zed.Value) (bool, error) {
 	scanner, object, err := newScanner(d.octx.Context, d.octx.Zctx, d.pool, d.unmarshaler, d.pruner, d.filter, d.progress, val)
 	if err != nil {
 		return false, err

--- a/runtime/op/meta/lister.go
+++ b/runtime/op/meta/lister.go
@@ -90,7 +90,7 @@ func (l *Lister) Pull(done bool) (zbuf.Batch, error) {
 			return nil, err
 		}
 		if !l.pruner.prune(val) {
-			return zbuf.NewArray([]zed.Value{*val}), nil
+			return zbuf.NewArray([]zed.Value{val}), nil
 		}
 	}
 	return nil, nil
@@ -106,7 +106,7 @@ func initObjectScan(snap commits.View, sortKey order.SortKey) []*data.Object {
 func sortObjects(objects []*data.Object, o order.Which) {
 	cmp := expr.NewValueCompareFn(o, true)
 	lessFunc := func(a, b *data.Object) bool {
-		aFrom, aTo, bFrom, bTo := &a.Min, &a.Max, &b.Min, &b.Max
+		aFrom, aTo, bFrom, bTo := a.Min, a.Max, b.Min, b.Max
 		if o == order.Desc {
 			aFrom, aTo, bFrom, bTo = aTo, aFrom, bTo, bFrom
 		}

--- a/runtime/op/meta/pruner.go
+++ b/runtime/op/meta/pruner.go
@@ -14,7 +14,7 @@ func newPruner(e expr.Evaluator) *pruner {
 	return &pruner{pred: e}
 }
 
-func (p *pruner) prune(val *zed.Value) bool {
+func (p *pruner) prune(val zed.Value) bool {
 	if p == nil {
 		return false
 	}

--- a/runtime/op/meta/scanner.go
+++ b/runtime/op/meta/scanner.go
@@ -121,7 +121,7 @@ func objectReader(ctx context.Context, zctx *zed.Context, snap commits.View, ord
 		}
 		val, err := m.Marshal(objects[0])
 		objects = objects[1:]
-		return val, err
+		return &val, err
 	}), nil
 }
 

--- a/runtime/op/meta/sequence.go
+++ b/runtime/op/meta/sequence.go
@@ -73,7 +73,7 @@ func (s *SequenceScanner) Pull(done bool) (zbuf.Batch, error) {
 				s.close(err)
 				return nil, err
 			}
-			s.scanner, _, err = newScanner(s.octx.Context, s.octx.Zctx, s.pool, s.unmarshaler, s.pruner, s.filter, s.progress, &vals[0])
+			s.scanner, _, err = newScanner(s.octx.Context, s.octx.Zctx, s.pool, s.unmarshaler, s.pruner, s.filter, s.progress, vals[0])
 			if err != nil {
 				s.close(err)
 				return nil, err
@@ -96,7 +96,7 @@ func (s *SequenceScanner) close(err error) {
 	s.done = true
 }
 
-func newScanner(ctx context.Context, zctx *zed.Context, pool *lake.Pool, u *zson.UnmarshalZNGContext, pruner expr.Evaluator, filter zbuf.Filter, progress *zbuf.Progress, val *zed.Value) (zbuf.Puller, *data.Object, error) {
+func newScanner(ctx context.Context, zctx *zed.Context, pool *lake.Pool, u *zson.UnmarshalZNGContext, pruner expr.Evaluator, filter zbuf.Filter, progress *zbuf.Progress, val zed.Value) (zbuf.Puller, *data.Object, error) {
 	named, ok := val.Type().(*zed.TypeNamed)
 	if !ok {
 		return nil, nil, errors.New("system error: SequenceScanner encountered unnamed object")

--- a/runtime/op/shape/shaper.go
+++ b/runtime/op/shape/shaper.go
@@ -20,7 +20,7 @@ type Shaper struct {
 	spiller    *spill.File
 	hash       maphash.Hash
 	val        zed.Value
-	vals       []*zed.Value
+	vals       []zed.Value
 }
 
 type anchor struct {
@@ -86,7 +86,7 @@ func (i *integer) check(val zed.Value) {
 func (a *anchor) updateInts(rec *zed.Value) error {
 	it := rec.Bytes().Iter()
 	for k, f := range rec.Fields() {
-		a.integers[k].check(*zed.NewValue(f.Type, it.Next()))
+		a.integers[k].check(zed.NewValue(f.Type, it.Next()))
 	}
 	return nil
 }
@@ -237,7 +237,7 @@ func (s *Shaper) stash(rec zed.Value) error {
 			return err
 		}
 		for _, rec := range s.vals {
-			if err := s.spiller.Write(*rec); err != nil {
+			if err := s.spiller.Write(rec); err != nil {
 				return err
 			}
 		}
@@ -268,7 +268,7 @@ func (s *Shaper) Read() (*zed.Value, error) {
 		}
 		typ = targetType
 	}
-	s.val = *zed.NewValue(typ, bytes)
+	s.val = zed.NewValue(typ, bytes)
 	return &s.val, nil
 }
 
@@ -302,7 +302,7 @@ func (s *Shaper) next() (*zed.Value, error) {
 	}
 	var rec *zed.Value
 	if len(s.vals) > 0 {
-		rec = s.vals[0]
+		rec = &s.vals[0]
 		s.vals = s.vals[1:]
 	}
 	return rec, nil

--- a/runtime/op/sort/sort.go
+++ b/runtime/op/sort/sort.go
@@ -118,7 +118,7 @@ func (o *Op) run() {
 		var delta int
 		out, delta = o.append(out, batch)
 		if o.comparator == nil && len(out) > 0 {
-			o.setComparator(&out[0])
+			o.setComparator(out[0])
 		}
 		nbytes += delta
 		if nbytes < MemMaxBytes {
@@ -190,7 +190,7 @@ func (o *Op) append(out []zed.Value, batch zbuf.Batch) ([]zed.Value, int) {
 	return out, nbytes
 }
 
-func (o *Op) setComparator(r *zed.Value) {
+func (o *Op) setComparator(r zed.Value) {
 	resolvers := o.fieldResolvers
 	if resolvers == nil {
 		fld := GuessSortKey(r)
@@ -205,7 +205,7 @@ func (o *Op) setComparator(r *zed.Value) {
 	o.comparator = expr.NewComparator(nullsMax, reverse, resolvers...).WithMissingAsNull()
 }
 
-func GuessSortKey(val *zed.Value) field.Path {
+func GuessSortKey(val zed.Value) field.Path {
 	recType := zed.TypeRecordOf(val.Type())
 	if recType == nil {
 		// A nil field.Path is equivalent to "this".

--- a/runtime/op/spill/merge.go
+++ b/runtime/op/spill/merge.go
@@ -139,7 +139,7 @@ func (r *MergeSort) SpillSize() int64 {
 func (r *MergeSort) Len() int { return len(r.runs) }
 
 func (r *MergeSort) Less(i, j int) bool {
-	if v := r.comparator.Compare(r.runs[i].nextRecord, r.runs[j].nextRecord); v != 0 {
+	if v := r.comparator.Compare(*r.runs[i].nextRecord, *r.runs[j].nextRecord); v != 0 {
 		return v < 0
 	}
 	// Maintain stability.

--- a/runtime/op/spill/peeker.go
+++ b/runtime/op/spill/peeker.go
@@ -39,7 +39,7 @@ func newPeeker(ctx context.Context, zctx *zed.Context, filename string, ordinal 
 func (p *peeker) read() (*zed.Value, bool, error) {
 	rec := p.nextRecord
 	if rec != nil {
-		rec = rec.Copy()
+		rec = rec.Copy().Ptr()
 	}
 	var err error
 	p.nextRecord, err = p.Read()

--- a/runtime/op/switcher/switch.go
+++ b/runtime/op/switcher/switch.go
@@ -40,7 +40,7 @@ func (s *Selector) Forward(router *op.Router, batch zbuf.Batch) bool {
 	s.ectx.SetVars(batch.Vars())
 	vals := batch.Values()
 	for i := range vals {
-		this := &vals[i]
+		this := vals[i]
 		for _, c := range s.cases {
 			val := c.filter.Eval(s.ectx.Reset(), this)
 			if val.IsMissing() {
@@ -49,13 +49,13 @@ func (s *Selector) Forward(router *op.Router, batch zbuf.Batch) bool {
 			if val.IsError() {
 				// XXX should use structured here to wrap
 				// the input value with the error
-				c.vals = append(c.vals, *val)
+				c.vals = append(c.vals, val)
 				continue
 				//XXX don't break here?
 				//break
 			}
 			if val.Type() == zed.TypeBool && val.Bool() {
-				c.vals = append(c.vals, *this)
+				c.vals = append(c.vals, this)
 				break
 			}
 		}

--- a/runtime/op/tail/tail.go
+++ b/runtime/op/tail/tail.go
@@ -77,7 +77,7 @@ func (o *Op) Pull(done bool) (zbuf.Batch, error) {
 		}
 		vals := batch.Values()
 		for i := range vals {
-			o.q[o.off] = *vals[i].Copy()
+			o.q[o.off] = vals[i].Copy()
 			o.off = (o.off + 1) % o.limit
 			o.count++
 			if o.count >= o.limit {

--- a/runtime/op/top/top.go
+++ b/runtime/op/top/top.go
@@ -49,7 +49,7 @@ func (o *Op) Pull(done bool) (zbuf.Batch, error) {
 		}
 		vals := batch.Values()
 		for i := range vals {
-			o.consume(&vals[i])
+			o.consume(vals[i])
 		}
 		batch.Unref()
 		if o.flushEvery {
@@ -58,7 +58,7 @@ func (o *Op) Pull(done bool) (zbuf.Batch, error) {
 	}
 }
 
-func (o *Op) consume(rec *zed.Value) {
+func (o *Op) consume(rec zed.Value) {
 	if o.fields == nil {
 		fld := sort.GuessSortKey(rec)
 		accessor := expr.NewDottedExpr(o.zctx, fld)
@@ -83,7 +83,7 @@ func (o *Op) sorted() zbuf.Batch {
 	}
 	out := make([]zed.Value, o.records.Len())
 	for i := o.records.Len() - 1; i >= 0; i-- {
-		out[i] = *heap.Pop(o.records).(*zed.Value)
+		out[i] = heap.Pop(o.records).(zed.Value)
 	}
 	// clear records
 	o.records = nil

--- a/runtime/op/traverse/scope.go
+++ b/runtime/op/traverse/scope.go
@@ -158,7 +158,7 @@ func NewEnter(names []string, exprs []expr.Evaluator) *Enter {
 	}
 }
 
-func (e *Enter) addLocals(batch zbuf.Batch, this *zed.Value) zbuf.Batch {
+func (e *Enter) addLocals(batch zbuf.Batch, this zed.Value) zbuf.Batch {
 	inner := newScopedBatch(batch, len(e.exprs))
 	for _, expr := range e.exprs {
 		// Note that we add a var to the frame on each Eval call
@@ -271,8 +271,8 @@ func (s *scope) Vars() []zed.Value {
 	return s.vars
 }
 
-func (s *scope) push(val *zed.Value) {
-	s.vars = append(s.vars, *val)
+func (s *scope) push(val zed.Value) {
+	s.vars = append(s.vars, val)
 }
 
 type exitScope struct {

--- a/runtime/op/uniq/uniq.go
+++ b/runtime/op/uniq/uniq.go
@@ -26,7 +26,7 @@ func New(octx *op.Context, parent zbuf.Puller, cflag bool) *Op {
 	}
 }
 
-func (o *Op) wrap(t *zed.Value) *zed.Value {
+func (o *Op) wrap(t *zed.Value) zed.Value {
 	if o.cflag {
 		o.builder.Reset()
 		o.builder.Append(t.Bytes())
@@ -37,20 +37,20 @@ func (o *Op) wrap(t *zed.Value) *zed.Value {
 		})
 		return zed.NewValue(typ, o.builder.Bytes()).Copy()
 	}
-	return t
+	return *t
 }
 
 func (o *Op) appendUniq(out []zed.Value, t *zed.Value) []zed.Value {
 	if o.count == 0 {
-		o.last = t.Copy()
+		o.last = t.Copy().Ptr()
 		o.count = 1
 		return out
 	} else if bytes.Equal(t.Bytes(), o.last.Bytes()) {
 		o.count++
 		return out
 	}
-	out = append(out, *o.wrap(o.last))
-	o.last = t.Copy()
+	out = append(out, o.wrap(o.last))
+	o.last = t.Copy().Ptr()
 	o.count = 1
 	return out
 }
@@ -69,7 +69,7 @@ func (o *Op) Pull(done bool) (zbuf.Batch, error) {
 			}
 			t := o.wrap(o.last)
 			o.last = nil
-			return zbuf.NewArray([]zed.Value{*t}), nil
+			return zbuf.NewArray([]zed.Value{t}), nil
 		}
 		var out []zed.Value
 		vals := batch.Values()

--- a/runtime/op/yield/yield.go
+++ b/runtime/op/yield/yield.go
@@ -30,11 +30,11 @@ func (o *Op) Pull(done bool) (zbuf.Batch, error) {
 		out := make([]zed.Value, 0, len(o.exprs)*len(vals))
 		for i := range vals {
 			for _, e := range o.exprs {
-				val := e.Eval(o.ectx.Reset(), &vals[i])
+				val := e.Eval(o.ectx.Reset(), vals[i])
 				if val.IsQuiet() {
 					continue
 				}
-				out = append(out, *val.Copy())
+				out = append(out, val.Copy())
 			}
 		}
 		if len(out) > 0 {

--- a/runtime/vam/materialize.go
+++ b/runtime/vam/materialize.go
@@ -37,7 +37,7 @@ func (m *Materializer) Pull(done bool) (zbuf.Batch, error) {
 		// will change soon anyway when we change out vector Builder to a
 		// slot-based indexing approach that isn't based on closures.
 		val := zed.NewValue(typ, bytes.Clone(builder.Bytes().Body()))
-		vals = append(vals, *val)
+		vals = append(vals, val)
 		builder.Reset()
 	}
 }

--- a/runtime/vam/projection.go
+++ b/runtime/vam/projection.go
@@ -127,7 +127,7 @@ func (p *Projection) Read() (*zed.Value, error) {
 			if ok := projector.build(&p.builder); !ok {
 				return nil, nil
 			}
-			return zed.NewValue(projector.recType, p.builder.Bytes().Body()), nil
+			return zed.NewValue(projector.recType, p.builder.Bytes().Body()).Ptr(), nil
 		}
 	}
 }

--- a/runtime/vam/scan.go
+++ b/runtime/vam/scan.go
@@ -120,7 +120,7 @@ func (v *VecScanner) run() {
 			return
 		}
 		var meta data.Object
-		if err := v.unmarshaler.Unmarshal(&vals[0], &meta); err != nil {
+		if err := v.unmarshaler.Unmarshal(vals[0], &meta); err != nil {
 			v.sendResult(nil, fmt.Errorf("system error: VecScanner could not unmarshal value: %q", zson.String(vals[0])))
 			return
 		}

--- a/runtime/vcache/reader.go
+++ b/runtime/vcache/reader.go
@@ -40,6 +40,6 @@ func (r *Reader) Read() (*zed.Value, error) {
 		panic(fmt.Sprintf("vector.Builder returned false for key %d at offset %d", key, r.off))
 	}
 	r.off++
-	r.val = *zed.NewValue(o.typeDict[key], r.builder.Bytes().Body())
+	r.val = zed.NewValue(o.typeDict[key], r.builder.Bytes().Body())
 	return &r.val, nil
 }

--- a/service/client_test.go
+++ b/service/client_test.go
@@ -61,7 +61,7 @@ func (c *testClient) TestPoolList() []pools.Config {
 			return confs
 		}
 		var pool pools.Config
-		err = zson.UnmarshalZNG(rec, &pool)
+		err = zson.UnmarshalZNG(*rec, &pool)
 		require.NoError(c, err)
 		confs = append(confs, pool)
 	}

--- a/service/eventstream.go
+++ b/service/eventstream.go
@@ -12,7 +12,7 @@ import (
 
 type event struct {
 	name  string
-	value *zed.Value
+	value zed.Value
 }
 
 type eventStreamWriter struct {
@@ -26,7 +26,7 @@ func (e *eventStreamWriter) writeEvent(ev event) error {
 	if err != nil {
 		return err
 	}
-	if err := w.Write(*ev.value); err != nil {
+	if err := w.Write(ev.value); err != nil {
 		return err
 	}
 	if err := w.Close(); err != nil {

--- a/service/request.go
+++ b/service/request.go
@@ -188,7 +188,7 @@ func (r *Request) Unmarshal(w *ResponseWriter, body interface{}, templates ...in
 	}
 	m := zson.NewZNGUnmarshaler()
 	m.Bind(templates...)
-	if err := m.Unmarshal(zv, body); err != nil {
+	if err := m.Unmarshal(*zv, body); err != nil {
 		w.Error(srverr.ErrInvalid(err))
 		return false
 	}
@@ -289,7 +289,7 @@ func (w *ResponseWriter) Marshal(body interface{}) bool {
 	if zw == nil {
 		return false
 	}
-	if err := zw.Write(*rec); err != nil {
+	if err := zw.Write(rec); err != nil {
 		w.Error(err)
 		return false
 	}

--- a/value.go
+++ b/value.go
@@ -424,11 +424,11 @@ func (v *Value) AsTime() nano.Ts {
 	return 0
 }
 
-func (v *Value) MissingAsNull() *Value {
+func (v *Value) MissingAsNull() Value {
 	if v.IsMissing() {
-		return &Null
+		return Null
 	}
-	return v
+	return *v
 }
 
 // Under resolves named types and untags unions repeatedly, returning a value

--- a/value.go
+++ b/value.go
@@ -357,8 +357,7 @@ func (r Value) Fields() []Field {
 func (v *Value) DerefByColumn(col int) *Value {
 	if v != nil {
 		if bytes := v.nth(col); bytes != nil {
-			val := NewValue(v.Fields()[col].Type, bytes)
-			return &val
+			return NewValue(v.Fields()[col].Type, bytes).Ptr()
 		}
 	}
 	return nil

--- a/value.go
+++ b/value.go
@@ -20,35 +20,32 @@ var (
 )
 
 var (
-	NullUint8    = &Value{typ: TypeUint8}
-	NullUint16   = &Value{typ: TypeUint16}
-	NullUint32   = &Value{typ: TypeUint32}
-	NullUint64   = &Value{typ: TypeUint64}
-	NullInt8     = &Value{typ: TypeInt8}
-	NullInt16    = &Value{typ: TypeInt16}
-	NullInt32    = &Value{typ: TypeInt32}
-	NullInt64    = &Value{typ: TypeInt64}
-	NullDuration = &Value{typ: TypeDuration}
-	NullTime     = &Value{typ: TypeTime}
-	NullFloat16  = &Value{typ: TypeFloat16}
-	NullFloat32  = &Value{typ: TypeFloat32}
-	NullFloat64  = &Value{typ: TypeFloat64}
-	NullBool     = &Value{typ: TypeBool}
-	NullBytes    = &Value{typ: TypeBytes}
-	NullString   = &Value{typ: TypeString}
-	NullIP       = &Value{typ: TypeIP}
-	NullNet      = &Value{typ: TypeNet}
-	NullType     = &Value{typ: TypeType}
-	Null         = &Value{typ: TypeNull}
+	NullUint8    = Value{typ: TypeUint8}
+	NullUint16   = Value{typ: TypeUint16}
+	NullUint32   = Value{typ: TypeUint32}
+	NullUint64   = Value{typ: TypeUint64}
+	NullInt8     = Value{typ: TypeInt8}
+	NullInt16    = Value{typ: TypeInt16}
+	NullInt32    = Value{typ: TypeInt32}
+	NullInt64    = Value{typ: TypeInt64}
+	NullDuration = Value{typ: TypeDuration}
+	NullTime     = Value{typ: TypeTime}
+	NullFloat16  = Value{typ: TypeFloat16}
+	NullFloat32  = Value{typ: TypeFloat32}
+	NullFloat64  = Value{typ: TypeFloat64}
+	NullBool     = Value{typ: TypeBool}
+	NullBytes    = Value{typ: TypeBytes}
+	NullString   = Value{typ: TypeString}
+	NullIP       = Value{typ: TypeIP}
+	NullNet      = Value{typ: TypeNet}
+	NullType     = Value{typ: TypeType}
+	Null         = Value{typ: TypeNull}
 
 	False = NewBool(false)
 	True  = NewBool(true)
 )
 
-type Allocator interface {
-	NewValue(Type, zcode.Bytes) *Value
-	CopyValue(Value) *Value
-}
+type Allocator interface{}
 
 type Value struct {
 	typ Type
@@ -58,41 +55,43 @@ type Value struct {
 	len  uint64
 }
 
-func (v *Value) Type() Type { return v.typ }
+func (v Value) Ptr() *Value { return &v }
 
-func NewValue(t Type, b zcode.Bytes) *Value { return &Value{t, unsafe.SliceData(b), uint64(len(b))} }
-func (v *Value) bytes() zcode.Bytes         { return unsafe.Slice(v.base, v.len) }
+func (v Value) Type() Type { return v.typ }
+
+func NewValue(t Type, b zcode.Bytes) Value { return Value{t, unsafe.SliceData(b), uint64(len(b))} }
+func (v Value) bytes() zcode.Bytes         { return unsafe.Slice(v.base, v.len) }
 
 // nativeBase is the base address for all native Values, which are encoded with
 // the base field set to this address and the len field set to the bits of the
 // Value's native representation.
 var nativeBase byte
 
-func newNativeValue(t Type, x uint64) *Value { return &Value{t, &nativeBase, x} }
-func (v *Value) native() (uint64, bool)      { return v.len, v.base == &nativeBase }
+func newNativeValue(t Type, x uint64) Value { return Value{t, &nativeBase, x} }
+func (v Value) native() (uint64, bool)      { return v.len, v.base == &nativeBase }
 
-func NewUint(t Type, u uint64) *Value    { return newNativeValue(t, u) }
-func NewUint8(u uint8) *Value            { return newNativeValue(TypeUint8, uint64(u)) }
-func NewUint16(u uint16) *Value          { return newNativeValue(TypeUint16, uint64(u)) }
-func NewUint32(u uint32) *Value          { return newNativeValue(TypeUint32, uint64(u)) }
-func NewUint64(u uint64) *Value          { return newNativeValue(TypeUint64, u) }
-func NewInt(t Type, i int64) *Value      { return newNativeValue(t, uint64(i)) }
-func NewInt8(i int8) *Value              { return newNativeValue(TypeInt8, uint64(i)) }
-func NewInt16(i int16) *Value            { return newNativeValue(TypeInt16, uint64(i)) }
-func NewInt32(i int32) *Value            { return newNativeValue(TypeInt32, uint64(i)) }
-func NewInt64(i int64) *Value            { return newNativeValue(TypeInt64, uint64(i)) }
-func NewDuration(d nano.Duration) *Value { return newNativeValue(TypeDuration, uint64(d)) }
-func NewTime(ts nano.Ts) *Value          { return newNativeValue(TypeTime, uint64(ts)) }
-func NewFloat(t Type, f float64) *Value  { return newNativeValue(t, math.Float64bits(f)) }
-func NewFloat16(f float32) *Value        { return newNativeValue(TypeFloat16, math.Float64bits(float64(f))) }
-func NewFloat32(f float32) *Value        { return newNativeValue(TypeFloat32, math.Float64bits(float64(f))) }
-func NewFloat64(f float64) *Value        { return newNativeValue(TypeFloat64, math.Float64bits(f)) }
-func NewBool(b bool) *Value              { return newNativeValue(TypeBool, boolToUint64(b)) }
-func NewBytes(b []byte) *Value           { return NewValue(TypeBytes, b) }
-func NewString(s string) *Value          { return &Value{TypeString, nonNilUnsafeStringData(s), uint64(len(s))} }
-func NewIP(a netip.Addr) *Value          { return NewValue(TypeIP, EncodeIP(a)) }
-func NewNet(p netip.Prefix) *Value       { return NewValue(TypeNet, EncodeNet(p)) }
-func NewTypeValue(t Type) *Value         { return NewValue(TypeNet, EncodeTypeValue(t)) }
+func NewUint(t Type, u uint64) Value    { return newNativeValue(t, u) }
+func NewUint8(u uint8) Value            { return newNativeValue(TypeUint8, uint64(u)) }
+func NewUint16(u uint16) Value          { return newNativeValue(TypeUint16, uint64(u)) }
+func NewUint32(u uint32) Value          { return newNativeValue(TypeUint32, uint64(u)) }
+func NewUint64(u uint64) Value          { return newNativeValue(TypeUint64, u) }
+func NewInt(t Type, i int64) Value      { return newNativeValue(t, uint64(i)) }
+func NewInt8(i int8) Value              { return newNativeValue(TypeInt8, uint64(i)) }
+func NewInt16(i int16) Value            { return newNativeValue(TypeInt16, uint64(i)) }
+func NewInt32(i int32) Value            { return newNativeValue(TypeInt32, uint64(i)) }
+func NewInt64(i int64) Value            { return newNativeValue(TypeInt64, uint64(i)) }
+func NewDuration(d nano.Duration) Value { return newNativeValue(TypeDuration, uint64(d)) }
+func NewTime(ts nano.Ts) Value          { return newNativeValue(TypeTime, uint64(ts)) }
+func NewFloat(t Type, f float64) Value  { return newNativeValue(t, math.Float64bits(f)) }
+func NewFloat16(f float32) Value        { return newNativeValue(TypeFloat16, math.Float64bits(float64(f))) }
+func NewFloat32(f float32) Value        { return newNativeValue(TypeFloat32, math.Float64bits(float64(f))) }
+func NewFloat64(f float64) Value        { return newNativeValue(TypeFloat64, math.Float64bits(f)) }
+func NewBool(b bool) Value              { return newNativeValue(TypeBool, boolToUint64(b)) }
+func NewBytes(b []byte) Value           { return NewValue(TypeBytes, b) }
+func NewString(s string) Value          { return Value{TypeString, nonNilUnsafeStringData(s), uint64(len(s))} }
+func NewIP(a netip.Addr) Value          { return NewValue(TypeIP, EncodeIP(a)) }
+func NewNet(p netip.Prefix) Value       { return NewValue(TypeNet, EncodeNet(p)) }
+func NewTypeValue(t Type) Value         { return NewValue(TypeNet, EncodeTypeValue(t)) }
 
 func boolToUint64(b bool) uint64 {
 	if b {
@@ -111,7 +110,7 @@ func nonNilUnsafeStringData(s string) *byte {
 
 // Uint returns v's underlying value.  It panics if v's underlying type is not
 // TypeUint8, TypeUint16, TypeUint32, or TypeUint64.
-func (v *Value) Uint() uint64 {
+func (v Value) Uint() uint64 {
 	if v.Type().ID() > IDUint64 {
 		panic(fmt.Sprintf("zed.Value.Uint called on %T", v.Type()))
 	}
@@ -123,7 +122,7 @@ func (v *Value) Uint() uint64 {
 
 // Int returns v's underlying value.  It panics if v's underlying type is not
 // TypeInt8, TypeInt16, TypeInt32, TypeInt64, TypeDuration, or TypeTime.
-func (v *Value) Int() int64 {
+func (v Value) Int() int64 {
 	if !IsSigned(v.Type().ID()) {
 		panic(fmt.Sprintf("zed.Value.Int called on %T", v.Type()))
 	}
@@ -135,7 +134,7 @@ func (v *Value) Int() int64 {
 
 // Float returns v's underlying value.  It panics if v's underlying type is not
 // TypeFloat16, TypeFloat32, or TypeFloat64.
-func (v *Value) Float() float64 {
+func (v Value) Float() float64 {
 	if !IsFloat(v.Type().ID()) {
 		panic(fmt.Sprintf("zed.Value.Float called on %T", v.Type()))
 	}
@@ -147,7 +146,7 @@ func (v *Value) Float() float64 {
 
 // Bool returns v's underlying value.  It panics if v's underlying type is not
 // TypeBool.
-func (v *Value) Bool() bool {
+func (v Value) Bool() bool {
 	if v.Type().ID() != IDBool {
 		panic(fmt.Sprintf("zed.Value.Bool called on %T", v.Type()))
 	}
@@ -158,7 +157,7 @@ func (v *Value) Bool() bool {
 }
 
 // Bytes returns v's ZNG representation.
-func (v *Value) Bytes() zcode.Bytes {
+func (v Value) Bytes() zcode.Bytes {
 	if x, ok := v.native(); ok {
 		switch v.Type().ID() {
 		case IDUint8, IDUint16, IDUint32, IDUint64:
@@ -179,26 +178,26 @@ func (v *Value) Bytes() zcode.Bytes {
 	return v.bytes()
 }
 
-func (v *Value) IsContainer() bool {
+func (v Value) IsContainer() bool {
 	return IsContainerType(v.Type())
 }
 
 // String implements fmt.Stringer.String.  It should only be used for logs,
 // debugging, etc.  Any caller that requires a specific output format should use
 // FormatAs() instead.
-func (v *Value) String() string {
+func (v Value) String() string {
 	return fmt.Sprintf("%s: %s", v.Type(), v.Encode(nil))
 }
 
 // Encode appends the ZNG representation of this value to the passed in
 // argument and returns the resulting zcode.Bytes (which may or may not
 // be the same underlying buffer, as with append(), depending on its capacity)
-func (v *Value) Encode(dst zcode.Bytes) zcode.Bytes {
+func (v Value) Encode(dst zcode.Bytes) zcode.Bytes {
 	//XXX don't need this...
 	return zcode.Append(dst, v.Bytes())
 }
 
-func (v *Value) Iter() zcode.Iter {
+func (v Value) Iter() zcode.Iter {
 	return v.Bytes().Iter()
 }
 
@@ -206,38 +205,38 @@ func (v *Value) Iter() zcode.Iter {
 // element, and return its type and raw representation.  Returns an
 // error if the passed-in element is not an array or if idx is
 // outside the array bounds.
-func (v *Value) ArrayIndex(idx int64) (Value, error) {
+func (v Value) ArrayIndex(idx int64) (Value, error) {
 	vec, ok := v.Type().(*TypeArray)
 	if !ok {
-		return Value{}, ErrNotArray
+		return Null, ErrNotArray
 	}
 	if idx < 0 {
-		return Value{}, ErrIndex
+		return Null, ErrIndex
 	}
 	for i, it := 0, v.Iter(); !it.Done(); i++ {
 		bytes := it.Next()
 		if i == int(idx) {
-			return *NewValue(vec.Type, bytes), nil
+			return NewValue(vec.Type, bytes), nil
 		}
 	}
-	return Value{}, ErrIndex
+	return Null, ErrIndex
 }
 
 // Elements returns an array of Values for the given container type.
 // Returns an error if the element is not an array or set.
-func (v *Value) Elements() ([]Value, error) {
+func (v Value) Elements() ([]Value, error) {
 	innerType := InnerType(v.Type())
 	if innerType == nil {
 		return nil, ErrNotContainer
 	}
 	var elements []Value
 	for it := v.Iter(); !it.Done(); {
-		elements = append(elements, *NewValue(innerType, it.Next()))
+		elements = append(elements, NewValue(innerType, it.Next()))
 	}
 	return elements, nil
 }
 
-func (v *Value) ContainerLength() (int, error) {
+func (v Value) ContainerLength() (int, error) {
 	switch v.Type().(type) {
 	case *TypeSet, *TypeArray:
 		if v.IsNull() {
@@ -266,12 +265,12 @@ func (v *Value) ContainerLength() (int, error) {
 }
 
 // IsNull returns true if and only if v is a null value of any type.
-func (v *Value) IsNull() bool {
+func (v Value) IsNull() bool {
 	return v.base == nil
 }
 
 // Copy returns a copy of v that shares no storage.
-func (v *Value) Copy() *Value {
+func (v Value) Copy() Value {
 	if x, ok := v.native(); ok {
 		return newNativeValue(v.Type(), x)
 	}
@@ -279,22 +278,22 @@ func (v *Value) Copy() *Value {
 }
 
 // CopyFrom copies from into v, reusing v's storage if possible.
-func (v *Value) CopyFrom(from *Value) {
+func (v *Value) CopyFrom(from Value) {
 	if _, ok := from.native(); ok || from.IsNull() {
-		*v = *from
+		*v = from
 	} else if _, ok := v.native(); ok || v.IsNull() || v.len < from.len {
-		*v = *NewValue(from.Type(), bytes.Clone(from.bytes()))
+		*v = NewValue(from.Type(), bytes.Clone(from.bytes()))
 	} else {
-		*v = *NewValue(from.Type(), append(v.bytes()[:0], from.bytes()...))
+		*v = NewValue(from.Type(), append(v.bytes()[:0], from.bytes()...))
 	}
 }
 
-func (v *Value) IsString() bool {
+func (v Value) IsString() bool {
 	_, ok := TypeUnder(v.Type()).(*TypeOfString)
 	return ok
 }
 
-func (v *Value) IsError() bool {
+func (v Value) IsError() bool {
 	_, ok := TypeUnder(v.Type()).(*TypeError)
 	return ok
 }
@@ -309,7 +308,7 @@ func (v *Value) IsMissing() bool {
 	return false
 }
 
-func (v *Value) IsQuiet() bool {
+func (v Value) IsQuiet() bool {
 	if typ, ok := v.Type().(*TypeError); ok {
 		return typ.IsQuiet(v.Bytes())
 	}
@@ -318,7 +317,7 @@ func (v *Value) IsQuiet() bool {
 
 // Equal reports whether p and v have the same type and the same ZNG
 // representation.
-func (v *Value) Equal(p Value) bool {
+func (v Value) Equal(p Value) bool {
 	if v.Type() != p.Type() {
 		return false
 	}
@@ -330,17 +329,17 @@ func (v *Value) Equal(p Value) bool {
 	return bytes.Equal(v.Bytes(), p.Bytes())
 }
 
-func (r *Value) HasField(field string) bool {
+func (r Value) HasField(field string) bool {
 	return TypeRecordOf(r.Type()).HasField(field)
 }
 
 // Walk traverses a value in depth-first order, calling a
 // Visitor on the way.
-func (r *Value) Walk(rv Visitor) error {
+func (r Value) Walk(rv Visitor) error {
 	return Walk(r.Type(), r.Bytes(), rv)
 }
 
-func (r *Value) nth(n int) zcode.Bytes {
+func (r Value) nth(n int) zcode.Bytes {
 	var zv zcode.Bytes
 	for i, it := 0, r.Bytes().Iter(); i <= n; i++ {
 		if it.Done() {
@@ -351,22 +350,21 @@ func (r *Value) nth(n int) zcode.Bytes {
 	return zv
 }
 
-func (r *Value) Fields() []Field {
+func (r Value) Fields() []Field {
 	return TypeRecordOf(r.Type()).Fields
 }
 
 func (v *Value) DerefByColumn(col int) *Value {
 	if v != nil {
 		if bytes := v.nth(col); bytes != nil {
-			v = NewValue(v.Fields()[col].Type, bytes)
-		} else {
-			v = nil
+			val := NewValue(v.Fields()[col].Type, bytes)
+			return &val
 		}
 	}
-	return v
+	return nil
 }
 
-func (v *Value) IndexOfField(field string) (int, bool) {
+func (v Value) IndexOfField(field string) (int, bool) {
 	if typ := TypeRecordOf(v.Type()); typ != nil {
 		return typ.IndexOfField(field)
 	}
@@ -429,36 +427,30 @@ func (v *Value) AsTime() nano.Ts {
 
 func (v *Value) MissingAsNull() *Value {
 	if v.IsMissing() {
-		return Null
+		return &Null
 	}
 	return v
 }
 
 // Under resolves named types and untags unions repeatedly, returning a value
-// guaranteed to have neither a named type nor a union type.  When Under returns
-// a new value (i.e., one that differs from v), it uses dst if not nil.
-// Otherwise, Under allocates a new value.
-func (v *Value) Under(dst *Value) *Value {
+// guaranteed to have neither a named type nor a union type.
+func (v Value) Under() Value {
 	switch v.Type().(type) {
 	case *TypeUnion, *TypeNamed:
-		return v.under(dst)
+		return v.under()
 	}
 	// This is the common case; make sure the compiler can inline it.
 	return v
 }
 
 // under contains logic for Under that the compiler won't inline.
-func (v *Value) under(dst *Value) *Value {
+func (v Value) under() Value {
 	typ, bytes := v.Type(), v.Bytes()
 	for {
 		typ = TypeUnder(typ)
 		union, ok := typ.(*TypeUnion)
 		if !ok {
-			if dst == nil {
-				return NewValue(typ, bytes)
-			}
-			*dst = *NewValue(typ, bytes)
-			return dst
+			return NewValue(typ, bytes)
 		}
 		typ, bytes = union.Untag(bytes)
 	}
@@ -467,7 +459,7 @@ func (v *Value) under(dst *Value) *Value {
 // Validate checks that v.Bytes is structurally consistent
 // with v.Type.  It does not check that the actual leaf
 // values when parsed are type compatible with the leaf types.
-func (v *Value) Validate() (err error) {
+func (v Value) Validate() (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("panic: %+v\n%s", r, debug.Stack())

--- a/value_test.go
+++ b/value_test.go
@@ -13,12 +13,11 @@ func TestNewStringNotNull(t *testing.T) {
 }
 
 func BenchmarkValueUnder(b *testing.B) {
-	var tmpVal zed.Value
 	b.Run("primitive", func(b *testing.B) {
 		val := zed.Null
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			val.Under(&tmpVal)
+			val.Under()
 		}
 	})
 	b.Run("named", func(b *testing.B) {
@@ -26,7 +25,7 @@ func BenchmarkValueUnder(b *testing.B) {
 		val := zed.NewValue(typ, nil)
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			val.Under(&tmpVal)
+			val.Under()
 		}
 	})
 }

--- a/vector/const.go
+++ b/vector/const.go
@@ -6,11 +6,11 @@ import (
 )
 
 type Const struct {
-	val *zed.Value
+	val zed.Value
 	len uint32
 }
 
-func NewConst(val *zed.Value, len uint32) *Const {
+func NewConst(val zed.Value, len uint32) *Const {
 	return &Const{val: val, len: len}
 }
 
@@ -38,6 +38,6 @@ func (c *Const) Length() int {
 	return int(c.len)
 }
 
-func (c *Const) Value() *zed.Value {
+func (c *Const) Value() zed.Value {
 	return c.val
 }

--- a/vector/vector_test.go
+++ b/vector/vector_test.go
@@ -51,7 +51,7 @@ func BenchmarkReadZng(b *testing.B) {
 	rand := rand.New(rand.NewSource(42))
 	valuesIn := make([]zed.Value, N)
 	for i := range valuesIn {
-		valuesIn[i] = *zed.NewInt64(rand.Int63n(N))
+		valuesIn[i] = zed.NewInt64(rand.Int63n(N))
 	}
 	var buf bytes.Buffer
 	fuzz.WriteZNG(b, valuesIn, &buf)
@@ -72,7 +72,7 @@ func BenchmarkReadVng(b *testing.B) {
 	rand := rand.New(rand.NewSource(42))
 	valuesIn := make([]zed.Value, N)
 	for i := range valuesIn {
-		valuesIn[i] = *zed.NewValue(zed.TypeInt64, zed.EncodeInt(int64(rand.Intn(N))))
+		valuesIn[i] = zed.NewValue(zed.TypeInt64, zed.EncodeInt(int64(rand.Intn(N))))
 	}
 	var buf bytes.Buffer
 	fuzz.WriteVNG(b, valuesIn, &buf, vngio.WriterOpts{

--- a/vng/object.go
+++ b/vng/object.go
@@ -140,7 +140,7 @@ func (o *Object) readMetaData() error {
 	u := zson.NewZNGUnmarshaler()
 	u.SetContext(o.Zctx)
 	u.Bind(vector.Template...)
-	if err := u.Unmarshal(val, &o.Root); err != nil {
+	if err := u.Unmarshal(*val, &o.Root); err != nil {
 		return err
 	}
 	// The rest of the values are vector.Metadata, one for each
@@ -154,7 +154,7 @@ func (o *Object) readMetaData() error {
 			break
 		}
 		var meta vector.Metadata
-		if err := u.Unmarshal(val, &meta); err != nil {
+		if err := u.Unmarshal(*val, &meta); err != nil {
 			return err
 		}
 		o.Maps = append(o.Maps, meta)

--- a/vng/reader.go
+++ b/vng/reader.go
@@ -53,6 +53,6 @@ func (r *Reader) Read() (*zed.Value, error) {
 	if err := tr.Reader.Read(&r.builder); err != nil {
 		return nil, err
 	}
-	r.val = *zed.NewValue(tr.Type, r.builder.Bytes().Body())
+	r.val = zed.NewValue(tr.Type, r.builder.Bytes().Body())
 	return &r.val, nil
 }

--- a/vng/trailer.go
+++ b/vng/trailer.go
@@ -30,7 +30,7 @@ func readTrailer(r io.ReaderAt, n int64) (*FileMeta, []int64, error) {
 		return nil, nil, fmt.Errorf("VNG version %d found while expecting version %d", trailer.Version, Version)
 	}
 	var meta FileMeta
-	if err := zson.UnmarshalZNG(&trailer.Meta, &meta); err != nil {
+	if err := zson.UnmarshalZNG(trailer.Meta, &meta); err != nil {
 		return nil, nil, err
 	}
 	return &meta, trailer.Sections, nil

--- a/vng/vector/metadata.go
+++ b/vng/vector/metadata.go
@@ -119,7 +119,7 @@ func (n *Named) Type(zctx *zed.Context) zed.Type {
 }
 
 type DictEntry struct {
-	Value *zed.Value
+	Value zed.Value
 	Count uint32
 }
 
@@ -147,7 +147,7 @@ func (n *Nulls) Type(zctx *zed.Context) zed.Type {
 }
 
 type Const struct {
-	Value *zed.Value
+	Value zed.Value
 	Count uint32
 }
 

--- a/vng/vector/primitive.go
+++ b/vng/vector/primitive.go
@@ -56,11 +56,11 @@ func (p *PrimitiveWriter) update(body zcode.Bytes) {
 		return
 	}
 	val := zed.NewValue(p.typ, body)
-	if p.min == nil || p.cmp(val, p.min) < 0 {
-		p.min = val.Copy()
+	if p.min == nil || p.cmp(val, *p.min) < 0 {
+		p.min = val.Copy().Ptr()
 	}
-	if p.max == nil || p.cmp(val, p.max) > 0 {
-		p.max = val.Copy()
+	if p.max == nil || p.cmp(val, *p.max) > 0 {
+		p.max = val.Copy().Ptr()
 	}
 	if p.dict != nil {
 		p.dict[string(body)]++

--- a/vng/writer.go
+++ b/vng/writer.go
@@ -126,7 +126,7 @@ func (w *Writer) finalize() error {
 		//XXX wrap
 		return err
 	}
-	if err := zw.Write(*val); err != nil {
+	if err := zw.Write(val); err != nil {
 		//XXX wrap
 		return err
 	}
@@ -137,7 +137,7 @@ func (w *Writer) finalize() error {
 			//XXX wrap
 			return err
 		}
-		if err := zw.Write(*val); err != nil {
+		if err := zw.Write(val); err != nil {
 			//XXX wrap
 			return err
 		}

--- a/zbuf/array.go
+++ b/zbuf/array.go
@@ -33,8 +33,8 @@ func (a *Array) Values() []zed.Value {
 	return a.values
 }
 
-func (a *Array) Append(r *zed.Value) {
-	a.values = append(a.values, *r)
+func (a *Array) Append(r zed.Value) {
+	a.values = append(a.values, r)
 }
 
 func (a *Array) Vars() []zed.Value {

--- a/zbuf/array_test.go
+++ b/zbuf/array_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestArrayWriteCopiesValueBytes(t *testing.T) {
 	var a Array
-	val := *zed.NewBytes([]byte{0})
+	val := zed.NewBytes([]byte{0})
 	a.Write(val)
 	copy(val.Bytes(), zed.EncodeBytes([]byte{1}))
-	require.Equal(t, zed.NewBytes([]byte{0}), &a.Values()[0])
+	require.Equal(t, zed.NewBytes([]byte{0}), a.Values()[0])
 }

--- a/zbuf/batch.go
+++ b/zbuf/batch.go
@@ -93,7 +93,7 @@ func (p *puller) Pull(bool) (Batch, error) {
 			}
 			return batch, nil
 		}
-		if batch.appendVal(val) {
+		if batch.appendVal(*val) {
 			return batch, nil
 		}
 	}
@@ -124,7 +124,7 @@ func newPullerBatch() *pullerBatch {
 // appendVal appends a copy of val to b.  appendVal returns true if b is full
 // (i.e., b.buf is full, b.buf had insufficient space for val.Bytes, or b.val is
 // full).  appendVal never reallocates b.buf or b.vals.
-func (b *pullerBatch) appendVal(val *zed.Value) bool {
+func (b *pullerBatch) appendVal(val zed.Value) bool {
 	var bytes []byte
 	var bufFull bool
 	if !val.IsNull() {
@@ -140,7 +140,7 @@ func (b *pullerBatch) appendVal(val *zed.Value) bool {
 			bufFull = true
 		}
 	}
-	b.vals = append(b.vals, *zed.NewValue(val.Type(), bytes))
+	b.vals = append(b.vals, zed.NewValue(val.Type(), bytes))
 	return bufFull || len(b.vals) == cap(b.vals)
 }
 
@@ -230,7 +230,7 @@ func CopyVars(b Batch) []zed.Value {
 	if len(vars) > 0 {
 		newvars := make([]zed.Value, len(vars))
 		for k, v := range vars {
-			newvars[k] = *v.Copy()
+			newvars[k] = v.Copy()
 		}
 		vars = newvars
 	}

--- a/zbuf/merger.go
+++ b/zbuf/merger.go
@@ -30,6 +30,6 @@ func NewComparatorNullsMax(zctx *zed.Context, sortKey order.SortKey) *expr.Compa
 
 type valueAsBytes struct{}
 
-func (v *valueAsBytes) Eval(ectx expr.Context, val *zed.Value) *zed.Value {
-	return ectx.NewValue(zed.TypeBytes, val.Bytes())
+func (v *valueAsBytes) Eval(ectx expr.Context, val zed.Value) zed.Value {
+	return zed.NewBytes(val.Bytes())
 }

--- a/zbuf/scanner.go
+++ b/zbuf/scanner.go
@@ -130,7 +130,7 @@ func (s *scanner) Read() (*zed.Value, error) {
 		atomic.AddInt64(&s.progress.BytesRead, int64(len(this.Bytes())))
 		atomic.AddInt64(&s.progress.RecordsRead, 1)
 		if s.filter != nil {
-			val := s.filter.Eval(s.ectx.Reset(), this)
+			val := s.filter.Eval(s.ectx.Reset(), *this)
 			if !(val.Type() == zed.TypeBool && val.Bool()) {
 				continue
 			}

--- a/zio/arrowio/reader.go
+++ b/zio/arrowio/reader.go
@@ -104,7 +104,7 @@ func (r *Reader) Read() (*zed.Value, error) {
 			return nil, err
 		}
 	}
-	r.val = *zed.NewValue(r.typ, r.builder.Bytes())
+	r.val = zed.NewValue(r.typ, r.builder.Bytes())
 	r.i++
 	if r.i >= int(r.rec.NumRows()) {
 		r.rec.Release()

--- a/zio/arrowio/writer.go
+++ b/zio/arrowio/writer.go
@@ -79,7 +79,7 @@ const recordBatchSize = 1024
 func (w *Writer) Write(val zed.Value) error {
 	recType, ok := zed.TypeUnder(val.Type()).(*zed.TypeRecord)
 	if !ok {
-		return fmt.Errorf("%w: %s", ErrNotRecord, zson.FormatValue(&val))
+		return fmt.Errorf("%w: %s", ErrNotRecord, zson.FormatValue(val))
 	}
 	if w.typ == nil {
 		w.typ = recType

--- a/zio/combiner.go
+++ b/zio/combiner.go
@@ -45,7 +45,7 @@ func (c *Combiner) run() {
 					// Make a copy since we don't wait for
 					// Combiner.Read's caller to finish with
 					// this value before we read the next.
-					rec = rec.Copy()
+					rec = rec.Copy().Ptr()
 				}
 				select {
 				case c.results <- combinerResult{err, idx, rec}:

--- a/zio/combiner_test.go
+++ b/zio/combiner_test.go
@@ -43,7 +43,7 @@ type errorReader struct{ error }
 
 func (e *errorReader) Read() (*zed.Value, error) { return nil, e }
 
-type sliceReader []*zed.Value
+type sliceReader []zed.Value
 
 func (t *sliceReader) Read() (*zed.Value, error) {
 	if len(*t) == 0 {
@@ -51,5 +51,5 @@ func (t *sliceReader) Read() (*zed.Value, error) {
 	}
 	val := (*t)[0]
 	*t = (*t)[1:]
-	return val, nil
+	return &val, nil
 }

--- a/zio/csvio/reader.go
+++ b/zio/csvio/reader.go
@@ -75,7 +75,7 @@ func (r *Reader) Read() (*zed.Value, error) {
 			return nil, err
 		}
 		r.valid = true
-		return rec, nil
+		return &rec, nil
 	}
 }
 
@@ -84,11 +84,11 @@ func (r *Reader) init(hdr []string) {
 	r.vals = make([]interface{}, len(hdr))
 }
 
-func (r *Reader) translate(fields []string) (*zed.Value, error) {
+func (r *Reader) translate(fields []string) (zed.Value, error) {
 	if len(fields) != len(r.vals) {
 		// This error shouldn't happen as it should be caught by the
 		// csv package but we check anyway.
-		return nil, errors.New("length of record doesn't match heading")
+		return zed.Null, errors.New("length of record doesn't match heading")
 	}
 	vals := r.vals[:0]
 	for _, field := range fields {

--- a/zio/csvio/writer.go
+++ b/zio/csvio/writer.go
@@ -54,7 +54,7 @@ func (w *Writer) Flush() error {
 
 func (w *Writer) Write(rec zed.Value) error {
 	if rec.Type().Kind() != zed.RecordKind {
-		return fmt.Errorf("CSV output encountered non-record value: %s", zson.FormatValue(&rec))
+		return fmt.Errorf("CSV output encountered non-record value: %s", zson.FormatValue(rec))
 	}
 	rec, err := w.flattener.Flatten(rec)
 	if err != nil {
@@ -80,8 +80,7 @@ func (w *Writer) Write(rec zed.Value) error {
 	for i, it := 0, rec.Bytes().Iter(); i < len(fields) && !it.Done(); i++ {
 		var s string
 		if zb := it.Next(); zb != nil {
-			val := zed.NewValue(fields[i].Type, zb)
-			val = val.Under(val)
+			val := zed.NewValue(fields[i].Type, zb).Under()
 			switch id := val.Type().ID(); {
 			case id == zed.IDBytes && len(val.Bytes()) == 0:
 				// We want "" instead of "0x" for a zero-length value.

--- a/zio/jsonio/builder.go
+++ b/zio/jsonio/builder.go
@@ -173,6 +173,6 @@ func (b *builder) value() *zed.Value {
 		panic("multiple items")
 	}
 	item := &b.items[0]
-	b.val = *zed.NewValue(item.typ, item.zb.Bytes().Body())
+	b.val = zed.NewValue(item.typ, item.zb.Bytes().Body())
 	return &b.val
 }

--- a/zio/lakeio/writer.go
+++ b/zio/lakeio/writer.go
@@ -57,7 +57,7 @@ func NewWriter(w io.WriteCloser, opts WriterOpts) *Writer {
 
 func (w *Writer) Write(rec zed.Value) error {
 	var v interface{}
-	if err := unmarshaler.Unmarshal(&rec, &v); err != nil {
+	if err := unmarshaler.Unmarshal(rec, &v); err != nil {
 		return w.WriteZSON(rec)
 	}
 	var b bytes.Buffer
@@ -71,7 +71,7 @@ func (w *Writer) Close() error {
 }
 
 func (w *Writer) WriteZSON(rec zed.Value) error {
-	if _, err := io.WriteString(w.writer, w.zson.FormatRecord(&rec)); err != nil {
+	if _, err := io.WriteString(w.writer, w.zson.FormatRecord(rec)); err != nil {
 		return err
 	}
 	_, err := io.WriteString(w.writer, "\n")

--- a/zio/lineio/reader.go
+++ b/zio/lineio/reader.go
@@ -20,6 +20,6 @@ func (r *Reader) Read() (*zed.Value, error) {
 	if !r.scanner.Scan() || r.scanner.Err() != nil {
 		return nil, r.scanner.Err()
 	}
-	r.val = *zed.NewString(r.scanner.Text())
+	r.val = zed.NewString(r.scanner.Text())
 	return &r.val, nil
 }

--- a/zio/mapper.go
+++ b/zio/mapper.go
@@ -32,6 +32,6 @@ func (m *Mapper) Read() (*zed.Value, error) {
 			return nil, err
 		}
 	}
-	*rec = *zed.NewValue(sharedType, rec.Bytes())
+	*rec = zed.NewValue(sharedType, rec.Bytes())
 	return rec, nil
 }

--- a/zio/peeker_test.go
+++ b/zio/peeker_test.go
@@ -24,7 +24,7 @@ func TestPeeker(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	rec1 = rec1.Copy()
+	rec1 = rec1.Copy().Ptr()
 	rec2, err := peeker.Peek()
 	if err != nil {
 		t.Error(err)
@@ -36,7 +36,7 @@ func TestPeeker(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	rec3 = rec3.Copy()
+	rec3 = rec3.Copy().Ptr()
 	if !bytes.Equal(rec1.Bytes(), rec3.Bytes()) {
 		t.Error("rec1 != rec3")
 	}
@@ -44,7 +44,7 @@ func TestPeeker(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	rec4 = rec4.Copy()
+	rec4 = rec4.Copy().Ptr()
 	if bytes.Equal(rec3.Bytes(), rec4.Bytes()) {
 		t.Error("rec3 == rec4")
 	}

--- a/zio/tableio/writer.go
+++ b/zio/tableio/writer.go
@@ -34,7 +34,7 @@ func NewWriter(w io.WriteCloser) *Writer {
 
 func (w *Writer) Write(r zed.Value) error {
 	if r.Type().Kind() != zed.RecordKind {
-		return fmt.Errorf("table output encountered non-record value: %s", zson.FormatValue(&r))
+		return fmt.Errorf("table output encountered non-record value: %s", zson.FormatValue(r))
 	}
 	r, err := w.flattener.Flatten(r)
 	if err != nil {

--- a/zio/tableio/writer.go
+++ b/zio/tableio/writer.go
@@ -58,7 +58,7 @@ func (w *Writer) Write(r zed.Value) error {
 	var out []string
 	for k, f := range r.Fields() {
 		var v string
-		value := *r.DerefByColumn(k).MissingAsNull()
+		value := r.DerefByColumn(k).MissingAsNull()
 		if f.Type == zed.TypeTime {
 			if !value.IsNull() {
 				v = zed.DecodeTime(value.Bytes()).Time().Format(time.RFC3339Nano)

--- a/zio/textio/writer.go
+++ b/zio/textio/writer.go
@@ -43,7 +43,7 @@ func (w *Writer) writeRecord(rec zed.Value) error {
 	var out []string
 	for k, f := range zed.TypeRecordOf(rec.Type()).Fields {
 		var s string
-		value := *rec.DerefByColumn(k).MissingAsNull()
+		value := rec.DerefByColumn(k).MissingAsNull()
 		if f.Type == zed.TypeTime {
 			if value.IsNull() {
 				s = "-"

--- a/zio/zeekio/builder.go
+++ b/zio/zeekio/builder.go
@@ -60,7 +60,7 @@ func (b *builder) build(typ *zed.TypeRecord, sourceFields []int, path []byte, da
 	if len(leftoverFields) != 0 {
 		return nil, errors.New("too many values")
 	}
-	b.val = *zed.NewValue(typ, b.Bytes())
+	b.val = zed.NewValue(typ, b.Bytes())
 	return &b.val, nil
 }
 

--- a/zio/zeekio/format.go
+++ b/zio/zeekio/format.go
@@ -20,7 +20,7 @@ func formatAny(val zed.Value, inContainer bool) string {
 	case *zed.TypeArray:
 		return formatArray(t, val.Bytes())
 	case *zed.TypeNamed:
-		return formatAny(*zed.NewValue(t.Type, val.Bytes()), inContainer)
+		return formatAny(zed.NewValue(t.Type, val.Bytes()), inContainer)
 	case *zed.TypeOfBool:
 		if val.Bool() {
 			return "T"
@@ -31,7 +31,7 @@ func formatAny(val zed.Value, inContainer bool) string {
 	case *zed.TypeOfDuration, *zed.TypeOfTime:
 		return formatTime(nano.Ts(val.Int()))
 	case *zed.TypeEnum:
-		return formatAny(*zed.NewValue(zed.TypeUint64, val.Bytes()), false)
+		return formatAny(zed.NewValue(zed.TypeUint64, val.Bytes()), false)
 	case *zed.TypeOfFloat16, *zed.TypeOfFloat32:
 		return strconv.FormatFloat(val.Float(), 'f', -1, 32)
 	case *zed.TypeOfFloat64:
@@ -62,7 +62,7 @@ func formatAny(val zed.Value, inContainer bool) string {
 		if zed.TypeUnder(t.Type) == zed.TypeString {
 			return string(val.Bytes())
 		}
-		return zson.FormatValue(&val)
+		return zson.FormatValue(val)
 	default:
 		return fmt.Sprintf("zeekio.StringOf(): unknown type: %T", t)
 	}
@@ -87,7 +87,7 @@ func formatArray(t *zed.TypeArray, zv zcode.Bytes) string {
 		if val := it.Next(); val == nil {
 			b.WriteByte('-')
 		} else {
-			b.WriteString(formatAny(*zed.NewValue(t.Type, val), true))
+			b.WriteString(formatAny(zed.NewValue(t.Type, val), true))
 		}
 	}
 	return b.String()
@@ -98,8 +98,8 @@ func formatMap(t *zed.TypeMap, zv zcode.Bytes) string {
 	it := zv.Iter()
 	b.WriteByte('[')
 	for !it.Done() {
-		b.WriteString(formatAny(*zed.NewValue(t.KeyType, it.Next()), true))
-		b.WriteString(formatAny(*zed.NewValue(t.ValType, it.Next()), true))
+		b.WriteString(formatAny(zed.NewValue(t.KeyType, it.Next()), true))
+		b.WriteString(formatAny(zed.NewValue(t.ValType, it.Next()), true))
 	}
 	b.WriteByte(']')
 	return b.String()
@@ -119,7 +119,7 @@ func formatRecord(t *zed.TypeRecord, zv zcode.Bytes) string {
 		if val := it.Next(); val == nil {
 			b.WriteByte('-')
 		} else {
-			b.WriteString(formatAny(*zed.NewValue(f.Type, val), false))
+			b.WriteString(formatAny(zed.NewValue(f.Type, val), false))
 		}
 	}
 	return b.String()
@@ -139,7 +139,7 @@ func formatSet(t *zed.TypeSet, zv zcode.Bytes) string {
 		} else {
 			b.WriteByte(separator)
 		}
-		b.WriteString(formatAny(*zed.NewValue(t.Type, it.Next()), true))
+		b.WriteString(formatAny(zed.NewValue(t.Type, it.Next()), true))
 	}
 	return b.String()
 }
@@ -191,11 +191,11 @@ func unescape(r rune) []byte {
 
 func formatUnion(t *zed.TypeUnion, zv zcode.Bytes) string {
 	if zv == nil {
-		return FormatValue(*zed.Null)
+		return FormatValue(zed.Null)
 	}
 	typ, iv := t.Untag(zv)
 	s := strconv.FormatInt(int64(t.TagOf(typ)), 10) + ":"
-	return s + formatAny(*zed.NewValue(typ, iv), false)
+	return s + formatAny(zed.NewValue(typ, iv), false)
 }
 
 func FormatValue(v zed.Value) string {

--- a/zio/zeekio/parser_test.go
+++ b/zio/zeekio/parser_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/brimdata/zed"
-	"github.com/brimdata/zed/pkg/nano"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -79,8 +78,7 @@ func TestLegacyZeekValid(t *testing.T) {
 	record, err := sendLegacyValues(parser, values)
 	require.NoError(t, err)
 
-	assert.Equal(t, record.Deref("ts").MissingAsNull(), &zed.Null)
-	assert.Equal(t, record.Deref("ts").MissingAsNull().AsTime(), nano.Ts(0))
+	assert.Equal(t, record.Deref("ts").MissingAsNull(), zed.Null)
 	// XXX check contents of other fields?
 
 	// Test standard headers with a timestamp in records

--- a/zio/zeekio/parser_test.go
+++ b/zio/zeekio/parser_test.go
@@ -79,7 +79,7 @@ func TestLegacyZeekValid(t *testing.T) {
 	record, err := sendLegacyValues(parser, values)
 	require.NoError(t, err)
 
-	assert.Equal(t, record.Deref("ts").MissingAsNull(), zed.Null)
+	assert.Equal(t, record.Deref("ts").MissingAsNull(), &zed.Null)
 	assert.Equal(t, record.Deref("ts").MissingAsNull().AsTime(), nano.Ts(0))
 	// XXX check contents of other fields?
 

--- a/zio/zeekio/writer.go
+++ b/zio/zeekio/writer.go
@@ -53,7 +53,7 @@ func (w *Writer) Write(r zed.Value) error {
 			w.buf.WriteByte('\t')
 		}
 		needSeparator = true
-		w.buf.WriteString(FormatValue(*zed.NewValue(f.Type, bytes)))
+		w.buf.WriteString(FormatValue(zed.NewValue(f.Type, bytes)))
 	}
 	w.buf.WriteByte('\n')
 	_, err = w.writer.Write(w.buf.Bytes())

--- a/zio/zjsonio/reader.go
+++ b/zio/zjsonio/reader.go
@@ -59,7 +59,7 @@ func (r *Reader) Read() (*zed.Value, error) {
 	if err := r.decodeValue(r.builder, typ, object.Value); err != nil {
 		return nil, e(err)
 	}
-	r.val = *zed.NewValue(typ, r.builder.Bytes().Body())
+	r.val = zed.NewValue(typ, r.builder.Bytes().Body())
 	return &r.val, nil
 }
 

--- a/zio/zngio/scanner.go
+++ b/zio/zngio/scanner.go
@@ -281,7 +281,7 @@ func (w *worker) scanBatch(buf *buffer, local localctx) (zbuf.Batch, error) {
 			buf.free()
 			return nil, err
 		}
-		if w.wantValue(valRef, &progress) {
+		if w.wantValue(*valRef, &progress) {
 			valRef = batch.extend()
 		}
 	}
@@ -319,7 +319,7 @@ func (w *worker) decodeVal(buf *buffer, valRef *zed.Value) error {
 	if typ == nil {
 		return fmt.Errorf("zngio: type ID %d not in context", id)
 	}
-	*valRef = *zed.NewValue(typ, b)
+	*valRef = zed.NewValue(typ, b)
 	if w.validate {
 		if err := valRef.Validate(); err != nil {
 			return err
@@ -328,7 +328,7 @@ func (w *worker) decodeVal(buf *buffer, valRef *zed.Value) error {
 	return nil
 }
 
-func (w *worker) wantValue(val *zed.Value, progress *zbuf.Progress) bool {
+func (w *worker) wantValue(val zed.Value, progress *zbuf.Progress) bool {
 	progress.BytesRead += int64(len(val.Bytes()))
 	progress.RecordsRead++
 	// It's tempting to call w.bufferFilter.Eval on rec.Bytes here, but that
@@ -344,7 +344,7 @@ func (w *worker) wantValue(val *zed.Value, progress *zbuf.Progress) bool {
 	return false
 }
 
-func check(ectx expr.Context, this *zed.Value, filter expr.Evaluator) bool {
+func check(ectx expr.Context, this zed.Value, filter expr.Evaluator) bool {
 	val := filter.Eval(ectx, this)
 	return val.Type() == zed.TypeBool && val.Bool()
 }

--- a/zio/zngio/scanner_test.go
+++ b/zio/zngio/scanner_test.go
@@ -32,7 +32,7 @@ func TestScannerContext(t *testing.T) {
 		var buf bytes.Buffer
 		w := NewWriter(zio.NopCloser(&buf))
 		for j := 0; j < 100; j++ {
-			require.NoError(t, w.Write(*rec))
+			require.NoError(t, w.Write(rec))
 		}
 		require.NoError(t, w.EndStream())
 		require.NoError(t, w.Close())

--- a/zio/zngio/trailer.go
+++ b/zio/zngio/trailer.go
@@ -31,19 +31,19 @@ func MarshalTrailer(typ string, version int, sections []int64, meta interface{})
 	m.Decorate(zson.StylePackage)
 	metaVal, err := m.Marshal(meta)
 	if err != nil {
-		return zed.Value{}, err
+		return zed.Null, err
 	}
 	val, err := m.Marshal(&Trailer{
 		Magic:    Magic,
 		Type:     typ,
 		Version:  version,
 		Sections: sections,
-		Meta:     *metaVal,
+		Meta:     metaVal,
 	})
 	if err != nil {
-		return zed.Value{}, err
+		return zed.Null, err
 	}
-	return *val, nil
+	return val, nil
 }
 
 func ReadTrailer(r io.ReaderAt, fileSize int64) (*Trailer, error) {
@@ -95,7 +95,7 @@ func findTrailer(b []byte) (*Trailer, []byte, error) {
 		}
 		if val := readTrailer(b[off:]); val != nil {
 			var trailer Trailer
-			uErr := u.Unmarshal(val, &trailer)
+			uErr := u.Unmarshal(*val, &trailer)
 			if uErr == nil {
 				if trailer.Magic != Magic {
 					return nil, nil, errors.New("bad trailer magic")

--- a/zio/zsonio/reader.go
+++ b/zio/zsonio/reader.go
@@ -14,6 +14,7 @@ type Reader struct {
 	parser   *zson.Parser
 	analyzer zson.Analyzer
 	builder  *zcode.Builder
+	val      zed.Value
 }
 
 func NewReader(zctx *zed.Context, r io.Reader) *Reader {
@@ -37,5 +38,6 @@ func (r *Reader) Read() (*zed.Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	return zson.Build(r.builder, val)
+	r.val, err = zson.Build(r.builder, val)
+	return &r.val, err
 }

--- a/zio/zsonio/writer.go
+++ b/zio/zsonio/writer.go
@@ -30,7 +30,7 @@ func (w *Writer) Close() error {
 }
 
 func (w *Writer) Write(rec zed.Value) error {
-	if _, err := io.WriteString(w.writer, w.formatter.FormatRecord(&rec)); err != nil {
+	if _, err := io.WriteString(w.writer, w.formatter.FormatRecord(rec)); err != nil {
 		return err
 	}
 	_, err := w.writer.Write([]byte("\n"))

--- a/zngbytes/deserializer.go
+++ b/zngbytes/deserializer.go
@@ -34,7 +34,7 @@ func (d *Deserializer) Read() (interface{}, error) {
 		return nil, err
 	}
 	var action interface{}
-	if err := d.unmarshaler.Unmarshal(rec, &action); err != nil {
+	if err := d.unmarshaler.Unmarshal(*rec, &action); err != nil {
 		return nil, err
 	}
 	return action, nil

--- a/zngbytes/serializer.go
+++ b/zngbytes/serializer.go
@@ -33,7 +33,7 @@ func (s *Serializer) Write(v interface{}) error {
 	if err != nil {
 		return err
 	}
-	return s.writer.Write(*rec)
+	return s.writer.Write(rec)
 }
 
 // Bytes returns a slice holding the serialized values.  Close must be called

--- a/zson/builder.go
+++ b/zson/builder.go
@@ -15,10 +15,10 @@ import (
 	"golang.org/x/text/unicode/norm"
 )
 
-func Build(b *zcode.Builder, val Value) (*zed.Value, error) {
+func Build(b *zcode.Builder, val Value) (zed.Value, error) {
 	b.Truncate()
 	if err := buildValue(b, val); err != nil {
-		return nil, err
+		return zed.Null, err
 	}
 	it := b.Bytes().Iter()
 	return zed.NewValue(val.TypeOf(), it.Next()), nil

--- a/zson/formatter.go
+++ b/zson/formatter.go
@@ -64,7 +64,7 @@ func (f *Formatter) pop() {
 	f.stack = f.stack[:n-1]
 }
 
-func (f *Formatter) FormatRecord(rec *zed.Value) string {
+func (f *Formatter) FormatRecord(rec zed.Value) string {
 	// We reset tyepdefs so named types are emitted with their
 	// definition at first use in each record according to the
 	// left-to-right DFS order.  We could make this more efficient
@@ -74,7 +74,7 @@ func (f *Formatter) FormatRecord(rec *zed.Value) string {
 	return f.Format(rec)
 }
 
-func FormatValue(val *zed.Value) string {
+func FormatValue(val zed.Value) string {
 	return NewFormatter(0, nil).Format(val)
 }
 
@@ -84,15 +84,15 @@ func String(p interface{}) string {
 	}
 	switch val := p.(type) {
 	case *zed.Value:
-		return FormatValue(val)
+		return FormatValue(*val)
 	case zed.Value:
-		return FormatValue(&val)
+		return FormatValue(val)
 	default:
 		panic("zson.String takes a zed.Type or *zed.Value")
 	}
 }
 
-func (f *Formatter) Format(val *zed.Value) string {
+func (f *Formatter) Format(val zed.Value) string {
 	f.builder.Reset()
 	f.formatValueAndDecorate(val.Type(), val.Bytes())
 	return f.builder.String()
@@ -418,7 +418,7 @@ func (f *Formatter) formatRecord(indent int, typ *zed.TypeRecord, bytes zcode.By
 	f.indent(indent-f.tab, "}")
 }
 
-func (f *Formatter) formatVector(indent int, open, close string, inner zed.Type, val *zed.Value, known, parentImplied bool) bool {
+func (f *Formatter) formatVector(indent int, open, close string, inner zed.Type, val zed.Value, known, parentImplied bool) bool {
 	f.build(open)
 	n, err := val.ContainerLength()
 	if err != nil {

--- a/zson/marshal_test.go
+++ b/zson/marshal_test.go
@@ -168,14 +168,14 @@ func TestMixedTypeArrayInsideRecord(t *testing.T) {
 	var buffer bytes.Buffer
 	writer := zngio.NewWriter(zio.NopCloser(&buffer))
 	recExpected := zed.NewValue(zv.Type(), zv.Bytes())
-	writer.Write(*recExpected)
+	writer.Write(recExpected)
 	writer.Close()
 
 	reader := zngio.NewReader(zed.NewContext(), &buffer)
 	defer reader.Close()
 	recActual, err := reader.Read()
 	exp := zson.FormatValue(recExpected)
-	actual := zson.FormatValue(recActual)
+	actual := zson.FormatValue(*recActual)
 	assert.Equal(t, exp, actual)
 	// Double check that all the proper typing made it into the implied union.
 	assert.Equal(t, `{X:"hello",S:[[{MyColor:"red"}(=Plant),{MyColor:"blue"}(=Animal)]]}(=RecordWithInterfaceSlice)`, actual)
@@ -227,7 +227,7 @@ func TestMixedTypeArrayOfStructWithInterface(t *testing.T) {
 	var buffer bytes.Buffer
 	writer := zngio.NewWriter(zio.NopCloser(&buffer))
 	recExpected := zed.NewValue(zv.Type(), zv.Bytes())
-	writer.Write(*recExpected)
+	writer.Write(recExpected)
 	writer.Close()
 
 	reader := zngio.NewReader(zed.NewContext(), &buffer)
@@ -235,7 +235,7 @@ func TestMixedTypeArrayOfStructWithInterface(t *testing.T) {
 	recActual, err := reader.Read()
 	require.NoError(t, err)
 	exp := zson.FormatValue(recExpected)
-	actual := zson.FormatValue(recActual)
+	actual := zson.FormatValue(*recActual)
 	assert.Equal(t, exp, actual)
 	// Double check that all the proper typing made it into the implied union.
 	assert.Equal(t, `[{Message:"hello",Thing:{MyColor:"red"}(=Plant)}(=MessageThing),{Message:"world",Thing:{MyColor:"blue"}(=Animal)}(=MessageThing)]`, actual)
@@ -269,7 +269,7 @@ func TestZNGValueField(t *testing.T) {
 	// Include a Zed int64 inside a Go struct as a zed.Value field.
 	zngValueField := &ZNGValueField{
 		Name:  "test1",
-		Field: *zed.NewInt64(123),
+		Field: zed.NewInt64(123),
 	}
 	m := zson.NewZNGMarshaler()
 	m.Decorate(zson.StyleSimple)
@@ -287,7 +287,7 @@ func TestZNGValueField(t *testing.T) {
 	require.NoError(t, err)
 	zngValueField2 := &ZNGValueField{
 		Name:  "test2",
-		Field: *zv2,
+		Field: zv2,
 	}
 	m2 := zson.NewZNGMarshaler()
 	m2.Decorate(zson.StyleSimple)

--- a/zson/marshal_zng_test.go
+++ b/zson/marshal_zng_test.go
@@ -24,15 +24,15 @@ func boomerang(t *testing.T, in interface{}, out interface{}) {
 	require.NoError(t, err)
 	var buf bytes.Buffer
 	zw := zngio.NewWriter(zio.NopCloser(&buf))
-	err = zw.Write(*rec)
+	err = zw.Write(rec)
 	require.NoError(t, err)
 	require.NoError(t, zw.Close())
 	zctx := zed.NewContext()
 	zr := zngio.NewReader(zctx, &buf)
 	defer zr.Close()
-	rec, err = zr.Read()
+	val, err := zr.Read()
 	require.NoError(t, err)
-	err = zson.UnmarshalZNG(rec, out)
+	err = zson.UnmarshalZNG(*val, out)
 	require.NoError(t, err)
 }
 
@@ -155,7 +155,6 @@ func TestIPType(t *testing.T) {
 	rec, err := m.Marshal(s)
 	require.NoError(t, err)
 	require.NotNil(t, rec)
-
 	assert.Equal(t, "{Addr:192.168.1.1}", zson.FormatValue(rec))
 
 	var tip TestIP
@@ -186,11 +185,11 @@ func TestUnmarshalRecord(t *testing.T) {
 	const expected = `{top:{T2f1:{T3f1:1(int32),T3f2:1.(float32)},T2f2:"t2f2-string1"}}`
 	require.Equal(t, expected, zson.FormatValue(rec))
 
-	rec, err = zsonio.NewReader(zed.NewContext(), strings.NewReader(expected)).Read()
+	val, err := zsonio.NewReader(zed.NewContext(), strings.NewReader(expected)).Read()
 	require.NoError(t, err)
 
 	var v2 T1
-	err = zson.UnmarshalZNG(rec, &v2)
+	err = zson.UnmarshalZNG(*val, &v2)
 	require.NoError(t, err)
 	require.Equal(t, v1, v2)
 
@@ -304,7 +303,7 @@ func (m testMarshaler) MarshalZNG(mc *zson.MarshalZNGContext) (zed.Type, error) 
 	return mc.MarshalValue("marshal-" + string(m))
 }
 
-func (m *testMarshaler) UnmarshalZNG(mc *zson.UnmarshalZNGContext, val *zed.Value) error {
+func (m *testMarshaler) UnmarshalZNG(mc *zson.UnmarshalZNGContext, val zed.Value) error {
 	var s string
 	if err := mc.Unmarshal(val, &s); err != nil {
 		return err

--- a/zson/parser-values.go
+++ b/zson/parser-values.go
@@ -602,14 +602,14 @@ func (p *Parser) matchTypeValue() (*astzed.TypeValue, error) {
 	}, nil
 }
 
-func ParsePrimitive(typeText, valText string) (*zed.Value, error) {
+func ParsePrimitive(typeText, valText string) (zed.Value, error) {
 	typ := zed.LookupPrimitive(typeText)
 	if typ == nil {
-		return nil, fmt.Errorf("no such type: %s", typeText)
+		return zed.Null, fmt.Errorf("no such type: %s", typeText)
 	}
 	var b zcode.Builder
 	if err := BuildPrimitive(&b, Primitive{Type: typ, Text: valText}); err != nil {
-		return nil, err
+		return zed.Null, err
 	}
 	it := b.Bytes().Iter()
 	return zed.NewValue(typ, it.Next()), nil

--- a/zson/zson.go
+++ b/zson/zson.go
@@ -66,20 +66,20 @@ func ParseType(zctx *zed.Context, zson string) (zed.Type, error) {
 	return NewAnalyzer().convertType(zctx, ast)
 }
 
-func ParseValue(zctx *zed.Context, zson string) (*zed.Value, error) {
+func ParseValue(zctx *zed.Context, zson string) (zed.Value, error) {
 	zp := NewParser(strings.NewReader(zson))
 	ast, err := zp.ParseValue()
 	if err != nil {
-		return nil, err
+		return zed.Null, err
 	}
 	val, err := NewAnalyzer().ConvertValue(zctx, ast)
 	if err != nil {
-		return nil, err
+		return zed.Null, err
 	}
 	return Build(zcode.NewBuilder(), val)
 }
 
-func MustParseValue(zctx *zed.Context, zson string) *zed.Value {
+func MustParseValue(zctx *zed.Context, zson string) zed.Value {
 	val, err := ParseValue(zctx, zson)
 	if err != nil {
 		panic(err)
@@ -87,10 +87,10 @@ func MustParseValue(zctx *zed.Context, zson string) *zed.Value {
 	return val
 }
 
-func ParseValueFromAST(zctx *zed.Context, ast astzed.Value) (*zed.Value, error) {
+func ParseValueFromAST(zctx *zed.Context, ast astzed.Value) (zed.Value, error) {
 	val, err := NewAnalyzer().ConvertValue(zctx, ast)
 	if err != nil {
-		return nil, err
+		return zed.Null, err
 	}
 	return Build(zcode.NewBuilder(), val)
 }


### PR DESCRIPTION
Remaining instances generally appear in contexts in which nil signals that no zed.Value is available, as with zio.Reader.Read's first return parameter.

This change removes all of zed.Allocator's methods and renders runtime/expr.ResetContext unnecessary.  Both types will eventually go away.