### PR TITLE
Add an integration doc that mentions the Grafana plugin

### DIFF
--- a/docs/integrations/grafana.md
+++ b/docs/integrations/grafana.md
@@ -1,0 +1,12 @@
+---
+sidebar_position: 3
+sidebar_label: Grafana
+---
+
+# Grafana Data Source Plugin
+
+A [data source plugin](https://grafana.com/grafana/plugins/?type=datasource)
+for [Grafana](https://grafana.com/) is available that enables plotting of
+time-series data that's stored in [Zed lakes](../commands/zed.md). See the
+README in the [grafana-zed-datasource repository](https://github.com/brimdata/grafana-zed-datasource)
+for details.

--- a/docs/integrations/zeek/_category_.yaml
+++ b/docs/integrations/zeek/_category_.yaml
@@ -1,2 +1,2 @@
-position: 3
+position: 4
 label: Zeek


### PR DESCRIPTION
We get periodic digests from Algolia of what users having been searching for on our docs site. Recently it showed a search attempt for "grafana" which made me realize it'd help to have _some_ reference in the Zed docs that points off to the detailed docs in the plugin repo.