### PR TITLE
service: Handle url encoded path parameters

### DIFF
--- a/python/zed/zed.py
+++ b/python/zed/zed.py
@@ -46,8 +46,8 @@ class Client():
 
     def load(self, pool_name_or_id, data, branch_name='main',
              commit_author=getpass.getuser(), commit_body=''):
-        pool = urllib.parse.quote_plus(pool_name_or_id)
-        branch = urllib.parse.quote_plus(branch_name)
+        pool = urllib.parse.quote_plus(pool_name_or_id, safe='')
+        branch = urllib.parse.quote_plus(branch_name, safe='')
         url = self.base_url + '/pool/' + pool + '/branch/' + branch
         commit_message = {'author': commit_author, 'body': commit_body}
         headers = {'Zed-Commit': json.dumps(commit_message)}

--- a/python/zed/zed.py
+++ b/python/zed/zed.py
@@ -46,8 +46,8 @@ class Client():
 
     def load(self, pool_name_or_id, data, branch_name='main',
              commit_author=getpass.getuser(), commit_body=''):
-        pool = urllib.parse.quote_plus(pool_name_or_id, safe='')
-        branch = urllib.parse.quote_plus(branch_name, safe='')
+        pool = urllib.parse.quote(pool_name_or_id, safe='')
+        branch = urllib.parse.quote(branch_name, safe='')
         url = self.base_url + '/pool/' + pool + '/branch/' + branch
         commit_message = {'author': commit_author, 'body': commit_body}
         headers = {'Zed-Commit': json.dumps(commit_message)}

--- a/python/zed/zed.py
+++ b/python/zed/zed.py
@@ -46,8 +46,8 @@ class Client():
 
     def load(self, pool_name_or_id, data, branch_name='main',
              commit_author=getpass.getuser(), commit_body=''):
-        pool = urllib.parse.quote(pool_name_or_id)
-        branch = urllib.parse.quote(branch_name)
+        pool = urllib.parse.quote_plus(pool_name_or_id)
+        branch = urllib.parse.quote_plus(branch_name)
         url = self.base_url + '/pool/' + pool + '/branch/' + branch
         commit_message = {'author': commit_author, 'body': commit_body}
         headers = {'Zed-Commit': json.dumps(commit_message)}

--- a/service/core.go
+++ b/service/core.go
@@ -136,7 +136,7 @@ func NewCore(ctx context.Context, conf Config) (*Core, error) {
 		json.NewEncoder(w).Encode(&api.VersionResponse{Version: conf.Version})
 	})
 
-	routerAPI := mux.NewRouter()
+	routerAPI := mux.NewRouter().UseEncodedPath()
 	routerAPI.Use(requestIDMiddleware())
 	routerAPI.Use(accessLogMiddleware(conf.Logger))
 	routerAPI.Use(panicCatchMiddleware(conf.Logger))

--- a/service/ztests/url-encoded-pool.yaml
+++ b/service/ztests/url-encoded-pool.yaml
@@ -1,0 +1,13 @@
+script: |
+  source service.sh
+  zed create -q test/new
+  curl -X DELETE $ZED_LAKE/pool/test%2Fnew
+  curl -X DELETE $ZED_LAKE/pool/test%2Fnew
+
+inputs:
+  - name: service.sh
+
+outputs:
+  - name: stdout
+    data: |
+      {"type":"Error","kind":"item does not exist","error":"test/new: pool not found"}


### PR DESCRIPTION
Change the service router to handle url encoded values in paths. Also change the python library to handle slashes when url encoding pool and branch names.

Closes #4814