### PR TITLE
Remove rctx.WaitGroup use in runtime/vam/op.Scanner

### DIFF
--- a/runtime/vam/op/scan.go
+++ b/runtime/vam/op/scan.go
@@ -60,12 +60,7 @@ func NewScanner(rctx *runtime.Context, cache *vcache.Cache, parent zbuf.Puller, 
 // vector of error("missing").
 
 func (s *Scanner) Pull(done bool) (vector.Any, error) {
-	s.once.Do(func() {
-		// Block p.ctx's cancel function until p.run finishes its
-		// cleanup.
-		s.rctx.WaitGroup.Add(1)
-		go s.run()
-	})
+	s.once.Do(func() { go s.run() })
 	if done {
 		select {
 		case s.doneCh <- struct{}{}:
@@ -81,9 +76,6 @@ func (s *Scanner) Pull(done bool) (vector.Any, error) {
 }
 
 func (s *Scanner) run() {
-	defer func() {
-		s.rctx.WaitGroup.Done()
-	}()
 	for {
 		//XXX should make an object puller that wraps this...
 		batch, err := s.parent.Pull(false)


### PR DESCRIPTION
Scanner.run does no cleanup so there's no need for Scanner to use runtime.Context.WaitGroup.