### PR TITLE
Fix stateful expressions in UDFs

### DIFF
--- a/compiler/kernel/expr.go
+++ b/compiler/kernel/expr.go
@@ -315,8 +315,13 @@ func (b *Builder) compileCall(call dag.Call) (expr.Evaluator, error) {
 	var path field.Path
 	// First check if call is to a user defined function, otherwise check for
 	// builtin function.
-	fn, ok := b.funcs[call.Name]
-	if !ok {
+	var fn expr.Function
+	if e, ok := b.udfs[call.Name]; ok {
+		var err error
+		if fn, err = b.compileUDFCall(call.Name, e); err != nil {
+			return nil, err
+		}
+	} else {
 		var err error
 		fn, path, err = function.New(b.zctx(), call.Name, len(call.Args))
 		if err != nil {
@@ -333,6 +338,26 @@ func (b *Builder) compileCall(call dag.Call) (expr.Evaluator, error) {
 		return nil, fmt.Errorf("%s(): bad argument: %w", call.Name, err)
 	}
 	return expr.NewCall(b.zctx(), fn, exprs), nil
+}
+
+func (b *Builder) compileUDFCall(name string, body dag.Expr) (expr.Function, error) {
+	if b.udfStack == nil {
+		// If udfStack is nil this means we are entering a udf invocation. We
+		// will store compiled udf calls in builder.udfStack in order to avoid
+		// infinite recursion when encountering recursive udf calls.
+		b.udfStack = make(map[string]*expr.UDF)
+		defer func() { b.udfStack = nil }()
+	}
+	if fn, ok := b.udfStack[name]; ok {
+		return fn, nil
+	}
+	fn := &expr.UDF{}
+	b.udfStack[name] = fn
+	var err error
+	if fn.Body, err = b.compileExpr(body); err != nil {
+		return nil, err
+	}
+	return fn, nil
 }
 
 func (b *Builder) compileMapCall(a *dag.MapCall) (expr.Evaluator, error) {

--- a/compiler/kernel/op.go
+++ b/compiler/kernel/op.go
@@ -51,16 +51,16 @@ import (
 var ErrJoinParents = errors.New("join requires two upstream parallel query paths")
 
 type Builder struct {
-	rctx      *runtime.Context
-	mctx      *zed.Context
-	source    *data.Source
-	readers   []zio.Reader
-	progress  *zbuf.Progress
-	arena     *zed.Arena // For zed.Values created during compilation.
-	deletes   *sync.Map
-	udfs      map[string]dag.Expr
-	udfStack  map[string]*expr.UDF
-	resetters expr.Resetters
+	rctx         *runtime.Context
+	mctx         *zed.Context
+	source       *data.Source
+	readers      []zio.Reader
+	progress     *zbuf.Progress
+	arena        *zed.Arena // For zed.Values created during compilation.
+	deletes      *sync.Map
+	udfs         map[string]dag.Expr
+	compiledUDFs map[string]*expr.UDF
+	resetters    expr.Resetters
 }
 
 func NewBuilder(rctx *runtime.Context, source *data.Source) *Builder {
@@ -76,8 +76,9 @@ func NewBuilder(rctx *runtime.Context, source *data.Source) *Builder {
 			RecordsRead:    0,
 			RecordsMatched: 0,
 		},
-		arena: arena,
-		udfs:  make(map[string]dag.Expr),
+		arena:        arena,
+		udfs:         make(map[string]dag.Expr),
+		compiledUDFs: make(map[string]*expr.UDF),
 	}
 }
 

--- a/runtime/sam/expr/ztests/udf-stateful-expr.yaml
+++ b/runtime/sam/expr/ztests/udf-stateful-expr.yaml
@@ -1,0 +1,8 @@
+zed: |
+  func c(): ( count() )
+  yield [c(),c(),c()]
+
+input: 'null'
+
+output: |
+  [1(uint64),1(uint64),1(uint64)]

--- a/runtime/sam/expr/ztests/udf-stateful-expr.yaml
+++ b/runtime/sam/expr/ztests/udf-stateful-expr.yaml
@@ -1,8 +1,9 @@
 zed: |
-  func c(): ( count() )
-  yield [c(),c(),c()]
+  func c1(): ( count() )
+  func c2(): ( c1()+c1() )
+  yield [c2(),c2(),c2()]
 
 input: 'null'
 
 output: |
-  [1(uint64),1(uint64),1(uint64)]
+  [2(uint64),2(uint64),2(uint64)]


### PR DESCRIPTION
This commit fixes an issue with using aggregation expressions user-defined functions where there wasn't a separate state per textual invocation.

Closes #5092