### PR TITLE
Allow output operators on non-leaves

### DIFF
--- a/compiler/parser/api.go
+++ b/compiler/parser/api.go
@@ -99,20 +99,22 @@ func (e *Error) Error() string {
 	if e.sset == nil {
 		return e.Msg
 	}
-	src := e.sset.SourceOf(e.Pos)
-	start := src.Position(e.Pos)
-	end := src.Position(e.End)
 	var b strings.Builder
 	b.WriteString(e.Msg)
-	if src.Filename != "" {
-		fmt.Fprintf(&b, " in %s", src.Filename)
-	}
-	line := src.LineOfPos(e.sset.Text, e.Pos)
-	fmt.Fprintf(&b, " at line %d, column %d:\n%s\n", start.Line, start.Column, line)
-	if end.IsValid() {
-		formatSpanError(&b, line, start, end)
-	} else {
-		formatPointError(&b, start)
+	if e.Pos >= 0 {
+		src := e.sset.SourceOf(e.Pos)
+		start := src.Position(e.Pos)
+		end := src.Position(e.End)
+		if src.Filename != "" {
+			fmt.Fprintf(&b, " in %s", src.Filename)
+		}
+		line := src.LineOfPos(e.sset.Text, e.Pos)
+		fmt.Fprintf(&b, " at line %d, column %d:\n%s\n", start.Line, start.Column, line)
+		if end.IsValid() {
+			formatSpanError(&b, line, start, end)
+		} else {
+			formatPointError(&b, start)
+		}
 	}
 	return b.String()
 }

--- a/zfmt/ztests/output.yaml
+++ b/zfmt/ztests/output.yaml
@@ -1,7 +1,14 @@
 script: |
   zc -C -s 'fork (=> output foo => pass)'
   echo '// ==='
-  zc -C -s 'switch x (case "foo" => output foo case "bar" => pass)'
+  zc -C -s 'switch x (case "foo" => output foo case "bar" => pass) | sort this'
+  echo '// ==='
+  zc -C -s 'over this => ( sum(this) | output bar )'
+  # error cases
+  ! zc -C -s 'over this => ( sum(this) | output bar ) | x := "foo"'
+  ! zc -C -s 'fork (=> output foo | "yield foo" => pass) | sort this'
+  ! zc -C -s 'fork (=> output foo => output bar) | count()'
+  ! zc -C -s 'switch x (case "foo" => output foo case "bar" => output bar) | count()'
 
 outputs:
   - name: stdout
@@ -21,5 +28,20 @@ outputs:
             output foo
           case "bar" =>
             pass
-            | output main
         )
+        | sort this
+        | output main
+      // ===
+      reader
+      | over this => (
+        summarize
+            sum:=sum(this)
+        | yield sum
+        | output bar
+      )
+  - name: stderr
+    data: |
+      unreachable operator
+      unreachable operator
+      unreachable operator
+      unreachable operator


### PR DESCRIPTION
The commit changes analysis of output operators so that it is permissable to place output operators anywhere in a flowgraph as long as it doesn't block downsteam operators. The commit also adjusts formatting for parser errors so that non-location specific errors can be passed to it.