### PR TITLE
Add a regexp_replace ztest entry for zed#4445 example

### DIFF
--- a/runtime/sam/expr/function/ztests/regexp-replace.yaml
+++ b/runtime/sam/expr/function/ztests/regexp-replace.yaml
@@ -5,6 +5,7 @@ input: |
   {in:"-ab-axxb-",re:"a(x*)b",new:"$1"}
   {in:"-ab-axxb-",re:"a(?P<X>x*)b",new:"$X"}
   {in:"Foo bar",re:"Foo",new:"foo"}
+  {in:"", re:"a(x*)b",new:""}
   {in:"seafood fool",re:"foo(.?",new:"food"}
   {in:4,re:5,new:["foo"]}
   {in:"foo",re:null(string),new:null(string)}
@@ -14,7 +15,7 @@ output: |
   "--xx-"
   "--xx-"
   "foo bar"
+  ""
   error("regexp_replace: error parsing regexp: missing closing ): `foo(.?`")
   error({message:"regexp_replace: string arg required",on:4})
   error("regexp_replace: 2nd and 3rd args cannot be null")
-


### PR DESCRIPTION
Per https://github.com/brimdata/zed/issues/4445#issuecomment-2111088198, the symptom described in that issue was fixed by the changes in #4968 but I only discovered that by accident. Since it's now exhibiting what seems to be the correct behavior, I'm seeking to lock that in going forward by adding this additional entry to the ztest for `regexp_replace()`.