### PR TITLE
Update cast function docs

### DIFF
--- a/docs/language/data-types.md
+++ b/docs/language/data-types.md
@@ -89,6 +89,7 @@ persist into the data model and thus into the serialized input and output.
 
 Named types may be defined in three ways:
 * with a [`type` statement](statements.md#type-statements),
+* with the [`cast` function](functions/cast.md),
 * with a definition inside of another type, or
 * by the input data itself.
 

--- a/docs/language/data-types.md
+++ b/docs/language/data-types.md
@@ -87,7 +87,7 @@ and a record type used as a value
 As in any modern programming language, types can be named and the type names
 persist into the data model and thus into the serialized input and output.
 
-Named types may be defined in three ways:
+Named types may be defined in four ways:
 * with a [`type` statement](statements.md#type-statements),
 * with the [`cast` function](functions/cast.md),
 * with a definition inside of another type, or

--- a/docs/language/functions/cast.md
+++ b/docs/language/functions/cast.md
@@ -11,15 +11,15 @@ cast(val: any, name: string) -> any
 
 ### Description
 
-The _cast_ function performs type casts but handles both primitive types and
-complex types.  If the input type `t` is a primitive type, then the result
+The _cast_ function performs type casts but handles both [primitive types](../../formats/zed.md#1-primitive-types) and
+[complex types](../../formats/zed.md#2-complex-types).  If the input type `t` is a primitive type, then the result
 is equivalent to
 ```
 t(val)
 ```
 e.g., the result of `cast(1, <string>)` is the same as `string(1)` which is `"1"`.
 In the second form, where the `name` argument is a string, cast creates
-a new named type where the name for the type is given by `name` and its
+a new [named type](../data-types.md#named-types) where the name for the type is given by `name` and its
 type is given by `typeof(val)`.  This provides a convenient mechanism
 to create new named types from the input data itself without having to
 hard code the type in the Zed source text.
@@ -81,7 +81,7 @@ produces
 {a:3,b:4}(=foo)
 ```
 
-_Name data based its properties_
+_Derive type names from the properties of data_
 ```mdtest-command
 echo '{x:1,y:2}{r:3}{x:4,y:5}' |
   zq -z 'switch (


### PR DESCRIPTION
## What's Changing

A few small improvements are proposed to the `cast` function docs and a related section on Named Types.

## Why

A user recently asked a question about the `cast` function on community Slack and from their question it was apparent that they were unfamiliar with the concept of Named Types. Reviewing the docs myself, I could see there were hyperlinks missing between the relevant pages, so by adding them now I'm hoping future users will fare better.

## Details

While reviewing I found some other hyperlinks that seemed worth adding. I also made a wording improvement.