### PR TITLE
Upgrade Node 16 actions in .github/workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,10 +12,10 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
       - run: make fmt
@@ -28,8 +28,8 @@ jobs:
   test-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
       - run: go test -short ./...
@@ -39,8 +39,8 @@ jobs:
   output-check:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
       - run: make install

--- a/.github/workflows/markdown-lint.yaml
+++ b/.github/workflows/markdown-lint.yaml
@@ -12,7 +12,7 @@ jobs:
   markdown-link:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Lint
       run: make markdown-lint
     - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/perf-compare.yaml
+++ b/.github/workflows/perf-compare.yaml
@@ -12,8 +12,8 @@ jobs:
   perf-compare:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
     - name: Add zeek-cut to PATH

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,10 +7,10 @@ jobs:
   publish:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
     - run: make fmt
@@ -20,7 +20,7 @@ jobs:
     - run: make test-unit
     - run: make test-system
     - run: make test-heavy
-    - uses: goreleaser/goreleaser-action@v3
+    - uses: goreleaser/goreleaser-action@v5
       with:
         args: release --clean
       env:


### PR DESCRIPTION
Node 16 actions are deprecated so upgrade to the Node 20 versions.

(Upgrade gorelease/goreleaser-action to v5 because v6 requires changes to .goreleaser.yaml.)