### PR TITLE
Add text to debug doc about multiple invocations

### DIFF
--- a/docs/language/operators/debug.md
+++ b/docs/language/operators/debug.md
@@ -17,6 +17,10 @@ channel is displayed on stderr.
 The `debug` operator is useful to view intermediate values when debugging a
 complex Zed query.
 
+If used more than once within a single Zed program, the relative order of
+outputs in the debug channel from each separate `debug` invocation is
+undefined.
+
 ### Examples
 
 The following query uses expressions containing [f-strings](../expressions.md#formatted-string-literals)


### PR DESCRIPTION
## What's Changing

Disclosing out-of-order output expectations in the `debug` operator docs.

## Why

When doing final verification of the `debug` operator, I revisited the recreation of the `jq` example shown in #5181 and noticed something for the first time in our implementation: Whereas `jq`'s debug outputs always appear in the relative order that matches their appearance in the pipeline:

```
$ jq -n '1 as $x | 2 | debug("Entering function foo with $x == \($x)", .) | (.+1)'
["DEBUG:","Entering function foo with $x == 1"]
["DEBUG:",2]
3
```

In our equivalent, the order of the debug outputs can vary. I understand this to be an expected side effect of our implementation, but I also expect this might look like a bug to some users, so I figure a disclosure might help.

```
$ zq 'const x=1 yield 2 | debug f"DEBUG: Entering function foo with x == {x}" | debug f"DEBUG: {this}" | yield this+1'
3
"DEBUG: 2"
"DEBUG: Entering function foo with x == 1"

$ zq 'const x=1 yield 2 | debug f"DEBUG: Entering function foo with x == {x}" | debug f"DEBUG: {this}" | yield this+1'
3
"DEBUG: Entering function foo with x == 1"
"DEBUG: 2"
```