### PR TITLE
Delete compiler/ast/dag.Assignment.ExprDAG

### DIFF
--- a/compiler/ast/dag/expr.go
+++ b/compiler/ast/dag/expr.go
@@ -141,7 +141,6 @@ type (
 
 func (*Agg) ExprDAG()          {}
 func (*ArrayExpr) ExprDAG()    {}
-func (*Assignment) ExprDAG()   {}
 func (*BadExpr) ExprDAG()      {}
 func (*BinaryExpr) ExprDAG()   {}
 func (*Call) ExprDAG()         {}


### PR DESCRIPTION
Assignment isn't an Expr so it need not implement ExprDAG.