### PR TITLE
Add a uniq docs example showing record values

### DIFF
--- a/docs/language/operators/uniq.md
+++ b/docs/language/operators/uniq.md
@@ -56,3 +56,19 @@ echo '"hello" "world" "goodbye" "world" "hello" "again"' |
 "hello"
 "world"
 ```
+_Complex values must match fully to be considered duplicate (e.g., every field/value pair in adjacent records)_
+```mdtest-command
+echo '{ts:2024-09-10T21:12:33Z, action:"start"}
+      {ts:2024-09-10T21:12:34Z, action:"running"}
+      {ts:2024-09-10T21:12:34Z, action:"running"}
+      {ts:2024-09-10T21:12:35Z, action:"running"}
+      {ts:2024-09-10T21:12:36Z, action:"stop"}' |
+  zq -z 'uniq' -
+```
+=>
+```mdtest-output
+{ts:2024-09-10T21:12:33Z,action:"start"}
+{ts:2024-09-10T21:12:34Z,action:"running"}
+{ts:2024-09-10T21:12:35Z,action:"running"}
+{ts:2024-09-10T21:12:36Z,action:"stop"}
+```

--- a/docs/language/operators/uniq.md
+++ b/docs/language/operators/uniq.md
@@ -56,6 +56,7 @@ echo '"hello" "world" "goodbye" "world" "hello" "again"' |
 "hello"
 "world"
 ```
+
 _Complex values must match fully to be considered duplicate (e.g., every field/value pair in adjacent records)_
 ```mdtest-command
 echo '{ts:2024-09-10T21:12:33Z, action:"start"}

--- a/docs/language/operators/uniq.md
+++ b/docs/language/operators/uniq.md
@@ -44,6 +44,7 @@ echo '1 2 2 3' | zq -z 'uniq -c' -
 {value:2,count:2(uint64)}
 {value:3,count:1(uint64)}
 ```
+
 _Use sort to deduplicate non-adjacent values_
 ```mdtest-command
 echo '"hello" "world" "goodbye" "world" "hello" "again"' |


### PR DESCRIPTION
## What's Changing

Another example is being added to the docs for the `uniq` operator showing record values.

## Why

An recent inquiry from a user on community Slack showed a lack of understanding about how `uniq` works. I got the sense that they thought things like differing timestamp values in adjacent records would not result in "uniqueness". While I can't say with certainty the docs update here would have made the difference, looking at what we've got through the eyes of a new user, the way all the current examples show only primitive values could be improved upon.

## Details

FWIW, here was was in the [community Slack thread](https://brimdata.slack.com/archives/C010DR0HHMF/p1720591839542189) I was reacting to:

> I want to know why I can't use `uniq` filtering on column data
>
>  ![image](https://github.com/user-attachments/assets/bd6e2da9-6cc1-49f6-a428-be61982fdc08)

i.e., they seemed to think that the named fields in the `sort` would somehow carry over to what fields are considered by `uniq`. That's a leap far enough that I'm not inclined to add text speaking to that precise misunderstanding. But considering how many of our users still process logs with Zed/Zui, I figure having at least one example showing records may help a future user self-service via the docs before coming to Slack.