### PR TITLE
Return a Super error on UDF stack overflow

### DIFF
--- a/compiler/kernel/expr.go
+++ b/compiler/kernel/expr.go
@@ -344,7 +344,7 @@ func (b *Builder) compileUDFCall(name string, body dag.Expr) (expr.Function, err
 	if fn, ok := b.compiledUDFs[name]; ok {
 		return fn, nil
 	}
-	fn := &expr.UDF{}
+	fn := &expr.UDF{Name: name, Zctx: b.zctx()}
 	// We store compiled UDF calls here so as to avoid stack overflows on
 	// recursive calls.
 	b.compiledUDFs[name] = fn

--- a/runtime/sam/expr/udf.go
+++ b/runtime/sam/expr/udf.go
@@ -10,6 +10,8 @@ const maxStackDepth = 10_000
 
 type UDF struct {
 	Body Evaluator
+	Name string
+	Zctx *super.Context
 }
 
 func (u *UDF) Call(ectx super.Allocator, args []super.Value) super.Value {
@@ -18,7 +20,7 @@ func (u *UDF) Call(ectx super.Allocator, args []super.Value) super.Value {
 		stack += f.stack
 	}
 	if stack > maxStackDepth {
-		panic("stack overflow")
+		return u.Zctx.NewErrorf("stack overflow in function %q", u.Name)
 	}
 	// args must be cloned otherwise the values will be overwritten in
 	// recursive calls.

--- a/runtime/sam/expr/ztests/udf-overflow.yaml
+++ b/runtime/sam/expr/ztests/udf-overflow.yaml
@@ -7,4 +7,5 @@ zed: |
 input: |
   3
 
-errorRE: "stack overflow"
+output: |
+  error("stack overflow in function \"overflow\"")


### PR DESCRIPTION
A stack overflow in a user-defined function causes a panic.  Return a Super error instead.