### PR TITLE
query describe endpoint: Fix scopes

### DIFF
--- a/compiler/describe/analyze.go
+++ b/compiler/describe/analyze.go
@@ -94,6 +94,8 @@ func Analyze(ctx context.Context, query string, src *data.Source, head *lakepars
 
 func describeSources(ctx context.Context, lk *lake.Root, o dag.Op, inferred bool) ([]Source, error) {
 	switch o := o.(type) {
+	case *dag.Scope:
+		return describeSources(ctx, lk, o.Body[0], inferred)
 	case *dag.Fork:
 		var s []Source
 		for _, p := range o.Paths {

--- a/service/ztests/query-describe.yaml
+++ b/service/ztests/query-describe.yaml
@@ -2,7 +2,7 @@ script: |
   source service.sh
   zed create -q test1
   zed create -q test2
-  for file in multifrom.zed agg.zed agg-no-keys.zed two-channels.zed agg-sort.zed; do
+  for file in multifrom.zed agg.zed agg-no-keys.zed two-channels.zed agg-sort.zed scope.zed; do
     echo // === $file ===
     query="$(cat $file | jq -Rsa .)"
     curl -H "Accept: application/json" -d "{\"query\":$query,\"head\":{\"pool\":\"test1\"}}" $ZED_LAKE/query/describe |
@@ -33,6 +33,10 @@ inputs:
   - name: agg-sort.zed
     data: |
       sum(this) by foo | sort x
+  - name: scope.zed
+    data: |
+      type port = uint16
+      from test1
 
 outputs:
   - name: stdout
@@ -165,6 +169,21 @@ outputs:
                           ]
                       ]
                   }
+              }
+          ]
+      }
+      // === scope.zed ===
+      {
+          "sources": {
+              "kind": "Pool",
+              "name": "test1",
+              "id": "XXX",
+              "inferred": false
+          },
+          "channels": [
+              {
+                  "aggregation_keys": null,
+                  "sort": null
               }
           ]
       }


### PR DESCRIPTION
This commit fixes an issue with the query describe endpoint where a query having a scope would cause the endpoint to return an error.

Fixes #5153