### PR TITLE
zbuf.Puller: respect done

### DIFF
--- a/zbuf/batch.go
+++ b/zbuf/batch.go
@@ -128,7 +128,10 @@ type puller struct {
 	zr zio.Reader
 }
 
-func (p *puller) Pull(bool) (Batch, error) {
+func (p *puller) Pull(done bool) (Batch, error) {
+	if done {
+		p.zr = nil
+	}
 	if p.zr == nil {
 		return nil, nil
 	}


### PR DESCRIPTION
Fix an issue with zbuf.Puller where done was not triggering it to return EOS.

Closes #5229