### PR TITLE
Fix panic on filepath.Walk error in ztest.findZTests

### DIFF
--- a/zed_test.go
+++ b/zed_test.go
@@ -55,10 +55,13 @@ func findZTests() (map[string]struct{}, error) {
 	pattern := fmt.Sprintf(`.*ztests\%c.*\.yaml$`, filepath.Separator)
 	re := regexp.MustCompile(pattern)
 	err := filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if !info.IsDir() && strings.HasSuffix(path, ".yaml") && re.MatchString(path) {
 			dirs[filepath.Dir(path)] = struct{}{}
 		}
-		return err
+		return nil
 	})
 	return dirs, err
 }


### PR DESCRIPTION
If filepath.Walk gets an error from os.Lstat, it invokes its callback with a nil os.FileInfo and the error.  This will cause findZTests to panic because its filepath.Walk callback does not check for an error before calling os.FileInfo.IsDir.  Fix by checking for an error in the callback.