### PR TITLE
Buffer zbuf.Batches in runtime/sam/op/tail.Op

### DIFF
--- a/runtime/sam/op/tail/tail.go
+++ b/runtime/sam/op/tail/tail.go
@@ -1,18 +1,17 @@
 package tail
 
 import (
-	"github.com/brimdata/zed"
+	"slices"
+
 	"github.com/brimdata/zed/zbuf"
 )
 
 type Op struct {
 	parent zbuf.Puller
 	limit  int
-	batch  zbuf.Batch
-	count  int
-	off    int
-	q      []zed.Value
-	eos    bool
+
+	batches []zbuf.Batch
+	eos     bool
 }
 
 func New(parent zbuf.Puller, limit int) *Op {
@@ -20,70 +19,63 @@ func New(parent zbuf.Puller, limit int) *Op {
 	return &Op{
 		parent: parent,
 		limit:  limit,
-		q:      make([]zed.Value, limit),
 	}
-}
-
-func (o *Op) tail() zbuf.Batch {
-	if o.count <= 0 {
-		return nil
-	}
-	start := o.off
-	if o.count < o.limit {
-		start = 0
-	}
-	out := make([]zed.Value, o.count)
-	for k := 0; k < o.count; k++ {
-		out[k] = o.q[(start+k)%o.limit]
-	}
-	return zbuf.NewBatch(o.batch, out)
-
 }
 
 func (o *Op) Pull(done bool) (zbuf.Batch, error) {
 	if o.eos {
 		// We don't check done here because if we already got EOS,
 		// we don't propagate done.
+		o.batches = nil
 		o.eos = false
 		return nil, nil
 	}
 	if done {
-		o.off = 0
-		o.count = 0
+		o.batches = nil
 		o.eos = false
 		return o.parent.Pull(true)
 	}
+	if len(o.batches) == 0 {
+		batches, err := o.tail()
+		if err != nil || len(batches) == 0 {
+			return nil, err
+		}
+		o.batches = batches
+	}
+	batch := o.batches[0]
+	o.batches = o.batches[1:]
+	if len(o.batches) == 0 {
+		o.eos = true
+	}
+	return batch, nil
+}
+
+// tail pulls from o.parent until EOS and returns batches containing the
+// last o.limit values.
+func (o *Op) tail() ([]zbuf.Batch, error) {
+	var batches []zbuf.Batch
+	var n int
 	for {
 		batch, err := o.parent.Pull(false)
 		if err != nil {
 			return nil, err
 		}
 		if batch == nil {
-			batch = o.tail()
-			if batch != nil {
-				o.eos = true
-				if o.batch != nil {
-					o.batch.Unref()
-					o.batch = nil
-				}
-			}
-			o.off = 0
-			o.count = 0
-			return batch, nil
+			break
 		}
-		if o.batch == nil {
-			batch.Ref()
-			o.batch = batch
+		batches = append(batches, batch)
+		n += len(batch.Values())
+		for len(batches) > 0 && n-len(batches[0].Values()) >= o.limit {
+			// We have enough values without batches[0] so drop it.
+			n -= len(batches[0].Values())
+			batches[0].Unref()
+			batches = slices.Delete(batches, 0, 1)
 		}
-		vals := batch.Values()
-		for i := range vals {
-			o.q[o.off] = vals[i].Copy()
-			o.off = (o.off + 1) % o.limit
-			o.count++
-			if o.count >= o.limit {
-				o.count = o.limit
-			}
-		}
-		batch.Unref()
 	}
+	if n > o.limit {
+		// We have too many values so remove some from batches[0].
+		vals := batches[0].Values()[n-o.limit:]
+		batches[0] = zbuf.NewBatch(batches[0], vals)
+	}
+	return batches, nil
 }


### PR DESCRIPTION
The tail operator buffers zed.Values.  Change it to buffer zbuf.Batches, which fits better with planned changes to memory management.