### PR TITLE
Test Go Library Examples

### DIFF
--- a/docs/libraries/go.md
+++ b/docs/libraries/go.md
@@ -55,6 +55,7 @@ import (
 func main() {
 	zctx := zed.NewContext()
 	reader := zsonio.NewReader(zctx, os.Stdin)
+	arena := zed.NewArena()
 	for {
 		val, err := reader.Read()
 		if err != nil {
@@ -63,9 +64,9 @@ func main() {
 		if val == nil {
 			return
 		}
-		s := val.Deref("s")
+		s := val.Deref(arena, "s")
 		if s == nil {
-			s = zctx.Missing().Ptr()
+			s = zctx.Missing(arena).Ptr()
 		}
 		fmt.Println(zson.String(s))
 	}
@@ -139,6 +140,7 @@ func main() {
 	}
 	defer reader.Close()
 	zctx := zed.NewContext()
+	arena := zed.NewArena()
 	for {
 		val, err := reader.Read()
 		if err != nil {
@@ -147,9 +149,9 @@ func main() {
 		if val == nil {
 			return
 		}
-		s := val.Deref("s")
+		s := val.Deref(arena, "s")
 		if s == nil {
-			s = zctx.Missing().Ptr()
+			s = zctx.Missing(arena).Ptr()
 		}
 		fmt.Println(zson.String(s))
 	}

--- a/docs/libraries/go.md
+++ b/docs/libraries/go.md
@@ -39,7 +39,7 @@ go get github.com/brimdata/zed
 ### ZSON Reader
 
 Read ZSON from stdin, dereference field `s`, and print results:
-```
+```mdtest-go-example
 package main
 
 import (
@@ -54,7 +54,7 @@ import (
 
 func main() {
 	zctx := zed.NewContext()
-	reader := zsonio.NewReader(os.Stdin, zctx)
+	reader := zsonio.NewReader(zctx, os.Stdin)
 	for {
 		val, err := reader.Read()
 		if err != nil {
@@ -65,7 +65,7 @@ func main() {
 		}
 		s := val.Deref("s")
 		if s == nil {
-			s = zctx.Missing()
+			s = zctx.Missing().Ptr()
 		}
 		fmt.Println(zson.String(s))
 	}
@@ -105,7 +105,7 @@ zed create -lake scratch Demo
 echo '{s:"hello, world"}{x:1}{s:"good bye"}' | zed load -lake scratch -use Demo -
 ```
 Now replace `main.go` with this code:
-```
+```mdtest-go-example
 package main
 
 import (
@@ -129,7 +129,7 @@ func main() {
 		log.Fatalln(err)
 	}
 	ctx := context.TODO()
-	lake, err := api.OpenLake(ctx, uri.String())
+	lake, err := api.OpenLake(ctx, nil, uri.String())
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -149,7 +149,7 @@ func main() {
 		}
 		s := val.Deref("s")
 		if s == nil {
-			s = zctx.Missing()
+			s = zctx.Missing().Ptr()
 		}
 		fmt.Println(zson.String(s))
 	}

--- a/mdtest/mdtest.go
+++ b/mdtest/mdtest.go
@@ -192,6 +192,11 @@ func parseMarkdown(source []byte) (map[string]string, []*Test, error) {
 				Line:     fcbLineNumber(commandFCB, source),
 			})
 			commandFCB = nil
+		case "mdtest-go-example":
+			tests = append(tests, &Test{
+				GoExample: fcbLines(fcb, source),
+				Line:      fcbLineNumber(fcb, source),
+			})
 		}
 		return ast.WalkContinue, nil
 	})


### PR DESCRIPTION
Add markdown test to run go vet on go library examples. Fix existing go library examples.

Closes #4703