### PR TITLE
output operator

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -97,11 +97,11 @@ type QueryRequest struct {
 }
 
 type QueryChannelSet struct {
-	ChannelID int `json:"channel_id" zed:"channel_id"`
+	Channel string `json:"channel" zed:"channel"`
 }
 
 type QueryChannelEnd struct {
-	ChannelID int `json:"channel_id" zed:"channel_id"`
+	Channel string `json:"channel" zed:"channel"`
 }
 
 type QueryError struct {

--- a/api/queryio/client.go
+++ b/api/queryio/client.go
@@ -56,9 +56,9 @@ func (q *Query) Read() (*zed.Value, error) {
 func controlToError(ctrl interface{}) error {
 	switch ctrl := ctrl.(type) {
 	case *api.QueryChannelSet:
-		return &zbuf.Control{Message: zbuf.SetChannel(ctrl.ChannelID)}
+		return &zbuf.Control{Message: zbuf.SetChannel(ctrl.Channel)}
 	case *api.QueryChannelEnd:
-		return &zbuf.Control{Message: zbuf.EndChannel(ctrl.ChannelID)}
+		return &zbuf.Control{Message: zbuf.EndChannel(ctrl.Channel)}
 	case *api.QueryStats:
 		return &zbuf.Control{Message: ctrl.Progress}
 	case *api.QueryError:

--- a/api/queryio/writer.go
+++ b/api/queryio/writer.go
@@ -18,7 +18,7 @@ type controlWriter interface {
 }
 
 type Writer struct {
-	cid     int
+	channel string
 	start   nano.Ts
 	writer  zio.WriteCloser
 	ctrl    bool
@@ -27,7 +27,6 @@ type Writer struct {
 
 func NewWriter(w io.WriteCloser, format string, flusher http.Flusher, ctrl bool) (*Writer, error) {
 	d := &Writer{
-		cid:     -1,
 		ctrl:    ctrl,
 		start:   nano.Now(),
 		flusher: flusher,
@@ -51,10 +50,10 @@ func NewWriter(w io.WriteCloser, format string, flusher http.Flusher, ctrl bool)
 	return d, err
 }
 
-func (w *Writer) WriteBatch(cid int, batch zbuf.Batch) error {
-	if w.cid != cid {
-		w.cid = cid
-		if err := w.WriteControl(api.QueryChannelSet{ChannelID: cid}); err != nil {
+func (w *Writer) WriteBatch(channel string, batch zbuf.Batch) error {
+	if w.channel != channel {
+		w.channel = channel
+		if err := w.WriteControl(api.QueryChannelSet{Channel: channel}); err != nil {
 			return err
 		}
 	}
@@ -62,8 +61,8 @@ func (w *Writer) WriteBatch(cid int, batch zbuf.Batch) error {
 	return zbuf.WriteBatch(w.writer, batch)
 }
 
-func (w *Writer) WhiteChannelEnd(channelID int) error {
-	return w.WriteControl(api.QueryChannelEnd{ChannelID: channelID})
+func (w *Writer) WhiteChannelEnd(channel string) error {
+	return w.WriteControl(api.QueryChannelEnd{Channel: channel})
 }
 
 func (w *Writer) WriteProgress(stats zbuf.Progress) error {

--- a/api/queryio/zjson_test.go
+++ b/api/queryio/zjson_test.go
@@ -15,20 +15,20 @@ import (
 func TestZJSONWriter(t *testing.T) {
 	const record = `{x:1}`
 	const expected = `
-{"type":"QueryChannelSet","value":{"channel_id":1}}
+{"type":"QueryChannelSet","value":{"channel":"main"}}
 {"type":{"kind":"record","id":30,"fields":[{"name":"x","type":{"kind":"primitive","name":"int64"}}]},"value":["1"]}
-{"type":"QueryChannelEnd","value":{"channel_id":1}}
+{"type":"QueryChannelEnd","value":{"channel":"main"}}
 {"type":"QueryError","value":{"error":"test.err"}}
 `
 	var buf bytes.Buffer
 	w := queryio.NewZJSONWriter(&buf)
-	err := w.WriteControl(api.QueryChannelSet{ChannelID: 1})
+	err := w.WriteControl(api.QueryChannelSet{Channel: "main"})
 	require.NoError(t, err)
 	arena := zed.NewArena()
 	defer arena.Unref()
 	err = w.Write(zson.MustParseValue(zed.NewContext(), arena, record))
 	require.NoError(t, err)
-	err = w.WriteControl(api.QueryChannelEnd{ChannelID: 1})
+	err = w.WriteControl(api.QueryChannelEnd{Channel: "main"})
 	require.NoError(t, err)
 	err = w.WriteControl(api.QueryError{Error: "test.err"})
 	require.NoError(t, err)

--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -622,6 +622,11 @@ type (
 		Expr       Expr   `json:"expr"`
 		Text       string `json:"text"`
 	}
+	Output struct {
+		Kind       string `json:"kind" unpack:""`
+		KeywordPos int    `json:"keyword_pos"`
+		Name       *ID    `json:"name"`
+	}
 )
 
 // Source structure
@@ -775,6 +780,7 @@ func (*Yield) OpAST()        {}
 func (*Sample) OpAST()       {}
 func (*Load) OpAST()         {}
 func (*Assert) OpAST()       {}
+func (*Output) OpAST()       {}
 
 func (x *Scope) Pos() int {
 	if x.Decls != nil {
@@ -810,6 +816,7 @@ func (x *Yield) Pos() int        { return x.KeywordPos }
 func (x *Sample) Pos() int       { return x.KeywordPos }
 func (x *Load) Pos() int         { return x.KeywordPos }
 func (x *Assert) Pos() int       { return x.KeywordPos }
+func (x *Output) Pos() int       { return x.KeywordPos }
 
 func (x *Scope) End() int    { return x.Body.End() }
 func (x *Parallel) End() int { return x.Rparen }
@@ -918,6 +925,7 @@ func (x *Sample) End() int {
 }
 func (x *Load) End() int   { return x.EndPos }
 func (x *Assert) End() int { return x.Expr.End() }
+func (x *Output) End() int { return x.Name.End() }
 
 // An Agg is an AST node that represents a aggregate function.  The Name
 // field indicates the aggregation method while the Expr field indicates

--- a/compiler/ast/dag/op.go
+++ b/compiler/ast/dag/op.go
@@ -93,6 +93,10 @@ type (
 		Vars  []Def  `json:"vars"`
 		Body  Seq    `json:"body"`
 	}
+	Output struct {
+		Kind string `json:"kind" unpack:""`
+		Name string `json:"name"`
+	}
 	Pass struct {
 		Kind string `json:"kind" unpack:""`
 	}
@@ -313,6 +317,7 @@ func (*Merge) OpNode()     {}
 func (*Combine) OpNode()   {}
 func (*Scope) OpNode()     {}
 func (*Load) OpNode()      {}
+func (*Output) OpNode()    {}
 
 // NewFilter returns a filter node for e.
 func NewFilter(e Expr) *Filter {

--- a/compiler/ast/dag/unpack.go
+++ b/compiler/ast/dag/unpack.go
@@ -41,6 +41,7 @@ var unpacker = unpack.New(
 	MapCall{},
 	MapExpr{},
 	Merge{},
+	Output{},
 	Over{},
 	OverExpr{},
 	Pass{},

--- a/compiler/ast/unpack.go
+++ b/compiler/ast/unpack.go
@@ -45,6 +45,7 @@ var unpacker = unpack.New(
 	Join{},
 	Load{},
 	Merge{},
+	Output{},
 	Over{},
 	Trunk{},
 	astzed.Map{},

--- a/compiler/kernel/vop.go
+++ b/compiler/kernel/vop.go
@@ -79,6 +79,9 @@ func (b *Builder) compileVamLeaf(o dag.Op, parent vector.Puller) (vector.Puller,
 			return nil, err
 		}
 		return vamop.NewYield(b.rctx.Zctx, parent, exprs), nil
+	case *dag.Output:
+		// XXX Ignore Output op for vectors for now.
+		return parent, nil
 	default:
 		return nil, fmt.Errorf("internal error: unknown dag.Op while compiling for vector runtime: %#v", o)
 	}

--- a/compiler/optimizer/op.go
+++ b/compiler/optimizer/op.go
@@ -39,7 +39,7 @@ func (o *Optimizer) analyzeSortKey(op dag.Op, in order.SortKey) (order.SortKey, 
 	case *dag.Lister:
 		// This shouldn't happen.
 		return order.Nil, errors.New("internal error: dag.Lister encountered in anaylzeSortKey")
-	case *dag.Filter, *dag.Head, *dag.Pass, *dag.Uniq, *dag.Tail, *dag.Fuse:
+	case *dag.Filter, *dag.Head, *dag.Pass, *dag.Uniq, *dag.Tail, *dag.Fuse, *dag.Output:
 		return in, nil
 	case *dag.Cut:
 		return analyzeCuts(op.Args, in), nil

--- a/compiler/optimizer/parallelize.go
+++ b/compiler/optimizer/parallelize.go
@@ -250,7 +250,7 @@ func (o *Optimizer) concurrentPath(ops []dag.Op, sortKey order.SortKey) (int, or
 			// upstream sort is the same as the Load destination sort we
 			// request a merge and set the Load operator to do a sorted write.
 			return k, order.Nil, false, false, nil
-		case *dag.Fork, *dag.Scatter, *dag.Head, *dag.Tail, *dag.Uniq, *dag.Fuse, *dag.Join:
+		case *dag.Fork, *dag.Scatter, *dag.Head, *dag.Tail, *dag.Uniq, *dag.Fuse, *dag.Join, *dag.Output:
 			return k, sortKey, true, true, nil
 		default:
 			next, err := o.analyzeSortKey(op, sortKey)

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -2632,6 +2632,10 @@ var g = &grammar{
 						pos:  position{line: 360, col: 5, offset: 8962},
 						name: "LoadOp",
 					},
+					&ruleRefExpr{
+						pos:  position{line: 361, col: 5, offset: 8973},
+						name: "OutputOp",
+					},
 				},
 			},
 			leader:        false,
@@ -2639,34 +2643,34 @@ var g = &grammar{
 		},
 		{
 			name: "AssertOp",
-			pos:  position{line: 362, col: 1, offset: 8970},
+			pos:  position{line: 363, col: 1, offset: 8983},
 			expr: &actionExpr{
-				pos: position{line: 363, col: 5, offset: 8983},
+				pos: position{line: 364, col: 5, offset: 8996},
 				run: (*parser).callonAssertOp1,
 				expr: &seqExpr{
-					pos: position{line: 363, col: 5, offset: 8983},
+					pos: position{line: 364, col: 5, offset: 8996},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 363, col: 5, offset: 8983},
+							pos:        position{line: 364, col: 5, offset: 8996},
 							val:        "assert",
 							ignoreCase: false,
 							want:       "\"assert\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 363, col: 14, offset: 8992},
+							pos:  position{line: 364, col: 14, offset: 9005},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 363, col: 16, offset: 8994},
+							pos:   position{line: 364, col: 16, offset: 9007},
 							label: "expr",
 							expr: &actionExpr{
-								pos: position{line: 363, col: 22, offset: 9000},
+								pos: position{line: 364, col: 22, offset: 9013},
 								run: (*parser).callonAssertOp6,
 								expr: &labeledExpr{
-									pos:   position{line: 363, col: 22, offset: 9000},
+									pos:   position{line: 364, col: 22, offset: 9013},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 363, col: 24, offset: 9002},
+										pos:  position{line: 364, col: 24, offset: 9015},
 										name: "Expr",
 									},
 								},
@@ -2680,54 +2684,54 @@ var g = &grammar{
 		},
 		{
 			name: "SortOp",
-			pos:  position{line: 372, col: 1, offset: 9245},
+			pos:  position{line: 373, col: 1, offset: 9258},
 			expr: &actionExpr{
-				pos: position{line: 373, col: 5, offset: 9256},
+				pos: position{line: 374, col: 5, offset: 9269},
 				run: (*parser).callonSortOp1,
 				expr: &seqExpr{
-					pos: position{line: 373, col: 5, offset: 9256},
+					pos: position{line: 374, col: 5, offset: 9269},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 373, col: 5, offset: 9256},
+							pos:        position{line: 374, col: 5, offset: 9269},
 							val:        "sort",
 							ignoreCase: false,
 							want:       "\"sort\"",
 						},
 						&andExpr{
-							pos: position{line: 373, col: 12, offset: 9263},
+							pos: position{line: 374, col: 12, offset: 9276},
 							expr: &ruleRefExpr{
-								pos:  position{line: 373, col: 13, offset: 9264},
+								pos:  position{line: 374, col: 13, offset: 9277},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 373, col: 18, offset: 9269},
+							pos:   position{line: 374, col: 18, offset: 9282},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 373, col: 23, offset: 9274},
+								pos:  position{line: 374, col: 23, offset: 9287},
 								name: "SortArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 373, col: 32, offset: 9283},
+							pos:   position{line: 374, col: 32, offset: 9296},
 							label: "list",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 373, col: 37, offset: 9288},
+								pos: position{line: 374, col: 37, offset: 9301},
 								expr: &actionExpr{
-									pos: position{line: 373, col: 38, offset: 9289},
+									pos: position{line: 374, col: 38, offset: 9302},
 									run: (*parser).callonSortOp10,
 									expr: &seqExpr{
-										pos: position{line: 373, col: 38, offset: 9289},
+										pos: position{line: 374, col: 38, offset: 9302},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 373, col: 38, offset: 9289},
+												pos:  position{line: 374, col: 38, offset: 9302},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 373, col: 40, offset: 9291},
+												pos:   position{line: 374, col: 40, offset: 9304},
 												label: "l",
 												expr: &ruleRefExpr{
-													pos:  position{line: 373, col: 42, offset: 9293},
+													pos:  position{line: 374, col: 42, offset: 9306},
 													name: "Exprs",
 												},
 											},
@@ -2744,30 +2748,30 @@ var g = &grammar{
 		},
 		{
 			name: "SortArgs",
-			pos:  position{line: 393, col: 1, offset: 9756},
+			pos:  position{line: 394, col: 1, offset: 9769},
 			expr: &actionExpr{
-				pos: position{line: 393, col: 12, offset: 9767},
+				pos: position{line: 394, col: 12, offset: 9780},
 				run: (*parser).callonSortArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 393, col: 12, offset: 9767},
+					pos:   position{line: 394, col: 12, offset: 9780},
 					label: "args",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 393, col: 17, offset: 9772},
+						pos: position{line: 394, col: 17, offset: 9785},
 						expr: &actionExpr{
-							pos: position{line: 393, col: 18, offset: 9773},
+							pos: position{line: 394, col: 18, offset: 9786},
 							run: (*parser).callonSortArgs4,
 							expr: &seqExpr{
-								pos: position{line: 393, col: 18, offset: 9773},
+								pos: position{line: 394, col: 18, offset: 9786},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 393, col: 18, offset: 9773},
+										pos:  position{line: 394, col: 18, offset: 9786},
 										name: "_",
 									},
 									&labeledExpr{
-										pos:   position{line: 393, col: 20, offset: 9775},
+										pos:   position{line: 394, col: 20, offset: 9788},
 										label: "a",
 										expr: &ruleRefExpr{
-											pos:  position{line: 393, col: 22, offset: 9777},
+											pos:  position{line: 394, col: 22, offset: 9790},
 											name: "SortArg",
 										},
 									},
@@ -2782,53 +2786,53 @@ var g = &grammar{
 		},
 		{
 			name: "SortArg",
-			pos:  position{line: 395, col: 1, offset: 9834},
+			pos:  position{line: 396, col: 1, offset: 9847},
 			expr: &choiceExpr{
-				pos: position{line: 396, col: 5, offset: 9846},
+				pos: position{line: 397, col: 5, offset: 9859},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 396, col: 5, offset: 9846},
+						pos: position{line: 397, col: 5, offset: 9859},
 						run: (*parser).callonSortArg2,
 						expr: &litMatcher{
-							pos:        position{line: 396, col: 5, offset: 9846},
+							pos:        position{line: 397, col: 5, offset: 9859},
 							val:        "-r",
 							ignoreCase: false,
 							want:       "\"-r\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 397, col: 5, offset: 9913},
+						pos: position{line: 398, col: 5, offset: 9926},
 						run: (*parser).callonSortArg4,
 						expr: &seqExpr{
-							pos: position{line: 397, col: 5, offset: 9913},
+							pos: position{line: 398, col: 5, offset: 9926},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 397, col: 5, offset: 9913},
+									pos:        position{line: 398, col: 5, offset: 9926},
 									val:        "-nulls",
 									ignoreCase: false,
 									want:       "\"-nulls\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 397, col: 14, offset: 9922},
+									pos:  position{line: 398, col: 14, offset: 9935},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 397, col: 16, offset: 9924},
+									pos:   position{line: 398, col: 16, offset: 9937},
 									label: "where",
 									expr: &actionExpr{
-										pos: position{line: 397, col: 23, offset: 9931},
+										pos: position{line: 398, col: 23, offset: 9944},
 										run: (*parser).callonSortArg9,
 										expr: &choiceExpr{
-											pos: position{line: 397, col: 24, offset: 9932},
+											pos: position{line: 398, col: 24, offset: 9945},
 											alternatives: []any{
 												&litMatcher{
-													pos:        position{line: 397, col: 24, offset: 9932},
+													pos:        position{line: 398, col: 24, offset: 9945},
 													val:        "first",
 													ignoreCase: false,
 													want:       "\"first\"",
 												},
 												&litMatcher{
-													pos:        position{line: 397, col: 34, offset: 9942},
+													pos:        position{line: 398, col: 34, offset: 9955},
 													val:        "last",
 													ignoreCase: false,
 													want:       "\"last\"",
@@ -2847,46 +2851,46 @@ var g = &grammar{
 		},
 		{
 			name: "TopOp",
-			pos:  position{line: 401, col: 1, offset: 10061},
+			pos:  position{line: 402, col: 1, offset: 10074},
 			expr: &actionExpr{
-				pos: position{line: 402, col: 5, offset: 10071},
+				pos: position{line: 403, col: 5, offset: 10084},
 				run: (*parser).callonTopOp1,
 				expr: &seqExpr{
-					pos: position{line: 402, col: 5, offset: 10071},
+					pos: position{line: 403, col: 5, offset: 10084},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 402, col: 5, offset: 10071},
+							pos:        position{line: 403, col: 5, offset: 10084},
 							val:        "top",
 							ignoreCase: false,
 							want:       "\"top\"",
 						},
 						&andExpr{
-							pos: position{line: 402, col: 11, offset: 10077},
+							pos: position{line: 403, col: 11, offset: 10090},
 							expr: &ruleRefExpr{
-								pos:  position{line: 402, col: 12, offset: 10078},
+								pos:  position{line: 403, col: 12, offset: 10091},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 402, col: 17, offset: 10083},
+							pos:   position{line: 403, col: 17, offset: 10096},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 402, col: 23, offset: 10089},
+								pos: position{line: 403, col: 23, offset: 10102},
 								expr: &actionExpr{
-									pos: position{line: 402, col: 24, offset: 10090},
+									pos: position{line: 403, col: 24, offset: 10103},
 									run: (*parser).callonTopOp8,
 									expr: &seqExpr{
-										pos: position{line: 402, col: 24, offset: 10090},
+										pos: position{line: 403, col: 24, offset: 10103},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 402, col: 24, offset: 10090},
+												pos:  position{line: 403, col: 24, offset: 10103},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 402, col: 26, offset: 10092},
+												pos:   position{line: 403, col: 26, offset: 10105},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 402, col: 28, offset: 10094},
+													pos:  position{line: 403, col: 28, offset: 10107},
 													name: "Expr",
 												},
 											},
@@ -2896,19 +2900,19 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 402, col: 53, offset: 10119},
+							pos:   position{line: 403, col: 53, offset: 10132},
 							label: "flush",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 402, col: 59, offset: 10125},
+								pos: position{line: 403, col: 59, offset: 10138},
 								expr: &seqExpr{
-									pos: position{line: 402, col: 60, offset: 10126},
+									pos: position{line: 403, col: 60, offset: 10139},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 402, col: 60, offset: 10126},
+											pos:  position{line: 403, col: 60, offset: 10139},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 402, col: 62, offset: 10128},
+											pos:        position{line: 403, col: 62, offset: 10141},
 											val:        "-flush",
 											ignoreCase: false,
 											want:       "\"-flush\"",
@@ -2918,25 +2922,25 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 402, col: 73, offset: 10139},
+							pos:   position{line: 403, col: 73, offset: 10152},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 402, col: 80, offset: 10146},
+								pos: position{line: 403, col: 80, offset: 10159},
 								expr: &actionExpr{
-									pos: position{line: 402, col: 81, offset: 10147},
+									pos: position{line: 403, col: 81, offset: 10160},
 									run: (*parser).callonTopOp20,
 									expr: &seqExpr{
-										pos: position{line: 402, col: 81, offset: 10147},
+										pos: position{line: 403, col: 81, offset: 10160},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 402, col: 81, offset: 10147},
+												pos:  position{line: 403, col: 81, offset: 10160},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 402, col: 83, offset: 10149},
+												pos:   position{line: 403, col: 83, offset: 10162},
 												label: "f",
 												expr: &ruleRefExpr{
-													pos:  position{line: 402, col: 85, offset: 10151},
+													pos:  position{line: 403, col: 85, offset: 10164},
 													name: "FieldExprs",
 												},
 											},
@@ -2953,28 +2957,28 @@ var g = &grammar{
 		},
 		{
 			name: "CutOp",
-			pos:  position{line: 419, col: 1, offset: 10498},
+			pos:  position{line: 420, col: 1, offset: 10511},
 			expr: &actionExpr{
-				pos: position{line: 420, col: 5, offset: 10508},
+				pos: position{line: 421, col: 5, offset: 10521},
 				run: (*parser).callonCutOp1,
 				expr: &seqExpr{
-					pos: position{line: 420, col: 5, offset: 10508},
+					pos: position{line: 421, col: 5, offset: 10521},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 420, col: 5, offset: 10508},
+							pos:        position{line: 421, col: 5, offset: 10521},
 							val:        "cut",
 							ignoreCase: false,
 							want:       "\"cut\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 420, col: 11, offset: 10514},
+							pos:  position{line: 421, col: 11, offset: 10527},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 420, col: 13, offset: 10516},
+							pos:   position{line: 421, col: 13, offset: 10529},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 420, col: 18, offset: 10521},
+								pos:  position{line: 421, col: 18, offset: 10534},
 								name: "FlexAssignments",
 							},
 						},
@@ -2986,28 +2990,28 @@ var g = &grammar{
 		},
 		{
 			name: "DropOp",
-			pos:  position{line: 428, col: 1, offset: 10682},
+			pos:  position{line: 429, col: 1, offset: 10695},
 			expr: &actionExpr{
-				pos: position{line: 429, col: 5, offset: 10693},
+				pos: position{line: 430, col: 5, offset: 10706},
 				run: (*parser).callonDropOp1,
 				expr: &seqExpr{
-					pos: position{line: 429, col: 5, offset: 10693},
+					pos: position{line: 430, col: 5, offset: 10706},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 429, col: 5, offset: 10693},
+							pos:        position{line: 430, col: 5, offset: 10706},
 							val:        "drop",
 							ignoreCase: false,
 							want:       "\"drop\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 429, col: 12, offset: 10700},
+							pos:  position{line: 430, col: 12, offset: 10713},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 429, col: 14, offset: 10702},
+							pos:   position{line: 430, col: 14, offset: 10715},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 429, col: 19, offset: 10707},
+								pos:  position{line: 430, col: 19, offset: 10720},
 								name: "FieldExprs",
 							},
 						},
@@ -3019,38 +3023,38 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOp",
-			pos:  position{line: 437, col: 1, offset: 10865},
+			pos:  position{line: 438, col: 1, offset: 10878},
 			expr: &choiceExpr{
-				pos: position{line: 438, col: 5, offset: 10876},
+				pos: position{line: 439, col: 5, offset: 10889},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 438, col: 5, offset: 10876},
+						pos: position{line: 439, col: 5, offset: 10889},
 						run: (*parser).callonHeadOp2,
 						expr: &seqExpr{
-							pos: position{line: 438, col: 5, offset: 10876},
+							pos: position{line: 439, col: 5, offset: 10889},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 438, col: 5, offset: 10876},
+									pos:        position{line: 439, col: 5, offset: 10889},
 									val:        "head",
 									ignoreCase: false,
 									want:       "\"head\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 438, col: 12, offset: 10883},
+									pos:  position{line: 439, col: 12, offset: 10896},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 438, col: 14, offset: 10885},
+									pos: position{line: 439, col: 14, offset: 10898},
 									expr: &ruleRefExpr{
-										pos:  position{line: 438, col: 15, offset: 10886},
+										pos:  position{line: 439, col: 15, offset: 10899},
 										name: "EndOfOp",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 438, col: 23, offset: 10894},
+									pos:   position{line: 439, col: 23, offset: 10907},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 438, col: 29, offset: 10900},
+										pos:  position{line: 439, col: 29, offset: 10913},
 										name: "Expr",
 									},
 								},
@@ -3058,28 +3062,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 445, col: 5, offset: 11043},
+						pos: position{line: 446, col: 5, offset: 11056},
 						run: (*parser).callonHeadOp10,
 						expr: &seqExpr{
-							pos: position{line: 445, col: 5, offset: 11043},
+							pos: position{line: 446, col: 5, offset: 11056},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 445, col: 5, offset: 11043},
+									pos:        position{line: 446, col: 5, offset: 11056},
 									val:        "head",
 									ignoreCase: false,
 									want:       "\"head\"",
 								},
 								&notExpr{
-									pos: position{line: 445, col: 12, offset: 11050},
+									pos: position{line: 446, col: 12, offset: 11063},
 									expr: &seqExpr{
-										pos: position{line: 445, col: 14, offset: 11052},
+										pos: position{line: 446, col: 14, offset: 11065},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 445, col: 14, offset: 11052},
+												pos:  position{line: 446, col: 14, offset: 11065},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 445, col: 17, offset: 11055},
+												pos:        position{line: 446, col: 17, offset: 11068},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -3088,9 +3092,9 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 445, col: 22, offset: 11060},
+									pos: position{line: 446, col: 22, offset: 11073},
 									expr: &ruleRefExpr{
-										pos:  position{line: 445, col: 23, offset: 11061},
+										pos:  position{line: 446, col: 23, offset: 11074},
 										name: "EOKW",
 									},
 								},
@@ -3104,38 +3108,38 @@ var g = &grammar{
 		},
 		{
 			name: "TailOp",
-			pos:  position{line: 452, col: 1, offset: 11168},
+			pos:  position{line: 453, col: 1, offset: 11181},
 			expr: &choiceExpr{
-				pos: position{line: 453, col: 5, offset: 11179},
+				pos: position{line: 454, col: 5, offset: 11192},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 453, col: 5, offset: 11179},
+						pos: position{line: 454, col: 5, offset: 11192},
 						run: (*parser).callonTailOp2,
 						expr: &seqExpr{
-							pos: position{line: 453, col: 5, offset: 11179},
+							pos: position{line: 454, col: 5, offset: 11192},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 453, col: 5, offset: 11179},
+									pos:        position{line: 454, col: 5, offset: 11192},
 									val:        "tail",
 									ignoreCase: false,
 									want:       "\"tail\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 453, col: 12, offset: 11186},
+									pos:  position{line: 454, col: 12, offset: 11199},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 453, col: 14, offset: 11188},
+									pos: position{line: 454, col: 14, offset: 11201},
 									expr: &ruleRefExpr{
-										pos:  position{line: 453, col: 15, offset: 11189},
+										pos:  position{line: 454, col: 15, offset: 11202},
 										name: "EndOfOp",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 453, col: 23, offset: 11197},
+									pos:   position{line: 454, col: 23, offset: 11210},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 453, col: 29, offset: 11203},
+										pos:  position{line: 454, col: 29, offset: 11216},
 										name: "Expr",
 									},
 								},
@@ -3143,28 +3147,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 460, col: 5, offset: 11346},
+						pos: position{line: 461, col: 5, offset: 11359},
 						run: (*parser).callonTailOp10,
 						expr: &seqExpr{
-							pos: position{line: 460, col: 5, offset: 11346},
+							pos: position{line: 461, col: 5, offset: 11359},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 460, col: 5, offset: 11346},
+									pos:        position{line: 461, col: 5, offset: 11359},
 									val:        "tail",
 									ignoreCase: false,
 									want:       "\"tail\"",
 								},
 								&notExpr{
-									pos: position{line: 460, col: 12, offset: 11353},
+									pos: position{line: 461, col: 12, offset: 11366},
 									expr: &seqExpr{
-										pos: position{line: 460, col: 14, offset: 11355},
+										pos: position{line: 461, col: 14, offset: 11368},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 460, col: 14, offset: 11355},
+												pos:  position{line: 461, col: 14, offset: 11368},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 460, col: 17, offset: 11358},
+												pos:        position{line: 461, col: 17, offset: 11371},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -3173,9 +3177,9 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 460, col: 22, offset: 11363},
+									pos: position{line: 461, col: 22, offset: 11376},
 									expr: &ruleRefExpr{
-										pos:  position{line: 460, col: 23, offset: 11364},
+										pos:  position{line: 461, col: 23, offset: 11377},
 										name: "EOKW",
 									},
 								},
@@ -3189,28 +3193,28 @@ var g = &grammar{
 		},
 		{
 			name: "WhereOp",
-			pos:  position{line: 467, col: 1, offset: 11471},
+			pos:  position{line: 468, col: 1, offset: 11484},
 			expr: &actionExpr{
-				pos: position{line: 468, col: 5, offset: 11483},
+				pos: position{line: 469, col: 5, offset: 11496},
 				run: (*parser).callonWhereOp1,
 				expr: &seqExpr{
-					pos: position{line: 468, col: 5, offset: 11483},
+					pos: position{line: 469, col: 5, offset: 11496},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 468, col: 5, offset: 11483},
+							pos:        position{line: 469, col: 5, offset: 11496},
 							val:        "where",
 							ignoreCase: false,
 							want:       "\"where\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 468, col: 13, offset: 11491},
+							pos:  position{line: 469, col: 13, offset: 11504},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 468, col: 15, offset: 11493},
+							pos:   position{line: 469, col: 15, offset: 11506},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 468, col: 20, offset: 11498},
+								pos:  position{line: 469, col: 20, offset: 11511},
 								name: "Expr",
 							},
 						},
@@ -3222,28 +3226,28 @@ var g = &grammar{
 		},
 		{
 			name: "UniqOp",
-			pos:  position{line: 476, col: 1, offset: 11638},
+			pos:  position{line: 477, col: 1, offset: 11651},
 			expr: &choiceExpr{
-				pos: position{line: 477, col: 5, offset: 11649},
+				pos: position{line: 478, col: 5, offset: 11662},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 477, col: 5, offset: 11649},
+						pos: position{line: 478, col: 5, offset: 11662},
 						run: (*parser).callonUniqOp2,
 						expr: &seqExpr{
-							pos: position{line: 477, col: 5, offset: 11649},
+							pos: position{line: 478, col: 5, offset: 11662},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 477, col: 5, offset: 11649},
+									pos:        position{line: 478, col: 5, offset: 11662},
 									val:        "uniq",
 									ignoreCase: false,
 									want:       "\"uniq\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 477, col: 12, offset: 11656},
+									pos:  position{line: 478, col: 12, offset: 11669},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 477, col: 14, offset: 11658},
+									pos:        position{line: 478, col: 14, offset: 11671},
 									val:        "-c",
 									ignoreCase: false,
 									want:       "\"-c\"",
@@ -3252,28 +3256,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 480, col: 5, offset: 11756},
+						pos: position{line: 481, col: 5, offset: 11769},
 						run: (*parser).callonUniqOp7,
 						expr: &seqExpr{
-							pos: position{line: 480, col: 5, offset: 11756},
+							pos: position{line: 481, col: 5, offset: 11769},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 480, col: 5, offset: 11756},
+									pos:        position{line: 481, col: 5, offset: 11769},
 									val:        "uniq",
 									ignoreCase: false,
 									want:       "\"uniq\"",
 								},
 								&notExpr{
-									pos: position{line: 480, col: 12, offset: 11763},
+									pos: position{line: 481, col: 12, offset: 11776},
 									expr: &seqExpr{
-										pos: position{line: 480, col: 14, offset: 11765},
+										pos: position{line: 481, col: 14, offset: 11778},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 480, col: 14, offset: 11765},
+												pos:  position{line: 481, col: 14, offset: 11778},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 480, col: 17, offset: 11768},
+												pos:        position{line: 481, col: 17, offset: 11781},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -3282,9 +3286,9 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 480, col: 22, offset: 11773},
+									pos: position{line: 481, col: 22, offset: 11786},
 									expr: &ruleRefExpr{
-										pos:  position{line: 480, col: 23, offset: 11774},
+										pos:  position{line: 481, col: 23, offset: 11787},
 										name: "EOKW",
 									},
 								},
@@ -3298,28 +3302,28 @@ var g = &grammar{
 		},
 		{
 			name: "PutOp",
-			pos:  position{line: 484, col: 1, offset: 11856},
+			pos:  position{line: 485, col: 1, offset: 11869},
 			expr: &actionExpr{
-				pos: position{line: 485, col: 5, offset: 11866},
+				pos: position{line: 486, col: 5, offset: 11879},
 				run: (*parser).callonPutOp1,
 				expr: &seqExpr{
-					pos: position{line: 485, col: 5, offset: 11866},
+					pos: position{line: 486, col: 5, offset: 11879},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 485, col: 5, offset: 11866},
+							pos:        position{line: 486, col: 5, offset: 11879},
 							val:        "put",
 							ignoreCase: false,
 							want:       "\"put\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 485, col: 11, offset: 11872},
+							pos:  position{line: 486, col: 11, offset: 11885},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 485, col: 13, offset: 11874},
+							pos:   position{line: 486, col: 13, offset: 11887},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 485, col: 18, offset: 11879},
+								pos:  position{line: 486, col: 18, offset: 11892},
 								name: "Assignments",
 							},
 						},
@@ -3331,61 +3335,61 @@ var g = &grammar{
 		},
 		{
 			name: "RenameOp",
-			pos:  position{line: 493, col: 1, offset: 12042},
+			pos:  position{line: 494, col: 1, offset: 12055},
 			expr: &actionExpr{
-				pos: position{line: 494, col: 5, offset: 12055},
+				pos: position{line: 495, col: 5, offset: 12068},
 				run: (*parser).callonRenameOp1,
 				expr: &seqExpr{
-					pos: position{line: 494, col: 5, offset: 12055},
+					pos: position{line: 495, col: 5, offset: 12068},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 494, col: 5, offset: 12055},
+							pos:        position{line: 495, col: 5, offset: 12068},
 							val:        "rename",
 							ignoreCase: false,
 							want:       "\"rename\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 494, col: 14, offset: 12064},
+							pos:  position{line: 495, col: 14, offset: 12077},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 494, col: 16, offset: 12066},
+							pos:   position{line: 495, col: 16, offset: 12079},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 494, col: 22, offset: 12072},
+								pos:  position{line: 495, col: 22, offset: 12085},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 494, col: 33, offset: 12083},
+							pos:   position{line: 495, col: 33, offset: 12096},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 494, col: 38, offset: 12088},
+								pos: position{line: 495, col: 38, offset: 12101},
 								expr: &actionExpr{
-									pos: position{line: 494, col: 39, offset: 12089},
+									pos: position{line: 495, col: 39, offset: 12102},
 									run: (*parser).callonRenameOp9,
 									expr: &seqExpr{
-										pos: position{line: 494, col: 39, offset: 12089},
+										pos: position{line: 495, col: 39, offset: 12102},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 494, col: 39, offset: 12089},
+												pos:  position{line: 495, col: 39, offset: 12102},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 494, col: 42, offset: 12092},
+												pos:        position{line: 495, col: 42, offset: 12105},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 494, col: 46, offset: 12096},
+												pos:  position{line: 495, col: 46, offset: 12109},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 494, col: 49, offset: 12099},
+												pos:   position{line: 495, col: 49, offset: 12112},
 												label: "cl",
 												expr: &ruleRefExpr{
-													pos:  position{line: 494, col: 52, offset: 12102},
+													pos:  position{line: 495, col: 52, offset: 12115},
 													name: "Assignment",
 												},
 											},
@@ -3402,30 +3406,30 @@ var g = &grammar{
 		},
 		{
 			name: "FuseOp",
-			pos:  position{line: 507, col: 1, offset: 12578},
+			pos:  position{line: 508, col: 1, offset: 12591},
 			expr: &actionExpr{
-				pos: position{line: 508, col: 5, offset: 12589},
+				pos: position{line: 509, col: 5, offset: 12602},
 				run: (*parser).callonFuseOp1,
 				expr: &seqExpr{
-					pos: position{line: 508, col: 5, offset: 12589},
+					pos: position{line: 509, col: 5, offset: 12602},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 508, col: 5, offset: 12589},
+							pos:        position{line: 509, col: 5, offset: 12602},
 							val:        "fuse",
 							ignoreCase: false,
 							want:       "\"fuse\"",
 						},
 						&notExpr{
-							pos: position{line: 508, col: 12, offset: 12596},
+							pos: position{line: 509, col: 12, offset: 12609},
 							expr: &seqExpr{
-								pos: position{line: 508, col: 14, offset: 12598},
+								pos: position{line: 509, col: 14, offset: 12611},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 508, col: 14, offset: 12598},
+										pos:  position{line: 509, col: 14, offset: 12611},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 508, col: 17, offset: 12601},
+										pos:        position{line: 509, col: 17, offset: 12614},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -3434,9 +3438,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 508, col: 22, offset: 12606},
+							pos: position{line: 509, col: 22, offset: 12619},
 							expr: &ruleRefExpr{
-								pos:  position{line: 508, col: 23, offset: 12607},
+								pos:  position{line: 509, col: 23, offset: 12620},
 								name: "EOKW",
 							},
 						},
@@ -3448,30 +3452,30 @@ var g = &grammar{
 		},
 		{
 			name: "ShapeOp",
-			pos:  position{line: 512, col: 1, offset: 12689},
+			pos:  position{line: 513, col: 1, offset: 12702},
 			expr: &actionExpr{
-				pos: position{line: 513, col: 5, offset: 12701},
+				pos: position{line: 514, col: 5, offset: 12714},
 				run: (*parser).callonShapeOp1,
 				expr: &seqExpr{
-					pos: position{line: 513, col: 5, offset: 12701},
+					pos: position{line: 514, col: 5, offset: 12714},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 513, col: 5, offset: 12701},
+							pos:        position{line: 514, col: 5, offset: 12714},
 							val:        "shape",
 							ignoreCase: false,
 							want:       "\"shape\"",
 						},
 						&notExpr{
-							pos: position{line: 513, col: 13, offset: 12709},
+							pos: position{line: 514, col: 13, offset: 12722},
 							expr: &seqExpr{
-								pos: position{line: 513, col: 15, offset: 12711},
+								pos: position{line: 514, col: 15, offset: 12724},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 513, col: 15, offset: 12711},
+										pos:  position{line: 514, col: 15, offset: 12724},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 513, col: 18, offset: 12714},
+										pos:        position{line: 514, col: 18, offset: 12727},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -3480,9 +3484,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 513, col: 23, offset: 12719},
+							pos: position{line: 514, col: 23, offset: 12732},
 							expr: &ruleRefExpr{
-								pos:  position{line: 513, col: 24, offset: 12720},
+								pos:  position{line: 514, col: 24, offset: 12733},
 								name: "EOKW",
 							},
 						},
@@ -3494,77 +3498,77 @@ var g = &grammar{
 		},
 		{
 			name: "JoinOp",
-			pos:  position{line: 517, col: 1, offset: 12804},
+			pos:  position{line: 518, col: 1, offset: 12817},
 			expr: &actionExpr{
-				pos: position{line: 518, col: 5, offset: 12815},
+				pos: position{line: 519, col: 5, offset: 12828},
 				run: (*parser).callonJoinOp1,
 				expr: &seqExpr{
-					pos: position{line: 518, col: 5, offset: 12815},
+					pos: position{line: 519, col: 5, offset: 12828},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 518, col: 5, offset: 12815},
+							pos:   position{line: 519, col: 5, offset: 12828},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 518, col: 11, offset: 12821},
+								pos:  position{line: 519, col: 11, offset: 12834},
 								name: "JoinStyle",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 518, col: 21, offset: 12831},
+							pos:        position{line: 519, col: 21, offset: 12844},
 							val:        "join",
 							ignoreCase: false,
 							want:       "\"join\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 518, col: 28, offset: 12838},
+							pos:   position{line: 519, col: 28, offset: 12851},
 							label: "rightInput",
 							expr: &ruleRefExpr{
-								pos:  position{line: 518, col: 39, offset: 12849},
+								pos:  position{line: 519, col: 39, offset: 12862},
 								name: "JoinRightInput",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 518, col: 54, offset: 12864},
+							pos:        position{line: 519, col: 54, offset: 12877},
 							val:        "on",
 							ignoreCase: false,
 							want:       "\"on\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 518, col: 59, offset: 12869},
+							pos:  position{line: 519, col: 59, offset: 12882},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 518, col: 61, offset: 12871},
+							pos:   position{line: 519, col: 61, offset: 12884},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 518, col: 65, offset: 12875},
+								pos:  position{line: 519, col: 65, offset: 12888},
 								name: "JoinKey",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 518, col: 73, offset: 12883},
+							pos:   position{line: 519, col: 73, offset: 12896},
 							label: "optKey",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 518, col: 80, offset: 12890},
+								pos: position{line: 519, col: 80, offset: 12903},
 								expr: &seqExpr{
-									pos: position{line: 518, col: 81, offset: 12891},
+									pos: position{line: 519, col: 81, offset: 12904},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 518, col: 81, offset: 12891},
+											pos:  position{line: 519, col: 81, offset: 12904},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 518, col: 84, offset: 12894},
+											pos:        position{line: 519, col: 84, offset: 12907},
 											val:        "=",
 											ignoreCase: false,
 											want:       "\"=\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 518, col: 88, offset: 12898},
+											pos:  position{line: 519, col: 88, offset: 12911},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 518, col: 91, offset: 12901},
+											pos:  position{line: 519, col: 91, offset: 12914},
 											name: "JoinKey",
 										},
 									},
@@ -3572,19 +3576,19 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 518, col: 101, offset: 12911},
+							pos:   position{line: 519, col: 101, offset: 12924},
 							label: "optArgs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 518, col: 109, offset: 12919},
+								pos: position{line: 519, col: 109, offset: 12932},
 								expr: &seqExpr{
-									pos: position{line: 518, col: 110, offset: 12920},
+									pos: position{line: 519, col: 110, offset: 12933},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 518, col: 110, offset: 12920},
+											pos:  position{line: 519, col: 110, offset: 12933},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 518, col: 112, offset: 12922},
+											pos:  position{line: 519, col: 112, offset: 12935},
 											name: "FlexAssignments",
 										},
 									},
@@ -3599,91 +3603,91 @@ var g = &grammar{
 		},
 		{
 			name: "JoinStyle",
-			pos:  position{line: 537, col: 1, offset: 13385},
+			pos:  position{line: 538, col: 1, offset: 13398},
 			expr: &choiceExpr{
-				pos: position{line: 538, col: 5, offset: 13399},
+				pos: position{line: 539, col: 5, offset: 13412},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 538, col: 5, offset: 13399},
+						pos: position{line: 539, col: 5, offset: 13412},
 						run: (*parser).callonJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 538, col: 5, offset: 13399},
+							pos: position{line: 539, col: 5, offset: 13412},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 538, col: 5, offset: 13399},
+									pos:        position{line: 539, col: 5, offset: 13412},
 									val:        "anti",
 									ignoreCase: false,
 									want:       "\"anti\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 538, col: 12, offset: 13406},
+									pos:  position{line: 539, col: 12, offset: 13419},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 539, col: 5, offset: 13436},
+						pos: position{line: 540, col: 5, offset: 13449},
 						run: (*parser).callonJoinStyle6,
 						expr: &seqExpr{
-							pos: position{line: 539, col: 5, offset: 13436},
+							pos: position{line: 540, col: 5, offset: 13449},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 539, col: 5, offset: 13436},
+									pos:        position{line: 540, col: 5, offset: 13449},
 									val:        "inner",
 									ignoreCase: false,
 									want:       "\"inner\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 539, col: 13, offset: 13444},
+									pos:  position{line: 540, col: 13, offset: 13457},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 540, col: 5, offset: 13474},
+						pos: position{line: 541, col: 5, offset: 13487},
 						run: (*parser).callonJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 540, col: 5, offset: 13474},
+							pos: position{line: 541, col: 5, offset: 13487},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 540, col: 5, offset: 13474},
+									pos:        position{line: 541, col: 5, offset: 13487},
 									val:        "left",
 									ignoreCase: false,
 									want:       "\"left\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 540, col: 13, offset: 13482},
+									pos:  position{line: 541, col: 13, offset: 13495},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 541, col: 5, offset: 13511},
+						pos: position{line: 542, col: 5, offset: 13524},
 						run: (*parser).callonJoinStyle14,
 						expr: &seqExpr{
-							pos: position{line: 541, col: 5, offset: 13511},
+							pos: position{line: 542, col: 5, offset: 13524},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 541, col: 5, offset: 13511},
+									pos:        position{line: 542, col: 5, offset: 13524},
 									val:        "right",
 									ignoreCase: false,
 									want:       "\"right\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 541, col: 13, offset: 13519},
+									pos:  position{line: 542, col: 13, offset: 13532},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 542, col: 5, offset: 13549},
+						pos: position{line: 543, col: 5, offset: 13562},
 						run: (*parser).callonJoinStyle18,
 						expr: &litMatcher{
-							pos:        position{line: 542, col: 5, offset: 13549},
+							pos:        position{line: 543, col: 5, offset: 13562},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -3696,60 +3700,60 @@ var g = &grammar{
 		},
 		{
 			name: "JoinRightInput",
-			pos:  position{line: 544, col: 1, offset: 13584},
+			pos:  position{line: 545, col: 1, offset: 13597},
 			expr: &choiceExpr{
-				pos: position{line: 545, col: 5, offset: 13603},
+				pos: position{line: 546, col: 5, offset: 13616},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 545, col: 5, offset: 13603},
+						pos: position{line: 546, col: 5, offset: 13616},
 						run: (*parser).callonJoinRightInput2,
 						expr: &seqExpr{
-							pos: position{line: 545, col: 5, offset: 13603},
+							pos: position{line: 546, col: 5, offset: 13616},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 545, col: 5, offset: 13603},
+									pos:  position{line: 546, col: 5, offset: 13616},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 545, col: 8, offset: 13606},
+									pos:        position{line: 546, col: 8, offset: 13619},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 545, col: 12, offset: 13610},
+									pos:  position{line: 546, col: 12, offset: 13623},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 545, col: 15, offset: 13613},
+									pos:   position{line: 546, col: 15, offset: 13626},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 545, col: 17, offset: 13615},
+										pos:  position{line: 546, col: 17, offset: 13628},
 										name: "Seq",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 545, col: 21, offset: 13619},
+									pos:  position{line: 546, col: 21, offset: 13632},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 545, col: 24, offset: 13622},
+									pos:        position{line: 546, col: 24, offset: 13635},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 545, col: 28, offset: 13626},
+									pos:  position{line: 546, col: 28, offset: 13639},
 									name: "__",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 546, col: 5, offset: 13651},
+						pos: position{line: 547, col: 5, offset: 13664},
 						run: (*parser).callonJoinRightInput12,
 						expr: &ruleRefExpr{
-							pos:  position{line: 546, col: 5, offset: 13651},
+							pos:  position{line: 547, col: 5, offset: 13664},
 							name: "_",
 						},
 					},
@@ -3760,36 +3764,36 @@ var g = &grammar{
 		},
 		{
 			name: "JoinKey",
-			pos:  position{line: 548, col: 1, offset: 13674},
+			pos:  position{line: 549, col: 1, offset: 13687},
 			expr: &choiceExpr{
-				pos: position{line: 549, col: 5, offset: 13686},
+				pos: position{line: 550, col: 5, offset: 13699},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 549, col: 5, offset: 13686},
+						pos:  position{line: 550, col: 5, offset: 13699},
 						name: "Lval",
 					},
 					&actionExpr{
-						pos: position{line: 550, col: 5, offset: 13695},
+						pos: position{line: 551, col: 5, offset: 13708},
 						run: (*parser).callonJoinKey3,
 						expr: &seqExpr{
-							pos: position{line: 550, col: 5, offset: 13695},
+							pos: position{line: 551, col: 5, offset: 13708},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 550, col: 5, offset: 13695},
+									pos:        position{line: 551, col: 5, offset: 13708},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 550, col: 9, offset: 13699},
+									pos:   position{line: 551, col: 9, offset: 13712},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 550, col: 14, offset: 13704},
+										pos:  position{line: 551, col: 14, offset: 13717},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 550, col: 19, offset: 13709},
+									pos:        position{line: 551, col: 19, offset: 13722},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -3804,46 +3808,46 @@ var g = &grammar{
 		},
 		{
 			name: "SampleOp",
-			pos:  position{line: 552, col: 1, offset: 13735},
+			pos:  position{line: 553, col: 1, offset: 13748},
 			expr: &actionExpr{
-				pos: position{line: 553, col: 5, offset: 13748},
+				pos: position{line: 554, col: 5, offset: 13761},
 				run: (*parser).callonSampleOp1,
 				expr: &seqExpr{
-					pos: position{line: 553, col: 5, offset: 13748},
+					pos: position{line: 554, col: 5, offset: 13761},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 553, col: 5, offset: 13748},
+							pos:        position{line: 554, col: 5, offset: 13761},
 							val:        "sample",
 							ignoreCase: false,
 							want:       "\"sample\"",
 						},
 						&andExpr{
-							pos: position{line: 553, col: 14, offset: 13757},
+							pos: position{line: 554, col: 14, offset: 13770},
 							expr: &ruleRefExpr{
-								pos:  position{line: 553, col: 15, offset: 13758},
+								pos:  position{line: 554, col: 15, offset: 13771},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 553, col: 20, offset: 13763},
+							pos:   position{line: 554, col: 20, offset: 13776},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 553, col: 25, offset: 13768},
+								pos: position{line: 554, col: 25, offset: 13781},
 								expr: &actionExpr{
-									pos: position{line: 553, col: 26, offset: 13769},
+									pos: position{line: 554, col: 26, offset: 13782},
 									run: (*parser).callonSampleOp8,
 									expr: &seqExpr{
-										pos: position{line: 553, col: 26, offset: 13769},
+										pos: position{line: 554, col: 26, offset: 13782},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 553, col: 26, offset: 13769},
+												pos:  position{line: 554, col: 26, offset: 13782},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 553, col: 28, offset: 13771},
+												pos:   position{line: 554, col: 28, offset: 13784},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 553, col: 30, offset: 13773},
+													pos:  position{line: 554, col: 30, offset: 13786},
 													name: "Lval",
 												},
 											},
@@ -3860,15 +3864,15 @@ var g = &grammar{
 		},
 		{
 			name: "OpAssignment",
-			pos:  position{line: 566, col: 1, offset: 14224},
+			pos:  position{line: 567, col: 1, offset: 14237},
 			expr: &actionExpr{
-				pos: position{line: 567, col: 5, offset: 14241},
+				pos: position{line: 568, col: 5, offset: 14254},
 				run: (*parser).callonOpAssignment1,
 				expr: &labeledExpr{
-					pos:   position{line: 567, col: 5, offset: 14241},
+					pos:   position{line: 568, col: 5, offset: 14254},
 					label: "a",
 					expr: &ruleRefExpr{
-						pos:  position{line: 567, col: 7, offset: 14243},
+						pos:  position{line: 568, col: 7, offset: 14256},
 						name: "Assignments",
 					},
 				},
@@ -3878,71 +3882,71 @@ var g = &grammar{
 		},
 		{
 			name: "LoadOp",
-			pos:  position{line: 574, col: 1, offset: 14392},
+			pos:  position{line: 575, col: 1, offset: 14405},
 			expr: &actionExpr{
-				pos: position{line: 575, col: 5, offset: 14403},
+				pos: position{line: 576, col: 5, offset: 14416},
 				run: (*parser).callonLoadOp1,
 				expr: &seqExpr{
-					pos: position{line: 575, col: 5, offset: 14403},
+					pos: position{line: 576, col: 5, offset: 14416},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 575, col: 5, offset: 14403},
+							pos:        position{line: 576, col: 5, offset: 14416},
 							val:        "load",
 							ignoreCase: false,
 							want:       "\"load\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 575, col: 12, offset: 14410},
+							pos:  position{line: 576, col: 12, offset: 14423},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 575, col: 14, offset: 14412},
+							pos:   position{line: 576, col: 14, offset: 14425},
 							label: "pool",
 							expr: &ruleRefExpr{
-								pos:  position{line: 575, col: 19, offset: 14417},
+								pos:  position{line: 576, col: 19, offset: 14430},
 								name: "PoolNameString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 575, col: 34, offset: 14432},
+							pos:   position{line: 576, col: 34, offset: 14445},
 							label: "branch",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 575, col: 41, offset: 14439},
+								pos: position{line: 576, col: 41, offset: 14452},
 								expr: &ruleRefExpr{
-									pos:  position{line: 575, col: 41, offset: 14439},
+									pos:  position{line: 576, col: 41, offset: 14452},
 									name: "PoolBranch",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 575, col: 53, offset: 14451},
+							pos:   position{line: 576, col: 53, offset: 14464},
 							label: "author",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 575, col: 60, offset: 14458},
+								pos: position{line: 576, col: 60, offset: 14471},
 								expr: &ruleRefExpr{
-									pos:  position{line: 575, col: 60, offset: 14458},
+									pos:  position{line: 576, col: 60, offset: 14471},
 									name: "AuthorArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 575, col: 71, offset: 14469},
+							pos:   position{line: 576, col: 71, offset: 14482},
 							label: "message",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 575, col: 79, offset: 14477},
+								pos: position{line: 576, col: 79, offset: 14490},
 								expr: &ruleRefExpr{
-									pos:  position{line: 575, col: 79, offset: 14477},
+									pos:  position{line: 576, col: 79, offset: 14490},
 									name: "MessageArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 575, col: 91, offset: 14489},
+							pos:   position{line: 576, col: 91, offset: 14502},
 							label: "meta",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 575, col: 96, offset: 14494},
+								pos: position{line: 576, col: 96, offset: 14507},
 								expr: &ruleRefExpr{
-									pos:  position{line: 575, col: 96, offset: 14494},
+									pos:  position{line: 576, col: 96, offset: 14507},
 									name: "MetaArg",
 								},
 							},
@@ -3955,32 +3959,32 @@ var g = &grammar{
 		},
 		{
 			name: "AuthorArg",
-			pos:  position{line: 588, col: 1, offset: 14841},
+			pos:  position{line: 589, col: 1, offset: 14854},
 			expr: &actionExpr{
-				pos: position{line: 589, col: 5, offset: 14855},
+				pos: position{line: 590, col: 5, offset: 14868},
 				run: (*parser).callonAuthorArg1,
 				expr: &seqExpr{
-					pos: position{line: 589, col: 5, offset: 14855},
+					pos: position{line: 590, col: 5, offset: 14868},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 589, col: 5, offset: 14855},
+							pos:  position{line: 590, col: 5, offset: 14868},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 589, col: 7, offset: 14857},
+							pos:        position{line: 590, col: 7, offset: 14870},
 							val:        "author",
 							ignoreCase: false,
 							want:       "\"author\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 589, col: 16, offset: 14866},
+							pos:  position{line: 590, col: 16, offset: 14879},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 589, col: 18, offset: 14868},
+							pos:   position{line: 590, col: 18, offset: 14881},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 589, col: 22, offset: 14872},
+								pos:  position{line: 590, col: 22, offset: 14885},
 								name: "QuotedString",
 							},
 						},
@@ -3992,32 +3996,32 @@ var g = &grammar{
 		},
 		{
 			name: "MessageArg",
-			pos:  position{line: 591, col: 1, offset: 14906},
+			pos:  position{line: 592, col: 1, offset: 14919},
 			expr: &actionExpr{
-				pos: position{line: 592, col: 5, offset: 14921},
+				pos: position{line: 593, col: 5, offset: 14934},
 				run: (*parser).callonMessageArg1,
 				expr: &seqExpr{
-					pos: position{line: 592, col: 5, offset: 14921},
+					pos: position{line: 593, col: 5, offset: 14934},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 592, col: 5, offset: 14921},
+							pos:  position{line: 593, col: 5, offset: 14934},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 592, col: 7, offset: 14923},
+							pos:        position{line: 593, col: 7, offset: 14936},
 							val:        "message",
 							ignoreCase: false,
 							want:       "\"message\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 592, col: 17, offset: 14933},
+							pos:  position{line: 593, col: 17, offset: 14946},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 592, col: 19, offset: 14935},
+							pos:   position{line: 593, col: 19, offset: 14948},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 592, col: 23, offset: 14939},
+								pos:  position{line: 593, col: 23, offset: 14952},
 								name: "QuotedString",
 							},
 						},
@@ -4029,32 +4033,32 @@ var g = &grammar{
 		},
 		{
 			name: "MetaArg",
-			pos:  position{line: 594, col: 1, offset: 14973},
+			pos:  position{line: 595, col: 1, offset: 14986},
 			expr: &actionExpr{
-				pos: position{line: 595, col: 5, offset: 14985},
+				pos: position{line: 596, col: 5, offset: 14998},
 				run: (*parser).callonMetaArg1,
 				expr: &seqExpr{
-					pos: position{line: 595, col: 5, offset: 14985},
+					pos: position{line: 596, col: 5, offset: 14998},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 595, col: 5, offset: 14985},
+							pos:  position{line: 596, col: 5, offset: 14998},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 595, col: 7, offset: 14987},
+							pos:        position{line: 596, col: 7, offset: 15000},
 							val:        "meta",
 							ignoreCase: false,
 							want:       "\"meta\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 595, col: 14, offset: 14994},
+							pos:  position{line: 596, col: 14, offset: 15007},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 595, col: 16, offset: 14996},
+							pos:   position{line: 596, col: 16, offset: 15009},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 595, col: 20, offset: 15000},
+								pos:  position{line: 596, col: 20, offset: 15013},
 								name: "QuotedString",
 							},
 						},
@@ -4066,31 +4070,31 @@ var g = &grammar{
 		},
 		{
 			name: "PoolBranch",
-			pos:  position{line: 597, col: 1, offset: 15034},
+			pos:  position{line: 598, col: 1, offset: 15047},
 			expr: &actionExpr{
-				pos: position{line: 598, col: 5, offset: 15049},
+				pos: position{line: 599, col: 5, offset: 15062},
 				run: (*parser).callonPoolBranch1,
 				expr: &seqExpr{
-					pos: position{line: 598, col: 5, offset: 15049},
+					pos: position{line: 599, col: 5, offset: 15062},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 598, col: 5, offset: 15049},
+							pos:        position{line: 599, col: 5, offset: 15062},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 598, col: 9, offset: 15053},
+							pos:   position{line: 599, col: 9, offset: 15066},
 							label: "branch",
 							expr: &choiceExpr{
-								pos: position{line: 598, col: 17, offset: 15061},
+								pos: position{line: 599, col: 17, offset: 15074},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 598, col: 17, offset: 15061},
+										pos:  position{line: 599, col: 17, offset: 15074},
 										name: "PoolIdentifier",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 598, col: 34, offset: 15078},
+										pos:  position{line: 599, col: 34, offset: 15091},
 										name: "QuotedString",
 									},
 								},
@@ -4103,21 +4107,54 @@ var g = &grammar{
 			leftRecursive: false,
 		},
 		{
+			name: "OutputOp",
+			pos:  position{line: 601, col: 1, offset: 15129},
+			expr: &actionExpr{
+				pos: position{line: 602, col: 5, offset: 15142},
+				run: (*parser).callonOutputOp1,
+				expr: &seqExpr{
+					pos: position{line: 602, col: 5, offset: 15142},
+					exprs: []any{
+						&litMatcher{
+							pos:        position{line: 602, col: 5, offset: 15142},
+							val:        "output",
+							ignoreCase: false,
+							want:       "\"output\"",
+						},
+						&ruleRefExpr{
+							pos:  position{line: 602, col: 14, offset: 15151},
+							name: "_",
+						},
+						&labeledExpr{
+							pos:   position{line: 602, col: 16, offset: 15153},
+							label: "name",
+							expr: &ruleRefExpr{
+								pos:  position{line: 602, col: 21, offset: 15158},
+								name: "Identifier",
+							},
+						},
+					},
+				},
+			},
+			leader:        false,
+			leftRecursive: false,
+		},
+		{
 			name: "FromOp",
-			pos:  position{line: 600, col: 1, offset: 15116},
+			pos:  position{line: 610, col: 1, offset: 15305},
 			expr: &choiceExpr{
-				pos: position{line: 601, col: 5, offset: 15127},
+				pos: position{line: 611, col: 5, offset: 15316},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 601, col: 5, offset: 15127},
+						pos:  position{line: 611, col: 5, offset: 15316},
 						name: "File",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 602, col: 5, offset: 15136},
+						pos:  position{line: 612, col: 5, offset: 15325},
 						name: "Get",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 603, col: 5, offset: 15144},
+						pos:  position{line: 613, col: 5, offset: 15333},
 						name: "From",
 					},
 				},
@@ -4127,49 +4164,49 @@ var g = &grammar{
 		},
 		{
 			name: "File",
-			pos:  position{line: 605, col: 1, offset: 15150},
+			pos:  position{line: 615, col: 1, offset: 15339},
 			expr: &actionExpr{
-				pos: position{line: 606, col: 5, offset: 15159},
+				pos: position{line: 616, col: 5, offset: 15348},
 				run: (*parser).callonFile1,
 				expr: &seqExpr{
-					pos: position{line: 606, col: 5, offset: 15159},
+					pos: position{line: 616, col: 5, offset: 15348},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 606, col: 5, offset: 15159},
+							pos:        position{line: 616, col: 5, offset: 15348},
 							val:        "file",
 							ignoreCase: false,
 							want:       "\"file\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 606, col: 12, offset: 15166},
+							pos:  position{line: 616, col: 12, offset: 15355},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 606, col: 14, offset: 15168},
+							pos:   position{line: 616, col: 14, offset: 15357},
 							label: "path",
 							expr: &ruleRefExpr{
-								pos:  position{line: 606, col: 19, offset: 15173},
+								pos:  position{line: 616, col: 19, offset: 15362},
 								name: "Path",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 606, col: 24, offset: 15178},
+							pos:   position{line: 616, col: 24, offset: 15367},
 							label: "format",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 606, col: 31, offset: 15185},
+								pos: position{line: 616, col: 31, offset: 15374},
 								expr: &ruleRefExpr{
-									pos:  position{line: 606, col: 31, offset: 15185},
+									pos:  position{line: 616, col: 31, offset: 15374},
 									name: "FormatArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 606, col: 42, offset: 15196},
+							pos:   position{line: 616, col: 42, offset: 15385},
 							label: "sortkey",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 606, col: 50, offset: 15204},
+								pos: position{line: 616, col: 50, offset: 15393},
 								expr: &ruleRefExpr{
-									pos:  position{line: 606, col: 50, offset: 15204},
+									pos:  position{line: 616, col: 50, offset: 15393},
 									name: "SortKeyArg",
 								},
 							},
@@ -4182,28 +4219,28 @@ var g = &grammar{
 		},
 		{
 			name: "From",
-			pos:  position{line: 620, col: 1, offset: 15524},
+			pos:  position{line: 630, col: 1, offset: 15713},
 			expr: &actionExpr{
-				pos: position{line: 621, col: 5, offset: 15533},
+				pos: position{line: 631, col: 5, offset: 15722},
 				run: (*parser).callonFrom1,
 				expr: &seqExpr{
-					pos: position{line: 621, col: 5, offset: 15533},
+					pos: position{line: 631, col: 5, offset: 15722},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 621, col: 5, offset: 15533},
+							pos:        position{line: 631, col: 5, offset: 15722},
 							val:        "from",
 							ignoreCase: false,
 							want:       "\"from\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 621, col: 12, offset: 15540},
+							pos:  position{line: 631, col: 12, offset: 15729},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 621, col: 14, offset: 15542},
+							pos:   position{line: 631, col: 14, offset: 15731},
 							label: "spec",
 							expr: &ruleRefExpr{
-								pos:  position{line: 621, col: 19, offset: 15547},
+								pos:  position{line: 631, col: 19, offset: 15736},
 								name: "PoolSpec",
 							},
 						},
@@ -4215,28 +4252,28 @@ var g = &grammar{
 		},
 		{
 			name: "Pool",
-			pos:  position{line: 630, col: 1, offset: 15735},
+			pos:  position{line: 640, col: 1, offset: 15924},
 			expr: &actionExpr{
-				pos: position{line: 631, col: 5, offset: 15744},
+				pos: position{line: 641, col: 5, offset: 15933},
 				run: (*parser).callonPool1,
 				expr: &seqExpr{
-					pos: position{line: 631, col: 5, offset: 15744},
+					pos: position{line: 641, col: 5, offset: 15933},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 631, col: 5, offset: 15744},
+							pos:        position{line: 641, col: 5, offset: 15933},
 							val:        "pool",
 							ignoreCase: false,
 							want:       "\"pool\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 631, col: 12, offset: 15751},
+							pos:  position{line: 641, col: 12, offset: 15940},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 631, col: 14, offset: 15753},
+							pos:   position{line: 641, col: 14, offset: 15942},
 							label: "spec",
 							expr: &ruleRefExpr{
-								pos:  position{line: 631, col: 19, offset: 15758},
+								pos:  position{line: 641, col: 19, offset: 15947},
 								name: "PoolSpec",
 							},
 						},
@@ -4248,82 +4285,82 @@ var g = &grammar{
 		},
 		{
 			name: "Get",
-			pos:  position{line: 640, col: 1, offset: 15946},
+			pos:  position{line: 650, col: 1, offset: 16135},
 			expr: &actionExpr{
-				pos: position{line: 641, col: 5, offset: 15954},
+				pos: position{line: 651, col: 5, offset: 16143},
 				run: (*parser).callonGet1,
 				expr: &seqExpr{
-					pos: position{line: 641, col: 5, offset: 15954},
+					pos: position{line: 651, col: 5, offset: 16143},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 641, col: 5, offset: 15954},
+							pos:        position{line: 651, col: 5, offset: 16143},
 							val:        "get",
 							ignoreCase: false,
 							want:       "\"get\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 641, col: 11, offset: 15960},
+							pos:  position{line: 651, col: 11, offset: 16149},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 641, col: 13, offset: 15962},
+							pos:   position{line: 651, col: 13, offset: 16151},
 							label: "url",
 							expr: &ruleRefExpr{
-								pos:  position{line: 641, col: 17, offset: 15966},
+								pos:  position{line: 651, col: 17, offset: 16155},
 								name: "Path",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 641, col: 22, offset: 15971},
+							pos:   position{line: 651, col: 22, offset: 16160},
 							label: "format",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 641, col: 29, offset: 15978},
+								pos: position{line: 651, col: 29, offset: 16167},
 								expr: &ruleRefExpr{
-									pos:  position{line: 641, col: 29, offset: 15978},
+									pos:  position{line: 651, col: 29, offset: 16167},
 									name: "FormatArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 641, col: 40, offset: 15989},
+							pos:   position{line: 651, col: 40, offset: 16178},
 							label: "sortkey",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 641, col: 48, offset: 15997},
+								pos: position{line: 651, col: 48, offset: 16186},
 								expr: &ruleRefExpr{
-									pos:  position{line: 641, col: 48, offset: 15997},
+									pos:  position{line: 651, col: 48, offset: 16186},
 									name: "SortKeyArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 641, col: 60, offset: 16009},
+							pos:   position{line: 651, col: 60, offset: 16198},
 							label: "method",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 641, col: 67, offset: 16016},
+								pos: position{line: 651, col: 67, offset: 16205},
 								expr: &ruleRefExpr{
-									pos:  position{line: 641, col: 67, offset: 16016},
+									pos:  position{line: 651, col: 67, offset: 16205},
 									name: "MethodArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 641, col: 78, offset: 16027},
+							pos:   position{line: 651, col: 78, offset: 16216},
 							label: "headers",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 641, col: 86, offset: 16035},
+								pos: position{line: 651, col: 86, offset: 16224},
 								expr: &ruleRefExpr{
-									pos:  position{line: 641, col: 86, offset: 16035},
+									pos:  position{line: 651, col: 86, offset: 16224},
 									name: "HeadersArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 641, col: 98, offset: 16047},
+							pos:   position{line: 651, col: 98, offset: 16236},
 							label: "body",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 641, col: 103, offset: 16052},
+								pos: position{line: 651, col: 103, offset: 16241},
 								expr: &ruleRefExpr{
-									pos:  position{line: 641, col: 103, offset: 16052},
+									pos:  position{line: 651, col: 103, offset: 16241},
 									name: "BodyArg",
 								},
 							},
@@ -4336,39 +4373,39 @@ var g = &grammar{
 		},
 		{
 			name: "MethodArg",
-			pos:  position{line: 660, col: 1, offset: 16523},
+			pos:  position{line: 670, col: 1, offset: 16712},
 			expr: &actionExpr{
-				pos: position{line: 660, col: 13, offset: 16535},
+				pos: position{line: 670, col: 13, offset: 16724},
 				run: (*parser).callonMethodArg1,
 				expr: &seqExpr{
-					pos: position{line: 660, col: 13, offset: 16535},
+					pos: position{line: 670, col: 13, offset: 16724},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 660, col: 13, offset: 16535},
+							pos:  position{line: 670, col: 13, offset: 16724},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 660, col: 15, offset: 16537},
+							pos:        position{line: 670, col: 15, offset: 16726},
 							val:        "method",
 							ignoreCase: false,
 							want:       "\"method\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 660, col: 24, offset: 16546},
+							pos:  position{line: 670, col: 24, offset: 16735},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 660, col: 26, offset: 16548},
+							pos:   position{line: 670, col: 26, offset: 16737},
 							label: "v",
 							expr: &choiceExpr{
-								pos: position{line: 660, col: 29, offset: 16551},
+								pos: position{line: 670, col: 29, offset: 16740},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 660, col: 29, offset: 16551},
+										pos:  position{line: 670, col: 29, offset: 16740},
 										name: "IdentifierName",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 660, col: 46, offset: 16568},
+										pos:  position{line: 670, col: 46, offset: 16757},
 										name: "QuotedString",
 									},
 								},
@@ -4382,32 +4419,32 @@ var g = &grammar{
 		},
 		{
 			name: "HeadersArg",
-			pos:  position{line: 662, col: 1, offset: 16601},
+			pos:  position{line: 672, col: 1, offset: 16790},
 			expr: &actionExpr{
-				pos: position{line: 662, col: 14, offset: 16614},
+				pos: position{line: 672, col: 14, offset: 16803},
 				run: (*parser).callonHeadersArg1,
 				expr: &seqExpr{
-					pos: position{line: 662, col: 14, offset: 16614},
+					pos: position{line: 672, col: 14, offset: 16803},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 662, col: 14, offset: 16614},
+							pos:  position{line: 672, col: 14, offset: 16803},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 662, col: 16, offset: 16616},
+							pos:        position{line: 672, col: 16, offset: 16805},
 							val:        "headers",
 							ignoreCase: false,
 							want:       "\"headers\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 662, col: 26, offset: 16626},
+							pos:  position{line: 672, col: 26, offset: 16815},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 662, col: 28, offset: 16628},
+							pos:   position{line: 672, col: 28, offset: 16817},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 662, col: 30, offset: 16630},
+								pos:  position{line: 672, col: 30, offset: 16819},
 								name: "Record",
 							},
 						},
@@ -4419,39 +4456,39 @@ var g = &grammar{
 		},
 		{
 			name: "BodyArg",
-			pos:  position{line: 664, col: 1, offset: 16656},
+			pos:  position{line: 674, col: 1, offset: 16845},
 			expr: &actionExpr{
-				pos: position{line: 664, col: 11, offset: 16666},
+				pos: position{line: 674, col: 11, offset: 16855},
 				run: (*parser).callonBodyArg1,
 				expr: &seqExpr{
-					pos: position{line: 664, col: 11, offset: 16666},
+					pos: position{line: 674, col: 11, offset: 16855},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 664, col: 11, offset: 16666},
+							pos:  position{line: 674, col: 11, offset: 16855},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 664, col: 13, offset: 16668},
+							pos:        position{line: 674, col: 13, offset: 16857},
 							val:        "body",
 							ignoreCase: false,
 							want:       "\"body\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 664, col: 20, offset: 16675},
+							pos:  position{line: 674, col: 20, offset: 16864},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 664, col: 22, offset: 16677},
+							pos:   position{line: 674, col: 22, offset: 16866},
 							label: "v",
 							expr: &choiceExpr{
-								pos: position{line: 664, col: 25, offset: 16680},
+								pos: position{line: 674, col: 25, offset: 16869},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 664, col: 25, offset: 16680},
+										pos:  position{line: 674, col: 25, offset: 16869},
 										name: "IdentifierName",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 664, col: 42, offset: 16697},
+										pos:  position{line: 674, col: 42, offset: 16886},
 										name: "QuotedString",
 									},
 								},
@@ -4465,21 +4502,21 @@ var g = &grammar{
 		},
 		{
 			name: "Path",
-			pos:  position{line: 666, col: 1, offset: 16730},
+			pos:  position{line: 676, col: 1, offset: 16919},
 			expr: &choiceExpr{
-				pos: position{line: 667, col: 5, offset: 16739},
+				pos: position{line: 677, col: 5, offset: 16928},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 667, col: 5, offset: 16739},
+						pos:  position{line: 677, col: 5, offset: 16928},
 						name: "QuotedStringNode",
 					},
 					&actionExpr{
-						pos: position{line: 668, col: 5, offset: 16760},
+						pos: position{line: 678, col: 5, offset: 16949},
 						run: (*parser).callonPath3,
 						expr: &oneOrMoreExpr{
-							pos: position{line: 668, col: 5, offset: 16760},
+							pos: position{line: 678, col: 5, offset: 16949},
 							expr: &charClassMatcher{
-								pos:        position{line: 668, col: 5, offset: 16760},
+								pos:        position{line: 678, col: 5, offset: 16949},
 								val:        "[0-9a-zA-Z!@$%^&*_=<>,./?:[\\]{}~+-]",
 								chars:      []rune{'!', '@', '$', '%', '^', '&', '*', '_', '=', '<', '>', ',', '.', '/', '?', ':', '[', ']', '{', '}', '~', '+', '-'},
 								ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
@@ -4495,32 +4532,32 @@ var g = &grammar{
 		},
 		{
 			name: "PoolAt",
-			pos:  position{line: 673, col: 1, offset: 16930},
+			pos:  position{line: 683, col: 1, offset: 17119},
 			expr: &actionExpr{
-				pos: position{line: 674, col: 5, offset: 16941},
+				pos: position{line: 684, col: 5, offset: 17130},
 				run: (*parser).callonPoolAt1,
 				expr: &seqExpr{
-					pos: position{line: 674, col: 5, offset: 16941},
+					pos: position{line: 684, col: 5, offset: 17130},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 674, col: 5, offset: 16941},
+							pos:  position{line: 684, col: 5, offset: 17130},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 674, col: 7, offset: 16943},
+							pos:        position{line: 684, col: 7, offset: 17132},
 							val:        "at",
 							ignoreCase: false,
 							want:       "\"at\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 674, col: 12, offset: 16948},
+							pos:  position{line: 684, col: 12, offset: 17137},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 674, col: 14, offset: 16950},
+							pos:   position{line: 684, col: 14, offset: 17139},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 674, col: 17, offset: 16953},
+								pos:  position{line: 684, col: 17, offset: 17142},
 								name: "KSUID",
 							},
 						},
@@ -4532,14 +4569,14 @@ var g = &grammar{
 		},
 		{
 			name: "KSUID",
-			pos:  position{line: 677, col: 1, offset: 17019},
+			pos:  position{line: 687, col: 1, offset: 17208},
 			expr: &actionExpr{
-				pos: position{line: 677, col: 9, offset: 17027},
+				pos: position{line: 687, col: 9, offset: 17216},
 				run: (*parser).callonKSUID1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 677, col: 9, offset: 17027},
+					pos: position{line: 687, col: 9, offset: 17216},
 					expr: &charClassMatcher{
-						pos:        position{line: 677, col: 10, offset: 17028},
+						pos:        position{line: 687, col: 10, offset: 17217},
 						val:        "[0-9a-zA-Z]",
 						ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
 						ignoreCase: false,
@@ -4552,51 +4589,51 @@ var g = &grammar{
 		},
 		{
 			name: "PoolSpec",
-			pos:  position{line: 679, col: 1, offset: 17074},
+			pos:  position{line: 689, col: 1, offset: 17263},
 			expr: &choiceExpr{
-				pos: position{line: 680, col: 5, offset: 17087},
+				pos: position{line: 690, col: 5, offset: 17276},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 680, col: 5, offset: 17087},
+						pos: position{line: 690, col: 5, offset: 17276},
 						run: (*parser).callonPoolSpec2,
 						expr: &seqExpr{
-							pos: position{line: 680, col: 5, offset: 17087},
+							pos: position{line: 690, col: 5, offset: 17276},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 680, col: 5, offset: 17087},
+									pos:   position{line: 690, col: 5, offset: 17276},
 									label: "pool",
 									expr: &ruleRefExpr{
-										pos:  position{line: 680, col: 10, offset: 17092},
+										pos:  position{line: 690, col: 10, offset: 17281},
 										name: "PoolName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 680, col: 19, offset: 17101},
+									pos:   position{line: 690, col: 19, offset: 17290},
 									label: "commit",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 680, col: 26, offset: 17108},
+										pos: position{line: 690, col: 26, offset: 17297},
 										expr: &ruleRefExpr{
-											pos:  position{line: 680, col: 26, offset: 17108},
+											pos:  position{line: 690, col: 26, offset: 17297},
 											name: "PoolCommit",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 680, col: 38, offset: 17120},
+									pos:   position{line: 690, col: 38, offset: 17309},
 									label: "meta",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 680, col: 43, offset: 17125},
+										pos: position{line: 690, col: 43, offset: 17314},
 										expr: &ruleRefExpr{
-											pos:  position{line: 680, col: 43, offset: 17125},
+											pos:  position{line: 690, col: 43, offset: 17314},
 											name: "PoolMeta",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 680, col: 53, offset: 17135},
+									pos:   position{line: 690, col: 53, offset: 17324},
 									label: "tap",
 									expr: &ruleRefExpr{
-										pos:  position{line: 680, col: 57, offset: 17139},
+										pos:  position{line: 690, col: 57, offset: 17328},
 										name: "TapArg",
 									},
 								},
@@ -4604,13 +4641,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 688, col: 5, offset: 17333},
+						pos: position{line: 698, col: 5, offset: 17522},
 						run: (*parser).callonPoolSpec14,
 						expr: &labeledExpr{
-							pos:   position{line: 688, col: 5, offset: 17333},
+							pos:   position{line: 698, col: 5, offset: 17522},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 688, col: 10, offset: 17338},
+								pos:  position{line: 698, col: 10, offset: 17527},
 								name: "PoolMeta",
 							},
 						},
@@ -4622,24 +4659,24 @@ var g = &grammar{
 		},
 		{
 			name: "PoolCommit",
-			pos:  position{line: 692, col: 1, offset: 17408},
+			pos:  position{line: 702, col: 1, offset: 17597},
 			expr: &actionExpr{
-				pos: position{line: 693, col: 5, offset: 17423},
+				pos: position{line: 703, col: 5, offset: 17612},
 				run: (*parser).callonPoolCommit1,
 				expr: &seqExpr{
-					pos: position{line: 693, col: 5, offset: 17423},
+					pos: position{line: 703, col: 5, offset: 17612},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 693, col: 5, offset: 17423},
+							pos:        position{line: 703, col: 5, offset: 17612},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 693, col: 9, offset: 17427},
+							pos:   position{line: 703, col: 9, offset: 17616},
 							label: "commit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 693, col: 16, offset: 17434},
+								pos:  position{line: 703, col: 16, offset: 17623},
 								name: "PoolNameString",
 							},
 						},
@@ -4651,24 +4688,24 @@ var g = &grammar{
 		},
 		{
 			name: "PoolMeta",
-			pos:  position{line: 695, col: 1, offset: 17473},
+			pos:  position{line: 705, col: 1, offset: 17662},
 			expr: &actionExpr{
-				pos: position{line: 696, col: 5, offset: 17486},
+				pos: position{line: 706, col: 5, offset: 17675},
 				run: (*parser).callonPoolMeta1,
 				expr: &seqExpr{
-					pos: position{line: 696, col: 5, offset: 17486},
+					pos: position{line: 706, col: 5, offset: 17675},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 696, col: 5, offset: 17486},
+							pos:        position{line: 706, col: 5, offset: 17675},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 696, col: 9, offset: 17490},
+							pos:   position{line: 706, col: 9, offset: 17679},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 696, col: 14, offset: 17495},
+								pos:  position{line: 706, col: 14, offset: 17684},
 								name: "PoolIdentifier",
 							},
 						},
@@ -4680,34 +4717,34 @@ var g = &grammar{
 		},
 		{
 			name: "PoolName",
-			pos:  position{line: 698, col: 1, offset: 17532},
+			pos:  position{line: 708, col: 1, offset: 17721},
 			expr: &choiceExpr{
-				pos: position{line: 699, col: 5, offset: 17545},
+				pos: position{line: 709, col: 5, offset: 17734},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 699, col: 5, offset: 17545},
+						pos:  position{line: 709, col: 5, offset: 17734},
 						name: "Regexp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 700, col: 5, offset: 17556},
+						pos:  position{line: 710, col: 5, offset: 17745},
 						name: "Glob",
 					},
 					&actionExpr{
-						pos: position{line: 701, col: 5, offset: 17565},
+						pos: position{line: 711, col: 5, offset: 17754},
 						run: (*parser).callonPoolName4,
 						expr: &seqExpr{
-							pos: position{line: 701, col: 5, offset: 17565},
+							pos: position{line: 711, col: 5, offset: 17754},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 701, col: 5, offset: 17565},
+									pos:        position{line: 711, col: 5, offset: 17754},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 								&notExpr{
-									pos: position{line: 701, col: 9, offset: 17569},
+									pos: position{line: 711, col: 9, offset: 17758},
 									expr: &ruleRefExpr{
-										pos:  position{line: 701, col: 10, offset: 17570},
+										pos:  position{line: 711, col: 10, offset: 17759},
 										name: "ExprGuard",
 									},
 								},
@@ -4715,17 +4752,17 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 702, col: 5, offset: 17664},
+						pos:  position{line: 712, col: 5, offset: 17853},
 						name: "QuotedStringNode",
 					},
 					&actionExpr{
-						pos: position{line: 703, col: 5, offset: 17685},
+						pos: position{line: 713, col: 5, offset: 17874},
 						run: (*parser).callonPoolName10,
 						expr: &labeledExpr{
-							pos:   position{line: 703, col: 5, offset: 17685},
+							pos:   position{line: 713, col: 5, offset: 17874},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 703, col: 10, offset: 17690},
+								pos:  position{line: 713, col: 10, offset: 17879},
 								name: "PoolNameString",
 							},
 						},
@@ -4737,20 +4774,20 @@ var g = &grammar{
 		},
 		{
 			name: "PoolNameString",
-			pos:  position{line: 705, col: 1, offset: 17794},
+			pos:  position{line: 715, col: 1, offset: 17983},
 			expr: &choiceExpr{
-				pos: position{line: 706, col: 5, offset: 17813},
+				pos: position{line: 716, col: 5, offset: 18002},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 706, col: 5, offset: 17813},
+						pos:  position{line: 716, col: 5, offset: 18002},
 						name: "PoolIdentifier",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 707, col: 5, offset: 17832},
+						pos:  position{line: 717, col: 5, offset: 18021},
 						name: "KSUID",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 708, col: 5, offset: 17842},
+						pos:  position{line: 718, col: 5, offset: 18031},
 						name: "QuotedString",
 					},
 				},
@@ -4760,22 +4797,22 @@ var g = &grammar{
 		},
 		{
 			name: "PoolIdentifier",
-			pos:  position{line: 710, col: 1, offset: 17856},
+			pos:  position{line: 720, col: 1, offset: 18045},
 			expr: &actionExpr{
-				pos: position{line: 711, col: 5, offset: 17875},
+				pos: position{line: 721, col: 5, offset: 18064},
 				run: (*parser).callonPoolIdentifier1,
 				expr: &seqExpr{
-					pos: position{line: 711, col: 5, offset: 17875},
+					pos: position{line: 721, col: 5, offset: 18064},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 711, col: 6, offset: 17876},
+							pos: position{line: 721, col: 6, offset: 18065},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 711, col: 6, offset: 17876},
+									pos:  position{line: 721, col: 6, offset: 18065},
 									name: "IdentifierStart",
 								},
 								&litMatcher{
-									pos:        position{line: 711, col: 24, offset: 17894},
+									pos:        position{line: 721, col: 24, offset: 18083},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
@@ -4783,16 +4820,16 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 711, col: 29, offset: 17899},
+							pos: position{line: 721, col: 29, offset: 18088},
 							expr: &choiceExpr{
-								pos: position{line: 711, col: 30, offset: 17900},
+								pos: position{line: 721, col: 30, offset: 18089},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 711, col: 30, offset: 17900},
+										pos:  position{line: 721, col: 30, offset: 18089},
 										name: "IdentifierRest",
 									},
 									&litMatcher{
-										pos:        position{line: 711, col: 47, offset: 17917},
+										pos:        position{line: 721, col: 47, offset: 18106},
 										val:        ".",
 										ignoreCase: false,
 										want:       "\".\"",
@@ -4808,40 +4845,40 @@ var g = &grammar{
 		},
 		{
 			name: "SortKeyArg",
-			pos:  position{line: 713, col: 1, offset: 17955},
+			pos:  position{line: 723, col: 1, offset: 18144},
 			expr: &actionExpr{
-				pos: position{line: 714, col: 5, offset: 17970},
+				pos: position{line: 724, col: 5, offset: 18159},
 				run: (*parser).callonSortKeyArg1,
 				expr: &seqExpr{
-					pos: position{line: 714, col: 5, offset: 17970},
+					pos: position{line: 724, col: 5, offset: 18159},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 714, col: 5, offset: 17970},
+							pos:  position{line: 724, col: 5, offset: 18159},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 714, col: 7, offset: 17972},
+							pos:        position{line: 724, col: 7, offset: 18161},
 							val:        "order",
 							ignoreCase: false,
 							want:       "\"order\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 714, col: 15, offset: 17980},
+							pos:  position{line: 724, col: 15, offset: 18169},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 714, col: 17, offset: 17982},
+							pos:   position{line: 724, col: 17, offset: 18171},
 							label: "keys",
 							expr: &ruleRefExpr{
-								pos:  position{line: 714, col: 22, offset: 17987},
+								pos:  position{line: 724, col: 22, offset: 18176},
 								name: "FieldExprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 714, col: 33, offset: 17998},
+							pos:   position{line: 724, col: 33, offset: 18187},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 714, col: 39, offset: 18004},
+								pos:  position{line: 724, col: 39, offset: 18193},
 								name: "OrderSuffix",
 							},
 						},
@@ -4853,22 +4890,22 @@ var g = &grammar{
 		},
 		{
 			name: "TapArg",
-			pos:  position{line: 722, col: 1, offset: 18160},
+			pos:  position{line: 732, col: 1, offset: 18349},
 			expr: &choiceExpr{
-				pos: position{line: 723, col: 5, offset: 18171},
+				pos: position{line: 733, col: 5, offset: 18360},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 723, col: 5, offset: 18171},
+						pos: position{line: 733, col: 5, offset: 18360},
 						run: (*parser).callonTapArg2,
 						expr: &seqExpr{
-							pos: position{line: 723, col: 5, offset: 18171},
+							pos: position{line: 733, col: 5, offset: 18360},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 723, col: 5, offset: 18171},
+									pos:  position{line: 733, col: 5, offset: 18360},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 723, col: 7, offset: 18173},
+									pos:        position{line: 733, col: 7, offset: 18362},
 									val:        "tap",
 									ignoreCase: false,
 									want:       "\"tap\"",
@@ -4877,10 +4914,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 724, col: 5, offset: 18204},
+						pos: position{line: 734, col: 5, offset: 18393},
 						run: (*parser).callonTapArg6,
 						expr: &litMatcher{
-							pos:        position{line: 724, col: 5, offset: 18204},
+							pos:        position{line: 734, col: 5, offset: 18393},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -4893,32 +4930,32 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArg",
-			pos:  position{line: 726, col: 1, offset: 18230},
+			pos:  position{line: 736, col: 1, offset: 18419},
 			expr: &actionExpr{
-				pos: position{line: 727, col: 5, offset: 18244},
+				pos: position{line: 737, col: 5, offset: 18433},
 				run: (*parser).callonFormatArg1,
 				expr: &seqExpr{
-					pos: position{line: 727, col: 5, offset: 18244},
+					pos: position{line: 737, col: 5, offset: 18433},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 727, col: 5, offset: 18244},
+							pos:  position{line: 737, col: 5, offset: 18433},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 727, col: 7, offset: 18246},
+							pos:        position{line: 737, col: 7, offset: 18435},
 							val:        "format",
 							ignoreCase: false,
 							want:       "\"format\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 727, col: 16, offset: 18255},
+							pos:  position{line: 737, col: 16, offset: 18444},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 727, col: 18, offset: 18257},
+							pos:   position{line: 737, col: 18, offset: 18446},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 727, col: 22, offset: 18261},
+								pos:  position{line: 737, col: 22, offset: 18450},
 								name: "IdentifierName",
 							},
 						},
@@ -4930,35 +4967,35 @@ var g = &grammar{
 		},
 		{
 			name: "OrderSuffix",
-			pos:  position{line: 729, col: 1, offset: 18297},
+			pos:  position{line: 739, col: 1, offset: 18486},
 			expr: &choiceExpr{
-				pos: position{line: 730, col: 5, offset: 18313},
+				pos: position{line: 740, col: 5, offset: 18502},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 730, col: 5, offset: 18313},
+						pos: position{line: 740, col: 5, offset: 18502},
 						run: (*parser).callonOrderSuffix2,
 						expr: &litMatcher{
-							pos:        position{line: 730, col: 5, offset: 18313},
+							pos:        position{line: 740, col: 5, offset: 18502},
 							val:        ":asc",
 							ignoreCase: false,
 							want:       "\":asc\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 731, col: 5, offset: 18347},
+						pos: position{line: 741, col: 5, offset: 18536},
 						run: (*parser).callonOrderSuffix4,
 						expr: &litMatcher{
-							pos:        position{line: 731, col: 5, offset: 18347},
+							pos:        position{line: 741, col: 5, offset: 18536},
 							val:        ":desc",
 							ignoreCase: false,
 							want:       "\":desc\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 732, col: 5, offset: 18382},
+						pos: position{line: 742, col: 5, offset: 18571},
 						run: (*parser).callonOrderSuffix6,
 						expr: &litMatcher{
-							pos:        position{line: 732, col: 5, offset: 18382},
+							pos:        position{line: 742, col: 5, offset: 18571},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -4971,30 +5008,30 @@ var g = &grammar{
 		},
 		{
 			name: "PassOp",
-			pos:  position{line: 734, col: 1, offset: 18413},
+			pos:  position{line: 744, col: 1, offset: 18602},
 			expr: &actionExpr{
-				pos: position{line: 735, col: 5, offset: 18424},
+				pos: position{line: 745, col: 5, offset: 18613},
 				run: (*parser).callonPassOp1,
 				expr: &seqExpr{
-					pos: position{line: 735, col: 5, offset: 18424},
+					pos: position{line: 745, col: 5, offset: 18613},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 735, col: 5, offset: 18424},
+							pos:        position{line: 745, col: 5, offset: 18613},
 							val:        "pass",
 							ignoreCase: false,
 							want:       "\"pass\"",
 						},
 						&notExpr{
-							pos: position{line: 735, col: 12, offset: 18431},
+							pos: position{line: 745, col: 12, offset: 18620},
 							expr: &seqExpr{
-								pos: position{line: 735, col: 14, offset: 18433},
+								pos: position{line: 745, col: 14, offset: 18622},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 735, col: 14, offset: 18433},
+										pos:  position{line: 745, col: 14, offset: 18622},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 735, col: 17, offset: 18436},
+										pos:        position{line: 745, col: 17, offset: 18625},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -5003,9 +5040,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 735, col: 22, offset: 18441},
+							pos: position{line: 745, col: 22, offset: 18630},
 							expr: &ruleRefExpr{
-								pos:  position{line: 735, col: 23, offset: 18442},
+								pos:  position{line: 745, col: 23, offset: 18631},
 								name: "EOKW",
 							},
 						},
@@ -5017,46 +5054,46 @@ var g = &grammar{
 		},
 		{
 			name: "ExplodeOp",
-			pos:  position{line: 741, col: 1, offset: 18646},
+			pos:  position{line: 751, col: 1, offset: 18835},
 			expr: &actionExpr{
-				pos: position{line: 742, col: 5, offset: 18660},
+				pos: position{line: 752, col: 5, offset: 18849},
 				run: (*parser).callonExplodeOp1,
 				expr: &seqExpr{
-					pos: position{line: 742, col: 5, offset: 18660},
+					pos: position{line: 752, col: 5, offset: 18849},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 742, col: 5, offset: 18660},
+							pos:        position{line: 752, col: 5, offset: 18849},
 							val:        "explode",
 							ignoreCase: false,
 							want:       "\"explode\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 742, col: 15, offset: 18670},
+							pos:  position{line: 752, col: 15, offset: 18859},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 742, col: 17, offset: 18672},
+							pos:   position{line: 752, col: 17, offset: 18861},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 742, col: 22, offset: 18677},
+								pos:  position{line: 752, col: 22, offset: 18866},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 742, col: 28, offset: 18683},
+							pos:   position{line: 752, col: 28, offset: 18872},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 742, col: 32, offset: 18687},
+								pos:  position{line: 752, col: 32, offset: 18876},
 								name: "TypeArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 742, col: 40, offset: 18695},
+							pos:   position{line: 752, col: 40, offset: 18884},
 							label: "as",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 742, col: 43, offset: 18698},
+								pos: position{line: 752, col: 43, offset: 18887},
 								expr: &ruleRefExpr{
-									pos:  position{line: 742, col: 43, offset: 18698},
+									pos:  position{line: 752, col: 43, offset: 18887},
 									name: "AsArg",
 								},
 							},
@@ -5069,28 +5106,28 @@ var g = &grammar{
 		},
 		{
 			name: "MergeOp",
-			pos:  position{line: 755, col: 1, offset: 18956},
+			pos:  position{line: 765, col: 1, offset: 19145},
 			expr: &actionExpr{
-				pos: position{line: 756, col: 5, offset: 18968},
+				pos: position{line: 766, col: 5, offset: 19157},
 				run: (*parser).callonMergeOp1,
 				expr: &seqExpr{
-					pos: position{line: 756, col: 5, offset: 18968},
+					pos: position{line: 766, col: 5, offset: 19157},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 756, col: 5, offset: 18968},
+							pos:        position{line: 766, col: 5, offset: 19157},
 							val:        "merge",
 							ignoreCase: false,
 							want:       "\"merge\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 756, col: 13, offset: 18976},
+							pos:  position{line: 766, col: 13, offset: 19165},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 756, col: 15, offset: 18978},
+							pos:   position{line: 766, col: 15, offset: 19167},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 756, col: 20, offset: 18983},
+								pos:  position{line: 766, col: 20, offset: 19172},
 								name: "Expr",
 							},
 						},
@@ -5102,49 +5139,49 @@ var g = &grammar{
 		},
 		{
 			name: "OverOp",
-			pos:  position{line: 764, col: 1, offset: 19123},
+			pos:  position{line: 774, col: 1, offset: 19312},
 			expr: &actionExpr{
-				pos: position{line: 765, col: 5, offset: 19134},
+				pos: position{line: 775, col: 5, offset: 19323},
 				run: (*parser).callonOverOp1,
 				expr: &seqExpr{
-					pos: position{line: 765, col: 5, offset: 19134},
+					pos: position{line: 775, col: 5, offset: 19323},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 765, col: 5, offset: 19134},
+							pos:        position{line: 775, col: 5, offset: 19323},
 							val:        "over",
 							ignoreCase: false,
 							want:       "\"over\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 765, col: 12, offset: 19141},
+							pos:  position{line: 775, col: 12, offset: 19330},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 765, col: 14, offset: 19143},
+							pos:   position{line: 775, col: 14, offset: 19332},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 765, col: 20, offset: 19149},
+								pos:  position{line: 775, col: 20, offset: 19338},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 765, col: 26, offset: 19155},
+							pos:   position{line: 775, col: 26, offset: 19344},
 							label: "locals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 765, col: 33, offset: 19162},
+								pos: position{line: 775, col: 33, offset: 19351},
 								expr: &ruleRefExpr{
-									pos:  position{line: 765, col: 33, offset: 19162},
+									pos:  position{line: 775, col: 33, offset: 19351},
 									name: "Locals",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 765, col: 41, offset: 19170},
+							pos:   position{line: 775, col: 41, offset: 19359},
 							label: "body",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 765, col: 46, offset: 19175},
+								pos: position{line: 775, col: 46, offset: 19364},
 								expr: &ruleRefExpr{
-									pos:  position{line: 765, col: 46, offset: 19175},
+									pos:  position{line: 775, col: 46, offset: 19364},
 									name: "Lateral",
 								},
 							},
@@ -5157,54 +5194,54 @@ var g = &grammar{
 		},
 		{
 			name: "Lateral",
-			pos:  position{line: 780, col: 1, offset: 19524},
+			pos:  position{line: 790, col: 1, offset: 19713},
 			expr: &choiceExpr{
-				pos: position{line: 781, col: 5, offset: 19536},
+				pos: position{line: 791, col: 5, offset: 19725},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 781, col: 5, offset: 19536},
+						pos: position{line: 791, col: 5, offset: 19725},
 						run: (*parser).callonLateral2,
 						expr: &seqExpr{
-							pos: position{line: 781, col: 5, offset: 19536},
+							pos: position{line: 791, col: 5, offset: 19725},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 781, col: 5, offset: 19536},
+									pos:  position{line: 791, col: 5, offset: 19725},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 781, col: 8, offset: 19539},
+									pos:        position{line: 791, col: 8, offset: 19728},
 									val:        "=>",
 									ignoreCase: false,
 									want:       "\"=>\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 781, col: 13, offset: 19544},
+									pos:  position{line: 791, col: 13, offset: 19733},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 781, col: 16, offset: 19547},
+									pos:        position{line: 791, col: 16, offset: 19736},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 781, col: 20, offset: 19551},
+									pos:  position{line: 791, col: 20, offset: 19740},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 781, col: 23, offset: 19554},
+									pos:   position{line: 791, col: 23, offset: 19743},
 									label: "scope",
 									expr: &ruleRefExpr{
-										pos:  position{line: 781, col: 29, offset: 19560},
+										pos:  position{line: 791, col: 29, offset: 19749},
 										name: "Scope",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 781, col: 35, offset: 19566},
+									pos:  position{line: 791, col: 35, offset: 19755},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 781, col: 38, offset: 19569},
+									pos:        position{line: 791, col: 38, offset: 19758},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -5213,49 +5250,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 784, col: 5, offset: 19653},
+						pos: position{line: 794, col: 5, offset: 19842},
 						run: (*parser).callonLateral13,
 						expr: &seqExpr{
-							pos: position{line: 784, col: 5, offset: 19653},
+							pos: position{line: 794, col: 5, offset: 19842},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 784, col: 5, offset: 19653},
+									pos:  position{line: 794, col: 5, offset: 19842},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 784, col: 8, offset: 19656},
+									pos:        position{line: 794, col: 8, offset: 19845},
 									val:        "=>",
 									ignoreCase: false,
 									want:       "\"=>\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 784, col: 13, offset: 19661},
+									pos:  position{line: 794, col: 13, offset: 19850},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 784, col: 16, offset: 19664},
+									pos:        position{line: 794, col: 16, offset: 19853},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 784, col: 20, offset: 19668},
+									pos:  position{line: 794, col: 20, offset: 19857},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 784, col: 23, offset: 19671},
+									pos:   position{line: 794, col: 23, offset: 19860},
 									label: "seq",
 									expr: &ruleRefExpr{
-										pos:  position{line: 784, col: 27, offset: 19675},
+										pos:  position{line: 794, col: 27, offset: 19864},
 										name: "Seq",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 784, col: 31, offset: 19679},
+									pos:  position{line: 794, col: 31, offset: 19868},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 784, col: 34, offset: 19682},
+									pos:        position{line: 794, col: 34, offset: 19871},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -5270,65 +5307,65 @@ var g = &grammar{
 		},
 		{
 			name: "Locals",
-			pos:  position{line: 788, col: 1, offset: 19741},
+			pos:  position{line: 798, col: 1, offset: 19930},
 			expr: &actionExpr{
-				pos: position{line: 789, col: 5, offset: 19752},
+				pos: position{line: 799, col: 5, offset: 19941},
 				run: (*parser).callonLocals1,
 				expr: &seqExpr{
-					pos: position{line: 789, col: 5, offset: 19752},
+					pos: position{line: 799, col: 5, offset: 19941},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 789, col: 5, offset: 19752},
+							pos:  position{line: 799, col: 5, offset: 19941},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 789, col: 7, offset: 19754},
+							pos:        position{line: 799, col: 7, offset: 19943},
 							val:        "with",
 							ignoreCase: false,
 							want:       "\"with\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 789, col: 14, offset: 19761},
+							pos:  position{line: 799, col: 14, offset: 19950},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 789, col: 16, offset: 19763},
+							pos:   position{line: 799, col: 16, offset: 19952},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 789, col: 22, offset: 19769},
+								pos:  position{line: 799, col: 22, offset: 19958},
 								name: "LocalsAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 789, col: 39, offset: 19786},
+							pos:   position{line: 799, col: 39, offset: 19975},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 789, col: 44, offset: 19791},
+								pos: position{line: 799, col: 44, offset: 19980},
 								expr: &actionExpr{
-									pos: position{line: 789, col: 45, offset: 19792},
+									pos: position{line: 799, col: 45, offset: 19981},
 									run: (*parser).callonLocals10,
 									expr: &seqExpr{
-										pos: position{line: 789, col: 45, offset: 19792},
+										pos: position{line: 799, col: 45, offset: 19981},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 789, col: 45, offset: 19792},
+												pos:  position{line: 799, col: 45, offset: 19981},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 789, col: 48, offset: 19795},
+												pos:        position{line: 799, col: 48, offset: 19984},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 789, col: 52, offset: 19799},
+												pos:  position{line: 799, col: 52, offset: 19988},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 789, col: 55, offset: 19802},
+												pos:   position{line: 799, col: 55, offset: 19991},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 789, col: 57, offset: 19804},
+													pos:  position{line: 799, col: 57, offset: 19993},
 													name: "LocalsAssignment",
 												},
 											},
@@ -5345,45 +5382,45 @@ var g = &grammar{
 		},
 		{
 			name: "LocalsAssignment",
-			pos:  position{line: 793, col: 1, offset: 19889},
+			pos:  position{line: 803, col: 1, offset: 20078},
 			expr: &actionExpr{
-				pos: position{line: 794, col: 5, offset: 19910},
+				pos: position{line: 804, col: 5, offset: 20099},
 				run: (*parser).callonLocalsAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 794, col: 5, offset: 19910},
+					pos: position{line: 804, col: 5, offset: 20099},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 794, col: 5, offset: 19910},
+							pos:   position{line: 804, col: 5, offset: 20099},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 794, col: 10, offset: 19915},
+								pos:  position{line: 804, col: 10, offset: 20104},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 794, col: 21, offset: 19926},
+							pos:   position{line: 804, col: 21, offset: 20115},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 794, col: 25, offset: 19930},
+								pos: position{line: 804, col: 25, offset: 20119},
 								expr: &seqExpr{
-									pos: position{line: 794, col: 26, offset: 19931},
+									pos: position{line: 804, col: 26, offset: 20120},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 794, col: 26, offset: 19931},
+											pos:  position{line: 804, col: 26, offset: 20120},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 794, col: 29, offset: 19934},
+											pos:        position{line: 804, col: 29, offset: 20123},
 											val:        "=",
 											ignoreCase: false,
 											want:       "\"=\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 794, col: 33, offset: 19938},
+											pos:  position{line: 804, col: 33, offset: 20127},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 794, col: 36, offset: 19941},
+											pos:  position{line: 804, col: 36, offset: 20130},
 											name: "Expr",
 										},
 									},
@@ -5398,28 +5435,28 @@ var g = &grammar{
 		},
 		{
 			name: "YieldOp",
-			pos:  position{line: 805, col: 1, offset: 20144},
+			pos:  position{line: 815, col: 1, offset: 20333},
 			expr: &actionExpr{
-				pos: position{line: 806, col: 5, offset: 20156},
+				pos: position{line: 816, col: 5, offset: 20345},
 				run: (*parser).callonYieldOp1,
 				expr: &seqExpr{
-					pos: position{line: 806, col: 5, offset: 20156},
+					pos: position{line: 816, col: 5, offset: 20345},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 806, col: 5, offset: 20156},
+							pos:        position{line: 816, col: 5, offset: 20345},
 							val:        "yield",
 							ignoreCase: false,
 							want:       "\"yield\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 806, col: 13, offset: 20164},
+							pos:  position{line: 816, col: 13, offset: 20353},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 806, col: 15, offset: 20166},
+							pos:   position{line: 816, col: 15, offset: 20355},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 806, col: 21, offset: 20172},
+								pos:  position{line: 816, col: 21, offset: 20361},
 								name: "Exprs",
 							},
 						},
@@ -5431,32 +5468,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeArg",
-			pos:  position{line: 814, col: 1, offset: 20329},
+			pos:  position{line: 824, col: 1, offset: 20518},
 			expr: &actionExpr{
-				pos: position{line: 815, col: 5, offset: 20341},
+				pos: position{line: 825, col: 5, offset: 20530},
 				run: (*parser).callonTypeArg1,
 				expr: &seqExpr{
-					pos: position{line: 815, col: 5, offset: 20341},
+					pos: position{line: 825, col: 5, offset: 20530},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 815, col: 5, offset: 20341},
+							pos:  position{line: 825, col: 5, offset: 20530},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 815, col: 7, offset: 20343},
+							pos:        position{line: 825, col: 7, offset: 20532},
 							val:        "by",
 							ignoreCase: false,
 							want:       "\"by\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 815, col: 12, offset: 20348},
+							pos:  position{line: 825, col: 12, offset: 20537},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 815, col: 14, offset: 20350},
+							pos:   position{line: 825, col: 14, offset: 20539},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 815, col: 18, offset: 20354},
+								pos:  position{line: 825, col: 18, offset: 20543},
 								name: "Type",
 							},
 						},
@@ -5468,32 +5505,32 @@ var g = &grammar{
 		},
 		{
 			name: "AsArg",
-			pos:  position{line: 817, col: 1, offset: 20380},
+			pos:  position{line: 827, col: 1, offset: 20569},
 			expr: &actionExpr{
-				pos: position{line: 818, col: 5, offset: 20390},
+				pos: position{line: 828, col: 5, offset: 20579},
 				run: (*parser).callonAsArg1,
 				expr: &seqExpr{
-					pos: position{line: 818, col: 5, offset: 20390},
+					pos: position{line: 828, col: 5, offset: 20579},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 818, col: 5, offset: 20390},
+							pos:  position{line: 828, col: 5, offset: 20579},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 818, col: 7, offset: 20392},
+							pos:        position{line: 828, col: 7, offset: 20581},
 							val:        "as",
 							ignoreCase: false,
 							want:       "\"as\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 818, col: 12, offset: 20397},
+							pos:  position{line: 828, col: 12, offset: 20586},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 818, col: 14, offset: 20399},
+							pos:   position{line: 828, col: 14, offset: 20588},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 818, col: 18, offset: 20403},
+								pos:  position{line: 828, col: 18, offset: 20592},
 								name: "Lval",
 							},
 						},
@@ -5505,9 +5542,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 822, col: 1, offset: 20454},
+			pos:  position{line: 832, col: 1, offset: 20643},
 			expr: &ruleRefExpr{
-				pos:  position{line: 822, col: 8, offset: 20461},
+				pos:  position{line: 832, col: 8, offset: 20650},
 				name: "DerefExpr",
 			},
 			leader:        false,
@@ -5515,51 +5552,51 @@ var g = &grammar{
 		},
 		{
 			name: "Lvals",
-			pos:  position{line: 824, col: 1, offset: 20472},
+			pos:  position{line: 834, col: 1, offset: 20661},
 			expr: &actionExpr{
-				pos: position{line: 825, col: 5, offset: 20482},
+				pos: position{line: 835, col: 5, offset: 20671},
 				run: (*parser).callonLvals1,
 				expr: &seqExpr{
-					pos: position{line: 825, col: 5, offset: 20482},
+					pos: position{line: 835, col: 5, offset: 20671},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 825, col: 5, offset: 20482},
+							pos:   position{line: 835, col: 5, offset: 20671},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 825, col: 11, offset: 20488},
+								pos:  position{line: 835, col: 11, offset: 20677},
 								name: "Lval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 825, col: 16, offset: 20493},
+							pos:   position{line: 835, col: 16, offset: 20682},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 825, col: 21, offset: 20498},
+								pos: position{line: 835, col: 21, offset: 20687},
 								expr: &actionExpr{
-									pos: position{line: 825, col: 22, offset: 20499},
+									pos: position{line: 835, col: 22, offset: 20688},
 									run: (*parser).callonLvals7,
 									expr: &seqExpr{
-										pos: position{line: 825, col: 22, offset: 20499},
+										pos: position{line: 835, col: 22, offset: 20688},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 825, col: 22, offset: 20499},
+												pos:  position{line: 835, col: 22, offset: 20688},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 825, col: 25, offset: 20502},
+												pos:        position{line: 835, col: 25, offset: 20691},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 825, col: 29, offset: 20506},
+												pos:  position{line: 835, col: 29, offset: 20695},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 825, col: 32, offset: 20509},
+												pos:   position{line: 835, col: 32, offset: 20698},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 825, col: 37, offset: 20514},
+													pos:  position{line: 835, col: 37, offset: 20703},
 													name: "Lval",
 												},
 											},
@@ -5576,9 +5613,9 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 829, col: 1, offset: 20590},
+			pos:  position{line: 839, col: 1, offset: 20779},
 			expr: &ruleRefExpr{
-				pos:  position{line: 829, col: 13, offset: 20602},
+				pos:  position{line: 839, col: 13, offset: 20791},
 				name: "Lval",
 			},
 			leader:        false,
@@ -5586,51 +5623,51 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExprs",
-			pos:  position{line: 831, col: 1, offset: 20608},
+			pos:  position{line: 841, col: 1, offset: 20797},
 			expr: &actionExpr{
-				pos: position{line: 832, col: 5, offset: 20623},
+				pos: position{line: 842, col: 5, offset: 20812},
 				run: (*parser).callonFieldExprs1,
 				expr: &seqExpr{
-					pos: position{line: 832, col: 5, offset: 20623},
+					pos: position{line: 842, col: 5, offset: 20812},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 832, col: 5, offset: 20623},
+							pos:   position{line: 842, col: 5, offset: 20812},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 832, col: 11, offset: 20629},
+								pos:  position{line: 842, col: 11, offset: 20818},
 								name: "FieldExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 832, col: 21, offset: 20639},
+							pos:   position{line: 842, col: 21, offset: 20828},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 832, col: 26, offset: 20644},
+								pos: position{line: 842, col: 26, offset: 20833},
 								expr: &actionExpr{
-									pos: position{line: 832, col: 27, offset: 20645},
+									pos: position{line: 842, col: 27, offset: 20834},
 									run: (*parser).callonFieldExprs7,
 									expr: &seqExpr{
-										pos: position{line: 832, col: 27, offset: 20645},
+										pos: position{line: 842, col: 27, offset: 20834},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 832, col: 27, offset: 20645},
+												pos:  position{line: 842, col: 27, offset: 20834},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 832, col: 30, offset: 20648},
+												pos:        position{line: 842, col: 30, offset: 20837},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 832, col: 34, offset: 20652},
+												pos:  position{line: 842, col: 34, offset: 20841},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 832, col: 37, offset: 20655},
+												pos:   position{line: 842, col: 37, offset: 20844},
 												label: "f",
 												expr: &ruleRefExpr{
-													pos:  position{line: 832, col: 39, offset: 20657},
+													pos:  position{line: 842, col: 39, offset: 20846},
 													name: "FieldExpr",
 												},
 											},
@@ -5647,51 +5684,51 @@ var g = &grammar{
 		},
 		{
 			name: "Assignments",
-			pos:  position{line: 836, col: 1, offset: 20734},
+			pos:  position{line: 846, col: 1, offset: 20923},
 			expr: &actionExpr{
-				pos: position{line: 837, col: 5, offset: 20750},
+				pos: position{line: 847, col: 5, offset: 20939},
 				run: (*parser).callonAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 837, col: 5, offset: 20750},
+					pos: position{line: 847, col: 5, offset: 20939},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 837, col: 5, offset: 20750},
+							pos:   position{line: 847, col: 5, offset: 20939},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 837, col: 11, offset: 20756},
+								pos:  position{line: 847, col: 11, offset: 20945},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 837, col: 22, offset: 20767},
+							pos:   position{line: 847, col: 22, offset: 20956},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 837, col: 27, offset: 20772},
+								pos: position{line: 847, col: 27, offset: 20961},
 								expr: &actionExpr{
-									pos: position{line: 837, col: 28, offset: 20773},
+									pos: position{line: 847, col: 28, offset: 20962},
 									run: (*parser).callonAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 837, col: 28, offset: 20773},
+										pos: position{line: 847, col: 28, offset: 20962},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 837, col: 28, offset: 20773},
+												pos:  position{line: 847, col: 28, offset: 20962},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 837, col: 31, offset: 20776},
+												pos:        position{line: 847, col: 31, offset: 20965},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 837, col: 35, offset: 20780},
+												pos:  position{line: 847, col: 35, offset: 20969},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 837, col: 38, offset: 20783},
+												pos:   position{line: 847, col: 38, offset: 20972},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 837, col: 40, offset: 20785},
+													pos:  position{line: 847, col: 40, offset: 20974},
 													name: "Assignment",
 												},
 											},
@@ -5708,40 +5745,40 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 841, col: 1, offset: 20860},
+			pos:  position{line: 851, col: 1, offset: 21049},
 			expr: &actionExpr{
-				pos: position{line: 842, col: 5, offset: 20875},
+				pos: position{line: 852, col: 5, offset: 21064},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 842, col: 5, offset: 20875},
+					pos: position{line: 852, col: 5, offset: 21064},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 842, col: 5, offset: 20875},
+							pos:   position{line: 852, col: 5, offset: 21064},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 842, col: 9, offset: 20879},
+								pos:  position{line: 852, col: 9, offset: 21068},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 842, col: 14, offset: 20884},
+							pos:  position{line: 852, col: 14, offset: 21073},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 842, col: 17, offset: 20887},
+							pos:        position{line: 852, col: 17, offset: 21076},
 							val:        ":=",
 							ignoreCase: false,
 							want:       "\":=\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 842, col: 22, offset: 20892},
+							pos:  position{line: 852, col: 22, offset: 21081},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 842, col: 25, offset: 20895},
+							pos:   position{line: 852, col: 25, offset: 21084},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 842, col: 29, offset: 20899},
+								pos:  position{line: 852, col: 29, offset: 21088},
 								name: "Expr",
 							},
 						},
@@ -5753,9 +5790,9 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 850, col: 1, offset: 21047},
+			pos:  position{line: 860, col: 1, offset: 21236},
 			expr: &ruleRefExpr{
-				pos:  position{line: 850, col: 8, offset: 21054},
+				pos:  position{line: 860, col: 8, offset: 21243},
 				name: "ConditionalExpr",
 			},
 			leader:        false,
@@ -5763,63 +5800,63 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 852, col: 1, offset: 21071},
+			pos:  position{line: 862, col: 1, offset: 21260},
 			expr: &actionExpr{
-				pos: position{line: 853, col: 5, offset: 21091},
+				pos: position{line: 863, col: 5, offset: 21280},
 				run: (*parser).callonConditionalExpr1,
 				expr: &seqExpr{
-					pos: position{line: 853, col: 5, offset: 21091},
+					pos: position{line: 863, col: 5, offset: 21280},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 853, col: 5, offset: 21091},
+							pos:   position{line: 863, col: 5, offset: 21280},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 853, col: 10, offset: 21096},
+								pos:  position{line: 863, col: 10, offset: 21285},
 								name: "LogicalOrExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 853, col: 24, offset: 21110},
+							pos:   position{line: 863, col: 24, offset: 21299},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 853, col: 28, offset: 21114},
+								pos: position{line: 863, col: 28, offset: 21303},
 								expr: &seqExpr{
-									pos: position{line: 853, col: 29, offset: 21115},
+									pos: position{line: 863, col: 29, offset: 21304},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 853, col: 29, offset: 21115},
+											pos:  position{line: 863, col: 29, offset: 21304},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 853, col: 32, offset: 21118},
+											pos:        position{line: 863, col: 32, offset: 21307},
 											val:        "?",
 											ignoreCase: false,
 											want:       "\"?\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 853, col: 36, offset: 21122},
+											pos:  position{line: 863, col: 36, offset: 21311},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 853, col: 39, offset: 21125},
+											pos:  position{line: 863, col: 39, offset: 21314},
 											name: "Expr",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 853, col: 44, offset: 21130},
+											pos:  position{line: 863, col: 44, offset: 21319},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 853, col: 47, offset: 21133},
+											pos:        position{line: 863, col: 47, offset: 21322},
 											val:        ":",
 											ignoreCase: false,
 											want:       "\":\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 853, col: 51, offset: 21137},
+											pos:  position{line: 863, col: 51, offset: 21326},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 853, col: 54, offset: 21140},
+											pos:  position{line: 863, col: 54, offset: 21329},
 											name: "Expr",
 										},
 									},
@@ -5834,53 +5871,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 866, col: 1, offset: 21436},
+			pos:  position{line: 876, col: 1, offset: 21625},
 			expr: &actionExpr{
-				pos: position{line: 867, col: 5, offset: 21454},
+				pos: position{line: 877, col: 5, offset: 21643},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 867, col: 5, offset: 21454},
+					pos: position{line: 877, col: 5, offset: 21643},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 867, col: 5, offset: 21454},
+							pos:   position{line: 877, col: 5, offset: 21643},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 867, col: 11, offset: 21460},
+								pos:  position{line: 877, col: 11, offset: 21649},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 868, col: 5, offset: 21479},
+							pos:   position{line: 878, col: 5, offset: 21668},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 868, col: 10, offset: 21484},
+								pos: position{line: 878, col: 10, offset: 21673},
 								expr: &actionExpr{
-									pos: position{line: 868, col: 11, offset: 21485},
+									pos: position{line: 878, col: 11, offset: 21674},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 868, col: 11, offset: 21485},
+										pos: position{line: 878, col: 11, offset: 21674},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 868, col: 11, offset: 21485},
+												pos:  position{line: 878, col: 11, offset: 21674},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 868, col: 14, offset: 21488},
+												pos:   position{line: 878, col: 14, offset: 21677},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 868, col: 17, offset: 21491},
+													pos:  position{line: 878, col: 17, offset: 21680},
 													name: "OrToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 868, col: 25, offset: 21499},
+												pos:  position{line: 878, col: 25, offset: 21688},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 868, col: 28, offset: 21502},
+												pos:   position{line: 878, col: 28, offset: 21691},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 868, col: 33, offset: 21507},
+													pos:  position{line: 878, col: 33, offset: 21696},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -5897,53 +5934,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 872, col: 1, offset: 21618},
+			pos:  position{line: 882, col: 1, offset: 21807},
 			expr: &actionExpr{
-				pos: position{line: 873, col: 5, offset: 21637},
+				pos: position{line: 883, col: 5, offset: 21826},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 873, col: 5, offset: 21637},
+					pos: position{line: 883, col: 5, offset: 21826},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 873, col: 5, offset: 21637},
+							pos:   position{line: 883, col: 5, offset: 21826},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 873, col: 11, offset: 21643},
+								pos:  position{line: 883, col: 11, offset: 21832},
 								name: "ComparisonExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 874, col: 5, offset: 21662},
+							pos:   position{line: 884, col: 5, offset: 21851},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 874, col: 10, offset: 21667},
+								pos: position{line: 884, col: 10, offset: 21856},
 								expr: &actionExpr{
-									pos: position{line: 874, col: 11, offset: 21668},
+									pos: position{line: 884, col: 11, offset: 21857},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 874, col: 11, offset: 21668},
+										pos: position{line: 884, col: 11, offset: 21857},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 874, col: 11, offset: 21668},
+												pos:  position{line: 884, col: 11, offset: 21857},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 874, col: 14, offset: 21671},
+												pos:   position{line: 884, col: 14, offset: 21860},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 874, col: 17, offset: 21674},
+													pos:  position{line: 884, col: 17, offset: 21863},
 													name: "AndToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 874, col: 26, offset: 21683},
+												pos:  position{line: 884, col: 26, offset: 21872},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 874, col: 29, offset: 21686},
+												pos:   position{line: 884, col: 29, offset: 21875},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 874, col: 34, offset: 21691},
+													pos:  position{line: 884, col: 34, offset: 21880},
 													name: "ComparisonExpr",
 												},
 											},
@@ -5960,73 +5997,73 @@ var g = &grammar{
 		},
 		{
 			name: "ComparisonExpr",
-			pos:  position{line: 878, col: 1, offset: 21802},
+			pos:  position{line: 888, col: 1, offset: 21991},
 			expr: &actionExpr{
-				pos: position{line: 879, col: 5, offset: 21821},
+				pos: position{line: 889, col: 5, offset: 22010},
 				run: (*parser).callonComparisonExpr1,
 				expr: &seqExpr{
-					pos: position{line: 879, col: 5, offset: 21821},
+					pos: position{line: 889, col: 5, offset: 22010},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 879, col: 5, offset: 21821},
+							pos:   position{line: 889, col: 5, offset: 22010},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 879, col: 9, offset: 21825},
+								pos:  position{line: 889, col: 9, offset: 22014},
 								name: "AdditiveExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 879, col: 22, offset: 21838},
+							pos:   position{line: 889, col: 22, offset: 22027},
 							label: "opAndRHS",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 879, col: 31, offset: 21847},
+								pos: position{line: 889, col: 31, offset: 22036},
 								expr: &choiceExpr{
-									pos: position{line: 879, col: 32, offset: 21848},
+									pos: position{line: 889, col: 32, offset: 22037},
 									alternatives: []any{
 										&seqExpr{
-											pos: position{line: 879, col: 32, offset: 21848},
+											pos: position{line: 889, col: 32, offset: 22037},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 879, col: 32, offset: 21848},
+													pos:  position{line: 889, col: 32, offset: 22037},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 879, col: 35, offset: 21851},
+													pos:  position{line: 889, col: 35, offset: 22040},
 													name: "Comparator",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 879, col: 46, offset: 21862},
+													pos:  position{line: 889, col: 46, offset: 22051},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 879, col: 49, offset: 21865},
+													pos:  position{line: 889, col: 49, offset: 22054},
 													name: "AdditiveExpr",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 879, col: 64, offset: 21880},
+											pos: position{line: 889, col: 64, offset: 22069},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 879, col: 64, offset: 21880},
+													pos:  position{line: 889, col: 64, offset: 22069},
 													name: "__",
 												},
 												&actionExpr{
-													pos: position{line: 879, col: 68, offset: 21884},
+													pos: position{line: 889, col: 68, offset: 22073},
 													run: (*parser).callonComparisonExpr15,
 													expr: &litMatcher{
-														pos:        position{line: 879, col: 68, offset: 21884},
+														pos:        position{line: 889, col: 68, offset: 22073},
 														val:        "~",
 														ignoreCase: false,
 														want:       "\"~\"",
 													},
 												},
 												&ruleRefExpr{
-													pos:  position{line: 879, col: 104, offset: 21920},
+													pos:  position{line: 889, col: 104, offset: 22109},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 879, col: 107, offset: 21923},
+													pos:  position{line: 889, col: 107, offset: 22112},
 													name: "Regexp",
 												},
 											},
@@ -6043,53 +6080,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 891, col: 1, offset: 22187},
+			pos:  position{line: 901, col: 1, offset: 22376},
 			expr: &actionExpr{
-				pos: position{line: 892, col: 5, offset: 22204},
+				pos: position{line: 902, col: 5, offset: 22393},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 892, col: 5, offset: 22204},
+					pos: position{line: 902, col: 5, offset: 22393},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 892, col: 5, offset: 22204},
+							pos:   position{line: 902, col: 5, offset: 22393},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 892, col: 11, offset: 22210},
+								pos:  position{line: 902, col: 11, offset: 22399},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 893, col: 5, offset: 22233},
+							pos:   position{line: 903, col: 5, offset: 22422},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 893, col: 10, offset: 22238},
+								pos: position{line: 903, col: 10, offset: 22427},
 								expr: &actionExpr{
-									pos: position{line: 893, col: 11, offset: 22239},
+									pos: position{line: 903, col: 11, offset: 22428},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 893, col: 11, offset: 22239},
+										pos: position{line: 903, col: 11, offset: 22428},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 893, col: 11, offset: 22239},
+												pos:  position{line: 903, col: 11, offset: 22428},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 893, col: 14, offset: 22242},
+												pos:   position{line: 903, col: 14, offset: 22431},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 893, col: 17, offset: 22245},
+													pos:  position{line: 903, col: 17, offset: 22434},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 893, col: 34, offset: 22262},
+												pos:  position{line: 903, col: 34, offset: 22451},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 893, col: 37, offset: 22265},
+												pos:   position{line: 903, col: 37, offset: 22454},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 893, col: 42, offset: 22270},
+													pos:  position{line: 903, col: 42, offset: 22459},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -6106,21 +6143,21 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 897, col: 1, offset: 22385},
+			pos:  position{line: 907, col: 1, offset: 22574},
 			expr: &actionExpr{
-				pos: position{line: 897, col: 20, offset: 22404},
+				pos: position{line: 907, col: 20, offset: 22593},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 897, col: 21, offset: 22405},
+					pos: position{line: 907, col: 21, offset: 22594},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 897, col: 21, offset: 22405},
+							pos:        position{line: 907, col: 21, offset: 22594},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&litMatcher{
-							pos:        position{line: 897, col: 27, offset: 22411},
+							pos:        position{line: 907, col: 27, offset: 22600},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
@@ -6133,53 +6170,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 899, col: 1, offset: 22448},
+			pos:  position{line: 909, col: 1, offset: 22637},
 			expr: &actionExpr{
-				pos: position{line: 900, col: 5, offset: 22471},
+				pos: position{line: 910, col: 5, offset: 22660},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 900, col: 5, offset: 22471},
+					pos: position{line: 910, col: 5, offset: 22660},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 900, col: 5, offset: 22471},
+							pos:   position{line: 910, col: 5, offset: 22660},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 900, col: 11, offset: 22477},
+								pos:  position{line: 910, col: 11, offset: 22666},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 901, col: 5, offset: 22489},
+							pos:   position{line: 911, col: 5, offset: 22678},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 901, col: 10, offset: 22494},
+								pos: position{line: 911, col: 10, offset: 22683},
 								expr: &actionExpr{
-									pos: position{line: 901, col: 11, offset: 22495},
+									pos: position{line: 911, col: 11, offset: 22684},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 901, col: 11, offset: 22495},
+										pos: position{line: 911, col: 11, offset: 22684},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 901, col: 11, offset: 22495},
+												pos:  position{line: 911, col: 11, offset: 22684},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 901, col: 14, offset: 22498},
+												pos:   position{line: 911, col: 14, offset: 22687},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 901, col: 17, offset: 22501},
+													pos:  position{line: 911, col: 17, offset: 22690},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 901, col: 40, offset: 22524},
+												pos:  position{line: 911, col: 40, offset: 22713},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 901, col: 43, offset: 22527},
+												pos:   position{line: 911, col: 43, offset: 22716},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 901, col: 48, offset: 22532},
+													pos:  position{line: 911, col: 48, offset: 22721},
 													name: "NotExpr",
 												},
 											},
@@ -6196,27 +6233,27 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 905, col: 1, offset: 22636},
+			pos:  position{line: 915, col: 1, offset: 22825},
 			expr: &actionExpr{
-				pos: position{line: 905, col: 26, offset: 22661},
+				pos: position{line: 915, col: 26, offset: 22850},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 905, col: 27, offset: 22662},
+					pos: position{line: 915, col: 27, offset: 22851},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 905, col: 27, offset: 22662},
+							pos:        position{line: 915, col: 27, offset: 22851},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&litMatcher{
-							pos:        position{line: 905, col: 33, offset: 22668},
+							pos:        position{line: 915, col: 33, offset: 22857},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&litMatcher{
-							pos:        position{line: 905, col: 39, offset: 22674},
+							pos:        position{line: 915, col: 39, offset: 22863},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
@@ -6229,43 +6266,43 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 907, col: 1, offset: 22711},
+			pos:  position{line: 917, col: 1, offset: 22900},
 			expr: &choiceExpr{
-				pos: position{line: 908, col: 5, offset: 22723},
+				pos: position{line: 918, col: 5, offset: 22912},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 908, col: 5, offset: 22723},
+						pos: position{line: 918, col: 5, offset: 22912},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 908, col: 5, offset: 22723},
+							pos: position{line: 918, col: 5, offset: 22912},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 908, col: 6, offset: 22724},
+									pos: position{line: 918, col: 6, offset: 22913},
 									alternatives: []any{
 										&seqExpr{
-											pos: position{line: 908, col: 6, offset: 22724},
+											pos: position{line: 918, col: 6, offset: 22913},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 908, col: 6, offset: 22724},
+													pos:  position{line: 918, col: 6, offset: 22913},
 													name: "NotToken",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 908, col: 15, offset: 22733},
+													pos:  position{line: 918, col: 15, offset: 22922},
 													name: "_",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 908, col: 19, offset: 22737},
+											pos: position{line: 918, col: 19, offset: 22926},
 											exprs: []any{
 												&litMatcher{
-													pos:        position{line: 908, col: 19, offset: 22737},
+													pos:        position{line: 918, col: 19, offset: 22926},
 													val:        "!",
 													ignoreCase: false,
 													want:       "\"!\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 908, col: 23, offset: 22741},
+													pos:  position{line: 918, col: 23, offset: 22930},
 													name: "__",
 												},
 											},
@@ -6273,10 +6310,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 908, col: 27, offset: 22745},
+									pos:   position{line: 918, col: 27, offset: 22934},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 908, col: 29, offset: 22747},
+										pos:  position{line: 918, col: 29, offset: 22936},
 										name: "NotExpr",
 									},
 								},
@@ -6284,7 +6321,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 916, col: 5, offset: 22921},
+						pos:  position{line: 926, col: 5, offset: 23110},
 						name: "NegationExpr",
 					},
 				},
@@ -6294,38 +6331,38 @@ var g = &grammar{
 		},
 		{
 			name: "NegationExpr",
-			pos:  position{line: 918, col: 1, offset: 22935},
+			pos:  position{line: 928, col: 1, offset: 23124},
 			expr: &choiceExpr{
-				pos: position{line: 919, col: 5, offset: 22952},
+				pos: position{line: 929, col: 5, offset: 23141},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 919, col: 5, offset: 22952},
+						pos: position{line: 929, col: 5, offset: 23141},
 						run: (*parser).callonNegationExpr2,
 						expr: &seqExpr{
-							pos: position{line: 919, col: 5, offset: 22952},
+							pos: position{line: 929, col: 5, offset: 23141},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 919, col: 5, offset: 22952},
+									pos: position{line: 929, col: 5, offset: 23141},
 									expr: &ruleRefExpr{
-										pos:  position{line: 919, col: 6, offset: 22953},
+										pos:  position{line: 929, col: 6, offset: 23142},
 										name: "Literal",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 919, col: 14, offset: 22961},
+									pos:        position{line: 929, col: 14, offset: 23150},
 									val:        "-",
 									ignoreCase: false,
 									want:       "\"-\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 919, col: 18, offset: 22965},
+									pos:  position{line: 929, col: 18, offset: 23154},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 919, col: 21, offset: 22968},
+									pos:   position{line: 929, col: 21, offset: 23157},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 919, col: 23, offset: 22970},
+										pos:  position{line: 929, col: 23, offset: 23159},
 										name: "DerefExpr",
 									},
 								},
@@ -6333,7 +6370,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 927, col: 5, offset: 23146},
+						pos:  position{line: 937, col: 5, offset: 23335},
 						name: "DerefExpr",
 					},
 				},
@@ -6343,65 +6380,65 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 929, col: 1, offset: 23157},
+			pos:  position{line: 939, col: 1, offset: 23346},
 			expr: &choiceExpr{
-				pos: position{line: 930, col: 5, offset: 23171},
+				pos: position{line: 940, col: 5, offset: 23360},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 930, col: 5, offset: 23171},
+						pos: position{line: 940, col: 5, offset: 23360},
 						run: (*parser).callonDerefExpr2,
 						expr: &seqExpr{
-							pos: position{line: 930, col: 5, offset: 23171},
+							pos: position{line: 940, col: 5, offset: 23360},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 930, col: 5, offset: 23171},
+									pos:   position{line: 940, col: 5, offset: 23360},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 930, col: 10, offset: 23176},
+										pos:  position{line: 940, col: 10, offset: 23365},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 930, col: 20, offset: 23186},
+									pos:        position{line: 940, col: 20, offset: 23375},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 930, col: 24, offset: 23190},
+									pos:   position{line: 940, col: 24, offset: 23379},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 930, col: 29, offset: 23195},
+										pos:  position{line: 940, col: 29, offset: 23384},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 930, col: 42, offset: 23208},
+									pos:  position{line: 940, col: 42, offset: 23397},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 930, col: 45, offset: 23211},
+									pos:        position{line: 940, col: 45, offset: 23400},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 930, col: 49, offset: 23215},
+									pos:  position{line: 940, col: 49, offset: 23404},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 930, col: 52, offset: 23218},
+									pos:   position{line: 940, col: 52, offset: 23407},
 									label: "to",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 930, col: 55, offset: 23221},
+										pos: position{line: 940, col: 55, offset: 23410},
 										expr: &ruleRefExpr{
-											pos:  position{line: 930, col: 55, offset: 23221},
+											pos:  position{line: 940, col: 55, offset: 23410},
 											name: "AdditiveExpr",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 930, col: 69, offset: 23235},
+									pos:        position{line: 940, col: 69, offset: 23424},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6410,49 +6447,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 942, col: 5, offset: 23486},
+						pos: position{line: 952, col: 5, offset: 23675},
 						run: (*parser).callonDerefExpr16,
 						expr: &seqExpr{
-							pos: position{line: 942, col: 5, offset: 23486},
+							pos: position{line: 952, col: 5, offset: 23675},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 942, col: 5, offset: 23486},
+									pos:   position{line: 952, col: 5, offset: 23675},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 942, col: 10, offset: 23491},
+										pos:  position{line: 952, col: 10, offset: 23680},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 942, col: 20, offset: 23501},
+									pos:        position{line: 952, col: 20, offset: 23690},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 942, col: 24, offset: 23505},
+									pos:  position{line: 952, col: 24, offset: 23694},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 942, col: 27, offset: 23508},
+									pos:        position{line: 952, col: 27, offset: 23697},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 942, col: 31, offset: 23512},
+									pos:  position{line: 952, col: 31, offset: 23701},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 942, col: 34, offset: 23515},
+									pos:   position{line: 952, col: 34, offset: 23704},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 942, col: 37, offset: 23518},
+										pos:  position{line: 952, col: 37, offset: 23707},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 942, col: 50, offset: 23531},
+									pos:        position{line: 952, col: 50, offset: 23720},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6461,35 +6498,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 950, col: 5, offset: 23707},
+						pos: position{line: 960, col: 5, offset: 23896},
 						run: (*parser).callonDerefExpr27,
 						expr: &seqExpr{
-							pos: position{line: 950, col: 5, offset: 23707},
+							pos: position{line: 960, col: 5, offset: 23896},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 950, col: 5, offset: 23707},
+									pos:   position{line: 960, col: 5, offset: 23896},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 950, col: 10, offset: 23712},
+										pos:  position{line: 960, col: 10, offset: 23901},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 950, col: 20, offset: 23722},
+									pos:        position{line: 960, col: 20, offset: 23911},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 950, col: 24, offset: 23726},
+									pos:   position{line: 960, col: 24, offset: 23915},
 									label: "index",
 									expr: &ruleRefExpr{
-										pos:  position{line: 950, col: 30, offset: 23732},
+										pos:  position{line: 960, col: 30, offset: 23921},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 950, col: 35, offset: 23737},
+									pos:        position{line: 960, col: 35, offset: 23926},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6498,30 +6535,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 958, col: 5, offset: 23919},
+						pos: position{line: 968, col: 5, offset: 24108},
 						run: (*parser).callonDerefExpr35,
 						expr: &seqExpr{
-							pos: position{line: 958, col: 5, offset: 23919},
+							pos: position{line: 968, col: 5, offset: 24108},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 958, col: 5, offset: 23919},
+									pos:   position{line: 968, col: 5, offset: 24108},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 958, col: 10, offset: 23924},
+										pos:  position{line: 968, col: 10, offset: 24113},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 958, col: 20, offset: 23934},
+									pos:        position{line: 968, col: 20, offset: 24123},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 958, col: 24, offset: 23938},
+									pos:   position{line: 968, col: 24, offset: 24127},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 958, col: 27, offset: 23941},
+										pos:  position{line: 968, col: 27, offset: 24130},
 										name: "Identifier",
 									},
 								},
@@ -6529,25 +6566,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 966, col: 5, offset: 24110},
+						pos: position{line: 976, col: 5, offset: 24299},
 						run: (*parser).callonDerefExpr42,
 						expr: &labeledExpr{
-							pos:   position{line: 966, col: 5, offset: 24110},
+							pos:   position{line: 976, col: 5, offset: 24299},
 							label: "fn",
 							expr: &ruleRefExpr{
-								pos:  position{line: 966, col: 8, offset: 24113},
+								pos:  position{line: 976, col: 8, offset: 24302},
 								name: "FuncExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 969, col: 5, offset: 24155},
+						pos: position{line: 979, col: 5, offset: 24344},
 						run: (*parser).callonDerefExpr45,
 						expr: &labeledExpr{
-							pos:   position{line: 969, col: 5, offset: 24155},
+							pos:   position{line: 979, col: 5, offset: 24344},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 969, col: 10, offset: 24160},
+								pos:  position{line: 979, col: 10, offset: 24349},
 								name: "Primary",
 							},
 						},
@@ -6559,30 +6596,30 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 974, col: 1, offset: 24201},
+			pos:  position{line: 984, col: 1, offset: 24390},
 			expr: &choiceExpr{
-				pos: position{line: 975, col: 5, offset: 24214},
+				pos: position{line: 985, col: 5, offset: 24403},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 975, col: 5, offset: 24214},
+						pos: position{line: 985, col: 5, offset: 24403},
 						run: (*parser).callonFuncExpr2,
 						expr: &labeledExpr{
-							pos:   position{line: 975, col: 5, offset: 24214},
+							pos:   position{line: 985, col: 5, offset: 24403},
 							label: "cast",
 							expr: &ruleRefExpr{
-								pos:  position{line: 975, col: 10, offset: 24219},
+								pos:  position{line: 985, col: 10, offset: 24408},
 								name: "Cast",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 978, col: 5, offset: 24259},
+						pos: position{line: 988, col: 5, offset: 24448},
 						run: (*parser).callonFuncExpr5,
 						expr: &labeledExpr{
-							pos:   position{line: 978, col: 5, offset: 24259},
+							pos:   position{line: 988, col: 5, offset: 24448},
 							label: "fn",
 							expr: &ruleRefExpr{
-								pos:  position{line: 978, col: 8, offset: 24262},
+								pos:  position{line: 988, col: 8, offset: 24451},
 								name: "Function",
 							},
 						},
@@ -6594,20 +6631,20 @@ var g = &grammar{
 		},
 		{
 			name: "FuncGuard",
-			pos:  position{line: 982, col: 1, offset: 24301},
+			pos:  position{line: 992, col: 1, offset: 24490},
 			expr: &seqExpr{
-				pos: position{line: 982, col: 13, offset: 24313},
+				pos: position{line: 992, col: 13, offset: 24502},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 982, col: 13, offset: 24313},
+						pos:  position{line: 992, col: 13, offset: 24502},
 						name: "NotFuncs",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 982, col: 22, offset: 24322},
+						pos:  position{line: 992, col: 22, offset: 24511},
 						name: "__",
 					},
 					&litMatcher{
-						pos:        position{line: 982, col: 25, offset: 24325},
+						pos:        position{line: 992, col: 25, offset: 24514},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
@@ -6619,18 +6656,18 @@ var g = &grammar{
 		},
 		{
 			name: "NotFuncs",
-			pos:  position{line: 984, col: 1, offset: 24330},
+			pos:  position{line: 994, col: 1, offset: 24519},
 			expr: &choiceExpr{
-				pos: position{line: 985, col: 5, offset: 24343},
+				pos: position{line: 995, col: 5, offset: 24532},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 985, col: 5, offset: 24343},
+						pos:        position{line: 995, col: 5, offset: 24532},
 						val:        "not",
 						ignoreCase: false,
 						want:       "\"not\"",
 					},
 					&litMatcher{
-						pos:        position{line: 986, col: 5, offset: 24353},
+						pos:        position{line: 996, col: 5, offset: 24542},
 						val:        "select",
 						ignoreCase: false,
 						want:       "\"select\"",
@@ -6642,58 +6679,58 @@ var g = &grammar{
 		},
 		{
 			name: "Cast",
-			pos:  position{line: 988, col: 1, offset: 24363},
+			pos:  position{line: 998, col: 1, offset: 24552},
 			expr: &actionExpr{
-				pos: position{line: 989, col: 5, offset: 24372},
+				pos: position{line: 999, col: 5, offset: 24561},
 				run: (*parser).callonCast1,
 				expr: &seqExpr{
-					pos: position{line: 989, col: 5, offset: 24372},
+					pos: position{line: 999, col: 5, offset: 24561},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 989, col: 5, offset: 24372},
+							pos:   position{line: 999, col: 5, offset: 24561},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 989, col: 9, offset: 24376},
+								pos:  position{line: 999, col: 9, offset: 24565},
 								name: "TypeLiteral",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 989, col: 21, offset: 24388},
+							pos:  position{line: 999, col: 21, offset: 24577},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 989, col: 24, offset: 24391},
+							pos:        position{line: 999, col: 24, offset: 24580},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 989, col: 28, offset: 24395},
+							pos:  position{line: 999, col: 28, offset: 24584},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 989, col: 31, offset: 24398},
+							pos:   position{line: 999, col: 31, offset: 24587},
 							label: "expr",
 							expr: &choiceExpr{
-								pos: position{line: 989, col: 37, offset: 24404},
+								pos: position{line: 999, col: 37, offset: 24593},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 989, col: 37, offset: 24404},
+										pos:  position{line: 999, col: 37, offset: 24593},
 										name: "OverExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 989, col: 48, offset: 24415},
+										pos:  position{line: 999, col: 48, offset: 24604},
 										name: "Expr",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 989, col: 54, offset: 24421},
+							pos:  position{line: 999, col: 54, offset: 24610},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 989, col: 57, offset: 24424},
+							pos:        position{line: 999, col: 57, offset: 24613},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -6706,87 +6743,87 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 993, col: 1, offset: 24549},
+			pos:  position{line: 1003, col: 1, offset: 24738},
 			expr: &choiceExpr{
-				pos: position{line: 994, col: 5, offset: 24562},
+				pos: position{line: 1004, col: 5, offset: 24751},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 994, col: 5, offset: 24562},
+						pos:  position{line: 1004, col: 5, offset: 24751},
 						name: "Grep",
 					},
 					&actionExpr{
-						pos: position{line: 996, col: 5, offset: 24649},
+						pos: position{line: 1006, col: 5, offset: 24838},
 						run: (*parser).callonFunction3,
 						expr: &seqExpr{
-							pos: position{line: 996, col: 5, offset: 24649},
+							pos: position{line: 1006, col: 5, offset: 24838},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 996, col: 5, offset: 24649},
+									pos:        position{line: 1006, col: 5, offset: 24838},
 									val:        "regexp",
 									ignoreCase: false,
 									want:       "\"regexp\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 996, col: 14, offset: 24658},
+									pos:  position{line: 1006, col: 14, offset: 24847},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 996, col: 17, offset: 24661},
+									pos:        position{line: 1006, col: 17, offset: 24850},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 996, col: 21, offset: 24665},
+									pos:  position{line: 1006, col: 21, offset: 24854},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 996, col: 24, offset: 24668},
+									pos:   position{line: 1006, col: 24, offset: 24857},
 									label: "arg0",
 									expr: &ruleRefExpr{
-										pos:  position{line: 996, col: 29, offset: 24673},
+										pos:  position{line: 1006, col: 29, offset: 24862},
 										name: "RegexpPrimitive",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 996, col: 45, offset: 24689},
+									pos:  position{line: 1006, col: 45, offset: 24878},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 996, col: 48, offset: 24692},
+									pos:        position{line: 1006, col: 48, offset: 24881},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 996, col: 52, offset: 24696},
+									pos:  position{line: 1006, col: 52, offset: 24885},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 996, col: 55, offset: 24699},
+									pos:   position{line: 1006, col: 55, offset: 24888},
 									label: "arg1",
 									expr: &ruleRefExpr{
-										pos:  position{line: 996, col: 60, offset: 24704},
+										pos:  position{line: 1006, col: 60, offset: 24893},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 996, col: 65, offset: 24709},
+									pos:  position{line: 1006, col: 65, offset: 24898},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 996, col: 68, offset: 24712},
+									pos:        position{line: 1006, col: 68, offset: 24901},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 996, col: 72, offset: 24716},
+									pos:   position{line: 1006, col: 72, offset: 24905},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 996, col: 78, offset: 24722},
+										pos: position{line: 1006, col: 78, offset: 24911},
 										expr: &ruleRefExpr{
-											pos:  position{line: 996, col: 78, offset: 24722},
+											pos:  position{line: 1006, col: 78, offset: 24911},
 											name: "WhereClause",
 										},
 									},
@@ -6795,100 +6832,100 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1000, col: 5, offset: 24877},
+						pos: position{line: 1010, col: 5, offset: 25066},
 						run: (*parser).callonFunction21,
 						expr: &seqExpr{
-							pos: position{line: 1000, col: 5, offset: 24877},
+							pos: position{line: 1010, col: 5, offset: 25066},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1000, col: 5, offset: 24877},
+									pos:        position{line: 1010, col: 5, offset: 25066},
 									val:        "regexp_replace",
 									ignoreCase: false,
 									want:       "\"regexp_replace\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1000, col: 22, offset: 24894},
+									pos:  position{line: 1010, col: 22, offset: 25083},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1000, col: 25, offset: 24897},
+									pos:        position{line: 1010, col: 25, offset: 25086},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1000, col: 29, offset: 24901},
+									pos:  position{line: 1010, col: 29, offset: 25090},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1000, col: 32, offset: 24904},
+									pos:   position{line: 1010, col: 32, offset: 25093},
 									label: "arg0",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1000, col: 37, offset: 24909},
+										pos:  position{line: 1010, col: 37, offset: 25098},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1000, col: 42, offset: 24914},
+									pos:  position{line: 1010, col: 42, offset: 25103},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1000, col: 45, offset: 24917},
+									pos:        position{line: 1010, col: 45, offset: 25106},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1000, col: 49, offset: 24921},
+									pos:  position{line: 1010, col: 49, offset: 25110},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1000, col: 52, offset: 24924},
+									pos:   position{line: 1010, col: 52, offset: 25113},
 									label: "arg1",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1000, col: 57, offset: 24929},
+										pos:  position{line: 1010, col: 57, offset: 25118},
 										name: "RegexpPrimitive",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1000, col: 73, offset: 24945},
+									pos:  position{line: 1010, col: 73, offset: 25134},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1000, col: 76, offset: 24948},
+									pos:        position{line: 1010, col: 76, offset: 25137},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1000, col: 80, offset: 24952},
+									pos:  position{line: 1010, col: 80, offset: 25141},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1000, col: 83, offset: 24955},
+									pos:   position{line: 1010, col: 83, offset: 25144},
 									label: "arg2",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1000, col: 88, offset: 24960},
+										pos:  position{line: 1010, col: 88, offset: 25149},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1000, col: 93, offset: 24965},
+									pos:  position{line: 1010, col: 93, offset: 25154},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1000, col: 96, offset: 24968},
+									pos:        position{line: 1010, col: 96, offset: 25157},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1000, col: 100, offset: 24972},
+									pos:   position{line: 1010, col: 100, offset: 25161},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1000, col: 106, offset: 24978},
+										pos: position{line: 1010, col: 106, offset: 25167},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1000, col: 106, offset: 24978},
+											pos:  position{line: 1010, col: 106, offset: 25167},
 											name: "WhereClause",
 										},
 									},
@@ -6897,65 +6934,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1004, col: 5, offset: 25147},
+						pos: position{line: 1014, col: 5, offset: 25336},
 						run: (*parser).callonFunction44,
 						expr: &seqExpr{
-							pos: position{line: 1004, col: 5, offset: 25147},
+							pos: position{line: 1014, col: 5, offset: 25336},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1004, col: 5, offset: 25147},
+									pos: position{line: 1014, col: 5, offset: 25336},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1004, col: 6, offset: 25148},
+										pos:  position{line: 1014, col: 6, offset: 25337},
 										name: "FuncGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1004, col: 16, offset: 25158},
+									pos:   position{line: 1014, col: 16, offset: 25347},
 									label: "fn",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1004, col: 19, offset: 25161},
+										pos:  position{line: 1014, col: 19, offset: 25350},
 										name: "Identifier",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1004, col: 30, offset: 25172},
+									pos:  position{line: 1014, col: 30, offset: 25361},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1004, col: 33, offset: 25175},
+									pos:        position{line: 1014, col: 33, offset: 25364},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1004, col: 37, offset: 25179},
+									pos:  position{line: 1014, col: 37, offset: 25368},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1004, col: 40, offset: 25182},
+									pos:   position{line: 1014, col: 40, offset: 25371},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1004, col: 45, offset: 25187},
+										pos:  position{line: 1014, col: 45, offset: 25376},
 										name: "FunctionArgs",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1004, col: 58, offset: 25200},
+									pos:  position{line: 1014, col: 58, offset: 25389},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1004, col: 61, offset: 25203},
+									pos:        position{line: 1014, col: 61, offset: 25392},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1004, col: 65, offset: 25207},
+									pos:   position{line: 1014, col: 65, offset: 25396},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1004, col: 71, offset: 25213},
+										pos: position{line: 1014, col: 71, offset: 25402},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1004, col: 71, offset: 25213},
+											pos:  position{line: 1014, col: 71, offset: 25402},
 											name: "WhereClause",
 										},
 									},
@@ -6970,15 +7007,15 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPrimitive",
-			pos:  position{line: 1008, col: 1, offset: 25281},
+			pos:  position{line: 1018, col: 1, offset: 25470},
 			expr: &actionExpr{
-				pos: position{line: 1009, col: 5, offset: 25301},
+				pos: position{line: 1019, col: 5, offset: 25490},
 				run: (*parser).callonRegexpPrimitive1,
 				expr: &labeledExpr{
-					pos:   position{line: 1009, col: 5, offset: 25301},
+					pos:   position{line: 1019, col: 5, offset: 25490},
 					label: "pat",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1009, col: 9, offset: 25305},
+						pos:  position{line: 1019, col: 9, offset: 25494},
 						name: "RegexpPattern",
 					},
 				},
@@ -6988,24 +7025,24 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionArgs",
-			pos:  position{line: 1011, col: 1, offset: 25376},
+			pos:  position{line: 1021, col: 1, offset: 25565},
 			expr: &choiceExpr{
-				pos: position{line: 1012, col: 5, offset: 25393},
+				pos: position{line: 1022, col: 5, offset: 25582},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1012, col: 5, offset: 25393},
+						pos: position{line: 1022, col: 5, offset: 25582},
 						run: (*parser).callonFunctionArgs2,
 						expr: &labeledExpr{
-							pos:   position{line: 1012, col: 5, offset: 25393},
+							pos:   position{line: 1022, col: 5, offset: 25582},
 							label: "o",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1012, col: 7, offset: 25395},
+								pos:  position{line: 1022, col: 7, offset: 25584},
 								name: "OverExpr",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1013, col: 5, offset: 25433},
+						pos:  position{line: 1023, col: 5, offset: 25622},
 						name: "OptionalExprs",
 					},
 				},
@@ -7015,98 +7052,98 @@ var g = &grammar{
 		},
 		{
 			name: "Grep",
-			pos:  position{line: 1015, col: 1, offset: 25448},
+			pos:  position{line: 1025, col: 1, offset: 25637},
 			expr: &actionExpr{
-				pos: position{line: 1016, col: 5, offset: 25457},
+				pos: position{line: 1026, col: 5, offset: 25646},
 				run: (*parser).callonGrep1,
 				expr: &seqExpr{
-					pos: position{line: 1016, col: 5, offset: 25457},
+					pos: position{line: 1026, col: 5, offset: 25646},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1016, col: 5, offset: 25457},
+							pos:        position{line: 1026, col: 5, offset: 25646},
 							val:        "grep",
 							ignoreCase: false,
 							want:       "\"grep\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1016, col: 12, offset: 25464},
+							pos:  position{line: 1026, col: 12, offset: 25653},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1016, col: 15, offset: 25467},
+							pos:        position{line: 1026, col: 15, offset: 25656},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1016, col: 19, offset: 25471},
+							pos:  position{line: 1026, col: 19, offset: 25660},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1016, col: 22, offset: 25474},
+							pos:   position{line: 1026, col: 22, offset: 25663},
 							label: "pattern",
 							expr: &choiceExpr{
-								pos: position{line: 1016, col: 31, offset: 25483},
+								pos: position{line: 1026, col: 31, offset: 25672},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1016, col: 31, offset: 25483},
+										pos:  position{line: 1026, col: 31, offset: 25672},
 										name: "Regexp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1016, col: 40, offset: 25492},
+										pos:  position{line: 1026, col: 40, offset: 25681},
 										name: "Glob",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1016, col: 47, offset: 25499},
+										pos:  position{line: 1026, col: 47, offset: 25688},
 										name: "Expr",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1016, col: 53, offset: 25505},
+							pos:  position{line: 1026, col: 53, offset: 25694},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1016, col: 56, offset: 25508},
+							pos:   position{line: 1026, col: 56, offset: 25697},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1016, col: 60, offset: 25512},
+								pos: position{line: 1026, col: 60, offset: 25701},
 								expr: &actionExpr{
-									pos: position{line: 1016, col: 61, offset: 25513},
+									pos: position{line: 1026, col: 61, offset: 25702},
 									run: (*parser).callonGrep15,
 									expr: &seqExpr{
-										pos: position{line: 1016, col: 61, offset: 25513},
+										pos: position{line: 1026, col: 61, offset: 25702},
 										exprs: []any{
 											&litMatcher{
-												pos:        position{line: 1016, col: 61, offset: 25513},
+												pos:        position{line: 1026, col: 61, offset: 25702},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1016, col: 65, offset: 25517},
+												pos:  position{line: 1026, col: 65, offset: 25706},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1016, col: 68, offset: 25520},
+												pos:   position{line: 1026, col: 68, offset: 25709},
 												label: "e",
 												expr: &choiceExpr{
-													pos: position{line: 1016, col: 71, offset: 25523},
+													pos: position{line: 1026, col: 71, offset: 25712},
 													alternatives: []any{
 														&ruleRefExpr{
-															pos:  position{line: 1016, col: 71, offset: 25523},
+															pos:  position{line: 1026, col: 71, offset: 25712},
 															name: "OverExpr",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 1016, col: 82, offset: 25534},
+															pos:  position{line: 1026, col: 82, offset: 25723},
 															name: "Expr",
 														},
 													},
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1016, col: 88, offset: 25540},
+												pos:  position{line: 1026, col: 88, offset: 25729},
 												name: "__",
 											},
 										},
@@ -7115,7 +7152,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1016, col: 111, offset: 25563},
+							pos:        position{line: 1026, col: 111, offset: 25752},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -7128,19 +7165,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptionalExprs",
-			pos:  position{line: 1029, col: 1, offset: 25824},
+			pos:  position{line: 1039, col: 1, offset: 26013},
 			expr: &choiceExpr{
-				pos: position{line: 1030, col: 5, offset: 25842},
+				pos: position{line: 1040, col: 5, offset: 26031},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1030, col: 5, offset: 25842},
+						pos:  position{line: 1040, col: 5, offset: 26031},
 						name: "Exprs",
 					},
 					&actionExpr{
-						pos: position{line: 1031, col: 5, offset: 25852},
+						pos: position{line: 1041, col: 5, offset: 26041},
 						run: (*parser).callonOptionalExprs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1031, col: 5, offset: 25852},
+							pos:  position{line: 1041, col: 5, offset: 26041},
 							name: "__",
 						},
 					},
@@ -7151,51 +7188,51 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 1033, col: 1, offset: 25880},
+			pos:  position{line: 1043, col: 1, offset: 26069},
 			expr: &actionExpr{
-				pos: position{line: 1034, col: 5, offset: 25890},
+				pos: position{line: 1044, col: 5, offset: 26079},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 1034, col: 5, offset: 25890},
+					pos: position{line: 1044, col: 5, offset: 26079},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1034, col: 5, offset: 25890},
+							pos:   position{line: 1044, col: 5, offset: 26079},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1034, col: 11, offset: 25896},
+								pos:  position{line: 1044, col: 11, offset: 26085},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1034, col: 16, offset: 25901},
+							pos:   position{line: 1044, col: 16, offset: 26090},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1034, col: 21, offset: 25906},
+								pos: position{line: 1044, col: 21, offset: 26095},
 								expr: &actionExpr{
-									pos: position{line: 1034, col: 22, offset: 25907},
+									pos: position{line: 1044, col: 22, offset: 26096},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 1034, col: 22, offset: 25907},
+										pos: position{line: 1044, col: 22, offset: 26096},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1034, col: 22, offset: 25907},
+												pos:  position{line: 1044, col: 22, offset: 26096},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1034, col: 25, offset: 25910},
+												pos:        position{line: 1044, col: 25, offset: 26099},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1034, col: 29, offset: 25914},
+												pos:  position{line: 1044, col: 29, offset: 26103},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1034, col: 32, offset: 25917},
+												pos:   position{line: 1044, col: 32, offset: 26106},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1034, col: 34, offset: 25919},
+													pos:  position{line: 1044, col: 34, offset: 26108},
 													name: "Expr",
 												},
 											},
@@ -7212,64 +7249,64 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 1038, col: 1, offset: 25992},
+			pos:  position{line: 1048, col: 1, offset: 26181},
 			expr: &choiceExpr{
-				pos: position{line: 1039, col: 5, offset: 26004},
+				pos: position{line: 1049, col: 5, offset: 26193},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1039, col: 5, offset: 26004},
+						pos:  position{line: 1049, col: 5, offset: 26193},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1040, col: 5, offset: 26015},
+						pos:  position{line: 1050, col: 5, offset: 26204},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1041, col: 5, offset: 26025},
+						pos:  position{line: 1051, col: 5, offset: 26214},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1042, col: 5, offset: 26033},
+						pos:  position{line: 1052, col: 5, offset: 26222},
 						name: "Map",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1043, col: 5, offset: 26041},
+						pos:  position{line: 1053, col: 5, offset: 26230},
 						name: "Literal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1044, col: 5, offset: 26053},
+						pos:  position{line: 1054, col: 5, offset: 26242},
 						name: "Identifier",
 					},
 					&actionExpr{
-						pos: position{line: 1045, col: 5, offset: 26068},
+						pos: position{line: 1055, col: 5, offset: 26257},
 						run: (*parser).callonPrimary8,
 						expr: &seqExpr{
-							pos: position{line: 1045, col: 5, offset: 26068},
+							pos: position{line: 1055, col: 5, offset: 26257},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1045, col: 5, offset: 26068},
+									pos:        position{line: 1055, col: 5, offset: 26257},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1045, col: 9, offset: 26072},
+									pos:  position{line: 1055, col: 9, offset: 26261},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1045, col: 12, offset: 26075},
+									pos:   position{line: 1055, col: 12, offset: 26264},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1045, col: 17, offset: 26080},
+										pos:  position{line: 1055, col: 17, offset: 26269},
 										name: "OverExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1045, col: 26, offset: 26089},
+									pos:  position{line: 1055, col: 26, offset: 26278},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1045, col: 29, offset: 26092},
+									pos:        position{line: 1055, col: 29, offset: 26281},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7278,35 +7315,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1046, col: 5, offset: 26121},
+						pos: position{line: 1056, col: 5, offset: 26310},
 						run: (*parser).callonPrimary16,
 						expr: &seqExpr{
-							pos: position{line: 1046, col: 5, offset: 26121},
+							pos: position{line: 1056, col: 5, offset: 26310},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1046, col: 5, offset: 26121},
+									pos:        position{line: 1056, col: 5, offset: 26310},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1046, col: 9, offset: 26125},
+									pos:  position{line: 1056, col: 9, offset: 26314},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1046, col: 12, offset: 26128},
+									pos:   position{line: 1056, col: 12, offset: 26317},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1046, col: 17, offset: 26133},
+										pos:  position{line: 1056, col: 17, offset: 26322},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1046, col: 22, offset: 26138},
+									pos:  position{line: 1056, col: 22, offset: 26327},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1046, col: 25, offset: 26141},
+									pos:        position{line: 1056, col: 25, offset: 26330},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7321,61 +7358,61 @@ var g = &grammar{
 		},
 		{
 			name: "OverExpr",
-			pos:  position{line: 1048, col: 1, offset: 26167},
+			pos:  position{line: 1058, col: 1, offset: 26356},
 			expr: &actionExpr{
-				pos: position{line: 1049, col: 5, offset: 26180},
+				pos: position{line: 1059, col: 5, offset: 26369},
 				run: (*parser).callonOverExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1049, col: 5, offset: 26180},
+					pos: position{line: 1059, col: 5, offset: 26369},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1049, col: 5, offset: 26180},
+							pos:        position{line: 1059, col: 5, offset: 26369},
 							val:        "over",
 							ignoreCase: false,
 							want:       "\"over\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1049, col: 12, offset: 26187},
+							pos:  position{line: 1059, col: 12, offset: 26376},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1049, col: 14, offset: 26189},
+							pos:   position{line: 1059, col: 14, offset: 26378},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1049, col: 20, offset: 26195},
+								pos:  position{line: 1059, col: 20, offset: 26384},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1049, col: 26, offset: 26201},
+							pos:   position{line: 1059, col: 26, offset: 26390},
 							label: "locals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1049, col: 33, offset: 26208},
+								pos: position{line: 1059, col: 33, offset: 26397},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1049, col: 33, offset: 26208},
+									pos:  position{line: 1059, col: 33, offset: 26397},
 									name: "Locals",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1049, col: 41, offset: 26216},
+							pos:  position{line: 1059, col: 41, offset: 26405},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1049, col: 44, offset: 26219},
+							pos:        position{line: 1059, col: 44, offset: 26408},
 							val:        "|",
 							ignoreCase: false,
 							want:       "\"|\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1049, col: 48, offset: 26223},
+							pos:  position{line: 1059, col: 48, offset: 26412},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1049, col: 51, offset: 26226},
+							pos:   position{line: 1059, col: 51, offset: 26415},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1049, col: 56, offset: 26231},
+								pos:  position{line: 1059, col: 56, offset: 26420},
 								name: "Seq",
 							},
 						},
@@ -7387,37 +7424,37 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 1059, col: 1, offset: 26475},
+			pos:  position{line: 1069, col: 1, offset: 26664},
 			expr: &actionExpr{
-				pos: position{line: 1060, col: 5, offset: 26486},
+				pos: position{line: 1070, col: 5, offset: 26675},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 1060, col: 5, offset: 26486},
+					pos: position{line: 1070, col: 5, offset: 26675},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1060, col: 5, offset: 26486},
+							pos:        position{line: 1070, col: 5, offset: 26675},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1060, col: 9, offset: 26490},
+							pos:  position{line: 1070, col: 9, offset: 26679},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1060, col: 12, offset: 26493},
+							pos:   position{line: 1070, col: 12, offset: 26682},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1060, col: 18, offset: 26499},
+								pos:  position{line: 1070, col: 18, offset: 26688},
 								name: "RecordElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1060, col: 30, offset: 26511},
+							pos:  position{line: 1070, col: 30, offset: 26700},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1060, col: 33, offset: 26514},
+							pos:        position{line: 1070, col: 33, offset: 26703},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -7430,31 +7467,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElems",
-			pos:  position{line: 1069, col: 1, offset: 26716},
+			pos:  position{line: 1079, col: 1, offset: 26905},
 			expr: &choiceExpr{
-				pos: position{line: 1070, col: 5, offset: 26732},
+				pos: position{line: 1080, col: 5, offset: 26921},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1070, col: 5, offset: 26732},
+						pos: position{line: 1080, col: 5, offset: 26921},
 						run: (*parser).callonRecordElems2,
 						expr: &seqExpr{
-							pos: position{line: 1070, col: 5, offset: 26732},
+							pos: position{line: 1080, col: 5, offset: 26921},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1070, col: 5, offset: 26732},
+									pos:   position{line: 1080, col: 5, offset: 26921},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1070, col: 11, offset: 26738},
+										pos:  position{line: 1080, col: 11, offset: 26927},
 										name: "RecordElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1070, col: 22, offset: 26749},
+									pos:   position{line: 1080, col: 22, offset: 26938},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1070, col: 27, offset: 26754},
+										pos: position{line: 1080, col: 27, offset: 26943},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1070, col: 27, offset: 26754},
+											pos:  position{line: 1080, col: 27, offset: 26943},
 											name: "RecordElemTail",
 										},
 									},
@@ -7463,10 +7500,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1073, col: 5, offset: 26817},
+						pos: position{line: 1083, col: 5, offset: 27006},
 						run: (*parser).callonRecordElems9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1073, col: 5, offset: 26817},
+							pos:  position{line: 1083, col: 5, offset: 27006},
 							name: "__",
 						},
 					},
@@ -7477,32 +7514,32 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElemTail",
-			pos:  position{line: 1075, col: 1, offset: 26841},
+			pos:  position{line: 1085, col: 1, offset: 27030},
 			expr: &actionExpr{
-				pos: position{line: 1075, col: 18, offset: 26858},
+				pos: position{line: 1085, col: 18, offset: 27047},
 				run: (*parser).callonRecordElemTail1,
 				expr: &seqExpr{
-					pos: position{line: 1075, col: 18, offset: 26858},
+					pos: position{line: 1085, col: 18, offset: 27047},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1075, col: 18, offset: 26858},
+							pos:  position{line: 1085, col: 18, offset: 27047},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1075, col: 21, offset: 26861},
+							pos:        position{line: 1085, col: 21, offset: 27050},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1075, col: 25, offset: 26865},
+							pos:  position{line: 1085, col: 25, offset: 27054},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1075, col: 28, offset: 26868},
+							pos:   position{line: 1085, col: 28, offset: 27057},
 							label: "elem",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1075, col: 33, offset: 26873},
+								pos:  position{line: 1085, col: 33, offset: 27062},
 								name: "RecordElem",
 							},
 						},
@@ -7514,20 +7551,20 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElem",
-			pos:  position{line: 1077, col: 1, offset: 26906},
+			pos:  position{line: 1087, col: 1, offset: 27095},
 			expr: &choiceExpr{
-				pos: position{line: 1078, col: 5, offset: 26921},
+				pos: position{line: 1088, col: 5, offset: 27110},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1078, col: 5, offset: 26921},
+						pos:  position{line: 1088, col: 5, offset: 27110},
 						name: "Spread",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1079, col: 5, offset: 26932},
+						pos:  position{line: 1089, col: 5, offset: 27121},
 						name: "Field",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1080, col: 5, offset: 26942},
+						pos:  position{line: 1090, col: 5, offset: 27131},
 						name: "Identifier",
 					},
 				},
@@ -7537,28 +7574,28 @@ var g = &grammar{
 		},
 		{
 			name: "Spread",
-			pos:  position{line: 1082, col: 1, offset: 26954},
+			pos:  position{line: 1092, col: 1, offset: 27143},
 			expr: &actionExpr{
-				pos: position{line: 1083, col: 5, offset: 26965},
+				pos: position{line: 1093, col: 5, offset: 27154},
 				run: (*parser).callonSpread1,
 				expr: &seqExpr{
-					pos: position{line: 1083, col: 5, offset: 26965},
+					pos: position{line: 1093, col: 5, offset: 27154},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1083, col: 5, offset: 26965},
+							pos:        position{line: 1093, col: 5, offset: 27154},
 							val:        "...",
 							ignoreCase: false,
 							want:       "\"...\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1083, col: 11, offset: 26971},
+							pos:  position{line: 1093, col: 11, offset: 27160},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1083, col: 14, offset: 26974},
+							pos:   position{line: 1093, col: 14, offset: 27163},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1083, col: 19, offset: 26979},
+								pos:  position{line: 1093, col: 19, offset: 27168},
 								name: "Expr",
 							},
 						},
@@ -7570,40 +7607,40 @@ var g = &grammar{
 		},
 		{
 			name: "Field",
-			pos:  position{line: 1087, col: 1, offset: 27086},
+			pos:  position{line: 1097, col: 1, offset: 27275},
 			expr: &actionExpr{
-				pos: position{line: 1088, col: 5, offset: 27096},
+				pos: position{line: 1098, col: 5, offset: 27285},
 				run: (*parser).callonField1,
 				expr: &seqExpr{
-					pos: position{line: 1088, col: 5, offset: 27096},
+					pos: position{line: 1098, col: 5, offset: 27285},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1088, col: 5, offset: 27096},
+							pos:   position{line: 1098, col: 5, offset: 27285},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1088, col: 10, offset: 27101},
+								pos:  position{line: 1098, col: 10, offset: 27290},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1088, col: 20, offset: 27111},
+							pos:  position{line: 1098, col: 20, offset: 27300},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1088, col: 23, offset: 27114},
+							pos:        position{line: 1098, col: 23, offset: 27303},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1088, col: 27, offset: 27118},
+							pos:  position{line: 1098, col: 27, offset: 27307},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1088, col: 30, offset: 27121},
+							pos:   position{line: 1098, col: 30, offset: 27310},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1088, col: 36, offset: 27127},
+								pos:  position{line: 1098, col: 36, offset: 27316},
 								name: "Expr",
 							},
 						},
@@ -7615,37 +7652,37 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 1097, col: 1, offset: 27295},
+			pos:  position{line: 1107, col: 1, offset: 27484},
 			expr: &actionExpr{
-				pos: position{line: 1098, col: 5, offset: 27305},
+				pos: position{line: 1108, col: 5, offset: 27494},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 1098, col: 5, offset: 27305},
+					pos: position{line: 1108, col: 5, offset: 27494},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1098, col: 5, offset: 27305},
+							pos:        position{line: 1108, col: 5, offset: 27494},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1098, col: 9, offset: 27309},
+							pos:  position{line: 1108, col: 9, offset: 27498},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1098, col: 12, offset: 27312},
+							pos:   position{line: 1108, col: 12, offset: 27501},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1098, col: 18, offset: 27318},
+								pos:  position{line: 1108, col: 18, offset: 27507},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1098, col: 30, offset: 27330},
+							pos:  position{line: 1108, col: 30, offset: 27519},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1098, col: 33, offset: 27333},
+							pos:        position{line: 1108, col: 33, offset: 27522},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -7658,37 +7695,37 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 1107, col: 1, offset: 27533},
+			pos:  position{line: 1117, col: 1, offset: 27722},
 			expr: &actionExpr{
-				pos: position{line: 1108, col: 5, offset: 27541},
+				pos: position{line: 1118, col: 5, offset: 27730},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 1108, col: 5, offset: 27541},
+					pos: position{line: 1118, col: 5, offset: 27730},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1108, col: 5, offset: 27541},
+							pos:        position{line: 1118, col: 5, offset: 27730},
 							val:        "|[",
 							ignoreCase: false,
 							want:       "\"|[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1108, col: 10, offset: 27546},
+							pos:  position{line: 1118, col: 10, offset: 27735},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1108, col: 13, offset: 27549},
+							pos:   position{line: 1118, col: 13, offset: 27738},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1108, col: 19, offset: 27555},
+								pos:  position{line: 1118, col: 19, offset: 27744},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1108, col: 31, offset: 27567},
+							pos:  position{line: 1118, col: 31, offset: 27756},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1108, col: 34, offset: 27570},
+							pos:        position{line: 1118, col: 34, offset: 27759},
 							val:        "]|",
 							ignoreCase: false,
 							want:       "\"]|\"",
@@ -7701,54 +7738,54 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElems",
-			pos:  position{line: 1117, col: 1, offset: 27765},
+			pos:  position{line: 1127, col: 1, offset: 27954},
 			expr: &choiceExpr{
-				pos: position{line: 1118, col: 5, offset: 27781},
+				pos: position{line: 1128, col: 5, offset: 27970},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1118, col: 5, offset: 27781},
+						pos: position{line: 1128, col: 5, offset: 27970},
 						run: (*parser).callonVectorElems2,
 						expr: &seqExpr{
-							pos: position{line: 1118, col: 5, offset: 27781},
+							pos: position{line: 1128, col: 5, offset: 27970},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1118, col: 5, offset: 27781},
+									pos:   position{line: 1128, col: 5, offset: 27970},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1118, col: 11, offset: 27787},
+										pos:  position{line: 1128, col: 11, offset: 27976},
 										name: "VectorElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1118, col: 22, offset: 27798},
+									pos:   position{line: 1128, col: 22, offset: 27987},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1118, col: 27, offset: 27803},
+										pos: position{line: 1128, col: 27, offset: 27992},
 										expr: &actionExpr{
-											pos: position{line: 1118, col: 28, offset: 27804},
+											pos: position{line: 1128, col: 28, offset: 27993},
 											run: (*parser).callonVectorElems8,
 											expr: &seqExpr{
-												pos: position{line: 1118, col: 28, offset: 27804},
+												pos: position{line: 1128, col: 28, offset: 27993},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1118, col: 28, offset: 27804},
+														pos:  position{line: 1128, col: 28, offset: 27993},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 1118, col: 31, offset: 27807},
+														pos:        position{line: 1128, col: 31, offset: 27996},
 														val:        ",",
 														ignoreCase: false,
 														want:       "\",\"",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1118, col: 35, offset: 27811},
+														pos:  position{line: 1128, col: 35, offset: 28000},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 1118, col: 38, offset: 27814},
+														pos:   position{line: 1128, col: 38, offset: 28003},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1118, col: 40, offset: 27816},
+															pos:  position{line: 1128, col: 40, offset: 28005},
 															name: "VectorElem",
 														},
 													},
@@ -7761,10 +7798,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1121, col: 5, offset: 27898},
+						pos: position{line: 1131, col: 5, offset: 28087},
 						run: (*parser).callonVectorElems15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1121, col: 5, offset: 27898},
+							pos:  position{line: 1131, col: 5, offset: 28087},
 							name: "__",
 						},
 					},
@@ -7775,22 +7812,22 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElem",
-			pos:  position{line: 1123, col: 1, offset: 27922},
+			pos:  position{line: 1133, col: 1, offset: 28111},
 			expr: &choiceExpr{
-				pos: position{line: 1124, col: 5, offset: 27937},
+				pos: position{line: 1134, col: 5, offset: 28126},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1124, col: 5, offset: 27937},
+						pos:  position{line: 1134, col: 5, offset: 28126},
 						name: "Spread",
 					},
 					&actionExpr{
-						pos: position{line: 1125, col: 5, offset: 27948},
+						pos: position{line: 1135, col: 5, offset: 28137},
 						run: (*parser).callonVectorElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1125, col: 5, offset: 27948},
+							pos:   position{line: 1135, col: 5, offset: 28137},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1125, col: 7, offset: 27950},
+								pos:  position{line: 1135, col: 7, offset: 28139},
 								name: "Expr",
 							},
 						},
@@ -7802,37 +7839,37 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 1127, col: 1, offset: 28030},
+			pos:  position{line: 1137, col: 1, offset: 28219},
 			expr: &actionExpr{
-				pos: position{line: 1128, col: 5, offset: 28038},
+				pos: position{line: 1138, col: 5, offset: 28227},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 1128, col: 5, offset: 28038},
+					pos: position{line: 1138, col: 5, offset: 28227},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1128, col: 5, offset: 28038},
+							pos:        position{line: 1138, col: 5, offset: 28227},
 							val:        "|{",
 							ignoreCase: false,
 							want:       "\"|{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1128, col: 10, offset: 28043},
+							pos:  position{line: 1138, col: 10, offset: 28232},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1128, col: 13, offset: 28046},
+							pos:   position{line: 1138, col: 13, offset: 28235},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1128, col: 19, offset: 28052},
+								pos:  position{line: 1138, col: 19, offset: 28241},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1128, col: 27, offset: 28060},
+							pos:  position{line: 1138, col: 27, offset: 28249},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1128, col: 30, offset: 28063},
+							pos:        position{line: 1138, col: 30, offset: 28252},
 							val:        "}|",
 							ignoreCase: false,
 							want:       "\"}|\"",
@@ -7845,31 +7882,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 1137, col: 1, offset: 28259},
+			pos:  position{line: 1147, col: 1, offset: 28448},
 			expr: &choiceExpr{
-				pos: position{line: 1138, col: 5, offset: 28271},
+				pos: position{line: 1148, col: 5, offset: 28460},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1138, col: 5, offset: 28271},
+						pos: position{line: 1148, col: 5, offset: 28460},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 1138, col: 5, offset: 28271},
+							pos: position{line: 1148, col: 5, offset: 28460},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1138, col: 5, offset: 28271},
+									pos:   position{line: 1148, col: 5, offset: 28460},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1138, col: 11, offset: 28277},
+										pos:  position{line: 1148, col: 11, offset: 28466},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1138, col: 17, offset: 28283},
+									pos:   position{line: 1148, col: 17, offset: 28472},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1138, col: 22, offset: 28288},
+										pos: position{line: 1148, col: 22, offset: 28477},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1138, col: 22, offset: 28288},
+											pos:  position{line: 1148, col: 22, offset: 28477},
 											name: "EntryTail",
 										},
 									},
@@ -7878,10 +7915,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1141, col: 5, offset: 28346},
+						pos: position{line: 1151, col: 5, offset: 28535},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1141, col: 5, offset: 28346},
+							pos:  position{line: 1151, col: 5, offset: 28535},
 							name: "__",
 						},
 					},
@@ -7892,32 +7929,32 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 1144, col: 1, offset: 28371},
+			pos:  position{line: 1154, col: 1, offset: 28560},
 			expr: &actionExpr{
-				pos: position{line: 1144, col: 13, offset: 28383},
+				pos: position{line: 1154, col: 13, offset: 28572},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 1144, col: 13, offset: 28383},
+					pos: position{line: 1154, col: 13, offset: 28572},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1144, col: 13, offset: 28383},
+							pos:  position{line: 1154, col: 13, offset: 28572},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1144, col: 16, offset: 28386},
+							pos:        position{line: 1154, col: 16, offset: 28575},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1144, col: 20, offset: 28390},
+							pos:  position{line: 1154, col: 20, offset: 28579},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1144, col: 23, offset: 28393},
+							pos:   position{line: 1154, col: 23, offset: 28582},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1144, col: 25, offset: 28395},
+								pos:  position{line: 1154, col: 25, offset: 28584},
 								name: "Entry",
 							},
 						},
@@ -7929,40 +7966,40 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 1146, col: 1, offset: 28420},
+			pos:  position{line: 1156, col: 1, offset: 28609},
 			expr: &actionExpr{
-				pos: position{line: 1147, col: 5, offset: 28430},
+				pos: position{line: 1157, col: 5, offset: 28619},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 1147, col: 5, offset: 28430},
+					pos: position{line: 1157, col: 5, offset: 28619},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1147, col: 5, offset: 28430},
+							pos:   position{line: 1157, col: 5, offset: 28619},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1147, col: 9, offset: 28434},
+								pos:  position{line: 1157, col: 9, offset: 28623},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1147, col: 14, offset: 28439},
+							pos:  position{line: 1157, col: 14, offset: 28628},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1147, col: 17, offset: 28442},
+							pos:        position{line: 1157, col: 17, offset: 28631},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1147, col: 21, offset: 28446},
+							pos:  position{line: 1157, col: 21, offset: 28635},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1147, col: 24, offset: 28449},
+							pos:   position{line: 1157, col: 24, offset: 28638},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1147, col: 30, offset: 28455},
+								pos:  position{line: 1157, col: 30, offset: 28644},
 								name: "Expr",
 							},
 						},
@@ -7974,56 +8011,56 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 1153, col: 1, offset: 28569},
+			pos:  position{line: 1163, col: 1, offset: 28758},
 			expr: &choiceExpr{
-				pos: position{line: 1154, col: 5, offset: 28581},
+				pos: position{line: 1164, col: 5, offset: 28770},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1154, col: 5, offset: 28581},
+						pos:  position{line: 1164, col: 5, offset: 28770},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1155, col: 5, offset: 28597},
+						pos:  position{line: 1165, col: 5, offset: 28786},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1156, col: 5, offset: 28615},
+						pos:  position{line: 1166, col: 5, offset: 28804},
 						name: "FString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1157, col: 5, offset: 28627},
+						pos:  position{line: 1167, col: 5, offset: 28816},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1158, col: 5, offset: 28645},
+						pos:  position{line: 1168, col: 5, offset: 28834},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1159, col: 5, offset: 28664},
+						pos:  position{line: 1169, col: 5, offset: 28853},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1160, col: 5, offset: 28681},
+						pos:  position{line: 1170, col: 5, offset: 28870},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1161, col: 5, offset: 28694},
+						pos:  position{line: 1171, col: 5, offset: 28883},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1162, col: 5, offset: 28703},
+						pos:  position{line: 1172, col: 5, offset: 28892},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1163, col: 5, offset: 28720},
+						pos:  position{line: 1173, col: 5, offset: 28909},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1164, col: 5, offset: 28739},
+						pos:  position{line: 1174, col: 5, offset: 28928},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1165, col: 5, offset: 28758},
+						pos:  position{line: 1175, col: 5, offset: 28947},
 						name: "NullLiteral",
 					},
 				},
@@ -8033,28 +8070,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 1167, col: 1, offset: 28771},
+			pos:  position{line: 1177, col: 1, offset: 28960},
 			expr: &choiceExpr{
-				pos: position{line: 1168, col: 5, offset: 28789},
+				pos: position{line: 1178, col: 5, offset: 28978},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1168, col: 5, offset: 28789},
+						pos: position{line: 1178, col: 5, offset: 28978},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1168, col: 5, offset: 28789},
+							pos: position{line: 1178, col: 5, offset: 28978},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1168, col: 5, offset: 28789},
+									pos:   position{line: 1178, col: 5, offset: 28978},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1168, col: 7, offset: 28791},
+										pos:  position{line: 1178, col: 7, offset: 28980},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1168, col: 14, offset: 28798},
+									pos: position{line: 1178, col: 14, offset: 28987},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1168, col: 15, offset: 28799},
+										pos:  position{line: 1178, col: 15, offset: 28988},
 										name: "IdentifierRest",
 									},
 								},
@@ -8062,13 +8099,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1171, col: 5, offset: 28879},
+						pos: position{line: 1181, col: 5, offset: 29068},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1171, col: 5, offset: 28879},
+							pos:   position{line: 1181, col: 5, offset: 29068},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1171, col: 7, offset: 28881},
+								pos:  position{line: 1181, col: 7, offset: 29070},
 								name: "IP4Net",
 							},
 						},
@@ -8080,28 +8117,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 1175, col: 1, offset: 28950},
+			pos:  position{line: 1185, col: 1, offset: 29139},
 			expr: &choiceExpr{
-				pos: position{line: 1176, col: 5, offset: 28969},
+				pos: position{line: 1186, col: 5, offset: 29158},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1176, col: 5, offset: 28969},
+						pos: position{line: 1186, col: 5, offset: 29158},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1176, col: 5, offset: 28969},
+							pos: position{line: 1186, col: 5, offset: 29158},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1176, col: 5, offset: 28969},
+									pos:   position{line: 1186, col: 5, offset: 29158},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1176, col: 7, offset: 28971},
+										pos:  position{line: 1186, col: 7, offset: 29160},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1176, col: 11, offset: 28975},
+									pos: position{line: 1186, col: 11, offset: 29164},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1176, col: 12, offset: 28976},
+										pos:  position{line: 1186, col: 12, offset: 29165},
 										name: "IdentifierRest",
 									},
 								},
@@ -8109,13 +8146,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1179, col: 5, offset: 29055},
+						pos: position{line: 1189, col: 5, offset: 29244},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1179, col: 5, offset: 29055},
+							pos:   position{line: 1189, col: 5, offset: 29244},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1179, col: 7, offset: 29057},
+								pos:  position{line: 1189, col: 7, offset: 29246},
 								name: "IP",
 							},
 						},
@@ -8127,15 +8164,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 1183, col: 1, offset: 29121},
+			pos:  position{line: 1193, col: 1, offset: 29310},
 			expr: &actionExpr{
-				pos: position{line: 1184, col: 5, offset: 29138},
+				pos: position{line: 1194, col: 5, offset: 29327},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1184, col: 5, offset: 29138},
+					pos:   position{line: 1194, col: 5, offset: 29327},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1184, col: 7, offset: 29140},
+						pos:  position{line: 1194, col: 7, offset: 29329},
 						name: "FloatString",
 					},
 				},
@@ -8145,15 +8182,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 1188, col: 1, offset: 29218},
+			pos:  position{line: 1198, col: 1, offset: 29407},
 			expr: &actionExpr{
-				pos: position{line: 1189, col: 5, offset: 29237},
+				pos: position{line: 1199, col: 5, offset: 29426},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1189, col: 5, offset: 29237},
+					pos:   position{line: 1199, col: 5, offset: 29426},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1189, col: 7, offset: 29239},
+						pos:  position{line: 1199, col: 7, offset: 29428},
 						name: "IntString",
 					},
 				},
@@ -8163,23 +8200,23 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 1193, col: 1, offset: 29313},
+			pos:  position{line: 1203, col: 1, offset: 29502},
 			expr: &choiceExpr{
-				pos: position{line: 1194, col: 5, offset: 29332},
+				pos: position{line: 1204, col: 5, offset: 29521},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1194, col: 5, offset: 29332},
+						pos: position{line: 1204, col: 5, offset: 29521},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1194, col: 5, offset: 29332},
+							pos:  position{line: 1204, col: 5, offset: 29521},
 							name: "TrueToken",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1195, col: 5, offset: 29395},
+						pos: position{line: 1205, col: 5, offset: 29584},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1195, col: 5, offset: 29395},
+							pos:  position{line: 1205, col: 5, offset: 29584},
 							name: "FalseToken",
 						},
 					},
@@ -8190,12 +8227,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 1197, col: 1, offset: 29456},
+			pos:  position{line: 1207, col: 1, offset: 29645},
 			expr: &actionExpr{
-				pos: position{line: 1198, col: 5, offset: 29472},
+				pos: position{line: 1208, col: 5, offset: 29661},
 				run: (*parser).callonNullLiteral1,
 				expr: &ruleRefExpr{
-					pos:  position{line: 1198, col: 5, offset: 29472},
+					pos:  position{line: 1208, col: 5, offset: 29661},
 					name: "NullToken",
 				},
 			},
@@ -8204,23 +8241,23 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 1200, col: 1, offset: 29527},
+			pos:  position{line: 1210, col: 1, offset: 29716},
 			expr: &actionExpr{
-				pos: position{line: 1201, col: 5, offset: 29544},
+				pos: position{line: 1211, col: 5, offset: 29733},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1201, col: 5, offset: 29544},
+					pos: position{line: 1211, col: 5, offset: 29733},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1201, col: 5, offset: 29544},
+							pos:        position{line: 1211, col: 5, offset: 29733},
 							val:        "0x",
 							ignoreCase: false,
 							want:       "\"0x\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1201, col: 10, offset: 29549},
+							pos: position{line: 1211, col: 10, offset: 29738},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1201, col: 10, offset: 29549},
+								pos:  position{line: 1211, col: 10, offset: 29738},
 								name: "HexDigit",
 							},
 						},
@@ -8232,29 +8269,29 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 1205, col: 1, offset: 29623},
+			pos:  position{line: 1215, col: 1, offset: 29812},
 			expr: &actionExpr{
-				pos: position{line: 1206, col: 5, offset: 29639},
+				pos: position{line: 1216, col: 5, offset: 29828},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1206, col: 5, offset: 29639},
+					pos: position{line: 1216, col: 5, offset: 29828},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1206, col: 5, offset: 29639},
+							pos:        position{line: 1216, col: 5, offset: 29828},
 							val:        "<",
 							ignoreCase: false,
 							want:       "\"<\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1206, col: 9, offset: 29643},
+							pos:   position{line: 1216, col: 9, offset: 29832},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1206, col: 13, offset: 29647},
+								pos:  position{line: 1216, col: 13, offset: 29836},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1206, col: 18, offset: 29652},
+							pos:        position{line: 1216, col: 18, offset: 29841},
 							val:        ">",
 							ignoreCase: false,
 							want:       "\">\"",
@@ -8267,16 +8304,16 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1215, col: 1, offset: 29833},
+			pos:  position{line: 1225, col: 1, offset: 30022},
 			expr: &choiceExpr{
-				pos: position{line: 1216, col: 5, offset: 29842},
+				pos: position{line: 1226, col: 5, offset: 30031},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1216, col: 5, offset: 29842},
+						pos:  position{line: 1226, col: 5, offset: 30031},
 						name: "AmbiguousType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1217, col: 5, offset: 29860},
+						pos:  position{line: 1227, col: 5, offset: 30049},
 						name: "ComplexType",
 					},
 				},
@@ -8286,28 +8323,28 @@ var g = &grammar{
 		},
 		{
 			name: "AmbiguousType",
-			pos:  position{line: 1219, col: 1, offset: 29873},
+			pos:  position{line: 1229, col: 1, offset: 30062},
 			expr: &choiceExpr{
-				pos: position{line: 1220, col: 5, offset: 29891},
+				pos: position{line: 1230, col: 5, offset: 30080},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1220, col: 5, offset: 29891},
+						pos: position{line: 1230, col: 5, offset: 30080},
 						run: (*parser).callonAmbiguousType2,
 						expr: &seqExpr{
-							pos: position{line: 1220, col: 5, offset: 29891},
+							pos: position{line: 1230, col: 5, offset: 30080},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1220, col: 5, offset: 29891},
+									pos:   position{line: 1230, col: 5, offset: 30080},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1220, col: 10, offset: 29896},
+										pos:  position{line: 1230, col: 10, offset: 30085},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1220, col: 24, offset: 29910},
+									pos: position{line: 1230, col: 24, offset: 30099},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1220, col: 25, offset: 29911},
+										pos:  position{line: 1230, col: 25, offset: 30100},
 										name: "IdentifierRest",
 									},
 								},
@@ -8315,45 +8352,45 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1221, col: 5, offset: 29951},
+						pos: position{line: 1231, col: 5, offset: 30140},
 						run: (*parser).callonAmbiguousType8,
 						expr: &seqExpr{
-							pos: position{line: 1221, col: 5, offset: 29951},
+							pos: position{line: 1231, col: 5, offset: 30140},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1221, col: 5, offset: 29951},
+									pos:        position{line: 1231, col: 5, offset: 30140},
 									val:        "error",
 									ignoreCase: false,
 									want:       "\"error\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1221, col: 13, offset: 29959},
+									pos:  position{line: 1231, col: 13, offset: 30148},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1221, col: 16, offset: 29962},
+									pos:        position{line: 1231, col: 16, offset: 30151},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1221, col: 20, offset: 29966},
+									pos:  position{line: 1231, col: 20, offset: 30155},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1221, col: 23, offset: 29969},
+									pos:   position{line: 1231, col: 23, offset: 30158},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1221, col: 25, offset: 29971},
+										pos:  position{line: 1231, col: 25, offset: 30160},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1221, col: 30, offset: 29976},
+									pos:  position{line: 1231, col: 30, offset: 30165},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1221, col: 33, offset: 29979},
+									pos:        position{line: 1231, col: 33, offset: 30168},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -8362,52 +8399,52 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1229, col: 5, offset: 30173},
+						pos: position{line: 1239, col: 5, offset: 30362},
 						run: (*parser).callonAmbiguousType18,
 						expr: &seqExpr{
-							pos: position{line: 1229, col: 5, offset: 30173},
+							pos: position{line: 1239, col: 5, offset: 30362},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1229, col: 5, offset: 30173},
+									pos:   position{line: 1239, col: 5, offset: 30362},
 									label: "name",
 									expr: &choiceExpr{
-										pos: position{line: 1229, col: 11, offset: 30179},
+										pos: position{line: 1239, col: 11, offset: 30368},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1229, col: 11, offset: 30179},
+												pos:  position{line: 1239, col: 11, offset: 30368},
 												name: "IdentifierName",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1229, col: 28, offset: 30196},
+												pos:  position{line: 1239, col: 28, offset: 30385},
 												name: "QuotedString",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1229, col: 42, offset: 30210},
+									pos:   position{line: 1239, col: 42, offset: 30399},
 									label: "opt",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1229, col: 46, offset: 30214},
+										pos: position{line: 1239, col: 46, offset: 30403},
 										expr: &seqExpr{
-											pos: position{line: 1229, col: 47, offset: 30215},
+											pos: position{line: 1239, col: 47, offset: 30404},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1229, col: 47, offset: 30215},
+													pos:  position{line: 1239, col: 47, offset: 30404},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1229, col: 50, offset: 30218},
+													pos:        position{line: 1239, col: 50, offset: 30407},
 													val:        "=",
 													ignoreCase: false,
 													want:       "\"=\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1229, col: 54, offset: 30222},
+													pos:  position{line: 1239, col: 54, offset: 30411},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1229, col: 57, offset: 30225},
+													pos:  position{line: 1239, col: 57, offset: 30414},
 													name: "Type",
 												},
 											},
@@ -8418,31 +8455,31 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1240, col: 5, offset: 30563},
+						pos: position{line: 1250, col: 5, offset: 30752},
 						run: (*parser).callonAmbiguousType31,
 						expr: &seqExpr{
-							pos: position{line: 1240, col: 5, offset: 30563},
+							pos: position{line: 1250, col: 5, offset: 30752},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1240, col: 5, offset: 30563},
+									pos:        position{line: 1250, col: 5, offset: 30752},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1240, col: 9, offset: 30567},
+									pos:  position{line: 1250, col: 9, offset: 30756},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1240, col: 12, offset: 30570},
+									pos:   position{line: 1250, col: 12, offset: 30759},
 									label: "types",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1240, col: 18, offset: 30576},
+										pos:  position{line: 1250, col: 18, offset: 30765},
 										name: "TypeList",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1240, col: 27, offset: 30585},
+									pos:        position{line: 1250, col: 27, offset: 30774},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -8457,28 +8494,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1249, col: 1, offset: 30777},
+			pos:  position{line: 1259, col: 1, offset: 30966},
 			expr: &actionExpr{
-				pos: position{line: 1250, col: 5, offset: 30790},
+				pos: position{line: 1260, col: 5, offset: 30979},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1250, col: 5, offset: 30790},
+					pos: position{line: 1260, col: 5, offset: 30979},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1250, col: 5, offset: 30790},
+							pos:   position{line: 1260, col: 5, offset: 30979},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1250, col: 11, offset: 30796},
+								pos:  position{line: 1260, col: 11, offset: 30985},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1250, col: 16, offset: 30801},
+							pos:   position{line: 1260, col: 16, offset: 30990},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1250, col: 21, offset: 30806},
+								pos: position{line: 1260, col: 21, offset: 30995},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1250, col: 21, offset: 30806},
+									pos:  position{line: 1260, col: 21, offset: 30995},
 									name: "TypeListTail",
 								},
 							},
@@ -8491,32 +8528,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1254, col: 1, offset: 30864},
+			pos:  position{line: 1264, col: 1, offset: 31053},
 			expr: &actionExpr{
-				pos: position{line: 1254, col: 16, offset: 30879},
+				pos: position{line: 1264, col: 16, offset: 31068},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1254, col: 16, offset: 30879},
+					pos: position{line: 1264, col: 16, offset: 31068},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1254, col: 16, offset: 30879},
+							pos:  position{line: 1264, col: 16, offset: 31068},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1254, col: 19, offset: 30882},
+							pos:        position{line: 1264, col: 19, offset: 31071},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1254, col: 23, offset: 30886},
+							pos:  position{line: 1264, col: 23, offset: 31075},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1254, col: 26, offset: 30889},
+							pos:   position{line: 1264, col: 26, offset: 31078},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1254, col: 30, offset: 30893},
+								pos:  position{line: 1264, col: 30, offset: 31082},
 								name: "Type",
 							},
 						},
@@ -8528,40 +8565,40 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 1256, col: 1, offset: 30919},
+			pos:  position{line: 1266, col: 1, offset: 31108},
 			expr: &choiceExpr{
-				pos: position{line: 1257, col: 5, offset: 30935},
+				pos: position{line: 1267, col: 5, offset: 31124},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1257, col: 5, offset: 30935},
+						pos: position{line: 1267, col: 5, offset: 31124},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 1257, col: 5, offset: 30935},
+							pos: position{line: 1267, col: 5, offset: 31124},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1257, col: 5, offset: 30935},
+									pos:        position{line: 1267, col: 5, offset: 31124},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1257, col: 9, offset: 30939},
+									pos:  position{line: 1267, col: 9, offset: 31128},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1257, col: 12, offset: 30942},
+									pos:   position{line: 1267, col: 12, offset: 31131},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1257, col: 19, offset: 30949},
+										pos:  position{line: 1267, col: 19, offset: 31138},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1257, col: 33, offset: 30963},
+									pos:  position{line: 1267, col: 33, offset: 31152},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1257, col: 36, offset: 30966},
+									pos:        position{line: 1267, col: 36, offset: 31155},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -8570,35 +8607,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1265, col: 5, offset: 31178},
+						pos: position{line: 1275, col: 5, offset: 31367},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 1265, col: 5, offset: 31178},
+							pos: position{line: 1275, col: 5, offset: 31367},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1265, col: 5, offset: 31178},
+									pos:        position{line: 1275, col: 5, offset: 31367},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1265, col: 9, offset: 31182},
+									pos:  position{line: 1275, col: 9, offset: 31371},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1265, col: 12, offset: 31185},
+									pos:   position{line: 1275, col: 12, offset: 31374},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1265, col: 16, offset: 31189},
+										pos:  position{line: 1275, col: 16, offset: 31378},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1265, col: 21, offset: 31194},
+									pos:  position{line: 1275, col: 21, offset: 31383},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1265, col: 24, offset: 31197},
+									pos:        position{line: 1275, col: 24, offset: 31386},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -8607,35 +8644,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1273, col: 5, offset: 31389},
+						pos: position{line: 1283, col: 5, offset: 31578},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 1273, col: 5, offset: 31389},
+							pos: position{line: 1283, col: 5, offset: 31578},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1273, col: 5, offset: 31389},
+									pos:        position{line: 1283, col: 5, offset: 31578},
 									val:        "|[",
 									ignoreCase: false,
 									want:       "\"|[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1273, col: 10, offset: 31394},
+									pos:  position{line: 1283, col: 10, offset: 31583},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1273, col: 13, offset: 31397},
+									pos:   position{line: 1283, col: 13, offset: 31586},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1273, col: 17, offset: 31401},
+										pos:  position{line: 1283, col: 17, offset: 31590},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1273, col: 22, offset: 31406},
+									pos:  position{line: 1283, col: 22, offset: 31595},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1273, col: 25, offset: 31409},
+									pos:        position{line: 1283, col: 25, offset: 31598},
 									val:        "]|",
 									ignoreCase: false,
 									want:       "\"]|\"",
@@ -8644,57 +8681,57 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1281, col: 5, offset: 31596},
+						pos: position{line: 1291, col: 5, offset: 31785},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 1281, col: 5, offset: 31596},
+							pos: position{line: 1291, col: 5, offset: 31785},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1281, col: 5, offset: 31596},
+									pos:        position{line: 1291, col: 5, offset: 31785},
 									val:        "|{",
 									ignoreCase: false,
 									want:       "\"|{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1281, col: 10, offset: 31601},
+									pos:  position{line: 1291, col: 10, offset: 31790},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1281, col: 13, offset: 31604},
+									pos:   position{line: 1291, col: 13, offset: 31793},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1281, col: 21, offset: 31612},
+										pos:  position{line: 1291, col: 21, offset: 31801},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1281, col: 26, offset: 31617},
+									pos:  position{line: 1291, col: 26, offset: 31806},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1281, col: 29, offset: 31620},
+									pos:        position{line: 1291, col: 29, offset: 31809},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1281, col: 33, offset: 31624},
+									pos:  position{line: 1291, col: 33, offset: 31813},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1281, col: 36, offset: 31627},
+									pos:   position{line: 1291, col: 36, offset: 31816},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1281, col: 44, offset: 31635},
+										pos:  position{line: 1291, col: 44, offset: 31824},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1281, col: 49, offset: 31640},
+									pos:  position{line: 1291, col: 49, offset: 31829},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1281, col: 52, offset: 31643},
+									pos:        position{line: 1291, col: 52, offset: 31832},
 									val:        "}|",
 									ignoreCase: false,
 									want:       "\"}|\"",
@@ -8709,35 +8746,35 @@ var g = &grammar{
 		},
 		{
 			name: "StringLiteral",
-			pos:  position{line: 1291, col: 1, offset: 31866},
+			pos:  position{line: 1301, col: 1, offset: 32055},
 			expr: &choiceExpr{
-				pos: position{line: 1292, col: 5, offset: 31884},
+				pos: position{line: 1302, col: 5, offset: 32073},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1292, col: 5, offset: 31884},
+						pos: position{line: 1302, col: 5, offset: 32073},
 						run: (*parser).callonStringLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1292, col: 5, offset: 31884},
+							pos: position{line: 1302, col: 5, offset: 32073},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1292, col: 5, offset: 31884},
+									pos:        position{line: 1302, col: 5, offset: 32073},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1292, col: 9, offset: 31888},
+									pos:   position{line: 1302, col: 9, offset: 32077},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1292, col: 11, offset: 31890},
+										pos: position{line: 1302, col: 11, offset: 32079},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1292, col: 11, offset: 31890},
+											pos:  position{line: 1302, col: 11, offset: 32079},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1292, col: 29, offset: 31908},
+									pos:        position{line: 1302, col: 29, offset: 32097},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -8746,30 +8783,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1293, col: 5, offset: 31972},
+						pos: position{line: 1303, col: 5, offset: 32161},
 						run: (*parser).callonStringLiteral9,
 						expr: &seqExpr{
-							pos: position{line: 1293, col: 5, offset: 31972},
+							pos: position{line: 1303, col: 5, offset: 32161},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1293, col: 5, offset: 31972},
+									pos:        position{line: 1303, col: 5, offset: 32161},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1293, col: 9, offset: 31976},
+									pos:   position{line: 1303, col: 9, offset: 32165},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1293, col: 11, offset: 31978},
+										pos: position{line: 1303, col: 11, offset: 32167},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1293, col: 11, offset: 31978},
+											pos:  position{line: 1303, col: 11, offset: 32167},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1293, col: 29, offset: 31996},
+									pos:        position{line: 1303, col: 29, offset: 32185},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -8784,35 +8821,35 @@ var g = &grammar{
 		},
 		{
 			name: "FString",
-			pos:  position{line: 1295, col: 1, offset: 32057},
+			pos:  position{line: 1305, col: 1, offset: 32246},
 			expr: &choiceExpr{
-				pos: position{line: 1296, col: 5, offset: 32069},
+				pos: position{line: 1306, col: 5, offset: 32258},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1296, col: 5, offset: 32069},
+						pos: position{line: 1306, col: 5, offset: 32258},
 						run: (*parser).callonFString2,
 						expr: &seqExpr{
-							pos: position{line: 1296, col: 5, offset: 32069},
+							pos: position{line: 1306, col: 5, offset: 32258},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1296, col: 5, offset: 32069},
+									pos:        position{line: 1306, col: 5, offset: 32258},
 									val:        "f\"",
 									ignoreCase: false,
 									want:       "\"f\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1296, col: 11, offset: 32075},
+									pos:   position{line: 1306, col: 11, offset: 32264},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1296, col: 13, offset: 32077},
+										pos: position{line: 1306, col: 13, offset: 32266},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1296, col: 13, offset: 32077},
+											pos:  position{line: 1306, col: 13, offset: 32266},
 											name: "FStringDoubleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1296, col: 38, offset: 32102},
+									pos:        position{line: 1306, col: 38, offset: 32291},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -8821,30 +8858,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1303, col: 5, offset: 32259},
+						pos: position{line: 1313, col: 5, offset: 32448},
 						run: (*parser).callonFString9,
 						expr: &seqExpr{
-							pos: position{line: 1303, col: 5, offset: 32259},
+							pos: position{line: 1313, col: 5, offset: 32448},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1303, col: 5, offset: 32259},
+									pos:        position{line: 1313, col: 5, offset: 32448},
 									val:        "f'",
 									ignoreCase: false,
 									want:       "\"f'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1303, col: 10, offset: 32264},
+									pos:   position{line: 1313, col: 10, offset: 32453},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1303, col: 12, offset: 32266},
+										pos: position{line: 1313, col: 12, offset: 32455},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1303, col: 12, offset: 32266},
+											pos:  position{line: 1313, col: 12, offset: 32455},
 											name: "FStringSingleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1303, col: 37, offset: 32291},
+									pos:        position{line: 1313, col: 37, offset: 32480},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -8859,24 +8896,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedElem",
-			pos:  position{line: 1311, col: 1, offset: 32445},
+			pos:  position{line: 1321, col: 1, offset: 32634},
 			expr: &choiceExpr{
-				pos: position{line: 1312, col: 5, offset: 32473},
+				pos: position{line: 1322, col: 5, offset: 32662},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1312, col: 5, offset: 32473},
+						pos:  position{line: 1322, col: 5, offset: 32662},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1313, col: 5, offset: 32489},
+						pos: position{line: 1323, col: 5, offset: 32678},
 						run: (*parser).callonFStringDoubleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1313, col: 5, offset: 32489},
+							pos:   position{line: 1323, col: 5, offset: 32678},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1313, col: 7, offset: 32491},
+								pos: position{line: 1323, col: 7, offset: 32680},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1313, col: 7, offset: 32491},
+									pos:  position{line: 1323, col: 7, offset: 32680},
 									name: "FStringDoubleQuotedChar",
 								},
 							},
@@ -8889,27 +8926,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedChar",
-			pos:  position{line: 1317, col: 1, offset: 32624},
+			pos:  position{line: 1327, col: 1, offset: 32813},
 			expr: &choiceExpr{
-				pos: position{line: 1318, col: 5, offset: 32652},
+				pos: position{line: 1328, col: 5, offset: 32841},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1318, col: 5, offset: 32652},
+						pos: position{line: 1328, col: 5, offset: 32841},
 						run: (*parser).callonFStringDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1318, col: 5, offset: 32652},
+							pos: position{line: 1328, col: 5, offset: 32841},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1318, col: 5, offset: 32652},
+									pos:        position{line: 1328, col: 5, offset: 32841},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1318, col: 10, offset: 32657},
+									pos:   position{line: 1328, col: 10, offset: 32846},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1318, col: 12, offset: 32659},
+										pos:        position{line: 1328, col: 12, offset: 32848},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -8919,25 +8956,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1319, col: 5, offset: 32685},
+						pos: position{line: 1329, col: 5, offset: 32874},
 						run: (*parser).callonFStringDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1319, col: 5, offset: 32685},
+							pos: position{line: 1329, col: 5, offset: 32874},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1319, col: 5, offset: 32685},
+									pos: position{line: 1329, col: 5, offset: 32874},
 									expr: &litMatcher{
-										pos:        position{line: 1319, col: 7, offset: 32687},
+										pos:        position{line: 1329, col: 7, offset: 32876},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1319, col: 12, offset: 32692},
+									pos:   position{line: 1329, col: 12, offset: 32881},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1319, col: 14, offset: 32694},
+										pos:  position{line: 1329, col: 14, offset: 32883},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -8951,24 +8988,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedElem",
-			pos:  position{line: 1321, col: 1, offset: 32730},
+			pos:  position{line: 1331, col: 1, offset: 32919},
 			expr: &choiceExpr{
-				pos: position{line: 1322, col: 5, offset: 32758},
+				pos: position{line: 1332, col: 5, offset: 32947},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1322, col: 5, offset: 32758},
+						pos:  position{line: 1332, col: 5, offset: 32947},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1323, col: 5, offset: 32774},
+						pos: position{line: 1333, col: 5, offset: 32963},
 						run: (*parser).callonFStringSingleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1323, col: 5, offset: 32774},
+							pos:   position{line: 1333, col: 5, offset: 32963},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1323, col: 7, offset: 32776},
+								pos: position{line: 1333, col: 7, offset: 32965},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1323, col: 7, offset: 32776},
+									pos:  position{line: 1333, col: 7, offset: 32965},
 									name: "FStringSingleQuotedChar",
 								},
 							},
@@ -8981,27 +9018,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedChar",
-			pos:  position{line: 1327, col: 1, offset: 32909},
+			pos:  position{line: 1337, col: 1, offset: 33098},
 			expr: &choiceExpr{
-				pos: position{line: 1328, col: 5, offset: 32937},
+				pos: position{line: 1338, col: 5, offset: 33126},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1328, col: 5, offset: 32937},
+						pos: position{line: 1338, col: 5, offset: 33126},
 						run: (*parser).callonFStringSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1328, col: 5, offset: 32937},
+							pos: position{line: 1338, col: 5, offset: 33126},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1328, col: 5, offset: 32937},
+									pos:        position{line: 1338, col: 5, offset: 33126},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1328, col: 10, offset: 32942},
+									pos:   position{line: 1338, col: 10, offset: 33131},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1328, col: 12, offset: 32944},
+										pos:        position{line: 1338, col: 12, offset: 33133},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9011,25 +9048,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1329, col: 5, offset: 32970},
+						pos: position{line: 1339, col: 5, offset: 33159},
 						run: (*parser).callonFStringSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1329, col: 5, offset: 32970},
+							pos: position{line: 1339, col: 5, offset: 33159},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1329, col: 5, offset: 32970},
+									pos: position{line: 1339, col: 5, offset: 33159},
 									expr: &litMatcher{
-										pos:        position{line: 1329, col: 7, offset: 32972},
+										pos:        position{line: 1339, col: 7, offset: 33161},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1329, col: 12, offset: 32977},
+									pos:   position{line: 1339, col: 12, offset: 33166},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1329, col: 14, offset: 32979},
+										pos:  position{line: 1339, col: 14, offset: 33168},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -9043,37 +9080,37 @@ var g = &grammar{
 		},
 		{
 			name: "FStringExpr",
-			pos:  position{line: 1331, col: 1, offset: 33015},
+			pos:  position{line: 1341, col: 1, offset: 33204},
 			expr: &actionExpr{
-				pos: position{line: 1332, col: 5, offset: 33031},
+				pos: position{line: 1342, col: 5, offset: 33220},
 				run: (*parser).callonFStringExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1332, col: 5, offset: 33031},
+					pos: position{line: 1342, col: 5, offset: 33220},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1332, col: 5, offset: 33031},
+							pos:        position{line: 1342, col: 5, offset: 33220},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1332, col: 9, offset: 33035},
+							pos:  position{line: 1342, col: 9, offset: 33224},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1332, col: 12, offset: 33038},
+							pos:   position{line: 1342, col: 12, offset: 33227},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1332, col: 14, offset: 33040},
+								pos:  position{line: 1342, col: 14, offset: 33229},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1332, col: 19, offset: 33045},
+							pos:  position{line: 1342, col: 19, offset: 33234},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1332, col: 22, offset: 33048},
+							pos:        position{line: 1342, col: 22, offset: 33237},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -9086,129 +9123,129 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1341, col: 1, offset: 33226},
+			pos:  position{line: 1351, col: 1, offset: 33415},
 			expr: &actionExpr{
-				pos: position{line: 1342, col: 5, offset: 33244},
+				pos: position{line: 1352, col: 5, offset: 33433},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1342, col: 9, offset: 33248},
+					pos: position{line: 1352, col: 9, offset: 33437},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1342, col: 9, offset: 33248},
+							pos:        position{line: 1352, col: 9, offset: 33437},
 							val:        "uint8",
 							ignoreCase: false,
 							want:       "\"uint8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1342, col: 19, offset: 33258},
+							pos:        position{line: 1352, col: 19, offset: 33447},
 							val:        "uint16",
 							ignoreCase: false,
 							want:       "\"uint16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1342, col: 30, offset: 33269},
+							pos:        position{line: 1352, col: 30, offset: 33458},
 							val:        "uint32",
 							ignoreCase: false,
 							want:       "\"uint32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1342, col: 41, offset: 33280},
+							pos:        position{line: 1352, col: 41, offset: 33469},
 							val:        "uint64",
 							ignoreCase: false,
 							want:       "\"uint64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1343, col: 9, offset: 33297},
+							pos:        position{line: 1353, col: 9, offset: 33486},
 							val:        "int8",
 							ignoreCase: false,
 							want:       "\"int8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1343, col: 18, offset: 33306},
+							pos:        position{line: 1353, col: 18, offset: 33495},
 							val:        "int16",
 							ignoreCase: false,
 							want:       "\"int16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1343, col: 28, offset: 33316},
+							pos:        position{line: 1353, col: 28, offset: 33505},
 							val:        "int32",
 							ignoreCase: false,
 							want:       "\"int32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1343, col: 38, offset: 33326},
+							pos:        position{line: 1353, col: 38, offset: 33515},
 							val:        "int64",
 							ignoreCase: false,
 							want:       "\"int64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1344, col: 9, offset: 33342},
+							pos:        position{line: 1354, col: 9, offset: 33531},
 							val:        "float16",
 							ignoreCase: false,
 							want:       "\"float16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1344, col: 21, offset: 33354},
+							pos:        position{line: 1354, col: 21, offset: 33543},
 							val:        "float32",
 							ignoreCase: false,
 							want:       "\"float32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1344, col: 33, offset: 33366},
+							pos:        position{line: 1354, col: 33, offset: 33555},
 							val:        "float64",
 							ignoreCase: false,
 							want:       "\"float64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1345, col: 9, offset: 33384},
+							pos:        position{line: 1355, col: 9, offset: 33573},
 							val:        "bool",
 							ignoreCase: false,
 							want:       "\"bool\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1345, col: 18, offset: 33393},
+							pos:        position{line: 1355, col: 18, offset: 33582},
 							val:        "string",
 							ignoreCase: false,
 							want:       "\"string\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1346, col: 9, offset: 33410},
+							pos:        position{line: 1356, col: 9, offset: 33599},
 							val:        "duration",
 							ignoreCase: false,
 							want:       "\"duration\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1346, col: 22, offset: 33423},
+							pos:        position{line: 1356, col: 22, offset: 33612},
 							val:        "time",
 							ignoreCase: false,
 							want:       "\"time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1347, col: 9, offset: 33438},
+							pos:        position{line: 1357, col: 9, offset: 33627},
 							val:        "bytes",
 							ignoreCase: false,
 							want:       "\"bytes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1348, col: 9, offset: 33454},
+							pos:        position{line: 1358, col: 9, offset: 33643},
 							val:        "ip",
 							ignoreCase: false,
 							want:       "\"ip\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1348, col: 16, offset: 33461},
+							pos:        position{line: 1358, col: 16, offset: 33650},
 							val:        "net",
 							ignoreCase: false,
 							want:       "\"net\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1349, col: 9, offset: 33475},
+							pos:        position{line: 1359, col: 9, offset: 33664},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1349, col: 18, offset: 33484},
+							pos:        position{line: 1359, col: 18, offset: 33673},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
@@ -9221,31 +9258,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1357, col: 1, offset: 33682},
+			pos:  position{line: 1367, col: 1, offset: 33871},
 			expr: &choiceExpr{
-				pos: position{line: 1358, col: 5, offset: 33700},
+				pos: position{line: 1368, col: 5, offset: 33889},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1358, col: 5, offset: 33700},
+						pos: position{line: 1368, col: 5, offset: 33889},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1358, col: 5, offset: 33700},
+							pos: position{line: 1368, col: 5, offset: 33889},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1358, col: 5, offset: 33700},
+									pos:   position{line: 1368, col: 5, offset: 33889},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1358, col: 11, offset: 33706},
+										pos:  position{line: 1368, col: 11, offset: 33895},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1358, col: 21, offset: 33716},
+									pos:   position{line: 1368, col: 21, offset: 33905},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1358, col: 26, offset: 33721},
+										pos: position{line: 1368, col: 26, offset: 33910},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1358, col: 26, offset: 33721},
+											pos:  position{line: 1368, col: 26, offset: 33910},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -9254,10 +9291,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1361, col: 5, offset: 33787},
+						pos: position{line: 1371, col: 5, offset: 33976},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1361, col: 5, offset: 33787},
+							pos:        position{line: 1371, col: 5, offset: 33976},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -9270,32 +9307,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1363, col: 1, offset: 33811},
+			pos:  position{line: 1373, col: 1, offset: 34000},
 			expr: &actionExpr{
-				pos: position{line: 1363, col: 21, offset: 33831},
+				pos: position{line: 1373, col: 21, offset: 34020},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1363, col: 21, offset: 33831},
+					pos: position{line: 1373, col: 21, offset: 34020},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1363, col: 21, offset: 33831},
+							pos:  position{line: 1373, col: 21, offset: 34020},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1363, col: 24, offset: 33834},
+							pos:        position{line: 1373, col: 24, offset: 34023},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1363, col: 28, offset: 33838},
+							pos:  position{line: 1373, col: 28, offset: 34027},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1363, col: 31, offset: 33841},
+							pos:   position{line: 1373, col: 31, offset: 34030},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1363, col: 35, offset: 33845},
+								pos:  position{line: 1373, col: 35, offset: 34034},
 								name: "TypeField",
 							},
 						},
@@ -9307,40 +9344,40 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1365, col: 1, offset: 33876},
+			pos:  position{line: 1375, col: 1, offset: 34065},
 			expr: &actionExpr{
-				pos: position{line: 1366, col: 5, offset: 33890},
+				pos: position{line: 1376, col: 5, offset: 34079},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1366, col: 5, offset: 33890},
+					pos: position{line: 1376, col: 5, offset: 34079},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1366, col: 5, offset: 33890},
+							pos:   position{line: 1376, col: 5, offset: 34079},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1366, col: 10, offset: 33895},
+								pos:  position{line: 1376, col: 10, offset: 34084},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1366, col: 20, offset: 33905},
+							pos:  position{line: 1376, col: 20, offset: 34094},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1366, col: 23, offset: 33908},
+							pos:        position{line: 1376, col: 23, offset: 34097},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1366, col: 27, offset: 33912},
+							pos:  position{line: 1376, col: 27, offset: 34101},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1366, col: 30, offset: 33915},
+							pos:   position{line: 1376, col: 30, offset: 34104},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1366, col: 34, offset: 33919},
+								pos:  position{line: 1376, col: 34, offset: 34108},
 								name: "Type",
 							},
 						},
@@ -9352,16 +9389,16 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 1373, col: 1, offset: 34043},
+			pos:  position{line: 1383, col: 1, offset: 34232},
 			expr: &choiceExpr{
-				pos: position{line: 1374, col: 5, offset: 34057},
+				pos: position{line: 1384, col: 5, offset: 34246},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1374, col: 5, offset: 34057},
+						pos:  position{line: 1384, col: 5, offset: 34246},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1375, col: 5, offset: 34076},
+						pos:  position{line: 1385, col: 5, offset: 34265},
 						name: "QuotedString",
 					},
 				},
@@ -9371,24 +9408,24 @@ var g = &grammar{
 		},
 		{
 			name: "AndToken",
-			pos:  position{line: 1377, col: 1, offset: 34090},
+			pos:  position{line: 1387, col: 1, offset: 34279},
 			expr: &actionExpr{
-				pos: position{line: 1377, col: 12, offset: 34101},
+				pos: position{line: 1387, col: 12, offset: 34290},
 				run: (*parser).callonAndToken1,
 				expr: &seqExpr{
-					pos: position{line: 1377, col: 12, offset: 34101},
+					pos: position{line: 1387, col: 12, offset: 34290},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 1377, col: 13, offset: 34102},
+							pos: position{line: 1387, col: 13, offset: 34291},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1377, col: 13, offset: 34102},
+									pos:        position{line: 1387, col: 13, offset: 34291},
 									val:        "and",
 									ignoreCase: false,
 									want:       "\"and\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1377, col: 21, offset: 34110},
+									pos:        position{line: 1387, col: 21, offset: 34299},
 									val:        "AND",
 									ignoreCase: false,
 									want:       "\"AND\"",
@@ -9396,9 +9433,9 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 1377, col: 28, offset: 34117},
+							pos: position{line: 1387, col: 28, offset: 34306},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1377, col: 29, offset: 34118},
+								pos:  position{line: 1387, col: 29, offset: 34307},
 								name: "IdentifierRest",
 							},
 						},
@@ -9410,20 +9447,20 @@ var g = &grammar{
 		},
 		{
 			name: "ByToken",
-			pos:  position{line: 1378, col: 1, offset: 34155},
+			pos:  position{line: 1388, col: 1, offset: 34344},
 			expr: &seqExpr{
-				pos: position{line: 1378, col: 11, offset: 34165},
+				pos: position{line: 1388, col: 11, offset: 34354},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1378, col: 11, offset: 34165},
+						pos:        position{line: 1388, col: 11, offset: 34354},
 						val:        "by",
 						ignoreCase: false,
 						want:       "\"by\"",
 					},
 					&notExpr{
-						pos: position{line: 1378, col: 16, offset: 34170},
+						pos: position{line: 1388, col: 16, offset: 34359},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1378, col: 17, offset: 34171},
+							pos:  position{line: 1388, col: 17, offset: 34360},
 							name: "IdentifierRest",
 						},
 					},
@@ -9434,20 +9471,20 @@ var g = &grammar{
 		},
 		{
 			name: "FalseToken",
-			pos:  position{line: 1379, col: 1, offset: 34186},
+			pos:  position{line: 1389, col: 1, offset: 34375},
 			expr: &seqExpr{
-				pos: position{line: 1379, col: 14, offset: 34199},
+				pos: position{line: 1389, col: 14, offset: 34388},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1379, col: 14, offset: 34199},
+						pos:        position{line: 1389, col: 14, offset: 34388},
 						val:        "false",
 						ignoreCase: false,
 						want:       "\"false\"",
 					},
 					&notExpr{
-						pos: position{line: 1379, col: 22, offset: 34207},
+						pos: position{line: 1389, col: 22, offset: 34396},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1379, col: 23, offset: 34208},
+							pos:  position{line: 1389, col: 23, offset: 34397},
 							name: "IdentifierRest",
 						},
 					},
@@ -9458,20 +9495,20 @@ var g = &grammar{
 		},
 		{
 			name: "InToken",
-			pos:  position{line: 1380, col: 1, offset: 34223},
+			pos:  position{line: 1390, col: 1, offset: 34412},
 			expr: &seqExpr{
-				pos: position{line: 1380, col: 11, offset: 34233},
+				pos: position{line: 1390, col: 11, offset: 34422},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1380, col: 11, offset: 34233},
+						pos:        position{line: 1390, col: 11, offset: 34422},
 						val:        "in",
 						ignoreCase: false,
 						want:       "\"in\"",
 					},
 					&notExpr{
-						pos: position{line: 1380, col: 16, offset: 34238},
+						pos: position{line: 1390, col: 16, offset: 34427},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1380, col: 17, offset: 34239},
+							pos:  position{line: 1390, col: 17, offset: 34428},
 							name: "IdentifierRest",
 						},
 					},
@@ -9482,24 +9519,24 @@ var g = &grammar{
 		},
 		{
 			name: "NotToken",
-			pos:  position{line: 1381, col: 1, offset: 34254},
+			pos:  position{line: 1391, col: 1, offset: 34443},
 			expr: &actionExpr{
-				pos: position{line: 1381, col: 12, offset: 34265},
+				pos: position{line: 1391, col: 12, offset: 34454},
 				run: (*parser).callonNotToken1,
 				expr: &seqExpr{
-					pos: position{line: 1381, col: 12, offset: 34265},
+					pos: position{line: 1391, col: 12, offset: 34454},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 1381, col: 13, offset: 34266},
+							pos: position{line: 1391, col: 13, offset: 34455},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1381, col: 13, offset: 34266},
+									pos:        position{line: 1391, col: 13, offset: 34455},
 									val:        "not",
 									ignoreCase: false,
 									want:       "\"not\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1381, col: 21, offset: 34274},
+									pos:        position{line: 1391, col: 21, offset: 34463},
 									val:        "NOT",
 									ignoreCase: false,
 									want:       "\"NOT\"",
@@ -9507,9 +9544,9 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 1381, col: 28, offset: 34281},
+							pos: position{line: 1391, col: 28, offset: 34470},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1381, col: 29, offset: 34282},
+								pos:  position{line: 1391, col: 29, offset: 34471},
 								name: "IdentifierRest",
 							},
 						},
@@ -9521,20 +9558,20 @@ var g = &grammar{
 		},
 		{
 			name: "NullToken",
-			pos:  position{line: 1382, col: 1, offset: 34319},
+			pos:  position{line: 1392, col: 1, offset: 34508},
 			expr: &seqExpr{
-				pos: position{line: 1382, col: 13, offset: 34331},
+				pos: position{line: 1392, col: 13, offset: 34520},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1382, col: 13, offset: 34331},
+						pos:        position{line: 1392, col: 13, offset: 34520},
 						val:        "null",
 						ignoreCase: false,
 						want:       "\"null\"",
 					},
 					&notExpr{
-						pos: position{line: 1382, col: 20, offset: 34338},
+						pos: position{line: 1392, col: 20, offset: 34527},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1382, col: 21, offset: 34339},
+							pos:  position{line: 1392, col: 21, offset: 34528},
 							name: "IdentifierRest",
 						},
 					},
@@ -9545,24 +9582,24 @@ var g = &grammar{
 		},
 		{
 			name: "OrToken",
-			pos:  position{line: 1383, col: 1, offset: 34354},
+			pos:  position{line: 1393, col: 1, offset: 34543},
 			expr: &actionExpr{
-				pos: position{line: 1383, col: 11, offset: 34364},
+				pos: position{line: 1393, col: 11, offset: 34553},
 				run: (*parser).callonOrToken1,
 				expr: &seqExpr{
-					pos: position{line: 1383, col: 11, offset: 34364},
+					pos: position{line: 1393, col: 11, offset: 34553},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 1383, col: 12, offset: 34365},
+							pos: position{line: 1393, col: 12, offset: 34554},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1383, col: 12, offset: 34365},
+									pos:        position{line: 1393, col: 12, offset: 34554},
 									val:        "or",
 									ignoreCase: false,
 									want:       "\"or\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1383, col: 19, offset: 34372},
+									pos:        position{line: 1393, col: 19, offset: 34561},
 									val:        "OR",
 									ignoreCase: false,
 									want:       "\"OR\"",
@@ -9570,9 +9607,9 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 1383, col: 25, offset: 34378},
+							pos: position{line: 1393, col: 25, offset: 34567},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1383, col: 26, offset: 34379},
+								pos:  position{line: 1393, col: 26, offset: 34568},
 								name: "IdentifierRest",
 							},
 						},
@@ -9584,20 +9621,20 @@ var g = &grammar{
 		},
 		{
 			name: "TrueToken",
-			pos:  position{line: 1384, col: 1, offset: 34415},
+			pos:  position{line: 1394, col: 1, offset: 34604},
 			expr: &seqExpr{
-				pos: position{line: 1384, col: 13, offset: 34427},
+				pos: position{line: 1394, col: 13, offset: 34616},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1384, col: 13, offset: 34427},
+						pos:        position{line: 1394, col: 13, offset: 34616},
 						val:        "true",
 						ignoreCase: false,
 						want:       "\"true\"",
 					},
 					&notExpr{
-						pos: position{line: 1384, col: 20, offset: 34434},
+						pos: position{line: 1394, col: 20, offset: 34623},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1384, col: 21, offset: 34435},
+							pos:  position{line: 1394, col: 21, offset: 34624},
 							name: "IdentifierRest",
 						},
 					},
@@ -9608,15 +9645,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1386, col: 1, offset: 34451},
+			pos:  position{line: 1396, col: 1, offset: 34640},
 			expr: &actionExpr{
-				pos: position{line: 1387, col: 5, offset: 34466},
+				pos: position{line: 1397, col: 5, offset: 34655},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1387, col: 5, offset: 34466},
+					pos:   position{line: 1397, col: 5, offset: 34655},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1387, col: 8, offset: 34469},
+						pos:  position{line: 1397, col: 8, offset: 34658},
 						name: "IdentifierName",
 					},
 				},
@@ -9626,51 +9663,51 @@ var g = &grammar{
 		},
 		{
 			name: "Identifiers",
-			pos:  position{line: 1395, col: 1, offset: 34612},
+			pos:  position{line: 1405, col: 1, offset: 34801},
 			expr: &actionExpr{
-				pos: position{line: 1396, col: 5, offset: 34628},
+				pos: position{line: 1406, col: 5, offset: 34817},
 				run: (*parser).callonIdentifiers1,
 				expr: &seqExpr{
-					pos: position{line: 1396, col: 5, offset: 34628},
+					pos: position{line: 1406, col: 5, offset: 34817},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1396, col: 5, offset: 34628},
+							pos:   position{line: 1406, col: 5, offset: 34817},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1396, col: 11, offset: 34634},
+								pos:  position{line: 1406, col: 11, offset: 34823},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1396, col: 22, offset: 34645},
+							pos:   position{line: 1406, col: 22, offset: 34834},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1396, col: 27, offset: 34650},
+								pos: position{line: 1406, col: 27, offset: 34839},
 								expr: &actionExpr{
-									pos: position{line: 1396, col: 28, offset: 34651},
+									pos: position{line: 1406, col: 28, offset: 34840},
 									run: (*parser).callonIdentifiers7,
 									expr: &seqExpr{
-										pos: position{line: 1396, col: 28, offset: 34651},
+										pos: position{line: 1406, col: 28, offset: 34840},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1396, col: 28, offset: 34651},
+												pos:  position{line: 1406, col: 28, offset: 34840},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1396, col: 31, offset: 34654},
+												pos:        position{line: 1406, col: 31, offset: 34843},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1396, col: 35, offset: 34658},
+												pos:  position{line: 1406, col: 35, offset: 34847},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1396, col: 38, offset: 34661},
+												pos:   position{line: 1406, col: 38, offset: 34850},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1396, col: 43, offset: 34666},
+													pos:  position{line: 1406, col: 43, offset: 34855},
 													name: "Identifier",
 												},
 											},
@@ -9687,29 +9724,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1400, col: 1, offset: 34744},
+			pos:  position{line: 1410, col: 1, offset: 34933},
 			expr: &choiceExpr{
-				pos: position{line: 1401, col: 5, offset: 34763},
+				pos: position{line: 1411, col: 5, offset: 34952},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1401, col: 5, offset: 34763},
+						pos: position{line: 1411, col: 5, offset: 34952},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1401, col: 5, offset: 34763},
+							pos: position{line: 1411, col: 5, offset: 34952},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1401, col: 5, offset: 34763},
+									pos: position{line: 1411, col: 5, offset: 34952},
 									expr: &seqExpr{
-										pos: position{line: 1401, col: 7, offset: 34765},
+										pos: position{line: 1411, col: 7, offset: 34954},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1401, col: 7, offset: 34765},
+												pos:  position{line: 1411, col: 7, offset: 34954},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1401, col: 15, offset: 34773},
+												pos: position{line: 1411, col: 15, offset: 34962},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1401, col: 16, offset: 34774},
+													pos:  position{line: 1411, col: 16, offset: 34963},
 													name: "IdentifierRest",
 												},
 											},
@@ -9717,13 +9754,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1401, col: 32, offset: 34790},
+									pos:  position{line: 1411, col: 32, offset: 34979},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1401, col: 48, offset: 34806},
+									pos: position{line: 1411, col: 48, offset: 34995},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1401, col: 48, offset: 34806},
+										pos:  position{line: 1411, col: 48, offset: 34995},
 										name: "IdentifierRest",
 									},
 								},
@@ -9731,32 +9768,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1402, col: 5, offset: 34857},
+						pos: position{line: 1412, col: 5, offset: 35046},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 1402, col: 5, offset: 34857},
+							pos:        position{line: 1412, col: 5, offset: 35046},
 							val:        "$",
 							ignoreCase: false,
 							want:       "\"$\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1403, col: 5, offset: 34896},
+						pos: position{line: 1413, col: 5, offset: 35085},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 1403, col: 5, offset: 34896},
+							pos: position{line: 1413, col: 5, offset: 35085},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1403, col: 5, offset: 34896},
+									pos:        position{line: 1413, col: 5, offset: 35085},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1403, col: 10, offset: 34901},
+									pos:   position{line: 1413, col: 10, offset: 35090},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1403, col: 13, offset: 34904},
+										pos:  position{line: 1413, col: 13, offset: 35093},
 										name: "IDGuard",
 									},
 								},
@@ -9764,10 +9801,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1405, col: 5, offset: 34995},
+						pos: position{line: 1415, col: 5, offset: 35184},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 1405, col: 5, offset: 34995},
+							pos:        position{line: 1415, col: 5, offset: 35184},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
@@ -9780,22 +9817,22 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1407, col: 1, offset: 35034},
+			pos:  position{line: 1417, col: 1, offset: 35223},
 			expr: &choiceExpr{
-				pos: position{line: 1408, col: 5, offset: 35054},
+				pos: position{line: 1418, col: 5, offset: 35243},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1408, col: 5, offset: 35054},
+						pos:  position{line: 1418, col: 5, offset: 35243},
 						name: "UnicodeLetter",
 					},
 					&litMatcher{
-						pos:        position{line: 1409, col: 5, offset: 35072},
+						pos:        position{line: 1419, col: 5, offset: 35261},
 						val:        "$",
 						ignoreCase: false,
 						want:       "\"$\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1410, col: 5, offset: 35080},
+						pos:        position{line: 1420, col: 5, offset: 35269},
 						val:        "_",
 						ignoreCase: false,
 						want:       "\"_\"",
@@ -9807,24 +9844,24 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1412, col: 1, offset: 35085},
+			pos:  position{line: 1422, col: 1, offset: 35274},
 			expr: &choiceExpr{
-				pos: position{line: 1413, col: 5, offset: 35104},
+				pos: position{line: 1423, col: 5, offset: 35293},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1413, col: 5, offset: 35104},
+						pos:  position{line: 1423, col: 5, offset: 35293},
 						name: "IdentifierStart",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1414, col: 5, offset: 35124},
+						pos:  position{line: 1424, col: 5, offset: 35313},
 						name: "UnicodeCombiningMark",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1415, col: 5, offset: 35149},
+						pos:  position{line: 1425, col: 5, offset: 35338},
 						name: "UnicodeDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1416, col: 5, offset: 35166},
+						pos:  position{line: 1426, col: 5, offset: 35355},
 						name: "UnicodeConnectorPunctuation",
 					},
 				},
@@ -9834,24 +9871,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1418, col: 1, offset: 35195},
+			pos:  position{line: 1428, col: 1, offset: 35384},
 			expr: &choiceExpr{
-				pos: position{line: 1419, col: 5, offset: 35207},
+				pos: position{line: 1429, col: 5, offset: 35396},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1419, col: 5, offset: 35207},
+						pos:  position{line: 1429, col: 5, offset: 35396},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1420, col: 5, offset: 35226},
+						pos:  position{line: 1430, col: 5, offset: 35415},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1421, col: 5, offset: 35242},
+						pos:  position{line: 1431, col: 5, offset: 35431},
 						name: "NaN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1422, col: 5, offset: 35250},
+						pos:  position{line: 1432, col: 5, offset: 35439},
 						name: "Infinity",
 					},
 				},
@@ -9861,25 +9898,25 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1424, col: 1, offset: 35260},
+			pos:  position{line: 1434, col: 1, offset: 35449},
 			expr: &actionExpr{
-				pos: position{line: 1425, col: 5, offset: 35269},
+				pos: position{line: 1435, col: 5, offset: 35458},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1425, col: 5, offset: 35269},
+					pos: position{line: 1435, col: 5, offset: 35458},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1425, col: 5, offset: 35269},
+							pos:  position{line: 1435, col: 5, offset: 35458},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1425, col: 14, offset: 35278},
+							pos:        position{line: 1435, col: 14, offset: 35467},
 							val:        "T",
 							ignoreCase: false,
 							want:       "\"T\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1425, col: 18, offset: 35282},
+							pos:  position{line: 1435, col: 18, offset: 35471},
 							name: "FullTime",
 						},
 					},
@@ -9890,32 +9927,32 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1429, col: 1, offset: 35358},
+			pos:  position{line: 1439, col: 1, offset: 35547},
 			expr: &seqExpr{
-				pos: position{line: 1429, col: 12, offset: 35369},
+				pos: position{line: 1439, col: 12, offset: 35558},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1429, col: 12, offset: 35369},
+						pos:  position{line: 1439, col: 12, offset: 35558},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1429, col: 15, offset: 35372},
+						pos:        position{line: 1439, col: 15, offset: 35561},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1429, col: 19, offset: 35376},
+						pos:  position{line: 1439, col: 19, offset: 35565},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1429, col: 22, offset: 35379},
+						pos:        position{line: 1439, col: 22, offset: 35568},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1429, col: 26, offset: 35383},
+						pos:  position{line: 1439, col: 26, offset: 35572},
 						name: "D2",
 					},
 				},
@@ -9925,33 +9962,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1431, col: 1, offset: 35387},
+			pos:  position{line: 1441, col: 1, offset: 35576},
 			expr: &seqExpr{
-				pos: position{line: 1431, col: 6, offset: 35392},
+				pos: position{line: 1441, col: 6, offset: 35581},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1431, col: 6, offset: 35392},
+						pos:        position{line: 1441, col: 6, offset: 35581},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1431, col: 11, offset: 35397},
+						pos:        position{line: 1441, col: 11, offset: 35586},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1431, col: 16, offset: 35402},
+						pos:        position{line: 1441, col: 16, offset: 35591},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1431, col: 21, offset: 35407},
+						pos:        position{line: 1441, col: 21, offset: 35596},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9964,19 +10001,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1432, col: 1, offset: 35413},
+			pos:  position{line: 1442, col: 1, offset: 35602},
 			expr: &seqExpr{
-				pos: position{line: 1432, col: 6, offset: 35418},
+				pos: position{line: 1442, col: 6, offset: 35607},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1432, col: 6, offset: 35418},
+						pos:        position{line: 1442, col: 6, offset: 35607},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1432, col: 11, offset: 35423},
+						pos:        position{line: 1442, col: 11, offset: 35612},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -9989,16 +10026,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1434, col: 1, offset: 35430},
+			pos:  position{line: 1444, col: 1, offset: 35619},
 			expr: &seqExpr{
-				pos: position{line: 1434, col: 12, offset: 35441},
+				pos: position{line: 1444, col: 12, offset: 35630},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1434, col: 12, offset: 35441},
+						pos:  position{line: 1444, col: 12, offset: 35630},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1434, col: 24, offset: 35453},
+						pos:  position{line: 1444, col: 24, offset: 35642},
 						name: "TimeOffset",
 					},
 				},
@@ -10008,49 +10045,49 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1436, col: 1, offset: 35465},
+			pos:  position{line: 1446, col: 1, offset: 35654},
 			expr: &seqExpr{
-				pos: position{line: 1436, col: 15, offset: 35479},
+				pos: position{line: 1446, col: 15, offset: 35668},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1436, col: 15, offset: 35479},
+						pos:  position{line: 1446, col: 15, offset: 35668},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1436, col: 18, offset: 35482},
+						pos:        position{line: 1446, col: 18, offset: 35671},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1436, col: 22, offset: 35486},
+						pos:  position{line: 1446, col: 22, offset: 35675},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1436, col: 25, offset: 35489},
+						pos:        position{line: 1446, col: 25, offset: 35678},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1436, col: 29, offset: 35493},
+						pos:  position{line: 1446, col: 29, offset: 35682},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1436, col: 32, offset: 35496},
+						pos: position{line: 1446, col: 32, offset: 35685},
 						expr: &seqExpr{
-							pos: position{line: 1436, col: 33, offset: 35497},
+							pos: position{line: 1446, col: 33, offset: 35686},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1436, col: 33, offset: 35497},
+									pos:        position{line: 1446, col: 33, offset: 35686},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1436, col: 37, offset: 35501},
+									pos: position{line: 1446, col: 37, offset: 35690},
 									expr: &charClassMatcher{
-										pos:        position{line: 1436, col: 37, offset: 35501},
+										pos:        position{line: 1446, col: 37, offset: 35690},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10067,30 +10104,30 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1438, col: 1, offset: 35511},
+			pos:  position{line: 1448, col: 1, offset: 35700},
 			expr: &choiceExpr{
-				pos: position{line: 1439, col: 5, offset: 35526},
+				pos: position{line: 1449, col: 5, offset: 35715},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1439, col: 5, offset: 35526},
+						pos:        position{line: 1449, col: 5, offset: 35715},
 						val:        "Z",
 						ignoreCase: false,
 						want:       "\"Z\"",
 					},
 					&seqExpr{
-						pos: position{line: 1440, col: 5, offset: 35534},
+						pos: position{line: 1450, col: 5, offset: 35723},
 						exprs: []any{
 							&choiceExpr{
-								pos: position{line: 1440, col: 6, offset: 35535},
+								pos: position{line: 1450, col: 6, offset: 35724},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 1440, col: 6, offset: 35535},
+										pos:        position{line: 1450, col: 6, offset: 35724},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 1440, col: 12, offset: 35541},
+										pos:        position{line: 1450, col: 12, offset: 35730},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
@@ -10098,34 +10135,34 @@ var g = &grammar{
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1440, col: 17, offset: 35546},
+								pos:  position{line: 1450, col: 17, offset: 35735},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1440, col: 20, offset: 35549},
+								pos:        position{line: 1450, col: 20, offset: 35738},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1440, col: 24, offset: 35553},
+								pos:  position{line: 1450, col: 24, offset: 35742},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1440, col: 27, offset: 35556},
+								pos: position{line: 1450, col: 27, offset: 35745},
 								expr: &seqExpr{
-									pos: position{line: 1440, col: 28, offset: 35557},
+									pos: position{line: 1450, col: 28, offset: 35746},
 									exprs: []any{
 										&litMatcher{
-											pos:        position{line: 1440, col: 28, offset: 35557},
+											pos:        position{line: 1450, col: 28, offset: 35746},
 											val:        ".",
 											ignoreCase: false,
 											want:       "\".\"",
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1440, col: 32, offset: 35561},
+											pos: position{line: 1450, col: 32, offset: 35750},
 											expr: &charClassMatcher{
-												pos:        position{line: 1440, col: 32, offset: 35561},
+												pos:        position{line: 1450, col: 32, offset: 35750},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -10144,33 +10181,33 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1442, col: 1, offset: 35571},
+			pos:  position{line: 1452, col: 1, offset: 35760},
 			expr: &actionExpr{
-				pos: position{line: 1443, col: 5, offset: 35584},
+				pos: position{line: 1453, col: 5, offset: 35773},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1443, col: 5, offset: 35584},
+					pos: position{line: 1453, col: 5, offset: 35773},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 1443, col: 5, offset: 35584},
+							pos: position{line: 1453, col: 5, offset: 35773},
 							expr: &litMatcher{
-								pos:        position{line: 1443, col: 5, offset: 35584},
+								pos:        position{line: 1453, col: 5, offset: 35773},
 								val:        "-",
 								ignoreCase: false,
 								want:       "\"-\"",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1443, col: 10, offset: 35589},
+							pos: position{line: 1453, col: 10, offset: 35778},
 							expr: &seqExpr{
-								pos: position{line: 1443, col: 11, offset: 35590},
+								pos: position{line: 1453, col: 11, offset: 35779},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1443, col: 11, offset: 35590},
+										pos:  position{line: 1453, col: 11, offset: 35779},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1443, col: 19, offset: 35598},
+										pos:  position{line: 1453, col: 19, offset: 35787},
 										name: "TimeUnit",
 									},
 								},
@@ -10184,27 +10221,27 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1447, col: 1, offset: 35680},
+			pos:  position{line: 1457, col: 1, offset: 35869},
 			expr: &seqExpr{
-				pos: position{line: 1447, col: 11, offset: 35690},
+				pos: position{line: 1457, col: 11, offset: 35879},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1447, col: 11, offset: 35690},
+						pos:  position{line: 1457, col: 11, offset: 35879},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1447, col: 16, offset: 35695},
+						pos: position{line: 1457, col: 16, offset: 35884},
 						expr: &seqExpr{
-							pos: position{line: 1447, col: 17, offset: 35696},
+							pos: position{line: 1457, col: 17, offset: 35885},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1447, col: 17, offset: 35696},
+									pos:        position{line: 1457, col: 17, offset: 35885},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1447, col: 21, offset: 35700},
+									pos:  position{line: 1457, col: 21, offset: 35889},
 									name: "UInt",
 								},
 							},
@@ -10217,60 +10254,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1449, col: 1, offset: 35708},
+			pos:  position{line: 1459, col: 1, offset: 35897},
 			expr: &choiceExpr{
-				pos: position{line: 1450, col: 5, offset: 35721},
+				pos: position{line: 1460, col: 5, offset: 35910},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1450, col: 5, offset: 35721},
+						pos:        position{line: 1460, col: 5, offset: 35910},
 						val:        "ns",
 						ignoreCase: false,
 						want:       "\"ns\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1451, col: 5, offset: 35730},
+						pos:        position{line: 1461, col: 5, offset: 35919},
 						val:        "us",
 						ignoreCase: false,
 						want:       "\"us\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1452, col: 5, offset: 35739},
+						pos:        position{line: 1462, col: 5, offset: 35928},
 						val:        "ms",
 						ignoreCase: false,
 						want:       "\"ms\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1453, col: 5, offset: 35748},
+						pos:        position{line: 1463, col: 5, offset: 35937},
 						val:        "s",
 						ignoreCase: false,
 						want:       "\"s\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1454, col: 5, offset: 35756},
+						pos:        position{line: 1464, col: 5, offset: 35945},
 						val:        "m",
 						ignoreCase: false,
 						want:       "\"m\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1455, col: 5, offset: 35764},
+						pos:        position{line: 1465, col: 5, offset: 35953},
 						val:        "h",
 						ignoreCase: false,
 						want:       "\"h\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1456, col: 5, offset: 35772},
+						pos:        position{line: 1466, col: 5, offset: 35961},
 						val:        "d",
 						ignoreCase: false,
 						want:       "\"d\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1457, col: 5, offset: 35780},
+						pos:        position{line: 1467, col: 5, offset: 35969},
 						val:        "w",
 						ignoreCase: false,
 						want:       "\"w\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1458, col: 5, offset: 35788},
+						pos:        position{line: 1468, col: 5, offset: 35977},
 						val:        "y",
 						ignoreCase: false,
 						want:       "\"y\"",
@@ -10282,45 +10319,45 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1460, col: 1, offset: 35793},
+			pos:  position{line: 1470, col: 1, offset: 35982},
 			expr: &actionExpr{
-				pos: position{line: 1461, col: 5, offset: 35800},
+				pos: position{line: 1471, col: 5, offset: 35989},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1461, col: 5, offset: 35800},
+					pos: position{line: 1471, col: 5, offset: 35989},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1461, col: 5, offset: 35800},
+							pos:  position{line: 1471, col: 5, offset: 35989},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1461, col: 10, offset: 35805},
+							pos:        position{line: 1471, col: 10, offset: 35994},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1461, col: 14, offset: 35809},
+							pos:  position{line: 1471, col: 14, offset: 35998},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1461, col: 19, offset: 35814},
+							pos:        position{line: 1471, col: 19, offset: 36003},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1461, col: 23, offset: 35818},
+							pos:  position{line: 1471, col: 23, offset: 36007},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1461, col: 28, offset: 35823},
+							pos:        position{line: 1471, col: 28, offset: 36012},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1461, col: 32, offset: 35827},
+							pos:  position{line: 1471, col: 32, offset: 36016},
 							name: "UInt",
 						},
 					},
@@ -10331,43 +10368,43 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1463, col: 1, offset: 35864},
+			pos:  position{line: 1473, col: 1, offset: 36053},
 			expr: &actionExpr{
-				pos: position{line: 1464, col: 5, offset: 35872},
+				pos: position{line: 1474, col: 5, offset: 36061},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1464, col: 5, offset: 35872},
+					pos: position{line: 1474, col: 5, offset: 36061},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1464, col: 5, offset: 35872},
+							pos: position{line: 1474, col: 5, offset: 36061},
 							expr: &seqExpr{
-								pos: position{line: 1464, col: 7, offset: 35874},
+								pos: position{line: 1474, col: 7, offset: 36063},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1464, col: 7, offset: 35874},
+										pos:  position{line: 1474, col: 7, offset: 36063},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1464, col: 11, offset: 35878},
+										pos:        position{line: 1474, col: 11, offset: 36067},
 										val:        ":",
 										ignoreCase: false,
 										want:       "\":\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1464, col: 15, offset: 35882},
+										pos:  position{line: 1474, col: 15, offset: 36071},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1464, col: 19, offset: 35886},
+										pos: position{line: 1474, col: 19, offset: 36075},
 										expr: &choiceExpr{
-											pos: position{line: 1464, col: 21, offset: 35888},
+											pos: position{line: 1474, col: 21, offset: 36077},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1464, col: 21, offset: 35888},
+													pos:  position{line: 1474, col: 21, offset: 36077},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1464, col: 32, offset: 35899},
+													pos:        position{line: 1474, col: 32, offset: 36088},
 													val:        ":",
 													ignoreCase: false,
 													want:       "\":\"",
@@ -10379,10 +10416,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1464, col: 38, offset: 35905},
+							pos:   position{line: 1474, col: 38, offset: 36094},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1464, col: 40, offset: 35907},
+								pos:  position{line: 1474, col: 40, offset: 36096},
 								name: "IP6Variations",
 							},
 						},
@@ -10394,32 +10431,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1468, col: 1, offset: 36071},
+			pos:  position{line: 1478, col: 1, offset: 36260},
 			expr: &choiceExpr{
-				pos: position{line: 1469, col: 5, offset: 36089},
+				pos: position{line: 1479, col: 5, offset: 36278},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1469, col: 5, offset: 36089},
+						pos: position{line: 1479, col: 5, offset: 36278},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1469, col: 5, offset: 36089},
+							pos: position{line: 1479, col: 5, offset: 36278},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1469, col: 5, offset: 36089},
+									pos:   position{line: 1479, col: 5, offset: 36278},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1469, col: 7, offset: 36091},
+										pos: position{line: 1479, col: 7, offset: 36280},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1469, col: 7, offset: 36091},
+											pos:  position{line: 1479, col: 7, offset: 36280},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1469, col: 17, offset: 36101},
+									pos:   position{line: 1479, col: 17, offset: 36290},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1469, col: 19, offset: 36103},
+										pos:  position{line: 1479, col: 19, offset: 36292},
 										name: "IP6Tail",
 									},
 								},
@@ -10427,52 +10464,52 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1472, col: 5, offset: 36167},
+						pos: position{line: 1482, col: 5, offset: 36356},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1472, col: 5, offset: 36167},
+							pos: position{line: 1482, col: 5, offset: 36356},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1472, col: 5, offset: 36167},
+									pos:   position{line: 1482, col: 5, offset: 36356},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1472, col: 7, offset: 36169},
+										pos:  position{line: 1482, col: 7, offset: 36358},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1472, col: 11, offset: 36173},
+									pos:   position{line: 1482, col: 11, offset: 36362},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1472, col: 13, offset: 36175},
+										pos: position{line: 1482, col: 13, offset: 36364},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1472, col: 13, offset: 36175},
+											pos:  position{line: 1482, col: 13, offset: 36364},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1472, col: 23, offset: 36185},
+									pos:        position{line: 1482, col: 23, offset: 36374},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1472, col: 28, offset: 36190},
+									pos:   position{line: 1482, col: 28, offset: 36379},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1472, col: 30, offset: 36192},
+										pos: position{line: 1482, col: 30, offset: 36381},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1472, col: 30, offset: 36192},
+											pos:  position{line: 1482, col: 30, offset: 36381},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1472, col: 40, offset: 36202},
+									pos:   position{line: 1482, col: 40, offset: 36391},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1472, col: 42, offset: 36204},
+										pos:  position{line: 1482, col: 42, offset: 36393},
 										name: "IP6Tail",
 									},
 								},
@@ -10480,33 +10517,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1475, col: 5, offset: 36303},
+						pos: position{line: 1485, col: 5, offset: 36492},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1475, col: 5, offset: 36303},
+							pos: position{line: 1485, col: 5, offset: 36492},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1475, col: 5, offset: 36303},
+									pos:        position{line: 1485, col: 5, offset: 36492},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1475, col: 10, offset: 36308},
+									pos:   position{line: 1485, col: 10, offset: 36497},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1475, col: 12, offset: 36310},
+										pos: position{line: 1485, col: 12, offset: 36499},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1475, col: 12, offset: 36310},
+											pos:  position{line: 1485, col: 12, offset: 36499},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1475, col: 22, offset: 36320},
+									pos:   position{line: 1485, col: 22, offset: 36509},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1475, col: 24, offset: 36322},
+										pos:  position{line: 1485, col: 24, offset: 36511},
 										name: "IP6Tail",
 									},
 								},
@@ -10514,32 +10551,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1478, col: 5, offset: 36393},
+						pos: position{line: 1488, col: 5, offset: 36582},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1478, col: 5, offset: 36393},
+							pos: position{line: 1488, col: 5, offset: 36582},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1478, col: 5, offset: 36393},
+									pos:   position{line: 1488, col: 5, offset: 36582},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1478, col: 7, offset: 36395},
+										pos:  position{line: 1488, col: 7, offset: 36584},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1478, col: 11, offset: 36399},
+									pos:   position{line: 1488, col: 11, offset: 36588},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1478, col: 13, offset: 36401},
+										pos: position{line: 1488, col: 13, offset: 36590},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1478, col: 13, offset: 36401},
+											pos:  position{line: 1488, col: 13, offset: 36590},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1478, col: 23, offset: 36411},
+									pos:        position{line: 1488, col: 23, offset: 36600},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
@@ -10548,10 +10585,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1481, col: 5, offset: 36479},
+						pos: position{line: 1491, col: 5, offset: 36668},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 1481, col: 5, offset: 36479},
+							pos:        position{line: 1491, col: 5, offset: 36668},
 							val:        "::",
 							ignoreCase: false,
 							want:       "\"::\"",
@@ -10564,16 +10601,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1485, col: 1, offset: 36516},
+			pos:  position{line: 1495, col: 1, offset: 36705},
 			expr: &choiceExpr{
-				pos: position{line: 1486, col: 5, offset: 36528},
+				pos: position{line: 1496, col: 5, offset: 36717},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1486, col: 5, offset: 36528},
+						pos:  position{line: 1496, col: 5, offset: 36717},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1487, col: 5, offset: 36535},
+						pos:  position{line: 1497, col: 5, offset: 36724},
 						name: "Hex",
 					},
 				},
@@ -10583,24 +10620,24 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1489, col: 1, offset: 36540},
+			pos:  position{line: 1499, col: 1, offset: 36729},
 			expr: &actionExpr{
-				pos: position{line: 1489, col: 12, offset: 36551},
+				pos: position{line: 1499, col: 12, offset: 36740},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1489, col: 12, offset: 36551},
+					pos: position{line: 1499, col: 12, offset: 36740},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1489, col: 12, offset: 36551},
+							pos:        position{line: 1499, col: 12, offset: 36740},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1489, col: 16, offset: 36555},
+							pos:   position{line: 1499, col: 16, offset: 36744},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1489, col: 18, offset: 36557},
+								pos:  position{line: 1499, col: 18, offset: 36746},
 								name: "Hex",
 							},
 						},
@@ -10612,23 +10649,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1491, col: 1, offset: 36595},
+			pos:  position{line: 1501, col: 1, offset: 36784},
 			expr: &actionExpr{
-				pos: position{line: 1491, col: 12, offset: 36606},
+				pos: position{line: 1501, col: 12, offset: 36795},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1491, col: 12, offset: 36606},
+					pos: position{line: 1501, col: 12, offset: 36795},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1491, col: 12, offset: 36606},
+							pos:   position{line: 1501, col: 12, offset: 36795},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1491, col: 14, offset: 36608},
+								pos:  position{line: 1501, col: 14, offset: 36797},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1491, col: 18, offset: 36612},
+							pos:        position{line: 1501, col: 18, offset: 36801},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
@@ -10641,32 +10678,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1493, col: 1, offset: 36650},
+			pos:  position{line: 1503, col: 1, offset: 36839},
 			expr: &actionExpr{
-				pos: position{line: 1494, col: 5, offset: 36661},
+				pos: position{line: 1504, col: 5, offset: 36850},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1494, col: 5, offset: 36661},
+					pos: position{line: 1504, col: 5, offset: 36850},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1494, col: 5, offset: 36661},
+							pos:   position{line: 1504, col: 5, offset: 36850},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1494, col: 7, offset: 36663},
+								pos:  position{line: 1504, col: 7, offset: 36852},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1494, col: 10, offset: 36666},
+							pos:        position{line: 1504, col: 10, offset: 36855},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1494, col: 14, offset: 36670},
+							pos:   position{line: 1504, col: 14, offset: 36859},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1494, col: 16, offset: 36672},
+								pos:  position{line: 1504, col: 16, offset: 36861},
 								name: "UIntString",
 							},
 						},
@@ -10678,32 +10715,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1498, col: 1, offset: 36740},
+			pos:  position{line: 1508, col: 1, offset: 36929},
 			expr: &actionExpr{
-				pos: position{line: 1499, col: 5, offset: 36751},
+				pos: position{line: 1509, col: 5, offset: 36940},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1499, col: 5, offset: 36751},
+					pos: position{line: 1509, col: 5, offset: 36940},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1499, col: 5, offset: 36751},
+							pos:   position{line: 1509, col: 5, offset: 36940},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1499, col: 7, offset: 36753},
+								pos:  position{line: 1509, col: 7, offset: 36942},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1499, col: 11, offset: 36757},
+							pos:        position{line: 1509, col: 11, offset: 36946},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1499, col: 15, offset: 36761},
+							pos:   position{line: 1509, col: 15, offset: 36950},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1499, col: 17, offset: 36763},
+								pos:  position{line: 1509, col: 17, offset: 36952},
 								name: "UIntString",
 							},
 						},
@@ -10715,15 +10752,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1503, col: 1, offset: 36831},
+			pos:  position{line: 1513, col: 1, offset: 37020},
 			expr: &actionExpr{
-				pos: position{line: 1504, col: 4, offset: 36839},
+				pos: position{line: 1514, col: 4, offset: 37028},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1504, col: 4, offset: 36839},
+					pos:   position{line: 1514, col: 4, offset: 37028},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1504, col: 6, offset: 36841},
+						pos:  position{line: 1514, col: 6, offset: 37030},
 						name: "UIntString",
 					},
 				},
@@ -10733,16 +10770,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1506, col: 1, offset: 36881},
+			pos:  position{line: 1516, col: 1, offset: 37070},
 			expr: &choiceExpr{
-				pos: position{line: 1507, col: 5, offset: 36895},
+				pos: position{line: 1517, col: 5, offset: 37084},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1507, col: 5, offset: 36895},
+						pos:  position{line: 1517, col: 5, offset: 37084},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1508, col: 5, offset: 36910},
+						pos:  position{line: 1518, col: 5, offset: 37099},
 						name: "MinusIntString",
 					},
 				},
@@ -10752,14 +10789,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1510, col: 1, offset: 36926},
+			pos:  position{line: 1520, col: 1, offset: 37115},
 			expr: &actionExpr{
-				pos: position{line: 1510, col: 14, offset: 36939},
+				pos: position{line: 1520, col: 14, offset: 37128},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1510, col: 14, offset: 36939},
+					pos: position{line: 1520, col: 14, offset: 37128},
 					expr: &charClassMatcher{
-						pos:        position{line: 1510, col: 14, offset: 36939},
+						pos:        position{line: 1520, col: 14, offset: 37128},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10772,21 +10809,21 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1512, col: 1, offset: 36978},
+			pos:  position{line: 1522, col: 1, offset: 37167},
 			expr: &actionExpr{
-				pos: position{line: 1513, col: 5, offset: 36997},
+				pos: position{line: 1523, col: 5, offset: 37186},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1513, col: 5, offset: 36997},
+					pos: position{line: 1523, col: 5, offset: 37186},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1513, col: 5, offset: 36997},
+							pos:        position{line: 1523, col: 5, offset: 37186},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1513, col: 9, offset: 37001},
+							pos:  position{line: 1523, col: 9, offset: 37190},
 							name: "UIntString",
 						},
 					},
@@ -10797,29 +10834,29 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1515, col: 1, offset: 37044},
+			pos:  position{line: 1525, col: 1, offset: 37233},
 			expr: &choiceExpr{
-				pos: position{line: 1516, col: 5, offset: 37060},
+				pos: position{line: 1526, col: 5, offset: 37249},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1516, col: 5, offset: 37060},
+						pos: position{line: 1526, col: 5, offset: 37249},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1516, col: 5, offset: 37060},
+							pos: position{line: 1526, col: 5, offset: 37249},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1516, col: 5, offset: 37060},
+									pos: position{line: 1526, col: 5, offset: 37249},
 									expr: &litMatcher{
-										pos:        position{line: 1516, col: 5, offset: 37060},
+										pos:        position{line: 1526, col: 5, offset: 37249},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1516, col: 10, offset: 37065},
+									pos: position{line: 1526, col: 10, offset: 37254},
 									expr: &charClassMatcher{
-										pos:        position{line: 1516, col: 10, offset: 37065},
+										pos:        position{line: 1526, col: 10, offset: 37254},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10827,15 +10864,15 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1516, col: 17, offset: 37072},
+									pos:        position{line: 1526, col: 17, offset: 37261},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1516, col: 21, offset: 37076},
+									pos: position{line: 1526, col: 21, offset: 37265},
 									expr: &charClassMatcher{
-										pos:        position{line: 1516, col: 21, offset: 37076},
+										pos:        position{line: 1526, col: 21, offset: 37265},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10843,9 +10880,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1516, col: 28, offset: 37083},
+									pos: position{line: 1526, col: 28, offset: 37272},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1516, col: 28, offset: 37083},
+										pos:  position{line: 1526, col: 28, offset: 37272},
 										name: "ExponentPart",
 									},
 								},
@@ -10853,30 +10890,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1517, col: 5, offset: 37132},
+						pos: position{line: 1527, col: 5, offset: 37321},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1517, col: 5, offset: 37132},
+							pos: position{line: 1527, col: 5, offset: 37321},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1517, col: 5, offset: 37132},
+									pos: position{line: 1527, col: 5, offset: 37321},
 									expr: &litMatcher{
-										pos:        position{line: 1517, col: 5, offset: 37132},
+										pos:        position{line: 1527, col: 5, offset: 37321},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1517, col: 10, offset: 37137},
+									pos:        position{line: 1527, col: 10, offset: 37326},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1517, col: 14, offset: 37141},
+									pos: position{line: 1527, col: 14, offset: 37330},
 									expr: &charClassMatcher{
-										pos:        position{line: 1517, col: 14, offset: 37141},
+										pos:        position{line: 1527, col: 14, offset: 37330},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10884,9 +10921,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1517, col: 21, offset: 37148},
+									pos: position{line: 1527, col: 21, offset: 37337},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1517, col: 21, offset: 37148},
+										pos:  position{line: 1527, col: 21, offset: 37337},
 										name: "ExponentPart",
 									},
 								},
@@ -10894,17 +10931,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1518, col: 5, offset: 37197},
+						pos: position{line: 1528, col: 5, offset: 37386},
 						run: (*parser).callonFloatString22,
 						expr: &choiceExpr{
-							pos: position{line: 1518, col: 6, offset: 37198},
+							pos: position{line: 1528, col: 6, offset: 37387},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1518, col: 6, offset: 37198},
+									pos:  position{line: 1528, col: 6, offset: 37387},
 									name: "NaN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1518, col: 12, offset: 37204},
+									pos:  position{line: 1528, col: 12, offset: 37393},
 									name: "Infinity",
 								},
 							},
@@ -10917,20 +10954,20 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1521, col: 1, offset: 37247},
+			pos:  position{line: 1531, col: 1, offset: 37436},
 			expr: &seqExpr{
-				pos: position{line: 1521, col: 16, offset: 37262},
+				pos: position{line: 1531, col: 16, offset: 37451},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1521, col: 16, offset: 37262},
+						pos:        position{line: 1531, col: 16, offset: 37451},
 						val:        "e",
 						ignoreCase: true,
 						want:       "\"e\"i",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1521, col: 21, offset: 37267},
+						pos: position{line: 1531, col: 21, offset: 37456},
 						expr: &charClassMatcher{
-							pos:        position{line: 1521, col: 21, offset: 37267},
+							pos:        position{line: 1531, col: 21, offset: 37456},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -10938,7 +10975,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1521, col: 27, offset: 37273},
+						pos:  position{line: 1531, col: 27, offset: 37462},
 						name: "UIntString",
 					},
 				},
@@ -10948,9 +10985,9 @@ var g = &grammar{
 		},
 		{
 			name: "NaN",
-			pos:  position{line: 1523, col: 1, offset: 37285},
+			pos:  position{line: 1533, col: 1, offset: 37474},
 			expr: &litMatcher{
-				pos:        position{line: 1523, col: 7, offset: 37291},
+				pos:        position{line: 1533, col: 7, offset: 37480},
 				val:        "NaN",
 				ignoreCase: false,
 				want:       "\"NaN\"",
@@ -10960,23 +10997,23 @@ var g = &grammar{
 		},
 		{
 			name: "Infinity",
-			pos:  position{line: 1525, col: 1, offset: 37298},
+			pos:  position{line: 1535, col: 1, offset: 37487},
 			expr: &seqExpr{
-				pos: position{line: 1525, col: 12, offset: 37309},
+				pos: position{line: 1535, col: 12, offset: 37498},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 1525, col: 12, offset: 37309},
+						pos: position{line: 1535, col: 12, offset: 37498},
 						expr: &choiceExpr{
-							pos: position{line: 1525, col: 13, offset: 37310},
+							pos: position{line: 1535, col: 13, offset: 37499},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1525, col: 13, offset: 37310},
+									pos:        position{line: 1535, col: 13, offset: 37499},
 									val:        "-",
 									ignoreCase: false,
 									want:       "\"-\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1525, col: 19, offset: 37316},
+									pos:        position{line: 1535, col: 19, offset: 37505},
 									val:        "+",
 									ignoreCase: false,
 									want:       "\"+\"",
@@ -10985,7 +11022,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1525, col: 25, offset: 37322},
+						pos:        position{line: 1535, col: 25, offset: 37511},
 						val:        "Inf",
 						ignoreCase: false,
 						want:       "\"Inf\"",
@@ -10997,14 +11034,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1527, col: 1, offset: 37329},
+			pos:  position{line: 1537, col: 1, offset: 37518},
 			expr: &actionExpr{
-				pos: position{line: 1527, col: 7, offset: 37335},
+				pos: position{line: 1537, col: 7, offset: 37524},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1527, col: 7, offset: 37335},
+					pos: position{line: 1537, col: 7, offset: 37524},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1527, col: 7, offset: 37335},
+						pos:  position{line: 1537, col: 7, offset: 37524},
 						name: "HexDigit",
 					},
 				},
@@ -11014,9 +11051,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1529, col: 1, offset: 37377},
+			pos:  position{line: 1539, col: 1, offset: 37566},
 			expr: &charClassMatcher{
-				pos:        position{line: 1529, col: 12, offset: 37388},
+				pos:        position{line: 1539, col: 12, offset: 37577},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -11027,35 +11064,35 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1531, col: 1, offset: 37401},
+			pos:  position{line: 1541, col: 1, offset: 37590},
 			expr: &choiceExpr{
-				pos: position{line: 1532, col: 5, offset: 37418},
+				pos: position{line: 1542, col: 5, offset: 37607},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1532, col: 5, offset: 37418},
+						pos: position{line: 1542, col: 5, offset: 37607},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 1532, col: 5, offset: 37418},
+							pos: position{line: 1542, col: 5, offset: 37607},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1532, col: 5, offset: 37418},
+									pos:        position{line: 1542, col: 5, offset: 37607},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1532, col: 9, offset: 37422},
+									pos:   position{line: 1542, col: 9, offset: 37611},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1532, col: 11, offset: 37424},
+										pos: position{line: 1542, col: 11, offset: 37613},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1532, col: 11, offset: 37424},
+											pos:  position{line: 1542, col: 11, offset: 37613},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1532, col: 29, offset: 37442},
+									pos:        position{line: 1542, col: 29, offset: 37631},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -11064,30 +11101,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1533, col: 5, offset: 37479},
+						pos: position{line: 1543, col: 5, offset: 37668},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 1533, col: 5, offset: 37479},
+							pos: position{line: 1543, col: 5, offset: 37668},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1533, col: 5, offset: 37479},
+									pos:        position{line: 1543, col: 5, offset: 37668},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1533, col: 9, offset: 37483},
+									pos:   position{line: 1543, col: 9, offset: 37672},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1533, col: 11, offset: 37485},
+										pos: position{line: 1543, col: 11, offset: 37674},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1533, col: 11, offset: 37485},
+											pos:  position{line: 1543, col: 11, offset: 37674},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1533, col: 29, offset: 37503},
+									pos:        position{line: 1543, col: 29, offset: 37692},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -11102,57 +11139,57 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1535, col: 1, offset: 37537},
+			pos:  position{line: 1545, col: 1, offset: 37726},
 			expr: &choiceExpr{
-				pos: position{line: 1536, col: 5, offset: 37558},
+				pos: position{line: 1546, col: 5, offset: 37747},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1536, col: 5, offset: 37558},
+						pos: position{line: 1546, col: 5, offset: 37747},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1536, col: 5, offset: 37558},
+							pos: position{line: 1546, col: 5, offset: 37747},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1536, col: 5, offset: 37558},
+									pos: position{line: 1546, col: 5, offset: 37747},
 									expr: &choiceExpr{
-										pos: position{line: 1536, col: 7, offset: 37560},
+										pos: position{line: 1546, col: 7, offset: 37749},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1536, col: 7, offset: 37560},
+												pos:        position{line: 1546, col: 7, offset: 37749},
 												val:        "\"",
 												ignoreCase: false,
 												want:       "\"\\\"\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1536, col: 13, offset: 37566},
+												pos:  position{line: 1546, col: 13, offset: 37755},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1536, col: 26, offset: 37579,
+									line: 1546, col: 26, offset: 37768,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1537, col: 5, offset: 37616},
+						pos: position{line: 1547, col: 5, offset: 37805},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1537, col: 5, offset: 37616},
+							pos: position{line: 1547, col: 5, offset: 37805},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1537, col: 5, offset: 37616},
+									pos:        position{line: 1547, col: 5, offset: 37805},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1537, col: 10, offset: 37621},
+									pos:   position{line: 1547, col: 10, offset: 37810},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1537, col: 12, offset: 37623},
+										pos:  position{line: 1547, col: 12, offset: 37812},
 										name: "EscapeSequence",
 									},
 								},
@@ -11166,28 +11203,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1539, col: 1, offset: 37657},
+			pos:  position{line: 1549, col: 1, offset: 37846},
 			expr: &actionExpr{
-				pos: position{line: 1540, col: 5, offset: 37669},
+				pos: position{line: 1550, col: 5, offset: 37858},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1540, col: 5, offset: 37669},
+					pos: position{line: 1550, col: 5, offset: 37858},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1540, col: 5, offset: 37669},
+							pos:   position{line: 1550, col: 5, offset: 37858},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1540, col: 10, offset: 37674},
+								pos:  position{line: 1550, col: 10, offset: 37863},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1540, col: 23, offset: 37687},
+							pos:   position{line: 1550, col: 23, offset: 37876},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1540, col: 28, offset: 37692},
+								pos: position{line: 1550, col: 28, offset: 37881},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1540, col: 28, offset: 37692},
+									pos:  position{line: 1550, col: 28, offset: 37881},
 									name: "KeyWordRest",
 								},
 							},
@@ -11200,16 +11237,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1542, col: 1, offset: 37754},
+			pos:  position{line: 1552, col: 1, offset: 37943},
 			expr: &choiceExpr{
-				pos: position{line: 1543, col: 5, offset: 37771},
+				pos: position{line: 1553, col: 5, offset: 37960},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1543, col: 5, offset: 37771},
+						pos:  position{line: 1553, col: 5, offset: 37960},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1544, col: 5, offset: 37788},
+						pos:  position{line: 1554, col: 5, offset: 37977},
 						name: "KeyWordEsc",
 					},
 				},
@@ -11219,16 +11256,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1546, col: 1, offset: 37800},
+			pos:  position{line: 1556, col: 1, offset: 37989},
 			expr: &choiceExpr{
-				pos: position{line: 1547, col: 5, offset: 37816},
+				pos: position{line: 1557, col: 5, offset: 38005},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1547, col: 5, offset: 37816},
+						pos:  position{line: 1557, col: 5, offset: 38005},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1548, col: 5, offset: 37833},
+						pos:        position{line: 1558, col: 5, offset: 38022},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11241,19 +11278,19 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1550, col: 1, offset: 37840},
+			pos:  position{line: 1560, col: 1, offset: 38029},
 			expr: &actionExpr{
-				pos: position{line: 1550, col: 16, offset: 37855},
+				pos: position{line: 1560, col: 16, offset: 38044},
 				run: (*parser).callonKeyWordChars1,
 				expr: &choiceExpr{
-					pos: position{line: 1550, col: 17, offset: 37856},
+					pos: position{line: 1560, col: 17, offset: 38045},
 					alternatives: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1550, col: 17, offset: 37856},
+							pos:  position{line: 1560, col: 17, offset: 38045},
 							name: "UnicodeLetter",
 						},
 						&charClassMatcher{
-							pos:        position{line: 1550, col: 33, offset: 37872},
+							pos:        position{line: 1560, col: 33, offset: 38061},
 							val:        "[_.:/%#@~]",
 							chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 							ignoreCase: false,
@@ -11267,31 +11304,31 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1552, col: 1, offset: 37916},
+			pos:  position{line: 1562, col: 1, offset: 38105},
 			expr: &actionExpr{
-				pos: position{line: 1552, col: 14, offset: 37929},
+				pos: position{line: 1562, col: 14, offset: 38118},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1552, col: 14, offset: 37929},
+					pos: position{line: 1562, col: 14, offset: 38118},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1552, col: 14, offset: 37929},
+							pos:        position{line: 1562, col: 14, offset: 38118},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1552, col: 19, offset: 37934},
+							pos:   position{line: 1562, col: 19, offset: 38123},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1552, col: 22, offset: 37937},
+								pos: position{line: 1562, col: 22, offset: 38126},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1552, col: 22, offset: 37937},
+										pos:  position{line: 1562, col: 22, offset: 38126},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1552, col: 38, offset: 37953},
+										pos:  position{line: 1562, col: 38, offset: 38142},
 										name: "EscapeSequence",
 									},
 								},
@@ -11305,42 +11342,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1554, col: 1, offset: 37988},
+			pos:  position{line: 1564, col: 1, offset: 38177},
 			expr: &actionExpr{
-				pos: position{line: 1555, col: 5, offset: 38004},
+				pos: position{line: 1565, col: 5, offset: 38193},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1555, col: 5, offset: 38004},
+					pos: position{line: 1565, col: 5, offset: 38193},
 					exprs: []any{
 						&andExpr{
-							pos: position{line: 1555, col: 5, offset: 38004},
+							pos: position{line: 1565, col: 5, offset: 38193},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1555, col: 6, offset: 38005},
+								pos:  position{line: 1565, col: 6, offset: 38194},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1555, col: 22, offset: 38021},
+							pos: position{line: 1565, col: 22, offset: 38210},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1555, col: 23, offset: 38022},
+								pos:  position{line: 1565, col: 23, offset: 38211},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1555, col: 35, offset: 38034},
+							pos:   position{line: 1565, col: 35, offset: 38223},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1555, col: 40, offset: 38039},
+								pos:  position{line: 1565, col: 40, offset: 38228},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1555, col: 50, offset: 38049},
+							pos:   position{line: 1565, col: 50, offset: 38238},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1555, col: 55, offset: 38054},
+								pos: position{line: 1565, col: 55, offset: 38243},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1555, col: 55, offset: 38054},
+									pos:  position{line: 1565, col: 55, offset: 38243},
 									name: "GlobRest",
 								},
 							},
@@ -11353,28 +11390,28 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1559, col: 1, offset: 38123},
+			pos:  position{line: 1569, col: 1, offset: 38312},
 			expr: &choiceExpr{
-				pos: position{line: 1559, col: 19, offset: 38141},
+				pos: position{line: 1569, col: 19, offset: 38330},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1559, col: 19, offset: 38141},
+						pos:  position{line: 1569, col: 19, offset: 38330},
 						name: "KeyWordStart",
 					},
 					&seqExpr{
-						pos: position{line: 1559, col: 34, offset: 38156},
+						pos: position{line: 1569, col: 34, offset: 38345},
 						exprs: []any{
 							&oneOrMoreExpr{
-								pos: position{line: 1559, col: 34, offset: 38156},
+								pos: position{line: 1569, col: 34, offset: 38345},
 								expr: &litMatcher{
-									pos:        position{line: 1559, col: 34, offset: 38156},
+									pos:        position{line: 1569, col: 34, offset: 38345},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1559, col: 39, offset: 38161},
+								pos:  position{line: 1569, col: 39, offset: 38350},
 								name: "KeyWordRest",
 							},
 						},
@@ -11386,19 +11423,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1560, col: 1, offset: 38173},
+			pos:  position{line: 1570, col: 1, offset: 38362},
 			expr: &seqExpr{
-				pos: position{line: 1560, col: 15, offset: 38187},
+				pos: position{line: 1570, col: 15, offset: 38376},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1560, col: 15, offset: 38187},
+						pos: position{line: 1570, col: 15, offset: 38376},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1560, col: 15, offset: 38187},
+							pos:  position{line: 1570, col: 15, offset: 38376},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1560, col: 28, offset: 38200},
+						pos:        position{line: 1570, col: 28, offset: 38389},
 						val:        "*",
 						ignoreCase: false,
 						want:       "\"*\"",
@@ -11410,23 +11447,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1562, col: 1, offset: 38205},
+			pos:  position{line: 1572, col: 1, offset: 38394},
 			expr: &choiceExpr{
-				pos: position{line: 1563, col: 5, offset: 38219},
+				pos: position{line: 1573, col: 5, offset: 38408},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1563, col: 5, offset: 38219},
+						pos:  position{line: 1573, col: 5, offset: 38408},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1564, col: 5, offset: 38236},
+						pos:  position{line: 1574, col: 5, offset: 38425},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1565, col: 5, offset: 38248},
+						pos: position{line: 1575, col: 5, offset: 38437},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1565, col: 5, offset: 38248},
+							pos:        position{line: 1575, col: 5, offset: 38437},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -11439,16 +11476,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1567, col: 1, offset: 38273},
+			pos:  position{line: 1577, col: 1, offset: 38462},
 			expr: &choiceExpr{
-				pos: position{line: 1568, col: 5, offset: 38286},
+				pos: position{line: 1578, col: 5, offset: 38475},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1568, col: 5, offset: 38286},
+						pos:  position{line: 1578, col: 5, offset: 38475},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1569, col: 5, offset: 38300},
+						pos:        position{line: 1579, col: 5, offset: 38489},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11461,31 +11498,31 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1571, col: 1, offset: 38307},
+			pos:  position{line: 1581, col: 1, offset: 38496},
 			expr: &actionExpr{
-				pos: position{line: 1571, col: 11, offset: 38317},
+				pos: position{line: 1581, col: 11, offset: 38506},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1571, col: 11, offset: 38317},
+					pos: position{line: 1581, col: 11, offset: 38506},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1571, col: 11, offset: 38317},
+							pos:        position{line: 1581, col: 11, offset: 38506},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1571, col: 16, offset: 38322},
+							pos:   position{line: 1581, col: 16, offset: 38511},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1571, col: 19, offset: 38325},
+								pos: position{line: 1581, col: 19, offset: 38514},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1571, col: 19, offset: 38325},
+										pos:  position{line: 1581, col: 19, offset: 38514},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1571, col: 32, offset: 38338},
+										pos:  position{line: 1581, col: 32, offset: 38527},
 										name: "EscapeSequence",
 									},
 								},
@@ -11499,32 +11536,32 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1573, col: 1, offset: 38373},
+			pos:  position{line: 1583, col: 1, offset: 38562},
 			expr: &choiceExpr{
-				pos: position{line: 1574, col: 5, offset: 38388},
+				pos: position{line: 1584, col: 5, offset: 38577},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1574, col: 5, offset: 38388},
+						pos: position{line: 1584, col: 5, offset: 38577},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1574, col: 5, offset: 38388},
+							pos:        position{line: 1584, col: 5, offset: 38577},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1575, col: 5, offset: 38416},
+						pos: position{line: 1585, col: 5, offset: 38605},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1575, col: 5, offset: 38416},
+							pos:        position{line: 1585, col: 5, offset: 38605},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1576, col: 5, offset: 38446},
+						pos:        position{line: 1586, col: 5, offset: 38635},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -11537,57 +11574,57 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1578, col: 1, offset: 38452},
+			pos:  position{line: 1588, col: 1, offset: 38641},
 			expr: &choiceExpr{
-				pos: position{line: 1579, col: 5, offset: 38473},
+				pos: position{line: 1589, col: 5, offset: 38662},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1579, col: 5, offset: 38473},
+						pos: position{line: 1589, col: 5, offset: 38662},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1579, col: 5, offset: 38473},
+							pos: position{line: 1589, col: 5, offset: 38662},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1579, col: 5, offset: 38473},
+									pos: position{line: 1589, col: 5, offset: 38662},
 									expr: &choiceExpr{
-										pos: position{line: 1579, col: 7, offset: 38475},
+										pos: position{line: 1589, col: 7, offset: 38664},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1579, col: 7, offset: 38475},
+												pos:        position{line: 1589, col: 7, offset: 38664},
 												val:        "'",
 												ignoreCase: false,
 												want:       "\"'\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1579, col: 13, offset: 38481},
+												pos:  position{line: 1589, col: 13, offset: 38670},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1579, col: 26, offset: 38494,
+									line: 1589, col: 26, offset: 38683,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1580, col: 5, offset: 38531},
+						pos: position{line: 1590, col: 5, offset: 38720},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1580, col: 5, offset: 38531},
+							pos: position{line: 1590, col: 5, offset: 38720},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1580, col: 5, offset: 38531},
+									pos:        position{line: 1590, col: 5, offset: 38720},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1580, col: 10, offset: 38536},
+									pos:   position{line: 1590, col: 10, offset: 38725},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1580, col: 12, offset: 38538},
+										pos:  position{line: 1590, col: 12, offset: 38727},
 										name: "EscapeSequence",
 									},
 								},
@@ -11601,16 +11638,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1582, col: 1, offset: 38572},
+			pos:  position{line: 1592, col: 1, offset: 38761},
 			expr: &choiceExpr{
-				pos: position{line: 1583, col: 5, offset: 38591},
+				pos: position{line: 1593, col: 5, offset: 38780},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1583, col: 5, offset: 38591},
+						pos:  position{line: 1593, col: 5, offset: 38780},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1584, col: 5, offset: 38612},
+						pos:  position{line: 1594, col: 5, offset: 38801},
 						name: "UnicodeEscape",
 					},
 				},
@@ -11620,87 +11657,87 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1586, col: 1, offset: 38627},
+			pos:  position{line: 1596, col: 1, offset: 38816},
 			expr: &choiceExpr{
-				pos: position{line: 1587, col: 5, offset: 38648},
+				pos: position{line: 1597, col: 5, offset: 38837},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1587, col: 5, offset: 38648},
+						pos:        position{line: 1597, col: 5, offset: 38837},
 						val:        "'",
 						ignoreCase: false,
 						want:       "\"'\"",
 					},
 					&actionExpr{
-						pos: position{line: 1588, col: 5, offset: 38656},
+						pos: position{line: 1598, col: 5, offset: 38845},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1588, col: 5, offset: 38656},
+							pos:        position{line: 1598, col: 5, offset: 38845},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1589, col: 5, offset: 38696},
+						pos:        position{line: 1599, col: 5, offset: 38885},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
 					},
 					&actionExpr{
-						pos: position{line: 1590, col: 5, offset: 38705},
+						pos: position{line: 1600, col: 5, offset: 38894},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1590, col: 5, offset: 38705},
+							pos:        position{line: 1600, col: 5, offset: 38894},
 							val:        "b",
 							ignoreCase: false,
 							want:       "\"b\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1591, col: 5, offset: 38734},
+						pos: position{line: 1601, col: 5, offset: 38923},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1591, col: 5, offset: 38734},
+							pos:        position{line: 1601, col: 5, offset: 38923},
 							val:        "f",
 							ignoreCase: false,
 							want:       "\"f\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1592, col: 5, offset: 38763},
+						pos: position{line: 1602, col: 5, offset: 38952},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1592, col: 5, offset: 38763},
+							pos:        position{line: 1602, col: 5, offset: 38952},
 							val:        "n",
 							ignoreCase: false,
 							want:       "\"n\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1593, col: 5, offset: 38792},
+						pos: position{line: 1603, col: 5, offset: 38981},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1593, col: 5, offset: 38792},
+							pos:        position{line: 1603, col: 5, offset: 38981},
 							val:        "r",
 							ignoreCase: false,
 							want:       "\"r\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1594, col: 5, offset: 38821},
+						pos: position{line: 1604, col: 5, offset: 39010},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1594, col: 5, offset: 38821},
+							pos:        position{line: 1604, col: 5, offset: 39010},
 							val:        "t",
 							ignoreCase: false,
 							want:       "\"t\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1595, col: 5, offset: 38850},
+						pos: position{line: 1605, col: 5, offset: 39039},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1595, col: 5, offset: 38850},
+							pos:        position{line: 1605, col: 5, offset: 39039},
 							val:        "v",
 							ignoreCase: false,
 							want:       "\"v\"",
@@ -11713,32 +11750,32 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1597, col: 1, offset: 38876},
+			pos:  position{line: 1607, col: 1, offset: 39065},
 			expr: &choiceExpr{
-				pos: position{line: 1598, col: 5, offset: 38894},
+				pos: position{line: 1608, col: 5, offset: 39083},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1598, col: 5, offset: 38894},
+						pos: position{line: 1608, col: 5, offset: 39083},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1598, col: 5, offset: 38894},
+							pos:        position{line: 1608, col: 5, offset: 39083},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1599, col: 5, offset: 38922},
+						pos: position{line: 1609, col: 5, offset: 39111},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1599, col: 5, offset: 38922},
+							pos:        position{line: 1609, col: 5, offset: 39111},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1600, col: 5, offset: 38950},
+						pos:        position{line: 1610, col: 5, offset: 39139},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -11751,42 +11788,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1602, col: 1, offset: 38956},
+			pos:  position{line: 1612, col: 1, offset: 39145},
 			expr: &choiceExpr{
-				pos: position{line: 1603, col: 5, offset: 38974},
+				pos: position{line: 1613, col: 5, offset: 39163},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1603, col: 5, offset: 38974},
+						pos: position{line: 1613, col: 5, offset: 39163},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1603, col: 5, offset: 38974},
+							pos: position{line: 1613, col: 5, offset: 39163},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1603, col: 5, offset: 38974},
+									pos:        position{line: 1613, col: 5, offset: 39163},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1603, col: 9, offset: 38978},
+									pos:   position{line: 1613, col: 9, offset: 39167},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1603, col: 16, offset: 38985},
+										pos: position{line: 1613, col: 16, offset: 39174},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1603, col: 16, offset: 38985},
+												pos:  position{line: 1613, col: 16, offset: 39174},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1603, col: 25, offset: 38994},
+												pos:  position{line: 1613, col: 25, offset: 39183},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1603, col: 34, offset: 39003},
+												pos:  position{line: 1613, col: 34, offset: 39192},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1603, col: 43, offset: 39012},
+												pos:  position{line: 1613, col: 43, offset: 39201},
 												name: "HexDigit",
 											},
 										},
@@ -11796,65 +11833,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1606, col: 5, offset: 39075},
+						pos: position{line: 1616, col: 5, offset: 39264},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1606, col: 5, offset: 39075},
+							pos: position{line: 1616, col: 5, offset: 39264},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1606, col: 5, offset: 39075},
+									pos:        position{line: 1616, col: 5, offset: 39264},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1606, col: 9, offset: 39079},
+									pos:        position{line: 1616, col: 9, offset: 39268},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1606, col: 13, offset: 39083},
+									pos:   position{line: 1616, col: 13, offset: 39272},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1606, col: 20, offset: 39090},
+										pos: position{line: 1616, col: 20, offset: 39279},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1606, col: 20, offset: 39090},
+												pos:  position{line: 1616, col: 20, offset: 39279},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1606, col: 29, offset: 39099},
+												pos: position{line: 1616, col: 29, offset: 39288},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1606, col: 29, offset: 39099},
+													pos:  position{line: 1616, col: 29, offset: 39288},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1606, col: 39, offset: 39109},
+												pos: position{line: 1616, col: 39, offset: 39298},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1606, col: 39, offset: 39109},
+													pos:  position{line: 1616, col: 39, offset: 39298},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1606, col: 49, offset: 39119},
+												pos: position{line: 1616, col: 49, offset: 39308},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1606, col: 49, offset: 39119},
+													pos:  position{line: 1616, col: 49, offset: 39308},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1606, col: 59, offset: 39129},
+												pos: position{line: 1616, col: 59, offset: 39318},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1606, col: 59, offset: 39129},
+													pos:  position{line: 1616, col: 59, offset: 39318},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1606, col: 69, offset: 39139},
+												pos: position{line: 1616, col: 69, offset: 39328},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1606, col: 69, offset: 39139},
+													pos:  position{line: 1616, col: 69, offset: 39328},
 													name: "HexDigit",
 												},
 											},
@@ -11862,7 +11899,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1606, col: 80, offset: 39150},
+									pos:        position{line: 1616, col: 80, offset: 39339},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -11877,37 +11914,37 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPattern",
-			pos:  position{line: 1610, col: 1, offset: 39204},
+			pos:  position{line: 1620, col: 1, offset: 39393},
 			expr: &actionExpr{
-				pos: position{line: 1611, col: 5, offset: 39222},
+				pos: position{line: 1621, col: 5, offset: 39411},
 				run: (*parser).callonRegexpPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1611, col: 5, offset: 39222},
+					pos: position{line: 1621, col: 5, offset: 39411},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1611, col: 5, offset: 39222},
+							pos:        position{line: 1621, col: 5, offset: 39411},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1611, col: 9, offset: 39226},
+							pos:   position{line: 1621, col: 9, offset: 39415},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1611, col: 14, offset: 39231},
+								pos:  position{line: 1621, col: 14, offset: 39420},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1611, col: 25, offset: 39242},
+							pos:        position{line: 1621, col: 25, offset: 39431},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&notExpr{
-							pos: position{line: 1611, col: 29, offset: 39246},
+							pos: position{line: 1621, col: 29, offset: 39435},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1611, col: 30, offset: 39247},
+								pos:  position{line: 1621, col: 30, offset: 39436},
 								name: "KeyWordStart",
 							},
 						},
@@ -11919,33 +11956,33 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1613, col: 1, offset: 39282},
+			pos:  position{line: 1623, col: 1, offset: 39471},
 			expr: &actionExpr{
-				pos: position{line: 1614, col: 5, offset: 39297},
+				pos: position{line: 1624, col: 5, offset: 39486},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1614, col: 5, offset: 39297},
+					pos: position{line: 1624, col: 5, offset: 39486},
 					expr: &choiceExpr{
-						pos: position{line: 1614, col: 6, offset: 39298},
+						pos: position{line: 1624, col: 6, offset: 39487},
 						alternatives: []any{
 							&charClassMatcher{
-								pos:        position{line: 1614, col: 6, offset: 39298},
+								pos:        position{line: 1624, col: 6, offset: 39487},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&seqExpr{
-								pos: position{line: 1614, col: 15, offset: 39307},
+								pos: position{line: 1624, col: 15, offset: 39496},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 1614, col: 15, offset: 39307},
+										pos:        position{line: 1624, col: 15, offset: 39496},
 										val:        "\\",
 										ignoreCase: false,
 										want:       "\"\\\\\"",
 									},
 									&anyMatcher{
-										line: 1614, col: 20, offset: 39312,
+										line: 1624, col: 20, offset: 39501,
 									},
 								},
 							},
@@ -11958,9 +11995,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1616, col: 1, offset: 39348},
+			pos:  position{line: 1626, col: 1, offset: 39537},
 			expr: &charClassMatcher{
-				pos:        position{line: 1617, col: 5, offset: 39364},
+				pos:        position{line: 1627, col: 5, offset: 39553},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -11972,11 +12009,11 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1619, col: 1, offset: 39379},
+			pos:  position{line: 1629, col: 1, offset: 39568},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1619, col: 5, offset: 39383},
+				pos: position{line: 1629, col: 5, offset: 39572},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1619, col: 5, offset: 39383},
+					pos:  position{line: 1629, col: 5, offset: 39572},
 					name: "AnySpace",
 				},
 			},
@@ -11985,11 +12022,11 @@ var g = &grammar{
 		},
 		{
 			name: "__",
-			pos:  position{line: 1621, col: 1, offset: 39394},
+			pos:  position{line: 1631, col: 1, offset: 39583},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1621, col: 6, offset: 39399},
+				pos: position{line: 1631, col: 6, offset: 39588},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1621, col: 6, offset: 39399},
+					pos:  position{line: 1631, col: 6, offset: 39588},
 					name: "AnySpace",
 				},
 			},
@@ -11998,20 +12035,20 @@ var g = &grammar{
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1623, col: 1, offset: 39410},
+			pos:  position{line: 1633, col: 1, offset: 39599},
 			expr: &choiceExpr{
-				pos: position{line: 1624, col: 5, offset: 39423},
+				pos: position{line: 1634, col: 5, offset: 39612},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1624, col: 5, offset: 39423},
+						pos:  position{line: 1634, col: 5, offset: 39612},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1625, col: 5, offset: 39438},
+						pos:  position{line: 1635, col: 5, offset: 39627},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1626, col: 5, offset: 39457},
+						pos:  position{line: 1636, col: 5, offset: 39646},
 						name: "Comment",
 					},
 				},
@@ -12021,32 +12058,32 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeLetter",
-			pos:  position{line: 1628, col: 1, offset: 39466},
+			pos:  position{line: 1638, col: 1, offset: 39655},
 			expr: &choiceExpr{
-				pos: position{line: 1629, col: 5, offset: 39484},
+				pos: position{line: 1639, col: 5, offset: 39673},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1629, col: 5, offset: 39484},
+						pos:  position{line: 1639, col: 5, offset: 39673},
 						name: "Lu",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1630, col: 5, offset: 39491},
+						pos:  position{line: 1640, col: 5, offset: 39680},
 						name: "Ll",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1631, col: 5, offset: 39498},
+						pos:  position{line: 1641, col: 5, offset: 39687},
 						name: "Lt",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1632, col: 5, offset: 39505},
+						pos:  position{line: 1642, col: 5, offset: 39694},
 						name: "Lm",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1633, col: 5, offset: 39512},
+						pos:  position{line: 1643, col: 5, offset: 39701},
 						name: "Lo",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1634, col: 5, offset: 39519},
+						pos:  position{line: 1644, col: 5, offset: 39708},
 						name: "Nl",
 					},
 				},
@@ -12056,16 +12093,16 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeCombiningMark",
-			pos:  position{line: 1636, col: 1, offset: 39523},
+			pos:  position{line: 1646, col: 1, offset: 39712},
 			expr: &choiceExpr{
-				pos: position{line: 1637, col: 5, offset: 39548},
+				pos: position{line: 1647, col: 5, offset: 39737},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1637, col: 5, offset: 39548},
+						pos:  position{line: 1647, col: 5, offset: 39737},
 						name: "Mn",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1638, col: 5, offset: 39555},
+						pos:  position{line: 1648, col: 5, offset: 39744},
 						name: "Mc",
 					},
 				},
@@ -12075,9 +12112,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeDigit",
-			pos:  position{line: 1640, col: 1, offset: 39559},
+			pos:  position{line: 1650, col: 1, offset: 39748},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1641, col: 5, offset: 39576},
+				pos:  position{line: 1651, col: 5, offset: 39765},
 				name: "Nd",
 			},
 			leader:        false,
@@ -12085,9 +12122,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeConnectorPunctuation",
-			pos:  position{line: 1643, col: 1, offset: 39580},
+			pos:  position{line: 1653, col: 1, offset: 39769},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1644, col: 5, offset: 39612},
+				pos:  position{line: 1654, col: 5, offset: 39801},
 				name: "Pc",
 			},
 			leader:        false,
@@ -12095,9 +12132,9 @@ var g = &grammar{
 		},
 		{
 			name: "Ll",
-			pos:  position{line: 1650, col: 1, offset: 39793},
+			pos:  position{line: 1660, col: 1, offset: 39982},
 			expr: &charClassMatcher{
-				pos:        position{line: 1650, col: 6, offset: 39798},
+				pos:        position{line: 1660, col: 6, offset: 39987},
 				val:        "[\\u0061-\\u007A\\u00B5\\u00DF-\\u00F6\\u00F8-\\u00FF\\u0101\\u0103\\u0105\\u0107\\u0109\\u010B\\u010D\\u010F\\u0111\\u0113\\u0115\\u0117\\u0119\\u011B\\u011D\\u011F\\u0121\\u0123\\u0125\\u0127\\u0129\\u012B\\u012D\\u012F\\u0131\\u0133\\u0135\\u0137-\\u0138\\u013A\\u013C\\u013E\\u0140\\u0142\\u0144\\u0146\\u0148-\\u0149\\u014B\\u014D\\u014F\\u0151\\u0153\\u0155\\u0157\\u0159\\u015B\\u015D\\u015F\\u0161\\u0163\\u0165\\u0167\\u0169\\u016B\\u016D\\u016F\\u0171\\u0173\\u0175\\u0177\\u017A\\u017C\\u017E-\\u0180\\u0183\\u0185\\u0188\\u018C-\\u018D\\u0192\\u0195\\u0199-\\u019B\\u019E\\u01A1\\u01A3\\u01A5\\u01A8\\u01AA-\\u01AB\\u01AD\\u01B0\\u01B4\\u01B6\\u01B9-\\u01BA\\u01BD-\\u01BF\\u01C6\\u01C9\\u01CC\\u01CE\\u01D0\\u01D2\\u01D4\\u01D6\\u01D8\\u01DA\\u01DC-\\u01DD\\u01DF\\u01E1\\u01E3\\u01E5\\u01E7\\u01E9\\u01EB\\u01ED\\u01EF-\\u01F0\\u01F3\\u01F5\\u01F9\\u01FB\\u01FD\\u01FF\\u0201\\u0203\\u0205\\u0207\\u0209\\u020B\\u020D\\u020F\\u0211\\u0213\\u0215\\u0217\\u0219\\u021B\\u021D\\u021F\\u0221\\u0223\\u0225\\u0227\\u0229\\u022B\\u022D\\u022F\\u0231\\u0233-\\u0239\\u023C\\u023F-\\u0240\\u0242\\u0247\\u0249\\u024B\\u024D\\u024F-\\u0293\\u0295-\\u02AF\\u0371\\u0373\\u0377\\u037B-\\u037D\\u0390\\u03AC-\\u03CE\\u03D0-\\u03D1\\u03D5-\\u03D7\\u03D9\\u03DB\\u03DD\\u03DF\\u03E1\\u03E3\\u03E5\\u03E7\\u03E9\\u03EB\\u03ED\\u03EF-\\u03F3\\u03F5\\u03F8\\u03FB-\\u03FC\\u0430-\\u045F\\u0461\\u0463\\u0465\\u0467\\u0469\\u046B\\u046D\\u046F\\u0471\\u0473\\u0475\\u0477\\u0479\\u047B\\u047D\\u047F\\u0481\\u048B\\u048D\\u048F\\u0491\\u0493\\u0495\\u0497\\u0499\\u049B\\u049D\\u049F\\u04A1\\u04A3\\u04A5\\u04A7\\u04A9\\u04AB\\u04AD\\u04AF\\u04B1\\u04B3\\u04B5\\u04B7\\u04B9\\u04BB\\u04BD\\u04BF\\u04C2\\u04C4\\u04C6\\u04C8\\u04CA\\u04CC\\u04CE-\\u04CF\\u04D1\\u04D3\\u04D5\\u04D7\\u04D9\\u04DB\\u04DD\\u04DF\\u04E1\\u04E3\\u04E5\\u04E7\\u04E9\\u04EB\\u04ED\\u04EF\\u04F1\\u04F3\\u04F5\\u04F7\\u04F9\\u04FB\\u04FD\\u04FF\\u0501\\u0503\\u0505\\u0507\\u0509\\u050B\\u050D\\u050F\\u0511\\u0513\\u0515\\u0517\\u0519\\u051B\\u051D\\u051F\\u0521\\u0523\\u0525\\u0527\\u0529\\u052B\\u052D\\u052F\\u0560-\\u0588\\u10D0-\\u10FA\\u10FD-\\u10FF\\u13F8-\\u13FD\\u1C80-\\u1C88\\u1D00-\\u1D2B\\u1D6B-\\u1D77\\u1D79-\\u1D9A\\u1E01\\u1E03\\u1E05\\u1E07\\u1E09\\u1E0B\\u1E0D\\u1E0F\\u1E11\\u1E13\\u1E15\\u1E17\\u1E19\\u1E1B\\u1E1D\\u1E1F\\u1E21\\u1E23\\u1E25\\u1E27\\u1E29\\u1E2B\\u1E2D\\u1E2F\\u1E31\\u1E33\\u1E35\\u1E37\\u1E39\\u1E3B\\u1E3D\\u1E3F\\u1E41\\u1E43\\u1E45\\u1E47\\u1E49\\u1E4B\\u1E4D\\u1E4F\\u1E51\\u1E53\\u1E55\\u1E57\\u1E59\\u1E5B\\u1E5D\\u1E5F\\u1E61\\u1E63\\u1E65\\u1E67\\u1E69\\u1E6B\\u1E6D\\u1E6F\\u1E71\\u1E73\\u1E75\\u1E77\\u1E79\\u1E7B\\u1E7D\\u1E7F\\u1E81\\u1E83\\u1E85\\u1E87\\u1E89\\u1E8B\\u1E8D\\u1E8F\\u1E91\\u1E93\\u1E95-\\u1E9D\\u1E9F\\u1EA1\\u1EA3\\u1EA5\\u1EA7\\u1EA9\\u1EAB\\u1EAD\\u1EAF\\u1EB1\\u1EB3\\u1EB5\\u1EB7\\u1EB9\\u1EBB\\u1EBD\\u1EBF\\u1EC1\\u1EC3\\u1EC5\\u1EC7\\u1EC9\\u1ECB\\u1ECD\\u1ECF\\u1ED1\\u1ED3\\u1ED5\\u1ED7\\u1ED9\\u1EDB\\u1EDD\\u1EDF\\u1EE1\\u1EE3\\u1EE5\\u1EE7\\u1EE9\\u1EEB\\u1EED\\u1EEF\\u1EF1\\u1EF3\\u1EF5\\u1EF7\\u1EF9\\u1EFB\\u1EFD\\u1EFF-\\u1F07\\u1F10-\\u1F15\\u1F20-\\u1F27\\u1F30-\\u1F37\\u1F40-\\u1F45\\u1F50-\\u1F57\\u1F60-\\u1F67\\u1F70-\\u1F7D\\u1F80-\\u1F87\\u1F90-\\u1F97\\u1FA0-\\u1FA7\\u1FB0-\\u1FB4\\u1FB6-\\u1FB7\\u1FBE\\u1FC2-\\u1FC4\\u1FC6-\\u1FC7\\u1FD0-\\u1FD3\\u1FD6-\\u1FD7\\u1FE0-\\u1FE7\\u1FF2-\\u1FF4\\u1FF6-\\u1FF7\\u210A\\u210E-\\u210F\\u2113\\u212F\\u2134\\u2139\\u213C-\\u213D\\u2146-\\u2149\\u214E\\u2184\\u2C30-\\u2C5E\\u2C61\\u2C65-\\u2C66\\u2C68\\u2C6A\\u2C6C\\u2C71\\u2C73-\\u2C74\\u2C76-\\u2C7B\\u2C81\\u2C83\\u2C85\\u2C87\\u2C89\\u2C8B\\u2C8D\\u2C8F\\u2C91\\u2C93\\u2C95\\u2C97\\u2C99\\u2C9B\\u2C9D\\u2C9F\\u2CA1\\u2CA3\\u2CA5\\u2CA7\\u2CA9\\u2CAB\\u2CAD\\u2CAF\\u2CB1\\u2CB3\\u2CB5\\u2CB7\\u2CB9\\u2CBB\\u2CBD\\u2CBF\\u2CC1\\u2CC3\\u2CC5\\u2CC7\\u2CC9\\u2CCB\\u2CCD\\u2CCF\\u2CD1\\u2CD3\\u2CD5\\u2CD7\\u2CD9\\u2CDB\\u2CDD\\u2CDF\\u2CE1\\u2CE3-\\u2CE4\\u2CEC\\u2CEE\\u2CF3\\u2D00-\\u2D25\\u2D27\\u2D2D\\uA641\\uA643\\uA645\\uA647\\uA649\\uA64B\\uA64D\\uA64F\\uA651\\uA653\\uA655\\uA657\\uA659\\uA65B\\uA65D\\uA65F\\uA661\\uA663\\uA665\\uA667\\uA669\\uA66B\\uA66D\\uA681\\uA683\\uA685\\uA687\\uA689\\uA68B\\uA68D\\uA68F\\uA691\\uA693\\uA695\\uA697\\uA699\\uA69B\\uA723\\uA725\\uA727\\uA729\\uA72B\\uA72D\\uA72F-\\uA731\\uA733\\uA735\\uA737\\uA739\\uA73B\\uA73D\\uA73F\\uA741\\uA743\\uA745\\uA747\\uA749\\uA74B\\uA74D\\uA74F\\uA751\\uA753\\uA755\\uA757\\uA759\\uA75B\\uA75D\\uA75F\\uA761\\uA763\\uA765\\uA767\\uA769\\uA76B\\uA76D\\uA76F\\uA771-\\uA778\\uA77A\\uA77C\\uA77F\\uA781\\uA783\\uA785\\uA787\\uA78C\\uA78E\\uA791\\uA793-\\uA795\\uA797\\uA799\\uA79B\\uA79D\\uA79F\\uA7A1\\uA7A3\\uA7A5\\uA7A7\\uA7A9\\uA7AF\\uA7B5\\uA7B7\\uA7B9\\uA7FA\\uAB30-\\uAB5A\\uAB60-\\uAB65\\uAB70-\\uABBF\\uFB00-\\uFB06\\uFB13-\\uFB17\\uFF41-\\uFF5A]",
 				chars:      []rune{'µ', 'ā', 'ă', 'ą', 'ć', 'ĉ', 'ċ', 'č', 'ď', 'đ', 'ē', 'ĕ', 'ė', 'ę', 'ě', 'ĝ', 'ğ', 'ġ', 'ģ', 'ĥ', 'ħ', 'ĩ', 'ī', 'ĭ', 'į', 'ı', 'ĳ', 'ĵ', 'ĺ', 'ļ', 'ľ', 'ŀ', 'ł', 'ń', 'ņ', 'ŋ', 'ō', 'ŏ', 'ő', 'œ', 'ŕ', 'ŗ', 'ř', 'ś', 'ŝ', 'ş', 'š', 'ţ', 'ť', 'ŧ', 'ũ', 'ū', 'ŭ', 'ů', 'ű', 'ų', 'ŵ', 'ŷ', 'ź', 'ż', 'ƃ', 'ƅ', 'ƈ', 'ƒ', 'ƕ', 'ƞ', 'ơ', 'ƣ', 'ƥ', 'ƨ', 'ƭ', 'ư', 'ƴ', 'ƶ', 'ǆ', 'ǉ', 'ǌ', 'ǎ', 'ǐ', 'ǒ', 'ǔ', 'ǖ', 'ǘ', 'ǚ', 'ǟ', 'ǡ', 'ǣ', 'ǥ', 'ǧ', 'ǩ', 'ǫ', 'ǭ', 'ǳ', 'ǵ', 'ǹ', 'ǻ', 'ǽ', 'ǿ', 'ȁ', 'ȃ', 'ȅ', 'ȇ', 'ȉ', 'ȋ', 'ȍ', 'ȏ', 'ȑ', 'ȓ', 'ȕ', 'ȗ', 'ș', 'ț', 'ȝ', 'ȟ', 'ȡ', 'ȣ', 'ȥ', 'ȧ', 'ȩ', 'ȫ', 'ȭ', 'ȯ', 'ȱ', 'ȼ', 'ɂ', 'ɇ', 'ɉ', 'ɋ', 'ɍ', 'ͱ', 'ͳ', 'ͷ', 'ΐ', 'ϙ', 'ϛ', 'ϝ', 'ϟ', 'ϡ', 'ϣ', 'ϥ', 'ϧ', 'ϩ', 'ϫ', 'ϭ', 'ϵ', 'ϸ', 'ѡ', 'ѣ', 'ѥ', 'ѧ', 'ѩ', 'ѫ', 'ѭ', 'ѯ', 'ѱ', 'ѳ', 'ѵ', 'ѷ', 'ѹ', 'ѻ', 'ѽ', 'ѿ', 'ҁ', 'ҋ', 'ҍ', 'ҏ', 'ґ', 'ғ', 'ҕ', 'җ', 'ҙ', 'қ', 'ҝ', 'ҟ', 'ҡ', 'ң', 'ҥ', 'ҧ', 'ҩ', 'ҫ', 'ҭ', 'ү', 'ұ', 'ҳ', 'ҵ', 'ҷ', 'ҹ', 'һ', 'ҽ', 'ҿ', 'ӂ', 'ӄ', 'ӆ', 'ӈ', 'ӊ', 'ӌ', 'ӑ', 'ӓ', 'ӕ', 'ӗ', 'ә', 'ӛ', 'ӝ', 'ӟ', 'ӡ', 'ӣ', 'ӥ', 'ӧ', 'ө', 'ӫ', 'ӭ', 'ӯ', 'ӱ', 'ӳ', 'ӵ', 'ӷ', 'ӹ', 'ӻ', 'ӽ', 'ӿ', 'ԁ', 'ԃ', 'ԅ', 'ԇ', 'ԉ', 'ԋ', 'ԍ', 'ԏ', 'ԑ', 'ԓ', 'ԕ', 'ԗ', 'ԙ', 'ԛ', 'ԝ', 'ԟ', 'ԡ', 'ԣ', 'ԥ', 'ԧ', 'ԩ', 'ԫ', 'ԭ', 'ԯ', 'ḁ', 'ḃ', 'ḅ', 'ḇ', 'ḉ', 'ḋ', 'ḍ', 'ḏ', 'ḑ', 'ḓ', 'ḕ', 'ḗ', 'ḙ', 'ḛ', 'ḝ', 'ḟ', 'ḡ', 'ḣ', 'ḥ', 'ḧ', 'ḩ', 'ḫ', 'ḭ', 'ḯ', 'ḱ', 'ḳ', 'ḵ', 'ḷ', 'ḹ', 'ḻ', 'ḽ', 'ḿ', 'ṁ', 'ṃ', 'ṅ', 'ṇ', 'ṉ', 'ṋ', 'ṍ', 'ṏ', 'ṑ', 'ṓ', 'ṕ', 'ṗ', 'ṙ', 'ṛ', 'ṝ', 'ṟ', 'ṡ', 'ṣ', 'ṥ', 'ṧ', 'ṩ', 'ṫ', 'ṭ', 'ṯ', 'ṱ', 'ṳ', 'ṵ', 'ṷ', 'ṹ', 'ṻ', 'ṽ', 'ṿ', 'ẁ', 'ẃ', 'ẅ', 'ẇ', 'ẉ', 'ẋ', 'ẍ', 'ẏ', 'ẑ', 'ẓ', 'ẟ', 'ạ', 'ả', 'ấ', 'ầ', 'ẩ', 'ẫ', 'ậ', 'ắ', 'ằ', 'ẳ', 'ẵ', 'ặ', 'ẹ', 'ẻ', 'ẽ', 'ế', 'ề', 'ể', 'ễ', 'ệ', 'ỉ', 'ị', 'ọ', 'ỏ', 'ố', 'ồ', 'ổ', 'ỗ', 'ộ', 'ớ', 'ờ', 'ở', 'ỡ', 'ợ', 'ụ', 'ủ', 'ứ', 'ừ', 'ử', 'ữ', 'ự', 'ỳ', 'ỵ', 'ỷ', 'ỹ', 'ỻ', 'ỽ', 'ι', 'ℊ', 'ℓ', 'ℯ', 'ℴ', 'ℹ', 'ⅎ', 'ↄ', 'ⱡ', 'ⱨ', 'ⱪ', 'ⱬ', 'ⱱ', 'ⲁ', 'ⲃ', 'ⲅ', 'ⲇ', 'ⲉ', 'ⲋ', 'ⲍ', 'ⲏ', 'ⲑ', 'ⲓ', 'ⲕ', 'ⲗ', 'ⲙ', 'ⲛ', 'ⲝ', 'ⲟ', 'ⲡ', 'ⲣ', 'ⲥ', 'ⲧ', 'ⲩ', 'ⲫ', 'ⲭ', 'ⲯ', 'ⲱ', 'ⲳ', 'ⲵ', 'ⲷ', 'ⲹ', 'ⲻ', 'ⲽ', 'ⲿ', 'ⳁ', 'ⳃ', 'ⳅ', 'ⳇ', 'ⳉ', 'ⳋ', 'ⳍ', 'ⳏ', 'ⳑ', 'ⳓ', 'ⳕ', 'ⳗ', 'ⳙ', 'ⳛ', 'ⳝ', 'ⳟ', 'ⳡ', 'ⳬ', 'ⳮ', 'ⳳ', 'ⴧ', 'ⴭ', 'ꙁ', 'ꙃ', 'ꙅ', 'ꙇ', 'ꙉ', 'ꙋ', 'ꙍ', 'ꙏ', 'ꙑ', 'ꙓ', 'ꙕ', 'ꙗ', 'ꙙ', 'ꙛ', 'ꙝ', 'ꙟ', 'ꙡ', 'ꙣ', 'ꙥ', 'ꙧ', 'ꙩ', 'ꙫ', 'ꙭ', 'ꚁ', 'ꚃ', 'ꚅ', 'ꚇ', 'ꚉ', 'ꚋ', 'ꚍ', 'ꚏ', 'ꚑ', 'ꚓ', 'ꚕ', 'ꚗ', 'ꚙ', 'ꚛ', 'ꜣ', 'ꜥ', 'ꜧ', 'ꜩ', 'ꜫ', 'ꜭ', 'ꜳ', 'ꜵ', 'ꜷ', 'ꜹ', 'ꜻ', 'ꜽ', 'ꜿ', 'ꝁ', 'ꝃ', 'ꝅ', 'ꝇ', 'ꝉ', 'ꝋ', 'ꝍ', 'ꝏ', 'ꝑ', 'ꝓ', 'ꝕ', 'ꝗ', 'ꝙ', 'ꝛ', 'ꝝ', 'ꝟ', 'ꝡ', 'ꝣ', 'ꝥ', 'ꝧ', 'ꝩ', 'ꝫ', 'ꝭ', 'ꝯ', 'ꝺ', 'ꝼ', 'ꝿ', 'ꞁ', 'ꞃ', 'ꞅ', 'ꞇ', 'ꞌ', 'ꞎ', 'ꞑ', 'ꞗ', 'ꞙ', 'ꞛ', 'ꞝ', 'ꞟ', 'ꞡ', 'ꞣ', 'ꞥ', 'ꞧ', 'ꞩ', 'ꞯ', 'ꞵ', 'ꞷ', 'ꞹ', 'ꟺ'},
 				ranges:     []rune{'a', 'z', 'ß', 'ö', 'ø', 'ÿ', 'ķ', 'ĸ', 'ň', 'ŉ', 'ž', 'ƀ', 'ƌ', 'ƍ', 'ƙ', 'ƛ', 'ƪ', 'ƫ', 'ƹ', 'ƺ', 'ƽ', 'ƿ', 'ǜ', 'ǝ', 'ǯ', 'ǰ', 'ȳ', 'ȹ', 'ȿ', 'ɀ', 'ɏ', 'ʓ', 'ʕ', 'ʯ', 'ͻ', 'ͽ', 'ά', 'ώ', 'ϐ', 'ϑ', 'ϕ', 'ϗ', 'ϯ', 'ϳ', 'ϻ', 'ϼ', 'а', 'џ', 'ӎ', 'ӏ', 'ՠ', 'ֈ', 'ა', 'ჺ', 'ჽ', 'ჿ', 'ᏸ', 'ᏽ', 'ᲀ', 'ᲈ', 'ᴀ', 'ᴫ', 'ᵫ', 'ᵷ', 'ᵹ', 'ᶚ', 'ẕ', 'ẝ', 'ỿ', 'ἇ', 'ἐ', 'ἕ', 'ἠ', 'ἧ', 'ἰ', 'ἷ', 'ὀ', 'ὅ', 'ὐ', 'ὗ', 'ὠ', 'ὧ', 'ὰ', 'ώ', 'ᾀ', 'ᾇ', 'ᾐ', 'ᾗ', 'ᾠ', 'ᾧ', 'ᾰ', 'ᾴ', 'ᾶ', 'ᾷ', 'ῂ', 'ῄ', 'ῆ', 'ῇ', 'ῐ', 'ΐ', 'ῖ', 'ῗ', 'ῠ', 'ῧ', 'ῲ', 'ῴ', 'ῶ', 'ῷ', 'ℎ', 'ℏ', 'ℼ', 'ℽ', 'ⅆ', 'ⅉ', 'ⰰ', 'ⱞ', 'ⱥ', 'ⱦ', 'ⱳ', 'ⱴ', 'ⱶ', 'ⱻ', 'ⳣ', 'ⳤ', 'ⴀ', 'ⴥ', 'ꜯ', 'ꜱ', 'ꝱ', 'ꝸ', 'ꞓ', 'ꞕ', 'ꬰ', 'ꭚ', 'ꭠ', 'ꭥ', 'ꭰ', 'ꮿ', 'ﬀ', 'ﬆ', 'ﬓ', 'ﬗ', 'ａ', 'ｚ'},
@@ -12109,9 +12146,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lm",
-			pos:  position{line: 1653, col: 1, offset: 43950},
+			pos:  position{line: 1663, col: 1, offset: 44139},
 			expr: &charClassMatcher{
-				pos:        position{line: 1653, col: 6, offset: 43955},
+				pos:        position{line: 1663, col: 6, offset: 44144},
 				val:        "[\\u02B0-\\u02C1\\u02C6-\\u02D1\\u02E0-\\u02E4\\u02EC\\u02EE\\u0374\\u037A\\u0559\\u0640\\u06E5-\\u06E6\\u07F4-\\u07F5\\u07FA\\u081A\\u0824\\u0828\\u0971\\u0E46\\u0EC6\\u10FC\\u17D7\\u1843\\u1AA7\\u1C78-\\u1C7D\\u1D2C-\\u1D6A\\u1D78\\u1D9B-\\u1DBF\\u2071\\u207F\\u2090-\\u209C\\u2C7C-\\u2C7D\\u2D6F\\u2E2F\\u3005\\u3031-\\u3035\\u303B\\u309D-\\u309E\\u30FC-\\u30FE\\uA015\\uA4F8-\\uA4FD\\uA60C\\uA67F\\uA69C-\\uA69D\\uA717-\\uA71F\\uA770\\uA788\\uA7F8-\\uA7F9\\uA9CF\\uA9E6\\uAA70\\uAADD\\uAAF3-\\uAAF4\\uAB5C-\\uAB5F\\uFF70\\uFF9E-\\uFF9F]",
 				chars:      []rune{'ˬ', 'ˮ', 'ʹ', 'ͺ', 'ՙ', 'ـ', 'ߺ', 'ࠚ', 'ࠤ', 'ࠨ', 'ॱ', 'ๆ', 'ໆ', 'ჼ', 'ៗ', 'ᡃ', 'ᪧ', 'ᵸ', 'ⁱ', 'ⁿ', 'ⵯ', 'ⸯ', '々', '〻', 'ꀕ', 'ꘌ', 'ꙿ', 'ꝰ', 'ꞈ', 'ꧏ', 'ꧦ', 'ꩰ', 'ꫝ', 'ｰ'},
 				ranges:     []rune{'ʰ', 'ˁ', 'ˆ', 'ˑ', 'ˠ', 'ˤ', 'ۥ', 'ۦ', 'ߴ', 'ߵ', 'ᱸ', 'ᱽ', 'ᴬ', 'ᵪ', 'ᶛ', 'ᶿ', 'ₐ', 'ₜ', 'ⱼ', 'ⱽ', '〱', '〵', 'ゝ', 'ゞ', 'ー', 'ヾ', 'ꓸ', 'ꓽ', 'ꚜ', 'ꚝ', 'ꜗ', 'ꜟ', 'ꟸ', 'ꟹ', 'ꫳ', 'ꫴ', 'ꭜ', 'ꭟ', 'ﾞ', 'ﾟ'},
@@ -12123,9 +12160,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lo",
-			pos:  position{line: 1656, col: 1, offset: 44440},
+			pos:  position{line: 1666, col: 1, offset: 44629},
 			expr: &charClassMatcher{
-				pos:        position{line: 1656, col: 6, offset: 44445},
+				pos:        position{line: 1666, col: 6, offset: 44634},
 				val:        "[\\u00AA\\u00BA\\u01BB\\u01C0-\\u01C3\\u0294\\u05D0-\\u05EA\\u05EF-\\u05F2\\u0620-\\u063F\\u0641-\\u064A\\u066E-\\u066F\\u0671-\\u06D3\\u06D5\\u06EE-\\u06EF\\u06FA-\\u06FC\\u06FF\\u0710\\u0712-\\u072F\\u074D-\\u07A5\\u07B1\\u07CA-\\u07EA\\u0800-\\u0815\\u0840-\\u0858\\u0860-\\u086A\\u08A0-\\u08B4\\u08B6-\\u08BD\\u0904-\\u0939\\u093D\\u0950\\u0958-\\u0961\\u0972-\\u0980\\u0985-\\u098C\\u098F-\\u0990\\u0993-\\u09A8\\u09AA-\\u09B0\\u09B2\\u09B6-\\u09B9\\u09BD\\u09CE\\u09DC-\\u09DD\\u09DF-\\u09E1\\u09F0-\\u09F1\\u09FC\\u0A05-\\u0A0A\\u0A0F-\\u0A10\\u0A13-\\u0A28\\u0A2A-\\u0A30\\u0A32-\\u0A33\\u0A35-\\u0A36\\u0A38-\\u0A39\\u0A59-\\u0A5C\\u0A5E\\u0A72-\\u0A74\\u0A85-\\u0A8D\\u0A8F-\\u0A91\\u0A93-\\u0AA8\\u0AAA-\\u0AB0\\u0AB2-\\u0AB3\\u0AB5-\\u0AB9\\u0ABD\\u0AD0\\u0AE0-\\u0AE1\\u0AF9\\u0B05-\\u0B0C\\u0B0F-\\u0B10\\u0B13-\\u0B28\\u0B2A-\\u0B30\\u0B32-\\u0B33\\u0B35-\\u0B39\\u0B3D\\u0B5C-\\u0B5D\\u0B5F-\\u0B61\\u0B71\\u0B83\\u0B85-\\u0B8A\\u0B8E-\\u0B90\\u0B92-\\u0B95\\u0B99-\\u0B9A\\u0B9C\\u0B9E-\\u0B9F\\u0BA3-\\u0BA4\\u0BA8-\\u0BAA\\u0BAE-\\u0BB9\\u0BD0\\u0C05-\\u0C0C\\u0C0E-\\u0C10\\u0C12-\\u0C28\\u0C2A-\\u0C39\\u0C3D\\u0C58-\\u0C5A\\u0C60-\\u0C61\\u0C80\\u0C85-\\u0C8C\\u0C8E-\\u0C90\\u0C92-\\u0CA8\\u0CAA-\\u0CB3\\u0CB5-\\u0CB9\\u0CBD\\u0CDE\\u0CE0-\\u0CE1\\u0CF1-\\u0CF2\\u0D05-\\u0D0C\\u0D0E-\\u0D10\\u0D12-\\u0D3A\\u0D3D\\u0D4E\\u0D54-\\u0D56\\u0D5F-\\u0D61\\u0D7A-\\u0D7F\\u0D85-\\u0D96\\u0D9A-\\u0DB1\\u0DB3-\\u0DBB\\u0DBD\\u0DC0-\\u0DC6\\u0E01-\\u0E30\\u0E32-\\u0E33\\u0E40-\\u0E45\\u0E81-\\u0E82\\u0E84\\u0E87-\\u0E88\\u0E8A\\u0E8D\\u0E94-\\u0E97\\u0E99-\\u0E9F\\u0EA1-\\u0EA3\\u0EA5\\u0EA7\\u0EAA-\\u0EAB\\u0EAD-\\u0EB0\\u0EB2-\\u0EB3\\u0EBD\\u0EC0-\\u0EC4\\u0EDC-\\u0EDF\\u0F00\\u0F40-\\u0F47\\u0F49-\\u0F6C\\u0F88-\\u0F8C\\u1000-\\u102A\\u103F\\u1050-\\u1055\\u105A-\\u105D\\u1061\\u1065-\\u1066\\u106E-\\u1070\\u1075-\\u1081\\u108E\\u1100-\\u1248\\u124A-\\u124D\\u1250-\\u1256\\u1258\\u125A-\\u125D\\u1260-\\u1288\\u128A-\\u128D\\u1290-\\u12B0\\u12B2-\\u12B5\\u12B8-\\u12BE\\u12C0\\u12C2-\\u12C5\\u12C8-\\u12D6\\u12D8-\\u1310\\u1312-\\u1315\\u1318-\\u135A\\u1380-\\u138F\\u1401-\\u166C\\u166F-\\u167F\\u1681-\\u169A\\u16A0-\\u16EA\\u16F1-\\u16F8\\u1700-\\u170C\\u170E-\\u1711\\u1720-\\u1731\\u1740-\\u1751\\u1760-\\u176C\\u176E-\\u1770\\u1780-\\u17B3\\u17DC\\u1820-\\u1842\\u1844-\\u1878\\u1880-\\u1884\\u1887-\\u18A8\\u18AA\\u18B0-\\u18F5\\u1900-\\u191E\\u1950-\\u196D\\u1970-\\u1974\\u1980-\\u19AB\\u19B0-\\u19C9\\u1A00-\\u1A16\\u1A20-\\u1A54\\u1B05-\\u1B33\\u1B45-\\u1B4B\\u1B83-\\u1BA0\\u1BAE-\\u1BAF\\u1BBA-\\u1BE5\\u1C00-\\u1C23\\u1C4D-\\u1C4F\\u1C5A-\\u1C77\\u1CE9-\\u1CEC\\u1CEE-\\u1CF1\\u1CF5-\\u1CF6\\u2135-\\u2138\\u2D30-\\u2D67\\u2D80-\\u2D96\\u2DA0-\\u2DA6\\u2DA8-\\u2DAE\\u2DB0-\\u2DB6\\u2DB8-\\u2DBE\\u2DC0-\\u2DC6\\u2DC8-\\u2DCE\\u2DD0-\\u2DD6\\u2DD8-\\u2DDE\\u3006\\u303C\\u3041-\\u3096\\u309F\\u30A1-\\u30FA\\u30FF\\u3105-\\u312F\\u3131-\\u318E\\u31A0-\\u31BA\\u31F0-\\u31FF\\u3400-\\u4DB5\\u4E00-\\u9FEF\\uA000-\\uA014\\uA016-\\uA48C\\uA4D0-\\uA4F7\\uA500-\\uA60B\\uA610-\\uA61F\\uA62A-\\uA62B\\uA66E\\uA6A0-\\uA6E5\\uA78F\\uA7F7\\uA7FB-\\uA801\\uA803-\\uA805\\uA807-\\uA80A\\uA80C-\\uA822\\uA840-\\uA873\\uA882-\\uA8B3\\uA8F2-\\uA8F7\\uA8FB\\uA8FD-\\uA8FE\\uA90A-\\uA925\\uA930-\\uA946\\uA960-\\uA97C\\uA984-\\uA9B2\\uA9E0-\\uA9E4\\uA9E7-\\uA9EF\\uA9FA-\\uA9FE\\uAA00-\\uAA28\\uAA40-\\uAA42\\uAA44-\\uAA4B\\uAA60-\\uAA6F\\uAA71-\\uAA76\\uAA7A\\uAA7E-\\uAAAF\\uAAB1\\uAAB5-\\uAAB6\\uAAB9-\\uAABD\\uAAC0\\uAAC2\\uAADB-\\uAADC\\uAAE0-\\uAAEA\\uAAF2\\uAB01-\\uAB06\\uAB09-\\uAB0E\\uAB11-\\uAB16\\uAB20-\\uAB26\\uAB28-\\uAB2E\\uABC0-\\uABE2\\uAC00-\\uD7A3\\uD7B0-\\uD7C6\\uD7CB-\\uD7FB\\uF900-\\uFA6D\\uFA70-\\uFAD9\\uFB1D\\uFB1F-\\uFB28\\uFB2A-\\uFB36\\uFB38-\\uFB3C\\uFB3E\\uFB40-\\uFB41\\uFB43-\\uFB44\\uFB46-\\uFBB1\\uFBD3-\\uFD3D\\uFD50-\\uFD8F\\uFD92-\\uFDC7\\uFDF0-\\uFDFB\\uFE70-\\uFE74\\uFE76-\\uFEFC\\uFF66-\\uFF6F\\uFF71-\\uFF9D\\uFFA0-\\uFFBE\\uFFC2-\\uFFC7\\uFFCA-\\uFFCF\\uFFD2-\\uFFD7\\uFFDA-\\uFFDC]",
 				chars:      []rune{'ª', 'º', 'ƻ', 'ʔ', 'ە', 'ۿ', 'ܐ', 'ޱ', 'ऽ', 'ॐ', 'ল', 'ঽ', 'ৎ', 'ৼ', 'ਫ਼', 'ઽ', 'ૐ', 'ૹ', 'ଽ', 'ୱ', 'ஃ', 'ஜ', 'ௐ', 'ఽ', 'ಀ', 'ಽ', 'ೞ', 'ഽ', 'ൎ', 'ල', 'ຄ', 'ຊ', 'ຍ', 'ລ', 'ວ', 'ຽ', 'ༀ', 'ဿ', 'ၡ', 'ႎ', 'ቘ', 'ዀ', 'ៜ', 'ᢪ', '〆', '〼', 'ゟ', 'ヿ', 'ꙮ', 'ꞏ', 'ꟷ', 'ꣻ', 'ꩺ', 'ꪱ', 'ꫀ', 'ꫂ', 'ꫲ', 'יִ', 'מּ'},
 				ranges:     []rune{'ǀ', 'ǃ', 'א', 'ת', 'ׯ', 'ײ', 'ؠ', 'ؿ', 'ف', 'ي', 'ٮ', 'ٯ', 'ٱ', 'ۓ', 'ۮ', 'ۯ', 'ۺ', 'ۼ', 'ܒ', 'ܯ', 'ݍ', 'ޥ', 'ߊ', 'ߪ', 'ࠀ', 'ࠕ', 'ࡀ', 'ࡘ', 'ࡠ', 'ࡪ', 'ࢠ', 'ࢴ', 'ࢶ', 'ࢽ', 'ऄ', 'ह', 'क़', 'ॡ', 'ॲ', 'ঀ', 'অ', 'ঌ', 'এ', 'ঐ', 'ও', 'ন', 'প', 'র', 'শ', 'হ', 'ড়', 'ঢ়', 'য়', 'ৡ', 'ৰ', 'ৱ', 'ਅ', 'ਊ', 'ਏ', 'ਐ', 'ਓ', 'ਨ', 'ਪ', 'ਰ', 'ਲ', 'ਲ਼', 'ਵ', 'ਸ਼', 'ਸ', 'ਹ', 'ਖ਼', 'ੜ', 'ੲ', 'ੴ', 'અ', 'ઍ', 'એ', 'ઑ', 'ઓ', 'ન', 'પ', 'ર', 'લ', 'ળ', 'વ', 'હ', 'ૠ', 'ૡ', 'ଅ', 'ଌ', 'ଏ', 'ଐ', 'ଓ', 'ନ', 'ପ', 'ର', 'ଲ', 'ଳ', 'ଵ', 'ହ', 'ଡ଼', 'ଢ଼', 'ୟ', 'ୡ', 'அ', 'ஊ', 'எ', 'ஐ', 'ஒ', 'க', 'ங', 'ச', 'ஞ', 'ட', 'ண', 'த', 'ந', 'ப', 'ம', 'ஹ', 'అ', 'ఌ', 'ఎ', 'ఐ', 'ఒ', 'న', 'ప', 'హ', 'ౘ', 'ౚ', 'ౠ', 'ౡ', 'ಅ', 'ಌ', 'ಎ', 'ಐ', 'ಒ', 'ನ', 'ಪ', 'ಳ', 'ವ', 'ಹ', 'ೠ', 'ೡ', 'ೱ', 'ೲ', 'അ', 'ഌ', 'എ', 'ഐ', 'ഒ', 'ഺ', 'ൔ', 'ൖ', 'ൟ', 'ൡ', 'ൺ', 'ൿ', 'අ', 'ඖ', 'ක', 'න', 'ඳ', 'ර', 'ව', 'ෆ', 'ก', 'ะ', 'า', 'ำ', 'เ', 'ๅ', 'ກ', 'ຂ', 'ງ', 'ຈ', 'ດ', 'ທ', 'ນ', 'ຟ', 'ມ', 'ຣ', 'ສ', 'ຫ', 'ອ', 'ະ', 'າ', 'ຳ', 'ເ', 'ໄ', 'ໜ', 'ໟ', 'ཀ', 'ཇ', 'ཉ', 'ཬ', 'ྈ', 'ྌ', 'က', 'ဪ', 'ၐ', 'ၕ', 'ၚ', 'ၝ', 'ၥ', 'ၦ', 'ၮ', 'ၰ', 'ၵ', 'ႁ', 'ᄀ', 'ቈ', 'ቊ', 'ቍ', 'ቐ', 'ቖ', 'ቚ', 'ቝ', 'በ', 'ኈ', 'ኊ', 'ኍ', 'ነ', 'ኰ', 'ኲ', 'ኵ', 'ኸ', 'ኾ', 'ዂ', 'ዅ', 'ወ', 'ዖ', 'ዘ', 'ጐ', 'ጒ', 'ጕ', 'ጘ', 'ፚ', 'ᎀ', 'ᎏ', 'ᐁ', 'ᙬ', 'ᙯ', 'ᙿ', 'ᚁ', 'ᚚ', 'ᚠ', 'ᛪ', 'ᛱ', 'ᛸ', 'ᜀ', 'ᜌ', 'ᜎ', 'ᜑ', 'ᜠ', 'ᜱ', 'ᝀ', 'ᝑ', 'ᝠ', 'ᝬ', 'ᝮ', 'ᝰ', 'ក', 'ឳ', 'ᠠ', 'ᡂ', 'ᡄ', 'ᡸ', 'ᢀ', 'ᢄ', 'ᢇ', 'ᢨ', 'ᢰ', 'ᣵ', 'ᤀ', 'ᤞ', 'ᥐ', 'ᥭ', 'ᥰ', 'ᥴ', 'ᦀ', 'ᦫ', 'ᦰ', 'ᧉ', 'ᨀ', 'ᨖ', 'ᨠ', 'ᩔ', 'ᬅ', 'ᬳ', 'ᭅ', 'ᭋ', 'ᮃ', 'ᮠ', 'ᮮ', 'ᮯ', 'ᮺ', 'ᯥ', 'ᰀ', 'ᰣ', 'ᱍ', 'ᱏ', 'ᱚ', 'ᱷ', 'ᳩ', 'ᳬ', 'ᳮ', 'ᳱ', 'ᳵ', 'ᳶ', 'ℵ', 'ℸ', 'ⴰ', 'ⵧ', 'ⶀ', 'ⶖ', 'ⶠ', 'ⶦ', 'ⶨ', 'ⶮ', 'ⶰ', 'ⶶ', 'ⶸ', 'ⶾ', 'ⷀ', 'ⷆ', 'ⷈ', 'ⷎ', 'ⷐ', 'ⷖ', 'ⷘ', 'ⷞ', 'ぁ', 'ゖ', 'ァ', 'ヺ', 'ㄅ', 'ㄯ', 'ㄱ', 'ㆎ', 'ㆠ', 'ㆺ', 'ㇰ', 'ㇿ', '㐀', '䶵', '一', '鿯', 'ꀀ', 'ꀔ', 'ꀖ', 'ꒌ', 'ꓐ', 'ꓷ', 'ꔀ', 'ꘋ', 'ꘐ', 'ꘟ', 'ꘪ', 'ꘫ', 'ꚠ', 'ꛥ', 'ꟻ', 'ꠁ', 'ꠃ', 'ꠅ', 'ꠇ', 'ꠊ', 'ꠌ', 'ꠢ', 'ꡀ', 'ꡳ', 'ꢂ', 'ꢳ', 'ꣲ', 'ꣷ', 'ꣽ', 'ꣾ', 'ꤊ', 'ꤥ', 'ꤰ', 'ꥆ', 'ꥠ', 'ꥼ', 'ꦄ', 'ꦲ', 'ꧠ', 'ꧤ', 'ꧧ', 'ꧯ', 'ꧺ', 'ꧾ', 'ꨀ', 'ꨨ', 'ꩀ', 'ꩂ', 'ꩄ', 'ꩋ', 'ꩠ', 'ꩯ', 'ꩱ', 'ꩶ', 'ꩾ', 'ꪯ', 'ꪵ', 'ꪶ', 'ꪹ', 'ꪽ', 'ꫛ', 'ꫜ', 'ꫠ', 'ꫪ', 'ꬁ', 'ꬆ', 'ꬉ', 'ꬎ', 'ꬑ', 'ꬖ', 'ꬠ', 'ꬦ', 'ꬨ', 'ꬮ', 'ꯀ', 'ꯢ', '가', '힣', 'ힰ', 'ퟆ', 'ퟋ', 'ퟻ', '豈', '舘', '並', '龎', 'ײַ', 'ﬨ', 'שׁ', 'זּ', 'טּ', 'לּ', 'נּ', 'סּ', 'ףּ', 'פּ', 'צּ', 'ﮱ', 'ﯓ', 'ﴽ', 'ﵐ', 'ﶏ', 'ﶒ', 'ﷇ', 'ﷰ', 'ﷻ', 'ﹰ', 'ﹴ', 'ﹶ', 'ﻼ', 'ｦ', 'ｯ', 'ｱ', 'ﾝ', 'ﾠ', 'ﾾ', 'ￂ', 'ￇ', 'ￊ', 'ￏ', 'ￒ', 'ￗ', 'ￚ', 'ￜ'},
@@ -12137,9 +12174,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lt",
-			pos:  position{line: 1659, col: 1, offset: 47892},
+			pos:  position{line: 1669, col: 1, offset: 48081},
 			expr: &charClassMatcher{
-				pos:        position{line: 1659, col: 6, offset: 47897},
+				pos:        position{line: 1669, col: 6, offset: 48086},
 				val:        "[\\u01C5\\u01C8\\u01CB\\u01F2\\u1F88-\\u1F8F\\u1F98-\\u1F9F\\u1FA8-\\u1FAF\\u1FBC\\u1FCC\\u1FFC]",
 				chars:      []rune{'ǅ', 'ǈ', 'ǋ', 'ǲ', 'ᾼ', 'ῌ', 'ῼ'},
 				ranges:     []rune{'ᾈ', 'ᾏ', 'ᾘ', 'ᾟ', 'ᾨ', 'ᾯ'},
@@ -12151,9 +12188,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lu",
-			pos:  position{line: 1662, col: 1, offset: 48003},
+			pos:  position{line: 1672, col: 1, offset: 48192},
 			expr: &charClassMatcher{
-				pos:        position{line: 1662, col: 6, offset: 48008},
+				pos:        position{line: 1672, col: 6, offset: 48197},
 				val:        "[\\u0041-\\u005A\\u00C0-\\u00D6\\u00D8-\\u00DE\\u0100\\u0102\\u0104\\u0106\\u0108\\u010A\\u010C\\u010E\\u0110\\u0112\\u0114\\u0116\\u0118\\u011A\\u011C\\u011E\\u0120\\u0122\\u0124\\u0126\\u0128\\u012A\\u012C\\u012E\\u0130\\u0132\\u0134\\u0136\\u0139\\u013B\\u013D\\u013F\\u0141\\u0143\\u0145\\u0147\\u014A\\u014C\\u014E\\u0150\\u0152\\u0154\\u0156\\u0158\\u015A\\u015C\\u015E\\u0160\\u0162\\u0164\\u0166\\u0168\\u016A\\u016C\\u016E\\u0170\\u0172\\u0174\\u0176\\u0178-\\u0179\\u017B\\u017D\\u0181-\\u0182\\u0184\\u0186-\\u0187\\u0189-\\u018B\\u018E-\\u0191\\u0193-\\u0194\\u0196-\\u0198\\u019C-\\u019D\\u019F-\\u01A0\\u01A2\\u01A4\\u01A6-\\u01A7\\u01A9\\u01AC\\u01AE-\\u01AF\\u01B1-\\u01B3\\u01B5\\u01B7-\\u01B8\\u01BC\\u01C4\\u01C7\\u01CA\\u01CD\\u01CF\\u01D1\\u01D3\\u01D5\\u01D7\\u01D9\\u01DB\\u01DE\\u01E0\\u01E2\\u01E4\\u01E6\\u01E8\\u01EA\\u01EC\\u01EE\\u01F1\\u01F4\\u01F6-\\u01F8\\u01FA\\u01FC\\u01FE\\u0200\\u0202\\u0204\\u0206\\u0208\\u020A\\u020C\\u020E\\u0210\\u0212\\u0214\\u0216\\u0218\\u021A\\u021C\\u021E\\u0220\\u0222\\u0224\\u0226\\u0228\\u022A\\u022C\\u022E\\u0230\\u0232\\u023A-\\u023B\\u023D-\\u023E\\u0241\\u0243-\\u0246\\u0248\\u024A\\u024C\\u024E\\u0370\\u0372\\u0376\\u037F\\u0386\\u0388-\\u038A\\u038C\\u038E-\\u038F\\u0391-\\u03A1\\u03A3-\\u03AB\\u03CF\\u03D2-\\u03D4\\u03D8\\u03DA\\u03DC\\u03DE\\u03E0\\u03E2\\u03E4\\u03E6\\u03E8\\u03EA\\u03EC\\u03EE\\u03F4\\u03F7\\u03F9-\\u03FA\\u03FD-\\u042F\\u0460\\u0462\\u0464\\u0466\\u0468\\u046A\\u046C\\u046E\\u0470\\u0472\\u0474\\u0476\\u0478\\u047A\\u047C\\u047E\\u0480\\u048A\\u048C\\u048E\\u0490\\u0492\\u0494\\u0496\\u0498\\u049A\\u049C\\u049E\\u04A0\\u04A2\\u04A4\\u04A6\\u04A8\\u04AA\\u04AC\\u04AE\\u04B0\\u04B2\\u04B4\\u04B6\\u04B8\\u04BA\\u04BC\\u04BE\\u04C0-\\u04C1\\u04C3\\u04C5\\u04C7\\u04C9\\u04CB\\u04CD\\u04D0\\u04D2\\u04D4\\u04D6\\u04D8\\u04DA\\u04DC\\u04DE\\u04E0\\u04E2\\u04E4\\u04E6\\u04E8\\u04EA\\u04EC\\u04EE\\u04F0\\u04F2\\u04F4\\u04F6\\u04F8\\u04FA\\u04FC\\u04FE\\u0500\\u0502\\u0504\\u0506\\u0508\\u050A\\u050C\\u050E\\u0510\\u0512\\u0514\\u0516\\u0518\\u051A\\u051C\\u051E\\u0520\\u0522\\u0524\\u0526\\u0528\\u052A\\u052C\\u052E\\u0531-\\u0556\\u10A0-\\u10C5\\u10C7\\u10CD\\u13A0-\\u13F5\\u1C90-\\u1CBA\\u1CBD-\\u1CBF\\u1E00\\u1E02\\u1E04\\u1E06\\u1E08\\u1E0A\\u1E0C\\u1E0E\\u1E10\\u1E12\\u1E14\\u1E16\\u1E18\\u1E1A\\u1E1C\\u1E1E\\u1E20\\u1E22\\u1E24\\u1E26\\u1E28\\u1E2A\\u1E2C\\u1E2E\\u1E30\\u1E32\\u1E34\\u1E36\\u1E38\\u1E3A\\u1E3C\\u1E3E\\u1E40\\u1E42\\u1E44\\u1E46\\u1E48\\u1E4A\\u1E4C\\u1E4E\\u1E50\\u1E52\\u1E54\\u1E56\\u1E58\\u1E5A\\u1E5C\\u1E5E\\u1E60\\u1E62\\u1E64\\u1E66\\u1E68\\u1E6A\\u1E6C\\u1E6E\\u1E70\\u1E72\\u1E74\\u1E76\\u1E78\\u1E7A\\u1E7C\\u1E7E\\u1E80\\u1E82\\u1E84\\u1E86\\u1E88\\u1E8A\\u1E8C\\u1E8E\\u1E90\\u1E92\\u1E94\\u1E9E\\u1EA0\\u1EA2\\u1EA4\\u1EA6\\u1EA8\\u1EAA\\u1EAC\\u1EAE\\u1EB0\\u1EB2\\u1EB4\\u1EB6\\u1EB8\\u1EBA\\u1EBC\\u1EBE\\u1EC0\\u1EC2\\u1EC4\\u1EC6\\u1EC8\\u1ECA\\u1ECC\\u1ECE\\u1ED0\\u1ED2\\u1ED4\\u1ED6\\u1ED8\\u1EDA\\u1EDC\\u1EDE\\u1EE0\\u1EE2\\u1EE4\\u1EE6\\u1EE8\\u1EEA\\u1EEC\\u1EEE\\u1EF0\\u1EF2\\u1EF4\\u1EF6\\u1EF8\\u1EFA\\u1EFC\\u1EFE\\u1F08-\\u1F0F\\u1F18-\\u1F1D\\u1F28-\\u1F2F\\u1F38-\\u1F3F\\u1F48-\\u1F4D\\u1F59\\u1F5B\\u1F5D\\u1F5F\\u1F68-\\u1F6F\\u1FB8-\\u1FBB\\u1FC8-\\u1FCB\\u1FD8-\\u1FDB\\u1FE8-\\u1FEC\\u1FF8-\\u1FFB\\u2102\\u2107\\u210B-\\u210D\\u2110-\\u2112\\u2115\\u2119-\\u211D\\u2124\\u2126\\u2128\\u212A-\\u212D\\u2130-\\u2133\\u213E-\\u213F\\u2145\\u2183\\u2C00-\\u2C2E\\u2C60\\u2C62-\\u2C64\\u2C67\\u2C69\\u2C6B\\u2C6D-\\u2C70\\u2C72\\u2C75\\u2C7E-\\u2C80\\u2C82\\u2C84\\u2C86\\u2C88\\u2C8A\\u2C8C\\u2C8E\\u2C90\\u2C92\\u2C94\\u2C96\\u2C98\\u2C9A\\u2C9C\\u2C9E\\u2CA0\\u2CA2\\u2CA4\\u2CA6\\u2CA8\\u2CAA\\u2CAC\\u2CAE\\u2CB0\\u2CB2\\u2CB4\\u2CB6\\u2CB8\\u2CBA\\u2CBC\\u2CBE\\u2CC0\\u2CC2\\u2CC4\\u2CC6\\u2CC8\\u2CCA\\u2CCC\\u2CCE\\u2CD0\\u2CD2\\u2CD4\\u2CD6\\u2CD8\\u2CDA\\u2CDC\\u2CDE\\u2CE0\\u2CE2\\u2CEB\\u2CED\\u2CF2\\uA640\\uA642\\uA644\\uA646\\uA648\\uA64A\\uA64C\\uA64E\\uA650\\uA652\\uA654\\uA656\\uA658\\uA65A\\uA65C\\uA65E\\uA660\\uA662\\uA664\\uA666\\uA668\\uA66A\\uA66C\\uA680\\uA682\\uA684\\uA686\\uA688\\uA68A\\uA68C\\uA68E\\uA690\\uA692\\uA694\\uA696\\uA698\\uA69A\\uA722\\uA724\\uA726\\uA728\\uA72A\\uA72C\\uA72E\\uA732\\uA734\\uA736\\uA738\\uA73A\\uA73C\\uA73E\\uA740\\uA742\\uA744\\uA746\\uA748\\uA74A\\uA74C\\uA74E\\uA750\\uA752\\uA754\\uA756\\uA758\\uA75A\\uA75C\\uA75E\\uA760\\uA762\\uA764\\uA766\\uA768\\uA76A\\uA76C\\uA76E\\uA779\\uA77B\\uA77D-\\uA77E\\uA780\\uA782\\uA784\\uA786\\uA78B\\uA78D\\uA790\\uA792\\uA796\\uA798\\uA79A\\uA79C\\uA79E\\uA7A0\\uA7A2\\uA7A4\\uA7A6\\uA7A8\\uA7AA-\\uA7AE\\uA7B0-\\uA7B4\\uA7B6\\uA7B8\\uFF21-\\uFF3A]",
 				chars:      []rune{'Ā', 'Ă', 'Ą', 'Ć', 'Ĉ', 'Ċ', 'Č', 'Ď', 'Đ', 'Ē', 'Ĕ', 'Ė', 'Ę', 'Ě', 'Ĝ', 'Ğ', 'Ġ', 'Ģ', 'Ĥ', 'Ħ', 'Ĩ', 'Ī', 'Ĭ', 'Į', 'İ', 'Ĳ', 'Ĵ', 'Ķ', 'Ĺ', 'Ļ', 'Ľ', 'Ŀ', 'Ł', 'Ń', 'Ņ', 'Ň', 'Ŋ', 'Ō', 'Ŏ', 'Ő', 'Œ', 'Ŕ', 'Ŗ', 'Ř', 'Ś', 'Ŝ', 'Ş', 'Š', 'Ţ', 'Ť', 'Ŧ', 'Ũ', 'Ū', 'Ŭ', 'Ů', 'Ű', 'Ų', 'Ŵ', 'Ŷ', 'Ż', 'Ž', 'Ƅ', 'Ƣ', 'Ƥ', 'Ʃ', 'Ƭ', 'Ƶ', 'Ƽ', 'Ǆ', 'Ǉ', 'Ǌ', 'Ǎ', 'Ǐ', 'Ǒ', 'Ǔ', 'Ǖ', 'Ǘ', 'Ǚ', 'Ǜ', 'Ǟ', 'Ǡ', 'Ǣ', 'Ǥ', 'Ǧ', 'Ǩ', 'Ǫ', 'Ǭ', 'Ǯ', 'Ǳ', 'Ǵ', 'Ǻ', 'Ǽ', 'Ǿ', 'Ȁ', 'Ȃ', 'Ȅ', 'Ȇ', 'Ȉ', 'Ȋ', 'Ȍ', 'Ȏ', 'Ȑ', 'Ȓ', 'Ȕ', 'Ȗ', 'Ș', 'Ț', 'Ȝ', 'Ȟ', 'Ƞ', 'Ȣ', 'Ȥ', 'Ȧ', 'Ȩ', 'Ȫ', 'Ȭ', 'Ȯ', 'Ȱ', 'Ȳ', 'Ɂ', 'Ɉ', 'Ɋ', 'Ɍ', 'Ɏ', 'Ͱ', 'Ͳ', 'Ͷ', 'Ϳ', 'Ά', 'Ό', 'Ϗ', 'Ϙ', 'Ϛ', 'Ϝ', 'Ϟ', 'Ϡ', 'Ϣ', 'Ϥ', 'Ϧ', 'Ϩ', 'Ϫ', 'Ϭ', 'Ϯ', 'ϴ', 'Ϸ', 'Ѡ', 'Ѣ', 'Ѥ', 'Ѧ', 'Ѩ', 'Ѫ', 'Ѭ', 'Ѯ', 'Ѱ', 'Ѳ', 'Ѵ', 'Ѷ', 'Ѹ', 'Ѻ', 'Ѽ', 'Ѿ', 'Ҁ', 'Ҋ', 'Ҍ', 'Ҏ', 'Ґ', 'Ғ', 'Ҕ', 'Җ', 'Ҙ', 'Қ', 'Ҝ', 'Ҟ', 'Ҡ', 'Ң', 'Ҥ', 'Ҧ', 'Ҩ', 'Ҫ', 'Ҭ', 'Ү', 'Ұ', 'Ҳ', 'Ҵ', 'Ҷ', 'Ҹ', 'Һ', 'Ҽ', 'Ҿ', 'Ӄ', 'Ӆ', 'Ӈ', 'Ӊ', 'Ӌ', 'Ӎ', 'Ӑ', 'Ӓ', 'Ӕ', 'Ӗ', 'Ә', 'Ӛ', 'Ӝ', 'Ӟ', 'Ӡ', 'Ӣ', 'Ӥ', 'Ӧ', 'Ө', 'Ӫ', 'Ӭ', 'Ӯ', 'Ӱ', 'Ӳ', 'Ӵ', 'Ӷ', 'Ӹ', 'Ӻ', 'Ӽ', 'Ӿ', 'Ԁ', 'Ԃ', 'Ԅ', 'Ԇ', 'Ԉ', 'Ԋ', 'Ԍ', 'Ԏ', 'Ԑ', 'Ԓ', 'Ԕ', 'Ԗ', 'Ԙ', 'Ԛ', 'Ԝ', 'Ԟ', 'Ԡ', 'Ԣ', 'Ԥ', 'Ԧ', 'Ԩ', 'Ԫ', 'Ԭ', 'Ԯ', 'Ⴧ', 'Ⴭ', 'Ḁ', 'Ḃ', 'Ḅ', 'Ḇ', 'Ḉ', 'Ḋ', 'Ḍ', 'Ḏ', 'Ḑ', 'Ḓ', 'Ḕ', 'Ḗ', 'Ḙ', 'Ḛ', 'Ḝ', 'Ḟ', 'Ḡ', 'Ḣ', 'Ḥ', 'Ḧ', 'Ḩ', 'Ḫ', 'Ḭ', 'Ḯ', 'Ḱ', 'Ḳ', 'Ḵ', 'Ḷ', 'Ḹ', 'Ḻ', 'Ḽ', 'Ḿ', 'Ṁ', 'Ṃ', 'Ṅ', 'Ṇ', 'Ṉ', 'Ṋ', 'Ṍ', 'Ṏ', 'Ṑ', 'Ṓ', 'Ṕ', 'Ṗ', 'Ṙ', 'Ṛ', 'Ṝ', 'Ṟ', 'Ṡ', 'Ṣ', 'Ṥ', 'Ṧ', 'Ṩ', 'Ṫ', 'Ṭ', 'Ṯ', 'Ṱ', 'Ṳ', 'Ṵ', 'Ṷ', 'Ṹ', 'Ṻ', 'Ṽ', 'Ṿ', 'Ẁ', 'Ẃ', 'Ẅ', 'Ẇ', 'Ẉ', 'Ẋ', 'Ẍ', 'Ẏ', 'Ẑ', 'Ẓ', 'Ẕ', 'ẞ', 'Ạ', 'Ả', 'Ấ', 'Ầ', 'Ẩ', 'Ẫ', 'Ậ', 'Ắ', 'Ằ', 'Ẳ', 'Ẵ', 'Ặ', 'Ẹ', 'Ẻ', 'Ẽ', 'Ế', 'Ề', 'Ể', 'Ễ', 'Ệ', 'Ỉ', 'Ị', 'Ọ', 'Ỏ', 'Ố', 'Ồ', 'Ổ', 'Ỗ', 'Ộ', 'Ớ', 'Ờ', 'Ở', 'Ỡ', 'Ợ', 'Ụ', 'Ủ', 'Ứ', 'Ừ', 'Ử', 'Ữ', 'Ự', 'Ỳ', 'Ỵ', 'Ỷ', 'Ỹ', 'Ỻ', 'Ỽ', 'Ỿ', 'Ὑ', 'Ὓ', 'Ὕ', 'Ὗ', 'ℂ', 'ℇ', 'ℕ', 'ℤ', 'Ω', 'ℨ', 'ⅅ', 'Ↄ', 'Ⱡ', 'Ⱨ', 'Ⱪ', 'Ⱬ', 'Ⱳ', 'Ⱶ', 'Ⲃ', 'Ⲅ', 'Ⲇ', 'Ⲉ', 'Ⲋ', 'Ⲍ', 'Ⲏ', 'Ⲑ', 'Ⲓ', 'Ⲕ', 'Ⲗ', 'Ⲙ', 'Ⲛ', 'Ⲝ', 'Ⲟ', 'Ⲡ', 'Ⲣ', 'Ⲥ', 'Ⲧ', 'Ⲩ', 'Ⲫ', 'Ⲭ', 'Ⲯ', 'Ⲱ', 'Ⲳ', 'Ⲵ', 'Ⲷ', 'Ⲹ', 'Ⲻ', 'Ⲽ', 'Ⲿ', 'Ⳁ', 'Ⳃ', 'Ⳅ', 'Ⳇ', 'Ⳉ', 'Ⳋ', 'Ⳍ', 'Ⳏ', 'Ⳑ', 'Ⳓ', 'Ⳕ', 'Ⳗ', 'Ⳙ', 'Ⳛ', 'Ⳝ', 'Ⳟ', 'Ⳡ', 'Ⳣ', 'Ⳬ', 'Ⳮ', 'Ⳳ', 'Ꙁ', 'Ꙃ', 'Ꙅ', 'Ꙇ', 'Ꙉ', 'Ꙋ', 'Ꙍ', 'Ꙏ', 'Ꙑ', 'Ꙓ', 'Ꙕ', 'Ꙗ', 'Ꙙ', 'Ꙛ', 'Ꙝ', 'Ꙟ', 'Ꙡ', 'Ꙣ', 'Ꙥ', 'Ꙧ', 'Ꙩ', 'Ꙫ', 'Ꙭ', 'Ꚁ', 'Ꚃ', 'Ꚅ', 'Ꚇ', 'Ꚉ', 'Ꚋ', 'Ꚍ', 'Ꚏ', 'Ꚑ', 'Ꚓ', 'Ꚕ', 'Ꚗ', 'Ꚙ', 'Ꚛ', 'Ꜣ', 'Ꜥ', 'Ꜧ', 'Ꜩ', 'Ꜫ', 'Ꜭ', 'Ꜯ', 'Ꜳ', 'Ꜵ', 'Ꜷ', 'Ꜹ', 'Ꜻ', 'Ꜽ', 'Ꜿ', 'Ꝁ', 'Ꝃ', 'Ꝅ', 'Ꝇ', 'Ꝉ', 'Ꝋ', 'Ꝍ', 'Ꝏ', 'Ꝑ', 'Ꝓ', 'Ꝕ', 'Ꝗ', 'Ꝙ', 'Ꝛ', 'Ꝝ', 'Ꝟ', 'Ꝡ', 'Ꝣ', 'Ꝥ', 'Ꝧ', 'Ꝩ', 'Ꝫ', 'Ꝭ', 'Ꝯ', 'Ꝺ', 'Ꝼ', 'Ꞁ', 'Ꞃ', 'Ꞅ', 'Ꞇ', 'Ꞌ', 'Ɥ', 'Ꞑ', 'Ꞓ', 'Ꞗ', 'Ꞙ', 'Ꞛ', 'Ꞝ', 'Ꞟ', 'Ꞡ', 'Ꞣ', 'Ꞥ', 'Ꞧ', 'Ꞩ', 'Ꞷ', 'Ꞹ'},
 				ranges:     []rune{'A', 'Z', 'À', 'Ö', 'Ø', 'Þ', 'Ÿ', 'Ź', 'Ɓ', 'Ƃ', 'Ɔ', 'Ƈ', 'Ɖ', 'Ƌ', 'Ǝ', 'Ƒ', 'Ɠ', 'Ɣ', 'Ɩ', 'Ƙ', 'Ɯ', 'Ɲ', 'Ɵ', 'Ơ', 'Ʀ', 'Ƨ', 'Ʈ', 'Ư', 'Ʊ', 'Ƴ', 'Ʒ', 'Ƹ', 'Ƕ', 'Ǹ', 'Ⱥ', 'Ȼ', 'Ƚ', 'Ⱦ', 'Ƀ', 'Ɇ', 'Έ', 'Ί', 'Ύ', 'Ώ', 'Α', 'Ρ', 'Σ', 'Ϋ', 'ϒ', 'ϔ', 'Ϲ', 'Ϻ', 'Ͻ', 'Я', 'Ӏ', 'Ӂ', 'Ա', 'Ֆ', 'Ⴀ', 'Ⴥ', 'Ꭰ', 'Ᏽ', 'Ა', 'Ჺ', 'Ჽ', 'Ჿ', 'Ἀ', 'Ἇ', 'Ἐ', 'Ἕ', 'Ἠ', 'Ἧ', 'Ἰ', 'Ἷ', 'Ὀ', 'Ὅ', 'Ὠ', 'Ὧ', 'Ᾰ', 'Ά', 'Ὲ', 'Ή', 'Ῐ', 'Ί', 'Ῠ', 'Ῥ', 'Ὸ', 'Ώ', 'ℋ', 'ℍ', 'ℐ', 'ℒ', 'ℙ', 'ℝ', 'K', 'ℭ', 'ℰ', 'ℳ', 'ℾ', 'ℿ', 'Ⰰ', 'Ⱞ', 'Ɫ', 'Ɽ', 'Ɑ', 'Ɒ', 'Ȿ', 'Ⲁ', 'Ᵹ', 'Ꝿ', 'Ɦ', 'Ɪ', 'Ʞ', 'Ꞵ', 'Ａ', 'Ｚ'},
@@ -12165,9 +12202,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mc",
-			pos:  position{line: 1665, col: 1, offset: 52009},
+			pos:  position{line: 1675, col: 1, offset: 52198},
 			expr: &charClassMatcher{
-				pos:        position{line: 1665, col: 6, offset: 52014},
+				pos:        position{line: 1675, col: 6, offset: 52203},
 				val:        "[\\u0903\\u093B\\u093E-\\u0940\\u0949-\\u094C\\u094E-\\u094F\\u0982-\\u0983\\u09BE-\\u09C0\\u09C7-\\u09C8\\u09CB-\\u09CC\\u09D7\\u0A03\\u0A3E-\\u0A40\\u0A83\\u0ABE-\\u0AC0\\u0AC9\\u0ACB-\\u0ACC\\u0B02-\\u0B03\\u0B3E\\u0B40\\u0B47-\\u0B48\\u0B4B-\\u0B4C\\u0B57\\u0BBE-\\u0BBF\\u0BC1-\\u0BC2\\u0BC6-\\u0BC8\\u0BCA-\\u0BCC\\u0BD7\\u0C01-\\u0C03\\u0C41-\\u0C44\\u0C82-\\u0C83\\u0CBE\\u0CC0-\\u0CC4\\u0CC7-\\u0CC8\\u0CCA-\\u0CCB\\u0CD5-\\u0CD6\\u0D02-\\u0D03\\u0D3E-\\u0D40\\u0D46-\\u0D48\\u0D4A-\\u0D4C\\u0D57\\u0D82-\\u0D83\\u0DCF-\\u0DD1\\u0DD8-\\u0DDF\\u0DF2-\\u0DF3\\u0F3E-\\u0F3F\\u0F7F\\u102B-\\u102C\\u1031\\u1038\\u103B-\\u103C\\u1056-\\u1057\\u1062-\\u1064\\u1067-\\u106D\\u1083-\\u1084\\u1087-\\u108C\\u108F\\u109A-\\u109C\\u17B6\\u17BE-\\u17C5\\u17C7-\\u17C8\\u1923-\\u1926\\u1929-\\u192B\\u1930-\\u1931\\u1933-\\u1938\\u1A19-\\u1A1A\\u1A55\\u1A57\\u1A61\\u1A63-\\u1A64\\u1A6D-\\u1A72\\u1B04\\u1B35\\u1B3B\\u1B3D-\\u1B41\\u1B43-\\u1B44\\u1B82\\u1BA1\\u1BA6-\\u1BA7\\u1BAA\\u1BE7\\u1BEA-\\u1BEC\\u1BEE\\u1BF2-\\u1BF3\\u1C24-\\u1C2B\\u1C34-\\u1C35\\u1CE1\\u1CF2-\\u1CF3\\u1CF7\\u302E-\\u302F\\uA823-\\uA824\\uA827\\uA880-\\uA881\\uA8B4-\\uA8C3\\uA952-\\uA953\\uA983\\uA9B4-\\uA9B5\\uA9BA-\\uA9BB\\uA9BD-\\uA9C0\\uAA2F-\\uAA30\\uAA33-\\uAA34\\uAA4D\\uAA7B\\uAA7D\\uAAEB\\uAAEE-\\uAAEF\\uAAF5\\uABE3-\\uABE4\\uABE6-\\uABE7\\uABE9-\\uABEA\\uABEC]",
 				chars:      []rune{'ः', 'ऻ', 'ৗ', 'ਃ', 'ઃ', 'ૉ', 'ା', 'ୀ', 'ୗ', 'ௗ', 'ಾ', 'ൗ', 'ཿ', 'ေ', 'း', 'ႏ', 'ា', 'ᩕ', 'ᩗ', 'ᩡ', 'ᬄ', 'ᬵ', 'ᬻ', 'ᮂ', 'ᮡ', '᮪', 'ᯧ', 'ᯮ', '᳡', '᳷', 'ꠧ', 'ꦃ', 'ꩍ', 'ꩻ', 'ꩽ', 'ꫫ', 'ꫵ', '꯬'},
 				ranges:     []rune{'ा', 'ी', 'ॉ', 'ौ', 'ॎ', 'ॏ', 'ং', 'ঃ', 'া', 'ী', 'ে', 'ৈ', 'ো', 'ৌ', 'ਾ', 'ੀ', 'ા', 'ી', 'ો', 'ૌ', 'ଂ', 'ଃ', 'େ', 'ୈ', 'ୋ', 'ୌ', 'ா', 'ி', 'ு', 'ூ', 'ெ', 'ை', 'ொ', 'ௌ', 'ఁ', 'ః', 'ు', 'ౄ', 'ಂ', 'ಃ', 'ೀ', 'ೄ', 'ೇ', 'ೈ', 'ೊ', 'ೋ', 'ೕ', 'ೖ', 'ം', 'ഃ', 'ാ', 'ീ', 'െ', 'ൈ', 'ൊ', 'ൌ', 'ං', 'ඃ', 'ා', 'ෑ', 'ෘ', 'ෟ', 'ෲ', 'ෳ', '༾', '༿', 'ါ', 'ာ', 'ျ', 'ြ', 'ၖ', 'ၗ', 'ၢ', 'ၤ', 'ၧ', 'ၭ', 'ႃ', 'ႄ', 'ႇ', 'ႌ', 'ႚ', 'ႜ', 'ើ', 'ៅ', 'ះ', 'ៈ', 'ᤣ', 'ᤦ', 'ᤩ', 'ᤫ', 'ᤰ', 'ᤱ', 'ᤳ', 'ᤸ', 'ᨙ', 'ᨚ', 'ᩣ', 'ᩤ', 'ᩭ', 'ᩲ', 'ᬽ', 'ᭁ', 'ᭃ', '᭄', 'ᮦ', 'ᮧ', 'ᯪ', 'ᯬ', '᯲', '᯳', 'ᰤ', 'ᰫ', 'ᰴ', 'ᰵ', 'ᳲ', 'ᳳ', '〮', '〯', 'ꠣ', 'ꠤ', 'ꢀ', 'ꢁ', 'ꢴ', 'ꣃ', 'ꥒ', '꥓', 'ꦴ', 'ꦵ', 'ꦺ', 'ꦻ', 'ꦽ', '꧀', 'ꨯ', 'ꨰ', 'ꨳ', 'ꨴ', 'ꫮ', 'ꫯ', 'ꯣ', 'ꯤ', 'ꯦ', 'ꯧ', 'ꯩ', 'ꯪ'},
@@ -12179,9 +12216,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mn",
-			pos:  position{line: 1668, col: 1, offset: 53202},
+			pos:  position{line: 1678, col: 1, offset: 53391},
 			expr: &charClassMatcher{
-				pos:        position{line: 1668, col: 6, offset: 53207},
+				pos:        position{line: 1678, col: 6, offset: 53396},
 				val:        "[\\u0300-\\u036F\\u0483-\\u0487\\u0591-\\u05BD\\u05BF\\u05C1-\\u05C2\\u05C4-\\u05C5\\u05C7\\u0610-\\u061A\\u064B-\\u065F\\u0670\\u06D6-\\u06DC\\u06DF-\\u06E4\\u06E7-\\u06E8\\u06EA-\\u06ED\\u0711\\u0730-\\u074A\\u07A6-\\u07B0\\u07EB-\\u07F3\\u07FD\\u0816-\\u0819\\u081B-\\u0823\\u0825-\\u0827\\u0829-\\u082D\\u0859-\\u085B\\u08D3-\\u08E1\\u08E3-\\u0902\\u093A\\u093C\\u0941-\\u0948\\u094D\\u0951-\\u0957\\u0962-\\u0963\\u0981\\u09BC\\u09C1-\\u09C4\\u09CD\\u09E2-\\u09E3\\u09FE\\u0A01-\\u0A02\\u0A3C\\u0A41-\\u0A42\\u0A47-\\u0A48\\u0A4B-\\u0A4D\\u0A51\\u0A70-\\u0A71\\u0A75\\u0A81-\\u0A82\\u0ABC\\u0AC1-\\u0AC5\\u0AC7-\\u0AC8\\u0ACD\\u0AE2-\\u0AE3\\u0AFA-\\u0AFF\\u0B01\\u0B3C\\u0B3F\\u0B41-\\u0B44\\u0B4D\\u0B56\\u0B62-\\u0B63\\u0B82\\u0BC0\\u0BCD\\u0C00\\u0C04\\u0C3E-\\u0C40\\u0C46-\\u0C48\\u0C4A-\\u0C4D\\u0C55-\\u0C56\\u0C62-\\u0C63\\u0C81\\u0CBC\\u0CBF\\u0CC6\\u0CCC-\\u0CCD\\u0CE2-\\u0CE3\\u0D00-\\u0D01\\u0D3B-\\u0D3C\\u0D41-\\u0D44\\u0D4D\\u0D62-\\u0D63\\u0DCA\\u0DD2-\\u0DD4\\u0DD6\\u0E31\\u0E34-\\u0E3A\\u0E47-\\u0E4E\\u0EB1\\u0EB4-\\u0EB9\\u0EBB-\\u0EBC\\u0EC8-\\u0ECD\\u0F18-\\u0F19\\u0F35\\u0F37\\u0F39\\u0F71-\\u0F7E\\u0F80-\\u0F84\\u0F86-\\u0F87\\u0F8D-\\u0F97\\u0F99-\\u0FBC\\u0FC6\\u102D-\\u1030\\u1032-\\u1037\\u1039-\\u103A\\u103D-\\u103E\\u1058-\\u1059\\u105E-\\u1060\\u1071-\\u1074\\u1082\\u1085-\\u1086\\u108D\\u109D\\u135D-\\u135F\\u1712-\\u1714\\u1732-\\u1734\\u1752-\\u1753\\u1772-\\u1773\\u17B4-\\u17B5\\u17B7-\\u17BD\\u17C6\\u17C9-\\u17D3\\u17DD\\u180B-\\u180D\\u1885-\\u1886\\u18A9\\u1920-\\u1922\\u1927-\\u1928\\u1932\\u1939-\\u193B\\u1A17-\\u1A18\\u1A1B\\u1A56\\u1A58-\\u1A5E\\u1A60\\u1A62\\u1A65-\\u1A6C\\u1A73-\\u1A7C\\u1A7F\\u1AB0-\\u1ABD\\u1B00-\\u1B03\\u1B34\\u1B36-\\u1B3A\\u1B3C\\u1B42\\u1B6B-\\u1B73\\u1B80-\\u1B81\\u1BA2-\\u1BA5\\u1BA8-\\u1BA9\\u1BAB-\\u1BAD\\u1BE6\\u1BE8-\\u1BE9\\u1BED\\u1BEF-\\u1BF1\\u1C2C-\\u1C33\\u1C36-\\u1C37\\u1CD0-\\u1CD2\\u1CD4-\\u1CE0\\u1CE2-\\u1CE8\\u1CED\\u1CF4\\u1CF8-\\u1CF9\\u1DC0-\\u1DF9\\u1DFB-\\u1DFF\\u20D0-\\u20DC\\u20E1\\u20E5-\\u20F0\\u2CEF-\\u2CF1\\u2D7F\\u2DE0-\\u2DFF\\u302A-\\u302D\\u3099-\\u309A\\uA66F\\uA674-\\uA67D\\uA69E-\\uA69F\\uA6F0-\\uA6F1\\uA802\\uA806\\uA80B\\uA825-\\uA826\\uA8C4-\\uA8C5\\uA8E0-\\uA8F1\\uA8FF\\uA926-\\uA92D\\uA947-\\uA951\\uA980-\\uA982\\uA9B3\\uA9B6-\\uA9B9\\uA9BC\\uA9E5\\uAA29-\\uAA2E\\uAA31-\\uAA32\\uAA35-\\uAA36\\uAA43\\uAA4C\\uAA7C\\uAAB0\\uAAB2-\\uAAB4\\uAAB7-\\uAAB8\\uAABE-\\uAABF\\uAAC1\\uAAEC-\\uAAED\\uAAF6\\uABE5\\uABE8\\uABED\\uFB1E\\uFE00-\\uFE0F\\uFE20-\\uFE2F]",
 				chars:      []rune{'ֿ', 'ׇ', 'ٰ', 'ܑ', '߽', 'ऺ', '़', '्', 'ঁ', '়', '্', '৾', '਼', 'ੑ', 'ੵ', '઼', '્', 'ଁ', '଼', 'ି', '୍', 'ୖ', 'ஂ', 'ீ', '்', 'ఀ', 'ఄ', 'ಁ', '಼', 'ಿ', 'ೆ', '്', '්', 'ූ', 'ั', 'ັ', '༵', '༷', '༹', '࿆', 'ႂ', 'ႍ', 'ႝ', 'ំ', '៝', 'ᢩ', 'ᤲ', 'ᨛ', 'ᩖ', '᩠', 'ᩢ', '᩿', '᬴', 'ᬼ', 'ᭂ', '᯦', 'ᯭ', '᳭', '᳴', '⃡', '⵿', '꙯', 'ꠂ', '꠆', 'ꠋ', 'ꣿ', '꦳', 'ꦼ', 'ꧥ', 'ꩃ', 'ꩌ', 'ꩼ', 'ꪰ', '꫁', '꫶', 'ꯥ', 'ꯨ', '꯭', 'ﬞ'},
 				ranges:     []rune{'̀', 'ͯ', '҃', '҇', '֑', 'ֽ', 'ׁ', 'ׂ', 'ׄ', 'ׅ', 'ؐ', 'ؚ', 'ً', 'ٟ', 'ۖ', 'ۜ', '۟', 'ۤ', 'ۧ', 'ۨ', '۪', 'ۭ', 'ܰ', '݊', 'ަ', 'ް', '߫', '߳', 'ࠖ', '࠙', 'ࠛ', 'ࠣ', 'ࠥ', 'ࠧ', 'ࠩ', '࠭', '࡙', '࡛', '࣓', '࣡', 'ࣣ', 'ं', 'ु', 'ै', '॑', 'ॗ', 'ॢ', 'ॣ', 'ু', 'ৄ', 'ৢ', 'ৣ', 'ਁ', 'ਂ', 'ੁ', 'ੂ', 'ੇ', 'ੈ', 'ੋ', '੍', 'ੰ', 'ੱ', 'ઁ', 'ં', 'ુ', 'ૅ', 'ે', 'ૈ', 'ૢ', 'ૣ', 'ૺ', '૿', 'ୁ', 'ୄ', 'ୢ', 'ୣ', 'ా', 'ీ', 'ె', 'ై', 'ొ', '్', 'ౕ', 'ౖ', 'ౢ', 'ౣ', 'ೌ', '್', 'ೢ', 'ೣ', 'ഀ', 'ഁ', '഻', '഼', 'ു', 'ൄ', 'ൢ', 'ൣ', 'ි', 'ු', 'ิ', 'ฺ', '็', '๎', 'ິ', 'ູ', 'ົ', 'ຼ', '່', 'ໍ', '༘', '༙', 'ཱ', 'ཾ', 'ྀ', '྄', '྆', '྇', 'ྍ', 'ྗ', 'ྙ', 'ྼ', 'ိ', 'ူ', 'ဲ', '့', '္', '်', 'ွ', 'ှ', 'ၘ', 'ၙ', 'ၞ', 'ၠ', 'ၱ', 'ၴ', 'ႅ', 'ႆ', '፝', '፟', 'ᜒ', '᜔', 'ᜲ', '᜴', 'ᝒ', 'ᝓ', 'ᝲ', 'ᝳ', '឴', '឵', 'ិ', 'ួ', '៉', '៓', '᠋', '᠍', 'ᢅ', 'ᢆ', 'ᤠ', 'ᤢ', 'ᤧ', 'ᤨ', '᤹', '᤻', 'ᨗ', 'ᨘ', 'ᩘ', 'ᩞ', 'ᩥ', 'ᩬ', 'ᩳ', '᩼', '᪰', '᪽', 'ᬀ', 'ᬃ', 'ᬶ', 'ᬺ', '᭫', '᭳', 'ᮀ', 'ᮁ', 'ᮢ', 'ᮥ', 'ᮨ', 'ᮩ', '᮫', 'ᮭ', 'ᯨ', 'ᯩ', 'ᯯ', 'ᯱ', 'ᰬ', 'ᰳ', 'ᰶ', '᰷', '᳐', '᳒', '᳔', '᳠', '᳢', '᳨', '᳸', '᳹', '᷀', '᷹', '᷻', '᷿', '⃐', '⃜', '⃥', '⃰', '⳯', '⳱', 'ⷠ', 'ⷿ', '〪', '〭', '゙', '゚', 'ꙴ', '꙽', 'ꚞ', 'ꚟ', '꛰', '꛱', 'ꠥ', 'ꠦ', '꣄', 'ꣅ', '꣠', '꣱', 'ꤦ', '꤭', 'ꥇ', 'ꥑ', 'ꦀ', 'ꦂ', 'ꦶ', 'ꦹ', 'ꨩ', 'ꨮ', 'ꨱ', 'ꨲ', 'ꨵ', 'ꨶ', 'ꪲ', 'ꪴ', 'ꪷ', 'ꪸ', 'ꪾ', '꪿', 'ꫬ', 'ꫭ', '︀', '️', '︠', '︯'},
@@ -12193,9 +12230,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nd",
-			pos:  position{line: 1671, col: 1, offset: 55387},
+			pos:  position{line: 1681, col: 1, offset: 55576},
 			expr: &charClassMatcher{
-				pos:        position{line: 1671, col: 6, offset: 55392},
+				pos:        position{line: 1681, col: 6, offset: 55581},
 				val:        "[\\u0030-\\u0039\\u0660-\\u0669\\u06F0-\\u06F9\\u07C0-\\u07C9\\u0966-\\u096F\\u09E6-\\u09EF\\u0A66-\\u0A6F\\u0AE6-\\u0AEF\\u0B66-\\u0B6F\\u0BE6-\\u0BEF\\u0C66-\\u0C6F\\u0CE6-\\u0CEF\\u0D66-\\u0D6F\\u0DE6-\\u0DEF\\u0E50-\\u0E59\\u0ED0-\\u0ED9\\u0F20-\\u0F29\\u1040-\\u1049\\u1090-\\u1099\\u17E0-\\u17E9\\u1810-\\u1819\\u1946-\\u194F\\u19D0-\\u19D9\\u1A80-\\u1A89\\u1A90-\\u1A99\\u1B50-\\u1B59\\u1BB0-\\u1BB9\\u1C40-\\u1C49\\u1C50-\\u1C59\\uA620-\\uA629\\uA8D0-\\uA8D9\\uA900-\\uA909\\uA9D0-\\uA9D9\\uA9F0-\\uA9F9\\uAA50-\\uAA59\\uABF0-\\uABF9\\uFF10-\\uFF19]",
 				ranges:     []rune{'0', '9', '٠', '٩', '۰', '۹', '߀', '߉', '०', '९', '০', '৯', '੦', '੯', '૦', '૯', '୦', '୯', '௦', '௯', '౦', '౯', '೦', '೯', '൦', '൯', '෦', '෯', '๐', '๙', '໐', '໙', '༠', '༩', '၀', '၉', '႐', '႙', '០', '៩', '᠐', '᠙', '᥆', '᥏', '᧐', '᧙', '᪀', '᪉', '᪐', '᪙', '᭐', '᭙', '᮰', '᮹', '᱀', '᱉', '᱐', '᱙', '꘠', '꘩', '꣐', '꣙', '꤀', '꤉', '꧐', '꧙', '꧰', '꧹', '꩐', '꩙', '꯰', '꯹', '０', '９'},
 				ignoreCase: false,
@@ -12206,9 +12243,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nl",
-			pos:  position{line: 1674, col: 1, offset: 55895},
+			pos:  position{line: 1684, col: 1, offset: 56084},
 			expr: &charClassMatcher{
-				pos:        position{line: 1674, col: 6, offset: 55900},
+				pos:        position{line: 1684, col: 6, offset: 56089},
 				val:        "[\\u16EE-\\u16F0\\u2160-\\u2182\\u2185-\\u2188\\u3007\\u3021-\\u3029\\u3038-\\u303A\\uA6E6-\\uA6EF]",
 				chars:      []rune{'〇'},
 				ranges:     []rune{'ᛮ', 'ᛰ', 'Ⅰ', 'ↂ', 'ↅ', 'ↈ', '〡', '〩', '〸', '〺', 'ꛦ', 'ꛯ'},
@@ -12220,9 +12257,9 @@ var g = &grammar{
 		},
 		{
 			name: "Pc",
-			pos:  position{line: 1677, col: 1, offset: 56014},
+			pos:  position{line: 1687, col: 1, offset: 56203},
 			expr: &charClassMatcher{
-				pos:        position{line: 1677, col: 6, offset: 56019},
+				pos:        position{line: 1687, col: 6, offset: 56208},
 				val:        "[\\u005F\\u203F-\\u2040\\u2054\\uFE33-\\uFE34\\uFE4D-\\uFE4F\\uFF3F]",
 				chars:      []rune{'_', '⁔', '＿'},
 				ranges:     []rune{'‿', '⁀', '︳', '︴', '﹍', '﹏'},
@@ -12234,9 +12271,9 @@ var g = &grammar{
 		},
 		{
 			name: "Zs",
-			pos:  position{line: 1680, col: 1, offset: 56100},
+			pos:  position{line: 1690, col: 1, offset: 56289},
 			expr: &charClassMatcher{
-				pos:        position{line: 1680, col: 6, offset: 56105},
+				pos:        position{line: 1690, col: 6, offset: 56294},
 				val:        "[\\u0020\\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000]",
 				chars:      []rune{' ', '\u00a0', '\u1680', '\u202f', '\u205f', '\u3000'},
 				ranges:     []rune{'\u2000', '\u200a'},
@@ -12248,9 +12285,9 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1682, col: 1, offset: 56158},
+			pos:  position{line: 1692, col: 1, offset: 56347},
 			expr: &anyMatcher{
-				line: 1683, col: 5, offset: 56178,
+				line: 1693, col: 5, offset: 56367,
 			},
 			leader:        false,
 			leftRecursive: false,
@@ -12258,48 +12295,48 @@ var g = &grammar{
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1685, col: 1, offset: 56181},
+			pos:         position{line: 1695, col: 1, offset: 56370},
 			expr: &choiceExpr{
-				pos: position{line: 1686, col: 5, offset: 56209},
+				pos: position{line: 1696, col: 5, offset: 56398},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1686, col: 5, offset: 56209},
+						pos:        position{line: 1696, col: 5, offset: 56398},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1687, col: 5, offset: 56218},
+						pos:        position{line: 1697, col: 5, offset: 56407},
 						val:        "\v",
 						ignoreCase: false,
 						want:       "\"\\v\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1688, col: 5, offset: 56227},
+						pos:        position{line: 1698, col: 5, offset: 56416},
 						val:        "\f",
 						ignoreCase: false,
 						want:       "\"\\f\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1689, col: 5, offset: 56236},
+						pos:        position{line: 1699, col: 5, offset: 56425},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 1690, col: 5, offset: 56244},
+						pos:        position{line: 1700, col: 5, offset: 56433},
 						val:        "\u00a0",
 						ignoreCase: false,
 						want:       "\"\\u00a0\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1691, col: 5, offset: 56257},
+						pos:        position{line: 1701, col: 5, offset: 56446},
 						val:        "\ufeff",
 						ignoreCase: false,
 						want:       "\"\\ufeff\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1692, col: 5, offset: 56270},
+						pos:  position{line: 1702, col: 5, offset: 56459},
 						name: "Zs",
 					},
 				},
@@ -12309,9 +12346,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1694, col: 1, offset: 56274},
+			pos:  position{line: 1704, col: 1, offset: 56463},
 			expr: &charClassMatcher{
-				pos:        position{line: 1695, col: 5, offset: 56293},
+				pos:        position{line: 1705, col: 5, offset: 56482},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -12323,9 +12360,9 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1701, col: 1, offset: 56623},
+			pos:         position{line: 1711, col: 1, offset: 56812},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1704, col: 5, offset: 56694},
+				pos:  position{line: 1714, col: 5, offset: 56883},
 				name: "SingleLineComment",
 			},
 			leader:        false,
@@ -12333,39 +12370,39 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1706, col: 1, offset: 56713},
+			pos:  position{line: 1716, col: 1, offset: 56902},
 			expr: &seqExpr{
-				pos: position{line: 1707, col: 5, offset: 56734},
+				pos: position{line: 1717, col: 5, offset: 56923},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1707, col: 5, offset: 56734},
+						pos:        position{line: 1717, col: 5, offset: 56923},
 						val:        "/*",
 						ignoreCase: false,
 						want:       "\"/*\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1707, col: 10, offset: 56739},
+						pos: position{line: 1717, col: 10, offset: 56928},
 						expr: &seqExpr{
-							pos: position{line: 1707, col: 11, offset: 56740},
+							pos: position{line: 1717, col: 11, offset: 56929},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1707, col: 11, offset: 56740},
+									pos: position{line: 1717, col: 11, offset: 56929},
 									expr: &litMatcher{
-										pos:        position{line: 1707, col: 12, offset: 56741},
+										pos:        position{line: 1717, col: 12, offset: 56930},
 										val:        "*/",
 										ignoreCase: false,
 										want:       "\"*/\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1707, col: 17, offset: 56746},
+									pos:  position{line: 1717, col: 17, offset: 56935},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1707, col: 35, offset: 56764},
+						pos:        position{line: 1717, col: 35, offset: 56953},
 						val:        "*/",
 						ignoreCase: false,
 						want:       "\"*/\"",
@@ -12377,30 +12414,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1709, col: 1, offset: 56770},
+			pos:  position{line: 1719, col: 1, offset: 56959},
 			expr: &seqExpr{
-				pos: position{line: 1710, col: 5, offset: 56792},
+				pos: position{line: 1720, col: 5, offset: 56981},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1710, col: 5, offset: 56792},
+						pos:        position{line: 1720, col: 5, offset: 56981},
 						val:        "//",
 						ignoreCase: false,
 						want:       "\"//\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1710, col: 10, offset: 56797},
+						pos: position{line: 1720, col: 10, offset: 56986},
 						expr: &seqExpr{
-							pos: position{line: 1710, col: 11, offset: 56798},
+							pos: position{line: 1720, col: 11, offset: 56987},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1710, col: 11, offset: 56798},
+									pos: position{line: 1720, col: 11, offset: 56987},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1710, col: 12, offset: 56799},
+										pos:  position{line: 1720, col: 12, offset: 56988},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1710, col: 27, offset: 56814},
+									pos:  position{line: 1720, col: 27, offset: 57003},
 									name: "SourceCharacter",
 								},
 							},
@@ -12413,19 +12450,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1712, col: 1, offset: 56833},
+			pos:  position{line: 1722, col: 1, offset: 57022},
 			expr: &seqExpr{
-				pos: position{line: 1712, col: 7, offset: 56839},
+				pos: position{line: 1722, col: 7, offset: 57028},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1712, col: 7, offset: 56839},
+						pos: position{line: 1722, col: 7, offset: 57028},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1712, col: 7, offset: 56839},
+							pos:  position{line: 1722, col: 7, offset: 57028},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1712, col: 19, offset: 56851},
+						pos:  position{line: 1722, col: 19, offset: 57040},
 						name: "LineTerminator",
 					},
 				},
@@ -12435,16 +12472,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1714, col: 1, offset: 56867},
+			pos:  position{line: 1724, col: 1, offset: 57056},
 			expr: &choiceExpr{
-				pos: position{line: 1714, col: 7, offset: 56873},
+				pos: position{line: 1724, col: 7, offset: 57062},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1714, col: 7, offset: 56873},
+						pos:  position{line: 1724, col: 7, offset: 57062},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1714, col: 11, offset: 56877},
+						pos:  position{line: 1724, col: 11, offset: 57066},
 						name: "EOF",
 					},
 				},
@@ -12454,11 +12491,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1716, col: 1, offset: 56882},
+			pos:  position{line: 1726, col: 1, offset: 57071},
 			expr: &notExpr{
-				pos: position{line: 1716, col: 7, offset: 56888},
+				pos: position{line: 1726, col: 7, offset: 57077},
 				expr: &anyMatcher{
-					line: 1716, col: 8, offset: 56889,
+					line: 1726, col: 8, offset: 57078,
 				},
 			},
 			leader:        false,
@@ -12466,11 +12503,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOKW",
-			pos:  position{line: 1718, col: 1, offset: 56892},
+			pos:  position{line: 1728, col: 1, offset: 57081},
 			expr: &notExpr{
-				pos: position{line: 1718, col: 8, offset: 56899},
+				pos: position{line: 1728, col: 8, offset: 57088},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1718, col: 9, offset: 56900},
+					pos:  position{line: 1728, col: 9, offset: 57089},
 					name: "KeyWordChars",
 				},
 			},
@@ -13737,6 +13774,21 @@ func (p *parser) callonPoolBranch1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onPoolBranch1(stack["branch"])
+}
+
+func (c *current) onOutputOp1(name any) (any, error) {
+	return &ast.Output{
+		Kind:       "Output",
+		KeywordPos: c.pos.offset,
+		Name:       name.(*ast.ID),
+	}, nil
+
+}
+
+func (p *parser) callonOutputOp1() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onOutputOp1(stack["name"])
 }
 
 func (c *current) onFile1(path, format, sortkey any) (any, error) {

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -358,6 +358,7 @@ Operator
   / OverOp
   / YieldOp
   / LoadOp
+  / OutputOp
 
 AssertOp
   = "assert" _ expr:(e:Expr { return []any{e, string(c.text)}, nil }) {
@@ -596,6 +597,15 @@ MetaArg
 
 PoolBranch
   = "@" branch:(PoolIdentifier / QuotedString) { return branch, nil }
+
+OutputOp
+  = "output" _ name:Identifier {
+      return &ast.Output{
+        Kind: "Output",
+        KeywordPos: c.pos.offset,
+        Name: name.(*ast.ID),
+      }, nil
+    }
 
 FromOp
   = File

--- a/compiler/semantic/op.go
+++ b/compiler/semantic/op.go
@@ -791,6 +791,10 @@ func (a *analyzer) semOp(o ast.Op, seq dag.Seq) dag.Seq {
 			Message: o.Message,
 			Meta:    o.Meta,
 		})
+	case *ast.Output:
+		out := &dag.Output{Kind: "Output", Name: o.Name.Name}
+		a.outputs[out] = o
+		return append(seq, out)
 	}
 	panic(fmt.Errorf("semantic transform: unknown AST operator type: %T", o))
 }

--- a/compiler/ztests/const-source.yaml
+++ b/compiler/ztests/const-source.yaml
@@ -18,18 +18,21 @@ outputs:
         const POOL = "test"
         
         pool XXX
+        | output main
       )
       ===
       (
         const FILE = "A.zson"
         
         file A.zson
+        | output main
       )
       ===
       (
         const URL = "http://brimdata.io"
         
         get http://brimdata.io
+        | output main
       )
   - name: stderr
     data: |

--- a/compiler/ztests/head.yaml
+++ b/compiler/ztests/head.yaml
@@ -11,12 +11,14 @@ outputs:
     data: |
       reader
       | head 1
+      | output main
       ===
       reader
       | (
         const x = 1
         
         head 2
+        | output main
       )
   - name: stderr
     data: |

--- a/compiler/ztests/join-subquery.yaml
+++ b/compiler/ztests/join-subquery.yaml
@@ -19,3 +19,4 @@ outputs:
             file b
         )
         | join on c=c
+        | output main

--- a/compiler/ztests/merge-filters.yaml
+++ b/compiler/ztests/merge-filters.yaml
@@ -11,6 +11,7 @@ outputs:
   - name: stdout
     data: |
       reader filter (a and b)
+      | output main
       ===
       fork (
         =>
@@ -18,16 +19,20 @@ outputs:
         =>
           file d filter (e and f and g)
       )
+      | output main
       ===
       reader
       | over a => (
         where b and c
       )
+      | output main
       ===
       reader
       | fork (
         =>
           where a and b
+          | output main
         =>
           where c and d
+          | output main
       )

--- a/compiler/ztests/par-count.yaml
+++ b/compiler/ztests/par-count.yaml
@@ -23,6 +23,7 @@ outputs:
       | combine
       | summarize partials-in
           count:=count() by y:=y
+      | output main
       ===
       lister ...
       | scatter (
@@ -39,3 +40,4 @@ outputs:
       | summarize partials-in
           count:=count()
       | yield count
+      | output main

--- a/compiler/ztests/par-groupby-func.yaml
+++ b/compiler/ztests/par-groupby-func.yaml
@@ -21,3 +21,4 @@ outputs:
       | combine
       | summarize partials-in
           union:=union(s) by n:=n
+      | output main

--- a/compiler/ztests/par-join.yaml
+++ b/compiler/ztests/par-join.yaml
@@ -33,3 +33,4 @@ outputs:
           | merge ts:asc
       )
       | join on a=b
+      | output main

--- a/compiler/ztests/par-layout-dataflow.yaml
+++ b/compiler/ztests/par-layout-dataflow.yaml
@@ -21,6 +21,7 @@ outputs:
           | cut x:=ts,ts:=1
       )
       | merge x:asc
+      | output main
       ===
       lister ...
       | slicer
@@ -33,3 +34,4 @@ outputs:
           | cut x:=ts,ts:=1
       )
       | merge x:desc
+      | output main

--- a/compiler/ztests/par-ts.yaml
+++ b/compiler/ztests/par-ts.yaml
@@ -42,6 +42,7 @@ outputs:
           | rename y:=z
       )
       | merge ts:asc
+      | output main
       <CUT UNIQ>
       lister ...
       | slicer
@@ -55,6 +56,7 @@ outputs:
       )
       | merge ts:asc
       | uniq
+      | output main
       <DROP UNIQ>
       lister ...
       | slicer
@@ -68,6 +70,7 @@ outputs:
       )
       | merge ts:asc
       | uniq
+      | output main
       <EVERY COUNT>
       lister ...
       | slicer
@@ -84,6 +87,7 @@ outputs:
       | merge ts:asc
       | summarize partials-in sort-dir 1
           count:=count() by y:=y,ts:=ts
+      | output main
       <PUT COUNTDISTINCT UNIQ>
       lister ...
       | scatter (
@@ -102,6 +106,7 @@ outputs:
       | summarize partials-in
           countdistinct:=countdistinct(x) by y:=y
       | uniq
+      | output main
       <RENAME UNIQ>
       lister ...
       | slicer
@@ -117,6 +122,7 @@ outputs:
       )
       | merge ts:asc
       | uniq
+      | output main
       <PUT TAIL>
       lister ...
       | slicer
@@ -132,6 +138,7 @@ outputs:
       )
       | merge ts:asc
       | tail 1
+      | output main
       <SORT UNIQ>
       lister ...
       | scatter (
@@ -143,6 +150,7 @@ outputs:
       | combine
       | sort
       | uniq
+      | output main
       <SORT X UNIQ>
       lister ...
       | scatter (
@@ -155,6 +163,7 @@ outputs:
       )
       | merge x:asc
       | uniq
+      | output main
       <UNIQ>
       lister ...
       | slicer
@@ -166,3 +175,4 @@ outputs:
       )
       | merge ts:asc
       | uniq
+      | output main

--- a/compiler/ztests/pushdown.yaml
+++ b/compiler/ztests/pushdown.yaml
@@ -20,23 +20,29 @@ outputs:
       lister
       | slicer
       | seqscan filter (x=="hello" or x==1.)
+      | output main
       ===
       lister
       | slicer
       | seqscan filter (x>1 and y<=1.)
+      | output main
       ===
       lister
       | slicer
       | seqscan filter (x=="hello" or x!=1.)
+      | output main
       ===
       lister
       | slicer
       | seqscan filter (x=="hello" or !(y==2 or y==3))
+      | output main
       ===
       lister pruner (compare(0, max, true)>0 or compare(2, min, true)<0)
       | slicer
       | seqscan pruner (compare(0, max, true)>0 or compare(2, min, true)<0) filter (ts>=0 and ts<=2)
+      | output main
       ===
       lister pruner (compare(0, max, true)>0 or compare(2, min, true)<0)
       | slicer
       | seqscan pruner (compare(0, max, true)>0 or compare(2, min, true)<0) filter (ts>=0 and ts<=2 and x=="hello")
+      | output main

--- a/compiler/ztests/remove-passops.yaml
+++ b/compiler/ztests/remove-passops.yaml
@@ -4,3 +4,4 @@ outputs:
   - name: stdout
     data: |
       reader filter (x>1 and x>2)
+      | output main

--- a/compiler/ztests/sem-groupby-input-dir.yaml
+++ b/compiler/ztests/sem-groupby-input-dir.yaml
@@ -12,3 +12,4 @@ outputs:
       | seqscan ...
       | summarize sort-dir 1
           count:=count() by ts:=every(1h)
+      | output main

--- a/compiler/ztests/tail.yaml
+++ b/compiler/ztests/tail.yaml
@@ -11,12 +11,14 @@ outputs:
     data: |
       reader
       | tail 1
+      | output main
       ===
       reader
       | (
         const x = 1
         
         tail 2
+        | output main
       )
   - name: stderr
     data: |

--- a/compiler/ztests/udf-implied-where.yaml
+++ b/compiler/ztests/udf-implied-where.yaml
@@ -11,4 +11,5 @@ outputs:
         )
         
         where h(foo)
+        | output main
       )

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -125,7 +125,7 @@ func handleQuery(c *Core, w *ResponseWriter, r *Request) {
 			}
 			if len(batch.Values()) == 0 {
 				if eoc, ok := batch.(*op.EndOfChannel); ok {
-					if err := writer.WhiteChannelEnd(int(*eoc)); err != nil {
+					if err := writer.WhiteChannelEnd(string(*eoc)); err != nil {
 						w.Logger.Warn("Error writing channel end", zap.Error(err))
 						handleError(err)
 						return
@@ -133,9 +133,9 @@ func handleQuery(c *Core, w *ResponseWriter, r *Request) {
 				}
 				continue
 			}
-			var cid int
-			batch, cid = op.Unwrap(batch)
-			if err := writer.WriteBatch(cid, batch); err != nil {
+			var label string
+			batch, label = op.Unwrap(batch)
+			if err := writer.WriteBatch(label, batch); err != nil {
 				w.Logger.Warn("Error writing batch", zap.Error(err))
 				handleError(err)
 				return

--- a/service/ztests/curl-query-ctrl.yaml
+++ b/service/ztests/curl-query-ctrl.yaml
@@ -17,9 +17,9 @@ outputs:
   - name: stdout
     data: |
       // control messages enabled
-      {"type":"QueryChannelSet","value":{"channel_id":0}}
+      {"type":"QueryChannelSet","value":{"channel":"main"}}
       {"type":{"kind":"record","id":30,"fields":[{"name":"ts","type":{"kind":"primitive","name":"int64"}}]},"value":["0"]}
-      {"type":"QueryChannelEnd","value":{"channel_id":0}}
+      {"type":"QueryChannelEnd","value":{"channel":"main"}}
       {"type":"QueryStats","value":{"start_time":{"sec":xxx,"ns":xxx},"update_time":{"sec":xxx,"ns":xxx},"bytes_read":1,"bytes_matched":1,"records_read":1,"records_matched":1}}
       // control messages disabled
       {"type":{"kind":"record","id":30,"fields":[{"name":"ts","type":{"kind":"primitive","name":"int64"}}]},"value":["0"]}

--- a/service/ztests/curl-query-split.yaml
+++ b/service/ztests/curl-query-split.yaml
@@ -4,8 +4,8 @@ script: |
   source service.sh
   zed create -q test
   zed load -q -use test -
-  curl --stderr ignore -H "Accept: application/x-zjson" -d '{"query":"from test | fork (=>pass =>pass)"}' $ZED_LAKE/query\?ctrl=true |
-      zq -z "QueryChannelEnd | sort value.channel_id" -
+  curl --stderr ignore -H "Accept: application/x-zjson" -d '{"query":"from test | fork (=>output main =>output test)"}' $ZED_LAKE/query\?ctrl=true |
+      zq -z "QueryChannelEnd | sort value.channel" -
 
 inputs:
   - name: service.sh
@@ -17,5 +17,5 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      {type:"QueryChannelEnd",value:{channel_id:0}}
-      {type:"QueryChannelEnd",value:{channel_id:1}}
+      {type:"QueryChannelEnd",value:{channel:"main"}}
+      {type:"QueryChannelEnd",value:{channel:"test"}}

--- a/service/ztests/curl-query.yaml
+++ b/service/ztests/curl-query.yaml
@@ -45,10 +45,10 @@ outputs:
       hello	world	goodbye
       one	two	three
       === application/x-zjson ===
-      {"type":"QueryChannelSet","value":{"channel_id":0}}
+      {"type":"QueryChannelSet","value":{"channel":"main"}}
       {"type":{"kind":"record","id":31,"fields":[{"name":"a","type":{"kind":"primitive","name":"string"}},{"name":"b","type":{"kind":"record","id":30,"fields":[{"name":"c","type":{"kind":"primitive","name":"string"}},{"name":"d","type":{"kind":"primitive","name":"string"}}]}}]},"value":["hello",["world","goodbye"]]}
       {"type":{"kind":"ref","id":31},"value":["one",["two","three"]]}
-      {"type":"QueryChannelEnd","value":{"channel_id":0}}
+      {"type":"QueryChannelEnd","value":{"channel":"main"}}
       {"type":"QueryStats","value":{"start_time":{"sec":xxx,"ns":xxx},"update_time":{"sec":xxx,"ns":xxx},"bytes_read":36,"bytes_matched":36,"records_read":2,"records_matched":2}}
       === application/x-zson ===
       {a:"hello",b:{c:"world",d:"goodbye"}}

--- a/service/ztests/query-describe.yaml
+++ b/service/ztests/query-describe.yaml
@@ -2,7 +2,7 @@ script: |
   source service.sh
   zed create -q test1
   zed create -q test2
-  for file in multifrom.zed agg.zed agg-no-keys.zed two-channels.zed agg-sort.zed scope.zed; do
+  for file in multifrom.zed agg.zed agg-no-keys.zed two-channels.zed agg-sort.zed scope.zed auto-combined-channels.zed; do
     echo // === $file ===
     query="$(cat $file | jq -Rsa .)"
     curl -H "Accept: application/json" -d "{\"query\":$query,\"head\":{\"pool\":\"test1\"}}" $ZED_LAKE/query/describe |
@@ -27,8 +27,8 @@ inputs:
   - name: two-channels.zed
     data: |
       fork (
-      => from test1 | sum(y) by key1
-      => from test2 | put x := "foo"
+      => from test1 | sum(y) by key1 | output main
+      => from test2 | put x := "foo" | output secondary
       )
   - name: agg-sort.zed
     data: |
@@ -36,7 +36,10 @@ inputs:
   - name: scope.zed
     data: |
       type port = uint16
-      from test1 | fork (=> pass => yield "bar")
+      from test1 | fork (=> output main => yield "bar" | output secondary)
+  - name: auto-combined-channels.zed
+    data: |
+      from test1 | fork (=> pass => pass)
 
 outputs:
   - name: stdout
@@ -59,6 +62,7 @@ outputs:
           ],
           "channels": [
               {
+                  "name": "main",
                   "aggregation_keys": null,
                   "sort": {
                       "order": "desc",
@@ -81,6 +85,7 @@ outputs:
           },
           "channels": [
               {
+                  "name": "main",
                   "aggregation_keys": [
                       [
                           "key1"
@@ -103,6 +108,7 @@ outputs:
           },
           "channels": [
               {
+                  "name": "main",
                   "aggregation_keys": [],
                   "sort": null
               }
@@ -126,6 +132,7 @@ outputs:
           ],
           "channels": [
               {
+                  "name": "main",
                   "aggregation_keys": [
                       [
                           "key1"
@@ -134,6 +141,7 @@ outputs:
                   "sort": null
               },
               {
+                  "name": "secondary",
                   "aggregation_keys": null,
                   "sort": {
                       "order": "desc",
@@ -156,6 +164,7 @@ outputs:
           },
           "channels": [
               {
+                  "name": "main",
                   "aggregation_keys": [
                       [
                           "foo"
@@ -182,6 +191,7 @@ outputs:
           },
           "channels": [
               {
+                  "name": "main",
                   "aggregation_keys": null,
                   "sort": {
                       "order": "desc",
@@ -193,6 +203,23 @@ outputs:
                   }
               },
               {
+                  "name": "secondary",
+                  "aggregation_keys": null,
+                  "sort": null
+              }
+          ]
+      }
+      // === auto-combined-channels.zed ===
+      {
+          "sources": {
+              "kind": "Pool",
+              "name": "test1",
+              "id": "XXX",
+              "inferred": false
+          },
+          "channels": [
+              {
+                  "name": "main",
                   "aggregation_keys": null,
                   "sort": null
               }

--- a/zbuf/reader.go
+++ b/zbuf/reader.go
@@ -15,8 +15,8 @@ func (c *Control) Error() string {
 	return "control"
 }
 
-type SetChannel int
-type EndChannel int
+type SetChannel string
+type EndChannel string
 
 type noControl struct {
 	zio.Reader

--- a/zfmt/ast.go
+++ b/zfmt/ast.go
@@ -627,6 +627,9 @@ func (c *canon) op(p ast.Op) {
 		c.next()
 		c.write("yield ")
 		c.exprs(p.Exprs)
+	case *ast.Output:
+		c.next()
+		c.write("output %s", p.Name.Name)
 	default:
 		c.open("unknown proc: %T", p)
 		c.close()

--- a/zfmt/dag.go
+++ b/zfmt/dag.go
@@ -527,6 +527,9 @@ func (c *canonDAG) op(p dag.Op) {
 		c.head = true
 		c.seq(p.Body)
 		c.close()
+	case *dag.Output:
+		c.next()
+		c.write("output %s", p.Name)
 	default:
 		c.next()
 		c.open("unknown proc: %T", p)

--- a/zfmt/ztests/decls.yaml
+++ b/zfmt/ztests/decls.yaml
@@ -66,4 +66,5 @@ outputs:
         )
         | join on flavor=likes eater:=name
         | yield {...this,assignee:"bob",ts:now()}
+        | output main
       )

--- a/zfmt/ztests/join.yaml
+++ b/zfmt/ztests/join.yaml
@@ -18,3 +18,4 @@ outputs:
           file test.zson
       )
       | join on x=x p:=a
+      | output main

--- a/zfmt/ztests/over.yaml
+++ b/zfmt/ztests/over.yaml
@@ -65,3 +65,4 @@ outputs:
       | over a, b with c=d, e=f => (
         where search("g")
       )
+      | output main

--- a/zfmt/ztests/parallel.yaml
+++ b/zfmt/ztests/parallel.yaml
@@ -19,3 +19,4 @@ outputs:
       )
       | cut cake:=cake
       | sort -r x
+      | output main

--- a/zfmt/ztests/precedence-dag.yaml
+++ b/zfmt/ztests/precedence-dag.yaml
@@ -18,7 +18,10 @@ outputs:
      data: |
         reader
         | yield (10+2)/8
+        | output main
         reader
         | where (y==2 or x==4) and z==5
+        | output main
         reader
         | where !(ts<=2)
+        | output main

--- a/zfmt/ztests/switch.yaml
+++ b/zfmt/ztests/switch.yaml
@@ -24,6 +24,7 @@ outputs:
           case search("c") =>
             tail 1
         )
+        | output main
       ===
       switch (
         case grep("a") =>
@@ -39,3 +40,4 @@ outputs:
           case true =>
             tail 1
         )
+        | output main

--- a/zfmt/ztests/type-value.yaml
+++ b/zfmt/ztests/type-value.yaml
@@ -8,3 +8,4 @@ outputs:
       search is(<foo>) and bar
       reader
       | where is(<(uint16,ip)>) and search(80)
+      | output main

--- a/zfmt/ztests/yield-shortcut.yaml
+++ b/zfmt/ztests/yield-shortcut.yaml
@@ -22,11 +22,16 @@ outputs:
       ===
       reader
       | yield {x:1,...y}
+      | output main
       reader
       | yield [1,2,3]
+      | output main
       reader
       | yield |["foo","bar"]|
+      | output main
       reader
       | yield |{"foo":1,"bar":2}|
+      | output main
       reader
       | yield cast(1, <(int64,string)>)
+      | output main


### PR DESCRIPTION
Add output operator which allows users to set the name of the resultant channel. Channels are no longer identified by an integer but instead with a string- if a channel doesn't not have an output it will be assigned to channel "main".