### PR TITLE
Add summarize docs for "by" without an aggregate function

### DIFF
--- a/docs/language/operators/summarize.md
+++ b/docs/language/operators/summarize.md
@@ -5,14 +5,20 @@
 ### Synopsis
 
 ```
-[summarize] [<field>:=]<agg> [where <expr>][, [<field>:=]<agg> [where <expr>] ...] [by [<field>][:=<expr>] ...]
+[summarize] [<field>:=]<agg> [where <expr>][, [<field>:=]<agg> [where <expr>] ...] [by [<field>][:=<expr>][, [<field>][:=<expr>]] ...]
+[summarize] by [<field>][:=<expr>][, [<field>][:=<expr>] ...]
 ```
 ### Description
 
-The `summarize` operator consumes all of its input, applies an [aggregate function](../aggregates/README.md)
+In the first form, the `summarize` operator consumes all of its input,
+applies an [aggregate function](../aggregates/README.md)
 to each input value optionally organized with the group-by keys specified after
 the `by` keyword, and at the end of input produces one or more aggregations
 for each unique set of group-by key values.
+
+In the second form, `summarize` consumes all of its input, then outputs each
+unique combination of values of the group-by keys specified after the `by`
+keyword.
 
 The `summarize` keyword is optional since it is an
 [implied operator](../dataflow-model.md#implied-operators).
@@ -101,4 +107,15 @@ echo '{k:"foo",v:1}{k:"bar",v:2}{k:"foo",v:3}{k:"baz",v:4}' | zq -z 'set:=union(
 {key:"bar",set:|[2]|}
 {key:"baz",set:|[4]|}
 {key:"foo",set:|[3]|}
+```
+
+Output just the unique key values:
+```mdtest-command
+echo '{k:"foo",v:1}{k:"bar",v:2}{k:"foo",v:3}{k:"baz",v:4}' | zq -z 'by k' - | sort
+```
+=>
+```mdtest-output
+{k:"bar"}
+{k:"baz"}
+{k:"foo"}
 ```

--- a/docs/language/operators/summarize.md
+++ b/docs/language/operators/summarize.md
@@ -5,18 +5,21 @@
 ### Synopsis
 
 ```
+[summarize] [<field>:=]<agg>
+[summarize] [<field>:=]<agg> [where <expr>][, [<field>:=]<agg> [where <expr>] ...]
+[summarize] [<field>:=]<agg> [by [<field>][:=<expr>][, [<field>][:=<expr>]] ...]
 [summarize] [<field>:=]<agg> [where <expr>][, [<field>:=]<agg> [where <expr>] ...] [by [<field>][:=<expr>][, [<field>][:=<expr>]] ...]
 [summarize] by [<field>][:=<expr>][, [<field>][:=<expr>] ...]
 ```
 ### Description
 
-In the first form, the `summarize` operator consumes all of its input,
-applies an [aggregate function](../aggregates/README.md)
-to each input value optionally organized with the group-by keys specified after
-the `by` keyword, and at the end of input produces one or more aggregations
-for each unique set of group-by key values.
+In the first four forms, the `summarize` operator consumes all of its input,
+applies an [aggregate function](../aggregates/README.md) to each input value
+optionally filtered by a `where` clause and/or organized with the group-by
+keys specified after the `by` keyword, and at the end of input produces one
+or more aggregations for each unique set of group-by key values.
 
-In the second form, `summarize` consumes all of its input, then outputs each
+In the final form, `summarize` consumes all of its input, then outputs each
 unique combination of values of the group-by keys specified after the `by`
 keyword.
 


### PR DESCRIPTION
A recent [community Slack thread](https://brimdata.slack.com/archives/CTSMAK6G7/p1722612689782589?thread_ts=1722611911.071209&cid=CTSMAK6G7) made me realize we were lacking usage docs and an example for `by` in the absence of an aggregate function.

While I was making this change, I saw that the existing `by` coverage didn't seem to show that multiple keys could be specified, so I've tried to address that as well.