### PR TITLE
zq: Correct error message when no source is found

### DIFF
--- a/cmd/zq/ztests/from-pool-error.yaml
+++ b/cmd/zq/ztests/from-pool-error.yaml
@@ -4,6 +4,6 @@ script: |
 outputs:
   - name: stderr
     data: |
-      zq: could not invoke zq with a single argument because:
-       - a file could not be found with the name "from ( pool a )"
-       - the argument did not parse as a valid Zed query
+      zq: "from pool" cannot be used without a lake at line 1, column 8:
+      from ( pool a )
+             ~~~~~~

--- a/cmd/zq/ztests/no-files.yaml
+++ b/cmd/zq/ztests/no-files.yaml
@@ -8,4 +8,4 @@ outputs:
     data: |
       zq: could not invoke zq with a single argument because:
        - a file could not be found with the name "doesnotexist"
-       - the argument did not parse as a valid Zed query
+       - the argument is a valid Zed query but does not begin with a source (e.g., "file input.zson") or yield operator

--- a/compiler/semantic/op.go
+++ b/compiler/semantic/op.go
@@ -158,7 +158,7 @@ func (a *analyzer) semSource(source ast.Source) []dag.Op {
 		}
 	case *ast.Pool:
 		if !a.source.IsLake() {
-			a.error(s, errors.New("from pool cannot be used without a lake"))
+			a.error(s, errors.New("\"from pool\" cannot be used without a lake"))
 			return []dag.Op{badOp()}
 		}
 		return a.semPool(s)

--- a/compiler/ztests/from-error.yaml
+++ b/compiler/ztests/from-error.yaml
@@ -15,7 +15,7 @@ script: |
 outputs:
   - name: stderr
     data: |
-      from pool cannot be used without a lake at line 1, column 1:
+      "from pool" cannot be used without a lake at line 1, column 1:
       from p
       ~~~~~~
       ===


### PR DESCRIPTION
This commit fixes an issue where the wrong error message was returned for a single argument zq invocation where the argument is a valid Zed query but the query contains no source.

Closes #5110