### PR TITLE
Link directly to section of Expressions doc from Aggregate Functions page

### DIFF
--- a/docs/language/aggregates/README.md
+++ b/docs/language/aggregates/README.md
@@ -3,7 +3,7 @@
 ---
 
 Aggregate functions appear in either [summarization](../operators/summarize.md)
-or [expression](../expressions.md) context and produce an aggregate
+or [expression](../expressions.md#aggregate-function-calls) context and produce an aggregate
 value for a sequence of input values.
 
 - [and](and.md) - logical AND of input values


### PR DESCRIPTION
In a recent [community Slack thread](https://brimdata.slack.com/archives/CTSMAK6G7/p1719855960575729?thread_ts=1719801076.425009&cid=CTSMAK6G7), a user was learning for the first time about how aggregate functions behave differently when called in "expression context" vs. "summarization context". When the user asked if this was documented anywhere, I checked and confirmed that it was, but looking at it through a user's eyes I recognized that the link on this page to the top of Expressions page was probably not ideal since it's such a big page. Since there's a section in Expressions that speaks specifically to difference vs. summarization, here I'm proposing we link to that directly instead. If the user gets what they need from that section and then want to stick around and learn about all things Expression from the rest of the page, great!