### PR TITLE
Make the "this" example in user-defined op docs more explicit

### DIFF
--- a/docs/language/statements.md
+++ b/docs/language/statements.md
@@ -108,7 +108,7 @@ calling sequence.
 For instance the program in `myop.zed`
 ```mdtest-input myop.zed
 op myop(): (
-  pass
+  yield this
 )
 myop()
 ```


### PR DESCRIPTION
In a [community Slack thread](https://brimdata.slack.com/archives/CTSMAK6G7/p1719937758651189), a user reported some struggles writing their first user-defined operator. In their own words:

>I was trying to use `switch` in a user-defined operator this morning, and it was giving me a parsing error, because I was trying to pass `this` (essentially) as an argument of the `op`.
> I figured out that if I’m just going to act on `this` inside the user-defined `op`, I don’t need an argument in that case.
>Re-reading the docs, that’s somewhat evident now to me in the existing [docs](https://zed.brimdata.io/docs/language/statements#sequence-this-value)
>but - the example here is so sparse, IMO, that I don’t think I grokked it very well.

After a little back & forth, we established that the minimal change of showing an explicit `yield this` instead of `pass` would have done the trick for him.

FWIW, in my usual slightly-more-verbose way, my first proposal was:

```
yield "I was called with " + string(this)
```

However, the user said that he was fine with either. Since the team members here tend to prefer examples that lean toward the minimal, that's what I'm proposing in the PR. But if folks actually _prefer_ my other idea, I'm happy to go that way too. 😉