### PR TITLE
Add vector.View

### DIFF
--- a/runtime/vam/expr/arith_test.go
+++ b/runtime/vam/expr/arith_test.go
@@ -10,13 +10,15 @@ import (
 
 // Test that Arith.Eval handles all ops for all vector forms.
 func TestArithOpsAndForms(t *testing.T) {
-	// These are both [0, 1, 2].
+	// These are all [0, 1, 2].
 	lhsFlat := vector.NewInt(zed.TypeInt64, []int64{0, 1, 2}, nil)
 	lhsDict := vector.NewDict(lhsFlat, []byte{0, 1, 2}, nil, nil)
+	lhsView := vector.NewView([]uint32{0, 1, 2}, lhsFlat)
 
 	// These are all [1, 1, 1].
 	rhsFlat := vector.NewInt(zed.TypeInt64, []int64{1, 1, 1}, nil)
 	rhsDict := vector.NewDict(rhsFlat, []byte{0, 0, 0}, nil, nil)
+	rhsView := vector.NewView([]uint32{0, 1, 2}, rhsFlat)
 	Const := vector.NewConst(nil, zed.NewInt64(1), 3, nil)
 
 	cases := []struct {
@@ -38,14 +40,22 @@ func TestArithOpsAndForms(t *testing.T) {
 
 		f(c.expected, lhsFlat, rhsFlat)
 		f(c.expected, lhsFlat, rhsDict)
+		f(c.expected, lhsFlat, rhsView)
 		f(c.expected, lhsFlat, Const)
 
 		f(c.expected, lhsDict, rhsFlat)
 		f(c.expected, lhsDict, rhsDict)
+		f(c.expected, lhsDict, rhsView)
 		f(c.expected, lhsDict, Const)
 
-		f(c.expectedForConstLHS, Const, rhsDict)
+		f(c.expected, lhsView, rhsFlat)
+		f(c.expected, lhsView, rhsDict)
+		f(c.expected, lhsView, rhsView)
+		f(c.expected, lhsView, Const)
+
 		f(c.expectedForConstLHS, Const, rhsFlat)
+		f(c.expectedForConstLHS, Const, rhsDict)
+		f(c.expectedForConstLHS, Const, rhsView)
 
 		// Arithmetic on two vector.Consts yields another vector.Const.
 		cmp := NewArith(zed.NewContext(), &testEval{Const}, &testEval{Const}, c.op)

--- a/runtime/vam/expr/arithfuncs.go
+++ b/runtime/vam/expr/arithfuncs.go
@@ -31,6 +31,19 @@ func arithAddIntFlatDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func arithAddIntFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Int)
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(k) + r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
 func arithAddIntFlatConst(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Int)
 	rconst, _ := rhs.(*vector.Const).AsInt()
@@ -70,8 +83,79 @@ func arithAddIntDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func arithAddIntDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) + r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
 func arithAddIntDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsInt()
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) + rconst)
+	}
+	return out
+}
+
+func arithAddIntViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	r := rhs.(*vector.Int)
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) + r.Value(k))
+	}
+	return out
+}
+
+func arithAddIntViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) + r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithAddIntViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) + r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithAddIntViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Int)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsInt()
@@ -107,6 +191,19 @@ func arithAddIntConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func arithAddIntConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsInt()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(lconst + r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
 func arithAddIntConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsInt()
 	rconst, _ := rhs.(*vector.Const).AsInt()
@@ -129,6 +226,19 @@ func arithAddUintFlatFlat(lhs, rhs vector.Any) vector.Any {
 func arithAddUintFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Uint)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(k) + r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithAddUintFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Uint)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Uint)
 	rx := rd.Index
 	n := lhs.Len()
@@ -178,8 +288,79 @@ func arithAddUintDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func arithAddUintDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) + r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
 func arithAddUintDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsUint()
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) + rconst)
+	}
+	return out
+}
+
+func arithAddUintViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	r := rhs.(*vector.Uint)
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) + r.Value(k))
+	}
+	return out
+}
+
+func arithAddUintViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) + r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithAddUintViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) + r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithAddUintViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Uint)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsUint()
@@ -215,6 +396,19 @@ func arithAddUintConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func arithAddUintConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsUint()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(lconst + r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
 func arithAddUintConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsUint()
 	rconst, _ := rhs.(*vector.Const).AsUint()
@@ -237,6 +431,19 @@ func arithAddFloatFlatFlat(lhs, rhs vector.Any) vector.Any {
 func arithAddFloatFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Float)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewFloatEmpty(zed.TypeFloat64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(k) + r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithAddFloatFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Float)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Float)
 	rx := rd.Index
 	n := lhs.Len()
@@ -286,8 +493,79 @@ func arithAddFloatDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func arithAddFloatDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewFloatEmpty(zed.TypeFloat64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) + r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
 func arithAddFloatDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsFloat()
+	n := lhs.Len()
+	out := vector.NewFloatEmpty(zed.TypeFloat64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) + rconst)
+	}
+	return out
+}
+
+func arithAddFloatViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	r := rhs.(*vector.Float)
+	n := lhs.Len()
+	out := vector.NewFloatEmpty(zed.TypeFloat64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) + r.Value(k))
+	}
+	return out
+}
+
+func arithAddFloatViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewFloatEmpty(zed.TypeFloat64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) + r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithAddFloatViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewFloatEmpty(zed.TypeFloat64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) + r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithAddFloatViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Float)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsFloat()
@@ -323,6 +601,19 @@ func arithAddFloatConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func arithAddFloatConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsFloat()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewFloatEmpty(zed.TypeFloat64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(lconst + r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
 func arithAddFloatConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsFloat()
 	rconst, _ := rhs.(*vector.Const).AsFloat()
@@ -345,6 +636,19 @@ func arithAddStringFlatFlat(lhs, rhs vector.Any) vector.Any {
 func arithAddStringFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.String)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewStringEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(k) + r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithAddStringFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.String)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.String)
 	rx := rd.Index
 	n := lhs.Len()
@@ -394,8 +698,79 @@ func arithAddStringDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func arithAddStringDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewStringEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) + r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
 func arithAddStringDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsString()
+	n := lhs.Len()
+	out := vector.NewStringEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) + rconst)
+	}
+	return out
+}
+
+func arithAddStringViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	r := rhs.(*vector.String)
+	n := lhs.Len()
+	out := vector.NewStringEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) + r.Value(k))
+	}
+	return out
+}
+
+func arithAddStringViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewStringEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) + r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithAddStringViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewStringEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) + r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithAddStringViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.String)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsString()
@@ -431,6 +806,19 @@ func arithAddStringConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func arithAddStringConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsString()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewStringEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(lconst + r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
 func arithAddStringConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsString()
 	rconst, _ := rhs.(*vector.Const).AsString()
@@ -454,6 +842,19 @@ func arithSubIntFlatFlat(lhs, rhs vector.Any) vector.Any {
 func arithSubIntFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Int)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(k) - r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithSubIntFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Int)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Int)
 	rx := rd.Index
 	n := lhs.Len()
@@ -503,8 +904,79 @@ func arithSubIntDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func arithSubIntDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) - r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
 func arithSubIntDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsInt()
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) - rconst)
+	}
+	return out
+}
+
+func arithSubIntViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	r := rhs.(*vector.Int)
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) - r.Value(k))
+	}
+	return out
+}
+
+func arithSubIntViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) - r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithSubIntViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) - r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithSubIntViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Int)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsInt()
@@ -540,6 +1012,19 @@ func arithSubIntConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func arithSubIntConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsInt()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(lconst - r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
 func arithSubIntConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsInt()
 	rconst, _ := rhs.(*vector.Const).AsInt()
@@ -562,6 +1047,19 @@ func arithSubUintFlatFlat(lhs, rhs vector.Any) vector.Any {
 func arithSubUintFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Uint)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(k) - r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithSubUintFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Uint)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Uint)
 	rx := rd.Index
 	n := lhs.Len()
@@ -611,8 +1109,79 @@ func arithSubUintDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func arithSubUintDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) - r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
 func arithSubUintDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsUint()
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) - rconst)
+	}
+	return out
+}
+
+func arithSubUintViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	r := rhs.(*vector.Uint)
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) - r.Value(k))
+	}
+	return out
+}
+
+func arithSubUintViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) - r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithSubUintViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) - r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithSubUintViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Uint)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsUint()
@@ -648,6 +1217,19 @@ func arithSubUintConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func arithSubUintConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsUint()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(lconst - r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
 func arithSubUintConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsUint()
 	rconst, _ := rhs.(*vector.Const).AsUint()
@@ -670,6 +1252,19 @@ func arithSubFloatFlatFlat(lhs, rhs vector.Any) vector.Any {
 func arithSubFloatFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Float)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewFloatEmpty(zed.TypeFloat64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(k) - r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithSubFloatFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Float)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Float)
 	rx := rd.Index
 	n := lhs.Len()
@@ -719,8 +1314,79 @@ func arithSubFloatDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func arithSubFloatDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewFloatEmpty(zed.TypeFloat64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) - r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
 func arithSubFloatDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsFloat()
+	n := lhs.Len()
+	out := vector.NewFloatEmpty(zed.TypeFloat64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) - rconst)
+	}
+	return out
+}
+
+func arithSubFloatViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	r := rhs.(*vector.Float)
+	n := lhs.Len()
+	out := vector.NewFloatEmpty(zed.TypeFloat64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) - r.Value(k))
+	}
+	return out
+}
+
+func arithSubFloatViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewFloatEmpty(zed.TypeFloat64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) - r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithSubFloatViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewFloatEmpty(zed.TypeFloat64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) - r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithSubFloatViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Float)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsFloat()
@@ -756,6 +1422,19 @@ func arithSubFloatConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func arithSubFloatConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsFloat()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewFloatEmpty(zed.TypeFloat64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(lconst - r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
 func arithSubFloatConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsFloat()
 	rconst, _ := rhs.(*vector.Const).AsFloat()
@@ -778,6 +1457,19 @@ func arithMulIntFlatFlat(lhs, rhs vector.Any) vector.Any {
 func arithMulIntFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Int)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(k) * r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithMulIntFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Int)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Int)
 	rx := rd.Index
 	n := lhs.Len()
@@ -827,8 +1519,79 @@ func arithMulIntDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func arithMulIntDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) * r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
 func arithMulIntDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsInt()
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) * rconst)
+	}
+	return out
+}
+
+func arithMulIntViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	r := rhs.(*vector.Int)
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) * r.Value(k))
+	}
+	return out
+}
+
+func arithMulIntViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) * r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithMulIntViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) * r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithMulIntViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Int)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsInt()
@@ -864,6 +1627,19 @@ func arithMulIntConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func arithMulIntConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsInt()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(lconst * r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
 func arithMulIntConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsInt()
 	rconst, _ := rhs.(*vector.Const).AsInt()
@@ -886,6 +1662,19 @@ func arithMulUintFlatFlat(lhs, rhs vector.Any) vector.Any {
 func arithMulUintFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Uint)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(k) * r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithMulUintFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Uint)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Uint)
 	rx := rd.Index
 	n := lhs.Len()
@@ -935,8 +1724,79 @@ func arithMulUintDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func arithMulUintDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) * r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
 func arithMulUintDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsUint()
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) * rconst)
+	}
+	return out
+}
+
+func arithMulUintViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	r := rhs.(*vector.Uint)
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) * r.Value(k))
+	}
+	return out
+}
+
+func arithMulUintViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) * r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithMulUintViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) * r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithMulUintViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Uint)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsUint()
@@ -972,6 +1832,19 @@ func arithMulUintConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func arithMulUintConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsUint()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(lconst * r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
 func arithMulUintConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsUint()
 	rconst, _ := rhs.(*vector.Const).AsUint()
@@ -994,6 +1867,19 @@ func arithMulFloatFlatFlat(lhs, rhs vector.Any) vector.Any {
 func arithMulFloatFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Float)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewFloatEmpty(zed.TypeFloat64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(k) * r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithMulFloatFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Float)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Float)
 	rx := rd.Index
 	n := lhs.Len()
@@ -1043,8 +1929,79 @@ func arithMulFloatDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func arithMulFloatDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewFloatEmpty(zed.TypeFloat64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) * r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
 func arithMulFloatDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsFloat()
+	n := lhs.Len()
+	out := vector.NewFloatEmpty(zed.TypeFloat64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) * rconst)
+	}
+	return out
+}
+
+func arithMulFloatViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	r := rhs.(*vector.Float)
+	n := lhs.Len()
+	out := vector.NewFloatEmpty(zed.TypeFloat64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) * r.Value(k))
+	}
+	return out
+}
+
+func arithMulFloatViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewFloatEmpty(zed.TypeFloat64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) * r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithMulFloatViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewFloatEmpty(zed.TypeFloat64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) * r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithMulFloatViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Float)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsFloat()
@@ -1080,6 +2037,19 @@ func arithMulFloatConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func arithMulFloatConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsFloat()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewFloatEmpty(zed.TypeFloat64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(lconst * r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
 func arithMulFloatConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsFloat()
 	rconst, _ := rhs.(*vector.Const).AsFloat()
@@ -1102,6 +2072,19 @@ func arithDivIntFlatFlat(lhs, rhs vector.Any) vector.Any {
 func arithDivIntFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Int)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(k) / r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithDivIntFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Int)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Int)
 	rx := rd.Index
 	n := lhs.Len()
@@ -1151,8 +2134,79 @@ func arithDivIntDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func arithDivIntDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) / r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
 func arithDivIntDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsInt()
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) / rconst)
+	}
+	return out
+}
+
+func arithDivIntViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	r := rhs.(*vector.Int)
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) / r.Value(k))
+	}
+	return out
+}
+
+func arithDivIntViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) / r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithDivIntViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) / r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithDivIntViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Int)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsInt()
@@ -1188,6 +2242,19 @@ func arithDivIntConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func arithDivIntConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsInt()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(lconst / r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
 func arithDivIntConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsInt()
 	rconst, _ := rhs.(*vector.Const).AsInt()
@@ -1210,6 +2277,19 @@ func arithDivUintFlatFlat(lhs, rhs vector.Any) vector.Any {
 func arithDivUintFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Uint)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(k) / r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithDivUintFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Uint)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Uint)
 	rx := rd.Index
 	n := lhs.Len()
@@ -1259,8 +2339,79 @@ func arithDivUintDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func arithDivUintDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) / r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
 func arithDivUintDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsUint()
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) / rconst)
+	}
+	return out
+}
+
+func arithDivUintViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	r := rhs.(*vector.Uint)
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) / r.Value(k))
+	}
+	return out
+}
+
+func arithDivUintViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) / r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithDivUintViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) / r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithDivUintViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Uint)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsUint()
@@ -1296,6 +2447,19 @@ func arithDivUintConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func arithDivUintConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsUint()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(lconst / r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
 func arithDivUintConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsUint()
 	rconst, _ := rhs.(*vector.Const).AsUint()
@@ -1318,6 +2482,19 @@ func arithDivFloatFlatFlat(lhs, rhs vector.Any) vector.Any {
 func arithDivFloatFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Float)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewFloatEmpty(zed.TypeFloat64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(k) / r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithDivFloatFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Float)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Float)
 	rx := rd.Index
 	n := lhs.Len()
@@ -1367,8 +2544,79 @@ func arithDivFloatDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func arithDivFloatDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewFloatEmpty(zed.TypeFloat64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) / r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
 func arithDivFloatDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsFloat()
+	n := lhs.Len()
+	out := vector.NewFloatEmpty(zed.TypeFloat64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) / rconst)
+	}
+	return out
+}
+
+func arithDivFloatViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	r := rhs.(*vector.Float)
+	n := lhs.Len()
+	out := vector.NewFloatEmpty(zed.TypeFloat64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) / r.Value(k))
+	}
+	return out
+}
+
+func arithDivFloatViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewFloatEmpty(zed.TypeFloat64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) / r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithDivFloatViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewFloatEmpty(zed.TypeFloat64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) / r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithDivFloatViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Float)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsFloat()
@@ -1404,6 +2652,19 @@ func arithDivFloatConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func arithDivFloatConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsFloat()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewFloatEmpty(zed.TypeFloat64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(lconst / r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
 func arithDivFloatConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsFloat()
 	rconst, _ := rhs.(*vector.Const).AsFloat()
@@ -1426,6 +2687,19 @@ func arithModIntFlatFlat(lhs, rhs vector.Any) vector.Any {
 func arithModIntFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Int)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(k) % r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithModIntFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Int)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Int)
 	rx := rd.Index
 	n := lhs.Len()
@@ -1475,8 +2749,79 @@ func arithModIntDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func arithModIntDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) % r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
 func arithModIntDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsInt()
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) % rconst)
+	}
+	return out
+}
+
+func arithModIntViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	r := rhs.(*vector.Int)
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) % r.Value(k))
+	}
+	return out
+}
+
+func arithModIntViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) % r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithModIntViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) % r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithModIntViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Int)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsInt()
@@ -1512,6 +2857,19 @@ func arithModIntConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func arithModIntConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsInt()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewIntEmpty(zed.TypeInt64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(lconst % r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
 func arithModIntConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsInt()
 	rconst, _ := rhs.(*vector.Const).AsInt()
@@ -1534,6 +2892,19 @@ func arithModUintFlatFlat(lhs, rhs vector.Any) vector.Any {
 func arithModUintFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Uint)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(k) % r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithModUintFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Uint)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Uint)
 	rx := rd.Index
 	n := lhs.Len()
@@ -1583,8 +2954,79 @@ func arithModUintDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func arithModUintDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) % r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
 func arithModUintDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsUint()
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) % rconst)
+	}
+	return out
+}
+
+func arithModUintViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	r := rhs.(*vector.Uint)
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) % r.Value(k))
+	}
+	return out
+}
+
+func arithModUintViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) % r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithModUintViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(l.Value(uint32(lx[k])) % r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
+func arithModUintViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Uint)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsUint()
@@ -1620,6 +3062,19 @@ func arithModUintConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func arithModUintConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsUint()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewUintEmpty(zed.TypeUint64, n, nil)
+	for k := uint32(0); k < n; k++ {
+		out.Append(lconst % r.Value(uint32(rx[k])))
+	}
+	return out
+}
+
 func arithModUintConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsUint()
 	rconst, _ := rhs.(*vector.Const).AsUint()
@@ -1631,137 +3086,242 @@ func arithModUintConstConst(lhs, rhs vector.Any) vector.Any {
 var arithFuncs = map[int]func(vector.Any, vector.Any) vector.Any{
 	16:  arithAddIntFlatFlat,
 	20:  arithAddIntFlatDict,
-	24:  arithAddIntFlatConst,
+	24:  arithAddIntFlatView,
+	28:  arithAddIntFlatConst,
 	17:  arithAddIntDictFlat,
 	21:  arithAddIntDictDict,
-	25:  arithAddIntDictConst,
-	18:  arithAddIntConstFlat,
-	22:  arithAddIntConstDict,
-	26:  arithAddIntConstConst,
+	25:  arithAddIntDictView,
+	29:  arithAddIntDictConst,
+	18:  arithAddIntViewFlat,
+	22:  arithAddIntViewDict,
+	26:  arithAddIntViewView,
+	30:  arithAddIntViewConst,
+	19:  arithAddIntConstFlat,
+	23:  arithAddIntConstDict,
+	27:  arithAddIntConstView,
+	31:  arithAddIntConstConst,
 	32:  arithAddUintFlatFlat,
 	36:  arithAddUintFlatDict,
-	40:  arithAddUintFlatConst,
+	40:  arithAddUintFlatView,
+	44:  arithAddUintFlatConst,
 	33:  arithAddUintDictFlat,
 	37:  arithAddUintDictDict,
-	41:  arithAddUintDictConst,
-	34:  arithAddUintConstFlat,
-	38:  arithAddUintConstDict,
-	42:  arithAddUintConstConst,
+	41:  arithAddUintDictView,
+	45:  arithAddUintDictConst,
+	34:  arithAddUintViewFlat,
+	38:  arithAddUintViewDict,
+	42:  arithAddUintViewView,
+	46:  arithAddUintViewConst,
+	35:  arithAddUintConstFlat,
+	39:  arithAddUintConstDict,
+	43:  arithAddUintConstView,
+	47:  arithAddUintConstConst,
 	48:  arithAddFloatFlatFlat,
 	52:  arithAddFloatFlatDict,
-	56:  arithAddFloatFlatConst,
+	56:  arithAddFloatFlatView,
+	60:  arithAddFloatFlatConst,
 	49:  arithAddFloatDictFlat,
 	53:  arithAddFloatDictDict,
-	57:  arithAddFloatDictConst,
-	50:  arithAddFloatConstFlat,
-	54:  arithAddFloatConstDict,
-	58:  arithAddFloatConstConst,
+	57:  arithAddFloatDictView,
+	61:  arithAddFloatDictConst,
+	50:  arithAddFloatViewFlat,
+	54:  arithAddFloatViewDict,
+	58:  arithAddFloatViewView,
+	62:  arithAddFloatViewConst,
+	51:  arithAddFloatConstFlat,
+	55:  arithAddFloatConstDict,
+	59:  arithAddFloatConstView,
+	63:  arithAddFloatConstConst,
 	64:  arithAddStringFlatFlat,
 	68:  arithAddStringFlatDict,
-	72:  arithAddStringFlatConst,
+	72:  arithAddStringFlatView,
+	76:  arithAddStringFlatConst,
 	65:  arithAddStringDictFlat,
 	69:  arithAddStringDictDict,
-	73:  arithAddStringDictConst,
-	66:  arithAddStringConstFlat,
-	70:  arithAddStringConstDict,
-	74:  arithAddStringConstConst,
+	73:  arithAddStringDictView,
+	77:  arithAddStringDictConst,
+	66:  arithAddStringViewFlat,
+	70:  arithAddStringViewDict,
+	74:  arithAddStringViewView,
+	78:  arithAddStringViewConst,
+	67:  arithAddStringConstFlat,
+	71:  arithAddStringConstDict,
+	75:  arithAddStringConstView,
+	79:  arithAddStringConstConst,
 	144: arithSubIntFlatFlat,
 	148: arithSubIntFlatDict,
-	152: arithSubIntFlatConst,
+	152: arithSubIntFlatView,
+	156: arithSubIntFlatConst,
 	145: arithSubIntDictFlat,
 	149: arithSubIntDictDict,
-	153: arithSubIntDictConst,
-	146: arithSubIntConstFlat,
-	150: arithSubIntConstDict,
-	154: arithSubIntConstConst,
+	153: arithSubIntDictView,
+	157: arithSubIntDictConst,
+	146: arithSubIntViewFlat,
+	150: arithSubIntViewDict,
+	154: arithSubIntViewView,
+	158: arithSubIntViewConst,
+	147: arithSubIntConstFlat,
+	151: arithSubIntConstDict,
+	155: arithSubIntConstView,
+	159: arithSubIntConstConst,
 	160: arithSubUintFlatFlat,
 	164: arithSubUintFlatDict,
-	168: arithSubUintFlatConst,
+	168: arithSubUintFlatView,
+	172: arithSubUintFlatConst,
 	161: arithSubUintDictFlat,
 	165: arithSubUintDictDict,
-	169: arithSubUintDictConst,
-	162: arithSubUintConstFlat,
-	166: arithSubUintConstDict,
-	170: arithSubUintConstConst,
+	169: arithSubUintDictView,
+	173: arithSubUintDictConst,
+	162: arithSubUintViewFlat,
+	166: arithSubUintViewDict,
+	170: arithSubUintViewView,
+	174: arithSubUintViewConst,
+	163: arithSubUintConstFlat,
+	167: arithSubUintConstDict,
+	171: arithSubUintConstView,
+	175: arithSubUintConstConst,
 	176: arithSubFloatFlatFlat,
 	180: arithSubFloatFlatDict,
-	184: arithSubFloatFlatConst,
+	184: arithSubFloatFlatView,
+	188: arithSubFloatFlatConst,
 	177: arithSubFloatDictFlat,
 	181: arithSubFloatDictDict,
-	185: arithSubFloatDictConst,
-	178: arithSubFloatConstFlat,
-	182: arithSubFloatConstDict,
-	186: arithSubFloatConstConst,
+	185: arithSubFloatDictView,
+	189: arithSubFloatDictConst,
+	178: arithSubFloatViewFlat,
+	182: arithSubFloatViewDict,
+	186: arithSubFloatViewView,
+	190: arithSubFloatViewConst,
+	179: arithSubFloatConstFlat,
+	183: arithSubFloatConstDict,
+	187: arithSubFloatConstView,
+	191: arithSubFloatConstConst,
 	272: arithMulIntFlatFlat,
 	276: arithMulIntFlatDict,
-	280: arithMulIntFlatConst,
+	280: arithMulIntFlatView,
+	284: arithMulIntFlatConst,
 	273: arithMulIntDictFlat,
 	277: arithMulIntDictDict,
-	281: arithMulIntDictConst,
-	274: arithMulIntConstFlat,
-	278: arithMulIntConstDict,
-	282: arithMulIntConstConst,
+	281: arithMulIntDictView,
+	285: arithMulIntDictConst,
+	274: arithMulIntViewFlat,
+	278: arithMulIntViewDict,
+	282: arithMulIntViewView,
+	286: arithMulIntViewConst,
+	275: arithMulIntConstFlat,
+	279: arithMulIntConstDict,
+	283: arithMulIntConstView,
+	287: arithMulIntConstConst,
 	288: arithMulUintFlatFlat,
 	292: arithMulUintFlatDict,
-	296: arithMulUintFlatConst,
+	296: arithMulUintFlatView,
+	300: arithMulUintFlatConst,
 	289: arithMulUintDictFlat,
 	293: arithMulUintDictDict,
-	297: arithMulUintDictConst,
-	290: arithMulUintConstFlat,
-	294: arithMulUintConstDict,
-	298: arithMulUintConstConst,
+	297: arithMulUintDictView,
+	301: arithMulUintDictConst,
+	290: arithMulUintViewFlat,
+	294: arithMulUintViewDict,
+	298: arithMulUintViewView,
+	302: arithMulUintViewConst,
+	291: arithMulUintConstFlat,
+	295: arithMulUintConstDict,
+	299: arithMulUintConstView,
+	303: arithMulUintConstConst,
 	304: arithMulFloatFlatFlat,
 	308: arithMulFloatFlatDict,
-	312: arithMulFloatFlatConst,
+	312: arithMulFloatFlatView,
+	316: arithMulFloatFlatConst,
 	305: arithMulFloatDictFlat,
 	309: arithMulFloatDictDict,
-	313: arithMulFloatDictConst,
-	306: arithMulFloatConstFlat,
-	310: arithMulFloatConstDict,
-	314: arithMulFloatConstConst,
+	313: arithMulFloatDictView,
+	317: arithMulFloatDictConst,
+	306: arithMulFloatViewFlat,
+	310: arithMulFloatViewDict,
+	314: arithMulFloatViewView,
+	318: arithMulFloatViewConst,
+	307: arithMulFloatConstFlat,
+	311: arithMulFloatConstDict,
+	315: arithMulFloatConstView,
+	319: arithMulFloatConstConst,
 	400: arithDivIntFlatFlat,
 	404: arithDivIntFlatDict,
-	408: arithDivIntFlatConst,
+	408: arithDivIntFlatView,
+	412: arithDivIntFlatConst,
 	401: arithDivIntDictFlat,
 	405: arithDivIntDictDict,
-	409: arithDivIntDictConst,
-	402: arithDivIntConstFlat,
-	406: arithDivIntConstDict,
-	410: arithDivIntConstConst,
+	409: arithDivIntDictView,
+	413: arithDivIntDictConst,
+	402: arithDivIntViewFlat,
+	406: arithDivIntViewDict,
+	410: arithDivIntViewView,
+	414: arithDivIntViewConst,
+	403: arithDivIntConstFlat,
+	407: arithDivIntConstDict,
+	411: arithDivIntConstView,
+	415: arithDivIntConstConst,
 	416: arithDivUintFlatFlat,
 	420: arithDivUintFlatDict,
-	424: arithDivUintFlatConst,
+	424: arithDivUintFlatView,
+	428: arithDivUintFlatConst,
 	417: arithDivUintDictFlat,
 	421: arithDivUintDictDict,
-	425: arithDivUintDictConst,
-	418: arithDivUintConstFlat,
-	422: arithDivUintConstDict,
-	426: arithDivUintConstConst,
+	425: arithDivUintDictView,
+	429: arithDivUintDictConst,
+	418: arithDivUintViewFlat,
+	422: arithDivUintViewDict,
+	426: arithDivUintViewView,
+	430: arithDivUintViewConst,
+	419: arithDivUintConstFlat,
+	423: arithDivUintConstDict,
+	427: arithDivUintConstView,
+	431: arithDivUintConstConst,
 	432: arithDivFloatFlatFlat,
 	436: arithDivFloatFlatDict,
-	440: arithDivFloatFlatConst,
+	440: arithDivFloatFlatView,
+	444: arithDivFloatFlatConst,
 	433: arithDivFloatDictFlat,
 	437: arithDivFloatDictDict,
-	441: arithDivFloatDictConst,
-	434: arithDivFloatConstFlat,
-	438: arithDivFloatConstDict,
-	442: arithDivFloatConstConst,
+	441: arithDivFloatDictView,
+	445: arithDivFloatDictConst,
+	434: arithDivFloatViewFlat,
+	438: arithDivFloatViewDict,
+	442: arithDivFloatViewView,
+	446: arithDivFloatViewConst,
+	435: arithDivFloatConstFlat,
+	439: arithDivFloatConstDict,
+	443: arithDivFloatConstView,
+	447: arithDivFloatConstConst,
 	528: arithModIntFlatFlat,
 	532: arithModIntFlatDict,
-	536: arithModIntFlatConst,
+	536: arithModIntFlatView,
+	540: arithModIntFlatConst,
 	529: arithModIntDictFlat,
 	533: arithModIntDictDict,
-	537: arithModIntDictConst,
-	530: arithModIntConstFlat,
-	534: arithModIntConstDict,
-	538: arithModIntConstConst,
+	537: arithModIntDictView,
+	541: arithModIntDictConst,
+	530: arithModIntViewFlat,
+	534: arithModIntViewDict,
+	538: arithModIntViewView,
+	542: arithModIntViewConst,
+	531: arithModIntConstFlat,
+	535: arithModIntConstDict,
+	539: arithModIntConstView,
+	543: arithModIntConstConst,
 	544: arithModUintFlatFlat,
 	548: arithModUintFlatDict,
-	552: arithModUintFlatConst,
+	552: arithModUintFlatView,
+	556: arithModUintFlatConst,
 	545: arithModUintDictFlat,
 	549: arithModUintDictDict,
-	553: arithModUintDictConst,
-	546: arithModUintConstFlat,
-	550: arithModUintConstDict,
-	554: arithModUintConstConst,
+	553: arithModUintDictView,
+	557: arithModUintDictConst,
+	546: arithModUintViewFlat,
+	550: arithModUintViewDict,
+	554: arithModUintViewView,
+	558: arithModUintViewConst,
+	547: arithModUintConstFlat,
+	551: arithModUintConstDict,
+	555: arithModUintConstView,
+	559: arithModUintConstConst,
 }

--- a/runtime/vam/expr/coerce.go
+++ b/runtime/vam/expr/coerce.go
@@ -106,6 +106,9 @@ func promoteWider(id int, val vector.Any) vector.Any {
 	case *vector.Dict:
 		promoted := val.Any.(vector.Promotable).Promote(typ)
 		return vector.NewDict(promoted, val.Index, val.Counts, val.Nulls)
+	case *vector.View:
+		promoted := val.Any.(vector.Promotable).Promote(typ)
+		return vector.NewView(val.Index, promoted)
 	default:
 		panic(fmt.Sprintf("promoteWider %T", val))
 	}
@@ -126,8 +129,11 @@ func promoteToSigned(val vector.Any) vector.Any {
 	case *vector.Dict:
 		promoted := promoteToSigned(val.Any)
 		return vector.NewDict(promoted, val.Index, val.Counts, val.Nulls)
+	case *vector.View:
+		promoted := promoteToSigned(val.Any)
+		return vector.NewView(val.Index, promoted)
 	default:
-		panic(fmt.Sprintf("intToFloat invalid type: %T", val))
+		panic(fmt.Sprintf("promoteToSigned %T", val))
 	}
 }
 
@@ -218,6 +224,8 @@ func intToFloat(val vector.Any) vector.Any {
 			f[k] = float64(vals[k])
 		}
 		return vector.NewFloat(zed.TypeFloat64, f, val.Nulls)
+	case *vector.View:
+		return vector.NewView(val.Index, intToFloat(val.Any))
 	default:
 		panic(fmt.Sprintf("intToFloat invalid type: %T", val))
 	}

--- a/runtime/vam/expr/compare_test.go
+++ b/runtime/vam/expr/compare_test.go
@@ -18,13 +18,15 @@ func (t *testEval) Eval(_ vector.Any) vector.Any {
 
 // Test that Compare.Eval handles all ops for all vector forms.
 func TestCompareOpsAndForms(t *testing.T) {
-	// These are both [0, 1, 2].
+	// These are all [0, 1, 2].
 	lhsFlat := vector.NewUint(zed.TypeUint64, []uint64{0, 1, 2}, nil)
 	lhsDict := vector.NewDict(lhsFlat, []byte{0, 1, 2}, nil, nil)
+	lhsView := vector.NewView([]uint32{0, 1, 2}, lhsFlat)
 
 	// These are all [1, 1, 1].
 	rhsFlat := vector.NewUint(zed.TypeUint64, []uint64{1, 1, 1}, nil)
 	rhsDict := vector.NewDict(rhsFlat, []byte{0, 0, 0}, nil, nil)
+	rhsView := vector.NewView([]uint32{0, 1, 2}, rhsFlat)
 	Const := vector.NewConst(nil, zed.NewUint64(1), 3, nil)
 
 	cases := []struct {
@@ -46,14 +48,22 @@ func TestCompareOpsAndForms(t *testing.T) {
 
 		f(c.expected, lhsFlat, rhsFlat)
 		f(c.expected, lhsFlat, rhsDict)
+		f(c.expected, lhsFlat, rhsView)
 		f(c.expected, lhsFlat, Const)
 
 		f(c.expected, lhsDict, rhsFlat)
 		f(c.expected, lhsDict, rhsDict)
+		f(c.expected, lhsDict, rhsView)
 		f(c.expected, lhsDict, Const)
 
-		f(c.expectedForConstLHS, Const, rhsDict)
+		f(c.expected, lhsView, rhsFlat)
+		f(c.expected, lhsView, rhsDict)
+		f(c.expected, lhsView, rhsView)
+		f(c.expected, lhsView, Const)
+
 		f(c.expectedForConstLHS, Const, rhsFlat)
+		f(c.expectedForConstLHS, Const, rhsDict)
+		f(c.expectedForConstLHS, Const, rhsView)
 
 		// Comparing two vector.Consts yields another vector.Const.
 		cmp := NewCompare(zed.NewContext(), &testEval{Const}, &testEval{Const}, c.op)

--- a/runtime/vam/expr/comparefuncs.go
+++ b/runtime/vam/expr/comparefuncs.go
@@ -35,6 +35,21 @@ func compareEQIntFlatDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareEQIntFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Int)
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(k) == r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareEQIntFlatConst(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Int)
 	rconst, _ := rhs.(*vector.Const).AsInt()
@@ -80,8 +95,89 @@ func compareEQIntDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareEQIntDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) == r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareEQIntDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsInt()
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) == rconst {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareEQIntViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	r := rhs.(*vector.Int)
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) == r.Value(k) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareEQIntViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) == r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareEQIntViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) == r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareEQIntViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Int)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsInt()
@@ -123,6 +219,21 @@ func compareEQIntConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareEQIntConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsInt()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if lconst == r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareEQIntConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsInt()
 	rconst, _ := rhs.(*vector.Const).AsInt()
@@ -145,6 +256,21 @@ func compareEQUintFlatFlat(lhs, rhs vector.Any) vector.Any {
 func compareEQUintFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Uint)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(k) == r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareEQUintFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Uint)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Uint)
 	rx := rd.Index
 	n := lhs.Len()
@@ -202,8 +328,89 @@ func compareEQUintDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareEQUintDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) == r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareEQUintDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsUint()
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) == rconst {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareEQUintViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	r := rhs.(*vector.Uint)
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) == r.Value(k) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareEQUintViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) == r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareEQUintViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) == r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareEQUintViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Uint)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsUint()
@@ -245,6 +452,21 @@ func compareEQUintConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareEQUintConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsUint()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if lconst == r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareEQUintConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsUint()
 	rconst, _ := rhs.(*vector.Const).AsUint()
@@ -267,6 +489,21 @@ func compareEQFloatFlatFlat(lhs, rhs vector.Any) vector.Any {
 func compareEQFloatFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Float)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(k) == r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareEQFloatFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Float)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Float)
 	rx := rd.Index
 	n := lhs.Len()
@@ -324,8 +561,89 @@ func compareEQFloatDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareEQFloatDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) == r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareEQFloatDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsFloat()
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) == rconst {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareEQFloatViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	r := rhs.(*vector.Float)
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) == r.Value(k) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareEQFloatViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) == r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareEQFloatViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) == r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareEQFloatViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Float)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsFloat()
@@ -367,6 +685,21 @@ func compareEQFloatConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareEQFloatConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsFloat()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if lconst == r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareEQFloatConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsFloat()
 	rconst, _ := rhs.(*vector.Const).AsFloat()
@@ -389,6 +722,21 @@ func compareEQStringFlatFlat(lhs, rhs vector.Any) vector.Any {
 func compareEQStringFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.String)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(k) == r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareEQStringFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.String)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.String)
 	rx := rd.Index
 	n := lhs.Len()
@@ -446,8 +794,89 @@ func compareEQStringDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareEQStringDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) == r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareEQStringDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsString()
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) == rconst {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareEQStringViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	r := rhs.(*vector.String)
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) == r.Value(k) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareEQStringViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) == r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareEQStringViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) == r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareEQStringViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.String)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsString()
@@ -489,6 +918,21 @@ func compareEQStringConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareEQStringConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsString()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if lconst == r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareEQStringConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsString()
 	rconst, _ := rhs.(*vector.Const).AsString()
@@ -511,6 +955,21 @@ func compareEQBytesFlatFlat(lhs, rhs vector.Any) vector.Any {
 func compareEQBytesFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Bytes)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Bytes)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(k)) == string(r.Value(uint32(rx[k]))) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareEQBytesFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Bytes)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Bytes)
 	rx := rd.Index
 	n := lhs.Len()
@@ -568,8 +1027,89 @@ func compareEQBytesDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareEQBytesDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Bytes)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Bytes)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(uint32(lx[k]))) == string(r.Value(uint32(rx[k]))) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareEQBytesDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Bytes)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsBytes()
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(uint32(lx[k]))) == string(rconst) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareEQBytesViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Bytes)
+	lx := ld.Index
+	r := rhs.(*vector.Bytes)
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(uint32(lx[k]))) == string(r.Value(k)) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareEQBytesViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Bytes)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Bytes)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(uint32(lx[k]))) == string(r.Value(uint32(rx[k]))) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareEQBytesViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Bytes)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Bytes)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(uint32(lx[k]))) == string(r.Value(uint32(rx[k]))) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareEQBytesViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Bytes)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsBytes()
@@ -611,6 +1151,21 @@ func compareEQBytesConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareEQBytesConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsBytes()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Bytes)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(lconst) == string(r.Value(uint32(rx[k]))) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareEQBytesConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsBytes()
 	rconst, _ := rhs.(*vector.Const).AsBytes()
@@ -633,6 +1188,21 @@ func compareNEIntFlatFlat(lhs, rhs vector.Any) vector.Any {
 func compareNEIntFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Int)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(k) != r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareNEIntFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Int)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Int)
 	rx := rd.Index
 	n := lhs.Len()
@@ -690,8 +1260,89 @@ func compareNEIntDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareNEIntDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) != r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareNEIntDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsInt()
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) != rconst {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareNEIntViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	r := rhs.(*vector.Int)
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) != r.Value(k) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareNEIntViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) != r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareNEIntViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) != r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareNEIntViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Int)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsInt()
@@ -733,6 +1384,21 @@ func compareNEIntConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareNEIntConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsInt()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if lconst != r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareNEIntConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsInt()
 	rconst, _ := rhs.(*vector.Const).AsInt()
@@ -755,6 +1421,21 @@ func compareNEUintFlatFlat(lhs, rhs vector.Any) vector.Any {
 func compareNEUintFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Uint)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(k) != r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareNEUintFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Uint)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Uint)
 	rx := rd.Index
 	n := lhs.Len()
@@ -812,8 +1493,89 @@ func compareNEUintDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareNEUintDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) != r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareNEUintDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsUint()
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) != rconst {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareNEUintViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	r := rhs.(*vector.Uint)
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) != r.Value(k) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareNEUintViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) != r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareNEUintViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) != r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareNEUintViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Uint)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsUint()
@@ -855,6 +1617,21 @@ func compareNEUintConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareNEUintConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsUint()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if lconst != r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareNEUintConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsUint()
 	rconst, _ := rhs.(*vector.Const).AsUint()
@@ -877,6 +1654,21 @@ func compareNEFloatFlatFlat(lhs, rhs vector.Any) vector.Any {
 func compareNEFloatFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Float)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(k) != r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareNEFloatFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Float)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Float)
 	rx := rd.Index
 	n := lhs.Len()
@@ -934,8 +1726,89 @@ func compareNEFloatDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareNEFloatDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) != r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareNEFloatDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsFloat()
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) != rconst {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareNEFloatViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	r := rhs.(*vector.Float)
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) != r.Value(k) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareNEFloatViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) != r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareNEFloatViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) != r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareNEFloatViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Float)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsFloat()
@@ -977,6 +1850,21 @@ func compareNEFloatConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareNEFloatConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsFloat()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if lconst != r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareNEFloatConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsFloat()
 	rconst, _ := rhs.(*vector.Const).AsFloat()
@@ -999,6 +1887,21 @@ func compareNEStringFlatFlat(lhs, rhs vector.Any) vector.Any {
 func compareNEStringFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.String)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(k) != r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareNEStringFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.String)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.String)
 	rx := rd.Index
 	n := lhs.Len()
@@ -1056,8 +1959,89 @@ func compareNEStringDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareNEStringDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) != r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareNEStringDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsString()
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) != rconst {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareNEStringViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	r := rhs.(*vector.String)
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) != r.Value(k) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareNEStringViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) != r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareNEStringViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) != r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareNEStringViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.String)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsString()
@@ -1099,6 +2083,21 @@ func compareNEStringConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareNEStringConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsString()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if lconst != r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareNEStringConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsString()
 	rconst, _ := rhs.(*vector.Const).AsString()
@@ -1121,6 +2120,21 @@ func compareNEBytesFlatFlat(lhs, rhs vector.Any) vector.Any {
 func compareNEBytesFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Bytes)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Bytes)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(k)) != string(r.Value(uint32(rx[k]))) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareNEBytesFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Bytes)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Bytes)
 	rx := rd.Index
 	n := lhs.Len()
@@ -1178,8 +2192,89 @@ func compareNEBytesDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareNEBytesDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Bytes)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Bytes)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(uint32(lx[k]))) != string(r.Value(uint32(rx[k]))) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareNEBytesDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Bytes)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsBytes()
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(uint32(lx[k]))) != string(rconst) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareNEBytesViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Bytes)
+	lx := ld.Index
+	r := rhs.(*vector.Bytes)
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(uint32(lx[k]))) != string(r.Value(k)) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareNEBytesViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Bytes)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Bytes)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(uint32(lx[k]))) != string(r.Value(uint32(rx[k]))) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareNEBytesViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Bytes)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Bytes)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(uint32(lx[k]))) != string(r.Value(uint32(rx[k]))) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareNEBytesViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Bytes)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsBytes()
@@ -1221,6 +2316,21 @@ func compareNEBytesConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareNEBytesConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsBytes()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Bytes)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(lconst) != string(r.Value(uint32(rx[k]))) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareNEBytesConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsBytes()
 	rconst, _ := rhs.(*vector.Const).AsBytes()
@@ -1243,6 +2353,21 @@ func compareLTIntFlatFlat(lhs, rhs vector.Any) vector.Any {
 func compareLTIntFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Int)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(k) < r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLTIntFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Int)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Int)
 	rx := rd.Index
 	n := lhs.Len()
@@ -1300,8 +2425,89 @@ func compareLTIntDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareLTIntDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) < r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareLTIntDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsInt()
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) < rconst {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLTIntViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	r := rhs.(*vector.Int)
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) < r.Value(k) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLTIntViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) < r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLTIntViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) < r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLTIntViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Int)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsInt()
@@ -1343,6 +2549,21 @@ func compareLTIntConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareLTIntConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsInt()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if lconst < r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareLTIntConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsInt()
 	rconst, _ := rhs.(*vector.Const).AsInt()
@@ -1365,6 +2586,21 @@ func compareLTUintFlatFlat(lhs, rhs vector.Any) vector.Any {
 func compareLTUintFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Uint)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(k) < r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLTUintFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Uint)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Uint)
 	rx := rd.Index
 	n := lhs.Len()
@@ -1422,8 +2658,89 @@ func compareLTUintDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareLTUintDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) < r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareLTUintDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsUint()
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) < rconst {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLTUintViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	r := rhs.(*vector.Uint)
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) < r.Value(k) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLTUintViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) < r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLTUintViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) < r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLTUintViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Uint)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsUint()
@@ -1465,6 +2782,21 @@ func compareLTUintConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareLTUintConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsUint()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if lconst < r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareLTUintConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsUint()
 	rconst, _ := rhs.(*vector.Const).AsUint()
@@ -1487,6 +2819,21 @@ func compareLTFloatFlatFlat(lhs, rhs vector.Any) vector.Any {
 func compareLTFloatFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Float)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(k) < r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLTFloatFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Float)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Float)
 	rx := rd.Index
 	n := lhs.Len()
@@ -1544,8 +2891,89 @@ func compareLTFloatDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareLTFloatDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) < r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareLTFloatDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsFloat()
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) < rconst {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLTFloatViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	r := rhs.(*vector.Float)
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) < r.Value(k) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLTFloatViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) < r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLTFloatViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) < r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLTFloatViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Float)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsFloat()
@@ -1587,6 +3015,21 @@ func compareLTFloatConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareLTFloatConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsFloat()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if lconst < r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareLTFloatConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsFloat()
 	rconst, _ := rhs.(*vector.Const).AsFloat()
@@ -1609,6 +3052,21 @@ func compareLTStringFlatFlat(lhs, rhs vector.Any) vector.Any {
 func compareLTStringFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.String)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(k) < r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLTStringFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.String)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.String)
 	rx := rd.Index
 	n := lhs.Len()
@@ -1666,8 +3124,89 @@ func compareLTStringDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareLTStringDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) < r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareLTStringDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsString()
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) < rconst {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLTStringViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	r := rhs.(*vector.String)
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) < r.Value(k) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLTStringViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) < r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLTStringViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) < r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLTStringViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.String)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsString()
@@ -1709,6 +3248,21 @@ func compareLTStringConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareLTStringConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsString()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if lconst < r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareLTStringConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsString()
 	rconst, _ := rhs.(*vector.Const).AsString()
@@ -1731,6 +3285,21 @@ func compareLTBytesFlatFlat(lhs, rhs vector.Any) vector.Any {
 func compareLTBytesFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Bytes)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Bytes)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(k)) < string(r.Value(uint32(rx[k]))) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLTBytesFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Bytes)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Bytes)
 	rx := rd.Index
 	n := lhs.Len()
@@ -1788,8 +3357,89 @@ func compareLTBytesDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareLTBytesDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Bytes)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Bytes)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(uint32(lx[k]))) < string(r.Value(uint32(rx[k]))) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareLTBytesDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Bytes)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsBytes()
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(uint32(lx[k]))) < string(rconst) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLTBytesViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Bytes)
+	lx := ld.Index
+	r := rhs.(*vector.Bytes)
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(uint32(lx[k]))) < string(r.Value(k)) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLTBytesViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Bytes)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Bytes)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(uint32(lx[k]))) < string(r.Value(uint32(rx[k]))) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLTBytesViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Bytes)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Bytes)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(uint32(lx[k]))) < string(r.Value(uint32(rx[k]))) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLTBytesViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Bytes)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsBytes()
@@ -1831,6 +3481,21 @@ func compareLTBytesConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareLTBytesConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsBytes()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Bytes)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(lconst) < string(r.Value(uint32(rx[k]))) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareLTBytesConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsBytes()
 	rconst, _ := rhs.(*vector.Const).AsBytes()
@@ -1853,6 +3518,21 @@ func compareLEIntFlatFlat(lhs, rhs vector.Any) vector.Any {
 func compareLEIntFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Int)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(k) <= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLEIntFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Int)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Int)
 	rx := rd.Index
 	n := lhs.Len()
@@ -1910,8 +3590,89 @@ func compareLEIntDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareLEIntDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) <= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareLEIntDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsInt()
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) <= rconst {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLEIntViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	r := rhs.(*vector.Int)
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) <= r.Value(k) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLEIntViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) <= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLEIntViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) <= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLEIntViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Int)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsInt()
@@ -1953,6 +3714,21 @@ func compareLEIntConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareLEIntConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsInt()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if lconst <= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareLEIntConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsInt()
 	rconst, _ := rhs.(*vector.Const).AsInt()
@@ -1975,6 +3751,21 @@ func compareLEUintFlatFlat(lhs, rhs vector.Any) vector.Any {
 func compareLEUintFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Uint)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(k) <= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLEUintFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Uint)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Uint)
 	rx := rd.Index
 	n := lhs.Len()
@@ -2032,8 +3823,89 @@ func compareLEUintDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareLEUintDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) <= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareLEUintDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsUint()
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) <= rconst {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLEUintViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	r := rhs.(*vector.Uint)
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) <= r.Value(k) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLEUintViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) <= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLEUintViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) <= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLEUintViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Uint)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsUint()
@@ -2075,6 +3947,21 @@ func compareLEUintConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareLEUintConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsUint()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if lconst <= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareLEUintConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsUint()
 	rconst, _ := rhs.(*vector.Const).AsUint()
@@ -2097,6 +3984,21 @@ func compareLEFloatFlatFlat(lhs, rhs vector.Any) vector.Any {
 func compareLEFloatFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Float)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(k) <= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLEFloatFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Float)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Float)
 	rx := rd.Index
 	n := lhs.Len()
@@ -2154,8 +4056,89 @@ func compareLEFloatDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareLEFloatDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) <= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareLEFloatDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsFloat()
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) <= rconst {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLEFloatViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	r := rhs.(*vector.Float)
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) <= r.Value(k) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLEFloatViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) <= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLEFloatViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) <= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLEFloatViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Float)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsFloat()
@@ -2197,6 +4180,21 @@ func compareLEFloatConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareLEFloatConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsFloat()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if lconst <= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareLEFloatConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsFloat()
 	rconst, _ := rhs.(*vector.Const).AsFloat()
@@ -2219,6 +4217,21 @@ func compareLEStringFlatFlat(lhs, rhs vector.Any) vector.Any {
 func compareLEStringFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.String)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(k) <= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLEStringFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.String)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.String)
 	rx := rd.Index
 	n := lhs.Len()
@@ -2276,8 +4289,89 @@ func compareLEStringDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareLEStringDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) <= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareLEStringDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsString()
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) <= rconst {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLEStringViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	r := rhs.(*vector.String)
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) <= r.Value(k) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLEStringViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) <= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLEStringViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) <= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLEStringViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.String)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsString()
@@ -2319,6 +4413,21 @@ func compareLEStringConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareLEStringConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsString()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if lconst <= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareLEStringConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsString()
 	rconst, _ := rhs.(*vector.Const).AsString()
@@ -2341,6 +4450,21 @@ func compareLEBytesFlatFlat(lhs, rhs vector.Any) vector.Any {
 func compareLEBytesFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Bytes)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Bytes)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(k)) <= string(r.Value(uint32(rx[k]))) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLEBytesFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Bytes)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Bytes)
 	rx := rd.Index
 	n := lhs.Len()
@@ -2398,8 +4522,89 @@ func compareLEBytesDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareLEBytesDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Bytes)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Bytes)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(uint32(lx[k]))) <= string(r.Value(uint32(rx[k]))) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareLEBytesDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Bytes)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsBytes()
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(uint32(lx[k]))) <= string(rconst) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLEBytesViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Bytes)
+	lx := ld.Index
+	r := rhs.(*vector.Bytes)
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(uint32(lx[k]))) <= string(r.Value(k)) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLEBytesViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Bytes)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Bytes)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(uint32(lx[k]))) <= string(r.Value(uint32(rx[k]))) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLEBytesViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Bytes)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Bytes)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(uint32(lx[k]))) <= string(r.Value(uint32(rx[k]))) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareLEBytesViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Bytes)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsBytes()
@@ -2441,6 +4646,21 @@ func compareLEBytesConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareLEBytesConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsBytes()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Bytes)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(lconst) <= string(r.Value(uint32(rx[k]))) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareLEBytesConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsBytes()
 	rconst, _ := rhs.(*vector.Const).AsBytes()
@@ -2463,6 +4683,21 @@ func compareGTIntFlatFlat(lhs, rhs vector.Any) vector.Any {
 func compareGTIntFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Int)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(k) > r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGTIntFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Int)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Int)
 	rx := rd.Index
 	n := lhs.Len()
@@ -2520,8 +4755,89 @@ func compareGTIntDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareGTIntDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) > r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareGTIntDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsInt()
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) > rconst {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGTIntViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	r := rhs.(*vector.Int)
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) > r.Value(k) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGTIntViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) > r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGTIntViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) > r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGTIntViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Int)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsInt()
@@ -2563,6 +4879,21 @@ func compareGTIntConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareGTIntConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsInt()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if lconst > r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareGTIntConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsInt()
 	rconst, _ := rhs.(*vector.Const).AsInt()
@@ -2585,6 +4916,21 @@ func compareGTUintFlatFlat(lhs, rhs vector.Any) vector.Any {
 func compareGTUintFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Uint)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(k) > r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGTUintFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Uint)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Uint)
 	rx := rd.Index
 	n := lhs.Len()
@@ -2642,8 +4988,89 @@ func compareGTUintDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareGTUintDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) > r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareGTUintDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsUint()
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) > rconst {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGTUintViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	r := rhs.(*vector.Uint)
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) > r.Value(k) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGTUintViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) > r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGTUintViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) > r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGTUintViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Uint)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsUint()
@@ -2685,6 +5112,21 @@ func compareGTUintConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareGTUintConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsUint()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if lconst > r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareGTUintConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsUint()
 	rconst, _ := rhs.(*vector.Const).AsUint()
@@ -2707,6 +5149,21 @@ func compareGTFloatFlatFlat(lhs, rhs vector.Any) vector.Any {
 func compareGTFloatFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Float)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(k) > r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGTFloatFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Float)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Float)
 	rx := rd.Index
 	n := lhs.Len()
@@ -2764,8 +5221,89 @@ func compareGTFloatDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareGTFloatDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) > r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareGTFloatDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsFloat()
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) > rconst {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGTFloatViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	r := rhs.(*vector.Float)
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) > r.Value(k) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGTFloatViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) > r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGTFloatViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) > r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGTFloatViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Float)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsFloat()
@@ -2807,6 +5345,21 @@ func compareGTFloatConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareGTFloatConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsFloat()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if lconst > r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareGTFloatConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsFloat()
 	rconst, _ := rhs.(*vector.Const).AsFloat()
@@ -2829,6 +5382,21 @@ func compareGTStringFlatFlat(lhs, rhs vector.Any) vector.Any {
 func compareGTStringFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.String)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(k) > r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGTStringFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.String)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.String)
 	rx := rd.Index
 	n := lhs.Len()
@@ -2886,8 +5454,89 @@ func compareGTStringDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareGTStringDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) > r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareGTStringDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsString()
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) > rconst {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGTStringViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	r := rhs.(*vector.String)
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) > r.Value(k) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGTStringViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) > r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGTStringViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) > r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGTStringViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.String)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsString()
@@ -2929,6 +5578,21 @@ func compareGTStringConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareGTStringConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsString()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if lconst > r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareGTStringConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsString()
 	rconst, _ := rhs.(*vector.Const).AsString()
@@ -2951,6 +5615,21 @@ func compareGTBytesFlatFlat(lhs, rhs vector.Any) vector.Any {
 func compareGTBytesFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Bytes)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Bytes)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(k)) > string(r.Value(uint32(rx[k]))) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGTBytesFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Bytes)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Bytes)
 	rx := rd.Index
 	n := lhs.Len()
@@ -3008,8 +5687,89 @@ func compareGTBytesDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareGTBytesDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Bytes)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Bytes)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(uint32(lx[k]))) > string(r.Value(uint32(rx[k]))) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareGTBytesDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Bytes)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsBytes()
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(uint32(lx[k]))) > string(rconst) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGTBytesViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Bytes)
+	lx := ld.Index
+	r := rhs.(*vector.Bytes)
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(uint32(lx[k]))) > string(r.Value(k)) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGTBytesViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Bytes)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Bytes)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(uint32(lx[k]))) > string(r.Value(uint32(rx[k]))) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGTBytesViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Bytes)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Bytes)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(uint32(lx[k]))) > string(r.Value(uint32(rx[k]))) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGTBytesViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Bytes)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsBytes()
@@ -3051,6 +5811,21 @@ func compareGTBytesConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareGTBytesConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsBytes()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Bytes)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(lconst) > string(r.Value(uint32(rx[k]))) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareGTBytesConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsBytes()
 	rconst, _ := rhs.(*vector.Const).AsBytes()
@@ -3073,6 +5848,21 @@ func compareGEIntFlatFlat(lhs, rhs vector.Any) vector.Any {
 func compareGEIntFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Int)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(k) >= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGEIntFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Int)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Int)
 	rx := rd.Index
 	n := lhs.Len()
@@ -3130,8 +5920,89 @@ func compareGEIntDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareGEIntDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) >= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareGEIntDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsInt()
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) >= rconst {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGEIntViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	r := rhs.(*vector.Int)
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) >= r.Value(k) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGEIntViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) >= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGEIntViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Int)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) >= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGEIntViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Int)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsInt()
@@ -3173,6 +6044,21 @@ func compareGEIntConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareGEIntConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsInt()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Int)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if lconst >= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareGEIntConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsInt()
 	rconst, _ := rhs.(*vector.Const).AsInt()
@@ -3195,6 +6081,21 @@ func compareGEUintFlatFlat(lhs, rhs vector.Any) vector.Any {
 func compareGEUintFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Uint)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(k) >= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGEUintFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Uint)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Uint)
 	rx := rd.Index
 	n := lhs.Len()
@@ -3252,8 +6153,89 @@ func compareGEUintDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareGEUintDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) >= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareGEUintDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsUint()
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) >= rconst {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGEUintViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	r := rhs.(*vector.Uint)
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) >= r.Value(k) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGEUintViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) >= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGEUintViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Uint)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) >= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGEUintViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Uint)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsUint()
@@ -3295,6 +6277,21 @@ func compareGEUintConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareGEUintConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsUint()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Uint)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if lconst >= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareGEUintConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsUint()
 	rconst, _ := rhs.(*vector.Const).AsUint()
@@ -3317,6 +6314,21 @@ func compareGEFloatFlatFlat(lhs, rhs vector.Any) vector.Any {
 func compareGEFloatFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Float)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(k) >= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGEFloatFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Float)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Float)
 	rx := rd.Index
 	n := lhs.Len()
@@ -3374,8 +6386,89 @@ func compareGEFloatDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareGEFloatDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) >= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareGEFloatDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsFloat()
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) >= rconst {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGEFloatViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	r := rhs.(*vector.Float)
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) >= r.Value(k) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGEFloatViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) >= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGEFloatViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Float)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) >= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGEFloatViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Float)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsFloat()
@@ -3417,6 +6510,21 @@ func compareGEFloatConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareGEFloatConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsFloat()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Float)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if lconst >= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareGEFloatConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsFloat()
 	rconst, _ := rhs.(*vector.Const).AsFloat()
@@ -3439,6 +6547,21 @@ func compareGEStringFlatFlat(lhs, rhs vector.Any) vector.Any {
 func compareGEStringFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.String)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(k) >= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGEStringFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.String)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.String)
 	rx := rd.Index
 	n := lhs.Len()
@@ -3496,8 +6619,89 @@ func compareGEStringDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareGEStringDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) >= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareGEStringDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsString()
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) >= rconst {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGEStringViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	r := rhs.(*vector.String)
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) >= r.Value(k) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGEStringViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) >= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGEStringViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.String)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if l.Value(uint32(lx[k])) >= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGEStringViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.String)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsString()
@@ -3539,6 +6743,21 @@ func compareGEStringConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareGEStringConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsString()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.String)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if lconst >= r.Value(uint32(rx[k])) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareGEStringConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsString()
 	rconst, _ := rhs.(*vector.Const).AsString()
@@ -3561,6 +6780,21 @@ func compareGEBytesFlatFlat(lhs, rhs vector.Any) vector.Any {
 func compareGEBytesFlatDict(lhs, rhs vector.Any) vector.Any {
 	l := lhs.(*vector.Bytes)
 	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Bytes)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(k)) >= string(r.Value(uint32(rx[k]))) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGEBytesFlatView(lhs, rhs vector.Any) vector.Any {
+	l := lhs.(*vector.Bytes)
+	rd := rhs.(*vector.View)
 	r := rd.Any.(*vector.Bytes)
 	rx := rd.Index
 	n := lhs.Len()
@@ -3618,8 +6852,89 @@ func compareGEBytesDictDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareGEBytesDictView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Bytes)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Bytes)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(uint32(lx[k]))) >= string(r.Value(uint32(rx[k]))) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareGEBytesDictConst(lhs, rhs vector.Any) vector.Any {
 	ld := lhs.(*vector.Dict)
+	l := ld.Any.(*vector.Bytes)
+	lx := ld.Index
+	rconst, _ := rhs.(*vector.Const).AsBytes()
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(uint32(lx[k]))) >= string(rconst) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGEBytesViewFlat(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Bytes)
+	lx := ld.Index
+	r := rhs.(*vector.Bytes)
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(uint32(lx[k]))) >= string(r.Value(k)) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGEBytesViewDict(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Bytes)
+	lx := ld.Index
+	rd := rhs.(*vector.Dict)
+	r := rd.Any.(*vector.Bytes)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(uint32(lx[k]))) >= string(r.Value(uint32(rx[k]))) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGEBytesViewView(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
+	l := ld.Any.(*vector.Bytes)
+	lx := ld.Index
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Bytes)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(l.Value(uint32(lx[k]))) >= string(r.Value(uint32(rx[k]))) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
+func compareGEBytesViewConst(lhs, rhs vector.Any) vector.Any {
+	ld := lhs.(*vector.View)
 	l := ld.Any.(*vector.Bytes)
 	lx := ld.Index
 	rconst, _ := rhs.(*vector.Const).AsBytes()
@@ -3661,6 +6976,21 @@ func compareGEBytesConstDict(lhs, rhs vector.Any) vector.Any {
 	return out
 }
 
+func compareGEBytesConstView(lhs, rhs vector.Any) vector.Any {
+	lconst, _ := lhs.(*vector.Const).AsBytes()
+	rd := rhs.(*vector.View)
+	r := rd.Any.(*vector.Bytes)
+	rx := rd.Index
+	n := lhs.Len()
+	out := vector.NewBoolEmpty(n, nil)
+	for k := uint32(0); k < n; k++ {
+		if string(lconst) >= string(r.Value(uint32(rx[k]))) {
+			out.Set(k)
+		}
+	}
+	return out
+}
+
 func compareGEBytesConstConst(lhs, rhs vector.Any) vector.Any {
 	lconst, _ := lhs.(*vector.Const).AsBytes()
 	rconst, _ := rhs.(*vector.Const).AsBytes()
@@ -3670,272 +7000,482 @@ func compareGEBytesConstConst(lhs, rhs vector.Any) vector.Any {
 var compareFuncs = map[int]func(vector.Any, vector.Any) vector.Any{
 	528: compareEQIntFlatFlat,
 	532: compareEQIntFlatDict,
-	536: compareEQIntFlatConst,
+	536: compareEQIntFlatView,
+	540: compareEQIntFlatConst,
 	529: compareEQIntDictFlat,
 	533: compareEQIntDictDict,
-	537: compareEQIntDictConst,
-	530: compareEQIntConstFlat,
-	534: compareEQIntConstDict,
-	538: compareEQIntConstConst,
+	537: compareEQIntDictView,
+	541: compareEQIntDictConst,
+	530: compareEQIntViewFlat,
+	534: compareEQIntViewDict,
+	538: compareEQIntViewView,
+	542: compareEQIntViewConst,
+	531: compareEQIntConstFlat,
+	535: compareEQIntConstDict,
+	539: compareEQIntConstView,
+	543: compareEQIntConstConst,
 	544: compareEQUintFlatFlat,
 	548: compareEQUintFlatDict,
-	552: compareEQUintFlatConst,
+	552: compareEQUintFlatView,
+	556: compareEQUintFlatConst,
 	545: compareEQUintDictFlat,
 	549: compareEQUintDictDict,
-	553: compareEQUintDictConst,
-	546: compareEQUintConstFlat,
-	550: compareEQUintConstDict,
-	554: compareEQUintConstConst,
+	553: compareEQUintDictView,
+	557: compareEQUintDictConst,
+	546: compareEQUintViewFlat,
+	550: compareEQUintViewDict,
+	554: compareEQUintViewView,
+	558: compareEQUintViewConst,
+	547: compareEQUintConstFlat,
+	551: compareEQUintConstDict,
+	555: compareEQUintConstView,
+	559: compareEQUintConstConst,
 	560: compareEQFloatFlatFlat,
 	564: compareEQFloatFlatDict,
-	568: compareEQFloatFlatConst,
+	568: compareEQFloatFlatView,
+	572: compareEQFloatFlatConst,
 	561: compareEQFloatDictFlat,
 	565: compareEQFloatDictDict,
-	569: compareEQFloatDictConst,
-	562: compareEQFloatConstFlat,
-	566: compareEQFloatConstDict,
-	570: compareEQFloatConstConst,
+	569: compareEQFloatDictView,
+	573: compareEQFloatDictConst,
+	562: compareEQFloatViewFlat,
+	566: compareEQFloatViewDict,
+	570: compareEQFloatViewView,
+	574: compareEQFloatViewConst,
+	563: compareEQFloatConstFlat,
+	567: compareEQFloatConstDict,
+	571: compareEQFloatConstView,
+	575: compareEQFloatConstConst,
 	576: compareEQStringFlatFlat,
 	580: compareEQStringFlatDict,
-	584: compareEQStringFlatConst,
+	584: compareEQStringFlatView,
+	588: compareEQStringFlatConst,
 	577: compareEQStringDictFlat,
 	581: compareEQStringDictDict,
-	585: compareEQStringDictConst,
-	578: compareEQStringConstFlat,
-	582: compareEQStringConstDict,
-	586: compareEQStringConstConst,
+	585: compareEQStringDictView,
+	589: compareEQStringDictConst,
+	578: compareEQStringViewFlat,
+	582: compareEQStringViewDict,
+	586: compareEQStringViewView,
+	590: compareEQStringViewConst,
+	579: compareEQStringConstFlat,
+	583: compareEQStringConstDict,
+	587: compareEQStringConstView,
+	591: compareEQStringConstConst,
 	592: compareEQBytesFlatFlat,
 	596: compareEQBytesFlatDict,
-	600: compareEQBytesFlatConst,
+	600: compareEQBytesFlatView,
+	604: compareEQBytesFlatConst,
 	593: compareEQBytesDictFlat,
 	597: compareEQBytesDictDict,
-	601: compareEQBytesDictConst,
-	594: compareEQBytesConstFlat,
-	598: compareEQBytesConstDict,
-	602: compareEQBytesConstConst,
+	601: compareEQBytesDictView,
+	605: compareEQBytesDictConst,
+	594: compareEQBytesViewFlat,
+	598: compareEQBytesViewDict,
+	602: compareEQBytesViewView,
+	606: compareEQBytesViewConst,
+	595: compareEQBytesConstFlat,
+	599: compareEQBytesConstDict,
+	603: compareEQBytesConstView,
+	607: compareEQBytesConstConst,
 	784: compareNEIntFlatFlat,
 	788: compareNEIntFlatDict,
-	792: compareNEIntFlatConst,
+	792: compareNEIntFlatView,
+	796: compareNEIntFlatConst,
 	785: compareNEIntDictFlat,
 	789: compareNEIntDictDict,
-	793: compareNEIntDictConst,
-	786: compareNEIntConstFlat,
-	790: compareNEIntConstDict,
-	794: compareNEIntConstConst,
+	793: compareNEIntDictView,
+	797: compareNEIntDictConst,
+	786: compareNEIntViewFlat,
+	790: compareNEIntViewDict,
+	794: compareNEIntViewView,
+	798: compareNEIntViewConst,
+	787: compareNEIntConstFlat,
+	791: compareNEIntConstDict,
+	795: compareNEIntConstView,
+	799: compareNEIntConstConst,
 	800: compareNEUintFlatFlat,
 	804: compareNEUintFlatDict,
-	808: compareNEUintFlatConst,
+	808: compareNEUintFlatView,
+	812: compareNEUintFlatConst,
 	801: compareNEUintDictFlat,
 	805: compareNEUintDictDict,
-	809: compareNEUintDictConst,
-	802: compareNEUintConstFlat,
-	806: compareNEUintConstDict,
-	810: compareNEUintConstConst,
+	809: compareNEUintDictView,
+	813: compareNEUintDictConst,
+	802: compareNEUintViewFlat,
+	806: compareNEUintViewDict,
+	810: compareNEUintViewView,
+	814: compareNEUintViewConst,
+	803: compareNEUintConstFlat,
+	807: compareNEUintConstDict,
+	811: compareNEUintConstView,
+	815: compareNEUintConstConst,
 	816: compareNEFloatFlatFlat,
 	820: compareNEFloatFlatDict,
-	824: compareNEFloatFlatConst,
+	824: compareNEFloatFlatView,
+	828: compareNEFloatFlatConst,
 	817: compareNEFloatDictFlat,
 	821: compareNEFloatDictDict,
-	825: compareNEFloatDictConst,
-	818: compareNEFloatConstFlat,
-	822: compareNEFloatConstDict,
-	826: compareNEFloatConstConst,
+	825: compareNEFloatDictView,
+	829: compareNEFloatDictConst,
+	818: compareNEFloatViewFlat,
+	822: compareNEFloatViewDict,
+	826: compareNEFloatViewView,
+	830: compareNEFloatViewConst,
+	819: compareNEFloatConstFlat,
+	823: compareNEFloatConstDict,
+	827: compareNEFloatConstView,
+	831: compareNEFloatConstConst,
 	832: compareNEStringFlatFlat,
 	836: compareNEStringFlatDict,
-	840: compareNEStringFlatConst,
+	840: compareNEStringFlatView,
+	844: compareNEStringFlatConst,
 	833: compareNEStringDictFlat,
 	837: compareNEStringDictDict,
-	841: compareNEStringDictConst,
-	834: compareNEStringConstFlat,
-	838: compareNEStringConstDict,
-	842: compareNEStringConstConst,
+	841: compareNEStringDictView,
+	845: compareNEStringDictConst,
+	834: compareNEStringViewFlat,
+	838: compareNEStringViewDict,
+	842: compareNEStringViewView,
+	846: compareNEStringViewConst,
+	835: compareNEStringConstFlat,
+	839: compareNEStringConstDict,
+	843: compareNEStringConstView,
+	847: compareNEStringConstConst,
 	848: compareNEBytesFlatFlat,
 	852: compareNEBytesFlatDict,
-	856: compareNEBytesFlatConst,
+	856: compareNEBytesFlatView,
+	860: compareNEBytesFlatConst,
 	849: compareNEBytesDictFlat,
 	853: compareNEBytesDictDict,
-	857: compareNEBytesDictConst,
-	850: compareNEBytesConstFlat,
-	854: compareNEBytesConstDict,
-	858: compareNEBytesConstConst,
+	857: compareNEBytesDictView,
+	861: compareNEBytesDictConst,
+	850: compareNEBytesViewFlat,
+	854: compareNEBytesViewDict,
+	858: compareNEBytesViewView,
+	862: compareNEBytesViewConst,
+	851: compareNEBytesConstFlat,
+	855: compareNEBytesConstDict,
+	859: compareNEBytesConstView,
+	863: compareNEBytesConstConst,
 	16:  compareLTIntFlatFlat,
 	20:  compareLTIntFlatDict,
-	24:  compareLTIntFlatConst,
+	24:  compareLTIntFlatView,
+	28:  compareLTIntFlatConst,
 	17:  compareLTIntDictFlat,
 	21:  compareLTIntDictDict,
-	25:  compareLTIntDictConst,
-	18:  compareLTIntConstFlat,
-	22:  compareLTIntConstDict,
-	26:  compareLTIntConstConst,
+	25:  compareLTIntDictView,
+	29:  compareLTIntDictConst,
+	18:  compareLTIntViewFlat,
+	22:  compareLTIntViewDict,
+	26:  compareLTIntViewView,
+	30:  compareLTIntViewConst,
+	19:  compareLTIntConstFlat,
+	23:  compareLTIntConstDict,
+	27:  compareLTIntConstView,
+	31:  compareLTIntConstConst,
 	32:  compareLTUintFlatFlat,
 	36:  compareLTUintFlatDict,
-	40:  compareLTUintFlatConst,
+	40:  compareLTUintFlatView,
+	44:  compareLTUintFlatConst,
 	33:  compareLTUintDictFlat,
 	37:  compareLTUintDictDict,
-	41:  compareLTUintDictConst,
-	34:  compareLTUintConstFlat,
-	38:  compareLTUintConstDict,
-	42:  compareLTUintConstConst,
+	41:  compareLTUintDictView,
+	45:  compareLTUintDictConst,
+	34:  compareLTUintViewFlat,
+	38:  compareLTUintViewDict,
+	42:  compareLTUintViewView,
+	46:  compareLTUintViewConst,
+	35:  compareLTUintConstFlat,
+	39:  compareLTUintConstDict,
+	43:  compareLTUintConstView,
+	47:  compareLTUintConstConst,
 	48:  compareLTFloatFlatFlat,
 	52:  compareLTFloatFlatDict,
-	56:  compareLTFloatFlatConst,
+	56:  compareLTFloatFlatView,
+	60:  compareLTFloatFlatConst,
 	49:  compareLTFloatDictFlat,
 	53:  compareLTFloatDictDict,
-	57:  compareLTFloatDictConst,
-	50:  compareLTFloatConstFlat,
-	54:  compareLTFloatConstDict,
-	58:  compareLTFloatConstConst,
+	57:  compareLTFloatDictView,
+	61:  compareLTFloatDictConst,
+	50:  compareLTFloatViewFlat,
+	54:  compareLTFloatViewDict,
+	58:  compareLTFloatViewView,
+	62:  compareLTFloatViewConst,
+	51:  compareLTFloatConstFlat,
+	55:  compareLTFloatConstDict,
+	59:  compareLTFloatConstView,
+	63:  compareLTFloatConstConst,
 	64:  compareLTStringFlatFlat,
 	68:  compareLTStringFlatDict,
-	72:  compareLTStringFlatConst,
+	72:  compareLTStringFlatView,
+	76:  compareLTStringFlatConst,
 	65:  compareLTStringDictFlat,
 	69:  compareLTStringDictDict,
-	73:  compareLTStringDictConst,
-	66:  compareLTStringConstFlat,
-	70:  compareLTStringConstDict,
-	74:  compareLTStringConstConst,
+	73:  compareLTStringDictView,
+	77:  compareLTStringDictConst,
+	66:  compareLTStringViewFlat,
+	70:  compareLTStringViewDict,
+	74:  compareLTStringViewView,
+	78:  compareLTStringViewConst,
+	67:  compareLTStringConstFlat,
+	71:  compareLTStringConstDict,
+	75:  compareLTStringConstView,
+	79:  compareLTStringConstConst,
 	80:  compareLTBytesFlatFlat,
 	84:  compareLTBytesFlatDict,
-	88:  compareLTBytesFlatConst,
+	88:  compareLTBytesFlatView,
+	92:  compareLTBytesFlatConst,
 	81:  compareLTBytesDictFlat,
 	85:  compareLTBytesDictDict,
-	89:  compareLTBytesDictConst,
-	82:  compareLTBytesConstFlat,
-	86:  compareLTBytesConstDict,
-	90:  compareLTBytesConstConst,
+	89:  compareLTBytesDictView,
+	93:  compareLTBytesDictConst,
+	82:  compareLTBytesViewFlat,
+	86:  compareLTBytesViewDict,
+	90:  compareLTBytesViewView,
+	94:  compareLTBytesViewConst,
+	83:  compareLTBytesConstFlat,
+	87:  compareLTBytesConstDict,
+	91:  compareLTBytesConstView,
+	95:  compareLTBytesConstConst,
 	144: compareLEIntFlatFlat,
 	148: compareLEIntFlatDict,
-	152: compareLEIntFlatConst,
+	152: compareLEIntFlatView,
+	156: compareLEIntFlatConst,
 	145: compareLEIntDictFlat,
 	149: compareLEIntDictDict,
-	153: compareLEIntDictConst,
-	146: compareLEIntConstFlat,
-	150: compareLEIntConstDict,
-	154: compareLEIntConstConst,
+	153: compareLEIntDictView,
+	157: compareLEIntDictConst,
+	146: compareLEIntViewFlat,
+	150: compareLEIntViewDict,
+	154: compareLEIntViewView,
+	158: compareLEIntViewConst,
+	147: compareLEIntConstFlat,
+	151: compareLEIntConstDict,
+	155: compareLEIntConstView,
+	159: compareLEIntConstConst,
 	160: compareLEUintFlatFlat,
 	164: compareLEUintFlatDict,
-	168: compareLEUintFlatConst,
+	168: compareLEUintFlatView,
+	172: compareLEUintFlatConst,
 	161: compareLEUintDictFlat,
 	165: compareLEUintDictDict,
-	169: compareLEUintDictConst,
-	162: compareLEUintConstFlat,
-	166: compareLEUintConstDict,
-	170: compareLEUintConstConst,
+	169: compareLEUintDictView,
+	173: compareLEUintDictConst,
+	162: compareLEUintViewFlat,
+	166: compareLEUintViewDict,
+	170: compareLEUintViewView,
+	174: compareLEUintViewConst,
+	163: compareLEUintConstFlat,
+	167: compareLEUintConstDict,
+	171: compareLEUintConstView,
+	175: compareLEUintConstConst,
 	176: compareLEFloatFlatFlat,
 	180: compareLEFloatFlatDict,
-	184: compareLEFloatFlatConst,
+	184: compareLEFloatFlatView,
+	188: compareLEFloatFlatConst,
 	177: compareLEFloatDictFlat,
 	181: compareLEFloatDictDict,
-	185: compareLEFloatDictConst,
-	178: compareLEFloatConstFlat,
-	182: compareLEFloatConstDict,
-	186: compareLEFloatConstConst,
+	185: compareLEFloatDictView,
+	189: compareLEFloatDictConst,
+	178: compareLEFloatViewFlat,
+	182: compareLEFloatViewDict,
+	186: compareLEFloatViewView,
+	190: compareLEFloatViewConst,
+	179: compareLEFloatConstFlat,
+	183: compareLEFloatConstDict,
+	187: compareLEFloatConstView,
+	191: compareLEFloatConstConst,
 	192: compareLEStringFlatFlat,
 	196: compareLEStringFlatDict,
-	200: compareLEStringFlatConst,
+	200: compareLEStringFlatView,
+	204: compareLEStringFlatConst,
 	193: compareLEStringDictFlat,
 	197: compareLEStringDictDict,
-	201: compareLEStringDictConst,
-	194: compareLEStringConstFlat,
-	198: compareLEStringConstDict,
-	202: compareLEStringConstConst,
+	201: compareLEStringDictView,
+	205: compareLEStringDictConst,
+	194: compareLEStringViewFlat,
+	198: compareLEStringViewDict,
+	202: compareLEStringViewView,
+	206: compareLEStringViewConst,
+	195: compareLEStringConstFlat,
+	199: compareLEStringConstDict,
+	203: compareLEStringConstView,
+	207: compareLEStringConstConst,
 	208: compareLEBytesFlatFlat,
 	212: compareLEBytesFlatDict,
-	216: compareLEBytesFlatConst,
+	216: compareLEBytesFlatView,
+	220: compareLEBytesFlatConst,
 	209: compareLEBytesDictFlat,
 	213: compareLEBytesDictDict,
-	217: compareLEBytesDictConst,
-	210: compareLEBytesConstFlat,
-	214: compareLEBytesConstDict,
-	218: compareLEBytesConstConst,
+	217: compareLEBytesDictView,
+	221: compareLEBytesDictConst,
+	210: compareLEBytesViewFlat,
+	214: compareLEBytesViewDict,
+	218: compareLEBytesViewView,
+	222: compareLEBytesViewConst,
+	211: compareLEBytesConstFlat,
+	215: compareLEBytesConstDict,
+	219: compareLEBytesConstView,
+	223: compareLEBytesConstConst,
 	272: compareGTIntFlatFlat,
 	276: compareGTIntFlatDict,
-	280: compareGTIntFlatConst,
+	280: compareGTIntFlatView,
+	284: compareGTIntFlatConst,
 	273: compareGTIntDictFlat,
 	277: compareGTIntDictDict,
-	281: compareGTIntDictConst,
-	274: compareGTIntConstFlat,
-	278: compareGTIntConstDict,
-	282: compareGTIntConstConst,
+	281: compareGTIntDictView,
+	285: compareGTIntDictConst,
+	274: compareGTIntViewFlat,
+	278: compareGTIntViewDict,
+	282: compareGTIntViewView,
+	286: compareGTIntViewConst,
+	275: compareGTIntConstFlat,
+	279: compareGTIntConstDict,
+	283: compareGTIntConstView,
+	287: compareGTIntConstConst,
 	288: compareGTUintFlatFlat,
 	292: compareGTUintFlatDict,
-	296: compareGTUintFlatConst,
+	296: compareGTUintFlatView,
+	300: compareGTUintFlatConst,
 	289: compareGTUintDictFlat,
 	293: compareGTUintDictDict,
-	297: compareGTUintDictConst,
-	290: compareGTUintConstFlat,
-	294: compareGTUintConstDict,
-	298: compareGTUintConstConst,
+	297: compareGTUintDictView,
+	301: compareGTUintDictConst,
+	290: compareGTUintViewFlat,
+	294: compareGTUintViewDict,
+	298: compareGTUintViewView,
+	302: compareGTUintViewConst,
+	291: compareGTUintConstFlat,
+	295: compareGTUintConstDict,
+	299: compareGTUintConstView,
+	303: compareGTUintConstConst,
 	304: compareGTFloatFlatFlat,
 	308: compareGTFloatFlatDict,
-	312: compareGTFloatFlatConst,
+	312: compareGTFloatFlatView,
+	316: compareGTFloatFlatConst,
 	305: compareGTFloatDictFlat,
 	309: compareGTFloatDictDict,
-	313: compareGTFloatDictConst,
-	306: compareGTFloatConstFlat,
-	310: compareGTFloatConstDict,
-	314: compareGTFloatConstConst,
+	313: compareGTFloatDictView,
+	317: compareGTFloatDictConst,
+	306: compareGTFloatViewFlat,
+	310: compareGTFloatViewDict,
+	314: compareGTFloatViewView,
+	318: compareGTFloatViewConst,
+	307: compareGTFloatConstFlat,
+	311: compareGTFloatConstDict,
+	315: compareGTFloatConstView,
+	319: compareGTFloatConstConst,
 	320: compareGTStringFlatFlat,
 	324: compareGTStringFlatDict,
-	328: compareGTStringFlatConst,
+	328: compareGTStringFlatView,
+	332: compareGTStringFlatConst,
 	321: compareGTStringDictFlat,
 	325: compareGTStringDictDict,
-	329: compareGTStringDictConst,
-	322: compareGTStringConstFlat,
-	326: compareGTStringConstDict,
-	330: compareGTStringConstConst,
+	329: compareGTStringDictView,
+	333: compareGTStringDictConst,
+	322: compareGTStringViewFlat,
+	326: compareGTStringViewDict,
+	330: compareGTStringViewView,
+	334: compareGTStringViewConst,
+	323: compareGTStringConstFlat,
+	327: compareGTStringConstDict,
+	331: compareGTStringConstView,
+	335: compareGTStringConstConst,
 	336: compareGTBytesFlatFlat,
 	340: compareGTBytesFlatDict,
-	344: compareGTBytesFlatConst,
+	344: compareGTBytesFlatView,
+	348: compareGTBytesFlatConst,
 	337: compareGTBytesDictFlat,
 	341: compareGTBytesDictDict,
-	345: compareGTBytesDictConst,
-	338: compareGTBytesConstFlat,
-	342: compareGTBytesConstDict,
-	346: compareGTBytesConstConst,
+	345: compareGTBytesDictView,
+	349: compareGTBytesDictConst,
+	338: compareGTBytesViewFlat,
+	342: compareGTBytesViewDict,
+	346: compareGTBytesViewView,
+	350: compareGTBytesViewConst,
+	339: compareGTBytesConstFlat,
+	343: compareGTBytesConstDict,
+	347: compareGTBytesConstView,
+	351: compareGTBytesConstConst,
 	400: compareGEIntFlatFlat,
 	404: compareGEIntFlatDict,
-	408: compareGEIntFlatConst,
+	408: compareGEIntFlatView,
+	412: compareGEIntFlatConst,
 	401: compareGEIntDictFlat,
 	405: compareGEIntDictDict,
-	409: compareGEIntDictConst,
-	402: compareGEIntConstFlat,
-	406: compareGEIntConstDict,
-	410: compareGEIntConstConst,
+	409: compareGEIntDictView,
+	413: compareGEIntDictConst,
+	402: compareGEIntViewFlat,
+	406: compareGEIntViewDict,
+	410: compareGEIntViewView,
+	414: compareGEIntViewConst,
+	403: compareGEIntConstFlat,
+	407: compareGEIntConstDict,
+	411: compareGEIntConstView,
+	415: compareGEIntConstConst,
 	416: compareGEUintFlatFlat,
 	420: compareGEUintFlatDict,
-	424: compareGEUintFlatConst,
+	424: compareGEUintFlatView,
+	428: compareGEUintFlatConst,
 	417: compareGEUintDictFlat,
 	421: compareGEUintDictDict,
-	425: compareGEUintDictConst,
-	418: compareGEUintConstFlat,
-	422: compareGEUintConstDict,
-	426: compareGEUintConstConst,
+	425: compareGEUintDictView,
+	429: compareGEUintDictConst,
+	418: compareGEUintViewFlat,
+	422: compareGEUintViewDict,
+	426: compareGEUintViewView,
+	430: compareGEUintViewConst,
+	419: compareGEUintConstFlat,
+	423: compareGEUintConstDict,
+	427: compareGEUintConstView,
+	431: compareGEUintConstConst,
 	432: compareGEFloatFlatFlat,
 	436: compareGEFloatFlatDict,
-	440: compareGEFloatFlatConst,
+	440: compareGEFloatFlatView,
+	444: compareGEFloatFlatConst,
 	433: compareGEFloatDictFlat,
 	437: compareGEFloatDictDict,
-	441: compareGEFloatDictConst,
-	434: compareGEFloatConstFlat,
-	438: compareGEFloatConstDict,
-	442: compareGEFloatConstConst,
+	441: compareGEFloatDictView,
+	445: compareGEFloatDictConst,
+	434: compareGEFloatViewFlat,
+	438: compareGEFloatViewDict,
+	442: compareGEFloatViewView,
+	446: compareGEFloatViewConst,
+	435: compareGEFloatConstFlat,
+	439: compareGEFloatConstDict,
+	443: compareGEFloatConstView,
+	447: compareGEFloatConstConst,
 	448: compareGEStringFlatFlat,
 	452: compareGEStringFlatDict,
-	456: compareGEStringFlatConst,
+	456: compareGEStringFlatView,
+	460: compareGEStringFlatConst,
 	449: compareGEStringDictFlat,
 	453: compareGEStringDictDict,
-	457: compareGEStringDictConst,
-	450: compareGEStringConstFlat,
-	454: compareGEStringConstDict,
-	458: compareGEStringConstConst,
+	457: compareGEStringDictView,
+	461: compareGEStringDictConst,
+	450: compareGEStringViewFlat,
+	454: compareGEStringViewDict,
+	458: compareGEStringViewView,
+	462: compareGEStringViewConst,
+	451: compareGEStringConstFlat,
+	455: compareGEStringConstDict,
+	459: compareGEStringConstView,
+	463: compareGEStringConstConst,
 	464: compareGEBytesFlatFlat,
 	468: compareGEBytesFlatDict,
-	472: compareGEBytesFlatConst,
+	472: compareGEBytesFlatView,
+	476: compareGEBytesFlatConst,
 	465: compareGEBytesDictFlat,
 	469: compareGEBytesDictDict,
-	473: compareGEBytesDictConst,
-	466: compareGEBytesConstFlat,
-	470: compareGEBytesConstDict,
-	474: compareGEBytesConstConst,
+	473: compareGEBytesDictView,
+	477: compareGEBytesDictConst,
+	466: compareGEBytesViewFlat,
+	470: compareGEBytesViewDict,
+	474: compareGEBytesViewView,
+	478: compareGEBytesViewConst,
+	467: compareGEBytesConstFlat,
+	471: compareGEBytesConstDict,
+	475: compareGEBytesConstView,
+	479: compareGEBytesConstConst,
 }

--- a/runtime/vam/expr/genarithfuncs.go
+++ b/runtime/vam/expr/genarithfuncs.go
@@ -38,8 +38,8 @@ func main() {
 				typ == "String" && op != "+" {
 				continue
 			}
-			for lform := vector.Form(0); lform < 3; lform++ {
-				for rform := vector.Form(0); rform < 3; rform++ {
+			for lform := vector.Form(0); lform < 4; lform++ {
+				for rform := vector.Form(0); rform < 4; rform++ {
 					name := "arith" + opToAlpha[op] + typ + lform.String() + rform.String()
 					fmt.Fprintln(&buf, genFunc(name, op, typ, lform, rform))
 					funcCode := vector.FuncCode(vector.ArithOpFromString(op), vector.KindFromString(typ), lform, rform)
@@ -98,8 +98,8 @@ func genVarInit(which, typ string, form vector.Form) string {
 	switch form {
 	case vector.FormFlat:
 		return fmt.Sprintf("%s := %shs.(*vector.%s)\n", which, which, typ)
-	case vector.FormDict:
-		s := fmt.Sprintf("%sd := %shs.(*vector.Dict)\n", which, which)
+	case vector.FormDict, vector.FormView:
+		s := fmt.Sprintf("%sd := %shs.(*vector.%s)\n", which, which, form)
 		s += fmt.Sprintf("%s := %sd.Any.(*vector.%s)\n", which, which, typ)
 		s += fmt.Sprintf("%sx := %sd.Index\n", which, which)
 		return s
@@ -124,7 +124,7 @@ func genExpr(which string, form vector.Form) string {
 	switch form {
 	case vector.FormFlat:
 		return which + ".Value(k)"
-	case vector.FormDict:
+	case vector.FormDict, vector.FormView:
 		return fmt.Sprintf("%s.Value(uint32(%sx[k]))", which, which)
 	case vector.FormConst:
 		return which + "const"

--- a/runtime/vam/expr/gencomparefuncs.go
+++ b/runtime/vam/expr/gencomparefuncs.go
@@ -35,8 +35,8 @@ func main() {
 	var ents strings.Builder
 	for _, op := range []string{"==", "!=", "<", "<=", ">", ">="} {
 		for _, typ := range []string{"Int", "Uint", "Float", "String", "Bytes"} {
-			for lform := vector.Form(0); lform < 3; lform++ {
-				for rform := vector.Form(0); rform < 3; rform++ {
+			for lform := vector.Form(0); lform < 4; lform++ {
+				for rform := vector.Form(0); rform < 4; rform++ {
 					name := "compare" + opToAlpha[op] + typ + lform.String() + rform.String()
 					fmt.Fprintln(&buf, genFunc(name, op, typ, lform, rform))
 					funcCode := vector.FuncCode(vector.CompareOpFromString(op), vector.KindFromString(typ), lform, rform)
@@ -90,8 +90,8 @@ func genVarInit(which, typ string, form vector.Form) string {
 	switch form {
 	case vector.FormFlat:
 		return fmt.Sprintf("%s := %shs.(*vector.%s)\n", which, which, typ)
-	case vector.FormDict:
-		s := fmt.Sprintf("%sd := %shs.(*vector.Dict)\n", which, which)
+	case vector.FormDict, vector.FormView:
+		s := fmt.Sprintf("%sd := %shs.(*vector.%s)\n", which, which, form)
 		s += fmt.Sprintf("%s := %sd.Any.(*vector.%s)\n", which, which, typ)
 		s += fmt.Sprintf("%sx := %sd.Index\n", which, which)
 		return s
@@ -105,7 +105,7 @@ func genExpr(which string, form vector.Form) string {
 	switch form {
 	case vector.FormFlat:
 		return which + ".Value(k)"
-	case vector.FormDict:
+	case vector.FormDict, vector.FormView:
 		return fmt.Sprintf("%s.Value(uint32(%sx[k]))", which, which)
 	case vector.FormConst:
 		return which + "const"

--- a/vector/kind.go
+++ b/vector/kind.go
@@ -22,7 +22,8 @@ const (
 const (
 	FormFlat  = 0
 	FormDict  = 1
-	FormConst = 2
+	FormView  = 2
+	FormConst = 3
 )
 
 //XXX might not need Kind...
@@ -40,6 +41,8 @@ func KindOf(v Any) Kind {
 	case *String:
 		return KindString
 	case *Dict:
+		return KindOf(v.Any)
+	case *View:
 		return KindOf(v.Any)
 	case *Const:
 		return KindOfType(v.Value().Type())
@@ -89,6 +92,8 @@ func FormOf(v Any) (Form, bool) {
 		return FormFlat, true
 	case *Dict:
 		return FormDict, true
+	case *View:
+		return FormView, true
 	case *Const:
 		return FormConst, true
 	default:
@@ -102,6 +107,8 @@ func (f Form) String() string {
 		return "Flat"
 	case FormDict:
 		return "Dict"
+	case FormView:
+		return "View"
 	case FormConst:
 		return "Const"
 	default:

--- a/vector/view.go
+++ b/vector/view.go
@@ -1,0 +1,40 @@
+package vector
+
+import (
+	"github.com/brimdata/zed/zcode"
+)
+
+type View struct {
+	Any
+	Index []uint32
+}
+
+var _ Any = (*View)(nil)
+
+func NewView(index []uint32, val Any) Any {
+	switch val := val.(type) {
+	case *Const:
+		return NewConst(val.arena, val.Value(), uint32(len(index)), nil)
+	case *Dict:
+		index2 := make([]uint32, len(index))
+		for k, idx := range index {
+			index2[k] = uint32(val.Index[idx])
+		}
+		return &View{val.Any, index2}
+	case *View:
+		index2 := make([]uint32, len(index))
+		for k, idx := range index {
+			index2[k] = uint32(val.Index[idx])
+		}
+		return &View{val.Any, index2}
+	}
+	return &View{val, index}
+}
+
+func (v *View) Len() uint32 {
+	return uint32(len(v.Index))
+}
+
+func (v *View) Serialize(b *zcode.Builder, slot uint32) {
+	v.Any.Serialize(b, v.Index[slot])
+}


### PR DESCRIPTION
A vector.View provides a view of another vector's elements (usually a subset of them).  The type isn't used here but will be later when we add support for comparisons and arithmetic involving vector.Union and vector.Variant (aka stitch).

Mostly extracted from @mccanne's vam-stitch branch.