### PR TITLE
Localized Errors

### DIFF
--- a/cli/queryflags/flags.go
+++ b/cli/queryflags/flags.go
@@ -32,7 +32,7 @@ func (f *Flags) SetFlags(fs *flag.FlagSet) {
 	fs.Var(&f.Includes, "I", "source file containing Zed query text (may be used multiple times)")
 }
 
-func (f *Flags) ParseSourcesAndInputs(paths []string) ([]string, ast.Seq, bool, error) {
+func (f *Flags) ParseSourcesAndInputs(paths []string) ([]string, ast.Seq, *parser.SourceSet, bool, error) {
 	var src string
 	if len(paths) != 0 && !cli.FileExists(paths[0]) && !isURLWithKnownScheme(paths[0], "http", "https", "s3") {
 		src = paths[0]
@@ -41,25 +41,25 @@ func (f *Flags) ParseSourcesAndInputs(paths []string) ([]string, ast.Seq, bool, 
 			// Consider a lone argument to be a query if it compiles
 			// and appears to start with a from or yield operator.
 			// Otherwise, consider it a file.
-			query, err := compiler.Parse(src, f.Includes...)
+			query, set, err := compiler.Parse(src, f.Includes...)
 			if err == nil {
 				if s, err := semantic.Analyze(context.Background(), query, data.NewSource(storage.NewLocalEngine(), nil), nil); err == nil {
 					if semantic.HasSource(s) {
-						return nil, query, false, nil
+						return nil, query, set, false, nil
 					}
 					if semantic.StartsWithYield(s) {
-						return nil, query, true, nil
+						return nil, query, set, true, nil
 					}
 				}
 			}
-			return nil, nil, false, singleArgError(src, err)
+			return nil, nil, nil, false, singleArgError(src, set.LocalizeError(err))
 		}
 	}
-	query, err := compiler.Parse(src, f.Includes...)
+	query, set, err := compiler.Parse(src, f.Includes...)
 	if err != nil {
-		return nil, nil, false, err
+		return nil, nil, set, false, set.LocalizeError(err)
 	}
-	return paths, query, false, nil
+	return paths, query, set, false, nil
 }
 
 func isURLWithKnownScheme(path string, schemes ...string) bool {
@@ -87,15 +87,11 @@ func singleArgError(src string, err error) error {
 		src = src[:20] + "..."
 	}
 	fmt.Fprintf(&b, "\n - a file could not be found with the name %q", src)
-	var perr *parser.Error
-	if errors.As(err, &perr) {
-		b.WriteString("\n - the argument could not be compiled as a valid Zed query due to parse error (")
-		if perr.LineNum > 0 {
-			fmt.Fprintf(&b, "line %d, ", perr.LineNum)
-		}
-		fmt.Fprintf(&b, "column %d):", perr.Column)
-		for _, l := range strings.Split(perr.ParseErrorContext(), "\n") {
-			fmt.Fprintf(&b, "\n   %s", l)
+	var lerrs parser.LocalizedErrors
+	if errors.As(err, &lerrs) {
+		b.WriteString("\n - the argument could not be compiled as a valid Zed query:")
+		for _, line := range strings.Split(err.Error(), "\n") {
+			fmt.Fprintf(&b, "\n   %s", line)
 		}
 	} else {
 		b.WriteString("\n - the argument did not parse as a valid Zed query")

--- a/cli/zq/command.go
+++ b/cli/zq/command.go
@@ -129,7 +129,7 @@ func (c *Command) Run(args []string) error {
 		// Prevent ParseSourcesAndInputs from treating args[0] as a path.
 		args = append(args, "-")
 	}
-	paths, flowgraph, null, err := c.queryFlags.ParseSourcesAndInputs(args)
+	paths, flowgraph, set, null, err := c.queryFlags.ParseSourcesAndInputs(args)
 	if err != nil {
 		return fmt.Errorf("zq: %w", err)
 	}
@@ -156,7 +156,7 @@ func (c *Command) Run(args []string) error {
 	comp := compiler.NewFileSystemCompiler(local)
 	query, err := runtime.CompileQuery(ctx, zctx, comp, flowgraph, readers)
 	if err != nil {
-		return err
+		return set.LocalizeError(err)
 	}
 	defer query.Pull(true)
 	err = zbuf.CopyPuller(writer, query)

--- a/cmd/zq/ztests/single-arg-error.yaml
+++ b/cmd/zq/ztests/single-arg-error.yaml
@@ -6,6 +6,7 @@ outputs:
     data: |
       zq: could not invoke zq with a single argument because:
        - a file could not be found with the name "file sample.zson | c..."
-       - the argument could not be compiled as a valid Zed query due to parse error (column 25):
+       - the argument could not be compiled as a valid Zed query:
+         error parsing Zed (line 1, column 26):
          file sample.zson | count(
                               === ^ ===

--- a/compiler/job.go
+++ b/compiler/job.go
@@ -88,13 +88,13 @@ func (j *Job) Parallelize(n int) error {
 	return err
 }
 
-func Parse(src string, filenames ...string) (ast.Seq, error) {
+func Parse(src string, filenames ...string) (ast.Seq, *parser.SourceSet, error) {
 	return parser.ParseZed(filenames, src)
 }
 
 // MustParse is like Parse but panics if an error is encountered.
 func MustParse(query string) ast.Seq {
-	seq, err := (*anyCompiler)(nil).Parse(query)
+	seq, _, err := (*anyCompiler)(nil).Parse(query)
 	if err != nil {
 		panic(err)
 	}
@@ -135,7 +135,7 @@ type anyCompiler struct{}
 
 // Parse concatenates the source files in filenames followed by src and parses
 // the resulting program.
-func (*anyCompiler) Parse(src string, filenames ...string) (ast.Seq, error) {
+func (*anyCompiler) Parse(src string, filenames ...string) (ast.Seq, *parser.SourceSet, error) {
 	return Parse(src, filenames...)
 }
 
@@ -144,7 +144,7 @@ func (*anyCompiler) Parse(src string, filenames ...string) (ast.Seq, error) {
 // nor does it compute the demand of the query to prune the projection
 // from the vcache.
 func VectorCompile(rctx *runtime.Context, query string, object *vcache.Object) (zbuf.Puller, error) {
-	seq, err := Parse(query)
+	seq, _, err := Parse(query)
 	if err != nil {
 		return nil, err
 	}
@@ -176,7 +176,7 @@ func VectorFilterCompile(rctx *runtime.Context, query string, src *data.Source, 
 	if err != nil {
 		return nil, err
 	}
-	seq, err := Parse(query)
+	seq, _, err := Parse(query)
 	if err != nil {
 		return nil, err
 	}

--- a/compiler/parser/errors.go
+++ b/compiler/parser/errors.go
@@ -1,0 +1,121 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/brimdata/zed/compiler/ast"
+	"go.uber.org/multierr"
+)
+
+type PositionalError interface {
+	error
+	ast.Node
+	Message() string
+}
+
+// LocalizeErrors returns a list of localized errors if the error can be
+// localized, else returns the original error.
+func (s *SourceSet) LocalizeError(errs error) error {
+	var list LocalizedErrors
+	for _, err := range multierr.Errors(errs) {
+		if perr, ok := err.(PositionalError); ok {
+			list = append(list, newLocalizedError(s, perr))
+		} else {
+			return errs
+		}
+	}
+	if len(list) > 0 {
+		return list
+	}
+	return nil
+}
+
+// LocalizedError is a parse error with nice formatting.  It includes the source code
+// line containing the error.
+type LocalizedError struct {
+	Kind     string   `json:"kind" unpack:""`
+	Filename string   `json:"filename"`
+	Line     string   `json:"line"` // contains no newlines
+	Open     Position `json:"open"`
+	Close    Position `json:"close"`
+	Msg      string   `json:"error"`
+}
+
+var _ PositionalError = (*LocalizedError)(nil)
+
+func newLocalizedError(s *SourceSet, perr PositionalError) *LocalizedError {
+	startPos := perr.Pos()
+	src := s.SourceOf(startPos)
+	filename, start := src.Position(startPos)
+	_, end := src.Position(perr.End())
+	return &LocalizedError{
+		Kind:     "LocalizedError",
+		Filename: filename,
+		Open:     start,
+		Close:    end,
+		Line:     src.LineOfPos(s, startPos),
+		Msg:      perr.Message(),
+	}
+}
+
+func (e *LocalizedError) Message() string { return e.Msg }
+func (e *LocalizedError) Pos() int        { return e.Open.Pos }
+func (e *LocalizedError) End() int        { return e.Close.Pos }
+
+func (e *LocalizedError) Error() string {
+	var b strings.Builder
+	b.WriteString(e.Msg)
+	b.WriteString(" (")
+	if e.Filename != "" {
+		fmt.Fprintf(&b, "%s: ", e.Filename)
+	}
+	if e.Open.Line >= 1 {
+		fmt.Fprintf(&b, "line %d, ", e.Open.Line)
+	}
+	fmt.Fprintf(&b, "column %d):\n", e.Open.Column)
+	b.WriteString(e.errorContext())
+	return b.String()
+}
+
+func (e *LocalizedError) errorContext() string {
+	var b strings.Builder
+	b.WriteString(e.Line + "\n")
+	if e.Close.IsValid() {
+		e.spanError(&b)
+	} else {
+		col := e.Open.Column - 1
+		for k := 0; k < col; k++ {
+			if k >= col-4 && k != col-1 {
+				b.WriteByte('=')
+			} else {
+				b.WriteByte(' ')
+			}
+		}
+		b.WriteString("^ ===")
+	}
+	return b.String()
+}
+
+func (e *LocalizedError) spanError(b *strings.Builder) {
+	col := e.Open.Column - 1
+	b.WriteString(strings.Repeat(" ", col))
+	end := len(e.Line) - col
+	if e.Open.Line == e.Close.Line {
+		end = e.Close.Column - col
+	}
+	b.WriteString(strings.Repeat("~", end))
+}
+
+type LocalizedErrors []*LocalizedError
+
+func (e LocalizedErrors) Error() string {
+	var b strings.Builder
+	for i, err := range e {
+		if i != 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(err.Error())
+	}
+	return b.String()
+}

--- a/compiler/parser/parser_test.go
+++ b/compiler/parser/parser_test.go
@@ -40,7 +40,7 @@ func searchForZed() ([]string, error) {
 }
 
 func parseOp(z string) ([]byte, error) {
-	o, err := compiler.Parse(z)
+	o, _, err := compiler.Parse(z)
 	if err != nil {
 		return nil, err
 	}

--- a/compiler/parser/source.go
+++ b/compiler/parser/source.go
@@ -1,0 +1,110 @@
+package parser
+
+import (
+	"bytes"
+	"os"
+	"sort"
+)
+
+// ConcatSource concatenates the source files in filenames followed by src,
+// returning the result and a corresponding slice of SourceInfos.
+func ConcatSource(filenames []string, src string) (*SourceSet, error) {
+	var b bytes.Buffer
+	set := new(SourceSet)
+	for _, f := range filenames {
+		bb, err := os.ReadFile(f)
+		if err != nil {
+			return nil, err
+		}
+		set.Sources = append(set.Sources, newSourceInfo(f, b.Len(), bb))
+		b.Write(bb)
+		b.WriteByte('\n')
+	}
+	if b.Len() == 0 && src == "" {
+		src = "*"
+	}
+	set.Sources = append(set.Sources, newSourceInfo("", b.Len(), []byte(src)))
+	b.WriteString(src)
+	set.Contents = b.Bytes()
+	return set, nil
+}
+
+type SourceSet struct {
+	Contents []byte
+	Sources  []*SourceInfo
+}
+
+func (s *SourceSet) SourceOf(pos int) *SourceInfo {
+	i := sort.Search(len(s.Sources), func(i int) bool { return s.Sources[i].start > pos }) - 1
+	return s.Sources[i]
+}
+
+// SourceInfo holds source file offsets.
+type SourceInfo struct {
+	filename string
+	lines    []int
+	size     int
+	start    int
+}
+
+func newSourceInfo(filename string, start int, src []byte) *SourceInfo {
+	var lines []int
+	line := 0
+	for offset, b := range src {
+		if line >= 0 {
+			lines = append(lines, line)
+		}
+		line = -1
+		if b == '\n' {
+			line = offset + 1
+		}
+	}
+	return &SourceInfo{
+		filename: filename,
+		lines:    lines,
+		size:     len(src),
+		start:    start,
+	}
+}
+
+func (s *SourceInfo) Position(pos int) (string, Position) {
+	if pos < 0 {
+		return "", Position{-1, -1, -1, -1}
+	}
+	offset := pos - s.start
+	i := searchLine(s.lines, offset)
+	return s.filename, Position{
+		Pos:    pos,
+		Offset: offset,
+		Line:   i + 1,
+		Column: offset - s.lines[i] + 1,
+	}
+}
+
+func (s *SourceInfo) LineOfPos(set *SourceSet, pos int) string {
+	i := searchLine(s.lines, pos-s.start)
+	start := s.lines[i]
+	end := s.size
+	if i+1 < len(s.lines) {
+		end = s.lines[i+1]
+	}
+	b := set.Contents[s.start+start : s.start+end]
+	if b[len(b)-1] == '\n' {
+		b = b[:len(b)-1]
+	}
+	return string(b)
+}
+
+func searchLine(lines []int, offset int) int {
+	return sort.Search(len(lines), func(i int) bool { return lines[i] > offset }) - 1
+
+}
+
+type Position struct {
+	Pos    int `json:"pos"`    // Offset relative to SourceSet.
+	Offset int `json:"offset"` // Offset relative to file start.
+	Line   int `json:"line"`   // 1-based line number.
+	Column int `json:"column"` // 1-based column number.
+}
+
+func (p Position) IsValid() bool { return p.Pos >= 0 }

--- a/compiler/parser/ztests/syntax-error.yaml
+++ b/compiler/parser/ztests/syntax-error.yaml
@@ -8,6 +8,6 @@ inputs:
 outputs:
   - name: stderr
     data: |
-      zq: error parsing Zed at column 12:
+      zq: error parsing Zed (line 1, column 12):
       count() by ,x,y
              === ^ ===

--- a/docs/tutorials/schools.md
+++ b/docs/tutorials/schools.md
@@ -229,7 +229,7 @@ zq -z 'Defunct=' *.zson
 ```
 produces
 ```mdtest-output
-zq: error parsing Zed at column 8:
+zq: error parsing Zed (line 1, column 8):
 Defunct=
    === ^ ===
 ```

--- a/fuzz/fuzz.go
+++ b/fuzz/fuzz.go
@@ -95,7 +95,7 @@ func RunQuery(t testing.TB, zctx *zed.Context, readers []zio.Reader, querySource
 	// Compile query
 	engine := mock.NewMockEngine(gomock.NewController(t))
 	comp := compiler.NewFileSystemCompiler(engine)
-	ast, err := compiler.Parse(querySource)
+	ast, _, err := compiler.Parse(querySource)
 	if err != nil {
 		t.Skipf("%v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/x448/float16 v0.8.4
 	github.com/yuin/goldmark v1.4.13
+	go.uber.org/multierr v1.8.0
 	go.uber.org/zap v1.23.0
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	golang.org/x/sync v0.4.0
@@ -67,7 +68,6 @@ require (
 	github.com/zeebo/xxh3 v1.0.2 // indirect
 	go.opentelemetry.io/otel v0.16.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
-	go.uber.org/multierr v1.8.0 // indirect
 	golang.org/x/mod v0.13.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/tools v0.14.0 // indirect

--- a/lake/api/local.go
+++ b/lake/api/local.go
@@ -113,13 +113,13 @@ func (l *local) Query(ctx context.Context, head *lakeparse.Commitish, src string
 }
 
 func (l *local) QueryWithControl(ctx context.Context, head *lakeparse.Commitish, src string, srcfiles ...string) (zbuf.ProgressReadCloser, error) {
-	flowgraph, err := l.compiler.Parse(src, srcfiles...)
+	flowgraph, set, err := l.compiler.Parse(src, srcfiles...)
 	if err != nil {
-		return nil, err
+		return nil, set.LocalizeError(err)
 	}
 	q, err := runtime.CompileLakeQuery(ctx, zed.NewContext(), l.compiler, flowgraph, head)
 	if err != nil {
-		return nil, err
+		return nil, set.LocalizeError(err)
 	}
 	return runtime.AsProgressReadCloser(q), nil
 }
@@ -173,7 +173,7 @@ func (l *local) Delete(ctx context.Context, poolID ksuid.KSUID, branchName strin
 }
 
 func (l *local) DeleteWhere(ctx context.Context, poolID ksuid.KSUID, branchName, src string, commit api.CommitMessage) (ksuid.KSUID, error) {
-	op, err := l.compiler.Parse(src)
+	op, _, err := l.compiler.Parse(src)
 	if err != nil {
 		return ksuid.Nil, err
 	}

--- a/lake/ztests/query-parse-error.yaml
+++ b/lake/ztests/query-parse-error.yaml
@@ -34,34 +34,34 @@ outputs:
   - name: stderr
     data: |
       =1=
-      error parsing Zed at column 11:
+      error parsing Zed (line 1, column 11):
       from test \ count()
             === ^ ===
       =2=
-      error parsing Zed at line 2, column 6:
+      error parsing Zed (line 2, column 6):
       test \ count()
        === ^ ===
       =3=
-      error parsing Zed at column 11:
+      error parsing Zed (line 1, column 11):
       from test \ count()
             === ^ ===
       =4=
-      error parsing Zed at line 2, column 6:
+      error parsing Zed (line 2, column 6):
       test \ count()
        === ^ ===
       =5=
-      error parsing Zed in bad-single-line.zed at line 1, column 11:
+      error parsing Zed (bad-single-line.zed: line 1, column 11):
       from test \ count()
             === ^ ===
       =6=
-      error parsing Zed in bad-multiple-lines.zed at line 2, column 6:
+      error parsing Zed (bad-multiple-lines.zed: line 2, column 6):
       test \ count()
        === ^ ===
       =7=
-      error parsing Zed in bad-single-line.zed at line 1, column 11:
+      error parsing Zed (bad-single-line.zed: line 1, column 11):
       from test \ count()
             === ^ ===
       =8=
-      error parsing Zed in bad-multiple-lines.zed at line 2, column 6:
+      error parsing Zed (bad-multiple-lines.zed: line 2, column 6):
       test \ count()
        === ^ ===

--- a/runtime/compiler.go
+++ b/runtime/compiler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/compiler/ast"
+	"github.com/brimdata/zed/compiler/parser"
 	"github.com/brimdata/zed/lakeparse"
 	"github.com/brimdata/zed/zbuf"
 	"github.com/brimdata/zed/zio"
@@ -16,7 +17,7 @@ type Compiler interface {
 	NewQuery(*Context, ast.Seq, []zio.Reader) (Query, error)
 	NewLakeQuery(*Context, ast.Seq, int, *lakeparse.Commitish) (Query, error)
 	NewLakeDeleteQuery(*Context, ast.Seq, *lakeparse.Commitish) (DeleteQuery, error)
-	Parse(string, ...string) (ast.Seq, error)
+	Parse(string, ...string) (ast.Seq, *parser.SourceSet, error)
 }
 
 type Query interface {

--- a/runtime/sam/expr/filter_test.go
+++ b/runtime/sam/expr/filter_test.go
@@ -51,7 +51,7 @@ func runCasesHelper(t *testing.T, record string, cases []testcase, expectBufferF
 	for _, c := range cases {
 		t.Run(c.filter, func(t *testing.T) {
 			t.Helper()
-			p, err := compiler.Parse(c.filter)
+			p, _, err := compiler.Parse(c.filter)
 			require.NoError(t, err, "filter: %q", c.filter)
 			job, err := compiler.NewJob(runtime.DefaultContext(), p, nil, nil)
 			require.NoError(t, err, "filter: %q", c.filter)
@@ -401,6 +401,6 @@ func TestFilters(t *testing.T) {
 
 func TestBadFilter(t *testing.T) {
 	t.Parallel()
-	_, err := compiler.Parse(`s matches \xa8*`)
+	_, _, err := compiler.Parse(`s matches \xa8*`)
 	require.Error(t, err)
 }

--- a/runtime/sam/op/groupby/groupby_test.go
+++ b/runtime/sam/op/groupby/groupby_test.go
@@ -103,7 +103,7 @@ func TestGroupbyStreamingSpill(t *testing.T) {
 	}
 
 	runOne := func(inputSortKey string) []string {
-		proc, err := compiler.Parse("count() by every(1s), ip")
+		proc, _, err := compiler.Parse("count() by every(1s), ip")
 		assert.NoError(t, err)
 
 		zctx := zed.NewContext()

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -51,14 +51,14 @@ func handleQuery(c *Core, w *ResponseWriter, r *Request) {
 	// The client must look at the return code and interpret the result
 	// accordingly and when it sees a ZNG error after underway,
 	// the error should be relay that to the caller/user.
-	query, err := c.compiler.Parse(req.Query)
+	query, set, err := c.compiler.Parse(req.Query)
 	if err != nil {
-		w.Error(srverr.ErrInvalid(err))
+		w.Error(srverr.ErrInvalid(set.LocalizeError(err)))
 		return
 	}
 	flowgraph, err := runtime.CompileLakeQuery(r.Context(), zed.NewContext(), c.compiler, query, &req.Head)
 	if err != nil {
-		w.Error(srverr.ErrInvalid(err))
+		w.Error(srverr.ErrInvalid(set.LocalizeError(err)))
 		return
 	}
 	flusher, _ := w.ResponseWriter.(http.Flusher)
@@ -162,9 +162,9 @@ func handleCompile(c *Core, w *ResponseWriter, r *Request) {
 	if !r.Unmarshal(w, &req) {
 		return
 	}
-	ast, err := c.compiler.Parse(req.Query)
+	ast, set, err := c.compiler.Parse(req.Query)
 	if err != nil {
-		w.Error(srverr.ErrInvalid(err))
+		w.Error(set.LocalizeError(err))
 		return
 	}
 	w.Respond(http.StatusOK, ast)
@@ -553,7 +553,7 @@ func handleDelete(c *Core, w *ResponseWriter, r *Request) {
 			return
 		}
 		var program ast.Seq
-		if program, err = c.compiler.Parse(payload.Where); err != nil {
+		if program, _, err = c.compiler.Parse(payload.Where); err != nil {
 			w.Error(srverr.ErrInvalid(err))
 			return
 		}

--- a/service/request.go
+++ b/service/request.go
@@ -303,9 +303,9 @@ func errorResponse(e error) (status int, ae *api.Error) {
 	status = http.StatusInternalServerError
 	ae = &api.Error{Type: "Error"}
 
-	var pe *parser.Error
-	if errors.As(e, &pe) {
-		ae.Info = map[string]int{"parse_error_offset": pe.Offset}
+	var lerr parser.LocalizedErrors
+	if errors.As(e, &lerr) {
+		ae.Info = lerr
 	}
 
 	var ze *srverr.Error

--- a/service/ztests/compile.yaml
+++ b/service/ztests/compile.yaml
@@ -8,4 +8,4 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      {info:{parse_error_offset:6}}
+      {info:[{kind:"LocalizedError",filename:"",line:"count(",open:{pos:6,offset:6,line:1,column:7},close:{pos:-1,offset:-1,line:-1,column:-1},error:"error parsing Zed"}]}

--- a/service/ztests/query-parse-error.yaml
+++ b/service/ztests/query-parse-error.yaml
@@ -34,34 +34,34 @@ outputs:
   - name: stderr
     data: |
       =1=
-      error parsing Zed at column 11:
+      error parsing Zed (line 1, column 11):
       from test \ count()
             === ^ ===
       =2=
-      error parsing Zed at line 2, column 6:
+      error parsing Zed (line 2, column 6):
       test \ count()
        === ^ ===
       =3=
-      error parsing Zed at column 11:
+      error parsing Zed (line 1, column 11):
       from test \ count()
             === ^ ===
       =4=
-      error parsing Zed at line 2, column 6:
+      error parsing Zed (line 2, column 6):
       test \ count()
        === ^ ===
       =5=
-      error parsing Zed in bad-single-line.zed at line 1, column 11:
+      error parsing Zed (bad-single-line.zed: line 1, column 11):
       from test \ count()
             === ^ ===
       =6=
-      error parsing Zed in bad-multiple-lines.zed at line 2, column 6:
+      error parsing Zed (bad-multiple-lines.zed: line 2, column 6):
       test \ count()
        === ^ ===
       =7=
-      error parsing Zed in bad-single-line.zed at line 1, column 11:
+      error parsing Zed (bad-single-line.zed: line 1, column 11):
       from test \ count()
             === ^ ===
       =8=
-      error parsing Zed in bad-multiple-lines.zed at line 2, column 6:
+      error parsing Zed (bad-multiple-lines.zed: line 2, column 6):
       test \ count()
        === ^ ===

--- a/zed_test.go
+++ b/zed_test.go
@@ -136,7 +136,7 @@ func runOneBoomerang(t *testing.T, format, data string) {
 	dataReader := zio.Reader(dataReadCloser)
 	if format == "parquet" {
 		// Fuse for formats that require uniform values.
-		proc, err := compiler.NewCompiler().Parse("fuse")
+		proc, _, err := compiler.NewCompiler().Parse("fuse")
 		require.NoError(t, err)
 		rctx := runtime.NewContext(context.Background(), zctx)
 		q, err := compiler.NewCompiler().NewQuery(rctx, proc, []zio.Reader{dataReadCloser})

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -480,7 +480,7 @@ func runzq(path, zedProgram, input string, outputFlags []string, inputFlags []st
 		// tests.
 		return outbuf.String(), errbuf.String(), err
 	}
-	proc, err := compiler.NewCompiler().Parse(zedProgram)
+	proc, _, err := compiler.NewCompiler().Parse(zedProgram)
 	if err != nil {
 		return "", err.Error(), err
 	}


### PR DESCRIPTION
This commit introduces localized errors- functionality for tying generated errors to a location in a Zed source set. A version of this somewhat exists currently but it is limited in that it is specific only to Parse errors and currently only supports returning a single error. In this pr localized errors are only used for parser errors but a follow up commit will enable localized errors for semantic errors as well.