### PR TITLE
Remove mention of zq "-query" flag

### DIFF
--- a/docs/commands/zq.md
+++ b/docs/commands/zq.md
@@ -65,12 +65,9 @@ To determine whether the first argument is a query or an input,
 or whether the name is an URL.
 If no such file or URL exists, it attempts to parse the text as a Zed program.
 If both checks fail, then an error is reported and `zq` exits.
-
 This heuristic is convenient but can result in a rare surprise when a simple
 Zed query (like a keyword search) happens to correspond with a file of the
 same name in the local directory.
-To avoid this, you can provide the query with the `-query` flag, which specifies
-the Zed program to run and forces all arguments to be interpreted as inputs.
 
 When `zq` is run with a query and no input arguments, then the query must
 begin with a


### PR DESCRIPTION
When work was being done on #5053, I happened to review the current `zq` docs on the topic and was surprised to see the `-query` flag mentioned. As described in #5052, I then realized the flag was documented but never implemented. I briefly thought it might be useful to hurry up and implement it so it could be mentioned in the error messages proposed in #5053, but in the end  I'm happy with where that landed without `-query` existing.

Since the "rare surprise" disclosed in the docs is still a valid exposure, I'd be fine with opening an issue as a reminder that we could go back and implement `-query` at some point in the future. But for now it's not serving our users to mention something in the docs that doesn't exist, so here I'm proposing dropping it from the docs for now.

Closes #5052