### PR TITLE
Link to the proper home of zed-js

### DIFF
--- a/docs/formats/README.md
+++ b/docs/formats/README.md
@@ -274,7 +274,7 @@ values.
 embodies Zed's more general model for heterogeneous and self-describing schemas.
 * [Zed over JSON](zjson.md) defines a JSON format for encapsulating Zed data
 in JSON for easy decoding by JSON-based clients, e.g.,
-the [zed-js JavaScript library](https://github.com/brimdata/zealot/tree/main/packages/zed-js)
+the [zed-js JavaScript library](https://github.com/brimdata/zui/tree/main/packages/zed-js)
 and the [Zed Python library](../libraries/python.md).
 
 Because all of the formats conform to the same Zed data model, conversions between

--- a/docs/formats/zjson.md
+++ b/docs/formats/zjson.md
@@ -65,7 +65,7 @@ so appropriate for a [super-structured data model](./README.md#2-zed-a-super-str
 like Zed.  That said, JSON can be used as an encoding format for Zed by mapping Zed data
 onto a JSON-based protocol.  This allows clients like web apps or
 Electron apps to receive and understand Zed and, with the help of client
-libraries like [zed-js](https://github.com/brimdata/zealot/tree/main/packages/zed-js),
+libraries like [zed-js](https://github.com/brimdata/zui/tree/main/packages/zed-js),
 to manipulate the rich, structured Zed types that are implemented on top of
 the basic JavaScript types.
 

--- a/docs/libraries/javascript.md
+++ b/docs/libraries/javascript.md
@@ -5,7 +5,7 @@ sidebar_label: JavaScript
 
 # JavaScript
 
-The [zed-js library](https://github.com/brimdata/zealot/tree/main/packages/zed-js)
+The [zed-js library](https://github.com/brimdata/zui/tree/main/packages/zed-js)
 provides support for the Zed data model from within
 JavaScript as well as methods for communicating with a Zed lake.
 


### PR DESCRIPTION
https://github.com/brimdata/zui/pull/2818 moved zed-js out of the old "Zealot" repo and into a subdirectory in the Zui monorepo. This PR fixes several links in the Zed docs that were still linking to the old zed-js location.