### PR TITLE
Fix comparisons with unions in runtime/sam/expr

### DIFF
--- a/runtime/sam/expr/eval.go
+++ b/runtime/sam/expr/eval.go
@@ -292,6 +292,8 @@ func (c *Compare) Eval(ectx Context, this zed.Value) zed.Value {
 	if rhs.IsError() {
 		return rhs
 	}
+	arena := ectx.Arena()
+	lhs, rhs = lhs.Under(arena), rhs.Under(arena)
 
 	if lhs.IsNull() {
 		if rhs.IsNull() {

--- a/runtime/sam/expr/expr_test.go
+++ b/runtime/sam/expr/expr_test.go
@@ -208,6 +208,15 @@ func TestCompareNumbers(t *testing.T) {
 	testSuccessful(t, "u <= f", rec2, "false")
 	testSuccessful(t, "u > f", rec2, "true")
 	testSuccessful(t, "u >= f", rec2, "true")
+
+	// Test comparisons with unions.
+	const rec3 = "{l:1((int64,bytes)),r:2.((string,float64))}"
+	testSuccessful(t, "l == r", rec3, "false")
+	testSuccessful(t, "l != r", rec3, "true")
+	testSuccessful(t, "l < r", rec3, "true")
+	testSuccessful(t, "l <= r", rec3, "true")
+	testSuccessful(t, "l > r", rec3, "false")
+	testSuccessful(t, "l >= r", rec3, "false")
 }
 
 func TestCompareNonNumbers(t *testing.T) {


### PR DESCRIPTION
Fix by calling zed.Value.Under in expr.Compare.Eval.

Closes #5209.