### PR TITLE
Improve runtime/expr Go test output

### DIFF
--- a/runtime/expr/expr_test.go
+++ b/runtime/expr/expr_test.go
@@ -14,30 +14,29 @@ import (
 )
 
 func testSuccessful(t *testing.T, e string, input string, expectedVal zed.Value) {
+	t.Helper()
 	if input == "" {
 		input = "{}"
 	}
-	runZTest(t, e, &ztest.ZTest{
+	zt := ztest.ZTest{
 		Zed:    fmt.Sprintf("yield %s", e),
 		Input:  input,
 		Output: zson.FormatValue(expectedVal) + "\n",
-	})
+	}
+	if err := zt.RunInternal(""); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func testError(t *testing.T, e string, expectErr error, description string) {
-	runZTest(t, e, &ztest.ZTest{
+	t.Helper()
+	zt := ztest.ZTest{
 		Zed:     fmt.Sprintf("yield %s", e),
 		ErrorRE: expectErr.Error(),
-	})
-}
-
-func runZTest(t *testing.T, e string, zt *ztest.ZTest) {
-	t.Run(e, func(t *testing.T) {
-		t.Parallel()
-		if err := zt.RunInternal(""); err != nil {
-			t.Fatal(err)
-		}
-	})
+	}
+	if err := zt.RunInternal(""); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestPrimitives(t *testing.T) {


### PR DESCRIPTION
The tests in runtime/expr/expr_test.go and functions_test.go are hard to debug because they don't print an accurate line number when they fail. Fix that in testSuccessful and testError by calling testing.T.Helper and avoiding testing.t.Run.