### PR TITLE
Update docs to reflect #5074 changes

### DIFF
--- a/docs/language/statements.md
+++ b/docs/language/statements.md
@@ -24,8 +24,10 @@ produces
 ```
 
 One or more `const` statements may appear only at the beginning of a scope
-(i.e., the main scope at the start of a Zed program or a [lateral scope](lateral-subqueries.md/#lateral-scope))
-defined by an [`over` operator](operators/over.md)
+(i.e., the main scope at the start of a Zed program,
+the start of the body of a [user-defined operator](#operator-statements),
+or a [lateral scope](lateral-subqueries.md/#lateral-scope)
+defined by an [`over` operator](operators/over.md))
 and binds the identifier to the value in the scope in which it appears in addition
 to any contained scopes.
 
@@ -57,7 +59,9 @@ produces
 ```
 
 One or more `func` statements may appear at the beginning of a scope
-(i.e., the main scope at the start of a Zed program or a [lateral scope](lateral-subqueries.md#lateral-scope)
+(i.e., the main scope at the start of a Zed program,
+the start of the body of a [user-defined operator](#operator-statements),
+or a [lateral scope](lateral-subqueries.md/#lateral-scope)
 defined by an [`over` operator](operators/over.md))
 and binds the identifier to the expression in the scope in which it appears in addition
 to any contained scopes.
@@ -87,6 +91,14 @@ A user-defined operator can then be called with using the familiar call syntax
 where `<id>` is the identifier of the user-defined operator and `<expr>` is a list
 of [expressions](expressions.md) matching the number of `<param>`s defined in
 the operator's signature.
+
+One or more `op` statements may appear only at the beginning of a scope
+(i.e., the main scope at the start of a Zed program,
+the start of the body of a [user-defined operator](#operator-statements),
+or a [lateral scope](lateral-subqueries.md/#lateral-scope)
+defined by an [`over` operator](operators/over.md))
+and binds the identifier to the value in the scope in which it appears in addition
+to any contained scopes.
 
 ### Sequence `this` Value
 
@@ -220,7 +232,9 @@ produces
 ```
 
 One or more `type` statements may appear at the beginning of a scope
-(i.e., the main scope at the start of a Zed program or a [lateral scope](lateral-subqueries.md#lateral-scope)
+(i.e., the main scope at the start of a Zed program,
+the start of the body of a [user-defined operator](#operator-statements),
+or a [lateral scope](lateral-subqueries.md/#lateral-scope)
 defined by an [`over` operator](operators/over.md))
 and binds the identifier to the type in the scope in which it appears in addition
 to any contained scopes.


### PR DESCRIPTION
This PR updates the Zed docs to reflect the changes from #5074 that allowed for the bodies of user-defined ops to be treated as scopes.

I paused for a bit before making this change because there was already some semi-verbose redundancy in these docs in terms of how we refer to scopes, and this extends that. I wondered if it would be justified to create a new top-level section under **Language** just to describe scopes, move this text over to there, then link to it and know we could continue making additions in that one spot as we further improve in this area (e.g., when we get to #5075). However, I pre-checked the idea with @nwt and his take was that we're probably due to undergo an ambitious re-thinking of scopes when we can justify the time, and more ambitious docs overhauls could come with that. Based on this I've decided for now to extend the life of what we've got.