### PR TITLE
Remove runtime/sam/expr.SortStable

### DIFF
--- a/runtime/sam/expr/sort.go
+++ b/runtime/sam/expr/sort.go
@@ -266,12 +266,6 @@ func (s *sortStableReader) Read() (*zed.Value, error) {
 	return val, nil
 }
 
-// SortStable performs a stable sort on the provided records.
-func SortStable(records []zed.Value, compare CompareFn) {
-	slice := &RecordSlice{records, compare}
-	sort.Stable(slice)
-}
-
 type RecordSlice struct {
 	vals    []zed.Value
 	compare CompareFn

--- a/runtime/sam/op/groupby/groupby.go
+++ b/runtime/sam/op/groupby/groupby.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"slices"
 	"sync"
 
 	"github.com/brimdata/zed"
@@ -244,7 +245,7 @@ func (o *Op) run() {
 			if res == nil {
 				break
 			}
-			expr.SortStable(res.Values(), o.agg.keyCompare)
+			slices.SortStableFunc(res.Values(), o.agg.keyCompare)
 			done, ok := o.sendResult(res, nil)
 			if !ok {
 				return


### PR DESCRIPTION
slices.SortStableFunc does the same thing and should be faster since it doesn't rely on sort.Interface.