### PR TITLE
exprswitch: Propagate batch variables

### DIFF
--- a/runtime/sam/op/exprswitch/exprswitch.go
+++ b/runtime/sam/op/exprswitch/exprswitch.go
@@ -68,7 +68,7 @@ func (s *ExprSwitch) Forward(router *op.Router, batch zbuf.Batch) bool {
 			// outgoing batch so we don't send these slices
 			// through GC.
 			batch.Ref()
-			out := zbuf.NewArray(c.vals)
+			out := zbuf.NewBatch(batch, c.vals)
 			c.vals = nil
 			if ok := router.Send(c.route, out, nil); !ok {
 				return false

--- a/runtime/sam/op/exprswitch/ztests/switch-vars.yaml
+++ b/runtime/sam/op/exprswitch/ztests/switch-vars.yaml
@@ -1,0 +1,13 @@
+zed: |
+  over this with var="foo" => (
+    switch this (
+      case 2 => yield var
+      default => yield this
+    )
+  )
+
+input: '1 2'
+
+output: |
+  1
+  "foo"


### PR DESCRIPTION
Fix issue with exprswitch op where batch variables where not getting propagated to inner batches.

Closes #5076