### PR TITLE
JSON pretty: empty containers

### DIFF
--- a/zio/jsonio/writer.go
+++ b/zio/jsonio/writer.go
@@ -94,6 +94,10 @@ func (w *Writer) writeAny(tab int, val zed.Value) {
 func (w *Writer) writeRecord(tab int, typ *zed.TypeRecord, bytes zcode.Bytes) {
 	tab += w.tab
 	w.punc('{')
+	if len(bytes) == 0 {
+		w.punc('}')
+		return
+	}
 	it := bytes.Iter()
 	for i, f := range typ.Fields {
 		if i != 0 {
@@ -109,6 +113,10 @@ func (w *Writer) writeRecord(tab int, typ *zed.TypeRecord, bytes zcode.Bytes) {
 func (w *Writer) writeArray(tab int, typ zed.Type, bytes zcode.Bytes) {
 	tab += w.tab
 	w.punc('[')
+	if len(bytes) == 0 {
+		w.punc(']')
+		return
+	}
 	it := bytes.Iter()
 	for i := 0; !it.Done(); i++ {
 		if i != 0 {
@@ -126,6 +134,10 @@ func (w *Writer) writeArray(tab int, typ zed.Type, bytes zcode.Bytes) {
 func (w *Writer) writeMap(tab int, typ *zed.TypeMap, bytes zcode.Bytes) {
 	tab += w.tab
 	w.punc('{')
+	if len(bytes) == 0 {
+		w.punc('}')
+		return
+	}
 	it := bytes.Iter()
 	for i := 0; !it.Done(); i++ {
 		if i != 0 {

--- a/zio/jsonio/ztests/pretty.yaml
+++ b/zio/jsonio/ztests/pretty.yaml
@@ -8,6 +8,9 @@ input: |
     f4: "a string",
     f5: [1,2,3],
     f6: {foo: "bar"},
+    f7: {},
+    f8: |{}|,
+    f9: [],
   }
 
 output-flags: -f json -pretty 4
@@ -25,5 +28,8 @@ output: |
       ],
       "f6": {
           "foo": "bar"
-      }
+      },
+      "f7": {},
+      "f8": {},
+      "f9": []
   }


### PR DESCRIPTION
For the JSON writer in pretty mode ensure that empty objects and array are printed on the same line.