### PR TITLE
Update CHANGELOG.md for v1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.14.0
+* Add the `-manage` flag to [`zed serve`](docs/commands/zed.md#serve) to have the Zed service process initiate [maintenance tasks](docs/commands/zed.md#manage) on a regular interval (#5017)
+* Fix an issue where the Python client would not allow loading to a pool with `/` in its name (#5020)
+* Fix an issue where pools with KSUID-like names could not be accessed by name (#5019)
+* Fix an reference counting issue that could cause a Zed service panic (#5029, #5030)
+
 ## v1.13.0
 * Improve the error message when [`zed manage -monitor`](docs/commands/zed.md#manage) is attempted on a local lake (#4979)
 * The [`zed serve`](docs/commands/zed.md#serve) log now includes version, storage root, and auth info at startup (#4988)


### PR DESCRIPTION
Our primary motivation in tagging a Zed release now is to get a fix for the reference counting issues into the hands of a community zync user, but by the rules of semver, the `zed serve -manage` change represents new functionality, so I'm bumping to a minor version rather than a patch version.

https://github.com/brimdata/zed/compare/v1.13.0...935c334