### PR TITLE
Add positional information to semantic errors

### DIFF
--- a/cli/zq/command.go
+++ b/cli/zq/command.go
@@ -129,7 +129,7 @@ func (c *Command) Run(args []string) error {
 		// Prevent ParseSourcesAndInputs from treating args[0] as a path.
 		args = append(args, "-")
 	}
-	paths, flowgraph, null, err := c.queryFlags.ParseSourcesAndInputs(args)
+	paths, flowgraph, sset, null, err := c.queryFlags.ParseSourcesAndInputs(args)
 	if err != nil {
 		return fmt.Errorf("zq: %w", err)
 	}
@@ -154,7 +154,7 @@ func (c *Command) Run(args []string) error {
 		return err
 	}
 	comp := compiler.NewFileSystemCompiler(local)
-	query, err := runtime.CompileQuery(ctx, zctx, comp, flowgraph, readers)
+	query, err := runtime.CompileQuery(ctx, zctx, comp, flowgraph, sset, readers)
 	if err != nil {
 		return err
 	}

--- a/cmd/zed/log/command.go
+++ b/cmd/zed/log/command.go
@@ -7,6 +7,7 @@ import (
 	"github.com/brimdata/zed/cli/outputflags"
 	"github.com/brimdata/zed/cli/poolflags"
 	"github.com/brimdata/zed/cmd/zed/root"
+	"github.com/brimdata/zed/compiler/parser"
 	"github.com/brimdata/zed/pkg/charm"
 	"github.com/brimdata/zed/pkg/storage"
 	"github.com/brimdata/zed/zio"
@@ -70,6 +71,9 @@ func (c *Command) Run(args []string) error {
 	defer w.Close()
 	q, err := lake.Query(ctx, nil, query)
 	if err != nil {
+		if list := (parser.ErrorList)(nil); errors.As(err, &list) && len(list) == 1 {
+			return errors.New(list[0].Msg)
+		}
 		return err
 	}
 	defer q.Close()

--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -110,7 +110,7 @@ func (c *Call) End() int {
 	if c.Where != nil {
 		return c.Where.End()
 	}
-	return c.Rparen
+	return c.Rparen + 1
 }
 
 type Cast struct {
@@ -180,7 +180,7 @@ type Regexp struct {
 }
 
 func (r *Regexp) Pos() int { return r.PatternPos }
-func (r *Regexp) End() int { return r.PatternPos + len(r.Pattern) }
+func (r *Regexp) End() int { return r.PatternPos + len(r.Pattern) + 2 }
 
 type String struct {
 	Kind    string `json:"kind" unpack:""`
@@ -432,9 +432,9 @@ type (
 		NullsFirst bool        `json:"nullsfirst"`
 	}
 	Cut struct {
-		Kind       string       `json:"kind" unpack:""`
-		KeywordPos int          `json:"keyword_pos"`
-		Args       []Assignment `json:"args"`
+		Kind       string      `json:"kind" unpack:""`
+		KeywordPos int         `json:"keyword_pos"`
+		Args       Assignments `json:"args"`
 	}
 	Drop struct {
 		Kind       string `json:"kind" unpack:""`
@@ -471,10 +471,10 @@ type (
 		Kind string `json:"kind" unpack:""`
 		// StartPos is not called KeywordPos for Summarize since the "summarize"
 		// keyword is optional.
-		StartPos int          `json:"start_pos"`
-		Limit    int          `json:"limit"`
-		Keys     []Assignment `json:"keys"`
-		Aggs     []Assignment `json:"aggs"`
+		StartPos int         `json:"start_pos"`
+		Limit    int         `json:"limit"`
+		Keys     Assignments `json:"keys"`
+		Aggs     Assignments `json:"aggs"`
 	}
 	Top struct {
 		Kind       string `json:"kind" unpack:""`
@@ -484,9 +484,9 @@ type (
 		Flush      bool   `json:"flush"`
 	}
 	Put struct {
-		Kind       string       `json:"kind" unpack:""`
-		KeywordPos int          `json:"keyword_pos"`
-		Args       []Assignment `json:"args"`
+		Kind       string      `json:"kind" unpack:""`
+		KeywordPos int         `json:"keyword_pos"`
+		Args       Assignments `json:"args"`
 	}
 	Merge struct {
 		Kind       string `json:"kind" unpack:""`
@@ -520,8 +520,8 @@ type (
 	// is unknown: It could be a Summarize or Put operator. This will be
 	// determined in the semantic phase.
 	OpAssignment struct {
-		Kind        string       `json:"kind" unpack:""`
-		Assignments []Assignment `json:"assignments"`
+		Kind        string      `json:"kind" unpack:""`
+		Assignments Assignments `json:"assignments"`
 	}
 	// An OpExpr operator is an expression that appears as an operator
 	// and requires semantic analysis to determine if it is a filter, a yield,
@@ -531,22 +531,22 @@ type (
 		Expr Expr   `json:"expr"`
 	}
 	Rename struct {
-		Kind       string       `json:"kind" unpack:""`
-		KeywordPos int          `json:"keyword_pos"`
-		Args       []Assignment `json:"args"`
+		Kind       string      `json:"kind" unpack:""`
+		KeywordPos int         `json:"keyword_pos"`
+		Args       Assignments `json:"args"`
 	}
 	Fuse struct {
 		Kind       string `json:"kind" unpack:""`
 		KeywordPos int    `json:"keyword_pos"`
 	}
 	Join struct {
-		Kind       string       `json:"kind" unpack:""`
-		KeywordPos int          `json:"keyword_pos"`
-		Style      string       `json:"style"`
-		RightInput Seq          `json:"right_input"`
-		LeftKey    Expr         `json:"left_key"`
-		RightKey   Expr         `json:"right_key"`
-		Args       []Assignment `json:"args"`
+		Kind       string      `json:"kind" unpack:""`
+		KeywordPos int         `json:"keyword_pos"`
+		Style      string      `json:"style"`
+		RightInput Seq         `json:"right_input"`
+		LeftKey    Expr        `json:"left_key"`
+		RightKey   Expr        `json:"right_key"`
+		Args       Assignments `json:"args"`
 	}
 	Sample struct {
 		Kind       string `json:"kind" unpack:""`
@@ -678,7 +678,12 @@ func (a *Assignment) Pos() int {
 	return a.RHS.Pos()
 }
 
-func (a *Assignment) End() int { return a.RHS.Pos() }
+func (a *Assignment) End() int { return a.RHS.End() }
+
+type Assignments []Assignment
+
+func (a Assignments) Pos() int { return a[0].Pos() }
+func (a Assignments) End() int { return a[len(a)-1].End() }
 
 // Def is like Assignment but the LHS is an identifier that may be later
 // referenced.  This is used for const blocks in Sequential and var blocks

--- a/compiler/ast/dag/expr.go
+++ b/compiler/ast/dag/expr.go
@@ -30,6 +30,11 @@ type (
 		LHS  Expr   `json:"lhs"`
 		RHS  Expr   `json:"rhs"`
 	}
+	// A BadExpr node is a placeholder for an expression containing semantic
+	// errors.
+	BadExpr struct {
+		Kind string `json:"kind" unpack:""`
+	}
 	BinaryExpr struct {
 		Kind string `json:"kind" unpack:""`
 		Op   string `json:"op"`
@@ -131,6 +136,7 @@ type (
 func (*Agg) ExprDAG()          {}
 func (*ArrayExpr) ExprDAG()    {}
 func (*Assignment) ExprDAG()   {}
+func (*BadExpr) ExprDAG()      {}
 func (*BinaryExpr) ExprDAG()   {}
 func (*Call) ExprDAG()         {}
 func (*Conditional) ExprDAG()  {}

--- a/compiler/ast/dag/op.go
+++ b/compiler/ast/dag/op.go
@@ -26,6 +26,11 @@ type Seq []Op
 // Ops
 
 type (
+	// A BadOp node is a placeholder for an expression containing semantic
+	// errors.
+	BadOp struct {
+		Kind string `json:"kind" unpack:""`
+	}
 	Combine struct {
 		Kind string `json:"kind" unpack:""`
 	}
@@ -281,6 +286,7 @@ type (
 	}
 )
 
+func (*BadOp) OpNode()     {}
 func (*Fork) OpNode()      {}
 func (*Scatter) OpNode()   {}
 func (*Switch) OpNode()    {}

--- a/compiler/ast/dag/unpack.go
+++ b/compiler/ast/dag/unpack.go
@@ -10,6 +10,8 @@ var unpacker = unpack.New(
 	Agg{},
 	ArrayExpr{},
 	Assignment{},
+	BadOp{},
+	BadExpr{},
 	BinaryExpr{},
 	Call{},
 	Combine{},

--- a/compiler/parser/parser_test.go
+++ b/compiler/parser/parser_test.go
@@ -40,7 +40,7 @@ func searchForZed() ([]string, error) {
 }
 
 func parseOp(z string) ([]byte, error) {
-	o, err := compiler.Parse(z)
+	o, _, err := compiler.Parse(z)
 	if err != nil {
 		return nil, err
 	}

--- a/compiler/semantic/expr.go
+++ b/compiler/semantic/expr.go
@@ -16,33 +16,34 @@ import (
 	"github.com/brimdata/zed/zson"
 )
 
-func (a *analyzer) semExpr(e ast.Expr) (dag.Expr, error) {
+func (a *analyzer) semExpr(e ast.Expr) dag.Expr {
 	switch e := e.(type) {
 	case nil:
-		return nil, errors.New("semantic analysis: illegal null value encountered in AST")
+		panic("semantic analysis: illegal null value encountered in AST")
 	case *ast.Regexp:
 		return &dag.RegexpSearch{
 			Kind:    "RegexpSearch",
 			Pattern: e.Pattern,
 			Expr:    pathOf("this"),
-		}, nil
+		}
 	case *ast.Glob:
 		return &dag.RegexpSearch{
 			Kind:    "RegexpSearch",
 			Pattern: reglob.Reglob(e.Pattern),
 			Expr:    pathOf("this"),
-		}, nil
+		}
 	case *ast.Grep:
 		return a.semGrep(e)
 	case *astzed.Primitive:
 		val, err := zson.ParsePrimitive(a.arena, e.Type, e.Text)
 		if err != nil {
-			return nil, err
+			a.error(e, err)
+			return badExpr()
 		}
 		return &dag.Literal{
 			Kind:  "Literal",
 			Value: zson.FormatValue(val),
-		}, nil
+		}
 	case *ast.ID:
 		return a.semID(e)
 	case *ast.Term:
@@ -51,109 +52,77 @@ func (a *analyzer) semExpr(e ast.Expr) (dag.Expr, error) {
 		case *astzed.Primitive:
 			v, err := zson.ParsePrimitive(a.arena, t.Type, t.Text)
 			if err != nil {
-				return nil, err
+				a.error(e, err)
+				return badExpr()
 			}
 			val = zson.FormatValue(v)
 		case *astzed.TypeValue:
 			tv, err := a.semType(t.Value)
 			if err != nil {
-				return nil, err
+				a.error(e, err)
+				return badExpr()
 			}
 			val = "<" + tv + ">"
 		default:
-			return nil, fmt.Errorf("unexpected term value: %s", e.Kind)
+			panic(fmt.Errorf("unexpected term value: %s", e.Kind))
 		}
 		return &dag.Search{
 			Kind:  "Search",
 			Text:  e.Text,
 			Value: val,
 			Expr:  pathOf("this"),
-		}, nil
-	case *ast.UnaryExpr:
-		expr, err := a.semExpr(e.Operand)
-		if err != nil {
-			return nil, err
 		}
+	case *ast.UnaryExpr:
 		return &dag.UnaryExpr{
 			Kind:    "UnaryExpr",
 			Op:      e.Op,
-			Operand: expr,
-		}, nil
+			Operand: a.semExpr(e.Operand),
+		}
 	case *ast.BinaryExpr:
 		return a.semBinary(e)
 	case *ast.Conditional:
-		cond, err := a.semExpr(e.Cond)
-		if err != nil {
-			return nil, err
-		}
-		thenExpr, err := a.semExpr(e.Then)
-		if err != nil {
-			return nil, err
-		}
-		elseExpr, err := a.semExpr(e.Else)
-		if err != nil {
-			return nil, err
-		}
+		cond := a.semExpr(e.Cond)
+		thenExpr := a.semExpr(e.Then)
+		elseExpr := a.semExpr(e.Else)
 		return &dag.Conditional{
 			Kind: "Conditional",
 			Cond: cond,
 			Then: thenExpr,
 			Else: elseExpr,
-		}, nil
+		}
 	case *ast.Call:
 		return a.semCall(e)
 	case *ast.Cast:
-		expr, err := a.semExpr(e.Expr)
-		if err != nil {
-			return nil, err
-		}
-		typ, err := a.semExpr(e.Type)
-		if err != nil {
-			return nil, err
-		}
+		expr := a.semExpr(e.Expr)
+		typ := a.semExpr(e.Type)
 		return &dag.Call{
 			Kind: "Call",
 			Name: "cast",
 			Args: []dag.Expr{expr, typ},
-		}, nil
+		}
 	case *ast.IndexExpr:
-		expr, err := a.semExpr(e.Expr)
-		if err != nil {
-			return nil, err
-		}
-		index, err := a.semExpr(e.Index)
-		if err != nil {
-			return nil, err
-		}
+		expr := a.semExpr(e.Expr)
+		index := a.semExpr(e.Index)
 		// If expr is a path and index is a string, then just extend the path.
 		if path := a.isIndexOfThis(expr, index); path != nil {
-			return path, nil
+			return path
 		}
 		return &dag.IndexExpr{
 			Kind:  "IndexExpr",
 			Expr:  expr,
 			Index: index,
-		}, nil
+		}
 	case *ast.SliceExpr:
-		expr, err := a.semExpr(e.Expr)
-		if err != nil {
-			return nil, err
-		}
+		expr := a.semExpr(e.Expr)
 		// XXX Literal indices should be type checked as int.
-		from, err := a.semExprNullable(e.From)
-		if err != nil {
-			return nil, err
-		}
-		to, err := a.semExprNullable(e.To)
-		if err != nil {
-			return nil, err
-		}
+		from := a.semExprNullable(e.From)
+		to := a.semExprNullable(e.To)
 		return &dag.SliceExpr{
 			Kind: "SliceExpr",
 			Expr: expr,
 			From: from,
 			To:   to,
-		}, nil
+		}
 	case *astzed.TypeValue:
 		typ, err := a.semType(e.Value)
 		if err != nil {
@@ -167,32 +136,28 @@ func (a *analyzer) semExpr(e ast.Expr) (dag.Expr, error) {
 			// complaining about the type not existing.
 			// XXX See issue #3413
 			if e := semDynamicType(e.Value); e != nil {
-				return e, nil
+				return e
 			}
-			return nil, err
+			a.error(e, err)
+			return badExpr()
 		}
 		return &dag.Literal{
 			Kind:  "Literal",
 			Value: "<" + typ + ">",
-		}, nil
+		}
 	case *ast.Agg:
-		expr, err := a.semExprNullable(e.Expr)
-		if err != nil {
-			return nil, err
-		}
+		expr := a.semExprNullable(e.Expr)
 		if expr == nil && e.Name != "count" {
-			return nil, fmt.Errorf("aggregator '%s' requires argument", e.Name)
+			a.error(e, fmt.Errorf("aggregator '%s' requires argument", e.Name))
+			return badExpr()
 		}
-		where, err := a.semExprNullable(e.Where)
-		if err != nil {
-			return nil, err
-		}
+		where := a.semExprNullable(e.Where)
 		return &dag.Agg{
 			Kind:  "Agg",
 			Name:  e.Name,
 			Expr:  expr,
 			Where: where,
-		}, nil
+		}
 	case *ast.RecordExpr:
 		fields := map[string]struct{}{}
 		var out []dag.RecordElem
@@ -200,13 +165,11 @@ func (a *analyzer) semExpr(e ast.Expr) (dag.Expr, error) {
 			switch elem := elem.(type) {
 			case *ast.Field:
 				if _, ok := fields[elem.Name]; ok {
-					return nil, fmt.Errorf("record expression: %w", &zed.DuplicateFieldError{Name: elem.Name})
+					a.error(elem, fmt.Errorf("record expression: %w", &zed.DuplicateFieldError{Name: elem.Name}))
+					continue
 				}
 				fields[elem.Name] = struct{}{}
-				e, err := a.semExpr(elem.Value)
-				if err != nil {
-					return nil, err
-				}
+				e := a.semExpr(elem.Value)
 				out = append(out, &dag.Field{
 					Kind:  "Field",
 					Name:  elem.Name,
@@ -214,23 +177,18 @@ func (a *analyzer) semExpr(e ast.Expr) (dag.Expr, error) {
 				})
 			case *ast.ID:
 				if _, ok := fields[elem.Name]; ok {
-					return nil, fmt.Errorf("record expression: %w", &zed.DuplicateFieldError{Name: elem.Name})
+					a.error(elem, fmt.Errorf("record expression: %w", &zed.DuplicateFieldError{Name: elem.Name}))
+					continue
 				}
 				fields[elem.Name] = struct{}{}
-				v, err := a.semID(elem)
-				if err != nil {
-					return nil, err
-				}
+				v := a.semID(elem)
 				out = append(out, &dag.Field{
 					Kind:  "Field",
 					Name:  elem.Name,
 					Value: v,
 				})
 			case *ast.Spread:
-				e, err := a.semExpr(elem.Expr)
-				if err != nil {
-					return nil, err
-				}
+				e := a.semExpr(elem.Expr)
 				out = append(out, &dag.Spread{
 					Kind: "Spread",
 					Expr: e,
@@ -240,71 +198,49 @@ func (a *analyzer) semExpr(e ast.Expr) (dag.Expr, error) {
 		return &dag.RecordExpr{
 			Kind:  "RecordExpr",
 			Elems: out,
-		}, nil
-	case *ast.ArrayExpr:
-		elems, err := a.semVectorElems(e.Elems)
-		if err != nil {
-			return nil, err
 		}
+	case *ast.ArrayExpr:
+		elems := a.semVectorElems(e.Elems)
 		return &dag.ArrayExpr{
 			Kind:  "ArrayExpr",
 			Elems: elems,
-		}, nil
-	case *ast.SetExpr:
-		elems, err := a.semVectorElems(e.Elems)
-		if err != nil {
-			return nil, err
 		}
+	case *ast.SetExpr:
+		elems := a.semVectorElems(e.Elems)
 		return &dag.SetExpr{
 			Kind:  "SetExpr",
 			Elems: elems,
-		}, nil
+		}
 	case *ast.MapExpr:
 		var entries []dag.Entry
 		for _, entry := range e.Entries {
-			key, err := a.semExpr(entry.Key)
-			if err != nil {
-				return nil, err
-			}
-			val, err := a.semExpr(entry.Value)
-			if err != nil {
-				return nil, err
-			}
+			key := a.semExpr(entry.Key)
+			val := a.semExpr(entry.Value)
 			entries = append(entries, dag.Entry{Key: key, Value: val})
 		}
 		return &dag.MapExpr{
 			Kind:    "MapExpr",
 			Entries: entries,
-		}, nil
-	case *ast.OverExpr:
-		exprs, err := a.semExprs(e.Exprs)
-		if err != nil {
-			return nil, err
 		}
+	case *ast.OverExpr:
+		exprs := a.semExprs(e.Exprs)
 		if e.Body == nil {
-			return nil, errors.New("over expression missing lateral scope")
+			a.error(e, errors.New("over expression missing lateral scope"))
+			return badExpr()
 		}
 		a.enterScope()
 		defer a.exitScope()
-		locals, err := a.semVars(e.Locals)
-		if err != nil {
-			return nil, err
-		}
-		body, err := a.semSeq(e.Body)
-		if err != nil {
-			return nil, err
-		}
 		return &dag.OverExpr{
 			Kind:  "OverExpr",
-			Defs:  locals,
+			Defs:  a.semVars(e.Locals),
 			Exprs: exprs,
-			Body:  body,
-		}, nil
+			Body:  a.semSeq(e.Body),
+		}
 	}
-	return nil, fmt.Errorf("invalid expression type %T", e)
+	panic(errors.New("invalid expression type"))
 }
 
-func (a *analyzer) semID(id *ast.ID) (dag.Expr, error) {
+func (a *analyzer) semID(id *ast.ID) dag.Expr {
 	// We use static scoping here to see if an identifier is
 	// a "var" reference to the name or a field access
 	// and transform the AST node appropriately.  The resulting DAG
@@ -312,12 +248,13 @@ func (a *analyzer) semID(id *ast.ID) (dag.Expr, error) {
 	// one way or the other.
 	ref, err := a.scope.LookupExpr(id.Name)
 	if err != nil {
-		return nil, err
+		a.error(id, err)
+		return badExpr()
 	}
 	if ref != nil {
-		return ref, nil
+		return ref
 	}
-	return pathOf(id.Name), nil
+	return pathOf(id.Name)
 }
 
 func semDynamicType(tv astzed.Type) *dag.Call {
@@ -341,21 +278,15 @@ func dynamicTypeName(name string) *dag.Call {
 	}
 }
 
-func (a *analyzer) semGrep(grep *ast.Grep) (dag.Expr, error) {
+func (a *analyzer) semGrep(grep *ast.Grep) dag.Expr {
 	e := dag.Expr(&dag.This{Kind: "This"})
 	if grep.Expr != nil {
-		var err error
-		if e, err = a.semExpr(grep.Expr); err != nil {
-			return nil, err
-		}
+		e = a.semExpr(grep.Expr)
 	}
-	p, err := a.semExpr(grep.Pattern)
-	if err != nil {
-		return nil, err
-	}
+	p := a.semExpr(grep.Pattern)
 	if s, ok := p.(*dag.RegexpSearch); ok {
 		s.Expr = e
-		return s, nil
+		return s
 	}
 	if s, ok := a.isStringConst(p); ok {
 		return &dag.Search{
@@ -363,75 +294,66 @@ func (a *analyzer) semGrep(grep *ast.Grep) (dag.Expr, error) {
 			Text:  s,
 			Value: zson.QuotedString([]byte(s)),
 			Expr:  e,
-		}, nil
+		}
 	}
 	return &dag.Call{
 		Kind: "Call",
 		Name: "grep",
 		Args: []dag.Expr{p, e},
-	}, nil
+	}
 }
 
-func (a *analyzer) semRegexp(b *ast.BinaryExpr) (dag.Expr, error) {
+func (a *analyzer) semRegexp(b *ast.BinaryExpr) dag.Expr {
 	if b.Op != "~" {
-		return nil, nil
+		return nil
 	}
 	re, ok := b.RHS.(*ast.Regexp)
 	if !ok {
-		return nil, errors.New(`right-hand side of ~ expression must be a regular expression`)
+		a.error(b, errors.New(`right-hand side of ~ expression must be a regular expression`))
+		return badExpr()
 	}
 	if _, err := expr.CompileRegexp(re.Pattern); err != nil {
-		return nil, err
+		a.error(b.RHS, err)
+		return badExpr()
 	}
-	e, err := a.semExpr(b.LHS)
-	if err != nil {
-		return nil, err
-	}
+	e := a.semExpr(b.LHS)
 	return &dag.RegexpMatch{
 		Kind:    "RegexpMatch",
 		Pattern: re.Pattern,
 		Expr:    e,
-	}, nil
+	}
 }
 
-func (a *analyzer) semBinary(e *ast.BinaryExpr) (dag.Expr, error) {
-	if e, err := a.semRegexp(e); e != nil || err != nil {
-		return e, err
+func (a *analyzer) semBinary(e *ast.BinaryExpr) dag.Expr {
+	if e := a.semRegexp(e); e != nil {
+		return e
 	}
 	op := e.Op
 	if op == "." {
-		lhs, err := a.semExpr(e.LHS)
-		if err != nil {
-			return nil, err
-		}
+		lhs := a.semExpr(e.LHS)
 		id, ok := e.RHS.(*ast.ID)
 		if !ok {
-			return nil, errors.New("RHS of dot operator is not an identifier")
+			a.error(e, errors.New("RHS of dot operator is not an identifier"))
+			return badExpr()
 		}
 		if lhs, ok := lhs.(*dag.This); ok {
 			lhs.Path = append(lhs.Path, id.Name)
-			return lhs, nil
+			return lhs
 		}
 		return &dag.Dot{
 			Kind: "Dot",
 			LHS:  lhs,
 			RHS:  id.Name,
-		}, nil
+		}
 	}
-	lhs, err := a.semExpr(e.LHS)
-	if err != nil {
-		return nil, err
-	}
-	rhs, err := a.semExpr(e.RHS)
-	if err != nil {
-		return nil, err
-	}
+	lhs := a.semExpr(e.LHS)
+	rhs := a.semExpr(e.RHS)
 	return &dag.BinaryExpr{
 		Kind: "BinaryExpr",
 		Op:   e.Op,
 		LHS:  lhs,
 		RHS:  rhs,
-	}, nil
+	}
 }
 
 func (a *analyzer) isIndexOfThis(lhs, rhs dag.Expr) *dag.This {
@@ -452,151 +374,140 @@ func (a *analyzer) isStringConst(e dag.Expr) (field string, ok bool) {
 	return "", false
 }
 
-func (a *analyzer) semSlice(slice *ast.BinaryExpr) (*dag.BinaryExpr, error) {
-	sliceFrom, err := a.semExprNullable(slice.LHS)
-	if err != nil {
-		return nil, err
-	}
-	sliceTo, err := a.semExprNullable(slice.RHS)
-	if err != nil {
-		return nil, err
-	}
+func (a *analyzer) semSlice(slice *ast.BinaryExpr) *dag.BinaryExpr {
+	sliceFrom := a.semExprNullable(slice.LHS)
+	sliceTo := a.semExprNullable(slice.RHS)
 	return &dag.BinaryExpr{
 		Kind: "BinaryExpr",
 		Op:   ":",
 		LHS:  sliceFrom,
 		RHS:  sliceTo,
-	}, nil
+	}
 }
 
-func (a *analyzer) semExprNullable(e ast.Expr) (dag.Expr, error) {
+func (a *analyzer) semExprNullable(e ast.Expr) dag.Expr {
 	if e == nil {
-		return nil, nil
+		return nil
 	}
 	return a.semExpr(e)
 }
 
-func (a *analyzer) semCall(call *ast.Call) (dag.Expr, error) {
-	if e, err := a.maybeConvertAgg(call); e != nil || err != nil {
-		return e, err
+func (a *analyzer) semCall(call *ast.Call) dag.Expr {
+	if e := a.maybeConvertAgg(call); e != nil {
+		return e
 	}
 	if call.Where != nil {
-		return nil, fmt.Errorf("'where' clause on non-aggregation function: %s", call.Name)
+		a.error(call, errors.New("'where' clause on non-aggregation function"))
+		return badExpr()
 	}
-	exprs, err := a.semExprs(call.Args)
-	if err != nil {
-		return nil, fmt.Errorf("%s(): bad argument: %w", call.Name, err)
-	}
+	exprs := a.semExprs(call.Args)
 	name, nargs := call.Name, len(call.Args)
 	// Call could be to a user defined func. Check if we have a matching func in
 	// scope.
 	udf, err := a.scope.LookupExpr(name)
 	if err != nil {
-		return nil, err
+		a.error(call, err)
+		return badExpr()
 	}
 	switch {
 	// udf should be checked first since a udf can override builtin functions.
 	case udf != nil:
 		f, ok := udf.(*dag.Func)
 		if !ok {
-			return nil, fmt.Errorf("%s(): definition is not a function type: %T", name, udf)
+			a.error(call, errors.New("not a function"))
+			return badExpr()
 		}
 		if len(f.Params) != nargs {
-			return nil, fmt.Errorf("%s(): expects %d argument(s)", name, len(f.Params))
+			a.error(call, fmt.Errorf("call expects %d argument(s)", len(f.Params)))
+			return badExpr()
 		}
 	case zed.LookupPrimitive(name) != nil:
 		// Primitive function call, change this to a cast.
 		if err := function.CheckArgCount(nargs, 1, 1); err != nil {
-			return nil, fmt.Errorf("%s(): %w", name, err)
+			a.error(call, err)
+			return badExpr()
 		}
 		exprs = append(exprs, &dag.Literal{Kind: "Literal", Value: "<" + name + ">"})
 		name = "cast"
 	case expr.NewShaperTransform(name) != 0:
 		if err := function.CheckArgCount(nargs, 1, 2); err != nil {
-			return nil, fmt.Errorf("%s(): %w", name, err)
+			a.error(call, err)
+			return badExpr()
 		}
 		if nargs == 1 {
 			exprs = append([]dag.Expr{&dag.This{Kind: "This"}}, exprs...)
 		}
 	case name == "map":
 		if err := function.CheckArgCount(nargs, 2, 2); err != nil {
-			return nil, fmt.Errorf("%s(): %w", name, err)
+			a.error(call, err)
+			return badExpr()
 		}
 		id, ok := call.Args[1].(*ast.ID)
 		if !ok {
-			return nil, fmt.Errorf("%s(): second argument must be the identifier of a function", name)
+			a.error(call.Args[1], errors.New("second argument must be the identifier of a function"))
+			return badExpr()
 		}
-		inner, err := a.semCall(&ast.Call{
+		inner := a.semCall(&ast.Call{
 			Kind: "Call",
 			Name: id.Name,
 			Args: []ast.Expr{&ast.ID{Kind: "ID", Name: "this"}},
 		})
-		if err != nil {
-			return nil, err
-		}
 		return &dag.MapCall{
 			Kind:  "MapCall",
 			Expr:  exprs[0],
 			Inner: inner,
-		}, nil
+		}
 	default:
 		if _, _, err = function.New(a.zctx, name, nargs); err != nil {
-			return nil, fmt.Errorf("%s(): %w", name, err)
+			a.error(call, err)
+			return badExpr()
 		}
 	}
 	return &dag.Call{
 		Kind: "Call",
 		Name: name,
 		Args: exprs,
-	}, nil
+	}
 }
 
-func (a *analyzer) semExprs(in []ast.Expr) ([]dag.Expr, error) {
+func (a *analyzer) semExprs(in []ast.Expr) []dag.Expr {
 	exprs := make([]dag.Expr, 0, len(in))
 	for _, e := range in {
-		expr, err := a.semExpr(e)
-		if err != nil {
-			return nil, err
-		}
-		exprs = append(exprs, expr)
+		exprs = append(exprs, a.semExpr(e))
 	}
-	return exprs, nil
+	return exprs
 }
 
-func (a *analyzer) semAssignments(assignments []ast.Assignment) ([]dag.Assignment, error) {
+func (a *analyzer) semAssignments(assignments []ast.Assignment) []dag.Assignment {
 	out := make([]dag.Assignment, 0, len(assignments))
 	for _, e := range assignments {
-		a, err := a.semAssignment(e)
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, a)
+		out = append(out, a.semAssignment(e))
 	}
-	return out, nil
+	return out
 }
 
-func (a *analyzer) semAssignment(assign ast.Assignment) (dag.Assignment, error) {
-	rhs, err := a.semExpr(assign.RHS)
-	if err != nil {
-		return dag.Assignment{}, fmt.Errorf("right-hand side of assignment: %w", err)
-	}
+func (a *analyzer) semAssignment(assign ast.Assignment) dag.Assignment {
+	rhs := a.semExpr(assign.RHS)
 	var lhs dag.Expr
 	if assign.LHS == nil {
-		path, err := deriveLHSPath(rhs)
-		if err != nil {
-			return dag.Assignment{}, err
+		if path, err := deriveLHSPath(rhs); err != nil {
+			a.error(&assign, err)
+			lhs = badExpr()
+		} else {
+			lhs = &dag.This{Kind: "This", Path: path}
 		}
-		lhs = &dag.This{Kind: "This", Path: path}
-	} else if lhs, err = a.semExpr(assign.LHS); err != nil {
-		return dag.Assignment{}, fmt.Errorf("left-hand side of assignment: %w", err)
+	} else {
+		lhs = a.semExpr(assign.LHS)
 	}
 	if !isLval(lhs) {
-		return dag.Assignment{}, errors.New("illegal left-hand side of assignment")
+		a.error(&assign, errors.New("illegal left-hand side of assignment"))
+		lhs = badExpr()
 	}
 	if this, ok := lhs.(*dag.This); ok && len(this.Path) == 0 {
-		return dag.Assignment{}, errors.New("cannot assign to 'this'")
+		a.error(&assign, errors.New("cannot assign to 'this'"))
+		lhs = badExpr()
 	}
-	return dag.Assignment{Kind: "Assignment", LHS: lhs, RHS: rhs}, nil
+	return dag.Assignment{Kind: "Assignment", LHS: lhs, RHS: rhs}
 }
 
 func isLval(e dag.Expr) bool {
@@ -637,66 +548,54 @@ func deriveLHSPath(rhs dag.Expr) ([]string, error) {
 	return nil, errors.New("cannot infer field from expression")
 }
 
-func (a *analyzer) semFields(exprs []ast.Expr) ([]dag.Expr, error) {
+func (a *analyzer) semFields(exprs []ast.Expr) []dag.Expr {
 	fields := make([]dag.Expr, 0, len(exprs))
 	for _, e := range exprs {
-		f, err := a.semField(e)
-		if err != nil {
-			return nil, err
-		}
-		fields = append(fields, f)
+		fields = append(fields, a.semField(e))
 	}
-	return fields, nil
+	return fields
 }
 
 // semField analyzes the expression f and makes sure that it's
 // a field reference returning an error if not.
-func (a *analyzer) semField(f ast.Expr) (*dag.This, error) {
-	e, err := a.semExpr(f)
-	if err != nil {
-		return nil, errors.New("invalid expression used as a field")
-	}
+func (a *analyzer) semField(f ast.Expr) dag.Expr {
+	e := a.semExpr(f)
 	field, ok := e.(*dag.This)
 	if !ok {
-		return nil, errors.New("invalid expression used as a field")
+		a.error(f, errors.New("invalid expression used as a field"))
+		return badExpr()
 	}
 	if len(field.Path) == 0 {
-		return nil, errors.New("cannot use 'this' as a field reference")
+		a.error(f, errors.New("cannot use 'this' as a field reference"))
+		return badExpr()
 	}
-	return field, nil
+	return field
 }
 
-func (a *analyzer) maybeConvertAgg(call *ast.Call) (dag.Expr, error) {
+func (a *analyzer) maybeConvertAgg(call *ast.Call) dag.Expr {
 	if _, err := agg.NewPattern(call.Name, true); err != nil {
-		return nil, nil
+		return nil
 	}
 	var e dag.Expr
-	if len(call.Args) > 1 {
+	if err := function.CheckArgCount(len(call.Args), 0, 1); err != nil {
 		if call.Name == "min" || call.Name == "max" {
 			// min and max are special cases as they are also functions. If the
 			// number of args is greater than 1 they're probably a function so do not
 			// return an error.
-			return nil, nil
+			return nil
 		}
-		return nil, fmt.Errorf("%s: wrong number of arguments", call.Name)
+		a.error(call, err)
+		return badExpr()
 	}
 	if len(call.Args) == 1 {
-		var err error
-		e, err = a.semExpr(call.Args[0])
-		if err != nil {
-			return nil, err
-		}
-	}
-	where, err := a.semExprNullable(call.Where)
-	if err != nil {
-		return nil, err
+		e = a.semExpr(call.Args[0])
 	}
 	return &dag.Agg{
 		Kind:  "Agg",
 		Name:  call.Name,
 		Expr:  e,
-		Where: where,
-	}, nil
+		Where: a.semExprNullable(call.Where),
+	}
 }
 
 func DotExprToFieldPath(e ast.Expr) *dag.This {
@@ -749,23 +648,17 @@ func (a *analyzer) semType(typ astzed.Type) (string, error) {
 	return zson.FormatType(ztype), nil
 }
 
-func (a *analyzer) semVectorElems(elems []ast.VectorElem) ([]dag.VectorElem, error) {
+func (a *analyzer) semVectorElems(elems []ast.VectorElem) []dag.VectorElem {
 	var out []dag.VectorElem
 	for _, elem := range elems {
 		switch elem := elem.(type) {
 		case *ast.Spread:
-			e, err := a.semExpr(elem.Expr)
-			if err != nil {
-				return nil, err
-			}
+			e := a.semExpr(elem.Expr)
 			out = append(out, &dag.Spread{Kind: "Spread", Expr: e})
 		case *ast.VectorValue:
-			e, err := a.semExpr(elem.Expr)
-			if err != nil {
-				return nil, err
-			}
+			e := a.semExpr(elem.Expr)
 			out = append(out, &dag.VectorValue{Kind: "VectorValue", Expr: e})
 		}
 	}
-	return out, nil
+	return out
 }

--- a/compiler/ztests/badshaper.yaml
+++ b/compiler/ztests/badshaper.yaml
@@ -13,4 +13,6 @@ inputs:
 outputs:
   - name: stderr
     data: |
-      no such type name: "null"
+      no such type name: "null" in badshaper.zed at line 1, column 10:
+      type foo={_path:string,testfield:"null"}
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/compiler/ztests/const-source.yaml
+++ b/compiler/ztests/const-source.yaml
@@ -33,6 +33,12 @@ outputs:
       )
   - name: stderr
     data: |
-      invalid pool name: POOL: string value required
-      invalid file path: FILE: string value required
-      invalid file path: URL: string value required
+      POOL: string value required at line 1, column 24:
+      const POOL = 3.14 from POOL
+                             ~~~~
+      FILE: string value required at line 1, column 29:
+      const FILE = 127.0.0.1 file FILE
+                                  ~~~~
+      URL: string value required at line 1, column 22:
+      const URL = true get URL
+                           ~~~

--- a/compiler/ztests/from-error.yaml
+++ b/compiler/ztests/from-error.yaml
@@ -15,12 +15,22 @@ script: |
 outputs:
   - name: stderr
     data: |
-      semantic analyzer: from pool cannot be used without a lake
+      from pool cannot be used without a lake at line 1, column 1:
+      from p
+      ~~~~~~
       ===
-      test: pool not found
+      test: pool not found at line 1, column 6:
+      from test
+           ~~~~
       ===
-      test*: pool matching glob not found
+      test*: pool matching glob not found at line 1, column 6:
+      from test*
+           ~~~~~
       ===
-      test: pool matching regexp not found
+      test: pool matching regexp not found at line 1, column 6:
+      from /test/
+           ~~~~~~
       ===
-      => not allowed after pool pattern in 'from' operator
+      => not allowed after pool pattern in 'from' operator at line 1, column 7:
+      from (pool * => count())
+            ~~~~~~~~~~~~~~~~~

--- a/compiler/ztests/head.yaml
+++ b/compiler/ztests/head.yaml
@@ -20,6 +20,12 @@ outputs:
       )
   - name: stderr
     data: |
-      head: expression value is not a positive integer: 1.
-      head: expression value is not a positive integer: "1"
-      head: expression value is not a positive integer: error("missing")
+      expression value must be an integer value: 1. at line 1, column 6:
+      head 1.
+           ~~
+      expression value must be an integer value: "1" at line 1, column 7:
+      head "1"
+            ~
+      expression value must be an integer value: error("missing") at line 1, column 6:
+      head x
+           ~

--- a/compiler/ztests/summarize-lhs-error.yaml
+++ b/compiler/ztests/summarize-lhs-error.yaml
@@ -6,6 +6,12 @@ script: |
 outputs:
   - name: stderr
     data: |
-      summarize: key output field must be static
-      summarize: aggregate output field must be static
-      summarize: aggregate output field must be static
+      output field must be static at line 1, column 12:
+      count() by this[a] := key
+                 ~~~~~~~
+      output field must be static at line 1, column 1:
+      this[a] := count() by key
+      ~~~~~~~
+      aggregate output field must be static at line 1, column 1:
+      this[a] := count()
+      ~~~~~~~

--- a/compiler/ztests/tail.yaml
+++ b/compiler/ztests/tail.yaml
@@ -20,6 +20,12 @@ outputs:
       )
   - name: stderr
     data: |
-      tail: expression value is not a positive integer: 1.
-      tail: expression value is not a positive integer: "1"
-      tail: expression value is not a positive integer: error("missing")
+      expression value must be an integer value: 1. at line 1, column 6:
+      tail 1.
+           ~~
+      expression value must be an integer value: "1" at line 1, column 7:
+      tail "1"
+            ~
+      expression value must be an integer value: error("missing") at line 1, column 6:
+      tail x
+           ~

--- a/compiler/ztests/udf-err.yaml
+++ b/compiler/ztests/udf-err.yaml
@@ -21,6 +21,12 @@ inputs:
 outputs:
   - name: stderr
     data: |
-      symbol "dup" redefined
-      notAFunc(): definition is not a function type: *dag.Literal
-      f(): expects 2 argument(s)
+      symbol "dup" redefined in duplicate.zed at line 2, column 1:
+      func dup(n): (n+2)
+      ~~~~~~~~~~~~~~~~~
+      not a function in call-non-func.zed at line 2, column 7:
+      yield notAFunc(this)
+            ~~~~~~~~~~~~~~
+      call expects 2 argument(s) in wrong-args.zed at line 2, column 7:
+      yield f(this)
+            ~~~~~~~

--- a/compiler/ztests/where-on-func.yaml
+++ b/compiler/ztests/where-on-func.yaml
@@ -1,3 +1,3 @@
 zed: cut hex := hex(this) where this % 2 == 0
 
-errorRE: "'where' clause on non-aggregation function: hex"
+errorRE: "'where' clause on non-aggregation function"

--- a/docs/language/operators/rename.md
+++ b/docs/language/operators/rename.md
@@ -49,7 +49,9 @@ echo '{a:1,r:{b:2,c:3}}' | zq -z 'rename w:=r.b' -
 ```
 =>
 ```mdtest-output
-rename: left-hand side and right-hand side must have the same depth (w vs r.b)
+left-hand side and right-hand side must have the same depth (w vs r.b) at line 1, column 8:
+rename w:=r.b
+       ~~~~~~
 ```
 _Record literals can be used instead of rename for mutation_
 ```mdtest-command

--- a/docs/language/statements.md
+++ b/docs/language/statements.md
@@ -158,7 +158,9 @@ echo '{greeting: "hi"}' | zq -z -I params.zed 'AddMessage("message", "hello")' -
 ```
 which produces
 ```mdtest-output
-illegal left-hand side of assignment
+illegal left-hand side of assignment in params.zed at line 2, column 3:
+  field_for_message:=msg
+  ~~~~~~~~~~~~~~~~~~~~~~
 ```
 
 A constant value must be used to pass a parameter that will be referenced as

--- a/docs/tutorials/schools.md
+++ b/docs/tutorials/schools.md
@@ -843,7 +843,9 @@ zq -Z 'rename toplevel:=outer.inner' nested.zson
 ```
 produces this compile-time error message and the query is not run:
 ```mdtest-output
-rename: left-hand side and right-hand side must have the same depth (toplevel vs outer.inner)
+left-hand side and right-hand side must have the same depth (toplevel vs outer.inner) at line 1, column 8:
+rename toplevel:=outer.inner
+       ~~~~~~~~~~~~~~~~~~~~~
 ```
 This goal could instead be achieved by combining [`put`](#44-put) and [`drop`](#42-drop),
 e.g.,

--- a/fuzz/fuzz.go
+++ b/fuzz/fuzz.go
@@ -95,11 +95,11 @@ func RunQuery(t testing.TB, zctx *zed.Context, readers []zio.Reader, querySource
 	// Compile query
 	engine := mock.NewMockEngine(gomock.NewController(t))
 	comp := compiler.NewFileSystemCompiler(engine)
-	ast, err := compiler.Parse(querySource)
+	ast, sset, err := compiler.Parse(querySource)
 	if err != nil {
 		t.Skipf("%v", err)
 	}
-	query, err := runtime.CompileQuery(ctx, zctx, comp, ast, readers)
+	query, err := runtime.CompileQuery(ctx, zctx, comp, ast, sset, readers)
 	if err != nil {
 		t.Skipf("%v", err)
 	}

--- a/lake/ztests/dirs.yaml
+++ b/lake/ztests/dirs.yaml
@@ -17,4 +17,6 @@ outputs:
       {min:2020-04-21T22:40:30.06852324Z,max:2020-04-22T01:23:40.0622373Z}
   - name: stderr
     data: |
-      logs: pool not found
+      logs: pool not found at line 1, column 6:
+      from logs@main:objects
+           ~~~~

--- a/lake/ztests/query-error.yaml
+++ b/lake/ztests/query-error.yaml
@@ -10,6 +10,12 @@ outputs:
   - name: stderr
     data: |
       query must include a 'from' operator
-      cannot scan from unknown HEAD
-      unknown lake metadata type "unknownmeta" in from operator
-      doesnotexist: pool not found
+      cannot scan from unknown HEAD at line 1, column 6:
+      from HEAD
+           ~~~~
+      unknown lake metadata type "unknownmeta" in from operator at line 1, column 1:
+      from :unknownmeta
+      ~~~~~~~~~~~~~~~~~
+      doesnotexist: pool not found at line 1, column 6:
+      from doesnotexist
+           ~~~~~~~~~~~~

--- a/runtime/compiler.go
+++ b/runtime/compiler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/compiler/ast"
+	"github.com/brimdata/zed/compiler/parser"
 	"github.com/brimdata/zed/lakeparse"
 	"github.com/brimdata/zed/zbuf"
 	"github.com/brimdata/zed/zio"
@@ -16,7 +17,7 @@ type Compiler interface {
 	NewQuery(*Context, ast.Seq, []zio.Reader) (Query, error)
 	NewLakeQuery(*Context, ast.Seq, int, *lakeparse.Commitish) (Query, error)
 	NewLakeDeleteQuery(*Context, ast.Seq, *lakeparse.Commitish) (DeleteQuery, error)
-	Parse(string, ...string) (ast.Seq, error)
+	Parse(string, ...string) (ast.Seq, *parser.SourceSet, error)
 }
 
 type Query interface {
@@ -43,21 +44,27 @@ func AsProgressReadCloser(q Query) zbuf.ProgressReadCloser {
 	}{AsReader(q), q, q}
 }
 
-func CompileQuery(ctx context.Context, zctx *zed.Context, c Compiler, program ast.Seq, readers []zio.Reader) (Query, error) {
+func CompileQuery(ctx context.Context, zctx *zed.Context, c Compiler, program ast.Seq, sset *parser.SourceSet, readers []zio.Reader) (Query, error) {
 	rctx := NewContext(ctx, zctx)
 	q, err := c.NewQuery(rctx, program, readers)
 	if err != nil {
 		rctx.Cancel()
+		if list, ok := err.(parser.ErrorList); ok {
+			list.SetSourceSet(sset)
+		}
 		return nil, err
 	}
 	return q, nil
 }
 
-func CompileLakeQuery(ctx context.Context, zctx *zed.Context, c Compiler, program ast.Seq, head *lakeparse.Commitish) (Query, error) {
+func CompileLakeQuery(ctx context.Context, zctx *zed.Context, c Compiler, program ast.Seq, sset *parser.SourceSet, head *lakeparse.Commitish) (Query, error) {
 	rctx := NewContext(ctx, zctx)
 	q, err := c.NewLakeQuery(rctx, program, 0, head)
 	if err != nil {
 		rctx.Cancel()
+		if list, ok := err.(parser.ErrorList); ok {
+			list.SetSourceSet(sset)
+		}
 		return nil, err
 	}
 	return q, nil

--- a/runtime/sam/expr/filter_test.go
+++ b/runtime/sam/expr/filter_test.go
@@ -54,7 +54,7 @@ func runCasesHelper(t *testing.T, record string, cases []testcase, expectBufferF
 	for _, c := range cases {
 		t.Run(c.filter, func(t *testing.T) {
 			t.Helper()
-			p, err := compiler.Parse(c.filter)
+			p, _, err := compiler.Parse(c.filter)
 			require.NoError(t, err, "filter: %q", c.filter)
 			rctx := runtime.NewContext(context.Background(), zctx)
 			job, err := compiler.NewJob(rctx, p, nil, nil)
@@ -405,6 +405,6 @@ func TestFilters(t *testing.T) {
 
 func TestBadFilter(t *testing.T) {
 	t.Parallel()
-	_, err := compiler.Parse(`s matches \xa8*`)
+	_, _, err := compiler.Parse(`s matches \xa8*`)
 	require.Error(t, err)
 }

--- a/runtime/sam/expr/ztests/cut-dup-fields.yaml
+++ b/runtime/sam/expr/ztests/cut-dup-fields.yaml
@@ -12,7 +12,15 @@ inputs:
 outputs:
   - name: stderr
     data: |
-      cut: duplicate field: "rec"
-      cut: duplicate field: "rec.sub1"
-      cut: duplicate field: "rec.sub.sub"
-      cut: duplicate field: "rec.sub"
+      duplicate field: "rec" at line 1, column 5:
+      cut rec,other,rec
+          ~~~~~~~~~~~~~
+      duplicate field: "rec.sub1" at line 1, column 5:
+      cut rec.sub1,rec.sub1
+          ~~~~~~~~~~~~~~~~~
+      duplicate field: "rec.sub.sub" at line 1, column 5:
+      cut rec.sub,rec.sub.sub
+          ~~~~~~~~~~~~~~~~~~~
+      duplicate field: "rec.sub" at line 1, column 5:
+      cut rec.sub.sub,rec.sub
+          ~~~~~~~~~~~~~~~~~~~

--- a/runtime/sam/expr/ztests/cut-not-adjacent.yaml
+++ b/runtime/sam/expr/ztests/cut-not-adjacent.yaml
@@ -12,7 +12,15 @@ inputs:
 outputs:
   - name: stderr
     data: |
-      cut: fields in record rec must be adjacent
-      cut: fields in record rec1 must be adjacent
-      cut: fields in record rec1 must be adjacent
-      cut: fields in record t.rec must be adjacent
+      fields in record rec must be adjacent at line 1, column 5:
+      cut rec.sub1,other,rec.sub2
+          ~~~~~~~~~~~~~~~~~~~~~~~
+      fields in record rec1 must be adjacent at line 1, column 5:
+      cut rec1.rec2.sub1,other,rec1.sub2
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      fields in record rec1 must be adjacent at line 1, column 5:
+      cut rec1.rec2.sub1,other,rec1.rec2.sub2
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      fields in record t.rec must be adjacent at line 1, column 5:
+      cut t.rec.sub1,t.other,t.rec.sub2
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/runtime/sam/expr/ztests/rename-error-move.yaml
+++ b/runtime/sam/expr/ztests/rename-error-move.yaml
@@ -3,4 +3,4 @@ zed: rename dst:=id.resp_h
 input: |
   {id:{orig_h:10.164.94.120,orig_p:39681(port=uint16),resp_h:10.47.3.155,resp_p:3389(port)}}
 
-errorRE: "rename: left-hand side and right-hand side must have the same depth \\(dst vs id.resp_h\\)"
+errorRE: "left-hand side and right-hand side must have the same depth \\(dst vs id.resp_h\\)"

--- a/runtime/sam/op/groupby/groupby_test.go
+++ b/runtime/sam/op/groupby/groupby_test.go
@@ -106,7 +106,7 @@ func TestGroupbyStreamingSpill(t *testing.T) {
 	defer arena.Unref()
 
 	runOne := func(inputSortKey string) []string {
-		proc, err := compiler.Parse("count() by every(1s), ip")
+		proc, _, err := compiler.Parse("count() by every(1s), ip")
 		assert.NoError(t, err)
 
 		zctx := zed.NewContext()

--- a/runtime/sam/op/ztests/cut-dynamic-field.yaml
+++ b/runtime/sam/op/ztests/cut-dynamic-field.yaml
@@ -43,4 +43,6 @@ outputs:
       error({message:"cut: missing",on:{}})
   - name: stderr
     data: |
-      left-hand side of assignment: symbol "foo" is not bound to an expression
+      symbol "foo" is not bound to an expression at line 1, column 38:
+      op foo(): ( yield "error" ) cut this[foo] := "hello world"
+                                           ~~~

--- a/runtime/sam/op/ztests/put-dynamic-field.yaml
+++ b/runtime/sam/op/ztests/put-dynamic-field.yaml
@@ -38,4 +38,6 @@ outputs:
       error({message:"put: missing",on:{}})
   - name: stderr
     data: |
-      left-hand side of assignment: symbol "foo" is not bound to an expression
+      symbol "foo" is not bound to an expression at line 1, column 38:
+      op foo(): ( yield "error" ) put this[foo] := "hello world"
+                                           ~~~

--- a/runtime/sam/op/ztests/user-errors.yaml
+++ b/runtime/sam/op/ztests/user-errors.yaml
@@ -8,7 +8,7 @@ inputs:
       op test(a, a): (
         pass
       )
-      op("a", "b")
+      test("a", "b")
   - name: error-const-lhs.zed
     data: |
       op test(a): (
@@ -19,5 +19,9 @@ inputs:
 outputs:
   - name: stderr
     data: |
-      test: duplicate parameter "a"
-      illegal left-hand side of assignment
+      duplicate parameter "a" in error-duplicate-parameters.zed at line 1, column 1:
+      op test(a, a): (
+      ~~~~~~~~~~~~~~~~
+      illegal left-hand side of assignment in error-const-lhs.zed at line 2, column 3:
+        a := a
+        ~~~~~~

--- a/service/ztests/curl-query-error.yaml
+++ b/service/ztests/curl-query-error.yaml
@@ -13,13 +13,13 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      {"type":"Error","kind":"invalid operation","error":"pool name missing"}
+      {"type":"Error","kind":"invalid operation","error":"no pool name given"}
       code 400
-      {"type":"Error","kind":"invalid operation","error":"pool name missing"}
+      {"type":"Error","kind":"invalid operation","error":"no pool name given"}
       code 400
-      {"type":"Error","kind":"invalid operation","error":"pool name missing"}
+      {"type":"Error","kind":"invalid operation","error":"pool name missing at line 1, column 1:\nfrom HEAD\n~~~~~~~~~","compilation_errors":[{"Msg":"pool name missing","Pos":0,"End":9}]}
       code 400
-      {"type":"Error","kind":"invalid operation","error":"unknown lake metadata type \"unknownmeta\" in from operator"}
+      {"type":"Error","kind":"invalid operation","error":"unknown lake metadata type \"unknownmeta\" in from operator at line 1, column 1:\nfrom :unknownmeta\n~~~~~~~~~~~~~~~~~","compilation_errors":[{"Msg":"unknown lake metadata type \"unknownmeta\" in from operator","Pos":0,"End":17}]}
       code 400
-      {"type":"Error","kind":"item does not exist","error":"doesnotexist: pool not found"}
-      code 404
+      {"type":"Error","kind":"invalid operation","error":"doesnotexist: pool not found at line 1, column 6:\nfrom doesnotexist\n     ~~~~~~~~~~~~","compilation_errors":[{"Msg":"doesnotexist: pool not found","Pos":5,"End":17}]}
+      code 400

--- a/service/ztests/python.yaml
+++ b/service/ztests/python.yaml
@@ -161,4 +161,4 @@ outputs:
       ===
       RequestError('test: pool already exists')
       ===
-      RequestError('nosuchpool: pool not found')
+      RequestError('nosuchpool: pool not found at line 1, column 6:\nfrom nosuchpool\n     ~~~~~~~~~~')

--- a/service/ztests/query-bad-commit.yaml
+++ b/service/ztests/query-bad-commit.yaml
@@ -10,4 +10,6 @@ inputs:
 outputs:
   - name: stderr
     data: |
-      status code 404: "doesnotexist": branch not found
+      "doesnotexist": branch not found at line 1, column 1:
+      from test@doesnotexist
+      ~~~~~~~~~~~~~~~~~~~~~~

--- a/service/ztests/query-error.yaml
+++ b/service/ztests/query-error.yaml
@@ -12,7 +12,14 @@ inputs:
 outputs:
   - name: stderr
     data: |
-      status code 400: pool name missing
-      status code 400: pool name missing
-      status code 400: unknown lake metadata type "unknownmeta" in from operator
-      status code 404: doesnotexist: pool not found
+      status code 400: no pool name given
+      pool name missing at line 1, column 1:
+      from HEAD
+      ~~~~~~~~~
+      unknown lake metadata type "unknownmeta" in from operator at line 1, column 1:
+      from :unknownmeta
+      ~~~~~~~~~~~~~~~~~
+      doesnotexist: pool not found at line 1, column 6:
+      from doesnotexist
+           ~~~~~~~~~~~~
+      

--- a/zed_test.go
+++ b/zed_test.go
@@ -136,7 +136,7 @@ func runOneBoomerang(t *testing.T, format, data string) {
 	dataReader := zio.Reader(dataReadCloser)
 	if format == "parquet" {
 		// Fuse for formats that require uniform values.
-		proc, err := compiler.NewCompiler().Parse("fuse")
+		proc, _, err := compiler.NewCompiler().Parse("fuse")
 		require.NoError(t, err)
 		rctx := runtime.NewContext(context.Background(), zctx)
 		q, err := compiler.NewCompiler().NewQuery(rctx, proc, []zio.Reader{dataReadCloser})

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -480,7 +480,7 @@ func runzq(path, zedProgram, input string, outputFlags []string, inputFlags []st
 		// tests.
 		return outbuf.String(), errbuf.String(), err
 	}
-	proc, err := compiler.NewCompiler().Parse(zedProgram)
+	proc, sset, err := compiler.Parse(zedProgram)
 	if err != nil {
 		return "", err.Error(), err
 	}
@@ -513,7 +513,7 @@ func runzq(path, zedProgram, input string, outputFlags []string, inputFlags []st
 	if err != nil {
 		return "", "", err
 	}
-	q, err := compiler.NewCompiler().NewQuery(runtime.NewContext(context.Background(), zctx), proc, []zio.Reader{zrc})
+	q, err := runtime.CompileQuery(context.Background(), zctx, compiler.NewCompiler(), proc, sset, []zio.Reader{zrc})
 	if err != nil {
 		zw.Close()
 		return "", err.Error(), err


### PR DESCRIPTION
This commit changes errors produced from semantic analysis so they include a reference to the AST node which produced the error. The allows for highlighting the specific portion of the source that caused a semantic error.

This commit also changes how semantic errors are collected in that the semantic analyzer no longer exits as soon as the first error is found and instead goes on the analyze the rest of the AST, reporting all semantic errors in the AST.