### PR TITLE
Reset stateful expressions on EOS

### DIFF
--- a/compiler/kernel/expr.go
+++ b/compiler/kernel/expr.go
@@ -96,7 +96,9 @@ func (b *Builder) compileExpr(e dag.Expr) (expr.Evaluator, error) {
 		if err != nil {
 			return nil, err
 		}
-		return expr.NewAggregatorExpr(b.zctx(), agg), nil
+		aggexpr := expr.NewAggregatorExpr(b.zctx(), agg)
+		b.resetters = append(b.resetters, aggexpr)
+		return aggexpr, nil
 	case *dag.OverExpr:
 		return b.compileOverExpr(e)
 	default:
@@ -497,7 +499,7 @@ func (b *Builder) compileOverExpr(over *dag.OverExpr) (expr.Evaluator, error) {
 		return nil, err
 	}
 	parent := traverse.NewExpr(b.rctx.Context, b.zctx())
-	enter := traverse.NewOver(b.rctx, parent, exprs)
+	enter := traverse.NewOver(b.rctx, parent, exprs, expr.Resetters{})
 	scope := enter.AddScope(b.rctx.Context, names, lets)
 	exits, err := b.compileSeq(over.Body, []zbuf.Puller{scope})
 	if err != nil {

--- a/compiler/kernel/groupby.go
+++ b/compiler/kernel/groupby.go
@@ -13,6 +13,7 @@ import (
 )
 
 func (b *Builder) compileGroupBy(parent zbuf.Puller, summarize *dag.Summarize) (*groupby.Op, error) {
+	b.resetResetters()
 	keys, err := b.compileAssignments(summarize.Keys)
 	if err != nil {
 		return nil, err
@@ -22,7 +23,7 @@ func (b *Builder) compileGroupBy(parent zbuf.Puller, summarize *dag.Summarize) (
 		return nil, err
 	}
 	dir := order.Direction(summarize.InputSortDir)
-	return groupby.New(b.rctx, parent, keys, names, reducers, summarize.Limit, dir, summarize.PartialsIn, summarize.PartialsOut)
+	return groupby.New(b.rctx, parent, keys, names, reducers, summarize.Limit, dir, summarize.PartialsIn, summarize.PartialsOut, b.resetters)
 }
 
 func (b *Builder) compileAggAssignments(assignments []dag.Assignment) (field.List, []*expr.Aggregator, error) {

--- a/compiler/kernel/op.go
+++ b/compiler/kernel/op.go
@@ -50,14 +50,15 @@ import (
 var ErrJoinParents = errors.New("join requires two upstream parallel query paths")
 
 type Builder struct {
-	rctx     *runtime.Context
-	mctx     *zed.Context
-	source   *data.Source
-	readers  []zio.Reader
-	progress *zbuf.Progress
-	arena    *zed.Arena // For zed.Values created during compilation.
-	deletes  *sync.Map
-	funcs    map[string]expr.Function
+	rctx      *runtime.Context
+	mctx      *zed.Context
+	source    *data.Source
+	readers   []zio.Reader
+	progress  *zbuf.Progress
+	arena     *zed.Arena // For zed.Values created during compilation.
+	deletes   *sync.Map
+	funcs     map[string]expr.Function
+	resetters expr.Resetters
 }
 
 func NewBuilder(rctx *runtime.Context, source *data.Source) *Builder {
@@ -132,11 +133,16 @@ func (b *Builder) Deletes() *sync.Map {
 	return b.deletes
 }
 
+func (b *Builder) resetResetters() {
+	b.resetters = nil
+}
+
 func (b *Builder) compileLeaf(o dag.Op, parent zbuf.Puller) (zbuf.Puller, error) {
 	switch v := o.(type) {
 	case *dag.Summarize:
 		return b.compileGroupBy(parent, v)
 	case *dag.Cut:
+		b.resetResetters()
 		assignments, err := b.compileAssignments(v.Args)
 		if err != nil {
 			return nil, err
@@ -146,7 +152,7 @@ func (b *Builder) compileLeaf(o dag.Op, parent zbuf.Puller) (zbuf.Puller, error)
 		if v.Quiet {
 			cutter.Quiet()
 		}
-		return op.NewApplier(b.rctx, parent, cutter), nil
+		return op.NewApplier(b.rctx, parent, cutter, b.resetters), nil
 	case *dag.Drop:
 		if len(v.Args) == 0 {
 			return nil, errors.New("drop: no fields given")
@@ -160,13 +166,14 @@ func (b *Builder) compileLeaf(o dag.Op, parent zbuf.Puller) (zbuf.Puller, error)
 			fields = append(fields, field.Path)
 		}
 		dropper := expr.NewDropper(b.rctx.Zctx, fields)
-		return op.NewApplier(b.rctx, parent, dropper), nil
+		return op.NewApplier(b.rctx, parent, dropper, expr.Resetters{}), nil
 	case *dag.Sort:
+		b.resetResetters()
 		fields, err := b.compileExprs(v.Args)
 		if err != nil {
 			return nil, err
 		}
-		sort, err := sort.New(b.rctx, parent, fields, v.Order, v.NullsFirst)
+		sort, err := sort.New(b.rctx, parent, fields, v.Order, v.NullsFirst, b.resetters)
 		if err != nil {
 			return nil, fmt.Errorf("compiling sort: %w", err)
 		}
@@ -188,25 +195,29 @@ func (b *Builder) compileLeaf(o dag.Op, parent zbuf.Puller) (zbuf.Puller, error)
 	case *dag.Pass:
 		return pass.New(parent), nil
 	case *dag.Filter:
+		b.resetResetters()
 		f, err := b.compileExpr(v.Expr)
 		if err != nil {
 			return nil, fmt.Errorf("compiling filter: %w", err)
 		}
-		return op.NewApplier(b.rctx, parent, expr.NewFilterApplier(b.rctx.Zctx, f)), nil
+		return op.NewApplier(b.rctx, parent, expr.NewFilterApplier(b.rctx.Zctx, f), b.resetters), nil
 	case *dag.Top:
+		b.resetResetters()
 		fields, err := b.compileExprs(v.Args)
 		if err != nil {
 			return nil, fmt.Errorf("compiling top: %w", err)
 		}
-		return top.New(b.rctx.Zctx, parent, v.Limit, fields, v.Flush), nil
+		return top.New(b.rctx.Zctx, parent, v.Limit, fields, v.Flush, b.resetters), nil
 	case *dag.Put:
+		b.resetResetters()
 		clauses, err := b.compileAssignments(v.Args)
 		if err != nil {
 			return nil, err
 		}
 		putter := expr.NewPutter(b.rctx.Zctx, clauses)
-		return op.NewApplier(b.rctx, parent, putter), nil
+		return op.NewApplier(b.rctx, parent, putter, b.resetters), nil
 	case *dag.Rename:
+		b.resetResetters()
 		var srcs, dsts []*expr.Lval
 		for _, a := range v.Args {
 			src, err := b.compileLval(a.RHS)
@@ -221,7 +232,7 @@ func (b *Builder) compileLeaf(o dag.Op, parent zbuf.Puller) (zbuf.Puller, error)
 			dsts = append(dsts, dst)
 		}
 		renamer := expr.NewRenamer(b.rctx.Zctx, srcs, dsts)
-		return op.NewApplier(b.rctx, parent, renamer), nil
+		return op.NewApplier(b.rctx, parent, renamer, b.resetters), nil
 	case *dag.Fuse:
 		return fuse.New(b.rctx, parent)
 	case *dag.Shape:
@@ -235,19 +246,21 @@ func (b *Builder) compileLeaf(o dag.Op, parent zbuf.Puller) (zbuf.Puller, error)
 		if err != nil {
 			return nil, err
 		}
+		b.resetResetters()
 		args, err := b.compileExprs(v.Args)
 		if err != nil {
 			return nil, err
 		}
-		return explode.New(b.rctx.Zctx, parent, args, typ, v.As)
+		return explode.New(b.rctx.Zctx, parent, args, typ, v.As, b.resetters)
 	case *dag.Over:
 		return b.compileOver(parent, v)
 	case *dag.Yield:
+		b.resetResetters()
 		exprs, err := b.compileExprs(v.Exprs)
 		if err != nil {
 			return nil, err
 		}
-		t := yield.New(parent, exprs)
+		t := yield.New(parent, exprs, b.resetters)
 		return t, nil
 	case *dag.PoolScan:
 		if parent != nil {
@@ -382,6 +395,7 @@ func (b *Builder) compileOver(parent zbuf.Puller, over *dag.Over) (zbuf.Puller, 
 	if len(over.Defs) != 0 && over.Body == nil {
 		return nil, errors.New("internal error: over operator has defs but no body")
 	}
+	b.resetResetters()
 	withNames, withExprs, err := b.compileDefs(over.Defs)
 	if err != nil {
 		return nil, err
@@ -390,7 +404,7 @@ func (b *Builder) compileOver(parent zbuf.Puller, over *dag.Over) (zbuf.Puller, 
 	if err != nil {
 		return nil, err
 	}
-	enter := traverse.NewOver(b.rctx, parent, exprs)
+	enter := traverse.NewOver(b.rctx, parent, exprs, b.resetters)
 	if over.Body == nil {
 		return enter, nil
 	}
@@ -445,6 +459,9 @@ func (b *Builder) compileSeq(seq dag.Seq, parents []zbuf.Puller) ([]zbuf.Puller,
 }
 
 func (b *Builder) compileScope(scope *dag.Scope, parents []zbuf.Puller) ([]zbuf.Puller, error) {
+	// XXX We need to fix how udfs are compiled since there is currently a bug
+	// where aggregation expressions in udfs do not have separate state per
+	// invocation.
 	if err := b.compileFuncs(scope.Funcs); err != nil {
 		return nil, err
 	}
@@ -517,11 +534,12 @@ func (b *Builder) compileExprSwitch(swtch *dag.Switch, parents []zbuf.Puller) ([
 	if len(parents) > 1 {
 		parent = combine.New(b.rctx, parents)
 	}
+	b.resetResetters()
 	e, err := b.compileExpr(swtch.Expr)
 	if err != nil {
 		return nil, err
 	}
-	s := exprswitch.New(b.rctx, parent, e)
+	s := exprswitch.New(b.rctx, parent, e, b.resetters)
 	var exits []zbuf.Puller
 	for _, c := range swtch.Cases {
 		var val *zed.Value
@@ -549,20 +567,19 @@ func (b *Builder) compileSwitch(swtch *dag.Switch, parents []zbuf.Puller) ([]zbu
 	if len(parents) > 1 {
 		parent = combine.New(b.rctx, parents)
 	}
-	n := len(swtch.Cases)
-	switcher := switcher.New(b.rctx, parent)
-	parents = []zbuf.Puller{}
+	b.resetResetters()
+	var exprs []expr.Evaluator
 	for _, c := range swtch.Cases {
-		f, err := b.compileExpr(c.Expr)
+		e, err := b.compileExpr(c.Expr)
 		if err != nil {
 			return nil, fmt.Errorf("compiling switch case filter: %w", err)
 		}
-		sc := switcher.AddCase(f)
-		parents = append(parents, sc)
+		exprs = append(exprs, e)
 	}
+	switcher := switcher.New(b.rctx, parent, b.resetters)
 	var ops []zbuf.Puller
-	for k := 0; k < n; k++ {
-		o, err := b.compileSeq(swtch.Cases[k].Path, []zbuf.Puller{parents[k]})
+	for i, e := range exprs {
+		o, err := b.compileSeq(swtch.Cases[i].Path, []zbuf.Puller{switcher.AddCase(e)})
 		if err != nil {
 			return nil, err
 		}
@@ -590,6 +607,7 @@ func (b *Builder) compile(o dag.Op, parents []zbuf.Puller) ([]zbuf.Puller, error
 		if len(parents) != 2 {
 			return nil, ErrJoinParents
 		}
+		b.resetResetters()
 		assignments, err := b.compileAssignments(o.Args)
 		if err != nil {
 			return nil, err
@@ -619,18 +637,19 @@ func (b *Builder) compile(o dag.Op, parents []zbuf.Puller) ([]zbuf.Puller, error
 		default:
 			return nil, fmt.Errorf("unknown kind of join: '%s'", o.Style)
 		}
-		join, err := join.New(b.rctx, anti, inner, leftParent, rightParent, leftKey, rightKey, leftDir, rightDir, lhs, rhs)
+		join, err := join.New(b.rctx, anti, inner, leftParent, rightParent, leftKey, rightKey, leftDir, rightDir, lhs, rhs, b.resetters)
 		if err != nil {
 			return nil, err
 		}
 		return []zbuf.Puller{join}, nil
 	case *dag.Merge:
+		b.resetResetters()
 		e, err := b.compileExpr(o.Expr)
 		if err != nil {
 			return nil, err
 		}
 		cmp := expr.NewComparator(true, o.Order == order.Desc, e).WithMissingAsNull()
-		return []zbuf.Puller{merge.New(b.rctx, parents, cmp.Compare)}, nil
+		return []zbuf.Puller{merge.New(b.rctx, parents, cmp.Compare, b.resetters)}, nil
 	case *dag.Combine:
 		return []zbuf.Puller{combine.New(b.rctx, parents)}, nil
 	default:

--- a/runtime/sam/expr/agg.go
+++ b/runtime/sam/expr/agg.go
@@ -48,22 +48,39 @@ func (a *Aggregator) Apply(zctx *zed.Context, ectx Context, f agg.Function, this
 // NewAggregatorExpr returns an Evaluator from agg. The returned Evaluator
 // retains the same functionality of the aggregation only it returns it's
 // current state every time a new value is consumed.
-func NewAggregatorExpr(zctx *zed.Context, agg *Aggregator) Evaluator {
-	return &aggregatorExpr{agg: agg, zctx: zctx}
+func NewAggregatorExpr(zctx *zed.Context, agg *Aggregator) *AggregatorExpr {
+	return &AggregatorExpr{agg: agg, zctx: zctx}
 }
 
-type aggregatorExpr struct {
+type AggregatorExpr struct {
 	agg  *Aggregator
 	fn   agg.Function
 	zctx *zed.Context
 }
 
-var _ Evaluator = (*aggregatorExpr)(nil)
+var _ Evaluator = (*AggregatorExpr)(nil)
+var _ Resetter = (*AggregatorExpr)(nil)
 
-func (s *aggregatorExpr) Eval(ectx Context, val zed.Value) zed.Value {
+func (s *AggregatorExpr) Eval(ectx Context, val zed.Value) zed.Value {
 	if s.fn == nil {
 		s.fn = s.agg.NewFunction()
 	}
 	s.agg.Apply(s.zctx, ectx, s.fn, val)
 	return s.fn.Result(s.zctx, ectx.Arena())
+}
+
+func (s *AggregatorExpr) Reset() {
+	s.fn = nil
+}
+
+type Resetter interface {
+	Reset()
+}
+
+type Resetters []Resetter
+
+func (rs Resetters) Reset() {
+	for _, r := range rs {
+		r.Reset()
+	}
 }

--- a/runtime/sam/op/apply.go
+++ b/runtime/sam/op/apply.go
@@ -8,16 +8,18 @@ import (
 )
 
 type applier struct {
-	rctx   *runtime.Context
-	parent zbuf.Puller
-	expr   expr.Evaluator
+	rctx     *runtime.Context
+	parent   zbuf.Puller
+	expr     expr.Evaluator
+	resetter expr.Resetter
 }
 
-func NewApplier(rctx *runtime.Context, parent zbuf.Puller, expr expr.Evaluator) *applier {
+func NewApplier(rctx *runtime.Context, parent zbuf.Puller, expr expr.Evaluator, resetter expr.Resetter) *applier {
 	return &applier{
-		rctx:   rctx,
-		parent: parent,
-		expr:   expr,
+		rctx:     rctx,
+		parent:   parent,
+		expr:     expr,
+		resetter: resetter,
 	}
 }
 
@@ -25,6 +27,7 @@ func (a *applier) Pull(done bool) (zbuf.Batch, error) {
 	for {
 		batch, err := a.parent.Pull(done)
 		if batch == nil || err != nil {
+			a.resetter.Reset()
 			return nil, err
 		}
 		arena := zed.NewArena()

--- a/runtime/sam/op/exprswitch/exprswitch.go
+++ b/runtime/sam/op/exprswitch/exprswitch.go
@@ -10,7 +10,7 @@ import (
 
 type ExprSwitch struct {
 	*op.Router
-	rctx        *runtime.Context
+	expr.Resetter
 	expr        expr.Evaluator
 	cases       map[string]*switchCase
 	defaultCase *switchCase
@@ -23,13 +23,13 @@ type switchCase struct {
 	vals  []zed.Value
 }
 
-func New(rctx *runtime.Context, parent zbuf.Puller, e expr.Evaluator) *ExprSwitch {
+func New(rctx *runtime.Context, parent zbuf.Puller, e expr.Evaluator, resetter expr.Resetter) *ExprSwitch {
 	router := op.NewRouter(rctx, parent)
 	s := &ExprSwitch{
-		Router: router,
-		rctx:   rctx,
-		expr:   e,
-		cases:  make(map[string]*switchCase),
+		Router:   router,
+		Resetter: resetter,
+		expr:     e,
+		cases:    make(map[string]*switchCase),
 	}
 	router.Link(s)
 	return s

--- a/runtime/sam/op/fork/fork.go
+++ b/runtime/sam/op/fork/fork.go
@@ -39,3 +39,5 @@ func (s splitter) Forward(r *op.Router, b zbuf.Batch) bool {
 	}
 	return true
 }
+
+func (s splitter) Reset() {}

--- a/runtime/sam/op/merge/merge_test.go
+++ b/runtime/sam/op/merge/merge_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/pkg/field"
+	"github.com/brimdata/zed/runtime/sam/expr"
 	"github.com/brimdata/zed/runtime/sam/op/merge"
 	"github.com/brimdata/zed/zbuf"
 	"github.com/brimdata/zed/zio"
@@ -102,7 +103,7 @@ func TestParallelOrder(t *testing.T) {
 			}
 			sortKey := order.NewSortKey(c.order, field.DottedList(c.field))
 			cmp := zbuf.NewComparator(zctx, sortKey).Compare
-			om := merge.New(context.Background(), parents, cmp)
+			om := merge.New(context.Background(), parents, cmp, expr.Resetters{})
 
 			var sb strings.Builder
 			err := zbuf.CopyPuller(zsonio.NewWriter(zio.NopCloser(&sb), zsonio.WriterOpts{}), om)

--- a/runtime/sam/op/meta/sequence.go
+++ b/runtime/sam/op/meta/sequence.go
@@ -205,7 +205,7 @@ func newObjectsScanner(ctx context.Context, zctx *zed.Context, pool *lake.Pool, 
 	if len(pullers) == 1 {
 		return pullers[0], nil
 	}
-	return merge.New(ctx, pullers, lake.ImportComparator(zctx, pool).Compare), nil
+	return merge.New(ctx, pullers, lake.ImportComparator(zctx, pool).Compare, expr.Resetters{}), nil
 }
 
 func newObjectScanner(ctx context.Context, zctx *zed.Context, pool *lake.Pool, object *data.Object, ranges []seekindex.Range, filter zbuf.Filter, progress *zbuf.Progress) (zbuf.Puller, error) {

--- a/runtime/sam/op/router.go
+++ b/runtime/sam/op/router.go
@@ -5,10 +5,12 @@ import (
 	"sync"
 
 	"github.com/brimdata/zed/runtime"
+	"github.com/brimdata/zed/runtime/sam/expr"
 	"github.com/brimdata/zed/zbuf"
 )
 
 type Selector interface {
+	expr.Resetter
 	Forward(*Router, zbuf.Batch) bool
 }
 
@@ -93,6 +95,7 @@ func (r *Router) blocked() bool {
 // after receiving the EOS, it's done will be captured as soon as we unblock
 // all channels.
 func (r *Router) sendEOS(err error) bool {
+	defer r.selector.Reset()
 	// First, we need to send EOS to all non-blocked legs and
 	// catch any dones in progress.  This result in all routes
 	// being blocked.

--- a/runtime/sam/op/switcher/switch.go
+++ b/runtime/sam/op/switcher/switch.go
@@ -10,6 +10,7 @@ import (
 
 type Selector struct {
 	*op.Router
+	expr.Resetter
 	zctx  *zed.Context
 	cases []*switchCase
 }
@@ -22,11 +23,12 @@ type switchCase struct {
 	vals   []zed.Value
 }
 
-func New(rctx *runtime.Context, parent zbuf.Puller) *Selector {
+func New(rctx *runtime.Context, parent zbuf.Puller, resetter expr.Resetter) *Selector {
 	router := op.NewRouter(rctx, parent)
 	s := &Selector{
-		Router: router,
-		zctx:   rctx.Zctx,
+		Router:   router,
+		Resetter: resetter,
+		zctx:     rctx.Zctx,
 	}
 	router.Link(s)
 	return s

--- a/runtime/sam/op/yield/yield.go
+++ b/runtime/sam/op/yield/yield.go
@@ -7,14 +7,16 @@ import (
 )
 
 type Op struct {
-	parent zbuf.Puller
-	exprs  []expr.Evaluator
+	parent   zbuf.Puller
+	exprs    []expr.Evaluator
+	resetter expr.Resetter
 }
 
-func New(parent zbuf.Puller, exprs []expr.Evaluator) *Op {
+func New(parent zbuf.Puller, exprs []expr.Evaluator, resetter expr.Resetter) *Op {
 	return &Op{
-		parent: parent,
-		exprs:  exprs,
+		parent:   parent,
+		exprs:    exprs,
+		resetter: resetter,
 	}
 }
 
@@ -22,6 +24,7 @@ func (o *Op) Pull(done bool) (zbuf.Batch, error) {
 	for {
 		batch, err := o.parent.Pull(done)
 		if batch == nil || err != nil {
+			o.resetter.Reset()
 			return nil, err
 		}
 		arena := zed.NewArena()

--- a/runtime/sam/op/ztests/stateful-expr-reset.yaml
+++ b/runtime/sam/op/ztests/stateful-expr-reset.yaml
@@ -1,0 +1,50 @@
+script: |
+  echo // yield
+  zq -z 'yield null, null | over this => ( yield count() )'
+  echo // filter
+  zq -z 'yield [1,2,3,4], [5,6,7] | over this => ( where count() % 3 == 0 )'
+  echo // switch
+  zq -z 'yield [1], [1] | over this => (
+    switch sum(this) (
+       case 1  => yield "sum is 1"
+    )
+  )'
+  echo // exprswitch
+  zq -z 'yield [1], [1] | over this => (
+    switch (
+      case sum(this) == 1 => yield "sum is 1"
+    )
+  )'
+  echo // over
+  zq -z 'yield null, null | over this => ( over count() )'
+  echo // over with
+  zq -z 'yield [1], [1] | over this => (
+    over this with count = count() => ( yield count )
+  )'
+  echo // summarize
+  zq -z 'yield [1], [1] | over this => ( sum(this) by c := count() )'
+
+outputs:
+  - name: stdout
+    data: |
+      // yield
+      1(uint64)
+      1(uint64)
+      // filter
+      3
+      7
+      // switch
+      "sum is 1"
+      "sum is 1"
+      // exprswitch
+      "sum is 1"
+      "sum is 1"
+      // over
+      1(uint64)
+      1(uint64)
+      // over with
+      1(uint64)
+      1(uint64)
+      // summarize
+      {c:1(uint64),sum:1}
+      {c:1(uint64),sum:1}


### PR DESCRIPTION
This commit fixes a bug where stateful expressions were not getting reset when an op encounters EOS. This would most notably result in unexpected values when using stateful expressions inside of lateral queries.

Closes #4943