### PR TITLE
jsonio: Fix parse errors on EOF

### DIFF
--- a/pkg/jsonlexer/lexer.go
+++ b/pkg/jsonlexer/lexer.go
@@ -93,6 +93,9 @@ func (l *Lexer) readLiteral(s string, t Token) Token {
 	for i := range s {
 		c, err := l.br.ReadByte()
 		if err != nil {
+			if err == io.EOF {
+				err = io.ErrUnexpectedEOF
+			}
 			l.err = err
 			return TokenErr
 		}
@@ -161,7 +164,7 @@ func (l *Lexer) readString() Token {
 		if err != nil {
 			l.err = err
 			if err == io.EOF {
-				l.err = errors.New("unexpected end of JSON input")
+				l.err = io.ErrUnexpectedEOF
 			}
 			return TokenErr
 		}

--- a/pkg/jsonlexer/lexer.go
+++ b/pkg/jsonlexer/lexer.go
@@ -160,6 +160,9 @@ func (l *Lexer) readString() Token {
 		c, err := l.br.ReadByte()
 		if err != nil {
 			l.err = err
+			if err == io.EOF {
+				l.err = errors.New("unexpected end of JSON input")
+			}
 			return TokenErr
 		}
 		l.buf = append(l.buf, c)

--- a/zio/jsonio/reader.go
+++ b/zio/jsonio/reader.go
@@ -36,7 +36,7 @@ func (r *Reader) Read() (*zed.Value, error) {
 		if err == io.EOF {
 			return nil, nil
 		}
-		return nil, err
+		return nil, r.error(t, "")
 	}
 	r.builder.reset()
 	if err := r.handleToken("", t); err != nil {
@@ -151,7 +151,7 @@ func (r *Reader) readNameValuePair(t jsonlexer.Token) error {
 func (r *Reader) error(t jsonlexer.Token, msg string) error {
 	if t == jsonlexer.TokenErr {
 		err := r.lexer.Err()
-		if err == io.EOF {
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
 			return errors.New("unexpected end of JSON input")
 		}
 		return err

--- a/zio/jsonio/reader.go
+++ b/zio/jsonio/reader.go
@@ -2,6 +2,7 @@ package jsonio
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 
@@ -149,7 +150,11 @@ func (r *Reader) readNameValuePair(t jsonlexer.Token) error {
 
 func (r *Reader) error(t jsonlexer.Token, msg string) error {
 	if t == jsonlexer.TokenErr {
-		return r.lexer.Err()
+		err := r.lexer.Err()
+		if err == io.EOF {
+			return errors.New("unexpected end of JSON input")
+		}
+		return err
 	}
 	return fmt.Errorf("invalid character %q %s", r.lexer.Buf()[0], msg)
 }

--- a/zio/jsonio/ztests/unexpected-input-end.yaml
+++ b/zio/jsonio/ztests/unexpected-input-end.yaml
@@ -1,11 +1,14 @@
 script: |
   while IFS= read -r line; do
-    ! echo "$line" | zq -i json -
+    ! printf "$line" | zq -i json -
   done < errors.txt
 
 inputs:
   - name: errors.txt
     data: |
+      tru
+      fal
+      nu
       "3
       ["3",
       ["3"
@@ -17,6 +20,9 @@ inputs:
 outputs:
   - name: stderr
     data: |
+      stdio:stdin: unexpected end of JSON input
+      stdio:stdin: unexpected end of JSON input
+      stdio:stdin: unexpected end of JSON input
       stdio:stdin: unexpected end of JSON input
       stdio:stdin: unexpected end of JSON input
       stdio:stdin: unexpected end of JSON input

--- a/zio/jsonio/ztests/unexpected-input-end.yaml
+++ b/zio/jsonio/ztests/unexpected-input-end.yaml
@@ -1,0 +1,28 @@
+script: |
+  while IFS= read -r line; do
+    ! echo "$line" | zq -i json -
+  done < errors.txt
+
+inputs:
+  - name: errors.txt
+    data: |
+      "3
+      ["3",
+      ["3"
+      {"foo":
+      {"foo":"bar",
+      {"foo":"bar"
+      {"foo":"bar
+
+outputs:
+  - name: stderr
+    data: |
+      stdio:stdin: unexpected end of JSON input
+      stdio:stdin: unexpected end of JSON input
+      stdio:stdin: unexpected end of JSON input
+      stdio:stdin: unexpected end of JSON input
+      stdio:stdin: unexpected end of JSON input
+      stdio:stdin: unexpected end of JSON input
+      stdio:stdin: unexpected end of JSON input
+  - name: stdout
+    data: ""


### PR DESCRIPTION
Fix an issue with jsonio.Reader where parse errors occurring at the end of an input (EOF) are often ignored or return an ambiguous EOF error.