### PR TITLE
Emphasize that head and tail take a constant expression

### DIFF
--- a/docs/language/operators/head.md
+++ b/docs/language/operators/head.md
@@ -5,12 +5,14 @@
 ### Synopsis
 
 ```
-head [ <expr> ]
+head [ <const-expr> ]
 ```
 ### Description
 
-The `head` operator copies the first `n` values, evaluated from `<expr>`, from its input to its output
-and ends the sequence thereafter. `<expr>` must evaluate to a positive integer at compile time.
+The `head` operator copies the first N values from its input to its output and ends
+the sequence thereafter. N is given by `<const-expr>`, a compile-time
+constant expression that evaluates to a positive integer. If `<const-expr>`
+is not provided, the value of N defaults to `1`.
 
 ### Examples
 

--- a/docs/language/operators/tail.md
+++ b/docs/language/operators/tail.md
@@ -5,12 +5,14 @@
 ### Synopsis
 
 ```
-tail [ <expr> ]
+tail [ <const-expr> ]
 ```
 ### Description
 
-The `tail` operator copies the last `n` values, evaluated from `<expr>`, from its input to its output
-and ends the sequence thereafter. `<expr>` must evaluate to a positive integer at compile time.
+The `tail` operator copies the last N from its input to its output and ends
+the sequence thereafter. N is given by `<const-expr>`, a compile-time
+constant expression that evaluates to a positive integer. If `<const-expr>`
+is not provided, the value of N defaults to `1`.
 
 ### Examples
 


### PR DESCRIPTION
## What's Changing

The user-facing docs for the `head` and `tail` operators will now emphasize that their parameter is a constant expression.

## Why

A user expressed confusion about this in a recent [community Slack thread](https://brimdata.slack.com/archives/CTSMAK6G7/p1727020579850509).

## Details

As described [here](https://github.com/brimdata/zed/pull/5276#discussion_r1759802265), we actually just recently disclosed this same subtlety as relates to the `top` operator.