### PR TITLE
Add a couple section headers in language overview doc

### DIFF
--- a/docs/language/overview.md
+++ b/docs/language/overview.md
@@ -17,7 +17,7 @@ by a number of commands:
 command | command | command | ...
 ```
 However, in Zed, the entities that transform data are called
-"operators" instead of "commands" and unlike Unix pipelines,
+"[operators](operators/README.md)" instead of "commands" and unlike Unix pipelines,
 the streams of data in a Zed query
 are typed data sequences that adhere to the
 [Zed data model](../formats/zed.md).
@@ -47,6 +47,8 @@ and the Zed compiler optimizes the data flow computation
 &mdash; e.g., often implementing a Zed program differently than
 the flow implied by the pipeline yet reaching the same result &mdash;
 much as a modern SQL engine optimizes a declarative SQL query.
+
+## Search and Analytics
 
 Zed is also intended to provide a seamless transition from a simple search experience
 (e.g., typed into a search bar or as the query argument of the [`zq`](../commands/zq.md) command-line
@@ -94,6 +96,8 @@ in the input
 The short-hand query from above might be typed into a search box while the
 latter query might be composed in a query editor or in Zed source files
 maintained in GitHub.  Both forms are valid Zed queries.
+
+## Comments
 
 To further ease the maintenance and readability of source files, comments
 beginning with `//` may appear in Zed.


### PR DESCRIPTION
I added mention of the Zed language `//` comment syntax back in #4308 after a community user reported not realizing this concept existed (#4302). Another community user just pointed out via https://github.com/brimdata/zed/issues/4310#issuecomment-2214786576 that the way it's covered in the docs now doesn't currently bubble up nicely in the search results. I'm not 100% certain if their proposed change of adding a section header would improve that, but rather than investing time into setting up a test sandbox to investigate, I spent some time re-reading the page to see if adding a header makes sense regardless.

Looking at it through that lens, indeed, I can see that the coverage as it's been feels a little "tacked on", but I was always had trouble coming up with a better idea. Having a wholly separate page under "Language" at the same level as "Expressions", "Operators" etc. just to briefly mention comments feels like overkill. I also don't see a different existing page into which it would graft nicely as a header-worthy section, though I'm open to suggestion.

The "Overview" page should surely be brief, so I respect the urge to avoid lots of section headers there. However, I did ultimately find that adding a "Search and Analytics" header feels pretty natural to me, so once I've got _that_, the header for Comments feels a bit more natural, too.

As for the user's point in [#4302 ](https://github.com/brimdata/zed/issues/4310#issuecomment-2214786576) about if we should divulge the gotcha here about multi-line `/* */` comment syntax being available in ZSON but not Zed language, I'm holding off on that for the moment in hopes it might be easier to just enhance the parser. 🤞