### PR TITLE
Add a "curly braces with named references" example in regexp_replace docs

### DIFF
--- a/docs/language/functions/regexp_replace.md
+++ b/docs/language/functions/regexp_replace.md
@@ -60,6 +60,7 @@ echo '"option: value"' | zq -z 'yield regexp_replace(this,/(?P<key>\w+):\s+(?P<v
 ```
 
 Wrap a named reference in curly braces to avoid ambiguity:
+
 ```mdtest-command
 echo '"option: value"' | zq -z 'yield regexp_replace(this,/(?P<key>\w+):\s+(?P<value>\w+)$/,"$key=${value}AppendedText")' -
 ```

--- a/docs/language/functions/regexp_replace.md
+++ b/docs/language/functions/regexp_replace.md
@@ -58,3 +58,12 @@ echo '"option: value"' | zq -z 'yield regexp_replace(this,/(?P<key>\w+):\s+(?P<v
 ```mdtest-output
 "option=value"
 ```
+
+Wrap a named reference in curly braces to avoid ambiguity:
+```mdtest-command
+echo '"option: value"' | zq -z 'yield regexp_replace(this,/(?P<key>\w+):\s+(?P<value>\w+)$/,"$key=${value}AppendedText")' -
+```
+=>
+```mdtest-output
+"option=valueAppendedText"
+```


### PR DESCRIPTION
As foretold in #4444, now that issue has been fixed, it seems worthwhile to add an example in the `regexp_replace()` docs that use this curly bracket syntax.