### PR TITLE
Enabled JSON and ZSON color by default

### DIFF
--- a/zio/jsonio/writer.go
+++ b/zio/jsonio/writer.go
@@ -233,7 +233,7 @@ func (w *Writer) punc(b byte) {
 }
 
 func (w *Writer) writeColor(b []byte, code []byte) {
-	if w.tab > 0 && color.Enabled {
+	if color.Enabled {
 		w.writer.Write(code)
 		defer w.writer.WriteString(color.Reset.String())
 	}

--- a/zio/lakeio/writer.go
+++ b/zio/lakeio/writer.go
@@ -39,7 +39,7 @@ type Writer struct {
 func NewWriter(w io.WriteCloser, opts WriterOpts) *Writer {
 	writer := &Writer{
 		writer:   w,
-		zson:     zson.NewFormatter(0, nil),
+		zson:     zson.NewFormatter(0, false, nil),
 		commits:  make(table),
 		branches: make(map[ksuid.KSUID][]string),
 		width:    80, //XXX

--- a/zio/zsonio/writer.go
+++ b/zio/zsonio/writer.go
@@ -14,13 +14,14 @@ type Writer struct {
 }
 
 type WriterOpts struct {
-	Pretty  int
-	Persist *regexp.Regexp
+	ColorDisabled bool
+	Pretty        int
+	Persist       *regexp.Regexp
 }
 
 func NewWriter(w io.WriteCloser, opts WriterOpts) *Writer {
 	return &Writer{
-		formatter: zson.NewFormatter(opts.Pretty, opts.Persist),
+		formatter: zson.NewFormatter(opts.Pretty, opts.ColorDisabled, opts.Persist),
 		writer:    w,
 	}
 }

--- a/zson/formatter.go
+++ b/zson/formatter.go
@@ -14,18 +14,19 @@ import (
 )
 
 type Formatter struct {
-	typedefs  map[string]*zed.TypeNamed
-	permanent map[string]*zed.TypeNamed
-	persist   *regexp.Regexp
-	tab       int
-	newline   string
-	builder   strings.Builder
-	stack     []strings.Builder
-	implied   map[zed.Type]bool
-	colors    color.Stack
+	typedefs      map[string]*zed.TypeNamed
+	permanent     map[string]*zed.TypeNamed
+	persist       *regexp.Regexp
+	tab           int
+	newline       string
+	builder       strings.Builder
+	stack         []strings.Builder
+	implied       map[zed.Type]bool
+	colors        color.Stack
+	colorDisabled bool
 }
 
-func NewFormatter(pretty int, persist *regexp.Regexp) *Formatter {
+func NewFormatter(pretty int, colorDisabled bool, persist *regexp.Regexp) *Formatter {
 	var newline string
 	if pretty > 0 {
 		newline = "\n"
@@ -35,12 +36,13 @@ func NewFormatter(pretty int, persist *regexp.Regexp) *Formatter {
 		permanent = make(map[string]*zed.TypeNamed)
 	}
 	return &Formatter{
-		typedefs:  make(map[string]*zed.TypeNamed),
-		permanent: permanent,
-		tab:       pretty,
-		newline:   newline,
-		implied:   make(map[zed.Type]bool),
-		persist:   persist,
+		typedefs:      make(map[string]*zed.TypeNamed),
+		permanent:     permanent,
+		tab:           pretty,
+		newline:       newline,
+		implied:       make(map[zed.Type]bool),
+		persist:       persist,
+		colorDisabled: colorDisabled,
 	}
 }
 
@@ -75,7 +77,7 @@ func (f *Formatter) FormatRecord(rec zed.Value) string {
 }
 
 func FormatValue(val zed.Value) string {
-	return NewFormatter(0, nil).Format(val)
+	return NewFormatter(0, true, nil).Format(val)
 }
 
 func String(p interface{}) string {
@@ -661,7 +663,7 @@ var colors = map[zed.Type]color.Code{
 }
 
 func (f *Formatter) startColorPrimitive(typ zed.Type) {
-	if f.tab > 0 {
+	if !f.colorDisabled {
 		c, ok := colors[zed.TypeUnder(typ)]
 		if !ok {
 			c = color.Reset
@@ -671,13 +673,13 @@ func (f *Formatter) startColorPrimitive(typ zed.Type) {
 }
 
 func (f *Formatter) startColor(code color.Code) {
-	if f.tab > 0 {
+	if !f.colorDisabled {
 		f.colors.Start(&f.builder, code)
 	}
 }
 
 func (f *Formatter) endColor() {
-	if f.tab > 0 {
+	if !f.colorDisabled {
 		f.colors.End(&f.builder)
 	}
 }
@@ -830,7 +832,7 @@ func formatPrimitive(b *strings.Builder, typ zed.Type, bytes zcode.Bytes) {
 }
 
 func FormatTypeValue(tv zcode.Bytes) string {
-	f := NewFormatter(0, nil)
+	f := NewFormatter(0, true, nil)
 	f.formatTypeValue(0, tv)
 	return f.builder.String()
 }

--- a/zson/marshal.go
+++ b/zson/marshal.go
@@ -34,7 +34,7 @@ func NewMarshaler() *MarshalContext {
 func NewMarshalerIndent(indent int) *MarshalContext {
 	return &MarshalContext{
 		MarshalZNGContext: NewZNGMarshaler(),
-		formatter:         NewFormatter(indent, nil),
+		formatter:         NewFormatter(indent, false, nil),
 	}
 }
 


### PR DESCRIPTION
This commit changes the behavior of the ZSON and JSON outputs where if the writer is writing to a terminal the output will be colorized- independent of whether the output is indented or not.