### PR TITLE
Clarify some language bits that only work in zq or Zed lake context

### DIFF
--- a/docs/language/operators/file.md
+++ b/docs/language/operators/file.md
@@ -5,3 +5,8 @@
 ### Synopsis
 
 `file` is a shorthand notation for `from`. See the [from operator](from.md) documentation for details.
+
+:::tip Note
+The `file` shorthand is exclusively for working with inputs to
+[`zq`](../../commands/zq.md) and is not available for use with [Zed lakes](../../commands/zed.md).
+:::

--- a/docs/language/operators/load.md
+++ b/docs/language/operators/load.md
@@ -7,6 +7,13 @@
 ```
 load <pool>[@<branch>] [author <author>] [message <message>] [meta <meta>]
 ```
+
+:::tip Note
+The `load` operator is exclusively for working with pools in a
+[Zed lake](../../commands/zed.md) and is not available for use in
+[`zq`](../../commands/zq.md).
+:::
+
 ### Description
 
 The `load` operator populates the specified `<pool>` with the values it


### PR DESCRIPTION
In a recent [community Slack thread](https://brimdata.slack.com/archives/CTSMAK6G7/p1719781802859209) a user that started learning the Zed language exclusively via `zq` became confused when they discovered the `load` operator and it wasn't immediately obvious to them that it would not work with `zq`. This was not helped by the fact this also caused a panic (#5157) so hopefully when that's fixed a more helpful error message will also help reinforce this. However, to make for a better experience when readers are reading the docs, here I propose some up-front clarity about bits of the language that work in one context but not the other.