### PR TITLE
Fix strftime docs and add another example

### DIFF
--- a/docs/language/functions/README.md
+++ b/docs/language/functions/README.md
@@ -59,6 +59,7 @@ Zed's [primitive types](../../formats/zed.md#1-primitive-types), e.g.,
 * [rune_len](rune_len.md) - length of a string in Unicode code points
 * [shape](shape.md) - apply cast, fill, and order
 * [split](split.md) - slice a string into an array of strings
+* [strftime](strftime.md) - format time values
 * [sqrt](sqrt.md) - square root of a number
 * [trim](trim.md) - strip leading and trailing whitespace
 * [typename](typename.md) - look up and return a named type

--- a/docs/language/functions/README.md
+++ b/docs/language/functions/README.md
@@ -59,8 +59,8 @@ Zed's [primitive types](../../formats/zed.md#1-primitive-types), e.g.,
 * [rune_len](rune_len.md) - length of a string in Unicode code points
 * [shape](shape.md) - apply cast, fill, and order
 * [split](split.md) - slice a string into an array of strings
-* [strftime](strftime.md) - format time values
 * [sqrt](sqrt.md) - square root of a number
+* [strftime](strftime.md) - format time values
 * [trim](trim.md) - strip leading and trailing whitespace
 * [typename](typename.md) - look up and return a named type
 * [typeof](typeof.md) - the type of a value

--- a/docs/language/functions/strftime.md
+++ b/docs/language/functions/strftime.md
@@ -8,7 +8,7 @@ strftime(format: string, t: time) -> string
 ```
 
 ### Description
-The _strftime_ function returns a string represenation of time `t`
+The _strftime_ function returns a string representation of time `t`
 as specified by the provided string `format`. `format` is a string
 containing format directives that dictate how the time string is
 formatted.
@@ -64,4 +64,13 @@ echo 2024-07-30T20:05:15.118252Z | zq -z 'strftime("%Y", this)' -
 =>
 ```mdtest-output
 "2024"
+```
+
+Print a date in European format with slashes
+```mdtest-command
+echo 2024-07-30T20:05:15.118252Z | zq -z 'strftime("%d/%m/%Y", this)' -
+```
+=>
+```mdtest-output
+"30/07/2024"
 ```


### PR DESCRIPTION
While trying out the new `strftime` function added in #5197 I found a couple small errors to fix, and while I was at it I figured it could use another example.