### PR TITLE
sort: Allow ordering on a per key basis

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -6,6 +6,7 @@ import (
 	"github.com/brimdata/zed/compiler/parser"
 	"github.com/brimdata/zed/lakeparse"
 	"github.com/brimdata/zed/order"
+	"github.com/brimdata/zed/pkg/field"
 	"github.com/brimdata/zed/pkg/nano"
 	"github.com/brimdata/zed/zbuf"
 	"github.com/segmentio/ksuid"
@@ -36,10 +37,15 @@ type VersionResponse struct {
 }
 
 type PoolPostRequest struct {
-	Name       string         `json:"name"`
-	SortKeys   order.SortKeys `json:"layout"`
-	SeekStride int            `json:"seek_stride"`
-	Thresh     int64          `json:"thresh"`
+	Name       string   `json:"name"`
+	SortKeys   SortKeys `json:"layout"`
+	SeekStride int      `json:"seek_stride"`
+	Thresh     int64    `json:"thresh"`
+}
+
+type SortKeys struct {
+	Order order.Which `json:"order" zed:"order"`
+	Keys  field.List  `json:"keys" zed:"keys"`
 }
 
 type PoolPutRequest struct {

--- a/api/api.go
+++ b/api/api.go
@@ -36,10 +36,10 @@ type VersionResponse struct {
 }
 
 type PoolPostRequest struct {
-	Name       string        `json:"name"`
-	SortKey    order.SortKey `json:"layout"`
-	SeekStride int           `json:"seek_stride"`
-	Thresh     int64         `json:"thresh"`
+	Name       string         `json:"name"`
+	SortKeys   order.SortKeys `json:"layout"`
+	SeekStride int            `json:"seek_stride"`
+	Thresh     int64          `json:"thresh"`
 }
 
 type PoolPutRequest struct {

--- a/cmd/zed/create/command.go
+++ b/cmd/zed/create/command.go
@@ -70,7 +70,7 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	sortKey, err := order.ParseSortKey(c.sortKey)
+	sortKey, err := order.ParseSortKeys(c.sortKey)
 	if err != nil {
 		return err
 	}

--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -4,7 +4,6 @@ package ast
 
 import (
 	astzed "github.com/brimdata/zed/compiler/ast/zed"
-	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/pkg/field"
 )
 
@@ -466,11 +465,11 @@ type (
 		Rparen     int    `json:"rparen"`
 	}
 	Sort struct {
-		Kind       string      `json:"kind" unpack:""`
-		KeywordPos int         `json:"keyword_pos"`
-		Args       []Expr      `json:"args"`
-		Order      order.Which `json:"order"`
-		NullsFirst bool        `json:"nullsfirst"`
+		Kind       string     `json:"kind" unpack:""`
+		KeywordPos int        `json:"keyword_pos"`
+		Reverse    bool       `json:"reverse"`
+		NullsFirst bool       `json:"nullsfirst"`
+		Args       []SortExpr `json:"args"`
 	}
 	Cut struct {
 		Kind       string      `json:"kind" unpack:""`
@@ -638,19 +637,19 @@ type (
 
 type (
 	File struct {
-		Kind       string   `json:"kind" unpack:""`
-		KeywordPos int      `json:"keyword_pos"`
-		Path       Pattern  `json:"path"`
-		Format     string   `json:"format"`
-		SortKey    *SortKey `json:"sort_key"`
-		EndPos     int      `json:"end_pos"`
+		Kind       string     `json:"kind" unpack:""`
+		KeywordPos int        `json:"keyword_pos"`
+		Path       Pattern    `json:"path"`
+		Format     string     `json:"format"`
+		SortKeys   []SortExpr `json:"sort_keys"`
+		EndPos     int        `json:"end_pos"`
 	}
 	HTTP struct {
 		Kind       string      `json:"kind" unpack:""`
 		KeywordPos int         `json:"keyword_pos"`
 		URL        Pattern     `json:"url"`
 		Format     string      `json:"format"`
-		SortKey    *SortKey    `json:"sort_key"`
+		SortKeys   []SortExpr  `json:"sort_keys"`
 		Method     string      `json:"method"`
 		Headers    *RecordExpr `json:"headers"`
 		Body       string      `json:"body"`
@@ -690,10 +689,18 @@ func (x *Pool) End() int { return x.EndPos }
 func (x *File) End() int { return x.EndPos }
 func (x *HTTP) End() int { return x.EndPos }
 
-type SortKey struct {
+type SortExpr struct {
 	Kind  string `json:"kind" unpack:""`
-	Keys  []Expr `json:"keys"`
-	Order string `json:"order"`
+	Expr  Expr   `json:"expr"`
+	Order *ID    `json:"order"`
+}
+
+func (s SortExpr) Pos() int { return s.Expr.Pos() }
+func (s SortExpr) End() int {
+	if s.Order != nil {
+		s.Order.End()
+	}
+	return s.Expr.End()
 }
 
 type Trunk struct {

--- a/compiler/ast/dag/expr.go
+++ b/compiler/ast/dag/expr.go
@@ -1,5 +1,7 @@
 package dag
 
+import "github.com/brimdata/zed/order"
+
 type (
 	Expr interface {
 		ExprDAG()
@@ -116,6 +118,10 @@ type (
 		Expr Expr   `json:"expr"`
 		From Expr   `json:"from"`
 		To   Expr   `json:"to"`
+	}
+	SortExpr struct {
+		Key   Expr        `json:"key"`
+		Order order.Which `json:"order"`
 	}
 	This struct {
 		Kind string   `json:"kind" unpack:""`

--- a/compiler/ast/dag/op.go
+++ b/compiler/ast/dag/op.go
@@ -127,10 +127,10 @@ type (
 		Kind string `json:"kind" unpack:""`
 	}
 	Sort struct {
-		Kind       string      `json:"kind" unpack:""`
-		Args       []Expr      `json:"args"`
-		Order      order.Which `json:"order"`
-		NullsFirst bool        `json:"nullsfirst"`
+		Kind       string     `json:"kind" unpack:""`
+		Args       []SortExpr `json:"args"`
+		NullsFirst bool       `json:"nullsfirst"`
+		Reverse    bool       `json:"reverse"`
 	}
 	Summarize struct {
 		Kind         string       `json:"kind" unpack:""`
@@ -202,25 +202,25 @@ type (
 
 	// DefaultScan scans an input stream provided by the runtime.
 	DefaultScan struct {
-		Kind    string        `json:"kind" unpack:""`
-		Filter  Expr          `json:"filter"`
-		SortKey order.SortKey `json:"sort_key"`
+		Kind     string         `json:"kind" unpack:""`
+		Filter   Expr           `json:"filter"`
+		SortKeys order.SortKeys `json:"sort_keys"`
 	}
 	FileScan struct {
-		Kind    string        `json:"kind" unpack:""`
-		Path    string        `json:"path"`
-		Format  string        `json:"format"`
-		SortKey order.SortKey `json:"sort_key"`
-		Filter  Expr          `json:"filter"`
+		Kind     string         `json:"kind" unpack:""`
+		Path     string         `json:"path"`
+		Format   string         `json:"format"`
+		SortKeys order.SortKeys `json:"sort_keys"`
+		Filter   Expr           `json:"filter"`
 	}
 	HTTPScan struct {
-		Kind    string              `json:"kind" unpack:""`
-		URL     string              `json:"url"`
-		Format  string              `json:"format"`
-		SortKey order.SortKey       `json:"sort_key"`
-		Method  string              `json:"method"`
-		Headers map[string][]string `json:"headers"`
-		Body    string              `json:"body"`
+		Kind     string              `json:"kind" unpack:""`
+		URL      string              `json:"url"`
+		Format   string              `json:"format"`
+		SortKeys order.SortKeys      `json:"sort_keys"`
+		Method   string              `json:"method"`
+		Headers  map[string][]string `json:"headers"`
+		Body     string              `json:"body"`
 	}
 	PoolScan struct {
 		Kind   string      `json:"kind" unpack:""`

--- a/compiler/data/source.go
+++ b/compiler/data/source.go
@@ -54,11 +54,11 @@ func (s *Source) CommitObject(ctx context.Context, id ksuid.KSUID, name string) 
 	return ksuid.Nil, nil
 }
 
-func (s *Source) SortKey(ctx context.Context, src dag.Op) order.SortKey {
+func (s *Source) SortKeys(ctx context.Context, src dag.Op) order.SortKeys {
 	if s.lake != nil {
-		return s.lake.SortKey(ctx, src)
+		return s.lake.SortKeys(ctx, src)
 	}
-	return order.Nil
+	return nil
 }
 
 func (s *Source) Open(ctx context.Context, zctx *zed.Context, path, format string, pushdown zbuf.Filter, demandOut demand.Demand) (zbuf.Puller, error) {

--- a/compiler/describe/analyze.go
+++ b/compiler/describe/analyze.go
@@ -50,7 +50,7 @@ func (*Path) Source()     {}
 type Channel struct {
 	Name            string         `json:"name"`
 	AggregationKeys field.List     `json:"aggregation_keys"`
-	Sort            *order.SortKey `json:"sort"`
+	Sort            order.SortKeys `json:"sort"`
 }
 
 func Analyze(ctx context.Context, query string, src *data.Source, head *lakeparse.Commitish) (*Info, error) {
@@ -85,13 +85,7 @@ func AnalyzeDAG(ctx context.Context, entry dag.Seq, src *data.Source, head *lake
 	aggKeys := describeAggs(entry, []field.List{nil})
 	outputs := collectOutputs(entry)
 	m := make(map[string]int)
-	for i := range sortKeys {
-		// Convert SortKey to a pointer so a nil sort is encoded as null for
-		// JSON/ZSON.
-		var s *order.SortKey
-		if !sortKeys[i].IsNil() {
-			s = &sortKeys[i]
-		}
+	for i, s := range sortKeys {
 		name := outputs[i].Name
 		if k, ok := m[name]; ok {
 			// If output already exists, this means the outputs will be

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/brimdata/zed/compiler/ast"
 	astzed "github.com/brimdata/zed/compiler/ast/zed"
-	"github.com/brimdata/zed/order"
 )
 
 var g = &grammar{
@@ -2718,25 +2717,25 @@ var g = &grammar{
 						},
 						&labeledExpr{
 							pos:   position{line: 375, col: 32, offset: 9308},
-							label: "list",
+							label: "exprs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 375, col: 37, offset: 9313},
+								pos: position{line: 375, col: 38, offset: 9314},
 								expr: &actionExpr{
-									pos: position{line: 375, col: 38, offset: 9314},
+									pos: position{line: 375, col: 39, offset: 9315},
 									run: (*parser).callonSortOp10,
 									expr: &seqExpr{
-										pos: position{line: 375, col: 38, offset: 9314},
+										pos: position{line: 375, col: 39, offset: 9315},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 375, col: 38, offset: 9314},
-												name: "_",
+												pos:  position{line: 375, col: 39, offset: 9315},
+												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 375, col: 40, offset: 9316},
-												label: "l",
+												pos:   position{line: 375, col: 42, offset: 9318},
+												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 375, col: 42, offset: 9318},
-													name: "Exprs",
+													pos:  position{line: 375, col: 44, offset: 9320},
+													name: "SortExprs",
 												},
 											},
 										},
@@ -2752,30 +2751,30 @@ var g = &grammar{
 		},
 		{
 			name: "SortArgs",
-			pos:  position{line: 395, col: 1, offset: 9781},
+			pos:  position{line: 391, col: 1, offset: 9702},
 			expr: &actionExpr{
-				pos: position{line: 395, col: 12, offset: 9792},
+				pos: position{line: 391, col: 12, offset: 9713},
 				run: (*parser).callonSortArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 395, col: 12, offset: 9792},
+					pos:   position{line: 391, col: 12, offset: 9713},
 					label: "args",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 395, col: 17, offset: 9797},
+						pos: position{line: 391, col: 17, offset: 9718},
 						expr: &actionExpr{
-							pos: position{line: 395, col: 18, offset: 9798},
+							pos: position{line: 391, col: 18, offset: 9719},
 							run: (*parser).callonSortArgs4,
 							expr: &seqExpr{
-								pos: position{line: 395, col: 18, offset: 9798},
+								pos: position{line: 391, col: 18, offset: 9719},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 395, col: 18, offset: 9798},
+										pos:  position{line: 391, col: 18, offset: 9719},
 										name: "_",
 									},
 									&labeledExpr{
-										pos:   position{line: 395, col: 20, offset: 9800},
+										pos:   position{line: 391, col: 20, offset: 9721},
 										label: "a",
 										expr: &ruleRefExpr{
-											pos:  position{line: 395, col: 22, offset: 9802},
+											pos:  position{line: 391, col: 22, offset: 9723},
 											name: "SortArg",
 										},
 									},
@@ -2790,53 +2789,53 @@ var g = &grammar{
 		},
 		{
 			name: "SortArg",
-			pos:  position{line: 397, col: 1, offset: 9859},
+			pos:  position{line: 393, col: 1, offset: 9780},
 			expr: &choiceExpr{
-				pos: position{line: 398, col: 5, offset: 9871},
+				pos: position{line: 394, col: 5, offset: 9792},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 398, col: 5, offset: 9871},
+						pos: position{line: 394, col: 5, offset: 9792},
 						run: (*parser).callonSortArg2,
 						expr: &litMatcher{
-							pos:        position{line: 398, col: 5, offset: 9871},
+							pos:        position{line: 394, col: 5, offset: 9792},
 							val:        "-r",
 							ignoreCase: false,
 							want:       "\"-r\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 399, col: 5, offset: 9938},
+						pos: position{line: 395, col: 5, offset: 9859},
 						run: (*parser).callonSortArg4,
 						expr: &seqExpr{
-							pos: position{line: 399, col: 5, offset: 9938},
+							pos: position{line: 395, col: 5, offset: 9859},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 399, col: 5, offset: 9938},
+									pos:        position{line: 395, col: 5, offset: 9859},
 									val:        "-nulls",
 									ignoreCase: false,
 									want:       "\"-nulls\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 399, col: 14, offset: 9947},
+									pos:  position{line: 395, col: 14, offset: 9868},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 399, col: 16, offset: 9949},
+									pos:   position{line: 395, col: 16, offset: 9870},
 									label: "where",
 									expr: &actionExpr{
-										pos: position{line: 399, col: 23, offset: 9956},
+										pos: position{line: 395, col: 23, offset: 9877},
 										run: (*parser).callonSortArg9,
 										expr: &choiceExpr{
-											pos: position{line: 399, col: 24, offset: 9957},
+											pos: position{line: 395, col: 24, offset: 9878},
 											alternatives: []any{
 												&litMatcher{
-													pos:        position{line: 399, col: 24, offset: 9957},
+													pos:        position{line: 395, col: 24, offset: 9878},
 													val:        "first",
 													ignoreCase: false,
 													want:       "\"first\"",
 												},
 												&litMatcher{
-													pos:        position{line: 399, col: 34, offset: 9967},
+													pos:        position{line: 395, col: 34, offset: 9888},
 													val:        "last",
 													ignoreCase: false,
 													want:       "\"last\"",
@@ -2855,46 +2854,46 @@ var g = &grammar{
 		},
 		{
 			name: "TopOp",
-			pos:  position{line: 403, col: 1, offset: 10086},
+			pos:  position{line: 399, col: 1, offset: 10007},
 			expr: &actionExpr{
-				pos: position{line: 404, col: 5, offset: 10096},
+				pos: position{line: 400, col: 5, offset: 10017},
 				run: (*parser).callonTopOp1,
 				expr: &seqExpr{
-					pos: position{line: 404, col: 5, offset: 10096},
+					pos: position{line: 400, col: 5, offset: 10017},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 404, col: 5, offset: 10096},
+							pos:        position{line: 400, col: 5, offset: 10017},
 							val:        "top",
 							ignoreCase: false,
 							want:       "\"top\"",
 						},
 						&andExpr{
-							pos: position{line: 404, col: 11, offset: 10102},
+							pos: position{line: 400, col: 11, offset: 10023},
 							expr: &ruleRefExpr{
-								pos:  position{line: 404, col: 12, offset: 10103},
+								pos:  position{line: 400, col: 12, offset: 10024},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 404, col: 17, offset: 10108},
+							pos:   position{line: 400, col: 17, offset: 10029},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 404, col: 23, offset: 10114},
+								pos: position{line: 400, col: 23, offset: 10035},
 								expr: &actionExpr{
-									pos: position{line: 404, col: 24, offset: 10115},
+									pos: position{line: 400, col: 24, offset: 10036},
 									run: (*parser).callonTopOp8,
 									expr: &seqExpr{
-										pos: position{line: 404, col: 24, offset: 10115},
+										pos: position{line: 400, col: 24, offset: 10036},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 404, col: 24, offset: 10115},
+												pos:  position{line: 400, col: 24, offset: 10036},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 404, col: 26, offset: 10117},
+												pos:   position{line: 400, col: 26, offset: 10038},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 404, col: 28, offset: 10119},
+													pos:  position{line: 400, col: 28, offset: 10040},
 													name: "Expr",
 												},
 											},
@@ -2904,19 +2903,19 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 404, col: 53, offset: 10144},
+							pos:   position{line: 400, col: 53, offset: 10065},
 							label: "flush",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 404, col: 59, offset: 10150},
+								pos: position{line: 400, col: 59, offset: 10071},
 								expr: &seqExpr{
-									pos: position{line: 404, col: 60, offset: 10151},
+									pos: position{line: 400, col: 60, offset: 10072},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 404, col: 60, offset: 10151},
+											pos:  position{line: 400, col: 60, offset: 10072},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 404, col: 62, offset: 10153},
+											pos:        position{line: 400, col: 62, offset: 10074},
 											val:        "-flush",
 											ignoreCase: false,
 											want:       "\"-flush\"",
@@ -2926,25 +2925,25 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 404, col: 73, offset: 10164},
+							pos:   position{line: 400, col: 73, offset: 10085},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 404, col: 80, offset: 10171},
+								pos: position{line: 400, col: 80, offset: 10092},
 								expr: &actionExpr{
-									pos: position{line: 404, col: 81, offset: 10172},
+									pos: position{line: 400, col: 81, offset: 10093},
 									run: (*parser).callonTopOp20,
 									expr: &seqExpr{
-										pos: position{line: 404, col: 81, offset: 10172},
+										pos: position{line: 400, col: 81, offset: 10093},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 404, col: 81, offset: 10172},
+												pos:  position{line: 400, col: 81, offset: 10093},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 404, col: 83, offset: 10174},
+												pos:   position{line: 400, col: 83, offset: 10095},
 												label: "f",
 												expr: &ruleRefExpr{
-													pos:  position{line: 404, col: 85, offset: 10176},
+													pos:  position{line: 400, col: 85, offset: 10097},
 													name: "FieldExprs",
 												},
 											},
@@ -2961,28 +2960,28 @@ var g = &grammar{
 		},
 		{
 			name: "CutOp",
-			pos:  position{line: 421, col: 1, offset: 10523},
+			pos:  position{line: 417, col: 1, offset: 10444},
 			expr: &actionExpr{
-				pos: position{line: 422, col: 5, offset: 10533},
+				pos: position{line: 418, col: 5, offset: 10454},
 				run: (*parser).callonCutOp1,
 				expr: &seqExpr{
-					pos: position{line: 422, col: 5, offset: 10533},
+					pos: position{line: 418, col: 5, offset: 10454},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 422, col: 5, offset: 10533},
+							pos:        position{line: 418, col: 5, offset: 10454},
 							val:        "cut",
 							ignoreCase: false,
 							want:       "\"cut\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 422, col: 11, offset: 10539},
+							pos:  position{line: 418, col: 11, offset: 10460},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 422, col: 13, offset: 10541},
+							pos:   position{line: 418, col: 13, offset: 10462},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 422, col: 18, offset: 10546},
+								pos:  position{line: 418, col: 18, offset: 10467},
 								name: "FlexAssignments",
 							},
 						},
@@ -2994,28 +2993,28 @@ var g = &grammar{
 		},
 		{
 			name: "DropOp",
-			pos:  position{line: 430, col: 1, offset: 10707},
+			pos:  position{line: 426, col: 1, offset: 10628},
 			expr: &actionExpr{
-				pos: position{line: 431, col: 5, offset: 10718},
+				pos: position{line: 427, col: 5, offset: 10639},
 				run: (*parser).callonDropOp1,
 				expr: &seqExpr{
-					pos: position{line: 431, col: 5, offset: 10718},
+					pos: position{line: 427, col: 5, offset: 10639},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 431, col: 5, offset: 10718},
+							pos:        position{line: 427, col: 5, offset: 10639},
 							val:        "drop",
 							ignoreCase: false,
 							want:       "\"drop\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 431, col: 12, offset: 10725},
+							pos:  position{line: 427, col: 12, offset: 10646},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 431, col: 14, offset: 10727},
+							pos:   position{line: 427, col: 14, offset: 10648},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 431, col: 19, offset: 10732},
+								pos:  position{line: 427, col: 19, offset: 10653},
 								name: "FieldExprs",
 							},
 						},
@@ -3027,38 +3026,38 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOp",
-			pos:  position{line: 439, col: 1, offset: 10890},
+			pos:  position{line: 435, col: 1, offset: 10811},
 			expr: &choiceExpr{
-				pos: position{line: 440, col: 5, offset: 10901},
+				pos: position{line: 436, col: 5, offset: 10822},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 440, col: 5, offset: 10901},
+						pos: position{line: 436, col: 5, offset: 10822},
 						run: (*parser).callonHeadOp2,
 						expr: &seqExpr{
-							pos: position{line: 440, col: 5, offset: 10901},
+							pos: position{line: 436, col: 5, offset: 10822},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 440, col: 5, offset: 10901},
+									pos:        position{line: 436, col: 5, offset: 10822},
 									val:        "head",
 									ignoreCase: false,
 									want:       "\"head\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 440, col: 12, offset: 10908},
+									pos:  position{line: 436, col: 12, offset: 10829},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 440, col: 14, offset: 10910},
+									pos: position{line: 436, col: 14, offset: 10831},
 									expr: &ruleRefExpr{
-										pos:  position{line: 440, col: 15, offset: 10911},
+										pos:  position{line: 436, col: 15, offset: 10832},
 										name: "EndOfOp",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 440, col: 23, offset: 10919},
+									pos:   position{line: 436, col: 23, offset: 10840},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 440, col: 29, offset: 10925},
+										pos:  position{line: 436, col: 29, offset: 10846},
 										name: "Expr",
 									},
 								},
@@ -3066,28 +3065,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 447, col: 5, offset: 11068},
+						pos: position{line: 443, col: 5, offset: 10989},
 						run: (*parser).callonHeadOp10,
 						expr: &seqExpr{
-							pos: position{line: 447, col: 5, offset: 11068},
+							pos: position{line: 443, col: 5, offset: 10989},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 447, col: 5, offset: 11068},
+									pos:        position{line: 443, col: 5, offset: 10989},
 									val:        "head",
 									ignoreCase: false,
 									want:       "\"head\"",
 								},
 								&notExpr{
-									pos: position{line: 447, col: 12, offset: 11075},
+									pos: position{line: 443, col: 12, offset: 10996},
 									expr: &seqExpr{
-										pos: position{line: 447, col: 14, offset: 11077},
+										pos: position{line: 443, col: 14, offset: 10998},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 447, col: 14, offset: 11077},
+												pos:  position{line: 443, col: 14, offset: 10998},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 447, col: 17, offset: 11080},
+												pos:        position{line: 443, col: 17, offset: 11001},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -3096,9 +3095,9 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 447, col: 22, offset: 11085},
+									pos: position{line: 443, col: 22, offset: 11006},
 									expr: &ruleRefExpr{
-										pos:  position{line: 447, col: 23, offset: 11086},
+										pos:  position{line: 443, col: 23, offset: 11007},
 										name: "EOKW",
 									},
 								},
@@ -3112,38 +3111,38 @@ var g = &grammar{
 		},
 		{
 			name: "TailOp",
-			pos:  position{line: 454, col: 1, offset: 11193},
+			pos:  position{line: 450, col: 1, offset: 11114},
 			expr: &choiceExpr{
-				pos: position{line: 455, col: 5, offset: 11204},
+				pos: position{line: 451, col: 5, offset: 11125},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 455, col: 5, offset: 11204},
+						pos: position{line: 451, col: 5, offset: 11125},
 						run: (*parser).callonTailOp2,
 						expr: &seqExpr{
-							pos: position{line: 455, col: 5, offset: 11204},
+							pos: position{line: 451, col: 5, offset: 11125},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 455, col: 5, offset: 11204},
+									pos:        position{line: 451, col: 5, offset: 11125},
 									val:        "tail",
 									ignoreCase: false,
 									want:       "\"tail\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 455, col: 12, offset: 11211},
+									pos:  position{line: 451, col: 12, offset: 11132},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 455, col: 14, offset: 11213},
+									pos: position{line: 451, col: 14, offset: 11134},
 									expr: &ruleRefExpr{
-										pos:  position{line: 455, col: 15, offset: 11214},
+										pos:  position{line: 451, col: 15, offset: 11135},
 										name: "EndOfOp",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 455, col: 23, offset: 11222},
+									pos:   position{line: 451, col: 23, offset: 11143},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 455, col: 29, offset: 11228},
+										pos:  position{line: 451, col: 29, offset: 11149},
 										name: "Expr",
 									},
 								},
@@ -3151,28 +3150,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 462, col: 5, offset: 11371},
+						pos: position{line: 458, col: 5, offset: 11292},
 						run: (*parser).callonTailOp10,
 						expr: &seqExpr{
-							pos: position{line: 462, col: 5, offset: 11371},
+							pos: position{line: 458, col: 5, offset: 11292},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 462, col: 5, offset: 11371},
+									pos:        position{line: 458, col: 5, offset: 11292},
 									val:        "tail",
 									ignoreCase: false,
 									want:       "\"tail\"",
 								},
 								&notExpr{
-									pos: position{line: 462, col: 12, offset: 11378},
+									pos: position{line: 458, col: 12, offset: 11299},
 									expr: &seqExpr{
-										pos: position{line: 462, col: 14, offset: 11380},
+										pos: position{line: 458, col: 14, offset: 11301},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 462, col: 14, offset: 11380},
+												pos:  position{line: 458, col: 14, offset: 11301},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 462, col: 17, offset: 11383},
+												pos:        position{line: 458, col: 17, offset: 11304},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -3181,9 +3180,9 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 462, col: 22, offset: 11388},
+									pos: position{line: 458, col: 22, offset: 11309},
 									expr: &ruleRefExpr{
-										pos:  position{line: 462, col: 23, offset: 11389},
+										pos:  position{line: 458, col: 23, offset: 11310},
 										name: "EOKW",
 									},
 								},
@@ -3197,28 +3196,28 @@ var g = &grammar{
 		},
 		{
 			name: "WhereOp",
-			pos:  position{line: 469, col: 1, offset: 11496},
+			pos:  position{line: 465, col: 1, offset: 11417},
 			expr: &actionExpr{
-				pos: position{line: 470, col: 5, offset: 11508},
+				pos: position{line: 466, col: 5, offset: 11429},
 				run: (*parser).callonWhereOp1,
 				expr: &seqExpr{
-					pos: position{line: 470, col: 5, offset: 11508},
+					pos: position{line: 466, col: 5, offset: 11429},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 470, col: 5, offset: 11508},
+							pos:        position{line: 466, col: 5, offset: 11429},
 							val:        "where",
 							ignoreCase: false,
 							want:       "\"where\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 470, col: 13, offset: 11516},
+							pos:  position{line: 466, col: 13, offset: 11437},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 470, col: 15, offset: 11518},
+							pos:   position{line: 466, col: 15, offset: 11439},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 470, col: 20, offset: 11523},
+								pos:  position{line: 466, col: 20, offset: 11444},
 								name: "Expr",
 							},
 						},
@@ -3230,28 +3229,28 @@ var g = &grammar{
 		},
 		{
 			name: "UniqOp",
-			pos:  position{line: 478, col: 1, offset: 11663},
+			pos:  position{line: 474, col: 1, offset: 11584},
 			expr: &choiceExpr{
-				pos: position{line: 479, col: 5, offset: 11674},
+				pos: position{line: 475, col: 5, offset: 11595},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 479, col: 5, offset: 11674},
+						pos: position{line: 475, col: 5, offset: 11595},
 						run: (*parser).callonUniqOp2,
 						expr: &seqExpr{
-							pos: position{line: 479, col: 5, offset: 11674},
+							pos: position{line: 475, col: 5, offset: 11595},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 479, col: 5, offset: 11674},
+									pos:        position{line: 475, col: 5, offset: 11595},
 									val:        "uniq",
 									ignoreCase: false,
 									want:       "\"uniq\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 479, col: 12, offset: 11681},
+									pos:  position{line: 475, col: 12, offset: 11602},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 479, col: 14, offset: 11683},
+									pos:        position{line: 475, col: 14, offset: 11604},
 									val:        "-c",
 									ignoreCase: false,
 									want:       "\"-c\"",
@@ -3260,28 +3259,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 482, col: 5, offset: 11781},
+						pos: position{line: 478, col: 5, offset: 11702},
 						run: (*parser).callonUniqOp7,
 						expr: &seqExpr{
-							pos: position{line: 482, col: 5, offset: 11781},
+							pos: position{line: 478, col: 5, offset: 11702},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 482, col: 5, offset: 11781},
+									pos:        position{line: 478, col: 5, offset: 11702},
 									val:        "uniq",
 									ignoreCase: false,
 									want:       "\"uniq\"",
 								},
 								&notExpr{
-									pos: position{line: 482, col: 12, offset: 11788},
+									pos: position{line: 478, col: 12, offset: 11709},
 									expr: &seqExpr{
-										pos: position{line: 482, col: 14, offset: 11790},
+										pos: position{line: 478, col: 14, offset: 11711},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 482, col: 14, offset: 11790},
+												pos:  position{line: 478, col: 14, offset: 11711},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 482, col: 17, offset: 11793},
+												pos:        position{line: 478, col: 17, offset: 11714},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -3290,9 +3289,9 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 482, col: 22, offset: 11798},
+									pos: position{line: 478, col: 22, offset: 11719},
 									expr: &ruleRefExpr{
-										pos:  position{line: 482, col: 23, offset: 11799},
+										pos:  position{line: 478, col: 23, offset: 11720},
 										name: "EOKW",
 									},
 								},
@@ -3306,28 +3305,28 @@ var g = &grammar{
 		},
 		{
 			name: "PutOp",
-			pos:  position{line: 486, col: 1, offset: 11881},
+			pos:  position{line: 482, col: 1, offset: 11802},
 			expr: &actionExpr{
-				pos: position{line: 487, col: 5, offset: 11891},
+				pos: position{line: 483, col: 5, offset: 11812},
 				run: (*parser).callonPutOp1,
 				expr: &seqExpr{
-					pos: position{line: 487, col: 5, offset: 11891},
+					pos: position{line: 483, col: 5, offset: 11812},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 487, col: 5, offset: 11891},
+							pos:        position{line: 483, col: 5, offset: 11812},
 							val:        "put",
 							ignoreCase: false,
 							want:       "\"put\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 487, col: 11, offset: 11897},
+							pos:  position{line: 483, col: 11, offset: 11818},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 487, col: 13, offset: 11899},
+							pos:   position{line: 483, col: 13, offset: 11820},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 487, col: 18, offset: 11904},
+								pos:  position{line: 483, col: 18, offset: 11825},
 								name: "Assignments",
 							},
 						},
@@ -3339,61 +3338,61 @@ var g = &grammar{
 		},
 		{
 			name: "RenameOp",
-			pos:  position{line: 495, col: 1, offset: 12067},
+			pos:  position{line: 491, col: 1, offset: 11988},
 			expr: &actionExpr{
-				pos: position{line: 496, col: 5, offset: 12080},
+				pos: position{line: 492, col: 5, offset: 12001},
 				run: (*parser).callonRenameOp1,
 				expr: &seqExpr{
-					pos: position{line: 496, col: 5, offset: 12080},
+					pos: position{line: 492, col: 5, offset: 12001},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 496, col: 5, offset: 12080},
+							pos:        position{line: 492, col: 5, offset: 12001},
 							val:        "rename",
 							ignoreCase: false,
 							want:       "\"rename\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 496, col: 14, offset: 12089},
+							pos:  position{line: 492, col: 14, offset: 12010},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 496, col: 16, offset: 12091},
+							pos:   position{line: 492, col: 16, offset: 12012},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 496, col: 22, offset: 12097},
+								pos:  position{line: 492, col: 22, offset: 12018},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 496, col: 33, offset: 12108},
+							pos:   position{line: 492, col: 33, offset: 12029},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 496, col: 38, offset: 12113},
+								pos: position{line: 492, col: 38, offset: 12034},
 								expr: &actionExpr{
-									pos: position{line: 496, col: 39, offset: 12114},
+									pos: position{line: 492, col: 39, offset: 12035},
 									run: (*parser).callonRenameOp9,
 									expr: &seqExpr{
-										pos: position{line: 496, col: 39, offset: 12114},
+										pos: position{line: 492, col: 39, offset: 12035},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 496, col: 39, offset: 12114},
+												pos:  position{line: 492, col: 39, offset: 12035},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 496, col: 42, offset: 12117},
+												pos:        position{line: 492, col: 42, offset: 12038},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 496, col: 46, offset: 12121},
+												pos:  position{line: 492, col: 46, offset: 12042},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 496, col: 49, offset: 12124},
+												pos:   position{line: 492, col: 49, offset: 12045},
 												label: "cl",
 												expr: &ruleRefExpr{
-													pos:  position{line: 496, col: 52, offset: 12127},
+													pos:  position{line: 492, col: 52, offset: 12048},
 													name: "Assignment",
 												},
 											},
@@ -3410,30 +3409,30 @@ var g = &grammar{
 		},
 		{
 			name: "FuseOp",
-			pos:  position{line: 509, col: 1, offset: 12603},
+			pos:  position{line: 505, col: 1, offset: 12524},
 			expr: &actionExpr{
-				pos: position{line: 510, col: 5, offset: 12614},
+				pos: position{line: 506, col: 5, offset: 12535},
 				run: (*parser).callonFuseOp1,
 				expr: &seqExpr{
-					pos: position{line: 510, col: 5, offset: 12614},
+					pos: position{line: 506, col: 5, offset: 12535},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 510, col: 5, offset: 12614},
+							pos:        position{line: 506, col: 5, offset: 12535},
 							val:        "fuse",
 							ignoreCase: false,
 							want:       "\"fuse\"",
 						},
 						&notExpr{
-							pos: position{line: 510, col: 12, offset: 12621},
+							pos: position{line: 506, col: 12, offset: 12542},
 							expr: &seqExpr{
-								pos: position{line: 510, col: 14, offset: 12623},
+								pos: position{line: 506, col: 14, offset: 12544},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 510, col: 14, offset: 12623},
+										pos:  position{line: 506, col: 14, offset: 12544},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 510, col: 17, offset: 12626},
+										pos:        position{line: 506, col: 17, offset: 12547},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -3442,9 +3441,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 510, col: 22, offset: 12631},
+							pos: position{line: 506, col: 22, offset: 12552},
 							expr: &ruleRefExpr{
-								pos:  position{line: 510, col: 23, offset: 12632},
+								pos:  position{line: 506, col: 23, offset: 12553},
 								name: "EOKW",
 							},
 						},
@@ -3456,30 +3455,30 @@ var g = &grammar{
 		},
 		{
 			name: "ShapeOp",
-			pos:  position{line: 514, col: 1, offset: 12714},
+			pos:  position{line: 510, col: 1, offset: 12635},
 			expr: &actionExpr{
-				pos: position{line: 515, col: 5, offset: 12726},
+				pos: position{line: 511, col: 5, offset: 12647},
 				run: (*parser).callonShapeOp1,
 				expr: &seqExpr{
-					pos: position{line: 515, col: 5, offset: 12726},
+					pos: position{line: 511, col: 5, offset: 12647},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 515, col: 5, offset: 12726},
+							pos:        position{line: 511, col: 5, offset: 12647},
 							val:        "shape",
 							ignoreCase: false,
 							want:       "\"shape\"",
 						},
 						&notExpr{
-							pos: position{line: 515, col: 13, offset: 12734},
+							pos: position{line: 511, col: 13, offset: 12655},
 							expr: &seqExpr{
-								pos: position{line: 515, col: 15, offset: 12736},
+								pos: position{line: 511, col: 15, offset: 12657},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 515, col: 15, offset: 12736},
+										pos:  position{line: 511, col: 15, offset: 12657},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 515, col: 18, offset: 12739},
+										pos:        position{line: 511, col: 18, offset: 12660},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -3488,9 +3487,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 515, col: 23, offset: 12744},
+							pos: position{line: 511, col: 23, offset: 12665},
 							expr: &ruleRefExpr{
-								pos:  position{line: 515, col: 24, offset: 12745},
+								pos:  position{line: 511, col: 24, offset: 12666},
 								name: "EOKW",
 							},
 						},
@@ -3502,77 +3501,77 @@ var g = &grammar{
 		},
 		{
 			name: "JoinOp",
-			pos:  position{line: 519, col: 1, offset: 12829},
+			pos:  position{line: 515, col: 1, offset: 12750},
 			expr: &actionExpr{
-				pos: position{line: 520, col: 5, offset: 12840},
+				pos: position{line: 516, col: 5, offset: 12761},
 				run: (*parser).callonJoinOp1,
 				expr: &seqExpr{
-					pos: position{line: 520, col: 5, offset: 12840},
+					pos: position{line: 516, col: 5, offset: 12761},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 520, col: 5, offset: 12840},
+							pos:   position{line: 516, col: 5, offset: 12761},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 520, col: 11, offset: 12846},
+								pos:  position{line: 516, col: 11, offset: 12767},
 								name: "JoinStyle",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 520, col: 21, offset: 12856},
+							pos:        position{line: 516, col: 21, offset: 12777},
 							val:        "join",
 							ignoreCase: false,
 							want:       "\"join\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 520, col: 28, offset: 12863},
+							pos:   position{line: 516, col: 28, offset: 12784},
 							label: "rightInput",
 							expr: &ruleRefExpr{
-								pos:  position{line: 520, col: 39, offset: 12874},
+								pos:  position{line: 516, col: 39, offset: 12795},
 								name: "JoinRightInput",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 520, col: 54, offset: 12889},
+							pos:        position{line: 516, col: 54, offset: 12810},
 							val:        "on",
 							ignoreCase: false,
 							want:       "\"on\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 520, col: 59, offset: 12894},
+							pos:  position{line: 516, col: 59, offset: 12815},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 520, col: 61, offset: 12896},
+							pos:   position{line: 516, col: 61, offset: 12817},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 520, col: 65, offset: 12900},
+								pos:  position{line: 516, col: 65, offset: 12821},
 								name: "JoinKey",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 520, col: 73, offset: 12908},
+							pos:   position{line: 516, col: 73, offset: 12829},
 							label: "optKey",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 520, col: 80, offset: 12915},
+								pos: position{line: 516, col: 80, offset: 12836},
 								expr: &seqExpr{
-									pos: position{line: 520, col: 81, offset: 12916},
+									pos: position{line: 516, col: 81, offset: 12837},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 520, col: 81, offset: 12916},
+											pos:  position{line: 516, col: 81, offset: 12837},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 520, col: 84, offset: 12919},
+											pos:        position{line: 516, col: 84, offset: 12840},
 											val:        "=",
 											ignoreCase: false,
 											want:       "\"=\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 520, col: 88, offset: 12923},
+											pos:  position{line: 516, col: 88, offset: 12844},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 520, col: 91, offset: 12926},
+											pos:  position{line: 516, col: 91, offset: 12847},
 											name: "JoinKey",
 										},
 									},
@@ -3580,19 +3579,19 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 520, col: 101, offset: 12936},
+							pos:   position{line: 516, col: 101, offset: 12857},
 							label: "optArgs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 520, col: 109, offset: 12944},
+								pos: position{line: 516, col: 109, offset: 12865},
 								expr: &seqExpr{
-									pos: position{line: 520, col: 110, offset: 12945},
+									pos: position{line: 516, col: 110, offset: 12866},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 520, col: 110, offset: 12945},
+											pos:  position{line: 516, col: 110, offset: 12866},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 520, col: 112, offset: 12947},
+											pos:  position{line: 516, col: 112, offset: 12868},
 											name: "FlexAssignments",
 										},
 									},
@@ -3607,91 +3606,91 @@ var g = &grammar{
 		},
 		{
 			name: "JoinStyle",
-			pos:  position{line: 539, col: 1, offset: 13410},
+			pos:  position{line: 535, col: 1, offset: 13331},
 			expr: &choiceExpr{
-				pos: position{line: 540, col: 5, offset: 13424},
+				pos: position{line: 536, col: 5, offset: 13345},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 540, col: 5, offset: 13424},
+						pos: position{line: 536, col: 5, offset: 13345},
 						run: (*parser).callonJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 540, col: 5, offset: 13424},
+							pos: position{line: 536, col: 5, offset: 13345},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 540, col: 5, offset: 13424},
+									pos:        position{line: 536, col: 5, offset: 13345},
 									val:        "anti",
 									ignoreCase: false,
 									want:       "\"anti\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 540, col: 12, offset: 13431},
+									pos:  position{line: 536, col: 12, offset: 13352},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 541, col: 5, offset: 13461},
+						pos: position{line: 537, col: 5, offset: 13382},
 						run: (*parser).callonJoinStyle6,
 						expr: &seqExpr{
-							pos: position{line: 541, col: 5, offset: 13461},
+							pos: position{line: 537, col: 5, offset: 13382},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 541, col: 5, offset: 13461},
+									pos:        position{line: 537, col: 5, offset: 13382},
 									val:        "inner",
 									ignoreCase: false,
 									want:       "\"inner\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 541, col: 13, offset: 13469},
+									pos:  position{line: 537, col: 13, offset: 13390},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 542, col: 5, offset: 13499},
+						pos: position{line: 538, col: 5, offset: 13420},
 						run: (*parser).callonJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 542, col: 5, offset: 13499},
+							pos: position{line: 538, col: 5, offset: 13420},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 542, col: 5, offset: 13499},
+									pos:        position{line: 538, col: 5, offset: 13420},
 									val:        "left",
 									ignoreCase: false,
 									want:       "\"left\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 542, col: 13, offset: 13507},
+									pos:  position{line: 538, col: 13, offset: 13428},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 543, col: 5, offset: 13536},
+						pos: position{line: 539, col: 5, offset: 13457},
 						run: (*parser).callonJoinStyle14,
 						expr: &seqExpr{
-							pos: position{line: 543, col: 5, offset: 13536},
+							pos: position{line: 539, col: 5, offset: 13457},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 543, col: 5, offset: 13536},
+									pos:        position{line: 539, col: 5, offset: 13457},
 									val:        "right",
 									ignoreCase: false,
 									want:       "\"right\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 543, col: 13, offset: 13544},
+									pos:  position{line: 539, col: 13, offset: 13465},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 544, col: 5, offset: 13574},
+						pos: position{line: 540, col: 5, offset: 13495},
 						run: (*parser).callonJoinStyle18,
 						expr: &litMatcher{
-							pos:        position{line: 544, col: 5, offset: 13574},
+							pos:        position{line: 540, col: 5, offset: 13495},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -3704,60 +3703,60 @@ var g = &grammar{
 		},
 		{
 			name: "JoinRightInput",
-			pos:  position{line: 546, col: 1, offset: 13609},
+			pos:  position{line: 542, col: 1, offset: 13530},
 			expr: &choiceExpr{
-				pos: position{line: 547, col: 5, offset: 13628},
+				pos: position{line: 543, col: 5, offset: 13549},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 547, col: 5, offset: 13628},
+						pos: position{line: 543, col: 5, offset: 13549},
 						run: (*parser).callonJoinRightInput2,
 						expr: &seqExpr{
-							pos: position{line: 547, col: 5, offset: 13628},
+							pos: position{line: 543, col: 5, offset: 13549},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 547, col: 5, offset: 13628},
+									pos:  position{line: 543, col: 5, offset: 13549},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 547, col: 8, offset: 13631},
+									pos:        position{line: 543, col: 8, offset: 13552},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 547, col: 12, offset: 13635},
+									pos:  position{line: 543, col: 12, offset: 13556},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 547, col: 15, offset: 13638},
+									pos:   position{line: 543, col: 15, offset: 13559},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 547, col: 17, offset: 13640},
+										pos:  position{line: 543, col: 17, offset: 13561},
 										name: "Seq",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 547, col: 21, offset: 13644},
+									pos:  position{line: 543, col: 21, offset: 13565},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 547, col: 24, offset: 13647},
+									pos:        position{line: 543, col: 24, offset: 13568},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 547, col: 28, offset: 13651},
+									pos:  position{line: 543, col: 28, offset: 13572},
 									name: "__",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 548, col: 5, offset: 13676},
+						pos: position{line: 544, col: 5, offset: 13597},
 						run: (*parser).callonJoinRightInput12,
 						expr: &ruleRefExpr{
-							pos:  position{line: 548, col: 5, offset: 13676},
+							pos:  position{line: 544, col: 5, offset: 13597},
 							name: "_",
 						},
 					},
@@ -3768,36 +3767,36 @@ var g = &grammar{
 		},
 		{
 			name: "JoinKey",
-			pos:  position{line: 550, col: 1, offset: 13699},
+			pos:  position{line: 546, col: 1, offset: 13620},
 			expr: &choiceExpr{
-				pos: position{line: 551, col: 5, offset: 13711},
+				pos: position{line: 547, col: 5, offset: 13632},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 551, col: 5, offset: 13711},
+						pos:  position{line: 547, col: 5, offset: 13632},
 						name: "Lval",
 					},
 					&actionExpr{
-						pos: position{line: 552, col: 5, offset: 13720},
+						pos: position{line: 548, col: 5, offset: 13641},
 						run: (*parser).callonJoinKey3,
 						expr: &seqExpr{
-							pos: position{line: 552, col: 5, offset: 13720},
+							pos: position{line: 548, col: 5, offset: 13641},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 552, col: 5, offset: 13720},
+									pos:        position{line: 548, col: 5, offset: 13641},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 552, col: 9, offset: 13724},
+									pos:   position{line: 548, col: 9, offset: 13645},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 552, col: 14, offset: 13729},
+										pos:  position{line: 548, col: 14, offset: 13650},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 552, col: 19, offset: 13734},
+									pos:        position{line: 548, col: 19, offset: 13655},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -3812,46 +3811,46 @@ var g = &grammar{
 		},
 		{
 			name: "SampleOp",
-			pos:  position{line: 554, col: 1, offset: 13760},
+			pos:  position{line: 550, col: 1, offset: 13681},
 			expr: &actionExpr{
-				pos: position{line: 555, col: 5, offset: 13773},
+				pos: position{line: 551, col: 5, offset: 13694},
 				run: (*parser).callonSampleOp1,
 				expr: &seqExpr{
-					pos: position{line: 555, col: 5, offset: 13773},
+					pos: position{line: 551, col: 5, offset: 13694},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 555, col: 5, offset: 13773},
+							pos:        position{line: 551, col: 5, offset: 13694},
 							val:        "sample",
 							ignoreCase: false,
 							want:       "\"sample\"",
 						},
 						&andExpr{
-							pos: position{line: 555, col: 14, offset: 13782},
+							pos: position{line: 551, col: 14, offset: 13703},
 							expr: &ruleRefExpr{
-								pos:  position{line: 555, col: 15, offset: 13783},
+								pos:  position{line: 551, col: 15, offset: 13704},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 555, col: 20, offset: 13788},
+							pos:   position{line: 551, col: 20, offset: 13709},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 555, col: 25, offset: 13793},
+								pos: position{line: 551, col: 25, offset: 13714},
 								expr: &actionExpr{
-									pos: position{line: 555, col: 26, offset: 13794},
+									pos: position{line: 551, col: 26, offset: 13715},
 									run: (*parser).callonSampleOp8,
 									expr: &seqExpr{
-										pos: position{line: 555, col: 26, offset: 13794},
+										pos: position{line: 551, col: 26, offset: 13715},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 555, col: 26, offset: 13794},
+												pos:  position{line: 551, col: 26, offset: 13715},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 555, col: 28, offset: 13796},
+												pos:   position{line: 551, col: 28, offset: 13717},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 555, col: 30, offset: 13798},
+													pos:  position{line: 551, col: 30, offset: 13719},
 													name: "Lval",
 												},
 											},
@@ -3868,15 +3867,15 @@ var g = &grammar{
 		},
 		{
 			name: "OpAssignment",
-			pos:  position{line: 568, col: 1, offset: 14249},
+			pos:  position{line: 564, col: 1, offset: 14170},
 			expr: &actionExpr{
-				pos: position{line: 569, col: 5, offset: 14266},
+				pos: position{line: 565, col: 5, offset: 14187},
 				run: (*parser).callonOpAssignment1,
 				expr: &labeledExpr{
-					pos:   position{line: 569, col: 5, offset: 14266},
+					pos:   position{line: 565, col: 5, offset: 14187},
 					label: "a",
 					expr: &ruleRefExpr{
-						pos:  position{line: 569, col: 7, offset: 14268},
+						pos:  position{line: 565, col: 7, offset: 14189},
 						name: "Assignments",
 					},
 				},
@@ -3886,71 +3885,71 @@ var g = &grammar{
 		},
 		{
 			name: "LoadOp",
-			pos:  position{line: 576, col: 1, offset: 14417},
+			pos:  position{line: 572, col: 1, offset: 14338},
 			expr: &actionExpr{
-				pos: position{line: 577, col: 5, offset: 14428},
+				pos: position{line: 573, col: 5, offset: 14349},
 				run: (*parser).callonLoadOp1,
 				expr: &seqExpr{
-					pos: position{line: 577, col: 5, offset: 14428},
+					pos: position{line: 573, col: 5, offset: 14349},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 577, col: 5, offset: 14428},
+							pos:        position{line: 573, col: 5, offset: 14349},
 							val:        "load",
 							ignoreCase: false,
 							want:       "\"load\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 577, col: 12, offset: 14435},
+							pos:  position{line: 573, col: 12, offset: 14356},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 577, col: 14, offset: 14437},
+							pos:   position{line: 573, col: 14, offset: 14358},
 							label: "pool",
 							expr: &ruleRefExpr{
-								pos:  position{line: 577, col: 19, offset: 14442},
+								pos:  position{line: 573, col: 19, offset: 14363},
 								name: "PoolNameString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 577, col: 34, offset: 14457},
+							pos:   position{line: 573, col: 34, offset: 14378},
 							label: "branch",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 577, col: 41, offset: 14464},
+								pos: position{line: 573, col: 41, offset: 14385},
 								expr: &ruleRefExpr{
-									pos:  position{line: 577, col: 41, offset: 14464},
+									pos:  position{line: 573, col: 41, offset: 14385},
 									name: "PoolBranch",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 577, col: 53, offset: 14476},
+							pos:   position{line: 573, col: 53, offset: 14397},
 							label: "author",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 577, col: 60, offset: 14483},
+								pos: position{line: 573, col: 60, offset: 14404},
 								expr: &ruleRefExpr{
-									pos:  position{line: 577, col: 60, offset: 14483},
+									pos:  position{line: 573, col: 60, offset: 14404},
 									name: "AuthorArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 577, col: 71, offset: 14494},
+							pos:   position{line: 573, col: 71, offset: 14415},
 							label: "message",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 577, col: 79, offset: 14502},
+								pos: position{line: 573, col: 79, offset: 14423},
 								expr: &ruleRefExpr{
-									pos:  position{line: 577, col: 79, offset: 14502},
+									pos:  position{line: 573, col: 79, offset: 14423},
 									name: "MessageArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 577, col: 91, offset: 14514},
+							pos:   position{line: 573, col: 91, offset: 14435},
 							label: "meta",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 577, col: 96, offset: 14519},
+								pos: position{line: 573, col: 96, offset: 14440},
 								expr: &ruleRefExpr{
-									pos:  position{line: 577, col: 96, offset: 14519},
+									pos:  position{line: 573, col: 96, offset: 14440},
 									name: "MetaArg",
 								},
 							},
@@ -3963,32 +3962,32 @@ var g = &grammar{
 		},
 		{
 			name: "AuthorArg",
-			pos:  position{line: 590, col: 1, offset: 14866},
+			pos:  position{line: 586, col: 1, offset: 14787},
 			expr: &actionExpr{
-				pos: position{line: 591, col: 5, offset: 14880},
+				pos: position{line: 587, col: 5, offset: 14801},
 				run: (*parser).callonAuthorArg1,
 				expr: &seqExpr{
-					pos: position{line: 591, col: 5, offset: 14880},
+					pos: position{line: 587, col: 5, offset: 14801},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 591, col: 5, offset: 14880},
+							pos:  position{line: 587, col: 5, offset: 14801},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 591, col: 7, offset: 14882},
+							pos:        position{line: 587, col: 7, offset: 14803},
 							val:        "author",
 							ignoreCase: false,
 							want:       "\"author\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 591, col: 16, offset: 14891},
+							pos:  position{line: 587, col: 16, offset: 14812},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 591, col: 18, offset: 14893},
+							pos:   position{line: 587, col: 18, offset: 14814},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 591, col: 22, offset: 14897},
+								pos:  position{line: 587, col: 22, offset: 14818},
 								name: "QuotedString",
 							},
 						},
@@ -4000,32 +3999,32 @@ var g = &grammar{
 		},
 		{
 			name: "MessageArg",
-			pos:  position{line: 593, col: 1, offset: 14931},
+			pos:  position{line: 589, col: 1, offset: 14852},
 			expr: &actionExpr{
-				pos: position{line: 594, col: 5, offset: 14946},
+				pos: position{line: 590, col: 5, offset: 14867},
 				run: (*parser).callonMessageArg1,
 				expr: &seqExpr{
-					pos: position{line: 594, col: 5, offset: 14946},
+					pos: position{line: 590, col: 5, offset: 14867},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 594, col: 5, offset: 14946},
+							pos:  position{line: 590, col: 5, offset: 14867},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 594, col: 7, offset: 14948},
+							pos:        position{line: 590, col: 7, offset: 14869},
 							val:        "message",
 							ignoreCase: false,
 							want:       "\"message\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 594, col: 17, offset: 14958},
+							pos:  position{line: 590, col: 17, offset: 14879},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 594, col: 19, offset: 14960},
+							pos:   position{line: 590, col: 19, offset: 14881},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 594, col: 23, offset: 14964},
+								pos:  position{line: 590, col: 23, offset: 14885},
 								name: "QuotedString",
 							},
 						},
@@ -4037,32 +4036,32 @@ var g = &grammar{
 		},
 		{
 			name: "MetaArg",
-			pos:  position{line: 596, col: 1, offset: 14998},
+			pos:  position{line: 592, col: 1, offset: 14919},
 			expr: &actionExpr{
-				pos: position{line: 597, col: 5, offset: 15010},
+				pos: position{line: 593, col: 5, offset: 14931},
 				run: (*parser).callonMetaArg1,
 				expr: &seqExpr{
-					pos: position{line: 597, col: 5, offset: 15010},
+					pos: position{line: 593, col: 5, offset: 14931},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 597, col: 5, offset: 15010},
+							pos:  position{line: 593, col: 5, offset: 14931},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 597, col: 7, offset: 15012},
+							pos:        position{line: 593, col: 7, offset: 14933},
 							val:        "meta",
 							ignoreCase: false,
 							want:       "\"meta\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 597, col: 14, offset: 15019},
+							pos:  position{line: 593, col: 14, offset: 14940},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 597, col: 16, offset: 15021},
+							pos:   position{line: 593, col: 16, offset: 14942},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 597, col: 20, offset: 15025},
+								pos:  position{line: 593, col: 20, offset: 14946},
 								name: "QuotedString",
 							},
 						},
@@ -4074,31 +4073,31 @@ var g = &grammar{
 		},
 		{
 			name: "PoolBranch",
-			pos:  position{line: 599, col: 1, offset: 15059},
+			pos:  position{line: 595, col: 1, offset: 14980},
 			expr: &actionExpr{
-				pos: position{line: 600, col: 5, offset: 15074},
+				pos: position{line: 596, col: 5, offset: 14995},
 				run: (*parser).callonPoolBranch1,
 				expr: &seqExpr{
-					pos: position{line: 600, col: 5, offset: 15074},
+					pos: position{line: 596, col: 5, offset: 14995},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 600, col: 5, offset: 15074},
+							pos:        position{line: 596, col: 5, offset: 14995},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 600, col: 9, offset: 15078},
+							pos:   position{line: 596, col: 9, offset: 14999},
 							label: "branch",
 							expr: &choiceExpr{
-								pos: position{line: 600, col: 17, offset: 15086},
+								pos: position{line: 596, col: 17, offset: 15007},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 600, col: 17, offset: 15086},
+										pos:  position{line: 596, col: 17, offset: 15007},
 										name: "PoolIdentifier",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 600, col: 34, offset: 15103},
+										pos:  position{line: 596, col: 34, offset: 15024},
 										name: "QuotedString",
 									},
 								},
@@ -4112,28 +4111,28 @@ var g = &grammar{
 		},
 		{
 			name: "OutputOp",
-			pos:  position{line: 602, col: 1, offset: 15141},
+			pos:  position{line: 598, col: 1, offset: 15062},
 			expr: &actionExpr{
-				pos: position{line: 603, col: 5, offset: 15154},
+				pos: position{line: 599, col: 5, offset: 15075},
 				run: (*parser).callonOutputOp1,
 				expr: &seqExpr{
-					pos: position{line: 603, col: 5, offset: 15154},
+					pos: position{line: 599, col: 5, offset: 15075},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 603, col: 5, offset: 15154},
+							pos:        position{line: 599, col: 5, offset: 15075},
 							val:        "output",
 							ignoreCase: false,
 							want:       "\"output\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 603, col: 14, offset: 15163},
+							pos:  position{line: 599, col: 14, offset: 15084},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 603, col: 16, offset: 15165},
+							pos:   position{line: 599, col: 16, offset: 15086},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 603, col: 21, offset: 15170},
+								pos:  position{line: 599, col: 21, offset: 15091},
 								name: "Identifier",
 							},
 						},
@@ -4145,46 +4144,46 @@ var g = &grammar{
 		},
 		{
 			name: "DebugOp",
-			pos:  position{line: 611, col: 1, offset: 15317},
+			pos:  position{line: 607, col: 1, offset: 15238},
 			expr: &actionExpr{
-				pos: position{line: 612, col: 5, offset: 15329},
+				pos: position{line: 608, col: 5, offset: 15250},
 				run: (*parser).callonDebugOp1,
 				expr: &seqExpr{
-					pos: position{line: 612, col: 5, offset: 15329},
+					pos: position{line: 608, col: 5, offset: 15250},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 612, col: 5, offset: 15329},
+							pos:        position{line: 608, col: 5, offset: 15250},
 							val:        "debug",
 							ignoreCase: false,
 							want:       "\"debug\"",
 						},
 						&andExpr{
-							pos: position{line: 612, col: 13, offset: 15337},
+							pos: position{line: 608, col: 13, offset: 15258},
 							expr: &ruleRefExpr{
-								pos:  position{line: 612, col: 14, offset: 15338},
+								pos:  position{line: 608, col: 14, offset: 15259},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 612, col: 19, offset: 15343},
+							pos:   position{line: 608, col: 19, offset: 15264},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 612, col: 24, offset: 15348},
+								pos: position{line: 608, col: 24, offset: 15269},
 								expr: &actionExpr{
-									pos: position{line: 612, col: 25, offset: 15349},
+									pos: position{line: 608, col: 25, offset: 15270},
 									run: (*parser).callonDebugOp8,
 									expr: &seqExpr{
-										pos: position{line: 612, col: 25, offset: 15349},
+										pos: position{line: 608, col: 25, offset: 15270},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 612, col: 25, offset: 15349},
+												pos:  position{line: 608, col: 25, offset: 15270},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 612, col: 27, offset: 15351},
+												pos:   position{line: 608, col: 27, offset: 15272},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 612, col: 29, offset: 15353},
+													pos:  position{line: 608, col: 29, offset: 15274},
 													name: "Expr",
 												},
 											},
@@ -4201,20 +4200,20 @@ var g = &grammar{
 		},
 		{
 			name: "FromOp",
-			pos:  position{line: 623, col: 1, offset: 15559},
+			pos:  position{line: 619, col: 1, offset: 15480},
 			expr: &choiceExpr{
-				pos: position{line: 624, col: 5, offset: 15570},
+				pos: position{line: 620, col: 5, offset: 15491},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 624, col: 5, offset: 15570},
+						pos:  position{line: 620, col: 5, offset: 15491},
 						name: "File",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 625, col: 5, offset: 15579},
+						pos:  position{line: 621, col: 5, offset: 15500},
 						name: "Get",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 626, col: 5, offset: 15587},
+						pos:  position{line: 622, col: 5, offset: 15508},
 						name: "From",
 					},
 				},
@@ -4224,50 +4223,50 @@ var g = &grammar{
 		},
 		{
 			name: "File",
-			pos:  position{line: 628, col: 1, offset: 15593},
+			pos:  position{line: 624, col: 1, offset: 15514},
 			expr: &actionExpr{
-				pos: position{line: 629, col: 5, offset: 15602},
+				pos: position{line: 625, col: 5, offset: 15523},
 				run: (*parser).callonFile1,
 				expr: &seqExpr{
-					pos: position{line: 629, col: 5, offset: 15602},
+					pos: position{line: 625, col: 5, offset: 15523},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 629, col: 5, offset: 15602},
+							pos:        position{line: 625, col: 5, offset: 15523},
 							val:        "file",
 							ignoreCase: false,
 							want:       "\"file\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 629, col: 12, offset: 15609},
+							pos:  position{line: 625, col: 12, offset: 15530},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 629, col: 14, offset: 15611},
+							pos:   position{line: 625, col: 14, offset: 15532},
 							label: "path",
 							expr: &ruleRefExpr{
-								pos:  position{line: 629, col: 19, offset: 15616},
+								pos:  position{line: 625, col: 19, offset: 15537},
 								name: "Path",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 629, col: 24, offset: 15621},
+							pos:   position{line: 625, col: 24, offset: 15542},
 							label: "format",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 629, col: 31, offset: 15628},
+								pos: position{line: 625, col: 31, offset: 15549},
 								expr: &ruleRefExpr{
-									pos:  position{line: 629, col: 31, offset: 15628},
+									pos:  position{line: 625, col: 31, offset: 15549},
 									name: "FormatArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 629, col: 42, offset: 15639},
-							label: "sortkey",
+							pos:   position{line: 625, col: 42, offset: 15560},
+							label: "sortKeys",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 629, col: 50, offset: 15647},
+								pos: position{line: 625, col: 51, offset: 15569},
 								expr: &ruleRefExpr{
-									pos:  position{line: 629, col: 50, offset: 15647},
-									name: "SortKeyArg",
+									pos:  position{line: 625, col: 51, offset: 15569},
+									name: "OrderArg",
 								},
 							},
 						},
@@ -4279,28 +4278,28 @@ var g = &grammar{
 		},
 		{
 			name: "From",
-			pos:  position{line: 643, col: 1, offset: 15967},
+			pos:  position{line: 636, col: 1, offset: 15848},
 			expr: &actionExpr{
-				pos: position{line: 644, col: 5, offset: 15976},
+				pos: position{line: 637, col: 5, offset: 15857},
 				run: (*parser).callonFrom1,
 				expr: &seqExpr{
-					pos: position{line: 644, col: 5, offset: 15976},
+					pos: position{line: 637, col: 5, offset: 15857},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 644, col: 5, offset: 15976},
+							pos:        position{line: 637, col: 5, offset: 15857},
 							val:        "from",
 							ignoreCase: false,
 							want:       "\"from\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 644, col: 12, offset: 15983},
+							pos:  position{line: 637, col: 12, offset: 15864},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 644, col: 14, offset: 15985},
+							pos:   position{line: 637, col: 14, offset: 15866},
 							label: "spec",
 							expr: &ruleRefExpr{
-								pos:  position{line: 644, col: 19, offset: 15990},
+								pos:  position{line: 637, col: 19, offset: 15871},
 								name: "PoolSpec",
 							},
 						},
@@ -4312,28 +4311,28 @@ var g = &grammar{
 		},
 		{
 			name: "Pool",
-			pos:  position{line: 653, col: 1, offset: 16178},
+			pos:  position{line: 646, col: 1, offset: 16059},
 			expr: &actionExpr{
-				pos: position{line: 654, col: 5, offset: 16187},
+				pos: position{line: 647, col: 5, offset: 16068},
 				run: (*parser).callonPool1,
 				expr: &seqExpr{
-					pos: position{line: 654, col: 5, offset: 16187},
+					pos: position{line: 647, col: 5, offset: 16068},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 654, col: 5, offset: 16187},
+							pos:        position{line: 647, col: 5, offset: 16068},
 							val:        "pool",
 							ignoreCase: false,
 							want:       "\"pool\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 654, col: 12, offset: 16194},
+							pos:  position{line: 647, col: 12, offset: 16075},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 654, col: 14, offset: 16196},
+							pos:   position{line: 647, col: 14, offset: 16077},
 							label: "spec",
 							expr: &ruleRefExpr{
-								pos:  position{line: 654, col: 19, offset: 16201},
+								pos:  position{line: 647, col: 19, offset: 16082},
 								name: "PoolSpec",
 							},
 						},
@@ -4345,82 +4344,82 @@ var g = &grammar{
 		},
 		{
 			name: "Get",
-			pos:  position{line: 663, col: 1, offset: 16389},
+			pos:  position{line: 656, col: 1, offset: 16270},
 			expr: &actionExpr{
-				pos: position{line: 664, col: 5, offset: 16397},
+				pos: position{line: 657, col: 5, offset: 16278},
 				run: (*parser).callonGet1,
 				expr: &seqExpr{
-					pos: position{line: 664, col: 5, offset: 16397},
+					pos: position{line: 657, col: 5, offset: 16278},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 664, col: 5, offset: 16397},
+							pos:        position{line: 657, col: 5, offset: 16278},
 							val:        "get",
 							ignoreCase: false,
 							want:       "\"get\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 664, col: 11, offset: 16403},
+							pos:  position{line: 657, col: 11, offset: 16284},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 664, col: 13, offset: 16405},
+							pos:   position{line: 657, col: 13, offset: 16286},
 							label: "url",
 							expr: &ruleRefExpr{
-								pos:  position{line: 664, col: 17, offset: 16409},
+								pos:  position{line: 657, col: 17, offset: 16290},
 								name: "Path",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 664, col: 22, offset: 16414},
+							pos:   position{line: 657, col: 22, offset: 16295},
 							label: "format",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 664, col: 29, offset: 16421},
+								pos: position{line: 657, col: 29, offset: 16302},
 								expr: &ruleRefExpr{
-									pos:  position{line: 664, col: 29, offset: 16421},
+									pos:  position{line: 657, col: 29, offset: 16302},
 									name: "FormatArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 664, col: 40, offset: 16432},
-							label: "sortkey",
+							pos:   position{line: 657, col: 40, offset: 16313},
+							label: "sortKeys",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 664, col: 48, offset: 16440},
+								pos: position{line: 657, col: 49, offset: 16322},
 								expr: &ruleRefExpr{
-									pos:  position{line: 664, col: 48, offset: 16440},
-									name: "SortKeyArg",
+									pos:  position{line: 657, col: 49, offset: 16322},
+									name: "OrderArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 664, col: 60, offset: 16452},
+							pos:   position{line: 657, col: 59, offset: 16332},
 							label: "method",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 664, col: 67, offset: 16459},
+								pos: position{line: 657, col: 66, offset: 16339},
 								expr: &ruleRefExpr{
-									pos:  position{line: 664, col: 67, offset: 16459},
+									pos:  position{line: 657, col: 66, offset: 16339},
 									name: "MethodArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 664, col: 78, offset: 16470},
+							pos:   position{line: 657, col: 77, offset: 16350},
 							label: "headers",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 664, col: 86, offset: 16478},
+								pos: position{line: 657, col: 85, offset: 16358},
 								expr: &ruleRefExpr{
-									pos:  position{line: 664, col: 86, offset: 16478},
+									pos:  position{line: 657, col: 85, offset: 16358},
 									name: "HeadersArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 664, col: 98, offset: 16490},
+							pos:   position{line: 657, col: 97, offset: 16370},
 							label: "body",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 664, col: 103, offset: 16495},
+								pos: position{line: 657, col: 102, offset: 16375},
 								expr: &ruleRefExpr{
-									pos:  position{line: 664, col: 103, offset: 16495},
+									pos:  position{line: 657, col: 102, offset: 16375},
 									name: "BodyArg",
 								},
 							},
@@ -4433,39 +4432,39 @@ var g = &grammar{
 		},
 		{
 			name: "MethodArg",
-			pos:  position{line: 683, col: 1, offset: 16966},
+			pos:  position{line: 674, col: 1, offset: 16820},
 			expr: &actionExpr{
-				pos: position{line: 683, col: 13, offset: 16978},
+				pos: position{line: 674, col: 13, offset: 16832},
 				run: (*parser).callonMethodArg1,
 				expr: &seqExpr{
-					pos: position{line: 683, col: 13, offset: 16978},
+					pos: position{line: 674, col: 13, offset: 16832},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 683, col: 13, offset: 16978},
+							pos:  position{line: 674, col: 13, offset: 16832},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 683, col: 15, offset: 16980},
+							pos:        position{line: 674, col: 15, offset: 16834},
 							val:        "method",
 							ignoreCase: false,
 							want:       "\"method\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 683, col: 24, offset: 16989},
+							pos:  position{line: 674, col: 24, offset: 16843},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 683, col: 26, offset: 16991},
+							pos:   position{line: 674, col: 26, offset: 16845},
 							label: "v",
 							expr: &choiceExpr{
-								pos: position{line: 683, col: 29, offset: 16994},
+								pos: position{line: 674, col: 29, offset: 16848},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 683, col: 29, offset: 16994},
+										pos:  position{line: 674, col: 29, offset: 16848},
 										name: "IdentifierName",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 683, col: 46, offset: 17011},
+										pos:  position{line: 674, col: 46, offset: 16865},
 										name: "QuotedString",
 									},
 								},
@@ -4479,32 +4478,32 @@ var g = &grammar{
 		},
 		{
 			name: "HeadersArg",
-			pos:  position{line: 685, col: 1, offset: 17044},
+			pos:  position{line: 676, col: 1, offset: 16898},
 			expr: &actionExpr{
-				pos: position{line: 685, col: 14, offset: 17057},
+				pos: position{line: 676, col: 14, offset: 16911},
 				run: (*parser).callonHeadersArg1,
 				expr: &seqExpr{
-					pos: position{line: 685, col: 14, offset: 17057},
+					pos: position{line: 676, col: 14, offset: 16911},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 685, col: 14, offset: 17057},
+							pos:  position{line: 676, col: 14, offset: 16911},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 685, col: 16, offset: 17059},
+							pos:        position{line: 676, col: 16, offset: 16913},
 							val:        "headers",
 							ignoreCase: false,
 							want:       "\"headers\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 685, col: 26, offset: 17069},
+							pos:  position{line: 676, col: 26, offset: 16923},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 685, col: 28, offset: 17071},
+							pos:   position{line: 676, col: 28, offset: 16925},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 685, col: 30, offset: 17073},
+								pos:  position{line: 676, col: 30, offset: 16927},
 								name: "Record",
 							},
 						},
@@ -4516,39 +4515,39 @@ var g = &grammar{
 		},
 		{
 			name: "BodyArg",
-			pos:  position{line: 687, col: 1, offset: 17099},
+			pos:  position{line: 678, col: 1, offset: 16953},
 			expr: &actionExpr{
-				pos: position{line: 687, col: 11, offset: 17109},
+				pos: position{line: 678, col: 11, offset: 16963},
 				run: (*parser).callonBodyArg1,
 				expr: &seqExpr{
-					pos: position{line: 687, col: 11, offset: 17109},
+					pos: position{line: 678, col: 11, offset: 16963},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 687, col: 11, offset: 17109},
+							pos:  position{line: 678, col: 11, offset: 16963},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 687, col: 13, offset: 17111},
+							pos:        position{line: 678, col: 13, offset: 16965},
 							val:        "body",
 							ignoreCase: false,
 							want:       "\"body\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 687, col: 20, offset: 17118},
+							pos:  position{line: 678, col: 20, offset: 16972},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 687, col: 22, offset: 17120},
+							pos:   position{line: 678, col: 22, offset: 16974},
 							label: "v",
 							expr: &choiceExpr{
-								pos: position{line: 687, col: 25, offset: 17123},
+								pos: position{line: 678, col: 25, offset: 16977},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 687, col: 25, offset: 17123},
+										pos:  position{line: 678, col: 25, offset: 16977},
 										name: "IdentifierName",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 687, col: 42, offset: 17140},
+										pos:  position{line: 678, col: 42, offset: 16994},
 										name: "QuotedString",
 									},
 								},
@@ -4562,21 +4561,21 @@ var g = &grammar{
 		},
 		{
 			name: "Path",
-			pos:  position{line: 689, col: 1, offset: 17173},
+			pos:  position{line: 680, col: 1, offset: 17027},
 			expr: &choiceExpr{
-				pos: position{line: 690, col: 5, offset: 17182},
+				pos: position{line: 681, col: 5, offset: 17036},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 690, col: 5, offset: 17182},
+						pos:  position{line: 681, col: 5, offset: 17036},
 						name: "QuotedStringNode",
 					},
 					&actionExpr{
-						pos: position{line: 691, col: 5, offset: 17203},
+						pos: position{line: 682, col: 5, offset: 17057},
 						run: (*parser).callonPath3,
 						expr: &oneOrMoreExpr{
-							pos: position{line: 691, col: 5, offset: 17203},
+							pos: position{line: 682, col: 5, offset: 17057},
 							expr: &charClassMatcher{
-								pos:        position{line: 691, col: 5, offset: 17203},
+								pos:        position{line: 682, col: 5, offset: 17057},
 								val:        "[0-9a-zA-Z!@$%^&*_=<>,./?:[\\]{}~+-]",
 								chars:      []rune{'!', '@', '$', '%', '^', '&', '*', '_', '=', '<', '>', ',', '.', '/', '?', ':', '[', ']', '{', '}', '~', '+', '-'},
 								ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
@@ -4592,32 +4591,32 @@ var g = &grammar{
 		},
 		{
 			name: "PoolAt",
-			pos:  position{line: 696, col: 1, offset: 17373},
+			pos:  position{line: 687, col: 1, offset: 17227},
 			expr: &actionExpr{
-				pos: position{line: 697, col: 5, offset: 17384},
+				pos: position{line: 688, col: 5, offset: 17238},
 				run: (*parser).callonPoolAt1,
 				expr: &seqExpr{
-					pos: position{line: 697, col: 5, offset: 17384},
+					pos: position{line: 688, col: 5, offset: 17238},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 697, col: 5, offset: 17384},
+							pos:  position{line: 688, col: 5, offset: 17238},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 697, col: 7, offset: 17386},
+							pos:        position{line: 688, col: 7, offset: 17240},
 							val:        "at",
 							ignoreCase: false,
 							want:       "\"at\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 697, col: 12, offset: 17391},
+							pos:  position{line: 688, col: 12, offset: 17245},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 697, col: 14, offset: 17393},
+							pos:   position{line: 688, col: 14, offset: 17247},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 697, col: 17, offset: 17396},
+								pos:  position{line: 688, col: 17, offset: 17250},
 								name: "KSUID",
 							},
 						},
@@ -4629,14 +4628,14 @@ var g = &grammar{
 		},
 		{
 			name: "KSUID",
-			pos:  position{line: 700, col: 1, offset: 17462},
+			pos:  position{line: 691, col: 1, offset: 17316},
 			expr: &actionExpr{
-				pos: position{line: 700, col: 9, offset: 17470},
+				pos: position{line: 691, col: 9, offset: 17324},
 				run: (*parser).callonKSUID1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 700, col: 9, offset: 17470},
+					pos: position{line: 691, col: 9, offset: 17324},
 					expr: &charClassMatcher{
-						pos:        position{line: 700, col: 10, offset: 17471},
+						pos:        position{line: 691, col: 10, offset: 17325},
 						val:        "[0-9a-zA-Z]",
 						ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
 						ignoreCase: false,
@@ -4649,51 +4648,51 @@ var g = &grammar{
 		},
 		{
 			name: "PoolSpec",
-			pos:  position{line: 702, col: 1, offset: 17517},
+			pos:  position{line: 693, col: 1, offset: 17371},
 			expr: &choiceExpr{
-				pos: position{line: 703, col: 5, offset: 17530},
+				pos: position{line: 694, col: 5, offset: 17384},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 703, col: 5, offset: 17530},
+						pos: position{line: 694, col: 5, offset: 17384},
 						run: (*parser).callonPoolSpec2,
 						expr: &seqExpr{
-							pos: position{line: 703, col: 5, offset: 17530},
+							pos: position{line: 694, col: 5, offset: 17384},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 703, col: 5, offset: 17530},
+									pos:   position{line: 694, col: 5, offset: 17384},
 									label: "pool",
 									expr: &ruleRefExpr{
-										pos:  position{line: 703, col: 10, offset: 17535},
+										pos:  position{line: 694, col: 10, offset: 17389},
 										name: "PoolName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 703, col: 19, offset: 17544},
+									pos:   position{line: 694, col: 19, offset: 17398},
 									label: "commit",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 703, col: 26, offset: 17551},
+										pos: position{line: 694, col: 26, offset: 17405},
 										expr: &ruleRefExpr{
-											pos:  position{line: 703, col: 26, offset: 17551},
+											pos:  position{line: 694, col: 26, offset: 17405},
 											name: "PoolCommit",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 703, col: 38, offset: 17563},
+									pos:   position{line: 694, col: 38, offset: 17417},
 									label: "meta",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 703, col: 43, offset: 17568},
+										pos: position{line: 694, col: 43, offset: 17422},
 										expr: &ruleRefExpr{
-											pos:  position{line: 703, col: 43, offset: 17568},
+											pos:  position{line: 694, col: 43, offset: 17422},
 											name: "PoolMeta",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 703, col: 53, offset: 17578},
+									pos:   position{line: 694, col: 53, offset: 17432},
 									label: "tap",
 									expr: &ruleRefExpr{
-										pos:  position{line: 703, col: 57, offset: 17582},
+										pos:  position{line: 694, col: 57, offset: 17436},
 										name: "TapArg",
 									},
 								},
@@ -4701,13 +4700,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 711, col: 5, offset: 17776},
+						pos: position{line: 702, col: 5, offset: 17630},
 						run: (*parser).callonPoolSpec14,
 						expr: &labeledExpr{
-							pos:   position{line: 711, col: 5, offset: 17776},
+							pos:   position{line: 702, col: 5, offset: 17630},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 711, col: 10, offset: 17781},
+								pos:  position{line: 702, col: 10, offset: 17635},
 								name: "PoolMeta",
 							},
 						},
@@ -4719,24 +4718,24 @@ var g = &grammar{
 		},
 		{
 			name: "PoolCommit",
-			pos:  position{line: 715, col: 1, offset: 17851},
+			pos:  position{line: 706, col: 1, offset: 17705},
 			expr: &actionExpr{
-				pos: position{line: 716, col: 5, offset: 17866},
+				pos: position{line: 707, col: 5, offset: 17720},
 				run: (*parser).callonPoolCommit1,
 				expr: &seqExpr{
-					pos: position{line: 716, col: 5, offset: 17866},
+					pos: position{line: 707, col: 5, offset: 17720},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 716, col: 5, offset: 17866},
+							pos:        position{line: 707, col: 5, offset: 17720},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 716, col: 9, offset: 17870},
+							pos:   position{line: 707, col: 9, offset: 17724},
 							label: "commit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 716, col: 16, offset: 17877},
+								pos:  position{line: 707, col: 16, offset: 17731},
 								name: "PoolNameString",
 							},
 						},
@@ -4748,24 +4747,24 @@ var g = &grammar{
 		},
 		{
 			name: "PoolMeta",
-			pos:  position{line: 718, col: 1, offset: 17916},
+			pos:  position{line: 709, col: 1, offset: 17770},
 			expr: &actionExpr{
-				pos: position{line: 719, col: 5, offset: 17929},
+				pos: position{line: 710, col: 5, offset: 17783},
 				run: (*parser).callonPoolMeta1,
 				expr: &seqExpr{
-					pos: position{line: 719, col: 5, offset: 17929},
+					pos: position{line: 710, col: 5, offset: 17783},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 719, col: 5, offset: 17929},
+							pos:        position{line: 710, col: 5, offset: 17783},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 719, col: 9, offset: 17933},
+							pos:   position{line: 710, col: 9, offset: 17787},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 719, col: 14, offset: 17938},
+								pos:  position{line: 710, col: 14, offset: 17792},
 								name: "PoolIdentifier",
 							},
 						},
@@ -4777,34 +4776,34 @@ var g = &grammar{
 		},
 		{
 			name: "PoolName",
-			pos:  position{line: 721, col: 1, offset: 17975},
+			pos:  position{line: 712, col: 1, offset: 17829},
 			expr: &choiceExpr{
-				pos: position{line: 722, col: 5, offset: 17988},
+				pos: position{line: 713, col: 5, offset: 17842},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 722, col: 5, offset: 17988},
+						pos:  position{line: 713, col: 5, offset: 17842},
 						name: "Regexp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 723, col: 5, offset: 17999},
+						pos:  position{line: 714, col: 5, offset: 17853},
 						name: "Glob",
 					},
 					&actionExpr{
-						pos: position{line: 724, col: 5, offset: 18008},
+						pos: position{line: 715, col: 5, offset: 17862},
 						run: (*parser).callonPoolName4,
 						expr: &seqExpr{
-							pos: position{line: 724, col: 5, offset: 18008},
+							pos: position{line: 715, col: 5, offset: 17862},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 724, col: 5, offset: 18008},
+									pos:        position{line: 715, col: 5, offset: 17862},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 								&notExpr{
-									pos: position{line: 724, col: 9, offset: 18012},
+									pos: position{line: 715, col: 9, offset: 17866},
 									expr: &ruleRefExpr{
-										pos:  position{line: 724, col: 10, offset: 18013},
+										pos:  position{line: 715, col: 10, offset: 17867},
 										name: "ExprGuard",
 									},
 								},
@@ -4812,17 +4811,17 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 725, col: 5, offset: 18107},
+						pos:  position{line: 716, col: 5, offset: 17961},
 						name: "QuotedStringNode",
 					},
 					&actionExpr{
-						pos: position{line: 726, col: 5, offset: 18128},
+						pos: position{line: 717, col: 5, offset: 17982},
 						run: (*parser).callonPoolName10,
 						expr: &labeledExpr{
-							pos:   position{line: 726, col: 5, offset: 18128},
+							pos:   position{line: 717, col: 5, offset: 17982},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 726, col: 10, offset: 18133},
+								pos:  position{line: 717, col: 10, offset: 17987},
 								name: "PoolNameString",
 							},
 						},
@@ -4834,20 +4833,20 @@ var g = &grammar{
 		},
 		{
 			name: "PoolNameString",
-			pos:  position{line: 728, col: 1, offset: 18237},
+			pos:  position{line: 719, col: 1, offset: 18091},
 			expr: &choiceExpr{
-				pos: position{line: 729, col: 5, offset: 18256},
+				pos: position{line: 720, col: 5, offset: 18110},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 729, col: 5, offset: 18256},
+						pos:  position{line: 720, col: 5, offset: 18110},
 						name: "PoolIdentifier",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 730, col: 5, offset: 18275},
+						pos:  position{line: 721, col: 5, offset: 18129},
 						name: "KSUID",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 731, col: 5, offset: 18285},
+						pos:  position{line: 722, col: 5, offset: 18139},
 						name: "QuotedString",
 					},
 				},
@@ -4857,22 +4856,22 @@ var g = &grammar{
 		},
 		{
 			name: "PoolIdentifier",
-			pos:  position{line: 733, col: 1, offset: 18299},
+			pos:  position{line: 724, col: 1, offset: 18153},
 			expr: &actionExpr{
-				pos: position{line: 734, col: 5, offset: 18318},
+				pos: position{line: 725, col: 5, offset: 18172},
 				run: (*parser).callonPoolIdentifier1,
 				expr: &seqExpr{
-					pos: position{line: 734, col: 5, offset: 18318},
+					pos: position{line: 725, col: 5, offset: 18172},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 734, col: 6, offset: 18319},
+							pos: position{line: 725, col: 6, offset: 18173},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 734, col: 6, offset: 18319},
+									pos:  position{line: 725, col: 6, offset: 18173},
 									name: "IdentifierStart",
 								},
 								&litMatcher{
-									pos:        position{line: 734, col: 24, offset: 18337},
+									pos:        position{line: 725, col: 24, offset: 18191},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
@@ -4880,16 +4879,16 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 734, col: 29, offset: 18342},
+							pos: position{line: 725, col: 29, offset: 18196},
 							expr: &choiceExpr{
-								pos: position{line: 734, col: 30, offset: 18343},
+								pos: position{line: 725, col: 30, offset: 18197},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 734, col: 30, offset: 18343},
+										pos:  position{line: 725, col: 30, offset: 18197},
 										name: "IdentifierRest",
 									},
 									&litMatcher{
-										pos:        position{line: 734, col: 47, offset: 18360},
+										pos:        position{line: 725, col: 47, offset: 18214},
 										val:        ".",
 										ignoreCase: false,
 										want:       "\".\"",
@@ -4904,42 +4903,34 @@ var g = &grammar{
 			leftRecursive: false,
 		},
 		{
-			name: "SortKeyArg",
-			pos:  position{line: 736, col: 1, offset: 18398},
+			name: "OrderArg",
+			pos:  position{line: 727, col: 1, offset: 18252},
 			expr: &actionExpr{
-				pos: position{line: 737, col: 5, offset: 18413},
-				run: (*parser).callonSortKeyArg1,
+				pos: position{line: 728, col: 5, offset: 18265},
+				run: (*parser).callonOrderArg1,
 				expr: &seqExpr{
-					pos: position{line: 737, col: 5, offset: 18413},
+					pos: position{line: 728, col: 5, offset: 18265},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 737, col: 5, offset: 18413},
+							pos:  position{line: 728, col: 5, offset: 18265},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 737, col: 7, offset: 18415},
+							pos:        position{line: 728, col: 7, offset: 18267},
 							val:        "order",
 							ignoreCase: false,
 							want:       "\"order\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 737, col: 15, offset: 18423},
+							pos:  position{line: 728, col: 15, offset: 18275},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 737, col: 17, offset: 18425},
-							label: "keys",
+							pos:   position{line: 728, col: 17, offset: 18277},
+							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 737, col: 22, offset: 18430},
-								name: "FieldExprs",
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 737, col: 33, offset: 18441},
-							label: "order",
-							expr: &ruleRefExpr{
-								pos:  position{line: 737, col: 39, offset: 18447},
-								name: "OrderSuffix",
+								pos:  position{line: 728, col: 23, offset: 18283},
+								name: "SortExprs",
 							},
 						},
 					},
@@ -4949,23 +4940,162 @@ var g = &grammar{
 			leftRecursive: false,
 		},
 		{
+			name: "SortExprs",
+			pos:  position{line: 732, col: 1, offset: 18326},
+			expr: &actionExpr{
+				pos: position{line: 733, col: 5, offset: 18340},
+				run: (*parser).callonSortExprs1,
+				expr: &seqExpr{
+					pos: position{line: 733, col: 5, offset: 18340},
+					exprs: []any{
+						&labeledExpr{
+							pos:   position{line: 733, col: 5, offset: 18340},
+							label: "first",
+							expr: &ruleRefExpr{
+								pos:  position{line: 733, col: 11, offset: 18346},
+								name: "SortExpr",
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 733, col: 20, offset: 18355},
+							label: "rest",
+							expr: &zeroOrMoreExpr{
+								pos: position{line: 733, col: 25, offset: 18360},
+								expr: &actionExpr{
+									pos: position{line: 733, col: 26, offset: 18361},
+									run: (*parser).callonSortExprs7,
+									expr: &seqExpr{
+										pos: position{line: 733, col: 26, offset: 18361},
+										exprs: []any{
+											&ruleRefExpr{
+												pos:  position{line: 733, col: 26, offset: 18361},
+												name: "__",
+											},
+											&litMatcher{
+												pos:        position{line: 733, col: 29, offset: 18364},
+												val:        ",",
+												ignoreCase: false,
+												want:       "\",\"",
+											},
+											&ruleRefExpr{
+												pos:  position{line: 733, col: 33, offset: 18368},
+												name: "__",
+											},
+											&labeledExpr{
+												pos:   position{line: 733, col: 36, offset: 18371},
+												label: "s",
+												expr: &ruleRefExpr{
+													pos:  position{line: 733, col: 38, offset: 18373},
+													name: "SortExpr",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			leader:        false,
+			leftRecursive: false,
+		},
+		{
+			name: "SortExpr",
+			pos:  position{line: 737, col: 1, offset: 18450},
+			expr: &actionExpr{
+				pos: position{line: 738, col: 5, offset: 18463},
+				run: (*parser).callonSortExpr1,
+				expr: &seqExpr{
+					pos: position{line: 738, col: 5, offset: 18463},
+					exprs: []any{
+						&labeledExpr{
+							pos:   position{line: 738, col: 5, offset: 18463},
+							label: "e",
+							expr: &ruleRefExpr{
+								pos:  position{line: 738, col: 7, offset: 18465},
+								name: "Expr",
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 738, col: 12, offset: 18470},
+							label: "order",
+							expr: &zeroOrOneExpr{
+								pos: position{line: 738, col: 18, offset: 18476},
+								expr: &actionExpr{
+									pos: position{line: 738, col: 19, offset: 18477},
+									run: (*parser).callonSortExpr7,
+									expr: &seqExpr{
+										pos: position{line: 738, col: 19, offset: 18477},
+										exprs: []any{
+											&ruleRefExpr{
+												pos:  position{line: 738, col: 19, offset: 18477},
+												name: "_",
+											},
+											&labeledExpr{
+												pos:   position{line: 738, col: 21, offset: 18479},
+												label: "o",
+												expr: &ruleRefExpr{
+													pos:  position{line: 738, col: 23, offset: 18481},
+													name: "OrderSpec",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			leader:        false,
+			leftRecursive: false,
+		},
+		{
+			name: "OrderSpec",
+			pos:  position{line: 746, col: 1, offset: 18674},
+			expr: &actionExpr{
+				pos: position{line: 747, col: 5, offset: 18688},
+				run: (*parser).callonOrderSpec1,
+				expr: &choiceExpr{
+					pos: position{line: 747, col: 6, offset: 18689},
+					alternatives: []any{
+						&litMatcher{
+							pos:        position{line: 747, col: 6, offset: 18689},
+							val:        "asc",
+							ignoreCase: false,
+							want:       "\"asc\"",
+						},
+						&litMatcher{
+							pos:        position{line: 747, col: 14, offset: 18697},
+							val:        "desc",
+							ignoreCase: false,
+							want:       "\"desc\"",
+						},
+					},
+				},
+			},
+			leader:        false,
+			leftRecursive: false,
+		},
+		{
 			name: "TapArg",
-			pos:  position{line: 745, col: 1, offset: 18603},
+			pos:  position{line: 751, col: 1, offset: 18797},
 			expr: &choiceExpr{
-				pos: position{line: 746, col: 5, offset: 18614},
+				pos: position{line: 752, col: 5, offset: 18808},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 746, col: 5, offset: 18614},
+						pos: position{line: 752, col: 5, offset: 18808},
 						run: (*parser).callonTapArg2,
 						expr: &seqExpr{
-							pos: position{line: 746, col: 5, offset: 18614},
+							pos: position{line: 752, col: 5, offset: 18808},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 746, col: 5, offset: 18614},
+									pos:  position{line: 752, col: 5, offset: 18808},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 746, col: 7, offset: 18616},
+									pos:        position{line: 752, col: 7, offset: 18810},
 									val:        "tap",
 									ignoreCase: false,
 									want:       "\"tap\"",
@@ -4974,10 +5104,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 747, col: 5, offset: 18647},
+						pos: position{line: 753, col: 5, offset: 18841},
 						run: (*parser).callonTapArg6,
 						expr: &litMatcher{
-							pos:        position{line: 747, col: 5, offset: 18647},
+							pos:        position{line: 753, col: 5, offset: 18841},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -4990,32 +5120,32 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArg",
-			pos:  position{line: 749, col: 1, offset: 18673},
+			pos:  position{line: 755, col: 1, offset: 18867},
 			expr: &actionExpr{
-				pos: position{line: 750, col: 5, offset: 18687},
+				pos: position{line: 756, col: 5, offset: 18881},
 				run: (*parser).callonFormatArg1,
 				expr: &seqExpr{
-					pos: position{line: 750, col: 5, offset: 18687},
+					pos: position{line: 756, col: 5, offset: 18881},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 750, col: 5, offset: 18687},
+							pos:  position{line: 756, col: 5, offset: 18881},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 750, col: 7, offset: 18689},
+							pos:        position{line: 756, col: 7, offset: 18883},
 							val:        "format",
 							ignoreCase: false,
 							want:       "\"format\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 750, col: 16, offset: 18698},
+							pos:  position{line: 756, col: 16, offset: 18892},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 750, col: 18, offset: 18700},
+							pos:   position{line: 756, col: 18, offset: 18894},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 750, col: 22, offset: 18704},
+								pos:  position{line: 756, col: 22, offset: 18898},
 								name: "IdentifierName",
 							},
 						},
@@ -5026,72 +5156,31 @@ var g = &grammar{
 			leftRecursive: false,
 		},
 		{
-			name: "OrderSuffix",
-			pos:  position{line: 752, col: 1, offset: 18740},
-			expr: &choiceExpr{
-				pos: position{line: 753, col: 5, offset: 18756},
-				alternatives: []any{
-					&actionExpr{
-						pos: position{line: 753, col: 5, offset: 18756},
-						run: (*parser).callonOrderSuffix2,
-						expr: &litMatcher{
-							pos:        position{line: 753, col: 5, offset: 18756},
-							val:        ":asc",
-							ignoreCase: false,
-							want:       "\":asc\"",
-						},
-					},
-					&actionExpr{
-						pos: position{line: 754, col: 5, offset: 18790},
-						run: (*parser).callonOrderSuffix4,
-						expr: &litMatcher{
-							pos:        position{line: 754, col: 5, offset: 18790},
-							val:        ":desc",
-							ignoreCase: false,
-							want:       "\":desc\"",
-						},
-					},
-					&actionExpr{
-						pos: position{line: 755, col: 5, offset: 18825},
-						run: (*parser).callonOrderSuffix6,
-						expr: &litMatcher{
-							pos:        position{line: 755, col: 5, offset: 18825},
-							val:        "",
-							ignoreCase: false,
-							want:       "\"\"",
-						},
-					},
-				},
-			},
-			leader:        false,
-			leftRecursive: false,
-		},
-		{
 			name: "PassOp",
-			pos:  position{line: 757, col: 1, offset: 18856},
+			pos:  position{line: 758, col: 1, offset: 18934},
 			expr: &actionExpr{
-				pos: position{line: 758, col: 5, offset: 18867},
+				pos: position{line: 759, col: 5, offset: 18945},
 				run: (*parser).callonPassOp1,
 				expr: &seqExpr{
-					pos: position{line: 758, col: 5, offset: 18867},
+					pos: position{line: 759, col: 5, offset: 18945},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 758, col: 5, offset: 18867},
+							pos:        position{line: 759, col: 5, offset: 18945},
 							val:        "pass",
 							ignoreCase: false,
 							want:       "\"pass\"",
 						},
 						&notExpr{
-							pos: position{line: 758, col: 12, offset: 18874},
+							pos: position{line: 759, col: 12, offset: 18952},
 							expr: &seqExpr{
-								pos: position{line: 758, col: 14, offset: 18876},
+								pos: position{line: 759, col: 14, offset: 18954},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 758, col: 14, offset: 18876},
+										pos:  position{line: 759, col: 14, offset: 18954},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 758, col: 17, offset: 18879},
+										pos:        position{line: 759, col: 17, offset: 18957},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -5100,9 +5189,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 758, col: 22, offset: 18884},
+							pos: position{line: 759, col: 22, offset: 18962},
 							expr: &ruleRefExpr{
-								pos:  position{line: 758, col: 23, offset: 18885},
+								pos:  position{line: 759, col: 23, offset: 18963},
 								name: "EOKW",
 							},
 						},
@@ -5114,46 +5203,46 @@ var g = &grammar{
 		},
 		{
 			name: "ExplodeOp",
-			pos:  position{line: 764, col: 1, offset: 19089},
+			pos:  position{line: 765, col: 1, offset: 19167},
 			expr: &actionExpr{
-				pos: position{line: 765, col: 5, offset: 19103},
+				pos: position{line: 766, col: 5, offset: 19181},
 				run: (*parser).callonExplodeOp1,
 				expr: &seqExpr{
-					pos: position{line: 765, col: 5, offset: 19103},
+					pos: position{line: 766, col: 5, offset: 19181},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 765, col: 5, offset: 19103},
+							pos:        position{line: 766, col: 5, offset: 19181},
 							val:        "explode",
 							ignoreCase: false,
 							want:       "\"explode\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 765, col: 15, offset: 19113},
+							pos:  position{line: 766, col: 15, offset: 19191},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 765, col: 17, offset: 19115},
+							pos:   position{line: 766, col: 17, offset: 19193},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 765, col: 22, offset: 19120},
+								pos:  position{line: 766, col: 22, offset: 19198},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 765, col: 28, offset: 19126},
+							pos:   position{line: 766, col: 28, offset: 19204},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 765, col: 32, offset: 19130},
+								pos:  position{line: 766, col: 32, offset: 19208},
 								name: "TypeArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 765, col: 40, offset: 19138},
+							pos:   position{line: 766, col: 40, offset: 19216},
 							label: "as",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 765, col: 43, offset: 19141},
+								pos: position{line: 766, col: 43, offset: 19219},
 								expr: &ruleRefExpr{
-									pos:  position{line: 765, col: 43, offset: 19141},
+									pos:  position{line: 766, col: 43, offset: 19219},
 									name: "AsArg",
 								},
 							},
@@ -5166,28 +5255,28 @@ var g = &grammar{
 		},
 		{
 			name: "MergeOp",
-			pos:  position{line: 778, col: 1, offset: 19399},
+			pos:  position{line: 779, col: 1, offset: 19477},
 			expr: &actionExpr{
-				pos: position{line: 779, col: 5, offset: 19411},
+				pos: position{line: 780, col: 5, offset: 19489},
 				run: (*parser).callonMergeOp1,
 				expr: &seqExpr{
-					pos: position{line: 779, col: 5, offset: 19411},
+					pos: position{line: 780, col: 5, offset: 19489},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 779, col: 5, offset: 19411},
+							pos:        position{line: 780, col: 5, offset: 19489},
 							val:        "merge",
 							ignoreCase: false,
 							want:       "\"merge\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 779, col: 13, offset: 19419},
+							pos:  position{line: 780, col: 13, offset: 19497},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 779, col: 15, offset: 19421},
+							pos:   position{line: 780, col: 15, offset: 19499},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 779, col: 20, offset: 19426},
+								pos:  position{line: 780, col: 20, offset: 19504},
 								name: "Expr",
 							},
 						},
@@ -5199,49 +5288,49 @@ var g = &grammar{
 		},
 		{
 			name: "OverOp",
-			pos:  position{line: 787, col: 1, offset: 19566},
+			pos:  position{line: 788, col: 1, offset: 19644},
 			expr: &actionExpr{
-				pos: position{line: 788, col: 5, offset: 19577},
+				pos: position{line: 789, col: 5, offset: 19655},
 				run: (*parser).callonOverOp1,
 				expr: &seqExpr{
-					pos: position{line: 788, col: 5, offset: 19577},
+					pos: position{line: 789, col: 5, offset: 19655},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 788, col: 5, offset: 19577},
+							pos:        position{line: 789, col: 5, offset: 19655},
 							val:        "over",
 							ignoreCase: false,
 							want:       "\"over\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 788, col: 12, offset: 19584},
+							pos:  position{line: 789, col: 12, offset: 19662},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 788, col: 14, offset: 19586},
+							pos:   position{line: 789, col: 14, offset: 19664},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 788, col: 20, offset: 19592},
+								pos:  position{line: 789, col: 20, offset: 19670},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 788, col: 26, offset: 19598},
+							pos:   position{line: 789, col: 26, offset: 19676},
 							label: "locals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 788, col: 33, offset: 19605},
+								pos: position{line: 789, col: 33, offset: 19683},
 								expr: &ruleRefExpr{
-									pos:  position{line: 788, col: 33, offset: 19605},
+									pos:  position{line: 789, col: 33, offset: 19683},
 									name: "Locals",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 788, col: 41, offset: 19613},
+							pos:   position{line: 789, col: 41, offset: 19691},
 							label: "body",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 788, col: 46, offset: 19618},
+								pos: position{line: 789, col: 46, offset: 19696},
 								expr: &ruleRefExpr{
-									pos:  position{line: 788, col: 46, offset: 19618},
+									pos:  position{line: 789, col: 46, offset: 19696},
 									name: "Lateral",
 								},
 							},
@@ -5254,54 +5343,54 @@ var g = &grammar{
 		},
 		{
 			name: "Lateral",
-			pos:  position{line: 803, col: 1, offset: 19967},
+			pos:  position{line: 804, col: 1, offset: 20045},
 			expr: &choiceExpr{
-				pos: position{line: 804, col: 5, offset: 19979},
+				pos: position{line: 805, col: 5, offset: 20057},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 804, col: 5, offset: 19979},
+						pos: position{line: 805, col: 5, offset: 20057},
 						run: (*parser).callonLateral2,
 						expr: &seqExpr{
-							pos: position{line: 804, col: 5, offset: 19979},
+							pos: position{line: 805, col: 5, offset: 20057},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 804, col: 5, offset: 19979},
+									pos:  position{line: 805, col: 5, offset: 20057},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 804, col: 8, offset: 19982},
+									pos:        position{line: 805, col: 8, offset: 20060},
 									val:        "=>",
 									ignoreCase: false,
 									want:       "\"=>\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 804, col: 13, offset: 19987},
+									pos:  position{line: 805, col: 13, offset: 20065},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 804, col: 16, offset: 19990},
+									pos:        position{line: 805, col: 16, offset: 20068},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 804, col: 20, offset: 19994},
+									pos:  position{line: 805, col: 20, offset: 20072},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 804, col: 23, offset: 19997},
+									pos:   position{line: 805, col: 23, offset: 20075},
 									label: "scope",
 									expr: &ruleRefExpr{
-										pos:  position{line: 804, col: 29, offset: 20003},
+										pos:  position{line: 805, col: 29, offset: 20081},
 										name: "Scope",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 804, col: 35, offset: 20009},
+									pos:  position{line: 805, col: 35, offset: 20087},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 804, col: 38, offset: 20012},
+									pos:        position{line: 805, col: 38, offset: 20090},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -5310,49 +5399,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 807, col: 5, offset: 20096},
+						pos: position{line: 808, col: 5, offset: 20174},
 						run: (*parser).callonLateral13,
 						expr: &seqExpr{
-							pos: position{line: 807, col: 5, offset: 20096},
+							pos: position{line: 808, col: 5, offset: 20174},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 807, col: 5, offset: 20096},
+									pos:  position{line: 808, col: 5, offset: 20174},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 807, col: 8, offset: 20099},
+									pos:        position{line: 808, col: 8, offset: 20177},
 									val:        "=>",
 									ignoreCase: false,
 									want:       "\"=>\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 807, col: 13, offset: 20104},
+									pos:  position{line: 808, col: 13, offset: 20182},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 807, col: 16, offset: 20107},
+									pos:        position{line: 808, col: 16, offset: 20185},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 807, col: 20, offset: 20111},
+									pos:  position{line: 808, col: 20, offset: 20189},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 807, col: 23, offset: 20114},
+									pos:   position{line: 808, col: 23, offset: 20192},
 									label: "seq",
 									expr: &ruleRefExpr{
-										pos:  position{line: 807, col: 27, offset: 20118},
+										pos:  position{line: 808, col: 27, offset: 20196},
 										name: "Seq",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 807, col: 31, offset: 20122},
+									pos:  position{line: 808, col: 31, offset: 20200},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 807, col: 34, offset: 20125},
+									pos:        position{line: 808, col: 34, offset: 20203},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -5367,65 +5456,65 @@ var g = &grammar{
 		},
 		{
 			name: "Locals",
-			pos:  position{line: 811, col: 1, offset: 20184},
+			pos:  position{line: 812, col: 1, offset: 20262},
 			expr: &actionExpr{
-				pos: position{line: 812, col: 5, offset: 20195},
+				pos: position{line: 813, col: 5, offset: 20273},
 				run: (*parser).callonLocals1,
 				expr: &seqExpr{
-					pos: position{line: 812, col: 5, offset: 20195},
+					pos: position{line: 813, col: 5, offset: 20273},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 812, col: 5, offset: 20195},
+							pos:  position{line: 813, col: 5, offset: 20273},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 812, col: 7, offset: 20197},
+							pos:        position{line: 813, col: 7, offset: 20275},
 							val:        "with",
 							ignoreCase: false,
 							want:       "\"with\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 812, col: 14, offset: 20204},
+							pos:  position{line: 813, col: 14, offset: 20282},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 812, col: 16, offset: 20206},
+							pos:   position{line: 813, col: 16, offset: 20284},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 812, col: 22, offset: 20212},
+								pos:  position{line: 813, col: 22, offset: 20290},
 								name: "LocalsAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 812, col: 39, offset: 20229},
+							pos:   position{line: 813, col: 39, offset: 20307},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 812, col: 44, offset: 20234},
+								pos: position{line: 813, col: 44, offset: 20312},
 								expr: &actionExpr{
-									pos: position{line: 812, col: 45, offset: 20235},
+									pos: position{line: 813, col: 45, offset: 20313},
 									run: (*parser).callonLocals10,
 									expr: &seqExpr{
-										pos: position{line: 812, col: 45, offset: 20235},
+										pos: position{line: 813, col: 45, offset: 20313},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 812, col: 45, offset: 20235},
+												pos:  position{line: 813, col: 45, offset: 20313},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 812, col: 48, offset: 20238},
+												pos:        position{line: 813, col: 48, offset: 20316},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 812, col: 52, offset: 20242},
+												pos:  position{line: 813, col: 52, offset: 20320},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 812, col: 55, offset: 20245},
+												pos:   position{line: 813, col: 55, offset: 20323},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 812, col: 57, offset: 20247},
+													pos:  position{line: 813, col: 57, offset: 20325},
 													name: "LocalsAssignment",
 												},
 											},
@@ -5442,45 +5531,45 @@ var g = &grammar{
 		},
 		{
 			name: "LocalsAssignment",
-			pos:  position{line: 816, col: 1, offset: 20332},
+			pos:  position{line: 817, col: 1, offset: 20410},
 			expr: &actionExpr{
-				pos: position{line: 817, col: 5, offset: 20353},
+				pos: position{line: 818, col: 5, offset: 20431},
 				run: (*parser).callonLocalsAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 817, col: 5, offset: 20353},
+					pos: position{line: 818, col: 5, offset: 20431},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 817, col: 5, offset: 20353},
+							pos:   position{line: 818, col: 5, offset: 20431},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 817, col: 10, offset: 20358},
+								pos:  position{line: 818, col: 10, offset: 20436},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 817, col: 21, offset: 20369},
+							pos:   position{line: 818, col: 21, offset: 20447},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 817, col: 25, offset: 20373},
+								pos: position{line: 818, col: 25, offset: 20451},
 								expr: &seqExpr{
-									pos: position{line: 817, col: 26, offset: 20374},
+									pos: position{line: 818, col: 26, offset: 20452},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 817, col: 26, offset: 20374},
+											pos:  position{line: 818, col: 26, offset: 20452},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 817, col: 29, offset: 20377},
+											pos:        position{line: 818, col: 29, offset: 20455},
 											val:        "=",
 											ignoreCase: false,
 											want:       "\"=\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 817, col: 33, offset: 20381},
+											pos:  position{line: 818, col: 33, offset: 20459},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 817, col: 36, offset: 20384},
+											pos:  position{line: 818, col: 36, offset: 20462},
 											name: "Expr",
 										},
 									},
@@ -5495,28 +5584,28 @@ var g = &grammar{
 		},
 		{
 			name: "YieldOp",
-			pos:  position{line: 828, col: 1, offset: 20587},
+			pos:  position{line: 829, col: 1, offset: 20665},
 			expr: &actionExpr{
-				pos: position{line: 829, col: 5, offset: 20599},
+				pos: position{line: 830, col: 5, offset: 20677},
 				run: (*parser).callonYieldOp1,
 				expr: &seqExpr{
-					pos: position{line: 829, col: 5, offset: 20599},
+					pos: position{line: 830, col: 5, offset: 20677},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 829, col: 5, offset: 20599},
+							pos:        position{line: 830, col: 5, offset: 20677},
 							val:        "yield",
 							ignoreCase: false,
 							want:       "\"yield\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 829, col: 13, offset: 20607},
+							pos:  position{line: 830, col: 13, offset: 20685},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 829, col: 15, offset: 20609},
+							pos:   position{line: 830, col: 15, offset: 20687},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 829, col: 21, offset: 20615},
+								pos:  position{line: 830, col: 21, offset: 20693},
 								name: "Exprs",
 							},
 						},
@@ -5528,32 +5617,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeArg",
-			pos:  position{line: 837, col: 1, offset: 20772},
+			pos:  position{line: 838, col: 1, offset: 20850},
 			expr: &actionExpr{
-				pos: position{line: 838, col: 5, offset: 20784},
+				pos: position{line: 839, col: 5, offset: 20862},
 				run: (*parser).callonTypeArg1,
 				expr: &seqExpr{
-					pos: position{line: 838, col: 5, offset: 20784},
+					pos: position{line: 839, col: 5, offset: 20862},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 838, col: 5, offset: 20784},
+							pos:  position{line: 839, col: 5, offset: 20862},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 838, col: 7, offset: 20786},
+							pos:        position{line: 839, col: 7, offset: 20864},
 							val:        "by",
 							ignoreCase: false,
 							want:       "\"by\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 838, col: 12, offset: 20791},
+							pos:  position{line: 839, col: 12, offset: 20869},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 838, col: 14, offset: 20793},
+							pos:   position{line: 839, col: 14, offset: 20871},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 838, col: 18, offset: 20797},
+								pos:  position{line: 839, col: 18, offset: 20875},
 								name: "Type",
 							},
 						},
@@ -5565,32 +5654,32 @@ var g = &grammar{
 		},
 		{
 			name: "AsArg",
-			pos:  position{line: 840, col: 1, offset: 20823},
+			pos:  position{line: 841, col: 1, offset: 20901},
 			expr: &actionExpr{
-				pos: position{line: 841, col: 5, offset: 20833},
+				pos: position{line: 842, col: 5, offset: 20911},
 				run: (*parser).callonAsArg1,
 				expr: &seqExpr{
-					pos: position{line: 841, col: 5, offset: 20833},
+					pos: position{line: 842, col: 5, offset: 20911},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 841, col: 5, offset: 20833},
+							pos:  position{line: 842, col: 5, offset: 20911},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 841, col: 7, offset: 20835},
+							pos:        position{line: 842, col: 7, offset: 20913},
 							val:        "as",
 							ignoreCase: false,
 							want:       "\"as\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 841, col: 12, offset: 20840},
+							pos:  position{line: 842, col: 12, offset: 20918},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 841, col: 14, offset: 20842},
+							pos:   position{line: 842, col: 14, offset: 20920},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 841, col: 18, offset: 20846},
+								pos:  position{line: 842, col: 18, offset: 20924},
 								name: "Lval",
 							},
 						},
@@ -5602,9 +5691,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 845, col: 1, offset: 20897},
+			pos:  position{line: 846, col: 1, offset: 20975},
 			expr: &ruleRefExpr{
-				pos:  position{line: 845, col: 8, offset: 20904},
+				pos:  position{line: 846, col: 8, offset: 20982},
 				name: "DerefExpr",
 			},
 			leader:        false,
@@ -5612,51 +5701,51 @@ var g = &grammar{
 		},
 		{
 			name: "Lvals",
-			pos:  position{line: 847, col: 1, offset: 20915},
+			pos:  position{line: 848, col: 1, offset: 20993},
 			expr: &actionExpr{
-				pos: position{line: 848, col: 5, offset: 20925},
+				pos: position{line: 849, col: 5, offset: 21003},
 				run: (*parser).callonLvals1,
 				expr: &seqExpr{
-					pos: position{line: 848, col: 5, offset: 20925},
+					pos: position{line: 849, col: 5, offset: 21003},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 848, col: 5, offset: 20925},
+							pos:   position{line: 849, col: 5, offset: 21003},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 848, col: 11, offset: 20931},
+								pos:  position{line: 849, col: 11, offset: 21009},
 								name: "Lval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 848, col: 16, offset: 20936},
+							pos:   position{line: 849, col: 16, offset: 21014},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 848, col: 21, offset: 20941},
+								pos: position{line: 849, col: 21, offset: 21019},
 								expr: &actionExpr{
-									pos: position{line: 848, col: 22, offset: 20942},
+									pos: position{line: 849, col: 22, offset: 21020},
 									run: (*parser).callonLvals7,
 									expr: &seqExpr{
-										pos: position{line: 848, col: 22, offset: 20942},
+										pos: position{line: 849, col: 22, offset: 21020},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 848, col: 22, offset: 20942},
+												pos:  position{line: 849, col: 22, offset: 21020},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 848, col: 25, offset: 20945},
+												pos:        position{line: 849, col: 25, offset: 21023},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 848, col: 29, offset: 20949},
+												pos:  position{line: 849, col: 29, offset: 21027},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 848, col: 32, offset: 20952},
+												pos:   position{line: 849, col: 32, offset: 21030},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 848, col: 37, offset: 20957},
+													pos:  position{line: 849, col: 37, offset: 21035},
 													name: "Lval",
 												},
 											},
@@ -5673,9 +5762,9 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 852, col: 1, offset: 21033},
+			pos:  position{line: 853, col: 1, offset: 21111},
 			expr: &ruleRefExpr{
-				pos:  position{line: 852, col: 13, offset: 21045},
+				pos:  position{line: 853, col: 13, offset: 21123},
 				name: "Lval",
 			},
 			leader:        false,
@@ -5683,51 +5772,51 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExprs",
-			pos:  position{line: 854, col: 1, offset: 21051},
+			pos:  position{line: 855, col: 1, offset: 21129},
 			expr: &actionExpr{
-				pos: position{line: 855, col: 5, offset: 21066},
+				pos: position{line: 856, col: 5, offset: 21144},
 				run: (*parser).callonFieldExprs1,
 				expr: &seqExpr{
-					pos: position{line: 855, col: 5, offset: 21066},
+					pos: position{line: 856, col: 5, offset: 21144},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 855, col: 5, offset: 21066},
+							pos:   position{line: 856, col: 5, offset: 21144},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 855, col: 11, offset: 21072},
+								pos:  position{line: 856, col: 11, offset: 21150},
 								name: "FieldExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 855, col: 21, offset: 21082},
+							pos:   position{line: 856, col: 21, offset: 21160},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 855, col: 26, offset: 21087},
+								pos: position{line: 856, col: 26, offset: 21165},
 								expr: &actionExpr{
-									pos: position{line: 855, col: 27, offset: 21088},
+									pos: position{line: 856, col: 27, offset: 21166},
 									run: (*parser).callonFieldExprs7,
 									expr: &seqExpr{
-										pos: position{line: 855, col: 27, offset: 21088},
+										pos: position{line: 856, col: 27, offset: 21166},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 855, col: 27, offset: 21088},
+												pos:  position{line: 856, col: 27, offset: 21166},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 855, col: 30, offset: 21091},
+												pos:        position{line: 856, col: 30, offset: 21169},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 855, col: 34, offset: 21095},
+												pos:  position{line: 856, col: 34, offset: 21173},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 855, col: 37, offset: 21098},
+												pos:   position{line: 856, col: 37, offset: 21176},
 												label: "f",
 												expr: &ruleRefExpr{
-													pos:  position{line: 855, col: 39, offset: 21100},
+													pos:  position{line: 856, col: 39, offset: 21178},
 													name: "FieldExpr",
 												},
 											},
@@ -5744,51 +5833,51 @@ var g = &grammar{
 		},
 		{
 			name: "Assignments",
-			pos:  position{line: 859, col: 1, offset: 21177},
+			pos:  position{line: 860, col: 1, offset: 21255},
 			expr: &actionExpr{
-				pos: position{line: 860, col: 5, offset: 21193},
+				pos: position{line: 861, col: 5, offset: 21271},
 				run: (*parser).callonAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 860, col: 5, offset: 21193},
+					pos: position{line: 861, col: 5, offset: 21271},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 860, col: 5, offset: 21193},
+							pos:   position{line: 861, col: 5, offset: 21271},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 860, col: 11, offset: 21199},
+								pos:  position{line: 861, col: 11, offset: 21277},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 860, col: 22, offset: 21210},
+							pos:   position{line: 861, col: 22, offset: 21288},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 860, col: 27, offset: 21215},
+								pos: position{line: 861, col: 27, offset: 21293},
 								expr: &actionExpr{
-									pos: position{line: 860, col: 28, offset: 21216},
+									pos: position{line: 861, col: 28, offset: 21294},
 									run: (*parser).callonAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 860, col: 28, offset: 21216},
+										pos: position{line: 861, col: 28, offset: 21294},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 860, col: 28, offset: 21216},
+												pos:  position{line: 861, col: 28, offset: 21294},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 860, col: 31, offset: 21219},
+												pos:        position{line: 861, col: 31, offset: 21297},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 860, col: 35, offset: 21223},
+												pos:  position{line: 861, col: 35, offset: 21301},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 860, col: 38, offset: 21226},
+												pos:   position{line: 861, col: 38, offset: 21304},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 860, col: 40, offset: 21228},
+													pos:  position{line: 861, col: 40, offset: 21306},
 													name: "Assignment",
 												},
 											},
@@ -5805,40 +5894,40 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 864, col: 1, offset: 21303},
+			pos:  position{line: 865, col: 1, offset: 21381},
 			expr: &actionExpr{
-				pos: position{line: 865, col: 5, offset: 21318},
+				pos: position{line: 866, col: 5, offset: 21396},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 865, col: 5, offset: 21318},
+					pos: position{line: 866, col: 5, offset: 21396},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 865, col: 5, offset: 21318},
+							pos:   position{line: 866, col: 5, offset: 21396},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 865, col: 9, offset: 21322},
+								pos:  position{line: 866, col: 9, offset: 21400},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 865, col: 14, offset: 21327},
+							pos:  position{line: 866, col: 14, offset: 21405},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 865, col: 17, offset: 21330},
+							pos:        position{line: 866, col: 17, offset: 21408},
 							val:        ":=",
 							ignoreCase: false,
 							want:       "\":=\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 865, col: 22, offset: 21335},
+							pos:  position{line: 866, col: 22, offset: 21413},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 865, col: 25, offset: 21338},
+							pos:   position{line: 866, col: 25, offset: 21416},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 865, col: 29, offset: 21342},
+								pos:  position{line: 866, col: 29, offset: 21420},
 								name: "Expr",
 							},
 						},
@@ -5850,9 +5939,9 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 873, col: 1, offset: 21490},
+			pos:  position{line: 874, col: 1, offset: 21568},
 			expr: &ruleRefExpr{
-				pos:  position{line: 873, col: 8, offset: 21497},
+				pos:  position{line: 874, col: 8, offset: 21575},
 				name: "ConditionalExpr",
 			},
 			leader:        false,
@@ -5860,63 +5949,63 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 875, col: 1, offset: 21514},
+			pos:  position{line: 876, col: 1, offset: 21592},
 			expr: &actionExpr{
-				pos: position{line: 876, col: 5, offset: 21534},
+				pos: position{line: 877, col: 5, offset: 21612},
 				run: (*parser).callonConditionalExpr1,
 				expr: &seqExpr{
-					pos: position{line: 876, col: 5, offset: 21534},
+					pos: position{line: 877, col: 5, offset: 21612},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 876, col: 5, offset: 21534},
+							pos:   position{line: 877, col: 5, offset: 21612},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 876, col: 10, offset: 21539},
+								pos:  position{line: 877, col: 10, offset: 21617},
 								name: "LogicalOrExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 876, col: 24, offset: 21553},
+							pos:   position{line: 877, col: 24, offset: 21631},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 876, col: 28, offset: 21557},
+								pos: position{line: 877, col: 28, offset: 21635},
 								expr: &seqExpr{
-									pos: position{line: 876, col: 29, offset: 21558},
+									pos: position{line: 877, col: 29, offset: 21636},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 876, col: 29, offset: 21558},
+											pos:  position{line: 877, col: 29, offset: 21636},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 876, col: 32, offset: 21561},
+											pos:        position{line: 877, col: 32, offset: 21639},
 											val:        "?",
 											ignoreCase: false,
 											want:       "\"?\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 876, col: 36, offset: 21565},
+											pos:  position{line: 877, col: 36, offset: 21643},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 876, col: 39, offset: 21568},
+											pos:  position{line: 877, col: 39, offset: 21646},
 											name: "Expr",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 876, col: 44, offset: 21573},
+											pos:  position{line: 877, col: 44, offset: 21651},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 876, col: 47, offset: 21576},
+											pos:        position{line: 877, col: 47, offset: 21654},
 											val:        ":",
 											ignoreCase: false,
 											want:       "\":\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 876, col: 51, offset: 21580},
+											pos:  position{line: 877, col: 51, offset: 21658},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 876, col: 54, offset: 21583},
+											pos:  position{line: 877, col: 54, offset: 21661},
 											name: "Expr",
 										},
 									},
@@ -5931,53 +6020,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 889, col: 1, offset: 21879},
+			pos:  position{line: 890, col: 1, offset: 21957},
 			expr: &actionExpr{
-				pos: position{line: 890, col: 5, offset: 21897},
+				pos: position{line: 891, col: 5, offset: 21975},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 890, col: 5, offset: 21897},
+					pos: position{line: 891, col: 5, offset: 21975},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 890, col: 5, offset: 21897},
+							pos:   position{line: 891, col: 5, offset: 21975},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 890, col: 11, offset: 21903},
+								pos:  position{line: 891, col: 11, offset: 21981},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 891, col: 5, offset: 21922},
+							pos:   position{line: 892, col: 5, offset: 22000},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 891, col: 10, offset: 21927},
+								pos: position{line: 892, col: 10, offset: 22005},
 								expr: &actionExpr{
-									pos: position{line: 891, col: 11, offset: 21928},
+									pos: position{line: 892, col: 11, offset: 22006},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 891, col: 11, offset: 21928},
+										pos: position{line: 892, col: 11, offset: 22006},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 891, col: 11, offset: 21928},
+												pos:  position{line: 892, col: 11, offset: 22006},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 891, col: 14, offset: 21931},
+												pos:   position{line: 892, col: 14, offset: 22009},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 891, col: 17, offset: 21934},
+													pos:  position{line: 892, col: 17, offset: 22012},
 													name: "OrToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 891, col: 25, offset: 21942},
+												pos:  position{line: 892, col: 25, offset: 22020},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 891, col: 28, offset: 21945},
+												pos:   position{line: 892, col: 28, offset: 22023},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 891, col: 33, offset: 21950},
+													pos:  position{line: 892, col: 33, offset: 22028},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -5994,53 +6083,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 895, col: 1, offset: 22061},
+			pos:  position{line: 896, col: 1, offset: 22139},
 			expr: &actionExpr{
-				pos: position{line: 896, col: 5, offset: 22080},
+				pos: position{line: 897, col: 5, offset: 22158},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 896, col: 5, offset: 22080},
+					pos: position{line: 897, col: 5, offset: 22158},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 896, col: 5, offset: 22080},
+							pos:   position{line: 897, col: 5, offset: 22158},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 896, col: 11, offset: 22086},
+								pos:  position{line: 897, col: 11, offset: 22164},
 								name: "ComparisonExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 897, col: 5, offset: 22105},
+							pos:   position{line: 898, col: 5, offset: 22183},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 897, col: 10, offset: 22110},
+								pos: position{line: 898, col: 10, offset: 22188},
 								expr: &actionExpr{
-									pos: position{line: 897, col: 11, offset: 22111},
+									pos: position{line: 898, col: 11, offset: 22189},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 897, col: 11, offset: 22111},
+										pos: position{line: 898, col: 11, offset: 22189},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 897, col: 11, offset: 22111},
+												pos:  position{line: 898, col: 11, offset: 22189},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 897, col: 14, offset: 22114},
+												pos:   position{line: 898, col: 14, offset: 22192},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 897, col: 17, offset: 22117},
+													pos:  position{line: 898, col: 17, offset: 22195},
 													name: "AndToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 897, col: 26, offset: 22126},
+												pos:  position{line: 898, col: 26, offset: 22204},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 897, col: 29, offset: 22129},
+												pos:   position{line: 898, col: 29, offset: 22207},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 897, col: 34, offset: 22134},
+													pos:  position{line: 898, col: 34, offset: 22212},
 													name: "ComparisonExpr",
 												},
 											},
@@ -6057,73 +6146,73 @@ var g = &grammar{
 		},
 		{
 			name: "ComparisonExpr",
-			pos:  position{line: 901, col: 1, offset: 22245},
+			pos:  position{line: 902, col: 1, offset: 22323},
 			expr: &actionExpr{
-				pos: position{line: 902, col: 5, offset: 22264},
+				pos: position{line: 903, col: 5, offset: 22342},
 				run: (*parser).callonComparisonExpr1,
 				expr: &seqExpr{
-					pos: position{line: 902, col: 5, offset: 22264},
+					pos: position{line: 903, col: 5, offset: 22342},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 902, col: 5, offset: 22264},
+							pos:   position{line: 903, col: 5, offset: 22342},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 902, col: 9, offset: 22268},
+								pos:  position{line: 903, col: 9, offset: 22346},
 								name: "AdditiveExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 902, col: 22, offset: 22281},
+							pos:   position{line: 903, col: 22, offset: 22359},
 							label: "opAndRHS",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 902, col: 31, offset: 22290},
+								pos: position{line: 903, col: 31, offset: 22368},
 								expr: &choiceExpr{
-									pos: position{line: 902, col: 32, offset: 22291},
+									pos: position{line: 903, col: 32, offset: 22369},
 									alternatives: []any{
 										&seqExpr{
-											pos: position{line: 902, col: 32, offset: 22291},
+											pos: position{line: 903, col: 32, offset: 22369},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 902, col: 32, offset: 22291},
+													pos:  position{line: 903, col: 32, offset: 22369},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 902, col: 35, offset: 22294},
+													pos:  position{line: 903, col: 35, offset: 22372},
 													name: "Comparator",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 902, col: 46, offset: 22305},
+													pos:  position{line: 903, col: 46, offset: 22383},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 902, col: 49, offset: 22308},
+													pos:  position{line: 903, col: 49, offset: 22386},
 													name: "AdditiveExpr",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 902, col: 64, offset: 22323},
+											pos: position{line: 903, col: 64, offset: 22401},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 902, col: 64, offset: 22323},
+													pos:  position{line: 903, col: 64, offset: 22401},
 													name: "__",
 												},
 												&actionExpr{
-													pos: position{line: 902, col: 68, offset: 22327},
+													pos: position{line: 903, col: 68, offset: 22405},
 													run: (*parser).callonComparisonExpr15,
 													expr: &litMatcher{
-														pos:        position{line: 902, col: 68, offset: 22327},
+														pos:        position{line: 903, col: 68, offset: 22405},
 														val:        "~",
 														ignoreCase: false,
 														want:       "\"~\"",
 													},
 												},
 												&ruleRefExpr{
-													pos:  position{line: 902, col: 104, offset: 22363},
+													pos:  position{line: 903, col: 104, offset: 22441},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 902, col: 107, offset: 22366},
+													pos:  position{line: 903, col: 107, offset: 22444},
 													name: "Regexp",
 												},
 											},
@@ -6140,53 +6229,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 914, col: 1, offset: 22630},
+			pos:  position{line: 915, col: 1, offset: 22708},
 			expr: &actionExpr{
-				pos: position{line: 915, col: 5, offset: 22647},
+				pos: position{line: 916, col: 5, offset: 22725},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 915, col: 5, offset: 22647},
+					pos: position{line: 916, col: 5, offset: 22725},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 915, col: 5, offset: 22647},
+							pos:   position{line: 916, col: 5, offset: 22725},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 915, col: 11, offset: 22653},
+								pos:  position{line: 916, col: 11, offset: 22731},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 916, col: 5, offset: 22676},
+							pos:   position{line: 917, col: 5, offset: 22754},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 916, col: 10, offset: 22681},
+								pos: position{line: 917, col: 10, offset: 22759},
 								expr: &actionExpr{
-									pos: position{line: 916, col: 11, offset: 22682},
+									pos: position{line: 917, col: 11, offset: 22760},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 916, col: 11, offset: 22682},
+										pos: position{line: 917, col: 11, offset: 22760},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 916, col: 11, offset: 22682},
+												pos:  position{line: 917, col: 11, offset: 22760},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 916, col: 14, offset: 22685},
+												pos:   position{line: 917, col: 14, offset: 22763},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 916, col: 17, offset: 22688},
+													pos:  position{line: 917, col: 17, offset: 22766},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 916, col: 34, offset: 22705},
+												pos:  position{line: 917, col: 34, offset: 22783},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 916, col: 37, offset: 22708},
+												pos:   position{line: 917, col: 37, offset: 22786},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 916, col: 42, offset: 22713},
+													pos:  position{line: 917, col: 42, offset: 22791},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -6203,21 +6292,21 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 920, col: 1, offset: 22828},
+			pos:  position{line: 921, col: 1, offset: 22906},
 			expr: &actionExpr{
-				pos: position{line: 920, col: 20, offset: 22847},
+				pos: position{line: 921, col: 20, offset: 22925},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 920, col: 21, offset: 22848},
+					pos: position{line: 921, col: 21, offset: 22926},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 920, col: 21, offset: 22848},
+							pos:        position{line: 921, col: 21, offset: 22926},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&litMatcher{
-							pos:        position{line: 920, col: 27, offset: 22854},
+							pos:        position{line: 921, col: 27, offset: 22932},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
@@ -6230,53 +6319,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 922, col: 1, offset: 22891},
+			pos:  position{line: 923, col: 1, offset: 22969},
 			expr: &actionExpr{
-				pos: position{line: 923, col: 5, offset: 22914},
+				pos: position{line: 924, col: 5, offset: 22992},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 923, col: 5, offset: 22914},
+					pos: position{line: 924, col: 5, offset: 22992},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 923, col: 5, offset: 22914},
+							pos:   position{line: 924, col: 5, offset: 22992},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 923, col: 11, offset: 22920},
+								pos:  position{line: 924, col: 11, offset: 22998},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 924, col: 5, offset: 22932},
+							pos:   position{line: 925, col: 5, offset: 23010},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 924, col: 10, offset: 22937},
+								pos: position{line: 925, col: 10, offset: 23015},
 								expr: &actionExpr{
-									pos: position{line: 924, col: 11, offset: 22938},
+									pos: position{line: 925, col: 11, offset: 23016},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 924, col: 11, offset: 22938},
+										pos: position{line: 925, col: 11, offset: 23016},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 924, col: 11, offset: 22938},
+												pos:  position{line: 925, col: 11, offset: 23016},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 924, col: 14, offset: 22941},
+												pos:   position{line: 925, col: 14, offset: 23019},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 924, col: 17, offset: 22944},
+													pos:  position{line: 925, col: 17, offset: 23022},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 924, col: 40, offset: 22967},
+												pos:  position{line: 925, col: 40, offset: 23045},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 924, col: 43, offset: 22970},
+												pos:   position{line: 925, col: 43, offset: 23048},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 924, col: 48, offset: 22975},
+													pos:  position{line: 925, col: 48, offset: 23053},
 													name: "NotExpr",
 												},
 											},
@@ -6293,27 +6382,27 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 928, col: 1, offset: 23079},
+			pos:  position{line: 929, col: 1, offset: 23157},
 			expr: &actionExpr{
-				pos: position{line: 928, col: 26, offset: 23104},
+				pos: position{line: 929, col: 26, offset: 23182},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 928, col: 27, offset: 23105},
+					pos: position{line: 929, col: 27, offset: 23183},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 928, col: 27, offset: 23105},
+							pos:        position{line: 929, col: 27, offset: 23183},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&litMatcher{
-							pos:        position{line: 928, col: 33, offset: 23111},
+							pos:        position{line: 929, col: 33, offset: 23189},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&litMatcher{
-							pos:        position{line: 928, col: 39, offset: 23117},
+							pos:        position{line: 929, col: 39, offset: 23195},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
@@ -6326,43 +6415,43 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 930, col: 1, offset: 23154},
+			pos:  position{line: 931, col: 1, offset: 23232},
 			expr: &choiceExpr{
-				pos: position{line: 931, col: 5, offset: 23166},
+				pos: position{line: 932, col: 5, offset: 23244},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 931, col: 5, offset: 23166},
+						pos: position{line: 932, col: 5, offset: 23244},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 931, col: 5, offset: 23166},
+							pos: position{line: 932, col: 5, offset: 23244},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 931, col: 6, offset: 23167},
+									pos: position{line: 932, col: 6, offset: 23245},
 									alternatives: []any{
 										&seqExpr{
-											pos: position{line: 931, col: 6, offset: 23167},
+											pos: position{line: 932, col: 6, offset: 23245},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 931, col: 6, offset: 23167},
+													pos:  position{line: 932, col: 6, offset: 23245},
 													name: "NotToken",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 931, col: 15, offset: 23176},
+													pos:  position{line: 932, col: 15, offset: 23254},
 													name: "_",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 931, col: 19, offset: 23180},
+											pos: position{line: 932, col: 19, offset: 23258},
 											exprs: []any{
 												&litMatcher{
-													pos:        position{line: 931, col: 19, offset: 23180},
+													pos:        position{line: 932, col: 19, offset: 23258},
 													val:        "!",
 													ignoreCase: false,
 													want:       "\"!\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 931, col: 23, offset: 23184},
+													pos:  position{line: 932, col: 23, offset: 23262},
 													name: "__",
 												},
 											},
@@ -6370,10 +6459,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 931, col: 27, offset: 23188},
+									pos:   position{line: 932, col: 27, offset: 23266},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 931, col: 29, offset: 23190},
+										pos:  position{line: 932, col: 29, offset: 23268},
 										name: "NotExpr",
 									},
 								},
@@ -6381,7 +6470,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 939, col: 5, offset: 23364},
+						pos:  position{line: 940, col: 5, offset: 23442},
 						name: "NegationExpr",
 					},
 				},
@@ -6391,38 +6480,38 @@ var g = &grammar{
 		},
 		{
 			name: "NegationExpr",
-			pos:  position{line: 941, col: 1, offset: 23378},
+			pos:  position{line: 942, col: 1, offset: 23456},
 			expr: &choiceExpr{
-				pos: position{line: 942, col: 5, offset: 23395},
+				pos: position{line: 943, col: 5, offset: 23473},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 942, col: 5, offset: 23395},
+						pos: position{line: 943, col: 5, offset: 23473},
 						run: (*parser).callonNegationExpr2,
 						expr: &seqExpr{
-							pos: position{line: 942, col: 5, offset: 23395},
+							pos: position{line: 943, col: 5, offset: 23473},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 942, col: 5, offset: 23395},
+									pos: position{line: 943, col: 5, offset: 23473},
 									expr: &ruleRefExpr{
-										pos:  position{line: 942, col: 6, offset: 23396},
+										pos:  position{line: 943, col: 6, offset: 23474},
 										name: "Literal",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 942, col: 14, offset: 23404},
+									pos:        position{line: 943, col: 14, offset: 23482},
 									val:        "-",
 									ignoreCase: false,
 									want:       "\"-\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 942, col: 18, offset: 23408},
+									pos:  position{line: 943, col: 18, offset: 23486},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 942, col: 21, offset: 23411},
+									pos:   position{line: 943, col: 21, offset: 23489},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 942, col: 23, offset: 23413},
+										pos:  position{line: 943, col: 23, offset: 23491},
 										name: "DerefExpr",
 									},
 								},
@@ -6430,7 +6519,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 950, col: 5, offset: 23589},
+						pos:  position{line: 951, col: 5, offset: 23667},
 						name: "DerefExpr",
 					},
 				},
@@ -6440,65 +6529,65 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 952, col: 1, offset: 23600},
+			pos:  position{line: 953, col: 1, offset: 23678},
 			expr: &choiceExpr{
-				pos: position{line: 953, col: 5, offset: 23614},
+				pos: position{line: 954, col: 5, offset: 23692},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 953, col: 5, offset: 23614},
+						pos: position{line: 954, col: 5, offset: 23692},
 						run: (*parser).callonDerefExpr2,
 						expr: &seqExpr{
-							pos: position{line: 953, col: 5, offset: 23614},
+							pos: position{line: 954, col: 5, offset: 23692},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 953, col: 5, offset: 23614},
+									pos:   position{line: 954, col: 5, offset: 23692},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 953, col: 10, offset: 23619},
+										pos:  position{line: 954, col: 10, offset: 23697},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 953, col: 20, offset: 23629},
+									pos:        position{line: 954, col: 20, offset: 23707},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 953, col: 24, offset: 23633},
+									pos:   position{line: 954, col: 24, offset: 23711},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 953, col: 29, offset: 23638},
+										pos:  position{line: 954, col: 29, offset: 23716},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 953, col: 42, offset: 23651},
+									pos:  position{line: 954, col: 42, offset: 23729},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 953, col: 45, offset: 23654},
+									pos:        position{line: 954, col: 45, offset: 23732},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 953, col: 49, offset: 23658},
+									pos:  position{line: 954, col: 49, offset: 23736},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 953, col: 52, offset: 23661},
+									pos:   position{line: 954, col: 52, offset: 23739},
 									label: "to",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 953, col: 55, offset: 23664},
+										pos: position{line: 954, col: 55, offset: 23742},
 										expr: &ruleRefExpr{
-											pos:  position{line: 953, col: 55, offset: 23664},
+											pos:  position{line: 954, col: 55, offset: 23742},
 											name: "AdditiveExpr",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 953, col: 69, offset: 23678},
+									pos:        position{line: 954, col: 69, offset: 23756},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6507,49 +6596,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 965, col: 5, offset: 23929},
+						pos: position{line: 966, col: 5, offset: 24007},
 						run: (*parser).callonDerefExpr16,
 						expr: &seqExpr{
-							pos: position{line: 965, col: 5, offset: 23929},
+							pos: position{line: 966, col: 5, offset: 24007},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 965, col: 5, offset: 23929},
+									pos:   position{line: 966, col: 5, offset: 24007},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 965, col: 10, offset: 23934},
+										pos:  position{line: 966, col: 10, offset: 24012},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 965, col: 20, offset: 23944},
+									pos:        position{line: 966, col: 20, offset: 24022},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 965, col: 24, offset: 23948},
+									pos:  position{line: 966, col: 24, offset: 24026},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 965, col: 27, offset: 23951},
+									pos:        position{line: 966, col: 27, offset: 24029},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 965, col: 31, offset: 23955},
+									pos:  position{line: 966, col: 31, offset: 24033},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 965, col: 34, offset: 23958},
+									pos:   position{line: 966, col: 34, offset: 24036},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 965, col: 37, offset: 23961},
+										pos:  position{line: 966, col: 37, offset: 24039},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 965, col: 50, offset: 23974},
+									pos:        position{line: 966, col: 50, offset: 24052},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6558,35 +6647,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 973, col: 5, offset: 24150},
+						pos: position{line: 974, col: 5, offset: 24228},
 						run: (*parser).callonDerefExpr27,
 						expr: &seqExpr{
-							pos: position{line: 973, col: 5, offset: 24150},
+							pos: position{line: 974, col: 5, offset: 24228},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 973, col: 5, offset: 24150},
+									pos:   position{line: 974, col: 5, offset: 24228},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 973, col: 10, offset: 24155},
+										pos:  position{line: 974, col: 10, offset: 24233},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 973, col: 20, offset: 24165},
+									pos:        position{line: 974, col: 20, offset: 24243},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 973, col: 24, offset: 24169},
+									pos:   position{line: 974, col: 24, offset: 24247},
 									label: "index",
 									expr: &ruleRefExpr{
-										pos:  position{line: 973, col: 30, offset: 24175},
+										pos:  position{line: 974, col: 30, offset: 24253},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 973, col: 35, offset: 24180},
+									pos:        position{line: 974, col: 35, offset: 24258},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6595,30 +6684,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 981, col: 5, offset: 24362},
+						pos: position{line: 982, col: 5, offset: 24440},
 						run: (*parser).callonDerefExpr35,
 						expr: &seqExpr{
-							pos: position{line: 981, col: 5, offset: 24362},
+							pos: position{line: 982, col: 5, offset: 24440},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 981, col: 5, offset: 24362},
+									pos:   position{line: 982, col: 5, offset: 24440},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 981, col: 10, offset: 24367},
+										pos:  position{line: 982, col: 10, offset: 24445},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 981, col: 20, offset: 24377},
+									pos:        position{line: 982, col: 20, offset: 24455},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 981, col: 24, offset: 24381},
+									pos:   position{line: 982, col: 24, offset: 24459},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 981, col: 27, offset: 24384},
+										pos:  position{line: 982, col: 27, offset: 24462},
 										name: "Identifier",
 									},
 								},
@@ -6626,25 +6715,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 989, col: 5, offset: 24553},
+						pos: position{line: 990, col: 5, offset: 24631},
 						run: (*parser).callonDerefExpr42,
 						expr: &labeledExpr{
-							pos:   position{line: 989, col: 5, offset: 24553},
+							pos:   position{line: 990, col: 5, offset: 24631},
 							label: "fn",
 							expr: &ruleRefExpr{
-								pos:  position{line: 989, col: 8, offset: 24556},
+								pos:  position{line: 990, col: 8, offset: 24634},
 								name: "FuncExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 992, col: 5, offset: 24598},
+						pos: position{line: 993, col: 5, offset: 24676},
 						run: (*parser).callonDerefExpr45,
 						expr: &labeledExpr{
-							pos:   position{line: 992, col: 5, offset: 24598},
+							pos:   position{line: 993, col: 5, offset: 24676},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 992, col: 10, offset: 24603},
+								pos:  position{line: 993, col: 10, offset: 24681},
 								name: "Primary",
 							},
 						},
@@ -6656,30 +6745,30 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 997, col: 1, offset: 24644},
+			pos:  position{line: 998, col: 1, offset: 24722},
 			expr: &choiceExpr{
-				pos: position{line: 998, col: 5, offset: 24657},
+				pos: position{line: 999, col: 5, offset: 24735},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 998, col: 5, offset: 24657},
+						pos: position{line: 999, col: 5, offset: 24735},
 						run: (*parser).callonFuncExpr2,
 						expr: &labeledExpr{
-							pos:   position{line: 998, col: 5, offset: 24657},
+							pos:   position{line: 999, col: 5, offset: 24735},
 							label: "cast",
 							expr: &ruleRefExpr{
-								pos:  position{line: 998, col: 10, offset: 24662},
+								pos:  position{line: 999, col: 10, offset: 24740},
 								name: "Cast",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1001, col: 5, offset: 24702},
+						pos: position{line: 1002, col: 5, offset: 24780},
 						run: (*parser).callonFuncExpr5,
 						expr: &labeledExpr{
-							pos:   position{line: 1001, col: 5, offset: 24702},
+							pos:   position{line: 1002, col: 5, offset: 24780},
 							label: "fn",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1001, col: 8, offset: 24705},
+								pos:  position{line: 1002, col: 8, offset: 24783},
 								name: "Function",
 							},
 						},
@@ -6691,20 +6780,20 @@ var g = &grammar{
 		},
 		{
 			name: "FuncGuard",
-			pos:  position{line: 1005, col: 1, offset: 24744},
+			pos:  position{line: 1006, col: 1, offset: 24822},
 			expr: &seqExpr{
-				pos: position{line: 1005, col: 13, offset: 24756},
+				pos: position{line: 1006, col: 13, offset: 24834},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1005, col: 13, offset: 24756},
+						pos:  position{line: 1006, col: 13, offset: 24834},
 						name: "NotFuncs",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1005, col: 22, offset: 24765},
+						pos:  position{line: 1006, col: 22, offset: 24843},
 						name: "__",
 					},
 					&litMatcher{
-						pos:        position{line: 1005, col: 25, offset: 24768},
+						pos:        position{line: 1006, col: 25, offset: 24846},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
@@ -6716,18 +6805,18 @@ var g = &grammar{
 		},
 		{
 			name: "NotFuncs",
-			pos:  position{line: 1007, col: 1, offset: 24773},
+			pos:  position{line: 1008, col: 1, offset: 24851},
 			expr: &choiceExpr{
-				pos: position{line: 1008, col: 5, offset: 24786},
+				pos: position{line: 1009, col: 5, offset: 24864},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1008, col: 5, offset: 24786},
+						pos:        position{line: 1009, col: 5, offset: 24864},
 						val:        "not",
 						ignoreCase: false,
 						want:       "\"not\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1009, col: 5, offset: 24796},
+						pos:        position{line: 1010, col: 5, offset: 24874},
 						val:        "select",
 						ignoreCase: false,
 						want:       "\"select\"",
@@ -6739,58 +6828,58 @@ var g = &grammar{
 		},
 		{
 			name: "Cast",
-			pos:  position{line: 1011, col: 1, offset: 24806},
+			pos:  position{line: 1012, col: 1, offset: 24884},
 			expr: &actionExpr{
-				pos: position{line: 1012, col: 5, offset: 24815},
+				pos: position{line: 1013, col: 5, offset: 24893},
 				run: (*parser).callonCast1,
 				expr: &seqExpr{
-					pos: position{line: 1012, col: 5, offset: 24815},
+					pos: position{line: 1013, col: 5, offset: 24893},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1012, col: 5, offset: 24815},
+							pos:   position{line: 1013, col: 5, offset: 24893},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1012, col: 9, offset: 24819},
+								pos:  position{line: 1013, col: 9, offset: 24897},
 								name: "TypeLiteral",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1012, col: 21, offset: 24831},
+							pos:  position{line: 1013, col: 21, offset: 24909},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1012, col: 24, offset: 24834},
+							pos:        position{line: 1013, col: 24, offset: 24912},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1012, col: 28, offset: 24838},
+							pos:  position{line: 1013, col: 28, offset: 24916},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1012, col: 31, offset: 24841},
+							pos:   position{line: 1013, col: 31, offset: 24919},
 							label: "expr",
 							expr: &choiceExpr{
-								pos: position{line: 1012, col: 37, offset: 24847},
+								pos: position{line: 1013, col: 37, offset: 24925},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1012, col: 37, offset: 24847},
+										pos:  position{line: 1013, col: 37, offset: 24925},
 										name: "OverExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1012, col: 48, offset: 24858},
+										pos:  position{line: 1013, col: 48, offset: 24936},
 										name: "Expr",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1012, col: 54, offset: 24864},
+							pos:  position{line: 1013, col: 54, offset: 24942},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1012, col: 57, offset: 24867},
+							pos:        position{line: 1013, col: 57, offset: 24945},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -6803,87 +6892,87 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 1016, col: 1, offset: 24992},
+			pos:  position{line: 1017, col: 1, offset: 25070},
 			expr: &choiceExpr{
-				pos: position{line: 1017, col: 5, offset: 25005},
+				pos: position{line: 1018, col: 5, offset: 25083},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1017, col: 5, offset: 25005},
+						pos:  position{line: 1018, col: 5, offset: 25083},
 						name: "Grep",
 					},
 					&actionExpr{
-						pos: position{line: 1019, col: 5, offset: 25092},
+						pos: position{line: 1020, col: 5, offset: 25170},
 						run: (*parser).callonFunction3,
 						expr: &seqExpr{
-							pos: position{line: 1019, col: 5, offset: 25092},
+							pos: position{line: 1020, col: 5, offset: 25170},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1019, col: 5, offset: 25092},
+									pos:        position{line: 1020, col: 5, offset: 25170},
 									val:        "regexp",
 									ignoreCase: false,
 									want:       "\"regexp\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1019, col: 14, offset: 25101},
+									pos:  position{line: 1020, col: 14, offset: 25179},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1019, col: 17, offset: 25104},
+									pos:        position{line: 1020, col: 17, offset: 25182},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1019, col: 21, offset: 25108},
+									pos:  position{line: 1020, col: 21, offset: 25186},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1019, col: 24, offset: 25111},
+									pos:   position{line: 1020, col: 24, offset: 25189},
 									label: "arg0",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1019, col: 29, offset: 25116},
+										pos:  position{line: 1020, col: 29, offset: 25194},
 										name: "RegexpPrimitive",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1019, col: 45, offset: 25132},
+									pos:  position{line: 1020, col: 45, offset: 25210},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1019, col: 48, offset: 25135},
+									pos:        position{line: 1020, col: 48, offset: 25213},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1019, col: 52, offset: 25139},
+									pos:  position{line: 1020, col: 52, offset: 25217},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1019, col: 55, offset: 25142},
+									pos:   position{line: 1020, col: 55, offset: 25220},
 									label: "arg1",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1019, col: 60, offset: 25147},
+										pos:  position{line: 1020, col: 60, offset: 25225},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1019, col: 65, offset: 25152},
+									pos:  position{line: 1020, col: 65, offset: 25230},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1019, col: 68, offset: 25155},
+									pos:        position{line: 1020, col: 68, offset: 25233},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1019, col: 72, offset: 25159},
+									pos:   position{line: 1020, col: 72, offset: 25237},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1019, col: 78, offset: 25165},
+										pos: position{line: 1020, col: 78, offset: 25243},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1019, col: 78, offset: 25165},
+											pos:  position{line: 1020, col: 78, offset: 25243},
 											name: "WhereClause",
 										},
 									},
@@ -6892,100 +6981,100 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1023, col: 5, offset: 25320},
+						pos: position{line: 1024, col: 5, offset: 25398},
 						run: (*parser).callonFunction21,
 						expr: &seqExpr{
-							pos: position{line: 1023, col: 5, offset: 25320},
+							pos: position{line: 1024, col: 5, offset: 25398},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1023, col: 5, offset: 25320},
+									pos:        position{line: 1024, col: 5, offset: 25398},
 									val:        "regexp_replace",
 									ignoreCase: false,
 									want:       "\"regexp_replace\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1023, col: 22, offset: 25337},
+									pos:  position{line: 1024, col: 22, offset: 25415},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1023, col: 25, offset: 25340},
+									pos:        position{line: 1024, col: 25, offset: 25418},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1023, col: 29, offset: 25344},
+									pos:  position{line: 1024, col: 29, offset: 25422},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1023, col: 32, offset: 25347},
+									pos:   position{line: 1024, col: 32, offset: 25425},
 									label: "arg0",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1023, col: 37, offset: 25352},
+										pos:  position{line: 1024, col: 37, offset: 25430},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1023, col: 42, offset: 25357},
+									pos:  position{line: 1024, col: 42, offset: 25435},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1023, col: 45, offset: 25360},
+									pos:        position{line: 1024, col: 45, offset: 25438},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1023, col: 49, offset: 25364},
+									pos:  position{line: 1024, col: 49, offset: 25442},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1023, col: 52, offset: 25367},
+									pos:   position{line: 1024, col: 52, offset: 25445},
 									label: "arg1",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1023, col: 57, offset: 25372},
+										pos:  position{line: 1024, col: 57, offset: 25450},
 										name: "RegexpPrimitive",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1023, col: 73, offset: 25388},
+									pos:  position{line: 1024, col: 73, offset: 25466},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1023, col: 76, offset: 25391},
+									pos:        position{line: 1024, col: 76, offset: 25469},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1023, col: 80, offset: 25395},
+									pos:  position{line: 1024, col: 80, offset: 25473},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1023, col: 83, offset: 25398},
+									pos:   position{line: 1024, col: 83, offset: 25476},
 									label: "arg2",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1023, col: 88, offset: 25403},
+										pos:  position{line: 1024, col: 88, offset: 25481},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1023, col: 93, offset: 25408},
+									pos:  position{line: 1024, col: 93, offset: 25486},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1023, col: 96, offset: 25411},
+									pos:        position{line: 1024, col: 96, offset: 25489},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1023, col: 100, offset: 25415},
+									pos:   position{line: 1024, col: 100, offset: 25493},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1023, col: 106, offset: 25421},
+										pos: position{line: 1024, col: 106, offset: 25499},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1023, col: 106, offset: 25421},
+											pos:  position{line: 1024, col: 106, offset: 25499},
 											name: "WhereClause",
 										},
 									},
@@ -6994,65 +7083,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1027, col: 5, offset: 25590},
+						pos: position{line: 1028, col: 5, offset: 25668},
 						run: (*parser).callonFunction44,
 						expr: &seqExpr{
-							pos: position{line: 1027, col: 5, offset: 25590},
+							pos: position{line: 1028, col: 5, offset: 25668},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1027, col: 5, offset: 25590},
+									pos: position{line: 1028, col: 5, offset: 25668},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1027, col: 6, offset: 25591},
+										pos:  position{line: 1028, col: 6, offset: 25669},
 										name: "FuncGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1027, col: 16, offset: 25601},
+									pos:   position{line: 1028, col: 16, offset: 25679},
 									label: "fn",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1027, col: 19, offset: 25604},
+										pos:  position{line: 1028, col: 19, offset: 25682},
 										name: "Identifier",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1027, col: 30, offset: 25615},
+									pos:  position{line: 1028, col: 30, offset: 25693},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1027, col: 33, offset: 25618},
+									pos:        position{line: 1028, col: 33, offset: 25696},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1027, col: 37, offset: 25622},
+									pos:  position{line: 1028, col: 37, offset: 25700},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1027, col: 40, offset: 25625},
+									pos:   position{line: 1028, col: 40, offset: 25703},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1027, col: 45, offset: 25630},
+										pos:  position{line: 1028, col: 45, offset: 25708},
 										name: "FunctionArgs",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1027, col: 58, offset: 25643},
+									pos:  position{line: 1028, col: 58, offset: 25721},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1027, col: 61, offset: 25646},
+									pos:        position{line: 1028, col: 61, offset: 25724},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1027, col: 65, offset: 25650},
+									pos:   position{line: 1028, col: 65, offset: 25728},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1027, col: 71, offset: 25656},
+										pos: position{line: 1028, col: 71, offset: 25734},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1027, col: 71, offset: 25656},
+											pos:  position{line: 1028, col: 71, offset: 25734},
 											name: "WhereClause",
 										},
 									},
@@ -7067,15 +7156,15 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPrimitive",
-			pos:  position{line: 1031, col: 1, offset: 25724},
+			pos:  position{line: 1032, col: 1, offset: 25802},
 			expr: &actionExpr{
-				pos: position{line: 1032, col: 5, offset: 25744},
+				pos: position{line: 1033, col: 5, offset: 25822},
 				run: (*parser).callonRegexpPrimitive1,
 				expr: &labeledExpr{
-					pos:   position{line: 1032, col: 5, offset: 25744},
+					pos:   position{line: 1033, col: 5, offset: 25822},
 					label: "pat",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1032, col: 9, offset: 25748},
+						pos:  position{line: 1033, col: 9, offset: 25826},
 						name: "RegexpPattern",
 					},
 				},
@@ -7085,24 +7174,24 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionArgs",
-			pos:  position{line: 1034, col: 1, offset: 25819},
+			pos:  position{line: 1035, col: 1, offset: 25897},
 			expr: &choiceExpr{
-				pos: position{line: 1035, col: 5, offset: 25836},
+				pos: position{line: 1036, col: 5, offset: 25914},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1035, col: 5, offset: 25836},
+						pos: position{line: 1036, col: 5, offset: 25914},
 						run: (*parser).callonFunctionArgs2,
 						expr: &labeledExpr{
-							pos:   position{line: 1035, col: 5, offset: 25836},
+							pos:   position{line: 1036, col: 5, offset: 25914},
 							label: "o",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1035, col: 7, offset: 25838},
+								pos:  position{line: 1036, col: 7, offset: 25916},
 								name: "OverExpr",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1036, col: 5, offset: 25876},
+						pos:  position{line: 1037, col: 5, offset: 25954},
 						name: "OptionalExprs",
 					},
 				},
@@ -7112,98 +7201,98 @@ var g = &grammar{
 		},
 		{
 			name: "Grep",
-			pos:  position{line: 1038, col: 1, offset: 25891},
+			pos:  position{line: 1039, col: 1, offset: 25969},
 			expr: &actionExpr{
-				pos: position{line: 1039, col: 5, offset: 25900},
+				pos: position{line: 1040, col: 5, offset: 25978},
 				run: (*parser).callonGrep1,
 				expr: &seqExpr{
-					pos: position{line: 1039, col: 5, offset: 25900},
+					pos: position{line: 1040, col: 5, offset: 25978},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1039, col: 5, offset: 25900},
+							pos:        position{line: 1040, col: 5, offset: 25978},
 							val:        "grep",
 							ignoreCase: false,
 							want:       "\"grep\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1039, col: 12, offset: 25907},
+							pos:  position{line: 1040, col: 12, offset: 25985},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1039, col: 15, offset: 25910},
+							pos:        position{line: 1040, col: 15, offset: 25988},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1039, col: 19, offset: 25914},
+							pos:  position{line: 1040, col: 19, offset: 25992},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1039, col: 22, offset: 25917},
+							pos:   position{line: 1040, col: 22, offset: 25995},
 							label: "pattern",
 							expr: &choiceExpr{
-								pos: position{line: 1039, col: 31, offset: 25926},
+								pos: position{line: 1040, col: 31, offset: 26004},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1039, col: 31, offset: 25926},
+										pos:  position{line: 1040, col: 31, offset: 26004},
 										name: "Regexp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1039, col: 40, offset: 25935},
+										pos:  position{line: 1040, col: 40, offset: 26013},
 										name: "Glob",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1039, col: 47, offset: 25942},
+										pos:  position{line: 1040, col: 47, offset: 26020},
 										name: "Expr",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1039, col: 53, offset: 25948},
+							pos:  position{line: 1040, col: 53, offset: 26026},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1039, col: 56, offset: 25951},
+							pos:   position{line: 1040, col: 56, offset: 26029},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1039, col: 60, offset: 25955},
+								pos: position{line: 1040, col: 60, offset: 26033},
 								expr: &actionExpr{
-									pos: position{line: 1039, col: 61, offset: 25956},
+									pos: position{line: 1040, col: 61, offset: 26034},
 									run: (*parser).callonGrep15,
 									expr: &seqExpr{
-										pos: position{line: 1039, col: 61, offset: 25956},
+										pos: position{line: 1040, col: 61, offset: 26034},
 										exprs: []any{
 											&litMatcher{
-												pos:        position{line: 1039, col: 61, offset: 25956},
+												pos:        position{line: 1040, col: 61, offset: 26034},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1039, col: 65, offset: 25960},
+												pos:  position{line: 1040, col: 65, offset: 26038},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1039, col: 68, offset: 25963},
+												pos:   position{line: 1040, col: 68, offset: 26041},
 												label: "e",
 												expr: &choiceExpr{
-													pos: position{line: 1039, col: 71, offset: 25966},
+													pos: position{line: 1040, col: 71, offset: 26044},
 													alternatives: []any{
 														&ruleRefExpr{
-															pos:  position{line: 1039, col: 71, offset: 25966},
+															pos:  position{line: 1040, col: 71, offset: 26044},
 															name: "OverExpr",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 1039, col: 82, offset: 25977},
+															pos:  position{line: 1040, col: 82, offset: 26055},
 															name: "Expr",
 														},
 													},
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1039, col: 88, offset: 25983},
+												pos:  position{line: 1040, col: 88, offset: 26061},
 												name: "__",
 											},
 										},
@@ -7212,7 +7301,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1039, col: 111, offset: 26006},
+							pos:        position{line: 1040, col: 111, offset: 26084},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -7225,19 +7314,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptionalExprs",
-			pos:  position{line: 1052, col: 1, offset: 26267},
+			pos:  position{line: 1053, col: 1, offset: 26345},
 			expr: &choiceExpr{
-				pos: position{line: 1053, col: 5, offset: 26285},
+				pos: position{line: 1054, col: 5, offset: 26363},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1053, col: 5, offset: 26285},
+						pos:  position{line: 1054, col: 5, offset: 26363},
 						name: "Exprs",
 					},
 					&actionExpr{
-						pos: position{line: 1054, col: 5, offset: 26295},
+						pos: position{line: 1055, col: 5, offset: 26373},
 						run: (*parser).callonOptionalExprs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1054, col: 5, offset: 26295},
+							pos:  position{line: 1055, col: 5, offset: 26373},
 							name: "__",
 						},
 					},
@@ -7248,51 +7337,51 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 1056, col: 1, offset: 26323},
+			pos:  position{line: 1057, col: 1, offset: 26401},
 			expr: &actionExpr{
-				pos: position{line: 1057, col: 5, offset: 26333},
+				pos: position{line: 1058, col: 5, offset: 26411},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 1057, col: 5, offset: 26333},
+					pos: position{line: 1058, col: 5, offset: 26411},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1057, col: 5, offset: 26333},
+							pos:   position{line: 1058, col: 5, offset: 26411},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1057, col: 11, offset: 26339},
+								pos:  position{line: 1058, col: 11, offset: 26417},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1057, col: 16, offset: 26344},
+							pos:   position{line: 1058, col: 16, offset: 26422},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1057, col: 21, offset: 26349},
+								pos: position{line: 1058, col: 21, offset: 26427},
 								expr: &actionExpr{
-									pos: position{line: 1057, col: 22, offset: 26350},
+									pos: position{line: 1058, col: 22, offset: 26428},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 1057, col: 22, offset: 26350},
+										pos: position{line: 1058, col: 22, offset: 26428},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1057, col: 22, offset: 26350},
+												pos:  position{line: 1058, col: 22, offset: 26428},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1057, col: 25, offset: 26353},
+												pos:        position{line: 1058, col: 25, offset: 26431},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1057, col: 29, offset: 26357},
+												pos:  position{line: 1058, col: 29, offset: 26435},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1057, col: 32, offset: 26360},
+												pos:   position{line: 1058, col: 32, offset: 26438},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1057, col: 34, offset: 26362},
+													pos:  position{line: 1058, col: 34, offset: 26440},
 													name: "Expr",
 												},
 											},
@@ -7309,64 +7398,64 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 1061, col: 1, offset: 26435},
+			pos:  position{line: 1062, col: 1, offset: 26513},
 			expr: &choiceExpr{
-				pos: position{line: 1062, col: 5, offset: 26447},
+				pos: position{line: 1063, col: 5, offset: 26525},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1062, col: 5, offset: 26447},
+						pos:  position{line: 1063, col: 5, offset: 26525},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1063, col: 5, offset: 26458},
+						pos:  position{line: 1064, col: 5, offset: 26536},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1064, col: 5, offset: 26468},
+						pos:  position{line: 1065, col: 5, offset: 26546},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1065, col: 5, offset: 26476},
+						pos:  position{line: 1066, col: 5, offset: 26554},
 						name: "Map",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1066, col: 5, offset: 26484},
+						pos:  position{line: 1067, col: 5, offset: 26562},
 						name: "Literal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1067, col: 5, offset: 26496},
+						pos:  position{line: 1068, col: 5, offset: 26574},
 						name: "Identifier",
 					},
 					&actionExpr{
-						pos: position{line: 1068, col: 5, offset: 26511},
+						pos: position{line: 1069, col: 5, offset: 26589},
 						run: (*parser).callonPrimary8,
 						expr: &seqExpr{
-							pos: position{line: 1068, col: 5, offset: 26511},
+							pos: position{line: 1069, col: 5, offset: 26589},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1068, col: 5, offset: 26511},
+									pos:        position{line: 1069, col: 5, offset: 26589},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1068, col: 9, offset: 26515},
+									pos:  position{line: 1069, col: 9, offset: 26593},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1068, col: 12, offset: 26518},
+									pos:   position{line: 1069, col: 12, offset: 26596},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1068, col: 17, offset: 26523},
+										pos:  position{line: 1069, col: 17, offset: 26601},
 										name: "OverExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1068, col: 26, offset: 26532},
+									pos:  position{line: 1069, col: 26, offset: 26610},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1068, col: 29, offset: 26535},
+									pos:        position{line: 1069, col: 29, offset: 26613},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7375,35 +7464,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1069, col: 5, offset: 26564},
+						pos: position{line: 1070, col: 5, offset: 26642},
 						run: (*parser).callonPrimary16,
 						expr: &seqExpr{
-							pos: position{line: 1069, col: 5, offset: 26564},
+							pos: position{line: 1070, col: 5, offset: 26642},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1069, col: 5, offset: 26564},
+									pos:        position{line: 1070, col: 5, offset: 26642},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1069, col: 9, offset: 26568},
+									pos:  position{line: 1070, col: 9, offset: 26646},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1069, col: 12, offset: 26571},
+									pos:   position{line: 1070, col: 12, offset: 26649},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1069, col: 17, offset: 26576},
+										pos:  position{line: 1070, col: 17, offset: 26654},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1069, col: 22, offset: 26581},
+									pos:  position{line: 1070, col: 22, offset: 26659},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1069, col: 25, offset: 26584},
+									pos:        position{line: 1070, col: 25, offset: 26662},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7418,61 +7507,61 @@ var g = &grammar{
 		},
 		{
 			name: "OverExpr",
-			pos:  position{line: 1071, col: 1, offset: 26610},
+			pos:  position{line: 1072, col: 1, offset: 26688},
 			expr: &actionExpr{
-				pos: position{line: 1072, col: 5, offset: 26623},
+				pos: position{line: 1073, col: 5, offset: 26701},
 				run: (*parser).callonOverExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1072, col: 5, offset: 26623},
+					pos: position{line: 1073, col: 5, offset: 26701},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1072, col: 5, offset: 26623},
+							pos:        position{line: 1073, col: 5, offset: 26701},
 							val:        "over",
 							ignoreCase: false,
 							want:       "\"over\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1072, col: 12, offset: 26630},
+							pos:  position{line: 1073, col: 12, offset: 26708},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1072, col: 14, offset: 26632},
+							pos:   position{line: 1073, col: 14, offset: 26710},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1072, col: 20, offset: 26638},
+								pos:  position{line: 1073, col: 20, offset: 26716},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1072, col: 26, offset: 26644},
+							pos:   position{line: 1073, col: 26, offset: 26722},
 							label: "locals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1072, col: 33, offset: 26651},
+								pos: position{line: 1073, col: 33, offset: 26729},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1072, col: 33, offset: 26651},
+									pos:  position{line: 1073, col: 33, offset: 26729},
 									name: "Locals",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1072, col: 41, offset: 26659},
+							pos:  position{line: 1073, col: 41, offset: 26737},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1072, col: 44, offset: 26662},
+							pos:        position{line: 1073, col: 44, offset: 26740},
 							val:        "|",
 							ignoreCase: false,
 							want:       "\"|\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1072, col: 48, offset: 26666},
+							pos:  position{line: 1073, col: 48, offset: 26744},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1072, col: 51, offset: 26669},
+							pos:   position{line: 1073, col: 51, offset: 26747},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1072, col: 56, offset: 26674},
+								pos:  position{line: 1073, col: 56, offset: 26752},
 								name: "Seq",
 							},
 						},
@@ -7484,37 +7573,37 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 1082, col: 1, offset: 26918},
+			pos:  position{line: 1083, col: 1, offset: 26996},
 			expr: &actionExpr{
-				pos: position{line: 1083, col: 5, offset: 26929},
+				pos: position{line: 1084, col: 5, offset: 27007},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 1083, col: 5, offset: 26929},
+					pos: position{line: 1084, col: 5, offset: 27007},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1083, col: 5, offset: 26929},
+							pos:        position{line: 1084, col: 5, offset: 27007},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1083, col: 9, offset: 26933},
+							pos:  position{line: 1084, col: 9, offset: 27011},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1083, col: 12, offset: 26936},
+							pos:   position{line: 1084, col: 12, offset: 27014},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1083, col: 18, offset: 26942},
+								pos:  position{line: 1084, col: 18, offset: 27020},
 								name: "RecordElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1083, col: 30, offset: 26954},
+							pos:  position{line: 1084, col: 30, offset: 27032},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1083, col: 33, offset: 26957},
+							pos:        position{line: 1084, col: 33, offset: 27035},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -7527,31 +7616,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElems",
-			pos:  position{line: 1092, col: 1, offset: 27159},
+			pos:  position{line: 1093, col: 1, offset: 27237},
 			expr: &choiceExpr{
-				pos: position{line: 1093, col: 5, offset: 27175},
+				pos: position{line: 1094, col: 5, offset: 27253},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1093, col: 5, offset: 27175},
+						pos: position{line: 1094, col: 5, offset: 27253},
 						run: (*parser).callonRecordElems2,
 						expr: &seqExpr{
-							pos: position{line: 1093, col: 5, offset: 27175},
+							pos: position{line: 1094, col: 5, offset: 27253},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1093, col: 5, offset: 27175},
+									pos:   position{line: 1094, col: 5, offset: 27253},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1093, col: 11, offset: 27181},
+										pos:  position{line: 1094, col: 11, offset: 27259},
 										name: "RecordElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1093, col: 22, offset: 27192},
+									pos:   position{line: 1094, col: 22, offset: 27270},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1093, col: 27, offset: 27197},
+										pos: position{line: 1094, col: 27, offset: 27275},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1093, col: 27, offset: 27197},
+											pos:  position{line: 1094, col: 27, offset: 27275},
 											name: "RecordElemTail",
 										},
 									},
@@ -7560,10 +7649,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1096, col: 5, offset: 27260},
+						pos: position{line: 1097, col: 5, offset: 27338},
 						run: (*parser).callonRecordElems9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1096, col: 5, offset: 27260},
+							pos:  position{line: 1097, col: 5, offset: 27338},
 							name: "__",
 						},
 					},
@@ -7574,32 +7663,32 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElemTail",
-			pos:  position{line: 1098, col: 1, offset: 27284},
+			pos:  position{line: 1099, col: 1, offset: 27362},
 			expr: &actionExpr{
-				pos: position{line: 1098, col: 18, offset: 27301},
+				pos: position{line: 1099, col: 18, offset: 27379},
 				run: (*parser).callonRecordElemTail1,
 				expr: &seqExpr{
-					pos: position{line: 1098, col: 18, offset: 27301},
+					pos: position{line: 1099, col: 18, offset: 27379},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1098, col: 18, offset: 27301},
+							pos:  position{line: 1099, col: 18, offset: 27379},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1098, col: 21, offset: 27304},
+							pos:        position{line: 1099, col: 21, offset: 27382},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1098, col: 25, offset: 27308},
+							pos:  position{line: 1099, col: 25, offset: 27386},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1098, col: 28, offset: 27311},
+							pos:   position{line: 1099, col: 28, offset: 27389},
 							label: "elem",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1098, col: 33, offset: 27316},
+								pos:  position{line: 1099, col: 33, offset: 27394},
 								name: "RecordElem",
 							},
 						},
@@ -7611,20 +7700,20 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElem",
-			pos:  position{line: 1100, col: 1, offset: 27349},
+			pos:  position{line: 1101, col: 1, offset: 27427},
 			expr: &choiceExpr{
-				pos: position{line: 1101, col: 5, offset: 27364},
+				pos: position{line: 1102, col: 5, offset: 27442},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1101, col: 5, offset: 27364},
+						pos:  position{line: 1102, col: 5, offset: 27442},
 						name: "Spread",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1102, col: 5, offset: 27375},
+						pos:  position{line: 1103, col: 5, offset: 27453},
 						name: "Field",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1103, col: 5, offset: 27385},
+						pos:  position{line: 1104, col: 5, offset: 27463},
 						name: "Identifier",
 					},
 				},
@@ -7634,28 +7723,28 @@ var g = &grammar{
 		},
 		{
 			name: "Spread",
-			pos:  position{line: 1105, col: 1, offset: 27397},
+			pos:  position{line: 1106, col: 1, offset: 27475},
 			expr: &actionExpr{
-				pos: position{line: 1106, col: 5, offset: 27408},
+				pos: position{line: 1107, col: 5, offset: 27486},
 				run: (*parser).callonSpread1,
 				expr: &seqExpr{
-					pos: position{line: 1106, col: 5, offset: 27408},
+					pos: position{line: 1107, col: 5, offset: 27486},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1106, col: 5, offset: 27408},
+							pos:        position{line: 1107, col: 5, offset: 27486},
 							val:        "...",
 							ignoreCase: false,
 							want:       "\"...\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1106, col: 11, offset: 27414},
+							pos:  position{line: 1107, col: 11, offset: 27492},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1106, col: 14, offset: 27417},
+							pos:   position{line: 1107, col: 14, offset: 27495},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1106, col: 19, offset: 27422},
+								pos:  position{line: 1107, col: 19, offset: 27500},
 								name: "Expr",
 							},
 						},
@@ -7667,40 +7756,40 @@ var g = &grammar{
 		},
 		{
 			name: "Field",
-			pos:  position{line: 1110, col: 1, offset: 27529},
+			pos:  position{line: 1111, col: 1, offset: 27607},
 			expr: &actionExpr{
-				pos: position{line: 1111, col: 5, offset: 27539},
+				pos: position{line: 1112, col: 5, offset: 27617},
 				run: (*parser).callonField1,
 				expr: &seqExpr{
-					pos: position{line: 1111, col: 5, offset: 27539},
+					pos: position{line: 1112, col: 5, offset: 27617},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1111, col: 5, offset: 27539},
+							pos:   position{line: 1112, col: 5, offset: 27617},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1111, col: 10, offset: 27544},
+								pos:  position{line: 1112, col: 10, offset: 27622},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1111, col: 20, offset: 27554},
+							pos:  position{line: 1112, col: 20, offset: 27632},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1111, col: 23, offset: 27557},
+							pos:        position{line: 1112, col: 23, offset: 27635},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1111, col: 27, offset: 27561},
+							pos:  position{line: 1112, col: 27, offset: 27639},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1111, col: 30, offset: 27564},
+							pos:   position{line: 1112, col: 30, offset: 27642},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1111, col: 36, offset: 27570},
+								pos:  position{line: 1112, col: 36, offset: 27648},
 								name: "Expr",
 							},
 						},
@@ -7712,37 +7801,37 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 1120, col: 1, offset: 27738},
+			pos:  position{line: 1121, col: 1, offset: 27816},
 			expr: &actionExpr{
-				pos: position{line: 1121, col: 5, offset: 27748},
+				pos: position{line: 1122, col: 5, offset: 27826},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 1121, col: 5, offset: 27748},
+					pos: position{line: 1122, col: 5, offset: 27826},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1121, col: 5, offset: 27748},
+							pos:        position{line: 1122, col: 5, offset: 27826},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1121, col: 9, offset: 27752},
+							pos:  position{line: 1122, col: 9, offset: 27830},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1121, col: 12, offset: 27755},
+							pos:   position{line: 1122, col: 12, offset: 27833},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1121, col: 18, offset: 27761},
+								pos:  position{line: 1122, col: 18, offset: 27839},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1121, col: 30, offset: 27773},
+							pos:  position{line: 1122, col: 30, offset: 27851},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1121, col: 33, offset: 27776},
+							pos:        position{line: 1122, col: 33, offset: 27854},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -7755,37 +7844,37 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 1130, col: 1, offset: 27976},
+			pos:  position{line: 1131, col: 1, offset: 28054},
 			expr: &actionExpr{
-				pos: position{line: 1131, col: 5, offset: 27984},
+				pos: position{line: 1132, col: 5, offset: 28062},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 1131, col: 5, offset: 27984},
+					pos: position{line: 1132, col: 5, offset: 28062},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1131, col: 5, offset: 27984},
+							pos:        position{line: 1132, col: 5, offset: 28062},
 							val:        "|[",
 							ignoreCase: false,
 							want:       "\"|[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1131, col: 10, offset: 27989},
+							pos:  position{line: 1132, col: 10, offset: 28067},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1131, col: 13, offset: 27992},
+							pos:   position{line: 1132, col: 13, offset: 28070},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1131, col: 19, offset: 27998},
+								pos:  position{line: 1132, col: 19, offset: 28076},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1131, col: 31, offset: 28010},
+							pos:  position{line: 1132, col: 31, offset: 28088},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1131, col: 34, offset: 28013},
+							pos:        position{line: 1132, col: 34, offset: 28091},
 							val:        "]|",
 							ignoreCase: false,
 							want:       "\"]|\"",
@@ -7798,54 +7887,54 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElems",
-			pos:  position{line: 1140, col: 1, offset: 28208},
+			pos:  position{line: 1141, col: 1, offset: 28286},
 			expr: &choiceExpr{
-				pos: position{line: 1141, col: 5, offset: 28224},
+				pos: position{line: 1142, col: 5, offset: 28302},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1141, col: 5, offset: 28224},
+						pos: position{line: 1142, col: 5, offset: 28302},
 						run: (*parser).callonVectorElems2,
 						expr: &seqExpr{
-							pos: position{line: 1141, col: 5, offset: 28224},
+							pos: position{line: 1142, col: 5, offset: 28302},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1141, col: 5, offset: 28224},
+									pos:   position{line: 1142, col: 5, offset: 28302},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1141, col: 11, offset: 28230},
+										pos:  position{line: 1142, col: 11, offset: 28308},
 										name: "VectorElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1141, col: 22, offset: 28241},
+									pos:   position{line: 1142, col: 22, offset: 28319},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1141, col: 27, offset: 28246},
+										pos: position{line: 1142, col: 27, offset: 28324},
 										expr: &actionExpr{
-											pos: position{line: 1141, col: 28, offset: 28247},
+											pos: position{line: 1142, col: 28, offset: 28325},
 											run: (*parser).callonVectorElems8,
 											expr: &seqExpr{
-												pos: position{line: 1141, col: 28, offset: 28247},
+												pos: position{line: 1142, col: 28, offset: 28325},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1141, col: 28, offset: 28247},
+														pos:  position{line: 1142, col: 28, offset: 28325},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 1141, col: 31, offset: 28250},
+														pos:        position{line: 1142, col: 31, offset: 28328},
 														val:        ",",
 														ignoreCase: false,
 														want:       "\",\"",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1141, col: 35, offset: 28254},
+														pos:  position{line: 1142, col: 35, offset: 28332},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 1141, col: 38, offset: 28257},
+														pos:   position{line: 1142, col: 38, offset: 28335},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1141, col: 40, offset: 28259},
+															pos:  position{line: 1142, col: 40, offset: 28337},
 															name: "VectorElem",
 														},
 													},
@@ -7858,10 +7947,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1144, col: 5, offset: 28341},
+						pos: position{line: 1145, col: 5, offset: 28419},
 						run: (*parser).callonVectorElems15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1144, col: 5, offset: 28341},
+							pos:  position{line: 1145, col: 5, offset: 28419},
 							name: "__",
 						},
 					},
@@ -7872,22 +7961,22 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElem",
-			pos:  position{line: 1146, col: 1, offset: 28365},
+			pos:  position{line: 1147, col: 1, offset: 28443},
 			expr: &choiceExpr{
-				pos: position{line: 1147, col: 5, offset: 28380},
+				pos: position{line: 1148, col: 5, offset: 28458},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1147, col: 5, offset: 28380},
+						pos:  position{line: 1148, col: 5, offset: 28458},
 						name: "Spread",
 					},
 					&actionExpr{
-						pos: position{line: 1148, col: 5, offset: 28391},
+						pos: position{line: 1149, col: 5, offset: 28469},
 						run: (*parser).callonVectorElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1148, col: 5, offset: 28391},
+							pos:   position{line: 1149, col: 5, offset: 28469},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1148, col: 7, offset: 28393},
+								pos:  position{line: 1149, col: 7, offset: 28471},
 								name: "Expr",
 							},
 						},
@@ -7899,37 +7988,37 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 1150, col: 1, offset: 28473},
+			pos:  position{line: 1151, col: 1, offset: 28551},
 			expr: &actionExpr{
-				pos: position{line: 1151, col: 5, offset: 28481},
+				pos: position{line: 1152, col: 5, offset: 28559},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 1151, col: 5, offset: 28481},
+					pos: position{line: 1152, col: 5, offset: 28559},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1151, col: 5, offset: 28481},
+							pos:        position{line: 1152, col: 5, offset: 28559},
 							val:        "|{",
 							ignoreCase: false,
 							want:       "\"|{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1151, col: 10, offset: 28486},
+							pos:  position{line: 1152, col: 10, offset: 28564},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1151, col: 13, offset: 28489},
+							pos:   position{line: 1152, col: 13, offset: 28567},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1151, col: 19, offset: 28495},
+								pos:  position{line: 1152, col: 19, offset: 28573},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1151, col: 27, offset: 28503},
+							pos:  position{line: 1152, col: 27, offset: 28581},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1151, col: 30, offset: 28506},
+							pos:        position{line: 1152, col: 30, offset: 28584},
 							val:        "}|",
 							ignoreCase: false,
 							want:       "\"}|\"",
@@ -7942,31 +8031,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 1160, col: 1, offset: 28702},
+			pos:  position{line: 1161, col: 1, offset: 28780},
 			expr: &choiceExpr{
-				pos: position{line: 1161, col: 5, offset: 28714},
+				pos: position{line: 1162, col: 5, offset: 28792},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1161, col: 5, offset: 28714},
+						pos: position{line: 1162, col: 5, offset: 28792},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 1161, col: 5, offset: 28714},
+							pos: position{line: 1162, col: 5, offset: 28792},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1161, col: 5, offset: 28714},
+									pos:   position{line: 1162, col: 5, offset: 28792},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1161, col: 11, offset: 28720},
+										pos:  position{line: 1162, col: 11, offset: 28798},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1161, col: 17, offset: 28726},
+									pos:   position{line: 1162, col: 17, offset: 28804},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1161, col: 22, offset: 28731},
+										pos: position{line: 1162, col: 22, offset: 28809},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1161, col: 22, offset: 28731},
+											pos:  position{line: 1162, col: 22, offset: 28809},
 											name: "EntryTail",
 										},
 									},
@@ -7975,10 +8064,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1164, col: 5, offset: 28789},
+						pos: position{line: 1165, col: 5, offset: 28867},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1164, col: 5, offset: 28789},
+							pos:  position{line: 1165, col: 5, offset: 28867},
 							name: "__",
 						},
 					},
@@ -7989,32 +8078,32 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 1167, col: 1, offset: 28814},
+			pos:  position{line: 1168, col: 1, offset: 28892},
 			expr: &actionExpr{
-				pos: position{line: 1167, col: 13, offset: 28826},
+				pos: position{line: 1168, col: 13, offset: 28904},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 1167, col: 13, offset: 28826},
+					pos: position{line: 1168, col: 13, offset: 28904},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1167, col: 13, offset: 28826},
+							pos:  position{line: 1168, col: 13, offset: 28904},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1167, col: 16, offset: 28829},
+							pos:        position{line: 1168, col: 16, offset: 28907},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1167, col: 20, offset: 28833},
+							pos:  position{line: 1168, col: 20, offset: 28911},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1167, col: 23, offset: 28836},
+							pos:   position{line: 1168, col: 23, offset: 28914},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1167, col: 25, offset: 28838},
+								pos:  position{line: 1168, col: 25, offset: 28916},
 								name: "Entry",
 							},
 						},
@@ -8026,40 +8115,40 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 1169, col: 1, offset: 28863},
+			pos:  position{line: 1170, col: 1, offset: 28941},
 			expr: &actionExpr{
-				pos: position{line: 1170, col: 5, offset: 28873},
+				pos: position{line: 1171, col: 5, offset: 28951},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 1170, col: 5, offset: 28873},
+					pos: position{line: 1171, col: 5, offset: 28951},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1170, col: 5, offset: 28873},
+							pos:   position{line: 1171, col: 5, offset: 28951},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1170, col: 9, offset: 28877},
+								pos:  position{line: 1171, col: 9, offset: 28955},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1170, col: 14, offset: 28882},
+							pos:  position{line: 1171, col: 14, offset: 28960},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1170, col: 17, offset: 28885},
+							pos:        position{line: 1171, col: 17, offset: 28963},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1170, col: 21, offset: 28889},
+							pos:  position{line: 1171, col: 21, offset: 28967},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1170, col: 24, offset: 28892},
+							pos:   position{line: 1171, col: 24, offset: 28970},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1170, col: 30, offset: 28898},
+								pos:  position{line: 1171, col: 30, offset: 28976},
 								name: "Expr",
 							},
 						},
@@ -8071,56 +8160,56 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 1176, col: 1, offset: 29012},
+			pos:  position{line: 1177, col: 1, offset: 29090},
 			expr: &choiceExpr{
-				pos: position{line: 1177, col: 5, offset: 29024},
+				pos: position{line: 1178, col: 5, offset: 29102},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1177, col: 5, offset: 29024},
+						pos:  position{line: 1178, col: 5, offset: 29102},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1178, col: 5, offset: 29040},
+						pos:  position{line: 1179, col: 5, offset: 29118},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1179, col: 5, offset: 29058},
+						pos:  position{line: 1180, col: 5, offset: 29136},
 						name: "FString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1180, col: 5, offset: 29070},
+						pos:  position{line: 1181, col: 5, offset: 29148},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1181, col: 5, offset: 29088},
+						pos:  position{line: 1182, col: 5, offset: 29166},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1182, col: 5, offset: 29107},
+						pos:  position{line: 1183, col: 5, offset: 29185},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1183, col: 5, offset: 29124},
+						pos:  position{line: 1184, col: 5, offset: 29202},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1184, col: 5, offset: 29137},
+						pos:  position{line: 1185, col: 5, offset: 29215},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1185, col: 5, offset: 29146},
+						pos:  position{line: 1186, col: 5, offset: 29224},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1186, col: 5, offset: 29163},
+						pos:  position{line: 1187, col: 5, offset: 29241},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1187, col: 5, offset: 29182},
+						pos:  position{line: 1188, col: 5, offset: 29260},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1188, col: 5, offset: 29201},
+						pos:  position{line: 1189, col: 5, offset: 29279},
 						name: "NullLiteral",
 					},
 				},
@@ -8130,28 +8219,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 1190, col: 1, offset: 29214},
+			pos:  position{line: 1191, col: 1, offset: 29292},
 			expr: &choiceExpr{
-				pos: position{line: 1191, col: 5, offset: 29232},
+				pos: position{line: 1192, col: 5, offset: 29310},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1191, col: 5, offset: 29232},
+						pos: position{line: 1192, col: 5, offset: 29310},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1191, col: 5, offset: 29232},
+							pos: position{line: 1192, col: 5, offset: 29310},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1191, col: 5, offset: 29232},
+									pos:   position{line: 1192, col: 5, offset: 29310},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1191, col: 7, offset: 29234},
+										pos:  position{line: 1192, col: 7, offset: 29312},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1191, col: 14, offset: 29241},
+									pos: position{line: 1192, col: 14, offset: 29319},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1191, col: 15, offset: 29242},
+										pos:  position{line: 1192, col: 15, offset: 29320},
 										name: "IdentifierRest",
 									},
 								},
@@ -8159,13 +8248,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1194, col: 5, offset: 29322},
+						pos: position{line: 1195, col: 5, offset: 29400},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1194, col: 5, offset: 29322},
+							pos:   position{line: 1195, col: 5, offset: 29400},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1194, col: 7, offset: 29324},
+								pos:  position{line: 1195, col: 7, offset: 29402},
 								name: "IP4Net",
 							},
 						},
@@ -8177,28 +8266,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 1198, col: 1, offset: 29393},
+			pos:  position{line: 1199, col: 1, offset: 29471},
 			expr: &choiceExpr{
-				pos: position{line: 1199, col: 5, offset: 29412},
+				pos: position{line: 1200, col: 5, offset: 29490},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1199, col: 5, offset: 29412},
+						pos: position{line: 1200, col: 5, offset: 29490},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1199, col: 5, offset: 29412},
+							pos: position{line: 1200, col: 5, offset: 29490},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1199, col: 5, offset: 29412},
+									pos:   position{line: 1200, col: 5, offset: 29490},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1199, col: 7, offset: 29414},
+										pos:  position{line: 1200, col: 7, offset: 29492},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1199, col: 11, offset: 29418},
+									pos: position{line: 1200, col: 11, offset: 29496},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1199, col: 12, offset: 29419},
+										pos:  position{line: 1200, col: 12, offset: 29497},
 										name: "IdentifierRest",
 									},
 								},
@@ -8206,13 +8295,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1202, col: 5, offset: 29498},
+						pos: position{line: 1203, col: 5, offset: 29576},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1202, col: 5, offset: 29498},
+							pos:   position{line: 1203, col: 5, offset: 29576},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1202, col: 7, offset: 29500},
+								pos:  position{line: 1203, col: 7, offset: 29578},
 								name: "IP",
 							},
 						},
@@ -8224,15 +8313,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 1206, col: 1, offset: 29564},
+			pos:  position{line: 1207, col: 1, offset: 29642},
 			expr: &actionExpr{
-				pos: position{line: 1207, col: 5, offset: 29581},
+				pos: position{line: 1208, col: 5, offset: 29659},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1207, col: 5, offset: 29581},
+					pos:   position{line: 1208, col: 5, offset: 29659},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1207, col: 7, offset: 29583},
+						pos:  position{line: 1208, col: 7, offset: 29661},
 						name: "FloatString",
 					},
 				},
@@ -8242,15 +8331,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 1211, col: 1, offset: 29661},
+			pos:  position{line: 1212, col: 1, offset: 29739},
 			expr: &actionExpr{
-				pos: position{line: 1212, col: 5, offset: 29680},
+				pos: position{line: 1213, col: 5, offset: 29758},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1212, col: 5, offset: 29680},
+					pos:   position{line: 1213, col: 5, offset: 29758},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1212, col: 7, offset: 29682},
+						pos:  position{line: 1213, col: 7, offset: 29760},
 						name: "IntString",
 					},
 				},
@@ -8260,23 +8349,23 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 1216, col: 1, offset: 29756},
+			pos:  position{line: 1217, col: 1, offset: 29834},
 			expr: &choiceExpr{
-				pos: position{line: 1217, col: 5, offset: 29775},
+				pos: position{line: 1218, col: 5, offset: 29853},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1217, col: 5, offset: 29775},
+						pos: position{line: 1218, col: 5, offset: 29853},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1217, col: 5, offset: 29775},
+							pos:  position{line: 1218, col: 5, offset: 29853},
 							name: "TrueToken",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1218, col: 5, offset: 29838},
+						pos: position{line: 1219, col: 5, offset: 29916},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1218, col: 5, offset: 29838},
+							pos:  position{line: 1219, col: 5, offset: 29916},
 							name: "FalseToken",
 						},
 					},
@@ -8287,12 +8376,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 1220, col: 1, offset: 29899},
+			pos:  position{line: 1221, col: 1, offset: 29977},
 			expr: &actionExpr{
-				pos: position{line: 1221, col: 5, offset: 29915},
+				pos: position{line: 1222, col: 5, offset: 29993},
 				run: (*parser).callonNullLiteral1,
 				expr: &ruleRefExpr{
-					pos:  position{line: 1221, col: 5, offset: 29915},
+					pos:  position{line: 1222, col: 5, offset: 29993},
 					name: "NullToken",
 				},
 			},
@@ -8301,23 +8390,23 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 1223, col: 1, offset: 29970},
+			pos:  position{line: 1224, col: 1, offset: 30048},
 			expr: &actionExpr{
-				pos: position{line: 1224, col: 5, offset: 29987},
+				pos: position{line: 1225, col: 5, offset: 30065},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1224, col: 5, offset: 29987},
+					pos: position{line: 1225, col: 5, offset: 30065},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1224, col: 5, offset: 29987},
+							pos:        position{line: 1225, col: 5, offset: 30065},
 							val:        "0x",
 							ignoreCase: false,
 							want:       "\"0x\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1224, col: 10, offset: 29992},
+							pos: position{line: 1225, col: 10, offset: 30070},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1224, col: 10, offset: 29992},
+								pos:  position{line: 1225, col: 10, offset: 30070},
 								name: "HexDigit",
 							},
 						},
@@ -8329,29 +8418,29 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 1228, col: 1, offset: 30066},
+			pos:  position{line: 1229, col: 1, offset: 30144},
 			expr: &actionExpr{
-				pos: position{line: 1229, col: 5, offset: 30082},
+				pos: position{line: 1230, col: 5, offset: 30160},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1229, col: 5, offset: 30082},
+					pos: position{line: 1230, col: 5, offset: 30160},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1229, col: 5, offset: 30082},
+							pos:        position{line: 1230, col: 5, offset: 30160},
 							val:        "<",
 							ignoreCase: false,
 							want:       "\"<\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1229, col: 9, offset: 30086},
+							pos:   position{line: 1230, col: 9, offset: 30164},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1229, col: 13, offset: 30090},
+								pos:  position{line: 1230, col: 13, offset: 30168},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1229, col: 18, offset: 30095},
+							pos:        position{line: 1230, col: 18, offset: 30173},
 							val:        ">",
 							ignoreCase: false,
 							want:       "\">\"",
@@ -8364,16 +8453,16 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1238, col: 1, offset: 30276},
+			pos:  position{line: 1239, col: 1, offset: 30354},
 			expr: &choiceExpr{
-				pos: position{line: 1239, col: 5, offset: 30285},
+				pos: position{line: 1240, col: 5, offset: 30363},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1239, col: 5, offset: 30285},
+						pos:  position{line: 1240, col: 5, offset: 30363},
 						name: "AmbiguousType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1240, col: 5, offset: 30303},
+						pos:  position{line: 1241, col: 5, offset: 30381},
 						name: "ComplexType",
 					},
 				},
@@ -8383,28 +8472,28 @@ var g = &grammar{
 		},
 		{
 			name: "AmbiguousType",
-			pos:  position{line: 1242, col: 1, offset: 30316},
+			pos:  position{line: 1243, col: 1, offset: 30394},
 			expr: &choiceExpr{
-				pos: position{line: 1243, col: 5, offset: 30334},
+				pos: position{line: 1244, col: 5, offset: 30412},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1243, col: 5, offset: 30334},
+						pos: position{line: 1244, col: 5, offset: 30412},
 						run: (*parser).callonAmbiguousType2,
 						expr: &seqExpr{
-							pos: position{line: 1243, col: 5, offset: 30334},
+							pos: position{line: 1244, col: 5, offset: 30412},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1243, col: 5, offset: 30334},
+									pos:   position{line: 1244, col: 5, offset: 30412},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1243, col: 10, offset: 30339},
+										pos:  position{line: 1244, col: 10, offset: 30417},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1243, col: 24, offset: 30353},
+									pos: position{line: 1244, col: 24, offset: 30431},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1243, col: 25, offset: 30354},
+										pos:  position{line: 1244, col: 25, offset: 30432},
 										name: "IdentifierRest",
 									},
 								},
@@ -8412,45 +8501,45 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1244, col: 5, offset: 30394},
+						pos: position{line: 1245, col: 5, offset: 30472},
 						run: (*parser).callonAmbiguousType8,
 						expr: &seqExpr{
-							pos: position{line: 1244, col: 5, offset: 30394},
+							pos: position{line: 1245, col: 5, offset: 30472},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1244, col: 5, offset: 30394},
+									pos:        position{line: 1245, col: 5, offset: 30472},
 									val:        "error",
 									ignoreCase: false,
 									want:       "\"error\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1244, col: 13, offset: 30402},
+									pos:  position{line: 1245, col: 13, offset: 30480},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1244, col: 16, offset: 30405},
+									pos:        position{line: 1245, col: 16, offset: 30483},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1244, col: 20, offset: 30409},
+									pos:  position{line: 1245, col: 20, offset: 30487},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1244, col: 23, offset: 30412},
+									pos:   position{line: 1245, col: 23, offset: 30490},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1244, col: 25, offset: 30414},
+										pos:  position{line: 1245, col: 25, offset: 30492},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1244, col: 30, offset: 30419},
+									pos:  position{line: 1245, col: 30, offset: 30497},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1244, col: 33, offset: 30422},
+									pos:        position{line: 1245, col: 33, offset: 30500},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -8459,52 +8548,52 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1252, col: 5, offset: 30616},
+						pos: position{line: 1253, col: 5, offset: 30694},
 						run: (*parser).callonAmbiguousType18,
 						expr: &seqExpr{
-							pos: position{line: 1252, col: 5, offset: 30616},
+							pos: position{line: 1253, col: 5, offset: 30694},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1252, col: 5, offset: 30616},
+									pos:   position{line: 1253, col: 5, offset: 30694},
 									label: "name",
 									expr: &choiceExpr{
-										pos: position{line: 1252, col: 11, offset: 30622},
+										pos: position{line: 1253, col: 11, offset: 30700},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1252, col: 11, offset: 30622},
+												pos:  position{line: 1253, col: 11, offset: 30700},
 												name: "IdentifierName",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1252, col: 28, offset: 30639},
+												pos:  position{line: 1253, col: 28, offset: 30717},
 												name: "QuotedString",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1252, col: 42, offset: 30653},
+									pos:   position{line: 1253, col: 42, offset: 30731},
 									label: "opt",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1252, col: 46, offset: 30657},
+										pos: position{line: 1253, col: 46, offset: 30735},
 										expr: &seqExpr{
-											pos: position{line: 1252, col: 47, offset: 30658},
+											pos: position{line: 1253, col: 47, offset: 30736},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1252, col: 47, offset: 30658},
+													pos:  position{line: 1253, col: 47, offset: 30736},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1252, col: 50, offset: 30661},
+													pos:        position{line: 1253, col: 50, offset: 30739},
 													val:        "=",
 													ignoreCase: false,
 													want:       "\"=\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1252, col: 54, offset: 30665},
+													pos:  position{line: 1253, col: 54, offset: 30743},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1252, col: 57, offset: 30668},
+													pos:  position{line: 1253, col: 57, offset: 30746},
 													name: "Type",
 												},
 											},
@@ -8515,31 +8604,31 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1263, col: 5, offset: 31006},
+						pos: position{line: 1264, col: 5, offset: 31084},
 						run: (*parser).callonAmbiguousType31,
 						expr: &seqExpr{
-							pos: position{line: 1263, col: 5, offset: 31006},
+							pos: position{line: 1264, col: 5, offset: 31084},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1263, col: 5, offset: 31006},
+									pos:        position{line: 1264, col: 5, offset: 31084},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1263, col: 9, offset: 31010},
+									pos:  position{line: 1264, col: 9, offset: 31088},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1263, col: 12, offset: 31013},
+									pos:   position{line: 1264, col: 12, offset: 31091},
 									label: "types",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1263, col: 18, offset: 31019},
+										pos:  position{line: 1264, col: 18, offset: 31097},
 										name: "TypeList",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1263, col: 27, offset: 31028},
+									pos:        position{line: 1264, col: 27, offset: 31106},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -8554,28 +8643,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1272, col: 1, offset: 31220},
+			pos:  position{line: 1273, col: 1, offset: 31298},
 			expr: &actionExpr{
-				pos: position{line: 1273, col: 5, offset: 31233},
+				pos: position{line: 1274, col: 5, offset: 31311},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1273, col: 5, offset: 31233},
+					pos: position{line: 1274, col: 5, offset: 31311},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1273, col: 5, offset: 31233},
+							pos:   position{line: 1274, col: 5, offset: 31311},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1273, col: 11, offset: 31239},
+								pos:  position{line: 1274, col: 11, offset: 31317},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1273, col: 16, offset: 31244},
+							pos:   position{line: 1274, col: 16, offset: 31322},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1273, col: 21, offset: 31249},
+								pos: position{line: 1274, col: 21, offset: 31327},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1273, col: 21, offset: 31249},
+									pos:  position{line: 1274, col: 21, offset: 31327},
 									name: "TypeListTail",
 								},
 							},
@@ -8588,32 +8677,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1277, col: 1, offset: 31307},
+			pos:  position{line: 1278, col: 1, offset: 31385},
 			expr: &actionExpr{
-				pos: position{line: 1277, col: 16, offset: 31322},
+				pos: position{line: 1278, col: 16, offset: 31400},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1277, col: 16, offset: 31322},
+					pos: position{line: 1278, col: 16, offset: 31400},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1277, col: 16, offset: 31322},
+							pos:  position{line: 1278, col: 16, offset: 31400},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1277, col: 19, offset: 31325},
+							pos:        position{line: 1278, col: 19, offset: 31403},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1277, col: 23, offset: 31329},
+							pos:  position{line: 1278, col: 23, offset: 31407},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1277, col: 26, offset: 31332},
+							pos:   position{line: 1278, col: 26, offset: 31410},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1277, col: 30, offset: 31336},
+								pos:  position{line: 1278, col: 30, offset: 31414},
 								name: "Type",
 							},
 						},
@@ -8625,40 +8714,40 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 1279, col: 1, offset: 31362},
+			pos:  position{line: 1280, col: 1, offset: 31440},
 			expr: &choiceExpr{
-				pos: position{line: 1280, col: 5, offset: 31378},
+				pos: position{line: 1281, col: 5, offset: 31456},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1280, col: 5, offset: 31378},
+						pos: position{line: 1281, col: 5, offset: 31456},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 1280, col: 5, offset: 31378},
+							pos: position{line: 1281, col: 5, offset: 31456},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1280, col: 5, offset: 31378},
+									pos:        position{line: 1281, col: 5, offset: 31456},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1280, col: 9, offset: 31382},
+									pos:  position{line: 1281, col: 9, offset: 31460},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1280, col: 12, offset: 31385},
+									pos:   position{line: 1281, col: 12, offset: 31463},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1280, col: 19, offset: 31392},
+										pos:  position{line: 1281, col: 19, offset: 31470},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1280, col: 33, offset: 31406},
+									pos:  position{line: 1281, col: 33, offset: 31484},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1280, col: 36, offset: 31409},
+									pos:        position{line: 1281, col: 36, offset: 31487},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -8667,35 +8756,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1288, col: 5, offset: 31621},
+						pos: position{line: 1289, col: 5, offset: 31699},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 1288, col: 5, offset: 31621},
+							pos: position{line: 1289, col: 5, offset: 31699},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1288, col: 5, offset: 31621},
+									pos:        position{line: 1289, col: 5, offset: 31699},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1288, col: 9, offset: 31625},
+									pos:  position{line: 1289, col: 9, offset: 31703},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1288, col: 12, offset: 31628},
+									pos:   position{line: 1289, col: 12, offset: 31706},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1288, col: 16, offset: 31632},
+										pos:  position{line: 1289, col: 16, offset: 31710},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1288, col: 21, offset: 31637},
+									pos:  position{line: 1289, col: 21, offset: 31715},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1288, col: 24, offset: 31640},
+									pos:        position{line: 1289, col: 24, offset: 31718},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -8704,35 +8793,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1296, col: 5, offset: 31832},
+						pos: position{line: 1297, col: 5, offset: 31910},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 1296, col: 5, offset: 31832},
+							pos: position{line: 1297, col: 5, offset: 31910},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1296, col: 5, offset: 31832},
+									pos:        position{line: 1297, col: 5, offset: 31910},
 									val:        "|[",
 									ignoreCase: false,
 									want:       "\"|[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1296, col: 10, offset: 31837},
+									pos:  position{line: 1297, col: 10, offset: 31915},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1296, col: 13, offset: 31840},
+									pos:   position{line: 1297, col: 13, offset: 31918},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1296, col: 17, offset: 31844},
+										pos:  position{line: 1297, col: 17, offset: 31922},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1296, col: 22, offset: 31849},
+									pos:  position{line: 1297, col: 22, offset: 31927},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1296, col: 25, offset: 31852},
+									pos:        position{line: 1297, col: 25, offset: 31930},
 									val:        "]|",
 									ignoreCase: false,
 									want:       "\"]|\"",
@@ -8741,57 +8830,57 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1304, col: 5, offset: 32039},
+						pos: position{line: 1305, col: 5, offset: 32117},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 1304, col: 5, offset: 32039},
+							pos: position{line: 1305, col: 5, offset: 32117},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1304, col: 5, offset: 32039},
+									pos:        position{line: 1305, col: 5, offset: 32117},
 									val:        "|{",
 									ignoreCase: false,
 									want:       "\"|{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1304, col: 10, offset: 32044},
+									pos:  position{line: 1305, col: 10, offset: 32122},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1304, col: 13, offset: 32047},
+									pos:   position{line: 1305, col: 13, offset: 32125},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1304, col: 21, offset: 32055},
+										pos:  position{line: 1305, col: 21, offset: 32133},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1304, col: 26, offset: 32060},
+									pos:  position{line: 1305, col: 26, offset: 32138},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1304, col: 29, offset: 32063},
+									pos:        position{line: 1305, col: 29, offset: 32141},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1304, col: 33, offset: 32067},
+									pos:  position{line: 1305, col: 33, offset: 32145},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1304, col: 36, offset: 32070},
+									pos:   position{line: 1305, col: 36, offset: 32148},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1304, col: 44, offset: 32078},
+										pos:  position{line: 1305, col: 44, offset: 32156},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1304, col: 49, offset: 32083},
+									pos:  position{line: 1305, col: 49, offset: 32161},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1304, col: 52, offset: 32086},
+									pos:        position{line: 1305, col: 52, offset: 32164},
 									val:        "}|",
 									ignoreCase: false,
 									want:       "\"}|\"",
@@ -8806,35 +8895,35 @@ var g = &grammar{
 		},
 		{
 			name: "StringLiteral",
-			pos:  position{line: 1314, col: 1, offset: 32309},
+			pos:  position{line: 1315, col: 1, offset: 32387},
 			expr: &choiceExpr{
-				pos: position{line: 1315, col: 5, offset: 32327},
+				pos: position{line: 1316, col: 5, offset: 32405},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1315, col: 5, offset: 32327},
+						pos: position{line: 1316, col: 5, offset: 32405},
 						run: (*parser).callonStringLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1315, col: 5, offset: 32327},
+							pos: position{line: 1316, col: 5, offset: 32405},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1315, col: 5, offset: 32327},
+									pos:        position{line: 1316, col: 5, offset: 32405},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1315, col: 9, offset: 32331},
+									pos:   position{line: 1316, col: 9, offset: 32409},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1315, col: 11, offset: 32333},
+										pos: position{line: 1316, col: 11, offset: 32411},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1315, col: 11, offset: 32333},
+											pos:  position{line: 1316, col: 11, offset: 32411},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1315, col: 29, offset: 32351},
+									pos:        position{line: 1316, col: 29, offset: 32429},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -8843,30 +8932,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1316, col: 5, offset: 32415},
+						pos: position{line: 1317, col: 5, offset: 32493},
 						run: (*parser).callonStringLiteral9,
 						expr: &seqExpr{
-							pos: position{line: 1316, col: 5, offset: 32415},
+							pos: position{line: 1317, col: 5, offset: 32493},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1316, col: 5, offset: 32415},
+									pos:        position{line: 1317, col: 5, offset: 32493},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1316, col: 9, offset: 32419},
+									pos:   position{line: 1317, col: 9, offset: 32497},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1316, col: 11, offset: 32421},
+										pos: position{line: 1317, col: 11, offset: 32499},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1316, col: 11, offset: 32421},
+											pos:  position{line: 1317, col: 11, offset: 32499},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1316, col: 29, offset: 32439},
+									pos:        position{line: 1317, col: 29, offset: 32517},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -8881,35 +8970,35 @@ var g = &grammar{
 		},
 		{
 			name: "FString",
-			pos:  position{line: 1318, col: 1, offset: 32500},
+			pos:  position{line: 1319, col: 1, offset: 32578},
 			expr: &choiceExpr{
-				pos: position{line: 1319, col: 5, offset: 32512},
+				pos: position{line: 1320, col: 5, offset: 32590},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1319, col: 5, offset: 32512},
+						pos: position{line: 1320, col: 5, offset: 32590},
 						run: (*parser).callonFString2,
 						expr: &seqExpr{
-							pos: position{line: 1319, col: 5, offset: 32512},
+							pos: position{line: 1320, col: 5, offset: 32590},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1319, col: 5, offset: 32512},
+									pos:        position{line: 1320, col: 5, offset: 32590},
 									val:        "f\"",
 									ignoreCase: false,
 									want:       "\"f\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1319, col: 11, offset: 32518},
+									pos:   position{line: 1320, col: 11, offset: 32596},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1319, col: 13, offset: 32520},
+										pos: position{line: 1320, col: 13, offset: 32598},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1319, col: 13, offset: 32520},
+											pos:  position{line: 1320, col: 13, offset: 32598},
 											name: "FStringDoubleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1319, col: 38, offset: 32545},
+									pos:        position{line: 1320, col: 38, offset: 32623},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -8918,30 +9007,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1326, col: 5, offset: 32702},
+						pos: position{line: 1327, col: 5, offset: 32780},
 						run: (*parser).callonFString9,
 						expr: &seqExpr{
-							pos: position{line: 1326, col: 5, offset: 32702},
+							pos: position{line: 1327, col: 5, offset: 32780},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1326, col: 5, offset: 32702},
+									pos:        position{line: 1327, col: 5, offset: 32780},
 									val:        "f'",
 									ignoreCase: false,
 									want:       "\"f'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1326, col: 10, offset: 32707},
+									pos:   position{line: 1327, col: 10, offset: 32785},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1326, col: 12, offset: 32709},
+										pos: position{line: 1327, col: 12, offset: 32787},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1326, col: 12, offset: 32709},
+											pos:  position{line: 1327, col: 12, offset: 32787},
 											name: "FStringSingleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1326, col: 37, offset: 32734},
+									pos:        position{line: 1327, col: 37, offset: 32812},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -8956,24 +9045,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedElem",
-			pos:  position{line: 1334, col: 1, offset: 32888},
+			pos:  position{line: 1335, col: 1, offset: 32966},
 			expr: &choiceExpr{
-				pos: position{line: 1335, col: 5, offset: 32916},
+				pos: position{line: 1336, col: 5, offset: 32994},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1335, col: 5, offset: 32916},
+						pos:  position{line: 1336, col: 5, offset: 32994},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1336, col: 5, offset: 32932},
+						pos: position{line: 1337, col: 5, offset: 33010},
 						run: (*parser).callonFStringDoubleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1336, col: 5, offset: 32932},
+							pos:   position{line: 1337, col: 5, offset: 33010},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1336, col: 7, offset: 32934},
+								pos: position{line: 1337, col: 7, offset: 33012},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1336, col: 7, offset: 32934},
+									pos:  position{line: 1337, col: 7, offset: 33012},
 									name: "FStringDoubleQuotedChar",
 								},
 							},
@@ -8986,27 +9075,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedChar",
-			pos:  position{line: 1340, col: 1, offset: 33067},
+			pos:  position{line: 1341, col: 1, offset: 33145},
 			expr: &choiceExpr{
-				pos: position{line: 1341, col: 5, offset: 33095},
+				pos: position{line: 1342, col: 5, offset: 33173},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1341, col: 5, offset: 33095},
+						pos: position{line: 1342, col: 5, offset: 33173},
 						run: (*parser).callonFStringDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1341, col: 5, offset: 33095},
+							pos: position{line: 1342, col: 5, offset: 33173},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1341, col: 5, offset: 33095},
+									pos:        position{line: 1342, col: 5, offset: 33173},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1341, col: 10, offset: 33100},
+									pos:   position{line: 1342, col: 10, offset: 33178},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1341, col: 12, offset: 33102},
+										pos:        position{line: 1342, col: 12, offset: 33180},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9016,25 +9105,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1342, col: 5, offset: 33128},
+						pos: position{line: 1343, col: 5, offset: 33206},
 						run: (*parser).callonFStringDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1342, col: 5, offset: 33128},
+							pos: position{line: 1343, col: 5, offset: 33206},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1342, col: 5, offset: 33128},
+									pos: position{line: 1343, col: 5, offset: 33206},
 									expr: &litMatcher{
-										pos:        position{line: 1342, col: 7, offset: 33130},
+										pos:        position{line: 1343, col: 7, offset: 33208},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1342, col: 12, offset: 33135},
+									pos:   position{line: 1343, col: 12, offset: 33213},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1342, col: 14, offset: 33137},
+										pos:  position{line: 1343, col: 14, offset: 33215},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -9048,24 +9137,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedElem",
-			pos:  position{line: 1344, col: 1, offset: 33173},
+			pos:  position{line: 1345, col: 1, offset: 33251},
 			expr: &choiceExpr{
-				pos: position{line: 1345, col: 5, offset: 33201},
+				pos: position{line: 1346, col: 5, offset: 33279},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1345, col: 5, offset: 33201},
+						pos:  position{line: 1346, col: 5, offset: 33279},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1346, col: 5, offset: 33217},
+						pos: position{line: 1347, col: 5, offset: 33295},
 						run: (*parser).callonFStringSingleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1346, col: 5, offset: 33217},
+							pos:   position{line: 1347, col: 5, offset: 33295},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1346, col: 7, offset: 33219},
+								pos: position{line: 1347, col: 7, offset: 33297},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1346, col: 7, offset: 33219},
+									pos:  position{line: 1347, col: 7, offset: 33297},
 									name: "FStringSingleQuotedChar",
 								},
 							},
@@ -9078,27 +9167,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedChar",
-			pos:  position{line: 1350, col: 1, offset: 33352},
+			pos:  position{line: 1351, col: 1, offset: 33430},
 			expr: &choiceExpr{
-				pos: position{line: 1351, col: 5, offset: 33380},
+				pos: position{line: 1352, col: 5, offset: 33458},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1351, col: 5, offset: 33380},
+						pos: position{line: 1352, col: 5, offset: 33458},
 						run: (*parser).callonFStringSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1351, col: 5, offset: 33380},
+							pos: position{line: 1352, col: 5, offset: 33458},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1351, col: 5, offset: 33380},
+									pos:        position{line: 1352, col: 5, offset: 33458},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1351, col: 10, offset: 33385},
+									pos:   position{line: 1352, col: 10, offset: 33463},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1351, col: 12, offset: 33387},
+										pos:        position{line: 1352, col: 12, offset: 33465},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9108,25 +9197,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1352, col: 5, offset: 33413},
+						pos: position{line: 1353, col: 5, offset: 33491},
 						run: (*parser).callonFStringSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1352, col: 5, offset: 33413},
+							pos: position{line: 1353, col: 5, offset: 33491},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1352, col: 5, offset: 33413},
+									pos: position{line: 1353, col: 5, offset: 33491},
 									expr: &litMatcher{
-										pos:        position{line: 1352, col: 7, offset: 33415},
+										pos:        position{line: 1353, col: 7, offset: 33493},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1352, col: 12, offset: 33420},
+									pos:   position{line: 1353, col: 12, offset: 33498},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1352, col: 14, offset: 33422},
+										pos:  position{line: 1353, col: 14, offset: 33500},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -9140,37 +9229,37 @@ var g = &grammar{
 		},
 		{
 			name: "FStringExpr",
-			pos:  position{line: 1354, col: 1, offset: 33458},
+			pos:  position{line: 1355, col: 1, offset: 33536},
 			expr: &actionExpr{
-				pos: position{line: 1355, col: 5, offset: 33474},
+				pos: position{line: 1356, col: 5, offset: 33552},
 				run: (*parser).callonFStringExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1355, col: 5, offset: 33474},
+					pos: position{line: 1356, col: 5, offset: 33552},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1355, col: 5, offset: 33474},
+							pos:        position{line: 1356, col: 5, offset: 33552},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1355, col: 9, offset: 33478},
+							pos:  position{line: 1356, col: 9, offset: 33556},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1355, col: 12, offset: 33481},
+							pos:   position{line: 1356, col: 12, offset: 33559},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1355, col: 14, offset: 33483},
+								pos:  position{line: 1356, col: 14, offset: 33561},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1355, col: 19, offset: 33488},
+							pos:  position{line: 1356, col: 19, offset: 33566},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1355, col: 22, offset: 33491},
+							pos:        position{line: 1356, col: 22, offset: 33569},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -9183,129 +9272,129 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1364, col: 1, offset: 33669},
+			pos:  position{line: 1365, col: 1, offset: 33747},
 			expr: &actionExpr{
-				pos: position{line: 1365, col: 5, offset: 33687},
+				pos: position{line: 1366, col: 5, offset: 33765},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1365, col: 9, offset: 33691},
+					pos: position{line: 1366, col: 9, offset: 33769},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1365, col: 9, offset: 33691},
+							pos:        position{line: 1366, col: 9, offset: 33769},
 							val:        "uint8",
 							ignoreCase: false,
 							want:       "\"uint8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1365, col: 19, offset: 33701},
+							pos:        position{line: 1366, col: 19, offset: 33779},
 							val:        "uint16",
 							ignoreCase: false,
 							want:       "\"uint16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1365, col: 30, offset: 33712},
+							pos:        position{line: 1366, col: 30, offset: 33790},
 							val:        "uint32",
 							ignoreCase: false,
 							want:       "\"uint32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1365, col: 41, offset: 33723},
+							pos:        position{line: 1366, col: 41, offset: 33801},
 							val:        "uint64",
 							ignoreCase: false,
 							want:       "\"uint64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1366, col: 9, offset: 33740},
+							pos:        position{line: 1367, col: 9, offset: 33818},
 							val:        "int8",
 							ignoreCase: false,
 							want:       "\"int8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1366, col: 18, offset: 33749},
+							pos:        position{line: 1367, col: 18, offset: 33827},
 							val:        "int16",
 							ignoreCase: false,
 							want:       "\"int16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1366, col: 28, offset: 33759},
+							pos:        position{line: 1367, col: 28, offset: 33837},
 							val:        "int32",
 							ignoreCase: false,
 							want:       "\"int32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1366, col: 38, offset: 33769},
+							pos:        position{line: 1367, col: 38, offset: 33847},
 							val:        "int64",
 							ignoreCase: false,
 							want:       "\"int64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1367, col: 9, offset: 33785},
+							pos:        position{line: 1368, col: 9, offset: 33863},
 							val:        "float16",
 							ignoreCase: false,
 							want:       "\"float16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1367, col: 21, offset: 33797},
+							pos:        position{line: 1368, col: 21, offset: 33875},
 							val:        "float32",
 							ignoreCase: false,
 							want:       "\"float32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1367, col: 33, offset: 33809},
+							pos:        position{line: 1368, col: 33, offset: 33887},
 							val:        "float64",
 							ignoreCase: false,
 							want:       "\"float64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1368, col: 9, offset: 33827},
+							pos:        position{line: 1369, col: 9, offset: 33905},
 							val:        "bool",
 							ignoreCase: false,
 							want:       "\"bool\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1368, col: 18, offset: 33836},
+							pos:        position{line: 1369, col: 18, offset: 33914},
 							val:        "string",
 							ignoreCase: false,
 							want:       "\"string\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1369, col: 9, offset: 33853},
+							pos:        position{line: 1370, col: 9, offset: 33931},
 							val:        "duration",
 							ignoreCase: false,
 							want:       "\"duration\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1369, col: 22, offset: 33866},
+							pos:        position{line: 1370, col: 22, offset: 33944},
 							val:        "time",
 							ignoreCase: false,
 							want:       "\"time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1370, col: 9, offset: 33881},
+							pos:        position{line: 1371, col: 9, offset: 33959},
 							val:        "bytes",
 							ignoreCase: false,
 							want:       "\"bytes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1371, col: 9, offset: 33897},
+							pos:        position{line: 1372, col: 9, offset: 33975},
 							val:        "ip",
 							ignoreCase: false,
 							want:       "\"ip\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1371, col: 16, offset: 33904},
+							pos:        position{line: 1372, col: 16, offset: 33982},
 							val:        "net",
 							ignoreCase: false,
 							want:       "\"net\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1372, col: 9, offset: 33918},
+							pos:        position{line: 1373, col: 9, offset: 33996},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1372, col: 18, offset: 33927},
+							pos:        position{line: 1373, col: 18, offset: 34005},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
@@ -9318,31 +9407,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1380, col: 1, offset: 34125},
+			pos:  position{line: 1381, col: 1, offset: 34203},
 			expr: &choiceExpr{
-				pos: position{line: 1381, col: 5, offset: 34143},
+				pos: position{line: 1382, col: 5, offset: 34221},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1381, col: 5, offset: 34143},
+						pos: position{line: 1382, col: 5, offset: 34221},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1381, col: 5, offset: 34143},
+							pos: position{line: 1382, col: 5, offset: 34221},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1381, col: 5, offset: 34143},
+									pos:   position{line: 1382, col: 5, offset: 34221},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1381, col: 11, offset: 34149},
+										pos:  position{line: 1382, col: 11, offset: 34227},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1381, col: 21, offset: 34159},
+									pos:   position{line: 1382, col: 21, offset: 34237},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1381, col: 26, offset: 34164},
+										pos: position{line: 1382, col: 26, offset: 34242},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1381, col: 26, offset: 34164},
+											pos:  position{line: 1382, col: 26, offset: 34242},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -9351,10 +9440,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1384, col: 5, offset: 34230},
+						pos: position{line: 1385, col: 5, offset: 34308},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1384, col: 5, offset: 34230},
+							pos:        position{line: 1385, col: 5, offset: 34308},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -9367,32 +9456,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1386, col: 1, offset: 34254},
+			pos:  position{line: 1387, col: 1, offset: 34332},
 			expr: &actionExpr{
-				pos: position{line: 1386, col: 21, offset: 34274},
+				pos: position{line: 1387, col: 21, offset: 34352},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1386, col: 21, offset: 34274},
+					pos: position{line: 1387, col: 21, offset: 34352},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1386, col: 21, offset: 34274},
+							pos:  position{line: 1387, col: 21, offset: 34352},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1386, col: 24, offset: 34277},
+							pos:        position{line: 1387, col: 24, offset: 34355},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1386, col: 28, offset: 34281},
+							pos:  position{line: 1387, col: 28, offset: 34359},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1386, col: 31, offset: 34284},
+							pos:   position{line: 1387, col: 31, offset: 34362},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1386, col: 35, offset: 34288},
+								pos:  position{line: 1387, col: 35, offset: 34366},
 								name: "TypeField",
 							},
 						},
@@ -9404,40 +9493,40 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1388, col: 1, offset: 34319},
+			pos:  position{line: 1389, col: 1, offset: 34397},
 			expr: &actionExpr{
-				pos: position{line: 1389, col: 5, offset: 34333},
+				pos: position{line: 1390, col: 5, offset: 34411},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1389, col: 5, offset: 34333},
+					pos: position{line: 1390, col: 5, offset: 34411},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1389, col: 5, offset: 34333},
+							pos:   position{line: 1390, col: 5, offset: 34411},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1389, col: 10, offset: 34338},
+								pos:  position{line: 1390, col: 10, offset: 34416},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1389, col: 20, offset: 34348},
+							pos:  position{line: 1390, col: 20, offset: 34426},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1389, col: 23, offset: 34351},
+							pos:        position{line: 1390, col: 23, offset: 34429},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1389, col: 27, offset: 34355},
+							pos:  position{line: 1390, col: 27, offset: 34433},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1389, col: 30, offset: 34358},
+							pos:   position{line: 1390, col: 30, offset: 34436},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1389, col: 34, offset: 34362},
+								pos:  position{line: 1390, col: 34, offset: 34440},
 								name: "Type",
 							},
 						},
@@ -9449,16 +9538,16 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 1396, col: 1, offset: 34486},
+			pos:  position{line: 1397, col: 1, offset: 34564},
 			expr: &choiceExpr{
-				pos: position{line: 1397, col: 5, offset: 34500},
+				pos: position{line: 1398, col: 5, offset: 34578},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1397, col: 5, offset: 34500},
+						pos:  position{line: 1398, col: 5, offset: 34578},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1398, col: 5, offset: 34519},
+						pos:  position{line: 1399, col: 5, offset: 34597},
 						name: "QuotedString",
 					},
 				},
@@ -9468,24 +9557,24 @@ var g = &grammar{
 		},
 		{
 			name: "AndToken",
-			pos:  position{line: 1400, col: 1, offset: 34533},
+			pos:  position{line: 1401, col: 1, offset: 34611},
 			expr: &actionExpr{
-				pos: position{line: 1400, col: 12, offset: 34544},
+				pos: position{line: 1401, col: 12, offset: 34622},
 				run: (*parser).callonAndToken1,
 				expr: &seqExpr{
-					pos: position{line: 1400, col: 12, offset: 34544},
+					pos: position{line: 1401, col: 12, offset: 34622},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 1400, col: 13, offset: 34545},
+							pos: position{line: 1401, col: 13, offset: 34623},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1400, col: 13, offset: 34545},
+									pos:        position{line: 1401, col: 13, offset: 34623},
 									val:        "and",
 									ignoreCase: false,
 									want:       "\"and\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1400, col: 21, offset: 34553},
+									pos:        position{line: 1401, col: 21, offset: 34631},
 									val:        "AND",
 									ignoreCase: false,
 									want:       "\"AND\"",
@@ -9493,9 +9582,9 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 1400, col: 28, offset: 34560},
+							pos: position{line: 1401, col: 28, offset: 34638},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1400, col: 29, offset: 34561},
+								pos:  position{line: 1401, col: 29, offset: 34639},
 								name: "IdentifierRest",
 							},
 						},
@@ -9507,20 +9596,20 @@ var g = &grammar{
 		},
 		{
 			name: "ByToken",
-			pos:  position{line: 1401, col: 1, offset: 34598},
+			pos:  position{line: 1402, col: 1, offset: 34676},
 			expr: &seqExpr{
-				pos: position{line: 1401, col: 11, offset: 34608},
+				pos: position{line: 1402, col: 11, offset: 34686},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1401, col: 11, offset: 34608},
+						pos:        position{line: 1402, col: 11, offset: 34686},
 						val:        "by",
 						ignoreCase: false,
 						want:       "\"by\"",
 					},
 					&notExpr{
-						pos: position{line: 1401, col: 16, offset: 34613},
+						pos: position{line: 1402, col: 16, offset: 34691},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1401, col: 17, offset: 34614},
+							pos:  position{line: 1402, col: 17, offset: 34692},
 							name: "IdentifierRest",
 						},
 					},
@@ -9531,20 +9620,20 @@ var g = &grammar{
 		},
 		{
 			name: "FalseToken",
-			pos:  position{line: 1402, col: 1, offset: 34629},
+			pos:  position{line: 1403, col: 1, offset: 34707},
 			expr: &seqExpr{
-				pos: position{line: 1402, col: 14, offset: 34642},
+				pos: position{line: 1403, col: 14, offset: 34720},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1402, col: 14, offset: 34642},
+						pos:        position{line: 1403, col: 14, offset: 34720},
 						val:        "false",
 						ignoreCase: false,
 						want:       "\"false\"",
 					},
 					&notExpr{
-						pos: position{line: 1402, col: 22, offset: 34650},
+						pos: position{line: 1403, col: 22, offset: 34728},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1402, col: 23, offset: 34651},
+							pos:  position{line: 1403, col: 23, offset: 34729},
 							name: "IdentifierRest",
 						},
 					},
@@ -9555,20 +9644,20 @@ var g = &grammar{
 		},
 		{
 			name: "InToken",
-			pos:  position{line: 1403, col: 1, offset: 34666},
+			pos:  position{line: 1404, col: 1, offset: 34744},
 			expr: &seqExpr{
-				pos: position{line: 1403, col: 11, offset: 34676},
+				pos: position{line: 1404, col: 11, offset: 34754},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1403, col: 11, offset: 34676},
+						pos:        position{line: 1404, col: 11, offset: 34754},
 						val:        "in",
 						ignoreCase: false,
 						want:       "\"in\"",
 					},
 					&notExpr{
-						pos: position{line: 1403, col: 16, offset: 34681},
+						pos: position{line: 1404, col: 16, offset: 34759},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1403, col: 17, offset: 34682},
+							pos:  position{line: 1404, col: 17, offset: 34760},
 							name: "IdentifierRest",
 						},
 					},
@@ -9579,24 +9668,24 @@ var g = &grammar{
 		},
 		{
 			name: "NotToken",
-			pos:  position{line: 1404, col: 1, offset: 34697},
+			pos:  position{line: 1405, col: 1, offset: 34775},
 			expr: &actionExpr{
-				pos: position{line: 1404, col: 12, offset: 34708},
+				pos: position{line: 1405, col: 12, offset: 34786},
 				run: (*parser).callonNotToken1,
 				expr: &seqExpr{
-					pos: position{line: 1404, col: 12, offset: 34708},
+					pos: position{line: 1405, col: 12, offset: 34786},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 1404, col: 13, offset: 34709},
+							pos: position{line: 1405, col: 13, offset: 34787},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1404, col: 13, offset: 34709},
+									pos:        position{line: 1405, col: 13, offset: 34787},
 									val:        "not",
 									ignoreCase: false,
 									want:       "\"not\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1404, col: 21, offset: 34717},
+									pos:        position{line: 1405, col: 21, offset: 34795},
 									val:        "NOT",
 									ignoreCase: false,
 									want:       "\"NOT\"",
@@ -9604,9 +9693,9 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 1404, col: 28, offset: 34724},
+							pos: position{line: 1405, col: 28, offset: 34802},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1404, col: 29, offset: 34725},
+								pos:  position{line: 1405, col: 29, offset: 34803},
 								name: "IdentifierRest",
 							},
 						},
@@ -9618,20 +9707,20 @@ var g = &grammar{
 		},
 		{
 			name: "NullToken",
-			pos:  position{line: 1405, col: 1, offset: 34762},
+			pos:  position{line: 1406, col: 1, offset: 34840},
 			expr: &seqExpr{
-				pos: position{line: 1405, col: 13, offset: 34774},
+				pos: position{line: 1406, col: 13, offset: 34852},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1405, col: 13, offset: 34774},
+						pos:        position{line: 1406, col: 13, offset: 34852},
 						val:        "null",
 						ignoreCase: false,
 						want:       "\"null\"",
 					},
 					&notExpr{
-						pos: position{line: 1405, col: 20, offset: 34781},
+						pos: position{line: 1406, col: 20, offset: 34859},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1405, col: 21, offset: 34782},
+							pos:  position{line: 1406, col: 21, offset: 34860},
 							name: "IdentifierRest",
 						},
 					},
@@ -9642,24 +9731,24 @@ var g = &grammar{
 		},
 		{
 			name: "OrToken",
-			pos:  position{line: 1406, col: 1, offset: 34797},
+			pos:  position{line: 1407, col: 1, offset: 34875},
 			expr: &actionExpr{
-				pos: position{line: 1406, col: 11, offset: 34807},
+				pos: position{line: 1407, col: 11, offset: 34885},
 				run: (*parser).callonOrToken1,
 				expr: &seqExpr{
-					pos: position{line: 1406, col: 11, offset: 34807},
+					pos: position{line: 1407, col: 11, offset: 34885},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 1406, col: 12, offset: 34808},
+							pos: position{line: 1407, col: 12, offset: 34886},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1406, col: 12, offset: 34808},
+									pos:        position{line: 1407, col: 12, offset: 34886},
 									val:        "or",
 									ignoreCase: false,
 									want:       "\"or\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1406, col: 19, offset: 34815},
+									pos:        position{line: 1407, col: 19, offset: 34893},
 									val:        "OR",
 									ignoreCase: false,
 									want:       "\"OR\"",
@@ -9667,9 +9756,9 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 1406, col: 25, offset: 34821},
+							pos: position{line: 1407, col: 25, offset: 34899},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1406, col: 26, offset: 34822},
+								pos:  position{line: 1407, col: 26, offset: 34900},
 								name: "IdentifierRest",
 							},
 						},
@@ -9681,20 +9770,20 @@ var g = &grammar{
 		},
 		{
 			name: "TrueToken",
-			pos:  position{line: 1407, col: 1, offset: 34858},
+			pos:  position{line: 1408, col: 1, offset: 34936},
 			expr: &seqExpr{
-				pos: position{line: 1407, col: 13, offset: 34870},
+				pos: position{line: 1408, col: 13, offset: 34948},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1407, col: 13, offset: 34870},
+						pos:        position{line: 1408, col: 13, offset: 34948},
 						val:        "true",
 						ignoreCase: false,
 						want:       "\"true\"",
 					},
 					&notExpr{
-						pos: position{line: 1407, col: 20, offset: 34877},
+						pos: position{line: 1408, col: 20, offset: 34955},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1407, col: 21, offset: 34878},
+							pos:  position{line: 1408, col: 21, offset: 34956},
 							name: "IdentifierRest",
 						},
 					},
@@ -9705,15 +9794,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1409, col: 1, offset: 34894},
+			pos:  position{line: 1410, col: 1, offset: 34972},
 			expr: &actionExpr{
-				pos: position{line: 1410, col: 5, offset: 34909},
+				pos: position{line: 1411, col: 5, offset: 34987},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1410, col: 5, offset: 34909},
+					pos:   position{line: 1411, col: 5, offset: 34987},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1410, col: 8, offset: 34912},
+						pos:  position{line: 1411, col: 8, offset: 34990},
 						name: "IdentifierName",
 					},
 				},
@@ -9723,51 +9812,51 @@ var g = &grammar{
 		},
 		{
 			name: "Identifiers",
-			pos:  position{line: 1418, col: 1, offset: 35055},
+			pos:  position{line: 1419, col: 1, offset: 35133},
 			expr: &actionExpr{
-				pos: position{line: 1419, col: 5, offset: 35071},
+				pos: position{line: 1420, col: 5, offset: 35149},
 				run: (*parser).callonIdentifiers1,
 				expr: &seqExpr{
-					pos: position{line: 1419, col: 5, offset: 35071},
+					pos: position{line: 1420, col: 5, offset: 35149},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1419, col: 5, offset: 35071},
+							pos:   position{line: 1420, col: 5, offset: 35149},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1419, col: 11, offset: 35077},
+								pos:  position{line: 1420, col: 11, offset: 35155},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1419, col: 22, offset: 35088},
+							pos:   position{line: 1420, col: 22, offset: 35166},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1419, col: 27, offset: 35093},
+								pos: position{line: 1420, col: 27, offset: 35171},
 								expr: &actionExpr{
-									pos: position{line: 1419, col: 28, offset: 35094},
+									pos: position{line: 1420, col: 28, offset: 35172},
 									run: (*parser).callonIdentifiers7,
 									expr: &seqExpr{
-										pos: position{line: 1419, col: 28, offset: 35094},
+										pos: position{line: 1420, col: 28, offset: 35172},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1419, col: 28, offset: 35094},
+												pos:  position{line: 1420, col: 28, offset: 35172},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1419, col: 31, offset: 35097},
+												pos:        position{line: 1420, col: 31, offset: 35175},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1419, col: 35, offset: 35101},
+												pos:  position{line: 1420, col: 35, offset: 35179},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1419, col: 38, offset: 35104},
+												pos:   position{line: 1420, col: 38, offset: 35182},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1419, col: 43, offset: 35109},
+													pos:  position{line: 1420, col: 43, offset: 35187},
 													name: "Identifier",
 												},
 											},
@@ -9784,29 +9873,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1423, col: 1, offset: 35187},
+			pos:  position{line: 1424, col: 1, offset: 35265},
 			expr: &choiceExpr{
-				pos: position{line: 1424, col: 5, offset: 35206},
+				pos: position{line: 1425, col: 5, offset: 35284},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1424, col: 5, offset: 35206},
+						pos: position{line: 1425, col: 5, offset: 35284},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1424, col: 5, offset: 35206},
+							pos: position{line: 1425, col: 5, offset: 35284},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1424, col: 5, offset: 35206},
+									pos: position{line: 1425, col: 5, offset: 35284},
 									expr: &seqExpr{
-										pos: position{line: 1424, col: 7, offset: 35208},
+										pos: position{line: 1425, col: 7, offset: 35286},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1424, col: 7, offset: 35208},
+												pos:  position{line: 1425, col: 7, offset: 35286},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1424, col: 15, offset: 35216},
+												pos: position{line: 1425, col: 15, offset: 35294},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1424, col: 16, offset: 35217},
+													pos:  position{line: 1425, col: 16, offset: 35295},
 													name: "IdentifierRest",
 												},
 											},
@@ -9814,13 +9903,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1424, col: 32, offset: 35233},
+									pos:  position{line: 1425, col: 32, offset: 35311},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1424, col: 48, offset: 35249},
+									pos: position{line: 1425, col: 48, offset: 35327},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1424, col: 48, offset: 35249},
+										pos:  position{line: 1425, col: 48, offset: 35327},
 										name: "IdentifierRest",
 									},
 								},
@@ -9828,32 +9917,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1425, col: 5, offset: 35300},
+						pos: position{line: 1426, col: 5, offset: 35378},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 1425, col: 5, offset: 35300},
+							pos:        position{line: 1426, col: 5, offset: 35378},
 							val:        "$",
 							ignoreCase: false,
 							want:       "\"$\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1426, col: 5, offset: 35339},
+						pos: position{line: 1427, col: 5, offset: 35417},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 1426, col: 5, offset: 35339},
+							pos: position{line: 1427, col: 5, offset: 35417},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1426, col: 5, offset: 35339},
+									pos:        position{line: 1427, col: 5, offset: 35417},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1426, col: 10, offset: 35344},
+									pos:   position{line: 1427, col: 10, offset: 35422},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1426, col: 13, offset: 35347},
+										pos:  position{line: 1427, col: 13, offset: 35425},
 										name: "IDGuard",
 									},
 								},
@@ -9861,10 +9950,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1428, col: 5, offset: 35438},
+						pos: position{line: 1429, col: 5, offset: 35516},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 1428, col: 5, offset: 35438},
+							pos:        position{line: 1429, col: 5, offset: 35516},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
@@ -9877,22 +9966,22 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1430, col: 1, offset: 35477},
+			pos:  position{line: 1431, col: 1, offset: 35555},
 			expr: &choiceExpr{
-				pos: position{line: 1431, col: 5, offset: 35497},
+				pos: position{line: 1432, col: 5, offset: 35575},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1431, col: 5, offset: 35497},
+						pos:  position{line: 1432, col: 5, offset: 35575},
 						name: "UnicodeLetter",
 					},
 					&litMatcher{
-						pos:        position{line: 1432, col: 5, offset: 35515},
+						pos:        position{line: 1433, col: 5, offset: 35593},
 						val:        "$",
 						ignoreCase: false,
 						want:       "\"$\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1433, col: 5, offset: 35523},
+						pos:        position{line: 1434, col: 5, offset: 35601},
 						val:        "_",
 						ignoreCase: false,
 						want:       "\"_\"",
@@ -9904,24 +9993,24 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1435, col: 1, offset: 35528},
+			pos:  position{line: 1436, col: 1, offset: 35606},
 			expr: &choiceExpr{
-				pos: position{line: 1436, col: 5, offset: 35547},
+				pos: position{line: 1437, col: 5, offset: 35625},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1436, col: 5, offset: 35547},
+						pos:  position{line: 1437, col: 5, offset: 35625},
 						name: "IdentifierStart",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1437, col: 5, offset: 35567},
+						pos:  position{line: 1438, col: 5, offset: 35645},
 						name: "UnicodeCombiningMark",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1438, col: 5, offset: 35592},
+						pos:  position{line: 1439, col: 5, offset: 35670},
 						name: "UnicodeDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1439, col: 5, offset: 35609},
+						pos:  position{line: 1440, col: 5, offset: 35687},
 						name: "UnicodeConnectorPunctuation",
 					},
 				},
@@ -9931,24 +10020,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1441, col: 1, offset: 35638},
+			pos:  position{line: 1442, col: 1, offset: 35716},
 			expr: &choiceExpr{
-				pos: position{line: 1442, col: 5, offset: 35650},
+				pos: position{line: 1443, col: 5, offset: 35728},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1442, col: 5, offset: 35650},
+						pos:  position{line: 1443, col: 5, offset: 35728},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1443, col: 5, offset: 35669},
+						pos:  position{line: 1444, col: 5, offset: 35747},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1444, col: 5, offset: 35685},
+						pos:  position{line: 1445, col: 5, offset: 35763},
 						name: "NaN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1445, col: 5, offset: 35693},
+						pos:  position{line: 1446, col: 5, offset: 35771},
 						name: "Infinity",
 					},
 				},
@@ -9958,25 +10047,25 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1447, col: 1, offset: 35703},
+			pos:  position{line: 1448, col: 1, offset: 35781},
 			expr: &actionExpr{
-				pos: position{line: 1448, col: 5, offset: 35712},
+				pos: position{line: 1449, col: 5, offset: 35790},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1448, col: 5, offset: 35712},
+					pos: position{line: 1449, col: 5, offset: 35790},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1448, col: 5, offset: 35712},
+							pos:  position{line: 1449, col: 5, offset: 35790},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1448, col: 14, offset: 35721},
+							pos:        position{line: 1449, col: 14, offset: 35799},
 							val:        "T",
 							ignoreCase: false,
 							want:       "\"T\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1448, col: 18, offset: 35725},
+							pos:  position{line: 1449, col: 18, offset: 35803},
 							name: "FullTime",
 						},
 					},
@@ -9987,32 +10076,32 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1452, col: 1, offset: 35801},
+			pos:  position{line: 1453, col: 1, offset: 35879},
 			expr: &seqExpr{
-				pos: position{line: 1452, col: 12, offset: 35812},
+				pos: position{line: 1453, col: 12, offset: 35890},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1452, col: 12, offset: 35812},
+						pos:  position{line: 1453, col: 12, offset: 35890},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1452, col: 15, offset: 35815},
+						pos:        position{line: 1453, col: 15, offset: 35893},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1452, col: 19, offset: 35819},
+						pos:  position{line: 1453, col: 19, offset: 35897},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1452, col: 22, offset: 35822},
+						pos:        position{line: 1453, col: 22, offset: 35900},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1452, col: 26, offset: 35826},
+						pos:  position{line: 1453, col: 26, offset: 35904},
 						name: "D2",
 					},
 				},
@@ -10022,33 +10111,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1454, col: 1, offset: 35830},
+			pos:  position{line: 1455, col: 1, offset: 35908},
 			expr: &seqExpr{
-				pos: position{line: 1454, col: 6, offset: 35835},
+				pos: position{line: 1455, col: 6, offset: 35913},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1454, col: 6, offset: 35835},
+						pos:        position{line: 1455, col: 6, offset: 35913},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1454, col: 11, offset: 35840},
+						pos:        position{line: 1455, col: 11, offset: 35918},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1454, col: 16, offset: 35845},
+						pos:        position{line: 1455, col: 16, offset: 35923},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1454, col: 21, offset: 35850},
+						pos:        position{line: 1455, col: 21, offset: 35928},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10061,19 +10150,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1455, col: 1, offset: 35856},
+			pos:  position{line: 1456, col: 1, offset: 35934},
 			expr: &seqExpr{
-				pos: position{line: 1455, col: 6, offset: 35861},
+				pos: position{line: 1456, col: 6, offset: 35939},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1455, col: 6, offset: 35861},
+						pos:        position{line: 1456, col: 6, offset: 35939},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1455, col: 11, offset: 35866},
+						pos:        position{line: 1456, col: 11, offset: 35944},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10086,16 +10175,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1457, col: 1, offset: 35873},
+			pos:  position{line: 1458, col: 1, offset: 35951},
 			expr: &seqExpr{
-				pos: position{line: 1457, col: 12, offset: 35884},
+				pos: position{line: 1458, col: 12, offset: 35962},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1457, col: 12, offset: 35884},
+						pos:  position{line: 1458, col: 12, offset: 35962},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1457, col: 24, offset: 35896},
+						pos:  position{line: 1458, col: 24, offset: 35974},
 						name: "TimeOffset",
 					},
 				},
@@ -10105,49 +10194,49 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1459, col: 1, offset: 35908},
+			pos:  position{line: 1460, col: 1, offset: 35986},
 			expr: &seqExpr{
-				pos: position{line: 1459, col: 15, offset: 35922},
+				pos: position{line: 1460, col: 15, offset: 36000},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1459, col: 15, offset: 35922},
+						pos:  position{line: 1460, col: 15, offset: 36000},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1459, col: 18, offset: 35925},
+						pos:        position{line: 1460, col: 18, offset: 36003},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1459, col: 22, offset: 35929},
+						pos:  position{line: 1460, col: 22, offset: 36007},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1459, col: 25, offset: 35932},
+						pos:        position{line: 1460, col: 25, offset: 36010},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1459, col: 29, offset: 35936},
+						pos:  position{line: 1460, col: 29, offset: 36014},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1459, col: 32, offset: 35939},
+						pos: position{line: 1460, col: 32, offset: 36017},
 						expr: &seqExpr{
-							pos: position{line: 1459, col: 33, offset: 35940},
+							pos: position{line: 1460, col: 33, offset: 36018},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1459, col: 33, offset: 35940},
+									pos:        position{line: 1460, col: 33, offset: 36018},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1459, col: 37, offset: 35944},
+									pos: position{line: 1460, col: 37, offset: 36022},
 									expr: &charClassMatcher{
-										pos:        position{line: 1459, col: 37, offset: 35944},
+										pos:        position{line: 1460, col: 37, offset: 36022},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10164,30 +10253,30 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1461, col: 1, offset: 35954},
+			pos:  position{line: 1462, col: 1, offset: 36032},
 			expr: &choiceExpr{
-				pos: position{line: 1462, col: 5, offset: 35969},
+				pos: position{line: 1463, col: 5, offset: 36047},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1462, col: 5, offset: 35969},
+						pos:        position{line: 1463, col: 5, offset: 36047},
 						val:        "Z",
 						ignoreCase: false,
 						want:       "\"Z\"",
 					},
 					&seqExpr{
-						pos: position{line: 1463, col: 5, offset: 35977},
+						pos: position{line: 1464, col: 5, offset: 36055},
 						exprs: []any{
 							&choiceExpr{
-								pos: position{line: 1463, col: 6, offset: 35978},
+								pos: position{line: 1464, col: 6, offset: 36056},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 1463, col: 6, offset: 35978},
+										pos:        position{line: 1464, col: 6, offset: 36056},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 1463, col: 12, offset: 35984},
+										pos:        position{line: 1464, col: 12, offset: 36062},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
@@ -10195,34 +10284,34 @@ var g = &grammar{
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1463, col: 17, offset: 35989},
+								pos:  position{line: 1464, col: 17, offset: 36067},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1463, col: 20, offset: 35992},
+								pos:        position{line: 1464, col: 20, offset: 36070},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1463, col: 24, offset: 35996},
+								pos:  position{line: 1464, col: 24, offset: 36074},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1463, col: 27, offset: 35999},
+								pos: position{line: 1464, col: 27, offset: 36077},
 								expr: &seqExpr{
-									pos: position{line: 1463, col: 28, offset: 36000},
+									pos: position{line: 1464, col: 28, offset: 36078},
 									exprs: []any{
 										&litMatcher{
-											pos:        position{line: 1463, col: 28, offset: 36000},
+											pos:        position{line: 1464, col: 28, offset: 36078},
 											val:        ".",
 											ignoreCase: false,
 											want:       "\".\"",
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1463, col: 32, offset: 36004},
+											pos: position{line: 1464, col: 32, offset: 36082},
 											expr: &charClassMatcher{
-												pos:        position{line: 1463, col: 32, offset: 36004},
+												pos:        position{line: 1464, col: 32, offset: 36082},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -10241,33 +10330,33 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1465, col: 1, offset: 36014},
+			pos:  position{line: 1466, col: 1, offset: 36092},
 			expr: &actionExpr{
-				pos: position{line: 1466, col: 5, offset: 36027},
+				pos: position{line: 1467, col: 5, offset: 36105},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1466, col: 5, offset: 36027},
+					pos: position{line: 1467, col: 5, offset: 36105},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 1466, col: 5, offset: 36027},
+							pos: position{line: 1467, col: 5, offset: 36105},
 							expr: &litMatcher{
-								pos:        position{line: 1466, col: 5, offset: 36027},
+								pos:        position{line: 1467, col: 5, offset: 36105},
 								val:        "-",
 								ignoreCase: false,
 								want:       "\"-\"",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1466, col: 10, offset: 36032},
+							pos: position{line: 1467, col: 10, offset: 36110},
 							expr: &seqExpr{
-								pos: position{line: 1466, col: 11, offset: 36033},
+								pos: position{line: 1467, col: 11, offset: 36111},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1466, col: 11, offset: 36033},
+										pos:  position{line: 1467, col: 11, offset: 36111},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1466, col: 19, offset: 36041},
+										pos:  position{line: 1467, col: 19, offset: 36119},
 										name: "TimeUnit",
 									},
 								},
@@ -10281,27 +10370,27 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1470, col: 1, offset: 36123},
+			pos:  position{line: 1471, col: 1, offset: 36201},
 			expr: &seqExpr{
-				pos: position{line: 1470, col: 11, offset: 36133},
+				pos: position{line: 1471, col: 11, offset: 36211},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1470, col: 11, offset: 36133},
+						pos:  position{line: 1471, col: 11, offset: 36211},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1470, col: 16, offset: 36138},
+						pos: position{line: 1471, col: 16, offset: 36216},
 						expr: &seqExpr{
-							pos: position{line: 1470, col: 17, offset: 36139},
+							pos: position{line: 1471, col: 17, offset: 36217},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1470, col: 17, offset: 36139},
+									pos:        position{line: 1471, col: 17, offset: 36217},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1470, col: 21, offset: 36143},
+									pos:  position{line: 1471, col: 21, offset: 36221},
 									name: "UInt",
 								},
 							},
@@ -10314,60 +10403,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1472, col: 1, offset: 36151},
+			pos:  position{line: 1473, col: 1, offset: 36229},
 			expr: &choiceExpr{
-				pos: position{line: 1473, col: 5, offset: 36164},
+				pos: position{line: 1474, col: 5, offset: 36242},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1473, col: 5, offset: 36164},
+						pos:        position{line: 1474, col: 5, offset: 36242},
 						val:        "ns",
 						ignoreCase: false,
 						want:       "\"ns\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1474, col: 5, offset: 36173},
+						pos:        position{line: 1475, col: 5, offset: 36251},
 						val:        "us",
 						ignoreCase: false,
 						want:       "\"us\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1475, col: 5, offset: 36182},
+						pos:        position{line: 1476, col: 5, offset: 36260},
 						val:        "ms",
 						ignoreCase: false,
 						want:       "\"ms\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1476, col: 5, offset: 36191},
+						pos:        position{line: 1477, col: 5, offset: 36269},
 						val:        "s",
 						ignoreCase: false,
 						want:       "\"s\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1477, col: 5, offset: 36199},
+						pos:        position{line: 1478, col: 5, offset: 36277},
 						val:        "m",
 						ignoreCase: false,
 						want:       "\"m\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1478, col: 5, offset: 36207},
+						pos:        position{line: 1479, col: 5, offset: 36285},
 						val:        "h",
 						ignoreCase: false,
 						want:       "\"h\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1479, col: 5, offset: 36215},
+						pos:        position{line: 1480, col: 5, offset: 36293},
 						val:        "d",
 						ignoreCase: false,
 						want:       "\"d\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1480, col: 5, offset: 36223},
+						pos:        position{line: 1481, col: 5, offset: 36301},
 						val:        "w",
 						ignoreCase: false,
 						want:       "\"w\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1481, col: 5, offset: 36231},
+						pos:        position{line: 1482, col: 5, offset: 36309},
 						val:        "y",
 						ignoreCase: false,
 						want:       "\"y\"",
@@ -10379,45 +10468,45 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1483, col: 1, offset: 36236},
+			pos:  position{line: 1484, col: 1, offset: 36314},
 			expr: &actionExpr{
-				pos: position{line: 1484, col: 5, offset: 36243},
+				pos: position{line: 1485, col: 5, offset: 36321},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1484, col: 5, offset: 36243},
+					pos: position{line: 1485, col: 5, offset: 36321},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1484, col: 5, offset: 36243},
+							pos:  position{line: 1485, col: 5, offset: 36321},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1484, col: 10, offset: 36248},
+							pos:        position{line: 1485, col: 10, offset: 36326},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1484, col: 14, offset: 36252},
+							pos:  position{line: 1485, col: 14, offset: 36330},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1484, col: 19, offset: 36257},
+							pos:        position{line: 1485, col: 19, offset: 36335},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1484, col: 23, offset: 36261},
+							pos:  position{line: 1485, col: 23, offset: 36339},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1484, col: 28, offset: 36266},
+							pos:        position{line: 1485, col: 28, offset: 36344},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1484, col: 32, offset: 36270},
+							pos:  position{line: 1485, col: 32, offset: 36348},
 							name: "UInt",
 						},
 					},
@@ -10428,43 +10517,43 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1486, col: 1, offset: 36307},
+			pos:  position{line: 1487, col: 1, offset: 36385},
 			expr: &actionExpr{
-				pos: position{line: 1487, col: 5, offset: 36315},
+				pos: position{line: 1488, col: 5, offset: 36393},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1487, col: 5, offset: 36315},
+					pos: position{line: 1488, col: 5, offset: 36393},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1487, col: 5, offset: 36315},
+							pos: position{line: 1488, col: 5, offset: 36393},
 							expr: &seqExpr{
-								pos: position{line: 1487, col: 7, offset: 36317},
+								pos: position{line: 1488, col: 7, offset: 36395},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1487, col: 7, offset: 36317},
+										pos:  position{line: 1488, col: 7, offset: 36395},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1487, col: 11, offset: 36321},
+										pos:        position{line: 1488, col: 11, offset: 36399},
 										val:        ":",
 										ignoreCase: false,
 										want:       "\":\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1487, col: 15, offset: 36325},
+										pos:  position{line: 1488, col: 15, offset: 36403},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1487, col: 19, offset: 36329},
+										pos: position{line: 1488, col: 19, offset: 36407},
 										expr: &choiceExpr{
-											pos: position{line: 1487, col: 21, offset: 36331},
+											pos: position{line: 1488, col: 21, offset: 36409},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1487, col: 21, offset: 36331},
+													pos:  position{line: 1488, col: 21, offset: 36409},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1487, col: 32, offset: 36342},
+													pos:        position{line: 1488, col: 32, offset: 36420},
 													val:        ":",
 													ignoreCase: false,
 													want:       "\":\"",
@@ -10476,10 +10565,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1487, col: 38, offset: 36348},
+							pos:   position{line: 1488, col: 38, offset: 36426},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1487, col: 40, offset: 36350},
+								pos:  position{line: 1488, col: 40, offset: 36428},
 								name: "IP6Variations",
 							},
 						},
@@ -10491,32 +10580,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1491, col: 1, offset: 36514},
+			pos:  position{line: 1492, col: 1, offset: 36592},
 			expr: &choiceExpr{
-				pos: position{line: 1492, col: 5, offset: 36532},
+				pos: position{line: 1493, col: 5, offset: 36610},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1492, col: 5, offset: 36532},
+						pos: position{line: 1493, col: 5, offset: 36610},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1492, col: 5, offset: 36532},
+							pos: position{line: 1493, col: 5, offset: 36610},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1492, col: 5, offset: 36532},
+									pos:   position{line: 1493, col: 5, offset: 36610},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1492, col: 7, offset: 36534},
+										pos: position{line: 1493, col: 7, offset: 36612},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1492, col: 7, offset: 36534},
+											pos:  position{line: 1493, col: 7, offset: 36612},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1492, col: 17, offset: 36544},
+									pos:   position{line: 1493, col: 17, offset: 36622},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1492, col: 19, offset: 36546},
+										pos:  position{line: 1493, col: 19, offset: 36624},
 										name: "IP6Tail",
 									},
 								},
@@ -10524,52 +10613,52 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1495, col: 5, offset: 36610},
+						pos: position{line: 1496, col: 5, offset: 36688},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1495, col: 5, offset: 36610},
+							pos: position{line: 1496, col: 5, offset: 36688},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1495, col: 5, offset: 36610},
+									pos:   position{line: 1496, col: 5, offset: 36688},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1495, col: 7, offset: 36612},
+										pos:  position{line: 1496, col: 7, offset: 36690},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1495, col: 11, offset: 36616},
+									pos:   position{line: 1496, col: 11, offset: 36694},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1495, col: 13, offset: 36618},
+										pos: position{line: 1496, col: 13, offset: 36696},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1495, col: 13, offset: 36618},
+											pos:  position{line: 1496, col: 13, offset: 36696},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1495, col: 23, offset: 36628},
+									pos:        position{line: 1496, col: 23, offset: 36706},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1495, col: 28, offset: 36633},
+									pos:   position{line: 1496, col: 28, offset: 36711},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1495, col: 30, offset: 36635},
+										pos: position{line: 1496, col: 30, offset: 36713},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1495, col: 30, offset: 36635},
+											pos:  position{line: 1496, col: 30, offset: 36713},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1495, col: 40, offset: 36645},
+									pos:   position{line: 1496, col: 40, offset: 36723},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1495, col: 42, offset: 36647},
+										pos:  position{line: 1496, col: 42, offset: 36725},
 										name: "IP6Tail",
 									},
 								},
@@ -10577,33 +10666,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1498, col: 5, offset: 36746},
+						pos: position{line: 1499, col: 5, offset: 36824},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1498, col: 5, offset: 36746},
+							pos: position{line: 1499, col: 5, offset: 36824},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1498, col: 5, offset: 36746},
+									pos:        position{line: 1499, col: 5, offset: 36824},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1498, col: 10, offset: 36751},
+									pos:   position{line: 1499, col: 10, offset: 36829},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1498, col: 12, offset: 36753},
+										pos: position{line: 1499, col: 12, offset: 36831},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1498, col: 12, offset: 36753},
+											pos:  position{line: 1499, col: 12, offset: 36831},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1498, col: 22, offset: 36763},
+									pos:   position{line: 1499, col: 22, offset: 36841},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1498, col: 24, offset: 36765},
+										pos:  position{line: 1499, col: 24, offset: 36843},
 										name: "IP6Tail",
 									},
 								},
@@ -10611,32 +10700,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1501, col: 5, offset: 36836},
+						pos: position{line: 1502, col: 5, offset: 36914},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1501, col: 5, offset: 36836},
+							pos: position{line: 1502, col: 5, offset: 36914},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1501, col: 5, offset: 36836},
+									pos:   position{line: 1502, col: 5, offset: 36914},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1501, col: 7, offset: 36838},
+										pos:  position{line: 1502, col: 7, offset: 36916},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1501, col: 11, offset: 36842},
+									pos:   position{line: 1502, col: 11, offset: 36920},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1501, col: 13, offset: 36844},
+										pos: position{line: 1502, col: 13, offset: 36922},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1501, col: 13, offset: 36844},
+											pos:  position{line: 1502, col: 13, offset: 36922},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1501, col: 23, offset: 36854},
+									pos:        position{line: 1502, col: 23, offset: 36932},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
@@ -10645,10 +10734,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1504, col: 5, offset: 36922},
+						pos: position{line: 1505, col: 5, offset: 37000},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 1504, col: 5, offset: 36922},
+							pos:        position{line: 1505, col: 5, offset: 37000},
 							val:        "::",
 							ignoreCase: false,
 							want:       "\"::\"",
@@ -10661,16 +10750,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1508, col: 1, offset: 36959},
+			pos:  position{line: 1509, col: 1, offset: 37037},
 			expr: &choiceExpr{
-				pos: position{line: 1509, col: 5, offset: 36971},
+				pos: position{line: 1510, col: 5, offset: 37049},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1509, col: 5, offset: 36971},
+						pos:  position{line: 1510, col: 5, offset: 37049},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1510, col: 5, offset: 36978},
+						pos:  position{line: 1511, col: 5, offset: 37056},
 						name: "Hex",
 					},
 				},
@@ -10680,24 +10769,24 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1512, col: 1, offset: 36983},
+			pos:  position{line: 1513, col: 1, offset: 37061},
 			expr: &actionExpr{
-				pos: position{line: 1512, col: 12, offset: 36994},
+				pos: position{line: 1513, col: 12, offset: 37072},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1512, col: 12, offset: 36994},
+					pos: position{line: 1513, col: 12, offset: 37072},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1512, col: 12, offset: 36994},
+							pos:        position{line: 1513, col: 12, offset: 37072},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1512, col: 16, offset: 36998},
+							pos:   position{line: 1513, col: 16, offset: 37076},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1512, col: 18, offset: 37000},
+								pos:  position{line: 1513, col: 18, offset: 37078},
 								name: "Hex",
 							},
 						},
@@ -10709,23 +10798,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1514, col: 1, offset: 37038},
+			pos:  position{line: 1515, col: 1, offset: 37116},
 			expr: &actionExpr{
-				pos: position{line: 1514, col: 12, offset: 37049},
+				pos: position{line: 1515, col: 12, offset: 37127},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1514, col: 12, offset: 37049},
+					pos: position{line: 1515, col: 12, offset: 37127},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1514, col: 12, offset: 37049},
+							pos:   position{line: 1515, col: 12, offset: 37127},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1514, col: 14, offset: 37051},
+								pos:  position{line: 1515, col: 14, offset: 37129},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1514, col: 18, offset: 37055},
+							pos:        position{line: 1515, col: 18, offset: 37133},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
@@ -10738,32 +10827,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1516, col: 1, offset: 37093},
+			pos:  position{line: 1517, col: 1, offset: 37171},
 			expr: &actionExpr{
-				pos: position{line: 1517, col: 5, offset: 37104},
+				pos: position{line: 1518, col: 5, offset: 37182},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1517, col: 5, offset: 37104},
+					pos: position{line: 1518, col: 5, offset: 37182},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1517, col: 5, offset: 37104},
+							pos:   position{line: 1518, col: 5, offset: 37182},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1517, col: 7, offset: 37106},
+								pos:  position{line: 1518, col: 7, offset: 37184},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1517, col: 10, offset: 37109},
+							pos:        position{line: 1518, col: 10, offset: 37187},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1517, col: 14, offset: 37113},
+							pos:   position{line: 1518, col: 14, offset: 37191},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1517, col: 16, offset: 37115},
+								pos:  position{line: 1518, col: 16, offset: 37193},
 								name: "UIntString",
 							},
 						},
@@ -10775,32 +10864,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1521, col: 1, offset: 37183},
+			pos:  position{line: 1522, col: 1, offset: 37261},
 			expr: &actionExpr{
-				pos: position{line: 1522, col: 5, offset: 37194},
+				pos: position{line: 1523, col: 5, offset: 37272},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1522, col: 5, offset: 37194},
+					pos: position{line: 1523, col: 5, offset: 37272},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1522, col: 5, offset: 37194},
+							pos:   position{line: 1523, col: 5, offset: 37272},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1522, col: 7, offset: 37196},
+								pos:  position{line: 1523, col: 7, offset: 37274},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1522, col: 11, offset: 37200},
+							pos:        position{line: 1523, col: 11, offset: 37278},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1522, col: 15, offset: 37204},
+							pos:   position{line: 1523, col: 15, offset: 37282},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1522, col: 17, offset: 37206},
+								pos:  position{line: 1523, col: 17, offset: 37284},
 								name: "UIntString",
 							},
 						},
@@ -10812,15 +10901,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1526, col: 1, offset: 37274},
+			pos:  position{line: 1527, col: 1, offset: 37352},
 			expr: &actionExpr{
-				pos: position{line: 1527, col: 4, offset: 37282},
+				pos: position{line: 1528, col: 4, offset: 37360},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1527, col: 4, offset: 37282},
+					pos:   position{line: 1528, col: 4, offset: 37360},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1527, col: 6, offset: 37284},
+						pos:  position{line: 1528, col: 6, offset: 37362},
 						name: "UIntString",
 					},
 				},
@@ -10830,16 +10919,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1529, col: 1, offset: 37324},
+			pos:  position{line: 1530, col: 1, offset: 37402},
 			expr: &choiceExpr{
-				pos: position{line: 1530, col: 5, offset: 37338},
+				pos: position{line: 1531, col: 5, offset: 37416},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1530, col: 5, offset: 37338},
+						pos:  position{line: 1531, col: 5, offset: 37416},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1531, col: 5, offset: 37353},
+						pos:  position{line: 1532, col: 5, offset: 37431},
 						name: "MinusIntString",
 					},
 				},
@@ -10849,14 +10938,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1533, col: 1, offset: 37369},
+			pos:  position{line: 1534, col: 1, offset: 37447},
 			expr: &actionExpr{
-				pos: position{line: 1533, col: 14, offset: 37382},
+				pos: position{line: 1534, col: 14, offset: 37460},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1533, col: 14, offset: 37382},
+					pos: position{line: 1534, col: 14, offset: 37460},
 					expr: &charClassMatcher{
-						pos:        position{line: 1533, col: 14, offset: 37382},
+						pos:        position{line: 1534, col: 14, offset: 37460},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10869,21 +10958,21 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1535, col: 1, offset: 37421},
+			pos:  position{line: 1536, col: 1, offset: 37499},
 			expr: &actionExpr{
-				pos: position{line: 1536, col: 5, offset: 37440},
+				pos: position{line: 1537, col: 5, offset: 37518},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1536, col: 5, offset: 37440},
+					pos: position{line: 1537, col: 5, offset: 37518},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1536, col: 5, offset: 37440},
+							pos:        position{line: 1537, col: 5, offset: 37518},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1536, col: 9, offset: 37444},
+							pos:  position{line: 1537, col: 9, offset: 37522},
 							name: "UIntString",
 						},
 					},
@@ -10894,29 +10983,29 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1538, col: 1, offset: 37487},
+			pos:  position{line: 1539, col: 1, offset: 37565},
 			expr: &choiceExpr{
-				pos: position{line: 1539, col: 5, offset: 37503},
+				pos: position{line: 1540, col: 5, offset: 37581},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1539, col: 5, offset: 37503},
+						pos: position{line: 1540, col: 5, offset: 37581},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1539, col: 5, offset: 37503},
+							pos: position{line: 1540, col: 5, offset: 37581},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1539, col: 5, offset: 37503},
+									pos: position{line: 1540, col: 5, offset: 37581},
 									expr: &litMatcher{
-										pos:        position{line: 1539, col: 5, offset: 37503},
+										pos:        position{line: 1540, col: 5, offset: 37581},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1539, col: 10, offset: 37508},
+									pos: position{line: 1540, col: 10, offset: 37586},
 									expr: &charClassMatcher{
-										pos:        position{line: 1539, col: 10, offset: 37508},
+										pos:        position{line: 1540, col: 10, offset: 37586},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10924,15 +11013,15 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1539, col: 17, offset: 37515},
+									pos:        position{line: 1540, col: 17, offset: 37593},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1539, col: 21, offset: 37519},
+									pos: position{line: 1540, col: 21, offset: 37597},
 									expr: &charClassMatcher{
-										pos:        position{line: 1539, col: 21, offset: 37519},
+										pos:        position{line: 1540, col: 21, offset: 37597},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10940,9 +11029,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1539, col: 28, offset: 37526},
+									pos: position{line: 1540, col: 28, offset: 37604},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1539, col: 28, offset: 37526},
+										pos:  position{line: 1540, col: 28, offset: 37604},
 										name: "ExponentPart",
 									},
 								},
@@ -10950,30 +11039,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1540, col: 5, offset: 37575},
+						pos: position{line: 1541, col: 5, offset: 37653},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1540, col: 5, offset: 37575},
+							pos: position{line: 1541, col: 5, offset: 37653},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1540, col: 5, offset: 37575},
+									pos: position{line: 1541, col: 5, offset: 37653},
 									expr: &litMatcher{
-										pos:        position{line: 1540, col: 5, offset: 37575},
+										pos:        position{line: 1541, col: 5, offset: 37653},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1540, col: 10, offset: 37580},
+									pos:        position{line: 1541, col: 10, offset: 37658},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1540, col: 14, offset: 37584},
+									pos: position{line: 1541, col: 14, offset: 37662},
 									expr: &charClassMatcher{
-										pos:        position{line: 1540, col: 14, offset: 37584},
+										pos:        position{line: 1541, col: 14, offset: 37662},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10981,9 +11070,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1540, col: 21, offset: 37591},
+									pos: position{line: 1541, col: 21, offset: 37669},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1540, col: 21, offset: 37591},
+										pos:  position{line: 1541, col: 21, offset: 37669},
 										name: "ExponentPart",
 									},
 								},
@@ -10991,17 +11080,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1541, col: 5, offset: 37640},
+						pos: position{line: 1542, col: 5, offset: 37718},
 						run: (*parser).callonFloatString22,
 						expr: &choiceExpr{
-							pos: position{line: 1541, col: 6, offset: 37641},
+							pos: position{line: 1542, col: 6, offset: 37719},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1541, col: 6, offset: 37641},
+									pos:  position{line: 1542, col: 6, offset: 37719},
 									name: "NaN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1541, col: 12, offset: 37647},
+									pos:  position{line: 1542, col: 12, offset: 37725},
 									name: "Infinity",
 								},
 							},
@@ -11014,20 +11103,20 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1544, col: 1, offset: 37690},
+			pos:  position{line: 1545, col: 1, offset: 37768},
 			expr: &seqExpr{
-				pos: position{line: 1544, col: 16, offset: 37705},
+				pos: position{line: 1545, col: 16, offset: 37783},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1544, col: 16, offset: 37705},
+						pos:        position{line: 1545, col: 16, offset: 37783},
 						val:        "e",
 						ignoreCase: true,
 						want:       "\"e\"i",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1544, col: 21, offset: 37710},
+						pos: position{line: 1545, col: 21, offset: 37788},
 						expr: &charClassMatcher{
-							pos:        position{line: 1544, col: 21, offset: 37710},
+							pos:        position{line: 1545, col: 21, offset: 37788},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -11035,7 +11124,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1544, col: 27, offset: 37716},
+						pos:  position{line: 1545, col: 27, offset: 37794},
 						name: "UIntString",
 					},
 				},
@@ -11045,9 +11134,9 @@ var g = &grammar{
 		},
 		{
 			name: "NaN",
-			pos:  position{line: 1546, col: 1, offset: 37728},
+			pos:  position{line: 1547, col: 1, offset: 37806},
 			expr: &litMatcher{
-				pos:        position{line: 1546, col: 7, offset: 37734},
+				pos:        position{line: 1547, col: 7, offset: 37812},
 				val:        "NaN",
 				ignoreCase: false,
 				want:       "\"NaN\"",
@@ -11057,23 +11146,23 @@ var g = &grammar{
 		},
 		{
 			name: "Infinity",
-			pos:  position{line: 1548, col: 1, offset: 37741},
+			pos:  position{line: 1549, col: 1, offset: 37819},
 			expr: &seqExpr{
-				pos: position{line: 1548, col: 12, offset: 37752},
+				pos: position{line: 1549, col: 12, offset: 37830},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 1548, col: 12, offset: 37752},
+						pos: position{line: 1549, col: 12, offset: 37830},
 						expr: &choiceExpr{
-							pos: position{line: 1548, col: 13, offset: 37753},
+							pos: position{line: 1549, col: 13, offset: 37831},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1548, col: 13, offset: 37753},
+									pos:        position{line: 1549, col: 13, offset: 37831},
 									val:        "-",
 									ignoreCase: false,
 									want:       "\"-\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1548, col: 19, offset: 37759},
+									pos:        position{line: 1549, col: 19, offset: 37837},
 									val:        "+",
 									ignoreCase: false,
 									want:       "\"+\"",
@@ -11082,7 +11171,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1548, col: 25, offset: 37765},
+						pos:        position{line: 1549, col: 25, offset: 37843},
 						val:        "Inf",
 						ignoreCase: false,
 						want:       "\"Inf\"",
@@ -11094,14 +11183,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1550, col: 1, offset: 37772},
+			pos:  position{line: 1551, col: 1, offset: 37850},
 			expr: &actionExpr{
-				pos: position{line: 1550, col: 7, offset: 37778},
+				pos: position{line: 1551, col: 7, offset: 37856},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1550, col: 7, offset: 37778},
+					pos: position{line: 1551, col: 7, offset: 37856},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1550, col: 7, offset: 37778},
+						pos:  position{line: 1551, col: 7, offset: 37856},
 						name: "HexDigit",
 					},
 				},
@@ -11111,9 +11200,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1552, col: 1, offset: 37820},
+			pos:  position{line: 1553, col: 1, offset: 37898},
 			expr: &charClassMatcher{
-				pos:        position{line: 1552, col: 12, offset: 37831},
+				pos:        position{line: 1553, col: 12, offset: 37909},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -11124,35 +11213,35 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1554, col: 1, offset: 37844},
+			pos:  position{line: 1555, col: 1, offset: 37922},
 			expr: &choiceExpr{
-				pos: position{line: 1555, col: 5, offset: 37861},
+				pos: position{line: 1556, col: 5, offset: 37939},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1555, col: 5, offset: 37861},
+						pos: position{line: 1556, col: 5, offset: 37939},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 1555, col: 5, offset: 37861},
+							pos: position{line: 1556, col: 5, offset: 37939},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1555, col: 5, offset: 37861},
+									pos:        position{line: 1556, col: 5, offset: 37939},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1555, col: 9, offset: 37865},
+									pos:   position{line: 1556, col: 9, offset: 37943},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1555, col: 11, offset: 37867},
+										pos: position{line: 1556, col: 11, offset: 37945},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1555, col: 11, offset: 37867},
+											pos:  position{line: 1556, col: 11, offset: 37945},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1555, col: 29, offset: 37885},
+									pos:        position{line: 1556, col: 29, offset: 37963},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -11161,30 +11250,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1556, col: 5, offset: 37922},
+						pos: position{line: 1557, col: 5, offset: 38000},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 1556, col: 5, offset: 37922},
+							pos: position{line: 1557, col: 5, offset: 38000},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1556, col: 5, offset: 37922},
+									pos:        position{line: 1557, col: 5, offset: 38000},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1556, col: 9, offset: 37926},
+									pos:   position{line: 1557, col: 9, offset: 38004},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1556, col: 11, offset: 37928},
+										pos: position{line: 1557, col: 11, offset: 38006},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1556, col: 11, offset: 37928},
+											pos:  position{line: 1557, col: 11, offset: 38006},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1556, col: 29, offset: 37946},
+									pos:        position{line: 1557, col: 29, offset: 38024},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -11199,57 +11288,57 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1558, col: 1, offset: 37980},
+			pos:  position{line: 1559, col: 1, offset: 38058},
 			expr: &choiceExpr{
-				pos: position{line: 1559, col: 5, offset: 38001},
+				pos: position{line: 1560, col: 5, offset: 38079},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1559, col: 5, offset: 38001},
+						pos: position{line: 1560, col: 5, offset: 38079},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1559, col: 5, offset: 38001},
+							pos: position{line: 1560, col: 5, offset: 38079},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1559, col: 5, offset: 38001},
+									pos: position{line: 1560, col: 5, offset: 38079},
 									expr: &choiceExpr{
-										pos: position{line: 1559, col: 7, offset: 38003},
+										pos: position{line: 1560, col: 7, offset: 38081},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1559, col: 7, offset: 38003},
+												pos:        position{line: 1560, col: 7, offset: 38081},
 												val:        "\"",
 												ignoreCase: false,
 												want:       "\"\\\"\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1559, col: 13, offset: 38009},
+												pos:  position{line: 1560, col: 13, offset: 38087},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1559, col: 26, offset: 38022,
+									line: 1560, col: 26, offset: 38100,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1560, col: 5, offset: 38059},
+						pos: position{line: 1561, col: 5, offset: 38137},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1560, col: 5, offset: 38059},
+							pos: position{line: 1561, col: 5, offset: 38137},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1560, col: 5, offset: 38059},
+									pos:        position{line: 1561, col: 5, offset: 38137},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1560, col: 10, offset: 38064},
+									pos:   position{line: 1561, col: 10, offset: 38142},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1560, col: 12, offset: 38066},
+										pos:  position{line: 1561, col: 12, offset: 38144},
 										name: "EscapeSequence",
 									},
 								},
@@ -11263,28 +11352,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1562, col: 1, offset: 38100},
+			pos:  position{line: 1563, col: 1, offset: 38178},
 			expr: &actionExpr{
-				pos: position{line: 1563, col: 5, offset: 38112},
+				pos: position{line: 1564, col: 5, offset: 38190},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1563, col: 5, offset: 38112},
+					pos: position{line: 1564, col: 5, offset: 38190},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1563, col: 5, offset: 38112},
+							pos:   position{line: 1564, col: 5, offset: 38190},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1563, col: 10, offset: 38117},
+								pos:  position{line: 1564, col: 10, offset: 38195},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1563, col: 23, offset: 38130},
+							pos:   position{line: 1564, col: 23, offset: 38208},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1563, col: 28, offset: 38135},
+								pos: position{line: 1564, col: 28, offset: 38213},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1563, col: 28, offset: 38135},
+									pos:  position{line: 1564, col: 28, offset: 38213},
 									name: "KeyWordRest",
 								},
 							},
@@ -11297,16 +11386,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1565, col: 1, offset: 38197},
+			pos:  position{line: 1566, col: 1, offset: 38275},
 			expr: &choiceExpr{
-				pos: position{line: 1566, col: 5, offset: 38214},
+				pos: position{line: 1567, col: 5, offset: 38292},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1566, col: 5, offset: 38214},
+						pos:  position{line: 1567, col: 5, offset: 38292},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1567, col: 5, offset: 38231},
+						pos:  position{line: 1568, col: 5, offset: 38309},
 						name: "KeyWordEsc",
 					},
 				},
@@ -11316,16 +11405,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1569, col: 1, offset: 38243},
+			pos:  position{line: 1570, col: 1, offset: 38321},
 			expr: &choiceExpr{
-				pos: position{line: 1570, col: 5, offset: 38259},
+				pos: position{line: 1571, col: 5, offset: 38337},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1570, col: 5, offset: 38259},
+						pos:  position{line: 1571, col: 5, offset: 38337},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1571, col: 5, offset: 38276},
+						pos:        position{line: 1572, col: 5, offset: 38354},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11338,19 +11427,19 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1573, col: 1, offset: 38283},
+			pos:  position{line: 1574, col: 1, offset: 38361},
 			expr: &actionExpr{
-				pos: position{line: 1573, col: 16, offset: 38298},
+				pos: position{line: 1574, col: 16, offset: 38376},
 				run: (*parser).callonKeyWordChars1,
 				expr: &choiceExpr{
-					pos: position{line: 1573, col: 17, offset: 38299},
+					pos: position{line: 1574, col: 17, offset: 38377},
 					alternatives: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1573, col: 17, offset: 38299},
+							pos:  position{line: 1574, col: 17, offset: 38377},
 							name: "UnicodeLetter",
 						},
 						&charClassMatcher{
-							pos:        position{line: 1573, col: 33, offset: 38315},
+							pos:        position{line: 1574, col: 33, offset: 38393},
 							val:        "[_.:/%#@~]",
 							chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 							ignoreCase: false,
@@ -11364,31 +11453,31 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1575, col: 1, offset: 38359},
+			pos:  position{line: 1576, col: 1, offset: 38437},
 			expr: &actionExpr{
-				pos: position{line: 1575, col: 14, offset: 38372},
+				pos: position{line: 1576, col: 14, offset: 38450},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1575, col: 14, offset: 38372},
+					pos: position{line: 1576, col: 14, offset: 38450},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1575, col: 14, offset: 38372},
+							pos:        position{line: 1576, col: 14, offset: 38450},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1575, col: 19, offset: 38377},
+							pos:   position{line: 1576, col: 19, offset: 38455},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1575, col: 22, offset: 38380},
+								pos: position{line: 1576, col: 22, offset: 38458},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1575, col: 22, offset: 38380},
+										pos:  position{line: 1576, col: 22, offset: 38458},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1575, col: 38, offset: 38396},
+										pos:  position{line: 1576, col: 38, offset: 38474},
 										name: "EscapeSequence",
 									},
 								},
@@ -11402,42 +11491,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1577, col: 1, offset: 38431},
+			pos:  position{line: 1578, col: 1, offset: 38509},
 			expr: &actionExpr{
-				pos: position{line: 1578, col: 5, offset: 38447},
+				pos: position{line: 1579, col: 5, offset: 38525},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1578, col: 5, offset: 38447},
+					pos: position{line: 1579, col: 5, offset: 38525},
 					exprs: []any{
 						&andExpr{
-							pos: position{line: 1578, col: 5, offset: 38447},
+							pos: position{line: 1579, col: 5, offset: 38525},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1578, col: 6, offset: 38448},
+								pos:  position{line: 1579, col: 6, offset: 38526},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1578, col: 22, offset: 38464},
+							pos: position{line: 1579, col: 22, offset: 38542},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1578, col: 23, offset: 38465},
+								pos:  position{line: 1579, col: 23, offset: 38543},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1578, col: 35, offset: 38477},
+							pos:   position{line: 1579, col: 35, offset: 38555},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1578, col: 40, offset: 38482},
+								pos:  position{line: 1579, col: 40, offset: 38560},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1578, col: 50, offset: 38492},
+							pos:   position{line: 1579, col: 50, offset: 38570},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1578, col: 55, offset: 38497},
+								pos: position{line: 1579, col: 55, offset: 38575},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1578, col: 55, offset: 38497},
+									pos:  position{line: 1579, col: 55, offset: 38575},
 									name: "GlobRest",
 								},
 							},
@@ -11450,28 +11539,28 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1582, col: 1, offset: 38566},
+			pos:  position{line: 1583, col: 1, offset: 38644},
 			expr: &choiceExpr{
-				pos: position{line: 1582, col: 19, offset: 38584},
+				pos: position{line: 1583, col: 19, offset: 38662},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1582, col: 19, offset: 38584},
+						pos:  position{line: 1583, col: 19, offset: 38662},
 						name: "KeyWordStart",
 					},
 					&seqExpr{
-						pos: position{line: 1582, col: 34, offset: 38599},
+						pos: position{line: 1583, col: 34, offset: 38677},
 						exprs: []any{
 							&oneOrMoreExpr{
-								pos: position{line: 1582, col: 34, offset: 38599},
+								pos: position{line: 1583, col: 34, offset: 38677},
 								expr: &litMatcher{
-									pos:        position{line: 1582, col: 34, offset: 38599},
+									pos:        position{line: 1583, col: 34, offset: 38677},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1582, col: 39, offset: 38604},
+								pos:  position{line: 1583, col: 39, offset: 38682},
 								name: "KeyWordRest",
 							},
 						},
@@ -11483,19 +11572,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1583, col: 1, offset: 38616},
+			pos:  position{line: 1584, col: 1, offset: 38694},
 			expr: &seqExpr{
-				pos: position{line: 1583, col: 15, offset: 38630},
+				pos: position{line: 1584, col: 15, offset: 38708},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1583, col: 15, offset: 38630},
+						pos: position{line: 1584, col: 15, offset: 38708},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1583, col: 15, offset: 38630},
+							pos:  position{line: 1584, col: 15, offset: 38708},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1583, col: 28, offset: 38643},
+						pos:        position{line: 1584, col: 28, offset: 38721},
 						val:        "*",
 						ignoreCase: false,
 						want:       "\"*\"",
@@ -11507,23 +11596,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1585, col: 1, offset: 38648},
+			pos:  position{line: 1586, col: 1, offset: 38726},
 			expr: &choiceExpr{
-				pos: position{line: 1586, col: 5, offset: 38662},
+				pos: position{line: 1587, col: 5, offset: 38740},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1586, col: 5, offset: 38662},
+						pos:  position{line: 1587, col: 5, offset: 38740},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1587, col: 5, offset: 38679},
+						pos:  position{line: 1588, col: 5, offset: 38757},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1588, col: 5, offset: 38691},
+						pos: position{line: 1589, col: 5, offset: 38769},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1588, col: 5, offset: 38691},
+							pos:        position{line: 1589, col: 5, offset: 38769},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -11536,16 +11625,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1590, col: 1, offset: 38716},
+			pos:  position{line: 1591, col: 1, offset: 38794},
 			expr: &choiceExpr{
-				pos: position{line: 1591, col: 5, offset: 38729},
+				pos: position{line: 1592, col: 5, offset: 38807},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1591, col: 5, offset: 38729},
+						pos:  position{line: 1592, col: 5, offset: 38807},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1592, col: 5, offset: 38743},
+						pos:        position{line: 1593, col: 5, offset: 38821},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11558,31 +11647,31 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1594, col: 1, offset: 38750},
+			pos:  position{line: 1595, col: 1, offset: 38828},
 			expr: &actionExpr{
-				pos: position{line: 1594, col: 11, offset: 38760},
+				pos: position{line: 1595, col: 11, offset: 38838},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1594, col: 11, offset: 38760},
+					pos: position{line: 1595, col: 11, offset: 38838},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1594, col: 11, offset: 38760},
+							pos:        position{line: 1595, col: 11, offset: 38838},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1594, col: 16, offset: 38765},
+							pos:   position{line: 1595, col: 16, offset: 38843},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1594, col: 19, offset: 38768},
+								pos: position{line: 1595, col: 19, offset: 38846},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1594, col: 19, offset: 38768},
+										pos:  position{line: 1595, col: 19, offset: 38846},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1594, col: 32, offset: 38781},
+										pos:  position{line: 1595, col: 32, offset: 38859},
 										name: "EscapeSequence",
 									},
 								},
@@ -11596,32 +11685,32 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1596, col: 1, offset: 38816},
+			pos:  position{line: 1597, col: 1, offset: 38894},
 			expr: &choiceExpr{
-				pos: position{line: 1597, col: 5, offset: 38831},
+				pos: position{line: 1598, col: 5, offset: 38909},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1597, col: 5, offset: 38831},
+						pos: position{line: 1598, col: 5, offset: 38909},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1597, col: 5, offset: 38831},
+							pos:        position{line: 1598, col: 5, offset: 38909},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1598, col: 5, offset: 38859},
+						pos: position{line: 1599, col: 5, offset: 38937},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1598, col: 5, offset: 38859},
+							pos:        position{line: 1599, col: 5, offset: 38937},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1599, col: 5, offset: 38889},
+						pos:        position{line: 1600, col: 5, offset: 38967},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -11634,57 +11723,57 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1601, col: 1, offset: 38895},
+			pos:  position{line: 1602, col: 1, offset: 38973},
 			expr: &choiceExpr{
-				pos: position{line: 1602, col: 5, offset: 38916},
+				pos: position{line: 1603, col: 5, offset: 38994},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1602, col: 5, offset: 38916},
+						pos: position{line: 1603, col: 5, offset: 38994},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1602, col: 5, offset: 38916},
+							pos: position{line: 1603, col: 5, offset: 38994},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1602, col: 5, offset: 38916},
+									pos: position{line: 1603, col: 5, offset: 38994},
 									expr: &choiceExpr{
-										pos: position{line: 1602, col: 7, offset: 38918},
+										pos: position{line: 1603, col: 7, offset: 38996},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1602, col: 7, offset: 38918},
+												pos:        position{line: 1603, col: 7, offset: 38996},
 												val:        "'",
 												ignoreCase: false,
 												want:       "\"'\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1602, col: 13, offset: 38924},
+												pos:  position{line: 1603, col: 13, offset: 39002},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1602, col: 26, offset: 38937,
+									line: 1603, col: 26, offset: 39015,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1603, col: 5, offset: 38974},
+						pos: position{line: 1604, col: 5, offset: 39052},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1603, col: 5, offset: 38974},
+							pos: position{line: 1604, col: 5, offset: 39052},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1603, col: 5, offset: 38974},
+									pos:        position{line: 1604, col: 5, offset: 39052},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1603, col: 10, offset: 38979},
+									pos:   position{line: 1604, col: 10, offset: 39057},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1603, col: 12, offset: 38981},
+										pos:  position{line: 1604, col: 12, offset: 39059},
 										name: "EscapeSequence",
 									},
 								},
@@ -11698,16 +11787,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1605, col: 1, offset: 39015},
+			pos:  position{line: 1606, col: 1, offset: 39093},
 			expr: &choiceExpr{
-				pos: position{line: 1606, col: 5, offset: 39034},
+				pos: position{line: 1607, col: 5, offset: 39112},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1606, col: 5, offset: 39034},
+						pos:  position{line: 1607, col: 5, offset: 39112},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1607, col: 5, offset: 39055},
+						pos:  position{line: 1608, col: 5, offset: 39133},
 						name: "UnicodeEscape",
 					},
 				},
@@ -11717,87 +11806,87 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1609, col: 1, offset: 39070},
+			pos:  position{line: 1610, col: 1, offset: 39148},
 			expr: &choiceExpr{
-				pos: position{line: 1610, col: 5, offset: 39091},
+				pos: position{line: 1611, col: 5, offset: 39169},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1610, col: 5, offset: 39091},
+						pos:        position{line: 1611, col: 5, offset: 39169},
 						val:        "'",
 						ignoreCase: false,
 						want:       "\"'\"",
 					},
 					&actionExpr{
-						pos: position{line: 1611, col: 5, offset: 39099},
+						pos: position{line: 1612, col: 5, offset: 39177},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1611, col: 5, offset: 39099},
+							pos:        position{line: 1612, col: 5, offset: 39177},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1612, col: 5, offset: 39139},
+						pos:        position{line: 1613, col: 5, offset: 39217},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
 					},
 					&actionExpr{
-						pos: position{line: 1613, col: 5, offset: 39148},
+						pos: position{line: 1614, col: 5, offset: 39226},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1613, col: 5, offset: 39148},
+							pos:        position{line: 1614, col: 5, offset: 39226},
 							val:        "b",
 							ignoreCase: false,
 							want:       "\"b\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1614, col: 5, offset: 39177},
+						pos: position{line: 1615, col: 5, offset: 39255},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1614, col: 5, offset: 39177},
+							pos:        position{line: 1615, col: 5, offset: 39255},
 							val:        "f",
 							ignoreCase: false,
 							want:       "\"f\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1615, col: 5, offset: 39206},
+						pos: position{line: 1616, col: 5, offset: 39284},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1615, col: 5, offset: 39206},
+							pos:        position{line: 1616, col: 5, offset: 39284},
 							val:        "n",
 							ignoreCase: false,
 							want:       "\"n\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1616, col: 5, offset: 39235},
+						pos: position{line: 1617, col: 5, offset: 39313},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1616, col: 5, offset: 39235},
+							pos:        position{line: 1617, col: 5, offset: 39313},
 							val:        "r",
 							ignoreCase: false,
 							want:       "\"r\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1617, col: 5, offset: 39264},
+						pos: position{line: 1618, col: 5, offset: 39342},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1617, col: 5, offset: 39264},
+							pos:        position{line: 1618, col: 5, offset: 39342},
 							val:        "t",
 							ignoreCase: false,
 							want:       "\"t\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1618, col: 5, offset: 39293},
+						pos: position{line: 1619, col: 5, offset: 39371},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1618, col: 5, offset: 39293},
+							pos:        position{line: 1619, col: 5, offset: 39371},
 							val:        "v",
 							ignoreCase: false,
 							want:       "\"v\"",
@@ -11810,32 +11899,32 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1620, col: 1, offset: 39319},
+			pos:  position{line: 1621, col: 1, offset: 39397},
 			expr: &choiceExpr{
-				pos: position{line: 1621, col: 5, offset: 39337},
+				pos: position{line: 1622, col: 5, offset: 39415},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1621, col: 5, offset: 39337},
+						pos: position{line: 1622, col: 5, offset: 39415},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1621, col: 5, offset: 39337},
+							pos:        position{line: 1622, col: 5, offset: 39415},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1622, col: 5, offset: 39365},
+						pos: position{line: 1623, col: 5, offset: 39443},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1622, col: 5, offset: 39365},
+							pos:        position{line: 1623, col: 5, offset: 39443},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1623, col: 5, offset: 39393},
+						pos:        position{line: 1624, col: 5, offset: 39471},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -11848,42 +11937,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1625, col: 1, offset: 39399},
+			pos:  position{line: 1626, col: 1, offset: 39477},
 			expr: &choiceExpr{
-				pos: position{line: 1626, col: 5, offset: 39417},
+				pos: position{line: 1627, col: 5, offset: 39495},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1626, col: 5, offset: 39417},
+						pos: position{line: 1627, col: 5, offset: 39495},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1626, col: 5, offset: 39417},
+							pos: position{line: 1627, col: 5, offset: 39495},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1626, col: 5, offset: 39417},
+									pos:        position{line: 1627, col: 5, offset: 39495},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1626, col: 9, offset: 39421},
+									pos:   position{line: 1627, col: 9, offset: 39499},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1626, col: 16, offset: 39428},
+										pos: position{line: 1627, col: 16, offset: 39506},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1626, col: 16, offset: 39428},
+												pos:  position{line: 1627, col: 16, offset: 39506},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1626, col: 25, offset: 39437},
+												pos:  position{line: 1627, col: 25, offset: 39515},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1626, col: 34, offset: 39446},
+												pos:  position{line: 1627, col: 34, offset: 39524},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1626, col: 43, offset: 39455},
+												pos:  position{line: 1627, col: 43, offset: 39533},
 												name: "HexDigit",
 											},
 										},
@@ -11893,65 +11982,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1629, col: 5, offset: 39518},
+						pos: position{line: 1630, col: 5, offset: 39596},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1629, col: 5, offset: 39518},
+							pos: position{line: 1630, col: 5, offset: 39596},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1629, col: 5, offset: 39518},
+									pos:        position{line: 1630, col: 5, offset: 39596},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1629, col: 9, offset: 39522},
+									pos:        position{line: 1630, col: 9, offset: 39600},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1629, col: 13, offset: 39526},
+									pos:   position{line: 1630, col: 13, offset: 39604},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1629, col: 20, offset: 39533},
+										pos: position{line: 1630, col: 20, offset: 39611},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1629, col: 20, offset: 39533},
+												pos:  position{line: 1630, col: 20, offset: 39611},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1629, col: 29, offset: 39542},
+												pos: position{line: 1630, col: 29, offset: 39620},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1629, col: 29, offset: 39542},
+													pos:  position{line: 1630, col: 29, offset: 39620},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1629, col: 39, offset: 39552},
+												pos: position{line: 1630, col: 39, offset: 39630},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1629, col: 39, offset: 39552},
+													pos:  position{line: 1630, col: 39, offset: 39630},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1629, col: 49, offset: 39562},
+												pos: position{line: 1630, col: 49, offset: 39640},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1629, col: 49, offset: 39562},
+													pos:  position{line: 1630, col: 49, offset: 39640},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1629, col: 59, offset: 39572},
+												pos: position{line: 1630, col: 59, offset: 39650},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1629, col: 59, offset: 39572},
+													pos:  position{line: 1630, col: 59, offset: 39650},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1629, col: 69, offset: 39582},
+												pos: position{line: 1630, col: 69, offset: 39660},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1629, col: 69, offset: 39582},
+													pos:  position{line: 1630, col: 69, offset: 39660},
 													name: "HexDigit",
 												},
 											},
@@ -11959,7 +12048,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1629, col: 80, offset: 39593},
+									pos:        position{line: 1630, col: 80, offset: 39671},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -11974,37 +12063,37 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPattern",
-			pos:  position{line: 1633, col: 1, offset: 39647},
+			pos:  position{line: 1634, col: 1, offset: 39725},
 			expr: &actionExpr{
-				pos: position{line: 1634, col: 5, offset: 39665},
+				pos: position{line: 1635, col: 5, offset: 39743},
 				run: (*parser).callonRegexpPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1634, col: 5, offset: 39665},
+					pos: position{line: 1635, col: 5, offset: 39743},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1634, col: 5, offset: 39665},
+							pos:        position{line: 1635, col: 5, offset: 39743},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1634, col: 9, offset: 39669},
+							pos:   position{line: 1635, col: 9, offset: 39747},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1634, col: 14, offset: 39674},
+								pos:  position{line: 1635, col: 14, offset: 39752},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1634, col: 25, offset: 39685},
+							pos:        position{line: 1635, col: 25, offset: 39763},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&notExpr{
-							pos: position{line: 1634, col: 29, offset: 39689},
+							pos: position{line: 1635, col: 29, offset: 39767},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1634, col: 30, offset: 39690},
+								pos:  position{line: 1635, col: 30, offset: 39768},
 								name: "KeyWordStart",
 							},
 						},
@@ -12016,33 +12105,33 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1636, col: 1, offset: 39725},
+			pos:  position{line: 1637, col: 1, offset: 39803},
 			expr: &actionExpr{
-				pos: position{line: 1637, col: 5, offset: 39740},
+				pos: position{line: 1638, col: 5, offset: 39818},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1637, col: 5, offset: 39740},
+					pos: position{line: 1638, col: 5, offset: 39818},
 					expr: &choiceExpr{
-						pos: position{line: 1637, col: 6, offset: 39741},
+						pos: position{line: 1638, col: 6, offset: 39819},
 						alternatives: []any{
 							&charClassMatcher{
-								pos:        position{line: 1637, col: 6, offset: 39741},
+								pos:        position{line: 1638, col: 6, offset: 39819},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&seqExpr{
-								pos: position{line: 1637, col: 15, offset: 39750},
+								pos: position{line: 1638, col: 15, offset: 39828},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 1637, col: 15, offset: 39750},
+										pos:        position{line: 1638, col: 15, offset: 39828},
 										val:        "\\",
 										ignoreCase: false,
 										want:       "\"\\\\\"",
 									},
 									&anyMatcher{
-										line: 1637, col: 20, offset: 39755,
+										line: 1638, col: 20, offset: 39833,
 									},
 								},
 							},
@@ -12055,9 +12144,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1639, col: 1, offset: 39791},
+			pos:  position{line: 1640, col: 1, offset: 39869},
 			expr: &charClassMatcher{
-				pos:        position{line: 1640, col: 5, offset: 39807},
+				pos:        position{line: 1641, col: 5, offset: 39885},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -12069,11 +12158,11 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1642, col: 1, offset: 39822},
+			pos:  position{line: 1643, col: 1, offset: 39900},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1642, col: 5, offset: 39826},
+				pos: position{line: 1643, col: 5, offset: 39904},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1642, col: 5, offset: 39826},
+					pos:  position{line: 1643, col: 5, offset: 39904},
 					name: "AnySpace",
 				},
 			},
@@ -12082,11 +12171,11 @@ var g = &grammar{
 		},
 		{
 			name: "__",
-			pos:  position{line: 1644, col: 1, offset: 39837},
+			pos:  position{line: 1645, col: 1, offset: 39915},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1644, col: 6, offset: 39842},
+				pos: position{line: 1645, col: 6, offset: 39920},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1644, col: 6, offset: 39842},
+					pos:  position{line: 1645, col: 6, offset: 39920},
 					name: "AnySpace",
 				},
 			},
@@ -12095,20 +12184,20 @@ var g = &grammar{
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1646, col: 1, offset: 39853},
+			pos:  position{line: 1647, col: 1, offset: 39931},
 			expr: &choiceExpr{
-				pos: position{line: 1647, col: 5, offset: 39866},
+				pos: position{line: 1648, col: 5, offset: 39944},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1647, col: 5, offset: 39866},
+						pos:  position{line: 1648, col: 5, offset: 39944},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1648, col: 5, offset: 39881},
+						pos:  position{line: 1649, col: 5, offset: 39959},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1649, col: 5, offset: 39900},
+						pos:  position{line: 1650, col: 5, offset: 39978},
 						name: "Comment",
 					},
 				},
@@ -12118,32 +12207,32 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeLetter",
-			pos:  position{line: 1651, col: 1, offset: 39909},
+			pos:  position{line: 1652, col: 1, offset: 39987},
 			expr: &choiceExpr{
-				pos: position{line: 1652, col: 5, offset: 39927},
+				pos: position{line: 1653, col: 5, offset: 40005},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1652, col: 5, offset: 39927},
+						pos:  position{line: 1653, col: 5, offset: 40005},
 						name: "Lu",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1653, col: 5, offset: 39934},
+						pos:  position{line: 1654, col: 5, offset: 40012},
 						name: "Ll",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1654, col: 5, offset: 39941},
+						pos:  position{line: 1655, col: 5, offset: 40019},
 						name: "Lt",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1655, col: 5, offset: 39948},
+						pos:  position{line: 1656, col: 5, offset: 40026},
 						name: "Lm",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1656, col: 5, offset: 39955},
+						pos:  position{line: 1657, col: 5, offset: 40033},
 						name: "Lo",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1657, col: 5, offset: 39962},
+						pos:  position{line: 1658, col: 5, offset: 40040},
 						name: "Nl",
 					},
 				},
@@ -12153,16 +12242,16 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeCombiningMark",
-			pos:  position{line: 1659, col: 1, offset: 39966},
+			pos:  position{line: 1660, col: 1, offset: 40044},
 			expr: &choiceExpr{
-				pos: position{line: 1660, col: 5, offset: 39991},
+				pos: position{line: 1661, col: 5, offset: 40069},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1660, col: 5, offset: 39991},
+						pos:  position{line: 1661, col: 5, offset: 40069},
 						name: "Mn",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1661, col: 5, offset: 39998},
+						pos:  position{line: 1662, col: 5, offset: 40076},
 						name: "Mc",
 					},
 				},
@@ -12172,9 +12261,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeDigit",
-			pos:  position{line: 1663, col: 1, offset: 40002},
+			pos:  position{line: 1664, col: 1, offset: 40080},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1664, col: 5, offset: 40019},
+				pos:  position{line: 1665, col: 5, offset: 40097},
 				name: "Nd",
 			},
 			leader:        false,
@@ -12182,9 +12271,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeConnectorPunctuation",
-			pos:  position{line: 1666, col: 1, offset: 40023},
+			pos:  position{line: 1667, col: 1, offset: 40101},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1667, col: 5, offset: 40055},
+				pos:  position{line: 1668, col: 5, offset: 40133},
 				name: "Pc",
 			},
 			leader:        false,
@@ -12192,9 +12281,9 @@ var g = &grammar{
 		},
 		{
 			name: "Ll",
-			pos:  position{line: 1673, col: 1, offset: 40236},
+			pos:  position{line: 1674, col: 1, offset: 40314},
 			expr: &charClassMatcher{
-				pos:        position{line: 1673, col: 6, offset: 40241},
+				pos:        position{line: 1674, col: 6, offset: 40319},
 				val:        "[\\u0061-\\u007A\\u00B5\\u00DF-\\u00F6\\u00F8-\\u00FF\\u0101\\u0103\\u0105\\u0107\\u0109\\u010B\\u010D\\u010F\\u0111\\u0113\\u0115\\u0117\\u0119\\u011B\\u011D\\u011F\\u0121\\u0123\\u0125\\u0127\\u0129\\u012B\\u012D\\u012F\\u0131\\u0133\\u0135\\u0137-\\u0138\\u013A\\u013C\\u013E\\u0140\\u0142\\u0144\\u0146\\u0148-\\u0149\\u014B\\u014D\\u014F\\u0151\\u0153\\u0155\\u0157\\u0159\\u015B\\u015D\\u015F\\u0161\\u0163\\u0165\\u0167\\u0169\\u016B\\u016D\\u016F\\u0171\\u0173\\u0175\\u0177\\u017A\\u017C\\u017E-\\u0180\\u0183\\u0185\\u0188\\u018C-\\u018D\\u0192\\u0195\\u0199-\\u019B\\u019E\\u01A1\\u01A3\\u01A5\\u01A8\\u01AA-\\u01AB\\u01AD\\u01B0\\u01B4\\u01B6\\u01B9-\\u01BA\\u01BD-\\u01BF\\u01C6\\u01C9\\u01CC\\u01CE\\u01D0\\u01D2\\u01D4\\u01D6\\u01D8\\u01DA\\u01DC-\\u01DD\\u01DF\\u01E1\\u01E3\\u01E5\\u01E7\\u01E9\\u01EB\\u01ED\\u01EF-\\u01F0\\u01F3\\u01F5\\u01F9\\u01FB\\u01FD\\u01FF\\u0201\\u0203\\u0205\\u0207\\u0209\\u020B\\u020D\\u020F\\u0211\\u0213\\u0215\\u0217\\u0219\\u021B\\u021D\\u021F\\u0221\\u0223\\u0225\\u0227\\u0229\\u022B\\u022D\\u022F\\u0231\\u0233-\\u0239\\u023C\\u023F-\\u0240\\u0242\\u0247\\u0249\\u024B\\u024D\\u024F-\\u0293\\u0295-\\u02AF\\u0371\\u0373\\u0377\\u037B-\\u037D\\u0390\\u03AC-\\u03CE\\u03D0-\\u03D1\\u03D5-\\u03D7\\u03D9\\u03DB\\u03DD\\u03DF\\u03E1\\u03E3\\u03E5\\u03E7\\u03E9\\u03EB\\u03ED\\u03EF-\\u03F3\\u03F5\\u03F8\\u03FB-\\u03FC\\u0430-\\u045F\\u0461\\u0463\\u0465\\u0467\\u0469\\u046B\\u046D\\u046F\\u0471\\u0473\\u0475\\u0477\\u0479\\u047B\\u047D\\u047F\\u0481\\u048B\\u048D\\u048F\\u0491\\u0493\\u0495\\u0497\\u0499\\u049B\\u049D\\u049F\\u04A1\\u04A3\\u04A5\\u04A7\\u04A9\\u04AB\\u04AD\\u04AF\\u04B1\\u04B3\\u04B5\\u04B7\\u04B9\\u04BB\\u04BD\\u04BF\\u04C2\\u04C4\\u04C6\\u04C8\\u04CA\\u04CC\\u04CE-\\u04CF\\u04D1\\u04D3\\u04D5\\u04D7\\u04D9\\u04DB\\u04DD\\u04DF\\u04E1\\u04E3\\u04E5\\u04E7\\u04E9\\u04EB\\u04ED\\u04EF\\u04F1\\u04F3\\u04F5\\u04F7\\u04F9\\u04FB\\u04FD\\u04FF\\u0501\\u0503\\u0505\\u0507\\u0509\\u050B\\u050D\\u050F\\u0511\\u0513\\u0515\\u0517\\u0519\\u051B\\u051D\\u051F\\u0521\\u0523\\u0525\\u0527\\u0529\\u052B\\u052D\\u052F\\u0560-\\u0588\\u10D0-\\u10FA\\u10FD-\\u10FF\\u13F8-\\u13FD\\u1C80-\\u1C88\\u1D00-\\u1D2B\\u1D6B-\\u1D77\\u1D79-\\u1D9A\\u1E01\\u1E03\\u1E05\\u1E07\\u1E09\\u1E0B\\u1E0D\\u1E0F\\u1E11\\u1E13\\u1E15\\u1E17\\u1E19\\u1E1B\\u1E1D\\u1E1F\\u1E21\\u1E23\\u1E25\\u1E27\\u1E29\\u1E2B\\u1E2D\\u1E2F\\u1E31\\u1E33\\u1E35\\u1E37\\u1E39\\u1E3B\\u1E3D\\u1E3F\\u1E41\\u1E43\\u1E45\\u1E47\\u1E49\\u1E4B\\u1E4D\\u1E4F\\u1E51\\u1E53\\u1E55\\u1E57\\u1E59\\u1E5B\\u1E5D\\u1E5F\\u1E61\\u1E63\\u1E65\\u1E67\\u1E69\\u1E6B\\u1E6D\\u1E6F\\u1E71\\u1E73\\u1E75\\u1E77\\u1E79\\u1E7B\\u1E7D\\u1E7F\\u1E81\\u1E83\\u1E85\\u1E87\\u1E89\\u1E8B\\u1E8D\\u1E8F\\u1E91\\u1E93\\u1E95-\\u1E9D\\u1E9F\\u1EA1\\u1EA3\\u1EA5\\u1EA7\\u1EA9\\u1EAB\\u1EAD\\u1EAF\\u1EB1\\u1EB3\\u1EB5\\u1EB7\\u1EB9\\u1EBB\\u1EBD\\u1EBF\\u1EC1\\u1EC3\\u1EC5\\u1EC7\\u1EC9\\u1ECB\\u1ECD\\u1ECF\\u1ED1\\u1ED3\\u1ED5\\u1ED7\\u1ED9\\u1EDB\\u1EDD\\u1EDF\\u1EE1\\u1EE3\\u1EE5\\u1EE7\\u1EE9\\u1EEB\\u1EED\\u1EEF\\u1EF1\\u1EF3\\u1EF5\\u1EF7\\u1EF9\\u1EFB\\u1EFD\\u1EFF-\\u1F07\\u1F10-\\u1F15\\u1F20-\\u1F27\\u1F30-\\u1F37\\u1F40-\\u1F45\\u1F50-\\u1F57\\u1F60-\\u1F67\\u1F70-\\u1F7D\\u1F80-\\u1F87\\u1F90-\\u1F97\\u1FA0-\\u1FA7\\u1FB0-\\u1FB4\\u1FB6-\\u1FB7\\u1FBE\\u1FC2-\\u1FC4\\u1FC6-\\u1FC7\\u1FD0-\\u1FD3\\u1FD6-\\u1FD7\\u1FE0-\\u1FE7\\u1FF2-\\u1FF4\\u1FF6-\\u1FF7\\u210A\\u210E-\\u210F\\u2113\\u212F\\u2134\\u2139\\u213C-\\u213D\\u2146-\\u2149\\u214E\\u2184\\u2C30-\\u2C5E\\u2C61\\u2C65-\\u2C66\\u2C68\\u2C6A\\u2C6C\\u2C71\\u2C73-\\u2C74\\u2C76-\\u2C7B\\u2C81\\u2C83\\u2C85\\u2C87\\u2C89\\u2C8B\\u2C8D\\u2C8F\\u2C91\\u2C93\\u2C95\\u2C97\\u2C99\\u2C9B\\u2C9D\\u2C9F\\u2CA1\\u2CA3\\u2CA5\\u2CA7\\u2CA9\\u2CAB\\u2CAD\\u2CAF\\u2CB1\\u2CB3\\u2CB5\\u2CB7\\u2CB9\\u2CBB\\u2CBD\\u2CBF\\u2CC1\\u2CC3\\u2CC5\\u2CC7\\u2CC9\\u2CCB\\u2CCD\\u2CCF\\u2CD1\\u2CD3\\u2CD5\\u2CD7\\u2CD9\\u2CDB\\u2CDD\\u2CDF\\u2CE1\\u2CE3-\\u2CE4\\u2CEC\\u2CEE\\u2CF3\\u2D00-\\u2D25\\u2D27\\u2D2D\\uA641\\uA643\\uA645\\uA647\\uA649\\uA64B\\uA64D\\uA64F\\uA651\\uA653\\uA655\\uA657\\uA659\\uA65B\\uA65D\\uA65F\\uA661\\uA663\\uA665\\uA667\\uA669\\uA66B\\uA66D\\uA681\\uA683\\uA685\\uA687\\uA689\\uA68B\\uA68D\\uA68F\\uA691\\uA693\\uA695\\uA697\\uA699\\uA69B\\uA723\\uA725\\uA727\\uA729\\uA72B\\uA72D\\uA72F-\\uA731\\uA733\\uA735\\uA737\\uA739\\uA73B\\uA73D\\uA73F\\uA741\\uA743\\uA745\\uA747\\uA749\\uA74B\\uA74D\\uA74F\\uA751\\uA753\\uA755\\uA757\\uA759\\uA75B\\uA75D\\uA75F\\uA761\\uA763\\uA765\\uA767\\uA769\\uA76B\\uA76D\\uA76F\\uA771-\\uA778\\uA77A\\uA77C\\uA77F\\uA781\\uA783\\uA785\\uA787\\uA78C\\uA78E\\uA791\\uA793-\\uA795\\uA797\\uA799\\uA79B\\uA79D\\uA79F\\uA7A1\\uA7A3\\uA7A5\\uA7A7\\uA7A9\\uA7AF\\uA7B5\\uA7B7\\uA7B9\\uA7FA\\uAB30-\\uAB5A\\uAB60-\\uAB65\\uAB70-\\uABBF\\uFB00-\\uFB06\\uFB13-\\uFB17\\uFF41-\\uFF5A]",
 				chars:      []rune{'µ', 'ā', 'ă', 'ą', 'ć', 'ĉ', 'ċ', 'č', 'ď', 'đ', 'ē', 'ĕ', 'ė', 'ę', 'ě', 'ĝ', 'ğ', 'ġ', 'ģ', 'ĥ', 'ħ', 'ĩ', 'ī', 'ĭ', 'į', 'ı', 'ĳ', 'ĵ', 'ĺ', 'ļ', 'ľ', 'ŀ', 'ł', 'ń', 'ņ', 'ŋ', 'ō', 'ŏ', 'ő', 'œ', 'ŕ', 'ŗ', 'ř', 'ś', 'ŝ', 'ş', 'š', 'ţ', 'ť', 'ŧ', 'ũ', 'ū', 'ŭ', 'ů', 'ű', 'ų', 'ŵ', 'ŷ', 'ź', 'ż', 'ƃ', 'ƅ', 'ƈ', 'ƒ', 'ƕ', 'ƞ', 'ơ', 'ƣ', 'ƥ', 'ƨ', 'ƭ', 'ư', 'ƴ', 'ƶ', 'ǆ', 'ǉ', 'ǌ', 'ǎ', 'ǐ', 'ǒ', 'ǔ', 'ǖ', 'ǘ', 'ǚ', 'ǟ', 'ǡ', 'ǣ', 'ǥ', 'ǧ', 'ǩ', 'ǫ', 'ǭ', 'ǳ', 'ǵ', 'ǹ', 'ǻ', 'ǽ', 'ǿ', 'ȁ', 'ȃ', 'ȅ', 'ȇ', 'ȉ', 'ȋ', 'ȍ', 'ȏ', 'ȑ', 'ȓ', 'ȕ', 'ȗ', 'ș', 'ț', 'ȝ', 'ȟ', 'ȡ', 'ȣ', 'ȥ', 'ȧ', 'ȩ', 'ȫ', 'ȭ', 'ȯ', 'ȱ', 'ȼ', 'ɂ', 'ɇ', 'ɉ', 'ɋ', 'ɍ', 'ͱ', 'ͳ', 'ͷ', 'ΐ', 'ϙ', 'ϛ', 'ϝ', 'ϟ', 'ϡ', 'ϣ', 'ϥ', 'ϧ', 'ϩ', 'ϫ', 'ϭ', 'ϵ', 'ϸ', 'ѡ', 'ѣ', 'ѥ', 'ѧ', 'ѩ', 'ѫ', 'ѭ', 'ѯ', 'ѱ', 'ѳ', 'ѵ', 'ѷ', 'ѹ', 'ѻ', 'ѽ', 'ѿ', 'ҁ', 'ҋ', 'ҍ', 'ҏ', 'ґ', 'ғ', 'ҕ', 'җ', 'ҙ', 'қ', 'ҝ', 'ҟ', 'ҡ', 'ң', 'ҥ', 'ҧ', 'ҩ', 'ҫ', 'ҭ', 'ү', 'ұ', 'ҳ', 'ҵ', 'ҷ', 'ҹ', 'һ', 'ҽ', 'ҿ', 'ӂ', 'ӄ', 'ӆ', 'ӈ', 'ӊ', 'ӌ', 'ӑ', 'ӓ', 'ӕ', 'ӗ', 'ә', 'ӛ', 'ӝ', 'ӟ', 'ӡ', 'ӣ', 'ӥ', 'ӧ', 'ө', 'ӫ', 'ӭ', 'ӯ', 'ӱ', 'ӳ', 'ӵ', 'ӷ', 'ӹ', 'ӻ', 'ӽ', 'ӿ', 'ԁ', 'ԃ', 'ԅ', 'ԇ', 'ԉ', 'ԋ', 'ԍ', 'ԏ', 'ԑ', 'ԓ', 'ԕ', 'ԗ', 'ԙ', 'ԛ', 'ԝ', 'ԟ', 'ԡ', 'ԣ', 'ԥ', 'ԧ', 'ԩ', 'ԫ', 'ԭ', 'ԯ', 'ḁ', 'ḃ', 'ḅ', 'ḇ', 'ḉ', 'ḋ', 'ḍ', 'ḏ', 'ḑ', 'ḓ', 'ḕ', 'ḗ', 'ḙ', 'ḛ', 'ḝ', 'ḟ', 'ḡ', 'ḣ', 'ḥ', 'ḧ', 'ḩ', 'ḫ', 'ḭ', 'ḯ', 'ḱ', 'ḳ', 'ḵ', 'ḷ', 'ḹ', 'ḻ', 'ḽ', 'ḿ', 'ṁ', 'ṃ', 'ṅ', 'ṇ', 'ṉ', 'ṋ', 'ṍ', 'ṏ', 'ṑ', 'ṓ', 'ṕ', 'ṗ', 'ṙ', 'ṛ', 'ṝ', 'ṟ', 'ṡ', 'ṣ', 'ṥ', 'ṧ', 'ṩ', 'ṫ', 'ṭ', 'ṯ', 'ṱ', 'ṳ', 'ṵ', 'ṷ', 'ṹ', 'ṻ', 'ṽ', 'ṿ', 'ẁ', 'ẃ', 'ẅ', 'ẇ', 'ẉ', 'ẋ', 'ẍ', 'ẏ', 'ẑ', 'ẓ', 'ẟ', 'ạ', 'ả', 'ấ', 'ầ', 'ẩ', 'ẫ', 'ậ', 'ắ', 'ằ', 'ẳ', 'ẵ', 'ặ', 'ẹ', 'ẻ', 'ẽ', 'ế', 'ề', 'ể', 'ễ', 'ệ', 'ỉ', 'ị', 'ọ', 'ỏ', 'ố', 'ồ', 'ổ', 'ỗ', 'ộ', 'ớ', 'ờ', 'ở', 'ỡ', 'ợ', 'ụ', 'ủ', 'ứ', 'ừ', 'ử', 'ữ', 'ự', 'ỳ', 'ỵ', 'ỷ', 'ỹ', 'ỻ', 'ỽ', 'ι', 'ℊ', 'ℓ', 'ℯ', 'ℴ', 'ℹ', 'ⅎ', 'ↄ', 'ⱡ', 'ⱨ', 'ⱪ', 'ⱬ', 'ⱱ', 'ⲁ', 'ⲃ', 'ⲅ', 'ⲇ', 'ⲉ', 'ⲋ', 'ⲍ', 'ⲏ', 'ⲑ', 'ⲓ', 'ⲕ', 'ⲗ', 'ⲙ', 'ⲛ', 'ⲝ', 'ⲟ', 'ⲡ', 'ⲣ', 'ⲥ', 'ⲧ', 'ⲩ', 'ⲫ', 'ⲭ', 'ⲯ', 'ⲱ', 'ⲳ', 'ⲵ', 'ⲷ', 'ⲹ', 'ⲻ', 'ⲽ', 'ⲿ', 'ⳁ', 'ⳃ', 'ⳅ', 'ⳇ', 'ⳉ', 'ⳋ', 'ⳍ', 'ⳏ', 'ⳑ', 'ⳓ', 'ⳕ', 'ⳗ', 'ⳙ', 'ⳛ', 'ⳝ', 'ⳟ', 'ⳡ', 'ⳬ', 'ⳮ', 'ⳳ', 'ⴧ', 'ⴭ', 'ꙁ', 'ꙃ', 'ꙅ', 'ꙇ', 'ꙉ', 'ꙋ', 'ꙍ', 'ꙏ', 'ꙑ', 'ꙓ', 'ꙕ', 'ꙗ', 'ꙙ', 'ꙛ', 'ꙝ', 'ꙟ', 'ꙡ', 'ꙣ', 'ꙥ', 'ꙧ', 'ꙩ', 'ꙫ', 'ꙭ', 'ꚁ', 'ꚃ', 'ꚅ', 'ꚇ', 'ꚉ', 'ꚋ', 'ꚍ', 'ꚏ', 'ꚑ', 'ꚓ', 'ꚕ', 'ꚗ', 'ꚙ', 'ꚛ', 'ꜣ', 'ꜥ', 'ꜧ', 'ꜩ', 'ꜫ', 'ꜭ', 'ꜳ', 'ꜵ', 'ꜷ', 'ꜹ', 'ꜻ', 'ꜽ', 'ꜿ', 'ꝁ', 'ꝃ', 'ꝅ', 'ꝇ', 'ꝉ', 'ꝋ', 'ꝍ', 'ꝏ', 'ꝑ', 'ꝓ', 'ꝕ', 'ꝗ', 'ꝙ', 'ꝛ', 'ꝝ', 'ꝟ', 'ꝡ', 'ꝣ', 'ꝥ', 'ꝧ', 'ꝩ', 'ꝫ', 'ꝭ', 'ꝯ', 'ꝺ', 'ꝼ', 'ꝿ', 'ꞁ', 'ꞃ', 'ꞅ', 'ꞇ', 'ꞌ', 'ꞎ', 'ꞑ', 'ꞗ', 'ꞙ', 'ꞛ', 'ꞝ', 'ꞟ', 'ꞡ', 'ꞣ', 'ꞥ', 'ꞧ', 'ꞩ', 'ꞯ', 'ꞵ', 'ꞷ', 'ꞹ', 'ꟺ'},
 				ranges:     []rune{'a', 'z', 'ß', 'ö', 'ø', 'ÿ', 'ķ', 'ĸ', 'ň', 'ŉ', 'ž', 'ƀ', 'ƌ', 'ƍ', 'ƙ', 'ƛ', 'ƪ', 'ƫ', 'ƹ', 'ƺ', 'ƽ', 'ƿ', 'ǜ', 'ǝ', 'ǯ', 'ǰ', 'ȳ', 'ȹ', 'ȿ', 'ɀ', 'ɏ', 'ʓ', 'ʕ', 'ʯ', 'ͻ', 'ͽ', 'ά', 'ώ', 'ϐ', 'ϑ', 'ϕ', 'ϗ', 'ϯ', 'ϳ', 'ϻ', 'ϼ', 'а', 'џ', 'ӎ', 'ӏ', 'ՠ', 'ֈ', 'ა', 'ჺ', 'ჽ', 'ჿ', 'ᏸ', 'ᏽ', 'ᲀ', 'ᲈ', 'ᴀ', 'ᴫ', 'ᵫ', 'ᵷ', 'ᵹ', 'ᶚ', 'ẕ', 'ẝ', 'ỿ', 'ἇ', 'ἐ', 'ἕ', 'ἠ', 'ἧ', 'ἰ', 'ἷ', 'ὀ', 'ὅ', 'ὐ', 'ὗ', 'ὠ', 'ὧ', 'ὰ', 'ώ', 'ᾀ', 'ᾇ', 'ᾐ', 'ᾗ', 'ᾠ', 'ᾧ', 'ᾰ', 'ᾴ', 'ᾶ', 'ᾷ', 'ῂ', 'ῄ', 'ῆ', 'ῇ', 'ῐ', 'ΐ', 'ῖ', 'ῗ', 'ῠ', 'ῧ', 'ῲ', 'ῴ', 'ῶ', 'ῷ', 'ℎ', 'ℏ', 'ℼ', 'ℽ', 'ⅆ', 'ⅉ', 'ⰰ', 'ⱞ', 'ⱥ', 'ⱦ', 'ⱳ', 'ⱴ', 'ⱶ', 'ⱻ', 'ⳣ', 'ⳤ', 'ⴀ', 'ⴥ', 'ꜯ', 'ꜱ', 'ꝱ', 'ꝸ', 'ꞓ', 'ꞕ', 'ꬰ', 'ꭚ', 'ꭠ', 'ꭥ', 'ꭰ', 'ꮿ', 'ﬀ', 'ﬆ', 'ﬓ', 'ﬗ', 'ａ', 'ｚ'},
@@ -12206,9 +12295,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lm",
-			pos:  position{line: 1676, col: 1, offset: 44393},
+			pos:  position{line: 1677, col: 1, offset: 44471},
 			expr: &charClassMatcher{
-				pos:        position{line: 1676, col: 6, offset: 44398},
+				pos:        position{line: 1677, col: 6, offset: 44476},
 				val:        "[\\u02B0-\\u02C1\\u02C6-\\u02D1\\u02E0-\\u02E4\\u02EC\\u02EE\\u0374\\u037A\\u0559\\u0640\\u06E5-\\u06E6\\u07F4-\\u07F5\\u07FA\\u081A\\u0824\\u0828\\u0971\\u0E46\\u0EC6\\u10FC\\u17D7\\u1843\\u1AA7\\u1C78-\\u1C7D\\u1D2C-\\u1D6A\\u1D78\\u1D9B-\\u1DBF\\u2071\\u207F\\u2090-\\u209C\\u2C7C-\\u2C7D\\u2D6F\\u2E2F\\u3005\\u3031-\\u3035\\u303B\\u309D-\\u309E\\u30FC-\\u30FE\\uA015\\uA4F8-\\uA4FD\\uA60C\\uA67F\\uA69C-\\uA69D\\uA717-\\uA71F\\uA770\\uA788\\uA7F8-\\uA7F9\\uA9CF\\uA9E6\\uAA70\\uAADD\\uAAF3-\\uAAF4\\uAB5C-\\uAB5F\\uFF70\\uFF9E-\\uFF9F]",
 				chars:      []rune{'ˬ', 'ˮ', 'ʹ', 'ͺ', 'ՙ', 'ـ', 'ߺ', 'ࠚ', 'ࠤ', 'ࠨ', 'ॱ', 'ๆ', 'ໆ', 'ჼ', 'ៗ', 'ᡃ', 'ᪧ', 'ᵸ', 'ⁱ', 'ⁿ', 'ⵯ', 'ⸯ', '々', '〻', 'ꀕ', 'ꘌ', 'ꙿ', 'ꝰ', 'ꞈ', 'ꧏ', 'ꧦ', 'ꩰ', 'ꫝ', 'ｰ'},
 				ranges:     []rune{'ʰ', 'ˁ', 'ˆ', 'ˑ', 'ˠ', 'ˤ', 'ۥ', 'ۦ', 'ߴ', 'ߵ', 'ᱸ', 'ᱽ', 'ᴬ', 'ᵪ', 'ᶛ', 'ᶿ', 'ₐ', 'ₜ', 'ⱼ', 'ⱽ', '〱', '〵', 'ゝ', 'ゞ', 'ー', 'ヾ', 'ꓸ', 'ꓽ', 'ꚜ', 'ꚝ', 'ꜗ', 'ꜟ', 'ꟸ', 'ꟹ', 'ꫳ', 'ꫴ', 'ꭜ', 'ꭟ', 'ﾞ', 'ﾟ'},
@@ -12220,9 +12309,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lo",
-			pos:  position{line: 1679, col: 1, offset: 44883},
+			pos:  position{line: 1680, col: 1, offset: 44961},
 			expr: &charClassMatcher{
-				pos:        position{line: 1679, col: 6, offset: 44888},
+				pos:        position{line: 1680, col: 6, offset: 44966},
 				val:        "[\\u00AA\\u00BA\\u01BB\\u01C0-\\u01C3\\u0294\\u05D0-\\u05EA\\u05EF-\\u05F2\\u0620-\\u063F\\u0641-\\u064A\\u066E-\\u066F\\u0671-\\u06D3\\u06D5\\u06EE-\\u06EF\\u06FA-\\u06FC\\u06FF\\u0710\\u0712-\\u072F\\u074D-\\u07A5\\u07B1\\u07CA-\\u07EA\\u0800-\\u0815\\u0840-\\u0858\\u0860-\\u086A\\u08A0-\\u08B4\\u08B6-\\u08BD\\u0904-\\u0939\\u093D\\u0950\\u0958-\\u0961\\u0972-\\u0980\\u0985-\\u098C\\u098F-\\u0990\\u0993-\\u09A8\\u09AA-\\u09B0\\u09B2\\u09B6-\\u09B9\\u09BD\\u09CE\\u09DC-\\u09DD\\u09DF-\\u09E1\\u09F0-\\u09F1\\u09FC\\u0A05-\\u0A0A\\u0A0F-\\u0A10\\u0A13-\\u0A28\\u0A2A-\\u0A30\\u0A32-\\u0A33\\u0A35-\\u0A36\\u0A38-\\u0A39\\u0A59-\\u0A5C\\u0A5E\\u0A72-\\u0A74\\u0A85-\\u0A8D\\u0A8F-\\u0A91\\u0A93-\\u0AA8\\u0AAA-\\u0AB0\\u0AB2-\\u0AB3\\u0AB5-\\u0AB9\\u0ABD\\u0AD0\\u0AE0-\\u0AE1\\u0AF9\\u0B05-\\u0B0C\\u0B0F-\\u0B10\\u0B13-\\u0B28\\u0B2A-\\u0B30\\u0B32-\\u0B33\\u0B35-\\u0B39\\u0B3D\\u0B5C-\\u0B5D\\u0B5F-\\u0B61\\u0B71\\u0B83\\u0B85-\\u0B8A\\u0B8E-\\u0B90\\u0B92-\\u0B95\\u0B99-\\u0B9A\\u0B9C\\u0B9E-\\u0B9F\\u0BA3-\\u0BA4\\u0BA8-\\u0BAA\\u0BAE-\\u0BB9\\u0BD0\\u0C05-\\u0C0C\\u0C0E-\\u0C10\\u0C12-\\u0C28\\u0C2A-\\u0C39\\u0C3D\\u0C58-\\u0C5A\\u0C60-\\u0C61\\u0C80\\u0C85-\\u0C8C\\u0C8E-\\u0C90\\u0C92-\\u0CA8\\u0CAA-\\u0CB3\\u0CB5-\\u0CB9\\u0CBD\\u0CDE\\u0CE0-\\u0CE1\\u0CF1-\\u0CF2\\u0D05-\\u0D0C\\u0D0E-\\u0D10\\u0D12-\\u0D3A\\u0D3D\\u0D4E\\u0D54-\\u0D56\\u0D5F-\\u0D61\\u0D7A-\\u0D7F\\u0D85-\\u0D96\\u0D9A-\\u0DB1\\u0DB3-\\u0DBB\\u0DBD\\u0DC0-\\u0DC6\\u0E01-\\u0E30\\u0E32-\\u0E33\\u0E40-\\u0E45\\u0E81-\\u0E82\\u0E84\\u0E87-\\u0E88\\u0E8A\\u0E8D\\u0E94-\\u0E97\\u0E99-\\u0E9F\\u0EA1-\\u0EA3\\u0EA5\\u0EA7\\u0EAA-\\u0EAB\\u0EAD-\\u0EB0\\u0EB2-\\u0EB3\\u0EBD\\u0EC0-\\u0EC4\\u0EDC-\\u0EDF\\u0F00\\u0F40-\\u0F47\\u0F49-\\u0F6C\\u0F88-\\u0F8C\\u1000-\\u102A\\u103F\\u1050-\\u1055\\u105A-\\u105D\\u1061\\u1065-\\u1066\\u106E-\\u1070\\u1075-\\u1081\\u108E\\u1100-\\u1248\\u124A-\\u124D\\u1250-\\u1256\\u1258\\u125A-\\u125D\\u1260-\\u1288\\u128A-\\u128D\\u1290-\\u12B0\\u12B2-\\u12B5\\u12B8-\\u12BE\\u12C0\\u12C2-\\u12C5\\u12C8-\\u12D6\\u12D8-\\u1310\\u1312-\\u1315\\u1318-\\u135A\\u1380-\\u138F\\u1401-\\u166C\\u166F-\\u167F\\u1681-\\u169A\\u16A0-\\u16EA\\u16F1-\\u16F8\\u1700-\\u170C\\u170E-\\u1711\\u1720-\\u1731\\u1740-\\u1751\\u1760-\\u176C\\u176E-\\u1770\\u1780-\\u17B3\\u17DC\\u1820-\\u1842\\u1844-\\u1878\\u1880-\\u1884\\u1887-\\u18A8\\u18AA\\u18B0-\\u18F5\\u1900-\\u191E\\u1950-\\u196D\\u1970-\\u1974\\u1980-\\u19AB\\u19B0-\\u19C9\\u1A00-\\u1A16\\u1A20-\\u1A54\\u1B05-\\u1B33\\u1B45-\\u1B4B\\u1B83-\\u1BA0\\u1BAE-\\u1BAF\\u1BBA-\\u1BE5\\u1C00-\\u1C23\\u1C4D-\\u1C4F\\u1C5A-\\u1C77\\u1CE9-\\u1CEC\\u1CEE-\\u1CF1\\u1CF5-\\u1CF6\\u2135-\\u2138\\u2D30-\\u2D67\\u2D80-\\u2D96\\u2DA0-\\u2DA6\\u2DA8-\\u2DAE\\u2DB0-\\u2DB6\\u2DB8-\\u2DBE\\u2DC0-\\u2DC6\\u2DC8-\\u2DCE\\u2DD0-\\u2DD6\\u2DD8-\\u2DDE\\u3006\\u303C\\u3041-\\u3096\\u309F\\u30A1-\\u30FA\\u30FF\\u3105-\\u312F\\u3131-\\u318E\\u31A0-\\u31BA\\u31F0-\\u31FF\\u3400-\\u4DB5\\u4E00-\\u9FEF\\uA000-\\uA014\\uA016-\\uA48C\\uA4D0-\\uA4F7\\uA500-\\uA60B\\uA610-\\uA61F\\uA62A-\\uA62B\\uA66E\\uA6A0-\\uA6E5\\uA78F\\uA7F7\\uA7FB-\\uA801\\uA803-\\uA805\\uA807-\\uA80A\\uA80C-\\uA822\\uA840-\\uA873\\uA882-\\uA8B3\\uA8F2-\\uA8F7\\uA8FB\\uA8FD-\\uA8FE\\uA90A-\\uA925\\uA930-\\uA946\\uA960-\\uA97C\\uA984-\\uA9B2\\uA9E0-\\uA9E4\\uA9E7-\\uA9EF\\uA9FA-\\uA9FE\\uAA00-\\uAA28\\uAA40-\\uAA42\\uAA44-\\uAA4B\\uAA60-\\uAA6F\\uAA71-\\uAA76\\uAA7A\\uAA7E-\\uAAAF\\uAAB1\\uAAB5-\\uAAB6\\uAAB9-\\uAABD\\uAAC0\\uAAC2\\uAADB-\\uAADC\\uAAE0-\\uAAEA\\uAAF2\\uAB01-\\uAB06\\uAB09-\\uAB0E\\uAB11-\\uAB16\\uAB20-\\uAB26\\uAB28-\\uAB2E\\uABC0-\\uABE2\\uAC00-\\uD7A3\\uD7B0-\\uD7C6\\uD7CB-\\uD7FB\\uF900-\\uFA6D\\uFA70-\\uFAD9\\uFB1D\\uFB1F-\\uFB28\\uFB2A-\\uFB36\\uFB38-\\uFB3C\\uFB3E\\uFB40-\\uFB41\\uFB43-\\uFB44\\uFB46-\\uFBB1\\uFBD3-\\uFD3D\\uFD50-\\uFD8F\\uFD92-\\uFDC7\\uFDF0-\\uFDFB\\uFE70-\\uFE74\\uFE76-\\uFEFC\\uFF66-\\uFF6F\\uFF71-\\uFF9D\\uFFA0-\\uFFBE\\uFFC2-\\uFFC7\\uFFCA-\\uFFCF\\uFFD2-\\uFFD7\\uFFDA-\\uFFDC]",
 				chars:      []rune{'ª', 'º', 'ƻ', 'ʔ', 'ە', 'ۿ', 'ܐ', 'ޱ', 'ऽ', 'ॐ', 'ল', 'ঽ', 'ৎ', 'ৼ', 'ਫ਼', 'ઽ', 'ૐ', 'ૹ', 'ଽ', 'ୱ', 'ஃ', 'ஜ', 'ௐ', 'ఽ', 'ಀ', 'ಽ', 'ೞ', 'ഽ', 'ൎ', 'ල', 'ຄ', 'ຊ', 'ຍ', 'ລ', 'ວ', 'ຽ', 'ༀ', 'ဿ', 'ၡ', 'ႎ', 'ቘ', 'ዀ', 'ៜ', 'ᢪ', '〆', '〼', 'ゟ', 'ヿ', 'ꙮ', 'ꞏ', 'ꟷ', 'ꣻ', 'ꩺ', 'ꪱ', 'ꫀ', 'ꫂ', 'ꫲ', 'יִ', 'מּ'},
 				ranges:     []rune{'ǀ', 'ǃ', 'א', 'ת', 'ׯ', 'ײ', 'ؠ', 'ؿ', 'ف', 'ي', 'ٮ', 'ٯ', 'ٱ', 'ۓ', 'ۮ', 'ۯ', 'ۺ', 'ۼ', 'ܒ', 'ܯ', 'ݍ', 'ޥ', 'ߊ', 'ߪ', 'ࠀ', 'ࠕ', 'ࡀ', 'ࡘ', 'ࡠ', 'ࡪ', 'ࢠ', 'ࢴ', 'ࢶ', 'ࢽ', 'ऄ', 'ह', 'क़', 'ॡ', 'ॲ', 'ঀ', 'অ', 'ঌ', 'এ', 'ঐ', 'ও', 'ন', 'প', 'র', 'শ', 'হ', 'ড়', 'ঢ়', 'য়', 'ৡ', 'ৰ', 'ৱ', 'ਅ', 'ਊ', 'ਏ', 'ਐ', 'ਓ', 'ਨ', 'ਪ', 'ਰ', 'ਲ', 'ਲ਼', 'ਵ', 'ਸ਼', 'ਸ', 'ਹ', 'ਖ਼', 'ੜ', 'ੲ', 'ੴ', 'અ', 'ઍ', 'એ', 'ઑ', 'ઓ', 'ન', 'પ', 'ર', 'લ', 'ળ', 'વ', 'હ', 'ૠ', 'ૡ', 'ଅ', 'ଌ', 'ଏ', 'ଐ', 'ଓ', 'ନ', 'ପ', 'ର', 'ଲ', 'ଳ', 'ଵ', 'ହ', 'ଡ଼', 'ଢ଼', 'ୟ', 'ୡ', 'அ', 'ஊ', 'எ', 'ஐ', 'ஒ', 'க', 'ங', 'ச', 'ஞ', 'ட', 'ண', 'த', 'ந', 'ப', 'ம', 'ஹ', 'అ', 'ఌ', 'ఎ', 'ఐ', 'ఒ', 'న', 'ప', 'హ', 'ౘ', 'ౚ', 'ౠ', 'ౡ', 'ಅ', 'ಌ', 'ಎ', 'ಐ', 'ಒ', 'ನ', 'ಪ', 'ಳ', 'ವ', 'ಹ', 'ೠ', 'ೡ', 'ೱ', 'ೲ', 'അ', 'ഌ', 'എ', 'ഐ', 'ഒ', 'ഺ', 'ൔ', 'ൖ', 'ൟ', 'ൡ', 'ൺ', 'ൿ', 'අ', 'ඖ', 'ක', 'න', 'ඳ', 'ර', 'ව', 'ෆ', 'ก', 'ะ', 'า', 'ำ', 'เ', 'ๅ', 'ກ', 'ຂ', 'ງ', 'ຈ', 'ດ', 'ທ', 'ນ', 'ຟ', 'ມ', 'ຣ', 'ສ', 'ຫ', 'ອ', 'ະ', 'າ', 'ຳ', 'ເ', 'ໄ', 'ໜ', 'ໟ', 'ཀ', 'ཇ', 'ཉ', 'ཬ', 'ྈ', 'ྌ', 'က', 'ဪ', 'ၐ', 'ၕ', 'ၚ', 'ၝ', 'ၥ', 'ၦ', 'ၮ', 'ၰ', 'ၵ', 'ႁ', 'ᄀ', 'ቈ', 'ቊ', 'ቍ', 'ቐ', 'ቖ', 'ቚ', 'ቝ', 'በ', 'ኈ', 'ኊ', 'ኍ', 'ነ', 'ኰ', 'ኲ', 'ኵ', 'ኸ', 'ኾ', 'ዂ', 'ዅ', 'ወ', 'ዖ', 'ዘ', 'ጐ', 'ጒ', 'ጕ', 'ጘ', 'ፚ', 'ᎀ', 'ᎏ', 'ᐁ', 'ᙬ', 'ᙯ', 'ᙿ', 'ᚁ', 'ᚚ', 'ᚠ', 'ᛪ', 'ᛱ', 'ᛸ', 'ᜀ', 'ᜌ', 'ᜎ', 'ᜑ', 'ᜠ', 'ᜱ', 'ᝀ', 'ᝑ', 'ᝠ', 'ᝬ', 'ᝮ', 'ᝰ', 'ក', 'ឳ', 'ᠠ', 'ᡂ', 'ᡄ', 'ᡸ', 'ᢀ', 'ᢄ', 'ᢇ', 'ᢨ', 'ᢰ', 'ᣵ', 'ᤀ', 'ᤞ', 'ᥐ', 'ᥭ', 'ᥰ', 'ᥴ', 'ᦀ', 'ᦫ', 'ᦰ', 'ᧉ', 'ᨀ', 'ᨖ', 'ᨠ', 'ᩔ', 'ᬅ', 'ᬳ', 'ᭅ', 'ᭋ', 'ᮃ', 'ᮠ', 'ᮮ', 'ᮯ', 'ᮺ', 'ᯥ', 'ᰀ', 'ᰣ', 'ᱍ', 'ᱏ', 'ᱚ', 'ᱷ', 'ᳩ', 'ᳬ', 'ᳮ', 'ᳱ', 'ᳵ', 'ᳶ', 'ℵ', 'ℸ', 'ⴰ', 'ⵧ', 'ⶀ', 'ⶖ', 'ⶠ', 'ⶦ', 'ⶨ', 'ⶮ', 'ⶰ', 'ⶶ', 'ⶸ', 'ⶾ', 'ⷀ', 'ⷆ', 'ⷈ', 'ⷎ', 'ⷐ', 'ⷖ', 'ⷘ', 'ⷞ', 'ぁ', 'ゖ', 'ァ', 'ヺ', 'ㄅ', 'ㄯ', 'ㄱ', 'ㆎ', 'ㆠ', 'ㆺ', 'ㇰ', 'ㇿ', '㐀', '䶵', '一', '鿯', 'ꀀ', 'ꀔ', 'ꀖ', 'ꒌ', 'ꓐ', 'ꓷ', 'ꔀ', 'ꘋ', 'ꘐ', 'ꘟ', 'ꘪ', 'ꘫ', 'ꚠ', 'ꛥ', 'ꟻ', 'ꠁ', 'ꠃ', 'ꠅ', 'ꠇ', 'ꠊ', 'ꠌ', 'ꠢ', 'ꡀ', 'ꡳ', 'ꢂ', 'ꢳ', 'ꣲ', 'ꣷ', 'ꣽ', 'ꣾ', 'ꤊ', 'ꤥ', 'ꤰ', 'ꥆ', 'ꥠ', 'ꥼ', 'ꦄ', 'ꦲ', 'ꧠ', 'ꧤ', 'ꧧ', 'ꧯ', 'ꧺ', 'ꧾ', 'ꨀ', 'ꨨ', 'ꩀ', 'ꩂ', 'ꩄ', 'ꩋ', 'ꩠ', 'ꩯ', 'ꩱ', 'ꩶ', 'ꩾ', 'ꪯ', 'ꪵ', 'ꪶ', 'ꪹ', 'ꪽ', 'ꫛ', 'ꫜ', 'ꫠ', 'ꫪ', 'ꬁ', 'ꬆ', 'ꬉ', 'ꬎ', 'ꬑ', 'ꬖ', 'ꬠ', 'ꬦ', 'ꬨ', 'ꬮ', 'ꯀ', 'ꯢ', '가', '힣', 'ힰ', 'ퟆ', 'ퟋ', 'ퟻ', '豈', '舘', '並', '龎', 'ײַ', 'ﬨ', 'שׁ', 'זּ', 'טּ', 'לּ', 'נּ', 'סּ', 'ףּ', 'פּ', 'צּ', 'ﮱ', 'ﯓ', 'ﴽ', 'ﵐ', 'ﶏ', 'ﶒ', 'ﷇ', 'ﷰ', 'ﷻ', 'ﹰ', 'ﹴ', 'ﹶ', 'ﻼ', 'ｦ', 'ｯ', 'ｱ', 'ﾝ', 'ﾠ', 'ﾾ', 'ￂ', 'ￇ', 'ￊ', 'ￏ', 'ￒ', 'ￗ', 'ￚ', 'ￜ'},
@@ -12234,9 +12323,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lt",
-			pos:  position{line: 1682, col: 1, offset: 48335},
+			pos:  position{line: 1683, col: 1, offset: 48413},
 			expr: &charClassMatcher{
-				pos:        position{line: 1682, col: 6, offset: 48340},
+				pos:        position{line: 1683, col: 6, offset: 48418},
 				val:        "[\\u01C5\\u01C8\\u01CB\\u01F2\\u1F88-\\u1F8F\\u1F98-\\u1F9F\\u1FA8-\\u1FAF\\u1FBC\\u1FCC\\u1FFC]",
 				chars:      []rune{'ǅ', 'ǈ', 'ǋ', 'ǲ', 'ᾼ', 'ῌ', 'ῼ'},
 				ranges:     []rune{'ᾈ', 'ᾏ', 'ᾘ', 'ᾟ', 'ᾨ', 'ᾯ'},
@@ -12248,9 +12337,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lu",
-			pos:  position{line: 1685, col: 1, offset: 48446},
+			pos:  position{line: 1686, col: 1, offset: 48524},
 			expr: &charClassMatcher{
-				pos:        position{line: 1685, col: 6, offset: 48451},
+				pos:        position{line: 1686, col: 6, offset: 48529},
 				val:        "[\\u0041-\\u005A\\u00C0-\\u00D6\\u00D8-\\u00DE\\u0100\\u0102\\u0104\\u0106\\u0108\\u010A\\u010C\\u010E\\u0110\\u0112\\u0114\\u0116\\u0118\\u011A\\u011C\\u011E\\u0120\\u0122\\u0124\\u0126\\u0128\\u012A\\u012C\\u012E\\u0130\\u0132\\u0134\\u0136\\u0139\\u013B\\u013D\\u013F\\u0141\\u0143\\u0145\\u0147\\u014A\\u014C\\u014E\\u0150\\u0152\\u0154\\u0156\\u0158\\u015A\\u015C\\u015E\\u0160\\u0162\\u0164\\u0166\\u0168\\u016A\\u016C\\u016E\\u0170\\u0172\\u0174\\u0176\\u0178-\\u0179\\u017B\\u017D\\u0181-\\u0182\\u0184\\u0186-\\u0187\\u0189-\\u018B\\u018E-\\u0191\\u0193-\\u0194\\u0196-\\u0198\\u019C-\\u019D\\u019F-\\u01A0\\u01A2\\u01A4\\u01A6-\\u01A7\\u01A9\\u01AC\\u01AE-\\u01AF\\u01B1-\\u01B3\\u01B5\\u01B7-\\u01B8\\u01BC\\u01C4\\u01C7\\u01CA\\u01CD\\u01CF\\u01D1\\u01D3\\u01D5\\u01D7\\u01D9\\u01DB\\u01DE\\u01E0\\u01E2\\u01E4\\u01E6\\u01E8\\u01EA\\u01EC\\u01EE\\u01F1\\u01F4\\u01F6-\\u01F8\\u01FA\\u01FC\\u01FE\\u0200\\u0202\\u0204\\u0206\\u0208\\u020A\\u020C\\u020E\\u0210\\u0212\\u0214\\u0216\\u0218\\u021A\\u021C\\u021E\\u0220\\u0222\\u0224\\u0226\\u0228\\u022A\\u022C\\u022E\\u0230\\u0232\\u023A-\\u023B\\u023D-\\u023E\\u0241\\u0243-\\u0246\\u0248\\u024A\\u024C\\u024E\\u0370\\u0372\\u0376\\u037F\\u0386\\u0388-\\u038A\\u038C\\u038E-\\u038F\\u0391-\\u03A1\\u03A3-\\u03AB\\u03CF\\u03D2-\\u03D4\\u03D8\\u03DA\\u03DC\\u03DE\\u03E0\\u03E2\\u03E4\\u03E6\\u03E8\\u03EA\\u03EC\\u03EE\\u03F4\\u03F7\\u03F9-\\u03FA\\u03FD-\\u042F\\u0460\\u0462\\u0464\\u0466\\u0468\\u046A\\u046C\\u046E\\u0470\\u0472\\u0474\\u0476\\u0478\\u047A\\u047C\\u047E\\u0480\\u048A\\u048C\\u048E\\u0490\\u0492\\u0494\\u0496\\u0498\\u049A\\u049C\\u049E\\u04A0\\u04A2\\u04A4\\u04A6\\u04A8\\u04AA\\u04AC\\u04AE\\u04B0\\u04B2\\u04B4\\u04B6\\u04B8\\u04BA\\u04BC\\u04BE\\u04C0-\\u04C1\\u04C3\\u04C5\\u04C7\\u04C9\\u04CB\\u04CD\\u04D0\\u04D2\\u04D4\\u04D6\\u04D8\\u04DA\\u04DC\\u04DE\\u04E0\\u04E2\\u04E4\\u04E6\\u04E8\\u04EA\\u04EC\\u04EE\\u04F0\\u04F2\\u04F4\\u04F6\\u04F8\\u04FA\\u04FC\\u04FE\\u0500\\u0502\\u0504\\u0506\\u0508\\u050A\\u050C\\u050E\\u0510\\u0512\\u0514\\u0516\\u0518\\u051A\\u051C\\u051E\\u0520\\u0522\\u0524\\u0526\\u0528\\u052A\\u052C\\u052E\\u0531-\\u0556\\u10A0-\\u10C5\\u10C7\\u10CD\\u13A0-\\u13F5\\u1C90-\\u1CBA\\u1CBD-\\u1CBF\\u1E00\\u1E02\\u1E04\\u1E06\\u1E08\\u1E0A\\u1E0C\\u1E0E\\u1E10\\u1E12\\u1E14\\u1E16\\u1E18\\u1E1A\\u1E1C\\u1E1E\\u1E20\\u1E22\\u1E24\\u1E26\\u1E28\\u1E2A\\u1E2C\\u1E2E\\u1E30\\u1E32\\u1E34\\u1E36\\u1E38\\u1E3A\\u1E3C\\u1E3E\\u1E40\\u1E42\\u1E44\\u1E46\\u1E48\\u1E4A\\u1E4C\\u1E4E\\u1E50\\u1E52\\u1E54\\u1E56\\u1E58\\u1E5A\\u1E5C\\u1E5E\\u1E60\\u1E62\\u1E64\\u1E66\\u1E68\\u1E6A\\u1E6C\\u1E6E\\u1E70\\u1E72\\u1E74\\u1E76\\u1E78\\u1E7A\\u1E7C\\u1E7E\\u1E80\\u1E82\\u1E84\\u1E86\\u1E88\\u1E8A\\u1E8C\\u1E8E\\u1E90\\u1E92\\u1E94\\u1E9E\\u1EA0\\u1EA2\\u1EA4\\u1EA6\\u1EA8\\u1EAA\\u1EAC\\u1EAE\\u1EB0\\u1EB2\\u1EB4\\u1EB6\\u1EB8\\u1EBA\\u1EBC\\u1EBE\\u1EC0\\u1EC2\\u1EC4\\u1EC6\\u1EC8\\u1ECA\\u1ECC\\u1ECE\\u1ED0\\u1ED2\\u1ED4\\u1ED6\\u1ED8\\u1EDA\\u1EDC\\u1EDE\\u1EE0\\u1EE2\\u1EE4\\u1EE6\\u1EE8\\u1EEA\\u1EEC\\u1EEE\\u1EF0\\u1EF2\\u1EF4\\u1EF6\\u1EF8\\u1EFA\\u1EFC\\u1EFE\\u1F08-\\u1F0F\\u1F18-\\u1F1D\\u1F28-\\u1F2F\\u1F38-\\u1F3F\\u1F48-\\u1F4D\\u1F59\\u1F5B\\u1F5D\\u1F5F\\u1F68-\\u1F6F\\u1FB8-\\u1FBB\\u1FC8-\\u1FCB\\u1FD8-\\u1FDB\\u1FE8-\\u1FEC\\u1FF8-\\u1FFB\\u2102\\u2107\\u210B-\\u210D\\u2110-\\u2112\\u2115\\u2119-\\u211D\\u2124\\u2126\\u2128\\u212A-\\u212D\\u2130-\\u2133\\u213E-\\u213F\\u2145\\u2183\\u2C00-\\u2C2E\\u2C60\\u2C62-\\u2C64\\u2C67\\u2C69\\u2C6B\\u2C6D-\\u2C70\\u2C72\\u2C75\\u2C7E-\\u2C80\\u2C82\\u2C84\\u2C86\\u2C88\\u2C8A\\u2C8C\\u2C8E\\u2C90\\u2C92\\u2C94\\u2C96\\u2C98\\u2C9A\\u2C9C\\u2C9E\\u2CA0\\u2CA2\\u2CA4\\u2CA6\\u2CA8\\u2CAA\\u2CAC\\u2CAE\\u2CB0\\u2CB2\\u2CB4\\u2CB6\\u2CB8\\u2CBA\\u2CBC\\u2CBE\\u2CC0\\u2CC2\\u2CC4\\u2CC6\\u2CC8\\u2CCA\\u2CCC\\u2CCE\\u2CD0\\u2CD2\\u2CD4\\u2CD6\\u2CD8\\u2CDA\\u2CDC\\u2CDE\\u2CE0\\u2CE2\\u2CEB\\u2CED\\u2CF2\\uA640\\uA642\\uA644\\uA646\\uA648\\uA64A\\uA64C\\uA64E\\uA650\\uA652\\uA654\\uA656\\uA658\\uA65A\\uA65C\\uA65E\\uA660\\uA662\\uA664\\uA666\\uA668\\uA66A\\uA66C\\uA680\\uA682\\uA684\\uA686\\uA688\\uA68A\\uA68C\\uA68E\\uA690\\uA692\\uA694\\uA696\\uA698\\uA69A\\uA722\\uA724\\uA726\\uA728\\uA72A\\uA72C\\uA72E\\uA732\\uA734\\uA736\\uA738\\uA73A\\uA73C\\uA73E\\uA740\\uA742\\uA744\\uA746\\uA748\\uA74A\\uA74C\\uA74E\\uA750\\uA752\\uA754\\uA756\\uA758\\uA75A\\uA75C\\uA75E\\uA760\\uA762\\uA764\\uA766\\uA768\\uA76A\\uA76C\\uA76E\\uA779\\uA77B\\uA77D-\\uA77E\\uA780\\uA782\\uA784\\uA786\\uA78B\\uA78D\\uA790\\uA792\\uA796\\uA798\\uA79A\\uA79C\\uA79E\\uA7A0\\uA7A2\\uA7A4\\uA7A6\\uA7A8\\uA7AA-\\uA7AE\\uA7B0-\\uA7B4\\uA7B6\\uA7B8\\uFF21-\\uFF3A]",
 				chars:      []rune{'Ā', 'Ă', 'Ą', 'Ć', 'Ĉ', 'Ċ', 'Č', 'Ď', 'Đ', 'Ē', 'Ĕ', 'Ė', 'Ę', 'Ě', 'Ĝ', 'Ğ', 'Ġ', 'Ģ', 'Ĥ', 'Ħ', 'Ĩ', 'Ī', 'Ĭ', 'Į', 'İ', 'Ĳ', 'Ĵ', 'Ķ', 'Ĺ', 'Ļ', 'Ľ', 'Ŀ', 'Ł', 'Ń', 'Ņ', 'Ň', 'Ŋ', 'Ō', 'Ŏ', 'Ő', 'Œ', 'Ŕ', 'Ŗ', 'Ř', 'Ś', 'Ŝ', 'Ş', 'Š', 'Ţ', 'Ť', 'Ŧ', 'Ũ', 'Ū', 'Ŭ', 'Ů', 'Ű', 'Ų', 'Ŵ', 'Ŷ', 'Ż', 'Ž', 'Ƅ', 'Ƣ', 'Ƥ', 'Ʃ', 'Ƭ', 'Ƶ', 'Ƽ', 'Ǆ', 'Ǉ', 'Ǌ', 'Ǎ', 'Ǐ', 'Ǒ', 'Ǔ', 'Ǖ', 'Ǘ', 'Ǚ', 'Ǜ', 'Ǟ', 'Ǡ', 'Ǣ', 'Ǥ', 'Ǧ', 'Ǩ', 'Ǫ', 'Ǭ', 'Ǯ', 'Ǳ', 'Ǵ', 'Ǻ', 'Ǽ', 'Ǿ', 'Ȁ', 'Ȃ', 'Ȅ', 'Ȇ', 'Ȉ', 'Ȋ', 'Ȍ', 'Ȏ', 'Ȑ', 'Ȓ', 'Ȕ', 'Ȗ', 'Ș', 'Ț', 'Ȝ', 'Ȟ', 'Ƞ', 'Ȣ', 'Ȥ', 'Ȧ', 'Ȩ', 'Ȫ', 'Ȭ', 'Ȯ', 'Ȱ', 'Ȳ', 'Ɂ', 'Ɉ', 'Ɋ', 'Ɍ', 'Ɏ', 'Ͱ', 'Ͳ', 'Ͷ', 'Ϳ', 'Ά', 'Ό', 'Ϗ', 'Ϙ', 'Ϛ', 'Ϝ', 'Ϟ', 'Ϡ', 'Ϣ', 'Ϥ', 'Ϧ', 'Ϩ', 'Ϫ', 'Ϭ', 'Ϯ', 'ϴ', 'Ϸ', 'Ѡ', 'Ѣ', 'Ѥ', 'Ѧ', 'Ѩ', 'Ѫ', 'Ѭ', 'Ѯ', 'Ѱ', 'Ѳ', 'Ѵ', 'Ѷ', 'Ѹ', 'Ѻ', 'Ѽ', 'Ѿ', 'Ҁ', 'Ҋ', 'Ҍ', 'Ҏ', 'Ґ', 'Ғ', 'Ҕ', 'Җ', 'Ҙ', 'Қ', 'Ҝ', 'Ҟ', 'Ҡ', 'Ң', 'Ҥ', 'Ҧ', 'Ҩ', 'Ҫ', 'Ҭ', 'Ү', 'Ұ', 'Ҳ', 'Ҵ', 'Ҷ', 'Ҹ', 'Һ', 'Ҽ', 'Ҿ', 'Ӄ', 'Ӆ', 'Ӈ', 'Ӊ', 'Ӌ', 'Ӎ', 'Ӑ', 'Ӓ', 'Ӕ', 'Ӗ', 'Ә', 'Ӛ', 'Ӝ', 'Ӟ', 'Ӡ', 'Ӣ', 'Ӥ', 'Ӧ', 'Ө', 'Ӫ', 'Ӭ', 'Ӯ', 'Ӱ', 'Ӳ', 'Ӵ', 'Ӷ', 'Ӹ', 'Ӻ', 'Ӽ', 'Ӿ', 'Ԁ', 'Ԃ', 'Ԅ', 'Ԇ', 'Ԉ', 'Ԋ', 'Ԍ', 'Ԏ', 'Ԑ', 'Ԓ', 'Ԕ', 'Ԗ', 'Ԙ', 'Ԛ', 'Ԝ', 'Ԟ', 'Ԡ', 'Ԣ', 'Ԥ', 'Ԧ', 'Ԩ', 'Ԫ', 'Ԭ', 'Ԯ', 'Ⴧ', 'Ⴭ', 'Ḁ', 'Ḃ', 'Ḅ', 'Ḇ', 'Ḉ', 'Ḋ', 'Ḍ', 'Ḏ', 'Ḑ', 'Ḓ', 'Ḕ', 'Ḗ', 'Ḙ', 'Ḛ', 'Ḝ', 'Ḟ', 'Ḡ', 'Ḣ', 'Ḥ', 'Ḧ', 'Ḩ', 'Ḫ', 'Ḭ', 'Ḯ', 'Ḱ', 'Ḳ', 'Ḵ', 'Ḷ', 'Ḹ', 'Ḻ', 'Ḽ', 'Ḿ', 'Ṁ', 'Ṃ', 'Ṅ', 'Ṇ', 'Ṉ', 'Ṋ', 'Ṍ', 'Ṏ', 'Ṑ', 'Ṓ', 'Ṕ', 'Ṗ', 'Ṙ', 'Ṛ', 'Ṝ', 'Ṟ', 'Ṡ', 'Ṣ', 'Ṥ', 'Ṧ', 'Ṩ', 'Ṫ', 'Ṭ', 'Ṯ', 'Ṱ', 'Ṳ', 'Ṵ', 'Ṷ', 'Ṹ', 'Ṻ', 'Ṽ', 'Ṿ', 'Ẁ', 'Ẃ', 'Ẅ', 'Ẇ', 'Ẉ', 'Ẋ', 'Ẍ', 'Ẏ', 'Ẑ', 'Ẓ', 'Ẕ', 'ẞ', 'Ạ', 'Ả', 'Ấ', 'Ầ', 'Ẩ', 'Ẫ', 'Ậ', 'Ắ', 'Ằ', 'Ẳ', 'Ẵ', 'Ặ', 'Ẹ', 'Ẻ', 'Ẽ', 'Ế', 'Ề', 'Ể', 'Ễ', 'Ệ', 'Ỉ', 'Ị', 'Ọ', 'Ỏ', 'Ố', 'Ồ', 'Ổ', 'Ỗ', 'Ộ', 'Ớ', 'Ờ', 'Ở', 'Ỡ', 'Ợ', 'Ụ', 'Ủ', 'Ứ', 'Ừ', 'Ử', 'Ữ', 'Ự', 'Ỳ', 'Ỵ', 'Ỷ', 'Ỹ', 'Ỻ', 'Ỽ', 'Ỿ', 'Ὑ', 'Ὓ', 'Ὕ', 'Ὗ', 'ℂ', 'ℇ', 'ℕ', 'ℤ', 'Ω', 'ℨ', 'ⅅ', 'Ↄ', 'Ⱡ', 'Ⱨ', 'Ⱪ', 'Ⱬ', 'Ⱳ', 'Ⱶ', 'Ⲃ', 'Ⲅ', 'Ⲇ', 'Ⲉ', 'Ⲋ', 'Ⲍ', 'Ⲏ', 'Ⲑ', 'Ⲓ', 'Ⲕ', 'Ⲗ', 'Ⲙ', 'Ⲛ', 'Ⲝ', 'Ⲟ', 'Ⲡ', 'Ⲣ', 'Ⲥ', 'Ⲧ', 'Ⲩ', 'Ⲫ', 'Ⲭ', 'Ⲯ', 'Ⲱ', 'Ⲳ', 'Ⲵ', 'Ⲷ', 'Ⲹ', 'Ⲻ', 'Ⲽ', 'Ⲿ', 'Ⳁ', 'Ⳃ', 'Ⳅ', 'Ⳇ', 'Ⳉ', 'Ⳋ', 'Ⳍ', 'Ⳏ', 'Ⳑ', 'Ⳓ', 'Ⳕ', 'Ⳗ', 'Ⳙ', 'Ⳛ', 'Ⳝ', 'Ⳟ', 'Ⳡ', 'Ⳣ', 'Ⳬ', 'Ⳮ', 'Ⳳ', 'Ꙁ', 'Ꙃ', 'Ꙅ', 'Ꙇ', 'Ꙉ', 'Ꙋ', 'Ꙍ', 'Ꙏ', 'Ꙑ', 'Ꙓ', 'Ꙕ', 'Ꙗ', 'Ꙙ', 'Ꙛ', 'Ꙝ', 'Ꙟ', 'Ꙡ', 'Ꙣ', 'Ꙥ', 'Ꙧ', 'Ꙩ', 'Ꙫ', 'Ꙭ', 'Ꚁ', 'Ꚃ', 'Ꚅ', 'Ꚇ', 'Ꚉ', 'Ꚋ', 'Ꚍ', 'Ꚏ', 'Ꚑ', 'Ꚓ', 'Ꚕ', 'Ꚗ', 'Ꚙ', 'Ꚛ', 'Ꜣ', 'Ꜥ', 'Ꜧ', 'Ꜩ', 'Ꜫ', 'Ꜭ', 'Ꜯ', 'Ꜳ', 'Ꜵ', 'Ꜷ', 'Ꜹ', 'Ꜻ', 'Ꜽ', 'Ꜿ', 'Ꝁ', 'Ꝃ', 'Ꝅ', 'Ꝇ', 'Ꝉ', 'Ꝋ', 'Ꝍ', 'Ꝏ', 'Ꝑ', 'Ꝓ', 'Ꝕ', 'Ꝗ', 'Ꝙ', 'Ꝛ', 'Ꝝ', 'Ꝟ', 'Ꝡ', 'Ꝣ', 'Ꝥ', 'Ꝧ', 'Ꝩ', 'Ꝫ', 'Ꝭ', 'Ꝯ', 'Ꝺ', 'Ꝼ', 'Ꞁ', 'Ꞃ', 'Ꞅ', 'Ꞇ', 'Ꞌ', 'Ɥ', 'Ꞑ', 'Ꞓ', 'Ꞗ', 'Ꞙ', 'Ꞛ', 'Ꞝ', 'Ꞟ', 'Ꞡ', 'Ꞣ', 'Ꞥ', 'Ꞧ', 'Ꞩ', 'Ꞷ', 'Ꞹ'},
 				ranges:     []rune{'A', 'Z', 'À', 'Ö', 'Ø', 'Þ', 'Ÿ', 'Ź', 'Ɓ', 'Ƃ', 'Ɔ', 'Ƈ', 'Ɖ', 'Ƌ', 'Ǝ', 'Ƒ', 'Ɠ', 'Ɣ', 'Ɩ', 'Ƙ', 'Ɯ', 'Ɲ', 'Ɵ', 'Ơ', 'Ʀ', 'Ƨ', 'Ʈ', 'Ư', 'Ʊ', 'Ƴ', 'Ʒ', 'Ƹ', 'Ƕ', 'Ǹ', 'Ⱥ', 'Ȼ', 'Ƚ', 'Ⱦ', 'Ƀ', 'Ɇ', 'Έ', 'Ί', 'Ύ', 'Ώ', 'Α', 'Ρ', 'Σ', 'Ϋ', 'ϒ', 'ϔ', 'Ϲ', 'Ϻ', 'Ͻ', 'Я', 'Ӏ', 'Ӂ', 'Ա', 'Ֆ', 'Ⴀ', 'Ⴥ', 'Ꭰ', 'Ᏽ', 'Ა', 'Ჺ', 'Ჽ', 'Ჿ', 'Ἀ', 'Ἇ', 'Ἐ', 'Ἕ', 'Ἠ', 'Ἧ', 'Ἰ', 'Ἷ', 'Ὀ', 'Ὅ', 'Ὠ', 'Ὧ', 'Ᾰ', 'Ά', 'Ὲ', 'Ή', 'Ῐ', 'Ί', 'Ῠ', 'Ῥ', 'Ὸ', 'Ώ', 'ℋ', 'ℍ', 'ℐ', 'ℒ', 'ℙ', 'ℝ', 'K', 'ℭ', 'ℰ', 'ℳ', 'ℾ', 'ℿ', 'Ⰰ', 'Ⱞ', 'Ɫ', 'Ɽ', 'Ɑ', 'Ɒ', 'Ȿ', 'Ⲁ', 'Ᵹ', 'Ꝿ', 'Ɦ', 'Ɪ', 'Ʞ', 'Ꞵ', 'Ａ', 'Ｚ'},
@@ -12262,9 +12351,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mc",
-			pos:  position{line: 1688, col: 1, offset: 52452},
+			pos:  position{line: 1689, col: 1, offset: 52530},
 			expr: &charClassMatcher{
-				pos:        position{line: 1688, col: 6, offset: 52457},
+				pos:        position{line: 1689, col: 6, offset: 52535},
 				val:        "[\\u0903\\u093B\\u093E-\\u0940\\u0949-\\u094C\\u094E-\\u094F\\u0982-\\u0983\\u09BE-\\u09C0\\u09C7-\\u09C8\\u09CB-\\u09CC\\u09D7\\u0A03\\u0A3E-\\u0A40\\u0A83\\u0ABE-\\u0AC0\\u0AC9\\u0ACB-\\u0ACC\\u0B02-\\u0B03\\u0B3E\\u0B40\\u0B47-\\u0B48\\u0B4B-\\u0B4C\\u0B57\\u0BBE-\\u0BBF\\u0BC1-\\u0BC2\\u0BC6-\\u0BC8\\u0BCA-\\u0BCC\\u0BD7\\u0C01-\\u0C03\\u0C41-\\u0C44\\u0C82-\\u0C83\\u0CBE\\u0CC0-\\u0CC4\\u0CC7-\\u0CC8\\u0CCA-\\u0CCB\\u0CD5-\\u0CD6\\u0D02-\\u0D03\\u0D3E-\\u0D40\\u0D46-\\u0D48\\u0D4A-\\u0D4C\\u0D57\\u0D82-\\u0D83\\u0DCF-\\u0DD1\\u0DD8-\\u0DDF\\u0DF2-\\u0DF3\\u0F3E-\\u0F3F\\u0F7F\\u102B-\\u102C\\u1031\\u1038\\u103B-\\u103C\\u1056-\\u1057\\u1062-\\u1064\\u1067-\\u106D\\u1083-\\u1084\\u1087-\\u108C\\u108F\\u109A-\\u109C\\u17B6\\u17BE-\\u17C5\\u17C7-\\u17C8\\u1923-\\u1926\\u1929-\\u192B\\u1930-\\u1931\\u1933-\\u1938\\u1A19-\\u1A1A\\u1A55\\u1A57\\u1A61\\u1A63-\\u1A64\\u1A6D-\\u1A72\\u1B04\\u1B35\\u1B3B\\u1B3D-\\u1B41\\u1B43-\\u1B44\\u1B82\\u1BA1\\u1BA6-\\u1BA7\\u1BAA\\u1BE7\\u1BEA-\\u1BEC\\u1BEE\\u1BF2-\\u1BF3\\u1C24-\\u1C2B\\u1C34-\\u1C35\\u1CE1\\u1CF2-\\u1CF3\\u1CF7\\u302E-\\u302F\\uA823-\\uA824\\uA827\\uA880-\\uA881\\uA8B4-\\uA8C3\\uA952-\\uA953\\uA983\\uA9B4-\\uA9B5\\uA9BA-\\uA9BB\\uA9BD-\\uA9C0\\uAA2F-\\uAA30\\uAA33-\\uAA34\\uAA4D\\uAA7B\\uAA7D\\uAAEB\\uAAEE-\\uAAEF\\uAAF5\\uABE3-\\uABE4\\uABE6-\\uABE7\\uABE9-\\uABEA\\uABEC]",
 				chars:      []rune{'ः', 'ऻ', 'ৗ', 'ਃ', 'ઃ', 'ૉ', 'ା', 'ୀ', 'ୗ', 'ௗ', 'ಾ', 'ൗ', 'ཿ', 'ေ', 'း', 'ႏ', 'ា', 'ᩕ', 'ᩗ', 'ᩡ', 'ᬄ', 'ᬵ', 'ᬻ', 'ᮂ', 'ᮡ', '᮪', 'ᯧ', 'ᯮ', '᳡', '᳷', 'ꠧ', 'ꦃ', 'ꩍ', 'ꩻ', 'ꩽ', 'ꫫ', 'ꫵ', '꯬'},
 				ranges:     []rune{'ा', 'ी', 'ॉ', 'ौ', 'ॎ', 'ॏ', 'ং', 'ঃ', 'া', 'ী', 'ে', 'ৈ', 'ো', 'ৌ', 'ਾ', 'ੀ', 'ા', 'ી', 'ો', 'ૌ', 'ଂ', 'ଃ', 'େ', 'ୈ', 'ୋ', 'ୌ', 'ா', 'ி', 'ு', 'ூ', 'ெ', 'ை', 'ொ', 'ௌ', 'ఁ', 'ః', 'ు', 'ౄ', 'ಂ', 'ಃ', 'ೀ', 'ೄ', 'ೇ', 'ೈ', 'ೊ', 'ೋ', 'ೕ', 'ೖ', 'ം', 'ഃ', 'ാ', 'ീ', 'െ', 'ൈ', 'ൊ', 'ൌ', 'ං', 'ඃ', 'ා', 'ෑ', 'ෘ', 'ෟ', 'ෲ', 'ෳ', '༾', '༿', 'ါ', 'ာ', 'ျ', 'ြ', 'ၖ', 'ၗ', 'ၢ', 'ၤ', 'ၧ', 'ၭ', 'ႃ', 'ႄ', 'ႇ', 'ႌ', 'ႚ', 'ႜ', 'ើ', 'ៅ', 'ះ', 'ៈ', 'ᤣ', 'ᤦ', 'ᤩ', 'ᤫ', 'ᤰ', 'ᤱ', 'ᤳ', 'ᤸ', 'ᨙ', 'ᨚ', 'ᩣ', 'ᩤ', 'ᩭ', 'ᩲ', 'ᬽ', 'ᭁ', 'ᭃ', '᭄', 'ᮦ', 'ᮧ', 'ᯪ', 'ᯬ', '᯲', '᯳', 'ᰤ', 'ᰫ', 'ᰴ', 'ᰵ', 'ᳲ', 'ᳳ', '〮', '〯', 'ꠣ', 'ꠤ', 'ꢀ', 'ꢁ', 'ꢴ', 'ꣃ', 'ꥒ', '꥓', 'ꦴ', 'ꦵ', 'ꦺ', 'ꦻ', 'ꦽ', '꧀', 'ꨯ', 'ꨰ', 'ꨳ', 'ꨴ', 'ꫮ', 'ꫯ', 'ꯣ', 'ꯤ', 'ꯦ', 'ꯧ', 'ꯩ', 'ꯪ'},
@@ -12276,9 +12365,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mn",
-			pos:  position{line: 1691, col: 1, offset: 53645},
+			pos:  position{line: 1692, col: 1, offset: 53723},
 			expr: &charClassMatcher{
-				pos:        position{line: 1691, col: 6, offset: 53650},
+				pos:        position{line: 1692, col: 6, offset: 53728},
 				val:        "[\\u0300-\\u036F\\u0483-\\u0487\\u0591-\\u05BD\\u05BF\\u05C1-\\u05C2\\u05C4-\\u05C5\\u05C7\\u0610-\\u061A\\u064B-\\u065F\\u0670\\u06D6-\\u06DC\\u06DF-\\u06E4\\u06E7-\\u06E8\\u06EA-\\u06ED\\u0711\\u0730-\\u074A\\u07A6-\\u07B0\\u07EB-\\u07F3\\u07FD\\u0816-\\u0819\\u081B-\\u0823\\u0825-\\u0827\\u0829-\\u082D\\u0859-\\u085B\\u08D3-\\u08E1\\u08E3-\\u0902\\u093A\\u093C\\u0941-\\u0948\\u094D\\u0951-\\u0957\\u0962-\\u0963\\u0981\\u09BC\\u09C1-\\u09C4\\u09CD\\u09E2-\\u09E3\\u09FE\\u0A01-\\u0A02\\u0A3C\\u0A41-\\u0A42\\u0A47-\\u0A48\\u0A4B-\\u0A4D\\u0A51\\u0A70-\\u0A71\\u0A75\\u0A81-\\u0A82\\u0ABC\\u0AC1-\\u0AC5\\u0AC7-\\u0AC8\\u0ACD\\u0AE2-\\u0AE3\\u0AFA-\\u0AFF\\u0B01\\u0B3C\\u0B3F\\u0B41-\\u0B44\\u0B4D\\u0B56\\u0B62-\\u0B63\\u0B82\\u0BC0\\u0BCD\\u0C00\\u0C04\\u0C3E-\\u0C40\\u0C46-\\u0C48\\u0C4A-\\u0C4D\\u0C55-\\u0C56\\u0C62-\\u0C63\\u0C81\\u0CBC\\u0CBF\\u0CC6\\u0CCC-\\u0CCD\\u0CE2-\\u0CE3\\u0D00-\\u0D01\\u0D3B-\\u0D3C\\u0D41-\\u0D44\\u0D4D\\u0D62-\\u0D63\\u0DCA\\u0DD2-\\u0DD4\\u0DD6\\u0E31\\u0E34-\\u0E3A\\u0E47-\\u0E4E\\u0EB1\\u0EB4-\\u0EB9\\u0EBB-\\u0EBC\\u0EC8-\\u0ECD\\u0F18-\\u0F19\\u0F35\\u0F37\\u0F39\\u0F71-\\u0F7E\\u0F80-\\u0F84\\u0F86-\\u0F87\\u0F8D-\\u0F97\\u0F99-\\u0FBC\\u0FC6\\u102D-\\u1030\\u1032-\\u1037\\u1039-\\u103A\\u103D-\\u103E\\u1058-\\u1059\\u105E-\\u1060\\u1071-\\u1074\\u1082\\u1085-\\u1086\\u108D\\u109D\\u135D-\\u135F\\u1712-\\u1714\\u1732-\\u1734\\u1752-\\u1753\\u1772-\\u1773\\u17B4-\\u17B5\\u17B7-\\u17BD\\u17C6\\u17C9-\\u17D3\\u17DD\\u180B-\\u180D\\u1885-\\u1886\\u18A9\\u1920-\\u1922\\u1927-\\u1928\\u1932\\u1939-\\u193B\\u1A17-\\u1A18\\u1A1B\\u1A56\\u1A58-\\u1A5E\\u1A60\\u1A62\\u1A65-\\u1A6C\\u1A73-\\u1A7C\\u1A7F\\u1AB0-\\u1ABD\\u1B00-\\u1B03\\u1B34\\u1B36-\\u1B3A\\u1B3C\\u1B42\\u1B6B-\\u1B73\\u1B80-\\u1B81\\u1BA2-\\u1BA5\\u1BA8-\\u1BA9\\u1BAB-\\u1BAD\\u1BE6\\u1BE8-\\u1BE9\\u1BED\\u1BEF-\\u1BF1\\u1C2C-\\u1C33\\u1C36-\\u1C37\\u1CD0-\\u1CD2\\u1CD4-\\u1CE0\\u1CE2-\\u1CE8\\u1CED\\u1CF4\\u1CF8-\\u1CF9\\u1DC0-\\u1DF9\\u1DFB-\\u1DFF\\u20D0-\\u20DC\\u20E1\\u20E5-\\u20F0\\u2CEF-\\u2CF1\\u2D7F\\u2DE0-\\u2DFF\\u302A-\\u302D\\u3099-\\u309A\\uA66F\\uA674-\\uA67D\\uA69E-\\uA69F\\uA6F0-\\uA6F1\\uA802\\uA806\\uA80B\\uA825-\\uA826\\uA8C4-\\uA8C5\\uA8E0-\\uA8F1\\uA8FF\\uA926-\\uA92D\\uA947-\\uA951\\uA980-\\uA982\\uA9B3\\uA9B6-\\uA9B9\\uA9BC\\uA9E5\\uAA29-\\uAA2E\\uAA31-\\uAA32\\uAA35-\\uAA36\\uAA43\\uAA4C\\uAA7C\\uAAB0\\uAAB2-\\uAAB4\\uAAB7-\\uAAB8\\uAABE-\\uAABF\\uAAC1\\uAAEC-\\uAAED\\uAAF6\\uABE5\\uABE8\\uABED\\uFB1E\\uFE00-\\uFE0F\\uFE20-\\uFE2F]",
 				chars:      []rune{'ֿ', 'ׇ', 'ٰ', 'ܑ', '߽', 'ऺ', '़', '्', 'ঁ', '়', '্', '৾', '਼', 'ੑ', 'ੵ', '઼', '્', 'ଁ', '଼', 'ି', '୍', 'ୖ', 'ஂ', 'ீ', '்', 'ఀ', 'ఄ', 'ಁ', '಼', 'ಿ', 'ೆ', '്', '්', 'ූ', 'ั', 'ັ', '༵', '༷', '༹', '࿆', 'ႂ', 'ႍ', 'ႝ', 'ំ', '៝', 'ᢩ', 'ᤲ', 'ᨛ', 'ᩖ', '᩠', 'ᩢ', '᩿', '᬴', 'ᬼ', 'ᭂ', '᯦', 'ᯭ', '᳭', '᳴', '⃡', '⵿', '꙯', 'ꠂ', '꠆', 'ꠋ', 'ꣿ', '꦳', 'ꦼ', 'ꧥ', 'ꩃ', 'ꩌ', 'ꩼ', 'ꪰ', '꫁', '꫶', 'ꯥ', 'ꯨ', '꯭', 'ﬞ'},
 				ranges:     []rune{'̀', 'ͯ', '҃', '҇', '֑', 'ֽ', 'ׁ', 'ׂ', 'ׄ', 'ׅ', 'ؐ', 'ؚ', 'ً', 'ٟ', 'ۖ', 'ۜ', '۟', 'ۤ', 'ۧ', 'ۨ', '۪', 'ۭ', 'ܰ', '݊', 'ަ', 'ް', '߫', '߳', 'ࠖ', '࠙', 'ࠛ', 'ࠣ', 'ࠥ', 'ࠧ', 'ࠩ', '࠭', '࡙', '࡛', '࣓', '࣡', 'ࣣ', 'ं', 'ु', 'ै', '॑', 'ॗ', 'ॢ', 'ॣ', 'ু', 'ৄ', 'ৢ', 'ৣ', 'ਁ', 'ਂ', 'ੁ', 'ੂ', 'ੇ', 'ੈ', 'ੋ', '੍', 'ੰ', 'ੱ', 'ઁ', 'ં', 'ુ', 'ૅ', 'ે', 'ૈ', 'ૢ', 'ૣ', 'ૺ', '૿', 'ୁ', 'ୄ', 'ୢ', 'ୣ', 'ా', 'ీ', 'ె', 'ై', 'ొ', '్', 'ౕ', 'ౖ', 'ౢ', 'ౣ', 'ೌ', '್', 'ೢ', 'ೣ', 'ഀ', 'ഁ', '഻', '഼', 'ു', 'ൄ', 'ൢ', 'ൣ', 'ි', 'ු', 'ิ', 'ฺ', '็', '๎', 'ິ', 'ູ', 'ົ', 'ຼ', '່', 'ໍ', '༘', '༙', 'ཱ', 'ཾ', 'ྀ', '྄', '྆', '྇', 'ྍ', 'ྗ', 'ྙ', 'ྼ', 'ိ', 'ူ', 'ဲ', '့', '္', '်', 'ွ', 'ှ', 'ၘ', 'ၙ', 'ၞ', 'ၠ', 'ၱ', 'ၴ', 'ႅ', 'ႆ', '፝', '፟', 'ᜒ', '᜔', 'ᜲ', '᜴', 'ᝒ', 'ᝓ', 'ᝲ', 'ᝳ', '឴', '឵', 'ិ', 'ួ', '៉', '៓', '᠋', '᠍', 'ᢅ', 'ᢆ', 'ᤠ', 'ᤢ', 'ᤧ', 'ᤨ', '᤹', '᤻', 'ᨗ', 'ᨘ', 'ᩘ', 'ᩞ', 'ᩥ', 'ᩬ', 'ᩳ', '᩼', '᪰', '᪽', 'ᬀ', 'ᬃ', 'ᬶ', 'ᬺ', '᭫', '᭳', 'ᮀ', 'ᮁ', 'ᮢ', 'ᮥ', 'ᮨ', 'ᮩ', '᮫', 'ᮭ', 'ᯨ', 'ᯩ', 'ᯯ', 'ᯱ', 'ᰬ', 'ᰳ', 'ᰶ', '᰷', '᳐', '᳒', '᳔', '᳠', '᳢', '᳨', '᳸', '᳹', '᷀', '᷹', '᷻', '᷿', '⃐', '⃜', '⃥', '⃰', '⳯', '⳱', 'ⷠ', 'ⷿ', '〪', '〭', '゙', '゚', 'ꙴ', '꙽', 'ꚞ', 'ꚟ', '꛰', '꛱', 'ꠥ', 'ꠦ', '꣄', 'ꣅ', '꣠', '꣱', 'ꤦ', '꤭', 'ꥇ', 'ꥑ', 'ꦀ', 'ꦂ', 'ꦶ', 'ꦹ', 'ꨩ', 'ꨮ', 'ꨱ', 'ꨲ', 'ꨵ', 'ꨶ', 'ꪲ', 'ꪴ', 'ꪷ', 'ꪸ', 'ꪾ', '꪿', 'ꫬ', 'ꫭ', '︀', '️', '︠', '︯'},
@@ -12290,9 +12379,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nd",
-			pos:  position{line: 1694, col: 1, offset: 55830},
+			pos:  position{line: 1695, col: 1, offset: 55908},
 			expr: &charClassMatcher{
-				pos:        position{line: 1694, col: 6, offset: 55835},
+				pos:        position{line: 1695, col: 6, offset: 55913},
 				val:        "[\\u0030-\\u0039\\u0660-\\u0669\\u06F0-\\u06F9\\u07C0-\\u07C9\\u0966-\\u096F\\u09E6-\\u09EF\\u0A66-\\u0A6F\\u0AE6-\\u0AEF\\u0B66-\\u0B6F\\u0BE6-\\u0BEF\\u0C66-\\u0C6F\\u0CE6-\\u0CEF\\u0D66-\\u0D6F\\u0DE6-\\u0DEF\\u0E50-\\u0E59\\u0ED0-\\u0ED9\\u0F20-\\u0F29\\u1040-\\u1049\\u1090-\\u1099\\u17E0-\\u17E9\\u1810-\\u1819\\u1946-\\u194F\\u19D0-\\u19D9\\u1A80-\\u1A89\\u1A90-\\u1A99\\u1B50-\\u1B59\\u1BB0-\\u1BB9\\u1C40-\\u1C49\\u1C50-\\u1C59\\uA620-\\uA629\\uA8D0-\\uA8D9\\uA900-\\uA909\\uA9D0-\\uA9D9\\uA9F0-\\uA9F9\\uAA50-\\uAA59\\uABF0-\\uABF9\\uFF10-\\uFF19]",
 				ranges:     []rune{'0', '9', '٠', '٩', '۰', '۹', '߀', '߉', '०', '९', '০', '৯', '੦', '੯', '૦', '૯', '୦', '୯', '௦', '௯', '౦', '౯', '೦', '೯', '൦', '൯', '෦', '෯', '๐', '๙', '໐', '໙', '༠', '༩', '၀', '၉', '႐', '႙', '០', '៩', '᠐', '᠙', '᥆', '᥏', '᧐', '᧙', '᪀', '᪉', '᪐', '᪙', '᭐', '᭙', '᮰', '᮹', '᱀', '᱉', '᱐', '᱙', '꘠', '꘩', '꣐', '꣙', '꤀', '꤉', '꧐', '꧙', '꧰', '꧹', '꩐', '꩙', '꯰', '꯹', '０', '９'},
 				ignoreCase: false,
@@ -12303,9 +12392,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nl",
-			pos:  position{line: 1697, col: 1, offset: 56338},
+			pos:  position{line: 1698, col: 1, offset: 56416},
 			expr: &charClassMatcher{
-				pos:        position{line: 1697, col: 6, offset: 56343},
+				pos:        position{line: 1698, col: 6, offset: 56421},
 				val:        "[\\u16EE-\\u16F0\\u2160-\\u2182\\u2185-\\u2188\\u3007\\u3021-\\u3029\\u3038-\\u303A\\uA6E6-\\uA6EF]",
 				chars:      []rune{'〇'},
 				ranges:     []rune{'ᛮ', 'ᛰ', 'Ⅰ', 'ↂ', 'ↅ', 'ↈ', '〡', '〩', '〸', '〺', 'ꛦ', 'ꛯ'},
@@ -12317,9 +12406,9 @@ var g = &grammar{
 		},
 		{
 			name: "Pc",
-			pos:  position{line: 1700, col: 1, offset: 56457},
+			pos:  position{line: 1701, col: 1, offset: 56535},
 			expr: &charClassMatcher{
-				pos:        position{line: 1700, col: 6, offset: 56462},
+				pos:        position{line: 1701, col: 6, offset: 56540},
 				val:        "[\\u005F\\u203F-\\u2040\\u2054\\uFE33-\\uFE34\\uFE4D-\\uFE4F\\uFF3F]",
 				chars:      []rune{'_', '⁔', '＿'},
 				ranges:     []rune{'‿', '⁀', '︳', '︴', '﹍', '﹏'},
@@ -12331,9 +12420,9 @@ var g = &grammar{
 		},
 		{
 			name: "Zs",
-			pos:  position{line: 1703, col: 1, offset: 56543},
+			pos:  position{line: 1704, col: 1, offset: 56621},
 			expr: &charClassMatcher{
-				pos:        position{line: 1703, col: 6, offset: 56548},
+				pos:        position{line: 1704, col: 6, offset: 56626},
 				val:        "[\\u0020\\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000]",
 				chars:      []rune{' ', '\u00a0', '\u1680', '\u202f', '\u205f', '\u3000'},
 				ranges:     []rune{'\u2000', '\u200a'},
@@ -12345,9 +12434,9 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1705, col: 1, offset: 56601},
+			pos:  position{line: 1706, col: 1, offset: 56679},
 			expr: &anyMatcher{
-				line: 1706, col: 5, offset: 56621,
+				line: 1707, col: 5, offset: 56699,
 			},
 			leader:        false,
 			leftRecursive: false,
@@ -12355,48 +12444,48 @@ var g = &grammar{
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1708, col: 1, offset: 56624},
+			pos:         position{line: 1709, col: 1, offset: 56702},
 			expr: &choiceExpr{
-				pos: position{line: 1709, col: 5, offset: 56652},
+				pos: position{line: 1710, col: 5, offset: 56730},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1709, col: 5, offset: 56652},
+						pos:        position{line: 1710, col: 5, offset: 56730},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1710, col: 5, offset: 56661},
+						pos:        position{line: 1711, col: 5, offset: 56739},
 						val:        "\v",
 						ignoreCase: false,
 						want:       "\"\\v\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1711, col: 5, offset: 56670},
+						pos:        position{line: 1712, col: 5, offset: 56748},
 						val:        "\f",
 						ignoreCase: false,
 						want:       "\"\\f\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1712, col: 5, offset: 56679},
+						pos:        position{line: 1713, col: 5, offset: 56757},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 1713, col: 5, offset: 56687},
+						pos:        position{line: 1714, col: 5, offset: 56765},
 						val:        "\u00a0",
 						ignoreCase: false,
 						want:       "\"\\u00a0\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1714, col: 5, offset: 56700},
+						pos:        position{line: 1715, col: 5, offset: 56778},
 						val:        "\ufeff",
 						ignoreCase: false,
 						want:       "\"\\ufeff\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1715, col: 5, offset: 56713},
+						pos:  position{line: 1716, col: 5, offset: 56791},
 						name: "Zs",
 					},
 				},
@@ -12406,9 +12495,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1717, col: 1, offset: 56717},
+			pos:  position{line: 1718, col: 1, offset: 56795},
 			expr: &charClassMatcher{
-				pos:        position{line: 1718, col: 5, offset: 56736},
+				pos:        position{line: 1719, col: 5, offset: 56814},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -12420,9 +12509,9 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1724, col: 1, offset: 57066},
+			pos:         position{line: 1725, col: 1, offset: 57144},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1727, col: 5, offset: 57137},
+				pos:  position{line: 1728, col: 5, offset: 57215},
 				name: "SingleLineComment",
 			},
 			leader:        false,
@@ -12430,39 +12519,39 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1729, col: 1, offset: 57156},
+			pos:  position{line: 1730, col: 1, offset: 57234},
 			expr: &seqExpr{
-				pos: position{line: 1730, col: 5, offset: 57177},
+				pos: position{line: 1731, col: 5, offset: 57255},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1730, col: 5, offset: 57177},
+						pos:        position{line: 1731, col: 5, offset: 57255},
 						val:        "/*",
 						ignoreCase: false,
 						want:       "\"/*\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1730, col: 10, offset: 57182},
+						pos: position{line: 1731, col: 10, offset: 57260},
 						expr: &seqExpr{
-							pos: position{line: 1730, col: 11, offset: 57183},
+							pos: position{line: 1731, col: 11, offset: 57261},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1730, col: 11, offset: 57183},
+									pos: position{line: 1731, col: 11, offset: 57261},
 									expr: &litMatcher{
-										pos:        position{line: 1730, col: 12, offset: 57184},
+										pos:        position{line: 1731, col: 12, offset: 57262},
 										val:        "*/",
 										ignoreCase: false,
 										want:       "\"*/\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1730, col: 17, offset: 57189},
+									pos:  position{line: 1731, col: 17, offset: 57267},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1730, col: 35, offset: 57207},
+						pos:        position{line: 1731, col: 35, offset: 57285},
 						val:        "*/",
 						ignoreCase: false,
 						want:       "\"*/\"",
@@ -12474,30 +12563,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1732, col: 1, offset: 57213},
+			pos:  position{line: 1733, col: 1, offset: 57291},
 			expr: &seqExpr{
-				pos: position{line: 1733, col: 5, offset: 57235},
+				pos: position{line: 1734, col: 5, offset: 57313},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1733, col: 5, offset: 57235},
+						pos:        position{line: 1734, col: 5, offset: 57313},
 						val:        "//",
 						ignoreCase: false,
 						want:       "\"//\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1733, col: 10, offset: 57240},
+						pos: position{line: 1734, col: 10, offset: 57318},
 						expr: &seqExpr{
-							pos: position{line: 1733, col: 11, offset: 57241},
+							pos: position{line: 1734, col: 11, offset: 57319},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1733, col: 11, offset: 57241},
+									pos: position{line: 1734, col: 11, offset: 57319},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1733, col: 12, offset: 57242},
+										pos:  position{line: 1734, col: 12, offset: 57320},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1733, col: 27, offset: 57257},
+									pos:  position{line: 1734, col: 27, offset: 57335},
 									name: "SourceCharacter",
 								},
 							},
@@ -12510,19 +12599,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1735, col: 1, offset: 57276},
+			pos:  position{line: 1736, col: 1, offset: 57354},
 			expr: &seqExpr{
-				pos: position{line: 1735, col: 7, offset: 57282},
+				pos: position{line: 1736, col: 7, offset: 57360},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1735, col: 7, offset: 57282},
+						pos: position{line: 1736, col: 7, offset: 57360},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1735, col: 7, offset: 57282},
+							pos:  position{line: 1736, col: 7, offset: 57360},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1735, col: 19, offset: 57294},
+						pos:  position{line: 1736, col: 19, offset: 57372},
 						name: "LineTerminator",
 					},
 				},
@@ -12532,16 +12621,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1737, col: 1, offset: 57310},
+			pos:  position{line: 1738, col: 1, offset: 57388},
 			expr: &choiceExpr{
-				pos: position{line: 1737, col: 7, offset: 57316},
+				pos: position{line: 1738, col: 7, offset: 57394},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1737, col: 7, offset: 57316},
+						pos:  position{line: 1738, col: 7, offset: 57394},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1737, col: 11, offset: 57320},
+						pos:  position{line: 1738, col: 11, offset: 57398},
 						name: "EOF",
 					},
 				},
@@ -12551,11 +12640,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1739, col: 1, offset: 57325},
+			pos:  position{line: 1740, col: 1, offset: 57403},
 			expr: &notExpr{
-				pos: position{line: 1739, col: 7, offset: 57331},
+				pos: position{line: 1740, col: 7, offset: 57409},
 				expr: &anyMatcher{
-					line: 1739, col: 8, offset: 57332,
+					line: 1740, col: 8, offset: 57410,
 				},
 			},
 			leader:        false,
@@ -12563,11 +12652,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOKW",
-			pos:  position{line: 1741, col: 1, offset: 57335},
+			pos:  position{line: 1742, col: 1, offset: 57413},
 			expr: &notExpr{
-				pos: position{line: 1741, col: 8, offset: 57342},
+				pos: position{line: 1742, col: 8, offset: 57420},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1741, col: 9, offset: 57343},
+					pos:  position{line: 1742, col: 9, offset: 57421},
 					name: "KeyWordChars",
 				},
 			},
@@ -13311,29 +13400,25 @@ func (p *parser) callonAssertOp1() (any, error) {
 	return p.cur.onAssertOp1(stack["expr"])
 }
 
-func (c *current) onSortOp10(l any) (any, error) {
-	return l, nil
+func (c *current) onSortOp10(e any) (any, error) {
+	return e, nil
 }
 
 func (p *parser) callonSortOp10() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSortOp10(stack["l"])
+	return p.cur.onSortOp10(stack["e"])
 }
 
-func (c *current) onSortOp1(args, list any) (any, error) {
+func (c *current) onSortOp1(args, exprs any) (any, error) {
 	o := &ast.Sort{
 		Kind:       "Sort",
-		Order:      order.Asc,
-		NullsFirst: false,
 		KeywordPos: c.pos.offset,
-	}
-	if list != nil {
-		o.Args = sliceOf[ast.Expr](list)
+		Args:       sliceOf[ast.SortExpr](exprs),
 	}
 	argm := args.(map[string]any)
 	if _, ok := argm["r"]; ok {
-		o.Order = order.Desc
+		o.Reverse = true
 	}
 	if n, ok := argm["nulls"]; ok && n == "first" {
 		o.NullsFirst = true
@@ -13345,7 +13430,7 @@ func (c *current) onSortOp1(args, list any) (any, error) {
 func (p *parser) callonSortOp1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSortOp1(stack["args"], stack["list"])
+	return p.cur.onSortOp1(stack["args"], stack["exprs"])
 }
 
 func (c *current) onSortArgs4(a any) (any, error) {
@@ -13879,25 +13964,22 @@ func (p *parser) callonDebugOp1() (any, error) {
 	return p.cur.onDebugOp1(stack["expr"])
 }
 
-func (c *current) onFile1(path, format, sortkey any) (any, error) {
-	f := &ast.File{
+func (c *current) onFile1(path, format, sortKeys any) (any, error) {
+	return &ast.File{
 		Kind:       "File",
 		KeywordPos: c.pos.offset,
 		Path:       path.(ast.Pattern),
 		Format:     nullableString(format),
+		SortKeys:   sliceOf[ast.SortExpr](sortKeys),
 		EndPos:     c.pos.offset + len(c.text),
-	}
-	if sortkey != nil {
-		f.SortKey = sortkey.(*ast.SortKey)
-	}
-	return f, nil
+	}, nil
 
 }
 
 func (p *parser) callonFile1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onFile1(stack["path"], stack["format"], stack["sortkey"])
+	return p.cur.onFile1(stack["path"], stack["format"], stack["sortKeys"])
 }
 
 func (c *current) onFrom1(spec any) (any, error) {
@@ -13932,18 +14014,16 @@ func (p *parser) callonPool1() (any, error) {
 	return p.cur.onPool1(stack["spec"])
 }
 
-func (c *current) onGet1(url, format, sortkey, method, headers, body any) (any, error) {
+func (c *current) onGet1(url, format, sortKeys, method, headers, body any) (any, error) {
 	h := &ast.HTTP{
 		Kind:       "HTTP",
 		URL:        url.(ast.Pattern),
 		Format:     nullableString(format),
+		SortKeys:   sliceOf[ast.SortExpr](sortKeys),
 		Method:     nullableString(method),
 		KeywordPos: c.pos.offset,
 		Body:       nullableString(body),
 		EndPos:     c.pos.offset + len(c.text),
-	}
-	if sortkey != nil {
-		h.SortKey = sortkey.(*ast.SortKey)
 	}
 	if headers != nil {
 		h.Headers = headers.(*ast.RecordExpr)
@@ -13955,7 +14035,7 @@ func (c *current) onGet1(url, format, sortkey, method, headers, body any) (any, 
 func (p *parser) callonGet1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onGet1(stack["url"], stack["format"], stack["sortkey"], stack["method"], stack["headers"], stack["body"])
+	return p.cur.onGet1(stack["url"], stack["format"], stack["sortKeys"], stack["method"], stack["headers"], stack["body"])
 }
 
 func (c *current) onMethodArg1(v any) (any, error) {
@@ -14096,19 +14176,72 @@ func (p *parser) callonPoolIdentifier1() (any, error) {
 	return p.cur.onPoolIdentifier1()
 }
 
-func (c *current) onSortKeyArg1(keys, order any) (any, error) {
-	return &ast.SortKey{
-		Kind:  "SortKey",
-		Keys:  sliceOf[ast.Expr](keys),
-		Order: order.(string),
-	}, nil
+func (c *current) onOrderArg1(exprs any) (any, error) {
+	return exprs, nil
 
 }
 
-func (p *parser) callonSortKeyArg1() (any, error) {
+func (p *parser) callonOrderArg1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSortKeyArg1(stack["keys"], stack["order"])
+	return p.cur.onOrderArg1(stack["exprs"])
+}
+
+func (c *current) onSortExprs7(s any) (any, error) {
+	return s, nil
+}
+
+func (p *parser) callonSortExprs7() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSortExprs7(stack["s"])
+}
+
+func (c *current) onSortExprs1(first, rest any) (any, error) {
+	return prepend(first, rest), nil
+
+}
+
+func (p *parser) callonSortExprs1() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSortExprs1(stack["first"], stack["rest"])
+}
+
+func (c *current) onSortExpr7(o any) (any, error) {
+	return o, nil
+}
+
+func (p *parser) callonSortExpr7() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSortExpr7(stack["o"])
+}
+
+func (c *current) onSortExpr1(e, order any) (any, error) {
+	s := ast.SortExpr{Kind: "SortExpr", Expr: e.(ast.Expr)}
+	if order != nil {
+		s.Order = order.(*ast.ID)
+	}
+	return s, nil
+
+}
+
+func (p *parser) callonSortExpr1() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSortExpr1(stack["e"], stack["order"])
+}
+
+func (c *current) onOrderSpec1() (any, error) {
+	return &ast.ID{Kind: "ID", Name: string(c.text), NamePos: c.pos.offset}, nil
+
+}
+
+func (p *parser) callonOrderSpec1() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onOrderSpec1()
 }
 
 func (c *current) onTapArg2() (any, error) {
@@ -14139,36 +14272,6 @@ func (p *parser) callonFormatArg1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFormatArg1(stack["val"])
-}
-
-func (c *current) onOrderSuffix2() (any, error) {
-	return "asc", nil
-}
-
-func (p *parser) callonOrderSuffix2() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onOrderSuffix2()
-}
-
-func (c *current) onOrderSuffix4() (any, error) {
-	return "desc", nil
-}
-
-func (p *parser) callonOrderSuffix4() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onOrderSuffix4()
-}
-
-func (c *current) onOrderSuffix6() (any, error) {
-	return "asc", nil
-}
-
-func (p *parser) callonOrderSuffix6() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onOrderSuffix6()
 }
 
 func (c *current) onPassOp1() (any, error) {

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -372,19 +372,15 @@ AssertOp
     }
 
 SortOp
-  = "sort" &EOKW args:SortArgs list:(_ l:Exprs { return l, nil })? {
+  = "sort" &EOKW args:SortArgs exprs:(__ e:SortExprs { return e, nil })? {
       o := &ast.Sort{
         Kind: "Sort",
-        Order: order.Asc,
-        NullsFirst: false,
         KeywordPos: c.pos.offset,
-      }
-      if list != nil {
-        o.Args = sliceOf[ast.Expr](list)
+        Args: sliceOf[ast.SortExpr](exprs),
       }
       argm := args.(map[string]any)
       if _, ok := argm["r"]; ok {
-        o.Order = order.Desc
+        o.Reverse = true
       }
       if n, ok := argm["nulls"]; ok && n == "first" {
         o.NullsFirst = true
@@ -626,18 +622,15 @@ FromOp
   / From
 
 File
-  = "file" _ path:Path format:FormatArg? sortkey:SortKeyArg? {
-      f := &ast.File{
+  = "file" _ path:Path format:FormatArg? sortKeys:OrderArg? {
+      return &ast.File{
         Kind: "File",
         KeywordPos: c.pos.offset,
         Path: path.(ast.Pattern),
         Format: nullableString(format),
+        SortKeys: sliceOf[ast.SortExpr](sortKeys),
         EndPos: c.pos.offset+len(c.text),
-      }
-      if sortkey != nil {
-        f.SortKey = sortkey.(*ast.SortKey)
-      }
-      return f, nil
+      }, nil
     }
 
 From
@@ -661,18 +654,16 @@ Pool
     }
 
 Get
-  = "get" _ url:Path format:FormatArg? sortkey:SortKeyArg? method:MethodArg? headers:HeadersArg? body:BodyArg? {
+  = "get" _ url:Path format:FormatArg? sortKeys:OrderArg? method:MethodArg? headers:HeadersArg? body:BodyArg? {
       h := &ast.HTTP{
         Kind: "HTTP",
         URL: url.(ast.Pattern),
         Format: nullableString(format),
+        SortKeys: sliceOf[ast.SortExpr](sortKeys),
         Method: nullableString(method),
         KeywordPos: c.pos.offset,
         Body: nullableString(body),
         EndPos: c.pos.offset+len(c.text),
-      }
-      if sortkey != nil {
-        h.SortKey = sortkey.(*ast.SortKey)
       }
       if headers != nil {
         h.Headers = headers.(*ast.RecordExpr)
@@ -733,13 +724,28 @@ PoolNameString
 PoolIdentifier
   = (IdentifierStart / ".") (IdentifierRest / ".")* { return string(c.text), nil }
 
-SortKeyArg
-  = _ "order" _ keys:FieldExprs order:OrderSuffix {
-      return &ast.SortKey{
-        Kind: "SortKey",
-        Keys: sliceOf[ast.Expr](keys),
-        Order: order.(string),
-      }, nil
+OrderArg
+  = _ "order" _ exprs:SortExprs {
+      return exprs, nil
+    }
+
+SortExprs
+  = first:SortExpr rest:(__ "," __ s:SortExpr { return s, nil })* {
+      return prepend(first, rest), nil
+    }
+
+SortExpr
+  = e:Expr order:(_ o:OrderSpec { return o, nil })? {
+      s := ast.SortExpr{Kind: "SortExpr", Expr: e.(ast.Expr)}      
+      if order != nil {
+        s.Order = order.(*ast.ID)
+      }
+      return s, nil
+    }
+
+OrderSpec
+  = ("asc" / "desc") {
+      return &ast.ID{Kind: "ID", Name: string(c.text), NamePos: c.pos.offset}, nil
     }
 
 TapArg
@@ -748,11 +754,6 @@ TapArg
 
 FormatArg
   = _ "format" _ val:IdentifierName { return val, nil }
-
-OrderSuffix
-  = ":asc"  { return "asc", nil }
-  / ":desc" { return "desc", nil }
-  / ""      { return "asc", nil }
 
 PassOp
   = "pass" !(__ "(") &EOKW {

--- a/compiler/reader.go
+++ b/compiler/reader.go
@@ -34,7 +34,7 @@ func CompileWithSortKey(rctx *runtime.Context, seq ast.Seq, r zio.Reader, sortKe
 	if !ok {
 		return nil, errors.New("CompileWithSortKey: Zed program expected a reader")
 	}
-	scan.SortKey = sortKey
+	scan.SortKeys = order.SortKeys{sortKey}
 	return optimizeAndBuild(job, []zio.Reader{r})
 }
 

--- a/compiler/ztests/par-ts.yaml
+++ b/compiler/ztests/par-ts.yaml
@@ -156,10 +156,10 @@ outputs:
       | scatter (
         =>
           seqscan ...
-          | sort x
+          | sort x asc
         =>
           seqscan ...
-          | sort x
+          | sort x asc
       )
       | merge x:asc
       | uniq

--- a/lake/api/api.go
+++ b/lake/api/api.go
@@ -25,7 +25,7 @@ type Interface interface {
 	Query(ctx context.Context, head *lakeparse.Commitish, src string, srcfiles ...string) (zbuf.Scanner, error)
 	PoolID(ctx context.Context, poolName string) (ksuid.KSUID, error)
 	CommitObject(ctx context.Context, poolID ksuid.KSUID, branchName string) (ksuid.KSUID, error)
-	CreatePool(context.Context, string, order.SortKey, int, int64) (ksuid.KSUID, error)
+	CreatePool(context.Context, string, order.SortKeys, int, int64) (ksuid.KSUID, error)
 	RemovePool(context.Context, ksuid.KSUID) error
 	RenamePool(context.Context, ksuid.KSUID, string) error
 	CreateBranch(ctx context.Context, pool ksuid.KSUID, name string, parent ksuid.KSUID) error

--- a/lake/api/local.go
+++ b/lake/api/local.go
@@ -61,11 +61,11 @@ func (l *local) Root() *lake.Root {
 	return l.root
 }
 
-func (l *local) CreatePool(ctx context.Context, name string, sortKey order.SortKey, seekStride int, thresh int64) (ksuid.KSUID, error) {
+func (l *local) CreatePool(ctx context.Context, name string, sortKeys order.SortKeys, seekStride int, thresh int64) (ksuid.KSUID, error) {
 	if name == "" {
 		return ksuid.Nil, errors.New("no pool name provided")
 	}
-	pool, err := l.root.CreatePool(ctx, name, sortKey, seekStride, thresh)
+	pool, err := l.root.CreatePool(ctx, name, sortKeys, seekStride, thresh)
 	if err != nil {
 		return ksuid.Nil, err
 	}

--- a/lake/api/remote.go
+++ b/lake/api/remote.go
@@ -50,10 +50,10 @@ func (r *remote) CommitObject(ctx context.Context, poolID ksuid.KSUID, branchNam
 	return res.Commit, err
 }
 
-func (r *remote) CreatePool(ctx context.Context, name string, sortKey order.SortKey, seekStride int, thresh int64) (ksuid.KSUID, error) {
+func (r *remote) CreatePool(ctx context.Context, name string, sortKeys order.SortKeys, seekStride int, thresh int64) (ksuid.KSUID, error) {
 	res, err := r.conn.CreatePool(ctx, api.PoolPostRequest{
 		Name:       name,
-		SortKey:    sortKey,
+		SortKeys:   sortKeys,
 		SeekStride: seekStride,
 		Thresh:     thresh,
 	})

--- a/lake/api/remote.go
+++ b/lake/api/remote.go
@@ -12,6 +12,7 @@ import (
 	"github.com/brimdata/zed/lake"
 	"github.com/brimdata/zed/lakeparse"
 	"github.com/brimdata/zed/order"
+	"github.com/brimdata/zed/pkg/field"
 	"github.com/brimdata/zed/zbuf"
 	"github.com/brimdata/zed/zio"
 	"github.com/brimdata/zed/zio/zngio"
@@ -52,8 +53,11 @@ func (r *remote) CommitObject(ctx context.Context, poolID ksuid.KSUID, branchNam
 
 func (r *remote) CreatePool(ctx context.Context, name string, sortKeys order.SortKeys, seekStride int, thresh int64) (ksuid.KSUID, error) {
 	res, err := r.conn.CreatePool(ctx, api.PoolPostRequest{
-		Name:       name,
-		SortKeys:   sortKeys,
+		Name: name,
+		SortKeys: api.SortKeys{
+			Order: sortKeys.Primary().Order,
+			Keys:  field.List{sortKeys.Primary().Key},
+		},
 		SeekStride: seekStride,
 		Thresh:     thresh,
 	})

--- a/lake/data/writer_test.go
+++ b/lake/data/writer_test.go
@@ -22,7 +22,7 @@ func TestDataReaderWriterVector(t *testing.T) {
 	tmp := storage.MustParseURI(t.TempDir())
 	object := data.NewObject()
 	ctx := context.Background()
-	w, err := object.NewWriter(ctx, engine, tmp, order.Asc, field.Path{"a"}, 1000)
+	w, err := object.NewWriter(ctx, engine, tmp, order.NewSortKey(order.Asc, field.Path{"a"}), 1000)
 	require.NoError(t, err)
 	zctx := zed.NewContext()
 	arena := zed.NewArena()

--- a/lake/pools/config.go
+++ b/lake/pools/config.go
@@ -1,29 +1,31 @@
 package pools
 
 import (
+	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/lake/data"
 	"github.com/brimdata/zed/lake/journal"
 	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/pkg/field"
 	"github.com/brimdata/zed/pkg/nano"
 	"github.com/brimdata/zed/pkg/storage"
+	"github.com/brimdata/zed/zson"
 	"github.com/segmentio/ksuid"
 )
 
 type Config struct {
-	Ts         nano.Ts       `zed:"ts"`
-	Name       string        `zed:"name"`
-	ID         ksuid.KSUID   `zed:"id"`
-	SortKey    order.SortKey `zed:"layout"`
-	SeekStride int           `zed:"seek_stride"`
-	Threshold  int64         `zed:"threshold"`
+	Ts         nano.Ts        `zed:"ts"`
+	Name       string         `zed:"name"`
+	ID         ksuid.KSUID    `zed:"id"`
+	SortKeys   order.SortKeys `zed:"layout"`
+	SeekStride int            `zed:"seek_stride"`
+	Threshold  int64          `zed:"threshold"`
 }
 
 var _ journal.Entry = (*Config)(nil)
 
-func NewConfig(name string, sortKey order.SortKey, thresh int64, seekStride int) *Config {
-	if sortKey.IsNil() {
-		sortKey = order.NewSortKey(order.Desc, field.DottedList("ts"))
+func NewConfig(name string, sortKeys order.SortKeys, thresh int64, seekStride int) *Config {
+	if sortKeys.IsNil() {
+		sortKeys = order.SortKeys{order.NewSortKey(order.Desc, field.Dotted("ts"))}
 	}
 	if thresh == 0 {
 		thresh = data.DefaultThreshold
@@ -35,7 +37,7 @@ func NewConfig(name string, sortKey order.SortKey, thresh int64, seekStride int)
 		Ts:         nano.Now(),
 		Name:       name,
 		ID:         ksuid.New(),
-		SortKey:    sortKey,
+		SortKeys:   sortKeys,
 		SeekStride: seekStride,
 		Threshold:  thresh,
 	}
@@ -47,4 +49,62 @@ func (p *Config) Key() string {
 
 func (p *Config) Path(root *storage.URI) *storage.URI {
 	return root.JoinPath(p.ID.String())
+}
+
+// This is a temporary hack to get the change in order.SortKey working with
+// previous versions. At some point we'll do a migration so we don't have to do
+// this.
+type marshalConfig struct {
+	Ts         nano.Ts     `zed:"ts"`
+	Name       string      `zed:"name"`
+	ID         ksuid.KSUID `zed:"id"`
+	SortKey    oldSortKey  `zed:"layout"`
+	SeekStride int         `zed:"seek_stride"`
+	Threshold  int64       `zed:"threshold"`
+}
+
+type oldSortKey struct {
+	Order order.Which `json:"order" zed:"order"`
+	Keys  field.List  `json:"keys" zed:"keys"`
+}
+
+var hackedBindings = []zson.Binding{
+	{Name: "order.SortKey", Template: oldSortKey{}},
+	{Name: "pools.Config", Template: marshalConfig{}},
+}
+
+func (p Config) MarshalZNG(ctx *zson.MarshalZNGContext) (zed.Type, error) {
+	ctx.NamedBindings(hackedBindings)
+	m := marshalConfig{
+		Ts:         p.Ts,
+		Name:       p.Name,
+		ID:         p.ID,
+		SeekStride: p.SeekStride,
+		Threshold:  p.Threshold,
+	}
+	if !p.SortKeys.IsNil() {
+		m.SortKey.Order = p.SortKeys[0].Order
+		for _, sortKey := range p.SortKeys {
+			m.SortKey.Keys = append(m.SortKey.Keys, sortKey.Key)
+		}
+	}
+	typ, err := ctx.MarshalValue(&m)
+	return typ, err
+}
+
+func (p *Config) UnmarshalZNG(ctx *zson.UnmarshalZNGContext, val zed.Value) error {
+	ctx.NamedBindings(hackedBindings)
+	var m marshalConfig
+	if err := ctx.Unmarshal(val, &m); err != nil {
+		return err
+	}
+	p.Ts = m.Ts
+	p.Name = m.Name
+	p.ID = m.ID
+	p.SeekStride = m.SeekStride
+	p.Threshold = m.Threshold
+	for _, k := range m.SortKey.Keys {
+		p.SortKeys = append(p.SortKeys, order.NewSortKey(m.SortKey.Order, k))
+	}
+	return nil
 }

--- a/python/zed/zed.py
+++ b/python/zed/zed.py
@@ -35,7 +35,7 @@ class Client():
             return creds['services'][self.base_url]['access']
         return None
 
-    def create_pool(self, name, layout={'order': 'desc', 'keys': [['ts']]},
+    def create_pool(self, name, layout=[{'order': 'desc', 'key': ['ts']}],
                     thresh=0):
         r = self.session.post(self.base_url + '/pool', json={
             'name': name,

--- a/python/zed/zed.py
+++ b/python/zed/zed.py
@@ -35,7 +35,7 @@ class Client():
             return creds['services'][self.base_url]['access']
         return None
 
-    def create_pool(self, name, layout=[{'order': 'desc', 'key': ['ts']}],
+    def create_pool(self, name, layout={'order': 'desc', 'keys': [['ts']]},
                     thresh=0):
         r = self.session.post(self.base_url + '/pool', json={
             'name': name,

--- a/runtime/exec/stats.go
+++ b/runtime/exec/stats.go
@@ -22,7 +22,7 @@ func GetPoolStats(ctx context.Context, p *lake.Pool, snap commits.View) (info Po
 	// XXX this doesn't scale... it should be stored in the snapshot and is
 	// not easy to compute in the face of deletes...
 	var poolSpan *extent.Generic
-	for _, object := range snap.Select(nil, p.SortKey.Order) {
+	for _, object := range snap.Select(nil, p.SortKeys.Primary().Order) {
 		info.Size += object.Size
 		if poolSpan == nil {
 			poolSpan = extent.NewGenericFromOrder(object.Min, object.Max, order.Asc)
@@ -57,7 +57,7 @@ func GetBranchStats(ctx context.Context, b *lake.Branch, snap commits.View) (inf
 	// XXX this doesn't scale... it should be stored in the snapshot and is
 	// not easy to compute in the face of deletes...
 	var poolSpan *extent.Generic
-	for _, object := range snap.Select(nil, b.Pool().SortKey.Order) {
+	for _, object := range snap.Select(nil, b.Pool().SortKeys.Primary().Order) {
 		info.Size += object.Size
 		if poolSpan == nil {
 			poolSpan = extent.NewGenericFromOrder(object.Min, object.Max, order.Asc)

--- a/runtime/sam/expr/sort_test.go
+++ b/runtime/sam/expr/sort_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/zson"
 )
 
@@ -24,7 +25,7 @@ func BenchmarkSort(b *testing.B) {
 		b.Run(zson.FormatType(c.typ), func(b *testing.B) {
 			arena := zed.NewArena()
 			defer arena.Unref()
-			cmp := NewComparator(false, false, &This{})
+			cmp := NewComparator(false, SortEvaluator{&This{}, order.Asc})
 			vals := make([]zed.Value, 1048576)
 			for i := 0; i < b.N; i++ {
 				b.StopTimer()

--- a/runtime/sam/op/groupby/groupby_test.go
+++ b/runtime/sam/op/groupby/groupby_test.go
@@ -124,7 +124,7 @@ func TestGroupbyStreamingSpill(t *testing.T) {
 				}
 			},
 		}
-		sortKey := order.NewSortKey(order.Asc, field.List{field.Path{inputSortKey}})
+		sortKey := order.NewSortKey(order.Asc, field.Path{inputSortKey})
 		query, err := newQueryOnOrderedReader(context.Background(), zctx, proc, cr, sortKey)
 		require.NoError(t, err)
 		defer query.Pull(true)

--- a/runtime/sam/op/join/join.go
+++ b/runtime/sam/op/join/join.go
@@ -48,13 +48,15 @@ func New(rctx *runtime.Context, anti, inner bool, left, right zbuf.Puller, leftK
 	var err error
 	// Add sorts if needed.
 	if !leftDir.HasOrder(o) {
-		left, err = sort.New(rctx, left, []expr.Evaluator{leftKey}, o, false, resetter)
+		s := expr.NewSortEvaluator(leftKey, o)
+		left, err = sort.New(rctx, left, []expr.SortEvaluator{s}, false, false, resetter)
 		if err != nil {
 			return nil, err
 		}
 	}
 	if !rightDir.HasOrder(o) {
-		right, err = sort.New(rctx, right, []expr.Evaluator{rightKey}, o, false, resetter)
+		s := expr.NewSortEvaluator(rightKey, o)
+		right, err = sort.New(rctx, right, []expr.SortEvaluator{s}, false, false, resetter)
 		if err != nil {
 			return nil, err
 		}

--- a/runtime/sam/op/merge/merge_test.go
+++ b/runtime/sam/op/merge/merge_test.go
@@ -101,8 +101,8 @@ func TestParallelOrder(t *testing.T) {
 				r := zsonio.NewReader(zctx, strings.NewReader(input))
 				parents = append(parents, zbuf.NewPuller(r))
 			}
-			sortKey := order.NewSortKey(c.order, field.DottedList(c.field))
-			cmp := zbuf.NewComparator(zctx, sortKey).Compare
+			sortKey := order.NewSortKey(c.order, field.Dotted(c.field))
+			cmp := zbuf.NewComparator(zctx, order.SortKeys{sortKey}).Compare
 			om := merge.New(context.Background(), parents, cmp, expr.Resetters{})
 
 			var sb strings.Builder

--- a/runtime/sam/op/meta/lister.go
+++ b/runtime/sam/op/meta/lister.go
@@ -79,7 +79,7 @@ func (l *Lister) Pull(done bool) (zbuf.Batch, error) {
 		return nil, l.err
 	}
 	if l.objects == nil {
-		l.objects = initObjectScan(l.snap, l.pool.SortKey)
+		l.objects = initObjectScan(l.snap, l.pool.SortKeys.Primary())
 	}
 	arena := zed.NewArena()
 	for len(l.objects) != 0 {

--- a/runtime/sam/op/meta/scanner.go
+++ b/runtime/sam/op/meta/scanner.go
@@ -104,7 +104,7 @@ func NewCommitMetaScanner(ctx context.Context, zctx *zed.Context, r *lake.Root, 
 			return nil, err
 		}
 		vectors := commits.Vectors(snap)
-		reader, err := objectReader(ctx, zctx, vectors, p.SortKey.Order)
+		reader, err := objectReader(ctx, zctx, vectors, p.SortKeys.Primary().Order)
 		if err != nil {
 			return nil, err
 		}

--- a/runtime/sam/op/sort/ztests/different-order-keys.yaml
+++ b/runtime/sam/op/sort/ztests/different-order-keys.yaml
@@ -1,0 +1,21 @@
+zed: sort foo asc, bar desc, baz asc
+
+input: |
+  {foo:2,bar:1,baz:2}
+  {foo:1,bar:2,baz:1}
+  {foo:2,bar:2,baz:2}
+  {foo:1,bar:2,baz:2}
+  {foo:2,bar:1,baz:1}
+  {foo:1,bar:1,baz:2}
+  {foo:1,bar:1,baz:1}
+  {foo:2,bar:2,baz:1}
+
+output: |
+  {foo:1,bar:2,baz:1}
+  {foo:1,bar:2,baz:2}
+  {foo:1,bar:1,baz:1}
+  {foo:1,bar:1,baz:2}
+  {foo:2,bar:2,baz:1}
+  {foo:2,bar:2,baz:2}
+  {foo:2,bar:1,baz:1}
+  {foo:2,bar:1,baz:2}

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -244,7 +244,7 @@ func handlePoolPost(c *Core, w *ResponseWriter, r *Request) {
 	if !r.Unmarshal(w, &req) {
 		return
 	}
-	pool, err := c.root.CreatePool(r.Context(), req.Name, req.SortKey, req.SeekStride, req.Thresh)
+	pool, err := c.root.CreatePool(r.Context(), req.Name, req.SortKeys, req.SeekStride, req.Thresh)
 	if err != nil {
 		w.Error(err)
 		return

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -20,6 +21,7 @@ import (
 	"github.com/brimdata/zed/lake/commits"
 	"github.com/brimdata/zed/lake/journal"
 	"github.com/brimdata/zed/lakeparse"
+	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/pkg/storage"
 	"github.com/brimdata/zed/runtime"
 	"github.com/brimdata/zed/runtime/exec"
@@ -242,9 +244,14 @@ func handlePoolStats(c *Core, w *ResponseWriter, r *Request) {
 func handlePoolPost(c *Core, w *ResponseWriter, r *Request) {
 	var req api.PoolPostRequest
 	if !r.Unmarshal(w, &req) {
+		fmt.Println("unmarshal.err")
 		return
 	}
-	pool, err := c.root.CreatePool(r.Context(), req.Name, req.SortKeys, req.SeekStride, req.Thresh)
+	var sortKeys order.SortKeys
+	if len(req.SortKeys.Keys) > 0 {
+		sortKeys = append(sortKeys, order.NewSortKey(req.SortKeys.Order, req.SortKeys.Keys[0]))
+	}
+	pool, err := c.root.CreatePool(r.Context(), req.Name, sortKeys, req.SeekStride, req.Thresh)
 	if err != nil {
 		w.Error(err)
 		return

--- a/service/ztests/curl-create.yaml
+++ b/service/ztests/curl-create.yaml
@@ -2,7 +2,7 @@ script: |
   source service.sh
   curl -X POST \
     -H "Accept: application/json" \
-    -d '{"name": "test", "layout": [{ "order": "desc", "key": ["ts"] }]}' \
+    -d '{"name": "test", "layout": { "order": "desc", "keys": [["ts"]] }}' \
     $ZED_LAKE/pool | zq -Z "pool.ts:=0,pool.id:=0,branch.ts:=0" -
 
 inputs:

--- a/service/ztests/curl-create.yaml
+++ b/service/ztests/curl-create.yaml
@@ -2,7 +2,7 @@ script: |
   source service.sh
   curl -X POST \
     -H "Accept: application/json" \
-    -d '{"name": "test", "layout": { "order": "desc", "keys": [["ts"]] }}' \
+    -d '{"name": "test", "layout": [{ "order": "desc", "key": ["ts"] }]}' \
     $ZED_LAKE/pool | zq -Z "pool.ts:=0,pool.id:=0,branch.ts:=0" -
 
 inputs:

--- a/service/ztests/curl-pool-rename.yaml
+++ b/service/ztests/curl-pool-rename.yaml
@@ -2,7 +2,7 @@ script: |
   source service.sh
   curl -X POST \
     -H "Accept: application/json" \
-    -d '{"name": "test", "layout": { "order": "desc", "keys": [["ts"]] }}' \
+    -d '{"name": "test", "layout": [{ "order": "desc", "key": ["ts"] }]}' \
     $ZED_LAKE/pool > /dev/null
   curl -X PUT \
     -H "Accept: application/json" \

--- a/service/ztests/curl-pool-rename.yaml
+++ b/service/ztests/curl-pool-rename.yaml
@@ -2,7 +2,7 @@ script: |
   source service.sh
   curl -X POST \
     -H "Accept: application/json" \
-    -d '{"name": "test", "layout": [{ "order": "desc", "key": ["ts"] }]}' \
+    -d '{"name": "test", "layout": { "order": "desc", "keys": [["ts"]] }}' \
     $ZED_LAKE/pool > /dev/null
   curl -X PUT \
     -H "Accept: application/json" \

--- a/service/ztests/query-describe.yaml
+++ b/service/ztests/query-describe.yaml
@@ -64,14 +64,14 @@ outputs:
               {
                   "name": "main",
                   "aggregation_keys": null,
-                  "sort": {
-                      "order": "desc",
-                      "keys": [
-                          [
+                  "sort": [
+                      {
+                          "order": "desc",
+                          "key": [
                               "ts"
                           ]
-                      ]
-                  }
+                      }
+                  ]
               }
           ]
       }
@@ -143,14 +143,14 @@ outputs:
               {
                   "name": "secondary",
                   "aggregation_keys": null,
-                  "sort": {
-                      "order": "desc",
-                      "keys": [
-                          [
+                  "sort": [
+                      {
+                          "order": "desc",
+                          "key": [
                               "ts"
                           ]
-                      ]
-                  }
+                      }
+                  ]
               }
           ]
       }
@@ -170,14 +170,14 @@ outputs:
                           "foo"
                       ]
                   ],
-                  "sort": {
-                      "order": "asc",
-                      "keys": [
-                          [
+                  "sort": [
+                      {
+                          "order": "asc",
+                          "key": [
                               "x"
                           ]
-                      ]
-                  }
+                      }
+                  ]
               }
           ]
       }
@@ -193,14 +193,14 @@ outputs:
               {
                   "name": "main",
                   "aggregation_keys": null,
-                  "sort": {
-                      "order": "desc",
-                      "keys": [
-                          [
+                  "sort": [
+                      {
+                          "order": "desc",
+                          "key": [
                               "ts"
                           ]
-                      ]
-                  }
+                      }
+                  ]
               },
               {
                   "name": "secondary",

--- a/zfmt/ast.go
+++ b/zfmt/ast.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/brimdata/zed/compiler/ast"
 	astzed "github.com/brimdata/zed/compiler/ast/zed"
-	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/runtime/sam/expr/agg"
 	"github.com/brimdata/zed/runtime/sam/expr/function"
 	"github.com/brimdata/zed/zson"
@@ -486,15 +485,21 @@ func (c *canon) op(p ast.Op) {
 	case *ast.Sort:
 		c.next()
 		c.write("sort")
-		if p.Order == order.Desc {
+		if p.Reverse {
 			c.write(" -r")
 		}
 		if p.NullsFirst {
 			c.write(" -nulls first")
 		}
-		if len(p.Args) > 0 {
+		for k, s := range p.Args {
+			if k > 0 {
+				c.write(",")
+			}
 			c.space()
-			c.exprs(p.Args)
+			c.expr(s.Expr, "")
+			if s.Order != nil {
+				c.write(" %s", s.Order.Name)
+			}
 		}
 	case *ast.Load:
 		c.next()

--- a/zfmt/dag.go
+++ b/zfmt/dag.go
@@ -3,7 +3,6 @@ package zfmt
 import (
 	"github.com/brimdata/zed/compiler/ast/dag"
 	astzed "github.com/brimdata/zed/compiler/ast/zed"
-	"github.com/brimdata/zed/order"
 	"github.com/brimdata/zed/zson"
 )
 
@@ -387,15 +386,19 @@ func (c *canonDAG) op(p dag.Op) {
 	case *dag.Sort:
 		c.next()
 		c.write("sort")
-		if p.Order == order.Desc {
+		if p.Reverse {
 			c.write(" -r")
 		}
 		if p.NullsFirst {
 			c.write(" -nulls first")
 		}
-		if len(p.Args) > 0 {
+		for i, s := range p.Args {
+			if i > 0 {
+				c.write(",")
+			}
 			c.space()
-			c.exprs(p.Args)
+			c.expr(s.Key, "")
+			c.write(" %s", s.Order)
 		}
 	case *dag.Load:
 		c.next()
@@ -508,8 +511,14 @@ func (c *canonDAG) op(p dag.Op) {
 		if p.Format != "" {
 			c.write(" format %s", p.Format)
 		}
-		if !p.SortKey.IsNil() {
-			c.write(" order %s", p.SortKey)
+		if !p.SortKeys.IsNil() {
+			c.write(" order")
+			for i, s := range p.SortKeys {
+				if i > 0 {
+					c.write(",")
+				}
+				c.write(" %s  %s", s.Key, s.Order)
+			}
 		}
 		if p.Filter != nil {
 			c.write(" filter (")

--- a/zfmt/ztests/parallel.yaml
+++ b/zfmt/ztests/parallel.yaml
@@ -18,5 +18,5 @@ outputs:
           put a:=b*c
       )
       | cut cake:=cake
-      | sort -r x
+      | sort -r x asc
       | output main

--- a/zio/lakeio/writer.go
+++ b/zio/lakeio/writer.go
@@ -110,9 +110,9 @@ func formatPoolConfig(b *bytes.Buffer, p *pools.Config) {
 	b.WriteByte(' ')
 	b.WriteString(p.ID.String())
 	b.WriteString(" key ")
-	b.WriteString(p.SortKey.Keys.String())
+	b.WriteString(p.SortKeys.Primary().Key.String())
 	b.WriteString(" order ")
-	b.WriteString(p.SortKey.Order.String())
+	b.WriteString(p.SortKeys.Primary().Order.String())
 	b.WriteByte('\n')
 }
 


### PR DESCRIPTION
Change the sort operator so that different ordering can be applied to each key in the sort.

Closes #4945