### PR TITLE
Fix batch reference counting in runtime/sam/op/groupby

### DIFF
--- a/runtime/sam/op/groupby/groupby.go
+++ b/runtime/sam/op/groupby/groupby.go
@@ -220,8 +220,8 @@ func (o *Op) run() {
 				return
 			}
 		}
-		batch.Unref()
 		if o.agg.inputDir == 0 {
+			batch.Unref()
 			continue
 		}
 		// sorted input: see if we have any completed keys we can emit.
@@ -245,6 +245,7 @@ func (o *Op) run() {
 				break
 			}
 		}
+		batch.Unref()
 	}
 }
 


### PR DESCRIPTION
groupby.Op.run can access the current batch after unreffing it.