### PR TITLE
Mention that conditionals can be chained

### DIFF
--- a/docs/language/expressions.md
+++ b/docs/language/expressions.md
@@ -195,7 +195,7 @@ produces
 -2
 ```
 
-Conditional expressions can be chained, providing the logical equivalent of
+Conditional expressions can be chained, providing behavior equivalent of
 "else if" as appears in other languages.
 
 For example,

--- a/docs/language/expressions.md
+++ b/docs/language/expressions.md
@@ -195,7 +195,7 @@ produces
 -2
 ```
 
-Conditional expressions can be chained, providing behavior equivalent of
+Conditional expressions can be chained, providing behavior equivalent to
 "else if" as appears in other languages.
 
 For example,

--- a/docs/language/expressions.md
+++ b/docs/language/expressions.md
@@ -195,6 +195,21 @@ produces
 -2
 ```
 
+Conditional expressions can be chained, providing the logical equivalent of
+"else if" as appears in other languages.
+
+For example,
+```mdtest-command
+echo '{s:"foo",v:1}{s:"bar",v:2}{s:"baz",v:3}' |
+  zq -z 'yield (s=="foo") ? v : (s=="bar") ? -v : v*v' -
+```
+produces
+```mdtest-output
+1
+-2
+9
+```
+
 Note that if the expression has side effects,
 as with [aggregate function calls](expressions.md#aggregate-function-calls), only the selected expression
 will be evaluated.


### PR DESCRIPTION
## What's Changing

An example is added to the user-facing docs for conditional expressions pointing out that they can be chained to provide an "else if" equivalent.

## Why

While astute readers would hopefully make this connection on their own, given the ternary syntax is already seen as obtuse by some, I figure the more we make explicit regarding its use, the better.
