### PR TITLE
Show named channels in the lake API doc

### DIFF
--- a/debug.out
+++ b/debug.out
@@ -1,0 +1,2 @@
+[38;5;2m"DEBUG: Entering function foo with x == 1"[0m
+[38;5;2m"DEBUG: 2"[0m

--- a/debug.out
+++ b/debug.out
@@ -1,2 +1,0 @@
-[38;5;2m"DEBUG: Entering function foo with x == 1"[0m
-[38;5;2m"DEBUG: 2"[0m

--- a/docs/lake/api.md
+++ b/docs/lake/api.md
@@ -433,11 +433,11 @@ curl -X POST \
 **Example Response**
 
 ```
-{"type":"QueryChannelSet","value":{"channel_id":0}}
+{"type":"QueryChannelSet","value":{"channel":"main"}}
 {"type":{"kind":"record","id":30,"fields":[{"name":"warehouse","type":{"kind":"primitive","name":"string"}},{"name":"count","type":{"kind":"primitive","name":"uint64"}}]},"value":["miami","1"]}
 {"type":{"kind":"ref","id":30},"value":["chicago","2"]}
-{"type":"QueryChannelEnd","value":{"channel_id":0}}
-{"type":"QueryStats","value":{"start_time":{"sec":1658193276,"ns":964207000},"update_time":{"sec":1658193276,"ns":964592000},"bytes_read":55,"bytes_matched":55,"records_read":3,"records_matched":3}}
+{"type":"QueryChannelEnd","value":{"channel":"main"}}
+{"type":"QueryStats","value":{"start_time":{"sec":1723830077,"ns":168637000},"update_time":{"sec":1723830077,"ns":169204000},"bytes_read":55,"bytes_matched":55,"records_read":3,"records_matched":3}}
 ```
 
 #### Query Status

--- a/docs/lake/api.md
+++ b/docs/lake/api.md
@@ -437,7 +437,7 @@ curl -X POST \
 {"type":{"kind":"record","id":30,"fields":[{"name":"warehouse","type":{"kind":"primitive","name":"string"}},{"name":"count","type":{"kind":"primitive","name":"uint64"}}]},"value":["miami","1"]}
 {"type":{"kind":"ref","id":30},"value":["chicago","2"]}
 {"type":"QueryChannelEnd","value":{"channel":"main"}}
-{"type":"QueryStats","value":{"start_time":{"sec":1723830077,"ns":168637000},"update_time":{"sec":1723830077,"ns":169204000},"bytes_read":55,"bytes_matched":55,"records_read":3,"records_matched":3}}
+{"type":"QueryStats","value":{"start_time":{"sec":1658193276,"ns":964207000},"update_time":{"sec":1658193276,"ns":964592000},"bytes_read":55,"bytes_matched":55,"records_read":3,"records_matched":3}}
 ```
 
 #### Query Status


### PR DESCRIPTION
## What's Changing

The lake API doc will now show named channels in the output of the Query example.

## Why

#5191 changed channels to use string-based names rather than numbers, so the API examples should stay in sync with this.