### PR TITLE
Fix batch reference counting in runtime/sam/op.applier

### DIFF
--- a/runtime/sam/op/apply.go
+++ b/runtime/sam/op/apply.go
@@ -39,7 +39,6 @@ func (a *applier) Pull(done bool) (zbuf.Batch, error) {
 			out = append(out, val)
 		}
 		if len(out) > 0 {
-			defer batch.Unref()
 			return zbuf.NewBatch(batch, out), nil
 		}
 		batch.Unref()


### PR DESCRIPTION
applier.Pull returns a batch of values pointing into a parent batch but unrefs the parent, allowing it to be recycled.  That can corrupt the returned batch.  Fix by not unreffing the parent batch.