### PR TITLE
Add "by" examples to aggregate function docs, plus a few more fixes

### DIFF
--- a/docs/language/aggregates/and.md
+++ b/docs/language/aggregates/and.md
@@ -32,6 +32,7 @@ true
 false
 false
 ```
+
 Unrecognized types are ignored and not coerced for truthiness:
 ```mdtest-command
 echo 'true "foo" 0 false true' | zq -z 'yield and(this)' -
@@ -43,4 +44,14 @@ true
 true
 false
 false
+```
+
+AND of values grouped by key:
+```mdtest-command
+echo '{a:true,k:1} {a:true,k:1} {a:true,k:2} {a:false,k:2}' | zq -z 'and(a) by k | sort' -
+```
+=>
+```mdtest-output
+{k:1,and:true}
+{k:2,and:false}
 ```

--- a/docs/language/aggregates/any.md
+++ b/docs/language/aggregates/any.md
@@ -34,6 +34,7 @@ echo '1 2 3 4' | zq -z 'yield any(this)' -
 1
 1
 ```
+
 Any is not sensitive to mixed types as it just picks one:
 ```mdtest-command
 echo '"foo" 1 2 3 ' | zq -z 'any(this)' -
@@ -41,4 +42,14 @@ echo '"foo" 1 2 3 ' | zq -z 'any(this)' -
 =>
 ```mdtest-output
 "foo"
+```
+
+Pick from groups bucketed by key:
+```mdtest-command
+echo '{a:1,k:1} {a:2,k:1} {a:3,k:2} {a:4,k:2}' | zq -z 'any(a) by k | sort' -
+```
+=>
+```mdtest-output
+{k:1,any:1}
+{k:2,any:3}
 ```

--- a/docs/language/aggregates/avg.md
+++ b/docs/language/aggregates/avg.md
@@ -33,6 +33,7 @@ echo '1 2 3 4' | zq -z 'yield avg(this)' -
 2.
 2.5
 ```
+
 Unrecognized types are ignored:
 ```mdtest-command
 echo '1 2 3 4 "foo"' | zq -z 'avg(this)' -
@@ -40,4 +41,14 @@ echo '1 2 3 4 "foo"' | zq -z 'avg(this)' -
 =>
 ```mdtest-output
 2.5
+```
+
+Average of values bucketed by key:
+```mdtest-command
+echo '{a:1,k:1} {a:2,k:1} {a:3,k:2} {a:4,k:2}' | zq -z 'avg(a) by k | sort' -
+```
+=>
+```mdtest-output
+{k:1,avg:1.5}
+{k:2,avg:3.5}
 ```

--- a/docs/language/aggregates/collect.md
+++ b/docs/language/aggregates/collect.md
@@ -35,6 +35,7 @@ echo '1 2 3 4' | zq -z 'yield collect(this)' -
 [1,2,3]
 [1,2,3,4]
 ```
+
 Mixed types create a union type for the array elements:
 ```mdtest-command
 echo '1 2 3 4 "foo"' | zq -z 'collect(this)' -
@@ -42,4 +43,14 @@ echo '1 2 3 4 "foo"' | zq -z 'collect(this)' -
 =>
 ```mdtest-output
 [1,2,3,4,"foo"]
+```
+
+Create arrays of values bucketed by key:
+```mdtest-command
+echo '{a:1,k:1} {a:2,k:1} {a:3,k:2} {a:4,k:2}' | zq -z 'collect(a) by k | sort' -
+```
+=>
+```mdtest-output
+{k:1,collect:[1,2]}
+{k:2,collect:[3,4]}
 ```

--- a/docs/language/aggregates/collect_map.md
+++ b/docs/language/aggregates/collect_map.md
@@ -35,3 +35,13 @@ echo '|{"APPL":145.03}| |{"GOOG":87.07}| |{"APPL":150.13}|' | zq -z 'yield colle
 |{"APPL":145.03,"GOOG":87.07}|
 |{"APPL":150.13,"GOOG":87.07}|
 ```
+
+Create maps by key:
+```mdtest-command
+echo '{stock:"APPL",price:145.03,day:0} {stock:"GOOG",price:87.07,day:0} {stock:"APPL",price:150.13,day:1} {stock:"GOOG",price:89.15,day:1}' | zq -z 'collect_map(|{stock:price}|) by day | sort' -
+```
+=>
+```mdtest-output
+{day:0,collect_map:|{"APPL":145.03,"GOOG":87.07}|}
+{day:1,collect_map:|{"APPL":150.13,"GOOG":89.15}|}
+```

--- a/docs/language/aggregates/count.md
+++ b/docs/language/aggregates/count.md
@@ -13,7 +13,7 @@ The _count_ aggregate function computes the number of values in its input.
 
 ### Examples
 
-Anded value of simple sequence:
+Count of values in a simple sequence:
 ```mdtest-command
 echo '1 2 3' | zq -z 'count()' -
 ```
@@ -32,6 +32,7 @@ echo '1 2 3' | zq -z 'yield count()' -
 2(uint64)
 3(uint64)
 ```
+
 Mixed types are handled:
 ```mdtest-command
 echo '1 "foo" 10.0.0.1' | zq -z 'yield count()' -
@@ -41,6 +42,16 @@ echo '1 "foo" 10.0.0.1' | zq -z 'yield count()' -
 1(uint64)
 2(uint64)
 3(uint64)
+```
+
+Count of values in buckets grouped by key:
+```mdtest-command
+echo '{a:1,k:1} {a:2,k:1} {a:3,k:2}' | zq -z 'count() by k | sort' -
+```
+=>
+```mdtest-output
+{k:1,count:2(uint64)}
+{k:2,count:1(uint64)}
 ```
 
 Note that the number of input values are counted, unlike the [`len` function](../functions/len.md) which counts the number of elements in a given value:

--- a/docs/language/aggregates/dcount.md
+++ b/docs/language/aggregates/dcount.md
@@ -14,7 +14,7 @@ of the input in a memory efficient manner.
 
 ### Examples
 
-Anded value of simple sequence:
+Count of values in a simple sequence:
 ```mdtest-command
 echo '1 2 2 3' | zq -z 'dcount(this)' -
 ```
@@ -34,6 +34,7 @@ echo '1 2 2 3' | zq -z 'yield dcount(this)' -
 2(uint64)
 3(uint64)
 ```
+
 Mixed types are handled:
 ```mdtest-command
 echo '1 "foo" 10.0.0.1' | zq -z 'yield dcount(this)' -
@@ -43,4 +44,23 @@ echo '1 "foo" 10.0.0.1' | zq -z 'yield dcount(this)' -
 1(uint64)
 2(uint64)
 3(uint64)
+```
+
+The estimated result may become less accurate with more unique input values:
+```mdtest-command
+seq 10000 | zq -z 'dcount(this)' -
+```
+=>
+```mdtest-output
+9987(uint64)
+```
+
+Count of values in buckets grouped by key:
+```mdtest-command
+echo '{a:1,k:1} {a:2,k:1} {a:3,k:2}' | zq -z 'dcount(a) by k | sort' -
+```
+=>
+```mdtest-output
+{k:1,dcount:2(uint64)}
+{k:2,dcount:1(uint64)}
 ```

--- a/docs/language/aggregates/max.md
+++ b/docs/language/aggregates/max.md
@@ -33,6 +33,7 @@ echo '1 2 3 4' | zq -z 'yield max(this)' -
 3
 4
 ```
+
 Unrecognized types are ignored:
 ```mdtest-command
 echo '1 2 3 4 "foo"' | zq -z 'max(this)' -
@@ -40,4 +41,14 @@ echo '1 2 3 4 "foo"' | zq -z 'max(this)' -
 =>
 ```mdtest-output
 4
+```
+
+Maximum value within buckets grouped by key:
+```mdtest-command
+echo '{a:1,k:1} {a:2,k:1} {a:3,k:2} {a:4,k:2}' | zq -z 'max(a) by k | sort' -
+```
+=>
+```mdtest-output
+{k:1,max:2}
+{k:2,max:4}
 ```

--- a/docs/language/aggregates/min.md
+++ b/docs/language/aggregates/min.md
@@ -33,6 +33,7 @@ echo '1 2 3 4' | zq -z 'yield min(this)' -
 1
 1
 ```
+
 Unrecognized types are ignored:
 ```mdtest-command
 echo '1 2 3 4 "foo"' | zq -z 'min(this)' -
@@ -40,4 +41,14 @@ echo '1 2 3 4 "foo"' | zq -z 'min(this)' -
 =>
 ```mdtest-output
 1
+```
+
+Minimum value within buckets grouped by key:
+```mdtest-command
+echo '{a:1,k:1} {a:2,k:1} {a:3,k:2} {a:4,k:2}' | zq -z 'min(a) by k | sort' -
+```
+=>
+```mdtest-output
+{k:1,min:1}
+{k:2,min:3}
 ```

--- a/docs/language/aggregates/or.md
+++ b/docs/language/aggregates/or.md
@@ -32,6 +32,7 @@ false
 true
 true
 ```
+
 Unrecognized types are ignored and not coerced for truthiness:
 ```mdtest-command
 echo 'false "foo" 1 true false' | zq -z 'yield or(this)' -
@@ -43,4 +44,14 @@ false
 false
 true
 true
+```
+
+OR of values grouped by key:
+```mdtest-command
+echo '{a:true,k:1} {a:false,k:1} {a:false,k:2} {a:false,k:2}' | zq -z 'or(a) by k | sort' -
+```
+=>
+```mdtest-output
+{k:1,or:true}
+{k:2,or:false}
 ```

--- a/docs/language/aggregates/sum.md
+++ b/docs/language/aggregates/sum.md
@@ -13,7 +13,7 @@ The _sum_ aggregate function computes the mathematical sum of its input.
 
 ### Examples
 
-Sume of simple sequence:
+Sum of simple sequence:
 ```mdtest-command
 echo '1 2 3 4' | zq -z 'sum(this)' -
 ```
@@ -33,6 +33,7 @@ echo '1 2 3 4' | zq -z 'yield sum(this)' -
 6
 10
 ```
+
 Unrecognized types are ignored:
 ```mdtest-command
 echo '1 2 3 4 "foo"' | zq -z 'sum(this)' -
@@ -40,4 +41,14 @@ echo '1 2 3 4 "foo"' | zq -z 'sum(this)' -
 =>
 ```mdtest-output
 10
+```
+
+Sum of values bucketed by key:
+```mdtest-command
+echo '{a:1,k:1} {a:2,k:1} {a:3,k:2} {a:4,k:2}' | zq -z 'sum(a) by k | sort' -
+```
+=>
+```mdtest-output
+{k:1,sum:3}
+{k:2,sum:7}
 ```

--- a/docs/language/aggregates/union.md
+++ b/docs/language/aggregates/union.md
@@ -16,7 +16,7 @@ types encountered.
 
 ### Examples
 
-Average value of simple sequence:
+Create a set of values from a simple sequence:
 ```mdtest-command
 echo '1 2 3 3' | zq -z 'union(this)' -
 ```
@@ -25,7 +25,7 @@ echo '1 2 3 3' | zq -z 'union(this)' -
 |[1,2,3]|
 ```
 
-Continuous average of simple sequence:
+Create sets continuously from values in a simple sequence:
 ```mdtest-command
 echo '1 2 3 3' | zq -z 'yield union(this)' -
 ```
@@ -36,6 +36,7 @@ echo '1 2 3 3' | zq -z 'yield union(this)' -
 |[1,2,3]|
 |[1,2,3]|
 ```
+
 Mixed types create a union type for the set elements:
 ```mdtest-command-issue-3610
 echo '1 2 3 "foo"' | zq -z 'set:=union(this) | yield this,typeof(set)' -
@@ -44,4 +45,14 @@ echo '1 2 3 "foo"' | zq -z 'set:=union(this) | yield this,typeof(set)' -
 ```mdtest-output-issue-3610
 {set:|[1,2,3,"foo"]|}
 <|[(int64,string)]|>
+```
+
+Create sets of values bucketed by key:
+```mdtest-command
+echo '{a:1,k:1} {a:2,k:1} {a:3,k:2} {a:4,k:2}' | zq -z 'union(a) by k | sort' -
+```
+=>
+```mdtest-output
+{k:1,union:|[1,2]|}
+{k:2,union:|[3,4]|}
 ```


### PR DESCRIPTION
## What's Changing

This adds group-`by` examples to all the aggregate function docs that were missing them.

As I was going through all the pages, I fixed a couple things along the way and added a bonus `dcount()` example.

## Why

In a recent [community Slack thread](https://brimdata.slack.com/archives/CTSMAK6G7/p1722613234924649?thread_ts=1722611911.071209&cid=CTSMAK6G7), a user needed some guidance on the proper use of `by`. He noted that `by` examples on each aggregate function pages may have helped him figure it out on his own, which makes sense.

## Details

While `by` is mentioned in the [`summarize` operator](https://zed.brimdata.io/docs/language/operators/summarize) page (and I'm proposing more improvements there via #5216) I suspect that new users may be more likely to land on the individual aggregate function pages first since they may do searches or follow links to them after seeing references to them in programs as they usually appear without `summarize`.