### PR TITLE
Implement vector record expressions

### DIFF
--- a/runtime/vam/expr/recordexpr.go
+++ b/runtime/vam/expr/recordexpr.go
@@ -68,7 +68,7 @@ func (r *recordExpr) addOrUpdateField(name string, vec vector.Any) {
 
 func (r *recordExpr) spread(vec vector.Any) {
 	// Ignore non-record values.
-	switch vec := vec.(type) {
+	switch vec := vector.Under(vec).(type) {
 	case *vector.Record:
 		for k, f := range zed.TypeRecordOf(vec.Type()).Fields {
 			r.addOrUpdateField(f.Name, vec.Fields[k])

--- a/runtime/vam/expr/recordexpr.go
+++ b/runtime/vam/expr/recordexpr.go
@@ -1,0 +1,83 @@
+package expr
+
+import (
+	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/vector"
+)
+
+type RecordElem struct {
+	Name string // "" means spread.
+	Expr Evaluator
+}
+
+func NewRecordExpr(zctx *zed.Context, elems []RecordElem) Evaluator {
+	return &recordExpr{
+		zctx:         zctx,
+		elems:        elems,
+		fieldIndexes: map[string]int{},
+	}
+}
+
+type recordExpr struct {
+	zctx  *zed.Context
+	elems []RecordElem
+
+	elemVecs     []vector.Any
+	fields       []zed.Field
+	fieldIndexes map[string]int
+	fieldVecs    []vector.Any
+}
+
+func (r *recordExpr) Eval(this vector.Any) vector.Any {
+	if len(r.elems) == 0 {
+		typ := r.zctx.MustLookupTypeRecord(nil)
+		return vector.NewRecord(typ, nil, this.Len(), nil)
+	}
+	r.elemVecs = r.elemVecs[:0]
+	for _, elem := range r.elems {
+		r.elemVecs = append(r.elemVecs, elem.Expr.Eval(this))
+	}
+	return vector.Apply(false, r.eval, r.elemVecs...)
+}
+
+func (r *recordExpr) eval(vecs ...vector.Any) vector.Any {
+	r.fields = r.fields[:0]
+	clear(r.fieldIndexes)
+	r.fieldVecs = make([]vector.Any, 0, len(r.elems))
+	for k, vec := range vecs {
+		if name := r.elems[k].Name; name != "" {
+			r.addOrUpdateField(name, vec)
+		} else {
+			r.spread(vec)
+		}
+	}
+	typ := r.zctx.MustLookupTypeRecord(r.fields)
+	return vector.NewRecord(typ, r.fieldVecs, r.fieldVecs[0].Len(), nil)
+}
+
+func (r *recordExpr) addOrUpdateField(name string, vec vector.Any) {
+	if i, ok := r.fieldIndexes[name]; ok {
+		r.fields[i].Type = vec.Type()
+		r.fieldVecs[i] = vec
+		return
+	}
+	r.fieldIndexes[name] = len(r.fields)
+	r.fields = append(r.fields, zed.NewField(name, vec.Type()))
+	r.fieldVecs = append(r.fieldVecs, vec)
+}
+
+func (r *recordExpr) spread(vec vector.Any) {
+	// Ignore non-record values.
+	switch vec := vec.(type) {
+	case *vector.Record:
+		for k, f := range zed.TypeRecordOf(vec.Type()).Fields {
+			r.addOrUpdateField(f.Name, vec.Fields[k])
+		}
+	case *vector.View:
+		if rec, ok := vec.Any.(*vector.Record); ok {
+			for k, f := range zed.TypeRecordOf(rec.Type()).Fields {
+				r.addOrUpdateField(f.Name, vector.NewView(vec.Index, rec.Fields[k]))
+			}
+		}
+	}
+}

--- a/runtime/ztests/expr/empty-record.yaml
+++ b/runtime/ztests/expr/empty-record.yaml
@@ -1,5 +1,7 @@
 zed: yield {}
 
+vector: true
+
 input: |
   {}
 

--- a/runtime/ztests/expr/record-spread-nested.yaml
+++ b/runtime/ztests/expr/record-spread-nested.yaml
@@ -1,5 +1,7 @@
 zed: yield {...{...r,a:1},b:2}
 
+vector: true
+
 input: |
   {r:{c:0}}
 

--- a/runtime/ztests/expr/record-spread.yaml
+++ b/runtime/ztests/expr/record-spread.yaml
@@ -1,5 +1,7 @@
 zed: yield {...r,b:b,c:2,...s}
 
+vector: true
+
 input: |
   123
   {r:{x:2},b:3}


### PR DESCRIPTION
Unlike the implementation in runtime/sam/expr/values.go, this one does not include an optimization for record expressions that do not include the spread operator.  That's on the assumption it isn't needed here since it only avoids work once per vector (compared with once per Zed value over in runtime/sam/expr).