### PR TITLE
Fix broken link to Avro spec

### DIFF
--- a/docs/commands/zq.md
+++ b/docs/commands/zq.md
@@ -36,7 +36,7 @@ simply run `zq` with no arguments.
 
 `zq` supports a number of [input](#input-formats) and [output](#output-formats) formats, but [ZNG](../formats/zng.md)
 tends to be the most space-efficient and most performant.  ZNG has efficiency similar to
-[Avro](https://avro.apache.org/docs/current/spec.html)
+[Avro](https://avro.apache.org)
 and [Protocol Buffers](https://developers.google.com/protocol-buffers)
 but its comprehensive [Zed type system](../formats/zed.md) obviates
 the need for schema specification or registries.


### PR DESCRIPTION
## What's Changing

Fixing a broken link to the Avro site.

## Why

The CI link checker spotted it when I put up unrelated changes in #5243.

## Details

It looks like the Avro site may be mid-overhaul and I suspect they might make more changes before the dust settles. The "specs" that were at the old link are now at a URL of the format `https://avro.apache.org/docs/1.12.0/specification/` with a locked-in version string, and `current` or `latest` doesn't work when I try it in place of the `1.12.0`. Meanwhile they do have a selection called `++version++` in their left-hand nav such that the URL https://avro.apache.org/docs/++version++/specification/ _does_ work and I suspect that's their equivalent of "current" now. But that looks ugly enough that I suspect if we start linking to it, they might well break it again if they find a way to put `current` or `latest` there instead.

Meanwhile, our [ZNG format doc](https://zed.brimdata.io/docs/formats/zng) also happens to link to Avro but in that case it just points to the top-level site, so in the interest of simplicity I've just proposed doing the same here. 🤪