### PR TITLE
vector search: Fix fields selector

### DIFF
--- a/compiler/job.go
+++ b/compiler/job.go
@@ -195,6 +195,5 @@ func VectorFilterCompile(rctx *runtime.Context, query string, src *data.Source, 
 	if !ok {
 		return nil, errors.New("filter query must be a single filter op")
 	}
-	d := optimizer.InferDemandSeqOut(entry)[entry[0]]
-	return kernel.NewBuilder(rctx, src).BuildVamToSeqFilter(f.Expr, d, poolID, commitID)
+	return kernel.NewBuilder(rctx, src).BuildVamToSeqFilter(f.Expr, poolID, commitID)
 }

--- a/compiler/kernel/op.go
+++ b/compiler/kernel/op.go
@@ -11,6 +11,7 @@ import (
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/compiler/ast/dag"
 	"github.com/brimdata/zed/compiler/data"
+	"github.com/brimdata/zed/compiler/optimizer"
 	"github.com/brimdata/zed/compiler/optimizer/demand"
 	"github.com/brimdata/zed/lake"
 	"github.com/brimdata/zed/order"
@@ -87,7 +88,7 @@ func (b *Builder) BuildWithPuller(seq dag.Seq, parent vector.Puller) ([]vector.P
 	return b.compileVamSeq(seq, []vector.Puller{parent})
 }
 
-func (b *Builder) BuildVamToSeqFilter(filter dag.Expr, d demand.Demand, poolID, commitID ksuid.KSUID) (zbuf.Puller, error) {
+func (b *Builder) BuildVamToSeqFilter(filter dag.Expr, poolID, commitID ksuid.KSUID) (zbuf.Puller, error) {
 	pool, err := b.source.Lake().OpenPool(b.rctx.Context, poolID)
 	if err != nil {
 		return nil, err
@@ -101,7 +102,8 @@ func (b *Builder) BuildVamToSeqFilter(filter dag.Expr, d demand.Demand, poolID, 
 		return nil, err
 	}
 	cache := b.source.Lake().VectorCache()
-	search, err := vop.NewSearcher(b.rctx, cache, l, pool, e, demand.Fields(d))
+	project, _ := optimizer.FieldsOf(filter)
+	search, err := vop.NewSearcher(b.rctx, cache, l, pool, e, project)
 	if err != nil {
 		return nil, err
 	}

--- a/compiler/optimizer/op.go
+++ b/compiler/optimizer/op.go
@@ -165,7 +165,7 @@ func analyzeCuts(assignments []dag.Assignment, sortKey order.SortKey) order.Sort
 			// to preserve, then we can continue along by clearing
 			// the LHS from the scoreboard knowing that is being set
 			// to something that does not have a defined order.
-			dependencies, ok := fieldsOf(a.RHS)
+			dependencies, ok := FieldsOf(a.RHS)
 			if !ok {
 				return order.Nil
 			}
@@ -237,7 +237,7 @@ func copyOp(o dag.Op) dag.Op {
 	return copy
 }
 
-func fieldsOf(e dag.Expr) (field.List, bool) {
+func FieldsOf(e dag.Expr) (field.List, bool) {
 	if e == nil {
 		return nil, false
 	}
@@ -250,13 +250,13 @@ func fieldsOf(e dag.Expr) (field.List, bool) {
 	case *dag.This:
 		return field.List{e.Path}, true
 	case *dag.UnaryExpr:
-		return fieldsOf(e.Operand)
+		return FieldsOf(e.Operand)
 	case *dag.BinaryExpr:
-		lhs, ok := fieldsOf(e.LHS)
+		lhs, ok := FieldsOf(e.LHS)
 		if !ok {
 			return nil, false
 		}
-		rhs, ok := fieldsOf(e.RHS)
+		rhs, ok := FieldsOf(e.RHS)
 		if !ok {
 			return nil, false
 		}
@@ -268,7 +268,7 @@ func fieldsOf(e dag.Expr) (field.List, bool) {
 		// finish with issue #2756
 		return nil, false
 	case *dag.RegexpMatch:
-		return fieldsOf(e.Expr)
+		return FieldsOf(e.Expr)
 	case *dag.RecordExpr:
 		// finish with issue #2756
 		return nil, false


### PR DESCRIPTION
Fix an issue with vector search where all fields where getting selected for the vector search portion of every search. Use optimizer.FieldsOf instead of the demand package.