### PR TITLE
csv reader: fix EOF on quotes

### DIFF
--- a/zio/csvio/preprocess_test.go
+++ b/zio/csvio/preprocess_test.go
@@ -19,7 +19,8 @@ field1,"field"2,field"3" my friend
 field4,"field"5 with "multiple" quotes "to" escape,field6
 """,""",""" has a couple "" embedded quotes and a , comma",""" """
 x,"hello,
-"" world , " foo,y`
+"" world , " foo,y
+field1,field2,"test eof with quotes"`
 	const expected = `
 ,,
 "","",""
@@ -28,7 +29,8 @@ field1,"field2","field3 my friend"
 field4,"field5 with multiple quotes to escape",field6
 """,""",""" has a couple "" embedded quotes and a , comma",""" """
 x,"hello,
-"" world ,  foo",y`
+"" world ,  foo",y
+field1,field2,"test eof with quotes"`
 
 	p := newPreprocess(strings.NewReader(input), ',')
 	var buf bytes.Buffer


### PR DESCRIPTION
This commit fixes an with the csv reader where and EOF occurring on a quoted field would cause a parsing error.

Closes #4732