### PR TITLE
Allow pools to be given a ksuid name

### DIFF
--- a/cmd/zed/use/command.go
+++ b/cmd/zed/use/command.go
@@ -107,12 +107,9 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	poolID, err := lakeparse.ParseID(commitish.Pool)
+	poolID, err := lake.PoolID(ctx, commitish.Pool)
 	if err != nil {
-		poolID, err = lake.PoolID(ctx, commitish.Pool)
-		if err != nil {
-			return err
-		}
+		return err
 	}
 	if _, err = lake.CommitObject(ctx, poolID, commitish.Branch); err != nil {
 		return err

--- a/compiler/data/source.go
+++ b/compiler/data/source.go
@@ -10,6 +10,7 @@ import (
 	"github.com/brimdata/zed/compiler/ast/dag"
 	"github.com/brimdata/zed/compiler/optimizer/demand"
 	"github.com/brimdata/zed/lake"
+	"github.com/brimdata/zed/lakeparse"
 	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/pkg/storage"
 	"github.com/brimdata/zed/zbuf"
@@ -37,11 +38,13 @@ func (s *Source) Lake() *lake.Root {
 	return s.lake
 }
 
-func (s *Source) PoolID(ctx context.Context, id string) (ksuid.KSUID, error) {
-	if s.lake != nil {
-		return s.lake.PoolID(ctx, id)
+func (s *Source) PoolID(ctx context.Context, name string) (ksuid.KSUID, error) {
+	if id, err := lakeparse.ParseID(name); err == nil {
+		if _, err := s.lake.OpenPool(ctx, id); err == nil {
+			return id, nil
+		}
 	}
-	return ksuid.Nil, nil
+	return s.lake.PoolID(ctx, name)
 }
 
 func (s *Source) CommitObject(ctx context.Context, id ksuid.KSUID, name string) (ksuid.KSUID, error) {

--- a/compiler/semantic/op.go
+++ b/compiler/semantic/op.go
@@ -285,14 +285,9 @@ func (a *analyzer) semPoolWithName(p *ast.Pool, poolName string) (dag.Op, error)
 			Meta: p.Spec.Meta,
 		}, nil
 	}
-	// If a name appears as an 0x bytes ksuid, convert it to the
-	// ksuid string form since the backend doesn't parse the 0x format.
-	poolID, err := lakeparse.ParseID(poolName)
+	poolID, err := a.source.PoolID(a.ctx, poolName)
 	if err != nil {
-		poolID, err = a.source.PoolID(a.ctx, poolName)
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	if p.At != "" {
 		// XXX

--- a/lake/api/local.go
+++ b/lake/api/local.go
@@ -128,6 +128,11 @@ func (l *local) PoolID(ctx context.Context, poolName string) (ksuid.KSUID, error
 	if poolName == "" {
 		return ksuid.Nil, errors.New("no pool name provided")
 	}
+	if id, err := lakeparse.ParseID(poolName); err == nil {
+		if _, err := l.root.OpenPool(ctx, id); err == nil {
+			return id, nil
+		}
+	}
 	return l.root.PoolID(ctx, poolName)
 }
 

--- a/lake/api/remote.go
+++ b/lake/api/remote.go
@@ -33,6 +33,11 @@ func (l *remote) Root() *lake.Root {
 }
 
 func (r *remote) PoolID(ctx context.Context, poolName string) (ksuid.KSUID, error) {
+	if id, err := lakeparse.ParseID(poolName); err == nil {
+		if _, err := LookupPoolByID(ctx, r, id); err == nil {
+			return id, nil
+		}
+	}
 	config, err := LookupPoolByName(ctx, r, poolName)
 	if err != nil {
 		return ksuid.Nil, err

--- a/lake/root.go
+++ b/lake/root.go
@@ -238,10 +238,11 @@ func (r *Root) PoolID(ctx context.Context, poolName string) (ksuid.KSUID, error)
 	if poolName == "" {
 		return ksuid.Nil, errors.New("no pool name given")
 	}
-	if poolRef := r.pools.LookupByName(ctx, poolName); poolRef != nil {
-		return poolRef.ID, nil
+	poolRef := r.pools.LookupByName(ctx, poolName)
+	if poolRef == nil {
+		return ksuid.Nil, fmt.Errorf("%s: %w", poolName, pools.ErrNotFound)
 	}
-	return ksuid.Nil, fmt.Errorf("%s: %w", poolName, pools.ErrNotFound)
+	return poolRef.ID, nil
 }
 
 func (r *Root) CommitObject(ctx context.Context, poolID ksuid.KSUID, branchName string) (ksuid.KSUID, error) {

--- a/lake/root.go
+++ b/lake/root.go
@@ -238,16 +238,10 @@ func (r *Root) PoolID(ctx context.Context, poolName string) (ksuid.KSUID, error)
 	if poolName == "" {
 		return ksuid.Nil, errors.New("no pool name given")
 	}
-	poolID, err := ksuid.Parse(poolName)
-	var poolRef *pools.Config
-	if err != nil {
-		poolRef = r.pools.LookupByName(ctx, poolName)
-		if poolRef == nil {
-			return ksuid.Nil, fmt.Errorf("%s: %w", poolName, pools.ErrNotFound)
-		}
-		poolID = poolRef.ID
+	if poolRef := r.pools.LookupByName(ctx, poolName); poolRef != nil {
+		return poolRef.ID, nil
 	}
-	return poolID, nil
+	return ksuid.Nil, fmt.Errorf("%s: %w", poolName, pools.ErrNotFound)
 }
 
 func (r *Root) CommitObject(ctx context.Context, poolID ksuid.KSUID, branchName string) (ksuid.KSUID, error) {

--- a/lake/ztests/create-ksuid-name.yaml
+++ b/lake/ztests/create-ksuid-name.yaml
@@ -4,8 +4,12 @@ script: |
   zed init -q
   zed create 2WwyVrZdEITo5WkKu1YsJC4dMjU
   zed use 2WwyVrZdEITo5WkKu1YsJC4dMjU
+  zed query 'from 2WwyVrZdEITo5WkKu1YsJC4dMjU'
+
 outputs:
   - name: stdout
     regexp: |
       pool created: 2WwyVrZdEITo5WkKu1YsJC4dMjU \w{27}
       Switched to branch "main" on pool "2WwyVrZdEITo5WkKu1YsJC4dMjU"
+  - name: stderr
+    data: ""

--- a/lake/ztests/create-ksuid-name.yaml
+++ b/lake/ztests/create-ksuid-name.yaml
@@ -1,0 +1,11 @@
+# Test that a pool can be given a ksuid name and everything still works.
+script: |
+  export ZED_LAKE=test
+  zed init -q
+  zed create 2WwyVrZdEITo5WkKu1YsJC4dMjU
+  zed use 2WwyVrZdEITo5WkKu1YsJC4dMjU
+outputs:
+  - name: stdout
+    regexp: |
+      pool created: 2WwyVrZdEITo5WkKu1YsJC4dMjU \w{27}
+      Switched to branch "main" on pool "2WwyVrZdEITo5WkKu1YsJC4dMjU"

--- a/service/ztests/create-ksuid-name.yaml
+++ b/service/ztests/create-ksuid-name.yaml
@@ -1,0 +1,12 @@
+# Test that a pool can be given a ksuid name and everything still works.
+script: |
+  source service.sh
+  zed create 2WwyVrZdEITo5WkKu1YsJC4dMjU
+  zed use 2WwyVrZdEITo5WkKu1YsJC4dMjU
+inputs:
+  - name: service.sh
+outputs:
+  - name: stdout
+    regexp: |
+      pool created: 2WwyVrZdEITo5WkKu1YsJC4dMjU \w{27}
+      Switched to branch "main" on pool "2WwyVrZdEITo5WkKu1YsJC4dMjU"

--- a/service/ztests/create-ksuid-name.yaml
+++ b/service/ztests/create-ksuid-name.yaml
@@ -3,10 +3,15 @@ script: |
   source service.sh
   zed create 2WwyVrZdEITo5WkKu1YsJC4dMjU
   zed use 2WwyVrZdEITo5WkKu1YsJC4dMjU
+  zed query 'from 2WwyVrZdEITo5WkKu1YsJC4dMjU'
+
 inputs:
   - name: service.sh
+
 outputs:
   - name: stdout
     regexp: |
       pool created: 2WwyVrZdEITo5WkKu1YsJC4dMjU \w{27}
       Switched to branch "main" on pool "2WwyVrZdEITo5WkKu1YsJC4dMjU"
+  - name: stderr
+    data: ""


### PR DESCRIPTION
The commit fixes an issue with pool looks that made it so pools with a ksuid-like name could not be looked up for most zed commands. Fix the logic for lake/api.PoolID so that looking up a pool by ID is tried first and then falls back to looking up a pool by name if nothing is found.

Closes #4431