### PR TITLE
jsonio: Parse error on EOF strings

### DIFF
--- a/pkg/jsonlexer/lexer.go
+++ b/pkg/jsonlexer/lexer.go
@@ -160,6 +160,9 @@ func (l *Lexer) readString() Token {
 		c, err := l.br.ReadByte()
 		if err != nil {
 			l.err = err
+			if err == io.EOF {
+				l.err = errors.New("unexpected end of JSON input")
+			}
 			return TokenErr
 		}
 		l.buf = append(l.buf, c)

--- a/zio/jsonio/ztests/unexpected-input-end.yaml
+++ b/zio/jsonio/ztests/unexpected-input-end.yaml
@@ -1,0 +1,7 @@
+script: |
+  echo '"3' | zq -i json -
+
+outputs:
+  - name: stderr
+    data: |
+      stdio:stdin: unexpected end of JSON input


### PR DESCRIPTION
Return a parse error if EOF on the input is reached before the string is terminated. Previously no error was getting returned.