### PR TITLE
Implement vector kind() function

### DIFF
--- a/runtime/vam/expr/eval.go
+++ b/runtime/vam/expr/eval.go
@@ -13,16 +13,22 @@ type Function interface {
 }
 
 type Call struct {
-	fn    Function
-	exprs []Evaluator
-	args  []vector.Any
+	fn        Function
+	exprs     []Evaluator
+	ripUnions bool
+	args      []vector.Any
 }
 
 func NewCall(fn Function, exprs []Evaluator) *Call {
+	ripUnions := true
+	if fn, ok := fn.(interface{ RipUnions() bool }); ok {
+		ripUnions = fn.RipUnions()
+	}
 	return &Call{
-		fn:    fn,
-		exprs: exprs,
-		args:  make([]vector.Any, len(exprs)),
+		fn:        fn,
+		exprs:     exprs,
+		ripUnions: ripUnions,
+		args:      make([]vector.Any, len(exprs)),
 	}
 }
 
@@ -30,5 +36,5 @@ func (c *Call) Eval(this vector.Any) vector.Any {
 	for k, e := range c.exprs {
 		c.args[k] = e.Eval(this)
 	}
-	return vector.Apply(true, c.fn.Call, c.args...)
+	return vector.Apply(c.ripUnions, c.fn.Call, c.args...)
 }

--- a/runtime/vam/expr/function/function.go
+++ b/runtime/vam/expr/function/function.go
@@ -23,6 +23,8 @@ func New(zctx *zed.Context, name string, narg int) (expr.Function, field.Path, e
 	case "join":
 		argmax = 2
 		f = &Join{zctx: zctx}
+	case "kind":
+		f = &Kind{zctx: zctx}
 	case "len":
 		f = &Len{zctx}
 	case "levenshtein":

--- a/runtime/vam/expr/function/types.go
+++ b/runtime/vam/expr/function/types.go
@@ -14,3 +14,37 @@ func (t *TypeOf) Call(args ...vector.Any) vector.Any {
 	val := t.zctx.LookupTypeValue(args[0].Type())
 	return vector.NewConst(val, args[0].Len(), nil)
 }
+
+// https://github.com/brimdata/zed/blob/main/docs/language/functions.md#kind
+type Kind struct {
+	zctx *zed.Context
+}
+
+func NewKind(zctx *zed.Context) *Kind {
+	return &Kind{zctx}
+}
+
+func (k *Kind) Call(args ...vector.Any) vector.Any {
+	vec := vector.Under(args[0])
+	if typ := vec.Type(); typ.ID() != zed.IDType {
+		s := typ.Kind().String()
+		return vector.NewConst(zed.NewString(s), vec.Len(), nil)
+	}
+	out := vector.NewStringEmpty(vec.Len(), nil)
+	for i, n := uint32(0), vec.Len(); i < n; i++ {
+		var s string
+		if bytes, null := vector.TypeValueValue(vec, i); !null {
+			typ, err := k.zctx.LookupByValue(bytes)
+			if err != nil {
+				panic(err)
+			}
+			s = typ.Kind().String()
+		}
+		out.Append(s)
+	}
+	return out
+}
+
+func (*Kind) RipUnions() bool {
+	return false
+}

--- a/runtime/ztests/expr/function/kind.yaml
+++ b/runtime/ztests/expr/function/kind.yaml
@@ -1,5 +1,7 @@
 zed: yield {val:this, kind:kind(this)}
 
+vector: true
+
 input: |
   null
   null(bytes)


### PR DESCRIPTION
This includes changes to runtime/vam/expr.Call that allow runtime/vam/expr/function.Kind to tell it not to rip unions by implementing a "RipUnions() bool" method.