### PR TITLE
Support lift optimization for dag.Fork

### DIFF
--- a/compiler/ztests/merge-filters.yaml
+++ b/compiler/ztests/merge-filters.yaml
@@ -1,7 +1,3 @@
-# We had a regression in the dagify-meta-ops PR and this first test should
-# lift the where g clause into the pushdown filter.  We will get this working
-# after we clean up Parallel to include named outputs and use []*dag.Sequential.
-# See issue #4503.
 script: |
   zc -C -O 'where a | where b'
   echo ===
@@ -18,11 +14,10 @@ outputs:
       ===
       fork (
         =>
-          file a filter (b and c)
+          file a filter (b and c and g)
         =>
-          file d filter (e and f)
+          file d filter (e and f and g)
       )
-      | where g
       ===
       reader
       | over a => (


### PR DESCRIPTION
Also fixes bug where the lift optimization would not get applied on eligible sequences with a length of 2.

Closes #4559, closes #4503, closes #5070