### PR TITLE
Update sort docs and examples to reflect zed#5203 changes

### DIFF
--- a/docs/language/shaping.md
+++ b/docs/language/shaping.md
@@ -498,7 +498,7 @@ switch len(this) (
 when we run
 ```mdtest-command
 echo '{x:1} {x:"foo",y:"foo"} {x:2,y:"bar"} {a:1,b:2,c:3}' |
-  zq -z -I shape.zed '| sort -r this' -
+  zq -z -I shape.zed '| sort this desc' -
 ```
 we get
 ```mdtest-output

--- a/docs/tutorials/schools.md
+++ b/docs/tutorials/schools.md
@@ -1298,7 +1298,7 @@ test scores and school count for each county/district pairing, this query:
 ```mdtest-command dir=testdata/edu
 zq -f table '
   avg(AvgScrRead),count() by cname,dname
-  | sort -r count
+  | sort count desc
 ' testscores.zson
 ```
 produces
@@ -1339,7 +1339,7 @@ the misspelled field would appear as embedded missing errors, e.g.,
 ```mdtest-command dir=testdata/edu
 zq -Z '
   avg(AvgScrRead),count() by cname,dnmae
-  | sort -r count
+  | sort count desc
 ' testscores.zson
 ```
 produces

--- a/docs/tutorials/zed.md
+++ b/docs/tutorials/zed.md
@@ -108,7 +108,7 @@ We can run an aggregation to see who has created the most PRs during the time ra
 of this first data set:
 
 ```bash
-$ zed query 'count() by user:=user.login | sort -r count'
+$ zed query 'count() by user:=user.login | sort count desc'
 ```
 =>
 ```
@@ -184,7 +184,7 @@ and see who created these PRs:
 
 ```
 $ zed query 'from prs range 2020-04-19T16:00:00Z to 2020-05-20T02:00:00Z
-             | count() by user:=user.login | sort -r count'
+             | count() by user:=user.login | sort count desc'
 ```
 =>
 ```

--- a/docs/tutorials/zq.md
+++ b/docs/tutorials/zq.md
@@ -981,7 +981,7 @@ DATE                 NUMBER TITLE
 How about some aggregations?  We can count the number of PRs and sort by the
 count highest first:
 ```mdtest-command dir=docs/tutorials
-zq -z "count() by user:=user.login | sort -r count" prs.zng
+zq -z "count() by user:=user.login | sort count desc" prs.zng
 ```
 produces
 ```mdtest-output


### PR DESCRIPTION
## What's Changing

* The `sort` operator docs are updated to reflect the changes in #5203
* Some mdtest-protected examples are modified to de-emphasize the use of `-r`
* Other small clarifications are made to the text/examples in the `sort` doc

If you'd like to review this branch's changes in rendered form, I've published them to a personal staging site:
https://capable-khapse-fa9d06.netlify.app/docs/next/language/operators/sort

## Why

The ability to specify different per-key `sort` order in #5203 represents new functionality to which we'd like to call attention.

## Details

When discussing with the team after the merge of #5203, for a bit there was consensus about framing the `-r` option as _deprecated_ and saying it was only there for backward compatibility. @nwt later pointed out that it still does provide a nice shorthand and I agree with this, so I've tried to walk the line of it still being mentioned but explained more "before the fold" to try to discourage its wide use.

It would be great if I could get an approval on https://github.com/brimdata/zed-docs-site/pull/83 before this merges so we can be spared yet another round of "broken link checker failures" due to a known issue.