### PR TITLE
Rework errors in compiler/parser

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 
+	"github.com/brimdata/zed/compiler/parser"
 	"github.com/brimdata/zed/lakeparse"
 	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/pkg/nano"
@@ -20,10 +21,10 @@ func RequestIDFromContext(ctx context.Context) string {
 }
 
 type Error struct {
-	Type    string      `json:"type"`
-	Kind    string      `json:"kind"`
-	Message string      `json:"error"`
-	Info    interface{} `json:"info,omitempty"`
+	Type              string           `json:"type"`
+	Kind              string           `json:"kind"`
+	Message           string           `json:"error"`
+	CompilationErrors parser.ErrorList `json:"compilation_errors,omitempty"`
 }
 
 func (e Error) Error() string {

--- a/cli/queryflags/flags.go
+++ b/cli/queryflags/flags.go
@@ -87,15 +87,10 @@ func singleArgError(src string, err error) error {
 		src = src[:20] + "..."
 	}
 	fmt.Fprintf(&b, "\n - a file could not be found with the name %q", src)
-	var perr *parser.Error
-	if errors.As(err, &perr) {
-		b.WriteString("\n - the argument could not be compiled as a valid Zed query due to parse error (")
-		if perr.LineNum > 0 {
-			fmt.Fprintf(&b, "line %d, ", perr.LineNum)
-		}
-		fmt.Fprintf(&b, "column %d):", perr.Column)
-		for _, l := range strings.Split(perr.ParseErrorContext(), "\n") {
-			fmt.Fprintf(&b, "\n   %s", l)
+	if list := (parser.ErrorList)(nil); errors.As(err, &list) {
+		b.WriteString("\n - the argument could not be compiled as a valid Zed query:")
+		for _, line := range strings.Split(list.Error(), "\n") {
+			fmt.Fprintf(&b, "\n   %s", line)
 		}
 	} else {
 		b.WriteString("\n - the argument did not parse as a valid Zed query")

--- a/cmd/zq/ztests/single-arg-error.yaml
+++ b/cmd/zq/ztests/single-arg-error.yaml
@@ -6,6 +6,7 @@ outputs:
     data: |
       zq: could not invoke zq with a single argument because:
        - a file could not be found with the name "file sample.zson | c..."
-       - the argument could not be compiled as a valid Zed query due to parse error (column 25):
+       - the argument could not be compiled as a valid Zed query:
+         error parsing Zed at line 1, column 26:
          file sample.zson | count(
                               === ^ ===

--- a/compiler/job.go
+++ b/compiler/job.go
@@ -89,7 +89,8 @@ func (j *Job) Parallelize(n int) error {
 }
 
 func Parse(src string, filenames ...string) (ast.Seq, error) {
-	return parser.ParseZed(filenames, src)
+	seq, _, err := parser.ParseZed(filenames, src)
+	return seq, err
 }
 
 // MustParse is like Parse but panics if an error is encountered.

--- a/compiler/parser/source.go
+++ b/compiler/parser/source.go
@@ -1,0 +1,85 @@
+package parser
+
+import (
+	"sort"
+)
+
+type SourceSet struct {
+	Text    string
+	Sources []*SourceInfo
+}
+
+func (s *SourceSet) SourceOf(pos int) *SourceInfo {
+	i := sort.Search(len(s.Sources), func(i int) bool { return s.Sources[i].start > pos }) - 1
+	return s.Sources[i]
+}
+
+// SourceInfo holds source file offsets.
+type SourceInfo struct {
+	Filename string
+	lines    []int
+	size     int
+	start    int
+}
+
+func newSourceInfo(filename string, start int, src []byte) *SourceInfo {
+	var lines []int
+	line := 0
+	for offset, b := range src {
+		if line >= 0 {
+			lines = append(lines, line)
+		}
+		line = -1
+		if b == '\n' {
+			line = offset + 1
+		}
+	}
+	return &SourceInfo{
+		Filename: filename,
+		lines:    lines,
+		size:     len(src),
+		start:    start,
+	}
+}
+
+func (s *SourceInfo) Position(pos int) Position {
+	if pos < 0 {
+		return Position{-1, -1, -1, -1}
+	}
+	offset := pos - s.start
+	i := searchLine(s.lines, offset)
+	return Position{
+		Pos:    pos,
+		Offset: offset,
+		Line:   i + 1,
+		Column: offset - s.lines[i] + 1,
+	}
+}
+
+func (s *SourceInfo) LineOfPos(src string, pos int) string {
+	i := searchLine(s.lines, pos-s.start)
+	start := s.lines[i]
+	end := s.size
+	if i+1 < len(s.lines) {
+		end = s.lines[i+1]
+	}
+	b := src[s.start+start : s.start+end]
+	if b[len(b)-1] == '\n' {
+		b = b[:len(b)-1]
+	}
+	return string(b)
+}
+
+func searchLine(lines []int, offset int) int {
+	return sort.Search(len(lines), func(i int) bool { return lines[i] > offset }) - 1
+
+}
+
+type Position struct {
+	Pos    int `json:"pos"`    // Offset relative to SourceSet.
+	Offset int `json:"offset"` // Offset relative to file start.
+	Line   int `json:"line"`   // 1-based line number.
+	Column int `json:"column"` // 1-based column number.
+}
+
+func (p Position) IsValid() bool { return p.Pos >= 0 }

--- a/compiler/parser/ztests/syntax-error.yaml
+++ b/compiler/parser/ztests/syntax-error.yaml
@@ -8,6 +8,6 @@ inputs:
 outputs:
   - name: stderr
     data: |
-      zq: error parsing Zed at column 12:
+      zq: error parsing Zed at line 1, column 12:
       count() by ,x,y
              === ^ ===

--- a/docs/tutorials/schools.md
+++ b/docs/tutorials/schools.md
@@ -229,7 +229,7 @@ zq -z 'Defunct=' *.zson
 ```
 produces
 ```mdtest-output
-zq: error parsing Zed at column 8:
+zq: error parsing Zed at line 1, column 8:
 Defunct=
    === ^ ===
 ```

--- a/lake/ztests/query-parse-error.yaml
+++ b/lake/ztests/query-parse-error.yaml
@@ -34,7 +34,7 @@ outputs:
   - name: stderr
     data: |
       =1=
-      error parsing Zed at column 11:
+      error parsing Zed at line 1, column 11:
       from test \ count()
             === ^ ===
       =2=
@@ -42,7 +42,7 @@ outputs:
       test \ count()
        === ^ ===
       =3=
-      error parsing Zed at column 11:
+      error parsing Zed at line 1, column 11:
       from test \ count()
             === ^ ===
       =4=

--- a/service/request.go
+++ b/service/request.go
@@ -303,9 +303,8 @@ func errorResponse(e error) (status int, ae *api.Error) {
 	status = http.StatusInternalServerError
 	ae = &api.Error{Type: "Error"}
 
-	var pe *parser.Error
-	if errors.As(e, &pe) {
-		ae.Info = map[string]int{"parse_error_offset": pe.Offset}
+	if list := (parser.ErrorList)(nil); errors.As(e, &list) {
+		ae.CompilationErrors = list
 	}
 
 	var ze *srverr.Error

--- a/service/ztests/compile.yaml
+++ b/service/ztests/compile.yaml
@@ -1,6 +1,6 @@
 script: |
   source service.sh
-  curl -d '{"query":"count("}' $ZED_LAKE/compile | zq -z 'cut info' -
+  curl -d '{"query":"count("}' $ZED_LAKE/compile | zq -z 'cut compilation_errors' -
 
 inputs:
   - name: service.sh
@@ -8,4 +8,4 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      {info:{parse_error_offset:6}}
+      {compilation_errors:[{Msg:"error parsing Zed",Pos:6,End:-1}]}

--- a/service/ztests/query-parse-error.yaml
+++ b/service/ztests/query-parse-error.yaml
@@ -34,7 +34,7 @@ outputs:
   - name: stderr
     data: |
       =1=
-      error parsing Zed at column 11:
+      error parsing Zed at line 1, column 11:
       from test \ count()
             === ^ ===
       =2=
@@ -42,7 +42,7 @@ outputs:
       test \ count()
        === ^ ===
       =3=
-      error parsing Zed at column 11:
+      error parsing Zed at line 1, column 11:
       from test \ count()
             === ^ ===
       =4=


### PR DESCRIPTION
This is based on #5122, from which compiler/parser/source.go and the `parser.Error.Error` implementation are copied.

---

* Add ErrorList, a list of Errors, and SourceSet, a struct containing Zed program text and source file offsets.  In the future, compiler/semantic will use these types to return multiple errors that point into the program.

* Remove ImproveError and NewError.

* Change ParseZed to return an ErrorList when Parse fails.

* Change ParseZed and ConcatSource to return a SourceSet.

* In api.Error, replace the `Info interface{}` field with `ComplationErrors parser.ErrorList`.