### PR TITLE
optimizer: Fix load unnecessary merge

### DIFF
--- a/compiler/optimizer/parallelize.go
+++ b/compiler/optimizer/parallelize.go
@@ -246,7 +246,10 @@ func (o *Optimizer) concurrentPath(ops []dag.Op, sortKey order.SortKey) (int, or
 			}
 			return k, newKey, false, true, nil
 		case *dag.Load:
-			return k, order.Nil, true, true, nil
+			// XXX At some point Load should have an optimization where if the
+			// upstream sort is the same as the Load destination sort we
+			// request a merge and set the Load operator to do a sorted write.
+			return k, order.Nil, false, false, nil
 		case *dag.Fork, *dag.Scatter, *dag.Head, *dag.Tail, *dag.Uniq, *dag.Fuse, *dag.Join:
 			return k, sortKey, true, true, nil
 		default:


### PR DESCRIPTION
Fix a bug in optimizer for Load where Load what requesting an unneccessary/inefficient merge for this for incoming values.