### PR TITLE
Morph "super tutorial" doc into "For jq Users"

### DIFF
--- a/docs/tutorials/super-for-jq.md
+++ b/docs/tutorials/super-for-jq.md
@@ -3,7 +3,7 @@ weight: 1
 title: For jq Users
 ---
 
-SuperSQL’s pipes and shortcuts provide a flexible and powerful way for SQL
+[SuperSQL](../language/_index.md)’s pipes and shortcuts provide a flexible and powerful way for SQL
 users to query their JSON data while leveraging their existing skills.
 However, users who've traditionally wrangled their JSON with other tools such
 as [`jq`](https://stedolan.github.io/jq/) will find `super` equally powerful


### PR DESCRIPTION
## What's Changing

As a de-Zed-ing exercise, in this PR I propose morphing the [Super Tutorial](https://superdb.org/docs/tutorials/zq/) doc into a doc titled "For jq Users". Most of the original content is maintained, but I attempt to adjust its approach slightly to nod toward the SuperDB project's current lead-with-SuperSQL approach.

To review by reading the doc in its final form (which I recommend) rather than as diffs, I've put a copy of the rendered doc in a personal staging site: https://capable-khapse-fa9d06.netlify.app/docs/tutorials/super-for-jq/

## Details

Back when this doc was originally the "`zq` Tutorial" our target audience largely consisted of users of `jq` and similar command-line tools. In the current era of SuperSQL that's no longer the case, and yet everything about the data model, pipeline queries, and language shortcuts that first made the doc compelling are still present in the SuperDB project. We'd probably not _lead_ with this doc today--instead we'd be more likely to prominently point to the [`super` command doc](https://superdb.org/docs/commands/super/) that provides an introduction more tailored to a SQL-centric audience. But considering the original comparison to `jq` accumulated [460+ upvotes on HackerNews](https://news.ycombinator.com/item?id=31166956) and a [corresponding quick bump in ~500 GitHub stars](https://www.star-history.com/#brimdata/super&Date) back in April of 2022, it feels like the text is worth keeping in some form, either for a secondary audience of users that find SuperDB after having had a `jq`-centric background _or_ a SQL-centric user that quickly catches on that SuperSQL's approach provides the option to avoid static schemas, tables, and SQL itself if that's their preference.