### PR TITLE
Buffer zngio.scanner.workerCh for more concurrency

### DIFF
--- a/zio/zngio/scanner.go
+++ b/zio/zngio/scanner.go
@@ -40,7 +40,7 @@ func newScanner(ctx context.Context, zctx *zed.Context, r io.Reader, filter zbuf
 			maxSize: opts.Max,
 		},
 		validate:   opts.Validate,
-		workerCh:   make(chan *worker),
+		workerCh:   make(chan *worker, opts.Threads+1),
 		resultChCh: make(chan chan op.Result, opts.Threads+1),
 	}
 	for i := 0; i < opts.Threads; i++ {


### PR DESCRIPTION
Tracing with package runtime/trace shows the scanner.start and worker.run goroutines block frequently on the workerCh channel.  Add buffering to workerCH to reduce blocking and increase concurrency.

When scanning a 4 GB ZNG file containing Zeek logs, this yields a 1.1X speedup on my 10-core machine.