### PR TITLE
Fix panics due to bad batch reference counts

### DIFF
--- a/runtime/sam/op/groupby/groupby.go
+++ b/runtime/sam/op/groupby/groupby.go
@@ -220,8 +220,8 @@ func (o *Op) run() {
 				return
 			}
 		}
-		batch.Unref()
 		if o.agg.inputDir == 0 {
+			batch.Unref()
 			continue
 		}
 		// sorted input: see if we have any completed keys we can emit.
@@ -245,6 +245,7 @@ func (o *Op) run() {
 				break
 			}
 		}
+		batch.Unref()
 	}
 }
 


### PR DESCRIPTION
* runtime/sam/op/groupby.Op.run accesses its batch after unreffing it.

* zbuf.NewBatch does not ref its batch parameter, allowing premature reuse when its vals parameter contains values that live in that batch.  Fix by adding proper reference counting for zbuf.batch.