### PR TITLE
Add a ztest for math between all numeric types

### DIFF
--- a/runtime/sam/expr/ztests/math-coerce.yaml
+++ b/runtime/sam/expr/ztests/math-coerce.yaml
@@ -1,0 +1,147 @@
+script: |
+  for type1 in $(cat types.txt); do
+    for type2 in $(cat types.txt); do
+      echo -n "$type1 $type2: "
+      echo "{num1: 5($type1), num2: 4($type2)}" | zq -z "yield num1 - num2" -
+    done
+  done
+
+inputs:
+  - name: types.txt
+    data: |
+      uint8
+      uint16
+      uint32
+      uint64
+      int8
+      int16
+      int32
+      int64
+      float16
+      float32
+      float64
+
+outputs:
+  - name: stdout
+    data: |
+      uint8 uint8: 1(uint8)
+      uint8 uint16: 1(uint16)
+      uint8 uint32: 1(uint32)
+      uint8 uint64: 1(uint64)
+      uint8 int8: 1(int8)
+      uint8 int16: 1(int16)
+      uint8 int32: 1(int32)
+      uint8 int64: 1
+      uint8 float16: 1.(float16)
+      uint8 float32: 1.(float32)
+      uint8 float64: 1.
+      uint16 uint8: 1(uint16)
+      uint16 uint16: 1(uint16)
+      uint16 uint32: 1(uint32)
+      uint16 uint64: 1(uint64)
+      uint16 int8: 1(int16)
+      uint16 int16: 1(int16)
+      uint16 int32: 1(int32)
+      uint16 int64: 1
+      uint16 float16: 1.(float16)
+      uint16 float32: 1.(float32)
+      uint16 float64: 1.
+      uint32 uint8: 1(uint32)
+      uint32 uint16: 1(uint32)
+      uint32 uint32: 1(uint32)
+      uint32 uint64: 1(uint64)
+      uint32 int8: 1(int32)
+      uint32 int16: 1(int32)
+      uint32 int32: 1(int32)
+      uint32 int64: 1
+      uint32 float16: 1.(float32)
+      uint32 float32: 1.(float32)
+      uint32 float64: 1.
+      uint64 uint8: 1(uint64)
+      uint64 uint16: 1(uint64)
+      uint64 uint32: 1(uint64)
+      uint64 uint64: 1(uint64)
+      uint64 int8: 1
+      uint64 int16: 1
+      uint64 int32: 1
+      uint64 int64: 1
+      uint64 float16: 1.
+      uint64 float32: 1.
+      uint64 float64: 1.
+      int8 uint8: 1(int8)
+      int8 uint16: 1(int16)
+      int8 uint32: 1(int32)
+      int8 uint64: 1
+      int8 int8: 1(int8)
+      int8 int16: 1(int16)
+      int8 int32: 1(int32)
+      int8 int64: 1
+      int8 float16: 1.(float16)
+      int8 float32: 1.(float32)
+      int8 float64: 1.
+      int16 uint8: 1(int16)
+      int16 uint16: 1(int16)
+      int16 uint32: 1(int32)
+      int16 uint64: 1
+      int16 int8: 1(int16)
+      int16 int16: 1(int16)
+      int16 int32: 1(int32)
+      int16 int64: 1
+      int16 float16: 1.(float16)
+      int16 float32: 1.(float32)
+      int16 float64: 1.
+      int32 uint8: 1(int32)
+      int32 uint16: 1(int32)
+      int32 uint32: 1(int32)
+      int32 uint64: 1
+      int32 int8: 1(int32)
+      int32 int16: 1(int32)
+      int32 int32: 1(int32)
+      int32 int64: 1
+      int32 float16: 1.(float32)
+      int32 float32: 1.(float32)
+      int32 float64: 1.
+      int64 uint8: 1
+      int64 uint16: 1
+      int64 uint32: 1
+      int64 uint64: 1
+      int64 int8: 1
+      int64 int16: 1
+      int64 int32: 1
+      int64 int64: 1
+      int64 float16: 1.
+      int64 float32: 1.
+      int64 float64: 1.
+      float16 uint8: 1.(float16)
+      float16 uint16: 1.(float16)
+      float16 uint32: 1.(float32)
+      float16 uint64: 1.
+      float16 int8: 1.(float16)
+      float16 int16: 1.(float16)
+      float16 int32: 1.(float32)
+      float16 int64: 1.
+      float16 float16: 1.(float16)
+      float16 float32: 1.(float32)
+      float16 float64: 1.
+      float32 uint8: 1.(float32)
+      float32 uint16: 1.(float32)
+      float32 uint32: 1.(float32)
+      float32 uint64: 1.
+      float32 int8: 1.(float32)
+      float32 int16: 1.(float32)
+      float32 int32: 1.(float32)
+      float32 int64: 1.
+      float32 float16: 1.(float32)
+      float32 float32: 1.(float32)
+      float32 float64: 1.
+      float64 uint8: 1.
+      float64 uint16: 1.
+      float64 uint32: 1.
+      float64 uint64: 1.
+      float64 int8: 1.
+      float64 int16: 1.
+      float64 int32: 1.
+      float64 int64: 1.
+      float64 float16: 1.
+      float64 float32: 1.
+      float64 float64: 1.


### PR DESCRIPTION
As discussed in #5086, this PR proposes a ztest that performs simple math between all numeric types. https://github.com/brimdata/zed/pull/5086#issuecomment-2021216766 shows an example of how drastically the output would differ if a bug like #4719 crept back in.