### PR TITLE
ztest: Add vector tests

### DIFF
--- a/runtime/ztests/expr/function/lower.yaml
+++ b/runtime/ztests/expr/function/lower.yaml
@@ -1,0 +1,17 @@
+zed: "lower(this)"
+
+vector: true
+
+input: |
+  "fOo"
+  null(string)
+  "BaR"
+  null(string)
+  "BAz"
+
+output: |
+  "foo"
+  null(string)
+  "bar"
+  null(string)
+  "baz"


### PR DESCRIPTION
This commit adds the ability to run vector tests for Zed style ztests. If enabled this will run a given test for both sequential and vector runtimes ensuring that equal outputs are returned for both.