### PR TITLE
Update docs to reflect escaping of "{" in f-strings

### DIFF
--- a/docs/language/expressions.md
+++ b/docs/language/expressions.md
@@ -267,8 +267,7 @@ as long as it is compatible with the semantics of the expression.
 
 String literals are enclosed in either single quotes or double quotes and
 must conform to UTF-8 encoding and follow the JavaScript escaping
-conventions and unicode escape syntax.  Also, if the sequence `${` appears
-in a string the `$` character must be escaped, i.e., `\$`.
+conventions and unicode escape syntax.
 
 ### Formatted String Literals
 
@@ -307,6 +306,18 @@ echo '{foo:"hello", bar:"world", HELLOWORLD:"hi!"}' | zq -z 'yield f"oh {this[up
 produces
 ```mdtest-output
 "oh hi!"
+```
+
+To represent a literal `{` character inside an f-string, it must be escaped,
+i.e., `\{`.
+
+For example,
+```mdtest-command
+echo '"brackets"' | zq -z 'yield f"{this} look like: \{ }"' -
+```
+produces
+```mdtest-output
+"brackets look like: { }"
 ```
 
 ### Record Expressions


### PR DESCRIPTION
## What's Changing

Updating the [f-string docs](https://zed.brimdata.io/docs/next/language/expressions#formatted-string-literals) to reflect new escaping.

## Why

When we moved to f-strings thanks to the changes in #5123, a bit of docs were still left behind advising that `${` appearing in strings needed to be escaped, but that was no longer the case.

```
$ zq -version
Version: v1.15.0-24-g8e696671

$ zq 'yield "Escape me? ${"'
zq: could not invoke zq with a single argument because:
 - a file could not be found with the name "yield \"Escape me? ${..."
 - the argument could not be compiled as a valid Zed query:
   error parsing Zed at line 1, column 22:
   yield "Escape me? ${"
                    === ^ ===

$ zq -version
Version: v1.15.0-25-gb43cd0a1

$ zq 'yield "Escape me? ${"'
"Escape me? ${"
```

## Details

I've tried to add some new text to the docs to describe what I think still needs to be escaped in this new world of f-strings. If those of you that know the code can spot more escaping stuff that needs to be disclosed, please speak up. Thanks!
