### PR TITLE
Ensure invalid path element error is displayed once

### DIFF
--- a/compiler/ztests/dotted-path-err.yaml
+++ b/compiler/ztests/dotted-path-err.yaml
@@ -1,0 +1,12 @@
+# Previously the semantic pass would return this invalid path error twice.
+# This test verifies a change the ensures this error is only returned once.
+spq: |
+  op test(): ( yield this )
+  yield test.that
+
+vector: true
+
+error: |
+  symbol "test" is not bound to an expression at line 2, column 7:
+  yield test.that
+        ~~~~


### PR DESCRIPTION
Previously the semantic pass would display an invalid path error in dotted expressions twice, this commit fixes this behavior so the error is returned once.