### PR TITLE
lineio reader: Increase max buffer size

### DIFF
--- a/zio/lineio/reader.go
+++ b/zio/lineio/reader.go
@@ -13,7 +13,9 @@ type Reader struct {
 }
 
 func NewReader(r io.Reader) *Reader {
-	return &Reader{scanner: bufio.NewScanner(r)}
+	s := bufio.NewScanner(r)
+	s.Buffer(nil, 25*1024*2014)
+	return &Reader{scanner: s}
 }
 
 func (r *Reader) Read() (*zed.Value, error) {


### PR DESCRIPTION
Increase the max buffer size for the lineio reader from the default 64KB to 25MB.

Closes #5043