### PR TITLE
Mention the re-run of "go mod tidy"

### DIFF
--- a/docs/libraries/go.md
+++ b/docs/libraries/go.md
@@ -157,7 +157,8 @@ func main() {
 	}
 }
 ```
-Now, run this command to interact with the lake via the local file system:
+After a re-run of `go mod tidy`, run this command to interact with the lake via
+the local file system:
 ```
 go run . ./scratch
 ```


### PR DESCRIPTION
Now that #5095 has merged, I can successfully run through the [Go library examples in the docs](https://zed.brimdata.io/docs/next/libraries/go) as long as I'm pointing at a recent Zed commit. The one tiny snag I hit is that I did need to re-run `go mod tidy` to move on to the second example, so here I'm proposing we mention that explicitly. I'm sure this is a no-brainer for any real Go developers, but when walking readers through the most basic examples I figure it can't hurt.