### PR TITLE
Update shaper for Zeek v6.2.0

### DIFF
--- a/docs/integrations/zeek/data-type-compatibility.md
+++ b/docs/integrations/zeek/data-type-compatibility.md
@@ -5,7 +5,7 @@ sidebar_label: Zed/Zeek Data Type Compatibility
 
 # Zed/Zeek Data Type Compatibility
 
-As the Zed data model was in many ways inspired by the
+As the [Zed data model](../../formats/zed.md) was in many ways inspired by the
 [Zeek TSV log format](https://docs.zeek.org/en/master/log-formats.html#zeek-tsv-format-logs),
 the rich Zed storage formats ([ZSON](../../formats/zson.md),
 [ZNG](../../formats/zng.md), etc.) maintain comprehensive interoperability
@@ -18,12 +18,11 @@ Zeek TSV without any loss of information.
 This document describes how the Zed type system is able to represent each of
 the types that may appear in Zeek logs.
 
-Tools like [`zq`](../../commands/zq.md) and
-[Zui](https://zui.brimdata.io/) maintain an internal Zed-typed
+Zed tools maintain an internal Zed-typed
 representation of any Zeek data that is read or imported. Therefore, knowing
 the equivalent types will prove useful when performing operations in the
 [Zed language](../../language/README.md) such as
-[type casting](../../language/data-types.md) or looking at the data
+[type casting](../../language/shaping.md#cast) or looking at the data
 when output as ZSON.
 
 ## Equivalent Types
@@ -37,35 +36,37 @@ applicable to handling certain types.
 
 | Zeek Type  | Zed Type   | Additional Detail |
 |------------|------------|-------------------|
-| [`bool`](https://docs.zeek.org/en/current/script-reference/types.html#type-bool)         | [`bool`](../../formats/zson.md#23-primitive-values)     | |
-| [`count`](https://docs.zeek.org/en/current/script-reference/types.html#type-count)       | [`uint64`](../../formats/zson.md#23-primitive-values)   | |
-| [`int`](https://docs.zeek.org/en/current/script-reference/types.html#type-int)           | [`int64`](../../formats/zson.md#23-primitive-values)    | |
-| [`double`](https://docs.zeek.org/en/current/script-reference/types.html#type-double)     | [`float64`](../../formats/zson.md#23-primitive-values)  | See [`double` details](#double) |
-| [`time`](https://docs.zeek.org/en/current/script-reference/types.html#type-time)         | [`time`](../../formats/zson.md#23-primitive-values)     | |
-| [`interval`](https://docs.zeek.org/en/current/script-reference/types.html#type-interval) | [`duration`](../../formats/zson.md#23-primitive-values) | |
-| [`string`](https://docs.zeek.org/en/current/script-reference/types.html#type-string)     | [`string`](../../formats/zson.md#23-primitive-values) | See [`string` details about escaping](#string) |
-| [`port`](https://docs.zeek.org/en/current/script-reference/types.html#type-port)         | [`uint16`](../../formats/zson.md#23-primitive-values)   | See [`port` details](#port) |
-| [`addr`](https://docs.zeek.org/en/current/script-reference/types.html#type-addr)         | [`ip`](../../formats/zson.md#23-primitive-values)       | |
-| [`subnet`](https://docs.zeek.org/en/current/script-reference/types.html#type-subnet)     | [`net`](../../formats/zson.md#23-primitive-values)      | |
-| [`enum`](https://docs.zeek.org/en/current/script-reference/types.html#type-enum)         | [`string`](../../formats/zson.md#23-primitive-values)   | See [`enum` details](#enum) |
-| [`set`](https://docs.zeek.org/en/current/script-reference/types.html#type-set)           | [`set`](../../formats/zson.md#243-set-value)       | See [`set` details](#set) |
-| [`vector`](https://docs.zeek.org/en/current/script-reference/types.html#type-vector)     | [`array`](../../formats/zson.md#242-array-value)   | |
-| [`record`](https://docs.zeek.org/en/current/script-reference/types.html#type-record)     | [`record`](../../formats/zson.md#241-record-value) | See [`record` details](#record) |
+| [`bool`](https://docs.zeek.org/en/current/script-reference/types.html#type-bool)         | [`bool`](../../formats/zed.md#1-primitive-types)     | |
+| [`count`](https://docs.zeek.org/en/current/script-reference/types.html#type-count)       | [`uint64`](../../formats/zed.md#1-primitive-types)   | |
+| [`int`](https://docs.zeek.org/en/current/script-reference/types.html#type-int)           | [`int64`](../../formats/zed.md#1-primitive-types)    | |
+| [`double`](https://docs.zeek.org/en/current/script-reference/types.html#type-double)     | [`float64`](../../formats/zed.md#1-primitive-types)  | See [`double` details](#double) |
+| [`time`](https://docs.zeek.org/en/current/script-reference/types.html#type-time)         | [`time`](../../formats/zed.md#1-primitive-types)     | |
+| [`interval`](https://docs.zeek.org/en/current/script-reference/types.html#type-interval) | [`duration`](../../formats/zed.md#1-primitive-types) | |
+| [`string`](https://docs.zeek.org/en/current/script-reference/types.html#type-string)     | [`string`](../../formats/zed.md#1-primitive-types)   | See [`string` details about escaping](#string) |
+| [`port`](https://docs.zeek.org/en/current/script-reference/types.html#type-port)         | [`uint16`](../../formats/zed.md#1-primitive-types)   | See [`port` details](#port) |
+| [`addr`](https://docs.zeek.org/en/current/script-reference/types.html#type-addr)         | [`ip`](../../formats/zed.md#1-primitive-types)       | |
+| [`subnet`](https://docs.zeek.org/en/current/script-reference/types.html#type-subnet)     | [`net`](../../formats/zed.md#1-primitive-types)      | |
+| [`enum`](https://docs.zeek.org/en/current/script-reference/types.html#type-enum)         | [`string`](../../formats/zed.md#1-primitive-types)   | See [`enum` details](#enum) |
+| [`set`](https://docs.zeek.org/en/current/script-reference/types.html#type-set)           | [`set`](../../formats/zed.md#23-set)                 | See [`set` details](#set) |
+| [`vector`](https://docs.zeek.org/en/current/script-reference/types.html#type-vector)     | [`array`](../../formats/zed.md#22-array              | |
+| [`record`](https://docs.zeek.org/en/current/script-reference/types.html#type-record)     | [`record`](../../formats/zed.md#21-record            | See [`record` details](#record) |
 
-> **Note:** The [Zeek data type](https://docs.zeek.org/en/current/script-reference/types.html)
-> page describes the types in the context of the
-> [Zeek scripting language](https://docs.zeek.org/en/master/scripting/index.html).
-> The Zeek types available in scripting are a superset of the data types that
-> may appear in Zeek log files. The encodings of the types also differ in some
-> ways between the two contexts. However, we link to this reference because
-> there is no authoritative specification of the Zeek TSV log format.
+:::tip Note
+The [Zeek data type](https://docs.zeek.org/en/current/script-reference/types.html)
+page describes the types in the context of the
+[Zeek scripting language](https://docs.zeek.org/en/master/scripting/index.html).
+The Zeek types available in scripting are a superset of the data types that
+may appear in Zeek log files. The encodings of the types also differ in some
+ways between the two contexts. However, we link to this reference because
+there is no authoritative specification of the Zeek TSV log format.
+:::
 
 ## Example
 
 The following example shows a TSV log that includes each Zeek data type, how
-it's output as ZSON by `zq`, and then how it's written back out again as a Zeek
+it's output as ZSON by [`zq`](../../commands/zq.md), and then how it's written back out again as a Zeek
 log. You may find it helpful to refer to this example when reading the
-[Type-Specific Details](#type-specific-details) sections.
+[type-specific details](#type-specific-details).
 
 #### Viewing the TSV log:
 
@@ -152,10 +153,10 @@ formats (should they exist) may handle these differently.
 
 Multiple Zeek types discussed below are represented via a
 [type definition](../../formats/zson.md#22-type-decorators) to one of Zed's
-[primitive types](../../formats/zson.md#23-primitive-values). The Zed type
+[primitive types](../../formats/zed.md#1-primitive-types). The Zed type
 definitions maintain the history of the field's original Zeek type name
 such that `zq` may restore it if the field is later output in
-Zeek format. Knowledge of its original Zeek type may also enable special
+Zeek TSV format. Knowledge of its original Zeek type may also enable special
 operations in Zed that are unique to values known to have originated as a
 specific Zeek type, though no such operations are currently implemented in
 `zq`.
@@ -174,14 +175,14 @@ typically hold one of a set of predefined values. While this is
 how Zeek's `enum` type behaves inside the Zeek scripting language,
 when the `enum` type is output in a Zeek log, the log does not communicate
 any such set of "allowed" values as they were originally defined. Therefore,
-these values are represented with a ZSON type name bound to the Zed `string`
+these values are represented with a type name bound to the Zed `string`
 type. See the text above regarding [type definitions](#type-specific-details)
 for more details.
 
 ### `port`
 
 The numeric values that appear in Zeek logs under this type are represented
-in ZSON with a type name of `port` bound to the `uint16` type. See the text
+in Zed with a type name of `port` bound to the `uint16` type. See the text
 above regarding [type names](#type-specific-details) for more details.
 
 ### `set`
@@ -205,27 +206,27 @@ _not_ intended to be read or presented as such. Meanwhile, another Zeek
 UTF-8. These details are currently only captured within the Zeek source code
 itself that defines how these values are generated.
 
-Zed includes a [primitive type](../../formats/zson.md#23-primitive-values)
+Zed includes a [primitive type](../../formats/zed.md#1-primitive-types)
 called `bytes` that's suited to storing the former "always binary" case and a
 `string` type for the latter "always printable" case. However, Zeek logs do
 not currently communicate details that would allow an implementation to know
 which Zeek `string` fields to store as which of these two Zed data types.
 Instead, the Zed system does what the Zeek system does when writing strings
 to JSON: any `\x` escapes used in Zeek TSV strings are translated into valid
-Zed UTF-8 strings by escaping the backslash before the `x.`  In this way,
+Zed UTF-8 strings by escaping the backslash before the `x`.  In this way,
 you can still see binary-corrupted strings that are generated by Zeek in
 the Zed data formats.
 
 Unfortunately there is no way to distinguish whether a `\x` escape occurred
-or whether that string pattern happen to occur in the original data.  A nice
+or whether that string pattern happened to occur in the original data.  A nice
 solution would be to convert Zeek strings that are valid UTF-8 strings into
 Zed strings and convert invalid strings into a Zed `bytes` type, or we could
-covert both of them into a Zed union of `string` and `bytes`.  If you have
-interest in a capability like this, please let us know and we can elevate
+convert both of them into a Zed union of `string` and `bytes`.  If you have
+interest in a capability like this, please [let us know](https://www.brimdata.io/join-slack/) and we can elevate
 the priority.
 
 If Zeek were to provide an option to output logs directly in one or more of
-Zed's richer storage storage formats, this would create an opportunity to
+Zed's richer storage formats, this would create an opportunity to
 assign the appropriate Zed `bytes` or `string` type at the point of origin,
 depending on what's known about how the field's value is intended to be
 populated and used.
@@ -248,8 +249,8 @@ itself before it was output by its logging system. This enables operations in
 Zed that refer to the record at a higher level but affect all values lower
 down in the record hierarchy.
 
-Revisiting the data from our example, we can output all fields within
-`my_record` via a Zed [`cut`](../../language/operators/cut.md) operation.
+For instance, revisiting the data from our example, we can output all fields within
+`my_record` using Zed's [`cut` operator](../../language/operators/cut.md).
 
 #### Command:
 

--- a/docs/integrations/zeek/data-type-compatibility.md
+++ b/docs/integrations/zeek/data-type-compatibility.md
@@ -52,7 +52,7 @@ applicable to handling certain types.
 | [`record`](https://docs.zeek.org/en/current/script-reference/types.html#type-record)     | [`record`](../../formats/zed.md#21-record            | See [`record` details](#record) |
 
 :::tip Note
-The [Zeek data type](https://docs.zeek.org/en/current/script-reference/types.html)
+The [Zeek data types](https://docs.zeek.org/en/current/script-reference/types.html)
 page describes the types in the context of the
 [Zeek scripting language](https://docs.zeek.org/en/master/scripting/index.html).
 The Zeek types available in scripting are a superset of the data types that

--- a/docs/integrations/zeek/reading-zeek-log-formats.md
+++ b/docs/integrations/zeek/reading-zeek-log-formats.md
@@ -7,16 +7,16 @@ sidebar_label: Reading Zeek Log Formats
 
 Zed is capable of reading both common Zeek log formats. This document
 provides guidance for what to expect when reading logs of these formats using
-the Zed tools such as `zq`.
+the Zed [command line tools](../../commands/README.md).
 
 ## Zeek TSV
 
 [Zeek TSV](https://docs.zeek.org/en/master/log-formats.html#zeek-tsv-format-logs)
 is Zeek's default output format for logs. This format can be read automatically
 (i.e., no `-i` command line flag is necessary to indicate the input format)
-with the Zed tools such as `zq`.
+with the Zed tools such as [`zq`](../../commands/zq.md).
 
-The following example shows a TSV `conn.log` being read via `zq` and
+The following example shows a TSV [`conn.log`](https://docs.zeek.org/en/master/logs/conn.html) being read via `zq` and
 output as [ZSON](../../formats/zson.md).
 
 #### conn.log
@@ -74,7 +74,7 @@ and therefore such records typically need no adjustment to their data types
 once they've been read in as is. The
 [Zed/Zeek Data Type Compatibility](data-type-compatibility.md) document
 provides further detail on how the rich data types in Zeek TSV map to the
-equivalent [rich types in Zed](../../formats/zson.md#23-primitive-values).
+equivalent [rich types in Zed](../../formats/zed.md#1-primitive-types).
 
 ## Zeek NDJSON
 
@@ -133,11 +133,11 @@ When we compare this to the TSV example, we notice a few things right away that
 all follow from the records having been previously output as JSON.
 
 1. The timestamps like `_write_ts` and `ts` are printed as strings rather than
-   the ZSON `time` type.
+   the Zed `time` type.
 2. The IP addresses such as `id.orig_h` and `id.resp_h` are printed as strings
-   rather than the ZSON `ip` type.
+   rather than the Zed `ip` type.
 3. The connection `duration` is printed as a floating point number rather than
-   the ZSON `duration` type.
+   the Zed `duration` type.
 4. The keys for the null-valued fields in the record read from
    TSV are not present in the record read from NDJSON.
 
@@ -149,7 +149,7 @@ to perform operations like
 [aggregations with time-based grouping](../../language/functions/bucket.md)
 or [CIDR matches](../../language/functions/network_of.md)
 on IP addresses, you would likely want to restore the rich Zed data types as
-the records are being read. The document on [Shaping Zeek NDJSON](shaping-zeek-ndjson.md)
+the records are being read. The document on [shaping Zeek NDJSON](shaping-zeek-ndjson.md)
 provides details on how this can be done.
 
 ## The Role of `_path`

--- a/docs/integrations/zeek/shaping-zeek-ndjson.md
+++ b/docs/integrations/zeek/shaping-zeek-ndjson.md
@@ -5,20 +5,17 @@ sidebar_label: Shaping Zeek NDJSON
 
 # Shaping Zeek NDJSON
 
-As described in [Reading Zeek Log Formats](reading-zeek-log-formats.md),
-logs output by Zeek in NDJSON format lose much of their rich data typing that
-was originally present inside Zeek. This detail can be restored using a Zed
-shaper, such as the reference `shaper.zed` described below.
-
-A full description of all that's possible with shapers is beyond the scope of
-this doc. However, this example for shaping Zeek NDJSON is quite simple and
-is described below.
+When [reading Zeek NDJSON format logs](reading-zeek-log-formats.md#zeek-ndjson),
+much of the rich data typing that was originally present inside Zeek is at risk
+of being lost. This detail can be restored using a Zed
+[shaper](../../language/shaping.md), such as the
+[reference shaper described below](#reference-shaper-contents).
 
 ## Zeek Version/Configuration
 
-The fields and data types in the reference `shaper.zed` reflect the default
+The fields and data types in the reference shaper reflect the default
 NDJSON-format logs output by Zeek releases up to the version number referenced
-in the comments at the top of that file. They have been revisited periodically
+in the comments at the top. They have been revisited periodically
 as new Zeek versions have been released.
 
 Most changes we've observed in Zeek logs between versions have involved only the
@@ -27,23 +24,15 @@ as is for Zeek releases older than the one most recently tested, since fields
 in the shaper not present in your environment would just be filled in with
 `null` values.
 
-[Zeek v4.1.0](https://github.com/zeek/zeek/releases/tag/v4.1.0) is the first
-release we've seen since starting to maintain this reference shaper where
-field names for the same log type have _changed_ between releases. Because
-of this, as shown below, the shaper includes `switch` logic that applies
-different type definitions based on the observed field names that are known
-to be specific to newer Zeek releases.
-
 All attempts will be made to update this reference shaper in a timely manner
 as new Zeek versions are released. However, if you have modified your Zeek
 installation with [packages](https://packages.zeek.org/)
 or other customizations, or if you are using a [Corelight Sensor](https://corelight.com/products/appliance-sensors/)
 that produces Zeek logs with many fields and logs beyond those found in open
 source Zeek, the reference shaper will not cover all the fields in your logs.
-[As described below](#zed-pipeline), the reference shaper will assign
-inferred types to such additional fields. By exploring your data, you can then
-iteratively enhance your shaper to match your environment. If you need
-assistance, please speak up on our [public Slack](https://www.brimdata.io/join-slack/).
+[As described below](#zed-pipeline), by default the shaper will produce errors
+when this happens, though it can also be configured to silently crop such
+fields or keep them while assigning inferred types.
 
 ## Reference Shaper Contents
 
@@ -52,150 +41,133 @@ fairly simple pattern that repeats across the many [Zeek log types](https://docs
 
 ```mdtest-input shaper.zed
 // This reference Zed shaper for Zeek NDJSON logs was most recently tested with
-// Zeek v4.1.0. The fields and data types reflect the default NDJSON
+// Zeek v6.2.0. The fields and data types reflect the default NDJSON
 // logs output by that Zeek version when using the JSON Streaming Logs package.
+// (https://github.com/corelight/json-streaming-logs).
+
+const _crop_records = true
+const _error_if_cropped = true
 
 type port=uint16
 type zenum=string
 type conn_id={orig_h:ip,orig_p:port,resp_h:ip,resp_p:port}
 
-// This first block of type definitions covers the fields we've observed in
-// an out-of-the-box Zeek v4.0.3 and earlier, as well as all out-of-the-box
-// Zeek v4.1.0 log types except for "ssl" and "x509".
-
-type broker={_path:string,ts:time,ty:zenum,ev:string,peer:{address:string,bound_port:port},message:string,_write_ts:time}
-type capture_loss={_path:string,ts:time,ts_delta:duration,peer:string,gaps:uint64,acks:uint64,percent_lost:float64,_write_ts:time}
-type cluster={_path:string,ts:time,node:string,message:string,_write_ts:time}
-type config={_path:string,ts:time,id:string,old_value:string,new_value:string,location:string,_write_ts:time}
-type conn={_path:string,ts:time,uid:string,id:conn_id,proto:zenum,service:string,duration:duration,orig_bytes:uint64,resp_bytes:uint64,conn_state:string,local_orig:bool,local_resp:bool,missed_bytes:uint64,history:string,orig_pkts:uint64,orig_ip_bytes:uint64,resp_pkts:uint64,resp_ip_bytes:uint64,tunnel_parents:|[string]|,_write_ts:time}
-type dce_rpc={_path:string,ts:time,uid:string,id:conn_id,rtt:duration,named_pipe:string,endpoint:string,operation:string,_write_ts:time}
-type dhcp={_path:string,ts:time,uids:|[string]|,client_addr:ip,server_addr:ip,mac:string,host_name:string,client_fqdn:string,domain:string,requested_addr:ip,assigned_addr:ip,lease_time:duration,client_message:string,server_message:string,msg_types:[string],duration:duration,_write_ts:time}
-type dnp3={_path:string,ts:time,uid:string,id:conn_id,fc_request:string,fc_reply:string,iin:uint64,_write_ts:time}
-type dns={_path:string,ts:time,uid:string,id:conn_id,proto:zenum,trans_id:uint64,rtt:duration,query:string,qclass:uint64,qclass_name:string,qtype:uint64,qtype_name:string,rcode:uint64,rcode_name:string,AA:bool,TC:bool,RD:bool,RA:bool,Z:uint64,answers:[string],TTLs:[duration],rejected:bool,_write_ts:time}
-type dpd={_path:string,ts:time,uid:string,id:conn_id,proto:zenum,analyzer:string,failure_reason:string,_write_ts:time}
-type files={_path:string,ts:time,fuid:string,tx_hosts:|[ip]|,rx_hosts:|[ip]|,conn_uids:|[string]|,source:string,depth:uint64,analyzers:|[string]|,mime_type:string,filename:string,duration:duration,local_orig:bool,is_orig:bool,seen_bytes:uint64,total_bytes:uint64,missing_bytes:uint64,overflow_bytes:uint64,timedout:bool,parent_fuid:string,md5:string,sha1:string,sha256:string,extracted:string,extracted_cutoff:bool,extracted_size:uint64,_write_ts:time}
-type ftp={_path:string,ts:time,uid:string,id:conn_id,user:string,password:string,command:string,arg:string,mime_type:string,file_size:uint64,reply_code:uint64,reply_msg:string,data_channel:{passive:bool,orig_h:ip,resp_h:ip,resp_p:port},fuid:string,_write_ts:time}
-type http={_path:string,ts:time,uid:string,id:conn_id,trans_depth:uint64,method:string,host:string,uri:string,referrer:string,version:string,user_agent:string,origin:string,request_body_len:uint64,response_body_len:uint64,status_code:uint64,status_msg:string,info_code:uint64,info_msg:string,tags:|[zenum]|,username:string,password:string,proxied:|[string]|,orig_fuids:[string],orig_filenames:[string],orig_mime_types:[string],resp_fuids:[string],resp_filenames:[string],resp_mime_types:[string],_write_ts:time}
-type intel={_path:string,ts:time,uid:string,id:conn_id,seen:{indicator:string,indicator_type:zenum,where:zenum,node:string},matched:|[zenum]|,sources:|[string]|,fuid:string,file_mime_type:string,file_desc:string,_write_ts:time}
-type irc={_path:string,ts:time,uid:string,id:conn_id,nick:string,user:string,command:string,value:string,addl:string,dcc_file_name:string,dcc_file_size:uint64,dcc_mime_type:string,fuid:string,_write_ts:time}
-type kerberos={_path:string,ts:time,uid:string,id:conn_id,request_type:string,client:string,service:string,success:bool,error_msg:string,from:time,till:time,cipher:string,forwardable:bool,renewable:bool,client_cert_subject:string,client_cert_fuid:string,server_cert_subject:string,server_cert_fuid:string,_write_ts:time}
-type known_certs={_path:string,ts:time,host:ip,port_num:port,subject:string,issuer_subject:string,serial:string,_write_ts:time}
-type known_hosts={_path:string,ts:time,host:ip,_write_ts:time}
-type known_services={_path:string,ts:time,host:ip,port_num:port,port_proto:zenum,service:|[string]|,_write_ts:time}
-type loaded_scripts={_path:string,name:string,_write_ts:time}
-type modbus={_path:string,ts:time,uid:string,id:conn_id,func:string,exception:string,_write_ts:time}
-type mysql={_path:string,ts:time,uid:string,id:conn_id,cmd:string,arg:string,success:bool,rows:uint64,response:string,_write_ts:time}
-type netcontrol={_path:string,ts:time,rule_id:string,category:zenum,cmd:string,state:zenum,action:string,target:zenum,entity_type:string,entity:string,mod:string,msg:string,priority:int64,expire:duration,location:string,plugin:string,_write_ts:time}
-type netcontrol_drop={_path:string,ts:time,rule_id:string,orig_h:ip,orig_p:port,resp_h:ip,resp_p:port,expire:duration,location:string,_write_ts:time}
-type netcontrol_shunt={_path:string,ts:time,rule_id:string,f:{src_h:ip,src_p:port,dst_h:ip,dst_p:port},expire:duration,location:string,_write_ts:time}
-type notice={_path:string,ts:time,uid:string,id:conn_id,fuid:string,file_mime_type:string,file_desc:string,proto:zenum,note:zenum,msg:string,sub:string,src:ip,dst:ip,p:port,n:uint64,peer_descr:string,actions:|[zenum]|,email_dest:|[string]|,suppress_for:duration,remote_location:{country_code:string,region:string,city:string,latitude:float64,longitude:float64},_write_ts:time}
-type notice_alarm={_path:string,ts:time,uid:string,id:conn_id,fuid:string,file_mime_type:string,file_desc:string,proto:zenum,note:zenum,msg:string,sub:string,src:ip,dst:ip,p:port,n:uint64,peer_descr:string,actions:|[zenum]|,email_dest:|[string]|,suppress_for:duration,remote_location:{country_code:string,region:string,city:string,latitude:float64,longitude:float64},_write_ts:time}
-type ntlm={_path:string,ts:time,uid:string,id:conn_id,username:string,hostname:string,domainname:string,server_nb_computer_name:string,server_dns_computer_name:string,server_tree_name:string,success:bool,_write_ts:time}
-type ntp={_path:string,ts:time,uid:string,id:conn_id,version:uint64,mode:uint64,stratum:uint64,poll:duration,precision:duration,root_delay:duration,root_disp:duration,ref_id:string,ref_time:time,org_time:time,rec_time:time,xmt_time:time,num_exts:uint64,_write_ts:time}
-type ocsp={_path:string,ts:time,id:string,hashAlgorithm:string,issuerNameHash:string,issuerKeyHash:string,serialNumber:string,certStatus:string,revoketime:time,revokereason:string,thisUpdate:time,nextUpdate:time,_write_ts:time}
-type openflow={_path:string,ts:time,dpid:uint64,match:{in_port:uint64,dl_src:string,dl_dst:string,dl_vlan:uint64,dl_vlan_pcp:uint64,dl_type:uint64,nw_tos:uint64,nw_proto:uint64,nw_src:net,nw_dst:net,tp_src:uint64,tp_dst:uint64},flow_mod:{cookie:uint64,table_id:uint64,command:zenum=string,idle_timeout:uint64,hard_timeout:uint64,priority:uint64,out_port:uint64,out_group:uint64,flags:uint64,actions:{out_ports:[uint64],vlan_vid:uint64,vlan_pcp:uint64,vlan_strip:bool,dl_src:string,dl_dst:string,nw_tos:uint64,nw_src:ip,nw_dst:ip,tp_src:uint64,tp_dst:uint64}},_write_ts:time}
-type packet_filter={_path:string,ts:time,node:string,filter:string,init:bool,success:bool,_write_ts:time}
-type pe={_path:string,ts:time,id:string,machine:string,compile_ts:time,os:string,subsystem:string,is_exe:bool,is_64bit:bool,uses_aslr:bool,uses_dep:bool,uses_code_integrity:bool,uses_seh:bool,has_import_table:bool,has_export_table:bool,has_cert_table:bool,has_debug_data:bool,section_names:[string],_write_ts:time}
-type radius={_path:string,ts:time,uid:string,id:conn_id,username:string,mac:string,framed_addr:ip,tunnel_client:string,connect_info:string,reply_msg:string,result:string,ttl:duration,_write_ts:time}
-type rdp={_path:string,ts:time,uid:string,id:conn_id,cookie:string,result:string,security_protocol:string,client_channels:[string],keyboard_layout:string,client_build:string,client_name:string,client_dig_product_id:string,desktop_width:uint64,desktop_height:uint64,requested_color_depth:string,cert_type:string,cert_count:uint64,cert_permanent:bool,encryption_level:string,encryption_method:string,_write_ts:time}
-type reporter={_path:string,ts:time,level:zenum,message:string,location:string,_write_ts:time}
-type rfb={_path:string,ts:time,uid:string,id:conn_id,client_major_version:string,client_minor_version:string,server_major_version:string,server_minor_version:string,authentication_method:string,auth:bool,share_flag:bool,desktop_name:string,width:uint64,height:uint64,_write_ts:time}
-type signatures={_path:string,ts:time,uid:string,src_addr:ip,src_port:port,dst_addr:ip,dst_port:port,note:zenum,sig_id:string,event_msg:string,sub_msg:string,sig_count:uint64,host_count:uint64,_write_ts:time}
-type sip={_path:string,ts:time,uid:string,id:conn_id,trans_depth:uint64,method:string,uri:string,date:string,request_from:string,request_to:string,response_from:string,response_to:string,reply_to:string,call_id:string,seq:string,subject:string,request_path:[string],response_path:[string],user_agent:string,status_code:uint64,status_msg:string,warning:string,request_body_len:uint64,response_body_len:uint64,content_type:string,_write_ts:time}
-type smb_files={_path:string,ts:time,uid:string,id:conn_id,fuid:string,action:zenum,path:string,name:string,size:uint64,prev_name:string,times:{modified:time,accessed:time,created:time,changed:time},_write_ts:time}
-type smb_mapping={_path:string,ts:time,uid:string,id:conn_id,path:string,service:string,native_file_system:string,share_type:string,_write_ts:time}
-type smtp={_path:string,ts:time,uid:string,id:conn_id,trans_depth:uint64,helo:string,mailfrom:string,rcptto:|[string]|,date:string,from:string,to:|[string]|,cc:|[string]|,reply_to:string,msg_id:string,in_reply_to:string,subject:string,x_originating_ip:ip,first_received:string,second_received:string,last_reply:string,path:[ip],user_agent:string,tls:bool,fuids:[string],is_webmail:bool,_write_ts:time}
-type snmp={_path:string,ts:time,uid:string,id:conn_id,duration:duration,version:string,community:string,get_requests:uint64,get_bulk_requests:uint64,get_responses:uint64,set_requests:uint64,display_string:string,up_since:time,_write_ts:time}
-type socks={_path:string,ts:time,uid:string,id:conn_id,version:uint64,user:string,password:string,status:string,request:{host:ip,name:string},request_p:port,bound:{host:ip,name:string},bound_p:port,_write_ts:time}
-type software={_path:string,ts:time,host:ip,host_p:port,software_type:zenum,name:string,version:{major:uint64,minor:uint64,minor2:uint64,minor3:uint64,addl:string},unparsed_version:string,_write_ts:time}
-type ssh={_path:string,ts:time,uid:string,id:conn_id,version:uint64,auth_success:bool,auth_attempts:uint64,direction:zenum,client:string,server:string,cipher_alg:string,mac_alg:string,compression_alg:string,kex_alg:string,host_key_alg:string,host_key:string,remote_location:{country_code:string,region:string,city:string,latitude:float64,longitude:float64},_write_ts:time}
-type ssl={_path:string,ts:time,uid:string,id:conn_id,version:string,cipher:string,curve:string,server_name:string,resumed:bool,last_alert:string,next_protocol:string,established:bool,cert_chain_fuids:[string],client_cert_chain_fuids:[string],subject:string,issuer:string,client_subject:string,client_issuer:string,validation_status:string,_write_ts:time}
-type stats={_path:string,ts:time,peer:string,mem:uint64,pkts_proc:uint64,bytes_recv:uint64,pkts_dropped:uint64,pkts_link:uint64,pkt_lag:duration,events_proc:uint64,events_queued:uint64,active_tcp_conns:uint64,active_udp_conns:uint64,active_icmp_conns:uint64,tcp_conns:uint64,udp_conns:uint64,icmp_conns:uint64,timers:uint64,active_timers:uint64,files:uint64,active_files:uint64,dns_requests:uint64,active_dns_requests:uint64,reassem_tcp_size:uint64,reassem_file_size:uint64,reassem_frag_size:uint64,reassem_unknown_size:uint64,_write_ts:time}
-type syslog={_path:string,ts:time,uid:string,id:conn_id,proto:zenum,facility:string,severity:string,message:string,_write_ts:time}
-type tunnel={_path:string,ts:time,uid:string,id:conn_id,tunnel_type:zenum,action:zenum,_write_ts:time}
-type weird={_path:string,ts:time,uid:string,id:conn_id,name:string,addl:string,notice:bool,peer:string,source:string,_write_ts:time}
-type x509={_path:string,ts:time,id:string,certificate:{version:uint64,serial:string,subject:string,issuer:string,not_valid_before:time,not_valid_after:time,key_alg:string,sig_alg:string,key_type:string,key_length:uint64,exponent:string,curve:string},san:{dns:[string],uri:[string],email:[string],ip:[ip]},basic_constraints:{ca:bool,path_len:uint64},_write_ts:time}
-
-// This second block of type definitions represent changes needed to cover
-// an out-of-the-box Zeek v4.1.0. In other Zeek revisions, we were accustomed
-// to only seeing new fields added, but this represented the first time fields
-// have changed, e.g., in SSL logs, "cert_chain_fuids" became "cert_chain_fps".
-// Therefore we have wholly separate type definitions for this revision so we
-// can cover 100% of the expected fields.
-
-type ssl_4_1_0={_path:string,ts:time,uid:string,id:conn_id,version:string,cipher:string,curve:string,server_name:string,resumed:bool,last_alert:string,next_protocol:string,established:bool,ssl_history:string,cert_chain_fps:[string],client_cert_chain_fps:[string],subject:string,issuer:string,client_subject:string,client_issuer:string,sni_matches_cert:bool,validation_status:string,_write_ts:time}
-type x509_4_1_0={_path:string,ts:time,fingerprint:string,certificate:{version:uint64,serial:string,subject:string,issuer:string,not_valid_before:time,not_valid_after:time,key_alg:string,sig_alg:string,key_type:string,key_length:uint64,exponent:string,curve:string},san:{dns:[string],uri:[string],email:[string],ip:[ip]},basic_constraints:{ca:bool,path_len:uint64},host_cert:bool,client_cert:bool,_write_ts:time}
-
-const schemas = |{
-  "broker": <broker>,
-  "capture_loss": <capture_loss>,
-  "cluster": <cluster>,
-  "config": <config>,
-  "conn": <conn>,
-  "dce_rpc": <dce_rpc>,
-  "dhcp": <dhcp>,
-  "dnp3": <dnp3>,
-  "dns": <dns>,
-  "dpd": <dpd>,
-  "files": <files>,
-  "ftp": <ftp>,
-  "http": <http>,
-  "intel": <intel>,
-  "irc": <irc>,
-  "kerberos": <kerberos>,
-  "known_certs": <known_certs>,
-  "known_hosts": <known_hosts>,
-  "known_services": <known_services>,
-  "loaded_scripts": <loaded_scripts>,
-  "modbus": <modbus>,
-  "mysql": <mysql>,
-  "netcontrol": <netcontrol>,
-  "netcontrol_drop": <netcontrol_drop>,
-  "netcontrol_shunt": <netcontrol_shunt>,
-  "notice": <notice>,
-  "notice_alarm": <notice_alarm>,
-  "ntlm": <ntlm>,
-  "ntp": <ntp>,
-  "ocsp": <ocsp>,
-  "openflow": <openflow>,
-  "packet_filter": <packet_filter>,
-  "pe": <pe>,
-  "radius": <radius>,
-  "rdp": <rdp>,
-  "reporter": <reporter>,
-  "rfb": <rfb>,
-  "signatures": <signatures>,
-  "sip": <sip>,
-  "smb_files": <smb_files>,
-  "smb_mapping": <smb_mapping>,
-  "smtp": <smtp>,
-  "snmp": <snmp>,
-  "socks": <socks>,
-  "software": <software>,
-  "ssh": <ssh>,
-  "ssl": <ssl>,
-  "stats": <stats>,
-  "syslog": <syslog>,
-  "tunnel": <tunnel>,
-  "weird": <weird>,
-  "x509": <x509>
+const zeek_log_types = |{
+  "analyzer": <analyzer={_path:string,ts:time,cause:string,analyzer_kind:string,analyzer_name:string,uid:string,fuid:string,id:conn_id,failure_reason:string,failure_data:string,_write_ts:time}>,
+  "broker": <broker={_path:string,ts:time,ty:zenum,ev:string,peer:{address:string,bound_port:port},message:string,_write_ts:time}>,
+  "capture_loss": <capture_loss={_path:string,ts:time,ts_delta:duration,peer:string,gaps:uint64,acks:uint64,percent_lost:float64,_write_ts:time}>,
+  "cluster": <cluster={_path:string,ts:time,node:string,message:string,_write_ts:time}>,
+  "config": <config={_path:string,ts:time,id:string,old_value:string,new_value:string,location:string,_write_ts:time}>,
+  "conn": <conn={_path:string,ts:time,uid:string,id:conn_id,proto:zenum,service:string,duration:duration,orig_bytes:uint64,resp_bytes:uint64,conn_state:string,local_orig:bool,local_resp:bool,missed_bytes:uint64,history:string,orig_pkts:uint64,orig_ip_bytes:uint64,resp_pkts:uint64,resp_ip_bytes:uint64,tunnel_parents:|[string]|,_write_ts:time}>,
+  "dce_rpc": <dce_rpc={_path:string,ts:time,uid:string,id:conn_id,rtt:duration,named_pipe:string,endpoint:string,operation:string,_write_ts:time}>,
+  "dhcp": <dhcp={_path:string,ts:time,uids:|[string]|,client_addr:ip,server_addr:ip,mac:string,host_name:string,client_fqdn:string,domain:string,requested_addr:ip,assigned_addr:ip,lease_time:duration,client_message:string,server_message:string,msg_types:[string],duration:duration,_write_ts:time}>,
+  "dnp3": <dnp3={_path:string,ts:time,uid:string,id:conn_id,fc_request:string,fc_reply:string,iin:uint64,_write_ts:time}>,
+  "dns": <dns={_path:string,ts:time,uid:string,id:conn_id,proto:zenum,trans_id:uint64,rtt:duration,query:string,qclass:uint64,qclass_name:string,qtype:uint64,qtype_name:string,rcode:uint64,rcode_name:string,AA:bool,TC:bool,RD:bool,RA:bool,Z:uint64,answers:[string],TTLs:[duration],rejected:bool,_write_ts:time}>,
+  "dpd": <dpd={_path:string,ts:time,uid:string,id:conn_id,proto:zenum,analyzer:string,failure_reason:string,_write_ts:time}>,
+  "files": <files={_path:string,ts:time,fuid:string,uid:string,id:conn_id,source:string,depth:uint64,analyzers:|[string]|,mime_type:string,filename:string,duration:duration,local_orig:bool,is_orig:bool,seen_bytes:uint64,total_bytes:uint64,missing_bytes:uint64,overflow_bytes:uint64,timedout:bool,parent_fuid:string,md5:string,sha1:string,sha256:string,extracted:string,extracted_cutoff:bool,extracted_size:uint64,_write_ts:time}>,
+  "ftp": <ftp={_path:string,ts:time,uid:string,id:conn_id,user:string,password:string,command:string,arg:string,mime_type:string,file_size:uint64,reply_code:uint64,reply_msg:string,data_channel:{passive:bool,orig_h:ip,resp_h:ip,resp_p:port},fuid:string,_write_ts:time}>,
+  "http": <http={_path:string,ts:time,uid:string,id:conn_id,trans_depth:uint64,method:string,host:string,uri:string,referrer:string,version:string,user_agent:string,origin:string,request_body_len:uint64,response_body_len:uint64,status_code:uint64,status_msg:string,info_code:uint64,info_msg:string,tags:|[zenum]|,username:string,password:string,proxied:|[string]|,orig_fuids:[string],orig_filenames:[string],orig_mime_types:[string],resp_fuids:[string],resp_filenames:[string],resp_mime_types:[string],_write_ts:time}>,
+  "intel": <intel={_path:string,ts:time,uid:string,id:conn_id,seen:{indicator:string,indicator_type:zenum,where:zenum,node:string},matched:|[zenum]|,sources:|[string]|,fuid:string,file_mime_type:string,file_desc:string,_write_ts:time}>,
+  "irc": <irc={_path:string,ts:time,uid:string,id:conn_id,nick:string,user:string,command:string,value:string,addl:string,dcc_file_name:string,dcc_file_size:uint64,dcc_mime_type:string,fuid:string,_write_ts:time}>,
+  "kerberos": <kerberos={_path:string,ts:time,uid:string,id:conn_id,request_type:string,client:string,service:string,success:bool,error_msg:string,from:time,till:time,cipher:string,forwardable:bool,renewable:bool,client_cert_subject:string,client_cert_fuid:string,server_cert_subject:string,server_cert_fuid:string,_write_ts:time}>,
+  "known_certs": <known_certs={_path:string,ts:time,host:ip,port_num:port,subject:string,issuer_subject:string,serial:string,_write_ts:time}>,
+  "known_hosts": <known_hosts={_path:string,ts:time,host:ip,_write_ts:time}>,
+  "known_services": <known_services={_path:string,ts:time,host:ip,port_num:port,port_proto:zenum,service:|[string]|,_write_ts:time}>,
+  "ldap": <ldap={_path:string,ts:time,uid:string,id:conn_id,message_id:int64,version:int64,opcode:string,result:string,diagnostic_message:string,object:string,argument:string,_write_ts:time}>,
+  "ldap_search": <ldap_search={_path:string,ts:time,uid:string,id:conn_id,message_id:int64,scope:string,deref_aliases:string,base_object:string,result_count:uint64,result:string,diagnostic_message:string,filter:string,attributes:[string],_write_ts:time}>,
+  "loaded_scripts": <loaded_scripts={_path:string,name:string,_write_ts:time}>,
+  "modbus": <modbus={_path:string,ts:time,uid:string,id:conn_id,tid:uint64,unit:uint64,func:string,pdu_type:string,exception:string,_write_ts:time}>,
+  "mqtt_connect": <mqtt_connect={_path:string,ts:time,uid:string,id:conn_id,proto_name:string,proto_version:string,client_id:string,connect_status:string,will_topic:string,will_payload:string,_write_ts:time}>,
+  "mqtt_publish": <mqtt_publish={_path:string,ts:time,uid:string,id:conn_id,from_client:bool,retain:bool,qos:string,status:string,topic:string,payload:string,payload_len:uint64,_write_ts:time}>,
+  "mqtt_subscribe": <mqtt_subscribe={_path:string,ts:time,uid:string,id:conn_id,action:zenum,topics:[string],qos_levels:[uint64],granted_qos_level:uint64,ack:bool,_write_ts:time}>,
+  "mysql": <mysql={_path:string,ts:time,uid:string,id:conn_id,cmd:string,arg:string,success:bool,rows:uint64,response:string,_write_ts:time}>,
+  "netcontrol": <netcontrol={_path:string,ts:time,rule_id:string,category:zenum,cmd:string,state:zenum,action:string,target:zenum,entity_type:string,entity:string,mod:string,msg:string,priority:int64,expire:duration,location:string,plugin:string,_write_ts:time}>,
+  "netcontrol_drop": <netcontrol_drop={_path:string,ts:time,rule_id:string,orig_h:ip,orig_p:port,resp_h:ip,resp_p:port,expire:duration,location:string,_write_ts:time}>,
+  "netcontrol_shunt": <netcontrol_shunt={_path:string,ts:time,rule_id:string,f:{src_h:ip,src_p:port,dst_h:ip,dst_p:port},expire:duration,location:string,_write_ts:time}>,
+  "notice": <notice={_path:string,ts:time,uid:string,id:conn_id,fuid:string,file_mime_type:string,file_desc:string,proto:zenum,note:zenum,msg:string,sub:string,src:ip,dst:ip,p:port,n:uint64,peer_descr:string,actions:|[zenum]|,email_dest:|[string]|,suppress_for:duration,remote_location:{country_code:string,region:string,city:string,latitude:float64,longitude:float64},_write_ts:time}>,
+  "notice_alarm": <notice_alarm={_path:string,ts:time,uid:string,id:conn_id,fuid:string,file_mime_type:string,file_desc:string,proto:zenum,note:zenum,msg:string,sub:string,src:ip,dst:ip,p:port,n:uint64,peer_descr:string,actions:|[zenum]|,email_dest:|[string]|,suppress_for:duration,remote_location:{country_code:string,region:string,city:string,latitude:float64,longitude:float64},_write_ts:time}>,
+  "ntlm": <ntlm={_path:string,ts:time,uid:string,id:conn_id,username:string,hostname:string,domainname:string,server_nb_computer_name:string,server_dns_computer_name:string,server_tree_name:string,success:bool,_write_ts:time}>,
+  "ntp": <ntp={_path:string,ts:time,uid:string,id:conn_id,version:uint64,mode:uint64,stratum:uint64,poll:duration,precision:duration,root_delay:duration,root_disp:duration,ref_id:string,ref_time:time,org_time:time,rec_time:time,xmt_time:time,num_exts:uint64,_write_ts:time}>,
+  "ocsp": <ocsp={_path:string,ts:time,id:string,hashAlgorithm:string,issuerNameHash:string,issuerKeyHash:string,serialNumber:string,certStatus:string,revoketime:time,revokereason:string,thisUpdate:time,nextUpdate:time,_write_ts:time}>,
+  "openflow": <openflow={_path:string,ts:time,dpid:uint64,match:{in_port:uint64,dl_src:string,dl_dst:string,dl_vlan:uint64,dl_vlan_pcp:uint64,dl_type:uint64,nw_tos:uint64,nw_proto:uint64,nw_src:net,nw_dst:net,tp_src:uint64,tp_dst:uint64},flow_mod:{cookie:uint64,table_id:uint64,command:zenum,idle_timeout:uint64,hard_timeout:uint64,priority:uint64,out_port:uint64,out_group:uint64,flags:uint64,actions:{out_ports:[uint64],vlan_vid:uint64,vlan_pcp:uint64,vlan_strip:bool,dl_src:string,dl_dst:string,nw_tos:uint64,nw_src:ip,nw_dst:ip,tp_src:uint64,tp_dst:uint64}},_write_ts:time}>,
+  "packet_filter": <packet_filter={_path:string,ts:time,node:string,filter:string,init:bool,success:bool,failure_reason:string,_write_ts:time}>,
+  "pe": <pe={_path:string,ts:time,id:string,machine:string,compile_ts:time,os:string,subsystem:string,is_exe:bool,is_64bit:bool,uses_aslr:bool,uses_dep:bool,uses_code_integrity:bool,uses_seh:bool,has_import_table:bool,has_export_table:bool,has_cert_table:bool,has_debug_data:bool,section_names:[string],_write_ts:time}>,
+  "quic": <quic={_path:string,ts:time,uid:string,id:conn_id,version:string,client_initial_dcid:string,client_scid:string,server_scid:string,server_name:string,client_protocol:string,history:string,_write_ts:time}>,
+  "radius": <radius={_path:string,ts:time,uid:string,id:conn_id,username:string,mac:string,framed_addr:ip,tunnel_client:string,connect_info:string,reply_msg:string,result:string,ttl:duration,_write_ts:time}>,
+  "rdp": <rdp={_path:string,ts:time,uid:string,id:conn_id,cookie:string,result:string,security_protocol:string,client_channels:[string],keyboard_layout:string,client_build:string,client_name:string,client_dig_product_id:string,desktop_width:uint64,desktop_height:uint64,requested_color_depth:string,cert_type:string,cert_count:uint64,cert_permanent:bool,encryption_level:string,encryption_method:string,_write_ts:time}>,
+  "reporter": <reporter={_path:string,ts:time,level:zenum,message:string,location:string,_write_ts:time}>,
+  "rfb": <rfb={_path:string,ts:time,uid:string,id:conn_id,client_major_version:string,client_minor_version:string,server_major_version:string,server_minor_version:string,authentication_method:string,auth:bool,share_flag:bool,desktop_name:string,width:uint64,height:uint64,_write_ts:time}>,
+  "signatures": <signatures={_path:string,ts:time,uid:string,src_addr:ip,src_port:port,dst_addr:ip,dst_port:port,note:zenum,sig_id:string,event_msg:string,sub_msg:string,sig_count:uint64,host_count:uint64,_write_ts:time}>,
+  "sip": <sip={_path:string,ts:time,uid:string,id:conn_id,trans_depth:uint64,method:string,uri:string,date:string,request_from:string,request_to:string,response_from:string,response_to:string,reply_to:string,call_id:string,seq:string,subject:string,request_path:[string],response_path:[string],user_agent:string,status_code:uint64,status_msg:string,warning:string,request_body_len:uint64,response_body_len:uint64,content_type:string,_write_ts:time}>,
+  "smb_files": <smb_files={_path:string,ts:time,uid:string,id:conn_id,fuid:string,action:zenum,path:string,name:string,size:uint64,prev_name:string,times:{modified:time,accessed:time,created:time,changed:time},_write_ts:time}>,
+  "smb_mapping": <smb_mapping={_path:string,ts:time,uid:string,id:conn_id,path:string,service:string,native_file_system:string,share_type:string,_write_ts:time}>,
+  "smtp": <smtp={_path:string,ts:time,uid:string,id:conn_id,trans_depth:uint64,helo:string,mailfrom:string,rcptto:|[string]|,date:string,from:string,to:|[string]|,cc:|[string]|,reply_to:string,msg_id:string,in_reply_to:string,subject:string,x_originating_ip:ip,first_received:string,second_received:string,last_reply:string,path:[ip],user_agent:string,tls:bool,fuids:[string],is_webmail:bool,_write_ts:time}>,
+  "snmp": <snmp={_path:string,ts:time,uid:string,id:conn_id,duration:duration,version:string,community:string,get_requests:uint64,get_bulk_requests:uint64,get_responses:uint64,set_requests:uint64,display_string:string,up_since:time,_write_ts:time}>,
+  "socks": <socks={_path:string,ts:time,uid:string,id:conn_id,version:uint64,user:string,password:string,status:string,request:{host:ip,name:string},request_p:port,bound:{host:ip,name:string},bound_p:port,_write_ts:time}>,
+  "software": <software={_path:string,ts:time,host:ip,host_p:port,software_type:zenum,name:string,version:{major:uint64,minor:uint64,minor2:uint64,minor3:uint64,addl:string},unparsed_version:string,_write_ts:time}>,
+  "ssh": <ssh={_path:string,ts:time,uid:string,id:conn_id,version:uint64,auth_success:bool,auth_attempts:uint64,direction:zenum,client:string,server:string,cipher_alg:string,mac_alg:string,compression_alg:string,kex_alg:string,host_key_alg:string,host_key:string,remote_location:{country_code:string,region:string,city:string,latitude:float64,longitude:float64},_write_ts:time}>,
+  "ssl": <ssl={_path:string,ts:time,uid:string,id:conn_id,version:string,cipher:string,curve:string,server_name:string,resumed:bool,last_alert:string,next_protocol:string,established:bool,ssl_history:string,cert_chain_fps:[string],client_cert_chain_fps:[string],subject:string,issuer:string,client_subject:string,client_issuer:string,sni_matches_cert:bool,validation_status:string,_write_ts:time}>,
+  "stats": <stats={_path:string,ts:time,peer:string,mem:uint64,pkts_proc:uint64,bytes_recv:uint64,pkts_dropped:uint64,pkts_link:uint64,pkt_lag:duration,pkts_filtered:uint64,events_proc:uint64,events_queued:uint64,active_tcp_conns:uint64,active_udp_conns:uint64,active_icmp_conns:uint64,tcp_conns:uint64,udp_conns:uint64,icmp_conns:uint64,timers:uint64,active_timers:uint64,files:uint64,active_files:uint64,dns_requests:uint64,active_dns_requests:uint64,reassem_tcp_size:uint64,reassem_file_size:uint64,reassem_frag_size:uint64,reassem_unknown_size:uint64,_write_ts:time}>,
+  "syslog": <syslog={_path:string,ts:time,uid:string,id:conn_id,proto:zenum,facility:string,severity:string,message:string,_write_ts:time}>,
+  "telemetry_histogram": <telemetry_histogram={_path:string,ts:time,peer:string,prefix:string,name:string,unit:string,labels:[string],label_values:[string],bounds:[float64],values:[float64],sum:float64,observations:float64,_write_ts:time}>,
+  "telemetry": <telemetry={_path:string,ts:time,peer:string,metric_type:string,prefix:string,name:string,unit:string,labels:[string],label_values:[string],value:float64,_write_ts:time}>,
+  "tunnel": <tunnel={_path:string,ts:time,uid:string,id:conn_id,tunnel_type:zenum,action:zenum,_write_ts:time}>,
+  "websocket": <websocket={_path:string,ts:time,uid:string,id:conn_id,host:string,uri:string,user_agent:string,subprotocol:string,client_protocols:[string],server_extensions:[string],client_extensions:[string],_write_ts:time}>,
+  "weird": <weird={_path:string,ts:time,uid:string,id:conn_id,name:string,addl:string,notice:bool,peer:string,source:string,_write_ts:time}>,
+  "x509": <x509={_path:string,ts:time,fingerprint:string,certificate:{version:uint64,serial:string,subject:string,issuer:string,not_valid_before:time,not_valid_after:time,key_alg:string,sig_alg:string,key_type:string,key_length:uint64,exponent:string,curve:string},san:{dns:[string],uri:[string],email:[string],ip:[ip]},basic_constraints:{ca:bool,path_len:uint64},host_cert:bool,client_cert:bool,_write_ts:time}>
 }|
 
-// We'll check for the presence of fields we know are unique to records that
-// changed in Zeek v4.1.0 and shape those with special v4.1.0-specific config.
-// For everything else we'll apply the default type definitions.
-
-yield nest_dotted(this) | switch (
-  case _path=="ssl" and has(ssl_history) => yield shape(<ssl_4_1_0>)
-  case _path=="x509" and has(fingerprint) => yield shape(<x509_4_1_0>)
-  default => yield shape(schemas[_path])
+yield nest_dotted(this)
+| switch has(_path) (
+  case true => switch (_path in zeek_log_types) (
+    case true => yield {_original: this, _shaped: shape(zeek_log_types[_path])}
+      | switch has_error(_shaped) (
+          case true => yield error({msg: "shaper error(s): see inner error value(s) for details", _original, _shaped})
+          case false => yield {_original, _shaped}
+            | switch _crop_records (
+                case true => put _cropped := crop(_shaped, zeek_log_types[_shaped._path])
+                  | switch (_cropped == _shaped) (
+                      case true => yield _shaped
+                      case false => yield {_original, _shaped, _cropped}
+                      | switch _error_if_cropped (
+                          case true => yield error({msg: "shaper error: one or more fields were cropped", _original, _shaped, _cropped})
+                          case false => yield _cropped
+                        )
+                  )
+                case false => yield _shaped
+            )
+      )
+    case false => yield error({msg: "shaper error: _path '" + _path + "' is not a known zeek log type in shaper config", _original: this})
+  )
+  case false => yield error({msg: "shaper error: input record lacks _path field", _original: this})
 )
 ```
 
+### Configurable Options
+
+The shaper begins with some configurable boolean constants that control how
+the shaper will behave when the NDJSON data does not precisely match the Zeek
+type definitions.
+
+* `_crop_records` (default: `true`) - Fields in the NDJSON records whose names
+are not referenced in the type definitions will be removed. If set to `false`,
+such a field would be maintained and assigned an inferred type.
+
+* `_error_if_cropped` (default: `true`) - If such a field is cropped, the
+original input record will be
+[wrapped inside a Zed `error` value](../../language/shaping.md#error-handling)
+along with the shaped and cropped variations.
+
+At these default settings, the shaper is well-suited for an iterative workflow
+with a goal of establishing full coverage of the NDJSON data with rich Zed
+types. For instance, the [`has_error` function](../../language/functions/has_error.md)
+can be applied on the shaped output and any error values surfaced will point
+to fields that can be added to the type definitions in the shaper.
+
 ### Leading Type Definitions
 
-The top three lines define types that are referenced further below in the main
-portion of the Zed shaper.
+The next three lines define types that are referenced further below in the
+type definitions for the different Zeek events.
 
 ```
 type port=uint16;
@@ -207,7 +179,7 @@ doc. The `conn_id` type will just save us from having to repeat these fields
 individually in the many Zeek record types that contain an embedded `id`
 record.
 
-### Default Type Definitions Per Zeek Log `_path`
+### Type Definitions Per Zeek Log `_path`
 
 The bulk of this Zed shaper consists of detailed per-field data type
 definitions for each record in the default set of NDJSON logs output by Zeek.
@@ -218,40 +190,16 @@ specification.
 
 ```
 ...
-type conn={_path:string,ts:time,uid:string,id:conn_id,proto:zenum,service:string,duration:duration,orig_bytes:uint64,resp_bytes:uint64,conn_state:string,local_orig:bool,local_resp:bool,missed_bytes:uint64,history:string,orig_pkts:uint64,orig_ip_bytes:uint64,resp_pkts:uint64,resp_ip_bytes:uint64,tunnel_parents:|[string]|,_write_ts:time};
-type dce_rpc={_path:string,ts:time,uid:string,id:conn_id,rtt:duration,named_pipe:string,endpoint:string,operation:string,_write_ts:time};
+  "conn": <conn={_path:string,ts:time,uid:string,id:conn_id,proto:zenum,service:string,duration:duration,orig_bytes:uint64,resp_bytes:uint64,conn_state:string,local_orig:bool,local_resp:bool,missed_bytes:uint64,history:string,orig_pkts:uint64,orig_ip_bytes:uint64,resp_pkts:uint64,resp_ip_bytes:uint64,tunnel_parents:|[string]|,_write_ts:time}>,
+  "dce_rpc": <dce_rpc={_path:string,ts:time,uid:string,id:conn_id,rtt:duration,named_pipe:string,endpoint:string,operation:string,_write_ts:time}>,
 ...
 ```
 
-> **Note:** See [the role of `_path`](reading-zeek-log-formats.md#the-role-of-_path)
-> for important details if you're using Zeek's built-in [ASCII logger](https://docs.zeek.org/en/current/scripts/base/frameworks/logging/writers/ascii.zeek.html)
-> to generate NDJSON rather than the [JSON Streaming Logs](https://github.com/corelight/json-streaming-logs) package.
-
-### Version-Specific Type Definitions
-
-The next block of type definitions are exceptions for Zeek v4.1.0 where the
-names of fields for certain log types have changed from prior releases.
-
-```
-type ssl_4_1_0={_path:string,ts:time,uid:string,id:conn_id,version:string,cipher:string,curve:string,server_name:string,resumed:bool,last_alert:string,next_protocol:string,established:bool,ssl_history:string,cert_chain_fps:[string],client_cert_chain_fps:[string],subject:string,issuer:string,client_subject:string,client_issuer:string,sni_matches_cert:bool,validation_status:string,_write_ts:time};
-type x509_4_1_0={_path:string,ts:time,fingerprint:string,certificate:{version:uint64,serial:string,subject:string,issuer:string,not_valid_before:time,not_valid_after:time,key_alg:string,sig_alg:string,key_type:string,key_length:uint64,exponent:string,curve:string},san:{dns:[string],uri:[string],email:[string],ip:[ip]},basic_constraints:{ca:bool,path_len:uint64},host_cert:bool,client_cert:bool,_write_ts:time};
-```
-
-### Mapping From `_path` Values to Types
-
-The next section is just simple mapping from the string values typically found
-in the Zeek `_path` field to the name of one of the types we defined above.
-
-```
-const schemas = |{
-  "broker": broker,
-  "capture_loss": capture_loss,
-  "cluster": cluster,
-  "config": config,
-  "conn": conn,
-  "dce_rpc": dce_rpc,
-...
-```
+:::tip note
+See [the role of `_path`](reading-zeek-log-formats.md#the-role-of-_path)
+for important details if you're using Zeek's built-in [ASCII logger](https://docs.zeek.org/en/current/scripts/base/frameworks/logging/writers/ascii.zeek.html)
+to generate NDJSON rather than the [JSON Streaming Logs](https://github.com/corelight/json-streaming-logs) package.
+:::
 
 ### Zed Pipeline
 
@@ -259,58 +207,65 @@ The Zed shaper ends with a pipeline that stitches together everything we've defi
 so far.
 
 ```
-put this := unflatten(this) | switch (
-  _path=="ssl" has(ssl_history) => put this := shape(ssl_4_1_0);
-  _path=="x509" has(fingerprint) => put this := shape(x509_4_1_0);
-  default => put this := shape(schemas[_path]);
+yield nest_dotted(this)
+| switch has(_path) (
+  case true => switch (_path in zeek_log_types) (
+    case true => yield {_original: this, _shaped: shape(zeek_log_types[_path])}
+      | switch has_error(_shaped) (
+          case true => yield error({msg: "shaper error(s): see inner error value(s) for details", _original, _shaped})
+          case false => yield {_original, _shaped}
+            | switch _crop_records (
+                case true => put _cropped := crop(_shaped, zeek_log_types[_shaped._path])
+                  | switch (_cropped == _shaped) (
+                      case true => yield _shaped
+                      case false => yield {_original, _shaped, _cropped}
+                      | switch _error_if_cropped (
+                          case true => yield error({msg: "shaper error: one ore more fields were cropped", _original, _shaped, _cropped})
+                          case false => yield _cropped
+                        )
+                  )
+                case false => yield _shaped
+            )
+      )
+    case false => yield error({msg: "shaper error: _path '" + _path + "' is not a known zeek log type in shaper config", _original: this})
+  )
+  case false => yield error({msg: "shaper error: input record lacks _path field", _original: this})
 )
 ```
 
-Picking this apart, it transforms reach record as it's being read, in three
-steps:
+Picking this apart, it transforms each record as it's being read in several
+steps.
 
-1. `unflatten()` reverses the Zeek NDJSON logger's "flattening" of nested
-   records, e.g., how it populates a field named `id.orig_h` rather than
-   creating a field `id` with sub-field `orig_h` inside it. Restoring the
-   original nesting now gives us the option to reference the record named `id`
-   in the Zed language and access the entire 4-tuple of values, but still
-   access the individual values using the same dotted syntax like `id.orig_h`
-   when needed.
+1. The [`nest_dotted` function](../../language/functions/nest_dotted.md)
+   reverses the Zeek NDJSON logger's "flattening" of nested records, e.g., how
+   it populates a field named `id.orig_h` rather than creating a field `id` with
+   sub-field `orig_h` inside it. Restoring the original nesting now gives us
+   the option to reference the embedded record named `id` in the Zed language
+   and access the entire 4-tuple of values, but still access the individual
+   values using the same dotted syntax like `id.orig_h` when needed.
 
-2. The `switch()` detects if fields specific to Zeek v4.1.0 are present for the
-   two log types for which the [version-specific type definitions](#version-specific-type-definitions)
-   should be applied. For all log lines and types other than these exceptions,
-   the [default type definitions](#default-type-definitions-per-zeek-log-_path)
-   are applied.
+2. The [`switch` operator](../../language/operators/switch.md) is used to flag
+   any problems encountered when applying the shaper logic, e.g.,
 
-3. Each `shape()` call applies an appropriate type definition based on the
-   nature of the incoming record. The logic of `shape()` includes:
+   * An incoming Zeek NDJSON record has a `_path` value for which the shaper
+    lacks a type definition.
+   * A field in an incoming Zeek NDJSON record is located in our type
+     definitions but cannot be successfully [cast](../../language/functions/cast.md)
+     to the target type defined in the shaper.
+   * An incoming Zeek NDJSON record has additional field(s) beyond those in
+     the target type definition and the [configurable options](#configurable-options)
+     are set such that this should be treated as an error.
+
+3. Each [`shape` function](../../language/functions/shape.md) call applies an
+   appropriate type definition based on the nature of the incoming Zeek NDJSON
+   record. The logic of `shape` includes:
 
    * For any fields referenced in the type definition that aren't present in
-     the input record, the field is added with a `null` value. (Note: This
-     could be performed separately via the `fill()` function.)
-
-   * The data type of each field in the type definition is applied to the
-     field of that name in the input record. (Note: This could be performed
-     separately via the `cast()` function.)
-
+     the input record, the field is added with a `null` value.
+   * Each field in the input record is cast to the corresponding type of the
+     field of the same name in the type definition.
    * The fields in the input record are ordered to match the order in which
-     they appear in the type definition. (Note: This could be performed
-     separately via the `order()` function.)
-
-   Any fields that appear in the input record that are not present in the
-   type definition are kept and assigned an inferred data type. If you would
-   prefer to have such additional fields dropped (i.e., to maintain strict
-   adherence to the shape), append a call to the `crop()` function to the
-   Zed pipeline, e.g.:
-
-      ```
-      ... | put this := shape(schemas[_path]) | put this := crop(schemas[_path])
-      ```
-
-   Open issues [zed/2585](https://github.com/brimdata/zed/issues/2585) and
-   [zed/2776](https://github.com/brimdata/zed/issues/2776) both track planned
-   future improvements to this part of Zed shapers.
+     they appear in the type definition.
 
 ## Invoking the Shaper From `zq`
 
@@ -376,33 +331,20 @@ operations on the richly-typed records, the Zed query on the command line
 should begin with a `|`, as this appends it to the pipeline at the bottom of
 the shaper from the included file.
 
-For example, to count Zeek `conn` records into CIDR-based buckets based on
-originating IP address:
+For example, to see a ZSON representation of just the errors that may have
+come from attempting to shape all the logs in the current directory:
 
 ```
-zq -I shaper.zed -f table '| count() by network_of(id.orig_h) | sort -r' conn.log
+zq -Z -I shaper.zed '| has_error(this)' *.log
 ```
-
-[zed/2584](https://github.com/brimdata/zed/issues/2584) tracks a planned
-improvement for this use of `zq -I`.
-
-If you intend to frequently shape the same NDJSON data, you may want to create
-an alias in your
-shell to always invoke `zq` with the necessary `-I` flag pointing to the path
-of your finalized shaper. [zed/1059](https://github.com/brimdata/zed/issues/1059)
-tracks a planned enhancement to persist such settings within Zed itself rather
-than relying on external mechanisms such as shell aliases.
 
 ## Importing Shaped Data Into Zui
 
-If you wish to browse your shaped data with [Zui](https://zui.brimdata.io/),
-the best way to accomplish this at the moment would be to use `zq` to convert
-it to ZNG [as shown above](#invoking-the-shaper-from-zq), then drag the ZNG
-into Zui as you would any other log. An enhancement [zed/2695](https://github.com/brimdata/zed/issues/2695)
-is planned that will soon make it possible to attach your shaper to a
-Pool. This will allow you to drag the original NDJSON logs directly into the
-Pool in Zui and have the shaping applied as the records are being committed to
-the Pool.
+If you wish to shape your Zeek NDJSON data in [Zui](https://zui.brimdata.io/),
+drag the NDJSON files into the app and then paste the contents of the
+[`shaper.zed` shown above](#reference-shaper-contents) into the
+**Shaper Editor** of the [**Preview & Load**](https://zui.brimdata.io/docs/features/Preview-Load)
+screen.
 
 ## Contact us!
 


### PR DESCRIPTION
## tl;dr

This is a significant update to the Zeek integration docs, in particular bringing the shaper script current with Zeek v6.2.0. You can see the rendered version of them [here](https://6616d57a0260af2ee74d1a3e--spiffy-gnome-8f2834.netlify.app/docs/next/integrations/zeek).

## Details

The changes in this PR are the long overdue "material changes" foretold in #4694. In addition to bringing the type definitions up to date with current GA Zeek release [v6.2.0](https://github.com/zeek/zeek/releases/tag/v6.2.0), I've made the shaper more compact and also started using Zed's `error` type to surface problems encountered during shaping. I think this all provides a solid working example of many Zed concepts coming together to solve a challenging problem. Now that [build-zeek](https://github.com/brimdata/build-zeek) has me in the habit of keeping up with GA Zeek releases, I'm hopeful that I'll be able to keep this shaping doc current as the log types gradually change and avoid having to do grand overhauls like this going forward.

In addition to the changes to the Zeek shaper itself and how it's described, I've made some general improvements to the Zeek integration docs to fix typos, add links, and bring them more current with the evolving state of the other Zed docs. In some cases this actually involved removing some text since we've got better coverage of topics in their proper homes, e.g., we now have the detailed [Shaping and Type Fusion](https://zed.brimdata.io/docs/language/shaping) doc whereas in the past the Zeek shaper doc effectively served as the most comprehensive doc about shaping. There's still a little redundancy in the Zeek shaper doc because I figured it was helpful to present the concepts in context like a "user guide" rather than sending the reader on a scavenger hunt through reference materials, though of course I still link off to all the relevant functions/operators/etc.

If reviewers would like to see the rendered docs rather than trying to pick through the diffs here, I've pushed a built copy of the docs site based on this branch to a personal staging site at https://6616d57a0260af2ee74d1a3e--spiffy-gnome-8f2834.netlify.app/docs/next/integrations/zeek.

## How it was done

Here's some notes-to-self on how I came up with the changes here, as I expect they may come in handy the next time I do this.

While its output is no longer directly usable in Zed tooling, the [print-types.zeek](https://github.com/brimdata/zeek/blob/master/brim/print-types.zeek) script from our (now archived) Zeek repo remains useful for assessing the default fields/types output by a particular Zeek release. To gather these for the old/new endpoints of this exercise I ran this on Zeek v4.1.1:

```
$ ZEEK_ALLOW_INIT_ERRORS=1 zeek print-types.zeek local | tail +2 | jq -S | python3 -m json.tool > types-4.1.1.json
```

And on Zeek v6.2.0:

```
$ ZEEK_ALLOW_INIT_ERRORS=1 zeek print-types.zeek local | jq -S | python3 -m json.tool > types-6.2.0.json
```

Then check for differences:

```
$ diff -y types-4.1.1.json types-6.2.0.json > types-diff.txt
```

If an entirely new log type is spotted in the diff (e.g., `ldap` in this case) or an existing log type is overhauled significantly, the lines that define the descriptor array for that log type were copied from the `types-6.2.0.json` to a separate file, then run through this pipeline in a script `cleanup-type.sh`:

```
#!/bin/sh
cat $1 |
  jq -c . |
  sed 's/"bstring"/"string"/g' |
  sed 's/set\[bstring\]/|[string]|/g' |
  sed 's/array\[bstring\]/[string]/g' |
  sed 's/array\[uint64\]/[uint64]/g' |
  sed 's/array\[float64\]/[float64]/g' |
  sed 's/{"name":"//g' |
  sed 's/","type":"/:/g' |
  sed 's/"},/,/g' |
  sed 's/id","type":\[orig_h:ip,orig_p:port,resp_h:ip,resp_p:port"}\]}/id:conn_id/g' |
  sed 's/^\[/{/' | sed 's/"}\]$/}/'
```

For example:

```
$ cat ldap.json 
        [
            {
                "name": "_path",
                "type": "string"
            },
            {
                "name": "ts",
                "type": "time"
            },
            {
                "name": "uid",
                "type": "bstring"
            },
            {
                "name": "id",
                "type": [
                    {
                        "name": "orig_h",
                        "type": "ip"
                    },
                    {
                        "name": "orig_p",
                        "type": "port"
                    },
                    {
                        "name": "resp_h",
                        "type": "ip"
                    },
                    {
                        "name": "resp_p",
                        "type": "port"
                    }
                ]
            },
            {
                "name": "message_id",
                "type": "int64"
            },
            {
                "name": "version",
                "type": "int64"
            },
            {
                "name": "opcode",
                "type": "bstring"
            },
            {
                "name": "result",
                "type": "bstring"
            },
            {
                "name": "diagnostic_message",
                "type": "bstring"
            },
            {
                "name": "object",
                "type": "bstring"
            },
            {
                "name": "argument",
                "type": "bstring"
            },
            {
                "name": "_write_ts",
                "type": "time"
            }
        ]

$ ./cleanup-type.sh ldap.json 
{_path:string,ts:time,uid:string,id:conn_id,message_id:int64,version:int64,opcode:string,result:string,diagnostic_message:string,object:string,argument:string,_write_ts:time}
```

Because of the known limitation of `print-types.zeek` described in https://github.com/brimdata/zeek/issues/15, I also manually eyeballed the type definition for Zeek's `openflow` and confirmed nothing has changed since the last shaper update.