### PR TITLE
remove unused logger from op.Context

### DIFF
--- a/compiler/kernel/op.go
+++ b/compiler/kernel/op.go
@@ -642,14 +642,14 @@ func (b *Builder) evalAtCompileTime(in dag.Expr) (val zed.Value, err error) {
 }
 
 func compileExpr(in dag.Expr) (expr.Evaluator, error) {
-	b := NewBuilder(op.NewContext(context.Background(), zed.NewContext(), nil), nil)
+	b := NewBuilder(op.NewContext(context.Background(), zed.NewContext()), nil)
 	return b.compileExpr(in)
 }
 
 func EvalAtCompileTime(zctx *zed.Context, in dag.Expr) (val zed.Value, err error) {
 	// We pass in a nil adaptor, which causes a panic for anything adaptor
 	// related, which is not currently allowed in an expression sub-query.
-	b := NewBuilder(op.NewContext(context.Background(), zctx, nil), nil)
+	b := NewBuilder(op.NewContext(context.Background(), zctx), nil)
 	return b.evalAtCompileTime(in)
 }
 

--- a/lake/api/local.go
+++ b/lake/api/local.go
@@ -117,7 +117,7 @@ func (l *local) QueryWithControl(ctx context.Context, head *lakeparse.Commitish,
 	if err != nil {
 		return nil, err
 	}
-	q, err := runtime.CompileLakeQuery(ctx, zed.NewContext(), l.compiler, flowgraph, head, nil)
+	q, err := runtime.CompileLakeQuery(ctx, zed.NewContext(), l.compiler, flowgraph, head)
 	if err != nil {
 		return nil, err
 	}

--- a/lake/branch.go
+++ b/lake/branch.go
@@ -136,7 +136,7 @@ func (b *Branch) DeleteWhere(ctx context.Context, c runtime.Compiler, program as
 		return ksuid.Nil, err
 	}
 	return b.commit(ctx, func(parent *branches.Config, retries int) (*commits.Object, error) {
-		octx := op.NewContext(ctx, zctx, nil)
+		octx := op.NewContext(ctx, zctx)
 		defer octx.Cancel()
 		// XXX It would be great to not do this since and just pass the snapshot
 		// into c.NewLakeDeleteQuery since we have to load the snapshot later

--- a/runtime/exec/compact.go
+++ b/runtime/exec/compact.go
@@ -35,7 +35,7 @@ func Compact(ctx context.Context, lk *lake.Root, pool *lake.Pool, branchName str
 	}
 	zctx := zed.NewContext()
 	lister := meta.NewSortedListerFromSnap(ctx, zed.NewContext(), lk, pool, compact, nil)
-	octx := op.NewContext(ctx, zctx, nil)
+	octx := op.NewContext(ctx, zctx)
 	slicer := meta.NewSlicer(lister, zctx)
 	puller := meta.NewSequenceScanner(octx, slicer, pool, nil, nil, nil)
 	w := lake.NewSortedWriter(ctx, zctx, pool, writeVectors)

--- a/runtime/op/groupby/groupby_test.go
+++ b/runtime/op/groupby/groupby_test.go
@@ -139,7 +139,7 @@ func TestGroupbyStreamingSpill(t *testing.T) {
 }
 
 func newQueryOnOrderedReader(ctx context.Context, zctx *zed.Context, program ast.Seq, reader zio.Reader, sortKey order.SortKey) (*runtime.Query, error) {
-	octx := op.NewContext(ctx, zctx, nil)
+	octx := op.NewContext(ctx, zctx)
 	q, err := compiler.CompileWithSortKey(octx, program, reader, sortKey)
 	if err != nil {
 		octx.Cancel()

--- a/runtime/op/op.go
+++ b/runtime/op/op.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/zbuf"
-	"go.uber.org/zap"
 )
 
 const BatchLen = 100
@@ -22,7 +21,6 @@ type Result struct {
 // in which they are running.
 type Context struct {
 	context.Context
-	Logger *zap.Logger
 	// WaitGroup is used to ensure that goroutines complete cleanup work
 	// (e.g., removing temporary files) before Cancel returns.
 	WaitGroup sync.WaitGroup
@@ -30,21 +28,17 @@ type Context struct {
 	cancel    context.CancelFunc
 }
 
-func NewContext(ctx context.Context, zctx *zed.Context, logger *zap.Logger) *Context {
+func NewContext(ctx context.Context, zctx *zed.Context) *Context {
 	ctx, cancel := context.WithCancel(ctx)
-	if logger == nil {
-		logger = zap.NewNop()
-	}
 	return &Context{
 		Context: ctx,
 		cancel:  cancel,
-		Logger:  logger,
 		Zctx:    zctx,
 	}
 }
 
 func DefaultContext() *Context {
-	return NewContext(context.Background(), zed.NewContext(), nil)
+	return NewContext(context.Background(), zed.NewContext())
 }
 
 // Cancel cancels the context.  Cancel must be called to ensure that operators

--- a/runtime/query.go
+++ b/runtime/query.go
@@ -10,7 +10,6 @@ import (
 	"github.com/brimdata/zed/runtime/op"
 	"github.com/brimdata/zed/zbuf"
 	"github.com/brimdata/zed/zio"
-	"go.uber.org/zap"
 )
 
 // Query runs a flowgraph as a zbuf.Puller and implements a Close() method
@@ -40,7 +39,7 @@ type Compiler interface {
 }
 
 func CompileQuery(ctx context.Context, zctx *zed.Context, c Compiler, program ast.Seq, readers []zio.Reader) (*Query, error) {
-	octx := op.NewContext(ctx, zctx, nil)
+	octx := op.NewContext(ctx, zctx)
 	q, err := c.NewQuery(octx, program, readers)
 	if err != nil {
 		octx.Cancel()
@@ -49,8 +48,8 @@ func CompileQuery(ctx context.Context, zctx *zed.Context, c Compiler, program as
 	return q, nil
 }
 
-func CompileLakeQuery(ctx context.Context, zctx *zed.Context, c Compiler, program ast.Seq, head *lakeparse.Commitish, logger *zap.Logger) (*Query, error) {
-	octx := op.NewContext(ctx, zctx, logger)
+func CompileLakeQuery(ctx context.Context, zctx *zed.Context, c Compiler, program ast.Seq, head *lakeparse.Commitish) (*Query, error) {
+	octx := op.NewContext(ctx, zctx)
 	q, err := c.NewLakeQuery(octx, program, 0, head)
 	if err != nil {
 		octx.Cancel()

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -56,7 +56,7 @@ func handleQuery(c *Core, w *ResponseWriter, r *Request) {
 		w.Error(srverr.ErrInvalid(err))
 		return
 	}
-	flowgraph, err := runtime.CompileLakeQuery(r.Context(), zed.NewContext(), c.compiler, query, &req.Head, r.Logger)
+	flowgraph, err := runtime.CompileLakeQuery(r.Context(), zed.NewContext(), c.compiler, query, &req.Head)
 	if err != nil {
 		w.Error(srverr.ErrInvalid(err))
 		return

--- a/zed_test.go
+++ b/zed_test.go
@@ -138,7 +138,7 @@ func runOneBoomerang(t *testing.T, format, data string) {
 		// Fuse for formats that require uniform values.
 		proc, err := compiler.NewCompiler().Parse("fuse")
 		require.NoError(t, err)
-		octx := op.NewContext(context.Background(), zctx, nil)
+		octx := op.NewContext(context.Background(), zctx)
 		q, err := compiler.NewCompiler().NewQuery(octx, proc, []zio.Reader{dataReadCloser})
 		require.NoError(t, err)
 		defer q.Pull(true)

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -510,7 +510,7 @@ func runzq(path, zedProgram, input string, outputFlags []string, inputFlags []st
 	if err != nil {
 		return "", "", err
 	}
-	q, err := compiler.NewCompiler().NewQuery(op.NewContext(context.Background(), zctx, nil), proc, []zio.Reader{zrc})
+	q, err := compiler.NewCompiler().NewQuery(op.NewContext(context.Background(), zctx), proc, []zio.Reader{zrc})
 	if err != nil {
 		zw.Close()
 		return "", err.Error(), err


### PR DESCRIPTION
This commit removes the logger from the query runtime context. We no longer emit logging info from a query and instead favor a model where query errors are embedded in the query's output and system errors are caught with panic and logged.

The task in #4487 will further obviate the need for any logging from the query runtime.