### PR TITLE
Clarify in join doc that fields can be copied from the right side without assignment

### DIFF
--- a/docs/language/operators/join.md
+++ b/docs/language/operators/join.md
@@ -8,10 +8,10 @@
 <left-input>
 | [anti|inner|left|right] join (
   <right-input>
-) on <left-key>=<right-key> [<field>:=<right-expr>, ...]
+) on <left-key>=<right-key> [[<field>:=]<right-expr>, ...]
 
 ( => <left-input> => <right-input> )
-| [anti|inner|left|right] join on <left-key>=<right-key> [<field>:=<right-expr>, ...]
+| [anti|inner|left|right] join on <left-key>=<right-key> [[<field>:=]<right-expr>, ...]
 ```
 
 :::tip Note


### PR DESCRIPTION
## What's changing

A small clarification is being made to the `join` operator doc.

## Why

A community user recently spotted this omission.

## Details

In the user's own words from the [community Slack thread](https://brimdata.slack.com/archives/CTSMAK6G7/p1722437293178469):

> for joins - I feel like the syntax here in the docs could somehow also illustrate that just the name of a field from the right-side can be included without assignment:
> now:
>```
><left-input>
>| [anti|inner|left|right] join (
>  <right-input>
>) on <left-key>=<right-key> [<field>:=<right-expr>, ...]
>```
>
>off-the-cuff proposal:
>```
><left-input>
>| [anti|inner|left|right] join (
>  <right-input>
>) on <left-key>=<right-key> [<field>:=<right-expr>, <right-field>, ...]
>```

At first I toyed with updating it to ` [<field>:=<right-expr>|<right-field>, ...]`, but that may give the impression that only an explicit right-side field name would be supported, but expressions such as function calls cook up field names on the fly, e.g., this change from the [Inner Join example in the `join` tutorial](https://zed.brimdata.io/docs/next/tutorials/join#inner-join):

```
$ zq -z '
file fruit.ndjson | sort flavor
| inner join (
  file people.ndjson | sort likes
) on flavor=likes upper(name)'
{name:"figs",color:"brown",flavor:"plain",upper:"JESSIE"}
{name:"banana",color:"yellow",flavor:"sweet",upper:"QUINN"}
{name:"strawberry",color:"red",flavor:"sweet",upper:"QUINN"}
{name:"dates",color:"brown",flavor:"sweet",note:"in season",upper:"QUINN"}
{name:"apple",color:"red",flavor:"tart",upper:"MORGAN"}
{name:"apple",color:"red",flavor:"tart",upper:"CHRIS"}
```

So instead I've taken the approach of making the assignment portion appear optional, knowing that errors will further communicate the limitations if the user tries something unworkable, e.g.,

```
$ zq -z '
file fruit.ndjson | sort flavor
| inner join (
  file people.ndjson | sort likes
) on flavor=likes name+"hi"
'
zq: cannot infer field from expression at line 5, column 19:
) on flavor=likes name+"hi"
                  ~~~~~~~~~
illegal left-hand side of assignment at line 5, column 19:
) on flavor=likes name+"hi"
                  ~~~~~~~~~
```