### PR TITLE
Implement vector put operator

### DIFF
--- a/runtime/vam/expr/coerce.go
+++ b/runtime/vam/expr/coerce.go
@@ -91,8 +91,6 @@ func coerceVals(zctx *zed.Context, a, b vector.Any) (vector.Any, vector.Any, vec
 	//return id, ok
 }
 
-//XXX need to handle const here
-
 func promoteWider(id int, val vector.Any) vector.Any {
 	typ, err := zed.LookupPrimitiveByID(id)
 	if err != nil {
@@ -103,6 +101,14 @@ func promoteWider(id int, val vector.Any) vector.Any {
 		return val.Promote(typ)
 	case *vector.Uint:
 		return val.Promote(typ)
+	case *vector.Const:
+		var zedVal zed.Value
+		if zed.IsSigned(id) {
+			zedVal = zed.NewInt(typ, val.Value().Int())
+		} else {
+			zedVal = zed.NewUint(typ, val.Value().Uint())
+		}
+		return vector.NewConst(zedVal, val.Len(), val.Nulls)
 	case *vector.Dict:
 		promoted := val.Any.(vector.Promotable).Promote(typ)
 		return vector.NewDict(promoted, val.Index, val.Counts, val.Nulls)

--- a/runtime/vam/expr/putter.go
+++ b/runtime/vam/expr/putter.go
@@ -1,0 +1,30 @@
+package expr
+
+import (
+	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/vector"
+)
+
+// Putter adapts the behavior of recordExpr (obtained from NewRecordExpr) to
+// match that of the put operator, which emits an error when an input value is
+// not a record.
+type Putter struct {
+	zctx       *zed.Context
+	recordExpr Evaluator
+}
+
+func NewPutter(zctx *zed.Context, recordExpr Evaluator) *Putter {
+	return &Putter{zctx, recordExpr}
+}
+
+func (p *Putter) Eval(vec vector.Any) vector.Any {
+	return vector.Apply(false, p.eval, vec)
+}
+
+func (p *Putter) eval(vecs ...vector.Any) vector.Any {
+	vec := vecs[0]
+	if vec.Type().Kind() != zed.RecordKind {
+		return vector.NewWrappedError(p.zctx, "put: not a record", vec)
+	}
+	return p.recordExpr.Eval(vec)
+}

--- a/runtime/ztests/op/put-1.yaml
+++ b/runtime/ztests/op/put-1.yaml
@@ -1,6 +1,8 @@
 # Tests a simple expression written into a new field
 zed: put y := x + 1
 
+vector: true
+
 input: |
   {x:1(int32)}
   {x:2(int32)}

--- a/runtime/ztests/op/put-2.yaml
+++ b/runtime/ztests/op/put-2.yaml
@@ -1,6 +1,8 @@
 # Tests a simple expression written into an existing field
 zed: put x := x + 1
 
+vector: true
+
 input: |
   {x:1(int32)}
   {x:2(int32)}

--- a/runtime/ztests/op/put-3.yaml
+++ b/runtime/ztests/op/put-3.yaml
@@ -1,6 +1,8 @@
 # Tests writing a new record
 zed: put r2 := r
 
+vector: true
+
 input: |
   {r:{s:"hello"}}
   {r:{s:"world"}}

--- a/runtime/ztests/op/put-4.yaml
+++ b/runtime/ztests/op/put-4.yaml
@@ -1,6 +1,8 @@
 # Tests overwriting a primitive value with a record
 zed: put x := r
 
+vector: true
+
 input: |
   {x:1(int32),r:{s:"hello"}}
   {x:2(int32),r:{s:"world"}}

--- a/runtime/ztests/op/put-5.yaml
+++ b/runtime/ztests/op/put-5.yaml
@@ -1,6 +1,8 @@
 # Tests overwriting a record with a primitive value
 zed: put r := x
 
+vector: true
+
 input: |
   {x:1(int32),r:{s:"hello"}}
   {x:2(int32),r:{s:"world"}}

--- a/runtime/ztests/op/put-implied-1.yaml
+++ b/runtime/ztests/op/put-implied-1.yaml
@@ -1,5 +1,7 @@
 zed: y := x + 1
 
+vector: true
+
 input: |
   {x:1(int32)}
   {x:2(int32)}

--- a/runtime/ztests/op/put-implied-2.yaml
+++ b/runtime/ztests/op/put-implied-2.yaml
@@ -1,5 +1,7 @@
 zed: 'x:=upper(x), y:=lower(x)'
 
+vector: true
+
 input: |
   {x:"vAlUe1"}
 

--- a/runtime/ztests/op/put-multi-1.yaml
+++ b/runtime/ztests/op/put-multi-1.yaml
@@ -1,6 +1,8 @@
 # Tests multiple output expressions
 zed: put a:=1, b:=2
 
+vector: true
+
 input: |
   {x:1(int32)}
   {x:2(int32)}

--- a/runtime/ztests/op/put-multi-2.yaml
+++ b/runtime/ztests/op/put-multi-2.yaml
@@ -1,5 +1,7 @@
-# Test overwriting multiple fields out of order
-zed: put b:=a, a:=b
+# Test overwriting multiple fields in-order
+zed: put a:=b, b:=a
+
+vector: true
 
 input: |
   {a:1(int32),b:2(int32)}

--- a/runtime/ztests/op/put-multi-3.yaml
+++ b/runtime/ztests/op/put-multi-3.yaml
@@ -1,5 +1,7 @@
-# Test overwriting multiple fields in-order
-zed: put a:=b, b:=a
+# Test overwriting multiple fields out of order
+zed: put b:=a, a:=b
+
+vector: true
 
 input: |
   {a:1(int32),b:2(int32)}

--- a/runtime/ztests/op/put-multi-4.yaml
+++ b/runtime/ztests/op/put-multi-4.yaml
@@ -2,6 +2,8 @@
 # creates a new field
 zed: put new:=1, x:=x+1
 
+vector: true
+
 input: |
   {x:1(int32)}
   {x:2(int32)}

--- a/runtime/ztests/op/put-non-record.yaml
+++ b/runtime/ztests/op/put-non-record.yaml
@@ -1,0 +1,9 @@
+zed: put a:=1
+
+vector: true
+
+input: |
+  0
+
+output: |
+  error({message:"put: not a record",on:0})

--- a/runtime/ztests/op/put-null.yaml
+++ b/runtime/ztests/op/put-null.yaml
@@ -1,5 +1,7 @@
 zed: put b:=null
 
+vector: true
+
 input: |
   {a:1(int32)}
 

--- a/runtime/ztests/op/put-overwrite-132.yaml
+++ b/runtime/ztests/op/put-overwrite-132.yaml
@@ -4,6 +4,8 @@
 # and this test will need to be updated.
 zed: put c:=1,a:=3,b:=2
 
+vector: true
+
 input: |
   {a:1(int32),b:2(int32),c:3(int32)}
 

--- a/runtime/ztests/op/put-overwrite-321.yaml
+++ b/runtime/ztests/op/put-overwrite-321.yaml
@@ -1,5 +1,7 @@
 zed: put a:=3,b:=2,c:=1
 
+vector: true
+
 input: |
   {a:1(int32),b:2(int32)}
 

--- a/runtime/ztests/op/put-root.yaml
+++ b/runtime/ztests/op/put-root.yaml
@@ -1,5 +1,7 @@
 zed: yield a
 
+vector: true
+
 input: |
   {"a": {"a": "a", "b": "b"}, "b": "b"}
 


### PR DESCRIPTION
Unlike the sequence put operator, this does not yet support dynamic field names (e.g., "put this[a] := 1") because it is implemented in terms of record expressions.