### PR TITLE
expr: Improve complex type math error message

### DIFF
--- a/runtime/sam/expr/eval.go
+++ b/runtime/sam/expr/eval.go
@@ -416,7 +416,7 @@ func (a *Add) Eval(ectx Context, this zed.Value) zed.Value {
 	if zerr != nil {
 		return *zerr
 	}
-	typ, err := zed.LookupPrimitiveByID(id)
+	typ, err := a.zctx.LookupType(id)
 	if err != nil {
 		return a.zctx.NewError(err)
 	}
@@ -446,7 +446,7 @@ func (s *Subtract) Eval(ectx Context, this zed.Value) zed.Value {
 	if zerr != nil {
 		return *zerr
 	}
-	typ, err := zed.LookupPrimitiveByID(id)
+	typ, err := s.zctx.LookupType(id)
 	if err != nil {
 		return s.zctx.NewError(err)
 	}
@@ -476,7 +476,7 @@ func (m *Multiply) Eval(ectx Context, this zed.Value) zed.Value {
 	if zerr != nil {
 		return *zerr
 	}
-	typ, err := zed.LookupPrimitiveByID(id)
+	typ, err := m.zctx.LookupType(id)
 	if err != nil {
 		return m.zctx.NewError(err)
 	}
@@ -502,7 +502,7 @@ func (d *Divide) Eval(ectx Context, this zed.Value) zed.Value {
 	if zerr != nil {
 		return *zerr
 	}
-	typ, err := zed.LookupPrimitiveByID(id)
+	typ, err := d.zctx.LookupType(id)
 	if err != nil {
 		return d.zctx.NewError(err)
 	}
@@ -537,7 +537,7 @@ func (m *Modulo) Eval(ectx Context, this zed.Value) zed.Value {
 	if zerr != nil {
 		return *zerr
 	}
-	typ, err := zed.LookupPrimitiveByID(id)
+	typ, err := m.zctx.LookupType(id)
 	if err != nil {
 		return m.zctx.NewError(err)
 	}

--- a/runtime/sam/expr/ztests/math-incompatible.yaml
+++ b/runtime/sam/expr/ztests/math-incompatible.yaml
@@ -1,0 +1,30 @@
+zed: |
+  yield a+b, a-b, a*b, a/b, a%b
+
+input: |
+  {a:[1,2],b:[3,4]}
+  {a:|[1,2]|,b:|[3,4]|}
+  {a:{foo:"bar"},b:{foo:"baz"}}
+  {a:|{"foo":"bar"}|,b:|{"foo":"baz"}|}
+
+output: |
+  error("type [int64] incompatible with '+' operator")
+  error("type [int64] incompatible with '-' operator")
+  error("type [int64] incompatible with '*' operator")
+  error("type [int64] incompatible with '/' operator")
+  error("type [int64] incompatible with '%' operator")
+  error("type |[int64]| incompatible with '+' operator")
+  error("type |[int64]| incompatible with '-' operator")
+  error("type |[int64]| incompatible with '*' operator")
+  error("type |[int64]| incompatible with '/' operator")
+  error("type |[int64]| incompatible with '%' operator")
+  error("type {foo:string} incompatible with '+' operator")
+  error("type {foo:string} incompatible with '-' operator")
+  error("type {foo:string} incompatible with '*' operator")
+  error("type {foo:string} incompatible with '/' operator")
+  error("type {foo:string} incompatible with '%' operator")
+  error("type |{string:string}| incompatible with '+' operator")
+  error("type |{string:string}| incompatible with '-' operator")
+  error("type |{string:string}| incompatible with '*' operator")
+  error("type |{string:string}| incompatible with '/' operator")
+  error("type |{string:string}| incompatible with '%' operator")


### PR DESCRIPTION
This commit adjusts functionality so that a better error message is returned when attempting to perform simple math expressions on complex types.

Closes #4944