### PR TITLE
vam: Use vector.Apply for lower()

### DIFF
--- a/runtime/sam/expr/function/string.go
+++ b/runtime/sam/expr/function/string.go
@@ -59,7 +59,7 @@ type ToLower struct {
 }
 
 func (t *ToLower) Call(ectx expr.Context, args []zed.Value) zed.Value {
-	val := args[0]
+	val := args[0].Under(ectx.Arena())
 	if !val.IsString() {
 		return t.zctx.WrapError(ectx.Arena(), "lower: string arg required", val)
 	}

--- a/runtime/vam/expr/function/string.go
+++ b/runtime/vam/expr/function/string.go
@@ -13,6 +13,10 @@ type ToLower struct {
 }
 
 func (t *ToLower) Call(args []vector.Any) vector.Any {
+	return vector.Apply(true, t.call, args...)
+}
+
+func (t *ToLower) call(args ...vector.Any) vector.Any {
 	v := vector.Under(args[0])
 	if v.Type() != zed.TypeString {
 		return vector.NewWrappedError(t.zctx, "lower: string arg required", v)

--- a/runtime/ztests/expr/function/lower.yaml
+++ b/runtime/ztests/expr/function/lower.yaml
@@ -4,14 +4,16 @@ vector: true
 
 input: |
   "fOo"
+  127.0.0.1
   null(string)
-  "BaR"
-  null(string)
-  "BAz"
+  null(int64)
+  "BaR"((string,int64))
+  1((string,int64))
 
 output: |
   "foo"
+  error({message:"lower: string arg required",on:127.0.0.1})
   null(string)
+  error({message:"lower: string arg required",on:null(int64)})
   "bar"
-  null(string)
-  "baz"
+  error({message:"lower: string arg required",on:1})

--- a/vector/bool.go
+++ b/vector/bool.go
@@ -28,7 +28,9 @@ func (b *Bool) Type() zed.Type {
 }
 
 func (b *Bool) Value(slot uint32) bool {
-	return (b.Bits[slot>>6] & (1 << (slot & 0x3f))) != 0
+	// Because Bool is used to store nulls for many vectors and it is often
+	// nil check to see if receiver is nil and return false.
+	return b != nil && (b.Bits[slot>>6]&(1<<(slot&0x3f))) != 0
 }
 
 func (b *Bool) Set(slot uint32) {


### PR DESCRIPTION
This commit changes vam lower() so that it uses vector.Apply and can now handle Variant and Union types. Also adjust sam lower() so that it de-unions parameters before evaluation.

Partially fixes #5211