### PR TITLE
Quick fix to Grok doc

### DIFF
--- a/docs/language/functions/grok.md
+++ b/docs/language/functions/grok.md
@@ -13,7 +13,7 @@ grok(p: string, s: string, definitions: string) -> any
 
 The _grok_ function parses a string `s` using grok pattern `p` and returns
 a record containing the parsed fields. The syntax for pattern `p`
-is `{%pattern:field_name}` where _pattern_ is the name of the pattern
+is `%{pattern:field_name}` where _pattern_ is the name of the pattern
 to match in `s` and _field_name_ is the resultant field name of the capture
 value.
 


### PR DESCRIPTION
I have a more significant set of Grok doc improvements I'm working on, but since we just put out a new GA release and I know there's a push to put up a tweet mentioning Grok ASAP, I wanted to get this quick fix in (which I'll backport to the versioned `v0.13.0` docs on the Zed docs site after this merges). It's pretty basic and would likely trip up a new user that's making their first attempt at using `grok()` while following the doc.