### PR TITLE
Fix dot expressions on vector.Union and vector.Variant

### DIFF
--- a/runtime/vam/expr/dot.go
+++ b/runtime/vam/expr/dot.go
@@ -34,10 +34,12 @@ func NewDottedExpr(zctx *zed.Context, f field.Path) Evaluator {
 	return ret
 }
 
-func (d *DotExpr) Eval(val vector.Any) vector.Any {
-	switch val := vector.Under(d.record.Eval(val)).(type) {
-	case nil: //XXX
-		return nil
+func (d *DotExpr) Eval(vec vector.Any) vector.Any {
+	return vector.Apply(true, d.eval, d.record.Eval(vec))
+}
+
+func (d *DotExpr) eval(vecs ...vector.Any) vector.Any {
+	switch val := vector.Under(vecs[0]).(type) {
 	case *vector.Record:
 		i, ok := val.Typ.IndexOfField(d.field)
 		if !ok {
@@ -48,24 +50,6 @@ func (d *DotExpr) Eval(val vector.Any) vector.Any {
 		panic("vam.DotExpr TypeValue TBD")
 	case *vector.Map:
 		panic("vam.DotExpr Map TBD")
-	case *vector.Union:
-		vals := make([]vector.Any, 0, len(val.Values))
-		for _, val := range val.Values {
-			//XXX blend errors... we need a generic rollup that
-			// would take any child variants and flatten them so that
-			// a variant always appears at top level, e.g., in a union
-			// with embedded variant(s) we need to pop the variant above
-			// the union and create different versions of top-level types
-			// reflecting the new mix of consituent union components.
-			vals = append(vals, d.Eval(val))
-		}
-		return val.Copy(vals)
-	case *vector.Variant:
-		vals := make([]vector.Any, 0, len(val.Values))
-		for _, val := range val.Values {
-			vals = append(vals, d.Eval(val))
-		}
-		return vector.NewVariant(val.Tags, vals)
 	default:
 		return vector.NewMissing(d.zctx, val.Len())
 	}

--- a/runtime/ztests/expr/dot.yaml
+++ b/runtime/ztests/expr/dot.yaml
@@ -1,0 +1,23 @@
+zed: yield a.b
+
+vector: true
+
+input: |
+  {a:{b:1}}
+  {a:{b:1((int64,string))}}
+  {a:{b:1}((int64,{b:int64}))}
+  {a:{b:1}}((int64,{a:{b:int64}}))
+  {a:1}
+  {}
+  null({})
+  null
+
+output: |
+  1
+  1((int64,string))
+  1
+  1
+  error("missing")
+  error("missing")
+  error("missing")
+  error("missing")


### PR DESCRIPTION
Dot expressions don't work correctly when applied to a vector.Union or vector.Variant.  Fix by using vector.Apply.