### PR TITLE
allow panics inside PEG parser

### DIFF
--- a/compiler/parser/api.go
+++ b/compiler/parser/api.go
@@ -15,7 +15,7 @@ func ParseZed(filenames []string, src string) (ast.Seq, *SourceSet, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	p, err := Parse("", []byte(sset.Text))
+	p, err := Parse("", []byte(sset.Text), Recover(false))
 	if err != nil {
 		return nil, nil, convertErrList(err, sset)
 	}


### PR DESCRIPTION
This commit changes the default behavior of the PEG parser to not recover from panics.  Previously, a panic would be caught and converted to an error then we would report the error as a syntax error. There should be no panics in the grammar and if there are, they should be displayed to users so bugs can be filed and fixed.