### PR TITLE
over expr: Pass outer vars into batches

### DIFF
--- a/runtime/sam/op/traverse/eval.go
+++ b/runtime/sam/op/traverse/eval.go
@@ -42,8 +42,10 @@ func (e *Expr) SetExit(exit *Exit) {
 }
 
 func (e *Expr) Eval(ectx expr.Context, this zed.Value) zed.Value {
+	b := zbuf.NewArray([]zed.Value{this})
+	b.SetVars(ectx.Vars())
 	select {
-	case e.batchCh <- zbuf.NewArray([]zed.Value{this}):
+	case e.batchCh <- b:
 	case <-e.ctx.Done():
 		return e.zctx.NewError(e.ctx.Err())
 	}

--- a/runtime/sam/op/traverse/ztests/over-expr-outer-vars.yaml
+++ b/runtime/sam/op/traverse/ztests/over-expr-outer-vars.yaml
@@ -1,0 +1,11 @@
+zed: |
+  func sumvals(vals): (
+    (over vals | sum(this))
+  )
+  sum := sumvals(v)
+
+input: |
+  {v:[1,2,3,4]}
+
+output: |
+  {v:[1,2,3,4],sum:10}

--- a/zbuf/array.go
+++ b/zbuf/array.go
@@ -9,6 +9,7 @@ import (
 // the Reader interfaces.
 type Array struct {
 	values []zed.Value
+	vars   []zed.Value
 }
 
 var _ Batch = (*Array)(nil)
@@ -37,9 +38,12 @@ func (a *Array) Append(r zed.Value) {
 	a.values = append(a.values, r)
 }
 
+func (a *Array) SetVars(vars []zed.Value) {
+	a.vars = vars
+}
+
 func (a *Array) Vars() []zed.Value {
-	// XXX TBD
-	return nil
+	return a.vars
 }
 
 func (a *Array) Write(r zed.Value) error {


### PR DESCRIPTION
This commit fixes a bug in over expressions where outer variables were not getting propagated to batches in the inner scope.

Closes #5077