### PR TITLE
Embed *vector.Variant in vector.Union

### DIFF
--- a/vector/union.go
+++ b/vector/union.go
@@ -6,37 +6,32 @@ import (
 )
 
 type Union struct {
-	Typ    *zed.TypeUnion
-	Tags   []uint32
-	TagMap TagMap
-	Values []Any
-	Nulls  *Bool
+	*Variant
+	Typ   *zed.TypeUnion
+	Nulls *Bool
 }
 
 var _ Any = (*Union)(nil)
 
 func NewUnion(typ *zed.TypeUnion, tags []uint32, vals []Any, nulls *Bool) *Union {
-	return &Union{typ, tags, *NewTagMap(tags, vals), vals, nulls}
+	return &Union{NewVariant(tags, vals), typ, nulls}
 }
 
 func (u *Union) Type() zed.Type {
 	return u.Typ
 }
 
-func (u *Union) Len() uint32 {
-	return uint32(len(u.Tags))
-}
-
 func (u *Union) Serialize(b *zcode.Builder, slot uint32) {
-	tag := u.Tags[slot]
 	b.BeginContainer()
-	b.Append(zed.EncodeInt(int64(tag)))
-	u.Values[tag].Serialize(b, u.TagMap.Forward[slot])
+	b.Append(zed.EncodeInt(int64(u.Tags[slot])))
+	u.Variant.Serialize(b, slot)
 	b.EndContainer()
 }
 
 func (u *Union) Copy(vals []Any) *Union {
+	variant := *u.Variant
+	variant.Values = vals
 	u2 := *u
-	u2.Values = vals
+	u2.Variant = &variant
 	return &u2
 }


### PR DESCRIPTION
This simplifies Union a little and enables zero-cost conversions from Union to Variant.