### PR TITLE
Parser: Allowed quoted named types

### DIFF
--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -8271,35 +8271,44 @@ var g = &grammar{
 								&labeledExpr{
 									pos:   position{line: 1228, col: 5, offset: 30072},
 									label: "name",
-									expr: &ruleRefExpr{
-										pos:  position{line: 1228, col: 10, offset: 30077},
-										name: "IdentifierName",
+									expr: &choiceExpr{
+										pos: position{line: 1228, col: 11, offset: 30078},
+										alternatives: []any{
+											&ruleRefExpr{
+												pos:  position{line: 1228, col: 11, offset: 30078},
+												name: "IdentifierName",
+											},
+											&ruleRefExpr{
+												pos:  position{line: 1228, col: 28, offset: 30095},
+												name: "QuotedString",
+											},
+										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1228, col: 25, offset: 30092},
+									pos:   position{line: 1228, col: 42, offset: 30109},
 									label: "opt",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1228, col: 29, offset: 30096},
+										pos: position{line: 1228, col: 46, offset: 30113},
 										expr: &seqExpr{
-											pos: position{line: 1228, col: 30, offset: 30097},
+											pos: position{line: 1228, col: 47, offset: 30114},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1228, col: 30, offset: 30097},
+													pos:  position{line: 1228, col: 47, offset: 30114},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1228, col: 33, offset: 30100},
+													pos:        position{line: 1228, col: 50, offset: 30117},
 													val:        "=",
 													ignoreCase: false,
 													want:       "\"=\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1228, col: 37, offset: 30104},
+													pos:  position{line: 1228, col: 54, offset: 30121},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1228, col: 40, offset: 30107},
+													pos:  position{line: 1228, col: 57, offset: 30124},
 													name: "Type",
 												},
 											},
@@ -8310,43 +8319,31 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1239, col: 5, offset: 30445},
-						run: (*parser).callonAmbiguousType29,
-						expr: &labeledExpr{
-							pos:   position{line: 1239, col: 5, offset: 30445},
-							label: "name",
-							expr: &ruleRefExpr{
-								pos:  position{line: 1239, col: 10, offset: 30450},
-								name: "QuotedString",
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 1242, col: 5, offset: 30572},
-						run: (*parser).callonAmbiguousType32,
+						pos: position{line: 1239, col: 5, offset: 30462},
+						run: (*parser).callonAmbiguousType31,
 						expr: &seqExpr{
-							pos: position{line: 1242, col: 5, offset: 30572},
+							pos: position{line: 1239, col: 5, offset: 30462},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1242, col: 5, offset: 30572},
+									pos:        position{line: 1239, col: 5, offset: 30462},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1242, col: 9, offset: 30576},
+									pos:  position{line: 1239, col: 9, offset: 30466},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1242, col: 12, offset: 30579},
+									pos:   position{line: 1239, col: 12, offset: 30469},
 									label: "types",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1242, col: 18, offset: 30585},
+										pos:  position{line: 1239, col: 18, offset: 30475},
 										name: "TypeList",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1242, col: 27, offset: 30594},
+									pos:        position{line: 1239, col: 27, offset: 30484},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -8361,28 +8358,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1251, col: 1, offset: 30786},
+			pos:  position{line: 1248, col: 1, offset: 30676},
 			expr: &actionExpr{
-				pos: position{line: 1252, col: 5, offset: 30799},
+				pos: position{line: 1249, col: 5, offset: 30689},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1252, col: 5, offset: 30799},
+					pos: position{line: 1249, col: 5, offset: 30689},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1252, col: 5, offset: 30799},
+							pos:   position{line: 1249, col: 5, offset: 30689},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1252, col: 11, offset: 30805},
+								pos:  position{line: 1249, col: 11, offset: 30695},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1252, col: 16, offset: 30810},
+							pos:   position{line: 1249, col: 16, offset: 30700},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1252, col: 21, offset: 30815},
+								pos: position{line: 1249, col: 21, offset: 30705},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1252, col: 21, offset: 30815},
+									pos:  position{line: 1249, col: 21, offset: 30705},
 									name: "TypeListTail",
 								},
 							},
@@ -8395,32 +8392,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1256, col: 1, offset: 30873},
+			pos:  position{line: 1253, col: 1, offset: 30763},
 			expr: &actionExpr{
-				pos: position{line: 1256, col: 16, offset: 30888},
+				pos: position{line: 1253, col: 16, offset: 30778},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1256, col: 16, offset: 30888},
+					pos: position{line: 1253, col: 16, offset: 30778},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1256, col: 16, offset: 30888},
+							pos:  position{line: 1253, col: 16, offset: 30778},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1256, col: 19, offset: 30891},
+							pos:        position{line: 1253, col: 19, offset: 30781},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1256, col: 23, offset: 30895},
+							pos:  position{line: 1253, col: 23, offset: 30785},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1256, col: 26, offset: 30898},
+							pos:   position{line: 1253, col: 26, offset: 30788},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1256, col: 30, offset: 30902},
+								pos:  position{line: 1253, col: 30, offset: 30792},
 								name: "Type",
 							},
 						},
@@ -8432,40 +8429,40 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 1258, col: 1, offset: 30928},
+			pos:  position{line: 1255, col: 1, offset: 30818},
 			expr: &choiceExpr{
-				pos: position{line: 1259, col: 5, offset: 30944},
+				pos: position{line: 1256, col: 5, offset: 30834},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1259, col: 5, offset: 30944},
+						pos: position{line: 1256, col: 5, offset: 30834},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 1259, col: 5, offset: 30944},
+							pos: position{line: 1256, col: 5, offset: 30834},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1259, col: 5, offset: 30944},
+									pos:        position{line: 1256, col: 5, offset: 30834},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1259, col: 9, offset: 30948},
+									pos:  position{line: 1256, col: 9, offset: 30838},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1259, col: 12, offset: 30951},
+									pos:   position{line: 1256, col: 12, offset: 30841},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1259, col: 19, offset: 30958},
+										pos:  position{line: 1256, col: 19, offset: 30848},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1259, col: 33, offset: 30972},
+									pos:  position{line: 1256, col: 33, offset: 30862},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1259, col: 36, offset: 30975},
+									pos:        position{line: 1256, col: 36, offset: 30865},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -8474,35 +8471,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1267, col: 5, offset: 31187},
+						pos: position{line: 1264, col: 5, offset: 31077},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 1267, col: 5, offset: 31187},
+							pos: position{line: 1264, col: 5, offset: 31077},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1267, col: 5, offset: 31187},
+									pos:        position{line: 1264, col: 5, offset: 31077},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1267, col: 9, offset: 31191},
+									pos:  position{line: 1264, col: 9, offset: 31081},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1267, col: 12, offset: 31194},
+									pos:   position{line: 1264, col: 12, offset: 31084},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1267, col: 16, offset: 31198},
+										pos:  position{line: 1264, col: 16, offset: 31088},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1267, col: 21, offset: 31203},
+									pos:  position{line: 1264, col: 21, offset: 31093},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1267, col: 24, offset: 31206},
+									pos:        position{line: 1264, col: 24, offset: 31096},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -8511,35 +8508,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1275, col: 5, offset: 31398},
+						pos: position{line: 1272, col: 5, offset: 31288},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 1275, col: 5, offset: 31398},
+							pos: position{line: 1272, col: 5, offset: 31288},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1275, col: 5, offset: 31398},
+									pos:        position{line: 1272, col: 5, offset: 31288},
 									val:        "|[",
 									ignoreCase: false,
 									want:       "\"|[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1275, col: 10, offset: 31403},
+									pos:  position{line: 1272, col: 10, offset: 31293},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1275, col: 13, offset: 31406},
+									pos:   position{line: 1272, col: 13, offset: 31296},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1275, col: 17, offset: 31410},
+										pos:  position{line: 1272, col: 17, offset: 31300},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1275, col: 22, offset: 31415},
+									pos:  position{line: 1272, col: 22, offset: 31305},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1275, col: 25, offset: 31418},
+									pos:        position{line: 1272, col: 25, offset: 31308},
 									val:        "]|",
 									ignoreCase: false,
 									want:       "\"]|\"",
@@ -8548,57 +8545,57 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1283, col: 5, offset: 31605},
+						pos: position{line: 1280, col: 5, offset: 31495},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 1283, col: 5, offset: 31605},
+							pos: position{line: 1280, col: 5, offset: 31495},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1283, col: 5, offset: 31605},
+									pos:        position{line: 1280, col: 5, offset: 31495},
 									val:        "|{",
 									ignoreCase: false,
 									want:       "\"|{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1283, col: 10, offset: 31610},
+									pos:  position{line: 1280, col: 10, offset: 31500},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1283, col: 13, offset: 31613},
+									pos:   position{line: 1280, col: 13, offset: 31503},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1283, col: 21, offset: 31621},
+										pos:  position{line: 1280, col: 21, offset: 31511},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1283, col: 26, offset: 31626},
+									pos:  position{line: 1280, col: 26, offset: 31516},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1283, col: 29, offset: 31629},
+									pos:        position{line: 1280, col: 29, offset: 31519},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1283, col: 33, offset: 31633},
+									pos:  position{line: 1280, col: 33, offset: 31523},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1283, col: 36, offset: 31636},
+									pos:   position{line: 1280, col: 36, offset: 31526},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1283, col: 44, offset: 31644},
+										pos:  position{line: 1280, col: 44, offset: 31534},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1283, col: 49, offset: 31649},
+									pos:  position{line: 1280, col: 49, offset: 31539},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1283, col: 52, offset: 31652},
+									pos:        position{line: 1280, col: 52, offset: 31542},
 									val:        "}|",
 									ignoreCase: false,
 									want:       "\"}|\"",
@@ -8613,35 +8610,35 @@ var g = &grammar{
 		},
 		{
 			name: "StringLiteral",
-			pos:  position{line: 1293, col: 1, offset: 31875},
+			pos:  position{line: 1290, col: 1, offset: 31765},
 			expr: &choiceExpr{
-				pos: position{line: 1294, col: 5, offset: 31893},
+				pos: position{line: 1291, col: 5, offset: 31783},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1294, col: 5, offset: 31893},
+						pos: position{line: 1291, col: 5, offset: 31783},
 						run: (*parser).callonStringLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1294, col: 5, offset: 31893},
+							pos: position{line: 1291, col: 5, offset: 31783},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1294, col: 5, offset: 31893},
+									pos:        position{line: 1291, col: 5, offset: 31783},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1294, col: 9, offset: 31897},
+									pos:   position{line: 1291, col: 9, offset: 31787},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1294, col: 11, offset: 31899},
+										pos: position{line: 1291, col: 11, offset: 31789},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1294, col: 11, offset: 31899},
+											pos:  position{line: 1291, col: 11, offset: 31789},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1294, col: 29, offset: 31917},
+									pos:        position{line: 1291, col: 29, offset: 31807},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -8650,30 +8647,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1295, col: 5, offset: 31981},
+						pos: position{line: 1292, col: 5, offset: 31871},
 						run: (*parser).callonStringLiteral9,
 						expr: &seqExpr{
-							pos: position{line: 1295, col: 5, offset: 31981},
+							pos: position{line: 1292, col: 5, offset: 31871},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1295, col: 5, offset: 31981},
+									pos:        position{line: 1292, col: 5, offset: 31871},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1295, col: 9, offset: 31985},
+									pos:   position{line: 1292, col: 9, offset: 31875},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1295, col: 11, offset: 31987},
+										pos: position{line: 1292, col: 11, offset: 31877},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1295, col: 11, offset: 31987},
+											pos:  position{line: 1292, col: 11, offset: 31877},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1295, col: 29, offset: 32005},
+									pos:        position{line: 1292, col: 29, offset: 31895},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -8688,35 +8685,35 @@ var g = &grammar{
 		},
 		{
 			name: "FString",
-			pos:  position{line: 1297, col: 1, offset: 32066},
+			pos:  position{line: 1294, col: 1, offset: 31956},
 			expr: &choiceExpr{
-				pos: position{line: 1298, col: 5, offset: 32078},
+				pos: position{line: 1295, col: 5, offset: 31968},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1298, col: 5, offset: 32078},
+						pos: position{line: 1295, col: 5, offset: 31968},
 						run: (*parser).callonFString2,
 						expr: &seqExpr{
-							pos: position{line: 1298, col: 5, offset: 32078},
+							pos: position{line: 1295, col: 5, offset: 31968},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1298, col: 5, offset: 32078},
+									pos:        position{line: 1295, col: 5, offset: 31968},
 									val:        "f\"",
 									ignoreCase: false,
 									want:       "\"f\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1298, col: 11, offset: 32084},
+									pos:   position{line: 1295, col: 11, offset: 31974},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1298, col: 13, offset: 32086},
+										pos: position{line: 1295, col: 13, offset: 31976},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1298, col: 13, offset: 32086},
+											pos:  position{line: 1295, col: 13, offset: 31976},
 											name: "FStringDoubleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1298, col: 38, offset: 32111},
+									pos:        position{line: 1295, col: 38, offset: 32001},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -8725,30 +8722,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1305, col: 5, offset: 32268},
+						pos: position{line: 1302, col: 5, offset: 32158},
 						run: (*parser).callonFString9,
 						expr: &seqExpr{
-							pos: position{line: 1305, col: 5, offset: 32268},
+							pos: position{line: 1302, col: 5, offset: 32158},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1305, col: 5, offset: 32268},
+									pos:        position{line: 1302, col: 5, offset: 32158},
 									val:        "f'",
 									ignoreCase: false,
 									want:       "\"f'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1305, col: 10, offset: 32273},
+									pos:   position{line: 1302, col: 10, offset: 32163},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1305, col: 12, offset: 32275},
+										pos: position{line: 1302, col: 12, offset: 32165},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1305, col: 12, offset: 32275},
+											pos:  position{line: 1302, col: 12, offset: 32165},
 											name: "FStringSingleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1305, col: 37, offset: 32300},
+									pos:        position{line: 1302, col: 37, offset: 32190},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -8763,24 +8760,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedElem",
-			pos:  position{line: 1313, col: 1, offset: 32454},
+			pos:  position{line: 1310, col: 1, offset: 32344},
 			expr: &choiceExpr{
-				pos: position{line: 1314, col: 5, offset: 32482},
+				pos: position{line: 1311, col: 5, offset: 32372},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1314, col: 5, offset: 32482},
+						pos:  position{line: 1311, col: 5, offset: 32372},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1315, col: 5, offset: 32498},
+						pos: position{line: 1312, col: 5, offset: 32388},
 						run: (*parser).callonFStringDoubleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1315, col: 5, offset: 32498},
+							pos:   position{line: 1312, col: 5, offset: 32388},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1315, col: 7, offset: 32500},
+								pos: position{line: 1312, col: 7, offset: 32390},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1315, col: 7, offset: 32500},
+									pos:  position{line: 1312, col: 7, offset: 32390},
 									name: "FStringDoubleQuotedChar",
 								},
 							},
@@ -8793,27 +8790,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedChar",
-			pos:  position{line: 1319, col: 1, offset: 32633},
+			pos:  position{line: 1316, col: 1, offset: 32523},
 			expr: &choiceExpr{
-				pos: position{line: 1320, col: 5, offset: 32661},
+				pos: position{line: 1317, col: 5, offset: 32551},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1320, col: 5, offset: 32661},
+						pos: position{line: 1317, col: 5, offset: 32551},
 						run: (*parser).callonFStringDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1320, col: 5, offset: 32661},
+							pos: position{line: 1317, col: 5, offset: 32551},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1320, col: 5, offset: 32661},
+									pos:        position{line: 1317, col: 5, offset: 32551},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1320, col: 10, offset: 32666},
+									pos:   position{line: 1317, col: 10, offset: 32556},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1320, col: 12, offset: 32668},
+										pos:        position{line: 1317, col: 12, offset: 32558},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -8823,25 +8820,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1321, col: 5, offset: 32694},
+						pos: position{line: 1318, col: 5, offset: 32584},
 						run: (*parser).callonFStringDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1321, col: 5, offset: 32694},
+							pos: position{line: 1318, col: 5, offset: 32584},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1321, col: 5, offset: 32694},
+									pos: position{line: 1318, col: 5, offset: 32584},
 									expr: &litMatcher{
-										pos:        position{line: 1321, col: 7, offset: 32696},
+										pos:        position{line: 1318, col: 7, offset: 32586},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1321, col: 12, offset: 32701},
+									pos:   position{line: 1318, col: 12, offset: 32591},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1321, col: 14, offset: 32703},
+										pos:  position{line: 1318, col: 14, offset: 32593},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -8855,24 +8852,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedElem",
-			pos:  position{line: 1323, col: 1, offset: 32739},
+			pos:  position{line: 1320, col: 1, offset: 32629},
 			expr: &choiceExpr{
-				pos: position{line: 1324, col: 5, offset: 32767},
+				pos: position{line: 1321, col: 5, offset: 32657},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1324, col: 5, offset: 32767},
+						pos:  position{line: 1321, col: 5, offset: 32657},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1325, col: 5, offset: 32783},
+						pos: position{line: 1322, col: 5, offset: 32673},
 						run: (*parser).callonFStringSingleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1325, col: 5, offset: 32783},
+							pos:   position{line: 1322, col: 5, offset: 32673},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1325, col: 7, offset: 32785},
+								pos: position{line: 1322, col: 7, offset: 32675},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1325, col: 7, offset: 32785},
+									pos:  position{line: 1322, col: 7, offset: 32675},
 									name: "FStringSingleQuotedChar",
 								},
 							},
@@ -8885,27 +8882,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedChar",
-			pos:  position{line: 1329, col: 1, offset: 32918},
+			pos:  position{line: 1326, col: 1, offset: 32808},
 			expr: &choiceExpr{
-				pos: position{line: 1330, col: 5, offset: 32946},
+				pos: position{line: 1327, col: 5, offset: 32836},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1330, col: 5, offset: 32946},
+						pos: position{line: 1327, col: 5, offset: 32836},
 						run: (*parser).callonFStringSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1330, col: 5, offset: 32946},
+							pos: position{line: 1327, col: 5, offset: 32836},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1330, col: 5, offset: 32946},
+									pos:        position{line: 1327, col: 5, offset: 32836},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1330, col: 10, offset: 32951},
+									pos:   position{line: 1327, col: 10, offset: 32841},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1330, col: 12, offset: 32953},
+										pos:        position{line: 1327, col: 12, offset: 32843},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -8915,25 +8912,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1331, col: 5, offset: 32979},
+						pos: position{line: 1328, col: 5, offset: 32869},
 						run: (*parser).callonFStringSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1331, col: 5, offset: 32979},
+							pos: position{line: 1328, col: 5, offset: 32869},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1331, col: 5, offset: 32979},
+									pos: position{line: 1328, col: 5, offset: 32869},
 									expr: &litMatcher{
-										pos:        position{line: 1331, col: 7, offset: 32981},
+										pos:        position{line: 1328, col: 7, offset: 32871},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1331, col: 12, offset: 32986},
+									pos:   position{line: 1328, col: 12, offset: 32876},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1331, col: 14, offset: 32988},
+										pos:  position{line: 1328, col: 14, offset: 32878},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -8947,37 +8944,37 @@ var g = &grammar{
 		},
 		{
 			name: "FStringExpr",
-			pos:  position{line: 1333, col: 1, offset: 33024},
+			pos:  position{line: 1330, col: 1, offset: 32914},
 			expr: &actionExpr{
-				pos: position{line: 1334, col: 5, offset: 33040},
+				pos: position{line: 1331, col: 5, offset: 32930},
 				run: (*parser).callonFStringExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1334, col: 5, offset: 33040},
+					pos: position{line: 1331, col: 5, offset: 32930},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1334, col: 5, offset: 33040},
+							pos:        position{line: 1331, col: 5, offset: 32930},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1334, col: 9, offset: 33044},
+							pos:  position{line: 1331, col: 9, offset: 32934},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1334, col: 12, offset: 33047},
+							pos:   position{line: 1331, col: 12, offset: 32937},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1334, col: 14, offset: 33049},
+								pos:  position{line: 1331, col: 14, offset: 32939},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1334, col: 19, offset: 33054},
+							pos:  position{line: 1331, col: 19, offset: 32944},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1334, col: 22, offset: 33057},
+							pos:        position{line: 1331, col: 22, offset: 32947},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -8990,129 +8987,129 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1343, col: 1, offset: 33235},
+			pos:  position{line: 1340, col: 1, offset: 33125},
 			expr: &actionExpr{
-				pos: position{line: 1344, col: 5, offset: 33253},
+				pos: position{line: 1341, col: 5, offset: 33143},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1344, col: 9, offset: 33257},
+					pos: position{line: 1341, col: 9, offset: 33147},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1344, col: 9, offset: 33257},
+							pos:        position{line: 1341, col: 9, offset: 33147},
 							val:        "uint8",
 							ignoreCase: false,
 							want:       "\"uint8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1344, col: 19, offset: 33267},
+							pos:        position{line: 1341, col: 19, offset: 33157},
 							val:        "uint16",
 							ignoreCase: false,
 							want:       "\"uint16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1344, col: 30, offset: 33278},
+							pos:        position{line: 1341, col: 30, offset: 33168},
 							val:        "uint32",
 							ignoreCase: false,
 							want:       "\"uint32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1344, col: 41, offset: 33289},
+							pos:        position{line: 1341, col: 41, offset: 33179},
 							val:        "uint64",
 							ignoreCase: false,
 							want:       "\"uint64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1345, col: 9, offset: 33306},
+							pos:        position{line: 1342, col: 9, offset: 33196},
 							val:        "int8",
 							ignoreCase: false,
 							want:       "\"int8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1345, col: 18, offset: 33315},
+							pos:        position{line: 1342, col: 18, offset: 33205},
 							val:        "int16",
 							ignoreCase: false,
 							want:       "\"int16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1345, col: 28, offset: 33325},
+							pos:        position{line: 1342, col: 28, offset: 33215},
 							val:        "int32",
 							ignoreCase: false,
 							want:       "\"int32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1345, col: 38, offset: 33335},
+							pos:        position{line: 1342, col: 38, offset: 33225},
 							val:        "int64",
 							ignoreCase: false,
 							want:       "\"int64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1346, col: 9, offset: 33351},
+							pos:        position{line: 1343, col: 9, offset: 33241},
 							val:        "float16",
 							ignoreCase: false,
 							want:       "\"float16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1346, col: 21, offset: 33363},
+							pos:        position{line: 1343, col: 21, offset: 33253},
 							val:        "float32",
 							ignoreCase: false,
 							want:       "\"float32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1346, col: 33, offset: 33375},
+							pos:        position{line: 1343, col: 33, offset: 33265},
 							val:        "float64",
 							ignoreCase: false,
 							want:       "\"float64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1347, col: 9, offset: 33393},
+							pos:        position{line: 1344, col: 9, offset: 33283},
 							val:        "bool",
 							ignoreCase: false,
 							want:       "\"bool\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1347, col: 18, offset: 33402},
+							pos:        position{line: 1344, col: 18, offset: 33292},
 							val:        "string",
 							ignoreCase: false,
 							want:       "\"string\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1348, col: 9, offset: 33419},
+							pos:        position{line: 1345, col: 9, offset: 33309},
 							val:        "duration",
 							ignoreCase: false,
 							want:       "\"duration\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1348, col: 22, offset: 33432},
+							pos:        position{line: 1345, col: 22, offset: 33322},
 							val:        "time",
 							ignoreCase: false,
 							want:       "\"time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1349, col: 9, offset: 33447},
+							pos:        position{line: 1346, col: 9, offset: 33337},
 							val:        "bytes",
 							ignoreCase: false,
 							want:       "\"bytes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1350, col: 9, offset: 33463},
+							pos:        position{line: 1347, col: 9, offset: 33353},
 							val:        "ip",
 							ignoreCase: false,
 							want:       "\"ip\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1350, col: 16, offset: 33470},
+							pos:        position{line: 1347, col: 16, offset: 33360},
 							val:        "net",
 							ignoreCase: false,
 							want:       "\"net\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1351, col: 9, offset: 33484},
+							pos:        position{line: 1348, col: 9, offset: 33374},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1351, col: 18, offset: 33493},
+							pos:        position{line: 1348, col: 18, offset: 33383},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
@@ -9125,31 +9122,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1359, col: 1, offset: 33691},
+			pos:  position{line: 1356, col: 1, offset: 33581},
 			expr: &choiceExpr{
-				pos: position{line: 1360, col: 5, offset: 33709},
+				pos: position{line: 1357, col: 5, offset: 33599},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1360, col: 5, offset: 33709},
+						pos: position{line: 1357, col: 5, offset: 33599},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1360, col: 5, offset: 33709},
+							pos: position{line: 1357, col: 5, offset: 33599},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1360, col: 5, offset: 33709},
+									pos:   position{line: 1357, col: 5, offset: 33599},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1360, col: 11, offset: 33715},
+										pos:  position{line: 1357, col: 11, offset: 33605},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1360, col: 21, offset: 33725},
+									pos:   position{line: 1357, col: 21, offset: 33615},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1360, col: 26, offset: 33730},
+										pos: position{line: 1357, col: 26, offset: 33620},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1360, col: 26, offset: 33730},
+											pos:  position{line: 1357, col: 26, offset: 33620},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -9158,10 +9155,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1363, col: 5, offset: 33796},
+						pos: position{line: 1360, col: 5, offset: 33686},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1363, col: 5, offset: 33796},
+							pos:        position{line: 1360, col: 5, offset: 33686},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -9174,32 +9171,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1365, col: 1, offset: 33820},
+			pos:  position{line: 1362, col: 1, offset: 33710},
 			expr: &actionExpr{
-				pos: position{line: 1365, col: 21, offset: 33840},
+				pos: position{line: 1362, col: 21, offset: 33730},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1365, col: 21, offset: 33840},
+					pos: position{line: 1362, col: 21, offset: 33730},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1365, col: 21, offset: 33840},
+							pos:  position{line: 1362, col: 21, offset: 33730},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1365, col: 24, offset: 33843},
+							pos:        position{line: 1362, col: 24, offset: 33733},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1365, col: 28, offset: 33847},
+							pos:  position{line: 1362, col: 28, offset: 33737},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1365, col: 31, offset: 33850},
+							pos:   position{line: 1362, col: 31, offset: 33740},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1365, col: 35, offset: 33854},
+								pos:  position{line: 1362, col: 35, offset: 33744},
 								name: "TypeField",
 							},
 						},
@@ -9211,40 +9208,40 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1367, col: 1, offset: 33885},
+			pos:  position{line: 1364, col: 1, offset: 33775},
 			expr: &actionExpr{
-				pos: position{line: 1368, col: 5, offset: 33899},
+				pos: position{line: 1365, col: 5, offset: 33789},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1368, col: 5, offset: 33899},
+					pos: position{line: 1365, col: 5, offset: 33789},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1368, col: 5, offset: 33899},
+							pos:   position{line: 1365, col: 5, offset: 33789},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1368, col: 10, offset: 33904},
+								pos:  position{line: 1365, col: 10, offset: 33794},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1368, col: 20, offset: 33914},
+							pos:  position{line: 1365, col: 20, offset: 33804},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1368, col: 23, offset: 33917},
+							pos:        position{line: 1365, col: 23, offset: 33807},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1368, col: 27, offset: 33921},
+							pos:  position{line: 1365, col: 27, offset: 33811},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1368, col: 30, offset: 33924},
+							pos:   position{line: 1365, col: 30, offset: 33814},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1368, col: 34, offset: 33928},
+								pos:  position{line: 1365, col: 34, offset: 33818},
 								name: "Type",
 							},
 						},
@@ -9256,16 +9253,16 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 1375, col: 1, offset: 34052},
+			pos:  position{line: 1372, col: 1, offset: 33942},
 			expr: &choiceExpr{
-				pos: position{line: 1376, col: 5, offset: 34066},
+				pos: position{line: 1373, col: 5, offset: 33956},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1376, col: 5, offset: 34066},
+						pos:  position{line: 1373, col: 5, offset: 33956},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1377, col: 5, offset: 34085},
+						pos:  position{line: 1374, col: 5, offset: 33975},
 						name: "QuotedString",
 					},
 				},
@@ -9275,24 +9272,24 @@ var g = &grammar{
 		},
 		{
 			name: "AndToken",
-			pos:  position{line: 1379, col: 1, offset: 34099},
+			pos:  position{line: 1376, col: 1, offset: 33989},
 			expr: &actionExpr{
-				pos: position{line: 1379, col: 12, offset: 34110},
+				pos: position{line: 1376, col: 12, offset: 34000},
 				run: (*parser).callonAndToken1,
 				expr: &seqExpr{
-					pos: position{line: 1379, col: 12, offset: 34110},
+					pos: position{line: 1376, col: 12, offset: 34000},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 1379, col: 13, offset: 34111},
+							pos: position{line: 1376, col: 13, offset: 34001},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1379, col: 13, offset: 34111},
+									pos:        position{line: 1376, col: 13, offset: 34001},
 									val:        "and",
 									ignoreCase: false,
 									want:       "\"and\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1379, col: 21, offset: 34119},
+									pos:        position{line: 1376, col: 21, offset: 34009},
 									val:        "AND",
 									ignoreCase: false,
 									want:       "\"AND\"",
@@ -9300,9 +9297,9 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 1379, col: 28, offset: 34126},
+							pos: position{line: 1376, col: 28, offset: 34016},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1379, col: 29, offset: 34127},
+								pos:  position{line: 1376, col: 29, offset: 34017},
 								name: "IdentifierRest",
 							},
 						},
@@ -9314,20 +9311,20 @@ var g = &grammar{
 		},
 		{
 			name: "ByToken",
-			pos:  position{line: 1380, col: 1, offset: 34164},
+			pos:  position{line: 1377, col: 1, offset: 34054},
 			expr: &seqExpr{
-				pos: position{line: 1380, col: 11, offset: 34174},
+				pos: position{line: 1377, col: 11, offset: 34064},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1380, col: 11, offset: 34174},
+						pos:        position{line: 1377, col: 11, offset: 34064},
 						val:        "by",
 						ignoreCase: false,
 						want:       "\"by\"",
 					},
 					&notExpr{
-						pos: position{line: 1380, col: 16, offset: 34179},
+						pos: position{line: 1377, col: 16, offset: 34069},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1380, col: 17, offset: 34180},
+							pos:  position{line: 1377, col: 17, offset: 34070},
 							name: "IdentifierRest",
 						},
 					},
@@ -9338,20 +9335,20 @@ var g = &grammar{
 		},
 		{
 			name: "FalseToken",
-			pos:  position{line: 1381, col: 1, offset: 34195},
+			pos:  position{line: 1378, col: 1, offset: 34085},
 			expr: &seqExpr{
-				pos: position{line: 1381, col: 14, offset: 34208},
+				pos: position{line: 1378, col: 14, offset: 34098},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1381, col: 14, offset: 34208},
+						pos:        position{line: 1378, col: 14, offset: 34098},
 						val:        "false",
 						ignoreCase: false,
 						want:       "\"false\"",
 					},
 					&notExpr{
-						pos: position{line: 1381, col: 22, offset: 34216},
+						pos: position{line: 1378, col: 22, offset: 34106},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1381, col: 23, offset: 34217},
+							pos:  position{line: 1378, col: 23, offset: 34107},
 							name: "IdentifierRest",
 						},
 					},
@@ -9362,20 +9359,20 @@ var g = &grammar{
 		},
 		{
 			name: "InToken",
-			pos:  position{line: 1382, col: 1, offset: 34232},
+			pos:  position{line: 1379, col: 1, offset: 34122},
 			expr: &seqExpr{
-				pos: position{line: 1382, col: 11, offset: 34242},
+				pos: position{line: 1379, col: 11, offset: 34132},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1382, col: 11, offset: 34242},
+						pos:        position{line: 1379, col: 11, offset: 34132},
 						val:        "in",
 						ignoreCase: false,
 						want:       "\"in\"",
 					},
 					&notExpr{
-						pos: position{line: 1382, col: 16, offset: 34247},
+						pos: position{line: 1379, col: 16, offset: 34137},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1382, col: 17, offset: 34248},
+							pos:  position{line: 1379, col: 17, offset: 34138},
 							name: "IdentifierRest",
 						},
 					},
@@ -9386,24 +9383,24 @@ var g = &grammar{
 		},
 		{
 			name: "NotToken",
-			pos:  position{line: 1383, col: 1, offset: 34263},
+			pos:  position{line: 1380, col: 1, offset: 34153},
 			expr: &actionExpr{
-				pos: position{line: 1383, col: 12, offset: 34274},
+				pos: position{line: 1380, col: 12, offset: 34164},
 				run: (*parser).callonNotToken1,
 				expr: &seqExpr{
-					pos: position{line: 1383, col: 12, offset: 34274},
+					pos: position{line: 1380, col: 12, offset: 34164},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 1383, col: 13, offset: 34275},
+							pos: position{line: 1380, col: 13, offset: 34165},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1383, col: 13, offset: 34275},
+									pos:        position{line: 1380, col: 13, offset: 34165},
 									val:        "not",
 									ignoreCase: false,
 									want:       "\"not\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1383, col: 21, offset: 34283},
+									pos:        position{line: 1380, col: 21, offset: 34173},
 									val:        "NOT",
 									ignoreCase: false,
 									want:       "\"NOT\"",
@@ -9411,9 +9408,9 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 1383, col: 28, offset: 34290},
+							pos: position{line: 1380, col: 28, offset: 34180},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1383, col: 29, offset: 34291},
+								pos:  position{line: 1380, col: 29, offset: 34181},
 								name: "IdentifierRest",
 							},
 						},
@@ -9425,20 +9422,20 @@ var g = &grammar{
 		},
 		{
 			name: "NullToken",
-			pos:  position{line: 1384, col: 1, offset: 34328},
+			pos:  position{line: 1381, col: 1, offset: 34218},
 			expr: &seqExpr{
-				pos: position{line: 1384, col: 13, offset: 34340},
+				pos: position{line: 1381, col: 13, offset: 34230},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1384, col: 13, offset: 34340},
+						pos:        position{line: 1381, col: 13, offset: 34230},
 						val:        "null",
 						ignoreCase: false,
 						want:       "\"null\"",
 					},
 					&notExpr{
-						pos: position{line: 1384, col: 20, offset: 34347},
+						pos: position{line: 1381, col: 20, offset: 34237},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1384, col: 21, offset: 34348},
+							pos:  position{line: 1381, col: 21, offset: 34238},
 							name: "IdentifierRest",
 						},
 					},
@@ -9449,24 +9446,24 @@ var g = &grammar{
 		},
 		{
 			name: "OrToken",
-			pos:  position{line: 1385, col: 1, offset: 34363},
+			pos:  position{line: 1382, col: 1, offset: 34253},
 			expr: &actionExpr{
-				pos: position{line: 1385, col: 11, offset: 34373},
+				pos: position{line: 1382, col: 11, offset: 34263},
 				run: (*parser).callonOrToken1,
 				expr: &seqExpr{
-					pos: position{line: 1385, col: 11, offset: 34373},
+					pos: position{line: 1382, col: 11, offset: 34263},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 1385, col: 12, offset: 34374},
+							pos: position{line: 1382, col: 12, offset: 34264},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1385, col: 12, offset: 34374},
+									pos:        position{line: 1382, col: 12, offset: 34264},
 									val:        "or",
 									ignoreCase: false,
 									want:       "\"or\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1385, col: 19, offset: 34381},
+									pos:        position{line: 1382, col: 19, offset: 34271},
 									val:        "OR",
 									ignoreCase: false,
 									want:       "\"OR\"",
@@ -9474,9 +9471,9 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 1385, col: 25, offset: 34387},
+							pos: position{line: 1382, col: 25, offset: 34277},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1385, col: 26, offset: 34388},
+								pos:  position{line: 1382, col: 26, offset: 34278},
 								name: "IdentifierRest",
 							},
 						},
@@ -9488,20 +9485,20 @@ var g = &grammar{
 		},
 		{
 			name: "TrueToken",
-			pos:  position{line: 1386, col: 1, offset: 34424},
+			pos:  position{line: 1383, col: 1, offset: 34314},
 			expr: &seqExpr{
-				pos: position{line: 1386, col: 13, offset: 34436},
+				pos: position{line: 1383, col: 13, offset: 34326},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1386, col: 13, offset: 34436},
+						pos:        position{line: 1383, col: 13, offset: 34326},
 						val:        "true",
 						ignoreCase: false,
 						want:       "\"true\"",
 					},
 					&notExpr{
-						pos: position{line: 1386, col: 20, offset: 34443},
+						pos: position{line: 1383, col: 20, offset: 34333},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1386, col: 21, offset: 34444},
+							pos:  position{line: 1383, col: 21, offset: 34334},
 							name: "IdentifierRest",
 						},
 					},
@@ -9512,15 +9509,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1388, col: 1, offset: 34460},
+			pos:  position{line: 1385, col: 1, offset: 34350},
 			expr: &actionExpr{
-				pos: position{line: 1389, col: 5, offset: 34475},
+				pos: position{line: 1386, col: 5, offset: 34365},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1389, col: 5, offset: 34475},
+					pos:   position{line: 1386, col: 5, offset: 34365},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1389, col: 8, offset: 34478},
+						pos:  position{line: 1386, col: 8, offset: 34368},
 						name: "IdentifierName",
 					},
 				},
@@ -9530,29 +9527,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1397, col: 1, offset: 34621},
+			pos:  position{line: 1394, col: 1, offset: 34511},
 			expr: &choiceExpr{
-				pos: position{line: 1398, col: 5, offset: 34640},
+				pos: position{line: 1395, col: 5, offset: 34530},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1398, col: 5, offset: 34640},
+						pos: position{line: 1395, col: 5, offset: 34530},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1398, col: 5, offset: 34640},
+							pos: position{line: 1395, col: 5, offset: 34530},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1398, col: 5, offset: 34640},
+									pos: position{line: 1395, col: 5, offset: 34530},
 									expr: &seqExpr{
-										pos: position{line: 1398, col: 7, offset: 34642},
+										pos: position{line: 1395, col: 7, offset: 34532},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1398, col: 7, offset: 34642},
+												pos:  position{line: 1395, col: 7, offset: 34532},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1398, col: 15, offset: 34650},
+												pos: position{line: 1395, col: 15, offset: 34540},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1398, col: 16, offset: 34651},
+													pos:  position{line: 1395, col: 16, offset: 34541},
 													name: "IdentifierRest",
 												},
 											},
@@ -9560,13 +9557,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1398, col: 32, offset: 34667},
+									pos:  position{line: 1395, col: 32, offset: 34557},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1398, col: 48, offset: 34683},
+									pos: position{line: 1395, col: 48, offset: 34573},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1398, col: 48, offset: 34683},
+										pos:  position{line: 1395, col: 48, offset: 34573},
 										name: "IdentifierRest",
 									},
 								},
@@ -9574,32 +9571,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1399, col: 5, offset: 34734},
+						pos: position{line: 1396, col: 5, offset: 34624},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 1399, col: 5, offset: 34734},
+							pos:        position{line: 1396, col: 5, offset: 34624},
 							val:        "$",
 							ignoreCase: false,
 							want:       "\"$\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1400, col: 5, offset: 34773},
+						pos: position{line: 1397, col: 5, offset: 34663},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 1400, col: 5, offset: 34773},
+							pos: position{line: 1397, col: 5, offset: 34663},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1400, col: 5, offset: 34773},
+									pos:        position{line: 1397, col: 5, offset: 34663},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1400, col: 10, offset: 34778},
+									pos:   position{line: 1397, col: 10, offset: 34668},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1400, col: 13, offset: 34781},
+										pos:  position{line: 1397, col: 13, offset: 34671},
 										name: "IDGuard",
 									},
 								},
@@ -9607,10 +9604,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1402, col: 5, offset: 34872},
+						pos: position{line: 1399, col: 5, offset: 34762},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 1402, col: 5, offset: 34872},
+							pos:        position{line: 1399, col: 5, offset: 34762},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
@@ -9623,51 +9620,51 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierNames",
-			pos:  position{line: 1404, col: 1, offset: 34911},
+			pos:  position{line: 1401, col: 1, offset: 34801},
 			expr: &actionExpr{
-				pos: position{line: 1405, col: 5, offset: 34931},
+				pos: position{line: 1402, col: 5, offset: 34821},
 				run: (*parser).callonIdentifierNames1,
 				expr: &seqExpr{
-					pos: position{line: 1405, col: 5, offset: 34931},
+					pos: position{line: 1402, col: 5, offset: 34821},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1405, col: 5, offset: 34931},
+							pos:   position{line: 1402, col: 5, offset: 34821},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1405, col: 11, offset: 34937},
+								pos:  position{line: 1402, col: 11, offset: 34827},
 								name: "IdentifierName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1405, col: 26, offset: 34952},
+							pos:   position{line: 1402, col: 26, offset: 34842},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1405, col: 31, offset: 34957},
+								pos: position{line: 1402, col: 31, offset: 34847},
 								expr: &actionExpr{
-									pos: position{line: 1405, col: 32, offset: 34958},
+									pos: position{line: 1402, col: 32, offset: 34848},
 									run: (*parser).callonIdentifierNames7,
 									expr: &seqExpr{
-										pos: position{line: 1405, col: 32, offset: 34958},
+										pos: position{line: 1402, col: 32, offset: 34848},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1405, col: 32, offset: 34958},
+												pos:  position{line: 1402, col: 32, offset: 34848},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1405, col: 35, offset: 34961},
+												pos:        position{line: 1402, col: 35, offset: 34851},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1405, col: 39, offset: 34965},
+												pos:  position{line: 1402, col: 39, offset: 34855},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1405, col: 42, offset: 34968},
+												pos:   position{line: 1402, col: 42, offset: 34858},
 												label: "id",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1405, col: 45, offset: 34971},
+													pos:  position{line: 1402, col: 45, offset: 34861},
 													name: "IdentifierName",
 												},
 											},
@@ -9684,22 +9681,22 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1409, col: 1, offset: 35051},
+			pos:  position{line: 1406, col: 1, offset: 34941},
 			expr: &choiceExpr{
-				pos: position{line: 1410, col: 5, offset: 35071},
+				pos: position{line: 1407, col: 5, offset: 34961},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1410, col: 5, offset: 35071},
+						pos:  position{line: 1407, col: 5, offset: 34961},
 						name: "UnicodeLetter",
 					},
 					&litMatcher{
-						pos:        position{line: 1411, col: 5, offset: 35089},
+						pos:        position{line: 1408, col: 5, offset: 34979},
 						val:        "$",
 						ignoreCase: false,
 						want:       "\"$\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1412, col: 5, offset: 35097},
+						pos:        position{line: 1409, col: 5, offset: 34987},
 						val:        "_",
 						ignoreCase: false,
 						want:       "\"_\"",
@@ -9711,24 +9708,24 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1414, col: 1, offset: 35102},
+			pos:  position{line: 1411, col: 1, offset: 34992},
 			expr: &choiceExpr{
-				pos: position{line: 1415, col: 5, offset: 35121},
+				pos: position{line: 1412, col: 5, offset: 35011},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1415, col: 5, offset: 35121},
+						pos:  position{line: 1412, col: 5, offset: 35011},
 						name: "IdentifierStart",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1416, col: 5, offset: 35141},
+						pos:  position{line: 1413, col: 5, offset: 35031},
 						name: "UnicodeCombiningMark",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1417, col: 5, offset: 35166},
+						pos:  position{line: 1414, col: 5, offset: 35056},
 						name: "UnicodeDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1418, col: 5, offset: 35183},
+						pos:  position{line: 1415, col: 5, offset: 35073},
 						name: "UnicodeConnectorPunctuation",
 					},
 				},
@@ -9738,24 +9735,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1420, col: 1, offset: 35212},
+			pos:  position{line: 1417, col: 1, offset: 35102},
 			expr: &choiceExpr{
-				pos: position{line: 1421, col: 5, offset: 35224},
+				pos: position{line: 1418, col: 5, offset: 35114},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1421, col: 5, offset: 35224},
+						pos:  position{line: 1418, col: 5, offset: 35114},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1422, col: 5, offset: 35243},
+						pos:  position{line: 1419, col: 5, offset: 35133},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1423, col: 5, offset: 35259},
+						pos:  position{line: 1420, col: 5, offset: 35149},
 						name: "NaN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1424, col: 5, offset: 35267},
+						pos:  position{line: 1421, col: 5, offset: 35157},
 						name: "Infinity",
 					},
 				},
@@ -9765,25 +9762,25 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1426, col: 1, offset: 35277},
+			pos:  position{line: 1423, col: 1, offset: 35167},
 			expr: &actionExpr{
-				pos: position{line: 1427, col: 5, offset: 35286},
+				pos: position{line: 1424, col: 5, offset: 35176},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1427, col: 5, offset: 35286},
+					pos: position{line: 1424, col: 5, offset: 35176},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1427, col: 5, offset: 35286},
+							pos:  position{line: 1424, col: 5, offset: 35176},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1427, col: 14, offset: 35295},
+							pos:        position{line: 1424, col: 14, offset: 35185},
 							val:        "T",
 							ignoreCase: false,
 							want:       "\"T\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1427, col: 18, offset: 35299},
+							pos:  position{line: 1424, col: 18, offset: 35189},
 							name: "FullTime",
 						},
 					},
@@ -9794,32 +9791,32 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1431, col: 1, offset: 35375},
+			pos:  position{line: 1428, col: 1, offset: 35265},
 			expr: &seqExpr{
-				pos: position{line: 1431, col: 12, offset: 35386},
+				pos: position{line: 1428, col: 12, offset: 35276},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1431, col: 12, offset: 35386},
+						pos:  position{line: 1428, col: 12, offset: 35276},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1431, col: 15, offset: 35389},
+						pos:        position{line: 1428, col: 15, offset: 35279},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1431, col: 19, offset: 35393},
+						pos:  position{line: 1428, col: 19, offset: 35283},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1431, col: 22, offset: 35396},
+						pos:        position{line: 1428, col: 22, offset: 35286},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1431, col: 26, offset: 35400},
+						pos:  position{line: 1428, col: 26, offset: 35290},
 						name: "D2",
 					},
 				},
@@ -9829,33 +9826,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1433, col: 1, offset: 35404},
+			pos:  position{line: 1430, col: 1, offset: 35294},
 			expr: &seqExpr{
-				pos: position{line: 1433, col: 6, offset: 35409},
+				pos: position{line: 1430, col: 6, offset: 35299},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1433, col: 6, offset: 35409},
+						pos:        position{line: 1430, col: 6, offset: 35299},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1433, col: 11, offset: 35414},
+						pos:        position{line: 1430, col: 11, offset: 35304},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1433, col: 16, offset: 35419},
+						pos:        position{line: 1430, col: 16, offset: 35309},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1433, col: 21, offset: 35424},
+						pos:        position{line: 1430, col: 21, offset: 35314},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9868,19 +9865,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1434, col: 1, offset: 35430},
+			pos:  position{line: 1431, col: 1, offset: 35320},
 			expr: &seqExpr{
-				pos: position{line: 1434, col: 6, offset: 35435},
+				pos: position{line: 1431, col: 6, offset: 35325},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1434, col: 6, offset: 35435},
+						pos:        position{line: 1431, col: 6, offset: 35325},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1434, col: 11, offset: 35440},
+						pos:        position{line: 1431, col: 11, offset: 35330},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9893,16 +9890,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1436, col: 1, offset: 35447},
+			pos:  position{line: 1433, col: 1, offset: 35337},
 			expr: &seqExpr{
-				pos: position{line: 1436, col: 12, offset: 35458},
+				pos: position{line: 1433, col: 12, offset: 35348},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1436, col: 12, offset: 35458},
+						pos:  position{line: 1433, col: 12, offset: 35348},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1436, col: 24, offset: 35470},
+						pos:  position{line: 1433, col: 24, offset: 35360},
 						name: "TimeOffset",
 					},
 				},
@@ -9912,49 +9909,49 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1438, col: 1, offset: 35482},
+			pos:  position{line: 1435, col: 1, offset: 35372},
 			expr: &seqExpr{
-				pos: position{line: 1438, col: 15, offset: 35496},
+				pos: position{line: 1435, col: 15, offset: 35386},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1438, col: 15, offset: 35496},
+						pos:  position{line: 1435, col: 15, offset: 35386},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1438, col: 18, offset: 35499},
+						pos:        position{line: 1435, col: 18, offset: 35389},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1438, col: 22, offset: 35503},
+						pos:  position{line: 1435, col: 22, offset: 35393},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1438, col: 25, offset: 35506},
+						pos:        position{line: 1435, col: 25, offset: 35396},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1438, col: 29, offset: 35510},
+						pos:  position{line: 1435, col: 29, offset: 35400},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1438, col: 32, offset: 35513},
+						pos: position{line: 1435, col: 32, offset: 35403},
 						expr: &seqExpr{
-							pos: position{line: 1438, col: 33, offset: 35514},
+							pos: position{line: 1435, col: 33, offset: 35404},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1438, col: 33, offset: 35514},
+									pos:        position{line: 1435, col: 33, offset: 35404},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1438, col: 37, offset: 35518},
+									pos: position{line: 1435, col: 37, offset: 35408},
 									expr: &charClassMatcher{
-										pos:        position{line: 1438, col: 37, offset: 35518},
+										pos:        position{line: 1435, col: 37, offset: 35408},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -9971,30 +9968,30 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1440, col: 1, offset: 35528},
+			pos:  position{line: 1437, col: 1, offset: 35418},
 			expr: &choiceExpr{
-				pos: position{line: 1441, col: 5, offset: 35543},
+				pos: position{line: 1438, col: 5, offset: 35433},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1441, col: 5, offset: 35543},
+						pos:        position{line: 1438, col: 5, offset: 35433},
 						val:        "Z",
 						ignoreCase: false,
 						want:       "\"Z\"",
 					},
 					&seqExpr{
-						pos: position{line: 1442, col: 5, offset: 35551},
+						pos: position{line: 1439, col: 5, offset: 35441},
 						exprs: []any{
 							&choiceExpr{
-								pos: position{line: 1442, col: 6, offset: 35552},
+								pos: position{line: 1439, col: 6, offset: 35442},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 1442, col: 6, offset: 35552},
+										pos:        position{line: 1439, col: 6, offset: 35442},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 1442, col: 12, offset: 35558},
+										pos:        position{line: 1439, col: 12, offset: 35448},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
@@ -10002,34 +9999,34 @@ var g = &grammar{
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1442, col: 17, offset: 35563},
+								pos:  position{line: 1439, col: 17, offset: 35453},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1442, col: 20, offset: 35566},
+								pos:        position{line: 1439, col: 20, offset: 35456},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1442, col: 24, offset: 35570},
+								pos:  position{line: 1439, col: 24, offset: 35460},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1442, col: 27, offset: 35573},
+								pos: position{line: 1439, col: 27, offset: 35463},
 								expr: &seqExpr{
-									pos: position{line: 1442, col: 28, offset: 35574},
+									pos: position{line: 1439, col: 28, offset: 35464},
 									exprs: []any{
 										&litMatcher{
-											pos:        position{line: 1442, col: 28, offset: 35574},
+											pos:        position{line: 1439, col: 28, offset: 35464},
 											val:        ".",
 											ignoreCase: false,
 											want:       "\".\"",
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1442, col: 32, offset: 35578},
+											pos: position{line: 1439, col: 32, offset: 35468},
 											expr: &charClassMatcher{
-												pos:        position{line: 1442, col: 32, offset: 35578},
+												pos:        position{line: 1439, col: 32, offset: 35468},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -10048,33 +10045,33 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1444, col: 1, offset: 35588},
+			pos:  position{line: 1441, col: 1, offset: 35478},
 			expr: &actionExpr{
-				pos: position{line: 1445, col: 5, offset: 35601},
+				pos: position{line: 1442, col: 5, offset: 35491},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1445, col: 5, offset: 35601},
+					pos: position{line: 1442, col: 5, offset: 35491},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 1445, col: 5, offset: 35601},
+							pos: position{line: 1442, col: 5, offset: 35491},
 							expr: &litMatcher{
-								pos:        position{line: 1445, col: 5, offset: 35601},
+								pos:        position{line: 1442, col: 5, offset: 35491},
 								val:        "-",
 								ignoreCase: false,
 								want:       "\"-\"",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1445, col: 10, offset: 35606},
+							pos: position{line: 1442, col: 10, offset: 35496},
 							expr: &seqExpr{
-								pos: position{line: 1445, col: 11, offset: 35607},
+								pos: position{line: 1442, col: 11, offset: 35497},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1445, col: 11, offset: 35607},
+										pos:  position{line: 1442, col: 11, offset: 35497},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1445, col: 19, offset: 35615},
+										pos:  position{line: 1442, col: 19, offset: 35505},
 										name: "TimeUnit",
 									},
 								},
@@ -10088,27 +10085,27 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1449, col: 1, offset: 35697},
+			pos:  position{line: 1446, col: 1, offset: 35587},
 			expr: &seqExpr{
-				pos: position{line: 1449, col: 11, offset: 35707},
+				pos: position{line: 1446, col: 11, offset: 35597},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1449, col: 11, offset: 35707},
+						pos:  position{line: 1446, col: 11, offset: 35597},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1449, col: 16, offset: 35712},
+						pos: position{line: 1446, col: 16, offset: 35602},
 						expr: &seqExpr{
-							pos: position{line: 1449, col: 17, offset: 35713},
+							pos: position{line: 1446, col: 17, offset: 35603},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1449, col: 17, offset: 35713},
+									pos:        position{line: 1446, col: 17, offset: 35603},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1449, col: 21, offset: 35717},
+									pos:  position{line: 1446, col: 21, offset: 35607},
 									name: "UInt",
 								},
 							},
@@ -10121,60 +10118,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1451, col: 1, offset: 35725},
+			pos:  position{line: 1448, col: 1, offset: 35615},
 			expr: &choiceExpr{
-				pos: position{line: 1452, col: 5, offset: 35738},
+				pos: position{line: 1449, col: 5, offset: 35628},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1452, col: 5, offset: 35738},
+						pos:        position{line: 1449, col: 5, offset: 35628},
 						val:        "ns",
 						ignoreCase: false,
 						want:       "\"ns\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1453, col: 5, offset: 35747},
+						pos:        position{line: 1450, col: 5, offset: 35637},
 						val:        "us",
 						ignoreCase: false,
 						want:       "\"us\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1454, col: 5, offset: 35756},
+						pos:        position{line: 1451, col: 5, offset: 35646},
 						val:        "ms",
 						ignoreCase: false,
 						want:       "\"ms\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1455, col: 5, offset: 35765},
+						pos:        position{line: 1452, col: 5, offset: 35655},
 						val:        "s",
 						ignoreCase: false,
 						want:       "\"s\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1456, col: 5, offset: 35773},
+						pos:        position{line: 1453, col: 5, offset: 35663},
 						val:        "m",
 						ignoreCase: false,
 						want:       "\"m\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1457, col: 5, offset: 35781},
+						pos:        position{line: 1454, col: 5, offset: 35671},
 						val:        "h",
 						ignoreCase: false,
 						want:       "\"h\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1458, col: 5, offset: 35789},
+						pos:        position{line: 1455, col: 5, offset: 35679},
 						val:        "d",
 						ignoreCase: false,
 						want:       "\"d\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1459, col: 5, offset: 35797},
+						pos:        position{line: 1456, col: 5, offset: 35687},
 						val:        "w",
 						ignoreCase: false,
 						want:       "\"w\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1460, col: 5, offset: 35805},
+						pos:        position{line: 1457, col: 5, offset: 35695},
 						val:        "y",
 						ignoreCase: false,
 						want:       "\"y\"",
@@ -10186,45 +10183,45 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1462, col: 1, offset: 35810},
+			pos:  position{line: 1459, col: 1, offset: 35700},
 			expr: &actionExpr{
-				pos: position{line: 1463, col: 5, offset: 35817},
+				pos: position{line: 1460, col: 5, offset: 35707},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1463, col: 5, offset: 35817},
+					pos: position{line: 1460, col: 5, offset: 35707},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1463, col: 5, offset: 35817},
+							pos:  position{line: 1460, col: 5, offset: 35707},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1463, col: 10, offset: 35822},
+							pos:        position{line: 1460, col: 10, offset: 35712},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1463, col: 14, offset: 35826},
+							pos:  position{line: 1460, col: 14, offset: 35716},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1463, col: 19, offset: 35831},
+							pos:        position{line: 1460, col: 19, offset: 35721},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1463, col: 23, offset: 35835},
+							pos:  position{line: 1460, col: 23, offset: 35725},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1463, col: 28, offset: 35840},
+							pos:        position{line: 1460, col: 28, offset: 35730},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1463, col: 32, offset: 35844},
+							pos:  position{line: 1460, col: 32, offset: 35734},
 							name: "UInt",
 						},
 					},
@@ -10235,43 +10232,43 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1465, col: 1, offset: 35881},
+			pos:  position{line: 1462, col: 1, offset: 35771},
 			expr: &actionExpr{
-				pos: position{line: 1466, col: 5, offset: 35889},
+				pos: position{line: 1463, col: 5, offset: 35779},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1466, col: 5, offset: 35889},
+					pos: position{line: 1463, col: 5, offset: 35779},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1466, col: 5, offset: 35889},
+							pos: position{line: 1463, col: 5, offset: 35779},
 							expr: &seqExpr{
-								pos: position{line: 1466, col: 7, offset: 35891},
+								pos: position{line: 1463, col: 7, offset: 35781},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1466, col: 7, offset: 35891},
+										pos:  position{line: 1463, col: 7, offset: 35781},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1466, col: 11, offset: 35895},
+										pos:        position{line: 1463, col: 11, offset: 35785},
 										val:        ":",
 										ignoreCase: false,
 										want:       "\":\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1466, col: 15, offset: 35899},
+										pos:  position{line: 1463, col: 15, offset: 35789},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1466, col: 19, offset: 35903},
+										pos: position{line: 1463, col: 19, offset: 35793},
 										expr: &choiceExpr{
-											pos: position{line: 1466, col: 21, offset: 35905},
+											pos: position{line: 1463, col: 21, offset: 35795},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1466, col: 21, offset: 35905},
+													pos:  position{line: 1463, col: 21, offset: 35795},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1466, col: 32, offset: 35916},
+													pos:        position{line: 1463, col: 32, offset: 35806},
 													val:        ":",
 													ignoreCase: false,
 													want:       "\":\"",
@@ -10283,10 +10280,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1466, col: 38, offset: 35922},
+							pos:   position{line: 1463, col: 38, offset: 35812},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1466, col: 40, offset: 35924},
+								pos:  position{line: 1463, col: 40, offset: 35814},
 								name: "IP6Variations",
 							},
 						},
@@ -10298,32 +10295,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1470, col: 1, offset: 36088},
+			pos:  position{line: 1467, col: 1, offset: 35978},
 			expr: &choiceExpr{
-				pos: position{line: 1471, col: 5, offset: 36106},
+				pos: position{line: 1468, col: 5, offset: 35996},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1471, col: 5, offset: 36106},
+						pos: position{line: 1468, col: 5, offset: 35996},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1471, col: 5, offset: 36106},
+							pos: position{line: 1468, col: 5, offset: 35996},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1471, col: 5, offset: 36106},
+									pos:   position{line: 1468, col: 5, offset: 35996},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1471, col: 7, offset: 36108},
+										pos: position{line: 1468, col: 7, offset: 35998},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1471, col: 7, offset: 36108},
+											pos:  position{line: 1468, col: 7, offset: 35998},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1471, col: 17, offset: 36118},
+									pos:   position{line: 1468, col: 17, offset: 36008},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1471, col: 19, offset: 36120},
+										pos:  position{line: 1468, col: 19, offset: 36010},
 										name: "IP6Tail",
 									},
 								},
@@ -10331,52 +10328,52 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1474, col: 5, offset: 36184},
+						pos: position{line: 1471, col: 5, offset: 36074},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1474, col: 5, offset: 36184},
+							pos: position{line: 1471, col: 5, offset: 36074},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1474, col: 5, offset: 36184},
+									pos:   position{line: 1471, col: 5, offset: 36074},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1474, col: 7, offset: 36186},
+										pos:  position{line: 1471, col: 7, offset: 36076},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1474, col: 11, offset: 36190},
+									pos:   position{line: 1471, col: 11, offset: 36080},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1474, col: 13, offset: 36192},
+										pos: position{line: 1471, col: 13, offset: 36082},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1474, col: 13, offset: 36192},
+											pos:  position{line: 1471, col: 13, offset: 36082},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1474, col: 23, offset: 36202},
+									pos:        position{line: 1471, col: 23, offset: 36092},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1474, col: 28, offset: 36207},
+									pos:   position{line: 1471, col: 28, offset: 36097},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1474, col: 30, offset: 36209},
+										pos: position{line: 1471, col: 30, offset: 36099},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1474, col: 30, offset: 36209},
+											pos:  position{line: 1471, col: 30, offset: 36099},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1474, col: 40, offset: 36219},
+									pos:   position{line: 1471, col: 40, offset: 36109},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1474, col: 42, offset: 36221},
+										pos:  position{line: 1471, col: 42, offset: 36111},
 										name: "IP6Tail",
 									},
 								},
@@ -10384,33 +10381,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1477, col: 5, offset: 36320},
+						pos: position{line: 1474, col: 5, offset: 36210},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1477, col: 5, offset: 36320},
+							pos: position{line: 1474, col: 5, offset: 36210},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1477, col: 5, offset: 36320},
+									pos:        position{line: 1474, col: 5, offset: 36210},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1477, col: 10, offset: 36325},
+									pos:   position{line: 1474, col: 10, offset: 36215},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1477, col: 12, offset: 36327},
+										pos: position{line: 1474, col: 12, offset: 36217},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1477, col: 12, offset: 36327},
+											pos:  position{line: 1474, col: 12, offset: 36217},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1477, col: 22, offset: 36337},
+									pos:   position{line: 1474, col: 22, offset: 36227},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1477, col: 24, offset: 36339},
+										pos:  position{line: 1474, col: 24, offset: 36229},
 										name: "IP6Tail",
 									},
 								},
@@ -10418,32 +10415,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1480, col: 5, offset: 36410},
+						pos: position{line: 1477, col: 5, offset: 36300},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1480, col: 5, offset: 36410},
+							pos: position{line: 1477, col: 5, offset: 36300},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1480, col: 5, offset: 36410},
+									pos:   position{line: 1477, col: 5, offset: 36300},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1480, col: 7, offset: 36412},
+										pos:  position{line: 1477, col: 7, offset: 36302},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1480, col: 11, offset: 36416},
+									pos:   position{line: 1477, col: 11, offset: 36306},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1480, col: 13, offset: 36418},
+										pos: position{line: 1477, col: 13, offset: 36308},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1480, col: 13, offset: 36418},
+											pos:  position{line: 1477, col: 13, offset: 36308},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1480, col: 23, offset: 36428},
+									pos:        position{line: 1477, col: 23, offset: 36318},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
@@ -10452,10 +10449,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1483, col: 5, offset: 36496},
+						pos: position{line: 1480, col: 5, offset: 36386},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 1483, col: 5, offset: 36496},
+							pos:        position{line: 1480, col: 5, offset: 36386},
 							val:        "::",
 							ignoreCase: false,
 							want:       "\"::\"",
@@ -10468,16 +10465,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1487, col: 1, offset: 36533},
+			pos:  position{line: 1484, col: 1, offset: 36423},
 			expr: &choiceExpr{
-				pos: position{line: 1488, col: 5, offset: 36545},
+				pos: position{line: 1485, col: 5, offset: 36435},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1488, col: 5, offset: 36545},
+						pos:  position{line: 1485, col: 5, offset: 36435},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1489, col: 5, offset: 36552},
+						pos:  position{line: 1486, col: 5, offset: 36442},
 						name: "Hex",
 					},
 				},
@@ -10487,24 +10484,24 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1491, col: 1, offset: 36557},
+			pos:  position{line: 1488, col: 1, offset: 36447},
 			expr: &actionExpr{
-				pos: position{line: 1491, col: 12, offset: 36568},
+				pos: position{line: 1488, col: 12, offset: 36458},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1491, col: 12, offset: 36568},
+					pos: position{line: 1488, col: 12, offset: 36458},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1491, col: 12, offset: 36568},
+							pos:        position{line: 1488, col: 12, offset: 36458},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1491, col: 16, offset: 36572},
+							pos:   position{line: 1488, col: 16, offset: 36462},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1491, col: 18, offset: 36574},
+								pos:  position{line: 1488, col: 18, offset: 36464},
 								name: "Hex",
 							},
 						},
@@ -10516,23 +10513,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1493, col: 1, offset: 36612},
+			pos:  position{line: 1490, col: 1, offset: 36502},
 			expr: &actionExpr{
-				pos: position{line: 1493, col: 12, offset: 36623},
+				pos: position{line: 1490, col: 12, offset: 36513},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1493, col: 12, offset: 36623},
+					pos: position{line: 1490, col: 12, offset: 36513},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1493, col: 12, offset: 36623},
+							pos:   position{line: 1490, col: 12, offset: 36513},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1493, col: 14, offset: 36625},
+								pos:  position{line: 1490, col: 14, offset: 36515},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1493, col: 18, offset: 36629},
+							pos:        position{line: 1490, col: 18, offset: 36519},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
@@ -10545,32 +10542,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1495, col: 1, offset: 36667},
+			pos:  position{line: 1492, col: 1, offset: 36557},
 			expr: &actionExpr{
-				pos: position{line: 1496, col: 5, offset: 36678},
+				pos: position{line: 1493, col: 5, offset: 36568},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1496, col: 5, offset: 36678},
+					pos: position{line: 1493, col: 5, offset: 36568},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1496, col: 5, offset: 36678},
+							pos:   position{line: 1493, col: 5, offset: 36568},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1496, col: 7, offset: 36680},
+								pos:  position{line: 1493, col: 7, offset: 36570},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1496, col: 10, offset: 36683},
+							pos:        position{line: 1493, col: 10, offset: 36573},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1496, col: 14, offset: 36687},
+							pos:   position{line: 1493, col: 14, offset: 36577},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1496, col: 16, offset: 36689},
+								pos:  position{line: 1493, col: 16, offset: 36579},
 								name: "UIntString",
 							},
 						},
@@ -10582,32 +10579,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1500, col: 1, offset: 36757},
+			pos:  position{line: 1497, col: 1, offset: 36647},
 			expr: &actionExpr{
-				pos: position{line: 1501, col: 5, offset: 36768},
+				pos: position{line: 1498, col: 5, offset: 36658},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1501, col: 5, offset: 36768},
+					pos: position{line: 1498, col: 5, offset: 36658},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1501, col: 5, offset: 36768},
+							pos:   position{line: 1498, col: 5, offset: 36658},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1501, col: 7, offset: 36770},
+								pos:  position{line: 1498, col: 7, offset: 36660},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1501, col: 11, offset: 36774},
+							pos:        position{line: 1498, col: 11, offset: 36664},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1501, col: 15, offset: 36778},
+							pos:   position{line: 1498, col: 15, offset: 36668},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1501, col: 17, offset: 36780},
+								pos:  position{line: 1498, col: 17, offset: 36670},
 								name: "UIntString",
 							},
 						},
@@ -10619,15 +10616,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1505, col: 1, offset: 36848},
+			pos:  position{line: 1502, col: 1, offset: 36738},
 			expr: &actionExpr{
-				pos: position{line: 1506, col: 4, offset: 36856},
+				pos: position{line: 1503, col: 4, offset: 36746},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1506, col: 4, offset: 36856},
+					pos:   position{line: 1503, col: 4, offset: 36746},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1506, col: 6, offset: 36858},
+						pos:  position{line: 1503, col: 6, offset: 36748},
 						name: "UIntString",
 					},
 				},
@@ -10637,16 +10634,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1508, col: 1, offset: 36898},
+			pos:  position{line: 1505, col: 1, offset: 36788},
 			expr: &choiceExpr{
-				pos: position{line: 1509, col: 5, offset: 36912},
+				pos: position{line: 1506, col: 5, offset: 36802},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1509, col: 5, offset: 36912},
+						pos:  position{line: 1506, col: 5, offset: 36802},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1510, col: 5, offset: 36927},
+						pos:  position{line: 1507, col: 5, offset: 36817},
 						name: "MinusIntString",
 					},
 				},
@@ -10656,14 +10653,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1512, col: 1, offset: 36943},
+			pos:  position{line: 1509, col: 1, offset: 36833},
 			expr: &actionExpr{
-				pos: position{line: 1512, col: 14, offset: 36956},
+				pos: position{line: 1509, col: 14, offset: 36846},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1512, col: 14, offset: 36956},
+					pos: position{line: 1509, col: 14, offset: 36846},
 					expr: &charClassMatcher{
-						pos:        position{line: 1512, col: 14, offset: 36956},
+						pos:        position{line: 1509, col: 14, offset: 36846},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10676,21 +10673,21 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1514, col: 1, offset: 36995},
+			pos:  position{line: 1511, col: 1, offset: 36885},
 			expr: &actionExpr{
-				pos: position{line: 1515, col: 5, offset: 37014},
+				pos: position{line: 1512, col: 5, offset: 36904},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1515, col: 5, offset: 37014},
+					pos: position{line: 1512, col: 5, offset: 36904},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1515, col: 5, offset: 37014},
+							pos:        position{line: 1512, col: 5, offset: 36904},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1515, col: 9, offset: 37018},
+							pos:  position{line: 1512, col: 9, offset: 36908},
 							name: "UIntString",
 						},
 					},
@@ -10701,29 +10698,29 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1517, col: 1, offset: 37061},
+			pos:  position{line: 1514, col: 1, offset: 36951},
 			expr: &choiceExpr{
-				pos: position{line: 1518, col: 5, offset: 37077},
+				pos: position{line: 1515, col: 5, offset: 36967},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1518, col: 5, offset: 37077},
+						pos: position{line: 1515, col: 5, offset: 36967},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1518, col: 5, offset: 37077},
+							pos: position{line: 1515, col: 5, offset: 36967},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1518, col: 5, offset: 37077},
+									pos: position{line: 1515, col: 5, offset: 36967},
 									expr: &litMatcher{
-										pos:        position{line: 1518, col: 5, offset: 37077},
+										pos:        position{line: 1515, col: 5, offset: 36967},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1518, col: 10, offset: 37082},
+									pos: position{line: 1515, col: 10, offset: 36972},
 									expr: &charClassMatcher{
-										pos:        position{line: 1518, col: 10, offset: 37082},
+										pos:        position{line: 1515, col: 10, offset: 36972},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10731,15 +10728,15 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1518, col: 17, offset: 37089},
+									pos:        position{line: 1515, col: 17, offset: 36979},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1518, col: 21, offset: 37093},
+									pos: position{line: 1515, col: 21, offset: 36983},
 									expr: &charClassMatcher{
-										pos:        position{line: 1518, col: 21, offset: 37093},
+										pos:        position{line: 1515, col: 21, offset: 36983},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10747,9 +10744,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1518, col: 28, offset: 37100},
+									pos: position{line: 1515, col: 28, offset: 36990},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1518, col: 28, offset: 37100},
+										pos:  position{line: 1515, col: 28, offset: 36990},
 										name: "ExponentPart",
 									},
 								},
@@ -10757,30 +10754,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1519, col: 5, offset: 37149},
+						pos: position{line: 1516, col: 5, offset: 37039},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1519, col: 5, offset: 37149},
+							pos: position{line: 1516, col: 5, offset: 37039},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1519, col: 5, offset: 37149},
+									pos: position{line: 1516, col: 5, offset: 37039},
 									expr: &litMatcher{
-										pos:        position{line: 1519, col: 5, offset: 37149},
+										pos:        position{line: 1516, col: 5, offset: 37039},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1519, col: 10, offset: 37154},
+									pos:        position{line: 1516, col: 10, offset: 37044},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1519, col: 14, offset: 37158},
+									pos: position{line: 1516, col: 14, offset: 37048},
 									expr: &charClassMatcher{
-										pos:        position{line: 1519, col: 14, offset: 37158},
+										pos:        position{line: 1516, col: 14, offset: 37048},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10788,9 +10785,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1519, col: 21, offset: 37165},
+									pos: position{line: 1516, col: 21, offset: 37055},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1519, col: 21, offset: 37165},
+										pos:  position{line: 1516, col: 21, offset: 37055},
 										name: "ExponentPart",
 									},
 								},
@@ -10798,17 +10795,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1520, col: 5, offset: 37214},
+						pos: position{line: 1517, col: 5, offset: 37104},
 						run: (*parser).callonFloatString22,
 						expr: &choiceExpr{
-							pos: position{line: 1520, col: 6, offset: 37215},
+							pos: position{line: 1517, col: 6, offset: 37105},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1520, col: 6, offset: 37215},
+									pos:  position{line: 1517, col: 6, offset: 37105},
 									name: "NaN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1520, col: 12, offset: 37221},
+									pos:  position{line: 1517, col: 12, offset: 37111},
 									name: "Infinity",
 								},
 							},
@@ -10821,20 +10818,20 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1523, col: 1, offset: 37264},
+			pos:  position{line: 1520, col: 1, offset: 37154},
 			expr: &seqExpr{
-				pos: position{line: 1523, col: 16, offset: 37279},
+				pos: position{line: 1520, col: 16, offset: 37169},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1523, col: 16, offset: 37279},
+						pos:        position{line: 1520, col: 16, offset: 37169},
 						val:        "e",
 						ignoreCase: true,
 						want:       "\"e\"i",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1523, col: 21, offset: 37284},
+						pos: position{line: 1520, col: 21, offset: 37174},
 						expr: &charClassMatcher{
-							pos:        position{line: 1523, col: 21, offset: 37284},
+							pos:        position{line: 1520, col: 21, offset: 37174},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -10842,7 +10839,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1523, col: 27, offset: 37290},
+						pos:  position{line: 1520, col: 27, offset: 37180},
 						name: "UIntString",
 					},
 				},
@@ -10852,9 +10849,9 @@ var g = &grammar{
 		},
 		{
 			name: "NaN",
-			pos:  position{line: 1525, col: 1, offset: 37302},
+			pos:  position{line: 1522, col: 1, offset: 37192},
 			expr: &litMatcher{
-				pos:        position{line: 1525, col: 7, offset: 37308},
+				pos:        position{line: 1522, col: 7, offset: 37198},
 				val:        "NaN",
 				ignoreCase: false,
 				want:       "\"NaN\"",
@@ -10864,23 +10861,23 @@ var g = &grammar{
 		},
 		{
 			name: "Infinity",
-			pos:  position{line: 1527, col: 1, offset: 37315},
+			pos:  position{line: 1524, col: 1, offset: 37205},
 			expr: &seqExpr{
-				pos: position{line: 1527, col: 12, offset: 37326},
+				pos: position{line: 1524, col: 12, offset: 37216},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 1527, col: 12, offset: 37326},
+						pos: position{line: 1524, col: 12, offset: 37216},
 						expr: &choiceExpr{
-							pos: position{line: 1527, col: 13, offset: 37327},
+							pos: position{line: 1524, col: 13, offset: 37217},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1527, col: 13, offset: 37327},
+									pos:        position{line: 1524, col: 13, offset: 37217},
 									val:        "-",
 									ignoreCase: false,
 									want:       "\"-\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1527, col: 19, offset: 37333},
+									pos:        position{line: 1524, col: 19, offset: 37223},
 									val:        "+",
 									ignoreCase: false,
 									want:       "\"+\"",
@@ -10889,7 +10886,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1527, col: 25, offset: 37339},
+						pos:        position{line: 1524, col: 25, offset: 37229},
 						val:        "Inf",
 						ignoreCase: false,
 						want:       "\"Inf\"",
@@ -10901,14 +10898,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1529, col: 1, offset: 37346},
+			pos:  position{line: 1526, col: 1, offset: 37236},
 			expr: &actionExpr{
-				pos: position{line: 1529, col: 7, offset: 37352},
+				pos: position{line: 1526, col: 7, offset: 37242},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1529, col: 7, offset: 37352},
+					pos: position{line: 1526, col: 7, offset: 37242},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1529, col: 7, offset: 37352},
+						pos:  position{line: 1526, col: 7, offset: 37242},
 						name: "HexDigit",
 					},
 				},
@@ -10918,9 +10915,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1531, col: 1, offset: 37394},
+			pos:  position{line: 1528, col: 1, offset: 37284},
 			expr: &charClassMatcher{
-				pos:        position{line: 1531, col: 12, offset: 37405},
+				pos:        position{line: 1528, col: 12, offset: 37295},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -10931,35 +10928,35 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1533, col: 1, offset: 37418},
+			pos:  position{line: 1530, col: 1, offset: 37308},
 			expr: &choiceExpr{
-				pos: position{line: 1534, col: 5, offset: 37435},
+				pos: position{line: 1531, col: 5, offset: 37325},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1534, col: 5, offset: 37435},
+						pos: position{line: 1531, col: 5, offset: 37325},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 1534, col: 5, offset: 37435},
+							pos: position{line: 1531, col: 5, offset: 37325},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1534, col: 5, offset: 37435},
+									pos:        position{line: 1531, col: 5, offset: 37325},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1534, col: 9, offset: 37439},
+									pos:   position{line: 1531, col: 9, offset: 37329},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1534, col: 11, offset: 37441},
+										pos: position{line: 1531, col: 11, offset: 37331},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1534, col: 11, offset: 37441},
+											pos:  position{line: 1531, col: 11, offset: 37331},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1534, col: 29, offset: 37459},
+									pos:        position{line: 1531, col: 29, offset: 37349},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -10968,30 +10965,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1535, col: 5, offset: 37496},
+						pos: position{line: 1532, col: 5, offset: 37386},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 1535, col: 5, offset: 37496},
+							pos: position{line: 1532, col: 5, offset: 37386},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1535, col: 5, offset: 37496},
+									pos:        position{line: 1532, col: 5, offset: 37386},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1535, col: 9, offset: 37500},
+									pos:   position{line: 1532, col: 9, offset: 37390},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1535, col: 11, offset: 37502},
+										pos: position{line: 1532, col: 11, offset: 37392},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1535, col: 11, offset: 37502},
+											pos:  position{line: 1532, col: 11, offset: 37392},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1535, col: 29, offset: 37520},
+									pos:        position{line: 1532, col: 29, offset: 37410},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -11006,57 +11003,57 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1537, col: 1, offset: 37554},
+			pos:  position{line: 1534, col: 1, offset: 37444},
 			expr: &choiceExpr{
-				pos: position{line: 1538, col: 5, offset: 37575},
+				pos: position{line: 1535, col: 5, offset: 37465},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1538, col: 5, offset: 37575},
+						pos: position{line: 1535, col: 5, offset: 37465},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1538, col: 5, offset: 37575},
+							pos: position{line: 1535, col: 5, offset: 37465},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1538, col: 5, offset: 37575},
+									pos: position{line: 1535, col: 5, offset: 37465},
 									expr: &choiceExpr{
-										pos: position{line: 1538, col: 7, offset: 37577},
+										pos: position{line: 1535, col: 7, offset: 37467},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1538, col: 7, offset: 37577},
+												pos:        position{line: 1535, col: 7, offset: 37467},
 												val:        "\"",
 												ignoreCase: false,
 												want:       "\"\\\"\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1538, col: 13, offset: 37583},
+												pos:  position{line: 1535, col: 13, offset: 37473},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1538, col: 26, offset: 37596,
+									line: 1535, col: 26, offset: 37486,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1539, col: 5, offset: 37633},
+						pos: position{line: 1536, col: 5, offset: 37523},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1539, col: 5, offset: 37633},
+							pos: position{line: 1536, col: 5, offset: 37523},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1539, col: 5, offset: 37633},
+									pos:        position{line: 1536, col: 5, offset: 37523},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1539, col: 10, offset: 37638},
+									pos:   position{line: 1536, col: 10, offset: 37528},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1539, col: 12, offset: 37640},
+										pos:  position{line: 1536, col: 12, offset: 37530},
 										name: "EscapeSequence",
 									},
 								},
@@ -11070,28 +11067,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1541, col: 1, offset: 37674},
+			pos:  position{line: 1538, col: 1, offset: 37564},
 			expr: &actionExpr{
-				pos: position{line: 1542, col: 5, offset: 37686},
+				pos: position{line: 1539, col: 5, offset: 37576},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1542, col: 5, offset: 37686},
+					pos: position{line: 1539, col: 5, offset: 37576},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1542, col: 5, offset: 37686},
+							pos:   position{line: 1539, col: 5, offset: 37576},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1542, col: 10, offset: 37691},
+								pos:  position{line: 1539, col: 10, offset: 37581},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1542, col: 23, offset: 37704},
+							pos:   position{line: 1539, col: 23, offset: 37594},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1542, col: 28, offset: 37709},
+								pos: position{line: 1539, col: 28, offset: 37599},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1542, col: 28, offset: 37709},
+									pos:  position{line: 1539, col: 28, offset: 37599},
 									name: "KeyWordRest",
 								},
 							},
@@ -11104,16 +11101,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1544, col: 1, offset: 37771},
+			pos:  position{line: 1541, col: 1, offset: 37661},
 			expr: &choiceExpr{
-				pos: position{line: 1545, col: 5, offset: 37788},
+				pos: position{line: 1542, col: 5, offset: 37678},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1545, col: 5, offset: 37788},
+						pos:  position{line: 1542, col: 5, offset: 37678},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1546, col: 5, offset: 37805},
+						pos:  position{line: 1543, col: 5, offset: 37695},
 						name: "KeyWordEsc",
 					},
 				},
@@ -11123,16 +11120,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1548, col: 1, offset: 37817},
+			pos:  position{line: 1545, col: 1, offset: 37707},
 			expr: &choiceExpr{
-				pos: position{line: 1549, col: 5, offset: 37833},
+				pos: position{line: 1546, col: 5, offset: 37723},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1549, col: 5, offset: 37833},
+						pos:  position{line: 1546, col: 5, offset: 37723},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1550, col: 5, offset: 37850},
+						pos:        position{line: 1547, col: 5, offset: 37740},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11145,19 +11142,19 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1552, col: 1, offset: 37857},
+			pos:  position{line: 1549, col: 1, offset: 37747},
 			expr: &actionExpr{
-				pos: position{line: 1552, col: 16, offset: 37872},
+				pos: position{line: 1549, col: 16, offset: 37762},
 				run: (*parser).callonKeyWordChars1,
 				expr: &choiceExpr{
-					pos: position{line: 1552, col: 17, offset: 37873},
+					pos: position{line: 1549, col: 17, offset: 37763},
 					alternatives: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1552, col: 17, offset: 37873},
+							pos:  position{line: 1549, col: 17, offset: 37763},
 							name: "UnicodeLetter",
 						},
 						&charClassMatcher{
-							pos:        position{line: 1552, col: 33, offset: 37889},
+							pos:        position{line: 1549, col: 33, offset: 37779},
 							val:        "[_.:/%#@~]",
 							chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 							ignoreCase: false,
@@ -11171,31 +11168,31 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1554, col: 1, offset: 37933},
+			pos:  position{line: 1551, col: 1, offset: 37823},
 			expr: &actionExpr{
-				pos: position{line: 1554, col: 14, offset: 37946},
+				pos: position{line: 1551, col: 14, offset: 37836},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1554, col: 14, offset: 37946},
+					pos: position{line: 1551, col: 14, offset: 37836},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1554, col: 14, offset: 37946},
+							pos:        position{line: 1551, col: 14, offset: 37836},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1554, col: 19, offset: 37951},
+							pos:   position{line: 1551, col: 19, offset: 37841},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1554, col: 22, offset: 37954},
+								pos: position{line: 1551, col: 22, offset: 37844},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1554, col: 22, offset: 37954},
+										pos:  position{line: 1551, col: 22, offset: 37844},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1554, col: 38, offset: 37970},
+										pos:  position{line: 1551, col: 38, offset: 37860},
 										name: "EscapeSequence",
 									},
 								},
@@ -11209,42 +11206,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1556, col: 1, offset: 38005},
+			pos:  position{line: 1553, col: 1, offset: 37895},
 			expr: &actionExpr{
-				pos: position{line: 1557, col: 5, offset: 38021},
+				pos: position{line: 1554, col: 5, offset: 37911},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1557, col: 5, offset: 38021},
+					pos: position{line: 1554, col: 5, offset: 37911},
 					exprs: []any{
 						&andExpr{
-							pos: position{line: 1557, col: 5, offset: 38021},
+							pos: position{line: 1554, col: 5, offset: 37911},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1557, col: 6, offset: 38022},
+								pos:  position{line: 1554, col: 6, offset: 37912},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1557, col: 22, offset: 38038},
+							pos: position{line: 1554, col: 22, offset: 37928},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1557, col: 23, offset: 38039},
+								pos:  position{line: 1554, col: 23, offset: 37929},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1557, col: 35, offset: 38051},
+							pos:   position{line: 1554, col: 35, offset: 37941},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1557, col: 40, offset: 38056},
+								pos:  position{line: 1554, col: 40, offset: 37946},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1557, col: 50, offset: 38066},
+							pos:   position{line: 1554, col: 50, offset: 37956},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1557, col: 55, offset: 38071},
+								pos: position{line: 1554, col: 55, offset: 37961},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1557, col: 55, offset: 38071},
+									pos:  position{line: 1554, col: 55, offset: 37961},
 									name: "GlobRest",
 								},
 							},
@@ -11257,28 +11254,28 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1561, col: 1, offset: 38140},
+			pos:  position{line: 1558, col: 1, offset: 38030},
 			expr: &choiceExpr{
-				pos: position{line: 1561, col: 19, offset: 38158},
+				pos: position{line: 1558, col: 19, offset: 38048},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1561, col: 19, offset: 38158},
+						pos:  position{line: 1558, col: 19, offset: 38048},
 						name: "KeyWordStart",
 					},
 					&seqExpr{
-						pos: position{line: 1561, col: 34, offset: 38173},
+						pos: position{line: 1558, col: 34, offset: 38063},
 						exprs: []any{
 							&oneOrMoreExpr{
-								pos: position{line: 1561, col: 34, offset: 38173},
+								pos: position{line: 1558, col: 34, offset: 38063},
 								expr: &litMatcher{
-									pos:        position{line: 1561, col: 34, offset: 38173},
+									pos:        position{line: 1558, col: 34, offset: 38063},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1561, col: 39, offset: 38178},
+								pos:  position{line: 1558, col: 39, offset: 38068},
 								name: "KeyWordRest",
 							},
 						},
@@ -11290,19 +11287,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1562, col: 1, offset: 38190},
+			pos:  position{line: 1559, col: 1, offset: 38080},
 			expr: &seqExpr{
-				pos: position{line: 1562, col: 15, offset: 38204},
+				pos: position{line: 1559, col: 15, offset: 38094},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1562, col: 15, offset: 38204},
+						pos: position{line: 1559, col: 15, offset: 38094},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1562, col: 15, offset: 38204},
+							pos:  position{line: 1559, col: 15, offset: 38094},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1562, col: 28, offset: 38217},
+						pos:        position{line: 1559, col: 28, offset: 38107},
 						val:        "*",
 						ignoreCase: false,
 						want:       "\"*\"",
@@ -11314,23 +11311,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1564, col: 1, offset: 38222},
+			pos:  position{line: 1561, col: 1, offset: 38112},
 			expr: &choiceExpr{
-				pos: position{line: 1565, col: 5, offset: 38236},
+				pos: position{line: 1562, col: 5, offset: 38126},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1565, col: 5, offset: 38236},
+						pos:  position{line: 1562, col: 5, offset: 38126},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1566, col: 5, offset: 38253},
+						pos:  position{line: 1563, col: 5, offset: 38143},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1567, col: 5, offset: 38265},
+						pos: position{line: 1564, col: 5, offset: 38155},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1567, col: 5, offset: 38265},
+							pos:        position{line: 1564, col: 5, offset: 38155},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -11343,16 +11340,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1569, col: 1, offset: 38290},
+			pos:  position{line: 1566, col: 1, offset: 38180},
 			expr: &choiceExpr{
-				pos: position{line: 1570, col: 5, offset: 38303},
+				pos: position{line: 1567, col: 5, offset: 38193},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1570, col: 5, offset: 38303},
+						pos:  position{line: 1567, col: 5, offset: 38193},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1571, col: 5, offset: 38317},
+						pos:        position{line: 1568, col: 5, offset: 38207},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11365,31 +11362,31 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1573, col: 1, offset: 38324},
+			pos:  position{line: 1570, col: 1, offset: 38214},
 			expr: &actionExpr{
-				pos: position{line: 1573, col: 11, offset: 38334},
+				pos: position{line: 1570, col: 11, offset: 38224},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1573, col: 11, offset: 38334},
+					pos: position{line: 1570, col: 11, offset: 38224},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1573, col: 11, offset: 38334},
+							pos:        position{line: 1570, col: 11, offset: 38224},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1573, col: 16, offset: 38339},
+							pos:   position{line: 1570, col: 16, offset: 38229},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1573, col: 19, offset: 38342},
+								pos: position{line: 1570, col: 19, offset: 38232},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1573, col: 19, offset: 38342},
+										pos:  position{line: 1570, col: 19, offset: 38232},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1573, col: 32, offset: 38355},
+										pos:  position{line: 1570, col: 32, offset: 38245},
 										name: "EscapeSequence",
 									},
 								},
@@ -11403,32 +11400,32 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1575, col: 1, offset: 38390},
+			pos:  position{line: 1572, col: 1, offset: 38280},
 			expr: &choiceExpr{
-				pos: position{line: 1576, col: 5, offset: 38405},
+				pos: position{line: 1573, col: 5, offset: 38295},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1576, col: 5, offset: 38405},
+						pos: position{line: 1573, col: 5, offset: 38295},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1576, col: 5, offset: 38405},
+							pos:        position{line: 1573, col: 5, offset: 38295},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1577, col: 5, offset: 38433},
+						pos: position{line: 1574, col: 5, offset: 38323},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1577, col: 5, offset: 38433},
+							pos:        position{line: 1574, col: 5, offset: 38323},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1578, col: 5, offset: 38463},
+						pos:        position{line: 1575, col: 5, offset: 38353},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -11441,57 +11438,57 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1580, col: 1, offset: 38469},
+			pos:  position{line: 1577, col: 1, offset: 38359},
 			expr: &choiceExpr{
-				pos: position{line: 1581, col: 5, offset: 38490},
+				pos: position{line: 1578, col: 5, offset: 38380},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1581, col: 5, offset: 38490},
+						pos: position{line: 1578, col: 5, offset: 38380},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1581, col: 5, offset: 38490},
+							pos: position{line: 1578, col: 5, offset: 38380},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1581, col: 5, offset: 38490},
+									pos: position{line: 1578, col: 5, offset: 38380},
 									expr: &choiceExpr{
-										pos: position{line: 1581, col: 7, offset: 38492},
+										pos: position{line: 1578, col: 7, offset: 38382},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1581, col: 7, offset: 38492},
+												pos:        position{line: 1578, col: 7, offset: 38382},
 												val:        "'",
 												ignoreCase: false,
 												want:       "\"'\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1581, col: 13, offset: 38498},
+												pos:  position{line: 1578, col: 13, offset: 38388},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1581, col: 26, offset: 38511,
+									line: 1578, col: 26, offset: 38401,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1582, col: 5, offset: 38548},
+						pos: position{line: 1579, col: 5, offset: 38438},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1582, col: 5, offset: 38548},
+							pos: position{line: 1579, col: 5, offset: 38438},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1582, col: 5, offset: 38548},
+									pos:        position{line: 1579, col: 5, offset: 38438},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1582, col: 10, offset: 38553},
+									pos:   position{line: 1579, col: 10, offset: 38443},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1582, col: 12, offset: 38555},
+										pos:  position{line: 1579, col: 12, offset: 38445},
 										name: "EscapeSequence",
 									},
 								},
@@ -11505,16 +11502,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1584, col: 1, offset: 38589},
+			pos:  position{line: 1581, col: 1, offset: 38479},
 			expr: &choiceExpr{
-				pos: position{line: 1585, col: 5, offset: 38608},
+				pos: position{line: 1582, col: 5, offset: 38498},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1585, col: 5, offset: 38608},
+						pos:  position{line: 1582, col: 5, offset: 38498},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1586, col: 5, offset: 38629},
+						pos:  position{line: 1583, col: 5, offset: 38519},
 						name: "UnicodeEscape",
 					},
 				},
@@ -11524,87 +11521,87 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1588, col: 1, offset: 38644},
+			pos:  position{line: 1585, col: 1, offset: 38534},
 			expr: &choiceExpr{
-				pos: position{line: 1589, col: 5, offset: 38665},
+				pos: position{line: 1586, col: 5, offset: 38555},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1589, col: 5, offset: 38665},
+						pos:        position{line: 1586, col: 5, offset: 38555},
 						val:        "'",
 						ignoreCase: false,
 						want:       "\"'\"",
 					},
 					&actionExpr{
-						pos: position{line: 1590, col: 5, offset: 38673},
+						pos: position{line: 1587, col: 5, offset: 38563},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1590, col: 5, offset: 38673},
+							pos:        position{line: 1587, col: 5, offset: 38563},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1591, col: 5, offset: 38713},
+						pos:        position{line: 1588, col: 5, offset: 38603},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
 					},
 					&actionExpr{
-						pos: position{line: 1592, col: 5, offset: 38722},
+						pos: position{line: 1589, col: 5, offset: 38612},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1592, col: 5, offset: 38722},
+							pos:        position{line: 1589, col: 5, offset: 38612},
 							val:        "b",
 							ignoreCase: false,
 							want:       "\"b\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1593, col: 5, offset: 38751},
+						pos: position{line: 1590, col: 5, offset: 38641},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1593, col: 5, offset: 38751},
+							pos:        position{line: 1590, col: 5, offset: 38641},
 							val:        "f",
 							ignoreCase: false,
 							want:       "\"f\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1594, col: 5, offset: 38780},
+						pos: position{line: 1591, col: 5, offset: 38670},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1594, col: 5, offset: 38780},
+							pos:        position{line: 1591, col: 5, offset: 38670},
 							val:        "n",
 							ignoreCase: false,
 							want:       "\"n\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1595, col: 5, offset: 38809},
+						pos: position{line: 1592, col: 5, offset: 38699},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1595, col: 5, offset: 38809},
+							pos:        position{line: 1592, col: 5, offset: 38699},
 							val:        "r",
 							ignoreCase: false,
 							want:       "\"r\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1596, col: 5, offset: 38838},
+						pos: position{line: 1593, col: 5, offset: 38728},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1596, col: 5, offset: 38838},
+							pos:        position{line: 1593, col: 5, offset: 38728},
 							val:        "t",
 							ignoreCase: false,
 							want:       "\"t\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1597, col: 5, offset: 38867},
+						pos: position{line: 1594, col: 5, offset: 38757},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1597, col: 5, offset: 38867},
+							pos:        position{line: 1594, col: 5, offset: 38757},
 							val:        "v",
 							ignoreCase: false,
 							want:       "\"v\"",
@@ -11617,32 +11614,32 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1599, col: 1, offset: 38893},
+			pos:  position{line: 1596, col: 1, offset: 38783},
 			expr: &choiceExpr{
-				pos: position{line: 1600, col: 5, offset: 38911},
+				pos: position{line: 1597, col: 5, offset: 38801},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1600, col: 5, offset: 38911},
+						pos: position{line: 1597, col: 5, offset: 38801},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1600, col: 5, offset: 38911},
+							pos:        position{line: 1597, col: 5, offset: 38801},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1601, col: 5, offset: 38939},
+						pos: position{line: 1598, col: 5, offset: 38829},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1601, col: 5, offset: 38939},
+							pos:        position{line: 1598, col: 5, offset: 38829},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1602, col: 5, offset: 38967},
+						pos:        position{line: 1599, col: 5, offset: 38857},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -11655,42 +11652,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1604, col: 1, offset: 38973},
+			pos:  position{line: 1601, col: 1, offset: 38863},
 			expr: &choiceExpr{
-				pos: position{line: 1605, col: 5, offset: 38991},
+				pos: position{line: 1602, col: 5, offset: 38881},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1605, col: 5, offset: 38991},
+						pos: position{line: 1602, col: 5, offset: 38881},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1605, col: 5, offset: 38991},
+							pos: position{line: 1602, col: 5, offset: 38881},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1605, col: 5, offset: 38991},
+									pos:        position{line: 1602, col: 5, offset: 38881},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1605, col: 9, offset: 38995},
+									pos:   position{line: 1602, col: 9, offset: 38885},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1605, col: 16, offset: 39002},
+										pos: position{line: 1602, col: 16, offset: 38892},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1605, col: 16, offset: 39002},
+												pos:  position{line: 1602, col: 16, offset: 38892},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1605, col: 25, offset: 39011},
+												pos:  position{line: 1602, col: 25, offset: 38901},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1605, col: 34, offset: 39020},
+												pos:  position{line: 1602, col: 34, offset: 38910},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1605, col: 43, offset: 39029},
+												pos:  position{line: 1602, col: 43, offset: 38919},
 												name: "HexDigit",
 											},
 										},
@@ -11700,65 +11697,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1608, col: 5, offset: 39092},
+						pos: position{line: 1605, col: 5, offset: 38982},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1608, col: 5, offset: 39092},
+							pos: position{line: 1605, col: 5, offset: 38982},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1608, col: 5, offset: 39092},
+									pos:        position{line: 1605, col: 5, offset: 38982},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1608, col: 9, offset: 39096},
+									pos:        position{line: 1605, col: 9, offset: 38986},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1608, col: 13, offset: 39100},
+									pos:   position{line: 1605, col: 13, offset: 38990},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1608, col: 20, offset: 39107},
+										pos: position{line: 1605, col: 20, offset: 38997},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1608, col: 20, offset: 39107},
+												pos:  position{line: 1605, col: 20, offset: 38997},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1608, col: 29, offset: 39116},
+												pos: position{line: 1605, col: 29, offset: 39006},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1608, col: 29, offset: 39116},
+													pos:  position{line: 1605, col: 29, offset: 39006},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1608, col: 39, offset: 39126},
+												pos: position{line: 1605, col: 39, offset: 39016},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1608, col: 39, offset: 39126},
+													pos:  position{line: 1605, col: 39, offset: 39016},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1608, col: 49, offset: 39136},
+												pos: position{line: 1605, col: 49, offset: 39026},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1608, col: 49, offset: 39136},
+													pos:  position{line: 1605, col: 49, offset: 39026},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1608, col: 59, offset: 39146},
+												pos: position{line: 1605, col: 59, offset: 39036},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1608, col: 59, offset: 39146},
+													pos:  position{line: 1605, col: 59, offset: 39036},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1608, col: 69, offset: 39156},
+												pos: position{line: 1605, col: 69, offset: 39046},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1608, col: 69, offset: 39156},
+													pos:  position{line: 1605, col: 69, offset: 39046},
 													name: "HexDigit",
 												},
 											},
@@ -11766,7 +11763,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1608, col: 80, offset: 39167},
+									pos:        position{line: 1605, col: 80, offset: 39057},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -11781,37 +11778,37 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPattern",
-			pos:  position{line: 1612, col: 1, offset: 39221},
+			pos:  position{line: 1609, col: 1, offset: 39111},
 			expr: &actionExpr{
-				pos: position{line: 1613, col: 5, offset: 39239},
+				pos: position{line: 1610, col: 5, offset: 39129},
 				run: (*parser).callonRegexpPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1613, col: 5, offset: 39239},
+					pos: position{line: 1610, col: 5, offset: 39129},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1613, col: 5, offset: 39239},
+							pos:        position{line: 1610, col: 5, offset: 39129},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1613, col: 9, offset: 39243},
+							pos:   position{line: 1610, col: 9, offset: 39133},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1613, col: 14, offset: 39248},
+								pos:  position{line: 1610, col: 14, offset: 39138},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1613, col: 25, offset: 39259},
+							pos:        position{line: 1610, col: 25, offset: 39149},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&notExpr{
-							pos: position{line: 1613, col: 29, offset: 39263},
+							pos: position{line: 1610, col: 29, offset: 39153},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1613, col: 30, offset: 39264},
+								pos:  position{line: 1610, col: 30, offset: 39154},
 								name: "KeyWordStart",
 							},
 						},
@@ -11823,33 +11820,33 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1615, col: 1, offset: 39299},
+			pos:  position{line: 1612, col: 1, offset: 39189},
 			expr: &actionExpr{
-				pos: position{line: 1616, col: 5, offset: 39314},
+				pos: position{line: 1613, col: 5, offset: 39204},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1616, col: 5, offset: 39314},
+					pos: position{line: 1613, col: 5, offset: 39204},
 					expr: &choiceExpr{
-						pos: position{line: 1616, col: 6, offset: 39315},
+						pos: position{line: 1613, col: 6, offset: 39205},
 						alternatives: []any{
 							&charClassMatcher{
-								pos:        position{line: 1616, col: 6, offset: 39315},
+								pos:        position{line: 1613, col: 6, offset: 39205},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&seqExpr{
-								pos: position{line: 1616, col: 15, offset: 39324},
+								pos: position{line: 1613, col: 15, offset: 39214},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 1616, col: 15, offset: 39324},
+										pos:        position{line: 1613, col: 15, offset: 39214},
 										val:        "\\",
 										ignoreCase: false,
 										want:       "\"\\\\\"",
 									},
 									&anyMatcher{
-										line: 1616, col: 20, offset: 39329,
+										line: 1613, col: 20, offset: 39219,
 									},
 								},
 							},
@@ -11862,9 +11859,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1618, col: 1, offset: 39365},
+			pos:  position{line: 1615, col: 1, offset: 39255},
 			expr: &charClassMatcher{
-				pos:        position{line: 1619, col: 5, offset: 39381},
+				pos:        position{line: 1616, col: 5, offset: 39271},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -11876,11 +11873,11 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1621, col: 1, offset: 39396},
+			pos:  position{line: 1618, col: 1, offset: 39286},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1621, col: 5, offset: 39400},
+				pos: position{line: 1618, col: 5, offset: 39290},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1621, col: 5, offset: 39400},
+					pos:  position{line: 1618, col: 5, offset: 39290},
 					name: "AnySpace",
 				},
 			},
@@ -11889,11 +11886,11 @@ var g = &grammar{
 		},
 		{
 			name: "__",
-			pos:  position{line: 1623, col: 1, offset: 39411},
+			pos:  position{line: 1620, col: 1, offset: 39301},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1623, col: 6, offset: 39416},
+				pos: position{line: 1620, col: 6, offset: 39306},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1623, col: 6, offset: 39416},
+					pos:  position{line: 1620, col: 6, offset: 39306},
 					name: "AnySpace",
 				},
 			},
@@ -11902,20 +11899,20 @@ var g = &grammar{
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1625, col: 1, offset: 39427},
+			pos:  position{line: 1622, col: 1, offset: 39317},
 			expr: &choiceExpr{
-				pos: position{line: 1626, col: 5, offset: 39440},
+				pos: position{line: 1623, col: 5, offset: 39330},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1626, col: 5, offset: 39440},
+						pos:  position{line: 1623, col: 5, offset: 39330},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1627, col: 5, offset: 39455},
+						pos:  position{line: 1624, col: 5, offset: 39345},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1628, col: 5, offset: 39474},
+						pos:  position{line: 1625, col: 5, offset: 39364},
 						name: "Comment",
 					},
 				},
@@ -11925,32 +11922,32 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeLetter",
-			pos:  position{line: 1630, col: 1, offset: 39483},
+			pos:  position{line: 1627, col: 1, offset: 39373},
 			expr: &choiceExpr{
-				pos: position{line: 1631, col: 5, offset: 39501},
+				pos: position{line: 1628, col: 5, offset: 39391},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1631, col: 5, offset: 39501},
+						pos:  position{line: 1628, col: 5, offset: 39391},
 						name: "Lu",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1632, col: 5, offset: 39508},
+						pos:  position{line: 1629, col: 5, offset: 39398},
 						name: "Ll",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1633, col: 5, offset: 39515},
+						pos:  position{line: 1630, col: 5, offset: 39405},
 						name: "Lt",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1634, col: 5, offset: 39522},
+						pos:  position{line: 1631, col: 5, offset: 39412},
 						name: "Lm",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1635, col: 5, offset: 39529},
+						pos:  position{line: 1632, col: 5, offset: 39419},
 						name: "Lo",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1636, col: 5, offset: 39536},
+						pos:  position{line: 1633, col: 5, offset: 39426},
 						name: "Nl",
 					},
 				},
@@ -11960,16 +11957,16 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeCombiningMark",
-			pos:  position{line: 1638, col: 1, offset: 39540},
+			pos:  position{line: 1635, col: 1, offset: 39430},
 			expr: &choiceExpr{
-				pos: position{line: 1639, col: 5, offset: 39565},
+				pos: position{line: 1636, col: 5, offset: 39455},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1639, col: 5, offset: 39565},
+						pos:  position{line: 1636, col: 5, offset: 39455},
 						name: "Mn",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1640, col: 5, offset: 39572},
+						pos:  position{line: 1637, col: 5, offset: 39462},
 						name: "Mc",
 					},
 				},
@@ -11979,9 +11976,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeDigit",
-			pos:  position{line: 1642, col: 1, offset: 39576},
+			pos:  position{line: 1639, col: 1, offset: 39466},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1643, col: 5, offset: 39593},
+				pos:  position{line: 1640, col: 5, offset: 39483},
 				name: "Nd",
 			},
 			leader:        false,
@@ -11989,9 +11986,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeConnectorPunctuation",
-			pos:  position{line: 1645, col: 1, offset: 39597},
+			pos:  position{line: 1642, col: 1, offset: 39487},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1646, col: 5, offset: 39629},
+				pos:  position{line: 1643, col: 5, offset: 39519},
 				name: "Pc",
 			},
 			leader:        false,
@@ -11999,9 +11996,9 @@ var g = &grammar{
 		},
 		{
 			name: "Ll",
-			pos:  position{line: 1652, col: 1, offset: 39810},
+			pos:  position{line: 1649, col: 1, offset: 39700},
 			expr: &charClassMatcher{
-				pos:        position{line: 1652, col: 6, offset: 39815},
+				pos:        position{line: 1649, col: 6, offset: 39705},
 				val:        "[\\u0061-\\u007A\\u00B5\\u00DF-\\u00F6\\u00F8-\\u00FF\\u0101\\u0103\\u0105\\u0107\\u0109\\u010B\\u010D\\u010F\\u0111\\u0113\\u0115\\u0117\\u0119\\u011B\\u011D\\u011F\\u0121\\u0123\\u0125\\u0127\\u0129\\u012B\\u012D\\u012F\\u0131\\u0133\\u0135\\u0137-\\u0138\\u013A\\u013C\\u013E\\u0140\\u0142\\u0144\\u0146\\u0148-\\u0149\\u014B\\u014D\\u014F\\u0151\\u0153\\u0155\\u0157\\u0159\\u015B\\u015D\\u015F\\u0161\\u0163\\u0165\\u0167\\u0169\\u016B\\u016D\\u016F\\u0171\\u0173\\u0175\\u0177\\u017A\\u017C\\u017E-\\u0180\\u0183\\u0185\\u0188\\u018C-\\u018D\\u0192\\u0195\\u0199-\\u019B\\u019E\\u01A1\\u01A3\\u01A5\\u01A8\\u01AA-\\u01AB\\u01AD\\u01B0\\u01B4\\u01B6\\u01B9-\\u01BA\\u01BD-\\u01BF\\u01C6\\u01C9\\u01CC\\u01CE\\u01D0\\u01D2\\u01D4\\u01D6\\u01D8\\u01DA\\u01DC-\\u01DD\\u01DF\\u01E1\\u01E3\\u01E5\\u01E7\\u01E9\\u01EB\\u01ED\\u01EF-\\u01F0\\u01F3\\u01F5\\u01F9\\u01FB\\u01FD\\u01FF\\u0201\\u0203\\u0205\\u0207\\u0209\\u020B\\u020D\\u020F\\u0211\\u0213\\u0215\\u0217\\u0219\\u021B\\u021D\\u021F\\u0221\\u0223\\u0225\\u0227\\u0229\\u022B\\u022D\\u022F\\u0231\\u0233-\\u0239\\u023C\\u023F-\\u0240\\u0242\\u0247\\u0249\\u024B\\u024D\\u024F-\\u0293\\u0295-\\u02AF\\u0371\\u0373\\u0377\\u037B-\\u037D\\u0390\\u03AC-\\u03CE\\u03D0-\\u03D1\\u03D5-\\u03D7\\u03D9\\u03DB\\u03DD\\u03DF\\u03E1\\u03E3\\u03E5\\u03E7\\u03E9\\u03EB\\u03ED\\u03EF-\\u03F3\\u03F5\\u03F8\\u03FB-\\u03FC\\u0430-\\u045F\\u0461\\u0463\\u0465\\u0467\\u0469\\u046B\\u046D\\u046F\\u0471\\u0473\\u0475\\u0477\\u0479\\u047B\\u047D\\u047F\\u0481\\u048B\\u048D\\u048F\\u0491\\u0493\\u0495\\u0497\\u0499\\u049B\\u049D\\u049F\\u04A1\\u04A3\\u04A5\\u04A7\\u04A9\\u04AB\\u04AD\\u04AF\\u04B1\\u04B3\\u04B5\\u04B7\\u04B9\\u04BB\\u04BD\\u04BF\\u04C2\\u04C4\\u04C6\\u04C8\\u04CA\\u04CC\\u04CE-\\u04CF\\u04D1\\u04D3\\u04D5\\u04D7\\u04D9\\u04DB\\u04DD\\u04DF\\u04E1\\u04E3\\u04E5\\u04E7\\u04E9\\u04EB\\u04ED\\u04EF\\u04F1\\u04F3\\u04F5\\u04F7\\u04F9\\u04FB\\u04FD\\u04FF\\u0501\\u0503\\u0505\\u0507\\u0509\\u050B\\u050D\\u050F\\u0511\\u0513\\u0515\\u0517\\u0519\\u051B\\u051D\\u051F\\u0521\\u0523\\u0525\\u0527\\u0529\\u052B\\u052D\\u052F\\u0560-\\u0588\\u10D0-\\u10FA\\u10FD-\\u10FF\\u13F8-\\u13FD\\u1C80-\\u1C88\\u1D00-\\u1D2B\\u1D6B-\\u1D77\\u1D79-\\u1D9A\\u1E01\\u1E03\\u1E05\\u1E07\\u1E09\\u1E0B\\u1E0D\\u1E0F\\u1E11\\u1E13\\u1E15\\u1E17\\u1E19\\u1E1B\\u1E1D\\u1E1F\\u1E21\\u1E23\\u1E25\\u1E27\\u1E29\\u1E2B\\u1E2D\\u1E2F\\u1E31\\u1E33\\u1E35\\u1E37\\u1E39\\u1E3B\\u1E3D\\u1E3F\\u1E41\\u1E43\\u1E45\\u1E47\\u1E49\\u1E4B\\u1E4D\\u1E4F\\u1E51\\u1E53\\u1E55\\u1E57\\u1E59\\u1E5B\\u1E5D\\u1E5F\\u1E61\\u1E63\\u1E65\\u1E67\\u1E69\\u1E6B\\u1E6D\\u1E6F\\u1E71\\u1E73\\u1E75\\u1E77\\u1E79\\u1E7B\\u1E7D\\u1E7F\\u1E81\\u1E83\\u1E85\\u1E87\\u1E89\\u1E8B\\u1E8D\\u1E8F\\u1E91\\u1E93\\u1E95-\\u1E9D\\u1E9F\\u1EA1\\u1EA3\\u1EA5\\u1EA7\\u1EA9\\u1EAB\\u1EAD\\u1EAF\\u1EB1\\u1EB3\\u1EB5\\u1EB7\\u1EB9\\u1EBB\\u1EBD\\u1EBF\\u1EC1\\u1EC3\\u1EC5\\u1EC7\\u1EC9\\u1ECB\\u1ECD\\u1ECF\\u1ED1\\u1ED3\\u1ED5\\u1ED7\\u1ED9\\u1EDB\\u1EDD\\u1EDF\\u1EE1\\u1EE3\\u1EE5\\u1EE7\\u1EE9\\u1EEB\\u1EED\\u1EEF\\u1EF1\\u1EF3\\u1EF5\\u1EF7\\u1EF9\\u1EFB\\u1EFD\\u1EFF-\\u1F07\\u1F10-\\u1F15\\u1F20-\\u1F27\\u1F30-\\u1F37\\u1F40-\\u1F45\\u1F50-\\u1F57\\u1F60-\\u1F67\\u1F70-\\u1F7D\\u1F80-\\u1F87\\u1F90-\\u1F97\\u1FA0-\\u1FA7\\u1FB0-\\u1FB4\\u1FB6-\\u1FB7\\u1FBE\\u1FC2-\\u1FC4\\u1FC6-\\u1FC7\\u1FD0-\\u1FD3\\u1FD6-\\u1FD7\\u1FE0-\\u1FE7\\u1FF2-\\u1FF4\\u1FF6-\\u1FF7\\u210A\\u210E-\\u210F\\u2113\\u212F\\u2134\\u2139\\u213C-\\u213D\\u2146-\\u2149\\u214E\\u2184\\u2C30-\\u2C5E\\u2C61\\u2C65-\\u2C66\\u2C68\\u2C6A\\u2C6C\\u2C71\\u2C73-\\u2C74\\u2C76-\\u2C7B\\u2C81\\u2C83\\u2C85\\u2C87\\u2C89\\u2C8B\\u2C8D\\u2C8F\\u2C91\\u2C93\\u2C95\\u2C97\\u2C99\\u2C9B\\u2C9D\\u2C9F\\u2CA1\\u2CA3\\u2CA5\\u2CA7\\u2CA9\\u2CAB\\u2CAD\\u2CAF\\u2CB1\\u2CB3\\u2CB5\\u2CB7\\u2CB9\\u2CBB\\u2CBD\\u2CBF\\u2CC1\\u2CC3\\u2CC5\\u2CC7\\u2CC9\\u2CCB\\u2CCD\\u2CCF\\u2CD1\\u2CD3\\u2CD5\\u2CD7\\u2CD9\\u2CDB\\u2CDD\\u2CDF\\u2CE1\\u2CE3-\\u2CE4\\u2CEC\\u2CEE\\u2CF3\\u2D00-\\u2D25\\u2D27\\u2D2D\\uA641\\uA643\\uA645\\uA647\\uA649\\uA64B\\uA64D\\uA64F\\uA651\\uA653\\uA655\\uA657\\uA659\\uA65B\\uA65D\\uA65F\\uA661\\uA663\\uA665\\uA667\\uA669\\uA66B\\uA66D\\uA681\\uA683\\uA685\\uA687\\uA689\\uA68B\\uA68D\\uA68F\\uA691\\uA693\\uA695\\uA697\\uA699\\uA69B\\uA723\\uA725\\uA727\\uA729\\uA72B\\uA72D\\uA72F-\\uA731\\uA733\\uA735\\uA737\\uA739\\uA73B\\uA73D\\uA73F\\uA741\\uA743\\uA745\\uA747\\uA749\\uA74B\\uA74D\\uA74F\\uA751\\uA753\\uA755\\uA757\\uA759\\uA75B\\uA75D\\uA75F\\uA761\\uA763\\uA765\\uA767\\uA769\\uA76B\\uA76D\\uA76F\\uA771-\\uA778\\uA77A\\uA77C\\uA77F\\uA781\\uA783\\uA785\\uA787\\uA78C\\uA78E\\uA791\\uA793-\\uA795\\uA797\\uA799\\uA79B\\uA79D\\uA79F\\uA7A1\\uA7A3\\uA7A5\\uA7A7\\uA7A9\\uA7AF\\uA7B5\\uA7B7\\uA7B9\\uA7FA\\uAB30-\\uAB5A\\uAB60-\\uAB65\\uAB70-\\uABBF\\uFB00-\\uFB06\\uFB13-\\uFB17\\uFF41-\\uFF5A]",
 				chars:      []rune{'µ', 'ā', 'ă', 'ą', 'ć', 'ĉ', 'ċ', 'č', 'ď', 'đ', 'ē', 'ĕ', 'ė', 'ę', 'ě', 'ĝ', 'ğ', 'ġ', 'ģ', 'ĥ', 'ħ', 'ĩ', 'ī', 'ĭ', 'į', 'ı', 'ĳ', 'ĵ', 'ĺ', 'ļ', 'ľ', 'ŀ', 'ł', 'ń', 'ņ', 'ŋ', 'ō', 'ŏ', 'ő', 'œ', 'ŕ', 'ŗ', 'ř', 'ś', 'ŝ', 'ş', 'š', 'ţ', 'ť', 'ŧ', 'ũ', 'ū', 'ŭ', 'ů', 'ű', 'ų', 'ŵ', 'ŷ', 'ź', 'ż', 'ƃ', 'ƅ', 'ƈ', 'ƒ', 'ƕ', 'ƞ', 'ơ', 'ƣ', 'ƥ', 'ƨ', 'ƭ', 'ư', 'ƴ', 'ƶ', 'ǆ', 'ǉ', 'ǌ', 'ǎ', 'ǐ', 'ǒ', 'ǔ', 'ǖ', 'ǘ', 'ǚ', 'ǟ', 'ǡ', 'ǣ', 'ǥ', 'ǧ', 'ǩ', 'ǫ', 'ǭ', 'ǳ', 'ǵ', 'ǹ', 'ǻ', 'ǽ', 'ǿ', 'ȁ', 'ȃ', 'ȅ', 'ȇ', 'ȉ', 'ȋ', 'ȍ', 'ȏ', 'ȑ', 'ȓ', 'ȕ', 'ȗ', 'ș', 'ț', 'ȝ', 'ȟ', 'ȡ', 'ȣ', 'ȥ', 'ȧ', 'ȩ', 'ȫ', 'ȭ', 'ȯ', 'ȱ', 'ȼ', 'ɂ', 'ɇ', 'ɉ', 'ɋ', 'ɍ', 'ͱ', 'ͳ', 'ͷ', 'ΐ', 'ϙ', 'ϛ', 'ϝ', 'ϟ', 'ϡ', 'ϣ', 'ϥ', 'ϧ', 'ϩ', 'ϫ', 'ϭ', 'ϵ', 'ϸ', 'ѡ', 'ѣ', 'ѥ', 'ѧ', 'ѩ', 'ѫ', 'ѭ', 'ѯ', 'ѱ', 'ѳ', 'ѵ', 'ѷ', 'ѹ', 'ѻ', 'ѽ', 'ѿ', 'ҁ', 'ҋ', 'ҍ', 'ҏ', 'ґ', 'ғ', 'ҕ', 'җ', 'ҙ', 'қ', 'ҝ', 'ҟ', 'ҡ', 'ң', 'ҥ', 'ҧ', 'ҩ', 'ҫ', 'ҭ', 'ү', 'ұ', 'ҳ', 'ҵ', 'ҷ', 'ҹ', 'һ', 'ҽ', 'ҿ', 'ӂ', 'ӄ', 'ӆ', 'ӈ', 'ӊ', 'ӌ', 'ӑ', 'ӓ', 'ӕ', 'ӗ', 'ә', 'ӛ', 'ӝ', 'ӟ', 'ӡ', 'ӣ', 'ӥ', 'ӧ', 'ө', 'ӫ', 'ӭ', 'ӯ', 'ӱ', 'ӳ', 'ӵ', 'ӷ', 'ӹ', 'ӻ', 'ӽ', 'ӿ', 'ԁ', 'ԃ', 'ԅ', 'ԇ', 'ԉ', 'ԋ', 'ԍ', 'ԏ', 'ԑ', 'ԓ', 'ԕ', 'ԗ', 'ԙ', 'ԛ', 'ԝ', 'ԟ', 'ԡ', 'ԣ', 'ԥ', 'ԧ', 'ԩ', 'ԫ', 'ԭ', 'ԯ', 'ḁ', 'ḃ', 'ḅ', 'ḇ', 'ḉ', 'ḋ', 'ḍ', 'ḏ', 'ḑ', 'ḓ', 'ḕ', 'ḗ', 'ḙ', 'ḛ', 'ḝ', 'ḟ', 'ḡ', 'ḣ', 'ḥ', 'ḧ', 'ḩ', 'ḫ', 'ḭ', 'ḯ', 'ḱ', 'ḳ', 'ḵ', 'ḷ', 'ḹ', 'ḻ', 'ḽ', 'ḿ', 'ṁ', 'ṃ', 'ṅ', 'ṇ', 'ṉ', 'ṋ', 'ṍ', 'ṏ', 'ṑ', 'ṓ', 'ṕ', 'ṗ', 'ṙ', 'ṛ', 'ṝ', 'ṟ', 'ṡ', 'ṣ', 'ṥ', 'ṧ', 'ṩ', 'ṫ', 'ṭ', 'ṯ', 'ṱ', 'ṳ', 'ṵ', 'ṷ', 'ṹ', 'ṻ', 'ṽ', 'ṿ', 'ẁ', 'ẃ', 'ẅ', 'ẇ', 'ẉ', 'ẋ', 'ẍ', 'ẏ', 'ẑ', 'ẓ', 'ẟ', 'ạ', 'ả', 'ấ', 'ầ', 'ẩ', 'ẫ', 'ậ', 'ắ', 'ằ', 'ẳ', 'ẵ', 'ặ', 'ẹ', 'ẻ', 'ẽ', 'ế', 'ề', 'ể', 'ễ', 'ệ', 'ỉ', 'ị', 'ọ', 'ỏ', 'ố', 'ồ', 'ổ', 'ỗ', 'ộ', 'ớ', 'ờ', 'ở', 'ỡ', 'ợ', 'ụ', 'ủ', 'ứ', 'ừ', 'ử', 'ữ', 'ự', 'ỳ', 'ỵ', 'ỷ', 'ỹ', 'ỻ', 'ỽ', 'ι', 'ℊ', 'ℓ', 'ℯ', 'ℴ', 'ℹ', 'ⅎ', 'ↄ', 'ⱡ', 'ⱨ', 'ⱪ', 'ⱬ', 'ⱱ', 'ⲁ', 'ⲃ', 'ⲅ', 'ⲇ', 'ⲉ', 'ⲋ', 'ⲍ', 'ⲏ', 'ⲑ', 'ⲓ', 'ⲕ', 'ⲗ', 'ⲙ', 'ⲛ', 'ⲝ', 'ⲟ', 'ⲡ', 'ⲣ', 'ⲥ', 'ⲧ', 'ⲩ', 'ⲫ', 'ⲭ', 'ⲯ', 'ⲱ', 'ⲳ', 'ⲵ', 'ⲷ', 'ⲹ', 'ⲻ', 'ⲽ', 'ⲿ', 'ⳁ', 'ⳃ', 'ⳅ', 'ⳇ', 'ⳉ', 'ⳋ', 'ⳍ', 'ⳏ', 'ⳑ', 'ⳓ', 'ⳕ', 'ⳗ', 'ⳙ', 'ⳛ', 'ⳝ', 'ⳟ', 'ⳡ', 'ⳬ', 'ⳮ', 'ⳳ', 'ⴧ', 'ⴭ', 'ꙁ', 'ꙃ', 'ꙅ', 'ꙇ', 'ꙉ', 'ꙋ', 'ꙍ', 'ꙏ', 'ꙑ', 'ꙓ', 'ꙕ', 'ꙗ', 'ꙙ', 'ꙛ', 'ꙝ', 'ꙟ', 'ꙡ', 'ꙣ', 'ꙥ', 'ꙧ', 'ꙩ', 'ꙫ', 'ꙭ', 'ꚁ', 'ꚃ', 'ꚅ', 'ꚇ', 'ꚉ', 'ꚋ', 'ꚍ', 'ꚏ', 'ꚑ', 'ꚓ', 'ꚕ', 'ꚗ', 'ꚙ', 'ꚛ', 'ꜣ', 'ꜥ', 'ꜧ', 'ꜩ', 'ꜫ', 'ꜭ', 'ꜳ', 'ꜵ', 'ꜷ', 'ꜹ', 'ꜻ', 'ꜽ', 'ꜿ', 'ꝁ', 'ꝃ', 'ꝅ', 'ꝇ', 'ꝉ', 'ꝋ', 'ꝍ', 'ꝏ', 'ꝑ', 'ꝓ', 'ꝕ', 'ꝗ', 'ꝙ', 'ꝛ', 'ꝝ', 'ꝟ', 'ꝡ', 'ꝣ', 'ꝥ', 'ꝧ', 'ꝩ', 'ꝫ', 'ꝭ', 'ꝯ', 'ꝺ', 'ꝼ', 'ꝿ', 'ꞁ', 'ꞃ', 'ꞅ', 'ꞇ', 'ꞌ', 'ꞎ', 'ꞑ', 'ꞗ', 'ꞙ', 'ꞛ', 'ꞝ', 'ꞟ', 'ꞡ', 'ꞣ', 'ꞥ', 'ꞧ', 'ꞩ', 'ꞯ', 'ꞵ', 'ꞷ', 'ꞹ', 'ꟺ'},
 				ranges:     []rune{'a', 'z', 'ß', 'ö', 'ø', 'ÿ', 'ķ', 'ĸ', 'ň', 'ŉ', 'ž', 'ƀ', 'ƌ', 'ƍ', 'ƙ', 'ƛ', 'ƪ', 'ƫ', 'ƹ', 'ƺ', 'ƽ', 'ƿ', 'ǜ', 'ǝ', 'ǯ', 'ǰ', 'ȳ', 'ȹ', 'ȿ', 'ɀ', 'ɏ', 'ʓ', 'ʕ', 'ʯ', 'ͻ', 'ͽ', 'ά', 'ώ', 'ϐ', 'ϑ', 'ϕ', 'ϗ', 'ϯ', 'ϳ', 'ϻ', 'ϼ', 'а', 'џ', 'ӎ', 'ӏ', 'ՠ', 'ֈ', 'ა', 'ჺ', 'ჽ', 'ჿ', 'ᏸ', 'ᏽ', 'ᲀ', 'ᲈ', 'ᴀ', 'ᴫ', 'ᵫ', 'ᵷ', 'ᵹ', 'ᶚ', 'ẕ', 'ẝ', 'ỿ', 'ἇ', 'ἐ', 'ἕ', 'ἠ', 'ἧ', 'ἰ', 'ἷ', 'ὀ', 'ὅ', 'ὐ', 'ὗ', 'ὠ', 'ὧ', 'ὰ', 'ώ', 'ᾀ', 'ᾇ', 'ᾐ', 'ᾗ', 'ᾠ', 'ᾧ', 'ᾰ', 'ᾴ', 'ᾶ', 'ᾷ', 'ῂ', 'ῄ', 'ῆ', 'ῇ', 'ῐ', 'ΐ', 'ῖ', 'ῗ', 'ῠ', 'ῧ', 'ῲ', 'ῴ', 'ῶ', 'ῷ', 'ℎ', 'ℏ', 'ℼ', 'ℽ', 'ⅆ', 'ⅉ', 'ⰰ', 'ⱞ', 'ⱥ', 'ⱦ', 'ⱳ', 'ⱴ', 'ⱶ', 'ⱻ', 'ⳣ', 'ⳤ', 'ⴀ', 'ⴥ', 'ꜯ', 'ꜱ', 'ꝱ', 'ꝸ', 'ꞓ', 'ꞕ', 'ꬰ', 'ꭚ', 'ꭠ', 'ꭥ', 'ꭰ', 'ꮿ', 'ﬀ', 'ﬆ', 'ﬓ', 'ﬗ', 'ａ', 'ｚ'},
@@ -12013,9 +12010,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lm",
-			pos:  position{line: 1655, col: 1, offset: 43967},
+			pos:  position{line: 1652, col: 1, offset: 43857},
 			expr: &charClassMatcher{
-				pos:        position{line: 1655, col: 6, offset: 43972},
+				pos:        position{line: 1652, col: 6, offset: 43862},
 				val:        "[\\u02B0-\\u02C1\\u02C6-\\u02D1\\u02E0-\\u02E4\\u02EC\\u02EE\\u0374\\u037A\\u0559\\u0640\\u06E5-\\u06E6\\u07F4-\\u07F5\\u07FA\\u081A\\u0824\\u0828\\u0971\\u0E46\\u0EC6\\u10FC\\u17D7\\u1843\\u1AA7\\u1C78-\\u1C7D\\u1D2C-\\u1D6A\\u1D78\\u1D9B-\\u1DBF\\u2071\\u207F\\u2090-\\u209C\\u2C7C-\\u2C7D\\u2D6F\\u2E2F\\u3005\\u3031-\\u3035\\u303B\\u309D-\\u309E\\u30FC-\\u30FE\\uA015\\uA4F8-\\uA4FD\\uA60C\\uA67F\\uA69C-\\uA69D\\uA717-\\uA71F\\uA770\\uA788\\uA7F8-\\uA7F9\\uA9CF\\uA9E6\\uAA70\\uAADD\\uAAF3-\\uAAF4\\uAB5C-\\uAB5F\\uFF70\\uFF9E-\\uFF9F]",
 				chars:      []rune{'ˬ', 'ˮ', 'ʹ', 'ͺ', 'ՙ', 'ـ', 'ߺ', 'ࠚ', 'ࠤ', 'ࠨ', 'ॱ', 'ๆ', 'ໆ', 'ჼ', 'ៗ', 'ᡃ', 'ᪧ', 'ᵸ', 'ⁱ', 'ⁿ', 'ⵯ', 'ⸯ', '々', '〻', 'ꀕ', 'ꘌ', 'ꙿ', 'ꝰ', 'ꞈ', 'ꧏ', 'ꧦ', 'ꩰ', 'ꫝ', 'ｰ'},
 				ranges:     []rune{'ʰ', 'ˁ', 'ˆ', 'ˑ', 'ˠ', 'ˤ', 'ۥ', 'ۦ', 'ߴ', 'ߵ', 'ᱸ', 'ᱽ', 'ᴬ', 'ᵪ', 'ᶛ', 'ᶿ', 'ₐ', 'ₜ', 'ⱼ', 'ⱽ', '〱', '〵', 'ゝ', 'ゞ', 'ー', 'ヾ', 'ꓸ', 'ꓽ', 'ꚜ', 'ꚝ', 'ꜗ', 'ꜟ', 'ꟸ', 'ꟹ', 'ꫳ', 'ꫴ', 'ꭜ', 'ꭟ', 'ﾞ', 'ﾟ'},
@@ -12027,9 +12024,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lo",
-			pos:  position{line: 1658, col: 1, offset: 44457},
+			pos:  position{line: 1655, col: 1, offset: 44347},
 			expr: &charClassMatcher{
-				pos:        position{line: 1658, col: 6, offset: 44462},
+				pos:        position{line: 1655, col: 6, offset: 44352},
 				val:        "[\\u00AA\\u00BA\\u01BB\\u01C0-\\u01C3\\u0294\\u05D0-\\u05EA\\u05EF-\\u05F2\\u0620-\\u063F\\u0641-\\u064A\\u066E-\\u066F\\u0671-\\u06D3\\u06D5\\u06EE-\\u06EF\\u06FA-\\u06FC\\u06FF\\u0710\\u0712-\\u072F\\u074D-\\u07A5\\u07B1\\u07CA-\\u07EA\\u0800-\\u0815\\u0840-\\u0858\\u0860-\\u086A\\u08A0-\\u08B4\\u08B6-\\u08BD\\u0904-\\u0939\\u093D\\u0950\\u0958-\\u0961\\u0972-\\u0980\\u0985-\\u098C\\u098F-\\u0990\\u0993-\\u09A8\\u09AA-\\u09B0\\u09B2\\u09B6-\\u09B9\\u09BD\\u09CE\\u09DC-\\u09DD\\u09DF-\\u09E1\\u09F0-\\u09F1\\u09FC\\u0A05-\\u0A0A\\u0A0F-\\u0A10\\u0A13-\\u0A28\\u0A2A-\\u0A30\\u0A32-\\u0A33\\u0A35-\\u0A36\\u0A38-\\u0A39\\u0A59-\\u0A5C\\u0A5E\\u0A72-\\u0A74\\u0A85-\\u0A8D\\u0A8F-\\u0A91\\u0A93-\\u0AA8\\u0AAA-\\u0AB0\\u0AB2-\\u0AB3\\u0AB5-\\u0AB9\\u0ABD\\u0AD0\\u0AE0-\\u0AE1\\u0AF9\\u0B05-\\u0B0C\\u0B0F-\\u0B10\\u0B13-\\u0B28\\u0B2A-\\u0B30\\u0B32-\\u0B33\\u0B35-\\u0B39\\u0B3D\\u0B5C-\\u0B5D\\u0B5F-\\u0B61\\u0B71\\u0B83\\u0B85-\\u0B8A\\u0B8E-\\u0B90\\u0B92-\\u0B95\\u0B99-\\u0B9A\\u0B9C\\u0B9E-\\u0B9F\\u0BA3-\\u0BA4\\u0BA8-\\u0BAA\\u0BAE-\\u0BB9\\u0BD0\\u0C05-\\u0C0C\\u0C0E-\\u0C10\\u0C12-\\u0C28\\u0C2A-\\u0C39\\u0C3D\\u0C58-\\u0C5A\\u0C60-\\u0C61\\u0C80\\u0C85-\\u0C8C\\u0C8E-\\u0C90\\u0C92-\\u0CA8\\u0CAA-\\u0CB3\\u0CB5-\\u0CB9\\u0CBD\\u0CDE\\u0CE0-\\u0CE1\\u0CF1-\\u0CF2\\u0D05-\\u0D0C\\u0D0E-\\u0D10\\u0D12-\\u0D3A\\u0D3D\\u0D4E\\u0D54-\\u0D56\\u0D5F-\\u0D61\\u0D7A-\\u0D7F\\u0D85-\\u0D96\\u0D9A-\\u0DB1\\u0DB3-\\u0DBB\\u0DBD\\u0DC0-\\u0DC6\\u0E01-\\u0E30\\u0E32-\\u0E33\\u0E40-\\u0E45\\u0E81-\\u0E82\\u0E84\\u0E87-\\u0E88\\u0E8A\\u0E8D\\u0E94-\\u0E97\\u0E99-\\u0E9F\\u0EA1-\\u0EA3\\u0EA5\\u0EA7\\u0EAA-\\u0EAB\\u0EAD-\\u0EB0\\u0EB2-\\u0EB3\\u0EBD\\u0EC0-\\u0EC4\\u0EDC-\\u0EDF\\u0F00\\u0F40-\\u0F47\\u0F49-\\u0F6C\\u0F88-\\u0F8C\\u1000-\\u102A\\u103F\\u1050-\\u1055\\u105A-\\u105D\\u1061\\u1065-\\u1066\\u106E-\\u1070\\u1075-\\u1081\\u108E\\u1100-\\u1248\\u124A-\\u124D\\u1250-\\u1256\\u1258\\u125A-\\u125D\\u1260-\\u1288\\u128A-\\u128D\\u1290-\\u12B0\\u12B2-\\u12B5\\u12B8-\\u12BE\\u12C0\\u12C2-\\u12C5\\u12C8-\\u12D6\\u12D8-\\u1310\\u1312-\\u1315\\u1318-\\u135A\\u1380-\\u138F\\u1401-\\u166C\\u166F-\\u167F\\u1681-\\u169A\\u16A0-\\u16EA\\u16F1-\\u16F8\\u1700-\\u170C\\u170E-\\u1711\\u1720-\\u1731\\u1740-\\u1751\\u1760-\\u176C\\u176E-\\u1770\\u1780-\\u17B3\\u17DC\\u1820-\\u1842\\u1844-\\u1878\\u1880-\\u1884\\u1887-\\u18A8\\u18AA\\u18B0-\\u18F5\\u1900-\\u191E\\u1950-\\u196D\\u1970-\\u1974\\u1980-\\u19AB\\u19B0-\\u19C9\\u1A00-\\u1A16\\u1A20-\\u1A54\\u1B05-\\u1B33\\u1B45-\\u1B4B\\u1B83-\\u1BA0\\u1BAE-\\u1BAF\\u1BBA-\\u1BE5\\u1C00-\\u1C23\\u1C4D-\\u1C4F\\u1C5A-\\u1C77\\u1CE9-\\u1CEC\\u1CEE-\\u1CF1\\u1CF5-\\u1CF6\\u2135-\\u2138\\u2D30-\\u2D67\\u2D80-\\u2D96\\u2DA0-\\u2DA6\\u2DA8-\\u2DAE\\u2DB0-\\u2DB6\\u2DB8-\\u2DBE\\u2DC0-\\u2DC6\\u2DC8-\\u2DCE\\u2DD0-\\u2DD6\\u2DD8-\\u2DDE\\u3006\\u303C\\u3041-\\u3096\\u309F\\u30A1-\\u30FA\\u30FF\\u3105-\\u312F\\u3131-\\u318E\\u31A0-\\u31BA\\u31F0-\\u31FF\\u3400-\\u4DB5\\u4E00-\\u9FEF\\uA000-\\uA014\\uA016-\\uA48C\\uA4D0-\\uA4F7\\uA500-\\uA60B\\uA610-\\uA61F\\uA62A-\\uA62B\\uA66E\\uA6A0-\\uA6E5\\uA78F\\uA7F7\\uA7FB-\\uA801\\uA803-\\uA805\\uA807-\\uA80A\\uA80C-\\uA822\\uA840-\\uA873\\uA882-\\uA8B3\\uA8F2-\\uA8F7\\uA8FB\\uA8FD-\\uA8FE\\uA90A-\\uA925\\uA930-\\uA946\\uA960-\\uA97C\\uA984-\\uA9B2\\uA9E0-\\uA9E4\\uA9E7-\\uA9EF\\uA9FA-\\uA9FE\\uAA00-\\uAA28\\uAA40-\\uAA42\\uAA44-\\uAA4B\\uAA60-\\uAA6F\\uAA71-\\uAA76\\uAA7A\\uAA7E-\\uAAAF\\uAAB1\\uAAB5-\\uAAB6\\uAAB9-\\uAABD\\uAAC0\\uAAC2\\uAADB-\\uAADC\\uAAE0-\\uAAEA\\uAAF2\\uAB01-\\uAB06\\uAB09-\\uAB0E\\uAB11-\\uAB16\\uAB20-\\uAB26\\uAB28-\\uAB2E\\uABC0-\\uABE2\\uAC00-\\uD7A3\\uD7B0-\\uD7C6\\uD7CB-\\uD7FB\\uF900-\\uFA6D\\uFA70-\\uFAD9\\uFB1D\\uFB1F-\\uFB28\\uFB2A-\\uFB36\\uFB38-\\uFB3C\\uFB3E\\uFB40-\\uFB41\\uFB43-\\uFB44\\uFB46-\\uFBB1\\uFBD3-\\uFD3D\\uFD50-\\uFD8F\\uFD92-\\uFDC7\\uFDF0-\\uFDFB\\uFE70-\\uFE74\\uFE76-\\uFEFC\\uFF66-\\uFF6F\\uFF71-\\uFF9D\\uFFA0-\\uFFBE\\uFFC2-\\uFFC7\\uFFCA-\\uFFCF\\uFFD2-\\uFFD7\\uFFDA-\\uFFDC]",
 				chars:      []rune{'ª', 'º', 'ƻ', 'ʔ', 'ە', 'ۿ', 'ܐ', 'ޱ', 'ऽ', 'ॐ', 'ল', 'ঽ', 'ৎ', 'ৼ', 'ਫ਼', 'ઽ', 'ૐ', 'ૹ', 'ଽ', 'ୱ', 'ஃ', 'ஜ', 'ௐ', 'ఽ', 'ಀ', 'ಽ', 'ೞ', 'ഽ', 'ൎ', 'ල', 'ຄ', 'ຊ', 'ຍ', 'ລ', 'ວ', 'ຽ', 'ༀ', 'ဿ', 'ၡ', 'ႎ', 'ቘ', 'ዀ', 'ៜ', 'ᢪ', '〆', '〼', 'ゟ', 'ヿ', 'ꙮ', 'ꞏ', 'ꟷ', 'ꣻ', 'ꩺ', 'ꪱ', 'ꫀ', 'ꫂ', 'ꫲ', 'יִ', 'מּ'},
 				ranges:     []rune{'ǀ', 'ǃ', 'א', 'ת', 'ׯ', 'ײ', 'ؠ', 'ؿ', 'ف', 'ي', 'ٮ', 'ٯ', 'ٱ', 'ۓ', 'ۮ', 'ۯ', 'ۺ', 'ۼ', 'ܒ', 'ܯ', 'ݍ', 'ޥ', 'ߊ', 'ߪ', 'ࠀ', 'ࠕ', 'ࡀ', 'ࡘ', 'ࡠ', 'ࡪ', 'ࢠ', 'ࢴ', 'ࢶ', 'ࢽ', 'ऄ', 'ह', 'क़', 'ॡ', 'ॲ', 'ঀ', 'অ', 'ঌ', 'এ', 'ঐ', 'ও', 'ন', 'প', 'র', 'শ', 'হ', 'ড়', 'ঢ়', 'য়', 'ৡ', 'ৰ', 'ৱ', 'ਅ', 'ਊ', 'ਏ', 'ਐ', 'ਓ', 'ਨ', 'ਪ', 'ਰ', 'ਲ', 'ਲ਼', 'ਵ', 'ਸ਼', 'ਸ', 'ਹ', 'ਖ਼', 'ੜ', 'ੲ', 'ੴ', 'અ', 'ઍ', 'એ', 'ઑ', 'ઓ', 'ન', 'પ', 'ર', 'લ', 'ળ', 'વ', 'હ', 'ૠ', 'ૡ', 'ଅ', 'ଌ', 'ଏ', 'ଐ', 'ଓ', 'ନ', 'ପ', 'ର', 'ଲ', 'ଳ', 'ଵ', 'ହ', 'ଡ଼', 'ଢ଼', 'ୟ', 'ୡ', 'அ', 'ஊ', 'எ', 'ஐ', 'ஒ', 'க', 'ங', 'ச', 'ஞ', 'ட', 'ண', 'த', 'ந', 'ப', 'ம', 'ஹ', 'అ', 'ఌ', 'ఎ', 'ఐ', 'ఒ', 'న', 'ప', 'హ', 'ౘ', 'ౚ', 'ౠ', 'ౡ', 'ಅ', 'ಌ', 'ಎ', 'ಐ', 'ಒ', 'ನ', 'ಪ', 'ಳ', 'ವ', 'ಹ', 'ೠ', 'ೡ', 'ೱ', 'ೲ', 'അ', 'ഌ', 'എ', 'ഐ', 'ഒ', 'ഺ', 'ൔ', 'ൖ', 'ൟ', 'ൡ', 'ൺ', 'ൿ', 'අ', 'ඖ', 'ක', 'න', 'ඳ', 'ර', 'ව', 'ෆ', 'ก', 'ะ', 'า', 'ำ', 'เ', 'ๅ', 'ກ', 'ຂ', 'ງ', 'ຈ', 'ດ', 'ທ', 'ນ', 'ຟ', 'ມ', 'ຣ', 'ສ', 'ຫ', 'ອ', 'ະ', 'າ', 'ຳ', 'ເ', 'ໄ', 'ໜ', 'ໟ', 'ཀ', 'ཇ', 'ཉ', 'ཬ', 'ྈ', 'ྌ', 'က', 'ဪ', 'ၐ', 'ၕ', 'ၚ', 'ၝ', 'ၥ', 'ၦ', 'ၮ', 'ၰ', 'ၵ', 'ႁ', 'ᄀ', 'ቈ', 'ቊ', 'ቍ', 'ቐ', 'ቖ', 'ቚ', 'ቝ', 'በ', 'ኈ', 'ኊ', 'ኍ', 'ነ', 'ኰ', 'ኲ', 'ኵ', 'ኸ', 'ኾ', 'ዂ', 'ዅ', 'ወ', 'ዖ', 'ዘ', 'ጐ', 'ጒ', 'ጕ', 'ጘ', 'ፚ', 'ᎀ', 'ᎏ', 'ᐁ', 'ᙬ', 'ᙯ', 'ᙿ', 'ᚁ', 'ᚚ', 'ᚠ', 'ᛪ', 'ᛱ', 'ᛸ', 'ᜀ', 'ᜌ', 'ᜎ', 'ᜑ', 'ᜠ', 'ᜱ', 'ᝀ', 'ᝑ', 'ᝠ', 'ᝬ', 'ᝮ', 'ᝰ', 'ក', 'ឳ', 'ᠠ', 'ᡂ', 'ᡄ', 'ᡸ', 'ᢀ', 'ᢄ', 'ᢇ', 'ᢨ', 'ᢰ', 'ᣵ', 'ᤀ', 'ᤞ', 'ᥐ', 'ᥭ', 'ᥰ', 'ᥴ', 'ᦀ', 'ᦫ', 'ᦰ', 'ᧉ', 'ᨀ', 'ᨖ', 'ᨠ', 'ᩔ', 'ᬅ', 'ᬳ', 'ᭅ', 'ᭋ', 'ᮃ', 'ᮠ', 'ᮮ', 'ᮯ', 'ᮺ', 'ᯥ', 'ᰀ', 'ᰣ', 'ᱍ', 'ᱏ', 'ᱚ', 'ᱷ', 'ᳩ', 'ᳬ', 'ᳮ', 'ᳱ', 'ᳵ', 'ᳶ', 'ℵ', 'ℸ', 'ⴰ', 'ⵧ', 'ⶀ', 'ⶖ', 'ⶠ', 'ⶦ', 'ⶨ', 'ⶮ', 'ⶰ', 'ⶶ', 'ⶸ', 'ⶾ', 'ⷀ', 'ⷆ', 'ⷈ', 'ⷎ', 'ⷐ', 'ⷖ', 'ⷘ', 'ⷞ', 'ぁ', 'ゖ', 'ァ', 'ヺ', 'ㄅ', 'ㄯ', 'ㄱ', 'ㆎ', 'ㆠ', 'ㆺ', 'ㇰ', 'ㇿ', '㐀', '䶵', '一', '鿯', 'ꀀ', 'ꀔ', 'ꀖ', 'ꒌ', 'ꓐ', 'ꓷ', 'ꔀ', 'ꘋ', 'ꘐ', 'ꘟ', 'ꘪ', 'ꘫ', 'ꚠ', 'ꛥ', 'ꟻ', 'ꠁ', 'ꠃ', 'ꠅ', 'ꠇ', 'ꠊ', 'ꠌ', 'ꠢ', 'ꡀ', 'ꡳ', 'ꢂ', 'ꢳ', 'ꣲ', 'ꣷ', 'ꣽ', 'ꣾ', 'ꤊ', 'ꤥ', 'ꤰ', 'ꥆ', 'ꥠ', 'ꥼ', 'ꦄ', 'ꦲ', 'ꧠ', 'ꧤ', 'ꧧ', 'ꧯ', 'ꧺ', 'ꧾ', 'ꨀ', 'ꨨ', 'ꩀ', 'ꩂ', 'ꩄ', 'ꩋ', 'ꩠ', 'ꩯ', 'ꩱ', 'ꩶ', 'ꩾ', 'ꪯ', 'ꪵ', 'ꪶ', 'ꪹ', 'ꪽ', 'ꫛ', 'ꫜ', 'ꫠ', 'ꫪ', 'ꬁ', 'ꬆ', 'ꬉ', 'ꬎ', 'ꬑ', 'ꬖ', 'ꬠ', 'ꬦ', 'ꬨ', 'ꬮ', 'ꯀ', 'ꯢ', '가', '힣', 'ힰ', 'ퟆ', 'ퟋ', 'ퟻ', '豈', '舘', '並', '龎', 'ײַ', 'ﬨ', 'שׁ', 'זּ', 'טּ', 'לּ', 'נּ', 'סּ', 'ףּ', 'פּ', 'צּ', 'ﮱ', 'ﯓ', 'ﴽ', 'ﵐ', 'ﶏ', 'ﶒ', 'ﷇ', 'ﷰ', 'ﷻ', 'ﹰ', 'ﹴ', 'ﹶ', 'ﻼ', 'ｦ', 'ｯ', 'ｱ', 'ﾝ', 'ﾠ', 'ﾾ', 'ￂ', 'ￇ', 'ￊ', 'ￏ', 'ￒ', 'ￗ', 'ￚ', 'ￜ'},
@@ -12041,9 +12038,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lt",
-			pos:  position{line: 1661, col: 1, offset: 47909},
+			pos:  position{line: 1658, col: 1, offset: 47799},
 			expr: &charClassMatcher{
-				pos:        position{line: 1661, col: 6, offset: 47914},
+				pos:        position{line: 1658, col: 6, offset: 47804},
 				val:        "[\\u01C5\\u01C8\\u01CB\\u01F2\\u1F88-\\u1F8F\\u1F98-\\u1F9F\\u1FA8-\\u1FAF\\u1FBC\\u1FCC\\u1FFC]",
 				chars:      []rune{'ǅ', 'ǈ', 'ǋ', 'ǲ', 'ᾼ', 'ῌ', 'ῼ'},
 				ranges:     []rune{'ᾈ', 'ᾏ', 'ᾘ', 'ᾟ', 'ᾨ', 'ᾯ'},
@@ -12055,9 +12052,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lu",
-			pos:  position{line: 1664, col: 1, offset: 48020},
+			pos:  position{line: 1661, col: 1, offset: 47910},
 			expr: &charClassMatcher{
-				pos:        position{line: 1664, col: 6, offset: 48025},
+				pos:        position{line: 1661, col: 6, offset: 47915},
 				val:        "[\\u0041-\\u005A\\u00C0-\\u00D6\\u00D8-\\u00DE\\u0100\\u0102\\u0104\\u0106\\u0108\\u010A\\u010C\\u010E\\u0110\\u0112\\u0114\\u0116\\u0118\\u011A\\u011C\\u011E\\u0120\\u0122\\u0124\\u0126\\u0128\\u012A\\u012C\\u012E\\u0130\\u0132\\u0134\\u0136\\u0139\\u013B\\u013D\\u013F\\u0141\\u0143\\u0145\\u0147\\u014A\\u014C\\u014E\\u0150\\u0152\\u0154\\u0156\\u0158\\u015A\\u015C\\u015E\\u0160\\u0162\\u0164\\u0166\\u0168\\u016A\\u016C\\u016E\\u0170\\u0172\\u0174\\u0176\\u0178-\\u0179\\u017B\\u017D\\u0181-\\u0182\\u0184\\u0186-\\u0187\\u0189-\\u018B\\u018E-\\u0191\\u0193-\\u0194\\u0196-\\u0198\\u019C-\\u019D\\u019F-\\u01A0\\u01A2\\u01A4\\u01A6-\\u01A7\\u01A9\\u01AC\\u01AE-\\u01AF\\u01B1-\\u01B3\\u01B5\\u01B7-\\u01B8\\u01BC\\u01C4\\u01C7\\u01CA\\u01CD\\u01CF\\u01D1\\u01D3\\u01D5\\u01D7\\u01D9\\u01DB\\u01DE\\u01E0\\u01E2\\u01E4\\u01E6\\u01E8\\u01EA\\u01EC\\u01EE\\u01F1\\u01F4\\u01F6-\\u01F8\\u01FA\\u01FC\\u01FE\\u0200\\u0202\\u0204\\u0206\\u0208\\u020A\\u020C\\u020E\\u0210\\u0212\\u0214\\u0216\\u0218\\u021A\\u021C\\u021E\\u0220\\u0222\\u0224\\u0226\\u0228\\u022A\\u022C\\u022E\\u0230\\u0232\\u023A-\\u023B\\u023D-\\u023E\\u0241\\u0243-\\u0246\\u0248\\u024A\\u024C\\u024E\\u0370\\u0372\\u0376\\u037F\\u0386\\u0388-\\u038A\\u038C\\u038E-\\u038F\\u0391-\\u03A1\\u03A3-\\u03AB\\u03CF\\u03D2-\\u03D4\\u03D8\\u03DA\\u03DC\\u03DE\\u03E0\\u03E2\\u03E4\\u03E6\\u03E8\\u03EA\\u03EC\\u03EE\\u03F4\\u03F7\\u03F9-\\u03FA\\u03FD-\\u042F\\u0460\\u0462\\u0464\\u0466\\u0468\\u046A\\u046C\\u046E\\u0470\\u0472\\u0474\\u0476\\u0478\\u047A\\u047C\\u047E\\u0480\\u048A\\u048C\\u048E\\u0490\\u0492\\u0494\\u0496\\u0498\\u049A\\u049C\\u049E\\u04A0\\u04A2\\u04A4\\u04A6\\u04A8\\u04AA\\u04AC\\u04AE\\u04B0\\u04B2\\u04B4\\u04B6\\u04B8\\u04BA\\u04BC\\u04BE\\u04C0-\\u04C1\\u04C3\\u04C5\\u04C7\\u04C9\\u04CB\\u04CD\\u04D0\\u04D2\\u04D4\\u04D6\\u04D8\\u04DA\\u04DC\\u04DE\\u04E0\\u04E2\\u04E4\\u04E6\\u04E8\\u04EA\\u04EC\\u04EE\\u04F0\\u04F2\\u04F4\\u04F6\\u04F8\\u04FA\\u04FC\\u04FE\\u0500\\u0502\\u0504\\u0506\\u0508\\u050A\\u050C\\u050E\\u0510\\u0512\\u0514\\u0516\\u0518\\u051A\\u051C\\u051E\\u0520\\u0522\\u0524\\u0526\\u0528\\u052A\\u052C\\u052E\\u0531-\\u0556\\u10A0-\\u10C5\\u10C7\\u10CD\\u13A0-\\u13F5\\u1C90-\\u1CBA\\u1CBD-\\u1CBF\\u1E00\\u1E02\\u1E04\\u1E06\\u1E08\\u1E0A\\u1E0C\\u1E0E\\u1E10\\u1E12\\u1E14\\u1E16\\u1E18\\u1E1A\\u1E1C\\u1E1E\\u1E20\\u1E22\\u1E24\\u1E26\\u1E28\\u1E2A\\u1E2C\\u1E2E\\u1E30\\u1E32\\u1E34\\u1E36\\u1E38\\u1E3A\\u1E3C\\u1E3E\\u1E40\\u1E42\\u1E44\\u1E46\\u1E48\\u1E4A\\u1E4C\\u1E4E\\u1E50\\u1E52\\u1E54\\u1E56\\u1E58\\u1E5A\\u1E5C\\u1E5E\\u1E60\\u1E62\\u1E64\\u1E66\\u1E68\\u1E6A\\u1E6C\\u1E6E\\u1E70\\u1E72\\u1E74\\u1E76\\u1E78\\u1E7A\\u1E7C\\u1E7E\\u1E80\\u1E82\\u1E84\\u1E86\\u1E88\\u1E8A\\u1E8C\\u1E8E\\u1E90\\u1E92\\u1E94\\u1E9E\\u1EA0\\u1EA2\\u1EA4\\u1EA6\\u1EA8\\u1EAA\\u1EAC\\u1EAE\\u1EB0\\u1EB2\\u1EB4\\u1EB6\\u1EB8\\u1EBA\\u1EBC\\u1EBE\\u1EC0\\u1EC2\\u1EC4\\u1EC6\\u1EC8\\u1ECA\\u1ECC\\u1ECE\\u1ED0\\u1ED2\\u1ED4\\u1ED6\\u1ED8\\u1EDA\\u1EDC\\u1EDE\\u1EE0\\u1EE2\\u1EE4\\u1EE6\\u1EE8\\u1EEA\\u1EEC\\u1EEE\\u1EF0\\u1EF2\\u1EF4\\u1EF6\\u1EF8\\u1EFA\\u1EFC\\u1EFE\\u1F08-\\u1F0F\\u1F18-\\u1F1D\\u1F28-\\u1F2F\\u1F38-\\u1F3F\\u1F48-\\u1F4D\\u1F59\\u1F5B\\u1F5D\\u1F5F\\u1F68-\\u1F6F\\u1FB8-\\u1FBB\\u1FC8-\\u1FCB\\u1FD8-\\u1FDB\\u1FE8-\\u1FEC\\u1FF8-\\u1FFB\\u2102\\u2107\\u210B-\\u210D\\u2110-\\u2112\\u2115\\u2119-\\u211D\\u2124\\u2126\\u2128\\u212A-\\u212D\\u2130-\\u2133\\u213E-\\u213F\\u2145\\u2183\\u2C00-\\u2C2E\\u2C60\\u2C62-\\u2C64\\u2C67\\u2C69\\u2C6B\\u2C6D-\\u2C70\\u2C72\\u2C75\\u2C7E-\\u2C80\\u2C82\\u2C84\\u2C86\\u2C88\\u2C8A\\u2C8C\\u2C8E\\u2C90\\u2C92\\u2C94\\u2C96\\u2C98\\u2C9A\\u2C9C\\u2C9E\\u2CA0\\u2CA2\\u2CA4\\u2CA6\\u2CA8\\u2CAA\\u2CAC\\u2CAE\\u2CB0\\u2CB2\\u2CB4\\u2CB6\\u2CB8\\u2CBA\\u2CBC\\u2CBE\\u2CC0\\u2CC2\\u2CC4\\u2CC6\\u2CC8\\u2CCA\\u2CCC\\u2CCE\\u2CD0\\u2CD2\\u2CD4\\u2CD6\\u2CD8\\u2CDA\\u2CDC\\u2CDE\\u2CE0\\u2CE2\\u2CEB\\u2CED\\u2CF2\\uA640\\uA642\\uA644\\uA646\\uA648\\uA64A\\uA64C\\uA64E\\uA650\\uA652\\uA654\\uA656\\uA658\\uA65A\\uA65C\\uA65E\\uA660\\uA662\\uA664\\uA666\\uA668\\uA66A\\uA66C\\uA680\\uA682\\uA684\\uA686\\uA688\\uA68A\\uA68C\\uA68E\\uA690\\uA692\\uA694\\uA696\\uA698\\uA69A\\uA722\\uA724\\uA726\\uA728\\uA72A\\uA72C\\uA72E\\uA732\\uA734\\uA736\\uA738\\uA73A\\uA73C\\uA73E\\uA740\\uA742\\uA744\\uA746\\uA748\\uA74A\\uA74C\\uA74E\\uA750\\uA752\\uA754\\uA756\\uA758\\uA75A\\uA75C\\uA75E\\uA760\\uA762\\uA764\\uA766\\uA768\\uA76A\\uA76C\\uA76E\\uA779\\uA77B\\uA77D-\\uA77E\\uA780\\uA782\\uA784\\uA786\\uA78B\\uA78D\\uA790\\uA792\\uA796\\uA798\\uA79A\\uA79C\\uA79E\\uA7A0\\uA7A2\\uA7A4\\uA7A6\\uA7A8\\uA7AA-\\uA7AE\\uA7B0-\\uA7B4\\uA7B6\\uA7B8\\uFF21-\\uFF3A]",
 				chars:      []rune{'Ā', 'Ă', 'Ą', 'Ć', 'Ĉ', 'Ċ', 'Č', 'Ď', 'Đ', 'Ē', 'Ĕ', 'Ė', 'Ę', 'Ě', 'Ĝ', 'Ğ', 'Ġ', 'Ģ', 'Ĥ', 'Ħ', 'Ĩ', 'Ī', 'Ĭ', 'Į', 'İ', 'Ĳ', 'Ĵ', 'Ķ', 'Ĺ', 'Ļ', 'Ľ', 'Ŀ', 'Ł', 'Ń', 'Ņ', 'Ň', 'Ŋ', 'Ō', 'Ŏ', 'Ő', 'Œ', 'Ŕ', 'Ŗ', 'Ř', 'Ś', 'Ŝ', 'Ş', 'Š', 'Ţ', 'Ť', 'Ŧ', 'Ũ', 'Ū', 'Ŭ', 'Ů', 'Ű', 'Ų', 'Ŵ', 'Ŷ', 'Ż', 'Ž', 'Ƅ', 'Ƣ', 'Ƥ', 'Ʃ', 'Ƭ', 'Ƶ', 'Ƽ', 'Ǆ', 'Ǉ', 'Ǌ', 'Ǎ', 'Ǐ', 'Ǒ', 'Ǔ', 'Ǖ', 'Ǘ', 'Ǚ', 'Ǜ', 'Ǟ', 'Ǡ', 'Ǣ', 'Ǥ', 'Ǧ', 'Ǩ', 'Ǫ', 'Ǭ', 'Ǯ', 'Ǳ', 'Ǵ', 'Ǻ', 'Ǽ', 'Ǿ', 'Ȁ', 'Ȃ', 'Ȅ', 'Ȇ', 'Ȉ', 'Ȋ', 'Ȍ', 'Ȏ', 'Ȑ', 'Ȓ', 'Ȕ', 'Ȗ', 'Ș', 'Ț', 'Ȝ', 'Ȟ', 'Ƞ', 'Ȣ', 'Ȥ', 'Ȧ', 'Ȩ', 'Ȫ', 'Ȭ', 'Ȯ', 'Ȱ', 'Ȳ', 'Ɂ', 'Ɉ', 'Ɋ', 'Ɍ', 'Ɏ', 'Ͱ', 'Ͳ', 'Ͷ', 'Ϳ', 'Ά', 'Ό', 'Ϗ', 'Ϙ', 'Ϛ', 'Ϝ', 'Ϟ', 'Ϡ', 'Ϣ', 'Ϥ', 'Ϧ', 'Ϩ', 'Ϫ', 'Ϭ', 'Ϯ', 'ϴ', 'Ϸ', 'Ѡ', 'Ѣ', 'Ѥ', 'Ѧ', 'Ѩ', 'Ѫ', 'Ѭ', 'Ѯ', 'Ѱ', 'Ѳ', 'Ѵ', 'Ѷ', 'Ѹ', 'Ѻ', 'Ѽ', 'Ѿ', 'Ҁ', 'Ҋ', 'Ҍ', 'Ҏ', 'Ґ', 'Ғ', 'Ҕ', 'Җ', 'Ҙ', 'Қ', 'Ҝ', 'Ҟ', 'Ҡ', 'Ң', 'Ҥ', 'Ҧ', 'Ҩ', 'Ҫ', 'Ҭ', 'Ү', 'Ұ', 'Ҳ', 'Ҵ', 'Ҷ', 'Ҹ', 'Һ', 'Ҽ', 'Ҿ', 'Ӄ', 'Ӆ', 'Ӈ', 'Ӊ', 'Ӌ', 'Ӎ', 'Ӑ', 'Ӓ', 'Ӕ', 'Ӗ', 'Ә', 'Ӛ', 'Ӝ', 'Ӟ', 'Ӡ', 'Ӣ', 'Ӥ', 'Ӧ', 'Ө', 'Ӫ', 'Ӭ', 'Ӯ', 'Ӱ', 'Ӳ', 'Ӵ', 'Ӷ', 'Ӹ', 'Ӻ', 'Ӽ', 'Ӿ', 'Ԁ', 'Ԃ', 'Ԅ', 'Ԇ', 'Ԉ', 'Ԋ', 'Ԍ', 'Ԏ', 'Ԑ', 'Ԓ', 'Ԕ', 'Ԗ', 'Ԙ', 'Ԛ', 'Ԝ', 'Ԟ', 'Ԡ', 'Ԣ', 'Ԥ', 'Ԧ', 'Ԩ', 'Ԫ', 'Ԭ', 'Ԯ', 'Ⴧ', 'Ⴭ', 'Ḁ', 'Ḃ', 'Ḅ', 'Ḇ', 'Ḉ', 'Ḋ', 'Ḍ', 'Ḏ', 'Ḑ', 'Ḓ', 'Ḕ', 'Ḗ', 'Ḙ', 'Ḛ', 'Ḝ', 'Ḟ', 'Ḡ', 'Ḣ', 'Ḥ', 'Ḧ', 'Ḩ', 'Ḫ', 'Ḭ', 'Ḯ', 'Ḱ', 'Ḳ', 'Ḵ', 'Ḷ', 'Ḹ', 'Ḻ', 'Ḽ', 'Ḿ', 'Ṁ', 'Ṃ', 'Ṅ', 'Ṇ', 'Ṉ', 'Ṋ', 'Ṍ', 'Ṏ', 'Ṑ', 'Ṓ', 'Ṕ', 'Ṗ', 'Ṙ', 'Ṛ', 'Ṝ', 'Ṟ', 'Ṡ', 'Ṣ', 'Ṥ', 'Ṧ', 'Ṩ', 'Ṫ', 'Ṭ', 'Ṯ', 'Ṱ', 'Ṳ', 'Ṵ', 'Ṷ', 'Ṹ', 'Ṻ', 'Ṽ', 'Ṿ', 'Ẁ', 'Ẃ', 'Ẅ', 'Ẇ', 'Ẉ', 'Ẋ', 'Ẍ', 'Ẏ', 'Ẑ', 'Ẓ', 'Ẕ', 'ẞ', 'Ạ', 'Ả', 'Ấ', 'Ầ', 'Ẩ', 'Ẫ', 'Ậ', 'Ắ', 'Ằ', 'Ẳ', 'Ẵ', 'Ặ', 'Ẹ', 'Ẻ', 'Ẽ', 'Ế', 'Ề', 'Ể', 'Ễ', 'Ệ', 'Ỉ', 'Ị', 'Ọ', 'Ỏ', 'Ố', 'Ồ', 'Ổ', 'Ỗ', 'Ộ', 'Ớ', 'Ờ', 'Ở', 'Ỡ', 'Ợ', 'Ụ', 'Ủ', 'Ứ', 'Ừ', 'Ử', 'Ữ', 'Ự', 'Ỳ', 'Ỵ', 'Ỷ', 'Ỹ', 'Ỻ', 'Ỽ', 'Ỿ', 'Ὑ', 'Ὓ', 'Ὕ', 'Ὗ', 'ℂ', 'ℇ', 'ℕ', 'ℤ', 'Ω', 'ℨ', 'ⅅ', 'Ↄ', 'Ⱡ', 'Ⱨ', 'Ⱪ', 'Ⱬ', 'Ⱳ', 'Ⱶ', 'Ⲃ', 'Ⲅ', 'Ⲇ', 'Ⲉ', 'Ⲋ', 'Ⲍ', 'Ⲏ', 'Ⲑ', 'Ⲓ', 'Ⲕ', 'Ⲗ', 'Ⲙ', 'Ⲛ', 'Ⲝ', 'Ⲟ', 'Ⲡ', 'Ⲣ', 'Ⲥ', 'Ⲧ', 'Ⲩ', 'Ⲫ', 'Ⲭ', 'Ⲯ', 'Ⲱ', 'Ⲳ', 'Ⲵ', 'Ⲷ', 'Ⲹ', 'Ⲻ', 'Ⲽ', 'Ⲿ', 'Ⳁ', 'Ⳃ', 'Ⳅ', 'Ⳇ', 'Ⳉ', 'Ⳋ', 'Ⳍ', 'Ⳏ', 'Ⳑ', 'Ⳓ', 'Ⳕ', 'Ⳗ', 'Ⳙ', 'Ⳛ', 'Ⳝ', 'Ⳟ', 'Ⳡ', 'Ⳣ', 'Ⳬ', 'Ⳮ', 'Ⳳ', 'Ꙁ', 'Ꙃ', 'Ꙅ', 'Ꙇ', 'Ꙉ', 'Ꙋ', 'Ꙍ', 'Ꙏ', 'Ꙑ', 'Ꙓ', 'Ꙕ', 'Ꙗ', 'Ꙙ', 'Ꙛ', 'Ꙝ', 'Ꙟ', 'Ꙡ', 'Ꙣ', 'Ꙥ', 'Ꙧ', 'Ꙩ', 'Ꙫ', 'Ꙭ', 'Ꚁ', 'Ꚃ', 'Ꚅ', 'Ꚇ', 'Ꚉ', 'Ꚋ', 'Ꚍ', 'Ꚏ', 'Ꚑ', 'Ꚓ', 'Ꚕ', 'Ꚗ', 'Ꚙ', 'Ꚛ', 'Ꜣ', 'Ꜥ', 'Ꜧ', 'Ꜩ', 'Ꜫ', 'Ꜭ', 'Ꜯ', 'Ꜳ', 'Ꜵ', 'Ꜷ', 'Ꜹ', 'Ꜻ', 'Ꜽ', 'Ꜿ', 'Ꝁ', 'Ꝃ', 'Ꝅ', 'Ꝇ', 'Ꝉ', 'Ꝋ', 'Ꝍ', 'Ꝏ', 'Ꝑ', 'Ꝓ', 'Ꝕ', 'Ꝗ', 'Ꝙ', 'Ꝛ', 'Ꝝ', 'Ꝟ', 'Ꝡ', 'Ꝣ', 'Ꝥ', 'Ꝧ', 'Ꝩ', 'Ꝫ', 'Ꝭ', 'Ꝯ', 'Ꝺ', 'Ꝼ', 'Ꞁ', 'Ꞃ', 'Ꞅ', 'Ꞇ', 'Ꞌ', 'Ɥ', 'Ꞑ', 'Ꞓ', 'Ꞗ', 'Ꞙ', 'Ꞛ', 'Ꞝ', 'Ꞟ', 'Ꞡ', 'Ꞣ', 'Ꞥ', 'Ꞧ', 'Ꞩ', 'Ꞷ', 'Ꞹ'},
 				ranges:     []rune{'A', 'Z', 'À', 'Ö', 'Ø', 'Þ', 'Ÿ', 'Ź', 'Ɓ', 'Ƃ', 'Ɔ', 'Ƈ', 'Ɖ', 'Ƌ', 'Ǝ', 'Ƒ', 'Ɠ', 'Ɣ', 'Ɩ', 'Ƙ', 'Ɯ', 'Ɲ', 'Ɵ', 'Ơ', 'Ʀ', 'Ƨ', 'Ʈ', 'Ư', 'Ʊ', 'Ƴ', 'Ʒ', 'Ƹ', 'Ƕ', 'Ǹ', 'Ⱥ', 'Ȼ', 'Ƚ', 'Ⱦ', 'Ƀ', 'Ɇ', 'Έ', 'Ί', 'Ύ', 'Ώ', 'Α', 'Ρ', 'Σ', 'Ϋ', 'ϒ', 'ϔ', 'Ϲ', 'Ϻ', 'Ͻ', 'Я', 'Ӏ', 'Ӂ', 'Ա', 'Ֆ', 'Ⴀ', 'Ⴥ', 'Ꭰ', 'Ᏽ', 'Ა', 'Ჺ', 'Ჽ', 'Ჿ', 'Ἀ', 'Ἇ', 'Ἐ', 'Ἕ', 'Ἠ', 'Ἧ', 'Ἰ', 'Ἷ', 'Ὀ', 'Ὅ', 'Ὠ', 'Ὧ', 'Ᾰ', 'Ά', 'Ὲ', 'Ή', 'Ῐ', 'Ί', 'Ῠ', 'Ῥ', 'Ὸ', 'Ώ', 'ℋ', 'ℍ', 'ℐ', 'ℒ', 'ℙ', 'ℝ', 'K', 'ℭ', 'ℰ', 'ℳ', 'ℾ', 'ℿ', 'Ⰰ', 'Ⱞ', 'Ɫ', 'Ɽ', 'Ɑ', 'Ɒ', 'Ȿ', 'Ⲁ', 'Ᵹ', 'Ꝿ', 'Ɦ', 'Ɪ', 'Ʞ', 'Ꞵ', 'Ａ', 'Ｚ'},
@@ -12069,9 +12066,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mc",
-			pos:  position{line: 1667, col: 1, offset: 52026},
+			pos:  position{line: 1664, col: 1, offset: 51916},
 			expr: &charClassMatcher{
-				pos:        position{line: 1667, col: 6, offset: 52031},
+				pos:        position{line: 1664, col: 6, offset: 51921},
 				val:        "[\\u0903\\u093B\\u093E-\\u0940\\u0949-\\u094C\\u094E-\\u094F\\u0982-\\u0983\\u09BE-\\u09C0\\u09C7-\\u09C8\\u09CB-\\u09CC\\u09D7\\u0A03\\u0A3E-\\u0A40\\u0A83\\u0ABE-\\u0AC0\\u0AC9\\u0ACB-\\u0ACC\\u0B02-\\u0B03\\u0B3E\\u0B40\\u0B47-\\u0B48\\u0B4B-\\u0B4C\\u0B57\\u0BBE-\\u0BBF\\u0BC1-\\u0BC2\\u0BC6-\\u0BC8\\u0BCA-\\u0BCC\\u0BD7\\u0C01-\\u0C03\\u0C41-\\u0C44\\u0C82-\\u0C83\\u0CBE\\u0CC0-\\u0CC4\\u0CC7-\\u0CC8\\u0CCA-\\u0CCB\\u0CD5-\\u0CD6\\u0D02-\\u0D03\\u0D3E-\\u0D40\\u0D46-\\u0D48\\u0D4A-\\u0D4C\\u0D57\\u0D82-\\u0D83\\u0DCF-\\u0DD1\\u0DD8-\\u0DDF\\u0DF2-\\u0DF3\\u0F3E-\\u0F3F\\u0F7F\\u102B-\\u102C\\u1031\\u1038\\u103B-\\u103C\\u1056-\\u1057\\u1062-\\u1064\\u1067-\\u106D\\u1083-\\u1084\\u1087-\\u108C\\u108F\\u109A-\\u109C\\u17B6\\u17BE-\\u17C5\\u17C7-\\u17C8\\u1923-\\u1926\\u1929-\\u192B\\u1930-\\u1931\\u1933-\\u1938\\u1A19-\\u1A1A\\u1A55\\u1A57\\u1A61\\u1A63-\\u1A64\\u1A6D-\\u1A72\\u1B04\\u1B35\\u1B3B\\u1B3D-\\u1B41\\u1B43-\\u1B44\\u1B82\\u1BA1\\u1BA6-\\u1BA7\\u1BAA\\u1BE7\\u1BEA-\\u1BEC\\u1BEE\\u1BF2-\\u1BF3\\u1C24-\\u1C2B\\u1C34-\\u1C35\\u1CE1\\u1CF2-\\u1CF3\\u1CF7\\u302E-\\u302F\\uA823-\\uA824\\uA827\\uA880-\\uA881\\uA8B4-\\uA8C3\\uA952-\\uA953\\uA983\\uA9B4-\\uA9B5\\uA9BA-\\uA9BB\\uA9BD-\\uA9C0\\uAA2F-\\uAA30\\uAA33-\\uAA34\\uAA4D\\uAA7B\\uAA7D\\uAAEB\\uAAEE-\\uAAEF\\uAAF5\\uABE3-\\uABE4\\uABE6-\\uABE7\\uABE9-\\uABEA\\uABEC]",
 				chars:      []rune{'ः', 'ऻ', 'ৗ', 'ਃ', 'ઃ', 'ૉ', 'ା', 'ୀ', 'ୗ', 'ௗ', 'ಾ', 'ൗ', 'ཿ', 'ေ', 'း', 'ႏ', 'ា', 'ᩕ', 'ᩗ', 'ᩡ', 'ᬄ', 'ᬵ', 'ᬻ', 'ᮂ', 'ᮡ', '᮪', 'ᯧ', 'ᯮ', '᳡', '᳷', 'ꠧ', 'ꦃ', 'ꩍ', 'ꩻ', 'ꩽ', 'ꫫ', 'ꫵ', '꯬'},
 				ranges:     []rune{'ा', 'ी', 'ॉ', 'ौ', 'ॎ', 'ॏ', 'ং', 'ঃ', 'া', 'ী', 'ে', 'ৈ', 'ো', 'ৌ', 'ਾ', 'ੀ', 'ા', 'ી', 'ો', 'ૌ', 'ଂ', 'ଃ', 'େ', 'ୈ', 'ୋ', 'ୌ', 'ா', 'ி', 'ு', 'ூ', 'ெ', 'ை', 'ொ', 'ௌ', 'ఁ', 'ః', 'ు', 'ౄ', 'ಂ', 'ಃ', 'ೀ', 'ೄ', 'ೇ', 'ೈ', 'ೊ', 'ೋ', 'ೕ', 'ೖ', 'ം', 'ഃ', 'ാ', 'ീ', 'െ', 'ൈ', 'ൊ', 'ൌ', 'ං', 'ඃ', 'ා', 'ෑ', 'ෘ', 'ෟ', 'ෲ', 'ෳ', '༾', '༿', 'ါ', 'ာ', 'ျ', 'ြ', 'ၖ', 'ၗ', 'ၢ', 'ၤ', 'ၧ', 'ၭ', 'ႃ', 'ႄ', 'ႇ', 'ႌ', 'ႚ', 'ႜ', 'ើ', 'ៅ', 'ះ', 'ៈ', 'ᤣ', 'ᤦ', 'ᤩ', 'ᤫ', 'ᤰ', 'ᤱ', 'ᤳ', 'ᤸ', 'ᨙ', 'ᨚ', 'ᩣ', 'ᩤ', 'ᩭ', 'ᩲ', 'ᬽ', 'ᭁ', 'ᭃ', '᭄', 'ᮦ', 'ᮧ', 'ᯪ', 'ᯬ', '᯲', '᯳', 'ᰤ', 'ᰫ', 'ᰴ', 'ᰵ', 'ᳲ', 'ᳳ', '〮', '〯', 'ꠣ', 'ꠤ', 'ꢀ', 'ꢁ', 'ꢴ', 'ꣃ', 'ꥒ', '꥓', 'ꦴ', 'ꦵ', 'ꦺ', 'ꦻ', 'ꦽ', '꧀', 'ꨯ', 'ꨰ', 'ꨳ', 'ꨴ', 'ꫮ', 'ꫯ', 'ꯣ', 'ꯤ', 'ꯦ', 'ꯧ', 'ꯩ', 'ꯪ'},
@@ -12083,9 +12080,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mn",
-			pos:  position{line: 1670, col: 1, offset: 53219},
+			pos:  position{line: 1667, col: 1, offset: 53109},
 			expr: &charClassMatcher{
-				pos:        position{line: 1670, col: 6, offset: 53224},
+				pos:        position{line: 1667, col: 6, offset: 53114},
 				val:        "[\\u0300-\\u036F\\u0483-\\u0487\\u0591-\\u05BD\\u05BF\\u05C1-\\u05C2\\u05C4-\\u05C5\\u05C7\\u0610-\\u061A\\u064B-\\u065F\\u0670\\u06D6-\\u06DC\\u06DF-\\u06E4\\u06E7-\\u06E8\\u06EA-\\u06ED\\u0711\\u0730-\\u074A\\u07A6-\\u07B0\\u07EB-\\u07F3\\u07FD\\u0816-\\u0819\\u081B-\\u0823\\u0825-\\u0827\\u0829-\\u082D\\u0859-\\u085B\\u08D3-\\u08E1\\u08E3-\\u0902\\u093A\\u093C\\u0941-\\u0948\\u094D\\u0951-\\u0957\\u0962-\\u0963\\u0981\\u09BC\\u09C1-\\u09C4\\u09CD\\u09E2-\\u09E3\\u09FE\\u0A01-\\u0A02\\u0A3C\\u0A41-\\u0A42\\u0A47-\\u0A48\\u0A4B-\\u0A4D\\u0A51\\u0A70-\\u0A71\\u0A75\\u0A81-\\u0A82\\u0ABC\\u0AC1-\\u0AC5\\u0AC7-\\u0AC8\\u0ACD\\u0AE2-\\u0AE3\\u0AFA-\\u0AFF\\u0B01\\u0B3C\\u0B3F\\u0B41-\\u0B44\\u0B4D\\u0B56\\u0B62-\\u0B63\\u0B82\\u0BC0\\u0BCD\\u0C00\\u0C04\\u0C3E-\\u0C40\\u0C46-\\u0C48\\u0C4A-\\u0C4D\\u0C55-\\u0C56\\u0C62-\\u0C63\\u0C81\\u0CBC\\u0CBF\\u0CC6\\u0CCC-\\u0CCD\\u0CE2-\\u0CE3\\u0D00-\\u0D01\\u0D3B-\\u0D3C\\u0D41-\\u0D44\\u0D4D\\u0D62-\\u0D63\\u0DCA\\u0DD2-\\u0DD4\\u0DD6\\u0E31\\u0E34-\\u0E3A\\u0E47-\\u0E4E\\u0EB1\\u0EB4-\\u0EB9\\u0EBB-\\u0EBC\\u0EC8-\\u0ECD\\u0F18-\\u0F19\\u0F35\\u0F37\\u0F39\\u0F71-\\u0F7E\\u0F80-\\u0F84\\u0F86-\\u0F87\\u0F8D-\\u0F97\\u0F99-\\u0FBC\\u0FC6\\u102D-\\u1030\\u1032-\\u1037\\u1039-\\u103A\\u103D-\\u103E\\u1058-\\u1059\\u105E-\\u1060\\u1071-\\u1074\\u1082\\u1085-\\u1086\\u108D\\u109D\\u135D-\\u135F\\u1712-\\u1714\\u1732-\\u1734\\u1752-\\u1753\\u1772-\\u1773\\u17B4-\\u17B5\\u17B7-\\u17BD\\u17C6\\u17C9-\\u17D3\\u17DD\\u180B-\\u180D\\u1885-\\u1886\\u18A9\\u1920-\\u1922\\u1927-\\u1928\\u1932\\u1939-\\u193B\\u1A17-\\u1A18\\u1A1B\\u1A56\\u1A58-\\u1A5E\\u1A60\\u1A62\\u1A65-\\u1A6C\\u1A73-\\u1A7C\\u1A7F\\u1AB0-\\u1ABD\\u1B00-\\u1B03\\u1B34\\u1B36-\\u1B3A\\u1B3C\\u1B42\\u1B6B-\\u1B73\\u1B80-\\u1B81\\u1BA2-\\u1BA5\\u1BA8-\\u1BA9\\u1BAB-\\u1BAD\\u1BE6\\u1BE8-\\u1BE9\\u1BED\\u1BEF-\\u1BF1\\u1C2C-\\u1C33\\u1C36-\\u1C37\\u1CD0-\\u1CD2\\u1CD4-\\u1CE0\\u1CE2-\\u1CE8\\u1CED\\u1CF4\\u1CF8-\\u1CF9\\u1DC0-\\u1DF9\\u1DFB-\\u1DFF\\u20D0-\\u20DC\\u20E1\\u20E5-\\u20F0\\u2CEF-\\u2CF1\\u2D7F\\u2DE0-\\u2DFF\\u302A-\\u302D\\u3099-\\u309A\\uA66F\\uA674-\\uA67D\\uA69E-\\uA69F\\uA6F0-\\uA6F1\\uA802\\uA806\\uA80B\\uA825-\\uA826\\uA8C4-\\uA8C5\\uA8E0-\\uA8F1\\uA8FF\\uA926-\\uA92D\\uA947-\\uA951\\uA980-\\uA982\\uA9B3\\uA9B6-\\uA9B9\\uA9BC\\uA9E5\\uAA29-\\uAA2E\\uAA31-\\uAA32\\uAA35-\\uAA36\\uAA43\\uAA4C\\uAA7C\\uAAB0\\uAAB2-\\uAAB4\\uAAB7-\\uAAB8\\uAABE-\\uAABF\\uAAC1\\uAAEC-\\uAAED\\uAAF6\\uABE5\\uABE8\\uABED\\uFB1E\\uFE00-\\uFE0F\\uFE20-\\uFE2F]",
 				chars:      []rune{'ֿ', 'ׇ', 'ٰ', 'ܑ', '߽', 'ऺ', '़', '्', 'ঁ', '়', '্', '৾', '਼', 'ੑ', 'ੵ', '઼', '્', 'ଁ', '଼', 'ି', '୍', 'ୖ', 'ஂ', 'ீ', '்', 'ఀ', 'ఄ', 'ಁ', '಼', 'ಿ', 'ೆ', '്', '්', 'ූ', 'ั', 'ັ', '༵', '༷', '༹', '࿆', 'ႂ', 'ႍ', 'ႝ', 'ំ', '៝', 'ᢩ', 'ᤲ', 'ᨛ', 'ᩖ', '᩠', 'ᩢ', '᩿', '᬴', 'ᬼ', 'ᭂ', '᯦', 'ᯭ', '᳭', '᳴', '⃡', '⵿', '꙯', 'ꠂ', '꠆', 'ꠋ', 'ꣿ', '꦳', 'ꦼ', 'ꧥ', 'ꩃ', 'ꩌ', 'ꩼ', 'ꪰ', '꫁', '꫶', 'ꯥ', 'ꯨ', '꯭', 'ﬞ'},
 				ranges:     []rune{'̀', 'ͯ', '҃', '҇', '֑', 'ֽ', 'ׁ', 'ׂ', 'ׄ', 'ׅ', 'ؐ', 'ؚ', 'ً', 'ٟ', 'ۖ', 'ۜ', '۟', 'ۤ', 'ۧ', 'ۨ', '۪', 'ۭ', 'ܰ', '݊', 'ަ', 'ް', '߫', '߳', 'ࠖ', '࠙', 'ࠛ', 'ࠣ', 'ࠥ', 'ࠧ', 'ࠩ', '࠭', '࡙', '࡛', '࣓', '࣡', 'ࣣ', 'ं', 'ु', 'ै', '॑', 'ॗ', 'ॢ', 'ॣ', 'ু', 'ৄ', 'ৢ', 'ৣ', 'ਁ', 'ਂ', 'ੁ', 'ੂ', 'ੇ', 'ੈ', 'ੋ', '੍', 'ੰ', 'ੱ', 'ઁ', 'ં', 'ુ', 'ૅ', 'ે', 'ૈ', 'ૢ', 'ૣ', 'ૺ', '૿', 'ୁ', 'ୄ', 'ୢ', 'ୣ', 'ా', 'ీ', 'ె', 'ై', 'ొ', '్', 'ౕ', 'ౖ', 'ౢ', 'ౣ', 'ೌ', '್', 'ೢ', 'ೣ', 'ഀ', 'ഁ', '഻', '഼', 'ു', 'ൄ', 'ൢ', 'ൣ', 'ි', 'ු', 'ิ', 'ฺ', '็', '๎', 'ິ', 'ູ', 'ົ', 'ຼ', '່', 'ໍ', '༘', '༙', 'ཱ', 'ཾ', 'ྀ', '྄', '྆', '྇', 'ྍ', 'ྗ', 'ྙ', 'ྼ', 'ိ', 'ူ', 'ဲ', '့', '္', '်', 'ွ', 'ှ', 'ၘ', 'ၙ', 'ၞ', 'ၠ', 'ၱ', 'ၴ', 'ႅ', 'ႆ', '፝', '፟', 'ᜒ', '᜔', 'ᜲ', '᜴', 'ᝒ', 'ᝓ', 'ᝲ', 'ᝳ', '឴', '឵', 'ិ', 'ួ', '៉', '៓', '᠋', '᠍', 'ᢅ', 'ᢆ', 'ᤠ', 'ᤢ', 'ᤧ', 'ᤨ', '᤹', '᤻', 'ᨗ', 'ᨘ', 'ᩘ', 'ᩞ', 'ᩥ', 'ᩬ', 'ᩳ', '᩼', '᪰', '᪽', 'ᬀ', 'ᬃ', 'ᬶ', 'ᬺ', '᭫', '᭳', 'ᮀ', 'ᮁ', 'ᮢ', 'ᮥ', 'ᮨ', 'ᮩ', '᮫', 'ᮭ', 'ᯨ', 'ᯩ', 'ᯯ', 'ᯱ', 'ᰬ', 'ᰳ', 'ᰶ', '᰷', '᳐', '᳒', '᳔', '᳠', '᳢', '᳨', '᳸', '᳹', '᷀', '᷹', '᷻', '᷿', '⃐', '⃜', '⃥', '⃰', '⳯', '⳱', 'ⷠ', 'ⷿ', '〪', '〭', '゙', '゚', 'ꙴ', '꙽', 'ꚞ', 'ꚟ', '꛰', '꛱', 'ꠥ', 'ꠦ', '꣄', 'ꣅ', '꣠', '꣱', 'ꤦ', '꤭', 'ꥇ', 'ꥑ', 'ꦀ', 'ꦂ', 'ꦶ', 'ꦹ', 'ꨩ', 'ꨮ', 'ꨱ', 'ꨲ', 'ꨵ', 'ꨶ', 'ꪲ', 'ꪴ', 'ꪷ', 'ꪸ', 'ꪾ', '꪿', 'ꫬ', 'ꫭ', '︀', '️', '︠', '︯'},
@@ -12097,9 +12094,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nd",
-			pos:  position{line: 1673, col: 1, offset: 55404},
+			pos:  position{line: 1670, col: 1, offset: 55294},
 			expr: &charClassMatcher{
-				pos:        position{line: 1673, col: 6, offset: 55409},
+				pos:        position{line: 1670, col: 6, offset: 55299},
 				val:        "[\\u0030-\\u0039\\u0660-\\u0669\\u06F0-\\u06F9\\u07C0-\\u07C9\\u0966-\\u096F\\u09E6-\\u09EF\\u0A66-\\u0A6F\\u0AE6-\\u0AEF\\u0B66-\\u0B6F\\u0BE6-\\u0BEF\\u0C66-\\u0C6F\\u0CE6-\\u0CEF\\u0D66-\\u0D6F\\u0DE6-\\u0DEF\\u0E50-\\u0E59\\u0ED0-\\u0ED9\\u0F20-\\u0F29\\u1040-\\u1049\\u1090-\\u1099\\u17E0-\\u17E9\\u1810-\\u1819\\u1946-\\u194F\\u19D0-\\u19D9\\u1A80-\\u1A89\\u1A90-\\u1A99\\u1B50-\\u1B59\\u1BB0-\\u1BB9\\u1C40-\\u1C49\\u1C50-\\u1C59\\uA620-\\uA629\\uA8D0-\\uA8D9\\uA900-\\uA909\\uA9D0-\\uA9D9\\uA9F0-\\uA9F9\\uAA50-\\uAA59\\uABF0-\\uABF9\\uFF10-\\uFF19]",
 				ranges:     []rune{'0', '9', '٠', '٩', '۰', '۹', '߀', '߉', '०', '९', '০', '৯', '੦', '੯', '૦', '૯', '୦', '୯', '௦', '௯', '౦', '౯', '೦', '೯', '൦', '൯', '෦', '෯', '๐', '๙', '໐', '໙', '༠', '༩', '၀', '၉', '႐', '႙', '០', '៩', '᠐', '᠙', '᥆', '᥏', '᧐', '᧙', '᪀', '᪉', '᪐', '᪙', '᭐', '᭙', '᮰', '᮹', '᱀', '᱉', '᱐', '᱙', '꘠', '꘩', '꣐', '꣙', '꤀', '꤉', '꧐', '꧙', '꧰', '꧹', '꩐', '꩙', '꯰', '꯹', '０', '９'},
 				ignoreCase: false,
@@ -12110,9 +12107,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nl",
-			pos:  position{line: 1676, col: 1, offset: 55912},
+			pos:  position{line: 1673, col: 1, offset: 55802},
 			expr: &charClassMatcher{
-				pos:        position{line: 1676, col: 6, offset: 55917},
+				pos:        position{line: 1673, col: 6, offset: 55807},
 				val:        "[\\u16EE-\\u16F0\\u2160-\\u2182\\u2185-\\u2188\\u3007\\u3021-\\u3029\\u3038-\\u303A\\uA6E6-\\uA6EF]",
 				chars:      []rune{'〇'},
 				ranges:     []rune{'ᛮ', 'ᛰ', 'Ⅰ', 'ↂ', 'ↅ', 'ↈ', '〡', '〩', '〸', '〺', 'ꛦ', 'ꛯ'},
@@ -12124,9 +12121,9 @@ var g = &grammar{
 		},
 		{
 			name: "Pc",
-			pos:  position{line: 1679, col: 1, offset: 56031},
+			pos:  position{line: 1676, col: 1, offset: 55921},
 			expr: &charClassMatcher{
-				pos:        position{line: 1679, col: 6, offset: 56036},
+				pos:        position{line: 1676, col: 6, offset: 55926},
 				val:        "[\\u005F\\u203F-\\u2040\\u2054\\uFE33-\\uFE34\\uFE4D-\\uFE4F\\uFF3F]",
 				chars:      []rune{'_', '⁔', '＿'},
 				ranges:     []rune{'‿', '⁀', '︳', '︴', '﹍', '﹏'},
@@ -12138,9 +12135,9 @@ var g = &grammar{
 		},
 		{
 			name: "Zs",
-			pos:  position{line: 1682, col: 1, offset: 56117},
+			pos:  position{line: 1679, col: 1, offset: 56007},
 			expr: &charClassMatcher{
-				pos:        position{line: 1682, col: 6, offset: 56122},
+				pos:        position{line: 1679, col: 6, offset: 56012},
 				val:        "[\\u0020\\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000]",
 				chars:      []rune{' ', '\u00a0', '\u1680', '\u202f', '\u205f', '\u3000'},
 				ranges:     []rune{'\u2000', '\u200a'},
@@ -12152,9 +12149,9 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1684, col: 1, offset: 56175},
+			pos:  position{line: 1681, col: 1, offset: 56065},
 			expr: &anyMatcher{
-				line: 1685, col: 5, offset: 56195,
+				line: 1682, col: 5, offset: 56085,
 			},
 			leader:        false,
 			leftRecursive: false,
@@ -12162,48 +12159,48 @@ var g = &grammar{
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1687, col: 1, offset: 56198},
+			pos:         position{line: 1684, col: 1, offset: 56088},
 			expr: &choiceExpr{
-				pos: position{line: 1688, col: 5, offset: 56226},
+				pos: position{line: 1685, col: 5, offset: 56116},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1688, col: 5, offset: 56226},
+						pos:        position{line: 1685, col: 5, offset: 56116},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1689, col: 5, offset: 56235},
+						pos:        position{line: 1686, col: 5, offset: 56125},
 						val:        "\v",
 						ignoreCase: false,
 						want:       "\"\\v\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1690, col: 5, offset: 56244},
+						pos:        position{line: 1687, col: 5, offset: 56134},
 						val:        "\f",
 						ignoreCase: false,
 						want:       "\"\\f\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1691, col: 5, offset: 56253},
+						pos:        position{line: 1688, col: 5, offset: 56143},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 1692, col: 5, offset: 56261},
+						pos:        position{line: 1689, col: 5, offset: 56151},
 						val:        "\u00a0",
 						ignoreCase: false,
 						want:       "\"\\u00a0\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1693, col: 5, offset: 56274},
+						pos:        position{line: 1690, col: 5, offset: 56164},
 						val:        "\ufeff",
 						ignoreCase: false,
 						want:       "\"\\ufeff\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1694, col: 5, offset: 56287},
+						pos:  position{line: 1691, col: 5, offset: 56177},
 						name: "Zs",
 					},
 				},
@@ -12213,9 +12210,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1696, col: 1, offset: 56291},
+			pos:  position{line: 1693, col: 1, offset: 56181},
 			expr: &charClassMatcher{
-				pos:        position{line: 1697, col: 5, offset: 56310},
+				pos:        position{line: 1694, col: 5, offset: 56200},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -12227,9 +12224,9 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1703, col: 1, offset: 56640},
+			pos:         position{line: 1700, col: 1, offset: 56530},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1706, col: 5, offset: 56711},
+				pos:  position{line: 1703, col: 5, offset: 56601},
 				name: "SingleLineComment",
 			},
 			leader:        false,
@@ -12237,39 +12234,39 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1708, col: 1, offset: 56730},
+			pos:  position{line: 1705, col: 1, offset: 56620},
 			expr: &seqExpr{
-				pos: position{line: 1709, col: 5, offset: 56751},
+				pos: position{line: 1706, col: 5, offset: 56641},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1709, col: 5, offset: 56751},
+						pos:        position{line: 1706, col: 5, offset: 56641},
 						val:        "/*",
 						ignoreCase: false,
 						want:       "\"/*\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1709, col: 10, offset: 56756},
+						pos: position{line: 1706, col: 10, offset: 56646},
 						expr: &seqExpr{
-							pos: position{line: 1709, col: 11, offset: 56757},
+							pos: position{line: 1706, col: 11, offset: 56647},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1709, col: 11, offset: 56757},
+									pos: position{line: 1706, col: 11, offset: 56647},
 									expr: &litMatcher{
-										pos:        position{line: 1709, col: 12, offset: 56758},
+										pos:        position{line: 1706, col: 12, offset: 56648},
 										val:        "*/",
 										ignoreCase: false,
 										want:       "\"*/\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1709, col: 17, offset: 56763},
+									pos:  position{line: 1706, col: 17, offset: 56653},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1709, col: 35, offset: 56781},
+						pos:        position{line: 1706, col: 35, offset: 56671},
 						val:        "*/",
 						ignoreCase: false,
 						want:       "\"*/\"",
@@ -12281,30 +12278,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1711, col: 1, offset: 56787},
+			pos:  position{line: 1708, col: 1, offset: 56677},
 			expr: &seqExpr{
-				pos: position{line: 1712, col: 5, offset: 56809},
+				pos: position{line: 1709, col: 5, offset: 56699},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1712, col: 5, offset: 56809},
+						pos:        position{line: 1709, col: 5, offset: 56699},
 						val:        "//",
 						ignoreCase: false,
 						want:       "\"//\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1712, col: 10, offset: 56814},
+						pos: position{line: 1709, col: 10, offset: 56704},
 						expr: &seqExpr{
-							pos: position{line: 1712, col: 11, offset: 56815},
+							pos: position{line: 1709, col: 11, offset: 56705},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1712, col: 11, offset: 56815},
+									pos: position{line: 1709, col: 11, offset: 56705},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1712, col: 12, offset: 56816},
+										pos:  position{line: 1709, col: 12, offset: 56706},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1712, col: 27, offset: 56831},
+									pos:  position{line: 1709, col: 27, offset: 56721},
 									name: "SourceCharacter",
 								},
 							},
@@ -12317,19 +12314,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1714, col: 1, offset: 56850},
+			pos:  position{line: 1711, col: 1, offset: 56740},
 			expr: &seqExpr{
-				pos: position{line: 1714, col: 7, offset: 56856},
+				pos: position{line: 1711, col: 7, offset: 56746},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1714, col: 7, offset: 56856},
+						pos: position{line: 1711, col: 7, offset: 56746},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1714, col: 7, offset: 56856},
+							pos:  position{line: 1711, col: 7, offset: 56746},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1714, col: 19, offset: 56868},
+						pos:  position{line: 1711, col: 19, offset: 56758},
 						name: "LineTerminator",
 					},
 				},
@@ -12339,16 +12336,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1716, col: 1, offset: 56884},
+			pos:  position{line: 1713, col: 1, offset: 56774},
 			expr: &choiceExpr{
-				pos: position{line: 1716, col: 7, offset: 56890},
+				pos: position{line: 1713, col: 7, offset: 56780},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1716, col: 7, offset: 56890},
+						pos:  position{line: 1713, col: 7, offset: 56780},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1716, col: 11, offset: 56894},
+						pos:  position{line: 1713, col: 11, offset: 56784},
 						name: "EOF",
 					},
 				},
@@ -12358,11 +12355,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1718, col: 1, offset: 56899},
+			pos:  position{line: 1715, col: 1, offset: 56789},
 			expr: &notExpr{
-				pos: position{line: 1718, col: 7, offset: 56905},
+				pos: position{line: 1715, col: 7, offset: 56795},
 				expr: &anyMatcher{
-					line: 1718, col: 8, offset: 56906,
+					line: 1715, col: 8, offset: 56796,
 				},
 			},
 			leader:        false,
@@ -12370,11 +12367,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOKW",
-			pos:  position{line: 1720, col: 1, offset: 56909},
+			pos:  position{line: 1717, col: 1, offset: 56799},
 			expr: &notExpr{
-				pos: position{line: 1720, col: 8, offset: 56916},
+				pos: position{line: 1717, col: 8, offset: 56806},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1720, col: 9, offset: 56917},
+					pos:  position{line: 1717, col: 9, offset: 56807},
 					name: "KeyWordChars",
 				},
 			},
@@ -15010,18 +15007,7 @@ func (p *parser) callonAmbiguousType18() (any, error) {
 	return p.cur.onAmbiguousType18(stack["name"], stack["opt"])
 }
 
-func (c *current) onAmbiguousType29(name any) (any, error) {
-	return &astzed.TypeName{Kind: "TypeName", Name: name.(string), NamePos: c.pos.offset}, nil
-
-}
-
-func (p *parser) callonAmbiguousType29() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onAmbiguousType29(stack["name"])
-}
-
-func (c *current) onAmbiguousType32(types any) (any, error) {
+func (c *current) onAmbiguousType31(types any) (any, error) {
 	return &astzed.TypeUnion{
 		Kind:   "TypeUnion",
 		Lparen: c.pos.offset,
@@ -15031,10 +15017,10 @@ func (c *current) onAmbiguousType32(types any) (any, error) {
 
 }
 
-func (p *parser) callonAmbiguousType32() (any, error) {
+func (p *parser) callonAmbiguousType31() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onAmbiguousType32(stack["types"])
+	return p.cur.onAmbiguousType31(stack["types"])
 }
 
 func (c *current) onTypeList1(first, rest any) (any, error) {

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -1225,7 +1225,7 @@ AmbiguousType
           Rparen: lastPos(c, ")"),
       }, nil
     }
-  / name:IdentifierName opt:(__ '=' __ Type)? {
+  / name:(IdentifierName / QuotedString) opt:(__ '=' __ Type)? {
       if opt != nil {
         return &astzed.TypeDef{
             Kind: "TypeDef",
@@ -1234,9 +1234,6 @@ AmbiguousType
             Type: opt.([]any)[3].(astzed.Type),
         }, nil
       }
-      return &astzed.TypeName{Kind: "TypeName", Name: name.(string), NamePos: c.pos.offset}, nil
-    }
-  / name:QuotedString {
       return &astzed.TypeName{Kind: "TypeName", Name: name.(string), NamePos: c.pos.offset}, nil
     }
   / "(" __ types:TypeList ")" {

--- a/compiler/parser/ztests/quoted-named-type.yaml
+++ b/compiler/parser/ztests/quoted-named-type.yaml
@@ -1,0 +1,8 @@
+zed: |
+  yield <"@foo"={x:int64}>
+
+input: |
+  null
+
+output: |
+  <"@foo"={x:int64}>


### PR DESCRIPTION
The commit adds support in the Zed parser to allow parsing of quoted named type values.