### PR TITLE
ZSON: Quoted name type values

### DIFF
--- a/zson/formatter.go
+++ b/zson/formatter.go
@@ -223,7 +223,7 @@ func (f *Formatter) formatTypeValue(indent int, tv zcode.Bytes) zcode.Bytes {
 			f.truncTypeValueErr()
 			return nil
 		}
-		f.build(name)
+		f.build(QuotedName(name))
 		f.build("=")
 		tv = f.formatTypeValue(indent, tv)
 	case zed.TypeValueNameRef:
@@ -233,7 +233,7 @@ func (f *Formatter) formatTypeValue(indent int, tv zcode.Bytes) zcode.Bytes {
 			f.truncTypeValueErr()
 			return nil
 		}
-		f.build(name)
+		f.build(QuotedName(name))
 	case zed.TypeValueRecord:
 		f.build("{")
 		var n int

--- a/zson/ztests/type-value.yaml
+++ b/zson/ztests/type-value.yaml
@@ -3,6 +3,6 @@ zed: "*"
 input: &input |
   <int64>
   {typ:<int64>}
-  <{a:"@foo"={bar:string},b:"@foo"}>
+  <{def:"@foo"=int64,ref:"@foo"}>
 
 output: *input

--- a/zson/ztests/type-value.yaml
+++ b/zson/ztests/type-value.yaml
@@ -3,5 +3,6 @@ zed: "*"
 input: &input |
   <int64>
   {typ:<int64>}
+  <{a:"@foo"={bar:string},b:"@foo"}>
 
 output: *input


### PR DESCRIPTION
This commit fixes an issue in the ZSON formatter where the name of a named type value is not getting placed in quotes when the name is not a valid identifier.