### PR TITLE
Adjust lineio reader buffer math to 25 MB

### DIFF
--- a/zio/lineio/reader.go
+++ b/zio/lineio/reader.go
@@ -14,7 +14,7 @@ type Reader struct {
 
 func NewReader(r io.Reader) *Reader {
 	s := bufio.NewScanner(r)
-	s.Buffer(nil, 25*1024*2014)
+	s.Buffer(nil, 25*1024*1024)
 	return &Reader{scanner: s}
 }
 


### PR DESCRIPTION
While verifying the fix in #5045 I noticed that the math to calculate the 25 MB buffer seemed to contain a typo (it said `2014` in one spot instead of `1024`).

Fixes #5043