### PR TITLE
parser: Name collisions with uniq, head, top ops

### DIFF
--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -3060,11 +3060,41 @@ var g = &grammar{
 					&actionExpr{
 						pos: position{line: 445, col: 5, offset: 11043},
 						run: (*parser).callonHeadOp10,
-						expr: &litMatcher{
-							pos:        position{line: 445, col: 5, offset: 11043},
-							val:        "head",
-							ignoreCase: false,
-							want:       "\"head\"",
+						expr: &seqExpr{
+							pos: position{line: 445, col: 5, offset: 11043},
+							exprs: []any{
+								&litMatcher{
+									pos:        position{line: 445, col: 5, offset: 11043},
+									val:        "head",
+									ignoreCase: false,
+									want:       "\"head\"",
+								},
+								&notExpr{
+									pos: position{line: 445, col: 12, offset: 11050},
+									expr: &seqExpr{
+										pos: position{line: 445, col: 14, offset: 11052},
+										exprs: []any{
+											&ruleRefExpr{
+												pos:  position{line: 445, col: 14, offset: 11052},
+												name: "__",
+											},
+											&litMatcher{
+												pos:        position{line: 445, col: 17, offset: 11055},
+												val:        "(",
+												ignoreCase: false,
+												want:       "\"(\"",
+											},
+										},
+									},
+								},
+								&andExpr{
+									pos: position{line: 445, col: 22, offset: 11060},
+									expr: &ruleRefExpr{
+										pos:  position{line: 445, col: 23, offset: 11061},
+										name: "EOKW",
+									},
+								},
+							},
 						},
 					},
 				},
@@ -3074,38 +3104,38 @@ var g = &grammar{
 		},
 		{
 			name: "TailOp",
-			pos:  position{line: 452, col: 1, offset: 11152},
+			pos:  position{line: 452, col: 1, offset: 11168},
 			expr: &choiceExpr{
-				pos: position{line: 453, col: 5, offset: 11163},
+				pos: position{line: 453, col: 5, offset: 11179},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 453, col: 5, offset: 11163},
+						pos: position{line: 453, col: 5, offset: 11179},
 						run: (*parser).callonTailOp2,
 						expr: &seqExpr{
-							pos: position{line: 453, col: 5, offset: 11163},
+							pos: position{line: 453, col: 5, offset: 11179},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 453, col: 5, offset: 11163},
+									pos:        position{line: 453, col: 5, offset: 11179},
 									val:        "tail",
 									ignoreCase: false,
 									want:       "\"tail\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 453, col: 12, offset: 11170},
+									pos:  position{line: 453, col: 12, offset: 11186},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 453, col: 14, offset: 11172},
+									pos: position{line: 453, col: 14, offset: 11188},
 									expr: &ruleRefExpr{
-										pos:  position{line: 453, col: 15, offset: 11173},
+										pos:  position{line: 453, col: 15, offset: 11189},
 										name: "EndOfOp",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 453, col: 23, offset: 11181},
+									pos:   position{line: 453, col: 23, offset: 11197},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 453, col: 29, offset: 11187},
+										pos:  position{line: 453, col: 29, offset: 11203},
 										name: "Expr",
 									},
 								},
@@ -3113,13 +3143,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 460, col: 5, offset: 11330},
+						pos: position{line: 460, col: 5, offset: 11346},
 						run: (*parser).callonTailOp10,
-						expr: &litMatcher{
-							pos:        position{line: 460, col: 5, offset: 11330},
-							val:        "tail",
-							ignoreCase: false,
-							want:       "\"tail\"",
+						expr: &seqExpr{
+							pos: position{line: 460, col: 5, offset: 11346},
+							exprs: []any{
+								&litMatcher{
+									pos:        position{line: 460, col: 5, offset: 11346},
+									val:        "tail",
+									ignoreCase: false,
+									want:       "\"tail\"",
+								},
+								&notExpr{
+									pos: position{line: 460, col: 12, offset: 11353},
+									expr: &seqExpr{
+										pos: position{line: 460, col: 14, offset: 11355},
+										exprs: []any{
+											&ruleRefExpr{
+												pos:  position{line: 460, col: 14, offset: 11355},
+												name: "__",
+											},
+											&litMatcher{
+												pos:        position{line: 460, col: 17, offset: 11358},
+												val:        "(",
+												ignoreCase: false,
+												want:       "\"(\"",
+											},
+										},
+									},
+								},
+								&andExpr{
+									pos: position{line: 460, col: 22, offset: 11363},
+									expr: &ruleRefExpr{
+										pos:  position{line: 460, col: 23, offset: 11364},
+										name: "EOKW",
+									},
+								},
+							},
 						},
 					},
 				},
@@ -3129,28 +3189,28 @@ var g = &grammar{
 		},
 		{
 			name: "WhereOp",
-			pos:  position{line: 467, col: 1, offset: 11439},
+			pos:  position{line: 467, col: 1, offset: 11471},
 			expr: &actionExpr{
-				pos: position{line: 468, col: 5, offset: 11451},
+				pos: position{line: 468, col: 5, offset: 11483},
 				run: (*parser).callonWhereOp1,
 				expr: &seqExpr{
-					pos: position{line: 468, col: 5, offset: 11451},
+					pos: position{line: 468, col: 5, offset: 11483},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 468, col: 5, offset: 11451},
+							pos:        position{line: 468, col: 5, offset: 11483},
 							val:        "where",
 							ignoreCase: false,
 							want:       "\"where\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 468, col: 13, offset: 11459},
+							pos:  position{line: 468, col: 13, offset: 11491},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 468, col: 15, offset: 11461},
+							pos:   position{line: 468, col: 15, offset: 11493},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 468, col: 20, offset: 11466},
+								pos:  position{line: 468, col: 20, offset: 11498},
 								name: "Expr",
 							},
 						},
@@ -3162,28 +3222,28 @@ var g = &grammar{
 		},
 		{
 			name: "UniqOp",
-			pos:  position{line: 476, col: 1, offset: 11606},
+			pos:  position{line: 476, col: 1, offset: 11638},
 			expr: &choiceExpr{
-				pos: position{line: 477, col: 5, offset: 11617},
+				pos: position{line: 477, col: 5, offset: 11649},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 477, col: 5, offset: 11617},
+						pos: position{line: 477, col: 5, offset: 11649},
 						run: (*parser).callonUniqOp2,
 						expr: &seqExpr{
-							pos: position{line: 477, col: 5, offset: 11617},
+							pos: position{line: 477, col: 5, offset: 11649},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 477, col: 5, offset: 11617},
+									pos:        position{line: 477, col: 5, offset: 11649},
 									val:        "uniq",
 									ignoreCase: false,
 									want:       "\"uniq\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 477, col: 12, offset: 11624},
+									pos:  position{line: 477, col: 12, offset: 11656},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 477, col: 14, offset: 11626},
+									pos:        position{line: 477, col: 14, offset: 11658},
 									val:        "-c",
 									ignoreCase: false,
 									want:       "\"-c\"",
@@ -3192,13 +3252,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 480, col: 5, offset: 11724},
+						pos: position{line: 480, col: 5, offset: 11756},
 						run: (*parser).callonUniqOp7,
-						expr: &litMatcher{
-							pos:        position{line: 480, col: 5, offset: 11724},
-							val:        "uniq",
-							ignoreCase: false,
-							want:       "\"uniq\"",
+						expr: &seqExpr{
+							pos: position{line: 480, col: 5, offset: 11756},
+							exprs: []any{
+								&litMatcher{
+									pos:        position{line: 480, col: 5, offset: 11756},
+									val:        "uniq",
+									ignoreCase: false,
+									want:       "\"uniq\"",
+								},
+								&notExpr{
+									pos: position{line: 480, col: 12, offset: 11763},
+									expr: &seqExpr{
+										pos: position{line: 480, col: 14, offset: 11765},
+										exprs: []any{
+											&ruleRefExpr{
+												pos:  position{line: 480, col: 14, offset: 11765},
+												name: "__",
+											},
+											&litMatcher{
+												pos:        position{line: 480, col: 17, offset: 11768},
+												val:        "(",
+												ignoreCase: false,
+												want:       "\"(\"",
+											},
+										},
+									},
+								},
+								&andExpr{
+									pos: position{line: 480, col: 22, offset: 11773},
+									expr: &ruleRefExpr{
+										pos:  position{line: 480, col: 23, offset: 11774},
+										name: "EOKW",
+									},
+								},
+							},
 						},
 					},
 				},
@@ -3208,28 +3298,28 @@ var g = &grammar{
 		},
 		{
 			name: "PutOp",
-			pos:  position{line: 484, col: 1, offset: 11808},
+			pos:  position{line: 484, col: 1, offset: 11856},
 			expr: &actionExpr{
-				pos: position{line: 485, col: 5, offset: 11818},
+				pos: position{line: 485, col: 5, offset: 11866},
 				run: (*parser).callonPutOp1,
 				expr: &seqExpr{
-					pos: position{line: 485, col: 5, offset: 11818},
+					pos: position{line: 485, col: 5, offset: 11866},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 485, col: 5, offset: 11818},
+							pos:        position{line: 485, col: 5, offset: 11866},
 							val:        "put",
 							ignoreCase: false,
 							want:       "\"put\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 485, col: 11, offset: 11824},
+							pos:  position{line: 485, col: 11, offset: 11872},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 485, col: 13, offset: 11826},
+							pos:   position{line: 485, col: 13, offset: 11874},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 485, col: 18, offset: 11831},
+								pos:  position{line: 485, col: 18, offset: 11879},
 								name: "Assignments",
 							},
 						},
@@ -3241,61 +3331,61 @@ var g = &grammar{
 		},
 		{
 			name: "RenameOp",
-			pos:  position{line: 493, col: 1, offset: 11994},
+			pos:  position{line: 493, col: 1, offset: 12042},
 			expr: &actionExpr{
-				pos: position{line: 494, col: 5, offset: 12007},
+				pos: position{line: 494, col: 5, offset: 12055},
 				run: (*parser).callonRenameOp1,
 				expr: &seqExpr{
-					pos: position{line: 494, col: 5, offset: 12007},
+					pos: position{line: 494, col: 5, offset: 12055},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 494, col: 5, offset: 12007},
+							pos:        position{line: 494, col: 5, offset: 12055},
 							val:        "rename",
 							ignoreCase: false,
 							want:       "\"rename\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 494, col: 14, offset: 12016},
+							pos:  position{line: 494, col: 14, offset: 12064},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 494, col: 16, offset: 12018},
+							pos:   position{line: 494, col: 16, offset: 12066},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 494, col: 22, offset: 12024},
+								pos:  position{line: 494, col: 22, offset: 12072},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 494, col: 33, offset: 12035},
+							pos:   position{line: 494, col: 33, offset: 12083},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 494, col: 38, offset: 12040},
+								pos: position{line: 494, col: 38, offset: 12088},
 								expr: &actionExpr{
-									pos: position{line: 494, col: 39, offset: 12041},
+									pos: position{line: 494, col: 39, offset: 12089},
 									run: (*parser).callonRenameOp9,
 									expr: &seqExpr{
-										pos: position{line: 494, col: 39, offset: 12041},
+										pos: position{line: 494, col: 39, offset: 12089},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 494, col: 39, offset: 12041},
+												pos:  position{line: 494, col: 39, offset: 12089},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 494, col: 42, offset: 12044},
+												pos:        position{line: 494, col: 42, offset: 12092},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 494, col: 46, offset: 12048},
+												pos:  position{line: 494, col: 46, offset: 12096},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 494, col: 49, offset: 12051},
+												pos:   position{line: 494, col: 49, offset: 12099},
 												label: "cl",
 												expr: &ruleRefExpr{
-													pos:  position{line: 494, col: 52, offset: 12054},
+													pos:  position{line: 494, col: 52, offset: 12102},
 													name: "Assignment",
 												},
 											},
@@ -3312,30 +3402,30 @@ var g = &grammar{
 		},
 		{
 			name: "FuseOp",
-			pos:  position{line: 507, col: 1, offset: 12530},
+			pos:  position{line: 507, col: 1, offset: 12578},
 			expr: &actionExpr{
-				pos: position{line: 508, col: 5, offset: 12541},
+				pos: position{line: 508, col: 5, offset: 12589},
 				run: (*parser).callonFuseOp1,
 				expr: &seqExpr{
-					pos: position{line: 508, col: 5, offset: 12541},
+					pos: position{line: 508, col: 5, offset: 12589},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 508, col: 5, offset: 12541},
+							pos:        position{line: 508, col: 5, offset: 12589},
 							val:        "fuse",
 							ignoreCase: false,
 							want:       "\"fuse\"",
 						},
 						&notExpr{
-							pos: position{line: 508, col: 12, offset: 12548},
+							pos: position{line: 508, col: 12, offset: 12596},
 							expr: &seqExpr{
-								pos: position{line: 508, col: 14, offset: 12550},
+								pos: position{line: 508, col: 14, offset: 12598},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 508, col: 14, offset: 12550},
+										pos:  position{line: 508, col: 14, offset: 12598},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 508, col: 17, offset: 12553},
+										pos:        position{line: 508, col: 17, offset: 12601},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -3344,9 +3434,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 508, col: 22, offset: 12558},
+							pos: position{line: 508, col: 22, offset: 12606},
 							expr: &ruleRefExpr{
-								pos:  position{line: 508, col: 23, offset: 12559},
+								pos:  position{line: 508, col: 23, offset: 12607},
 								name: "EOKW",
 							},
 						},
@@ -3358,30 +3448,30 @@ var g = &grammar{
 		},
 		{
 			name: "ShapeOp",
-			pos:  position{line: 512, col: 1, offset: 12641},
+			pos:  position{line: 512, col: 1, offset: 12689},
 			expr: &actionExpr{
-				pos: position{line: 513, col: 5, offset: 12653},
+				pos: position{line: 513, col: 5, offset: 12701},
 				run: (*parser).callonShapeOp1,
 				expr: &seqExpr{
-					pos: position{line: 513, col: 5, offset: 12653},
+					pos: position{line: 513, col: 5, offset: 12701},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 513, col: 5, offset: 12653},
+							pos:        position{line: 513, col: 5, offset: 12701},
 							val:        "shape",
 							ignoreCase: false,
 							want:       "\"shape\"",
 						},
 						&notExpr{
-							pos: position{line: 513, col: 13, offset: 12661},
+							pos: position{line: 513, col: 13, offset: 12709},
 							expr: &seqExpr{
-								pos: position{line: 513, col: 15, offset: 12663},
+								pos: position{line: 513, col: 15, offset: 12711},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 513, col: 15, offset: 12663},
+										pos:  position{line: 513, col: 15, offset: 12711},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 513, col: 18, offset: 12666},
+										pos:        position{line: 513, col: 18, offset: 12714},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -3390,9 +3480,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 513, col: 23, offset: 12671},
+							pos: position{line: 513, col: 23, offset: 12719},
 							expr: &ruleRefExpr{
-								pos:  position{line: 513, col: 24, offset: 12672},
+								pos:  position{line: 513, col: 24, offset: 12720},
 								name: "EOKW",
 							},
 						},
@@ -3404,77 +3494,77 @@ var g = &grammar{
 		},
 		{
 			name: "JoinOp",
-			pos:  position{line: 517, col: 1, offset: 12756},
+			pos:  position{line: 517, col: 1, offset: 12804},
 			expr: &actionExpr{
-				pos: position{line: 518, col: 5, offset: 12767},
+				pos: position{line: 518, col: 5, offset: 12815},
 				run: (*parser).callonJoinOp1,
 				expr: &seqExpr{
-					pos: position{line: 518, col: 5, offset: 12767},
+					pos: position{line: 518, col: 5, offset: 12815},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 518, col: 5, offset: 12767},
+							pos:   position{line: 518, col: 5, offset: 12815},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 518, col: 11, offset: 12773},
+								pos:  position{line: 518, col: 11, offset: 12821},
 								name: "JoinStyle",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 518, col: 21, offset: 12783},
+							pos:        position{line: 518, col: 21, offset: 12831},
 							val:        "join",
 							ignoreCase: false,
 							want:       "\"join\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 518, col: 28, offset: 12790},
+							pos:   position{line: 518, col: 28, offset: 12838},
 							label: "rightInput",
 							expr: &ruleRefExpr{
-								pos:  position{line: 518, col: 39, offset: 12801},
+								pos:  position{line: 518, col: 39, offset: 12849},
 								name: "JoinRightInput",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 518, col: 54, offset: 12816},
+							pos:        position{line: 518, col: 54, offset: 12864},
 							val:        "on",
 							ignoreCase: false,
 							want:       "\"on\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 518, col: 59, offset: 12821},
+							pos:  position{line: 518, col: 59, offset: 12869},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 518, col: 61, offset: 12823},
+							pos:   position{line: 518, col: 61, offset: 12871},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 518, col: 65, offset: 12827},
+								pos:  position{line: 518, col: 65, offset: 12875},
 								name: "JoinKey",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 518, col: 73, offset: 12835},
+							pos:   position{line: 518, col: 73, offset: 12883},
 							label: "optKey",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 518, col: 80, offset: 12842},
+								pos: position{line: 518, col: 80, offset: 12890},
 								expr: &seqExpr{
-									pos: position{line: 518, col: 81, offset: 12843},
+									pos: position{line: 518, col: 81, offset: 12891},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 518, col: 81, offset: 12843},
+											pos:  position{line: 518, col: 81, offset: 12891},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 518, col: 84, offset: 12846},
+											pos:        position{line: 518, col: 84, offset: 12894},
 											val:        "=",
 											ignoreCase: false,
 											want:       "\"=\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 518, col: 88, offset: 12850},
+											pos:  position{line: 518, col: 88, offset: 12898},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 518, col: 91, offset: 12853},
+											pos:  position{line: 518, col: 91, offset: 12901},
 											name: "JoinKey",
 										},
 									},
@@ -3482,19 +3572,19 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 518, col: 101, offset: 12863},
+							pos:   position{line: 518, col: 101, offset: 12911},
 							label: "optArgs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 518, col: 109, offset: 12871},
+								pos: position{line: 518, col: 109, offset: 12919},
 								expr: &seqExpr{
-									pos: position{line: 518, col: 110, offset: 12872},
+									pos: position{line: 518, col: 110, offset: 12920},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 518, col: 110, offset: 12872},
+											pos:  position{line: 518, col: 110, offset: 12920},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 518, col: 112, offset: 12874},
+											pos:  position{line: 518, col: 112, offset: 12922},
 											name: "FlexAssignments",
 										},
 									},
@@ -3509,91 +3599,91 @@ var g = &grammar{
 		},
 		{
 			name: "JoinStyle",
-			pos:  position{line: 537, col: 1, offset: 13337},
+			pos:  position{line: 537, col: 1, offset: 13385},
 			expr: &choiceExpr{
-				pos: position{line: 538, col: 5, offset: 13351},
+				pos: position{line: 538, col: 5, offset: 13399},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 538, col: 5, offset: 13351},
+						pos: position{line: 538, col: 5, offset: 13399},
 						run: (*parser).callonJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 538, col: 5, offset: 13351},
+							pos: position{line: 538, col: 5, offset: 13399},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 538, col: 5, offset: 13351},
+									pos:        position{line: 538, col: 5, offset: 13399},
 									val:        "anti",
 									ignoreCase: false,
 									want:       "\"anti\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 538, col: 12, offset: 13358},
+									pos:  position{line: 538, col: 12, offset: 13406},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 539, col: 5, offset: 13388},
+						pos: position{line: 539, col: 5, offset: 13436},
 						run: (*parser).callonJoinStyle6,
 						expr: &seqExpr{
-							pos: position{line: 539, col: 5, offset: 13388},
+							pos: position{line: 539, col: 5, offset: 13436},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 539, col: 5, offset: 13388},
+									pos:        position{line: 539, col: 5, offset: 13436},
 									val:        "inner",
 									ignoreCase: false,
 									want:       "\"inner\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 539, col: 13, offset: 13396},
+									pos:  position{line: 539, col: 13, offset: 13444},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 540, col: 5, offset: 13426},
+						pos: position{line: 540, col: 5, offset: 13474},
 						run: (*parser).callonJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 540, col: 5, offset: 13426},
+							pos: position{line: 540, col: 5, offset: 13474},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 540, col: 5, offset: 13426},
+									pos:        position{line: 540, col: 5, offset: 13474},
 									val:        "left",
 									ignoreCase: false,
 									want:       "\"left\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 540, col: 13, offset: 13434},
+									pos:  position{line: 540, col: 13, offset: 13482},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 541, col: 5, offset: 13463},
+						pos: position{line: 541, col: 5, offset: 13511},
 						run: (*parser).callonJoinStyle14,
 						expr: &seqExpr{
-							pos: position{line: 541, col: 5, offset: 13463},
+							pos: position{line: 541, col: 5, offset: 13511},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 541, col: 5, offset: 13463},
+									pos:        position{line: 541, col: 5, offset: 13511},
 									val:        "right",
 									ignoreCase: false,
 									want:       "\"right\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 541, col: 13, offset: 13471},
+									pos:  position{line: 541, col: 13, offset: 13519},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 542, col: 5, offset: 13501},
+						pos: position{line: 542, col: 5, offset: 13549},
 						run: (*parser).callonJoinStyle18,
 						expr: &litMatcher{
-							pos:        position{line: 542, col: 5, offset: 13501},
+							pos:        position{line: 542, col: 5, offset: 13549},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -3606,60 +3696,60 @@ var g = &grammar{
 		},
 		{
 			name: "JoinRightInput",
-			pos:  position{line: 544, col: 1, offset: 13536},
+			pos:  position{line: 544, col: 1, offset: 13584},
 			expr: &choiceExpr{
-				pos: position{line: 545, col: 5, offset: 13555},
+				pos: position{line: 545, col: 5, offset: 13603},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 545, col: 5, offset: 13555},
+						pos: position{line: 545, col: 5, offset: 13603},
 						run: (*parser).callonJoinRightInput2,
 						expr: &seqExpr{
-							pos: position{line: 545, col: 5, offset: 13555},
+							pos: position{line: 545, col: 5, offset: 13603},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 545, col: 5, offset: 13555},
+									pos:  position{line: 545, col: 5, offset: 13603},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 545, col: 8, offset: 13558},
+									pos:        position{line: 545, col: 8, offset: 13606},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 545, col: 12, offset: 13562},
+									pos:  position{line: 545, col: 12, offset: 13610},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 545, col: 15, offset: 13565},
+									pos:   position{line: 545, col: 15, offset: 13613},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 545, col: 17, offset: 13567},
+										pos:  position{line: 545, col: 17, offset: 13615},
 										name: "Seq",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 545, col: 21, offset: 13571},
+									pos:  position{line: 545, col: 21, offset: 13619},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 545, col: 24, offset: 13574},
+									pos:        position{line: 545, col: 24, offset: 13622},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 545, col: 28, offset: 13578},
+									pos:  position{line: 545, col: 28, offset: 13626},
 									name: "__",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 546, col: 5, offset: 13603},
+						pos: position{line: 546, col: 5, offset: 13651},
 						run: (*parser).callonJoinRightInput12,
 						expr: &ruleRefExpr{
-							pos:  position{line: 546, col: 5, offset: 13603},
+							pos:  position{line: 546, col: 5, offset: 13651},
 							name: "_",
 						},
 					},
@@ -3670,36 +3760,36 @@ var g = &grammar{
 		},
 		{
 			name: "JoinKey",
-			pos:  position{line: 548, col: 1, offset: 13626},
+			pos:  position{line: 548, col: 1, offset: 13674},
 			expr: &choiceExpr{
-				pos: position{line: 549, col: 5, offset: 13638},
+				pos: position{line: 549, col: 5, offset: 13686},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 549, col: 5, offset: 13638},
+						pos:  position{line: 549, col: 5, offset: 13686},
 						name: "Lval",
 					},
 					&actionExpr{
-						pos: position{line: 550, col: 5, offset: 13647},
+						pos: position{line: 550, col: 5, offset: 13695},
 						run: (*parser).callonJoinKey3,
 						expr: &seqExpr{
-							pos: position{line: 550, col: 5, offset: 13647},
+							pos: position{line: 550, col: 5, offset: 13695},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 550, col: 5, offset: 13647},
+									pos:        position{line: 550, col: 5, offset: 13695},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 550, col: 9, offset: 13651},
+									pos:   position{line: 550, col: 9, offset: 13699},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 550, col: 14, offset: 13656},
+										pos:  position{line: 550, col: 14, offset: 13704},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 550, col: 19, offset: 13661},
+									pos:        position{line: 550, col: 19, offset: 13709},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -3714,46 +3804,46 @@ var g = &grammar{
 		},
 		{
 			name: "SampleOp",
-			pos:  position{line: 552, col: 1, offset: 13687},
+			pos:  position{line: 552, col: 1, offset: 13735},
 			expr: &actionExpr{
-				pos: position{line: 553, col: 5, offset: 13700},
+				pos: position{line: 553, col: 5, offset: 13748},
 				run: (*parser).callonSampleOp1,
 				expr: &seqExpr{
-					pos: position{line: 553, col: 5, offset: 13700},
+					pos: position{line: 553, col: 5, offset: 13748},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 553, col: 5, offset: 13700},
+							pos:        position{line: 553, col: 5, offset: 13748},
 							val:        "sample",
 							ignoreCase: false,
 							want:       "\"sample\"",
 						},
 						&andExpr{
-							pos: position{line: 553, col: 14, offset: 13709},
+							pos: position{line: 553, col: 14, offset: 13757},
 							expr: &ruleRefExpr{
-								pos:  position{line: 553, col: 15, offset: 13710},
+								pos:  position{line: 553, col: 15, offset: 13758},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 553, col: 20, offset: 13715},
+							pos:   position{line: 553, col: 20, offset: 13763},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 553, col: 25, offset: 13720},
+								pos: position{line: 553, col: 25, offset: 13768},
 								expr: &actionExpr{
-									pos: position{line: 553, col: 26, offset: 13721},
+									pos: position{line: 553, col: 26, offset: 13769},
 									run: (*parser).callonSampleOp8,
 									expr: &seqExpr{
-										pos: position{line: 553, col: 26, offset: 13721},
+										pos: position{line: 553, col: 26, offset: 13769},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 553, col: 26, offset: 13721},
+												pos:  position{line: 553, col: 26, offset: 13769},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 553, col: 28, offset: 13723},
+												pos:   position{line: 553, col: 28, offset: 13771},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 553, col: 30, offset: 13725},
+													pos:  position{line: 553, col: 30, offset: 13773},
 													name: "Lval",
 												},
 											},
@@ -3770,15 +3860,15 @@ var g = &grammar{
 		},
 		{
 			name: "OpAssignment",
-			pos:  position{line: 566, col: 1, offset: 14176},
+			pos:  position{line: 566, col: 1, offset: 14224},
 			expr: &actionExpr{
-				pos: position{line: 567, col: 5, offset: 14193},
+				pos: position{line: 567, col: 5, offset: 14241},
 				run: (*parser).callonOpAssignment1,
 				expr: &labeledExpr{
-					pos:   position{line: 567, col: 5, offset: 14193},
+					pos:   position{line: 567, col: 5, offset: 14241},
 					label: "a",
 					expr: &ruleRefExpr{
-						pos:  position{line: 567, col: 7, offset: 14195},
+						pos:  position{line: 567, col: 7, offset: 14243},
 						name: "Assignments",
 					},
 				},
@@ -3788,71 +3878,71 @@ var g = &grammar{
 		},
 		{
 			name: "LoadOp",
-			pos:  position{line: 574, col: 1, offset: 14344},
+			pos:  position{line: 574, col: 1, offset: 14392},
 			expr: &actionExpr{
-				pos: position{line: 575, col: 5, offset: 14355},
+				pos: position{line: 575, col: 5, offset: 14403},
 				run: (*parser).callonLoadOp1,
 				expr: &seqExpr{
-					pos: position{line: 575, col: 5, offset: 14355},
+					pos: position{line: 575, col: 5, offset: 14403},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 575, col: 5, offset: 14355},
+							pos:        position{line: 575, col: 5, offset: 14403},
 							val:        "load",
 							ignoreCase: false,
 							want:       "\"load\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 575, col: 12, offset: 14362},
+							pos:  position{line: 575, col: 12, offset: 14410},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 575, col: 14, offset: 14364},
+							pos:   position{line: 575, col: 14, offset: 14412},
 							label: "pool",
 							expr: &ruleRefExpr{
-								pos:  position{line: 575, col: 19, offset: 14369},
+								pos:  position{line: 575, col: 19, offset: 14417},
 								name: "PoolNameString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 575, col: 34, offset: 14384},
+							pos:   position{line: 575, col: 34, offset: 14432},
 							label: "branch",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 575, col: 41, offset: 14391},
+								pos: position{line: 575, col: 41, offset: 14439},
 								expr: &ruleRefExpr{
-									pos:  position{line: 575, col: 41, offset: 14391},
+									pos:  position{line: 575, col: 41, offset: 14439},
 									name: "PoolBranch",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 575, col: 53, offset: 14403},
+							pos:   position{line: 575, col: 53, offset: 14451},
 							label: "author",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 575, col: 60, offset: 14410},
+								pos: position{line: 575, col: 60, offset: 14458},
 								expr: &ruleRefExpr{
-									pos:  position{line: 575, col: 60, offset: 14410},
+									pos:  position{line: 575, col: 60, offset: 14458},
 									name: "AuthorArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 575, col: 71, offset: 14421},
+							pos:   position{line: 575, col: 71, offset: 14469},
 							label: "message",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 575, col: 79, offset: 14429},
+								pos: position{line: 575, col: 79, offset: 14477},
 								expr: &ruleRefExpr{
-									pos:  position{line: 575, col: 79, offset: 14429},
+									pos:  position{line: 575, col: 79, offset: 14477},
 									name: "MessageArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 575, col: 91, offset: 14441},
+							pos:   position{line: 575, col: 91, offset: 14489},
 							label: "meta",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 575, col: 96, offset: 14446},
+								pos: position{line: 575, col: 96, offset: 14494},
 								expr: &ruleRefExpr{
-									pos:  position{line: 575, col: 96, offset: 14446},
+									pos:  position{line: 575, col: 96, offset: 14494},
 									name: "MetaArg",
 								},
 							},
@@ -3865,32 +3955,32 @@ var g = &grammar{
 		},
 		{
 			name: "AuthorArg",
-			pos:  position{line: 588, col: 1, offset: 14793},
+			pos:  position{line: 588, col: 1, offset: 14841},
 			expr: &actionExpr{
-				pos: position{line: 589, col: 5, offset: 14807},
+				pos: position{line: 589, col: 5, offset: 14855},
 				run: (*parser).callonAuthorArg1,
 				expr: &seqExpr{
-					pos: position{line: 589, col: 5, offset: 14807},
+					pos: position{line: 589, col: 5, offset: 14855},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 589, col: 5, offset: 14807},
+							pos:  position{line: 589, col: 5, offset: 14855},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 589, col: 7, offset: 14809},
+							pos:        position{line: 589, col: 7, offset: 14857},
 							val:        "author",
 							ignoreCase: false,
 							want:       "\"author\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 589, col: 16, offset: 14818},
+							pos:  position{line: 589, col: 16, offset: 14866},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 589, col: 18, offset: 14820},
+							pos:   position{line: 589, col: 18, offset: 14868},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 589, col: 22, offset: 14824},
+								pos:  position{line: 589, col: 22, offset: 14872},
 								name: "QuotedString",
 							},
 						},
@@ -3902,32 +3992,32 @@ var g = &grammar{
 		},
 		{
 			name: "MessageArg",
-			pos:  position{line: 591, col: 1, offset: 14858},
+			pos:  position{line: 591, col: 1, offset: 14906},
 			expr: &actionExpr{
-				pos: position{line: 592, col: 5, offset: 14873},
+				pos: position{line: 592, col: 5, offset: 14921},
 				run: (*parser).callonMessageArg1,
 				expr: &seqExpr{
-					pos: position{line: 592, col: 5, offset: 14873},
+					pos: position{line: 592, col: 5, offset: 14921},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 592, col: 5, offset: 14873},
+							pos:  position{line: 592, col: 5, offset: 14921},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 592, col: 7, offset: 14875},
+							pos:        position{line: 592, col: 7, offset: 14923},
 							val:        "message",
 							ignoreCase: false,
 							want:       "\"message\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 592, col: 17, offset: 14885},
+							pos:  position{line: 592, col: 17, offset: 14933},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 592, col: 19, offset: 14887},
+							pos:   position{line: 592, col: 19, offset: 14935},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 592, col: 23, offset: 14891},
+								pos:  position{line: 592, col: 23, offset: 14939},
 								name: "QuotedString",
 							},
 						},
@@ -3939,32 +4029,32 @@ var g = &grammar{
 		},
 		{
 			name: "MetaArg",
-			pos:  position{line: 594, col: 1, offset: 14925},
+			pos:  position{line: 594, col: 1, offset: 14973},
 			expr: &actionExpr{
-				pos: position{line: 595, col: 5, offset: 14937},
+				pos: position{line: 595, col: 5, offset: 14985},
 				run: (*parser).callonMetaArg1,
 				expr: &seqExpr{
-					pos: position{line: 595, col: 5, offset: 14937},
+					pos: position{line: 595, col: 5, offset: 14985},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 595, col: 5, offset: 14937},
+							pos:  position{line: 595, col: 5, offset: 14985},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 595, col: 7, offset: 14939},
+							pos:        position{line: 595, col: 7, offset: 14987},
 							val:        "meta",
 							ignoreCase: false,
 							want:       "\"meta\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 595, col: 14, offset: 14946},
+							pos:  position{line: 595, col: 14, offset: 14994},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 595, col: 16, offset: 14948},
+							pos:   position{line: 595, col: 16, offset: 14996},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 595, col: 20, offset: 14952},
+								pos:  position{line: 595, col: 20, offset: 15000},
 								name: "QuotedString",
 							},
 						},
@@ -3976,31 +4066,31 @@ var g = &grammar{
 		},
 		{
 			name: "PoolBranch",
-			pos:  position{line: 597, col: 1, offset: 14986},
+			pos:  position{line: 597, col: 1, offset: 15034},
 			expr: &actionExpr{
-				pos: position{line: 598, col: 5, offset: 15001},
+				pos: position{line: 598, col: 5, offset: 15049},
 				run: (*parser).callonPoolBranch1,
 				expr: &seqExpr{
-					pos: position{line: 598, col: 5, offset: 15001},
+					pos: position{line: 598, col: 5, offset: 15049},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 598, col: 5, offset: 15001},
+							pos:        position{line: 598, col: 5, offset: 15049},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 598, col: 9, offset: 15005},
+							pos:   position{line: 598, col: 9, offset: 15053},
 							label: "branch",
 							expr: &choiceExpr{
-								pos: position{line: 598, col: 17, offset: 15013},
+								pos: position{line: 598, col: 17, offset: 15061},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 598, col: 17, offset: 15013},
+										pos:  position{line: 598, col: 17, offset: 15061},
 										name: "PoolIdentifier",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 598, col: 34, offset: 15030},
+										pos:  position{line: 598, col: 34, offset: 15078},
 										name: "QuotedString",
 									},
 								},
@@ -4014,20 +4104,20 @@ var g = &grammar{
 		},
 		{
 			name: "FromOp",
-			pos:  position{line: 600, col: 1, offset: 15068},
+			pos:  position{line: 600, col: 1, offset: 15116},
 			expr: &choiceExpr{
-				pos: position{line: 601, col: 5, offset: 15079},
+				pos: position{line: 601, col: 5, offset: 15127},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 601, col: 5, offset: 15079},
+						pos:  position{line: 601, col: 5, offset: 15127},
 						name: "File",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 602, col: 5, offset: 15088},
+						pos:  position{line: 602, col: 5, offset: 15136},
 						name: "Get",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 603, col: 5, offset: 15096},
+						pos:  position{line: 603, col: 5, offset: 15144},
 						name: "From",
 					},
 				},
@@ -4037,49 +4127,49 @@ var g = &grammar{
 		},
 		{
 			name: "File",
-			pos:  position{line: 605, col: 1, offset: 15102},
+			pos:  position{line: 605, col: 1, offset: 15150},
 			expr: &actionExpr{
-				pos: position{line: 606, col: 5, offset: 15111},
+				pos: position{line: 606, col: 5, offset: 15159},
 				run: (*parser).callonFile1,
 				expr: &seqExpr{
-					pos: position{line: 606, col: 5, offset: 15111},
+					pos: position{line: 606, col: 5, offset: 15159},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 606, col: 5, offset: 15111},
+							pos:        position{line: 606, col: 5, offset: 15159},
 							val:        "file",
 							ignoreCase: false,
 							want:       "\"file\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 606, col: 12, offset: 15118},
+							pos:  position{line: 606, col: 12, offset: 15166},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 606, col: 14, offset: 15120},
+							pos:   position{line: 606, col: 14, offset: 15168},
 							label: "path",
 							expr: &ruleRefExpr{
-								pos:  position{line: 606, col: 19, offset: 15125},
+								pos:  position{line: 606, col: 19, offset: 15173},
 								name: "Path",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 606, col: 24, offset: 15130},
+							pos:   position{line: 606, col: 24, offset: 15178},
 							label: "format",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 606, col: 31, offset: 15137},
+								pos: position{line: 606, col: 31, offset: 15185},
 								expr: &ruleRefExpr{
-									pos:  position{line: 606, col: 31, offset: 15137},
+									pos:  position{line: 606, col: 31, offset: 15185},
 									name: "FormatArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 606, col: 42, offset: 15148},
+							pos:   position{line: 606, col: 42, offset: 15196},
 							label: "sortkey",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 606, col: 50, offset: 15156},
+								pos: position{line: 606, col: 50, offset: 15204},
 								expr: &ruleRefExpr{
-									pos:  position{line: 606, col: 50, offset: 15156},
+									pos:  position{line: 606, col: 50, offset: 15204},
 									name: "SortKeyArg",
 								},
 							},
@@ -4092,28 +4182,28 @@ var g = &grammar{
 		},
 		{
 			name: "From",
-			pos:  position{line: 620, col: 1, offset: 15476},
+			pos:  position{line: 620, col: 1, offset: 15524},
 			expr: &actionExpr{
-				pos: position{line: 621, col: 5, offset: 15485},
+				pos: position{line: 621, col: 5, offset: 15533},
 				run: (*parser).callonFrom1,
 				expr: &seqExpr{
-					pos: position{line: 621, col: 5, offset: 15485},
+					pos: position{line: 621, col: 5, offset: 15533},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 621, col: 5, offset: 15485},
+							pos:        position{line: 621, col: 5, offset: 15533},
 							val:        "from",
 							ignoreCase: false,
 							want:       "\"from\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 621, col: 12, offset: 15492},
+							pos:  position{line: 621, col: 12, offset: 15540},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 621, col: 14, offset: 15494},
+							pos:   position{line: 621, col: 14, offset: 15542},
 							label: "spec",
 							expr: &ruleRefExpr{
-								pos:  position{line: 621, col: 19, offset: 15499},
+								pos:  position{line: 621, col: 19, offset: 15547},
 								name: "PoolSpec",
 							},
 						},
@@ -4125,28 +4215,28 @@ var g = &grammar{
 		},
 		{
 			name: "Pool",
-			pos:  position{line: 630, col: 1, offset: 15687},
+			pos:  position{line: 630, col: 1, offset: 15735},
 			expr: &actionExpr{
-				pos: position{line: 631, col: 5, offset: 15696},
+				pos: position{line: 631, col: 5, offset: 15744},
 				run: (*parser).callonPool1,
 				expr: &seqExpr{
-					pos: position{line: 631, col: 5, offset: 15696},
+					pos: position{line: 631, col: 5, offset: 15744},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 631, col: 5, offset: 15696},
+							pos:        position{line: 631, col: 5, offset: 15744},
 							val:        "pool",
 							ignoreCase: false,
 							want:       "\"pool\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 631, col: 12, offset: 15703},
+							pos:  position{line: 631, col: 12, offset: 15751},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 631, col: 14, offset: 15705},
+							pos:   position{line: 631, col: 14, offset: 15753},
 							label: "spec",
 							expr: &ruleRefExpr{
-								pos:  position{line: 631, col: 19, offset: 15710},
+								pos:  position{line: 631, col: 19, offset: 15758},
 								name: "PoolSpec",
 							},
 						},
@@ -4158,82 +4248,82 @@ var g = &grammar{
 		},
 		{
 			name: "Get",
-			pos:  position{line: 640, col: 1, offset: 15898},
+			pos:  position{line: 640, col: 1, offset: 15946},
 			expr: &actionExpr{
-				pos: position{line: 641, col: 5, offset: 15906},
+				pos: position{line: 641, col: 5, offset: 15954},
 				run: (*parser).callonGet1,
 				expr: &seqExpr{
-					pos: position{line: 641, col: 5, offset: 15906},
+					pos: position{line: 641, col: 5, offset: 15954},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 641, col: 5, offset: 15906},
+							pos:        position{line: 641, col: 5, offset: 15954},
 							val:        "get",
 							ignoreCase: false,
 							want:       "\"get\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 641, col: 11, offset: 15912},
+							pos:  position{line: 641, col: 11, offset: 15960},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 641, col: 13, offset: 15914},
+							pos:   position{line: 641, col: 13, offset: 15962},
 							label: "url",
 							expr: &ruleRefExpr{
-								pos:  position{line: 641, col: 17, offset: 15918},
+								pos:  position{line: 641, col: 17, offset: 15966},
 								name: "Path",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 641, col: 22, offset: 15923},
+							pos:   position{line: 641, col: 22, offset: 15971},
 							label: "format",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 641, col: 29, offset: 15930},
+								pos: position{line: 641, col: 29, offset: 15978},
 								expr: &ruleRefExpr{
-									pos:  position{line: 641, col: 29, offset: 15930},
+									pos:  position{line: 641, col: 29, offset: 15978},
 									name: "FormatArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 641, col: 40, offset: 15941},
+							pos:   position{line: 641, col: 40, offset: 15989},
 							label: "sortkey",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 641, col: 48, offset: 15949},
+								pos: position{line: 641, col: 48, offset: 15997},
 								expr: &ruleRefExpr{
-									pos:  position{line: 641, col: 48, offset: 15949},
+									pos:  position{line: 641, col: 48, offset: 15997},
 									name: "SortKeyArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 641, col: 60, offset: 15961},
+							pos:   position{line: 641, col: 60, offset: 16009},
 							label: "method",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 641, col: 67, offset: 15968},
+								pos: position{line: 641, col: 67, offset: 16016},
 								expr: &ruleRefExpr{
-									pos:  position{line: 641, col: 67, offset: 15968},
+									pos:  position{line: 641, col: 67, offset: 16016},
 									name: "MethodArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 641, col: 78, offset: 15979},
+							pos:   position{line: 641, col: 78, offset: 16027},
 							label: "headers",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 641, col: 86, offset: 15987},
+								pos: position{line: 641, col: 86, offset: 16035},
 								expr: &ruleRefExpr{
-									pos:  position{line: 641, col: 86, offset: 15987},
+									pos:  position{line: 641, col: 86, offset: 16035},
 									name: "HeadersArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 641, col: 98, offset: 15999},
+							pos:   position{line: 641, col: 98, offset: 16047},
 							label: "body",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 641, col: 103, offset: 16004},
+								pos: position{line: 641, col: 103, offset: 16052},
 								expr: &ruleRefExpr{
-									pos:  position{line: 641, col: 103, offset: 16004},
+									pos:  position{line: 641, col: 103, offset: 16052},
 									name: "BodyArg",
 								},
 							},
@@ -4246,39 +4336,39 @@ var g = &grammar{
 		},
 		{
 			name: "MethodArg",
-			pos:  position{line: 660, col: 1, offset: 16475},
+			pos:  position{line: 660, col: 1, offset: 16523},
 			expr: &actionExpr{
-				pos: position{line: 660, col: 13, offset: 16487},
+				pos: position{line: 660, col: 13, offset: 16535},
 				run: (*parser).callonMethodArg1,
 				expr: &seqExpr{
-					pos: position{line: 660, col: 13, offset: 16487},
+					pos: position{line: 660, col: 13, offset: 16535},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 660, col: 13, offset: 16487},
+							pos:  position{line: 660, col: 13, offset: 16535},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 660, col: 15, offset: 16489},
+							pos:        position{line: 660, col: 15, offset: 16537},
 							val:        "method",
 							ignoreCase: false,
 							want:       "\"method\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 660, col: 24, offset: 16498},
+							pos:  position{line: 660, col: 24, offset: 16546},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 660, col: 26, offset: 16500},
+							pos:   position{line: 660, col: 26, offset: 16548},
 							label: "v",
 							expr: &choiceExpr{
-								pos: position{line: 660, col: 29, offset: 16503},
+								pos: position{line: 660, col: 29, offset: 16551},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 660, col: 29, offset: 16503},
+										pos:  position{line: 660, col: 29, offset: 16551},
 										name: "IdentifierName",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 660, col: 46, offset: 16520},
+										pos:  position{line: 660, col: 46, offset: 16568},
 										name: "QuotedString",
 									},
 								},
@@ -4292,32 +4382,32 @@ var g = &grammar{
 		},
 		{
 			name: "HeadersArg",
-			pos:  position{line: 662, col: 1, offset: 16553},
+			pos:  position{line: 662, col: 1, offset: 16601},
 			expr: &actionExpr{
-				pos: position{line: 662, col: 14, offset: 16566},
+				pos: position{line: 662, col: 14, offset: 16614},
 				run: (*parser).callonHeadersArg1,
 				expr: &seqExpr{
-					pos: position{line: 662, col: 14, offset: 16566},
+					pos: position{line: 662, col: 14, offset: 16614},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 662, col: 14, offset: 16566},
+							pos:  position{line: 662, col: 14, offset: 16614},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 662, col: 16, offset: 16568},
+							pos:        position{line: 662, col: 16, offset: 16616},
 							val:        "headers",
 							ignoreCase: false,
 							want:       "\"headers\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 662, col: 26, offset: 16578},
+							pos:  position{line: 662, col: 26, offset: 16626},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 662, col: 28, offset: 16580},
+							pos:   position{line: 662, col: 28, offset: 16628},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 662, col: 30, offset: 16582},
+								pos:  position{line: 662, col: 30, offset: 16630},
 								name: "Record",
 							},
 						},
@@ -4329,39 +4419,39 @@ var g = &grammar{
 		},
 		{
 			name: "BodyArg",
-			pos:  position{line: 664, col: 1, offset: 16608},
+			pos:  position{line: 664, col: 1, offset: 16656},
 			expr: &actionExpr{
-				pos: position{line: 664, col: 11, offset: 16618},
+				pos: position{line: 664, col: 11, offset: 16666},
 				run: (*parser).callonBodyArg1,
 				expr: &seqExpr{
-					pos: position{line: 664, col: 11, offset: 16618},
+					pos: position{line: 664, col: 11, offset: 16666},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 664, col: 11, offset: 16618},
+							pos:  position{line: 664, col: 11, offset: 16666},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 664, col: 13, offset: 16620},
+							pos:        position{line: 664, col: 13, offset: 16668},
 							val:        "body",
 							ignoreCase: false,
 							want:       "\"body\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 664, col: 20, offset: 16627},
+							pos:  position{line: 664, col: 20, offset: 16675},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 664, col: 22, offset: 16629},
+							pos:   position{line: 664, col: 22, offset: 16677},
 							label: "v",
 							expr: &choiceExpr{
-								pos: position{line: 664, col: 25, offset: 16632},
+								pos: position{line: 664, col: 25, offset: 16680},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 664, col: 25, offset: 16632},
+										pos:  position{line: 664, col: 25, offset: 16680},
 										name: "IdentifierName",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 664, col: 42, offset: 16649},
+										pos:  position{line: 664, col: 42, offset: 16697},
 										name: "QuotedString",
 									},
 								},
@@ -4375,21 +4465,21 @@ var g = &grammar{
 		},
 		{
 			name: "Path",
-			pos:  position{line: 666, col: 1, offset: 16682},
+			pos:  position{line: 666, col: 1, offset: 16730},
 			expr: &choiceExpr{
-				pos: position{line: 667, col: 5, offset: 16691},
+				pos: position{line: 667, col: 5, offset: 16739},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 667, col: 5, offset: 16691},
+						pos:  position{line: 667, col: 5, offset: 16739},
 						name: "QuotedStringNode",
 					},
 					&actionExpr{
-						pos: position{line: 668, col: 5, offset: 16712},
+						pos: position{line: 668, col: 5, offset: 16760},
 						run: (*parser).callonPath3,
 						expr: &oneOrMoreExpr{
-							pos: position{line: 668, col: 5, offset: 16712},
+							pos: position{line: 668, col: 5, offset: 16760},
 							expr: &charClassMatcher{
-								pos:        position{line: 668, col: 5, offset: 16712},
+								pos:        position{line: 668, col: 5, offset: 16760},
 								val:        "[0-9a-zA-Z!@$%^&*_=<>,./?:[\\]{}~+-]",
 								chars:      []rune{'!', '@', '$', '%', '^', '&', '*', '_', '=', '<', '>', ',', '.', '/', '?', ':', '[', ']', '{', '}', '~', '+', '-'},
 								ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
@@ -4405,32 +4495,32 @@ var g = &grammar{
 		},
 		{
 			name: "PoolAt",
-			pos:  position{line: 673, col: 1, offset: 16882},
+			pos:  position{line: 673, col: 1, offset: 16930},
 			expr: &actionExpr{
-				pos: position{line: 674, col: 5, offset: 16893},
+				pos: position{line: 674, col: 5, offset: 16941},
 				run: (*parser).callonPoolAt1,
 				expr: &seqExpr{
-					pos: position{line: 674, col: 5, offset: 16893},
+					pos: position{line: 674, col: 5, offset: 16941},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 674, col: 5, offset: 16893},
+							pos:  position{line: 674, col: 5, offset: 16941},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 674, col: 7, offset: 16895},
+							pos:        position{line: 674, col: 7, offset: 16943},
 							val:        "at",
 							ignoreCase: false,
 							want:       "\"at\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 674, col: 12, offset: 16900},
+							pos:  position{line: 674, col: 12, offset: 16948},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 674, col: 14, offset: 16902},
+							pos:   position{line: 674, col: 14, offset: 16950},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 674, col: 17, offset: 16905},
+								pos:  position{line: 674, col: 17, offset: 16953},
 								name: "KSUID",
 							},
 						},
@@ -4442,14 +4532,14 @@ var g = &grammar{
 		},
 		{
 			name: "KSUID",
-			pos:  position{line: 677, col: 1, offset: 16971},
+			pos:  position{line: 677, col: 1, offset: 17019},
 			expr: &actionExpr{
-				pos: position{line: 677, col: 9, offset: 16979},
+				pos: position{line: 677, col: 9, offset: 17027},
 				run: (*parser).callonKSUID1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 677, col: 9, offset: 16979},
+					pos: position{line: 677, col: 9, offset: 17027},
 					expr: &charClassMatcher{
-						pos:        position{line: 677, col: 10, offset: 16980},
+						pos:        position{line: 677, col: 10, offset: 17028},
 						val:        "[0-9a-zA-Z]",
 						ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
 						ignoreCase: false,
@@ -4462,51 +4552,51 @@ var g = &grammar{
 		},
 		{
 			name: "PoolSpec",
-			pos:  position{line: 679, col: 1, offset: 17026},
+			pos:  position{line: 679, col: 1, offset: 17074},
 			expr: &choiceExpr{
-				pos: position{line: 680, col: 5, offset: 17039},
+				pos: position{line: 680, col: 5, offset: 17087},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 680, col: 5, offset: 17039},
+						pos: position{line: 680, col: 5, offset: 17087},
 						run: (*parser).callonPoolSpec2,
 						expr: &seqExpr{
-							pos: position{line: 680, col: 5, offset: 17039},
+							pos: position{line: 680, col: 5, offset: 17087},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 680, col: 5, offset: 17039},
+									pos:   position{line: 680, col: 5, offset: 17087},
 									label: "pool",
 									expr: &ruleRefExpr{
-										pos:  position{line: 680, col: 10, offset: 17044},
+										pos:  position{line: 680, col: 10, offset: 17092},
 										name: "PoolName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 680, col: 19, offset: 17053},
+									pos:   position{line: 680, col: 19, offset: 17101},
 									label: "commit",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 680, col: 26, offset: 17060},
+										pos: position{line: 680, col: 26, offset: 17108},
 										expr: &ruleRefExpr{
-											pos:  position{line: 680, col: 26, offset: 17060},
+											pos:  position{line: 680, col: 26, offset: 17108},
 											name: "PoolCommit",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 680, col: 38, offset: 17072},
+									pos:   position{line: 680, col: 38, offset: 17120},
 									label: "meta",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 680, col: 43, offset: 17077},
+										pos: position{line: 680, col: 43, offset: 17125},
 										expr: &ruleRefExpr{
-											pos:  position{line: 680, col: 43, offset: 17077},
+											pos:  position{line: 680, col: 43, offset: 17125},
 											name: "PoolMeta",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 680, col: 53, offset: 17087},
+									pos:   position{line: 680, col: 53, offset: 17135},
 									label: "tap",
 									expr: &ruleRefExpr{
-										pos:  position{line: 680, col: 57, offset: 17091},
+										pos:  position{line: 680, col: 57, offset: 17139},
 										name: "TapArg",
 									},
 								},
@@ -4514,13 +4604,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 688, col: 5, offset: 17285},
+						pos: position{line: 688, col: 5, offset: 17333},
 						run: (*parser).callonPoolSpec14,
 						expr: &labeledExpr{
-							pos:   position{line: 688, col: 5, offset: 17285},
+							pos:   position{line: 688, col: 5, offset: 17333},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 688, col: 10, offset: 17290},
+								pos:  position{line: 688, col: 10, offset: 17338},
 								name: "PoolMeta",
 							},
 						},
@@ -4532,24 +4622,24 @@ var g = &grammar{
 		},
 		{
 			name: "PoolCommit",
-			pos:  position{line: 692, col: 1, offset: 17360},
+			pos:  position{line: 692, col: 1, offset: 17408},
 			expr: &actionExpr{
-				pos: position{line: 693, col: 5, offset: 17375},
+				pos: position{line: 693, col: 5, offset: 17423},
 				run: (*parser).callonPoolCommit1,
 				expr: &seqExpr{
-					pos: position{line: 693, col: 5, offset: 17375},
+					pos: position{line: 693, col: 5, offset: 17423},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 693, col: 5, offset: 17375},
+							pos:        position{line: 693, col: 5, offset: 17423},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 693, col: 9, offset: 17379},
+							pos:   position{line: 693, col: 9, offset: 17427},
 							label: "commit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 693, col: 16, offset: 17386},
+								pos:  position{line: 693, col: 16, offset: 17434},
 								name: "PoolNameString",
 							},
 						},
@@ -4561,24 +4651,24 @@ var g = &grammar{
 		},
 		{
 			name: "PoolMeta",
-			pos:  position{line: 695, col: 1, offset: 17425},
+			pos:  position{line: 695, col: 1, offset: 17473},
 			expr: &actionExpr{
-				pos: position{line: 696, col: 5, offset: 17438},
+				pos: position{line: 696, col: 5, offset: 17486},
 				run: (*parser).callonPoolMeta1,
 				expr: &seqExpr{
-					pos: position{line: 696, col: 5, offset: 17438},
+					pos: position{line: 696, col: 5, offset: 17486},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 696, col: 5, offset: 17438},
+							pos:        position{line: 696, col: 5, offset: 17486},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 696, col: 9, offset: 17442},
+							pos:   position{line: 696, col: 9, offset: 17490},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 696, col: 14, offset: 17447},
+								pos:  position{line: 696, col: 14, offset: 17495},
 								name: "PoolIdentifier",
 							},
 						},
@@ -4590,34 +4680,34 @@ var g = &grammar{
 		},
 		{
 			name: "PoolName",
-			pos:  position{line: 698, col: 1, offset: 17484},
+			pos:  position{line: 698, col: 1, offset: 17532},
 			expr: &choiceExpr{
-				pos: position{line: 699, col: 5, offset: 17497},
+				pos: position{line: 699, col: 5, offset: 17545},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 699, col: 5, offset: 17497},
+						pos:  position{line: 699, col: 5, offset: 17545},
 						name: "Regexp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 700, col: 5, offset: 17508},
+						pos:  position{line: 700, col: 5, offset: 17556},
 						name: "Glob",
 					},
 					&actionExpr{
-						pos: position{line: 701, col: 5, offset: 17517},
+						pos: position{line: 701, col: 5, offset: 17565},
 						run: (*parser).callonPoolName4,
 						expr: &seqExpr{
-							pos: position{line: 701, col: 5, offset: 17517},
+							pos: position{line: 701, col: 5, offset: 17565},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 701, col: 5, offset: 17517},
+									pos:        position{line: 701, col: 5, offset: 17565},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 								&notExpr{
-									pos: position{line: 701, col: 9, offset: 17521},
+									pos: position{line: 701, col: 9, offset: 17569},
 									expr: &ruleRefExpr{
-										pos:  position{line: 701, col: 10, offset: 17522},
+										pos:  position{line: 701, col: 10, offset: 17570},
 										name: "ExprGuard",
 									},
 								},
@@ -4625,17 +4715,17 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 702, col: 5, offset: 17616},
+						pos:  position{line: 702, col: 5, offset: 17664},
 						name: "QuotedStringNode",
 					},
 					&actionExpr{
-						pos: position{line: 703, col: 5, offset: 17637},
+						pos: position{line: 703, col: 5, offset: 17685},
 						run: (*parser).callonPoolName10,
 						expr: &labeledExpr{
-							pos:   position{line: 703, col: 5, offset: 17637},
+							pos:   position{line: 703, col: 5, offset: 17685},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 703, col: 10, offset: 17642},
+								pos:  position{line: 703, col: 10, offset: 17690},
 								name: "PoolNameString",
 							},
 						},
@@ -4647,20 +4737,20 @@ var g = &grammar{
 		},
 		{
 			name: "PoolNameString",
-			pos:  position{line: 705, col: 1, offset: 17746},
+			pos:  position{line: 705, col: 1, offset: 17794},
 			expr: &choiceExpr{
-				pos: position{line: 706, col: 5, offset: 17765},
+				pos: position{line: 706, col: 5, offset: 17813},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 706, col: 5, offset: 17765},
+						pos:  position{line: 706, col: 5, offset: 17813},
 						name: "PoolIdentifier",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 707, col: 5, offset: 17784},
+						pos:  position{line: 707, col: 5, offset: 17832},
 						name: "KSUID",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 708, col: 5, offset: 17794},
+						pos:  position{line: 708, col: 5, offset: 17842},
 						name: "QuotedString",
 					},
 				},
@@ -4670,22 +4760,22 @@ var g = &grammar{
 		},
 		{
 			name: "PoolIdentifier",
-			pos:  position{line: 710, col: 1, offset: 17808},
+			pos:  position{line: 710, col: 1, offset: 17856},
 			expr: &actionExpr{
-				pos: position{line: 711, col: 5, offset: 17827},
+				pos: position{line: 711, col: 5, offset: 17875},
 				run: (*parser).callonPoolIdentifier1,
 				expr: &seqExpr{
-					pos: position{line: 711, col: 5, offset: 17827},
+					pos: position{line: 711, col: 5, offset: 17875},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 711, col: 6, offset: 17828},
+							pos: position{line: 711, col: 6, offset: 17876},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 711, col: 6, offset: 17828},
+									pos:  position{line: 711, col: 6, offset: 17876},
 									name: "IdentifierStart",
 								},
 								&litMatcher{
-									pos:        position{line: 711, col: 24, offset: 17846},
+									pos:        position{line: 711, col: 24, offset: 17894},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
@@ -4693,16 +4783,16 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 711, col: 29, offset: 17851},
+							pos: position{line: 711, col: 29, offset: 17899},
 							expr: &choiceExpr{
-								pos: position{line: 711, col: 30, offset: 17852},
+								pos: position{line: 711, col: 30, offset: 17900},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 711, col: 30, offset: 17852},
+										pos:  position{line: 711, col: 30, offset: 17900},
 										name: "IdentifierRest",
 									},
 									&litMatcher{
-										pos:        position{line: 711, col: 47, offset: 17869},
+										pos:        position{line: 711, col: 47, offset: 17917},
 										val:        ".",
 										ignoreCase: false,
 										want:       "\".\"",
@@ -4718,40 +4808,40 @@ var g = &grammar{
 		},
 		{
 			name: "SortKeyArg",
-			pos:  position{line: 713, col: 1, offset: 17907},
+			pos:  position{line: 713, col: 1, offset: 17955},
 			expr: &actionExpr{
-				pos: position{line: 714, col: 5, offset: 17922},
+				pos: position{line: 714, col: 5, offset: 17970},
 				run: (*parser).callonSortKeyArg1,
 				expr: &seqExpr{
-					pos: position{line: 714, col: 5, offset: 17922},
+					pos: position{line: 714, col: 5, offset: 17970},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 714, col: 5, offset: 17922},
+							pos:  position{line: 714, col: 5, offset: 17970},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 714, col: 7, offset: 17924},
+							pos:        position{line: 714, col: 7, offset: 17972},
 							val:        "order",
 							ignoreCase: false,
 							want:       "\"order\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 714, col: 15, offset: 17932},
+							pos:  position{line: 714, col: 15, offset: 17980},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 714, col: 17, offset: 17934},
+							pos:   position{line: 714, col: 17, offset: 17982},
 							label: "keys",
 							expr: &ruleRefExpr{
-								pos:  position{line: 714, col: 22, offset: 17939},
+								pos:  position{line: 714, col: 22, offset: 17987},
 								name: "FieldExprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 714, col: 33, offset: 17950},
+							pos:   position{line: 714, col: 33, offset: 17998},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 714, col: 39, offset: 17956},
+								pos:  position{line: 714, col: 39, offset: 18004},
 								name: "OrderSuffix",
 							},
 						},
@@ -4763,22 +4853,22 @@ var g = &grammar{
 		},
 		{
 			name: "TapArg",
-			pos:  position{line: 722, col: 1, offset: 18112},
+			pos:  position{line: 722, col: 1, offset: 18160},
 			expr: &choiceExpr{
-				pos: position{line: 723, col: 5, offset: 18123},
+				pos: position{line: 723, col: 5, offset: 18171},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 723, col: 5, offset: 18123},
+						pos: position{line: 723, col: 5, offset: 18171},
 						run: (*parser).callonTapArg2,
 						expr: &seqExpr{
-							pos: position{line: 723, col: 5, offset: 18123},
+							pos: position{line: 723, col: 5, offset: 18171},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 723, col: 5, offset: 18123},
+									pos:  position{line: 723, col: 5, offset: 18171},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 723, col: 7, offset: 18125},
+									pos:        position{line: 723, col: 7, offset: 18173},
 									val:        "tap",
 									ignoreCase: false,
 									want:       "\"tap\"",
@@ -4787,10 +4877,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 724, col: 5, offset: 18156},
+						pos: position{line: 724, col: 5, offset: 18204},
 						run: (*parser).callonTapArg6,
 						expr: &litMatcher{
-							pos:        position{line: 724, col: 5, offset: 18156},
+							pos:        position{line: 724, col: 5, offset: 18204},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -4803,32 +4893,32 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArg",
-			pos:  position{line: 726, col: 1, offset: 18182},
+			pos:  position{line: 726, col: 1, offset: 18230},
 			expr: &actionExpr{
-				pos: position{line: 727, col: 5, offset: 18196},
+				pos: position{line: 727, col: 5, offset: 18244},
 				run: (*parser).callonFormatArg1,
 				expr: &seqExpr{
-					pos: position{line: 727, col: 5, offset: 18196},
+					pos: position{line: 727, col: 5, offset: 18244},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 727, col: 5, offset: 18196},
+							pos:  position{line: 727, col: 5, offset: 18244},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 727, col: 7, offset: 18198},
+							pos:        position{line: 727, col: 7, offset: 18246},
 							val:        "format",
 							ignoreCase: false,
 							want:       "\"format\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 727, col: 16, offset: 18207},
+							pos:  position{line: 727, col: 16, offset: 18255},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 727, col: 18, offset: 18209},
+							pos:   position{line: 727, col: 18, offset: 18257},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 727, col: 22, offset: 18213},
+								pos:  position{line: 727, col: 22, offset: 18261},
 								name: "IdentifierName",
 							},
 						},
@@ -4840,35 +4930,35 @@ var g = &grammar{
 		},
 		{
 			name: "OrderSuffix",
-			pos:  position{line: 729, col: 1, offset: 18249},
+			pos:  position{line: 729, col: 1, offset: 18297},
 			expr: &choiceExpr{
-				pos: position{line: 730, col: 5, offset: 18265},
+				pos: position{line: 730, col: 5, offset: 18313},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 730, col: 5, offset: 18265},
+						pos: position{line: 730, col: 5, offset: 18313},
 						run: (*parser).callonOrderSuffix2,
 						expr: &litMatcher{
-							pos:        position{line: 730, col: 5, offset: 18265},
+							pos:        position{line: 730, col: 5, offset: 18313},
 							val:        ":asc",
 							ignoreCase: false,
 							want:       "\":asc\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 731, col: 5, offset: 18299},
+						pos: position{line: 731, col: 5, offset: 18347},
 						run: (*parser).callonOrderSuffix4,
 						expr: &litMatcher{
-							pos:        position{line: 731, col: 5, offset: 18299},
+							pos:        position{line: 731, col: 5, offset: 18347},
 							val:        ":desc",
 							ignoreCase: false,
 							want:       "\":desc\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 732, col: 5, offset: 18334},
+						pos: position{line: 732, col: 5, offset: 18382},
 						run: (*parser).callonOrderSuffix6,
 						expr: &litMatcher{
-							pos:        position{line: 732, col: 5, offset: 18334},
+							pos:        position{line: 732, col: 5, offset: 18382},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -4881,23 +4971,41 @@ var g = &grammar{
 		},
 		{
 			name: "PassOp",
-			pos:  position{line: 734, col: 1, offset: 18365},
+			pos:  position{line: 734, col: 1, offset: 18413},
 			expr: &actionExpr{
-				pos: position{line: 735, col: 5, offset: 18376},
+				pos: position{line: 735, col: 5, offset: 18424},
 				run: (*parser).callonPassOp1,
 				expr: &seqExpr{
-					pos: position{line: 735, col: 5, offset: 18376},
+					pos: position{line: 735, col: 5, offset: 18424},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 735, col: 5, offset: 18376},
+							pos:        position{line: 735, col: 5, offset: 18424},
 							val:        "pass",
 							ignoreCase: false,
 							want:       "\"pass\"",
 						},
+						&notExpr{
+							pos: position{line: 735, col: 12, offset: 18431},
+							expr: &seqExpr{
+								pos: position{line: 735, col: 14, offset: 18433},
+								exprs: []any{
+									&ruleRefExpr{
+										pos:  position{line: 735, col: 14, offset: 18433},
+										name: "__",
+									},
+									&litMatcher{
+										pos:        position{line: 735, col: 17, offset: 18436},
+										val:        "(",
+										ignoreCase: false,
+										want:       "\"(\"",
+									},
+								},
+							},
+						},
 						&andExpr{
-							pos: position{line: 735, col: 12, offset: 18383},
+							pos: position{line: 735, col: 22, offset: 18441},
 							expr: &ruleRefExpr{
-								pos:  position{line: 735, col: 13, offset: 18384},
+								pos:  position{line: 735, col: 23, offset: 18442},
 								name: "EOKW",
 							},
 						},
@@ -4909,46 +5017,46 @@ var g = &grammar{
 		},
 		{
 			name: "ExplodeOp",
-			pos:  position{line: 741, col: 1, offset: 18588},
+			pos:  position{line: 741, col: 1, offset: 18646},
 			expr: &actionExpr{
-				pos: position{line: 742, col: 5, offset: 18602},
+				pos: position{line: 742, col: 5, offset: 18660},
 				run: (*parser).callonExplodeOp1,
 				expr: &seqExpr{
-					pos: position{line: 742, col: 5, offset: 18602},
+					pos: position{line: 742, col: 5, offset: 18660},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 742, col: 5, offset: 18602},
+							pos:        position{line: 742, col: 5, offset: 18660},
 							val:        "explode",
 							ignoreCase: false,
 							want:       "\"explode\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 742, col: 15, offset: 18612},
+							pos:  position{line: 742, col: 15, offset: 18670},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 742, col: 17, offset: 18614},
+							pos:   position{line: 742, col: 17, offset: 18672},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 742, col: 22, offset: 18619},
+								pos:  position{line: 742, col: 22, offset: 18677},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 742, col: 28, offset: 18625},
+							pos:   position{line: 742, col: 28, offset: 18683},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 742, col: 32, offset: 18629},
+								pos:  position{line: 742, col: 32, offset: 18687},
 								name: "TypeArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 742, col: 40, offset: 18637},
+							pos:   position{line: 742, col: 40, offset: 18695},
 							label: "as",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 742, col: 43, offset: 18640},
+								pos: position{line: 742, col: 43, offset: 18698},
 								expr: &ruleRefExpr{
-									pos:  position{line: 742, col: 43, offset: 18640},
+									pos:  position{line: 742, col: 43, offset: 18698},
 									name: "AsArg",
 								},
 							},
@@ -4961,28 +5069,28 @@ var g = &grammar{
 		},
 		{
 			name: "MergeOp",
-			pos:  position{line: 755, col: 1, offset: 18898},
+			pos:  position{line: 755, col: 1, offset: 18956},
 			expr: &actionExpr{
-				pos: position{line: 756, col: 5, offset: 18910},
+				pos: position{line: 756, col: 5, offset: 18968},
 				run: (*parser).callonMergeOp1,
 				expr: &seqExpr{
-					pos: position{line: 756, col: 5, offset: 18910},
+					pos: position{line: 756, col: 5, offset: 18968},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 756, col: 5, offset: 18910},
+							pos:        position{line: 756, col: 5, offset: 18968},
 							val:        "merge",
 							ignoreCase: false,
 							want:       "\"merge\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 756, col: 13, offset: 18918},
+							pos:  position{line: 756, col: 13, offset: 18976},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 756, col: 15, offset: 18920},
+							pos:   position{line: 756, col: 15, offset: 18978},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 756, col: 20, offset: 18925},
+								pos:  position{line: 756, col: 20, offset: 18983},
 								name: "Expr",
 							},
 						},
@@ -4994,49 +5102,49 @@ var g = &grammar{
 		},
 		{
 			name: "OverOp",
-			pos:  position{line: 764, col: 1, offset: 19065},
+			pos:  position{line: 764, col: 1, offset: 19123},
 			expr: &actionExpr{
-				pos: position{line: 765, col: 5, offset: 19076},
+				pos: position{line: 765, col: 5, offset: 19134},
 				run: (*parser).callonOverOp1,
 				expr: &seqExpr{
-					pos: position{line: 765, col: 5, offset: 19076},
+					pos: position{line: 765, col: 5, offset: 19134},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 765, col: 5, offset: 19076},
+							pos:        position{line: 765, col: 5, offset: 19134},
 							val:        "over",
 							ignoreCase: false,
 							want:       "\"over\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 765, col: 12, offset: 19083},
+							pos:  position{line: 765, col: 12, offset: 19141},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 765, col: 14, offset: 19085},
+							pos:   position{line: 765, col: 14, offset: 19143},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 765, col: 20, offset: 19091},
+								pos:  position{line: 765, col: 20, offset: 19149},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 765, col: 26, offset: 19097},
+							pos:   position{line: 765, col: 26, offset: 19155},
 							label: "locals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 765, col: 33, offset: 19104},
+								pos: position{line: 765, col: 33, offset: 19162},
 								expr: &ruleRefExpr{
-									pos:  position{line: 765, col: 33, offset: 19104},
+									pos:  position{line: 765, col: 33, offset: 19162},
 									name: "Locals",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 765, col: 41, offset: 19112},
+							pos:   position{line: 765, col: 41, offset: 19170},
 							label: "body",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 765, col: 46, offset: 19117},
+								pos: position{line: 765, col: 46, offset: 19175},
 								expr: &ruleRefExpr{
-									pos:  position{line: 765, col: 46, offset: 19117},
+									pos:  position{line: 765, col: 46, offset: 19175},
 									name: "Lateral",
 								},
 							},
@@ -5049,54 +5157,54 @@ var g = &grammar{
 		},
 		{
 			name: "Lateral",
-			pos:  position{line: 780, col: 1, offset: 19466},
+			pos:  position{line: 780, col: 1, offset: 19524},
 			expr: &choiceExpr{
-				pos: position{line: 781, col: 5, offset: 19478},
+				pos: position{line: 781, col: 5, offset: 19536},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 781, col: 5, offset: 19478},
+						pos: position{line: 781, col: 5, offset: 19536},
 						run: (*parser).callonLateral2,
 						expr: &seqExpr{
-							pos: position{line: 781, col: 5, offset: 19478},
+							pos: position{line: 781, col: 5, offset: 19536},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 781, col: 5, offset: 19478},
+									pos:  position{line: 781, col: 5, offset: 19536},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 781, col: 8, offset: 19481},
+									pos:        position{line: 781, col: 8, offset: 19539},
 									val:        "=>",
 									ignoreCase: false,
 									want:       "\"=>\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 781, col: 13, offset: 19486},
+									pos:  position{line: 781, col: 13, offset: 19544},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 781, col: 16, offset: 19489},
+									pos:        position{line: 781, col: 16, offset: 19547},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 781, col: 20, offset: 19493},
+									pos:  position{line: 781, col: 20, offset: 19551},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 781, col: 23, offset: 19496},
+									pos:   position{line: 781, col: 23, offset: 19554},
 									label: "scope",
 									expr: &ruleRefExpr{
-										pos:  position{line: 781, col: 29, offset: 19502},
+										pos:  position{line: 781, col: 29, offset: 19560},
 										name: "Scope",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 781, col: 35, offset: 19508},
+									pos:  position{line: 781, col: 35, offset: 19566},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 781, col: 38, offset: 19511},
+									pos:        position{line: 781, col: 38, offset: 19569},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -5105,49 +5213,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 784, col: 5, offset: 19595},
+						pos: position{line: 784, col: 5, offset: 19653},
 						run: (*parser).callonLateral13,
 						expr: &seqExpr{
-							pos: position{line: 784, col: 5, offset: 19595},
+							pos: position{line: 784, col: 5, offset: 19653},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 784, col: 5, offset: 19595},
+									pos:  position{line: 784, col: 5, offset: 19653},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 784, col: 8, offset: 19598},
+									pos:        position{line: 784, col: 8, offset: 19656},
 									val:        "=>",
 									ignoreCase: false,
 									want:       "\"=>\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 784, col: 13, offset: 19603},
+									pos:  position{line: 784, col: 13, offset: 19661},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 784, col: 16, offset: 19606},
+									pos:        position{line: 784, col: 16, offset: 19664},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 784, col: 20, offset: 19610},
+									pos:  position{line: 784, col: 20, offset: 19668},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 784, col: 23, offset: 19613},
+									pos:   position{line: 784, col: 23, offset: 19671},
 									label: "seq",
 									expr: &ruleRefExpr{
-										pos:  position{line: 784, col: 27, offset: 19617},
+										pos:  position{line: 784, col: 27, offset: 19675},
 										name: "Seq",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 784, col: 31, offset: 19621},
+									pos:  position{line: 784, col: 31, offset: 19679},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 784, col: 34, offset: 19624},
+									pos:        position{line: 784, col: 34, offset: 19682},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -5162,65 +5270,65 @@ var g = &grammar{
 		},
 		{
 			name: "Locals",
-			pos:  position{line: 788, col: 1, offset: 19683},
+			pos:  position{line: 788, col: 1, offset: 19741},
 			expr: &actionExpr{
-				pos: position{line: 789, col: 5, offset: 19694},
+				pos: position{line: 789, col: 5, offset: 19752},
 				run: (*parser).callonLocals1,
 				expr: &seqExpr{
-					pos: position{line: 789, col: 5, offset: 19694},
+					pos: position{line: 789, col: 5, offset: 19752},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 789, col: 5, offset: 19694},
+							pos:  position{line: 789, col: 5, offset: 19752},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 789, col: 7, offset: 19696},
+							pos:        position{line: 789, col: 7, offset: 19754},
 							val:        "with",
 							ignoreCase: false,
 							want:       "\"with\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 789, col: 14, offset: 19703},
+							pos:  position{line: 789, col: 14, offset: 19761},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 789, col: 16, offset: 19705},
+							pos:   position{line: 789, col: 16, offset: 19763},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 789, col: 22, offset: 19711},
+								pos:  position{line: 789, col: 22, offset: 19769},
 								name: "LocalsAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 789, col: 39, offset: 19728},
+							pos:   position{line: 789, col: 39, offset: 19786},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 789, col: 44, offset: 19733},
+								pos: position{line: 789, col: 44, offset: 19791},
 								expr: &actionExpr{
-									pos: position{line: 789, col: 45, offset: 19734},
+									pos: position{line: 789, col: 45, offset: 19792},
 									run: (*parser).callonLocals10,
 									expr: &seqExpr{
-										pos: position{line: 789, col: 45, offset: 19734},
+										pos: position{line: 789, col: 45, offset: 19792},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 789, col: 45, offset: 19734},
+												pos:  position{line: 789, col: 45, offset: 19792},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 789, col: 48, offset: 19737},
+												pos:        position{line: 789, col: 48, offset: 19795},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 789, col: 52, offset: 19741},
+												pos:  position{line: 789, col: 52, offset: 19799},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 789, col: 55, offset: 19744},
+												pos:   position{line: 789, col: 55, offset: 19802},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 789, col: 57, offset: 19746},
+													pos:  position{line: 789, col: 57, offset: 19804},
 													name: "LocalsAssignment",
 												},
 											},
@@ -5237,45 +5345,45 @@ var g = &grammar{
 		},
 		{
 			name: "LocalsAssignment",
-			pos:  position{line: 793, col: 1, offset: 19831},
+			pos:  position{line: 793, col: 1, offset: 19889},
 			expr: &actionExpr{
-				pos: position{line: 794, col: 5, offset: 19852},
+				pos: position{line: 794, col: 5, offset: 19910},
 				run: (*parser).callonLocalsAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 794, col: 5, offset: 19852},
+					pos: position{line: 794, col: 5, offset: 19910},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 794, col: 5, offset: 19852},
+							pos:   position{line: 794, col: 5, offset: 19910},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 794, col: 10, offset: 19857},
+								pos:  position{line: 794, col: 10, offset: 19915},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 794, col: 21, offset: 19868},
+							pos:   position{line: 794, col: 21, offset: 19926},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 794, col: 25, offset: 19872},
+								pos: position{line: 794, col: 25, offset: 19930},
 								expr: &seqExpr{
-									pos: position{line: 794, col: 26, offset: 19873},
+									pos: position{line: 794, col: 26, offset: 19931},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 794, col: 26, offset: 19873},
+											pos:  position{line: 794, col: 26, offset: 19931},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 794, col: 29, offset: 19876},
+											pos:        position{line: 794, col: 29, offset: 19934},
 											val:        "=",
 											ignoreCase: false,
 											want:       "\"=\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 794, col: 33, offset: 19880},
+											pos:  position{line: 794, col: 33, offset: 19938},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 794, col: 36, offset: 19883},
+											pos:  position{line: 794, col: 36, offset: 19941},
 											name: "Expr",
 										},
 									},
@@ -5290,28 +5398,28 @@ var g = &grammar{
 		},
 		{
 			name: "YieldOp",
-			pos:  position{line: 805, col: 1, offset: 20086},
+			pos:  position{line: 805, col: 1, offset: 20144},
 			expr: &actionExpr{
-				pos: position{line: 806, col: 5, offset: 20098},
+				pos: position{line: 806, col: 5, offset: 20156},
 				run: (*parser).callonYieldOp1,
 				expr: &seqExpr{
-					pos: position{line: 806, col: 5, offset: 20098},
+					pos: position{line: 806, col: 5, offset: 20156},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 806, col: 5, offset: 20098},
+							pos:        position{line: 806, col: 5, offset: 20156},
 							val:        "yield",
 							ignoreCase: false,
 							want:       "\"yield\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 806, col: 13, offset: 20106},
+							pos:  position{line: 806, col: 13, offset: 20164},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 806, col: 15, offset: 20108},
+							pos:   position{line: 806, col: 15, offset: 20166},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 806, col: 21, offset: 20114},
+								pos:  position{line: 806, col: 21, offset: 20172},
 								name: "Exprs",
 							},
 						},
@@ -5323,32 +5431,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeArg",
-			pos:  position{line: 814, col: 1, offset: 20271},
+			pos:  position{line: 814, col: 1, offset: 20329},
 			expr: &actionExpr{
-				pos: position{line: 815, col: 5, offset: 20283},
+				pos: position{line: 815, col: 5, offset: 20341},
 				run: (*parser).callonTypeArg1,
 				expr: &seqExpr{
-					pos: position{line: 815, col: 5, offset: 20283},
+					pos: position{line: 815, col: 5, offset: 20341},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 815, col: 5, offset: 20283},
+							pos:  position{line: 815, col: 5, offset: 20341},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 815, col: 7, offset: 20285},
+							pos:        position{line: 815, col: 7, offset: 20343},
 							val:        "by",
 							ignoreCase: false,
 							want:       "\"by\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 815, col: 12, offset: 20290},
+							pos:  position{line: 815, col: 12, offset: 20348},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 815, col: 14, offset: 20292},
+							pos:   position{line: 815, col: 14, offset: 20350},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 815, col: 18, offset: 20296},
+								pos:  position{line: 815, col: 18, offset: 20354},
 								name: "Type",
 							},
 						},
@@ -5360,32 +5468,32 @@ var g = &grammar{
 		},
 		{
 			name: "AsArg",
-			pos:  position{line: 817, col: 1, offset: 20322},
+			pos:  position{line: 817, col: 1, offset: 20380},
 			expr: &actionExpr{
-				pos: position{line: 818, col: 5, offset: 20332},
+				pos: position{line: 818, col: 5, offset: 20390},
 				run: (*parser).callonAsArg1,
 				expr: &seqExpr{
-					pos: position{line: 818, col: 5, offset: 20332},
+					pos: position{line: 818, col: 5, offset: 20390},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 818, col: 5, offset: 20332},
+							pos:  position{line: 818, col: 5, offset: 20390},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 818, col: 7, offset: 20334},
+							pos:        position{line: 818, col: 7, offset: 20392},
 							val:        "as",
 							ignoreCase: false,
 							want:       "\"as\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 818, col: 12, offset: 20339},
+							pos:  position{line: 818, col: 12, offset: 20397},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 818, col: 14, offset: 20341},
+							pos:   position{line: 818, col: 14, offset: 20399},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 818, col: 18, offset: 20345},
+								pos:  position{line: 818, col: 18, offset: 20403},
 								name: "Lval",
 							},
 						},
@@ -5397,9 +5505,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 822, col: 1, offset: 20396},
+			pos:  position{line: 822, col: 1, offset: 20454},
 			expr: &ruleRefExpr{
-				pos:  position{line: 822, col: 8, offset: 20403},
+				pos:  position{line: 822, col: 8, offset: 20461},
 				name: "DerefExpr",
 			},
 			leader:        false,
@@ -5407,51 +5515,51 @@ var g = &grammar{
 		},
 		{
 			name: "Lvals",
-			pos:  position{line: 824, col: 1, offset: 20414},
+			pos:  position{line: 824, col: 1, offset: 20472},
 			expr: &actionExpr{
-				pos: position{line: 825, col: 5, offset: 20424},
+				pos: position{line: 825, col: 5, offset: 20482},
 				run: (*parser).callonLvals1,
 				expr: &seqExpr{
-					pos: position{line: 825, col: 5, offset: 20424},
+					pos: position{line: 825, col: 5, offset: 20482},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 825, col: 5, offset: 20424},
+							pos:   position{line: 825, col: 5, offset: 20482},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 825, col: 11, offset: 20430},
+								pos:  position{line: 825, col: 11, offset: 20488},
 								name: "Lval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 825, col: 16, offset: 20435},
+							pos:   position{line: 825, col: 16, offset: 20493},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 825, col: 21, offset: 20440},
+								pos: position{line: 825, col: 21, offset: 20498},
 								expr: &actionExpr{
-									pos: position{line: 825, col: 22, offset: 20441},
+									pos: position{line: 825, col: 22, offset: 20499},
 									run: (*parser).callonLvals7,
 									expr: &seqExpr{
-										pos: position{line: 825, col: 22, offset: 20441},
+										pos: position{line: 825, col: 22, offset: 20499},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 825, col: 22, offset: 20441},
+												pos:  position{line: 825, col: 22, offset: 20499},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 825, col: 25, offset: 20444},
+												pos:        position{line: 825, col: 25, offset: 20502},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 825, col: 29, offset: 20448},
+												pos:  position{line: 825, col: 29, offset: 20506},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 825, col: 32, offset: 20451},
+												pos:   position{line: 825, col: 32, offset: 20509},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 825, col: 37, offset: 20456},
+													pos:  position{line: 825, col: 37, offset: 20514},
 													name: "Lval",
 												},
 											},
@@ -5468,9 +5576,9 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 829, col: 1, offset: 20532},
+			pos:  position{line: 829, col: 1, offset: 20590},
 			expr: &ruleRefExpr{
-				pos:  position{line: 829, col: 13, offset: 20544},
+				pos:  position{line: 829, col: 13, offset: 20602},
 				name: "Lval",
 			},
 			leader:        false,
@@ -5478,51 +5586,51 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExprs",
-			pos:  position{line: 831, col: 1, offset: 20550},
+			pos:  position{line: 831, col: 1, offset: 20608},
 			expr: &actionExpr{
-				pos: position{line: 832, col: 5, offset: 20565},
+				pos: position{line: 832, col: 5, offset: 20623},
 				run: (*parser).callonFieldExprs1,
 				expr: &seqExpr{
-					pos: position{line: 832, col: 5, offset: 20565},
+					pos: position{line: 832, col: 5, offset: 20623},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 832, col: 5, offset: 20565},
+							pos:   position{line: 832, col: 5, offset: 20623},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 832, col: 11, offset: 20571},
+								pos:  position{line: 832, col: 11, offset: 20629},
 								name: "FieldExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 832, col: 21, offset: 20581},
+							pos:   position{line: 832, col: 21, offset: 20639},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 832, col: 26, offset: 20586},
+								pos: position{line: 832, col: 26, offset: 20644},
 								expr: &actionExpr{
-									pos: position{line: 832, col: 27, offset: 20587},
+									pos: position{line: 832, col: 27, offset: 20645},
 									run: (*parser).callonFieldExprs7,
 									expr: &seqExpr{
-										pos: position{line: 832, col: 27, offset: 20587},
+										pos: position{line: 832, col: 27, offset: 20645},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 832, col: 27, offset: 20587},
+												pos:  position{line: 832, col: 27, offset: 20645},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 832, col: 30, offset: 20590},
+												pos:        position{line: 832, col: 30, offset: 20648},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 832, col: 34, offset: 20594},
+												pos:  position{line: 832, col: 34, offset: 20652},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 832, col: 37, offset: 20597},
+												pos:   position{line: 832, col: 37, offset: 20655},
 												label: "f",
 												expr: &ruleRefExpr{
-													pos:  position{line: 832, col: 39, offset: 20599},
+													pos:  position{line: 832, col: 39, offset: 20657},
 													name: "FieldExpr",
 												},
 											},
@@ -5539,51 +5647,51 @@ var g = &grammar{
 		},
 		{
 			name: "Assignments",
-			pos:  position{line: 836, col: 1, offset: 20676},
+			pos:  position{line: 836, col: 1, offset: 20734},
 			expr: &actionExpr{
-				pos: position{line: 837, col: 5, offset: 20692},
+				pos: position{line: 837, col: 5, offset: 20750},
 				run: (*parser).callonAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 837, col: 5, offset: 20692},
+					pos: position{line: 837, col: 5, offset: 20750},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 837, col: 5, offset: 20692},
+							pos:   position{line: 837, col: 5, offset: 20750},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 837, col: 11, offset: 20698},
+								pos:  position{line: 837, col: 11, offset: 20756},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 837, col: 22, offset: 20709},
+							pos:   position{line: 837, col: 22, offset: 20767},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 837, col: 27, offset: 20714},
+								pos: position{line: 837, col: 27, offset: 20772},
 								expr: &actionExpr{
-									pos: position{line: 837, col: 28, offset: 20715},
+									pos: position{line: 837, col: 28, offset: 20773},
 									run: (*parser).callonAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 837, col: 28, offset: 20715},
+										pos: position{line: 837, col: 28, offset: 20773},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 837, col: 28, offset: 20715},
+												pos:  position{line: 837, col: 28, offset: 20773},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 837, col: 31, offset: 20718},
+												pos:        position{line: 837, col: 31, offset: 20776},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 837, col: 35, offset: 20722},
+												pos:  position{line: 837, col: 35, offset: 20780},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 837, col: 38, offset: 20725},
+												pos:   position{line: 837, col: 38, offset: 20783},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 837, col: 40, offset: 20727},
+													pos:  position{line: 837, col: 40, offset: 20785},
 													name: "Assignment",
 												},
 											},
@@ -5600,40 +5708,40 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 841, col: 1, offset: 20802},
+			pos:  position{line: 841, col: 1, offset: 20860},
 			expr: &actionExpr{
-				pos: position{line: 842, col: 5, offset: 20817},
+				pos: position{line: 842, col: 5, offset: 20875},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 842, col: 5, offset: 20817},
+					pos: position{line: 842, col: 5, offset: 20875},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 842, col: 5, offset: 20817},
+							pos:   position{line: 842, col: 5, offset: 20875},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 842, col: 9, offset: 20821},
+								pos:  position{line: 842, col: 9, offset: 20879},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 842, col: 14, offset: 20826},
+							pos:  position{line: 842, col: 14, offset: 20884},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 842, col: 17, offset: 20829},
+							pos:        position{line: 842, col: 17, offset: 20887},
 							val:        ":=",
 							ignoreCase: false,
 							want:       "\":=\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 842, col: 22, offset: 20834},
+							pos:  position{line: 842, col: 22, offset: 20892},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 842, col: 25, offset: 20837},
+							pos:   position{line: 842, col: 25, offset: 20895},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 842, col: 29, offset: 20841},
+								pos:  position{line: 842, col: 29, offset: 20899},
 								name: "Expr",
 							},
 						},
@@ -5645,9 +5753,9 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 850, col: 1, offset: 20989},
+			pos:  position{line: 850, col: 1, offset: 21047},
 			expr: &ruleRefExpr{
-				pos:  position{line: 850, col: 8, offset: 20996},
+				pos:  position{line: 850, col: 8, offset: 21054},
 				name: "ConditionalExpr",
 			},
 			leader:        false,
@@ -5655,63 +5763,63 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 852, col: 1, offset: 21013},
+			pos:  position{line: 852, col: 1, offset: 21071},
 			expr: &actionExpr{
-				pos: position{line: 853, col: 5, offset: 21033},
+				pos: position{line: 853, col: 5, offset: 21091},
 				run: (*parser).callonConditionalExpr1,
 				expr: &seqExpr{
-					pos: position{line: 853, col: 5, offset: 21033},
+					pos: position{line: 853, col: 5, offset: 21091},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 853, col: 5, offset: 21033},
+							pos:   position{line: 853, col: 5, offset: 21091},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 853, col: 10, offset: 21038},
+								pos:  position{line: 853, col: 10, offset: 21096},
 								name: "LogicalOrExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 853, col: 24, offset: 21052},
+							pos:   position{line: 853, col: 24, offset: 21110},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 853, col: 28, offset: 21056},
+								pos: position{line: 853, col: 28, offset: 21114},
 								expr: &seqExpr{
-									pos: position{line: 853, col: 29, offset: 21057},
+									pos: position{line: 853, col: 29, offset: 21115},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 853, col: 29, offset: 21057},
+											pos:  position{line: 853, col: 29, offset: 21115},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 853, col: 32, offset: 21060},
+											pos:        position{line: 853, col: 32, offset: 21118},
 											val:        "?",
 											ignoreCase: false,
 											want:       "\"?\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 853, col: 36, offset: 21064},
+											pos:  position{line: 853, col: 36, offset: 21122},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 853, col: 39, offset: 21067},
+											pos:  position{line: 853, col: 39, offset: 21125},
 											name: "Expr",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 853, col: 44, offset: 21072},
+											pos:  position{line: 853, col: 44, offset: 21130},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 853, col: 47, offset: 21075},
+											pos:        position{line: 853, col: 47, offset: 21133},
 											val:        ":",
 											ignoreCase: false,
 											want:       "\":\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 853, col: 51, offset: 21079},
+											pos:  position{line: 853, col: 51, offset: 21137},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 853, col: 54, offset: 21082},
+											pos:  position{line: 853, col: 54, offset: 21140},
 											name: "Expr",
 										},
 									},
@@ -5726,53 +5834,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 866, col: 1, offset: 21378},
+			pos:  position{line: 866, col: 1, offset: 21436},
 			expr: &actionExpr{
-				pos: position{line: 867, col: 5, offset: 21396},
+				pos: position{line: 867, col: 5, offset: 21454},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 867, col: 5, offset: 21396},
+					pos: position{line: 867, col: 5, offset: 21454},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 867, col: 5, offset: 21396},
+							pos:   position{line: 867, col: 5, offset: 21454},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 867, col: 11, offset: 21402},
+								pos:  position{line: 867, col: 11, offset: 21460},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 868, col: 5, offset: 21421},
+							pos:   position{line: 868, col: 5, offset: 21479},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 868, col: 10, offset: 21426},
+								pos: position{line: 868, col: 10, offset: 21484},
 								expr: &actionExpr{
-									pos: position{line: 868, col: 11, offset: 21427},
+									pos: position{line: 868, col: 11, offset: 21485},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 868, col: 11, offset: 21427},
+										pos: position{line: 868, col: 11, offset: 21485},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 868, col: 11, offset: 21427},
+												pos:  position{line: 868, col: 11, offset: 21485},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 868, col: 14, offset: 21430},
+												pos:   position{line: 868, col: 14, offset: 21488},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 868, col: 17, offset: 21433},
+													pos:  position{line: 868, col: 17, offset: 21491},
 													name: "OrToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 868, col: 25, offset: 21441},
+												pos:  position{line: 868, col: 25, offset: 21499},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 868, col: 28, offset: 21444},
+												pos:   position{line: 868, col: 28, offset: 21502},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 868, col: 33, offset: 21449},
+													pos:  position{line: 868, col: 33, offset: 21507},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -5789,53 +5897,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 872, col: 1, offset: 21560},
+			pos:  position{line: 872, col: 1, offset: 21618},
 			expr: &actionExpr{
-				pos: position{line: 873, col: 5, offset: 21579},
+				pos: position{line: 873, col: 5, offset: 21637},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 873, col: 5, offset: 21579},
+					pos: position{line: 873, col: 5, offset: 21637},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 873, col: 5, offset: 21579},
+							pos:   position{line: 873, col: 5, offset: 21637},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 873, col: 11, offset: 21585},
+								pos:  position{line: 873, col: 11, offset: 21643},
 								name: "ComparisonExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 874, col: 5, offset: 21604},
+							pos:   position{line: 874, col: 5, offset: 21662},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 874, col: 10, offset: 21609},
+								pos: position{line: 874, col: 10, offset: 21667},
 								expr: &actionExpr{
-									pos: position{line: 874, col: 11, offset: 21610},
+									pos: position{line: 874, col: 11, offset: 21668},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 874, col: 11, offset: 21610},
+										pos: position{line: 874, col: 11, offset: 21668},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 874, col: 11, offset: 21610},
+												pos:  position{line: 874, col: 11, offset: 21668},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 874, col: 14, offset: 21613},
+												pos:   position{line: 874, col: 14, offset: 21671},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 874, col: 17, offset: 21616},
+													pos:  position{line: 874, col: 17, offset: 21674},
 													name: "AndToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 874, col: 26, offset: 21625},
+												pos:  position{line: 874, col: 26, offset: 21683},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 874, col: 29, offset: 21628},
+												pos:   position{line: 874, col: 29, offset: 21686},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 874, col: 34, offset: 21633},
+													pos:  position{line: 874, col: 34, offset: 21691},
 													name: "ComparisonExpr",
 												},
 											},
@@ -5852,73 +5960,73 @@ var g = &grammar{
 		},
 		{
 			name: "ComparisonExpr",
-			pos:  position{line: 878, col: 1, offset: 21744},
+			pos:  position{line: 878, col: 1, offset: 21802},
 			expr: &actionExpr{
-				pos: position{line: 879, col: 5, offset: 21763},
+				pos: position{line: 879, col: 5, offset: 21821},
 				run: (*parser).callonComparisonExpr1,
 				expr: &seqExpr{
-					pos: position{line: 879, col: 5, offset: 21763},
+					pos: position{line: 879, col: 5, offset: 21821},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 879, col: 5, offset: 21763},
+							pos:   position{line: 879, col: 5, offset: 21821},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 879, col: 9, offset: 21767},
+								pos:  position{line: 879, col: 9, offset: 21825},
 								name: "AdditiveExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 879, col: 22, offset: 21780},
+							pos:   position{line: 879, col: 22, offset: 21838},
 							label: "opAndRHS",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 879, col: 31, offset: 21789},
+								pos: position{line: 879, col: 31, offset: 21847},
 								expr: &choiceExpr{
-									pos: position{line: 879, col: 32, offset: 21790},
+									pos: position{line: 879, col: 32, offset: 21848},
 									alternatives: []any{
 										&seqExpr{
-											pos: position{line: 879, col: 32, offset: 21790},
+											pos: position{line: 879, col: 32, offset: 21848},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 879, col: 32, offset: 21790},
+													pos:  position{line: 879, col: 32, offset: 21848},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 879, col: 35, offset: 21793},
+													pos:  position{line: 879, col: 35, offset: 21851},
 													name: "Comparator",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 879, col: 46, offset: 21804},
+													pos:  position{line: 879, col: 46, offset: 21862},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 879, col: 49, offset: 21807},
+													pos:  position{line: 879, col: 49, offset: 21865},
 													name: "AdditiveExpr",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 879, col: 64, offset: 21822},
+											pos: position{line: 879, col: 64, offset: 21880},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 879, col: 64, offset: 21822},
+													pos:  position{line: 879, col: 64, offset: 21880},
 													name: "__",
 												},
 												&actionExpr{
-													pos: position{line: 879, col: 68, offset: 21826},
+													pos: position{line: 879, col: 68, offset: 21884},
 													run: (*parser).callonComparisonExpr15,
 													expr: &litMatcher{
-														pos:        position{line: 879, col: 68, offset: 21826},
+														pos:        position{line: 879, col: 68, offset: 21884},
 														val:        "~",
 														ignoreCase: false,
 														want:       "\"~\"",
 													},
 												},
 												&ruleRefExpr{
-													pos:  position{line: 879, col: 104, offset: 21862},
+													pos:  position{line: 879, col: 104, offset: 21920},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 879, col: 107, offset: 21865},
+													pos:  position{line: 879, col: 107, offset: 21923},
 													name: "Regexp",
 												},
 											},
@@ -5935,53 +6043,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 891, col: 1, offset: 22129},
+			pos:  position{line: 891, col: 1, offset: 22187},
 			expr: &actionExpr{
-				pos: position{line: 892, col: 5, offset: 22146},
+				pos: position{line: 892, col: 5, offset: 22204},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 892, col: 5, offset: 22146},
+					pos: position{line: 892, col: 5, offset: 22204},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 892, col: 5, offset: 22146},
+							pos:   position{line: 892, col: 5, offset: 22204},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 892, col: 11, offset: 22152},
+								pos:  position{line: 892, col: 11, offset: 22210},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 893, col: 5, offset: 22175},
+							pos:   position{line: 893, col: 5, offset: 22233},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 893, col: 10, offset: 22180},
+								pos: position{line: 893, col: 10, offset: 22238},
 								expr: &actionExpr{
-									pos: position{line: 893, col: 11, offset: 22181},
+									pos: position{line: 893, col: 11, offset: 22239},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 893, col: 11, offset: 22181},
+										pos: position{line: 893, col: 11, offset: 22239},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 893, col: 11, offset: 22181},
+												pos:  position{line: 893, col: 11, offset: 22239},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 893, col: 14, offset: 22184},
+												pos:   position{line: 893, col: 14, offset: 22242},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 893, col: 17, offset: 22187},
+													pos:  position{line: 893, col: 17, offset: 22245},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 893, col: 34, offset: 22204},
+												pos:  position{line: 893, col: 34, offset: 22262},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 893, col: 37, offset: 22207},
+												pos:   position{line: 893, col: 37, offset: 22265},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 893, col: 42, offset: 22212},
+													pos:  position{line: 893, col: 42, offset: 22270},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -5998,21 +6106,21 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 897, col: 1, offset: 22327},
+			pos:  position{line: 897, col: 1, offset: 22385},
 			expr: &actionExpr{
-				pos: position{line: 897, col: 20, offset: 22346},
+				pos: position{line: 897, col: 20, offset: 22404},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 897, col: 21, offset: 22347},
+					pos: position{line: 897, col: 21, offset: 22405},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 897, col: 21, offset: 22347},
+							pos:        position{line: 897, col: 21, offset: 22405},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&litMatcher{
-							pos:        position{line: 897, col: 27, offset: 22353},
+							pos:        position{line: 897, col: 27, offset: 22411},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
@@ -6025,53 +6133,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 899, col: 1, offset: 22390},
+			pos:  position{line: 899, col: 1, offset: 22448},
 			expr: &actionExpr{
-				pos: position{line: 900, col: 5, offset: 22413},
+				pos: position{line: 900, col: 5, offset: 22471},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 900, col: 5, offset: 22413},
+					pos: position{line: 900, col: 5, offset: 22471},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 900, col: 5, offset: 22413},
+							pos:   position{line: 900, col: 5, offset: 22471},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 900, col: 11, offset: 22419},
+								pos:  position{line: 900, col: 11, offset: 22477},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 901, col: 5, offset: 22431},
+							pos:   position{line: 901, col: 5, offset: 22489},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 901, col: 10, offset: 22436},
+								pos: position{line: 901, col: 10, offset: 22494},
 								expr: &actionExpr{
-									pos: position{line: 901, col: 11, offset: 22437},
+									pos: position{line: 901, col: 11, offset: 22495},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 901, col: 11, offset: 22437},
+										pos: position{line: 901, col: 11, offset: 22495},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 901, col: 11, offset: 22437},
+												pos:  position{line: 901, col: 11, offset: 22495},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 901, col: 14, offset: 22440},
+												pos:   position{line: 901, col: 14, offset: 22498},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 901, col: 17, offset: 22443},
+													pos:  position{line: 901, col: 17, offset: 22501},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 901, col: 40, offset: 22466},
+												pos:  position{line: 901, col: 40, offset: 22524},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 901, col: 43, offset: 22469},
+												pos:   position{line: 901, col: 43, offset: 22527},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 901, col: 48, offset: 22474},
+													pos:  position{line: 901, col: 48, offset: 22532},
 													name: "NotExpr",
 												},
 											},
@@ -6088,27 +6196,27 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 905, col: 1, offset: 22578},
+			pos:  position{line: 905, col: 1, offset: 22636},
 			expr: &actionExpr{
-				pos: position{line: 905, col: 26, offset: 22603},
+				pos: position{line: 905, col: 26, offset: 22661},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 905, col: 27, offset: 22604},
+					pos: position{line: 905, col: 27, offset: 22662},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 905, col: 27, offset: 22604},
+							pos:        position{line: 905, col: 27, offset: 22662},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&litMatcher{
-							pos:        position{line: 905, col: 33, offset: 22610},
+							pos:        position{line: 905, col: 33, offset: 22668},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&litMatcher{
-							pos:        position{line: 905, col: 39, offset: 22616},
+							pos:        position{line: 905, col: 39, offset: 22674},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
@@ -6121,43 +6229,43 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 907, col: 1, offset: 22653},
+			pos:  position{line: 907, col: 1, offset: 22711},
 			expr: &choiceExpr{
-				pos: position{line: 908, col: 5, offset: 22665},
+				pos: position{line: 908, col: 5, offset: 22723},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 908, col: 5, offset: 22665},
+						pos: position{line: 908, col: 5, offset: 22723},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 908, col: 5, offset: 22665},
+							pos: position{line: 908, col: 5, offset: 22723},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 908, col: 6, offset: 22666},
+									pos: position{line: 908, col: 6, offset: 22724},
 									alternatives: []any{
 										&seqExpr{
-											pos: position{line: 908, col: 6, offset: 22666},
+											pos: position{line: 908, col: 6, offset: 22724},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 908, col: 6, offset: 22666},
+													pos:  position{line: 908, col: 6, offset: 22724},
 													name: "NotToken",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 908, col: 15, offset: 22675},
+													pos:  position{line: 908, col: 15, offset: 22733},
 													name: "_",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 908, col: 19, offset: 22679},
+											pos: position{line: 908, col: 19, offset: 22737},
 											exprs: []any{
 												&litMatcher{
-													pos:        position{line: 908, col: 19, offset: 22679},
+													pos:        position{line: 908, col: 19, offset: 22737},
 													val:        "!",
 													ignoreCase: false,
 													want:       "\"!\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 908, col: 23, offset: 22683},
+													pos:  position{line: 908, col: 23, offset: 22741},
 													name: "__",
 												},
 											},
@@ -6165,10 +6273,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 908, col: 27, offset: 22687},
+									pos:   position{line: 908, col: 27, offset: 22745},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 908, col: 29, offset: 22689},
+										pos:  position{line: 908, col: 29, offset: 22747},
 										name: "NotExpr",
 									},
 								},
@@ -6176,7 +6284,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 916, col: 5, offset: 22863},
+						pos:  position{line: 916, col: 5, offset: 22921},
 						name: "NegationExpr",
 					},
 				},
@@ -6186,38 +6294,38 @@ var g = &grammar{
 		},
 		{
 			name: "NegationExpr",
-			pos:  position{line: 918, col: 1, offset: 22877},
+			pos:  position{line: 918, col: 1, offset: 22935},
 			expr: &choiceExpr{
-				pos: position{line: 919, col: 5, offset: 22894},
+				pos: position{line: 919, col: 5, offset: 22952},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 919, col: 5, offset: 22894},
+						pos: position{line: 919, col: 5, offset: 22952},
 						run: (*parser).callonNegationExpr2,
 						expr: &seqExpr{
-							pos: position{line: 919, col: 5, offset: 22894},
+							pos: position{line: 919, col: 5, offset: 22952},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 919, col: 5, offset: 22894},
+									pos: position{line: 919, col: 5, offset: 22952},
 									expr: &ruleRefExpr{
-										pos:  position{line: 919, col: 6, offset: 22895},
+										pos:  position{line: 919, col: 6, offset: 22953},
 										name: "Literal",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 919, col: 14, offset: 22903},
+									pos:        position{line: 919, col: 14, offset: 22961},
 									val:        "-",
 									ignoreCase: false,
 									want:       "\"-\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 919, col: 18, offset: 22907},
+									pos:  position{line: 919, col: 18, offset: 22965},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 919, col: 21, offset: 22910},
+									pos:   position{line: 919, col: 21, offset: 22968},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 919, col: 23, offset: 22912},
+										pos:  position{line: 919, col: 23, offset: 22970},
 										name: "DerefExpr",
 									},
 								},
@@ -6225,7 +6333,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 927, col: 5, offset: 23088},
+						pos:  position{line: 927, col: 5, offset: 23146},
 						name: "DerefExpr",
 					},
 				},
@@ -6235,65 +6343,65 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 929, col: 1, offset: 23099},
+			pos:  position{line: 929, col: 1, offset: 23157},
 			expr: &choiceExpr{
-				pos: position{line: 930, col: 5, offset: 23113},
+				pos: position{line: 930, col: 5, offset: 23171},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 930, col: 5, offset: 23113},
+						pos: position{line: 930, col: 5, offset: 23171},
 						run: (*parser).callonDerefExpr2,
 						expr: &seqExpr{
-							pos: position{line: 930, col: 5, offset: 23113},
+							pos: position{line: 930, col: 5, offset: 23171},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 930, col: 5, offset: 23113},
+									pos:   position{line: 930, col: 5, offset: 23171},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 930, col: 10, offset: 23118},
+										pos:  position{line: 930, col: 10, offset: 23176},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 930, col: 20, offset: 23128},
+									pos:        position{line: 930, col: 20, offset: 23186},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 930, col: 24, offset: 23132},
+									pos:   position{line: 930, col: 24, offset: 23190},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 930, col: 29, offset: 23137},
+										pos:  position{line: 930, col: 29, offset: 23195},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 930, col: 42, offset: 23150},
+									pos:  position{line: 930, col: 42, offset: 23208},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 930, col: 45, offset: 23153},
+									pos:        position{line: 930, col: 45, offset: 23211},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 930, col: 49, offset: 23157},
+									pos:  position{line: 930, col: 49, offset: 23215},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 930, col: 52, offset: 23160},
+									pos:   position{line: 930, col: 52, offset: 23218},
 									label: "to",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 930, col: 55, offset: 23163},
+										pos: position{line: 930, col: 55, offset: 23221},
 										expr: &ruleRefExpr{
-											pos:  position{line: 930, col: 55, offset: 23163},
+											pos:  position{line: 930, col: 55, offset: 23221},
 											name: "AdditiveExpr",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 930, col: 69, offset: 23177},
+									pos:        position{line: 930, col: 69, offset: 23235},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6302,49 +6410,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 942, col: 5, offset: 23428},
+						pos: position{line: 942, col: 5, offset: 23486},
 						run: (*parser).callonDerefExpr16,
 						expr: &seqExpr{
-							pos: position{line: 942, col: 5, offset: 23428},
+							pos: position{line: 942, col: 5, offset: 23486},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 942, col: 5, offset: 23428},
+									pos:   position{line: 942, col: 5, offset: 23486},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 942, col: 10, offset: 23433},
+										pos:  position{line: 942, col: 10, offset: 23491},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 942, col: 20, offset: 23443},
+									pos:        position{line: 942, col: 20, offset: 23501},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 942, col: 24, offset: 23447},
+									pos:  position{line: 942, col: 24, offset: 23505},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 942, col: 27, offset: 23450},
+									pos:        position{line: 942, col: 27, offset: 23508},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 942, col: 31, offset: 23454},
+									pos:  position{line: 942, col: 31, offset: 23512},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 942, col: 34, offset: 23457},
+									pos:   position{line: 942, col: 34, offset: 23515},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 942, col: 37, offset: 23460},
+										pos:  position{line: 942, col: 37, offset: 23518},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 942, col: 50, offset: 23473},
+									pos:        position{line: 942, col: 50, offset: 23531},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6353,35 +6461,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 950, col: 5, offset: 23649},
+						pos: position{line: 950, col: 5, offset: 23707},
 						run: (*parser).callonDerefExpr27,
 						expr: &seqExpr{
-							pos: position{line: 950, col: 5, offset: 23649},
+							pos: position{line: 950, col: 5, offset: 23707},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 950, col: 5, offset: 23649},
+									pos:   position{line: 950, col: 5, offset: 23707},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 950, col: 10, offset: 23654},
+										pos:  position{line: 950, col: 10, offset: 23712},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 950, col: 20, offset: 23664},
+									pos:        position{line: 950, col: 20, offset: 23722},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 950, col: 24, offset: 23668},
+									pos:   position{line: 950, col: 24, offset: 23726},
 									label: "index",
 									expr: &ruleRefExpr{
-										pos:  position{line: 950, col: 30, offset: 23674},
+										pos:  position{line: 950, col: 30, offset: 23732},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 950, col: 35, offset: 23679},
+									pos:        position{line: 950, col: 35, offset: 23737},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6390,30 +6498,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 958, col: 5, offset: 23861},
+						pos: position{line: 958, col: 5, offset: 23919},
 						run: (*parser).callonDerefExpr35,
 						expr: &seqExpr{
-							pos: position{line: 958, col: 5, offset: 23861},
+							pos: position{line: 958, col: 5, offset: 23919},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 958, col: 5, offset: 23861},
+									pos:   position{line: 958, col: 5, offset: 23919},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 958, col: 10, offset: 23866},
+										pos:  position{line: 958, col: 10, offset: 23924},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 958, col: 20, offset: 23876},
+									pos:        position{line: 958, col: 20, offset: 23934},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 958, col: 24, offset: 23880},
+									pos:   position{line: 958, col: 24, offset: 23938},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 958, col: 27, offset: 23883},
+										pos:  position{line: 958, col: 27, offset: 23941},
 										name: "Identifier",
 									},
 								},
@@ -6421,25 +6529,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 966, col: 5, offset: 24052},
+						pos: position{line: 966, col: 5, offset: 24110},
 						run: (*parser).callonDerefExpr42,
 						expr: &labeledExpr{
-							pos:   position{line: 966, col: 5, offset: 24052},
+							pos:   position{line: 966, col: 5, offset: 24110},
 							label: "fn",
 							expr: &ruleRefExpr{
-								pos:  position{line: 966, col: 8, offset: 24055},
+								pos:  position{line: 966, col: 8, offset: 24113},
 								name: "FuncExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 969, col: 5, offset: 24097},
+						pos: position{line: 969, col: 5, offset: 24155},
 						run: (*parser).callonDerefExpr45,
 						expr: &labeledExpr{
-							pos:   position{line: 969, col: 5, offset: 24097},
+							pos:   position{line: 969, col: 5, offset: 24155},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 969, col: 10, offset: 24102},
+								pos:  position{line: 969, col: 10, offset: 24160},
 								name: "Primary",
 							},
 						},
@@ -6451,30 +6559,30 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 974, col: 1, offset: 24143},
+			pos:  position{line: 974, col: 1, offset: 24201},
 			expr: &choiceExpr{
-				pos: position{line: 975, col: 5, offset: 24156},
+				pos: position{line: 975, col: 5, offset: 24214},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 975, col: 5, offset: 24156},
+						pos: position{line: 975, col: 5, offset: 24214},
 						run: (*parser).callonFuncExpr2,
 						expr: &labeledExpr{
-							pos:   position{line: 975, col: 5, offset: 24156},
+							pos:   position{line: 975, col: 5, offset: 24214},
 							label: "cast",
 							expr: &ruleRefExpr{
-								pos:  position{line: 975, col: 10, offset: 24161},
+								pos:  position{line: 975, col: 10, offset: 24219},
 								name: "Cast",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 978, col: 5, offset: 24201},
+						pos: position{line: 978, col: 5, offset: 24259},
 						run: (*parser).callonFuncExpr5,
 						expr: &labeledExpr{
-							pos:   position{line: 978, col: 5, offset: 24201},
+							pos:   position{line: 978, col: 5, offset: 24259},
 							label: "fn",
 							expr: &ruleRefExpr{
-								pos:  position{line: 978, col: 8, offset: 24204},
+								pos:  position{line: 978, col: 8, offset: 24262},
 								name: "Function",
 							},
 						},
@@ -6486,20 +6594,20 @@ var g = &grammar{
 		},
 		{
 			name: "FuncGuard",
-			pos:  position{line: 982, col: 1, offset: 24243},
+			pos:  position{line: 982, col: 1, offset: 24301},
 			expr: &seqExpr{
-				pos: position{line: 982, col: 13, offset: 24255},
+				pos: position{line: 982, col: 13, offset: 24313},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 982, col: 13, offset: 24255},
+						pos:  position{line: 982, col: 13, offset: 24313},
 						name: "NotFuncs",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 982, col: 22, offset: 24264},
+						pos:  position{line: 982, col: 22, offset: 24322},
 						name: "__",
 					},
 					&litMatcher{
-						pos:        position{line: 982, col: 25, offset: 24267},
+						pos:        position{line: 982, col: 25, offset: 24325},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
@@ -6511,18 +6619,18 @@ var g = &grammar{
 		},
 		{
 			name: "NotFuncs",
-			pos:  position{line: 984, col: 1, offset: 24272},
+			pos:  position{line: 984, col: 1, offset: 24330},
 			expr: &choiceExpr{
-				pos: position{line: 985, col: 5, offset: 24285},
+				pos: position{line: 985, col: 5, offset: 24343},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 985, col: 5, offset: 24285},
+						pos:        position{line: 985, col: 5, offset: 24343},
 						val:        "not",
 						ignoreCase: false,
 						want:       "\"not\"",
 					},
 					&litMatcher{
-						pos:        position{line: 986, col: 5, offset: 24295},
+						pos:        position{line: 986, col: 5, offset: 24353},
 						val:        "select",
 						ignoreCase: false,
 						want:       "\"select\"",
@@ -6534,58 +6642,58 @@ var g = &grammar{
 		},
 		{
 			name: "Cast",
-			pos:  position{line: 988, col: 1, offset: 24305},
+			pos:  position{line: 988, col: 1, offset: 24363},
 			expr: &actionExpr{
-				pos: position{line: 989, col: 5, offset: 24314},
+				pos: position{line: 989, col: 5, offset: 24372},
 				run: (*parser).callonCast1,
 				expr: &seqExpr{
-					pos: position{line: 989, col: 5, offset: 24314},
+					pos: position{line: 989, col: 5, offset: 24372},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 989, col: 5, offset: 24314},
+							pos:   position{line: 989, col: 5, offset: 24372},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 989, col: 9, offset: 24318},
+								pos:  position{line: 989, col: 9, offset: 24376},
 								name: "TypeLiteral",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 989, col: 21, offset: 24330},
+							pos:  position{line: 989, col: 21, offset: 24388},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 989, col: 24, offset: 24333},
+							pos:        position{line: 989, col: 24, offset: 24391},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 989, col: 28, offset: 24337},
+							pos:  position{line: 989, col: 28, offset: 24395},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 989, col: 31, offset: 24340},
+							pos:   position{line: 989, col: 31, offset: 24398},
 							label: "expr",
 							expr: &choiceExpr{
-								pos: position{line: 989, col: 37, offset: 24346},
+								pos: position{line: 989, col: 37, offset: 24404},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 989, col: 37, offset: 24346},
+										pos:  position{line: 989, col: 37, offset: 24404},
 										name: "OverExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 989, col: 48, offset: 24357},
+										pos:  position{line: 989, col: 48, offset: 24415},
 										name: "Expr",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 989, col: 54, offset: 24363},
+							pos:  position{line: 989, col: 54, offset: 24421},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 989, col: 57, offset: 24366},
+							pos:        position{line: 989, col: 57, offset: 24424},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -6598,87 +6706,87 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 993, col: 1, offset: 24491},
+			pos:  position{line: 993, col: 1, offset: 24549},
 			expr: &choiceExpr{
-				pos: position{line: 994, col: 5, offset: 24504},
+				pos: position{line: 994, col: 5, offset: 24562},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 994, col: 5, offset: 24504},
+						pos:  position{line: 994, col: 5, offset: 24562},
 						name: "Grep",
 					},
 					&actionExpr{
-						pos: position{line: 996, col: 5, offset: 24591},
+						pos: position{line: 996, col: 5, offset: 24649},
 						run: (*parser).callonFunction3,
 						expr: &seqExpr{
-							pos: position{line: 996, col: 5, offset: 24591},
+							pos: position{line: 996, col: 5, offset: 24649},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 996, col: 5, offset: 24591},
+									pos:        position{line: 996, col: 5, offset: 24649},
 									val:        "regexp",
 									ignoreCase: false,
 									want:       "\"regexp\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 996, col: 14, offset: 24600},
+									pos:  position{line: 996, col: 14, offset: 24658},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 996, col: 17, offset: 24603},
+									pos:        position{line: 996, col: 17, offset: 24661},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 996, col: 21, offset: 24607},
+									pos:  position{line: 996, col: 21, offset: 24665},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 996, col: 24, offset: 24610},
+									pos:   position{line: 996, col: 24, offset: 24668},
 									label: "arg0",
 									expr: &ruleRefExpr{
-										pos:  position{line: 996, col: 29, offset: 24615},
+										pos:  position{line: 996, col: 29, offset: 24673},
 										name: "RegexpPrimitive",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 996, col: 45, offset: 24631},
+									pos:  position{line: 996, col: 45, offset: 24689},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 996, col: 48, offset: 24634},
+									pos:        position{line: 996, col: 48, offset: 24692},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 996, col: 52, offset: 24638},
+									pos:  position{line: 996, col: 52, offset: 24696},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 996, col: 55, offset: 24641},
+									pos:   position{line: 996, col: 55, offset: 24699},
 									label: "arg1",
 									expr: &ruleRefExpr{
-										pos:  position{line: 996, col: 60, offset: 24646},
+										pos:  position{line: 996, col: 60, offset: 24704},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 996, col: 65, offset: 24651},
+									pos:  position{line: 996, col: 65, offset: 24709},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 996, col: 68, offset: 24654},
+									pos:        position{line: 996, col: 68, offset: 24712},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 996, col: 72, offset: 24658},
+									pos:   position{line: 996, col: 72, offset: 24716},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 996, col: 78, offset: 24664},
+										pos: position{line: 996, col: 78, offset: 24722},
 										expr: &ruleRefExpr{
-											pos:  position{line: 996, col: 78, offset: 24664},
+											pos:  position{line: 996, col: 78, offset: 24722},
 											name: "WhereClause",
 										},
 									},
@@ -6687,100 +6795,100 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1000, col: 5, offset: 24819},
+						pos: position{line: 1000, col: 5, offset: 24877},
 						run: (*parser).callonFunction21,
 						expr: &seqExpr{
-							pos: position{line: 1000, col: 5, offset: 24819},
+							pos: position{line: 1000, col: 5, offset: 24877},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1000, col: 5, offset: 24819},
+									pos:        position{line: 1000, col: 5, offset: 24877},
 									val:        "regexp_replace",
 									ignoreCase: false,
 									want:       "\"regexp_replace\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1000, col: 22, offset: 24836},
+									pos:  position{line: 1000, col: 22, offset: 24894},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1000, col: 25, offset: 24839},
+									pos:        position{line: 1000, col: 25, offset: 24897},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1000, col: 29, offset: 24843},
+									pos:  position{line: 1000, col: 29, offset: 24901},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1000, col: 32, offset: 24846},
+									pos:   position{line: 1000, col: 32, offset: 24904},
 									label: "arg0",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1000, col: 37, offset: 24851},
+										pos:  position{line: 1000, col: 37, offset: 24909},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1000, col: 42, offset: 24856},
+									pos:  position{line: 1000, col: 42, offset: 24914},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1000, col: 45, offset: 24859},
+									pos:        position{line: 1000, col: 45, offset: 24917},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1000, col: 49, offset: 24863},
+									pos:  position{line: 1000, col: 49, offset: 24921},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1000, col: 52, offset: 24866},
+									pos:   position{line: 1000, col: 52, offset: 24924},
 									label: "arg1",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1000, col: 57, offset: 24871},
+										pos:  position{line: 1000, col: 57, offset: 24929},
 										name: "RegexpPrimitive",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1000, col: 73, offset: 24887},
+									pos:  position{line: 1000, col: 73, offset: 24945},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1000, col: 76, offset: 24890},
+									pos:        position{line: 1000, col: 76, offset: 24948},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1000, col: 80, offset: 24894},
+									pos:  position{line: 1000, col: 80, offset: 24952},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1000, col: 83, offset: 24897},
+									pos:   position{line: 1000, col: 83, offset: 24955},
 									label: "arg2",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1000, col: 88, offset: 24902},
+										pos:  position{line: 1000, col: 88, offset: 24960},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1000, col: 93, offset: 24907},
+									pos:  position{line: 1000, col: 93, offset: 24965},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1000, col: 96, offset: 24910},
+									pos:        position{line: 1000, col: 96, offset: 24968},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1000, col: 100, offset: 24914},
+									pos:   position{line: 1000, col: 100, offset: 24972},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1000, col: 106, offset: 24920},
+										pos: position{line: 1000, col: 106, offset: 24978},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1000, col: 106, offset: 24920},
+											pos:  position{line: 1000, col: 106, offset: 24978},
 											name: "WhereClause",
 										},
 									},
@@ -6789,65 +6897,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1004, col: 5, offset: 25089},
+						pos: position{line: 1004, col: 5, offset: 25147},
 						run: (*parser).callonFunction44,
 						expr: &seqExpr{
-							pos: position{line: 1004, col: 5, offset: 25089},
+							pos: position{line: 1004, col: 5, offset: 25147},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1004, col: 5, offset: 25089},
+									pos: position{line: 1004, col: 5, offset: 25147},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1004, col: 6, offset: 25090},
+										pos:  position{line: 1004, col: 6, offset: 25148},
 										name: "FuncGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1004, col: 16, offset: 25100},
+									pos:   position{line: 1004, col: 16, offset: 25158},
 									label: "fn",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1004, col: 19, offset: 25103},
+										pos:  position{line: 1004, col: 19, offset: 25161},
 										name: "Identifier",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1004, col: 30, offset: 25114},
+									pos:  position{line: 1004, col: 30, offset: 25172},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1004, col: 33, offset: 25117},
+									pos:        position{line: 1004, col: 33, offset: 25175},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1004, col: 37, offset: 25121},
+									pos:  position{line: 1004, col: 37, offset: 25179},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1004, col: 40, offset: 25124},
+									pos:   position{line: 1004, col: 40, offset: 25182},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1004, col: 45, offset: 25129},
+										pos:  position{line: 1004, col: 45, offset: 25187},
 										name: "FunctionArgs",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1004, col: 58, offset: 25142},
+									pos:  position{line: 1004, col: 58, offset: 25200},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1004, col: 61, offset: 25145},
+									pos:        position{line: 1004, col: 61, offset: 25203},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1004, col: 65, offset: 25149},
+									pos:   position{line: 1004, col: 65, offset: 25207},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1004, col: 71, offset: 25155},
+										pos: position{line: 1004, col: 71, offset: 25213},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1004, col: 71, offset: 25155},
+											pos:  position{line: 1004, col: 71, offset: 25213},
 											name: "WhereClause",
 										},
 									},
@@ -6862,15 +6970,15 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPrimitive",
-			pos:  position{line: 1008, col: 1, offset: 25223},
+			pos:  position{line: 1008, col: 1, offset: 25281},
 			expr: &actionExpr{
-				pos: position{line: 1009, col: 5, offset: 25243},
+				pos: position{line: 1009, col: 5, offset: 25301},
 				run: (*parser).callonRegexpPrimitive1,
 				expr: &labeledExpr{
-					pos:   position{line: 1009, col: 5, offset: 25243},
+					pos:   position{line: 1009, col: 5, offset: 25301},
 					label: "pat",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1009, col: 9, offset: 25247},
+						pos:  position{line: 1009, col: 9, offset: 25305},
 						name: "RegexpPattern",
 					},
 				},
@@ -6880,24 +6988,24 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionArgs",
-			pos:  position{line: 1011, col: 1, offset: 25318},
+			pos:  position{line: 1011, col: 1, offset: 25376},
 			expr: &choiceExpr{
-				pos: position{line: 1012, col: 5, offset: 25335},
+				pos: position{line: 1012, col: 5, offset: 25393},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1012, col: 5, offset: 25335},
+						pos: position{line: 1012, col: 5, offset: 25393},
 						run: (*parser).callonFunctionArgs2,
 						expr: &labeledExpr{
-							pos:   position{line: 1012, col: 5, offset: 25335},
+							pos:   position{line: 1012, col: 5, offset: 25393},
 							label: "o",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1012, col: 7, offset: 25337},
+								pos:  position{line: 1012, col: 7, offset: 25395},
 								name: "OverExpr",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1013, col: 5, offset: 25375},
+						pos:  position{line: 1013, col: 5, offset: 25433},
 						name: "OptionalExprs",
 					},
 				},
@@ -6907,98 +7015,98 @@ var g = &grammar{
 		},
 		{
 			name: "Grep",
-			pos:  position{line: 1015, col: 1, offset: 25390},
+			pos:  position{line: 1015, col: 1, offset: 25448},
 			expr: &actionExpr{
-				pos: position{line: 1016, col: 5, offset: 25399},
+				pos: position{line: 1016, col: 5, offset: 25457},
 				run: (*parser).callonGrep1,
 				expr: &seqExpr{
-					pos: position{line: 1016, col: 5, offset: 25399},
+					pos: position{line: 1016, col: 5, offset: 25457},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1016, col: 5, offset: 25399},
+							pos:        position{line: 1016, col: 5, offset: 25457},
 							val:        "grep",
 							ignoreCase: false,
 							want:       "\"grep\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1016, col: 12, offset: 25406},
+							pos:  position{line: 1016, col: 12, offset: 25464},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1016, col: 15, offset: 25409},
+							pos:        position{line: 1016, col: 15, offset: 25467},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1016, col: 19, offset: 25413},
+							pos:  position{line: 1016, col: 19, offset: 25471},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1016, col: 22, offset: 25416},
+							pos:   position{line: 1016, col: 22, offset: 25474},
 							label: "pattern",
 							expr: &choiceExpr{
-								pos: position{line: 1016, col: 31, offset: 25425},
+								pos: position{line: 1016, col: 31, offset: 25483},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1016, col: 31, offset: 25425},
+										pos:  position{line: 1016, col: 31, offset: 25483},
 										name: "Regexp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1016, col: 40, offset: 25434},
+										pos:  position{line: 1016, col: 40, offset: 25492},
 										name: "Glob",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1016, col: 47, offset: 25441},
+										pos:  position{line: 1016, col: 47, offset: 25499},
 										name: "Expr",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1016, col: 53, offset: 25447},
+							pos:  position{line: 1016, col: 53, offset: 25505},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1016, col: 56, offset: 25450},
+							pos:   position{line: 1016, col: 56, offset: 25508},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1016, col: 60, offset: 25454},
+								pos: position{line: 1016, col: 60, offset: 25512},
 								expr: &actionExpr{
-									pos: position{line: 1016, col: 61, offset: 25455},
+									pos: position{line: 1016, col: 61, offset: 25513},
 									run: (*parser).callonGrep15,
 									expr: &seqExpr{
-										pos: position{line: 1016, col: 61, offset: 25455},
+										pos: position{line: 1016, col: 61, offset: 25513},
 										exprs: []any{
 											&litMatcher{
-												pos:        position{line: 1016, col: 61, offset: 25455},
+												pos:        position{line: 1016, col: 61, offset: 25513},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1016, col: 65, offset: 25459},
+												pos:  position{line: 1016, col: 65, offset: 25517},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1016, col: 68, offset: 25462},
+												pos:   position{line: 1016, col: 68, offset: 25520},
 												label: "e",
 												expr: &choiceExpr{
-													pos: position{line: 1016, col: 71, offset: 25465},
+													pos: position{line: 1016, col: 71, offset: 25523},
 													alternatives: []any{
 														&ruleRefExpr{
-															pos:  position{line: 1016, col: 71, offset: 25465},
+															pos:  position{line: 1016, col: 71, offset: 25523},
 															name: "OverExpr",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 1016, col: 82, offset: 25476},
+															pos:  position{line: 1016, col: 82, offset: 25534},
 															name: "Expr",
 														},
 													},
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1016, col: 88, offset: 25482},
+												pos:  position{line: 1016, col: 88, offset: 25540},
 												name: "__",
 											},
 										},
@@ -7007,7 +7115,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1016, col: 111, offset: 25505},
+							pos:        position{line: 1016, col: 111, offset: 25563},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -7020,19 +7128,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptionalExprs",
-			pos:  position{line: 1029, col: 1, offset: 25766},
+			pos:  position{line: 1029, col: 1, offset: 25824},
 			expr: &choiceExpr{
-				pos: position{line: 1030, col: 5, offset: 25784},
+				pos: position{line: 1030, col: 5, offset: 25842},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1030, col: 5, offset: 25784},
+						pos:  position{line: 1030, col: 5, offset: 25842},
 						name: "Exprs",
 					},
 					&actionExpr{
-						pos: position{line: 1031, col: 5, offset: 25794},
+						pos: position{line: 1031, col: 5, offset: 25852},
 						run: (*parser).callonOptionalExprs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1031, col: 5, offset: 25794},
+							pos:  position{line: 1031, col: 5, offset: 25852},
 							name: "__",
 						},
 					},
@@ -7043,51 +7151,51 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 1033, col: 1, offset: 25822},
+			pos:  position{line: 1033, col: 1, offset: 25880},
 			expr: &actionExpr{
-				pos: position{line: 1034, col: 5, offset: 25832},
+				pos: position{line: 1034, col: 5, offset: 25890},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 1034, col: 5, offset: 25832},
+					pos: position{line: 1034, col: 5, offset: 25890},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1034, col: 5, offset: 25832},
+							pos:   position{line: 1034, col: 5, offset: 25890},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1034, col: 11, offset: 25838},
+								pos:  position{line: 1034, col: 11, offset: 25896},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1034, col: 16, offset: 25843},
+							pos:   position{line: 1034, col: 16, offset: 25901},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1034, col: 21, offset: 25848},
+								pos: position{line: 1034, col: 21, offset: 25906},
 								expr: &actionExpr{
-									pos: position{line: 1034, col: 22, offset: 25849},
+									pos: position{line: 1034, col: 22, offset: 25907},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 1034, col: 22, offset: 25849},
+										pos: position{line: 1034, col: 22, offset: 25907},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1034, col: 22, offset: 25849},
+												pos:  position{line: 1034, col: 22, offset: 25907},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1034, col: 25, offset: 25852},
+												pos:        position{line: 1034, col: 25, offset: 25910},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1034, col: 29, offset: 25856},
+												pos:  position{line: 1034, col: 29, offset: 25914},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1034, col: 32, offset: 25859},
+												pos:   position{line: 1034, col: 32, offset: 25917},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1034, col: 34, offset: 25861},
+													pos:  position{line: 1034, col: 34, offset: 25919},
 													name: "Expr",
 												},
 											},
@@ -7104,64 +7212,64 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 1038, col: 1, offset: 25934},
+			pos:  position{line: 1038, col: 1, offset: 25992},
 			expr: &choiceExpr{
-				pos: position{line: 1039, col: 5, offset: 25946},
+				pos: position{line: 1039, col: 5, offset: 26004},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1039, col: 5, offset: 25946},
+						pos:  position{line: 1039, col: 5, offset: 26004},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1040, col: 5, offset: 25957},
+						pos:  position{line: 1040, col: 5, offset: 26015},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1041, col: 5, offset: 25967},
+						pos:  position{line: 1041, col: 5, offset: 26025},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1042, col: 5, offset: 25975},
+						pos:  position{line: 1042, col: 5, offset: 26033},
 						name: "Map",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1043, col: 5, offset: 25983},
+						pos:  position{line: 1043, col: 5, offset: 26041},
 						name: "Literal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1044, col: 5, offset: 25995},
+						pos:  position{line: 1044, col: 5, offset: 26053},
 						name: "Identifier",
 					},
 					&actionExpr{
-						pos: position{line: 1045, col: 5, offset: 26010},
+						pos: position{line: 1045, col: 5, offset: 26068},
 						run: (*parser).callonPrimary8,
 						expr: &seqExpr{
-							pos: position{line: 1045, col: 5, offset: 26010},
+							pos: position{line: 1045, col: 5, offset: 26068},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1045, col: 5, offset: 26010},
+									pos:        position{line: 1045, col: 5, offset: 26068},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1045, col: 9, offset: 26014},
+									pos:  position{line: 1045, col: 9, offset: 26072},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1045, col: 12, offset: 26017},
+									pos:   position{line: 1045, col: 12, offset: 26075},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1045, col: 17, offset: 26022},
+										pos:  position{line: 1045, col: 17, offset: 26080},
 										name: "OverExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1045, col: 26, offset: 26031},
+									pos:  position{line: 1045, col: 26, offset: 26089},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1045, col: 29, offset: 26034},
+									pos:        position{line: 1045, col: 29, offset: 26092},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7170,35 +7278,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1046, col: 5, offset: 26063},
+						pos: position{line: 1046, col: 5, offset: 26121},
 						run: (*parser).callonPrimary16,
 						expr: &seqExpr{
-							pos: position{line: 1046, col: 5, offset: 26063},
+							pos: position{line: 1046, col: 5, offset: 26121},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1046, col: 5, offset: 26063},
+									pos:        position{line: 1046, col: 5, offset: 26121},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1046, col: 9, offset: 26067},
+									pos:  position{line: 1046, col: 9, offset: 26125},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1046, col: 12, offset: 26070},
+									pos:   position{line: 1046, col: 12, offset: 26128},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1046, col: 17, offset: 26075},
+										pos:  position{line: 1046, col: 17, offset: 26133},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1046, col: 22, offset: 26080},
+									pos:  position{line: 1046, col: 22, offset: 26138},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1046, col: 25, offset: 26083},
+									pos:        position{line: 1046, col: 25, offset: 26141},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7213,61 +7321,61 @@ var g = &grammar{
 		},
 		{
 			name: "OverExpr",
-			pos:  position{line: 1048, col: 1, offset: 26109},
+			pos:  position{line: 1048, col: 1, offset: 26167},
 			expr: &actionExpr{
-				pos: position{line: 1049, col: 5, offset: 26122},
+				pos: position{line: 1049, col: 5, offset: 26180},
 				run: (*parser).callonOverExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1049, col: 5, offset: 26122},
+					pos: position{line: 1049, col: 5, offset: 26180},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1049, col: 5, offset: 26122},
+							pos:        position{line: 1049, col: 5, offset: 26180},
 							val:        "over",
 							ignoreCase: false,
 							want:       "\"over\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1049, col: 12, offset: 26129},
+							pos:  position{line: 1049, col: 12, offset: 26187},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1049, col: 14, offset: 26131},
+							pos:   position{line: 1049, col: 14, offset: 26189},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1049, col: 20, offset: 26137},
+								pos:  position{line: 1049, col: 20, offset: 26195},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1049, col: 26, offset: 26143},
+							pos:   position{line: 1049, col: 26, offset: 26201},
 							label: "locals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1049, col: 33, offset: 26150},
+								pos: position{line: 1049, col: 33, offset: 26208},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1049, col: 33, offset: 26150},
+									pos:  position{line: 1049, col: 33, offset: 26208},
 									name: "Locals",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1049, col: 41, offset: 26158},
+							pos:  position{line: 1049, col: 41, offset: 26216},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1049, col: 44, offset: 26161},
+							pos:        position{line: 1049, col: 44, offset: 26219},
 							val:        "|",
 							ignoreCase: false,
 							want:       "\"|\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1049, col: 48, offset: 26165},
+							pos:  position{line: 1049, col: 48, offset: 26223},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1049, col: 51, offset: 26168},
+							pos:   position{line: 1049, col: 51, offset: 26226},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1049, col: 56, offset: 26173},
+								pos:  position{line: 1049, col: 56, offset: 26231},
 								name: "Seq",
 							},
 						},
@@ -7279,37 +7387,37 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 1059, col: 1, offset: 26417},
+			pos:  position{line: 1059, col: 1, offset: 26475},
 			expr: &actionExpr{
-				pos: position{line: 1060, col: 5, offset: 26428},
+				pos: position{line: 1060, col: 5, offset: 26486},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 1060, col: 5, offset: 26428},
+					pos: position{line: 1060, col: 5, offset: 26486},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1060, col: 5, offset: 26428},
+							pos:        position{line: 1060, col: 5, offset: 26486},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1060, col: 9, offset: 26432},
+							pos:  position{line: 1060, col: 9, offset: 26490},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1060, col: 12, offset: 26435},
+							pos:   position{line: 1060, col: 12, offset: 26493},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1060, col: 18, offset: 26441},
+								pos:  position{line: 1060, col: 18, offset: 26499},
 								name: "RecordElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1060, col: 30, offset: 26453},
+							pos:  position{line: 1060, col: 30, offset: 26511},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1060, col: 33, offset: 26456},
+							pos:        position{line: 1060, col: 33, offset: 26514},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -7322,31 +7430,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElems",
-			pos:  position{line: 1069, col: 1, offset: 26658},
+			pos:  position{line: 1069, col: 1, offset: 26716},
 			expr: &choiceExpr{
-				pos: position{line: 1070, col: 5, offset: 26674},
+				pos: position{line: 1070, col: 5, offset: 26732},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1070, col: 5, offset: 26674},
+						pos: position{line: 1070, col: 5, offset: 26732},
 						run: (*parser).callonRecordElems2,
 						expr: &seqExpr{
-							pos: position{line: 1070, col: 5, offset: 26674},
+							pos: position{line: 1070, col: 5, offset: 26732},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1070, col: 5, offset: 26674},
+									pos:   position{line: 1070, col: 5, offset: 26732},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1070, col: 11, offset: 26680},
+										pos:  position{line: 1070, col: 11, offset: 26738},
 										name: "RecordElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1070, col: 22, offset: 26691},
+									pos:   position{line: 1070, col: 22, offset: 26749},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1070, col: 27, offset: 26696},
+										pos: position{line: 1070, col: 27, offset: 26754},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1070, col: 27, offset: 26696},
+											pos:  position{line: 1070, col: 27, offset: 26754},
 											name: "RecordElemTail",
 										},
 									},
@@ -7355,10 +7463,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1073, col: 5, offset: 26759},
+						pos: position{line: 1073, col: 5, offset: 26817},
 						run: (*parser).callonRecordElems9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1073, col: 5, offset: 26759},
+							pos:  position{line: 1073, col: 5, offset: 26817},
 							name: "__",
 						},
 					},
@@ -7369,32 +7477,32 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElemTail",
-			pos:  position{line: 1075, col: 1, offset: 26783},
+			pos:  position{line: 1075, col: 1, offset: 26841},
 			expr: &actionExpr{
-				pos: position{line: 1075, col: 18, offset: 26800},
+				pos: position{line: 1075, col: 18, offset: 26858},
 				run: (*parser).callonRecordElemTail1,
 				expr: &seqExpr{
-					pos: position{line: 1075, col: 18, offset: 26800},
+					pos: position{line: 1075, col: 18, offset: 26858},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1075, col: 18, offset: 26800},
+							pos:  position{line: 1075, col: 18, offset: 26858},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1075, col: 21, offset: 26803},
+							pos:        position{line: 1075, col: 21, offset: 26861},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1075, col: 25, offset: 26807},
+							pos:  position{line: 1075, col: 25, offset: 26865},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1075, col: 28, offset: 26810},
+							pos:   position{line: 1075, col: 28, offset: 26868},
 							label: "elem",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1075, col: 33, offset: 26815},
+								pos:  position{line: 1075, col: 33, offset: 26873},
 								name: "RecordElem",
 							},
 						},
@@ -7406,20 +7514,20 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElem",
-			pos:  position{line: 1077, col: 1, offset: 26848},
+			pos:  position{line: 1077, col: 1, offset: 26906},
 			expr: &choiceExpr{
-				pos: position{line: 1078, col: 5, offset: 26863},
+				pos: position{line: 1078, col: 5, offset: 26921},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1078, col: 5, offset: 26863},
+						pos:  position{line: 1078, col: 5, offset: 26921},
 						name: "Spread",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1079, col: 5, offset: 26874},
+						pos:  position{line: 1079, col: 5, offset: 26932},
 						name: "Field",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1080, col: 5, offset: 26884},
+						pos:  position{line: 1080, col: 5, offset: 26942},
 						name: "Identifier",
 					},
 				},
@@ -7429,28 +7537,28 @@ var g = &grammar{
 		},
 		{
 			name: "Spread",
-			pos:  position{line: 1082, col: 1, offset: 26896},
+			pos:  position{line: 1082, col: 1, offset: 26954},
 			expr: &actionExpr{
-				pos: position{line: 1083, col: 5, offset: 26907},
+				pos: position{line: 1083, col: 5, offset: 26965},
 				run: (*parser).callonSpread1,
 				expr: &seqExpr{
-					pos: position{line: 1083, col: 5, offset: 26907},
+					pos: position{line: 1083, col: 5, offset: 26965},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1083, col: 5, offset: 26907},
+							pos:        position{line: 1083, col: 5, offset: 26965},
 							val:        "...",
 							ignoreCase: false,
 							want:       "\"...\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1083, col: 11, offset: 26913},
+							pos:  position{line: 1083, col: 11, offset: 26971},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1083, col: 14, offset: 26916},
+							pos:   position{line: 1083, col: 14, offset: 26974},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1083, col: 19, offset: 26921},
+								pos:  position{line: 1083, col: 19, offset: 26979},
 								name: "Expr",
 							},
 						},
@@ -7462,40 +7570,40 @@ var g = &grammar{
 		},
 		{
 			name: "Field",
-			pos:  position{line: 1087, col: 1, offset: 27028},
+			pos:  position{line: 1087, col: 1, offset: 27086},
 			expr: &actionExpr{
-				pos: position{line: 1088, col: 5, offset: 27038},
+				pos: position{line: 1088, col: 5, offset: 27096},
 				run: (*parser).callonField1,
 				expr: &seqExpr{
-					pos: position{line: 1088, col: 5, offset: 27038},
+					pos: position{line: 1088, col: 5, offset: 27096},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1088, col: 5, offset: 27038},
+							pos:   position{line: 1088, col: 5, offset: 27096},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1088, col: 10, offset: 27043},
+								pos:  position{line: 1088, col: 10, offset: 27101},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1088, col: 20, offset: 27053},
+							pos:  position{line: 1088, col: 20, offset: 27111},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1088, col: 23, offset: 27056},
+							pos:        position{line: 1088, col: 23, offset: 27114},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1088, col: 27, offset: 27060},
+							pos:  position{line: 1088, col: 27, offset: 27118},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1088, col: 30, offset: 27063},
+							pos:   position{line: 1088, col: 30, offset: 27121},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1088, col: 36, offset: 27069},
+								pos:  position{line: 1088, col: 36, offset: 27127},
 								name: "Expr",
 							},
 						},
@@ -7507,37 +7615,37 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 1097, col: 1, offset: 27237},
+			pos:  position{line: 1097, col: 1, offset: 27295},
 			expr: &actionExpr{
-				pos: position{line: 1098, col: 5, offset: 27247},
+				pos: position{line: 1098, col: 5, offset: 27305},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 1098, col: 5, offset: 27247},
+					pos: position{line: 1098, col: 5, offset: 27305},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1098, col: 5, offset: 27247},
+							pos:        position{line: 1098, col: 5, offset: 27305},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1098, col: 9, offset: 27251},
+							pos:  position{line: 1098, col: 9, offset: 27309},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1098, col: 12, offset: 27254},
+							pos:   position{line: 1098, col: 12, offset: 27312},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1098, col: 18, offset: 27260},
+								pos:  position{line: 1098, col: 18, offset: 27318},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1098, col: 30, offset: 27272},
+							pos:  position{line: 1098, col: 30, offset: 27330},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1098, col: 33, offset: 27275},
+							pos:        position{line: 1098, col: 33, offset: 27333},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -7550,37 +7658,37 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 1107, col: 1, offset: 27475},
+			pos:  position{line: 1107, col: 1, offset: 27533},
 			expr: &actionExpr{
-				pos: position{line: 1108, col: 5, offset: 27483},
+				pos: position{line: 1108, col: 5, offset: 27541},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 1108, col: 5, offset: 27483},
+					pos: position{line: 1108, col: 5, offset: 27541},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1108, col: 5, offset: 27483},
+							pos:        position{line: 1108, col: 5, offset: 27541},
 							val:        "|[",
 							ignoreCase: false,
 							want:       "\"|[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1108, col: 10, offset: 27488},
+							pos:  position{line: 1108, col: 10, offset: 27546},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1108, col: 13, offset: 27491},
+							pos:   position{line: 1108, col: 13, offset: 27549},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1108, col: 19, offset: 27497},
+								pos:  position{line: 1108, col: 19, offset: 27555},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1108, col: 31, offset: 27509},
+							pos:  position{line: 1108, col: 31, offset: 27567},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1108, col: 34, offset: 27512},
+							pos:        position{line: 1108, col: 34, offset: 27570},
 							val:        "]|",
 							ignoreCase: false,
 							want:       "\"]|\"",
@@ -7593,54 +7701,54 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElems",
-			pos:  position{line: 1117, col: 1, offset: 27707},
+			pos:  position{line: 1117, col: 1, offset: 27765},
 			expr: &choiceExpr{
-				pos: position{line: 1118, col: 5, offset: 27723},
+				pos: position{line: 1118, col: 5, offset: 27781},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1118, col: 5, offset: 27723},
+						pos: position{line: 1118, col: 5, offset: 27781},
 						run: (*parser).callonVectorElems2,
 						expr: &seqExpr{
-							pos: position{line: 1118, col: 5, offset: 27723},
+							pos: position{line: 1118, col: 5, offset: 27781},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1118, col: 5, offset: 27723},
+									pos:   position{line: 1118, col: 5, offset: 27781},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1118, col: 11, offset: 27729},
+										pos:  position{line: 1118, col: 11, offset: 27787},
 										name: "VectorElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1118, col: 22, offset: 27740},
+									pos:   position{line: 1118, col: 22, offset: 27798},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1118, col: 27, offset: 27745},
+										pos: position{line: 1118, col: 27, offset: 27803},
 										expr: &actionExpr{
-											pos: position{line: 1118, col: 28, offset: 27746},
+											pos: position{line: 1118, col: 28, offset: 27804},
 											run: (*parser).callonVectorElems8,
 											expr: &seqExpr{
-												pos: position{line: 1118, col: 28, offset: 27746},
+												pos: position{line: 1118, col: 28, offset: 27804},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1118, col: 28, offset: 27746},
+														pos:  position{line: 1118, col: 28, offset: 27804},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 1118, col: 31, offset: 27749},
+														pos:        position{line: 1118, col: 31, offset: 27807},
 														val:        ",",
 														ignoreCase: false,
 														want:       "\",\"",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1118, col: 35, offset: 27753},
+														pos:  position{line: 1118, col: 35, offset: 27811},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 1118, col: 38, offset: 27756},
+														pos:   position{line: 1118, col: 38, offset: 27814},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1118, col: 40, offset: 27758},
+															pos:  position{line: 1118, col: 40, offset: 27816},
 															name: "VectorElem",
 														},
 													},
@@ -7653,10 +7761,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1121, col: 5, offset: 27840},
+						pos: position{line: 1121, col: 5, offset: 27898},
 						run: (*parser).callonVectorElems15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1121, col: 5, offset: 27840},
+							pos:  position{line: 1121, col: 5, offset: 27898},
 							name: "__",
 						},
 					},
@@ -7667,22 +7775,22 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElem",
-			pos:  position{line: 1123, col: 1, offset: 27864},
+			pos:  position{line: 1123, col: 1, offset: 27922},
 			expr: &choiceExpr{
-				pos: position{line: 1124, col: 5, offset: 27879},
+				pos: position{line: 1124, col: 5, offset: 27937},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1124, col: 5, offset: 27879},
+						pos:  position{line: 1124, col: 5, offset: 27937},
 						name: "Spread",
 					},
 					&actionExpr{
-						pos: position{line: 1125, col: 5, offset: 27890},
+						pos: position{line: 1125, col: 5, offset: 27948},
 						run: (*parser).callonVectorElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1125, col: 5, offset: 27890},
+							pos:   position{line: 1125, col: 5, offset: 27948},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1125, col: 7, offset: 27892},
+								pos:  position{line: 1125, col: 7, offset: 27950},
 								name: "Expr",
 							},
 						},
@@ -7694,37 +7802,37 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 1127, col: 1, offset: 27972},
+			pos:  position{line: 1127, col: 1, offset: 28030},
 			expr: &actionExpr{
-				pos: position{line: 1128, col: 5, offset: 27980},
+				pos: position{line: 1128, col: 5, offset: 28038},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 1128, col: 5, offset: 27980},
+					pos: position{line: 1128, col: 5, offset: 28038},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1128, col: 5, offset: 27980},
+							pos:        position{line: 1128, col: 5, offset: 28038},
 							val:        "|{",
 							ignoreCase: false,
 							want:       "\"|{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1128, col: 10, offset: 27985},
+							pos:  position{line: 1128, col: 10, offset: 28043},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1128, col: 13, offset: 27988},
+							pos:   position{line: 1128, col: 13, offset: 28046},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1128, col: 19, offset: 27994},
+								pos:  position{line: 1128, col: 19, offset: 28052},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1128, col: 27, offset: 28002},
+							pos:  position{line: 1128, col: 27, offset: 28060},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1128, col: 30, offset: 28005},
+							pos:        position{line: 1128, col: 30, offset: 28063},
 							val:        "}|",
 							ignoreCase: false,
 							want:       "\"}|\"",
@@ -7737,31 +7845,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 1137, col: 1, offset: 28201},
+			pos:  position{line: 1137, col: 1, offset: 28259},
 			expr: &choiceExpr{
-				pos: position{line: 1138, col: 5, offset: 28213},
+				pos: position{line: 1138, col: 5, offset: 28271},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1138, col: 5, offset: 28213},
+						pos: position{line: 1138, col: 5, offset: 28271},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 1138, col: 5, offset: 28213},
+							pos: position{line: 1138, col: 5, offset: 28271},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1138, col: 5, offset: 28213},
+									pos:   position{line: 1138, col: 5, offset: 28271},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1138, col: 11, offset: 28219},
+										pos:  position{line: 1138, col: 11, offset: 28277},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1138, col: 17, offset: 28225},
+									pos:   position{line: 1138, col: 17, offset: 28283},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1138, col: 22, offset: 28230},
+										pos: position{line: 1138, col: 22, offset: 28288},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1138, col: 22, offset: 28230},
+											pos:  position{line: 1138, col: 22, offset: 28288},
 											name: "EntryTail",
 										},
 									},
@@ -7770,10 +7878,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1141, col: 5, offset: 28288},
+						pos: position{line: 1141, col: 5, offset: 28346},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1141, col: 5, offset: 28288},
+							pos:  position{line: 1141, col: 5, offset: 28346},
 							name: "__",
 						},
 					},
@@ -7784,32 +7892,32 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 1144, col: 1, offset: 28313},
+			pos:  position{line: 1144, col: 1, offset: 28371},
 			expr: &actionExpr{
-				pos: position{line: 1144, col: 13, offset: 28325},
+				pos: position{line: 1144, col: 13, offset: 28383},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 1144, col: 13, offset: 28325},
+					pos: position{line: 1144, col: 13, offset: 28383},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1144, col: 13, offset: 28325},
+							pos:  position{line: 1144, col: 13, offset: 28383},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1144, col: 16, offset: 28328},
+							pos:        position{line: 1144, col: 16, offset: 28386},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1144, col: 20, offset: 28332},
+							pos:  position{line: 1144, col: 20, offset: 28390},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1144, col: 23, offset: 28335},
+							pos:   position{line: 1144, col: 23, offset: 28393},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1144, col: 25, offset: 28337},
+								pos:  position{line: 1144, col: 25, offset: 28395},
 								name: "Entry",
 							},
 						},
@@ -7821,40 +7929,40 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 1146, col: 1, offset: 28362},
+			pos:  position{line: 1146, col: 1, offset: 28420},
 			expr: &actionExpr{
-				pos: position{line: 1147, col: 5, offset: 28372},
+				pos: position{line: 1147, col: 5, offset: 28430},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 1147, col: 5, offset: 28372},
+					pos: position{line: 1147, col: 5, offset: 28430},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1147, col: 5, offset: 28372},
+							pos:   position{line: 1147, col: 5, offset: 28430},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1147, col: 9, offset: 28376},
+								pos:  position{line: 1147, col: 9, offset: 28434},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1147, col: 14, offset: 28381},
+							pos:  position{line: 1147, col: 14, offset: 28439},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1147, col: 17, offset: 28384},
+							pos:        position{line: 1147, col: 17, offset: 28442},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1147, col: 21, offset: 28388},
+							pos:  position{line: 1147, col: 21, offset: 28446},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1147, col: 24, offset: 28391},
+							pos:   position{line: 1147, col: 24, offset: 28449},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1147, col: 30, offset: 28397},
+								pos:  position{line: 1147, col: 30, offset: 28455},
 								name: "Expr",
 							},
 						},
@@ -7866,56 +7974,56 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 1153, col: 1, offset: 28511},
+			pos:  position{line: 1153, col: 1, offset: 28569},
 			expr: &choiceExpr{
-				pos: position{line: 1154, col: 5, offset: 28523},
+				pos: position{line: 1154, col: 5, offset: 28581},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1154, col: 5, offset: 28523},
+						pos:  position{line: 1154, col: 5, offset: 28581},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1155, col: 5, offset: 28539},
+						pos:  position{line: 1155, col: 5, offset: 28597},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1156, col: 5, offset: 28557},
+						pos:  position{line: 1156, col: 5, offset: 28615},
 						name: "FString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1157, col: 5, offset: 28569},
+						pos:  position{line: 1157, col: 5, offset: 28627},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1158, col: 5, offset: 28587},
+						pos:  position{line: 1158, col: 5, offset: 28645},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1159, col: 5, offset: 28606},
+						pos:  position{line: 1159, col: 5, offset: 28664},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1160, col: 5, offset: 28623},
+						pos:  position{line: 1160, col: 5, offset: 28681},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1161, col: 5, offset: 28636},
+						pos:  position{line: 1161, col: 5, offset: 28694},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1162, col: 5, offset: 28645},
+						pos:  position{line: 1162, col: 5, offset: 28703},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1163, col: 5, offset: 28662},
+						pos:  position{line: 1163, col: 5, offset: 28720},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1164, col: 5, offset: 28681},
+						pos:  position{line: 1164, col: 5, offset: 28739},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1165, col: 5, offset: 28700},
+						pos:  position{line: 1165, col: 5, offset: 28758},
 						name: "NullLiteral",
 					},
 				},
@@ -7925,28 +8033,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 1167, col: 1, offset: 28713},
+			pos:  position{line: 1167, col: 1, offset: 28771},
 			expr: &choiceExpr{
-				pos: position{line: 1168, col: 5, offset: 28731},
+				pos: position{line: 1168, col: 5, offset: 28789},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1168, col: 5, offset: 28731},
+						pos: position{line: 1168, col: 5, offset: 28789},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1168, col: 5, offset: 28731},
+							pos: position{line: 1168, col: 5, offset: 28789},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1168, col: 5, offset: 28731},
+									pos:   position{line: 1168, col: 5, offset: 28789},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1168, col: 7, offset: 28733},
+										pos:  position{line: 1168, col: 7, offset: 28791},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1168, col: 14, offset: 28740},
+									pos: position{line: 1168, col: 14, offset: 28798},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1168, col: 15, offset: 28741},
+										pos:  position{line: 1168, col: 15, offset: 28799},
 										name: "IdentifierRest",
 									},
 								},
@@ -7954,13 +8062,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1171, col: 5, offset: 28821},
+						pos: position{line: 1171, col: 5, offset: 28879},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1171, col: 5, offset: 28821},
+							pos:   position{line: 1171, col: 5, offset: 28879},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1171, col: 7, offset: 28823},
+								pos:  position{line: 1171, col: 7, offset: 28881},
 								name: "IP4Net",
 							},
 						},
@@ -7972,28 +8080,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 1175, col: 1, offset: 28892},
+			pos:  position{line: 1175, col: 1, offset: 28950},
 			expr: &choiceExpr{
-				pos: position{line: 1176, col: 5, offset: 28911},
+				pos: position{line: 1176, col: 5, offset: 28969},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1176, col: 5, offset: 28911},
+						pos: position{line: 1176, col: 5, offset: 28969},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1176, col: 5, offset: 28911},
+							pos: position{line: 1176, col: 5, offset: 28969},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1176, col: 5, offset: 28911},
+									pos:   position{line: 1176, col: 5, offset: 28969},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1176, col: 7, offset: 28913},
+										pos:  position{line: 1176, col: 7, offset: 28971},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1176, col: 11, offset: 28917},
+									pos: position{line: 1176, col: 11, offset: 28975},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1176, col: 12, offset: 28918},
+										pos:  position{line: 1176, col: 12, offset: 28976},
 										name: "IdentifierRest",
 									},
 								},
@@ -8001,13 +8109,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1179, col: 5, offset: 28997},
+						pos: position{line: 1179, col: 5, offset: 29055},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1179, col: 5, offset: 28997},
+							pos:   position{line: 1179, col: 5, offset: 29055},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1179, col: 7, offset: 28999},
+								pos:  position{line: 1179, col: 7, offset: 29057},
 								name: "IP",
 							},
 						},
@@ -8019,15 +8127,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 1183, col: 1, offset: 29063},
+			pos:  position{line: 1183, col: 1, offset: 29121},
 			expr: &actionExpr{
-				pos: position{line: 1184, col: 5, offset: 29080},
+				pos: position{line: 1184, col: 5, offset: 29138},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1184, col: 5, offset: 29080},
+					pos:   position{line: 1184, col: 5, offset: 29138},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1184, col: 7, offset: 29082},
+						pos:  position{line: 1184, col: 7, offset: 29140},
 						name: "FloatString",
 					},
 				},
@@ -8037,15 +8145,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 1188, col: 1, offset: 29160},
+			pos:  position{line: 1188, col: 1, offset: 29218},
 			expr: &actionExpr{
-				pos: position{line: 1189, col: 5, offset: 29179},
+				pos: position{line: 1189, col: 5, offset: 29237},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1189, col: 5, offset: 29179},
+					pos:   position{line: 1189, col: 5, offset: 29237},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1189, col: 7, offset: 29181},
+						pos:  position{line: 1189, col: 7, offset: 29239},
 						name: "IntString",
 					},
 				},
@@ -8055,23 +8163,23 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 1193, col: 1, offset: 29255},
+			pos:  position{line: 1193, col: 1, offset: 29313},
 			expr: &choiceExpr{
-				pos: position{line: 1194, col: 5, offset: 29274},
+				pos: position{line: 1194, col: 5, offset: 29332},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1194, col: 5, offset: 29274},
+						pos: position{line: 1194, col: 5, offset: 29332},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1194, col: 5, offset: 29274},
+							pos:  position{line: 1194, col: 5, offset: 29332},
 							name: "TrueToken",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1195, col: 5, offset: 29337},
+						pos: position{line: 1195, col: 5, offset: 29395},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1195, col: 5, offset: 29337},
+							pos:  position{line: 1195, col: 5, offset: 29395},
 							name: "FalseToken",
 						},
 					},
@@ -8082,12 +8190,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 1197, col: 1, offset: 29398},
+			pos:  position{line: 1197, col: 1, offset: 29456},
 			expr: &actionExpr{
-				pos: position{line: 1198, col: 5, offset: 29414},
+				pos: position{line: 1198, col: 5, offset: 29472},
 				run: (*parser).callonNullLiteral1,
 				expr: &ruleRefExpr{
-					pos:  position{line: 1198, col: 5, offset: 29414},
+					pos:  position{line: 1198, col: 5, offset: 29472},
 					name: "NullToken",
 				},
 			},
@@ -8096,23 +8204,23 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 1200, col: 1, offset: 29469},
+			pos:  position{line: 1200, col: 1, offset: 29527},
 			expr: &actionExpr{
-				pos: position{line: 1201, col: 5, offset: 29486},
+				pos: position{line: 1201, col: 5, offset: 29544},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1201, col: 5, offset: 29486},
+					pos: position{line: 1201, col: 5, offset: 29544},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1201, col: 5, offset: 29486},
+							pos:        position{line: 1201, col: 5, offset: 29544},
 							val:        "0x",
 							ignoreCase: false,
 							want:       "\"0x\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1201, col: 10, offset: 29491},
+							pos: position{line: 1201, col: 10, offset: 29549},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1201, col: 10, offset: 29491},
+								pos:  position{line: 1201, col: 10, offset: 29549},
 								name: "HexDigit",
 							},
 						},
@@ -8124,29 +8232,29 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 1205, col: 1, offset: 29565},
+			pos:  position{line: 1205, col: 1, offset: 29623},
 			expr: &actionExpr{
-				pos: position{line: 1206, col: 5, offset: 29581},
+				pos: position{line: 1206, col: 5, offset: 29639},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1206, col: 5, offset: 29581},
+					pos: position{line: 1206, col: 5, offset: 29639},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1206, col: 5, offset: 29581},
+							pos:        position{line: 1206, col: 5, offset: 29639},
 							val:        "<",
 							ignoreCase: false,
 							want:       "\"<\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1206, col: 9, offset: 29585},
+							pos:   position{line: 1206, col: 9, offset: 29643},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1206, col: 13, offset: 29589},
+								pos:  position{line: 1206, col: 13, offset: 29647},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1206, col: 18, offset: 29594},
+							pos:        position{line: 1206, col: 18, offset: 29652},
 							val:        ">",
 							ignoreCase: false,
 							want:       "\">\"",
@@ -8159,16 +8267,16 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1215, col: 1, offset: 29775},
+			pos:  position{line: 1215, col: 1, offset: 29833},
 			expr: &choiceExpr{
-				pos: position{line: 1216, col: 5, offset: 29784},
+				pos: position{line: 1216, col: 5, offset: 29842},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1216, col: 5, offset: 29784},
+						pos:  position{line: 1216, col: 5, offset: 29842},
 						name: "AmbiguousType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1217, col: 5, offset: 29802},
+						pos:  position{line: 1217, col: 5, offset: 29860},
 						name: "ComplexType",
 					},
 				},
@@ -8178,28 +8286,28 @@ var g = &grammar{
 		},
 		{
 			name: "AmbiguousType",
-			pos:  position{line: 1219, col: 1, offset: 29815},
+			pos:  position{line: 1219, col: 1, offset: 29873},
 			expr: &choiceExpr{
-				pos: position{line: 1220, col: 5, offset: 29833},
+				pos: position{line: 1220, col: 5, offset: 29891},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1220, col: 5, offset: 29833},
+						pos: position{line: 1220, col: 5, offset: 29891},
 						run: (*parser).callonAmbiguousType2,
 						expr: &seqExpr{
-							pos: position{line: 1220, col: 5, offset: 29833},
+							pos: position{line: 1220, col: 5, offset: 29891},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1220, col: 5, offset: 29833},
+									pos:   position{line: 1220, col: 5, offset: 29891},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1220, col: 10, offset: 29838},
+										pos:  position{line: 1220, col: 10, offset: 29896},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1220, col: 24, offset: 29852},
+									pos: position{line: 1220, col: 24, offset: 29910},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1220, col: 25, offset: 29853},
+										pos:  position{line: 1220, col: 25, offset: 29911},
 										name: "IdentifierRest",
 									},
 								},
@@ -8207,45 +8315,45 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1221, col: 5, offset: 29893},
+						pos: position{line: 1221, col: 5, offset: 29951},
 						run: (*parser).callonAmbiguousType8,
 						expr: &seqExpr{
-							pos: position{line: 1221, col: 5, offset: 29893},
+							pos: position{line: 1221, col: 5, offset: 29951},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1221, col: 5, offset: 29893},
+									pos:        position{line: 1221, col: 5, offset: 29951},
 									val:        "error",
 									ignoreCase: false,
 									want:       "\"error\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1221, col: 13, offset: 29901},
+									pos:  position{line: 1221, col: 13, offset: 29959},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1221, col: 16, offset: 29904},
+									pos:        position{line: 1221, col: 16, offset: 29962},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1221, col: 20, offset: 29908},
+									pos:  position{line: 1221, col: 20, offset: 29966},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1221, col: 23, offset: 29911},
+									pos:   position{line: 1221, col: 23, offset: 29969},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1221, col: 25, offset: 29913},
+										pos:  position{line: 1221, col: 25, offset: 29971},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1221, col: 30, offset: 29918},
+									pos:  position{line: 1221, col: 30, offset: 29976},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1221, col: 33, offset: 29921},
+									pos:        position{line: 1221, col: 33, offset: 29979},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -8254,52 +8362,52 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1229, col: 5, offset: 30115},
+						pos: position{line: 1229, col: 5, offset: 30173},
 						run: (*parser).callonAmbiguousType18,
 						expr: &seqExpr{
-							pos: position{line: 1229, col: 5, offset: 30115},
+							pos: position{line: 1229, col: 5, offset: 30173},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1229, col: 5, offset: 30115},
+									pos:   position{line: 1229, col: 5, offset: 30173},
 									label: "name",
 									expr: &choiceExpr{
-										pos: position{line: 1229, col: 11, offset: 30121},
+										pos: position{line: 1229, col: 11, offset: 30179},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1229, col: 11, offset: 30121},
+												pos:  position{line: 1229, col: 11, offset: 30179},
 												name: "IdentifierName",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1229, col: 28, offset: 30138},
+												pos:  position{line: 1229, col: 28, offset: 30196},
 												name: "QuotedString",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1229, col: 42, offset: 30152},
+									pos:   position{line: 1229, col: 42, offset: 30210},
 									label: "opt",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1229, col: 46, offset: 30156},
+										pos: position{line: 1229, col: 46, offset: 30214},
 										expr: &seqExpr{
-											pos: position{line: 1229, col: 47, offset: 30157},
+											pos: position{line: 1229, col: 47, offset: 30215},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1229, col: 47, offset: 30157},
+													pos:  position{line: 1229, col: 47, offset: 30215},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1229, col: 50, offset: 30160},
+													pos:        position{line: 1229, col: 50, offset: 30218},
 													val:        "=",
 													ignoreCase: false,
 													want:       "\"=\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1229, col: 54, offset: 30164},
+													pos:  position{line: 1229, col: 54, offset: 30222},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1229, col: 57, offset: 30167},
+													pos:  position{line: 1229, col: 57, offset: 30225},
 													name: "Type",
 												},
 											},
@@ -8310,31 +8418,31 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1240, col: 5, offset: 30505},
+						pos: position{line: 1240, col: 5, offset: 30563},
 						run: (*parser).callonAmbiguousType31,
 						expr: &seqExpr{
-							pos: position{line: 1240, col: 5, offset: 30505},
+							pos: position{line: 1240, col: 5, offset: 30563},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1240, col: 5, offset: 30505},
+									pos:        position{line: 1240, col: 5, offset: 30563},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1240, col: 9, offset: 30509},
+									pos:  position{line: 1240, col: 9, offset: 30567},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1240, col: 12, offset: 30512},
+									pos:   position{line: 1240, col: 12, offset: 30570},
 									label: "types",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1240, col: 18, offset: 30518},
+										pos:  position{line: 1240, col: 18, offset: 30576},
 										name: "TypeList",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1240, col: 27, offset: 30527},
+									pos:        position{line: 1240, col: 27, offset: 30585},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -8349,28 +8457,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1249, col: 1, offset: 30719},
+			pos:  position{line: 1249, col: 1, offset: 30777},
 			expr: &actionExpr{
-				pos: position{line: 1250, col: 5, offset: 30732},
+				pos: position{line: 1250, col: 5, offset: 30790},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1250, col: 5, offset: 30732},
+					pos: position{line: 1250, col: 5, offset: 30790},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1250, col: 5, offset: 30732},
+							pos:   position{line: 1250, col: 5, offset: 30790},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1250, col: 11, offset: 30738},
+								pos:  position{line: 1250, col: 11, offset: 30796},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1250, col: 16, offset: 30743},
+							pos:   position{line: 1250, col: 16, offset: 30801},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1250, col: 21, offset: 30748},
+								pos: position{line: 1250, col: 21, offset: 30806},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1250, col: 21, offset: 30748},
+									pos:  position{line: 1250, col: 21, offset: 30806},
 									name: "TypeListTail",
 								},
 							},
@@ -8383,32 +8491,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1254, col: 1, offset: 30806},
+			pos:  position{line: 1254, col: 1, offset: 30864},
 			expr: &actionExpr{
-				pos: position{line: 1254, col: 16, offset: 30821},
+				pos: position{line: 1254, col: 16, offset: 30879},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1254, col: 16, offset: 30821},
+					pos: position{line: 1254, col: 16, offset: 30879},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1254, col: 16, offset: 30821},
+							pos:  position{line: 1254, col: 16, offset: 30879},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1254, col: 19, offset: 30824},
+							pos:        position{line: 1254, col: 19, offset: 30882},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1254, col: 23, offset: 30828},
+							pos:  position{line: 1254, col: 23, offset: 30886},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1254, col: 26, offset: 30831},
+							pos:   position{line: 1254, col: 26, offset: 30889},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1254, col: 30, offset: 30835},
+								pos:  position{line: 1254, col: 30, offset: 30893},
 								name: "Type",
 							},
 						},
@@ -8420,40 +8528,40 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 1256, col: 1, offset: 30861},
+			pos:  position{line: 1256, col: 1, offset: 30919},
 			expr: &choiceExpr{
-				pos: position{line: 1257, col: 5, offset: 30877},
+				pos: position{line: 1257, col: 5, offset: 30935},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1257, col: 5, offset: 30877},
+						pos: position{line: 1257, col: 5, offset: 30935},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 1257, col: 5, offset: 30877},
+							pos: position{line: 1257, col: 5, offset: 30935},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1257, col: 5, offset: 30877},
+									pos:        position{line: 1257, col: 5, offset: 30935},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1257, col: 9, offset: 30881},
+									pos:  position{line: 1257, col: 9, offset: 30939},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1257, col: 12, offset: 30884},
+									pos:   position{line: 1257, col: 12, offset: 30942},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1257, col: 19, offset: 30891},
+										pos:  position{line: 1257, col: 19, offset: 30949},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1257, col: 33, offset: 30905},
+									pos:  position{line: 1257, col: 33, offset: 30963},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1257, col: 36, offset: 30908},
+									pos:        position{line: 1257, col: 36, offset: 30966},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -8462,35 +8570,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1265, col: 5, offset: 31120},
+						pos: position{line: 1265, col: 5, offset: 31178},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 1265, col: 5, offset: 31120},
+							pos: position{line: 1265, col: 5, offset: 31178},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1265, col: 5, offset: 31120},
+									pos:        position{line: 1265, col: 5, offset: 31178},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1265, col: 9, offset: 31124},
+									pos:  position{line: 1265, col: 9, offset: 31182},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1265, col: 12, offset: 31127},
+									pos:   position{line: 1265, col: 12, offset: 31185},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1265, col: 16, offset: 31131},
+										pos:  position{line: 1265, col: 16, offset: 31189},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1265, col: 21, offset: 31136},
+									pos:  position{line: 1265, col: 21, offset: 31194},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1265, col: 24, offset: 31139},
+									pos:        position{line: 1265, col: 24, offset: 31197},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -8499,35 +8607,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1273, col: 5, offset: 31331},
+						pos: position{line: 1273, col: 5, offset: 31389},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 1273, col: 5, offset: 31331},
+							pos: position{line: 1273, col: 5, offset: 31389},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1273, col: 5, offset: 31331},
+									pos:        position{line: 1273, col: 5, offset: 31389},
 									val:        "|[",
 									ignoreCase: false,
 									want:       "\"|[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1273, col: 10, offset: 31336},
+									pos:  position{line: 1273, col: 10, offset: 31394},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1273, col: 13, offset: 31339},
+									pos:   position{line: 1273, col: 13, offset: 31397},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1273, col: 17, offset: 31343},
+										pos:  position{line: 1273, col: 17, offset: 31401},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1273, col: 22, offset: 31348},
+									pos:  position{line: 1273, col: 22, offset: 31406},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1273, col: 25, offset: 31351},
+									pos:        position{line: 1273, col: 25, offset: 31409},
 									val:        "]|",
 									ignoreCase: false,
 									want:       "\"]|\"",
@@ -8536,57 +8644,57 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1281, col: 5, offset: 31538},
+						pos: position{line: 1281, col: 5, offset: 31596},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 1281, col: 5, offset: 31538},
+							pos: position{line: 1281, col: 5, offset: 31596},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1281, col: 5, offset: 31538},
+									pos:        position{line: 1281, col: 5, offset: 31596},
 									val:        "|{",
 									ignoreCase: false,
 									want:       "\"|{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1281, col: 10, offset: 31543},
+									pos:  position{line: 1281, col: 10, offset: 31601},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1281, col: 13, offset: 31546},
+									pos:   position{line: 1281, col: 13, offset: 31604},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1281, col: 21, offset: 31554},
+										pos:  position{line: 1281, col: 21, offset: 31612},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1281, col: 26, offset: 31559},
+									pos:  position{line: 1281, col: 26, offset: 31617},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1281, col: 29, offset: 31562},
+									pos:        position{line: 1281, col: 29, offset: 31620},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1281, col: 33, offset: 31566},
+									pos:  position{line: 1281, col: 33, offset: 31624},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1281, col: 36, offset: 31569},
+									pos:   position{line: 1281, col: 36, offset: 31627},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1281, col: 44, offset: 31577},
+										pos:  position{line: 1281, col: 44, offset: 31635},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1281, col: 49, offset: 31582},
+									pos:  position{line: 1281, col: 49, offset: 31640},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1281, col: 52, offset: 31585},
+									pos:        position{line: 1281, col: 52, offset: 31643},
 									val:        "}|",
 									ignoreCase: false,
 									want:       "\"}|\"",
@@ -8601,35 +8709,35 @@ var g = &grammar{
 		},
 		{
 			name: "StringLiteral",
-			pos:  position{line: 1291, col: 1, offset: 31808},
+			pos:  position{line: 1291, col: 1, offset: 31866},
 			expr: &choiceExpr{
-				pos: position{line: 1292, col: 5, offset: 31826},
+				pos: position{line: 1292, col: 5, offset: 31884},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1292, col: 5, offset: 31826},
+						pos: position{line: 1292, col: 5, offset: 31884},
 						run: (*parser).callonStringLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1292, col: 5, offset: 31826},
+							pos: position{line: 1292, col: 5, offset: 31884},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1292, col: 5, offset: 31826},
+									pos:        position{line: 1292, col: 5, offset: 31884},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1292, col: 9, offset: 31830},
+									pos:   position{line: 1292, col: 9, offset: 31888},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1292, col: 11, offset: 31832},
+										pos: position{line: 1292, col: 11, offset: 31890},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1292, col: 11, offset: 31832},
+											pos:  position{line: 1292, col: 11, offset: 31890},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1292, col: 29, offset: 31850},
+									pos:        position{line: 1292, col: 29, offset: 31908},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -8638,30 +8746,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1293, col: 5, offset: 31914},
+						pos: position{line: 1293, col: 5, offset: 31972},
 						run: (*parser).callonStringLiteral9,
 						expr: &seqExpr{
-							pos: position{line: 1293, col: 5, offset: 31914},
+							pos: position{line: 1293, col: 5, offset: 31972},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1293, col: 5, offset: 31914},
+									pos:        position{line: 1293, col: 5, offset: 31972},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1293, col: 9, offset: 31918},
+									pos:   position{line: 1293, col: 9, offset: 31976},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1293, col: 11, offset: 31920},
+										pos: position{line: 1293, col: 11, offset: 31978},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1293, col: 11, offset: 31920},
+											pos:  position{line: 1293, col: 11, offset: 31978},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1293, col: 29, offset: 31938},
+									pos:        position{line: 1293, col: 29, offset: 31996},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -8676,35 +8784,35 @@ var g = &grammar{
 		},
 		{
 			name: "FString",
-			pos:  position{line: 1295, col: 1, offset: 31999},
+			pos:  position{line: 1295, col: 1, offset: 32057},
 			expr: &choiceExpr{
-				pos: position{line: 1296, col: 5, offset: 32011},
+				pos: position{line: 1296, col: 5, offset: 32069},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1296, col: 5, offset: 32011},
+						pos: position{line: 1296, col: 5, offset: 32069},
 						run: (*parser).callonFString2,
 						expr: &seqExpr{
-							pos: position{line: 1296, col: 5, offset: 32011},
+							pos: position{line: 1296, col: 5, offset: 32069},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1296, col: 5, offset: 32011},
+									pos:        position{line: 1296, col: 5, offset: 32069},
 									val:        "f\"",
 									ignoreCase: false,
 									want:       "\"f\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1296, col: 11, offset: 32017},
+									pos:   position{line: 1296, col: 11, offset: 32075},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1296, col: 13, offset: 32019},
+										pos: position{line: 1296, col: 13, offset: 32077},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1296, col: 13, offset: 32019},
+											pos:  position{line: 1296, col: 13, offset: 32077},
 											name: "FStringDoubleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1296, col: 38, offset: 32044},
+									pos:        position{line: 1296, col: 38, offset: 32102},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -8713,30 +8821,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1303, col: 5, offset: 32201},
+						pos: position{line: 1303, col: 5, offset: 32259},
 						run: (*parser).callonFString9,
 						expr: &seqExpr{
-							pos: position{line: 1303, col: 5, offset: 32201},
+							pos: position{line: 1303, col: 5, offset: 32259},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1303, col: 5, offset: 32201},
+									pos:        position{line: 1303, col: 5, offset: 32259},
 									val:        "f'",
 									ignoreCase: false,
 									want:       "\"f'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1303, col: 10, offset: 32206},
+									pos:   position{line: 1303, col: 10, offset: 32264},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1303, col: 12, offset: 32208},
+										pos: position{line: 1303, col: 12, offset: 32266},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1303, col: 12, offset: 32208},
+											pos:  position{line: 1303, col: 12, offset: 32266},
 											name: "FStringSingleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1303, col: 37, offset: 32233},
+									pos:        position{line: 1303, col: 37, offset: 32291},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -8751,24 +8859,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedElem",
-			pos:  position{line: 1311, col: 1, offset: 32387},
+			pos:  position{line: 1311, col: 1, offset: 32445},
 			expr: &choiceExpr{
-				pos: position{line: 1312, col: 5, offset: 32415},
+				pos: position{line: 1312, col: 5, offset: 32473},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1312, col: 5, offset: 32415},
+						pos:  position{line: 1312, col: 5, offset: 32473},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1313, col: 5, offset: 32431},
+						pos: position{line: 1313, col: 5, offset: 32489},
 						run: (*parser).callonFStringDoubleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1313, col: 5, offset: 32431},
+							pos:   position{line: 1313, col: 5, offset: 32489},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1313, col: 7, offset: 32433},
+								pos: position{line: 1313, col: 7, offset: 32491},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1313, col: 7, offset: 32433},
+									pos:  position{line: 1313, col: 7, offset: 32491},
 									name: "FStringDoubleQuotedChar",
 								},
 							},
@@ -8781,27 +8889,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedChar",
-			pos:  position{line: 1317, col: 1, offset: 32566},
+			pos:  position{line: 1317, col: 1, offset: 32624},
 			expr: &choiceExpr{
-				pos: position{line: 1318, col: 5, offset: 32594},
+				pos: position{line: 1318, col: 5, offset: 32652},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1318, col: 5, offset: 32594},
+						pos: position{line: 1318, col: 5, offset: 32652},
 						run: (*parser).callonFStringDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1318, col: 5, offset: 32594},
+							pos: position{line: 1318, col: 5, offset: 32652},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1318, col: 5, offset: 32594},
+									pos:        position{line: 1318, col: 5, offset: 32652},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1318, col: 10, offset: 32599},
+									pos:   position{line: 1318, col: 10, offset: 32657},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1318, col: 12, offset: 32601},
+										pos:        position{line: 1318, col: 12, offset: 32659},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -8811,25 +8919,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1319, col: 5, offset: 32627},
+						pos: position{line: 1319, col: 5, offset: 32685},
 						run: (*parser).callonFStringDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1319, col: 5, offset: 32627},
+							pos: position{line: 1319, col: 5, offset: 32685},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1319, col: 5, offset: 32627},
+									pos: position{line: 1319, col: 5, offset: 32685},
 									expr: &litMatcher{
-										pos:        position{line: 1319, col: 7, offset: 32629},
+										pos:        position{line: 1319, col: 7, offset: 32687},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1319, col: 12, offset: 32634},
+									pos:   position{line: 1319, col: 12, offset: 32692},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1319, col: 14, offset: 32636},
+										pos:  position{line: 1319, col: 14, offset: 32694},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -8843,24 +8951,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedElem",
-			pos:  position{line: 1321, col: 1, offset: 32672},
+			pos:  position{line: 1321, col: 1, offset: 32730},
 			expr: &choiceExpr{
-				pos: position{line: 1322, col: 5, offset: 32700},
+				pos: position{line: 1322, col: 5, offset: 32758},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1322, col: 5, offset: 32700},
+						pos:  position{line: 1322, col: 5, offset: 32758},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1323, col: 5, offset: 32716},
+						pos: position{line: 1323, col: 5, offset: 32774},
 						run: (*parser).callonFStringSingleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1323, col: 5, offset: 32716},
+							pos:   position{line: 1323, col: 5, offset: 32774},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1323, col: 7, offset: 32718},
+								pos: position{line: 1323, col: 7, offset: 32776},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1323, col: 7, offset: 32718},
+									pos:  position{line: 1323, col: 7, offset: 32776},
 									name: "FStringSingleQuotedChar",
 								},
 							},
@@ -8873,27 +8981,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedChar",
-			pos:  position{line: 1327, col: 1, offset: 32851},
+			pos:  position{line: 1327, col: 1, offset: 32909},
 			expr: &choiceExpr{
-				pos: position{line: 1328, col: 5, offset: 32879},
+				pos: position{line: 1328, col: 5, offset: 32937},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1328, col: 5, offset: 32879},
+						pos: position{line: 1328, col: 5, offset: 32937},
 						run: (*parser).callonFStringSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1328, col: 5, offset: 32879},
+							pos: position{line: 1328, col: 5, offset: 32937},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1328, col: 5, offset: 32879},
+									pos:        position{line: 1328, col: 5, offset: 32937},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1328, col: 10, offset: 32884},
+									pos:   position{line: 1328, col: 10, offset: 32942},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1328, col: 12, offset: 32886},
+										pos:        position{line: 1328, col: 12, offset: 32944},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -8903,25 +9011,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1329, col: 5, offset: 32912},
+						pos: position{line: 1329, col: 5, offset: 32970},
 						run: (*parser).callonFStringSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1329, col: 5, offset: 32912},
+							pos: position{line: 1329, col: 5, offset: 32970},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1329, col: 5, offset: 32912},
+									pos: position{line: 1329, col: 5, offset: 32970},
 									expr: &litMatcher{
-										pos:        position{line: 1329, col: 7, offset: 32914},
+										pos:        position{line: 1329, col: 7, offset: 32972},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1329, col: 12, offset: 32919},
+									pos:   position{line: 1329, col: 12, offset: 32977},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1329, col: 14, offset: 32921},
+										pos:  position{line: 1329, col: 14, offset: 32979},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -8935,37 +9043,37 @@ var g = &grammar{
 		},
 		{
 			name: "FStringExpr",
-			pos:  position{line: 1331, col: 1, offset: 32957},
+			pos:  position{line: 1331, col: 1, offset: 33015},
 			expr: &actionExpr{
-				pos: position{line: 1332, col: 5, offset: 32973},
+				pos: position{line: 1332, col: 5, offset: 33031},
 				run: (*parser).callonFStringExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1332, col: 5, offset: 32973},
+					pos: position{line: 1332, col: 5, offset: 33031},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1332, col: 5, offset: 32973},
+							pos:        position{line: 1332, col: 5, offset: 33031},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1332, col: 9, offset: 32977},
+							pos:  position{line: 1332, col: 9, offset: 33035},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1332, col: 12, offset: 32980},
+							pos:   position{line: 1332, col: 12, offset: 33038},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1332, col: 14, offset: 32982},
+								pos:  position{line: 1332, col: 14, offset: 33040},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1332, col: 19, offset: 32987},
+							pos:  position{line: 1332, col: 19, offset: 33045},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1332, col: 22, offset: 32990},
+							pos:        position{line: 1332, col: 22, offset: 33048},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -8978,129 +9086,129 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1341, col: 1, offset: 33168},
+			pos:  position{line: 1341, col: 1, offset: 33226},
 			expr: &actionExpr{
-				pos: position{line: 1342, col: 5, offset: 33186},
+				pos: position{line: 1342, col: 5, offset: 33244},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1342, col: 9, offset: 33190},
+					pos: position{line: 1342, col: 9, offset: 33248},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1342, col: 9, offset: 33190},
+							pos:        position{line: 1342, col: 9, offset: 33248},
 							val:        "uint8",
 							ignoreCase: false,
 							want:       "\"uint8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1342, col: 19, offset: 33200},
+							pos:        position{line: 1342, col: 19, offset: 33258},
 							val:        "uint16",
 							ignoreCase: false,
 							want:       "\"uint16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1342, col: 30, offset: 33211},
+							pos:        position{line: 1342, col: 30, offset: 33269},
 							val:        "uint32",
 							ignoreCase: false,
 							want:       "\"uint32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1342, col: 41, offset: 33222},
+							pos:        position{line: 1342, col: 41, offset: 33280},
 							val:        "uint64",
 							ignoreCase: false,
 							want:       "\"uint64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1343, col: 9, offset: 33239},
+							pos:        position{line: 1343, col: 9, offset: 33297},
 							val:        "int8",
 							ignoreCase: false,
 							want:       "\"int8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1343, col: 18, offset: 33248},
+							pos:        position{line: 1343, col: 18, offset: 33306},
 							val:        "int16",
 							ignoreCase: false,
 							want:       "\"int16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1343, col: 28, offset: 33258},
+							pos:        position{line: 1343, col: 28, offset: 33316},
 							val:        "int32",
 							ignoreCase: false,
 							want:       "\"int32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1343, col: 38, offset: 33268},
+							pos:        position{line: 1343, col: 38, offset: 33326},
 							val:        "int64",
 							ignoreCase: false,
 							want:       "\"int64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1344, col: 9, offset: 33284},
+							pos:        position{line: 1344, col: 9, offset: 33342},
 							val:        "float16",
 							ignoreCase: false,
 							want:       "\"float16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1344, col: 21, offset: 33296},
+							pos:        position{line: 1344, col: 21, offset: 33354},
 							val:        "float32",
 							ignoreCase: false,
 							want:       "\"float32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1344, col: 33, offset: 33308},
+							pos:        position{line: 1344, col: 33, offset: 33366},
 							val:        "float64",
 							ignoreCase: false,
 							want:       "\"float64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1345, col: 9, offset: 33326},
+							pos:        position{line: 1345, col: 9, offset: 33384},
 							val:        "bool",
 							ignoreCase: false,
 							want:       "\"bool\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1345, col: 18, offset: 33335},
+							pos:        position{line: 1345, col: 18, offset: 33393},
 							val:        "string",
 							ignoreCase: false,
 							want:       "\"string\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1346, col: 9, offset: 33352},
+							pos:        position{line: 1346, col: 9, offset: 33410},
 							val:        "duration",
 							ignoreCase: false,
 							want:       "\"duration\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1346, col: 22, offset: 33365},
+							pos:        position{line: 1346, col: 22, offset: 33423},
 							val:        "time",
 							ignoreCase: false,
 							want:       "\"time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1347, col: 9, offset: 33380},
+							pos:        position{line: 1347, col: 9, offset: 33438},
 							val:        "bytes",
 							ignoreCase: false,
 							want:       "\"bytes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1348, col: 9, offset: 33396},
+							pos:        position{line: 1348, col: 9, offset: 33454},
 							val:        "ip",
 							ignoreCase: false,
 							want:       "\"ip\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1348, col: 16, offset: 33403},
+							pos:        position{line: 1348, col: 16, offset: 33461},
 							val:        "net",
 							ignoreCase: false,
 							want:       "\"net\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1349, col: 9, offset: 33417},
+							pos:        position{line: 1349, col: 9, offset: 33475},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1349, col: 18, offset: 33426},
+							pos:        position{line: 1349, col: 18, offset: 33484},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
@@ -9113,31 +9221,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1357, col: 1, offset: 33624},
+			pos:  position{line: 1357, col: 1, offset: 33682},
 			expr: &choiceExpr{
-				pos: position{line: 1358, col: 5, offset: 33642},
+				pos: position{line: 1358, col: 5, offset: 33700},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1358, col: 5, offset: 33642},
+						pos: position{line: 1358, col: 5, offset: 33700},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1358, col: 5, offset: 33642},
+							pos: position{line: 1358, col: 5, offset: 33700},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1358, col: 5, offset: 33642},
+									pos:   position{line: 1358, col: 5, offset: 33700},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1358, col: 11, offset: 33648},
+										pos:  position{line: 1358, col: 11, offset: 33706},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1358, col: 21, offset: 33658},
+									pos:   position{line: 1358, col: 21, offset: 33716},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1358, col: 26, offset: 33663},
+										pos: position{line: 1358, col: 26, offset: 33721},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1358, col: 26, offset: 33663},
+											pos:  position{line: 1358, col: 26, offset: 33721},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -9146,10 +9254,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1361, col: 5, offset: 33729},
+						pos: position{line: 1361, col: 5, offset: 33787},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1361, col: 5, offset: 33729},
+							pos:        position{line: 1361, col: 5, offset: 33787},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -9162,32 +9270,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1363, col: 1, offset: 33753},
+			pos:  position{line: 1363, col: 1, offset: 33811},
 			expr: &actionExpr{
-				pos: position{line: 1363, col: 21, offset: 33773},
+				pos: position{line: 1363, col: 21, offset: 33831},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1363, col: 21, offset: 33773},
+					pos: position{line: 1363, col: 21, offset: 33831},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1363, col: 21, offset: 33773},
+							pos:  position{line: 1363, col: 21, offset: 33831},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1363, col: 24, offset: 33776},
+							pos:        position{line: 1363, col: 24, offset: 33834},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1363, col: 28, offset: 33780},
+							pos:  position{line: 1363, col: 28, offset: 33838},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1363, col: 31, offset: 33783},
+							pos:   position{line: 1363, col: 31, offset: 33841},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1363, col: 35, offset: 33787},
+								pos:  position{line: 1363, col: 35, offset: 33845},
 								name: "TypeField",
 							},
 						},
@@ -9199,40 +9307,40 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1365, col: 1, offset: 33818},
+			pos:  position{line: 1365, col: 1, offset: 33876},
 			expr: &actionExpr{
-				pos: position{line: 1366, col: 5, offset: 33832},
+				pos: position{line: 1366, col: 5, offset: 33890},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1366, col: 5, offset: 33832},
+					pos: position{line: 1366, col: 5, offset: 33890},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1366, col: 5, offset: 33832},
+							pos:   position{line: 1366, col: 5, offset: 33890},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1366, col: 10, offset: 33837},
+								pos:  position{line: 1366, col: 10, offset: 33895},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1366, col: 20, offset: 33847},
+							pos:  position{line: 1366, col: 20, offset: 33905},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1366, col: 23, offset: 33850},
+							pos:        position{line: 1366, col: 23, offset: 33908},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1366, col: 27, offset: 33854},
+							pos:  position{line: 1366, col: 27, offset: 33912},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1366, col: 30, offset: 33857},
+							pos:   position{line: 1366, col: 30, offset: 33915},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1366, col: 34, offset: 33861},
+								pos:  position{line: 1366, col: 34, offset: 33919},
 								name: "Type",
 							},
 						},
@@ -9244,16 +9352,16 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 1373, col: 1, offset: 33985},
+			pos:  position{line: 1373, col: 1, offset: 34043},
 			expr: &choiceExpr{
-				pos: position{line: 1374, col: 5, offset: 33999},
+				pos: position{line: 1374, col: 5, offset: 34057},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1374, col: 5, offset: 33999},
+						pos:  position{line: 1374, col: 5, offset: 34057},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1375, col: 5, offset: 34018},
+						pos:  position{line: 1375, col: 5, offset: 34076},
 						name: "QuotedString",
 					},
 				},
@@ -9263,24 +9371,24 @@ var g = &grammar{
 		},
 		{
 			name: "AndToken",
-			pos:  position{line: 1377, col: 1, offset: 34032},
+			pos:  position{line: 1377, col: 1, offset: 34090},
 			expr: &actionExpr{
-				pos: position{line: 1377, col: 12, offset: 34043},
+				pos: position{line: 1377, col: 12, offset: 34101},
 				run: (*parser).callonAndToken1,
 				expr: &seqExpr{
-					pos: position{line: 1377, col: 12, offset: 34043},
+					pos: position{line: 1377, col: 12, offset: 34101},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 1377, col: 13, offset: 34044},
+							pos: position{line: 1377, col: 13, offset: 34102},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1377, col: 13, offset: 34044},
+									pos:        position{line: 1377, col: 13, offset: 34102},
 									val:        "and",
 									ignoreCase: false,
 									want:       "\"and\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1377, col: 21, offset: 34052},
+									pos:        position{line: 1377, col: 21, offset: 34110},
 									val:        "AND",
 									ignoreCase: false,
 									want:       "\"AND\"",
@@ -9288,9 +9396,9 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 1377, col: 28, offset: 34059},
+							pos: position{line: 1377, col: 28, offset: 34117},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1377, col: 29, offset: 34060},
+								pos:  position{line: 1377, col: 29, offset: 34118},
 								name: "IdentifierRest",
 							},
 						},
@@ -9302,20 +9410,20 @@ var g = &grammar{
 		},
 		{
 			name: "ByToken",
-			pos:  position{line: 1378, col: 1, offset: 34097},
+			pos:  position{line: 1378, col: 1, offset: 34155},
 			expr: &seqExpr{
-				pos: position{line: 1378, col: 11, offset: 34107},
+				pos: position{line: 1378, col: 11, offset: 34165},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1378, col: 11, offset: 34107},
+						pos:        position{line: 1378, col: 11, offset: 34165},
 						val:        "by",
 						ignoreCase: false,
 						want:       "\"by\"",
 					},
 					&notExpr{
-						pos: position{line: 1378, col: 16, offset: 34112},
+						pos: position{line: 1378, col: 16, offset: 34170},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1378, col: 17, offset: 34113},
+							pos:  position{line: 1378, col: 17, offset: 34171},
 							name: "IdentifierRest",
 						},
 					},
@@ -9326,20 +9434,20 @@ var g = &grammar{
 		},
 		{
 			name: "FalseToken",
-			pos:  position{line: 1379, col: 1, offset: 34128},
+			pos:  position{line: 1379, col: 1, offset: 34186},
 			expr: &seqExpr{
-				pos: position{line: 1379, col: 14, offset: 34141},
+				pos: position{line: 1379, col: 14, offset: 34199},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1379, col: 14, offset: 34141},
+						pos:        position{line: 1379, col: 14, offset: 34199},
 						val:        "false",
 						ignoreCase: false,
 						want:       "\"false\"",
 					},
 					&notExpr{
-						pos: position{line: 1379, col: 22, offset: 34149},
+						pos: position{line: 1379, col: 22, offset: 34207},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1379, col: 23, offset: 34150},
+							pos:  position{line: 1379, col: 23, offset: 34208},
 							name: "IdentifierRest",
 						},
 					},
@@ -9350,20 +9458,20 @@ var g = &grammar{
 		},
 		{
 			name: "InToken",
-			pos:  position{line: 1380, col: 1, offset: 34165},
+			pos:  position{line: 1380, col: 1, offset: 34223},
 			expr: &seqExpr{
-				pos: position{line: 1380, col: 11, offset: 34175},
+				pos: position{line: 1380, col: 11, offset: 34233},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1380, col: 11, offset: 34175},
+						pos:        position{line: 1380, col: 11, offset: 34233},
 						val:        "in",
 						ignoreCase: false,
 						want:       "\"in\"",
 					},
 					&notExpr{
-						pos: position{line: 1380, col: 16, offset: 34180},
+						pos: position{line: 1380, col: 16, offset: 34238},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1380, col: 17, offset: 34181},
+							pos:  position{line: 1380, col: 17, offset: 34239},
 							name: "IdentifierRest",
 						},
 					},
@@ -9374,24 +9482,24 @@ var g = &grammar{
 		},
 		{
 			name: "NotToken",
-			pos:  position{line: 1381, col: 1, offset: 34196},
+			pos:  position{line: 1381, col: 1, offset: 34254},
 			expr: &actionExpr{
-				pos: position{line: 1381, col: 12, offset: 34207},
+				pos: position{line: 1381, col: 12, offset: 34265},
 				run: (*parser).callonNotToken1,
 				expr: &seqExpr{
-					pos: position{line: 1381, col: 12, offset: 34207},
+					pos: position{line: 1381, col: 12, offset: 34265},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 1381, col: 13, offset: 34208},
+							pos: position{line: 1381, col: 13, offset: 34266},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1381, col: 13, offset: 34208},
+									pos:        position{line: 1381, col: 13, offset: 34266},
 									val:        "not",
 									ignoreCase: false,
 									want:       "\"not\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1381, col: 21, offset: 34216},
+									pos:        position{line: 1381, col: 21, offset: 34274},
 									val:        "NOT",
 									ignoreCase: false,
 									want:       "\"NOT\"",
@@ -9399,9 +9507,9 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 1381, col: 28, offset: 34223},
+							pos: position{line: 1381, col: 28, offset: 34281},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1381, col: 29, offset: 34224},
+								pos:  position{line: 1381, col: 29, offset: 34282},
 								name: "IdentifierRest",
 							},
 						},
@@ -9413,20 +9521,20 @@ var g = &grammar{
 		},
 		{
 			name: "NullToken",
-			pos:  position{line: 1382, col: 1, offset: 34261},
+			pos:  position{line: 1382, col: 1, offset: 34319},
 			expr: &seqExpr{
-				pos: position{line: 1382, col: 13, offset: 34273},
+				pos: position{line: 1382, col: 13, offset: 34331},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1382, col: 13, offset: 34273},
+						pos:        position{line: 1382, col: 13, offset: 34331},
 						val:        "null",
 						ignoreCase: false,
 						want:       "\"null\"",
 					},
 					&notExpr{
-						pos: position{line: 1382, col: 20, offset: 34280},
+						pos: position{line: 1382, col: 20, offset: 34338},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1382, col: 21, offset: 34281},
+							pos:  position{line: 1382, col: 21, offset: 34339},
 							name: "IdentifierRest",
 						},
 					},
@@ -9437,24 +9545,24 @@ var g = &grammar{
 		},
 		{
 			name: "OrToken",
-			pos:  position{line: 1383, col: 1, offset: 34296},
+			pos:  position{line: 1383, col: 1, offset: 34354},
 			expr: &actionExpr{
-				pos: position{line: 1383, col: 11, offset: 34306},
+				pos: position{line: 1383, col: 11, offset: 34364},
 				run: (*parser).callonOrToken1,
 				expr: &seqExpr{
-					pos: position{line: 1383, col: 11, offset: 34306},
+					pos: position{line: 1383, col: 11, offset: 34364},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 1383, col: 12, offset: 34307},
+							pos: position{line: 1383, col: 12, offset: 34365},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1383, col: 12, offset: 34307},
+									pos:        position{line: 1383, col: 12, offset: 34365},
 									val:        "or",
 									ignoreCase: false,
 									want:       "\"or\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1383, col: 19, offset: 34314},
+									pos:        position{line: 1383, col: 19, offset: 34372},
 									val:        "OR",
 									ignoreCase: false,
 									want:       "\"OR\"",
@@ -9462,9 +9570,9 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 1383, col: 25, offset: 34320},
+							pos: position{line: 1383, col: 25, offset: 34378},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1383, col: 26, offset: 34321},
+								pos:  position{line: 1383, col: 26, offset: 34379},
 								name: "IdentifierRest",
 							},
 						},
@@ -9476,20 +9584,20 @@ var g = &grammar{
 		},
 		{
 			name: "TrueToken",
-			pos:  position{line: 1384, col: 1, offset: 34357},
+			pos:  position{line: 1384, col: 1, offset: 34415},
 			expr: &seqExpr{
-				pos: position{line: 1384, col: 13, offset: 34369},
+				pos: position{line: 1384, col: 13, offset: 34427},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1384, col: 13, offset: 34369},
+						pos:        position{line: 1384, col: 13, offset: 34427},
 						val:        "true",
 						ignoreCase: false,
 						want:       "\"true\"",
 					},
 					&notExpr{
-						pos: position{line: 1384, col: 20, offset: 34376},
+						pos: position{line: 1384, col: 20, offset: 34434},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1384, col: 21, offset: 34377},
+							pos:  position{line: 1384, col: 21, offset: 34435},
 							name: "IdentifierRest",
 						},
 					},
@@ -9500,15 +9608,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1386, col: 1, offset: 34393},
+			pos:  position{line: 1386, col: 1, offset: 34451},
 			expr: &actionExpr{
-				pos: position{line: 1387, col: 5, offset: 34408},
+				pos: position{line: 1387, col: 5, offset: 34466},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1387, col: 5, offset: 34408},
+					pos:   position{line: 1387, col: 5, offset: 34466},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1387, col: 8, offset: 34411},
+						pos:  position{line: 1387, col: 8, offset: 34469},
 						name: "IdentifierName",
 					},
 				},
@@ -9518,51 +9626,51 @@ var g = &grammar{
 		},
 		{
 			name: "Identifiers",
-			pos:  position{line: 1395, col: 1, offset: 34554},
+			pos:  position{line: 1395, col: 1, offset: 34612},
 			expr: &actionExpr{
-				pos: position{line: 1396, col: 5, offset: 34570},
+				pos: position{line: 1396, col: 5, offset: 34628},
 				run: (*parser).callonIdentifiers1,
 				expr: &seqExpr{
-					pos: position{line: 1396, col: 5, offset: 34570},
+					pos: position{line: 1396, col: 5, offset: 34628},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1396, col: 5, offset: 34570},
+							pos:   position{line: 1396, col: 5, offset: 34628},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1396, col: 11, offset: 34576},
+								pos:  position{line: 1396, col: 11, offset: 34634},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1396, col: 22, offset: 34587},
+							pos:   position{line: 1396, col: 22, offset: 34645},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1396, col: 27, offset: 34592},
+								pos: position{line: 1396, col: 27, offset: 34650},
 								expr: &actionExpr{
-									pos: position{line: 1396, col: 28, offset: 34593},
+									pos: position{line: 1396, col: 28, offset: 34651},
 									run: (*parser).callonIdentifiers7,
 									expr: &seqExpr{
-										pos: position{line: 1396, col: 28, offset: 34593},
+										pos: position{line: 1396, col: 28, offset: 34651},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1396, col: 28, offset: 34593},
+												pos:  position{line: 1396, col: 28, offset: 34651},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1396, col: 31, offset: 34596},
+												pos:        position{line: 1396, col: 31, offset: 34654},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1396, col: 35, offset: 34600},
+												pos:  position{line: 1396, col: 35, offset: 34658},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1396, col: 38, offset: 34603},
+												pos:   position{line: 1396, col: 38, offset: 34661},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1396, col: 43, offset: 34608},
+													pos:  position{line: 1396, col: 43, offset: 34666},
 													name: "Identifier",
 												},
 											},
@@ -9579,29 +9687,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1400, col: 1, offset: 34686},
+			pos:  position{line: 1400, col: 1, offset: 34744},
 			expr: &choiceExpr{
-				pos: position{line: 1401, col: 5, offset: 34705},
+				pos: position{line: 1401, col: 5, offset: 34763},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1401, col: 5, offset: 34705},
+						pos: position{line: 1401, col: 5, offset: 34763},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1401, col: 5, offset: 34705},
+							pos: position{line: 1401, col: 5, offset: 34763},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1401, col: 5, offset: 34705},
+									pos: position{line: 1401, col: 5, offset: 34763},
 									expr: &seqExpr{
-										pos: position{line: 1401, col: 7, offset: 34707},
+										pos: position{line: 1401, col: 7, offset: 34765},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1401, col: 7, offset: 34707},
+												pos:  position{line: 1401, col: 7, offset: 34765},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1401, col: 15, offset: 34715},
+												pos: position{line: 1401, col: 15, offset: 34773},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1401, col: 16, offset: 34716},
+													pos:  position{line: 1401, col: 16, offset: 34774},
 													name: "IdentifierRest",
 												},
 											},
@@ -9609,13 +9717,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1401, col: 32, offset: 34732},
+									pos:  position{line: 1401, col: 32, offset: 34790},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1401, col: 48, offset: 34748},
+									pos: position{line: 1401, col: 48, offset: 34806},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1401, col: 48, offset: 34748},
+										pos:  position{line: 1401, col: 48, offset: 34806},
 										name: "IdentifierRest",
 									},
 								},
@@ -9623,32 +9731,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1402, col: 5, offset: 34799},
+						pos: position{line: 1402, col: 5, offset: 34857},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 1402, col: 5, offset: 34799},
+							pos:        position{line: 1402, col: 5, offset: 34857},
 							val:        "$",
 							ignoreCase: false,
 							want:       "\"$\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1403, col: 5, offset: 34838},
+						pos: position{line: 1403, col: 5, offset: 34896},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 1403, col: 5, offset: 34838},
+							pos: position{line: 1403, col: 5, offset: 34896},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1403, col: 5, offset: 34838},
+									pos:        position{line: 1403, col: 5, offset: 34896},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1403, col: 10, offset: 34843},
+									pos:   position{line: 1403, col: 10, offset: 34901},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1403, col: 13, offset: 34846},
+										pos:  position{line: 1403, col: 13, offset: 34904},
 										name: "IDGuard",
 									},
 								},
@@ -9656,10 +9764,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1405, col: 5, offset: 34937},
+						pos: position{line: 1405, col: 5, offset: 34995},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 1405, col: 5, offset: 34937},
+							pos:        position{line: 1405, col: 5, offset: 34995},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
@@ -9672,22 +9780,22 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1407, col: 1, offset: 34976},
+			pos:  position{line: 1407, col: 1, offset: 35034},
 			expr: &choiceExpr{
-				pos: position{line: 1408, col: 5, offset: 34996},
+				pos: position{line: 1408, col: 5, offset: 35054},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1408, col: 5, offset: 34996},
+						pos:  position{line: 1408, col: 5, offset: 35054},
 						name: "UnicodeLetter",
 					},
 					&litMatcher{
-						pos:        position{line: 1409, col: 5, offset: 35014},
+						pos:        position{line: 1409, col: 5, offset: 35072},
 						val:        "$",
 						ignoreCase: false,
 						want:       "\"$\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1410, col: 5, offset: 35022},
+						pos:        position{line: 1410, col: 5, offset: 35080},
 						val:        "_",
 						ignoreCase: false,
 						want:       "\"_\"",
@@ -9699,24 +9807,24 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1412, col: 1, offset: 35027},
+			pos:  position{line: 1412, col: 1, offset: 35085},
 			expr: &choiceExpr{
-				pos: position{line: 1413, col: 5, offset: 35046},
+				pos: position{line: 1413, col: 5, offset: 35104},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1413, col: 5, offset: 35046},
+						pos:  position{line: 1413, col: 5, offset: 35104},
 						name: "IdentifierStart",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1414, col: 5, offset: 35066},
+						pos:  position{line: 1414, col: 5, offset: 35124},
 						name: "UnicodeCombiningMark",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1415, col: 5, offset: 35091},
+						pos:  position{line: 1415, col: 5, offset: 35149},
 						name: "UnicodeDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1416, col: 5, offset: 35108},
+						pos:  position{line: 1416, col: 5, offset: 35166},
 						name: "UnicodeConnectorPunctuation",
 					},
 				},
@@ -9726,24 +9834,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1418, col: 1, offset: 35137},
+			pos:  position{line: 1418, col: 1, offset: 35195},
 			expr: &choiceExpr{
-				pos: position{line: 1419, col: 5, offset: 35149},
+				pos: position{line: 1419, col: 5, offset: 35207},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1419, col: 5, offset: 35149},
+						pos:  position{line: 1419, col: 5, offset: 35207},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1420, col: 5, offset: 35168},
+						pos:  position{line: 1420, col: 5, offset: 35226},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1421, col: 5, offset: 35184},
+						pos:  position{line: 1421, col: 5, offset: 35242},
 						name: "NaN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1422, col: 5, offset: 35192},
+						pos:  position{line: 1422, col: 5, offset: 35250},
 						name: "Infinity",
 					},
 				},
@@ -9753,25 +9861,25 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1424, col: 1, offset: 35202},
+			pos:  position{line: 1424, col: 1, offset: 35260},
 			expr: &actionExpr{
-				pos: position{line: 1425, col: 5, offset: 35211},
+				pos: position{line: 1425, col: 5, offset: 35269},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1425, col: 5, offset: 35211},
+					pos: position{line: 1425, col: 5, offset: 35269},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1425, col: 5, offset: 35211},
+							pos:  position{line: 1425, col: 5, offset: 35269},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1425, col: 14, offset: 35220},
+							pos:        position{line: 1425, col: 14, offset: 35278},
 							val:        "T",
 							ignoreCase: false,
 							want:       "\"T\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1425, col: 18, offset: 35224},
+							pos:  position{line: 1425, col: 18, offset: 35282},
 							name: "FullTime",
 						},
 					},
@@ -9782,32 +9890,32 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1429, col: 1, offset: 35300},
+			pos:  position{line: 1429, col: 1, offset: 35358},
 			expr: &seqExpr{
-				pos: position{line: 1429, col: 12, offset: 35311},
+				pos: position{line: 1429, col: 12, offset: 35369},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1429, col: 12, offset: 35311},
+						pos:  position{line: 1429, col: 12, offset: 35369},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1429, col: 15, offset: 35314},
+						pos:        position{line: 1429, col: 15, offset: 35372},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1429, col: 19, offset: 35318},
+						pos:  position{line: 1429, col: 19, offset: 35376},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1429, col: 22, offset: 35321},
+						pos:        position{line: 1429, col: 22, offset: 35379},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1429, col: 26, offset: 35325},
+						pos:  position{line: 1429, col: 26, offset: 35383},
 						name: "D2",
 					},
 				},
@@ -9817,33 +9925,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1431, col: 1, offset: 35329},
+			pos:  position{line: 1431, col: 1, offset: 35387},
 			expr: &seqExpr{
-				pos: position{line: 1431, col: 6, offset: 35334},
+				pos: position{line: 1431, col: 6, offset: 35392},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1431, col: 6, offset: 35334},
+						pos:        position{line: 1431, col: 6, offset: 35392},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1431, col: 11, offset: 35339},
+						pos:        position{line: 1431, col: 11, offset: 35397},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1431, col: 16, offset: 35344},
+						pos:        position{line: 1431, col: 16, offset: 35402},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1431, col: 21, offset: 35349},
+						pos:        position{line: 1431, col: 21, offset: 35407},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9856,19 +9964,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1432, col: 1, offset: 35355},
+			pos:  position{line: 1432, col: 1, offset: 35413},
 			expr: &seqExpr{
-				pos: position{line: 1432, col: 6, offset: 35360},
+				pos: position{line: 1432, col: 6, offset: 35418},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1432, col: 6, offset: 35360},
+						pos:        position{line: 1432, col: 6, offset: 35418},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1432, col: 11, offset: 35365},
+						pos:        position{line: 1432, col: 11, offset: 35423},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9881,16 +9989,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1434, col: 1, offset: 35372},
+			pos:  position{line: 1434, col: 1, offset: 35430},
 			expr: &seqExpr{
-				pos: position{line: 1434, col: 12, offset: 35383},
+				pos: position{line: 1434, col: 12, offset: 35441},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1434, col: 12, offset: 35383},
+						pos:  position{line: 1434, col: 12, offset: 35441},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1434, col: 24, offset: 35395},
+						pos:  position{line: 1434, col: 24, offset: 35453},
 						name: "TimeOffset",
 					},
 				},
@@ -9900,49 +10008,49 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1436, col: 1, offset: 35407},
+			pos:  position{line: 1436, col: 1, offset: 35465},
 			expr: &seqExpr{
-				pos: position{line: 1436, col: 15, offset: 35421},
+				pos: position{line: 1436, col: 15, offset: 35479},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1436, col: 15, offset: 35421},
+						pos:  position{line: 1436, col: 15, offset: 35479},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1436, col: 18, offset: 35424},
+						pos:        position{line: 1436, col: 18, offset: 35482},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1436, col: 22, offset: 35428},
+						pos:  position{line: 1436, col: 22, offset: 35486},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1436, col: 25, offset: 35431},
+						pos:        position{line: 1436, col: 25, offset: 35489},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1436, col: 29, offset: 35435},
+						pos:  position{line: 1436, col: 29, offset: 35493},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1436, col: 32, offset: 35438},
+						pos: position{line: 1436, col: 32, offset: 35496},
 						expr: &seqExpr{
-							pos: position{line: 1436, col: 33, offset: 35439},
+							pos: position{line: 1436, col: 33, offset: 35497},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1436, col: 33, offset: 35439},
+									pos:        position{line: 1436, col: 33, offset: 35497},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1436, col: 37, offset: 35443},
+									pos: position{line: 1436, col: 37, offset: 35501},
 									expr: &charClassMatcher{
-										pos:        position{line: 1436, col: 37, offset: 35443},
+										pos:        position{line: 1436, col: 37, offset: 35501},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -9959,30 +10067,30 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1438, col: 1, offset: 35453},
+			pos:  position{line: 1438, col: 1, offset: 35511},
 			expr: &choiceExpr{
-				pos: position{line: 1439, col: 5, offset: 35468},
+				pos: position{line: 1439, col: 5, offset: 35526},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1439, col: 5, offset: 35468},
+						pos:        position{line: 1439, col: 5, offset: 35526},
 						val:        "Z",
 						ignoreCase: false,
 						want:       "\"Z\"",
 					},
 					&seqExpr{
-						pos: position{line: 1440, col: 5, offset: 35476},
+						pos: position{line: 1440, col: 5, offset: 35534},
 						exprs: []any{
 							&choiceExpr{
-								pos: position{line: 1440, col: 6, offset: 35477},
+								pos: position{line: 1440, col: 6, offset: 35535},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 1440, col: 6, offset: 35477},
+										pos:        position{line: 1440, col: 6, offset: 35535},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 1440, col: 12, offset: 35483},
+										pos:        position{line: 1440, col: 12, offset: 35541},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
@@ -9990,34 +10098,34 @@ var g = &grammar{
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1440, col: 17, offset: 35488},
+								pos:  position{line: 1440, col: 17, offset: 35546},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1440, col: 20, offset: 35491},
+								pos:        position{line: 1440, col: 20, offset: 35549},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1440, col: 24, offset: 35495},
+								pos:  position{line: 1440, col: 24, offset: 35553},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1440, col: 27, offset: 35498},
+								pos: position{line: 1440, col: 27, offset: 35556},
 								expr: &seqExpr{
-									pos: position{line: 1440, col: 28, offset: 35499},
+									pos: position{line: 1440, col: 28, offset: 35557},
 									exprs: []any{
 										&litMatcher{
-											pos:        position{line: 1440, col: 28, offset: 35499},
+											pos:        position{line: 1440, col: 28, offset: 35557},
 											val:        ".",
 											ignoreCase: false,
 											want:       "\".\"",
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1440, col: 32, offset: 35503},
+											pos: position{line: 1440, col: 32, offset: 35561},
 											expr: &charClassMatcher{
-												pos:        position{line: 1440, col: 32, offset: 35503},
+												pos:        position{line: 1440, col: 32, offset: 35561},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -10036,33 +10144,33 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1442, col: 1, offset: 35513},
+			pos:  position{line: 1442, col: 1, offset: 35571},
 			expr: &actionExpr{
-				pos: position{line: 1443, col: 5, offset: 35526},
+				pos: position{line: 1443, col: 5, offset: 35584},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1443, col: 5, offset: 35526},
+					pos: position{line: 1443, col: 5, offset: 35584},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 1443, col: 5, offset: 35526},
+							pos: position{line: 1443, col: 5, offset: 35584},
 							expr: &litMatcher{
-								pos:        position{line: 1443, col: 5, offset: 35526},
+								pos:        position{line: 1443, col: 5, offset: 35584},
 								val:        "-",
 								ignoreCase: false,
 								want:       "\"-\"",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1443, col: 10, offset: 35531},
+							pos: position{line: 1443, col: 10, offset: 35589},
 							expr: &seqExpr{
-								pos: position{line: 1443, col: 11, offset: 35532},
+								pos: position{line: 1443, col: 11, offset: 35590},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1443, col: 11, offset: 35532},
+										pos:  position{line: 1443, col: 11, offset: 35590},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1443, col: 19, offset: 35540},
+										pos:  position{line: 1443, col: 19, offset: 35598},
 										name: "TimeUnit",
 									},
 								},
@@ -10076,27 +10184,27 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1447, col: 1, offset: 35622},
+			pos:  position{line: 1447, col: 1, offset: 35680},
 			expr: &seqExpr{
-				pos: position{line: 1447, col: 11, offset: 35632},
+				pos: position{line: 1447, col: 11, offset: 35690},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1447, col: 11, offset: 35632},
+						pos:  position{line: 1447, col: 11, offset: 35690},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1447, col: 16, offset: 35637},
+						pos: position{line: 1447, col: 16, offset: 35695},
 						expr: &seqExpr{
-							pos: position{line: 1447, col: 17, offset: 35638},
+							pos: position{line: 1447, col: 17, offset: 35696},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1447, col: 17, offset: 35638},
+									pos:        position{line: 1447, col: 17, offset: 35696},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1447, col: 21, offset: 35642},
+									pos:  position{line: 1447, col: 21, offset: 35700},
 									name: "UInt",
 								},
 							},
@@ -10109,60 +10217,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1449, col: 1, offset: 35650},
+			pos:  position{line: 1449, col: 1, offset: 35708},
 			expr: &choiceExpr{
-				pos: position{line: 1450, col: 5, offset: 35663},
+				pos: position{line: 1450, col: 5, offset: 35721},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1450, col: 5, offset: 35663},
+						pos:        position{line: 1450, col: 5, offset: 35721},
 						val:        "ns",
 						ignoreCase: false,
 						want:       "\"ns\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1451, col: 5, offset: 35672},
+						pos:        position{line: 1451, col: 5, offset: 35730},
 						val:        "us",
 						ignoreCase: false,
 						want:       "\"us\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1452, col: 5, offset: 35681},
+						pos:        position{line: 1452, col: 5, offset: 35739},
 						val:        "ms",
 						ignoreCase: false,
 						want:       "\"ms\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1453, col: 5, offset: 35690},
+						pos:        position{line: 1453, col: 5, offset: 35748},
 						val:        "s",
 						ignoreCase: false,
 						want:       "\"s\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1454, col: 5, offset: 35698},
+						pos:        position{line: 1454, col: 5, offset: 35756},
 						val:        "m",
 						ignoreCase: false,
 						want:       "\"m\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1455, col: 5, offset: 35706},
+						pos:        position{line: 1455, col: 5, offset: 35764},
 						val:        "h",
 						ignoreCase: false,
 						want:       "\"h\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1456, col: 5, offset: 35714},
+						pos:        position{line: 1456, col: 5, offset: 35772},
 						val:        "d",
 						ignoreCase: false,
 						want:       "\"d\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1457, col: 5, offset: 35722},
+						pos:        position{line: 1457, col: 5, offset: 35780},
 						val:        "w",
 						ignoreCase: false,
 						want:       "\"w\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1458, col: 5, offset: 35730},
+						pos:        position{line: 1458, col: 5, offset: 35788},
 						val:        "y",
 						ignoreCase: false,
 						want:       "\"y\"",
@@ -10174,45 +10282,45 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1460, col: 1, offset: 35735},
+			pos:  position{line: 1460, col: 1, offset: 35793},
 			expr: &actionExpr{
-				pos: position{line: 1461, col: 5, offset: 35742},
+				pos: position{line: 1461, col: 5, offset: 35800},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1461, col: 5, offset: 35742},
+					pos: position{line: 1461, col: 5, offset: 35800},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1461, col: 5, offset: 35742},
+							pos:  position{line: 1461, col: 5, offset: 35800},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1461, col: 10, offset: 35747},
+							pos:        position{line: 1461, col: 10, offset: 35805},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1461, col: 14, offset: 35751},
+							pos:  position{line: 1461, col: 14, offset: 35809},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1461, col: 19, offset: 35756},
+							pos:        position{line: 1461, col: 19, offset: 35814},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1461, col: 23, offset: 35760},
+							pos:  position{line: 1461, col: 23, offset: 35818},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1461, col: 28, offset: 35765},
+							pos:        position{line: 1461, col: 28, offset: 35823},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1461, col: 32, offset: 35769},
+							pos:  position{line: 1461, col: 32, offset: 35827},
 							name: "UInt",
 						},
 					},
@@ -10223,43 +10331,43 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1463, col: 1, offset: 35806},
+			pos:  position{line: 1463, col: 1, offset: 35864},
 			expr: &actionExpr{
-				pos: position{line: 1464, col: 5, offset: 35814},
+				pos: position{line: 1464, col: 5, offset: 35872},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1464, col: 5, offset: 35814},
+					pos: position{line: 1464, col: 5, offset: 35872},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1464, col: 5, offset: 35814},
+							pos: position{line: 1464, col: 5, offset: 35872},
 							expr: &seqExpr{
-								pos: position{line: 1464, col: 7, offset: 35816},
+								pos: position{line: 1464, col: 7, offset: 35874},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1464, col: 7, offset: 35816},
+										pos:  position{line: 1464, col: 7, offset: 35874},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1464, col: 11, offset: 35820},
+										pos:        position{line: 1464, col: 11, offset: 35878},
 										val:        ":",
 										ignoreCase: false,
 										want:       "\":\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1464, col: 15, offset: 35824},
+										pos:  position{line: 1464, col: 15, offset: 35882},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1464, col: 19, offset: 35828},
+										pos: position{line: 1464, col: 19, offset: 35886},
 										expr: &choiceExpr{
-											pos: position{line: 1464, col: 21, offset: 35830},
+											pos: position{line: 1464, col: 21, offset: 35888},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1464, col: 21, offset: 35830},
+													pos:  position{line: 1464, col: 21, offset: 35888},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1464, col: 32, offset: 35841},
+													pos:        position{line: 1464, col: 32, offset: 35899},
 													val:        ":",
 													ignoreCase: false,
 													want:       "\":\"",
@@ -10271,10 +10379,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1464, col: 38, offset: 35847},
+							pos:   position{line: 1464, col: 38, offset: 35905},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1464, col: 40, offset: 35849},
+								pos:  position{line: 1464, col: 40, offset: 35907},
 								name: "IP6Variations",
 							},
 						},
@@ -10286,32 +10394,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1468, col: 1, offset: 36013},
+			pos:  position{line: 1468, col: 1, offset: 36071},
 			expr: &choiceExpr{
-				pos: position{line: 1469, col: 5, offset: 36031},
+				pos: position{line: 1469, col: 5, offset: 36089},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1469, col: 5, offset: 36031},
+						pos: position{line: 1469, col: 5, offset: 36089},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1469, col: 5, offset: 36031},
+							pos: position{line: 1469, col: 5, offset: 36089},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1469, col: 5, offset: 36031},
+									pos:   position{line: 1469, col: 5, offset: 36089},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1469, col: 7, offset: 36033},
+										pos: position{line: 1469, col: 7, offset: 36091},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1469, col: 7, offset: 36033},
+											pos:  position{line: 1469, col: 7, offset: 36091},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1469, col: 17, offset: 36043},
+									pos:   position{line: 1469, col: 17, offset: 36101},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1469, col: 19, offset: 36045},
+										pos:  position{line: 1469, col: 19, offset: 36103},
 										name: "IP6Tail",
 									},
 								},
@@ -10319,52 +10427,52 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1472, col: 5, offset: 36109},
+						pos: position{line: 1472, col: 5, offset: 36167},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1472, col: 5, offset: 36109},
+							pos: position{line: 1472, col: 5, offset: 36167},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1472, col: 5, offset: 36109},
+									pos:   position{line: 1472, col: 5, offset: 36167},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1472, col: 7, offset: 36111},
+										pos:  position{line: 1472, col: 7, offset: 36169},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1472, col: 11, offset: 36115},
+									pos:   position{line: 1472, col: 11, offset: 36173},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1472, col: 13, offset: 36117},
+										pos: position{line: 1472, col: 13, offset: 36175},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1472, col: 13, offset: 36117},
+											pos:  position{line: 1472, col: 13, offset: 36175},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1472, col: 23, offset: 36127},
+									pos:        position{line: 1472, col: 23, offset: 36185},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1472, col: 28, offset: 36132},
+									pos:   position{line: 1472, col: 28, offset: 36190},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1472, col: 30, offset: 36134},
+										pos: position{line: 1472, col: 30, offset: 36192},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1472, col: 30, offset: 36134},
+											pos:  position{line: 1472, col: 30, offset: 36192},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1472, col: 40, offset: 36144},
+									pos:   position{line: 1472, col: 40, offset: 36202},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1472, col: 42, offset: 36146},
+										pos:  position{line: 1472, col: 42, offset: 36204},
 										name: "IP6Tail",
 									},
 								},
@@ -10372,33 +10480,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1475, col: 5, offset: 36245},
+						pos: position{line: 1475, col: 5, offset: 36303},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1475, col: 5, offset: 36245},
+							pos: position{line: 1475, col: 5, offset: 36303},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1475, col: 5, offset: 36245},
+									pos:        position{line: 1475, col: 5, offset: 36303},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1475, col: 10, offset: 36250},
+									pos:   position{line: 1475, col: 10, offset: 36308},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1475, col: 12, offset: 36252},
+										pos: position{line: 1475, col: 12, offset: 36310},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1475, col: 12, offset: 36252},
+											pos:  position{line: 1475, col: 12, offset: 36310},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1475, col: 22, offset: 36262},
+									pos:   position{line: 1475, col: 22, offset: 36320},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1475, col: 24, offset: 36264},
+										pos:  position{line: 1475, col: 24, offset: 36322},
 										name: "IP6Tail",
 									},
 								},
@@ -10406,32 +10514,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1478, col: 5, offset: 36335},
+						pos: position{line: 1478, col: 5, offset: 36393},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1478, col: 5, offset: 36335},
+							pos: position{line: 1478, col: 5, offset: 36393},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1478, col: 5, offset: 36335},
+									pos:   position{line: 1478, col: 5, offset: 36393},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1478, col: 7, offset: 36337},
+										pos:  position{line: 1478, col: 7, offset: 36395},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1478, col: 11, offset: 36341},
+									pos:   position{line: 1478, col: 11, offset: 36399},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1478, col: 13, offset: 36343},
+										pos: position{line: 1478, col: 13, offset: 36401},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1478, col: 13, offset: 36343},
+											pos:  position{line: 1478, col: 13, offset: 36401},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1478, col: 23, offset: 36353},
+									pos:        position{line: 1478, col: 23, offset: 36411},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
@@ -10440,10 +10548,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1481, col: 5, offset: 36421},
+						pos: position{line: 1481, col: 5, offset: 36479},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 1481, col: 5, offset: 36421},
+							pos:        position{line: 1481, col: 5, offset: 36479},
 							val:        "::",
 							ignoreCase: false,
 							want:       "\"::\"",
@@ -10456,16 +10564,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1485, col: 1, offset: 36458},
+			pos:  position{line: 1485, col: 1, offset: 36516},
 			expr: &choiceExpr{
-				pos: position{line: 1486, col: 5, offset: 36470},
+				pos: position{line: 1486, col: 5, offset: 36528},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1486, col: 5, offset: 36470},
+						pos:  position{line: 1486, col: 5, offset: 36528},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1487, col: 5, offset: 36477},
+						pos:  position{line: 1487, col: 5, offset: 36535},
 						name: "Hex",
 					},
 				},
@@ -10475,24 +10583,24 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1489, col: 1, offset: 36482},
+			pos:  position{line: 1489, col: 1, offset: 36540},
 			expr: &actionExpr{
-				pos: position{line: 1489, col: 12, offset: 36493},
+				pos: position{line: 1489, col: 12, offset: 36551},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1489, col: 12, offset: 36493},
+					pos: position{line: 1489, col: 12, offset: 36551},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1489, col: 12, offset: 36493},
+							pos:        position{line: 1489, col: 12, offset: 36551},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1489, col: 16, offset: 36497},
+							pos:   position{line: 1489, col: 16, offset: 36555},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1489, col: 18, offset: 36499},
+								pos:  position{line: 1489, col: 18, offset: 36557},
 								name: "Hex",
 							},
 						},
@@ -10504,23 +10612,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1491, col: 1, offset: 36537},
+			pos:  position{line: 1491, col: 1, offset: 36595},
 			expr: &actionExpr{
-				pos: position{line: 1491, col: 12, offset: 36548},
+				pos: position{line: 1491, col: 12, offset: 36606},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1491, col: 12, offset: 36548},
+					pos: position{line: 1491, col: 12, offset: 36606},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1491, col: 12, offset: 36548},
+							pos:   position{line: 1491, col: 12, offset: 36606},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1491, col: 14, offset: 36550},
+								pos:  position{line: 1491, col: 14, offset: 36608},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1491, col: 18, offset: 36554},
+							pos:        position{line: 1491, col: 18, offset: 36612},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
@@ -10533,32 +10641,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1493, col: 1, offset: 36592},
+			pos:  position{line: 1493, col: 1, offset: 36650},
 			expr: &actionExpr{
-				pos: position{line: 1494, col: 5, offset: 36603},
+				pos: position{line: 1494, col: 5, offset: 36661},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1494, col: 5, offset: 36603},
+					pos: position{line: 1494, col: 5, offset: 36661},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1494, col: 5, offset: 36603},
+							pos:   position{line: 1494, col: 5, offset: 36661},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1494, col: 7, offset: 36605},
+								pos:  position{line: 1494, col: 7, offset: 36663},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1494, col: 10, offset: 36608},
+							pos:        position{line: 1494, col: 10, offset: 36666},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1494, col: 14, offset: 36612},
+							pos:   position{line: 1494, col: 14, offset: 36670},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1494, col: 16, offset: 36614},
+								pos:  position{line: 1494, col: 16, offset: 36672},
 								name: "UIntString",
 							},
 						},
@@ -10570,32 +10678,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1498, col: 1, offset: 36682},
+			pos:  position{line: 1498, col: 1, offset: 36740},
 			expr: &actionExpr{
-				pos: position{line: 1499, col: 5, offset: 36693},
+				pos: position{line: 1499, col: 5, offset: 36751},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1499, col: 5, offset: 36693},
+					pos: position{line: 1499, col: 5, offset: 36751},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1499, col: 5, offset: 36693},
+							pos:   position{line: 1499, col: 5, offset: 36751},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1499, col: 7, offset: 36695},
+								pos:  position{line: 1499, col: 7, offset: 36753},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1499, col: 11, offset: 36699},
+							pos:        position{line: 1499, col: 11, offset: 36757},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1499, col: 15, offset: 36703},
+							pos:   position{line: 1499, col: 15, offset: 36761},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1499, col: 17, offset: 36705},
+								pos:  position{line: 1499, col: 17, offset: 36763},
 								name: "UIntString",
 							},
 						},
@@ -10607,15 +10715,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1503, col: 1, offset: 36773},
+			pos:  position{line: 1503, col: 1, offset: 36831},
 			expr: &actionExpr{
-				pos: position{line: 1504, col: 4, offset: 36781},
+				pos: position{line: 1504, col: 4, offset: 36839},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1504, col: 4, offset: 36781},
+					pos:   position{line: 1504, col: 4, offset: 36839},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1504, col: 6, offset: 36783},
+						pos:  position{line: 1504, col: 6, offset: 36841},
 						name: "UIntString",
 					},
 				},
@@ -10625,16 +10733,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1506, col: 1, offset: 36823},
+			pos:  position{line: 1506, col: 1, offset: 36881},
 			expr: &choiceExpr{
-				pos: position{line: 1507, col: 5, offset: 36837},
+				pos: position{line: 1507, col: 5, offset: 36895},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1507, col: 5, offset: 36837},
+						pos:  position{line: 1507, col: 5, offset: 36895},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1508, col: 5, offset: 36852},
+						pos:  position{line: 1508, col: 5, offset: 36910},
 						name: "MinusIntString",
 					},
 				},
@@ -10644,14 +10752,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1510, col: 1, offset: 36868},
+			pos:  position{line: 1510, col: 1, offset: 36926},
 			expr: &actionExpr{
-				pos: position{line: 1510, col: 14, offset: 36881},
+				pos: position{line: 1510, col: 14, offset: 36939},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1510, col: 14, offset: 36881},
+					pos: position{line: 1510, col: 14, offset: 36939},
 					expr: &charClassMatcher{
-						pos:        position{line: 1510, col: 14, offset: 36881},
+						pos:        position{line: 1510, col: 14, offset: 36939},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10664,21 +10772,21 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1512, col: 1, offset: 36920},
+			pos:  position{line: 1512, col: 1, offset: 36978},
 			expr: &actionExpr{
-				pos: position{line: 1513, col: 5, offset: 36939},
+				pos: position{line: 1513, col: 5, offset: 36997},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1513, col: 5, offset: 36939},
+					pos: position{line: 1513, col: 5, offset: 36997},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1513, col: 5, offset: 36939},
+							pos:        position{line: 1513, col: 5, offset: 36997},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1513, col: 9, offset: 36943},
+							pos:  position{line: 1513, col: 9, offset: 37001},
 							name: "UIntString",
 						},
 					},
@@ -10689,29 +10797,29 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1515, col: 1, offset: 36986},
+			pos:  position{line: 1515, col: 1, offset: 37044},
 			expr: &choiceExpr{
-				pos: position{line: 1516, col: 5, offset: 37002},
+				pos: position{line: 1516, col: 5, offset: 37060},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1516, col: 5, offset: 37002},
+						pos: position{line: 1516, col: 5, offset: 37060},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1516, col: 5, offset: 37002},
+							pos: position{line: 1516, col: 5, offset: 37060},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1516, col: 5, offset: 37002},
+									pos: position{line: 1516, col: 5, offset: 37060},
 									expr: &litMatcher{
-										pos:        position{line: 1516, col: 5, offset: 37002},
+										pos:        position{line: 1516, col: 5, offset: 37060},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1516, col: 10, offset: 37007},
+									pos: position{line: 1516, col: 10, offset: 37065},
 									expr: &charClassMatcher{
-										pos:        position{line: 1516, col: 10, offset: 37007},
+										pos:        position{line: 1516, col: 10, offset: 37065},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10719,15 +10827,15 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1516, col: 17, offset: 37014},
+									pos:        position{line: 1516, col: 17, offset: 37072},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1516, col: 21, offset: 37018},
+									pos: position{line: 1516, col: 21, offset: 37076},
 									expr: &charClassMatcher{
-										pos:        position{line: 1516, col: 21, offset: 37018},
+										pos:        position{line: 1516, col: 21, offset: 37076},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10735,9 +10843,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1516, col: 28, offset: 37025},
+									pos: position{line: 1516, col: 28, offset: 37083},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1516, col: 28, offset: 37025},
+										pos:  position{line: 1516, col: 28, offset: 37083},
 										name: "ExponentPart",
 									},
 								},
@@ -10745,30 +10853,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1517, col: 5, offset: 37074},
+						pos: position{line: 1517, col: 5, offset: 37132},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1517, col: 5, offset: 37074},
+							pos: position{line: 1517, col: 5, offset: 37132},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1517, col: 5, offset: 37074},
+									pos: position{line: 1517, col: 5, offset: 37132},
 									expr: &litMatcher{
-										pos:        position{line: 1517, col: 5, offset: 37074},
+										pos:        position{line: 1517, col: 5, offset: 37132},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1517, col: 10, offset: 37079},
+									pos:        position{line: 1517, col: 10, offset: 37137},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1517, col: 14, offset: 37083},
+									pos: position{line: 1517, col: 14, offset: 37141},
 									expr: &charClassMatcher{
-										pos:        position{line: 1517, col: 14, offset: 37083},
+										pos:        position{line: 1517, col: 14, offset: 37141},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10776,9 +10884,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1517, col: 21, offset: 37090},
+									pos: position{line: 1517, col: 21, offset: 37148},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1517, col: 21, offset: 37090},
+										pos:  position{line: 1517, col: 21, offset: 37148},
 										name: "ExponentPart",
 									},
 								},
@@ -10786,17 +10894,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1518, col: 5, offset: 37139},
+						pos: position{line: 1518, col: 5, offset: 37197},
 						run: (*parser).callonFloatString22,
 						expr: &choiceExpr{
-							pos: position{line: 1518, col: 6, offset: 37140},
+							pos: position{line: 1518, col: 6, offset: 37198},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1518, col: 6, offset: 37140},
+									pos:  position{line: 1518, col: 6, offset: 37198},
 									name: "NaN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1518, col: 12, offset: 37146},
+									pos:  position{line: 1518, col: 12, offset: 37204},
 									name: "Infinity",
 								},
 							},
@@ -10809,20 +10917,20 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1521, col: 1, offset: 37189},
+			pos:  position{line: 1521, col: 1, offset: 37247},
 			expr: &seqExpr{
-				pos: position{line: 1521, col: 16, offset: 37204},
+				pos: position{line: 1521, col: 16, offset: 37262},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1521, col: 16, offset: 37204},
+						pos:        position{line: 1521, col: 16, offset: 37262},
 						val:        "e",
 						ignoreCase: true,
 						want:       "\"e\"i",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1521, col: 21, offset: 37209},
+						pos: position{line: 1521, col: 21, offset: 37267},
 						expr: &charClassMatcher{
-							pos:        position{line: 1521, col: 21, offset: 37209},
+							pos:        position{line: 1521, col: 21, offset: 37267},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -10830,7 +10938,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1521, col: 27, offset: 37215},
+						pos:  position{line: 1521, col: 27, offset: 37273},
 						name: "UIntString",
 					},
 				},
@@ -10840,9 +10948,9 @@ var g = &grammar{
 		},
 		{
 			name: "NaN",
-			pos:  position{line: 1523, col: 1, offset: 37227},
+			pos:  position{line: 1523, col: 1, offset: 37285},
 			expr: &litMatcher{
-				pos:        position{line: 1523, col: 7, offset: 37233},
+				pos:        position{line: 1523, col: 7, offset: 37291},
 				val:        "NaN",
 				ignoreCase: false,
 				want:       "\"NaN\"",
@@ -10852,23 +10960,23 @@ var g = &grammar{
 		},
 		{
 			name: "Infinity",
-			pos:  position{line: 1525, col: 1, offset: 37240},
+			pos:  position{line: 1525, col: 1, offset: 37298},
 			expr: &seqExpr{
-				pos: position{line: 1525, col: 12, offset: 37251},
+				pos: position{line: 1525, col: 12, offset: 37309},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 1525, col: 12, offset: 37251},
+						pos: position{line: 1525, col: 12, offset: 37309},
 						expr: &choiceExpr{
-							pos: position{line: 1525, col: 13, offset: 37252},
+							pos: position{line: 1525, col: 13, offset: 37310},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1525, col: 13, offset: 37252},
+									pos:        position{line: 1525, col: 13, offset: 37310},
 									val:        "-",
 									ignoreCase: false,
 									want:       "\"-\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1525, col: 19, offset: 37258},
+									pos:        position{line: 1525, col: 19, offset: 37316},
 									val:        "+",
 									ignoreCase: false,
 									want:       "\"+\"",
@@ -10877,7 +10985,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1525, col: 25, offset: 37264},
+						pos:        position{line: 1525, col: 25, offset: 37322},
 						val:        "Inf",
 						ignoreCase: false,
 						want:       "\"Inf\"",
@@ -10889,14 +10997,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1527, col: 1, offset: 37271},
+			pos:  position{line: 1527, col: 1, offset: 37329},
 			expr: &actionExpr{
-				pos: position{line: 1527, col: 7, offset: 37277},
+				pos: position{line: 1527, col: 7, offset: 37335},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1527, col: 7, offset: 37277},
+					pos: position{line: 1527, col: 7, offset: 37335},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1527, col: 7, offset: 37277},
+						pos:  position{line: 1527, col: 7, offset: 37335},
 						name: "HexDigit",
 					},
 				},
@@ -10906,9 +11014,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1529, col: 1, offset: 37319},
+			pos:  position{line: 1529, col: 1, offset: 37377},
 			expr: &charClassMatcher{
-				pos:        position{line: 1529, col: 12, offset: 37330},
+				pos:        position{line: 1529, col: 12, offset: 37388},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -10919,35 +11027,35 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1531, col: 1, offset: 37343},
+			pos:  position{line: 1531, col: 1, offset: 37401},
 			expr: &choiceExpr{
-				pos: position{line: 1532, col: 5, offset: 37360},
+				pos: position{line: 1532, col: 5, offset: 37418},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1532, col: 5, offset: 37360},
+						pos: position{line: 1532, col: 5, offset: 37418},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 1532, col: 5, offset: 37360},
+							pos: position{line: 1532, col: 5, offset: 37418},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1532, col: 5, offset: 37360},
+									pos:        position{line: 1532, col: 5, offset: 37418},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1532, col: 9, offset: 37364},
+									pos:   position{line: 1532, col: 9, offset: 37422},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1532, col: 11, offset: 37366},
+										pos: position{line: 1532, col: 11, offset: 37424},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1532, col: 11, offset: 37366},
+											pos:  position{line: 1532, col: 11, offset: 37424},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1532, col: 29, offset: 37384},
+									pos:        position{line: 1532, col: 29, offset: 37442},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -10956,30 +11064,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1533, col: 5, offset: 37421},
+						pos: position{line: 1533, col: 5, offset: 37479},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 1533, col: 5, offset: 37421},
+							pos: position{line: 1533, col: 5, offset: 37479},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1533, col: 5, offset: 37421},
+									pos:        position{line: 1533, col: 5, offset: 37479},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1533, col: 9, offset: 37425},
+									pos:   position{line: 1533, col: 9, offset: 37483},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1533, col: 11, offset: 37427},
+										pos: position{line: 1533, col: 11, offset: 37485},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1533, col: 11, offset: 37427},
+											pos:  position{line: 1533, col: 11, offset: 37485},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1533, col: 29, offset: 37445},
+									pos:        position{line: 1533, col: 29, offset: 37503},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -10994,57 +11102,57 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1535, col: 1, offset: 37479},
+			pos:  position{line: 1535, col: 1, offset: 37537},
 			expr: &choiceExpr{
-				pos: position{line: 1536, col: 5, offset: 37500},
+				pos: position{line: 1536, col: 5, offset: 37558},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1536, col: 5, offset: 37500},
+						pos: position{line: 1536, col: 5, offset: 37558},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1536, col: 5, offset: 37500},
+							pos: position{line: 1536, col: 5, offset: 37558},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1536, col: 5, offset: 37500},
+									pos: position{line: 1536, col: 5, offset: 37558},
 									expr: &choiceExpr{
-										pos: position{line: 1536, col: 7, offset: 37502},
+										pos: position{line: 1536, col: 7, offset: 37560},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1536, col: 7, offset: 37502},
+												pos:        position{line: 1536, col: 7, offset: 37560},
 												val:        "\"",
 												ignoreCase: false,
 												want:       "\"\\\"\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1536, col: 13, offset: 37508},
+												pos:  position{line: 1536, col: 13, offset: 37566},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1536, col: 26, offset: 37521,
+									line: 1536, col: 26, offset: 37579,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1537, col: 5, offset: 37558},
+						pos: position{line: 1537, col: 5, offset: 37616},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1537, col: 5, offset: 37558},
+							pos: position{line: 1537, col: 5, offset: 37616},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1537, col: 5, offset: 37558},
+									pos:        position{line: 1537, col: 5, offset: 37616},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1537, col: 10, offset: 37563},
+									pos:   position{line: 1537, col: 10, offset: 37621},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1537, col: 12, offset: 37565},
+										pos:  position{line: 1537, col: 12, offset: 37623},
 										name: "EscapeSequence",
 									},
 								},
@@ -11058,28 +11166,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1539, col: 1, offset: 37599},
+			pos:  position{line: 1539, col: 1, offset: 37657},
 			expr: &actionExpr{
-				pos: position{line: 1540, col: 5, offset: 37611},
+				pos: position{line: 1540, col: 5, offset: 37669},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1540, col: 5, offset: 37611},
+					pos: position{line: 1540, col: 5, offset: 37669},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1540, col: 5, offset: 37611},
+							pos:   position{line: 1540, col: 5, offset: 37669},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1540, col: 10, offset: 37616},
+								pos:  position{line: 1540, col: 10, offset: 37674},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1540, col: 23, offset: 37629},
+							pos:   position{line: 1540, col: 23, offset: 37687},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1540, col: 28, offset: 37634},
+								pos: position{line: 1540, col: 28, offset: 37692},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1540, col: 28, offset: 37634},
+									pos:  position{line: 1540, col: 28, offset: 37692},
 									name: "KeyWordRest",
 								},
 							},
@@ -11092,16 +11200,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1542, col: 1, offset: 37696},
+			pos:  position{line: 1542, col: 1, offset: 37754},
 			expr: &choiceExpr{
-				pos: position{line: 1543, col: 5, offset: 37713},
+				pos: position{line: 1543, col: 5, offset: 37771},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1543, col: 5, offset: 37713},
+						pos:  position{line: 1543, col: 5, offset: 37771},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1544, col: 5, offset: 37730},
+						pos:  position{line: 1544, col: 5, offset: 37788},
 						name: "KeyWordEsc",
 					},
 				},
@@ -11111,16 +11219,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1546, col: 1, offset: 37742},
+			pos:  position{line: 1546, col: 1, offset: 37800},
 			expr: &choiceExpr{
-				pos: position{line: 1547, col: 5, offset: 37758},
+				pos: position{line: 1547, col: 5, offset: 37816},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1547, col: 5, offset: 37758},
+						pos:  position{line: 1547, col: 5, offset: 37816},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1548, col: 5, offset: 37775},
+						pos:        position{line: 1548, col: 5, offset: 37833},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11133,19 +11241,19 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1550, col: 1, offset: 37782},
+			pos:  position{line: 1550, col: 1, offset: 37840},
 			expr: &actionExpr{
-				pos: position{line: 1550, col: 16, offset: 37797},
+				pos: position{line: 1550, col: 16, offset: 37855},
 				run: (*parser).callonKeyWordChars1,
 				expr: &choiceExpr{
-					pos: position{line: 1550, col: 17, offset: 37798},
+					pos: position{line: 1550, col: 17, offset: 37856},
 					alternatives: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1550, col: 17, offset: 37798},
+							pos:  position{line: 1550, col: 17, offset: 37856},
 							name: "UnicodeLetter",
 						},
 						&charClassMatcher{
-							pos:        position{line: 1550, col: 33, offset: 37814},
+							pos:        position{line: 1550, col: 33, offset: 37872},
 							val:        "[_.:/%#@~]",
 							chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 							ignoreCase: false,
@@ -11159,31 +11267,31 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1552, col: 1, offset: 37858},
+			pos:  position{line: 1552, col: 1, offset: 37916},
 			expr: &actionExpr{
-				pos: position{line: 1552, col: 14, offset: 37871},
+				pos: position{line: 1552, col: 14, offset: 37929},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1552, col: 14, offset: 37871},
+					pos: position{line: 1552, col: 14, offset: 37929},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1552, col: 14, offset: 37871},
+							pos:        position{line: 1552, col: 14, offset: 37929},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1552, col: 19, offset: 37876},
+							pos:   position{line: 1552, col: 19, offset: 37934},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1552, col: 22, offset: 37879},
+								pos: position{line: 1552, col: 22, offset: 37937},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1552, col: 22, offset: 37879},
+										pos:  position{line: 1552, col: 22, offset: 37937},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1552, col: 38, offset: 37895},
+										pos:  position{line: 1552, col: 38, offset: 37953},
 										name: "EscapeSequence",
 									},
 								},
@@ -11197,42 +11305,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1554, col: 1, offset: 37930},
+			pos:  position{line: 1554, col: 1, offset: 37988},
 			expr: &actionExpr{
-				pos: position{line: 1555, col: 5, offset: 37946},
+				pos: position{line: 1555, col: 5, offset: 38004},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1555, col: 5, offset: 37946},
+					pos: position{line: 1555, col: 5, offset: 38004},
 					exprs: []any{
 						&andExpr{
-							pos: position{line: 1555, col: 5, offset: 37946},
+							pos: position{line: 1555, col: 5, offset: 38004},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1555, col: 6, offset: 37947},
+								pos:  position{line: 1555, col: 6, offset: 38005},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1555, col: 22, offset: 37963},
+							pos: position{line: 1555, col: 22, offset: 38021},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1555, col: 23, offset: 37964},
+								pos:  position{line: 1555, col: 23, offset: 38022},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1555, col: 35, offset: 37976},
+							pos:   position{line: 1555, col: 35, offset: 38034},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1555, col: 40, offset: 37981},
+								pos:  position{line: 1555, col: 40, offset: 38039},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1555, col: 50, offset: 37991},
+							pos:   position{line: 1555, col: 50, offset: 38049},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1555, col: 55, offset: 37996},
+								pos: position{line: 1555, col: 55, offset: 38054},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1555, col: 55, offset: 37996},
+									pos:  position{line: 1555, col: 55, offset: 38054},
 									name: "GlobRest",
 								},
 							},
@@ -11245,28 +11353,28 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1559, col: 1, offset: 38065},
+			pos:  position{line: 1559, col: 1, offset: 38123},
 			expr: &choiceExpr{
-				pos: position{line: 1559, col: 19, offset: 38083},
+				pos: position{line: 1559, col: 19, offset: 38141},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1559, col: 19, offset: 38083},
+						pos:  position{line: 1559, col: 19, offset: 38141},
 						name: "KeyWordStart",
 					},
 					&seqExpr{
-						pos: position{line: 1559, col: 34, offset: 38098},
+						pos: position{line: 1559, col: 34, offset: 38156},
 						exprs: []any{
 							&oneOrMoreExpr{
-								pos: position{line: 1559, col: 34, offset: 38098},
+								pos: position{line: 1559, col: 34, offset: 38156},
 								expr: &litMatcher{
-									pos:        position{line: 1559, col: 34, offset: 38098},
+									pos:        position{line: 1559, col: 34, offset: 38156},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1559, col: 39, offset: 38103},
+								pos:  position{line: 1559, col: 39, offset: 38161},
 								name: "KeyWordRest",
 							},
 						},
@@ -11278,19 +11386,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1560, col: 1, offset: 38115},
+			pos:  position{line: 1560, col: 1, offset: 38173},
 			expr: &seqExpr{
-				pos: position{line: 1560, col: 15, offset: 38129},
+				pos: position{line: 1560, col: 15, offset: 38187},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1560, col: 15, offset: 38129},
+						pos: position{line: 1560, col: 15, offset: 38187},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1560, col: 15, offset: 38129},
+							pos:  position{line: 1560, col: 15, offset: 38187},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1560, col: 28, offset: 38142},
+						pos:        position{line: 1560, col: 28, offset: 38200},
 						val:        "*",
 						ignoreCase: false,
 						want:       "\"*\"",
@@ -11302,23 +11410,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1562, col: 1, offset: 38147},
+			pos:  position{line: 1562, col: 1, offset: 38205},
 			expr: &choiceExpr{
-				pos: position{line: 1563, col: 5, offset: 38161},
+				pos: position{line: 1563, col: 5, offset: 38219},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1563, col: 5, offset: 38161},
+						pos:  position{line: 1563, col: 5, offset: 38219},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1564, col: 5, offset: 38178},
+						pos:  position{line: 1564, col: 5, offset: 38236},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1565, col: 5, offset: 38190},
+						pos: position{line: 1565, col: 5, offset: 38248},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1565, col: 5, offset: 38190},
+							pos:        position{line: 1565, col: 5, offset: 38248},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -11331,16 +11439,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1567, col: 1, offset: 38215},
+			pos:  position{line: 1567, col: 1, offset: 38273},
 			expr: &choiceExpr{
-				pos: position{line: 1568, col: 5, offset: 38228},
+				pos: position{line: 1568, col: 5, offset: 38286},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1568, col: 5, offset: 38228},
+						pos:  position{line: 1568, col: 5, offset: 38286},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1569, col: 5, offset: 38242},
+						pos:        position{line: 1569, col: 5, offset: 38300},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11353,31 +11461,31 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1571, col: 1, offset: 38249},
+			pos:  position{line: 1571, col: 1, offset: 38307},
 			expr: &actionExpr{
-				pos: position{line: 1571, col: 11, offset: 38259},
+				pos: position{line: 1571, col: 11, offset: 38317},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1571, col: 11, offset: 38259},
+					pos: position{line: 1571, col: 11, offset: 38317},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1571, col: 11, offset: 38259},
+							pos:        position{line: 1571, col: 11, offset: 38317},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1571, col: 16, offset: 38264},
+							pos:   position{line: 1571, col: 16, offset: 38322},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1571, col: 19, offset: 38267},
+								pos: position{line: 1571, col: 19, offset: 38325},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1571, col: 19, offset: 38267},
+										pos:  position{line: 1571, col: 19, offset: 38325},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1571, col: 32, offset: 38280},
+										pos:  position{line: 1571, col: 32, offset: 38338},
 										name: "EscapeSequence",
 									},
 								},
@@ -11391,32 +11499,32 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1573, col: 1, offset: 38315},
+			pos:  position{line: 1573, col: 1, offset: 38373},
 			expr: &choiceExpr{
-				pos: position{line: 1574, col: 5, offset: 38330},
+				pos: position{line: 1574, col: 5, offset: 38388},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1574, col: 5, offset: 38330},
+						pos: position{line: 1574, col: 5, offset: 38388},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1574, col: 5, offset: 38330},
+							pos:        position{line: 1574, col: 5, offset: 38388},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1575, col: 5, offset: 38358},
+						pos: position{line: 1575, col: 5, offset: 38416},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1575, col: 5, offset: 38358},
+							pos:        position{line: 1575, col: 5, offset: 38416},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1576, col: 5, offset: 38388},
+						pos:        position{line: 1576, col: 5, offset: 38446},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -11429,57 +11537,57 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1578, col: 1, offset: 38394},
+			pos:  position{line: 1578, col: 1, offset: 38452},
 			expr: &choiceExpr{
-				pos: position{line: 1579, col: 5, offset: 38415},
+				pos: position{line: 1579, col: 5, offset: 38473},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1579, col: 5, offset: 38415},
+						pos: position{line: 1579, col: 5, offset: 38473},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1579, col: 5, offset: 38415},
+							pos: position{line: 1579, col: 5, offset: 38473},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1579, col: 5, offset: 38415},
+									pos: position{line: 1579, col: 5, offset: 38473},
 									expr: &choiceExpr{
-										pos: position{line: 1579, col: 7, offset: 38417},
+										pos: position{line: 1579, col: 7, offset: 38475},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1579, col: 7, offset: 38417},
+												pos:        position{line: 1579, col: 7, offset: 38475},
 												val:        "'",
 												ignoreCase: false,
 												want:       "\"'\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1579, col: 13, offset: 38423},
+												pos:  position{line: 1579, col: 13, offset: 38481},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1579, col: 26, offset: 38436,
+									line: 1579, col: 26, offset: 38494,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1580, col: 5, offset: 38473},
+						pos: position{line: 1580, col: 5, offset: 38531},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1580, col: 5, offset: 38473},
+							pos: position{line: 1580, col: 5, offset: 38531},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1580, col: 5, offset: 38473},
+									pos:        position{line: 1580, col: 5, offset: 38531},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1580, col: 10, offset: 38478},
+									pos:   position{line: 1580, col: 10, offset: 38536},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1580, col: 12, offset: 38480},
+										pos:  position{line: 1580, col: 12, offset: 38538},
 										name: "EscapeSequence",
 									},
 								},
@@ -11493,16 +11601,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1582, col: 1, offset: 38514},
+			pos:  position{line: 1582, col: 1, offset: 38572},
 			expr: &choiceExpr{
-				pos: position{line: 1583, col: 5, offset: 38533},
+				pos: position{line: 1583, col: 5, offset: 38591},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1583, col: 5, offset: 38533},
+						pos:  position{line: 1583, col: 5, offset: 38591},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1584, col: 5, offset: 38554},
+						pos:  position{line: 1584, col: 5, offset: 38612},
 						name: "UnicodeEscape",
 					},
 				},
@@ -11512,87 +11620,87 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1586, col: 1, offset: 38569},
+			pos:  position{line: 1586, col: 1, offset: 38627},
 			expr: &choiceExpr{
-				pos: position{line: 1587, col: 5, offset: 38590},
+				pos: position{line: 1587, col: 5, offset: 38648},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1587, col: 5, offset: 38590},
+						pos:        position{line: 1587, col: 5, offset: 38648},
 						val:        "'",
 						ignoreCase: false,
 						want:       "\"'\"",
 					},
 					&actionExpr{
-						pos: position{line: 1588, col: 5, offset: 38598},
+						pos: position{line: 1588, col: 5, offset: 38656},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1588, col: 5, offset: 38598},
+							pos:        position{line: 1588, col: 5, offset: 38656},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1589, col: 5, offset: 38638},
+						pos:        position{line: 1589, col: 5, offset: 38696},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
 					},
 					&actionExpr{
-						pos: position{line: 1590, col: 5, offset: 38647},
+						pos: position{line: 1590, col: 5, offset: 38705},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1590, col: 5, offset: 38647},
+							pos:        position{line: 1590, col: 5, offset: 38705},
 							val:        "b",
 							ignoreCase: false,
 							want:       "\"b\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1591, col: 5, offset: 38676},
+						pos: position{line: 1591, col: 5, offset: 38734},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1591, col: 5, offset: 38676},
+							pos:        position{line: 1591, col: 5, offset: 38734},
 							val:        "f",
 							ignoreCase: false,
 							want:       "\"f\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1592, col: 5, offset: 38705},
+						pos: position{line: 1592, col: 5, offset: 38763},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1592, col: 5, offset: 38705},
+							pos:        position{line: 1592, col: 5, offset: 38763},
 							val:        "n",
 							ignoreCase: false,
 							want:       "\"n\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1593, col: 5, offset: 38734},
+						pos: position{line: 1593, col: 5, offset: 38792},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1593, col: 5, offset: 38734},
+							pos:        position{line: 1593, col: 5, offset: 38792},
 							val:        "r",
 							ignoreCase: false,
 							want:       "\"r\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1594, col: 5, offset: 38763},
+						pos: position{line: 1594, col: 5, offset: 38821},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1594, col: 5, offset: 38763},
+							pos:        position{line: 1594, col: 5, offset: 38821},
 							val:        "t",
 							ignoreCase: false,
 							want:       "\"t\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1595, col: 5, offset: 38792},
+						pos: position{line: 1595, col: 5, offset: 38850},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1595, col: 5, offset: 38792},
+							pos:        position{line: 1595, col: 5, offset: 38850},
 							val:        "v",
 							ignoreCase: false,
 							want:       "\"v\"",
@@ -11605,32 +11713,32 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1597, col: 1, offset: 38818},
+			pos:  position{line: 1597, col: 1, offset: 38876},
 			expr: &choiceExpr{
-				pos: position{line: 1598, col: 5, offset: 38836},
+				pos: position{line: 1598, col: 5, offset: 38894},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1598, col: 5, offset: 38836},
+						pos: position{line: 1598, col: 5, offset: 38894},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1598, col: 5, offset: 38836},
+							pos:        position{line: 1598, col: 5, offset: 38894},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1599, col: 5, offset: 38864},
+						pos: position{line: 1599, col: 5, offset: 38922},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1599, col: 5, offset: 38864},
+							pos:        position{line: 1599, col: 5, offset: 38922},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1600, col: 5, offset: 38892},
+						pos:        position{line: 1600, col: 5, offset: 38950},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -11643,42 +11751,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1602, col: 1, offset: 38898},
+			pos:  position{line: 1602, col: 1, offset: 38956},
 			expr: &choiceExpr{
-				pos: position{line: 1603, col: 5, offset: 38916},
+				pos: position{line: 1603, col: 5, offset: 38974},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1603, col: 5, offset: 38916},
+						pos: position{line: 1603, col: 5, offset: 38974},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1603, col: 5, offset: 38916},
+							pos: position{line: 1603, col: 5, offset: 38974},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1603, col: 5, offset: 38916},
+									pos:        position{line: 1603, col: 5, offset: 38974},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1603, col: 9, offset: 38920},
+									pos:   position{line: 1603, col: 9, offset: 38978},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1603, col: 16, offset: 38927},
+										pos: position{line: 1603, col: 16, offset: 38985},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1603, col: 16, offset: 38927},
+												pos:  position{line: 1603, col: 16, offset: 38985},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1603, col: 25, offset: 38936},
+												pos:  position{line: 1603, col: 25, offset: 38994},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1603, col: 34, offset: 38945},
+												pos:  position{line: 1603, col: 34, offset: 39003},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1603, col: 43, offset: 38954},
+												pos:  position{line: 1603, col: 43, offset: 39012},
 												name: "HexDigit",
 											},
 										},
@@ -11688,65 +11796,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1606, col: 5, offset: 39017},
+						pos: position{line: 1606, col: 5, offset: 39075},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1606, col: 5, offset: 39017},
+							pos: position{line: 1606, col: 5, offset: 39075},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1606, col: 5, offset: 39017},
+									pos:        position{line: 1606, col: 5, offset: 39075},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1606, col: 9, offset: 39021},
+									pos:        position{line: 1606, col: 9, offset: 39079},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1606, col: 13, offset: 39025},
+									pos:   position{line: 1606, col: 13, offset: 39083},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1606, col: 20, offset: 39032},
+										pos: position{line: 1606, col: 20, offset: 39090},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1606, col: 20, offset: 39032},
+												pos:  position{line: 1606, col: 20, offset: 39090},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1606, col: 29, offset: 39041},
+												pos: position{line: 1606, col: 29, offset: 39099},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1606, col: 29, offset: 39041},
+													pos:  position{line: 1606, col: 29, offset: 39099},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1606, col: 39, offset: 39051},
+												pos: position{line: 1606, col: 39, offset: 39109},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1606, col: 39, offset: 39051},
+													pos:  position{line: 1606, col: 39, offset: 39109},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1606, col: 49, offset: 39061},
+												pos: position{line: 1606, col: 49, offset: 39119},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1606, col: 49, offset: 39061},
+													pos:  position{line: 1606, col: 49, offset: 39119},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1606, col: 59, offset: 39071},
+												pos: position{line: 1606, col: 59, offset: 39129},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1606, col: 59, offset: 39071},
+													pos:  position{line: 1606, col: 59, offset: 39129},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1606, col: 69, offset: 39081},
+												pos: position{line: 1606, col: 69, offset: 39139},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1606, col: 69, offset: 39081},
+													pos:  position{line: 1606, col: 69, offset: 39139},
 													name: "HexDigit",
 												},
 											},
@@ -11754,7 +11862,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1606, col: 80, offset: 39092},
+									pos:        position{line: 1606, col: 80, offset: 39150},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -11769,37 +11877,37 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPattern",
-			pos:  position{line: 1610, col: 1, offset: 39146},
+			pos:  position{line: 1610, col: 1, offset: 39204},
 			expr: &actionExpr{
-				pos: position{line: 1611, col: 5, offset: 39164},
+				pos: position{line: 1611, col: 5, offset: 39222},
 				run: (*parser).callonRegexpPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1611, col: 5, offset: 39164},
+					pos: position{line: 1611, col: 5, offset: 39222},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1611, col: 5, offset: 39164},
+							pos:        position{line: 1611, col: 5, offset: 39222},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1611, col: 9, offset: 39168},
+							pos:   position{line: 1611, col: 9, offset: 39226},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1611, col: 14, offset: 39173},
+								pos:  position{line: 1611, col: 14, offset: 39231},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1611, col: 25, offset: 39184},
+							pos:        position{line: 1611, col: 25, offset: 39242},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&notExpr{
-							pos: position{line: 1611, col: 29, offset: 39188},
+							pos: position{line: 1611, col: 29, offset: 39246},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1611, col: 30, offset: 39189},
+								pos:  position{line: 1611, col: 30, offset: 39247},
 								name: "KeyWordStart",
 							},
 						},
@@ -11811,33 +11919,33 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1613, col: 1, offset: 39224},
+			pos:  position{line: 1613, col: 1, offset: 39282},
 			expr: &actionExpr{
-				pos: position{line: 1614, col: 5, offset: 39239},
+				pos: position{line: 1614, col: 5, offset: 39297},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1614, col: 5, offset: 39239},
+					pos: position{line: 1614, col: 5, offset: 39297},
 					expr: &choiceExpr{
-						pos: position{line: 1614, col: 6, offset: 39240},
+						pos: position{line: 1614, col: 6, offset: 39298},
 						alternatives: []any{
 							&charClassMatcher{
-								pos:        position{line: 1614, col: 6, offset: 39240},
+								pos:        position{line: 1614, col: 6, offset: 39298},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&seqExpr{
-								pos: position{line: 1614, col: 15, offset: 39249},
+								pos: position{line: 1614, col: 15, offset: 39307},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 1614, col: 15, offset: 39249},
+										pos:        position{line: 1614, col: 15, offset: 39307},
 										val:        "\\",
 										ignoreCase: false,
 										want:       "\"\\\\\"",
 									},
 									&anyMatcher{
-										line: 1614, col: 20, offset: 39254,
+										line: 1614, col: 20, offset: 39312,
 									},
 								},
 							},
@@ -11850,9 +11958,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1616, col: 1, offset: 39290},
+			pos:  position{line: 1616, col: 1, offset: 39348},
 			expr: &charClassMatcher{
-				pos:        position{line: 1617, col: 5, offset: 39306},
+				pos:        position{line: 1617, col: 5, offset: 39364},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -11864,11 +11972,11 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1619, col: 1, offset: 39321},
+			pos:  position{line: 1619, col: 1, offset: 39379},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1619, col: 5, offset: 39325},
+				pos: position{line: 1619, col: 5, offset: 39383},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1619, col: 5, offset: 39325},
+					pos:  position{line: 1619, col: 5, offset: 39383},
 					name: "AnySpace",
 				},
 			},
@@ -11877,11 +11985,11 @@ var g = &grammar{
 		},
 		{
 			name: "__",
-			pos:  position{line: 1621, col: 1, offset: 39336},
+			pos:  position{line: 1621, col: 1, offset: 39394},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1621, col: 6, offset: 39341},
+				pos: position{line: 1621, col: 6, offset: 39399},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1621, col: 6, offset: 39341},
+					pos:  position{line: 1621, col: 6, offset: 39399},
 					name: "AnySpace",
 				},
 			},
@@ -11890,20 +11998,20 @@ var g = &grammar{
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1623, col: 1, offset: 39352},
+			pos:  position{line: 1623, col: 1, offset: 39410},
 			expr: &choiceExpr{
-				pos: position{line: 1624, col: 5, offset: 39365},
+				pos: position{line: 1624, col: 5, offset: 39423},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1624, col: 5, offset: 39365},
+						pos:  position{line: 1624, col: 5, offset: 39423},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1625, col: 5, offset: 39380},
+						pos:  position{line: 1625, col: 5, offset: 39438},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1626, col: 5, offset: 39399},
+						pos:  position{line: 1626, col: 5, offset: 39457},
 						name: "Comment",
 					},
 				},
@@ -11913,32 +12021,32 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeLetter",
-			pos:  position{line: 1628, col: 1, offset: 39408},
+			pos:  position{line: 1628, col: 1, offset: 39466},
 			expr: &choiceExpr{
-				pos: position{line: 1629, col: 5, offset: 39426},
+				pos: position{line: 1629, col: 5, offset: 39484},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1629, col: 5, offset: 39426},
+						pos:  position{line: 1629, col: 5, offset: 39484},
 						name: "Lu",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1630, col: 5, offset: 39433},
+						pos:  position{line: 1630, col: 5, offset: 39491},
 						name: "Ll",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1631, col: 5, offset: 39440},
+						pos:  position{line: 1631, col: 5, offset: 39498},
 						name: "Lt",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1632, col: 5, offset: 39447},
+						pos:  position{line: 1632, col: 5, offset: 39505},
 						name: "Lm",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1633, col: 5, offset: 39454},
+						pos:  position{line: 1633, col: 5, offset: 39512},
 						name: "Lo",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1634, col: 5, offset: 39461},
+						pos:  position{line: 1634, col: 5, offset: 39519},
 						name: "Nl",
 					},
 				},
@@ -11948,16 +12056,16 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeCombiningMark",
-			pos:  position{line: 1636, col: 1, offset: 39465},
+			pos:  position{line: 1636, col: 1, offset: 39523},
 			expr: &choiceExpr{
-				pos: position{line: 1637, col: 5, offset: 39490},
+				pos: position{line: 1637, col: 5, offset: 39548},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1637, col: 5, offset: 39490},
+						pos:  position{line: 1637, col: 5, offset: 39548},
 						name: "Mn",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1638, col: 5, offset: 39497},
+						pos:  position{line: 1638, col: 5, offset: 39555},
 						name: "Mc",
 					},
 				},
@@ -11967,9 +12075,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeDigit",
-			pos:  position{line: 1640, col: 1, offset: 39501},
+			pos:  position{line: 1640, col: 1, offset: 39559},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1641, col: 5, offset: 39518},
+				pos:  position{line: 1641, col: 5, offset: 39576},
 				name: "Nd",
 			},
 			leader:        false,
@@ -11977,9 +12085,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeConnectorPunctuation",
-			pos:  position{line: 1643, col: 1, offset: 39522},
+			pos:  position{line: 1643, col: 1, offset: 39580},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1644, col: 5, offset: 39554},
+				pos:  position{line: 1644, col: 5, offset: 39612},
 				name: "Pc",
 			},
 			leader:        false,
@@ -11987,9 +12095,9 @@ var g = &grammar{
 		},
 		{
 			name: "Ll",
-			pos:  position{line: 1650, col: 1, offset: 39735},
+			pos:  position{line: 1650, col: 1, offset: 39793},
 			expr: &charClassMatcher{
-				pos:        position{line: 1650, col: 6, offset: 39740},
+				pos:        position{line: 1650, col: 6, offset: 39798},
 				val:        "[\\u0061-\\u007A\\u00B5\\u00DF-\\u00F6\\u00F8-\\u00FF\\u0101\\u0103\\u0105\\u0107\\u0109\\u010B\\u010D\\u010F\\u0111\\u0113\\u0115\\u0117\\u0119\\u011B\\u011D\\u011F\\u0121\\u0123\\u0125\\u0127\\u0129\\u012B\\u012D\\u012F\\u0131\\u0133\\u0135\\u0137-\\u0138\\u013A\\u013C\\u013E\\u0140\\u0142\\u0144\\u0146\\u0148-\\u0149\\u014B\\u014D\\u014F\\u0151\\u0153\\u0155\\u0157\\u0159\\u015B\\u015D\\u015F\\u0161\\u0163\\u0165\\u0167\\u0169\\u016B\\u016D\\u016F\\u0171\\u0173\\u0175\\u0177\\u017A\\u017C\\u017E-\\u0180\\u0183\\u0185\\u0188\\u018C-\\u018D\\u0192\\u0195\\u0199-\\u019B\\u019E\\u01A1\\u01A3\\u01A5\\u01A8\\u01AA-\\u01AB\\u01AD\\u01B0\\u01B4\\u01B6\\u01B9-\\u01BA\\u01BD-\\u01BF\\u01C6\\u01C9\\u01CC\\u01CE\\u01D0\\u01D2\\u01D4\\u01D6\\u01D8\\u01DA\\u01DC-\\u01DD\\u01DF\\u01E1\\u01E3\\u01E5\\u01E7\\u01E9\\u01EB\\u01ED\\u01EF-\\u01F0\\u01F3\\u01F5\\u01F9\\u01FB\\u01FD\\u01FF\\u0201\\u0203\\u0205\\u0207\\u0209\\u020B\\u020D\\u020F\\u0211\\u0213\\u0215\\u0217\\u0219\\u021B\\u021D\\u021F\\u0221\\u0223\\u0225\\u0227\\u0229\\u022B\\u022D\\u022F\\u0231\\u0233-\\u0239\\u023C\\u023F-\\u0240\\u0242\\u0247\\u0249\\u024B\\u024D\\u024F-\\u0293\\u0295-\\u02AF\\u0371\\u0373\\u0377\\u037B-\\u037D\\u0390\\u03AC-\\u03CE\\u03D0-\\u03D1\\u03D5-\\u03D7\\u03D9\\u03DB\\u03DD\\u03DF\\u03E1\\u03E3\\u03E5\\u03E7\\u03E9\\u03EB\\u03ED\\u03EF-\\u03F3\\u03F5\\u03F8\\u03FB-\\u03FC\\u0430-\\u045F\\u0461\\u0463\\u0465\\u0467\\u0469\\u046B\\u046D\\u046F\\u0471\\u0473\\u0475\\u0477\\u0479\\u047B\\u047D\\u047F\\u0481\\u048B\\u048D\\u048F\\u0491\\u0493\\u0495\\u0497\\u0499\\u049B\\u049D\\u049F\\u04A1\\u04A3\\u04A5\\u04A7\\u04A9\\u04AB\\u04AD\\u04AF\\u04B1\\u04B3\\u04B5\\u04B7\\u04B9\\u04BB\\u04BD\\u04BF\\u04C2\\u04C4\\u04C6\\u04C8\\u04CA\\u04CC\\u04CE-\\u04CF\\u04D1\\u04D3\\u04D5\\u04D7\\u04D9\\u04DB\\u04DD\\u04DF\\u04E1\\u04E3\\u04E5\\u04E7\\u04E9\\u04EB\\u04ED\\u04EF\\u04F1\\u04F3\\u04F5\\u04F7\\u04F9\\u04FB\\u04FD\\u04FF\\u0501\\u0503\\u0505\\u0507\\u0509\\u050B\\u050D\\u050F\\u0511\\u0513\\u0515\\u0517\\u0519\\u051B\\u051D\\u051F\\u0521\\u0523\\u0525\\u0527\\u0529\\u052B\\u052D\\u052F\\u0560-\\u0588\\u10D0-\\u10FA\\u10FD-\\u10FF\\u13F8-\\u13FD\\u1C80-\\u1C88\\u1D00-\\u1D2B\\u1D6B-\\u1D77\\u1D79-\\u1D9A\\u1E01\\u1E03\\u1E05\\u1E07\\u1E09\\u1E0B\\u1E0D\\u1E0F\\u1E11\\u1E13\\u1E15\\u1E17\\u1E19\\u1E1B\\u1E1D\\u1E1F\\u1E21\\u1E23\\u1E25\\u1E27\\u1E29\\u1E2B\\u1E2D\\u1E2F\\u1E31\\u1E33\\u1E35\\u1E37\\u1E39\\u1E3B\\u1E3D\\u1E3F\\u1E41\\u1E43\\u1E45\\u1E47\\u1E49\\u1E4B\\u1E4D\\u1E4F\\u1E51\\u1E53\\u1E55\\u1E57\\u1E59\\u1E5B\\u1E5D\\u1E5F\\u1E61\\u1E63\\u1E65\\u1E67\\u1E69\\u1E6B\\u1E6D\\u1E6F\\u1E71\\u1E73\\u1E75\\u1E77\\u1E79\\u1E7B\\u1E7D\\u1E7F\\u1E81\\u1E83\\u1E85\\u1E87\\u1E89\\u1E8B\\u1E8D\\u1E8F\\u1E91\\u1E93\\u1E95-\\u1E9D\\u1E9F\\u1EA1\\u1EA3\\u1EA5\\u1EA7\\u1EA9\\u1EAB\\u1EAD\\u1EAF\\u1EB1\\u1EB3\\u1EB5\\u1EB7\\u1EB9\\u1EBB\\u1EBD\\u1EBF\\u1EC1\\u1EC3\\u1EC5\\u1EC7\\u1EC9\\u1ECB\\u1ECD\\u1ECF\\u1ED1\\u1ED3\\u1ED5\\u1ED7\\u1ED9\\u1EDB\\u1EDD\\u1EDF\\u1EE1\\u1EE3\\u1EE5\\u1EE7\\u1EE9\\u1EEB\\u1EED\\u1EEF\\u1EF1\\u1EF3\\u1EF5\\u1EF7\\u1EF9\\u1EFB\\u1EFD\\u1EFF-\\u1F07\\u1F10-\\u1F15\\u1F20-\\u1F27\\u1F30-\\u1F37\\u1F40-\\u1F45\\u1F50-\\u1F57\\u1F60-\\u1F67\\u1F70-\\u1F7D\\u1F80-\\u1F87\\u1F90-\\u1F97\\u1FA0-\\u1FA7\\u1FB0-\\u1FB4\\u1FB6-\\u1FB7\\u1FBE\\u1FC2-\\u1FC4\\u1FC6-\\u1FC7\\u1FD0-\\u1FD3\\u1FD6-\\u1FD7\\u1FE0-\\u1FE7\\u1FF2-\\u1FF4\\u1FF6-\\u1FF7\\u210A\\u210E-\\u210F\\u2113\\u212F\\u2134\\u2139\\u213C-\\u213D\\u2146-\\u2149\\u214E\\u2184\\u2C30-\\u2C5E\\u2C61\\u2C65-\\u2C66\\u2C68\\u2C6A\\u2C6C\\u2C71\\u2C73-\\u2C74\\u2C76-\\u2C7B\\u2C81\\u2C83\\u2C85\\u2C87\\u2C89\\u2C8B\\u2C8D\\u2C8F\\u2C91\\u2C93\\u2C95\\u2C97\\u2C99\\u2C9B\\u2C9D\\u2C9F\\u2CA1\\u2CA3\\u2CA5\\u2CA7\\u2CA9\\u2CAB\\u2CAD\\u2CAF\\u2CB1\\u2CB3\\u2CB5\\u2CB7\\u2CB9\\u2CBB\\u2CBD\\u2CBF\\u2CC1\\u2CC3\\u2CC5\\u2CC7\\u2CC9\\u2CCB\\u2CCD\\u2CCF\\u2CD1\\u2CD3\\u2CD5\\u2CD7\\u2CD9\\u2CDB\\u2CDD\\u2CDF\\u2CE1\\u2CE3-\\u2CE4\\u2CEC\\u2CEE\\u2CF3\\u2D00-\\u2D25\\u2D27\\u2D2D\\uA641\\uA643\\uA645\\uA647\\uA649\\uA64B\\uA64D\\uA64F\\uA651\\uA653\\uA655\\uA657\\uA659\\uA65B\\uA65D\\uA65F\\uA661\\uA663\\uA665\\uA667\\uA669\\uA66B\\uA66D\\uA681\\uA683\\uA685\\uA687\\uA689\\uA68B\\uA68D\\uA68F\\uA691\\uA693\\uA695\\uA697\\uA699\\uA69B\\uA723\\uA725\\uA727\\uA729\\uA72B\\uA72D\\uA72F-\\uA731\\uA733\\uA735\\uA737\\uA739\\uA73B\\uA73D\\uA73F\\uA741\\uA743\\uA745\\uA747\\uA749\\uA74B\\uA74D\\uA74F\\uA751\\uA753\\uA755\\uA757\\uA759\\uA75B\\uA75D\\uA75F\\uA761\\uA763\\uA765\\uA767\\uA769\\uA76B\\uA76D\\uA76F\\uA771-\\uA778\\uA77A\\uA77C\\uA77F\\uA781\\uA783\\uA785\\uA787\\uA78C\\uA78E\\uA791\\uA793-\\uA795\\uA797\\uA799\\uA79B\\uA79D\\uA79F\\uA7A1\\uA7A3\\uA7A5\\uA7A7\\uA7A9\\uA7AF\\uA7B5\\uA7B7\\uA7B9\\uA7FA\\uAB30-\\uAB5A\\uAB60-\\uAB65\\uAB70-\\uABBF\\uFB00-\\uFB06\\uFB13-\\uFB17\\uFF41-\\uFF5A]",
 				chars:      []rune{'µ', 'ā', 'ă', 'ą', 'ć', 'ĉ', 'ċ', 'č', 'ď', 'đ', 'ē', 'ĕ', 'ė', 'ę', 'ě', 'ĝ', 'ğ', 'ġ', 'ģ', 'ĥ', 'ħ', 'ĩ', 'ī', 'ĭ', 'į', 'ı', 'ĳ', 'ĵ', 'ĺ', 'ļ', 'ľ', 'ŀ', 'ł', 'ń', 'ņ', 'ŋ', 'ō', 'ŏ', 'ő', 'œ', 'ŕ', 'ŗ', 'ř', 'ś', 'ŝ', 'ş', 'š', 'ţ', 'ť', 'ŧ', 'ũ', 'ū', 'ŭ', 'ů', 'ű', 'ų', 'ŵ', 'ŷ', 'ź', 'ż', 'ƃ', 'ƅ', 'ƈ', 'ƒ', 'ƕ', 'ƞ', 'ơ', 'ƣ', 'ƥ', 'ƨ', 'ƭ', 'ư', 'ƴ', 'ƶ', 'ǆ', 'ǉ', 'ǌ', 'ǎ', 'ǐ', 'ǒ', 'ǔ', 'ǖ', 'ǘ', 'ǚ', 'ǟ', 'ǡ', 'ǣ', 'ǥ', 'ǧ', 'ǩ', 'ǫ', 'ǭ', 'ǳ', 'ǵ', 'ǹ', 'ǻ', 'ǽ', 'ǿ', 'ȁ', 'ȃ', 'ȅ', 'ȇ', 'ȉ', 'ȋ', 'ȍ', 'ȏ', 'ȑ', 'ȓ', 'ȕ', 'ȗ', 'ș', 'ț', 'ȝ', 'ȟ', 'ȡ', 'ȣ', 'ȥ', 'ȧ', 'ȩ', 'ȫ', 'ȭ', 'ȯ', 'ȱ', 'ȼ', 'ɂ', 'ɇ', 'ɉ', 'ɋ', 'ɍ', 'ͱ', 'ͳ', 'ͷ', 'ΐ', 'ϙ', 'ϛ', 'ϝ', 'ϟ', 'ϡ', 'ϣ', 'ϥ', 'ϧ', 'ϩ', 'ϫ', 'ϭ', 'ϵ', 'ϸ', 'ѡ', 'ѣ', 'ѥ', 'ѧ', 'ѩ', 'ѫ', 'ѭ', 'ѯ', 'ѱ', 'ѳ', 'ѵ', 'ѷ', 'ѹ', 'ѻ', 'ѽ', 'ѿ', 'ҁ', 'ҋ', 'ҍ', 'ҏ', 'ґ', 'ғ', 'ҕ', 'җ', 'ҙ', 'қ', 'ҝ', 'ҟ', 'ҡ', 'ң', 'ҥ', 'ҧ', 'ҩ', 'ҫ', 'ҭ', 'ү', 'ұ', 'ҳ', 'ҵ', 'ҷ', 'ҹ', 'һ', 'ҽ', 'ҿ', 'ӂ', 'ӄ', 'ӆ', 'ӈ', 'ӊ', 'ӌ', 'ӑ', 'ӓ', 'ӕ', 'ӗ', 'ә', 'ӛ', 'ӝ', 'ӟ', 'ӡ', 'ӣ', 'ӥ', 'ӧ', 'ө', 'ӫ', 'ӭ', 'ӯ', 'ӱ', 'ӳ', 'ӵ', 'ӷ', 'ӹ', 'ӻ', 'ӽ', 'ӿ', 'ԁ', 'ԃ', 'ԅ', 'ԇ', 'ԉ', 'ԋ', 'ԍ', 'ԏ', 'ԑ', 'ԓ', 'ԕ', 'ԗ', 'ԙ', 'ԛ', 'ԝ', 'ԟ', 'ԡ', 'ԣ', 'ԥ', 'ԧ', 'ԩ', 'ԫ', 'ԭ', 'ԯ', 'ḁ', 'ḃ', 'ḅ', 'ḇ', 'ḉ', 'ḋ', 'ḍ', 'ḏ', 'ḑ', 'ḓ', 'ḕ', 'ḗ', 'ḙ', 'ḛ', 'ḝ', 'ḟ', 'ḡ', 'ḣ', 'ḥ', 'ḧ', 'ḩ', 'ḫ', 'ḭ', 'ḯ', 'ḱ', 'ḳ', 'ḵ', 'ḷ', 'ḹ', 'ḻ', 'ḽ', 'ḿ', 'ṁ', 'ṃ', 'ṅ', 'ṇ', 'ṉ', 'ṋ', 'ṍ', 'ṏ', 'ṑ', 'ṓ', 'ṕ', 'ṗ', 'ṙ', 'ṛ', 'ṝ', 'ṟ', 'ṡ', 'ṣ', 'ṥ', 'ṧ', 'ṩ', 'ṫ', 'ṭ', 'ṯ', 'ṱ', 'ṳ', 'ṵ', 'ṷ', 'ṹ', 'ṻ', 'ṽ', 'ṿ', 'ẁ', 'ẃ', 'ẅ', 'ẇ', 'ẉ', 'ẋ', 'ẍ', 'ẏ', 'ẑ', 'ẓ', 'ẟ', 'ạ', 'ả', 'ấ', 'ầ', 'ẩ', 'ẫ', 'ậ', 'ắ', 'ằ', 'ẳ', 'ẵ', 'ặ', 'ẹ', 'ẻ', 'ẽ', 'ế', 'ề', 'ể', 'ễ', 'ệ', 'ỉ', 'ị', 'ọ', 'ỏ', 'ố', 'ồ', 'ổ', 'ỗ', 'ộ', 'ớ', 'ờ', 'ở', 'ỡ', 'ợ', 'ụ', 'ủ', 'ứ', 'ừ', 'ử', 'ữ', 'ự', 'ỳ', 'ỵ', 'ỷ', 'ỹ', 'ỻ', 'ỽ', 'ι', 'ℊ', 'ℓ', 'ℯ', 'ℴ', 'ℹ', 'ⅎ', 'ↄ', 'ⱡ', 'ⱨ', 'ⱪ', 'ⱬ', 'ⱱ', 'ⲁ', 'ⲃ', 'ⲅ', 'ⲇ', 'ⲉ', 'ⲋ', 'ⲍ', 'ⲏ', 'ⲑ', 'ⲓ', 'ⲕ', 'ⲗ', 'ⲙ', 'ⲛ', 'ⲝ', 'ⲟ', 'ⲡ', 'ⲣ', 'ⲥ', 'ⲧ', 'ⲩ', 'ⲫ', 'ⲭ', 'ⲯ', 'ⲱ', 'ⲳ', 'ⲵ', 'ⲷ', 'ⲹ', 'ⲻ', 'ⲽ', 'ⲿ', 'ⳁ', 'ⳃ', 'ⳅ', 'ⳇ', 'ⳉ', 'ⳋ', 'ⳍ', 'ⳏ', 'ⳑ', 'ⳓ', 'ⳕ', 'ⳗ', 'ⳙ', 'ⳛ', 'ⳝ', 'ⳟ', 'ⳡ', 'ⳬ', 'ⳮ', 'ⳳ', 'ⴧ', 'ⴭ', 'ꙁ', 'ꙃ', 'ꙅ', 'ꙇ', 'ꙉ', 'ꙋ', 'ꙍ', 'ꙏ', 'ꙑ', 'ꙓ', 'ꙕ', 'ꙗ', 'ꙙ', 'ꙛ', 'ꙝ', 'ꙟ', 'ꙡ', 'ꙣ', 'ꙥ', 'ꙧ', 'ꙩ', 'ꙫ', 'ꙭ', 'ꚁ', 'ꚃ', 'ꚅ', 'ꚇ', 'ꚉ', 'ꚋ', 'ꚍ', 'ꚏ', 'ꚑ', 'ꚓ', 'ꚕ', 'ꚗ', 'ꚙ', 'ꚛ', 'ꜣ', 'ꜥ', 'ꜧ', 'ꜩ', 'ꜫ', 'ꜭ', 'ꜳ', 'ꜵ', 'ꜷ', 'ꜹ', 'ꜻ', 'ꜽ', 'ꜿ', 'ꝁ', 'ꝃ', 'ꝅ', 'ꝇ', 'ꝉ', 'ꝋ', 'ꝍ', 'ꝏ', 'ꝑ', 'ꝓ', 'ꝕ', 'ꝗ', 'ꝙ', 'ꝛ', 'ꝝ', 'ꝟ', 'ꝡ', 'ꝣ', 'ꝥ', 'ꝧ', 'ꝩ', 'ꝫ', 'ꝭ', 'ꝯ', 'ꝺ', 'ꝼ', 'ꝿ', 'ꞁ', 'ꞃ', 'ꞅ', 'ꞇ', 'ꞌ', 'ꞎ', 'ꞑ', 'ꞗ', 'ꞙ', 'ꞛ', 'ꞝ', 'ꞟ', 'ꞡ', 'ꞣ', 'ꞥ', 'ꞧ', 'ꞩ', 'ꞯ', 'ꞵ', 'ꞷ', 'ꞹ', 'ꟺ'},
 				ranges:     []rune{'a', 'z', 'ß', 'ö', 'ø', 'ÿ', 'ķ', 'ĸ', 'ň', 'ŉ', 'ž', 'ƀ', 'ƌ', 'ƍ', 'ƙ', 'ƛ', 'ƪ', 'ƫ', 'ƹ', 'ƺ', 'ƽ', 'ƿ', 'ǜ', 'ǝ', 'ǯ', 'ǰ', 'ȳ', 'ȹ', 'ȿ', 'ɀ', 'ɏ', 'ʓ', 'ʕ', 'ʯ', 'ͻ', 'ͽ', 'ά', 'ώ', 'ϐ', 'ϑ', 'ϕ', 'ϗ', 'ϯ', 'ϳ', 'ϻ', 'ϼ', 'а', 'џ', 'ӎ', 'ӏ', 'ՠ', 'ֈ', 'ა', 'ჺ', 'ჽ', 'ჿ', 'ᏸ', 'ᏽ', 'ᲀ', 'ᲈ', 'ᴀ', 'ᴫ', 'ᵫ', 'ᵷ', 'ᵹ', 'ᶚ', 'ẕ', 'ẝ', 'ỿ', 'ἇ', 'ἐ', 'ἕ', 'ἠ', 'ἧ', 'ἰ', 'ἷ', 'ὀ', 'ὅ', 'ὐ', 'ὗ', 'ὠ', 'ὧ', 'ὰ', 'ώ', 'ᾀ', 'ᾇ', 'ᾐ', 'ᾗ', 'ᾠ', 'ᾧ', 'ᾰ', 'ᾴ', 'ᾶ', 'ᾷ', 'ῂ', 'ῄ', 'ῆ', 'ῇ', 'ῐ', 'ΐ', 'ῖ', 'ῗ', 'ῠ', 'ῧ', 'ῲ', 'ῴ', 'ῶ', 'ῷ', 'ℎ', 'ℏ', 'ℼ', 'ℽ', 'ⅆ', 'ⅉ', 'ⰰ', 'ⱞ', 'ⱥ', 'ⱦ', 'ⱳ', 'ⱴ', 'ⱶ', 'ⱻ', 'ⳣ', 'ⳤ', 'ⴀ', 'ⴥ', 'ꜯ', 'ꜱ', 'ꝱ', 'ꝸ', 'ꞓ', 'ꞕ', 'ꬰ', 'ꭚ', 'ꭠ', 'ꭥ', 'ꭰ', 'ꮿ', 'ﬀ', 'ﬆ', 'ﬓ', 'ﬗ', 'ａ', 'ｚ'},
@@ -12001,9 +12109,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lm",
-			pos:  position{line: 1653, col: 1, offset: 43892},
+			pos:  position{line: 1653, col: 1, offset: 43950},
 			expr: &charClassMatcher{
-				pos:        position{line: 1653, col: 6, offset: 43897},
+				pos:        position{line: 1653, col: 6, offset: 43955},
 				val:        "[\\u02B0-\\u02C1\\u02C6-\\u02D1\\u02E0-\\u02E4\\u02EC\\u02EE\\u0374\\u037A\\u0559\\u0640\\u06E5-\\u06E6\\u07F4-\\u07F5\\u07FA\\u081A\\u0824\\u0828\\u0971\\u0E46\\u0EC6\\u10FC\\u17D7\\u1843\\u1AA7\\u1C78-\\u1C7D\\u1D2C-\\u1D6A\\u1D78\\u1D9B-\\u1DBF\\u2071\\u207F\\u2090-\\u209C\\u2C7C-\\u2C7D\\u2D6F\\u2E2F\\u3005\\u3031-\\u3035\\u303B\\u309D-\\u309E\\u30FC-\\u30FE\\uA015\\uA4F8-\\uA4FD\\uA60C\\uA67F\\uA69C-\\uA69D\\uA717-\\uA71F\\uA770\\uA788\\uA7F8-\\uA7F9\\uA9CF\\uA9E6\\uAA70\\uAADD\\uAAF3-\\uAAF4\\uAB5C-\\uAB5F\\uFF70\\uFF9E-\\uFF9F]",
 				chars:      []rune{'ˬ', 'ˮ', 'ʹ', 'ͺ', 'ՙ', 'ـ', 'ߺ', 'ࠚ', 'ࠤ', 'ࠨ', 'ॱ', 'ๆ', 'ໆ', 'ჼ', 'ៗ', 'ᡃ', 'ᪧ', 'ᵸ', 'ⁱ', 'ⁿ', 'ⵯ', 'ⸯ', '々', '〻', 'ꀕ', 'ꘌ', 'ꙿ', 'ꝰ', 'ꞈ', 'ꧏ', 'ꧦ', 'ꩰ', 'ꫝ', 'ｰ'},
 				ranges:     []rune{'ʰ', 'ˁ', 'ˆ', 'ˑ', 'ˠ', 'ˤ', 'ۥ', 'ۦ', 'ߴ', 'ߵ', 'ᱸ', 'ᱽ', 'ᴬ', 'ᵪ', 'ᶛ', 'ᶿ', 'ₐ', 'ₜ', 'ⱼ', 'ⱽ', '〱', '〵', 'ゝ', 'ゞ', 'ー', 'ヾ', 'ꓸ', 'ꓽ', 'ꚜ', 'ꚝ', 'ꜗ', 'ꜟ', 'ꟸ', 'ꟹ', 'ꫳ', 'ꫴ', 'ꭜ', 'ꭟ', 'ﾞ', 'ﾟ'},
@@ -12015,9 +12123,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lo",
-			pos:  position{line: 1656, col: 1, offset: 44382},
+			pos:  position{line: 1656, col: 1, offset: 44440},
 			expr: &charClassMatcher{
-				pos:        position{line: 1656, col: 6, offset: 44387},
+				pos:        position{line: 1656, col: 6, offset: 44445},
 				val:        "[\\u00AA\\u00BA\\u01BB\\u01C0-\\u01C3\\u0294\\u05D0-\\u05EA\\u05EF-\\u05F2\\u0620-\\u063F\\u0641-\\u064A\\u066E-\\u066F\\u0671-\\u06D3\\u06D5\\u06EE-\\u06EF\\u06FA-\\u06FC\\u06FF\\u0710\\u0712-\\u072F\\u074D-\\u07A5\\u07B1\\u07CA-\\u07EA\\u0800-\\u0815\\u0840-\\u0858\\u0860-\\u086A\\u08A0-\\u08B4\\u08B6-\\u08BD\\u0904-\\u0939\\u093D\\u0950\\u0958-\\u0961\\u0972-\\u0980\\u0985-\\u098C\\u098F-\\u0990\\u0993-\\u09A8\\u09AA-\\u09B0\\u09B2\\u09B6-\\u09B9\\u09BD\\u09CE\\u09DC-\\u09DD\\u09DF-\\u09E1\\u09F0-\\u09F1\\u09FC\\u0A05-\\u0A0A\\u0A0F-\\u0A10\\u0A13-\\u0A28\\u0A2A-\\u0A30\\u0A32-\\u0A33\\u0A35-\\u0A36\\u0A38-\\u0A39\\u0A59-\\u0A5C\\u0A5E\\u0A72-\\u0A74\\u0A85-\\u0A8D\\u0A8F-\\u0A91\\u0A93-\\u0AA8\\u0AAA-\\u0AB0\\u0AB2-\\u0AB3\\u0AB5-\\u0AB9\\u0ABD\\u0AD0\\u0AE0-\\u0AE1\\u0AF9\\u0B05-\\u0B0C\\u0B0F-\\u0B10\\u0B13-\\u0B28\\u0B2A-\\u0B30\\u0B32-\\u0B33\\u0B35-\\u0B39\\u0B3D\\u0B5C-\\u0B5D\\u0B5F-\\u0B61\\u0B71\\u0B83\\u0B85-\\u0B8A\\u0B8E-\\u0B90\\u0B92-\\u0B95\\u0B99-\\u0B9A\\u0B9C\\u0B9E-\\u0B9F\\u0BA3-\\u0BA4\\u0BA8-\\u0BAA\\u0BAE-\\u0BB9\\u0BD0\\u0C05-\\u0C0C\\u0C0E-\\u0C10\\u0C12-\\u0C28\\u0C2A-\\u0C39\\u0C3D\\u0C58-\\u0C5A\\u0C60-\\u0C61\\u0C80\\u0C85-\\u0C8C\\u0C8E-\\u0C90\\u0C92-\\u0CA8\\u0CAA-\\u0CB3\\u0CB5-\\u0CB9\\u0CBD\\u0CDE\\u0CE0-\\u0CE1\\u0CF1-\\u0CF2\\u0D05-\\u0D0C\\u0D0E-\\u0D10\\u0D12-\\u0D3A\\u0D3D\\u0D4E\\u0D54-\\u0D56\\u0D5F-\\u0D61\\u0D7A-\\u0D7F\\u0D85-\\u0D96\\u0D9A-\\u0DB1\\u0DB3-\\u0DBB\\u0DBD\\u0DC0-\\u0DC6\\u0E01-\\u0E30\\u0E32-\\u0E33\\u0E40-\\u0E45\\u0E81-\\u0E82\\u0E84\\u0E87-\\u0E88\\u0E8A\\u0E8D\\u0E94-\\u0E97\\u0E99-\\u0E9F\\u0EA1-\\u0EA3\\u0EA5\\u0EA7\\u0EAA-\\u0EAB\\u0EAD-\\u0EB0\\u0EB2-\\u0EB3\\u0EBD\\u0EC0-\\u0EC4\\u0EDC-\\u0EDF\\u0F00\\u0F40-\\u0F47\\u0F49-\\u0F6C\\u0F88-\\u0F8C\\u1000-\\u102A\\u103F\\u1050-\\u1055\\u105A-\\u105D\\u1061\\u1065-\\u1066\\u106E-\\u1070\\u1075-\\u1081\\u108E\\u1100-\\u1248\\u124A-\\u124D\\u1250-\\u1256\\u1258\\u125A-\\u125D\\u1260-\\u1288\\u128A-\\u128D\\u1290-\\u12B0\\u12B2-\\u12B5\\u12B8-\\u12BE\\u12C0\\u12C2-\\u12C5\\u12C8-\\u12D6\\u12D8-\\u1310\\u1312-\\u1315\\u1318-\\u135A\\u1380-\\u138F\\u1401-\\u166C\\u166F-\\u167F\\u1681-\\u169A\\u16A0-\\u16EA\\u16F1-\\u16F8\\u1700-\\u170C\\u170E-\\u1711\\u1720-\\u1731\\u1740-\\u1751\\u1760-\\u176C\\u176E-\\u1770\\u1780-\\u17B3\\u17DC\\u1820-\\u1842\\u1844-\\u1878\\u1880-\\u1884\\u1887-\\u18A8\\u18AA\\u18B0-\\u18F5\\u1900-\\u191E\\u1950-\\u196D\\u1970-\\u1974\\u1980-\\u19AB\\u19B0-\\u19C9\\u1A00-\\u1A16\\u1A20-\\u1A54\\u1B05-\\u1B33\\u1B45-\\u1B4B\\u1B83-\\u1BA0\\u1BAE-\\u1BAF\\u1BBA-\\u1BE5\\u1C00-\\u1C23\\u1C4D-\\u1C4F\\u1C5A-\\u1C77\\u1CE9-\\u1CEC\\u1CEE-\\u1CF1\\u1CF5-\\u1CF6\\u2135-\\u2138\\u2D30-\\u2D67\\u2D80-\\u2D96\\u2DA0-\\u2DA6\\u2DA8-\\u2DAE\\u2DB0-\\u2DB6\\u2DB8-\\u2DBE\\u2DC0-\\u2DC6\\u2DC8-\\u2DCE\\u2DD0-\\u2DD6\\u2DD8-\\u2DDE\\u3006\\u303C\\u3041-\\u3096\\u309F\\u30A1-\\u30FA\\u30FF\\u3105-\\u312F\\u3131-\\u318E\\u31A0-\\u31BA\\u31F0-\\u31FF\\u3400-\\u4DB5\\u4E00-\\u9FEF\\uA000-\\uA014\\uA016-\\uA48C\\uA4D0-\\uA4F7\\uA500-\\uA60B\\uA610-\\uA61F\\uA62A-\\uA62B\\uA66E\\uA6A0-\\uA6E5\\uA78F\\uA7F7\\uA7FB-\\uA801\\uA803-\\uA805\\uA807-\\uA80A\\uA80C-\\uA822\\uA840-\\uA873\\uA882-\\uA8B3\\uA8F2-\\uA8F7\\uA8FB\\uA8FD-\\uA8FE\\uA90A-\\uA925\\uA930-\\uA946\\uA960-\\uA97C\\uA984-\\uA9B2\\uA9E0-\\uA9E4\\uA9E7-\\uA9EF\\uA9FA-\\uA9FE\\uAA00-\\uAA28\\uAA40-\\uAA42\\uAA44-\\uAA4B\\uAA60-\\uAA6F\\uAA71-\\uAA76\\uAA7A\\uAA7E-\\uAAAF\\uAAB1\\uAAB5-\\uAAB6\\uAAB9-\\uAABD\\uAAC0\\uAAC2\\uAADB-\\uAADC\\uAAE0-\\uAAEA\\uAAF2\\uAB01-\\uAB06\\uAB09-\\uAB0E\\uAB11-\\uAB16\\uAB20-\\uAB26\\uAB28-\\uAB2E\\uABC0-\\uABE2\\uAC00-\\uD7A3\\uD7B0-\\uD7C6\\uD7CB-\\uD7FB\\uF900-\\uFA6D\\uFA70-\\uFAD9\\uFB1D\\uFB1F-\\uFB28\\uFB2A-\\uFB36\\uFB38-\\uFB3C\\uFB3E\\uFB40-\\uFB41\\uFB43-\\uFB44\\uFB46-\\uFBB1\\uFBD3-\\uFD3D\\uFD50-\\uFD8F\\uFD92-\\uFDC7\\uFDF0-\\uFDFB\\uFE70-\\uFE74\\uFE76-\\uFEFC\\uFF66-\\uFF6F\\uFF71-\\uFF9D\\uFFA0-\\uFFBE\\uFFC2-\\uFFC7\\uFFCA-\\uFFCF\\uFFD2-\\uFFD7\\uFFDA-\\uFFDC]",
 				chars:      []rune{'ª', 'º', 'ƻ', 'ʔ', 'ە', 'ۿ', 'ܐ', 'ޱ', 'ऽ', 'ॐ', 'ল', 'ঽ', 'ৎ', 'ৼ', 'ਫ਼', 'ઽ', 'ૐ', 'ૹ', 'ଽ', 'ୱ', 'ஃ', 'ஜ', 'ௐ', 'ఽ', 'ಀ', 'ಽ', 'ೞ', 'ഽ', 'ൎ', 'ල', 'ຄ', 'ຊ', 'ຍ', 'ລ', 'ວ', 'ຽ', 'ༀ', 'ဿ', 'ၡ', 'ႎ', 'ቘ', 'ዀ', 'ៜ', 'ᢪ', '〆', '〼', 'ゟ', 'ヿ', 'ꙮ', 'ꞏ', 'ꟷ', 'ꣻ', 'ꩺ', 'ꪱ', 'ꫀ', 'ꫂ', 'ꫲ', 'יִ', 'מּ'},
 				ranges:     []rune{'ǀ', 'ǃ', 'א', 'ת', 'ׯ', 'ײ', 'ؠ', 'ؿ', 'ف', 'ي', 'ٮ', 'ٯ', 'ٱ', 'ۓ', 'ۮ', 'ۯ', 'ۺ', 'ۼ', 'ܒ', 'ܯ', 'ݍ', 'ޥ', 'ߊ', 'ߪ', 'ࠀ', 'ࠕ', 'ࡀ', 'ࡘ', 'ࡠ', 'ࡪ', 'ࢠ', 'ࢴ', 'ࢶ', 'ࢽ', 'ऄ', 'ह', 'क़', 'ॡ', 'ॲ', 'ঀ', 'অ', 'ঌ', 'এ', 'ঐ', 'ও', 'ন', 'প', 'র', 'শ', 'হ', 'ড়', 'ঢ়', 'য়', 'ৡ', 'ৰ', 'ৱ', 'ਅ', 'ਊ', 'ਏ', 'ਐ', 'ਓ', 'ਨ', 'ਪ', 'ਰ', 'ਲ', 'ਲ਼', 'ਵ', 'ਸ਼', 'ਸ', 'ਹ', 'ਖ਼', 'ੜ', 'ੲ', 'ੴ', 'અ', 'ઍ', 'એ', 'ઑ', 'ઓ', 'ન', 'પ', 'ર', 'લ', 'ળ', 'વ', 'હ', 'ૠ', 'ૡ', 'ଅ', 'ଌ', 'ଏ', 'ଐ', 'ଓ', 'ନ', 'ପ', 'ର', 'ଲ', 'ଳ', 'ଵ', 'ହ', 'ଡ଼', 'ଢ଼', 'ୟ', 'ୡ', 'அ', 'ஊ', 'எ', 'ஐ', 'ஒ', 'க', 'ங', 'ச', 'ஞ', 'ட', 'ண', 'த', 'ந', 'ப', 'ம', 'ஹ', 'అ', 'ఌ', 'ఎ', 'ఐ', 'ఒ', 'న', 'ప', 'హ', 'ౘ', 'ౚ', 'ౠ', 'ౡ', 'ಅ', 'ಌ', 'ಎ', 'ಐ', 'ಒ', 'ನ', 'ಪ', 'ಳ', 'ವ', 'ಹ', 'ೠ', 'ೡ', 'ೱ', 'ೲ', 'അ', 'ഌ', 'എ', 'ഐ', 'ഒ', 'ഺ', 'ൔ', 'ൖ', 'ൟ', 'ൡ', 'ൺ', 'ൿ', 'අ', 'ඖ', 'ක', 'න', 'ඳ', 'ර', 'ව', 'ෆ', 'ก', 'ะ', 'า', 'ำ', 'เ', 'ๅ', 'ກ', 'ຂ', 'ງ', 'ຈ', 'ດ', 'ທ', 'ນ', 'ຟ', 'ມ', 'ຣ', 'ສ', 'ຫ', 'ອ', 'ະ', 'າ', 'ຳ', 'ເ', 'ໄ', 'ໜ', 'ໟ', 'ཀ', 'ཇ', 'ཉ', 'ཬ', 'ྈ', 'ྌ', 'က', 'ဪ', 'ၐ', 'ၕ', 'ၚ', 'ၝ', 'ၥ', 'ၦ', 'ၮ', 'ၰ', 'ၵ', 'ႁ', 'ᄀ', 'ቈ', 'ቊ', 'ቍ', 'ቐ', 'ቖ', 'ቚ', 'ቝ', 'በ', 'ኈ', 'ኊ', 'ኍ', 'ነ', 'ኰ', 'ኲ', 'ኵ', 'ኸ', 'ኾ', 'ዂ', 'ዅ', 'ወ', 'ዖ', 'ዘ', 'ጐ', 'ጒ', 'ጕ', 'ጘ', 'ፚ', 'ᎀ', 'ᎏ', 'ᐁ', 'ᙬ', 'ᙯ', 'ᙿ', 'ᚁ', 'ᚚ', 'ᚠ', 'ᛪ', 'ᛱ', 'ᛸ', 'ᜀ', 'ᜌ', 'ᜎ', 'ᜑ', 'ᜠ', 'ᜱ', 'ᝀ', 'ᝑ', 'ᝠ', 'ᝬ', 'ᝮ', 'ᝰ', 'ក', 'ឳ', 'ᠠ', 'ᡂ', 'ᡄ', 'ᡸ', 'ᢀ', 'ᢄ', 'ᢇ', 'ᢨ', 'ᢰ', 'ᣵ', 'ᤀ', 'ᤞ', 'ᥐ', 'ᥭ', 'ᥰ', 'ᥴ', 'ᦀ', 'ᦫ', 'ᦰ', 'ᧉ', 'ᨀ', 'ᨖ', 'ᨠ', 'ᩔ', 'ᬅ', 'ᬳ', 'ᭅ', 'ᭋ', 'ᮃ', 'ᮠ', 'ᮮ', 'ᮯ', 'ᮺ', 'ᯥ', 'ᰀ', 'ᰣ', 'ᱍ', 'ᱏ', 'ᱚ', 'ᱷ', 'ᳩ', 'ᳬ', 'ᳮ', 'ᳱ', 'ᳵ', 'ᳶ', 'ℵ', 'ℸ', 'ⴰ', 'ⵧ', 'ⶀ', 'ⶖ', 'ⶠ', 'ⶦ', 'ⶨ', 'ⶮ', 'ⶰ', 'ⶶ', 'ⶸ', 'ⶾ', 'ⷀ', 'ⷆ', 'ⷈ', 'ⷎ', 'ⷐ', 'ⷖ', 'ⷘ', 'ⷞ', 'ぁ', 'ゖ', 'ァ', 'ヺ', 'ㄅ', 'ㄯ', 'ㄱ', 'ㆎ', 'ㆠ', 'ㆺ', 'ㇰ', 'ㇿ', '㐀', '䶵', '一', '鿯', 'ꀀ', 'ꀔ', 'ꀖ', 'ꒌ', 'ꓐ', 'ꓷ', 'ꔀ', 'ꘋ', 'ꘐ', 'ꘟ', 'ꘪ', 'ꘫ', 'ꚠ', 'ꛥ', 'ꟻ', 'ꠁ', 'ꠃ', 'ꠅ', 'ꠇ', 'ꠊ', 'ꠌ', 'ꠢ', 'ꡀ', 'ꡳ', 'ꢂ', 'ꢳ', 'ꣲ', 'ꣷ', 'ꣽ', 'ꣾ', 'ꤊ', 'ꤥ', 'ꤰ', 'ꥆ', 'ꥠ', 'ꥼ', 'ꦄ', 'ꦲ', 'ꧠ', 'ꧤ', 'ꧧ', 'ꧯ', 'ꧺ', 'ꧾ', 'ꨀ', 'ꨨ', 'ꩀ', 'ꩂ', 'ꩄ', 'ꩋ', 'ꩠ', 'ꩯ', 'ꩱ', 'ꩶ', 'ꩾ', 'ꪯ', 'ꪵ', 'ꪶ', 'ꪹ', 'ꪽ', 'ꫛ', 'ꫜ', 'ꫠ', 'ꫪ', 'ꬁ', 'ꬆ', 'ꬉ', 'ꬎ', 'ꬑ', 'ꬖ', 'ꬠ', 'ꬦ', 'ꬨ', 'ꬮ', 'ꯀ', 'ꯢ', '가', '힣', 'ힰ', 'ퟆ', 'ퟋ', 'ퟻ', '豈', '舘', '並', '龎', 'ײַ', 'ﬨ', 'שׁ', 'זּ', 'טּ', 'לּ', 'נּ', 'סּ', 'ףּ', 'פּ', 'צּ', 'ﮱ', 'ﯓ', 'ﴽ', 'ﵐ', 'ﶏ', 'ﶒ', 'ﷇ', 'ﷰ', 'ﷻ', 'ﹰ', 'ﹴ', 'ﹶ', 'ﻼ', 'ｦ', 'ｯ', 'ｱ', 'ﾝ', 'ﾠ', 'ﾾ', 'ￂ', 'ￇ', 'ￊ', 'ￏ', 'ￒ', 'ￗ', 'ￚ', 'ￜ'},
@@ -12029,9 +12137,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lt",
-			pos:  position{line: 1659, col: 1, offset: 47834},
+			pos:  position{line: 1659, col: 1, offset: 47892},
 			expr: &charClassMatcher{
-				pos:        position{line: 1659, col: 6, offset: 47839},
+				pos:        position{line: 1659, col: 6, offset: 47897},
 				val:        "[\\u01C5\\u01C8\\u01CB\\u01F2\\u1F88-\\u1F8F\\u1F98-\\u1F9F\\u1FA8-\\u1FAF\\u1FBC\\u1FCC\\u1FFC]",
 				chars:      []rune{'ǅ', 'ǈ', 'ǋ', 'ǲ', 'ᾼ', 'ῌ', 'ῼ'},
 				ranges:     []rune{'ᾈ', 'ᾏ', 'ᾘ', 'ᾟ', 'ᾨ', 'ᾯ'},
@@ -12043,9 +12151,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lu",
-			pos:  position{line: 1662, col: 1, offset: 47945},
+			pos:  position{line: 1662, col: 1, offset: 48003},
 			expr: &charClassMatcher{
-				pos:        position{line: 1662, col: 6, offset: 47950},
+				pos:        position{line: 1662, col: 6, offset: 48008},
 				val:        "[\\u0041-\\u005A\\u00C0-\\u00D6\\u00D8-\\u00DE\\u0100\\u0102\\u0104\\u0106\\u0108\\u010A\\u010C\\u010E\\u0110\\u0112\\u0114\\u0116\\u0118\\u011A\\u011C\\u011E\\u0120\\u0122\\u0124\\u0126\\u0128\\u012A\\u012C\\u012E\\u0130\\u0132\\u0134\\u0136\\u0139\\u013B\\u013D\\u013F\\u0141\\u0143\\u0145\\u0147\\u014A\\u014C\\u014E\\u0150\\u0152\\u0154\\u0156\\u0158\\u015A\\u015C\\u015E\\u0160\\u0162\\u0164\\u0166\\u0168\\u016A\\u016C\\u016E\\u0170\\u0172\\u0174\\u0176\\u0178-\\u0179\\u017B\\u017D\\u0181-\\u0182\\u0184\\u0186-\\u0187\\u0189-\\u018B\\u018E-\\u0191\\u0193-\\u0194\\u0196-\\u0198\\u019C-\\u019D\\u019F-\\u01A0\\u01A2\\u01A4\\u01A6-\\u01A7\\u01A9\\u01AC\\u01AE-\\u01AF\\u01B1-\\u01B3\\u01B5\\u01B7-\\u01B8\\u01BC\\u01C4\\u01C7\\u01CA\\u01CD\\u01CF\\u01D1\\u01D3\\u01D5\\u01D7\\u01D9\\u01DB\\u01DE\\u01E0\\u01E2\\u01E4\\u01E6\\u01E8\\u01EA\\u01EC\\u01EE\\u01F1\\u01F4\\u01F6-\\u01F8\\u01FA\\u01FC\\u01FE\\u0200\\u0202\\u0204\\u0206\\u0208\\u020A\\u020C\\u020E\\u0210\\u0212\\u0214\\u0216\\u0218\\u021A\\u021C\\u021E\\u0220\\u0222\\u0224\\u0226\\u0228\\u022A\\u022C\\u022E\\u0230\\u0232\\u023A-\\u023B\\u023D-\\u023E\\u0241\\u0243-\\u0246\\u0248\\u024A\\u024C\\u024E\\u0370\\u0372\\u0376\\u037F\\u0386\\u0388-\\u038A\\u038C\\u038E-\\u038F\\u0391-\\u03A1\\u03A3-\\u03AB\\u03CF\\u03D2-\\u03D4\\u03D8\\u03DA\\u03DC\\u03DE\\u03E0\\u03E2\\u03E4\\u03E6\\u03E8\\u03EA\\u03EC\\u03EE\\u03F4\\u03F7\\u03F9-\\u03FA\\u03FD-\\u042F\\u0460\\u0462\\u0464\\u0466\\u0468\\u046A\\u046C\\u046E\\u0470\\u0472\\u0474\\u0476\\u0478\\u047A\\u047C\\u047E\\u0480\\u048A\\u048C\\u048E\\u0490\\u0492\\u0494\\u0496\\u0498\\u049A\\u049C\\u049E\\u04A0\\u04A2\\u04A4\\u04A6\\u04A8\\u04AA\\u04AC\\u04AE\\u04B0\\u04B2\\u04B4\\u04B6\\u04B8\\u04BA\\u04BC\\u04BE\\u04C0-\\u04C1\\u04C3\\u04C5\\u04C7\\u04C9\\u04CB\\u04CD\\u04D0\\u04D2\\u04D4\\u04D6\\u04D8\\u04DA\\u04DC\\u04DE\\u04E0\\u04E2\\u04E4\\u04E6\\u04E8\\u04EA\\u04EC\\u04EE\\u04F0\\u04F2\\u04F4\\u04F6\\u04F8\\u04FA\\u04FC\\u04FE\\u0500\\u0502\\u0504\\u0506\\u0508\\u050A\\u050C\\u050E\\u0510\\u0512\\u0514\\u0516\\u0518\\u051A\\u051C\\u051E\\u0520\\u0522\\u0524\\u0526\\u0528\\u052A\\u052C\\u052E\\u0531-\\u0556\\u10A0-\\u10C5\\u10C7\\u10CD\\u13A0-\\u13F5\\u1C90-\\u1CBA\\u1CBD-\\u1CBF\\u1E00\\u1E02\\u1E04\\u1E06\\u1E08\\u1E0A\\u1E0C\\u1E0E\\u1E10\\u1E12\\u1E14\\u1E16\\u1E18\\u1E1A\\u1E1C\\u1E1E\\u1E20\\u1E22\\u1E24\\u1E26\\u1E28\\u1E2A\\u1E2C\\u1E2E\\u1E30\\u1E32\\u1E34\\u1E36\\u1E38\\u1E3A\\u1E3C\\u1E3E\\u1E40\\u1E42\\u1E44\\u1E46\\u1E48\\u1E4A\\u1E4C\\u1E4E\\u1E50\\u1E52\\u1E54\\u1E56\\u1E58\\u1E5A\\u1E5C\\u1E5E\\u1E60\\u1E62\\u1E64\\u1E66\\u1E68\\u1E6A\\u1E6C\\u1E6E\\u1E70\\u1E72\\u1E74\\u1E76\\u1E78\\u1E7A\\u1E7C\\u1E7E\\u1E80\\u1E82\\u1E84\\u1E86\\u1E88\\u1E8A\\u1E8C\\u1E8E\\u1E90\\u1E92\\u1E94\\u1E9E\\u1EA0\\u1EA2\\u1EA4\\u1EA6\\u1EA8\\u1EAA\\u1EAC\\u1EAE\\u1EB0\\u1EB2\\u1EB4\\u1EB6\\u1EB8\\u1EBA\\u1EBC\\u1EBE\\u1EC0\\u1EC2\\u1EC4\\u1EC6\\u1EC8\\u1ECA\\u1ECC\\u1ECE\\u1ED0\\u1ED2\\u1ED4\\u1ED6\\u1ED8\\u1EDA\\u1EDC\\u1EDE\\u1EE0\\u1EE2\\u1EE4\\u1EE6\\u1EE8\\u1EEA\\u1EEC\\u1EEE\\u1EF0\\u1EF2\\u1EF4\\u1EF6\\u1EF8\\u1EFA\\u1EFC\\u1EFE\\u1F08-\\u1F0F\\u1F18-\\u1F1D\\u1F28-\\u1F2F\\u1F38-\\u1F3F\\u1F48-\\u1F4D\\u1F59\\u1F5B\\u1F5D\\u1F5F\\u1F68-\\u1F6F\\u1FB8-\\u1FBB\\u1FC8-\\u1FCB\\u1FD8-\\u1FDB\\u1FE8-\\u1FEC\\u1FF8-\\u1FFB\\u2102\\u2107\\u210B-\\u210D\\u2110-\\u2112\\u2115\\u2119-\\u211D\\u2124\\u2126\\u2128\\u212A-\\u212D\\u2130-\\u2133\\u213E-\\u213F\\u2145\\u2183\\u2C00-\\u2C2E\\u2C60\\u2C62-\\u2C64\\u2C67\\u2C69\\u2C6B\\u2C6D-\\u2C70\\u2C72\\u2C75\\u2C7E-\\u2C80\\u2C82\\u2C84\\u2C86\\u2C88\\u2C8A\\u2C8C\\u2C8E\\u2C90\\u2C92\\u2C94\\u2C96\\u2C98\\u2C9A\\u2C9C\\u2C9E\\u2CA0\\u2CA2\\u2CA4\\u2CA6\\u2CA8\\u2CAA\\u2CAC\\u2CAE\\u2CB0\\u2CB2\\u2CB4\\u2CB6\\u2CB8\\u2CBA\\u2CBC\\u2CBE\\u2CC0\\u2CC2\\u2CC4\\u2CC6\\u2CC8\\u2CCA\\u2CCC\\u2CCE\\u2CD0\\u2CD2\\u2CD4\\u2CD6\\u2CD8\\u2CDA\\u2CDC\\u2CDE\\u2CE0\\u2CE2\\u2CEB\\u2CED\\u2CF2\\uA640\\uA642\\uA644\\uA646\\uA648\\uA64A\\uA64C\\uA64E\\uA650\\uA652\\uA654\\uA656\\uA658\\uA65A\\uA65C\\uA65E\\uA660\\uA662\\uA664\\uA666\\uA668\\uA66A\\uA66C\\uA680\\uA682\\uA684\\uA686\\uA688\\uA68A\\uA68C\\uA68E\\uA690\\uA692\\uA694\\uA696\\uA698\\uA69A\\uA722\\uA724\\uA726\\uA728\\uA72A\\uA72C\\uA72E\\uA732\\uA734\\uA736\\uA738\\uA73A\\uA73C\\uA73E\\uA740\\uA742\\uA744\\uA746\\uA748\\uA74A\\uA74C\\uA74E\\uA750\\uA752\\uA754\\uA756\\uA758\\uA75A\\uA75C\\uA75E\\uA760\\uA762\\uA764\\uA766\\uA768\\uA76A\\uA76C\\uA76E\\uA779\\uA77B\\uA77D-\\uA77E\\uA780\\uA782\\uA784\\uA786\\uA78B\\uA78D\\uA790\\uA792\\uA796\\uA798\\uA79A\\uA79C\\uA79E\\uA7A0\\uA7A2\\uA7A4\\uA7A6\\uA7A8\\uA7AA-\\uA7AE\\uA7B0-\\uA7B4\\uA7B6\\uA7B8\\uFF21-\\uFF3A]",
 				chars:      []rune{'Ā', 'Ă', 'Ą', 'Ć', 'Ĉ', 'Ċ', 'Č', 'Ď', 'Đ', 'Ē', 'Ĕ', 'Ė', 'Ę', 'Ě', 'Ĝ', 'Ğ', 'Ġ', 'Ģ', 'Ĥ', 'Ħ', 'Ĩ', 'Ī', 'Ĭ', 'Į', 'İ', 'Ĳ', 'Ĵ', 'Ķ', 'Ĺ', 'Ļ', 'Ľ', 'Ŀ', 'Ł', 'Ń', 'Ņ', 'Ň', 'Ŋ', 'Ō', 'Ŏ', 'Ő', 'Œ', 'Ŕ', 'Ŗ', 'Ř', 'Ś', 'Ŝ', 'Ş', 'Š', 'Ţ', 'Ť', 'Ŧ', 'Ũ', 'Ū', 'Ŭ', 'Ů', 'Ű', 'Ų', 'Ŵ', 'Ŷ', 'Ż', 'Ž', 'Ƅ', 'Ƣ', 'Ƥ', 'Ʃ', 'Ƭ', 'Ƶ', 'Ƽ', 'Ǆ', 'Ǉ', 'Ǌ', 'Ǎ', 'Ǐ', 'Ǒ', 'Ǔ', 'Ǖ', 'Ǘ', 'Ǚ', 'Ǜ', 'Ǟ', 'Ǡ', 'Ǣ', 'Ǥ', 'Ǧ', 'Ǩ', 'Ǫ', 'Ǭ', 'Ǯ', 'Ǳ', 'Ǵ', 'Ǻ', 'Ǽ', 'Ǿ', 'Ȁ', 'Ȃ', 'Ȅ', 'Ȇ', 'Ȉ', 'Ȋ', 'Ȍ', 'Ȏ', 'Ȑ', 'Ȓ', 'Ȕ', 'Ȗ', 'Ș', 'Ț', 'Ȝ', 'Ȟ', 'Ƞ', 'Ȣ', 'Ȥ', 'Ȧ', 'Ȩ', 'Ȫ', 'Ȭ', 'Ȯ', 'Ȱ', 'Ȳ', 'Ɂ', 'Ɉ', 'Ɋ', 'Ɍ', 'Ɏ', 'Ͱ', 'Ͳ', 'Ͷ', 'Ϳ', 'Ά', 'Ό', 'Ϗ', 'Ϙ', 'Ϛ', 'Ϝ', 'Ϟ', 'Ϡ', 'Ϣ', 'Ϥ', 'Ϧ', 'Ϩ', 'Ϫ', 'Ϭ', 'Ϯ', 'ϴ', 'Ϸ', 'Ѡ', 'Ѣ', 'Ѥ', 'Ѧ', 'Ѩ', 'Ѫ', 'Ѭ', 'Ѯ', 'Ѱ', 'Ѳ', 'Ѵ', 'Ѷ', 'Ѹ', 'Ѻ', 'Ѽ', 'Ѿ', 'Ҁ', 'Ҋ', 'Ҍ', 'Ҏ', 'Ґ', 'Ғ', 'Ҕ', 'Җ', 'Ҙ', 'Қ', 'Ҝ', 'Ҟ', 'Ҡ', 'Ң', 'Ҥ', 'Ҧ', 'Ҩ', 'Ҫ', 'Ҭ', 'Ү', 'Ұ', 'Ҳ', 'Ҵ', 'Ҷ', 'Ҹ', 'Һ', 'Ҽ', 'Ҿ', 'Ӄ', 'Ӆ', 'Ӈ', 'Ӊ', 'Ӌ', 'Ӎ', 'Ӑ', 'Ӓ', 'Ӕ', 'Ӗ', 'Ә', 'Ӛ', 'Ӝ', 'Ӟ', 'Ӡ', 'Ӣ', 'Ӥ', 'Ӧ', 'Ө', 'Ӫ', 'Ӭ', 'Ӯ', 'Ӱ', 'Ӳ', 'Ӵ', 'Ӷ', 'Ӹ', 'Ӻ', 'Ӽ', 'Ӿ', 'Ԁ', 'Ԃ', 'Ԅ', 'Ԇ', 'Ԉ', 'Ԋ', 'Ԍ', 'Ԏ', 'Ԑ', 'Ԓ', 'Ԕ', 'Ԗ', 'Ԙ', 'Ԛ', 'Ԝ', 'Ԟ', 'Ԡ', 'Ԣ', 'Ԥ', 'Ԧ', 'Ԩ', 'Ԫ', 'Ԭ', 'Ԯ', 'Ⴧ', 'Ⴭ', 'Ḁ', 'Ḃ', 'Ḅ', 'Ḇ', 'Ḉ', 'Ḋ', 'Ḍ', 'Ḏ', 'Ḑ', 'Ḓ', 'Ḕ', 'Ḗ', 'Ḙ', 'Ḛ', 'Ḝ', 'Ḟ', 'Ḡ', 'Ḣ', 'Ḥ', 'Ḧ', 'Ḩ', 'Ḫ', 'Ḭ', 'Ḯ', 'Ḱ', 'Ḳ', 'Ḵ', 'Ḷ', 'Ḹ', 'Ḻ', 'Ḽ', 'Ḿ', 'Ṁ', 'Ṃ', 'Ṅ', 'Ṇ', 'Ṉ', 'Ṋ', 'Ṍ', 'Ṏ', 'Ṑ', 'Ṓ', 'Ṕ', 'Ṗ', 'Ṙ', 'Ṛ', 'Ṝ', 'Ṟ', 'Ṡ', 'Ṣ', 'Ṥ', 'Ṧ', 'Ṩ', 'Ṫ', 'Ṭ', 'Ṯ', 'Ṱ', 'Ṳ', 'Ṵ', 'Ṷ', 'Ṹ', 'Ṻ', 'Ṽ', 'Ṿ', 'Ẁ', 'Ẃ', 'Ẅ', 'Ẇ', 'Ẉ', 'Ẋ', 'Ẍ', 'Ẏ', 'Ẑ', 'Ẓ', 'Ẕ', 'ẞ', 'Ạ', 'Ả', 'Ấ', 'Ầ', 'Ẩ', 'Ẫ', 'Ậ', 'Ắ', 'Ằ', 'Ẳ', 'Ẵ', 'Ặ', 'Ẹ', 'Ẻ', 'Ẽ', 'Ế', 'Ề', 'Ể', 'Ễ', 'Ệ', 'Ỉ', 'Ị', 'Ọ', 'Ỏ', 'Ố', 'Ồ', 'Ổ', 'Ỗ', 'Ộ', 'Ớ', 'Ờ', 'Ở', 'Ỡ', 'Ợ', 'Ụ', 'Ủ', 'Ứ', 'Ừ', 'Ử', 'Ữ', 'Ự', 'Ỳ', 'Ỵ', 'Ỷ', 'Ỹ', 'Ỻ', 'Ỽ', 'Ỿ', 'Ὑ', 'Ὓ', 'Ὕ', 'Ὗ', 'ℂ', 'ℇ', 'ℕ', 'ℤ', 'Ω', 'ℨ', 'ⅅ', 'Ↄ', 'Ⱡ', 'Ⱨ', 'Ⱪ', 'Ⱬ', 'Ⱳ', 'Ⱶ', 'Ⲃ', 'Ⲅ', 'Ⲇ', 'Ⲉ', 'Ⲋ', 'Ⲍ', 'Ⲏ', 'Ⲑ', 'Ⲓ', 'Ⲕ', 'Ⲗ', 'Ⲙ', 'Ⲛ', 'Ⲝ', 'Ⲟ', 'Ⲡ', 'Ⲣ', 'Ⲥ', 'Ⲧ', 'Ⲩ', 'Ⲫ', 'Ⲭ', 'Ⲯ', 'Ⲱ', 'Ⲳ', 'Ⲵ', 'Ⲷ', 'Ⲹ', 'Ⲻ', 'Ⲽ', 'Ⲿ', 'Ⳁ', 'Ⳃ', 'Ⳅ', 'Ⳇ', 'Ⳉ', 'Ⳋ', 'Ⳍ', 'Ⳏ', 'Ⳑ', 'Ⳓ', 'Ⳕ', 'Ⳗ', 'Ⳙ', 'Ⳛ', 'Ⳝ', 'Ⳟ', 'Ⳡ', 'Ⳣ', 'Ⳬ', 'Ⳮ', 'Ⳳ', 'Ꙁ', 'Ꙃ', 'Ꙅ', 'Ꙇ', 'Ꙉ', 'Ꙋ', 'Ꙍ', 'Ꙏ', 'Ꙑ', 'Ꙓ', 'Ꙕ', 'Ꙗ', 'Ꙙ', 'Ꙛ', 'Ꙝ', 'Ꙟ', 'Ꙡ', 'Ꙣ', 'Ꙥ', 'Ꙧ', 'Ꙩ', 'Ꙫ', 'Ꙭ', 'Ꚁ', 'Ꚃ', 'Ꚅ', 'Ꚇ', 'Ꚉ', 'Ꚋ', 'Ꚍ', 'Ꚏ', 'Ꚑ', 'Ꚓ', 'Ꚕ', 'Ꚗ', 'Ꚙ', 'Ꚛ', 'Ꜣ', 'Ꜥ', 'Ꜧ', 'Ꜩ', 'Ꜫ', 'Ꜭ', 'Ꜯ', 'Ꜳ', 'Ꜵ', 'Ꜷ', 'Ꜹ', 'Ꜻ', 'Ꜽ', 'Ꜿ', 'Ꝁ', 'Ꝃ', 'Ꝅ', 'Ꝇ', 'Ꝉ', 'Ꝋ', 'Ꝍ', 'Ꝏ', 'Ꝑ', 'Ꝓ', 'Ꝕ', 'Ꝗ', 'Ꝙ', 'Ꝛ', 'Ꝝ', 'Ꝟ', 'Ꝡ', 'Ꝣ', 'Ꝥ', 'Ꝧ', 'Ꝩ', 'Ꝫ', 'Ꝭ', 'Ꝯ', 'Ꝺ', 'Ꝼ', 'Ꞁ', 'Ꞃ', 'Ꞅ', 'Ꞇ', 'Ꞌ', 'Ɥ', 'Ꞑ', 'Ꞓ', 'Ꞗ', 'Ꞙ', 'Ꞛ', 'Ꞝ', 'Ꞟ', 'Ꞡ', 'Ꞣ', 'Ꞥ', 'Ꞧ', 'Ꞩ', 'Ꞷ', 'Ꞹ'},
 				ranges:     []rune{'A', 'Z', 'À', 'Ö', 'Ø', 'Þ', 'Ÿ', 'Ź', 'Ɓ', 'Ƃ', 'Ɔ', 'Ƈ', 'Ɖ', 'Ƌ', 'Ǝ', 'Ƒ', 'Ɠ', 'Ɣ', 'Ɩ', 'Ƙ', 'Ɯ', 'Ɲ', 'Ɵ', 'Ơ', 'Ʀ', 'Ƨ', 'Ʈ', 'Ư', 'Ʊ', 'Ƴ', 'Ʒ', 'Ƹ', 'Ƕ', 'Ǹ', 'Ⱥ', 'Ȼ', 'Ƚ', 'Ⱦ', 'Ƀ', 'Ɇ', 'Έ', 'Ί', 'Ύ', 'Ώ', 'Α', 'Ρ', 'Σ', 'Ϋ', 'ϒ', 'ϔ', 'Ϲ', 'Ϻ', 'Ͻ', 'Я', 'Ӏ', 'Ӂ', 'Ա', 'Ֆ', 'Ⴀ', 'Ⴥ', 'Ꭰ', 'Ᏽ', 'Ა', 'Ჺ', 'Ჽ', 'Ჿ', 'Ἀ', 'Ἇ', 'Ἐ', 'Ἕ', 'Ἠ', 'Ἧ', 'Ἰ', 'Ἷ', 'Ὀ', 'Ὅ', 'Ὠ', 'Ὧ', 'Ᾰ', 'Ά', 'Ὲ', 'Ή', 'Ῐ', 'Ί', 'Ῠ', 'Ῥ', 'Ὸ', 'Ώ', 'ℋ', 'ℍ', 'ℐ', 'ℒ', 'ℙ', 'ℝ', 'K', 'ℭ', 'ℰ', 'ℳ', 'ℾ', 'ℿ', 'Ⰰ', 'Ⱞ', 'Ɫ', 'Ɽ', 'Ɑ', 'Ɒ', 'Ȿ', 'Ⲁ', 'Ᵹ', 'Ꝿ', 'Ɦ', 'Ɪ', 'Ʞ', 'Ꞵ', 'Ａ', 'Ｚ'},
@@ -12057,9 +12165,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mc",
-			pos:  position{line: 1665, col: 1, offset: 51951},
+			pos:  position{line: 1665, col: 1, offset: 52009},
 			expr: &charClassMatcher{
-				pos:        position{line: 1665, col: 6, offset: 51956},
+				pos:        position{line: 1665, col: 6, offset: 52014},
 				val:        "[\\u0903\\u093B\\u093E-\\u0940\\u0949-\\u094C\\u094E-\\u094F\\u0982-\\u0983\\u09BE-\\u09C0\\u09C7-\\u09C8\\u09CB-\\u09CC\\u09D7\\u0A03\\u0A3E-\\u0A40\\u0A83\\u0ABE-\\u0AC0\\u0AC9\\u0ACB-\\u0ACC\\u0B02-\\u0B03\\u0B3E\\u0B40\\u0B47-\\u0B48\\u0B4B-\\u0B4C\\u0B57\\u0BBE-\\u0BBF\\u0BC1-\\u0BC2\\u0BC6-\\u0BC8\\u0BCA-\\u0BCC\\u0BD7\\u0C01-\\u0C03\\u0C41-\\u0C44\\u0C82-\\u0C83\\u0CBE\\u0CC0-\\u0CC4\\u0CC7-\\u0CC8\\u0CCA-\\u0CCB\\u0CD5-\\u0CD6\\u0D02-\\u0D03\\u0D3E-\\u0D40\\u0D46-\\u0D48\\u0D4A-\\u0D4C\\u0D57\\u0D82-\\u0D83\\u0DCF-\\u0DD1\\u0DD8-\\u0DDF\\u0DF2-\\u0DF3\\u0F3E-\\u0F3F\\u0F7F\\u102B-\\u102C\\u1031\\u1038\\u103B-\\u103C\\u1056-\\u1057\\u1062-\\u1064\\u1067-\\u106D\\u1083-\\u1084\\u1087-\\u108C\\u108F\\u109A-\\u109C\\u17B6\\u17BE-\\u17C5\\u17C7-\\u17C8\\u1923-\\u1926\\u1929-\\u192B\\u1930-\\u1931\\u1933-\\u1938\\u1A19-\\u1A1A\\u1A55\\u1A57\\u1A61\\u1A63-\\u1A64\\u1A6D-\\u1A72\\u1B04\\u1B35\\u1B3B\\u1B3D-\\u1B41\\u1B43-\\u1B44\\u1B82\\u1BA1\\u1BA6-\\u1BA7\\u1BAA\\u1BE7\\u1BEA-\\u1BEC\\u1BEE\\u1BF2-\\u1BF3\\u1C24-\\u1C2B\\u1C34-\\u1C35\\u1CE1\\u1CF2-\\u1CF3\\u1CF7\\u302E-\\u302F\\uA823-\\uA824\\uA827\\uA880-\\uA881\\uA8B4-\\uA8C3\\uA952-\\uA953\\uA983\\uA9B4-\\uA9B5\\uA9BA-\\uA9BB\\uA9BD-\\uA9C0\\uAA2F-\\uAA30\\uAA33-\\uAA34\\uAA4D\\uAA7B\\uAA7D\\uAAEB\\uAAEE-\\uAAEF\\uAAF5\\uABE3-\\uABE4\\uABE6-\\uABE7\\uABE9-\\uABEA\\uABEC]",
 				chars:      []rune{'ः', 'ऻ', 'ৗ', 'ਃ', 'ઃ', 'ૉ', 'ା', 'ୀ', 'ୗ', 'ௗ', 'ಾ', 'ൗ', 'ཿ', 'ေ', 'း', 'ႏ', 'ា', 'ᩕ', 'ᩗ', 'ᩡ', 'ᬄ', 'ᬵ', 'ᬻ', 'ᮂ', 'ᮡ', '᮪', 'ᯧ', 'ᯮ', '᳡', '᳷', 'ꠧ', 'ꦃ', 'ꩍ', 'ꩻ', 'ꩽ', 'ꫫ', 'ꫵ', '꯬'},
 				ranges:     []rune{'ा', 'ी', 'ॉ', 'ौ', 'ॎ', 'ॏ', 'ং', 'ঃ', 'া', 'ী', 'ে', 'ৈ', 'ো', 'ৌ', 'ਾ', 'ੀ', 'ા', 'ી', 'ો', 'ૌ', 'ଂ', 'ଃ', 'େ', 'ୈ', 'ୋ', 'ୌ', 'ா', 'ி', 'ு', 'ூ', 'ெ', 'ை', 'ொ', 'ௌ', 'ఁ', 'ః', 'ు', 'ౄ', 'ಂ', 'ಃ', 'ೀ', 'ೄ', 'ೇ', 'ೈ', 'ೊ', 'ೋ', 'ೕ', 'ೖ', 'ം', 'ഃ', 'ാ', 'ീ', 'െ', 'ൈ', 'ൊ', 'ൌ', 'ං', 'ඃ', 'ා', 'ෑ', 'ෘ', 'ෟ', 'ෲ', 'ෳ', '༾', '༿', 'ါ', 'ာ', 'ျ', 'ြ', 'ၖ', 'ၗ', 'ၢ', 'ၤ', 'ၧ', 'ၭ', 'ႃ', 'ႄ', 'ႇ', 'ႌ', 'ႚ', 'ႜ', 'ើ', 'ៅ', 'ះ', 'ៈ', 'ᤣ', 'ᤦ', 'ᤩ', 'ᤫ', 'ᤰ', 'ᤱ', 'ᤳ', 'ᤸ', 'ᨙ', 'ᨚ', 'ᩣ', 'ᩤ', 'ᩭ', 'ᩲ', 'ᬽ', 'ᭁ', 'ᭃ', '᭄', 'ᮦ', 'ᮧ', 'ᯪ', 'ᯬ', '᯲', '᯳', 'ᰤ', 'ᰫ', 'ᰴ', 'ᰵ', 'ᳲ', 'ᳳ', '〮', '〯', 'ꠣ', 'ꠤ', 'ꢀ', 'ꢁ', 'ꢴ', 'ꣃ', 'ꥒ', '꥓', 'ꦴ', 'ꦵ', 'ꦺ', 'ꦻ', 'ꦽ', '꧀', 'ꨯ', 'ꨰ', 'ꨳ', 'ꨴ', 'ꫮ', 'ꫯ', 'ꯣ', 'ꯤ', 'ꯦ', 'ꯧ', 'ꯩ', 'ꯪ'},
@@ -12071,9 +12179,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mn",
-			pos:  position{line: 1668, col: 1, offset: 53144},
+			pos:  position{line: 1668, col: 1, offset: 53202},
 			expr: &charClassMatcher{
-				pos:        position{line: 1668, col: 6, offset: 53149},
+				pos:        position{line: 1668, col: 6, offset: 53207},
 				val:        "[\\u0300-\\u036F\\u0483-\\u0487\\u0591-\\u05BD\\u05BF\\u05C1-\\u05C2\\u05C4-\\u05C5\\u05C7\\u0610-\\u061A\\u064B-\\u065F\\u0670\\u06D6-\\u06DC\\u06DF-\\u06E4\\u06E7-\\u06E8\\u06EA-\\u06ED\\u0711\\u0730-\\u074A\\u07A6-\\u07B0\\u07EB-\\u07F3\\u07FD\\u0816-\\u0819\\u081B-\\u0823\\u0825-\\u0827\\u0829-\\u082D\\u0859-\\u085B\\u08D3-\\u08E1\\u08E3-\\u0902\\u093A\\u093C\\u0941-\\u0948\\u094D\\u0951-\\u0957\\u0962-\\u0963\\u0981\\u09BC\\u09C1-\\u09C4\\u09CD\\u09E2-\\u09E3\\u09FE\\u0A01-\\u0A02\\u0A3C\\u0A41-\\u0A42\\u0A47-\\u0A48\\u0A4B-\\u0A4D\\u0A51\\u0A70-\\u0A71\\u0A75\\u0A81-\\u0A82\\u0ABC\\u0AC1-\\u0AC5\\u0AC7-\\u0AC8\\u0ACD\\u0AE2-\\u0AE3\\u0AFA-\\u0AFF\\u0B01\\u0B3C\\u0B3F\\u0B41-\\u0B44\\u0B4D\\u0B56\\u0B62-\\u0B63\\u0B82\\u0BC0\\u0BCD\\u0C00\\u0C04\\u0C3E-\\u0C40\\u0C46-\\u0C48\\u0C4A-\\u0C4D\\u0C55-\\u0C56\\u0C62-\\u0C63\\u0C81\\u0CBC\\u0CBF\\u0CC6\\u0CCC-\\u0CCD\\u0CE2-\\u0CE3\\u0D00-\\u0D01\\u0D3B-\\u0D3C\\u0D41-\\u0D44\\u0D4D\\u0D62-\\u0D63\\u0DCA\\u0DD2-\\u0DD4\\u0DD6\\u0E31\\u0E34-\\u0E3A\\u0E47-\\u0E4E\\u0EB1\\u0EB4-\\u0EB9\\u0EBB-\\u0EBC\\u0EC8-\\u0ECD\\u0F18-\\u0F19\\u0F35\\u0F37\\u0F39\\u0F71-\\u0F7E\\u0F80-\\u0F84\\u0F86-\\u0F87\\u0F8D-\\u0F97\\u0F99-\\u0FBC\\u0FC6\\u102D-\\u1030\\u1032-\\u1037\\u1039-\\u103A\\u103D-\\u103E\\u1058-\\u1059\\u105E-\\u1060\\u1071-\\u1074\\u1082\\u1085-\\u1086\\u108D\\u109D\\u135D-\\u135F\\u1712-\\u1714\\u1732-\\u1734\\u1752-\\u1753\\u1772-\\u1773\\u17B4-\\u17B5\\u17B7-\\u17BD\\u17C6\\u17C9-\\u17D3\\u17DD\\u180B-\\u180D\\u1885-\\u1886\\u18A9\\u1920-\\u1922\\u1927-\\u1928\\u1932\\u1939-\\u193B\\u1A17-\\u1A18\\u1A1B\\u1A56\\u1A58-\\u1A5E\\u1A60\\u1A62\\u1A65-\\u1A6C\\u1A73-\\u1A7C\\u1A7F\\u1AB0-\\u1ABD\\u1B00-\\u1B03\\u1B34\\u1B36-\\u1B3A\\u1B3C\\u1B42\\u1B6B-\\u1B73\\u1B80-\\u1B81\\u1BA2-\\u1BA5\\u1BA8-\\u1BA9\\u1BAB-\\u1BAD\\u1BE6\\u1BE8-\\u1BE9\\u1BED\\u1BEF-\\u1BF1\\u1C2C-\\u1C33\\u1C36-\\u1C37\\u1CD0-\\u1CD2\\u1CD4-\\u1CE0\\u1CE2-\\u1CE8\\u1CED\\u1CF4\\u1CF8-\\u1CF9\\u1DC0-\\u1DF9\\u1DFB-\\u1DFF\\u20D0-\\u20DC\\u20E1\\u20E5-\\u20F0\\u2CEF-\\u2CF1\\u2D7F\\u2DE0-\\u2DFF\\u302A-\\u302D\\u3099-\\u309A\\uA66F\\uA674-\\uA67D\\uA69E-\\uA69F\\uA6F0-\\uA6F1\\uA802\\uA806\\uA80B\\uA825-\\uA826\\uA8C4-\\uA8C5\\uA8E0-\\uA8F1\\uA8FF\\uA926-\\uA92D\\uA947-\\uA951\\uA980-\\uA982\\uA9B3\\uA9B6-\\uA9B9\\uA9BC\\uA9E5\\uAA29-\\uAA2E\\uAA31-\\uAA32\\uAA35-\\uAA36\\uAA43\\uAA4C\\uAA7C\\uAAB0\\uAAB2-\\uAAB4\\uAAB7-\\uAAB8\\uAABE-\\uAABF\\uAAC1\\uAAEC-\\uAAED\\uAAF6\\uABE5\\uABE8\\uABED\\uFB1E\\uFE00-\\uFE0F\\uFE20-\\uFE2F]",
 				chars:      []rune{'ֿ', 'ׇ', 'ٰ', 'ܑ', '߽', 'ऺ', '़', '्', 'ঁ', '়', '্', '৾', '਼', 'ੑ', 'ੵ', '઼', '્', 'ଁ', '଼', 'ି', '୍', 'ୖ', 'ஂ', 'ீ', '்', 'ఀ', 'ఄ', 'ಁ', '಼', 'ಿ', 'ೆ', '്', '්', 'ූ', 'ั', 'ັ', '༵', '༷', '༹', '࿆', 'ႂ', 'ႍ', 'ႝ', 'ំ', '៝', 'ᢩ', 'ᤲ', 'ᨛ', 'ᩖ', '᩠', 'ᩢ', '᩿', '᬴', 'ᬼ', 'ᭂ', '᯦', 'ᯭ', '᳭', '᳴', '⃡', '⵿', '꙯', 'ꠂ', '꠆', 'ꠋ', 'ꣿ', '꦳', 'ꦼ', 'ꧥ', 'ꩃ', 'ꩌ', 'ꩼ', 'ꪰ', '꫁', '꫶', 'ꯥ', 'ꯨ', '꯭', 'ﬞ'},
 				ranges:     []rune{'̀', 'ͯ', '҃', '҇', '֑', 'ֽ', 'ׁ', 'ׂ', 'ׄ', 'ׅ', 'ؐ', 'ؚ', 'ً', 'ٟ', 'ۖ', 'ۜ', '۟', 'ۤ', 'ۧ', 'ۨ', '۪', 'ۭ', 'ܰ', '݊', 'ަ', 'ް', '߫', '߳', 'ࠖ', '࠙', 'ࠛ', 'ࠣ', 'ࠥ', 'ࠧ', 'ࠩ', '࠭', '࡙', '࡛', '࣓', '࣡', 'ࣣ', 'ं', 'ु', 'ै', '॑', 'ॗ', 'ॢ', 'ॣ', 'ু', 'ৄ', 'ৢ', 'ৣ', 'ਁ', 'ਂ', 'ੁ', 'ੂ', 'ੇ', 'ੈ', 'ੋ', '੍', 'ੰ', 'ੱ', 'ઁ', 'ં', 'ુ', 'ૅ', 'ે', 'ૈ', 'ૢ', 'ૣ', 'ૺ', '૿', 'ୁ', 'ୄ', 'ୢ', 'ୣ', 'ా', 'ీ', 'ె', 'ై', 'ొ', '్', 'ౕ', 'ౖ', 'ౢ', 'ౣ', 'ೌ', '್', 'ೢ', 'ೣ', 'ഀ', 'ഁ', '഻', '഼', 'ു', 'ൄ', 'ൢ', 'ൣ', 'ි', 'ු', 'ิ', 'ฺ', '็', '๎', 'ິ', 'ູ', 'ົ', 'ຼ', '່', 'ໍ', '༘', '༙', 'ཱ', 'ཾ', 'ྀ', '྄', '྆', '྇', 'ྍ', 'ྗ', 'ྙ', 'ྼ', 'ိ', 'ူ', 'ဲ', '့', '္', '်', 'ွ', 'ှ', 'ၘ', 'ၙ', 'ၞ', 'ၠ', 'ၱ', 'ၴ', 'ႅ', 'ႆ', '፝', '፟', 'ᜒ', '᜔', 'ᜲ', '᜴', 'ᝒ', 'ᝓ', 'ᝲ', 'ᝳ', '឴', '឵', 'ិ', 'ួ', '៉', '៓', '᠋', '᠍', 'ᢅ', 'ᢆ', 'ᤠ', 'ᤢ', 'ᤧ', 'ᤨ', '᤹', '᤻', 'ᨗ', 'ᨘ', 'ᩘ', 'ᩞ', 'ᩥ', 'ᩬ', 'ᩳ', '᩼', '᪰', '᪽', 'ᬀ', 'ᬃ', 'ᬶ', 'ᬺ', '᭫', '᭳', 'ᮀ', 'ᮁ', 'ᮢ', 'ᮥ', 'ᮨ', 'ᮩ', '᮫', 'ᮭ', 'ᯨ', 'ᯩ', 'ᯯ', 'ᯱ', 'ᰬ', 'ᰳ', 'ᰶ', '᰷', '᳐', '᳒', '᳔', '᳠', '᳢', '᳨', '᳸', '᳹', '᷀', '᷹', '᷻', '᷿', '⃐', '⃜', '⃥', '⃰', '⳯', '⳱', 'ⷠ', 'ⷿ', '〪', '〭', '゙', '゚', 'ꙴ', '꙽', 'ꚞ', 'ꚟ', '꛰', '꛱', 'ꠥ', 'ꠦ', '꣄', 'ꣅ', '꣠', '꣱', 'ꤦ', '꤭', 'ꥇ', 'ꥑ', 'ꦀ', 'ꦂ', 'ꦶ', 'ꦹ', 'ꨩ', 'ꨮ', 'ꨱ', 'ꨲ', 'ꨵ', 'ꨶ', 'ꪲ', 'ꪴ', 'ꪷ', 'ꪸ', 'ꪾ', '꪿', 'ꫬ', 'ꫭ', '︀', '️', '︠', '︯'},
@@ -12085,9 +12193,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nd",
-			pos:  position{line: 1671, col: 1, offset: 55329},
+			pos:  position{line: 1671, col: 1, offset: 55387},
 			expr: &charClassMatcher{
-				pos:        position{line: 1671, col: 6, offset: 55334},
+				pos:        position{line: 1671, col: 6, offset: 55392},
 				val:        "[\\u0030-\\u0039\\u0660-\\u0669\\u06F0-\\u06F9\\u07C0-\\u07C9\\u0966-\\u096F\\u09E6-\\u09EF\\u0A66-\\u0A6F\\u0AE6-\\u0AEF\\u0B66-\\u0B6F\\u0BE6-\\u0BEF\\u0C66-\\u0C6F\\u0CE6-\\u0CEF\\u0D66-\\u0D6F\\u0DE6-\\u0DEF\\u0E50-\\u0E59\\u0ED0-\\u0ED9\\u0F20-\\u0F29\\u1040-\\u1049\\u1090-\\u1099\\u17E0-\\u17E9\\u1810-\\u1819\\u1946-\\u194F\\u19D0-\\u19D9\\u1A80-\\u1A89\\u1A90-\\u1A99\\u1B50-\\u1B59\\u1BB0-\\u1BB9\\u1C40-\\u1C49\\u1C50-\\u1C59\\uA620-\\uA629\\uA8D0-\\uA8D9\\uA900-\\uA909\\uA9D0-\\uA9D9\\uA9F0-\\uA9F9\\uAA50-\\uAA59\\uABF0-\\uABF9\\uFF10-\\uFF19]",
 				ranges:     []rune{'0', '9', '٠', '٩', '۰', '۹', '߀', '߉', '०', '९', '০', '৯', '੦', '੯', '૦', '૯', '୦', '୯', '௦', '௯', '౦', '౯', '೦', '೯', '൦', '൯', '෦', '෯', '๐', '๙', '໐', '໙', '༠', '༩', '၀', '၉', '႐', '႙', '០', '៩', '᠐', '᠙', '᥆', '᥏', '᧐', '᧙', '᪀', '᪉', '᪐', '᪙', '᭐', '᭙', '᮰', '᮹', '᱀', '᱉', '᱐', '᱙', '꘠', '꘩', '꣐', '꣙', '꤀', '꤉', '꧐', '꧙', '꧰', '꧹', '꩐', '꩙', '꯰', '꯹', '０', '９'},
 				ignoreCase: false,
@@ -12098,9 +12206,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nl",
-			pos:  position{line: 1674, col: 1, offset: 55837},
+			pos:  position{line: 1674, col: 1, offset: 55895},
 			expr: &charClassMatcher{
-				pos:        position{line: 1674, col: 6, offset: 55842},
+				pos:        position{line: 1674, col: 6, offset: 55900},
 				val:        "[\\u16EE-\\u16F0\\u2160-\\u2182\\u2185-\\u2188\\u3007\\u3021-\\u3029\\u3038-\\u303A\\uA6E6-\\uA6EF]",
 				chars:      []rune{'〇'},
 				ranges:     []rune{'ᛮ', 'ᛰ', 'Ⅰ', 'ↂ', 'ↅ', 'ↈ', '〡', '〩', '〸', '〺', 'ꛦ', 'ꛯ'},
@@ -12112,9 +12220,9 @@ var g = &grammar{
 		},
 		{
 			name: "Pc",
-			pos:  position{line: 1677, col: 1, offset: 55956},
+			pos:  position{line: 1677, col: 1, offset: 56014},
 			expr: &charClassMatcher{
-				pos:        position{line: 1677, col: 6, offset: 55961},
+				pos:        position{line: 1677, col: 6, offset: 56019},
 				val:        "[\\u005F\\u203F-\\u2040\\u2054\\uFE33-\\uFE34\\uFE4D-\\uFE4F\\uFF3F]",
 				chars:      []rune{'_', '⁔', '＿'},
 				ranges:     []rune{'‿', '⁀', '︳', '︴', '﹍', '﹏'},
@@ -12126,9 +12234,9 @@ var g = &grammar{
 		},
 		{
 			name: "Zs",
-			pos:  position{line: 1680, col: 1, offset: 56042},
+			pos:  position{line: 1680, col: 1, offset: 56100},
 			expr: &charClassMatcher{
-				pos:        position{line: 1680, col: 6, offset: 56047},
+				pos:        position{line: 1680, col: 6, offset: 56105},
 				val:        "[\\u0020\\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000]",
 				chars:      []rune{' ', '\u00a0', '\u1680', '\u202f', '\u205f', '\u3000'},
 				ranges:     []rune{'\u2000', '\u200a'},
@@ -12140,9 +12248,9 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1682, col: 1, offset: 56100},
+			pos:  position{line: 1682, col: 1, offset: 56158},
 			expr: &anyMatcher{
-				line: 1683, col: 5, offset: 56120,
+				line: 1683, col: 5, offset: 56178,
 			},
 			leader:        false,
 			leftRecursive: false,
@@ -12150,48 +12258,48 @@ var g = &grammar{
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1685, col: 1, offset: 56123},
+			pos:         position{line: 1685, col: 1, offset: 56181},
 			expr: &choiceExpr{
-				pos: position{line: 1686, col: 5, offset: 56151},
+				pos: position{line: 1686, col: 5, offset: 56209},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1686, col: 5, offset: 56151},
+						pos:        position{line: 1686, col: 5, offset: 56209},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1687, col: 5, offset: 56160},
+						pos:        position{line: 1687, col: 5, offset: 56218},
 						val:        "\v",
 						ignoreCase: false,
 						want:       "\"\\v\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1688, col: 5, offset: 56169},
+						pos:        position{line: 1688, col: 5, offset: 56227},
 						val:        "\f",
 						ignoreCase: false,
 						want:       "\"\\f\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1689, col: 5, offset: 56178},
+						pos:        position{line: 1689, col: 5, offset: 56236},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 1690, col: 5, offset: 56186},
+						pos:        position{line: 1690, col: 5, offset: 56244},
 						val:        "\u00a0",
 						ignoreCase: false,
 						want:       "\"\\u00a0\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1691, col: 5, offset: 56199},
+						pos:        position{line: 1691, col: 5, offset: 56257},
 						val:        "\ufeff",
 						ignoreCase: false,
 						want:       "\"\\ufeff\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1692, col: 5, offset: 56212},
+						pos:  position{line: 1692, col: 5, offset: 56270},
 						name: "Zs",
 					},
 				},
@@ -12201,9 +12309,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1694, col: 1, offset: 56216},
+			pos:  position{line: 1694, col: 1, offset: 56274},
 			expr: &charClassMatcher{
-				pos:        position{line: 1695, col: 5, offset: 56235},
+				pos:        position{line: 1695, col: 5, offset: 56293},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -12215,9 +12323,9 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1701, col: 1, offset: 56565},
+			pos:         position{line: 1701, col: 1, offset: 56623},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1704, col: 5, offset: 56636},
+				pos:  position{line: 1704, col: 5, offset: 56694},
 				name: "SingleLineComment",
 			},
 			leader:        false,
@@ -12225,39 +12333,39 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1706, col: 1, offset: 56655},
+			pos:  position{line: 1706, col: 1, offset: 56713},
 			expr: &seqExpr{
-				pos: position{line: 1707, col: 5, offset: 56676},
+				pos: position{line: 1707, col: 5, offset: 56734},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1707, col: 5, offset: 56676},
+						pos:        position{line: 1707, col: 5, offset: 56734},
 						val:        "/*",
 						ignoreCase: false,
 						want:       "\"/*\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1707, col: 10, offset: 56681},
+						pos: position{line: 1707, col: 10, offset: 56739},
 						expr: &seqExpr{
-							pos: position{line: 1707, col: 11, offset: 56682},
+							pos: position{line: 1707, col: 11, offset: 56740},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1707, col: 11, offset: 56682},
+									pos: position{line: 1707, col: 11, offset: 56740},
 									expr: &litMatcher{
-										pos:        position{line: 1707, col: 12, offset: 56683},
+										pos:        position{line: 1707, col: 12, offset: 56741},
 										val:        "*/",
 										ignoreCase: false,
 										want:       "\"*/\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1707, col: 17, offset: 56688},
+									pos:  position{line: 1707, col: 17, offset: 56746},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1707, col: 35, offset: 56706},
+						pos:        position{line: 1707, col: 35, offset: 56764},
 						val:        "*/",
 						ignoreCase: false,
 						want:       "\"*/\"",
@@ -12269,30 +12377,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1709, col: 1, offset: 56712},
+			pos:  position{line: 1709, col: 1, offset: 56770},
 			expr: &seqExpr{
-				pos: position{line: 1710, col: 5, offset: 56734},
+				pos: position{line: 1710, col: 5, offset: 56792},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1710, col: 5, offset: 56734},
+						pos:        position{line: 1710, col: 5, offset: 56792},
 						val:        "//",
 						ignoreCase: false,
 						want:       "\"//\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1710, col: 10, offset: 56739},
+						pos: position{line: 1710, col: 10, offset: 56797},
 						expr: &seqExpr{
-							pos: position{line: 1710, col: 11, offset: 56740},
+							pos: position{line: 1710, col: 11, offset: 56798},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1710, col: 11, offset: 56740},
+									pos: position{line: 1710, col: 11, offset: 56798},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1710, col: 12, offset: 56741},
+										pos:  position{line: 1710, col: 12, offset: 56799},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1710, col: 27, offset: 56756},
+									pos:  position{line: 1710, col: 27, offset: 56814},
 									name: "SourceCharacter",
 								},
 							},
@@ -12305,19 +12413,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1712, col: 1, offset: 56775},
+			pos:  position{line: 1712, col: 1, offset: 56833},
 			expr: &seqExpr{
-				pos: position{line: 1712, col: 7, offset: 56781},
+				pos: position{line: 1712, col: 7, offset: 56839},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1712, col: 7, offset: 56781},
+						pos: position{line: 1712, col: 7, offset: 56839},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1712, col: 7, offset: 56781},
+							pos:  position{line: 1712, col: 7, offset: 56839},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1712, col: 19, offset: 56793},
+						pos:  position{line: 1712, col: 19, offset: 56851},
 						name: "LineTerminator",
 					},
 				},
@@ -12327,16 +12435,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1714, col: 1, offset: 56809},
+			pos:  position{line: 1714, col: 1, offset: 56867},
 			expr: &choiceExpr{
-				pos: position{line: 1714, col: 7, offset: 56815},
+				pos: position{line: 1714, col: 7, offset: 56873},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1714, col: 7, offset: 56815},
+						pos:  position{line: 1714, col: 7, offset: 56873},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1714, col: 11, offset: 56819},
+						pos:  position{line: 1714, col: 11, offset: 56877},
 						name: "EOF",
 					},
 				},
@@ -12346,11 +12454,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1716, col: 1, offset: 56824},
+			pos:  position{line: 1716, col: 1, offset: 56882},
 			expr: &notExpr{
-				pos: position{line: 1716, col: 7, offset: 56830},
+				pos: position{line: 1716, col: 7, offset: 56888},
 				expr: &anyMatcher{
-					line: 1716, col: 8, offset: 56831,
+					line: 1716, col: 8, offset: 56889,
 				},
 			},
 			leader:        false,
@@ -12358,11 +12466,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOKW",
-			pos:  position{line: 1718, col: 1, offset: 56834},
+			pos:  position{line: 1718, col: 1, offset: 56892},
 			expr: &notExpr{
-				pos: position{line: 1718, col: 8, offset: 56841},
+				pos: position{line: 1718, col: 8, offset: 56899},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1718, col: 9, offset: 56842},
+					pos:  position{line: 1718, col: 9, offset: 56900},
 					name: "KeyWordChars",
 				},
 			},

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -442,7 +442,7 @@ HeadOp
         KeywordPos: c.pos.offset,
       }, nil
     }
-  / "head" {
+  / "head" !(__ "(") &EOKW {
       return &ast.Head{
         Kind: "Head",
         KeywordPos: c.pos.offset,
@@ -457,7 +457,7 @@ TailOp
         KeywordPos: c.pos.offset,
       }, nil
     }
-  / "tail" {
+  / "tail" !(__ "(") &EOKW {
       return &ast.Tail{
         Kind: "Tail",
         KeywordPos: c.pos.offset,
@@ -477,7 +477,7 @@ UniqOp
   = "uniq" _ "-c" {
       return &ast.Uniq{Kind: "Uniq", Cflag: true, KeywordPos: c.pos.offset}, nil
     }
-  / "uniq" {
+  / "uniq" !(__ "(") &EOKW {
       return &ast.Uniq{Kind: "Uniq", KeywordPos: c.pos.offset}, nil
     }
 
@@ -732,7 +732,7 @@ OrderSuffix
   / ""      { return "asc", nil }
 
 PassOp
-  = "pass" &EOKW {
+  = "pass" !(__ "(") &EOKW {
       return &ast.Pass{Kind: "Pass", KeywordPos: c.pos.offset}, nil
     }
 

--- a/compiler/parser/valid.zed
+++ b/compiler/parser/valid.zed
@@ -37,3 +37,4 @@ nullkeys()
 truevals()
 falsevals()
 yield 2600:1901:101::/126, ::1/1, 2001:0db8:85a3:0000:0000:8a2e:0370:7334/55
+func head(): (1) func tail(): (1) func uniq(): (1) func pass(): (1) head() | tail() | uniq() | pass()


### PR DESCRIPTION
This commit fix an issue with the parser where yield-less calling a functions named uniq, head, top would result in a parser error.

Closes #5160