### PR TITLE
switch: Propagate batch variables

### DIFF
--- a/runtime/sam/op/switcher/switch.go
+++ b/runtime/sam/op/switcher/switch.go
@@ -68,7 +68,7 @@ func (s *Selector) Forward(router *op.Router, batch zbuf.Batch) bool {
 			// outgoing batch so we don't send these slices
 			// through GC.
 			batch.Ref()
-			out := zbuf.NewArray(c.vals)
+			out := zbuf.NewBatch(batch, c.vals)
 			c.vals = nil
 			if ok := router.Send(c.route, out, nil); !ok {
 				return false

--- a/runtime/sam/op/switcher/ztests/switch-vars.yaml
+++ b/runtime/sam/op/switcher/ztests/switch-vars.yaml
@@ -1,0 +1,12 @@
+zed: |
+  over this with foo = {foo:"bar"} => (
+    switch (
+      case x % 2 == 0 => yield {x, ...foo}
+    )
+  )
+
+input: "[{x:1},{x:2},{x:3},{x:4}]"
+
+output: |
+  {x:2,foo:"bar"}
+  {x:4,foo:"bar"}


### PR DESCRIPTION
Fix issue with switch op where batch variables where not getting propagated to newly created batches.

Closes #5031