### PR TITLE
Break many docs examples across multiple lines

### DIFF
--- a/docs/commands/zq.md
+++ b/docs/commands/zq.md
@@ -406,7 +406,8 @@ the previously-printed header line, a new header line will be output.
 For example:
 
 ```mdtest-command
-echo '{word:"one",digit: 1} {word:"hello",style:"greeting"}' | zq -f table -
+echo '{word:"one",digit: 1} {word:"hello",style:"greeting"}' |
+  zq -f table -
 ```
 produces
 ```mdtest-output
@@ -421,7 +422,8 @@ may prove useful to unify the input stream under a single record type that can
 be described with a single header line. Doing this to our last example, we find
 
 ```mdtest-command
-echo '{word:"one",digit:1} {word:"hello",style:"greeting"}' | zq -f table 'fuse' -
+echo '{word:"one",digit:1} {word:"hello",style:"greeting"}' |
+  zq -f table 'fuse' -
 ```
 now produces
 ```mdtest-output
@@ -517,22 +519,22 @@ alternative to the traditional technique of looking through logs for errors
 or trying to debug a halted program with a vague error message.
 
 For example, this query
-```
-echo '1 2 0 3' |  zq '10.0/this' -
+```mdtest-command
+echo '1 2 0 3' |  zq -z '10.0/this' -
 ```
 produces
-```
+```mdtest-output
 10.
 5.
 error("divide by zero")
 3.3333333333333335
 ```
 and
-```
-echo '1 2 0 3' |  zq '10.0/this' - | zq 'is_error(this)' -
+```mdtest-command
+echo '1 2 0 3' |  zq '10.0/this' - | zq -z 'is_error(this)' -
 ```
 produces just
-```
+```mdtest-output
 error("divide by zero")
 ```
 
@@ -550,70 +552,71 @@ The language documentation and [tutorials directory](../tutorials/README.md)
 have many examples, but here are a few more simple `zq` use cases.
 
 _Hello, world_
-```
+```mdtest-command
 echo '"hello, world"' | zq -z 'yield this' -
 ```
 produces this ZSON output
-```
+```mdtest-output
 "hello, world"
 ```
 
 _Some values of available [data types](../language/data-types.md)_
-```
+```mdtest-command
 echo '1 1.5 [1,"foo"] |["apple","banana"]|' | zq -z 'yield this' -
 ```
 produces
-```
+```mdtest-output
 1
 1.5
 [1,"foo"]
 |["apple","banana"]|
 ```
 _The types of various data_
-```
+```mdtest-command
 echo '1 1.5 [1,"foo"] |["apple","banana"]|' | zq -z 'yield typeof(this)' -
 ```
 produces
-```
+```mdtest-output
 <int64>
 <float64>
 <[(int64,string)]>
 <|[string]|>
 ```
 _A simple [aggregation](../language/aggregates/README.md)_
-```
-echo '{key:"foo",val:1}{key:"bar",val:2}{key:"foo",val:3}' | zq -z 'sum(val) by key | sort key' -
+```mdtest-command
+echo '{key:"foo",val:1}{key:"bar",val:2}{key:"foo",val:3}' |
+  zq -z 'sum(val) by key | sort key' -
 ```
 produces
-```
+```mdtest-output
 {key:"bar",sum:2}
 {key:"foo",sum:4}
 ```
 _Convert CSV to Zed and [cast](../language/functions/cast.md) a to an integer from default float_
-```
-printf "a,b\n1,foo\n2,bar\n" | zq 'a:=int64(a)' -
+```mdtest-command
+printf "a,b\n1,foo\n2,bar\n" | zq -z 'a:=int64(a)' -
 ```
 produces
-```
+```mdtest-output
 {a:1,b:"foo"}
 {a:2,b:"bar"}
 ```
 _Convert JSON to Zed and cast to an integer from default float_
-```
-echo '{"a":1,"b":"foo"}{"a":2,"b":"bar"}' | zq 'a:=int64(a)' -
+```mdtest-command
+echo '{"a":1,"b":"foo"}{"a":2,"b":"bar"}' | zq -z 'a:=int64(a)' -
 ```
 produces
-```
+```mdtest-output
 {a:1,b:"foo"}
 {a:2,b:"bar"}
 ```
 _Make a schema-rigid Parquet file using fuse and turn it back into Zed_
-```
+```mdtest-command
 echo '{a:1}{a:2}{b:3}' | zq -f parquet -o tmp.parquet fuse -
 zq -z tmp.parquet
 ```
 produces
-```
+```mdtest-output
 {a:1,b:null(int64)}
 {a:2,b:null(int64)}
 {a:null(int64),b:3}

--- a/docs/language/aggregates/and.md
+++ b/docs/language/aggregates/and.md
@@ -48,7 +48,8 @@ false
 
 AND of values grouped by key:
 ```mdtest-command
-echo '{a:true,k:1} {a:true,k:1} {a:true,k:2} {a:false,k:2}' | zq -z 'and(a) by k | sort' -
+echo '{a:true,k:1} {a:true,k:1} {a:true,k:2} {a:false,k:2}' |
+  zq -z 'and(a) by k | sort' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/aggregates/any.md
+++ b/docs/language/aggregates/any.md
@@ -46,7 +46,8 @@ echo '"foo" 1 2 3 ' | zq -z 'any(this)' -
 
 Pick from groups bucketed by key:
 ```mdtest-command
-echo '{a:1,k:1} {a:2,k:1} {a:3,k:2} {a:4,k:2}' | zq -z 'any(a) by k | sort' -
+echo '{a:1,k:1} {a:2,k:1} {a:3,k:2} {a:4,k:2}' |
+  zq -z 'any(a) by k | sort' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/aggregates/avg.md
+++ b/docs/language/aggregates/avg.md
@@ -45,7 +45,8 @@ echo '1 2 3 4 "foo"' | zq -z 'avg(this)' -
 
 Average of values bucketed by key:
 ```mdtest-command
-echo '{a:1,k:1} {a:2,k:1} {a:3,k:2} {a:4,k:2}' | zq -z 'avg(a) by k | sort' -
+echo '{a:1,k:1} {a:2,k:1} {a:3,k:2} {a:4,k:2}' |
+  zq -z 'avg(a) by k | sort' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/aggregates/collect.md
+++ b/docs/language/aggregates/collect.md
@@ -47,7 +47,8 @@ echo '1 2 3 4 "foo"' | zq -z 'collect(this)' -
 
 Create arrays of values bucketed by key:
 ```mdtest-command
-echo '{a:1,k:1} {a:2,k:1} {a:3,k:2} {a:4,k:2}' | zq -z 'collect(a) by k | sort' -
+echo '{a:1,k:1} {a:2,k:1} {a:3,k:2} {a:4,k:2}' |
+  zq -z 'collect(a) by k | sort' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/aggregates/collect_map.md
+++ b/docs/language/aggregates/collect_map.md
@@ -18,7 +18,8 @@ of union of those types.
 
 Combine a sequence of records into a map:
 ```mdtest-command
-echo '{stock:"APPL",price:145.03} {stock:"GOOG",price:87.07}' | zq -z 'collect_map(|{stock:price}|)' -
+echo '{stock:"APPL",price:145.03} {stock:"GOOG",price:87.07}' |
+  zq -z 'collect_map(|{stock:price}|)' -
 ```
 =>
 ```mdtest-output
@@ -27,7 +28,8 @@ echo '{stock:"APPL",price:145.03} {stock:"GOOG",price:87.07}' | zq -z 'collect_m
 
 Continuous collection over a simple sequence:
 ```mdtest-command
-echo '|{"APPL":145.03}| |{"GOOG":87.07}| |{"APPL":150.13}|' | zq -z 'yield collect_map(this)' -
+echo '|{"APPL":145.03}| |{"GOOG":87.07}| |{"APPL":150.13}|' |
+  zq -z 'yield collect_map(this)' -
 ```
 =>
 ```mdtest-output
@@ -38,7 +40,11 @@ echo '|{"APPL":145.03}| |{"GOOG":87.07}| |{"APPL":150.13}|' | zq -z 'yield colle
 
 Create maps by key:
 ```mdtest-command
-echo '{stock:"APPL",price:145.03,day:0} {stock:"GOOG",price:87.07,day:0} {stock:"APPL",price:150.13,day:1} {stock:"GOOG",price:89.15,day:1}' | zq -z 'collect_map(|{stock:price}|) by day | sort' -
+echo '{stock:"APPL",price:145.03,day:0}
+      {stock:"GOOG",price:87.07,day:0}
+      {stock:"APPL",price:150.13,day:1}
+      {stock:"GOOG",price:89.15,day:1}' |
+  zq -z 'collect_map(|{stock:price}|) by day | sort' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/aggregates/fuse.md
+++ b/docs/language/aggregates/fuse.md
@@ -28,7 +28,8 @@ echo '{a:1,b:2}{a:2,b:"foo"}' | zq -z 'fuse(this)' -
 ```
 Fuse records with a group-by key:
 ```mdtest-command
-echo '{a:1,b:"bar"}{a:2.1,b:"foo"}{a:3,b:"bar"}' | zq -z 'fuse(this) by b | sort' -
+echo '{a:1,b:"bar"}{a:2.1,b:"foo"}{a:3,b:"bar"}' |
+  zq -z 'fuse(this) by b | sort' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/aggregates/max.md
+++ b/docs/language/aggregates/max.md
@@ -45,7 +45,8 @@ echo '1 2 3 4 "foo"' | zq -z 'max(this)' -
 
 Maximum value within buckets grouped by key:
 ```mdtest-command
-echo '{a:1,k:1} {a:2,k:1} {a:3,k:2} {a:4,k:2}' | zq -z 'max(a) by k | sort' -
+echo '{a:1,k:1} {a:2,k:1} {a:3,k:2} {a:4,k:2}' |
+  zq -z 'max(a) by k | sort' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/aggregates/min.md
+++ b/docs/language/aggregates/min.md
@@ -45,7 +45,8 @@ echo '1 2 3 4 "foo"' | zq -z 'min(this)' -
 
 Minimum value within buckets grouped by key:
 ```mdtest-command
-echo '{a:1,k:1} {a:2,k:1} {a:3,k:2} {a:4,k:2}' | zq -z 'min(a) by k | sort' -
+echo '{a:1,k:1} {a:2,k:1} {a:3,k:2} {a:4,k:2}' |
+  zq -z 'min(a) by k | sort' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/aggregates/or.md
+++ b/docs/language/aggregates/or.md
@@ -48,7 +48,8 @@ true
 
 OR of values grouped by key:
 ```mdtest-command
-echo '{a:true,k:1} {a:false,k:1} {a:false,k:2} {a:false,k:2}' | zq -z 'or(a) by k | sort' -
+echo '{a:true,k:1} {a:false,k:1} {a:false,k:2} {a:false,k:2}' |
+  zq -z 'or(a) by k | sort' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/aggregates/sum.md
+++ b/docs/language/aggregates/sum.md
@@ -45,7 +45,8 @@ echo '1 2 3 4 "foo"' | zq -z 'sum(this)' -
 
 Sum of values bucketed by key:
 ```mdtest-command
-echo '{a:1,k:1} {a:2,k:1} {a:3,k:2} {a:4,k:2}' | zq -z 'sum(a) by k | sort' -
+echo '{a:1,k:1} {a:2,k:1} {a:3,k:2} {a:4,k:2}' |
+  zq -z 'sum(a) by k | sort' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/aggregates/union.md
+++ b/docs/language/aggregates/union.md
@@ -38,18 +38,19 @@ echo '1 2 3 3' | zq -z 'yield union(this)' -
 ```
 
 Mixed types create a union type for the set elements:
-```mdtest-command-issue-3610
+```mdtest-command
 echo '1 2 3 "foo"' | zq -z 'set:=union(this) | yield this,typeof(set)' -
 ```
 =>
-```mdtest-output-issue-3610
+```mdtest-output
 {set:|[1,2,3,"foo"]|}
 <|[(int64,string)]|>
 ```
 
 Create sets of values bucketed by key:
 ```mdtest-command
-echo '{a:1,k:1} {a:2,k:1} {a:3,k:2} {a:4,k:2}' | zq -z 'union(a) by k | sort' -
+echo '{a:1,k:1} {a:2,k:1} {a:3,k:2} {a:4,k:2}' |
+  zq -z 'union(a) by k | sort' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/data-types.md
+++ b/docs/language/data-types.md
@@ -58,7 +58,8 @@ search ... | count() by typeof(this)
 ```
 For example,
 ```mdtest-command
-echo '1 2 "foo" 10.0.0.1 <string>' | zq -z 'count() by typeof(this) | sort this' -
+echo '1 2 "foo" 10.0.0.1 <string>' |
+  zq -z 'count() by typeof(this) | sort this' -
 ```
 produces
 ```mdtest-output
@@ -142,7 +143,8 @@ Each value that references a named type retains its local definition of the
 named type retaining the proper type binding while accommodating changes in a
 particular named type.  For example,
 ```mdtest-command
-echo '1(=foo) 2(=bar) "hello"(=foo) 3(=foo)' | zq -z 'count() by typeof(this) | sort this' -
+echo '1(=foo) 2(=bar) "hello"(=foo) 3(=foo)' |
+  zq -z 'count() by typeof(this) | sort this' -
 ```
 results in
 ```mdtest-output
@@ -176,12 +178,20 @@ LIMIT 5
 ```
 In Zed, you would say
 ```
-from anywhere | typeof(this)==<employee> | cut last,salary | sort salary | head 5
+from anywhere
+| typeof(this)==<employee>
+| cut last,salary
+| sort salary
+| head 5
 ```
 and since type comparisons are so useful and common, the [`is` function](functions/is.md)
 can be used to perform the type match:
 ```
-from anywhere | is(<employee>) | cut last,salary | sort salary | head 5
+from anywhere
+| is(<employee>)
+| cut last,salary
+| sort salary
+| head 5
 ```
 The power of Zed is that you can interpret data on the fly as belonging to
 a certain schema, in this case "employee", and those records can be intermixed

--- a/docs/language/dataflow-model.md
+++ b/docs/language/dataflow-model.md
@@ -25,7 +25,8 @@ but as an example, you might use the `get` form of `from` to fetch data from an
 HTTP endpoint and process it with Zed, in this case, to extract the description
 and license of a GitHub repository:
 ```
-zq -f text "get https://api.github.com/repos/brimdata/zed | yield description,license.name"
+zq -f text 'get https://api.github.com/repos/brimdata/zed
+            | yield description,license.name'
 ```
 When a Zed query is run on the command-line with `zq`, the `from` source is
 typically omitted and implied instead by the command-line file arguments.

--- a/docs/language/expressions.md
+++ b/docs/language/expressions.md
@@ -80,7 +80,8 @@ produces
 ```
 You can also use this operator with a static array:
 ```mdtest-command
-echo '{accounts:[{id:1},{id:2},{id:3}]}' | zq -z 'over accounts | where id in [1,2]' -
+echo '{accounts:[{id:1},{id:2},{id:3}]}' |
+  zq -z 'over accounts | where id in [1,2]' -
 ```
 produces
 ```mdtest-output
@@ -200,7 +201,8 @@ will be evaluated.
 
 For example,
 ```mdtest-command
-echo '"foo" "bar" "foo"' | zq -z 'yield this=="foo" ? {foocount:count()} : {barcount:count()}' -
+echo '"foo" "bar" "foo"' |
+  zq -z 'yield this=="foo" ? {foocount:count()} : {barcount:count()}' -
 ```
 produces
 ```mdtest-output
@@ -283,7 +285,8 @@ a string, it is implicitly cast to a string.
 
 For example,
 ```mdtest-command
-echo '{numerator:22.0, denominator:7.0}' | zq -z 'yield f"pi is approximately {numerator / denominator}"' -
+echo '{numerator:22.0, denominator:7.0}' |
+  zq -z 'yield f"pi is approximately {numerator / denominator}"' -
 ```
 produces
 ```mdtest-output
@@ -301,7 +304,8 @@ F-strings may be nested, where a child `<expr>` may contain f-strings.
 
 For example,
 ```mdtest-command
-echo '{foo:"hello", bar:"world", HELLOWORLD:"hi!"}' | zq -z 'yield f"oh {this[upper(f"{foo + bar}")]}"' -
+echo '{foo:"hello", bar:"world", HELLOWORLD:"hi!"}' |
+  zq -z 'yield f"oh {this[upper(f"{foo + bar}")]}"' -
 ```
 produces
 ```mdtest-output
@@ -347,7 +351,8 @@ field's value.
 
 For example,
 ```mdtest-command
-echo '{x:1,y:2,r:{a:1,b:2}}' | zq -z 'yield {a:0},{x}, {...r}, {a:0,...r,b:3}' -
+echo '{x:1,y:2,r:{a:1,b:2}}' |
+  zq -z 'yield {a:0},{x}, {...r}, {a:0,...r,b:3}' -
 ```
 produces
 ```mdtest-output
@@ -563,7 +568,8 @@ produces
 ```
 and
 ```mdtest-command
-echo '{ts:"1/1/2022",r:{x:"1",y:"2"}} {ts:"1/2/2022",r:{x:3,y:4}}' | zq -z 'cast(this,<{ts:time,r:{x:float64,y:float64}}>)' -
+echo '{ts:"1/1/2022",r:{x:"1",y:"2"}} {ts:"1/2/2022",r:{x:3,y:4}}' |
+  zq -z 'cast(this,<{ts:time,r:{x:float64,y:float64}}>)' -
 ```
 produces
 ```mdtest-output

--- a/docs/language/functions/bucket.md
+++ b/docs/language/functions/bucket.md
@@ -20,7 +20,8 @@ aligns with 0.
 
 Bucket a couple times to hour intervals:
 ```mdtest-command
-echo '2020-05-26T15:27:47Z "5/26/2020 3:27pm"' | zq -z 'yield bucket(time(this), 1h)' -
+echo '2020-05-26T15:27:47Z "5/26/2020 3:27pm"' |
+  zq -z 'yield bucket(time(this), 1h)' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/functions/cast.md
+++ b/docs/language/functions/cast.md
@@ -83,7 +83,12 @@ produces
 
 _Name data based its properties_
 ```mdtest-command
-echo '{x:1,y:2}{r:3}{x:4,y:5}' | zq -z 'switch ( case has(x) => cast(this, "point")  default => cast(this, "radius") ) | sort this' -
+echo '{x:1,y:2}{r:3}{x:4,y:5}' |
+  zq -z 'switch (
+           case has(x) => cast(this, "point")
+           default => cast(this, "radius")
+         )
+         | sort this' -
 ```
 produces
 ```mdtest-output

--- a/docs/language/functions/cidr_match.md
+++ b/docs/language/functions/cidr_match.md
@@ -19,7 +19,8 @@ If `network` is not type `net`, then an error is returned.
 
 Test whether values are IP addresses in a network:
 ```mdtest-command
-echo '10.1.2.129 11.1.2.129 10 "foo"' | zq -z 'yield cidr_match(10.0.0.0/8, this)' -
+echo '10.1.2.129 11.1.2.129 10 "foo"' |
+  zq -z 'yield cidr_match(10.0.0.0/8, this)' -
 ```
 =>
 ```mdtest-output
@@ -31,7 +32,8 @@ false
 It also works for IPs in complex values:
 
 ```mdtest-command
-echo '[10.1.2.129,11.1.2.129] {a:10.0.0.1} {a:11.0.0.1}' | zq -z 'yield cidr_match(10.0.0.0/8, this)' -
+echo '[10.1.2.129,11.1.2.129] {a:10.0.0.1} {a:11.0.0.1}' |
+  zq -z 'yield cidr_match(10.0.0.0/8, this)' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/functions/error.md
+++ b/docs/language/functions/error.md
@@ -18,7 +18,8 @@ a means to create structured and stacked errors.
 
 Wrap a record as a structured error:
 ```mdtest-command
-echo '{foo:"foo"}' | zq -z 'yield error({message:"bad value", value:this})' -
+echo '{foo:"foo"}' |
+  zq -z 'yield error({message:"bad value", value:this})' -
 ```
 =>
 ```mdtest-output
@@ -38,7 +39,8 @@ error([1,2,3])
 
 Test if a value is an error and show its type "kind":
 ```mdtest-command
-echo 'error("exception") "exception"' | zq -Z 'yield {this,err:is_error(this),kind:kind(this)}' -
+echo 'error("exception") "exception"' |
+  zq -Z 'yield {this,err:is_error(this),kind:kind(this)}' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/functions/every.md
+++ b/docs/language/functions/every.md
@@ -18,7 +18,10 @@ when analyzing time-series data like logs that have a `ts` field.
 
 Operate on a sequence of times:
 ```mdtest-command
-echo '{ts:2021-02-01T12:00:01Z}' | zq -z 'yield {ts,val:0},{ts:ts+1s},{ts:ts+2h2s} | yield every(1h) | sort' -
+echo '{ts:2021-02-01T12:00:01Z}' |
+  zq -z 'yield {ts,val:0},{ts:ts+1s},{ts:ts+2h2s}
+         | yield every(1h)
+         | sort' -
 ```
 ->
 ```mdtest-output
@@ -28,7 +31,10 @@ echo '{ts:2021-02-01T12:00:01Z}' | zq -z 'yield {ts,val:0},{ts:ts+1s},{ts:ts+2h2
 ```
 Use as a group-by key:
 ```mdtest-command
-echo '{ts:2021-02-01T12:00:01Z}' | zq -z 'yield {ts,val:1},{ts:ts+1s,val:2},{ts:ts+2h2s,val:5} | sum(val) by every(1h) | sort' -
+echo '{ts:2021-02-01T12:00:01Z}' |
+  zq -z 'yield {ts,val:1},{ts:ts+1s,val:2},{ts:ts+2h2s,val:5}
+         | sum(val) by every(1h)
+         | sort' -
 ```
 ->
 ```mdtest-output

--- a/docs/language/functions/fields.md
+++ b/docs/language/functions/fields.md
@@ -29,7 +29,8 @@ echo '{a:1,b:2,c:{d:3,e:4}}' | zq -z 'yield fields(this)' -
 ```
 Easily convert to dotted names if you prefer:
 ```mdtest-command
-echo '{a:1,b:2,c:{d:3,e:4}}' | zq -z 'over fields(this) | yield join(this,".")' -
+echo '{a:1,b:2,c:{d:3,e:4}}' |
+  zq -z 'over fields(this) | yield join(this,".")' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/functions/has.md
+++ b/docs/language/functions/has.md
@@ -33,7 +33,8 @@ switch (
 ```mdtest-command
 echo '{foo:10}' | zq -z 'yield {yes:has(foo),no:has(bar)}' -
 echo '{foo:[1,2,3]}' | zq -z 'yield {yes: has(foo[0]),no:has(foo[3])}' -
-echo '{foo:{bar:"value"}}' | zq -z 'yield {yes:has(foo.bar),no:has(foo.baz)}' -
+echo '{foo:{bar:"value"}}' |
+  zq -z 'yield {yes:has(foo.bar),no:has(foo.baz)}' -
 echo '{foo:10}' | zq -z 'yield {yes:has(foo+1),no:has(bar+1)}' -
 echo 1 | zq -z 'yield has(bar)' -
 echo '{x:error("missing")}' | zq -z 'yield has(x)' -

--- a/docs/language/functions/is_error.md
+++ b/docs/language/functions/is_error.md
@@ -35,7 +35,8 @@ true
 
 Convert an error string into a record with an indicator and a message:
 ```mdtest-command
-echo '"not an error" error("an error")' | zq -z 'yield {err:is_error(this),message:under(this)}' -
+echo '"not an error" error("an error")' |
+  zq -z 'yield {err:is_error(this),message:under(this)}' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/functions/join.md
+++ b/docs/language/functions/join.md
@@ -26,7 +26,8 @@ echo '["a","b","c"]' | zq -z 'yield join(this, ",")' -
 
 Join non-string arrays by first casting:
 ```mdtest-command
-echo '[1,2,3] [10.0.0.1,10.0.0.2]' | zq -z 'yield join(cast(this, <[string]>), "...")' -
+echo '[1,2,3] [10.0.0.1,10.0.0.2]' |
+  zq -z 'yield join(cast(this, <[string]>), "...")' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/functions/ksuid.md
+++ b/docs/language/functions/ksuid.md
@@ -22,7 +22,8 @@ returned as a bytes value.
 #### Example:
 
 ```mdtest-command
-echo  '{id:0x0dfc90519b60f362e84a3fdddd9b9e63e1fb90d1}' | zq -z 'id := ksuid(id)' -
+echo  '{id:0x0dfc90519b60f362e84a3fdddd9b9e63e1fb90d1}' |
+  zq -z 'id := ksuid(id)' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/functions/len.md
+++ b/docs/language/functions/len.md
@@ -30,7 +30,8 @@ Supported types include:
 Take the length of various types:
 
 ```mdtest-command
-echo '[1,2,3] |["hello"]| {a:1,b:2} "hello" 10.0.0.1 1' | zq -z 'yield {this,len:len(this)}' -
+echo '[1,2,3] |["hello"]| {a:1,b:2} "hello" 10.0.0.1 1' |
+  zq -z 'yield {this,len:len(this)}' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/functions/map.md
+++ b/docs/language/functions/map.md
@@ -29,10 +29,13 @@ echo '["foo","bar","baz"]' | zq -z 'yield map(this, upper)' -
 Using a user-defined function to convert an epoch float to a time:
 
 ```mdtest-command
-echo '[1697151533.41415,1697151540.716529]' | zq -z '
-  func floatToTime(x): ( cast(x*1000000000, <time>) )
-  yield map(this, floatToTime)
-' -
+echo '[1697151533.41415,1697151540.716529]' |
+  zq -z '
+    func floatToTime(x): (
+      cast(x*1000000000, <time>)
+    )
+    yield map(this, floatToTime)
+  ' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/functions/missing.md
+++ b/docs/language/functions/missing.md
@@ -32,7 +32,8 @@ switch (
 ```mdtest-command
 echo '{foo:10}' | zq -z 'yield {yes:missing(bar),no:missing(foo)}' -
 echo '{foo:[1,2,3]}' | zq -z 'yield {yes:has(foo[3]),no:has(foo[0])}' -
-echo '{foo:{bar:"value"}}' | zq -z 'yield {yes:missing(foo.baz),no:missing(foo.bar)}' -
+echo '{foo:{bar:"value"}}' |
+  zq -z 'yield {yes:missing(foo.baz),no:missing(foo.bar)}' -
 echo '{foo:10}' | zq -z 'yield {yes:missing(bar+1),no:missing(foo+1)}' -
 echo 1 | zq -z 'yield missing(bar)' -
 echo '{x:error("missing")}' | zq -z 'yield missing(x)' -

--- a/docs/language/functions/parse_uri.md
+++ b/docs/language/functions/parse_uri.md
@@ -31,7 +31,8 @@ with the following type signature:
 ### Examples
 
 ```mdtest-command
-echo '"scheme://user:password@host:12345/path?a=1&a=2&b=3&c=#fragment"' | zq -Z 'yield parse_uri(this)' -
+echo '"scheme://user:password@host:12345/path?a=1&a=2&b=3&c=#fragment"' |
+  zq -Z 'yield parse_uri(this)' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/functions/parse_zson.md
+++ b/docs/language/functions/parse_zson.md
@@ -28,7 +28,8 @@ echo '{foo:"{a:\"1\",b:2}"}' | zq -z 'foo := parse_zson(foo)' -
 
 _Parse JSON text_
 ```mdtest-command
-echo '{"foo": "{\"a\": \"1\", \"b\": 2}"}' | zq -z 'foo := parse_zson(foo)' -
+echo '{"foo": "{\"a\": \"1\", \"b\": 2}"}' |
+  zq -z 'foo := parse_zson(foo)' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/functions/regexp.md
+++ b/docs/language/functions/regexp.md
@@ -19,7 +19,8 @@ groups) if there are any. A null value indicates no match.
 
 Regexp returns an array of the match and its subexpressions:
 ```mdtest-command
-echo '"seafood fool friend"' | zq -z 'yield regexp(/foo(.?) (\w+) fr.*/, this)' -
+echo '"seafood fool friend"' |
+  zq -z 'yield regexp(/foo(.?) (\w+) fr.*/, this)' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/functions/regexp_replace.md
+++ b/docs/language/functions/regexp_replace.md
@@ -42,7 +42,8 @@ echo '"-ab-axxb-"' | zq -z 'yield regexp_replace(this, /ax*b/, "T")' -
 Replace regular expression matches using numeric references to submatches:
 
 ```mdtest-command
-echo '"option: value"' | zq -z 'yield regexp_replace(this,/(\w+):\s+(\w+)$/,"$1=$2")' -
+echo '"option: value"' |
+  zq -z 'yield regexp_replace(this,/(\w+):\s+(\w+)$/,"$1=$2")' -
 ```
 =>
 ```mdtest-output
@@ -52,7 +53,12 @@ echo '"option: value"' | zq -z 'yield regexp_replace(this,/(\w+):\s+(\w+)$/,"$1=
 Replace regular expression matches using named references:
 
 ```mdtest-command
-echo '"option: value"' | zq -z 'yield regexp_replace(this,/(?P<key>\w+):\s+(?P<value>\w+)$/,"$key=$value")' -
+echo '"option: value"' |
+  zq -z 'yield regexp_replace(
+                 this,
+                 /(?P<key>\w+):\s+(?P<value>\w+)$/,
+                 "$key=$value")
+  ' -
 ```
 =>
 ```mdtest-output
@@ -62,7 +68,12 @@ echo '"option: value"' | zq -z 'yield regexp_replace(this,/(?P<key>\w+):\s+(?P<v
 Wrap a named reference in curly braces to avoid ambiguity:
 
 ```mdtest-command
-echo '"option: value"' | zq -z 'yield regexp_replace(this,/(?P<key>\w+):\s+(?P<value>\w+)$/,"$key=${value}AppendedText")' -
+echo '"option: value"' |
+  zq -z 'yield regexp_replace(
+                 this,
+                /(?P<key>\w+):\s+(?P<value>\w+)$/,
+                "$key=${value}AppendedText")
+  ' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/functions/shape.md
+++ b/docs/language/functions/shape.md
@@ -23,7 +23,8 @@ extra fields in the input are propagated to the output.
 
 _Shape input records_
 ```mdtest-command
-echo '{b:1,a:2}{a:3}{b:4,c:5}' | zq -z 'shape(this, <{a:int64,b:string}>)' -
+echo '{b:1,a:2}{a:3}{b:4,c:5}' |
+  zq -z 'shape(this, <{a:int64,b:string}>)' -
 ```
 produces
 ```mdtest-output

--- a/docs/language/functions/split.md
+++ b/docs/language/functions/split.md
@@ -28,7 +28,8 @@ echo '"apple;banana;pear;peach"' | zq -z 'yield split(this,";")' -
 Split a comma-separated list of IPs and cast the array of strings to an
 array of IPs:
 ```mdtest-command
-echo '"10.0.0.1,10.0.0.2,10.0.0.3"' | zq -z 'yield cast(split(this,","),<[ip]>)' -
+echo '"10.0.0.1,10.0.0.2,10.0.0.3"' |
+  zq -z 'yield cast(split(this,","),<[ip]>)' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/functions/typeof.md
+++ b/docs/language/functions/typeof.md
@@ -19,7 +19,8 @@ also a Zed value.  The type of a type is type `type`.
 The types of various values:
 
 ```mdtest-command
-echo  '1 "foo" 10.0.0.1 [1,2,3] {s:"foo"} null error("missing")' | zq -z 'yield typeof(this)' -
+echo  '1 "foo" 10.0.0.1 [1,2,3] {s:"foo"} null error("missing")' |
+  zq -z 'yield typeof(this)' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/functions/typeunder.md
+++ b/docs/language/functions/typeunder.md
@@ -17,7 +17,8 @@ returned instead of the named type.
 ### Examples
 
 ```mdtest-command
-echo  '{which:"chocolate"}(=flavor)' | zq -z 'yield {typeof:typeof(this),typeunder:typeunder(this)}' -
+echo  '{which:"chocolate"}(=flavor)' |
+  zq -z 'yield {typeof:typeof(this),typeunder:typeunder(this)}' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/functions/under.md
+++ b/docs/language/functions/under.md
@@ -20,8 +20,11 @@ The _under_ function returns the value underlying the argument `val`:
 
 Unions are unwrapped:
 ```mdtest-command
-echo '1((int64,string)) "foo"((int64,string))' | zq -z 'yield this' -
-echo '1((int64,string)) "foo"((int64,string))' | zq -z 'yield under(this)' -
+echo '1((int64,string)) "foo"((int64,string))' |
+  zq -z 'yield this' -
+
+echo '1((int64,string)) "foo"((int64,string))' |
+  zq -z 'yield under(this)' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/functions/unflatten.md
+++ b/docs/language/functions/unflatten.md
@@ -17,7 +17,8 @@ will produce a record identical to `r`.
 ### Examples
 Simple:
 ```mdtest-command
-echo '[{key:"a",value:1},{key:["b"],value:2}]' | zq -z 'yield unflatten(this)' -
+echo '[{key:"a",value:1},{key:["b"],value:2}]' |
+  zq -z 'yield unflatten(this)' -
 ```
 =>
 ```mdtest-output
@@ -26,7 +27,13 @@ echo '[{key:"a",value:1},{key:["b"],value:2}]' | zq -z 'yield unflatten(this)' -
 
 Flatten to unflatten:
 ```mdtest-command
-echo '{a:1,rm:2}' | zq -z 'over flatten(this) => (key[0] != "rm" | yield collect(this)) | yield unflatten(this)' -
+echo '{a:1,rm:2}' |
+  zq -z 'over flatten(this) => (
+           key[0] != "rm"
+           | yield collect(this)
+         )
+         | yield unflatten(this)
+  ' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/functions/upper.md
+++ b/docs/language/functions/upper.md
@@ -26,7 +26,12 @@ echo '"Zed"' | zq -z 'yield upper(this)' -
 [Slices](../expressions.md#slices) can be used to uppercase a subset of a string as well.
 
 ```mdtest-command
-echo '"zed"' | zq -z 'func upper_first_char(str): (upper(str[0:1]) + str[1:]) yield upper_first_char(this)' -
+echo '"zed"' |
+  zq -z 'func upper_first_char(str): (
+           upper(str[0:1]) + str[1:]
+         )
+         yield upper_first_char(this)
+  ' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/lateral-subqueries.md
+++ b/docs/language/lateral-subqueries.md
@@ -15,7 +15,8 @@ Lateral subqueries are created using the scoped form of the
 
 For example,
 ```mdtest-command
-echo '{s:"foo",a:[1,2]} {s:"bar",a:[3]}' | zq -z 'over a with name=s => (yield {name,elem:this})' -
+echo '{s:"foo",a:[1,2]} {s:"bar",a:[3]}' |
+  zq -z 'over a with name=s => (yield {name,elem:this})' -
 ```
 produces
 ```mdtest-output
@@ -49,7 +50,8 @@ and the second subquery operators on the input value `3` with the variable
 You can also import a parent-scope field reference into the inner scope by
 simply referring to its name without assignment, e.g.,
 ```mdtest-command
-echo '{s:"foo",a:[1,2]} {s:"bar",a:[3]}' | zq -z 'over a with s => (yield {s,elem:this})' -
+echo '{s:"foo",a:[1,2]} {s:"bar",a:[3]}' |
+  zq -z 'over a with s => (yield {s,elem:this})' -
 ```
 produces
 ```mdtest-output
@@ -93,7 +95,8 @@ applied to each subsequence in the subquery, where sort
 reads all values of the subsequence, sorts them, emits them, then
 repeats the process for the next subsequence.  For example,
 ```mdtest-command
-echo '[3,2,1] [4,1,7] [1,2,3]' | zq -z 'over this => (sort this | collect(this))' -
+echo '[3,2,1] [4,1,7] [1,2,3]' | 
+  zq -z 'over this => (sort this | collect(this))' -
 ```
 produces
 ```mdtest-output
@@ -134,7 +137,10 @@ This structure generalizes to any more complicated expression context,
 e.g., we can embed multiple lateral expressions inside of a record literal
 and use the spread operator to tighten up the output:
 ```mdtest-command
-echo '[3,2,1] [4,1,7] [1,2,3]' | zq -z '{...(over this | sort this | sorted:=collect(this)),...(over this | sum:=sum(this))}' -
+echo '[3,2,1] [4,1,7] [1,2,3]' |
+  zq -z '
+    {...(over this | sort this | sorted:=collect(this)),
+     ...(over this | sum:=sum(this))}' -
 ```
 produces
 ```mdtest-output

--- a/docs/language/operators/from.md
+++ b/docs/language/operators/from.md
@@ -80,12 +80,17 @@ by the following commands:
 export ZED_LAKE=example
 zed -q init
 zed -q create -orderby flip:desc coinflips
-echo '{flip:1,result:"heads"} {flip:2,result:"tails"}' | zed load -q -use coinflips -
+echo '{flip:1,result:"heads"} {flip:2,result:"tails"}' |
+  zed load -q -use coinflips -
 zed branch -q -use coinflips trial 
 echo '{flip:3,result:"heads"}' | zed load -q -use coinflips@trial -
 zed -q create numbers
-echo '{number:1,word:"one"} {number:2,word:"two"} {number:3,word:"three"}' | zed load -q -use numbers -
-zed query -f text 'from :branches | yield pool.name + "@" + branch.name | sort'
+echo '{number:1,word:"one"} {number:2,word:"two"} {number:3,word:"three"}' |
+  zed load -q -use numbers -
+zed query -f text '
+  from :branches
+  | yield pool.name + "@" + branch.name
+  | sort'
 ```
 
 The lake then contains the two pools:
@@ -125,7 +130,8 @@ zq -z 'file hello.zson format line'
 
 _Source structured data from a URI_
 ```
-zq -z 'get https://raw.githubusercontent.com/brimdata/zui-insiders/main/package.json | yield productName'
+zq -z 'get https://raw.githubusercontent.com/brimdata/zui-insiders/main/package.json
+       | yield productName'
 ```
 =>
 ```
@@ -184,7 +190,9 @@ zed -lake example query -z '
   ) on flip=number word
   | from (
     pass
-    pool coinflips@trial => c:=count() | yield f"There were {int64(c)} flips"
+    pool coinflips@trial =>
+      c:=count()
+      | yield f"There were {int64(c)} flips"
   ) | sort this'
 ```
 =>

--- a/docs/language/operators/load.md
+++ b/docs/language/operators/load.md
@@ -37,9 +37,13 @@ export ZED_LAKE=example
 zed -q init
 zed -q create -orderby flip:asc coinflips
 zed branch -q -use coinflips onlytails
-echo '{flip:1,result:"heads"} {flip:2,result:"tails"}' | zed load -q -use coinflips -
+echo '{flip:1,result:"heads"} {flip:2,result:"tails"}' |
+  zed load -q -use coinflips -
 zed -q create -orderby flip:asc bigflips
-zed query -f text 'from :branches | yield pool.name + "@" + branch.name | sort'
+zed query -f text '
+  from :branches
+  | yield pool.name + "@" + branch.name
+  | sort'
 ```
 
 The lake then contains the two pools:
@@ -54,7 +58,12 @@ coinflips@onlytails
 
 _Modify some values, load them into the `main` branch of our empty `bigflips` pool, and see what was loaded_
 ```mdtest-command
-zed -lake example query 'from coinflips | result:=upper(result) | load bigflips' > /dev/null
+zed -lake example query '
+  from coinflips
+  | result:=upper(result)
+  | load bigflips
+' > /dev/null
+
 zed -lake example query -z 'from bigflips'
 ```
 =>
@@ -65,7 +74,15 @@ zed -lake example query -z 'from bigflips'
 
 _Add a filtered subset of records to our `onlytails` branch, while also adding metadata_
 ```mdtest-command
-zed -lake example query 'from coinflips | result=="tails" | load coinflips@onlytails author "Steve" message "A subset" meta "\"Additional metadata\""' > /dev/null
+zed -lake example query '
+  from coinflips
+  | result=="tails"
+  | load coinflips@onlytails
+      author "Steve"
+      message "A subset"
+      meta "\"Additional metadata\""
+' > /dev/null
+
 zed -lake example query -z 'from coinflips@onlytails'
 ```
 =>

--- a/docs/language/operators/over.md
+++ b/docs/language/operators/over.md
@@ -128,7 +128,8 @@ echo '{a:[1,2]} {a:[3,4,5]}' | zq -z 'over a => ( sum(this) )' -
 ```
 _Access the outer values in a lateral query_
 ```mdtest-command
-echo '{a:[1,2],s:"foo"} {a:[3,4,5],s:"bar"}' | zq -z 'over a with s => (sum(this) | yield {s,sum:this})' -
+echo '{a:[1,2],s:"foo"} {a:[3,4,5],s:"bar"}' |
+  zq -z 'over a with s => (sum(this) | yield {s,sum:this})' -
 ```
 =>
 ```mdtest-output
@@ -137,7 +138,8 @@ echo '{a:[1,2],s:"foo"} {a:[3,4,5],s:"bar"}' | zq -z 'over a with s => (sum(this
 ```
 _Traverse a record by flattening it_
 ```mdtest-command
-echo '{s:"foo",r:{a:1,b:2}} {s:"bar",r:{a:3,b:4}} ' | zq -z 'over flatten(r) with s => (yield {s,key:key[0],value})' -
+echo '{s:"foo",r:{a:1,b:2}} {s:"bar",r:{a:3,b:4}} ' |
+  zq -z 'over flatten(r) with s => (yield {s,key:key[0],value})' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/operators/sample.md
+++ b/docs/language/operators/sample.md
@@ -34,7 +34,8 @@ echo '1 2 3 "foo" "bar" 10.0.0.1 10.0.0.2' | zq -z 'sample | sort this' -
 
 _Sampling record shapes_
 ```mdtest-command
-echo '{a:1}{a:2}{s:"foo"}{s:"bar"}{a:3,s:"baz"}' | zq -z 'sample | sort a' -
+echo '{a:1}{a:2}{s:"foo"}{s:"bar"}{a:3,s:"baz"}' |
+  zq -z 'sample | sort a' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/operators/sort.md
+++ b/docs/language/operators/sort.md
@@ -109,7 +109,8 @@ echo '{s:"bar",k:2}{s:"bar",k:3}{s:"foo",k:2}' | zq -z 'sort k,s' -
 ```
 _Sort with an expression_
 ```mdtest-command
-echo '{s:"sum 2",x:2,y:0}{s:"sum 3",x:1,y:2}{s:"sum 0",x:-1,y:-1}' | zq -z 'sort x+y' -
+echo '{s:"sum 2",x:2,y:0}{s:"sum 3",x:1,y:2}{s:"sum 0",x:-1,y:-1}' |
+  zq -z 'sort x+y' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/operators/summarize.md
+++ b/docs/language/operators/summarize.md
@@ -92,7 +92,8 @@ echo '1 2 3 4' | zq -z 'sum(this)' -
 
 Create integer sets by key and sort the output to get a deterministic order:
 ```mdtest-command
-echo '{k:"foo",v:1}{k:"bar",v:2}{k:"foo",v:3}{k:"baz",v:4}' | zq -z 'set:=union(v) by key:=k' - | sort
+echo '{k:"foo",v:1}{k:"bar",v:2}{k:"foo",v:3}{k:"baz",v:4}' |
+  zq -z 'set:=union(v) by key:=k' - | sort
 ```
 =>
 ```mdtest-output
@@ -103,7 +104,8 @@ echo '{k:"foo",v:1}{k:"bar",v:2}{k:"foo",v:3}{k:"baz",v:4}' | zq -z 'set:=union(
 
 Use a `where` clause:
 ```mdtest-command
-echo '{k:"foo",v:1}{k:"bar",v:2}{k:"foo",v:3}{k:"baz",v:4}' | zq -z 'set:=union(v) where v > 1 by key:=k' - | sort
+echo '{k:"foo",v:1}{k:"bar",v:2}{k:"foo",v:3}{k:"baz",v:4}' |
+  zq -z 'set:=union(v) where v > 1 by key:=k' - | sort
 ```
 =>
 ```mdtest-output
@@ -114,7 +116,8 @@ echo '{k:"foo",v:1}{k:"bar",v:2}{k:"foo",v:3}{k:"baz",v:4}' | zq -z 'set:=union(
 
 Output just the unique key values:
 ```mdtest-command
-echo '{k:"foo",v:1}{k:"bar",v:2}{k:"foo",v:3}{k:"baz",v:4}' | zq -z 'by k' - | sort
+echo '{k:"foo",v:1}{k:"bar",v:2}{k:"foo",v:3}{k:"baz",v:4}' |
+  zq -z 'by k' - | sort
 ```
 =>
 ```mdtest-output

--- a/docs/language/operators/switch.md
+++ b/docs/language/operators/switch.md
@@ -48,7 +48,14 @@ merged with an automatically inserted [combine operator](combine.md).
 
 _Split input into evens and odds_
 ```mdtest-command
-echo '1 2 3 4' | zq -z 'switch ( case this%2==0 => {even:this} case this%2==1 => {odd:this}) | sort odd,even' -
+echo '1 2 3 4' |
+  zq -z '
+    switch (
+      case this%2==0 => {even:this}
+      case this%2==1 => {odd:this}
+    )
+    | sort odd,even
+  ' -
 ```
 =>
 ```mdtest-output
@@ -59,7 +66,14 @@ echo '1 2 3 4' | zq -z 'switch ( case this%2==0 => {even:this} case this%2==1 =>
 ```
 _Switch on `this` with a constant case_
 ```mdtest-command
-echo '1 2 3 4' | zq -z 'switch this ( case 1 => yield "1!" default => yield string(this) ) | sort' -
+echo '1 2 3 4' |
+  zq -z '
+    switch this (
+      case 1 => yield "1!"
+      default => yield string(this)
+    )
+    | sort
+  ' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/operators/uniq.md
+++ b/docs/language/operators/uniq.md
@@ -46,7 +46,8 @@ echo '1 2 2 3' | zq -z 'uniq -c' -
 ```
 _Use sort to deduplicate non-adjacent values_
 ```mdtest-command
-echo '"hello" "world" "goodbye" "world" "hello" "again"' | zq -z 'sort | uniq' -
+echo '"hello" "world" "goodbye" "world" "hello" "again"' |
+  zq -z 'sort | uniq' -
 ```
 =>
 ```mdtest-output

--- a/docs/language/search-expressions.md
+++ b/docs/language/search-expressions.md
@@ -43,7 +43,8 @@ produces
 Regular expressions may also appear in the [`grep`](functions/grep.md),
 [`regexp`](functions/regexp.md), and [`regexp_replace`](functions/regexp_replace.md) functions:
 ```mdtest-command
-echo '"foo" {s:"bar"} {s:"baz"} {foo:1}' | zq -z 'yield {ba_start:grep(/^ba.*/, s),last_s_char:regexp(/(.)$/,s)[1]}' -
+echo '"foo" {s:"bar"} {s:"baz"} {foo:1}' |
+  zq -z 'yield {ba_start:grep(/^ba.*/, s),last_s_char:regexp(/(.)$/,s)[1]}' -
 ```
 produces
 ```mdtest-output
@@ -261,7 +262,8 @@ which can be abbreviated
 ```
 is equivalent to
 ```
-where (123 in this or grep("123", this)) and (10.0.0.1 in this or grep("10.0.0.1", this))
+where (123 in this or grep("123", this))
+  and (10.0.0.1 in this or grep("10.0.0.1", this))
 ```
 
 Complex values are not supported as search terms but may be queried with

--- a/docs/language/shaping.md
+++ b/docs/language/shaping.md
@@ -73,7 +73,7 @@ We also use this sample JSON input in a file called `sample.json`:
 The `cast` function applies a cast operation to each leaf value that matches the
 field path in the specified type, e.g.,
 ```mdtest-command
-zq -Z -I connection.zed "cast(this, <connection>)" sample.json
+zq -Z -I connection.zed 'cast(this, <connection>)' sample.json
 ```
 casts the address fields to type `ip`, the port fields to type `port`
 (which is a [named type](data-types.md#named-types) for type `uint16`) and the address port pairs to
@@ -98,7 +98,7 @@ order of the `server` and `client` fields:
 
 Cropping is useful when you want records to "fit" a schema tightly, e.g.,
 ```mdtest-command
-zq -Z -I connection.zed "crop(this, <connection>)" sample.json
+zq -Z -I connection.zed 'crop(this, <connection>)' sample.json
 ```
 removes the `uid` field since it is not in the `connection` type:
 ```mdtest-output
@@ -119,7 +119,7 @@ removes the `uid` field since it is not in the `connection` type:
 
 Use `fill` when you want to fill out missing fields with nulls, e.g.,
 ```mdtest-command
-zq -Z -I connection.zed "fill(this, <connection>)" sample.json
+zq -Z -I connection.zed 'fill(this, <connection>)' sample.json
 ```
 adds a null-valued `vlan` field since the input value is missing it and
 the `connection` type has it:
@@ -144,7 +144,7 @@ the `connection` type has it:
 The `order` function changes the order of fields in its input to match the
 order in the specified type, as field order is significant in Zed records, e.g.,
 ```mdtest-command
-zq -Z -I connection.zed "order(this, <connection>)" sample.json
+zq -Z -I connection.zed 'order(this, <connection>)' sample.json
 ```
 reorders the `client` and `server` fields to match the input but does nothing
 about the `uid` field as it is not in the `connection` type:
@@ -193,7 +193,7 @@ also produces
 The `shape` function brings everything together by applying `cast`,
 `fill`, and `order` all in one step, e.g.,
 ```mdtest-command
-zq -Z -I connection.zed "shape(this, <connection>)" sample.json
+zq -Z -I connection.zed 'shape(this, <connection>)' sample.json
 ```
 reorders the `client` and `server` fields to match the input but does nothing
 about the `uid` field as it is not in the `connection` type:
@@ -215,7 +215,10 @@ about the `uid` field as it is not in the `connection` type:
 To get a tight shape of the target type,
 apply `crop` to the output of `shape`, e.g.,
 ```mdtest-command
-zq -Z -I connection.zed "shape(this, <connection>) | crop(this, <connection>)" sample.json
+zq -Z -I connection.zed '
+  shape(this, <connection>)
+  | crop(this, <connection>)
+  ' sample.json
 ```
 drops the `uid` field after shaping:
 ```mdtest-output
@@ -257,7 +260,7 @@ file `malformed.json`.
 When we apply our shaper via
 
 ```mdtest-command
-zq -Z -I connection.zed "shape(this, <connection>)" malformed.json
+zq -Z -I connection.zed 'shape(this, <connection>)' malformed.json
 ```
 
 we see two errors:
@@ -295,7 +298,11 @@ to debug the problem, e.g.,
 zq -Z -I connection.zed '
   yield {original: this, shaped: shape(this, <connection>)}
   | yield has_error(shaped)
-    ? error({msg: "shaper error (see inner errors for details)", original, shaped})
+    ? error({
+      msg: "shaper error (see inner errors for details)",
+      original,
+      shaped
+    })
     : shaped
   ' malformed.json
 ```
@@ -471,7 +478,8 @@ the records in each category, we can use a group-by.  In this simple example, we
 will fuse records based on their number of fields using the
 [`len` function:](functions/len.md)
 ```mdtest-command
-echo '{x:1} {x:"foo",y:"foo"} {x:2,y:"bar"}' | zq -z 'fuse(this) by len(this) | sort len' -
+echo '{x:1} {x:"foo",y:"foo"} {x:2,y:"bar"}' |
+  zq -z 'fuse(this) by len(this) | sort len' -
 ```
 which produces
 ```mdtest-output
@@ -489,7 +497,8 @@ switch len(this) (
 ```
 when we run
 ```mdtest-command
-echo '{x:1} {x:"foo",y:"foo"} {x:2,y:"bar"} {a:1,b:2,c:3}' | zq -z -I shape.zed '| sort -r this' -
+echo '{x:1} {x:"foo",y:"foo"} {x:2,y:"bar"} {a:1,b:2,c:3}' |
+  zq -z -I shape.zed '| sort -r this' -
 ```
 we get
 ```mdtest-output

--- a/docs/language/statements.md
+++ b/docs/language/statements.md
@@ -140,8 +140,11 @@ op AddMessage(field_for_message, msg): (
 ```
 the `msg` parameter may be used flexibly
 ```mdtest-command
-echo '{greeting: "hi"}' | zq -z -I params.zed 'AddMessage(message, "hello")' -
-echo '{greeting: "hi"}' | zq -z -I params.zed 'AddMessage(message, greeting)' -
+echo '{greeting: "hi"}' |
+  zq -z -I params.zed 'AddMessage(message, "hello")' -
+
+echo '{greeting: "hi"}' |
+  zq -z -I params.zed 'AddMessage(message, greeting)' -
 ```
 to produce the respective outputs
 ```mdtest-output
@@ -154,7 +157,8 @@ where _only_ a certain category of argument is expected. For instance, having
 explicitly mentioned "field" in the name of our first parameter's name may help
 us avoid making mistakes when passing arguments, such as
 ```mdtest-command fails
-echo '{greeting: "hi"}' | zq -z -I params.zed 'AddMessage("message", "hello")' -
+echo '{greeting: "hi"}' |
+  zq -z -I params.zed 'AddMessage("message", "hello")' -
 ```
 which produces
 ```mdtest-output

--- a/docs/tutorials/schools.md
+++ b/docs/tutorials/schools.md
@@ -73,7 +73,13 @@ which does not utilize a terminal for standard output.
 
 You can also quickly see a list of the leaf-value data types with this query:
 ```mdtest-command dir=testdata/edu
-zq -Z "sample | over this | by typeof(value) | yield typeof | sort" schools.zson testscores.zson webaddrs.zson
+zq -Z '
+  sample
+  | over this
+  | by typeof(value)
+  | yield typeof
+  | sort
+' schools.zson testscores.zson webaddrs.zson
 ```
 which emits
 ```mdtest-output
@@ -402,7 +408,11 @@ create a [`set`](../formats/zson.md#243-set-value)-typed
 field called `Schools` that contains all unique school names per district. From
 these we'll find each set that contains a school named `Lincoln Elementary`, e.g.,
 ```mdtest-command dir=testdata/edu
-zq -Z 'Schools:=union(School) by District | "Lincoln Elementary" in Schools | sort this' schools.zson
+zq -Z '
+  Schools:=union(School) by District
+  | "Lincoln Elementary" in Schools
+  | sort this
+' schools.zson
 ```
 produces
 ```mdtest-output head
@@ -550,7 +560,9 @@ produces
 ```
 We can easily filter these out by negating the search for these records, e.g.,
 ```mdtest-command dir=testdata/edu
-zq -z 'not (AvgScrMath==null AvgScrRead==null AvgScrWrite==null)' testscores.zson
+zq -z '
+  not (AvgScrMath==null AvgScrRead==null AvgScrWrite==null)
+' testscores.zson
 ```
 produces
 ```mdtest-output head
@@ -561,7 +573,11 @@ produces
 ```
 Parentheses can also be nested, e.g.,
 ```mdtest-command dir=testdata/edu
-zq -z 'grep(*High*, sname) and (not (AvgScrMath==null AvgScrRead==null AvgScrWrite==null) and dname=="San Francisco Unified")' testscores.zson
+zq -z '
+  grep(*High*, sname)
+    and (not (AvgScrMath==null AvgScrRead==null AvgScrWrite==null)
+      and dname=="San Francisco Unified")
+' testscores.zson
 ```
 produces
 ```mdtest-output head
@@ -745,7 +761,10 @@ For example,
 to add a field to our test score records representing the computed average of the math,
 reading, and writing scores for each school that reported them, we could say:
 ```mdtest-command dir=testdata/edu
-zq -Z 'AvgScrMath!=null | put AvgAll:=(AvgScrMath+AvgScrRead+AvgScrWrite)/3.0' testscores.zson
+zq -Z '
+  AvgScrMath!=null
+  | put AvgAll:=(AvgScrMath+AvgScrRead+AvgScrWrite)/3.0
+' testscores.zson
 ```
 which produces
 ```mdtest-output head
@@ -763,7 +782,12 @@ which produces
 We can also use `put` to create derived tables and display them in tabular
 form using `-f table`, e.g.,
 ```mdtest-command dir=testdata/edu
-zq -f table 'AvgScrMath != null | put combined_scores:=AvgScrMath+AvgScrRead+AvgScrWrite | cut sname,combined_scores,AvgScrMath,AvgScrRead,AvgScrWrite | head 5' testscores.zson
+zq -f table '
+  AvgScrMath != null
+  | put combined_scores:=AvgScrMath+AvgScrRead+AvgScrWrite
+  | cut sname,combined_scores,AvgScrMath,AvgScrRead,AvgScrWrite
+  | head 5
+' testscores.zson
 ```
 produces
 ```mdtest-output
@@ -873,7 +897,9 @@ As with SQL, multiple aggregate functions may be invoked at the same time.
 For example, to simultaneously calculate the minimum, maximum, and average of
 the math test scores:
 ```mdtest-command dir=testdata/edu
-zq -f table 'min(AvgScrMath),max(AvgScrMath),avg(AvgScrMath)' testscores.zson
+zq -f table '
+  min(AvgScrMath),max(AvgScrMath),avg(AvgScrMath)
+' testscores.zson
 ```
 produces
 ```mdtest-output
@@ -894,7 +920,9 @@ As just shown, by default the result returned is placed in a field with the
 same name as the aggregate function. You may instead use `:=` to specify an
 explicit name for the generated field, e.g.,
 ```mdtest-command dir=testdata/edu
-zq -f table 'lowest:=min(AvgScrMath),highest:=max(AvgScrMath),typical:=avg(AvgScrMath)' testscores.zson
+zq -f table '
+  lowest:=min(AvgScrMath),highest:=max(AvgScrMath),typical:=avg(AvgScrMath)
+' testscores.zson
 ```
 produces
 ```mdtest-output
@@ -919,7 +947,10 @@ For example,
 this query calculates average math test scores for the cities of Los Angeles
 and San Francisco:
 ```mdtest-command dir=testdata/edu
-zq -Z 'LA_Math:=avg(AvgScrMath) where cname=="Los Angeles", SF_Math:=avg(AvgScrMath) where cname=="San Francisco"' testscores.zson
+zq -Z '
+  LA_Math:=avg(AvgScrMath) where cname=="Los Angeles",
+  SF_Math:=avg(AvgScrMath) where cname=="San Francisco"
+' testscores.zson
 ```
 produces
 ```mdtest-output
@@ -943,7 +974,10 @@ of all of its input.
 Many of the school records in our sample data include websites, but many do
 not. The following query shows the cities in which all schools have a website. e.g.,
 ```mdtest-command dir=testdata/edu
-zq -Z 'all_schools_have_website:=and(Website!=null) by City | sort City' schools.zson
+zq -Z '
+  all_schools_have_website:=and(Website!=null) by City
+  | sort City
+' schools.zson
 ```
 produces
 ```mdtest-output head
@@ -1000,7 +1034,11 @@ For schools in Fresno county that include websites, the following query
 constructs an ordered list per city of their websites along with a parallel
 list of which school each website represents:
 ```mdtest-command dir=testdata/edu
-zq -Z 'County=="Fresno" Website!=null | Websites:=collect(Website),Schools:=collect(School) by City | sort City' schools.zson
+zq -Z '
+  County=="Fresno" Website!=null
+  | Websites:=collect(Website),Schools:=collect(School) by City
+  | sort City
+' schools.zson
 ```
 and produces
 ```mdtest-output head
@@ -1124,7 +1162,10 @@ Many of the school records in our sample data include websites, but many do
 not. The following query shows the cities for which at least one school has
 a listed website:
 ```mdtest-command dir=testdata/edu
-zq -Z 'has_at_least_one_school_website:=or(Website!=null) by City | sort City' schools.zson
+zq -Z '
+  has_at_least_one_school_website:=or(Website!=null) by City
+  | sort City
+' schools.zson
 ```
 and produces
 ```mdtest-output head
@@ -1158,7 +1199,11 @@ The `sum` function computes the minimum numeric value over all of its input.
 This query calculates the total of all the math, reading, and writing test scores
 across all schools:
 ```mdtest-command dir=testdata/edu
-zq -Z 'AllMath:=sum(AvgScrMath),AllRead:=sum(AvgScrRead),AllWrite:=sum(AvgScrWrite)' testscores.zson
+zq -Z '
+  AllMath:=sum(AvgScrMath),
+  AllRead:=sum(AvgScrRead),
+  AllWrite:=sum(AvgScrWrite)
+' testscores.zson
 ```
 and produces
 ```mdtest-output
@@ -1177,7 +1222,11 @@ For schools in Fresno county that include websites, the following query
 constructs a set per city of all the unique websites for the schools in that
 city:
 ```mdtest-command dir=testdata/edu
-zq -Z 'County=="Fresno" Website!=null | Websites:=union(Website) by City | sort City' schools.zson
+zq -Z '
+  County=="Fresno" Website!=null
+  | Websites:=union(Website) by City
+  | sort City
+' schools.zson
 ```
 and produces
 ```mdtest-output head
@@ -1247,7 +1296,10 @@ When specifying multiple comma-separated field names, a group is formed for each
 unique combination of values found in those fields.  To see the average reading
 test scores and school count for each county/district pairing, this query:
 ```mdtest-command dir=testdata/edu
-zq -f table 'avg(AvgScrRead),count() by cname,dname | sort -r count' testscores.zson
+zq -f table '
+  avg(AvgScrRead),count() by cname,dname
+  | sort -r count
+' testscores.zson
 ```
 produces
 ```mdtest-output head
@@ -1285,7 +1337,10 @@ For instance, if we'd made an typographical error in our
 prior example when attempting to reference the `dname` field,
 the misspelled field would appear as embedded missing errors, e.g.,
 ```mdtest-command dir=testdata/edu
-zq -Z 'avg(AvgScrRead),count() by cname,dnmae | sort -r count' testscores.zson
+zq -Z '
+  avg(AvgScrRead),count() by cname,dnmae
+  | sort -r count
+' testscores.zson
 ```
 produces
 ```mdtest-output head
@@ -1510,7 +1565,10 @@ as arguments to yield.
 This example produce two simpler records for every school record listing
 the average math score with the school name and the county name:
 ```mdtest-command dir=testdata/edu
-zq -Z 'AvgScrMath!=null | yield {school:sname,avg:AvgScrMath}, {county:cname,zvg:AvgScrMath}' testscores.zson
+zq -Z '
+  AvgScrMath!=null
+  | yield {school:sname,avg:AvgScrMath}, {county:cname,zvg:AvgScrMath}
+' testscores.zson
 ```
 which produces
 ```mdtest-output head 4
@@ -1534,7 +1592,12 @@ which produces
 ```
 In earlier example, we used `put` to create a table using this query:
 ```mdtest-command dir=testdata/edu
-zq -f table 'AvgScrMath != null | put combined_scores:=AvgScrMath+AvgScrRead+AvgScrWrite | cut sname,combined_scores,AvgScrMath,AvgScrRead,AvgScrWrite | head 5' testscores.zson
+zq -f table '
+  AvgScrMath != null
+  | put combined_scores:=AvgScrMath+AvgScrRead+AvgScrWrite
+  | cut sname,combined_scores,AvgScrMath,AvgScrRead,AvgScrWrite
+  | head 5
+' testscores.zson
 ```
 produces
 ```mdtest-output
@@ -1549,7 +1612,16 @@ Academia Avance Charter     1148            386        380        382
 The same result can be achieved by yielding a record literal,
 sometimes with a more intuitive  structure, e.g.,
 ```mdtest-command dir=testdata/edu
-zq -f table 'AvgScrMath != null | yield  {sname,combined_scores:AvgScrMath+AvgScrRead+AvgScrWrite,AvgScrMath,AvgScrRead,AvgScrWrite} | head 5' testscores.zson
+zq -f table '
+AvgScrMath != null
+| yield {
+          sname,
+          combined_scores:AvgScrMath+AvgScrRead+AvgScrWrite,
+          AvgScrMath,
+          AvgScrRead,
+          AvgScrWrite
+        }
+| head 5' testscores.zson
 ```
 produces
 ```mdtest-output

--- a/docs/tutorials/zq.md
+++ b/docs/tutorials/zq.md
@@ -113,7 +113,8 @@ produces this "search result":
 In fact, this search syntax generalizes, and if we search over a more complex
 input:
 ```mdtest-command
-echo '1 2 [1,2,3] [4,5,6] {r:{x:1,y:2}} {r:{x:3,y:4}} "hello" "Number 2"' | zq -z 2 -
+echo '1 2 [1,2,3] [4,5,6] {r:{x:1,y:2}} {r:{x:3,y:4}} "hello" "Number 2"' |
+  zq -z 2 -
 ```
 we naturally find all the 2's whether as a value, inside a value, or inside a string:
 ```mdtest-output
@@ -124,7 +125,8 @@ we naturally find all the 2's whether as a value, inside a value, or inside a st
 ```
 You can also do keyword-text search, e.g.,
 ```mdtest-command
-echo '1 2 [1,2,3] [4,5,6] {r:{x:1,y:2}} {r:{x:3,y:4}} "hello" "Number 2"' | zq -z 'hello or Number' -
+echo '1 2 [1,2,3] [4,5,6] {r:{x:1,y:2}} {r:{x:3,y:4}} "hello" "Number 2"' |
+  zq -z 'hello or Number' -
 ```
 produces
 ```mdtest-output
@@ -445,7 +447,8 @@ produces
 But more powerfully, types can be used anywhere a value can be used and
 in particular, they can be group-by keys, e.g.,
 ```mdtest-command
-echo '{x:1,y:2}{s:"foo"}{x:3,y:4}' | zq -f table "count() by shape:=typeof(this) | sort count" -
+echo '{x:1,y:2}{s:"foo"}{x:3,y:4}' |
+  zq -f table "count() by shape:=typeof(this) | sort count" -
 ```
 produces
 ```mdtest-output
@@ -483,7 +486,8 @@ i.e., they match even though their underlying shape is different.
 With `zq` of course, these are different super-structured types so
 the result is false, e.g.,
 ```mdtest-command
-echo '{"a":{"s":"foo"},"b":{"x":1,"y":2}}' | zq -z 'yield typeof(a)==typeof(b)' -
+echo '{"a":{"s":"foo"},"b":{"x":1,"y":2}}' |
+  zq -z 'yield typeof(a)==typeof(b)' -
 ```
 produces
 ```mdtest-output
@@ -496,7 +500,8 @@ Sometimes you'd like to see a sample value of each shape, not its type.
 This is easy to do with the [any aggregate function](../language/aggregates/any.md),
 e.g,
 ```mdtest-command
-echo '{x:1,y:2}{s:"foo"}{x:3,y:4}' | zq -z 'val:=any(this) by typeof(this) | sort val | yield val' -
+echo '{x:1,y:2}{s:"foo"}{x:3,y:4}' |
+  zq -z 'val:=any(this) by typeof(this) | sort val | yield val' -
 ```
 produces
 ```mdtest-output
@@ -581,7 +586,9 @@ just use `zq` as `zq` can take URLs in addition to file name arguments.
 This command will grab descriptions of first 30 PRs created in the
 public `zed` repository and place it in a file called `prs.json`:
 ```
-zq -f json https://api.github.com/repos/brimdata/zed/pulls\?state\=all\&sort\=desc\&per_page=30 > prs.json
+zq -f json \
+  https://api.github.com/repos/brimdata/zed/pulls\?state\=all\&sort\=desc\&per_page=30 \
+  > prs.json
 ```
 Now that you have this JSON file on your local file system, how would you query it
 with `zq`?
@@ -710,7 +717,13 @@ We can take the output from `fuse | sample` and list the fields with
 and their "kind".  Note that when we do an `over this` with records as
 input, we get a new record value for each field structured as a key/value pair:
 ```mdtest-command dir=docs/tutorials
-zq -f table 'over this | fuse | sample | over this | {field:key[0],kind:kind(value)}' prs.json
+zq -f table '
+  over this
+  | fuse
+  | sample
+  | over this
+  | {field:key[0],kind:kind(value)}
+' prs.json
 ```
 produces
 ```mdtest-output
@@ -829,7 +842,11 @@ Finally, let's clean up those dates.  To track down all the candidates,
 we can run this Zed to group field names by their type and limit the output
 to primitive types:
 ```
-zq -z 'over this | kind(value)=="primitive" | fields:=union(key[0]) by type:=typeof(value)' prs2.zng
+zq -z '
+  over this
+  | kind(value)=="primitive"
+  | fields:=union(key[0]) by type:=typeof(value)
+' prs2.zng
 ```
 which gives
 ```
@@ -861,11 +878,21 @@ To fix those strings, we simply transform the fields in place using the
 (implied) [put operator](../language/operators/put.md) and redirect the final
 output the ZNG file `prs.zng`:
 ```
-zq 'closed_at:=time(closed_at),merged_at:=time(merged_at),created_at:=time(created_at),updated_at:=time(updated_at)' prs2.zng > prs.zng
+zq '
+  closed_at:=time(closed_at),
+  merged_at:=time(merged_at),
+  created_at:=time(created_at),
+  updated_at:=time(updated_at)
+' prs2.zng > prs.zng
 ```
 We can check the result with our type analysis:
 ```mdtest-command dir=docs/tutorials
-zq -z 'over this | kind(value)=="primitive" | fields:=union(key[0]) by type:=typeof(value) | sort type' prs.zng
+zq -z '
+  over this
+  | kind(value)=="primitive"
+  | fields:=union(key[0]) by type:=typeof(value)
+  | sort type
+' prs.zng
 ```
 which now gives:
 ```mdtest-output
@@ -936,7 +963,10 @@ Instead of old PRs, we can get the latest list of PRs using the
 [tail operator](../language/operators/tail.md) since we know the data is sorted
 chronologically. This command retrieves the last five PRs in the dataset:
 ```mdtest-command dir=docs/tutorials
-zq -f table 'tail 5 | {DATE:created_at,"NUMBER":f"PR #{number}",TITLE:title}' prs.zng
+zq -f table '
+  tail 5
+  | {DATE:created_at,"NUMBER":f"PR #{number}",TITLE:title}
+' prs.zng
 ```
 and the output is:
 ```mdtest-output
@@ -1022,7 +1052,13 @@ bringing that value into the scope using a `with` clause appended to the
 `over` expression and yielding a
 [record literal](../language/expressions.md#record-expressions) with the desired value:
 ```mdtest-command dir=docs/tutorials
-zq -z 'over requested_reviewers with user=user.login => ( reviewers:=union(login) | {user,reviewers}) | sort user,len(reviewers)' prs.zng
+zq -z '
+  over requested_reviewers with user=user.login => (
+    reviewers:=union(login)
+    | {user,reviewers}
+  )
+  | sort user,len(reviewers)
+' prs.zng
 ```
 which gives us
 ```mdtest-output head
@@ -1039,7 +1075,14 @@ which gives us
 The final step is to simply aggregate the "reviewer sets" with the `user` field
 as the group-by key:
 ```mdtest-command dir=docs/tutorials
-zq -Z 'over requested_reviewers with user=user.login => ( reviewers:=union(login) | {user,reviewers} ) | groups:=union(reviewers) by user | sort user,len(groups)' prs.zng
+zq -Z '
+  over requested_reviewers with user=user.login => (
+    reviewers:=union(login)
+    | {user,reviewers}
+  )
+  | groups:=union(reviewers) by user
+  | sort user,len(groups)
+' prs.zng
 ```
 and we get
 ```mdtest-output
@@ -1156,7 +1199,14 @@ the average number of reviewers requested instead of the set of groups
 of reviewers.  To do this, we just average the reviewer set size
 with an aggregation:
 ```mdtest-command dir=docs/tutorials
-zq -z 'over requested_reviewers with user=user.login => ( reviewers:=union(login) | {user,reviewers} ) | avg_reviewers:=avg(len(reviewers)) by user | sort avg_reviewers' prs.zng
+zq -z '
+  over requested_reviewers with user=user.login => (
+    reviewers:=union(login)
+    | {user,reviewers}
+  )
+  | avg_reviewers:=avg(len(reviewers)) by user
+  | sort avg_reviewers
+' prs.zng
 ```
 which produces
 ```mdtest-output
@@ -1170,7 +1220,14 @@ which produces
 Of course, if you'd like the query output in JSON, you can just say `-j` and
 `zq` will happily format the Zed sets as JSON arrays, e.g.,
 ```mdtest-command dir=docs/tutorials
-zq -j 'over requested_reviewers with user=user.login => ( reviewers:=union(login) | {user,reviewers} ) | groups:=union(reviewers) by user | sort user,len(groups)' prs.zng
+zq -j '
+  over requested_reviewers with user=user.login => (
+    reviewers:=union(login)
+    | {user,reviewers}
+  )
+  | groups:=union(reviewers) by user
+  | sort user,len(groups)
+' prs.zng
 ```
 produces
 ```mdtest-output


### PR DESCRIPTION
## What's Changing

I've reformatted many of the Zed docs examples across multiple lines to minimize the number of times readers need to "scroll right".

If you'd like to see the rendered site as part of review, I've put a copy of what's on this branch at a personal staging site at:

https://66c7d4d2d4764d84e6cdf484--spiffy-gnome-8f2834.netlify.app/docs/next

## Why

Several of us have noticed this before, but a user recently spoke up about it in a [community Slack thread](https://brimdata.slack.com/archives/CTSMAK6G7/p1724275452056539) and that inspired me to finally take action.

## Details

The majority of them were fixable by just changing from:

```
echo "input data" | zq -z '...zed code...`
```

to

```
echo "input data" |
  zq -z '...zed code...`
```

i.e., I adopted the convention of putting the pipe for shell continuation at end of line when it would help.

For situations where I needed continuation of Zed pipelines, I put the pipes at beginning of next line, e.g.:

```
from pool
| count()
```

Overall, I stopped short of being totally dogmatic. In some cases I was able to break long inputs across multiple lines (e.g., when there were many `echo'`ed individual records) but some things would have required using some of the more ugly shell continuation tricks (e.g., breaking up single long strings) so there remain a handful if situations where "scroll right" is still needed to see everything. I figure this is not the end of the world.

I found a couple bonus things I fixed up along the way, including:

1. Examples that weren't previously protected by `mdtest` at all but could be
2. Switched from `"` to `'` for surrounding the Zed code in some examples, since most already use `'` and I figured we should be consistent (plus `'` is a good habit for users since it avoids some shell surprises)