### PR TITLE
Reference the "zed serve -manage" option in zed command docs

### DIFF
--- a/cmd/zed/manage/command.go
+++ b/cmd/zed/manage/command.go
@@ -19,7 +19,30 @@ var Cmd = &charm.Spec{
 	Name:  "manage",
 	Usage: "manage",
 	Short: "run compaction and other maintenance tasks on a lake",
-	New:   New,
+	Long: `
+The manage command performs maintenance tasks on a lake.
+
+Currently the only supported task is compaction, which reduces
+fragmentation by reading data objects in a pool and writing their
+contents back to large, non-overlapping objects.
+
+If the -monitor option is specified and the lake is located via network
+connection, zed manage will run continuously and perform updates as
+needed. By default a check is performed once per minute to determine if
+updates are necessary. The -interval option may be used to specify an
+alternate check frequency in duration format.
+
+If -monitor is not specified, a single maintenance pass is performed on
+the lake.
+
+The output from manage provides a per-pool summary of the maintenance
+performed, including a count of objects_compacted.
+
+As an alternative to running manage as a separate command, the -manage
+option is also available on the "zed serve" command to have maintenance
+tasks run at the specified interval by the service process.
+`,
+	New: New,
 }
 
 type Command struct {

--- a/cmd/zed/serve/command.go
+++ b/cmd/zed/serve/command.go
@@ -30,9 +30,19 @@ var Cmd = &charm.Spec{
 	Usage: "serve [options]",
 	Short: "service requests to a Zed lake",
 	Long: `
-The serve command listens for Zed lake API requests on the provided
-interface and port, executes the requests, and returns results.
-Requests may be issued to this service via the "zed api" command.
+The serve command implements Zed's server personality to service
+requests from instances of Zed's client personality. It listens
+for Zed lake API requests on the interface and port specified by
+the -l option, executes the requests, and returns results.
+
+The -log.level option controls log verbosity. Available levels,
+ordered from most to least verbose, are debug, info (the default),
+warn, error, dpanic, panic, and fatal. If the volume of logging
+output at the default info level seems too excessive for
+production use, warn level is recommended.
+
+The -manage option enables the running of the same maintenance tasks
+normally performed via the separate "zed manage" command.
 `,
 	HiddenFlags: "brimfd,portfile",
 	New:         New,

--- a/docs/commands/zed.md
+++ b/docs/commands/zed.md
@@ -592,6 +592,10 @@ lake.
 The output from `manage` provides a per-pool summary of the maintenance
 performed, including a count of `objects_compacted`.
 
+As an alternative to running `manage` as a separate command, the `-manage`
+option is also available on the [`serve`](#serve) command to have maintenance
+tasks run at the specified interval by the service process.
+
 ### Merge
 
 Data is merged from one branch into another with the `merge` command, e.g.,
@@ -757,6 +761,9 @@ from most to least verbose, are `debug`, `info` (the default), `warn`,
 `error`, `dpanic`, `panic`, and `fatal`.  If the volume of logging output at
 the default `info` level seems too excessive for production use, `warn` level
 is recommended.
+
+The `-manage` option enables the running of the same maintenance tasks
+normally performed via the separate [`manage`](#manage) command.
 
 ### Use
 ```


### PR DESCRIPTION
With the merge of https://github.com/brimdata/zui/pull/3006 and wanting to generally be able to point users at the benefits of compaction when they have lots of small commits, I realized the docs could stand to mention the availability of the `zed serve -manage` option since I expect many users would prefer this over having to run `zed manage` as a separate process.