### PR TITLE
vector.View: rebuild nulls

### DIFF
--- a/vector/view.go
+++ b/vector/view.go
@@ -46,16 +46,16 @@ func nullsView(nulls *Bool, index []uint32) *Bool {
 	if nulls == nil {
 		return nil
 	}
-	out := NewBoolEmpty(uint32(len(index)), nil)
+	var out *Bool
 	for k, slot := range index {
 		if nulls.Value(slot) {
+			if out == nil {
+				out = NewBoolEmpty(uint32(len(index)), nil)
+			}
 			out.Set(uint32(k))
 		}
 	}
-	if out.Len() > 0 {
-		return out
-	}
-	return nil
+	return out
 }
 
 func viewForUnionOrDynamic(index, tags, forward []uint32, values []Any) ([]uint32, []Any) {

--- a/vector/view.go
+++ b/vector/view.go
@@ -13,6 +13,8 @@ var _ Any = (*View)(nil)
 
 func NewView(index []uint32, val Any) Any {
 	switch val := val.(type) {
+	case *Const:
+		return NewConst(val.val, uint32(len(index)), nullsView(val.Nulls, index))
 	case *Dict:
 		index2 := make([]byte, len(index))
 		nulls := NewBoolEmpty(uint32(len(index)), nil)
@@ -23,9 +25,11 @@ func NewView(index []uint32, val Any) Any {
 			index2[k] = val.Index[idx]
 		}
 		return NewDict(val.Any, index2, nil, nulls)
+	case *Error:
+		return NewError(val.Typ, NewView(index, val.Vals), nullsView(val.Nulls, index))
 	case *Union:
 		tags, values := viewForUnionOrDynamic(index, val.Tags, val.TagMap.Forward, val.Values)
-		return NewUnion(val.Typ, tags, values, nil)
+		return NewUnion(val.Typ, tags, values, nullsView(val.Nulls, index))
 	case *Dynamic:
 		return NewDynamic(viewForUnionOrDynamic(index, val.Tags, val.TagMap.Forward, val.Values))
 	case *View:
@@ -36,6 +40,22 @@ func NewView(index []uint32, val Any) Any {
 		return &View{val.Any, index2}
 	}
 	return &View{val, index}
+}
+
+func nullsView(nulls *Bool, index []uint32) *Bool {
+	if nulls == nil {
+		return nil
+	}
+	out := NewBoolEmpty(uint32(len(index)), nil)
+	for k, slot := range index {
+		if nulls.Value(slot) {
+			out.Set(uint32(k))
+		}
+	}
+	if out.Len() > 0 {
+		return out
+	}
+	return nil
 }
 
 func viewForUnionOrDynamic(index, tags, forward []uint32, values []Any) ([]uint32, []Any) {


### PR DESCRIPTION
The commit changes the behavior when wrapping Const, Errors and Unions. Consts and Errors are now rebuilt rather than getting wrapped in a View. For all these values if there is a non-nil nulls value the Bool vector is rebuilt.