### PR TITLE
Fix location of ast.JoinCond

### DIFF
--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -4011,28 +4011,32 @@ var g = &grammar{
 								name: "JoinRightInput",
 							},
 						},
+						&ruleRefExpr{
+							pos:  position{line: 581, col: 52, offset: 13824},
+							name: "_",
+						},
 						&labeledExpr{
-							pos:   position{line: 581, col: 52, offset: 13824},
+							pos:   position{line: 581, col: 54, offset: 13826},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 581, col: 54, offset: 13826},
+								pos:  position{line: 581, col: 56, offset: 13828},
 								name: "JoinExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 581, col: 63, offset: 13835},
+							pos:   position{line: 581, col: 65, offset: 13837},
 							label: "optArgs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 581, col: 71, offset: 13843},
+								pos: position{line: 581, col: 73, offset: 13845},
 								expr: &seqExpr{
-									pos: position{line: 581, col: 72, offset: 13844},
+									pos: position{line: 581, col: 74, offset: 13846},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 581, col: 72, offset: 13844},
+											pos:  position{line: 581, col: 74, offset: 13846},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 581, col: 74, offset: 13846},
+											pos:  position{line: 581, col: 76, offset: 13848},
 											name: "FlexAssignments",
 										},
 									},
@@ -4047,83 +4051,83 @@ var g = &grammar{
 		},
 		{
 			name: "JoinStyle",
-			pos:  position{line: 597, col: 1, offset: 14212},
+			pos:  position{line: 597, col: 1, offset: 14214},
 			expr: &choiceExpr{
-				pos: position{line: 598, col: 5, offset: 14226},
+				pos: position{line: 598, col: 5, offset: 14228},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 598, col: 5, offset: 14226},
+						pos: position{line: 598, col: 5, offset: 14228},
 						run: (*parser).callonJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 598, col: 5, offset: 14226},
+							pos: position{line: 598, col: 5, offset: 14228},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 598, col: 5, offset: 14226},
+									pos:  position{line: 598, col: 5, offset: 14228},
 									name: "ANTI",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 598, col: 10, offset: 14231},
+									pos:  position{line: 598, col: 10, offset: 14233},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 599, col: 5, offset: 14261},
+						pos: position{line: 599, col: 5, offset: 14263},
 						run: (*parser).callonJoinStyle6,
 						expr: &seqExpr{
-							pos: position{line: 599, col: 5, offset: 14261},
+							pos: position{line: 599, col: 5, offset: 14263},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 599, col: 5, offset: 14261},
+									pos:  position{line: 599, col: 5, offset: 14263},
 									name: "INNER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 599, col: 11, offset: 14267},
+									pos:  position{line: 599, col: 11, offset: 14269},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 600, col: 5, offset: 14297},
+						pos: position{line: 600, col: 5, offset: 14299},
 						run: (*parser).callonJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 600, col: 5, offset: 14297},
+							pos: position{line: 600, col: 5, offset: 14299},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 600, col: 5, offset: 14297},
+									pos:  position{line: 600, col: 5, offset: 14299},
 									name: "LEFT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 600, col: 11, offset: 14303},
+									pos:  position{line: 600, col: 11, offset: 14305},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 601, col: 5, offset: 14332},
+						pos: position{line: 601, col: 5, offset: 14334},
 						run: (*parser).callonJoinStyle14,
 						expr: &seqExpr{
-							pos: position{line: 601, col: 5, offset: 14332},
+							pos: position{line: 601, col: 5, offset: 14334},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 601, col: 5, offset: 14332},
+									pos:  position{line: 601, col: 5, offset: 14334},
 									name: "RIGHT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 601, col: 11, offset: 14338},
+									pos:  position{line: 601, col: 11, offset: 14340},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 602, col: 5, offset: 14368},
+						pos: position{line: 602, col: 5, offset: 14370},
 						run: (*parser).callonJoinStyle18,
 						expr: &litMatcher{
-							pos:        position{line: 602, col: 5, offset: 14368},
+							pos:        position{line: 602, col: 5, offset: 14370},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -4136,44 +4140,44 @@ var g = &grammar{
 		},
 		{
 			name: "JoinRightInput",
-			pos:  position{line: 604, col: 1, offset: 14396},
+			pos:  position{line: 604, col: 1, offset: 14398},
 			expr: &choiceExpr{
-				pos: position{line: 605, col: 5, offset: 14415},
+				pos: position{line: 605, col: 5, offset: 14417},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 605, col: 5, offset: 14415},
+						pos: position{line: 605, col: 5, offset: 14417},
 						run: (*parser).callonJoinRightInput2,
 						expr: &seqExpr{
-							pos: position{line: 605, col: 5, offset: 14415},
+							pos: position{line: 605, col: 5, offset: 14417},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 605, col: 5, offset: 14415},
+									pos:  position{line: 605, col: 5, offset: 14417},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 605, col: 8, offset: 14418},
+									pos:        position{line: 605, col: 8, offset: 14420},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 605, col: 12, offset: 14422},
+									pos:  position{line: 605, col: 12, offset: 14424},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 605, col: 15, offset: 14425},
+									pos:   position{line: 605, col: 15, offset: 14427},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 605, col: 17, offset: 14427},
+										pos:  position{line: 605, col: 17, offset: 14429},
 										name: "Seq",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 605, col: 21, offset: 14431},
+									pos:  position{line: 605, col: 21, offset: 14433},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 605, col: 24, offset: 14434},
+									pos:        position{line: 605, col: 24, offset: 14436},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4182,10 +4186,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 606, col: 5, offset: 14460},
+						pos: position{line: 606, col: 5, offset: 14462},
 						run: (*parser).callonJoinRightInput11,
 						expr: &litMatcher{
-							pos:        position{line: 606, col: 5, offset: 14460},
+							pos:        position{line: 606, col: 5, offset: 14462},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -4198,36 +4202,36 @@ var g = &grammar{
 		},
 		{
 			name: "JoinKey",
-			pos:  position{line: 608, col: 1, offset: 14484},
+			pos:  position{line: 608, col: 1, offset: 14486},
 			expr: &choiceExpr{
-				pos: position{line: 609, col: 5, offset: 14496},
+				pos: position{line: 609, col: 5, offset: 14498},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 609, col: 5, offset: 14496},
+						pos:  position{line: 609, col: 5, offset: 14498},
 						name: "Lval",
 					},
 					&actionExpr{
-						pos: position{line: 610, col: 5, offset: 14505},
+						pos: position{line: 610, col: 5, offset: 14507},
 						run: (*parser).callonJoinKey3,
 						expr: &seqExpr{
-							pos: position{line: 610, col: 5, offset: 14505},
+							pos: position{line: 610, col: 5, offset: 14507},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 610, col: 5, offset: 14505},
+									pos:        position{line: 610, col: 5, offset: 14507},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 610, col: 9, offset: 14509},
+									pos:   position{line: 610, col: 9, offset: 14511},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 610, col: 14, offset: 14514},
+										pos:  position{line: 610, col: 14, offset: 14516},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 610, col: 19, offset: 14519},
+									pos:        position{line: 610, col: 19, offset: 14521},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4242,44 +4246,44 @@ var g = &grammar{
 		},
 		{
 			name: "SampleOp",
-			pos:  position{line: 612, col: 1, offset: 14545},
+			pos:  position{line: 612, col: 1, offset: 14547},
 			expr: &actionExpr{
-				pos: position{line: 613, col: 5, offset: 14558},
+				pos: position{line: 613, col: 5, offset: 14560},
 				run: (*parser).callonSampleOp1,
 				expr: &seqExpr{
-					pos: position{line: 613, col: 5, offset: 14558},
+					pos: position{line: 613, col: 5, offset: 14560},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 613, col: 5, offset: 14558},
+							pos:  position{line: 613, col: 5, offset: 14560},
 							name: "SAMPLE",
 						},
 						&andExpr{
-							pos: position{line: 613, col: 12, offset: 14565},
+							pos: position{line: 613, col: 12, offset: 14567},
 							expr: &ruleRefExpr{
-								pos:  position{line: 613, col: 13, offset: 14566},
+								pos:  position{line: 613, col: 13, offset: 14568},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 613, col: 18, offset: 14571},
+							pos:   position{line: 613, col: 18, offset: 14573},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 613, col: 23, offset: 14576},
+								pos: position{line: 613, col: 23, offset: 14578},
 								expr: &actionExpr{
-									pos: position{line: 613, col: 24, offset: 14577},
+									pos: position{line: 613, col: 24, offset: 14579},
 									run: (*parser).callonSampleOp8,
 									expr: &seqExpr{
-										pos: position{line: 613, col: 24, offset: 14577},
+										pos: position{line: 613, col: 24, offset: 14579},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 613, col: 24, offset: 14577},
+												pos:  position{line: 613, col: 24, offset: 14579},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 613, col: 26, offset: 14579},
+												pos:   position{line: 613, col: 26, offset: 14581},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 613, col: 28, offset: 14581},
+													pos:  position{line: 613, col: 28, offset: 14583},
 													name: "Lval",
 												},
 											},
@@ -4296,15 +4300,15 @@ var g = &grammar{
 		},
 		{
 			name: "OpAssignment",
-			pos:  position{line: 626, col: 1, offset: 15020},
+			pos:  position{line: 626, col: 1, offset: 15022},
 			expr: &actionExpr{
-				pos: position{line: 627, col: 5, offset: 15037},
+				pos: position{line: 627, col: 5, offset: 15039},
 				run: (*parser).callonOpAssignment1,
 				expr: &labeledExpr{
-					pos:   position{line: 627, col: 5, offset: 15037},
+					pos:   position{line: 627, col: 5, offset: 15039},
 					label: "a",
 					expr: &ruleRefExpr{
-						pos:  position{line: 627, col: 7, offset: 15039},
+						pos:  position{line: 627, col: 7, offset: 15041},
 						name: "Assignments",
 					},
 				},
@@ -4314,69 +4318,69 @@ var g = &grammar{
 		},
 		{
 			name: "LoadOp",
-			pos:  position{line: 635, col: 1, offset: 15211},
+			pos:  position{line: 635, col: 1, offset: 15213},
 			expr: &actionExpr{
-				pos: position{line: 636, col: 5, offset: 15222},
+				pos: position{line: 636, col: 5, offset: 15224},
 				run: (*parser).callonLoadOp1,
 				expr: &seqExpr{
-					pos: position{line: 636, col: 5, offset: 15222},
+					pos: position{line: 636, col: 5, offset: 15224},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 636, col: 5, offset: 15222},
+							pos:  position{line: 636, col: 5, offset: 15224},
 							name: "LOAD",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 636, col: 10, offset: 15227},
+							pos:  position{line: 636, col: 10, offset: 15229},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 636, col: 12, offset: 15229},
+							pos:   position{line: 636, col: 12, offset: 15231},
 							label: "pool",
 							expr: &ruleRefExpr{
-								pos:  position{line: 636, col: 17, offset: 15234},
+								pos:  position{line: 636, col: 17, offset: 15236},
 								name: "Name",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 636, col: 22, offset: 15239},
+							pos:   position{line: 636, col: 22, offset: 15241},
 							label: "branch",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 636, col: 29, offset: 15246},
+								pos: position{line: 636, col: 29, offset: 15248},
 								expr: &ruleRefExpr{
-									pos:  position{line: 636, col: 29, offset: 15246},
+									pos:  position{line: 636, col: 29, offset: 15248},
 									name: "PoolBranch",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 636, col: 41, offset: 15258},
+							pos:   position{line: 636, col: 41, offset: 15260},
 							label: "author",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 636, col: 48, offset: 15265},
+								pos: position{line: 636, col: 48, offset: 15267},
 								expr: &ruleRefExpr{
-									pos:  position{line: 636, col: 48, offset: 15265},
+									pos:  position{line: 636, col: 48, offset: 15267},
 									name: "AuthorArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 636, col: 59, offset: 15276},
+							pos:   position{line: 636, col: 59, offset: 15278},
 							label: "message",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 636, col: 67, offset: 15284},
+								pos: position{line: 636, col: 67, offset: 15286},
 								expr: &ruleRefExpr{
-									pos:  position{line: 636, col: 67, offset: 15284},
+									pos:  position{line: 636, col: 67, offset: 15286},
 									name: "MessageArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 636, col: 79, offset: 15296},
+							pos:   position{line: 636, col: 79, offset: 15298},
 							label: "meta",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 636, col: 84, offset: 15301},
+								pos: position{line: 636, col: 84, offset: 15303},
 								expr: &ruleRefExpr{
-									pos:  position{line: 636, col: 84, offset: 15301},
+									pos:  position{line: 636, col: 84, offset: 15303},
 									name: "MetaArg",
 								},
 							},
@@ -4389,30 +4393,30 @@ var g = &grammar{
 		},
 		{
 			name: "AuthorArg",
-			pos:  position{line: 648, col: 1, offset: 15583},
+			pos:  position{line: 648, col: 1, offset: 15585},
 			expr: &actionExpr{
-				pos: position{line: 649, col: 5, offset: 15597},
+				pos: position{line: 649, col: 5, offset: 15599},
 				run: (*parser).callonAuthorArg1,
 				expr: &seqExpr{
-					pos: position{line: 649, col: 5, offset: 15597},
+					pos: position{line: 649, col: 5, offset: 15599},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 649, col: 5, offset: 15597},
+							pos:  position{line: 649, col: 5, offset: 15599},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 649, col: 7, offset: 15599},
+							pos:  position{line: 649, col: 7, offset: 15601},
 							name: "AUTHOR",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 649, col: 14, offset: 15606},
+							pos:  position{line: 649, col: 14, offset: 15608},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 649, col: 16, offset: 15608},
+							pos:   position{line: 649, col: 16, offset: 15610},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 649, col: 18, offset: 15610},
+								pos:  position{line: 649, col: 18, offset: 15612},
 								name: "Name",
 							},
 						},
@@ -4424,30 +4428,30 @@ var g = &grammar{
 		},
 		{
 			name: "MessageArg",
-			pos:  position{line: 651, col: 1, offset: 15634},
+			pos:  position{line: 651, col: 1, offset: 15636},
 			expr: &actionExpr{
-				pos: position{line: 652, col: 5, offset: 15649},
+				pos: position{line: 652, col: 5, offset: 15651},
 				run: (*parser).callonMessageArg1,
 				expr: &seqExpr{
-					pos: position{line: 652, col: 5, offset: 15649},
+					pos: position{line: 652, col: 5, offset: 15651},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 652, col: 5, offset: 15649},
+							pos:  position{line: 652, col: 5, offset: 15651},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 652, col: 7, offset: 15651},
+							pos:  position{line: 652, col: 7, offset: 15653},
 							name: "MESSAGE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 652, col: 15, offset: 15659},
+							pos:  position{line: 652, col: 15, offset: 15661},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 652, col: 17, offset: 15661},
+							pos:   position{line: 652, col: 17, offset: 15663},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 652, col: 19, offset: 15663},
+								pos:  position{line: 652, col: 19, offset: 15665},
 								name: "Name",
 							},
 						},
@@ -4459,30 +4463,30 @@ var g = &grammar{
 		},
 		{
 			name: "MetaArg",
-			pos:  position{line: 654, col: 1, offset: 15687},
+			pos:  position{line: 654, col: 1, offset: 15689},
 			expr: &actionExpr{
-				pos: position{line: 655, col: 5, offset: 15699},
+				pos: position{line: 655, col: 5, offset: 15701},
 				run: (*parser).callonMetaArg1,
 				expr: &seqExpr{
-					pos: position{line: 655, col: 5, offset: 15699},
+					pos: position{line: 655, col: 5, offset: 15701},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 655, col: 5, offset: 15699},
+							pos:  position{line: 655, col: 5, offset: 15701},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 655, col: 7, offset: 15701},
+							pos:  position{line: 655, col: 7, offset: 15703},
 							name: "META",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 655, col: 12, offset: 15706},
+							pos:  position{line: 655, col: 12, offset: 15708},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 655, col: 14, offset: 15708},
+							pos:   position{line: 655, col: 14, offset: 15710},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 655, col: 16, offset: 15710},
+								pos:  position{line: 655, col: 16, offset: 15712},
 								name: "Name",
 							},
 						},
@@ -4494,24 +4498,24 @@ var g = &grammar{
 		},
 		{
 			name: "PoolBranch",
-			pos:  position{line: 657, col: 1, offset: 15734},
+			pos:  position{line: 657, col: 1, offset: 15736},
 			expr: &actionExpr{
-				pos: position{line: 658, col: 5, offset: 15749},
+				pos: position{line: 658, col: 5, offset: 15751},
 				run: (*parser).callonPoolBranch1,
 				expr: &seqExpr{
-					pos: position{line: 658, col: 5, offset: 15749},
+					pos: position{line: 658, col: 5, offset: 15751},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 658, col: 5, offset: 15749},
+							pos:        position{line: 658, col: 5, offset: 15751},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 658, col: 9, offset: 15753},
+							pos:   position{line: 658, col: 9, offset: 15755},
 							label: "branch",
 							expr: &ruleRefExpr{
-								pos:  position{line: 658, col: 16, offset: 15760},
+								pos:  position{line: 658, col: 16, offset: 15762},
 								name: "Name",
 							},
 						},
@@ -4523,26 +4527,26 @@ var g = &grammar{
 		},
 		{
 			name: "OutputOp",
-			pos:  position{line: 660, col: 1, offset: 15789},
+			pos:  position{line: 660, col: 1, offset: 15791},
 			expr: &actionExpr{
-				pos: position{line: 661, col: 5, offset: 15802},
+				pos: position{line: 661, col: 5, offset: 15804},
 				run: (*parser).callonOutputOp1,
 				expr: &seqExpr{
-					pos: position{line: 661, col: 5, offset: 15802},
+					pos: position{line: 661, col: 5, offset: 15804},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 661, col: 5, offset: 15802},
+							pos:  position{line: 661, col: 5, offset: 15804},
 							name: "OUTPUT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 661, col: 12, offset: 15809},
+							pos:  position{line: 661, col: 12, offset: 15811},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 661, col: 14, offset: 15811},
+							pos:   position{line: 661, col: 14, offset: 15813},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 661, col: 19, offset: 15816},
+								pos:  position{line: 661, col: 19, offset: 15818},
 								name: "Identifier",
 							},
 						},
@@ -4554,44 +4558,44 @@ var g = &grammar{
 		},
 		{
 			name: "DebugOp",
-			pos:  position{line: 669, col: 1, offset: 15950},
+			pos:  position{line: 669, col: 1, offset: 15952},
 			expr: &actionExpr{
-				pos: position{line: 670, col: 5, offset: 15962},
+				pos: position{line: 670, col: 5, offset: 15964},
 				run: (*parser).callonDebugOp1,
 				expr: &seqExpr{
-					pos: position{line: 670, col: 5, offset: 15962},
+					pos: position{line: 670, col: 5, offset: 15964},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 670, col: 5, offset: 15962},
+							pos:  position{line: 670, col: 5, offset: 15964},
 							name: "DEBUG",
 						},
 						&andExpr{
-							pos: position{line: 670, col: 11, offset: 15968},
+							pos: position{line: 670, col: 11, offset: 15970},
 							expr: &ruleRefExpr{
-								pos:  position{line: 670, col: 12, offset: 15969},
+								pos:  position{line: 670, col: 12, offset: 15971},
 								name: "EOKW",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 670, col: 17, offset: 15974},
+							pos:   position{line: 670, col: 17, offset: 15976},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 670, col: 22, offset: 15979},
+								pos: position{line: 670, col: 22, offset: 15981},
 								expr: &actionExpr{
-									pos: position{line: 670, col: 23, offset: 15980},
+									pos: position{line: 670, col: 23, offset: 15982},
 									run: (*parser).callonDebugOp8,
 									expr: &seqExpr{
-										pos: position{line: 670, col: 23, offset: 15980},
+										pos: position{line: 670, col: 23, offset: 15982},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 670, col: 23, offset: 15980},
+												pos:  position{line: 670, col: 23, offset: 15982},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 670, col: 25, offset: 15982},
+												pos:   position{line: 670, col: 25, offset: 15984},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 670, col: 27, offset: 15984},
+													pos:  position{line: 670, col: 27, offset: 15986},
 													name: "Expr",
 												},
 											},
@@ -4608,26 +4612,26 @@ var g = &grammar{
 		},
 		{
 			name: "FromOp",
-			pos:  position{line: 681, col: 1, offset: 16177},
+			pos:  position{line: 681, col: 1, offset: 16179},
 			expr: &actionExpr{
-				pos: position{line: 682, col: 5, offset: 16188},
+				pos: position{line: 682, col: 5, offset: 16190},
 				run: (*parser).callonFromOp1,
 				expr: &seqExpr{
-					pos: position{line: 682, col: 5, offset: 16188},
+					pos: position{line: 682, col: 5, offset: 16190},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 682, col: 5, offset: 16188},
+							pos:  position{line: 682, col: 5, offset: 16190},
 							name: "FromKeyWord",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 682, col: 17, offset: 16200},
+							pos:  position{line: 682, col: 17, offset: 16202},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 682, col: 19, offset: 16202},
+							pos:   position{line: 682, col: 19, offset: 16204},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 682, col: 25, offset: 16208},
+								pos:  position{line: 682, col: 25, offset: 16210},
 								name: "FromElems",
 							},
 						},
@@ -4639,16 +4643,16 @@ var g = &grammar{
 		},
 		{
 			name: "FromKeyWord",
-			pos:  position{line: 690, col: 1, offset: 16351},
+			pos:  position{line: 690, col: 1, offset: 16353},
 			expr: &choiceExpr{
-				pos: position{line: 691, col: 5, offset: 16367},
+				pos: position{line: 691, col: 5, offset: 16369},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 691, col: 5, offset: 16367},
+						pos:  position{line: 691, col: 5, offset: 16369},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 692, col: 5, offset: 16376},
+						pos:  position{line: 692, col: 5, offset: 16378},
 						name: "DeprecatedFroms",
 					},
 				},
@@ -4658,24 +4662,24 @@ var g = &grammar{
 		},
 		{
 			name: "DeprecatedFroms",
-			pos:  position{line: 694, col: 1, offset: 16393},
+			pos:  position{line: 694, col: 1, offset: 16395},
 			expr: &choiceExpr{
-				pos: position{line: 694, col: 19, offset: 16411},
+				pos: position{line: 694, col: 19, offset: 16413},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 694, col: 19, offset: 16411},
+						pos:        position{line: 694, col: 19, offset: 16413},
 						val:        "get",
 						ignoreCase: false,
 						want:       "\"get\"",
 					},
 					&litMatcher{
-						pos:        position{line: 694, col: 27, offset: 16419},
+						pos:        position{line: 694, col: 27, offset: 16421},
 						val:        "file",
 						ignoreCase: false,
 						want:       "\"file\"",
 					},
 					&litMatcher{
-						pos:        position{line: 694, col: 36, offset: 16428},
+						pos:        position{line: 694, col: 36, offset: 16430},
 						val:        "pool",
 						ignoreCase: false,
 						want:       "\"pool\"",
@@ -4687,51 +4691,51 @@ var g = &grammar{
 		},
 		{
 			name: "FromElems",
-			pos:  position{line: 696, col: 1, offset: 16436},
+			pos:  position{line: 696, col: 1, offset: 16438},
 			expr: &actionExpr{
-				pos: position{line: 697, col: 5, offset: 16450},
+				pos: position{line: 697, col: 5, offset: 16452},
 				run: (*parser).callonFromElems1,
 				expr: &seqExpr{
-					pos: position{line: 697, col: 5, offset: 16450},
+					pos: position{line: 697, col: 5, offset: 16452},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 697, col: 5, offset: 16450},
+							pos:   position{line: 697, col: 5, offset: 16452},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 697, col: 11, offset: 16456},
+								pos:  position{line: 697, col: 11, offset: 16458},
 								name: "FromElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 697, col: 20, offset: 16465},
+							pos:   position{line: 697, col: 20, offset: 16467},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 697, col: 25, offset: 16470},
+								pos: position{line: 697, col: 25, offset: 16472},
 								expr: &actionExpr{
-									pos: position{line: 697, col: 27, offset: 16472},
+									pos: position{line: 697, col: 27, offset: 16474},
 									run: (*parser).callonFromElems7,
 									expr: &seqExpr{
-										pos: position{line: 697, col: 27, offset: 16472},
+										pos: position{line: 697, col: 27, offset: 16474},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 697, col: 27, offset: 16472},
+												pos:  position{line: 697, col: 27, offset: 16474},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 697, col: 30, offset: 16475},
+												pos:        position{line: 697, col: 30, offset: 16477},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 697, col: 34, offset: 16479},
+												pos:  position{line: 697, col: 34, offset: 16481},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 697, col: 37, offset: 16482},
+												pos:   position{line: 697, col: 37, offset: 16484},
 												label: "elem",
 												expr: &ruleRefExpr{
-													pos:  position{line: 697, col: 42, offset: 16487},
+													pos:  position{line: 697, col: 42, offset: 16489},
 													name: "FromElem",
 												},
 											},
@@ -4748,42 +4752,42 @@ var g = &grammar{
 		},
 		{
 			name: "FromElem",
-			pos:  position{line: 701, col: 1, offset: 16571},
+			pos:  position{line: 701, col: 1, offset: 16573},
 			expr: &actionExpr{
-				pos: position{line: 702, col: 5, offset: 16584},
+				pos: position{line: 702, col: 5, offset: 16586},
 				run: (*parser).callonFromElem1,
 				expr: &seqExpr{
-					pos: position{line: 702, col: 5, offset: 16584},
+					pos: position{line: 702, col: 5, offset: 16586},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 702, col: 5, offset: 16584},
+							pos:   position{line: 702, col: 5, offset: 16586},
 							label: "entity",
 							expr: &ruleRefExpr{
-								pos:  position{line: 702, col: 12, offset: 16591},
+								pos:  position{line: 702, col: 12, offset: 16593},
 								name: "FromEntity",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 702, col: 23, offset: 16602},
+							pos:   position{line: 702, col: 23, offset: 16604},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 702, col: 28, offset: 16607},
+								pos:  position{line: 702, col: 28, offset: 16609},
 								name: "FromArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 702, col: 37, offset: 16616},
+							pos:   position{line: 702, col: 37, offset: 16618},
 							label: "o",
 							expr: &ruleRefExpr{
-								pos:  position{line: 702, col: 39, offset: 16618},
+								pos:  position{line: 702, col: 39, offset: 16620},
 								name: "OptOrdinality",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 702, col: 53, offset: 16632},
+							pos:   position{line: 702, col: 53, offset: 16634},
 							label: "alias",
 							expr: &ruleRefExpr{
-								pos:  position{line: 702, col: 59, offset: 16638},
+								pos:  position{line: 702, col: 59, offset: 16640},
 								name: "OptAlias",
 							},
 						},
@@ -4795,46 +4799,46 @@ var g = &grammar{
 		},
 		{
 			name: "FromEntity",
-			pos:  position{line: 720, col: 1, offset: 17032},
+			pos:  position{line: 720, col: 1, offset: 17034},
 			expr: &choiceExpr{
-				pos: position{line: 721, col: 5, offset: 17047},
+				pos: position{line: 721, col: 5, offset: 17049},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 721, col: 5, offset: 17047},
+						pos: position{line: 721, col: 5, offset: 17049},
 						run: (*parser).callonFromEntity2,
 						expr: &labeledExpr{
-							pos:   position{line: 721, col: 5, offset: 17047},
+							pos:   position{line: 721, col: 5, offset: 17049},
 							label: "url",
 							expr: &ruleRefExpr{
-								pos:  position{line: 721, col: 9, offset: 17051},
+								pos:  position{line: 721, col: 9, offset: 17053},
 								name: "UnquotedURL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 728, col: 5, offset: 17183},
+						pos:  position{line: 728, col: 5, offset: 17185},
 						name: "Regexp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 729, col: 5, offset: 17194},
+						pos:  position{line: 729, col: 5, offset: 17196},
 						name: "Glob",
 					},
 					&actionExpr{
-						pos: position{line: 730, col: 5, offset: 17203},
+						pos: position{line: 730, col: 5, offset: 17205},
 						run: (*parser).callonFromEntity7,
 						expr: &seqExpr{
-							pos: position{line: 730, col: 5, offset: 17203},
+							pos: position{line: 730, col: 5, offset: 17205},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 730, col: 5, offset: 17203},
+									pos:        position{line: 730, col: 5, offset: 17205},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 								&notExpr{
-									pos: position{line: 730, col: 9, offset: 17207},
+									pos: position{line: 730, col: 9, offset: 17209},
 									expr: &ruleRefExpr{
-										pos:  position{line: 730, col: 10, offset: 17208},
+										pos:  position{line: 730, col: 10, offset: 17210},
 										name: "ExprGuard",
 									},
 								},
@@ -4842,43 +4846,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 731, col: 5, offset: 17289},
+						pos: position{line: 731, col: 5, offset: 17291},
 						run: (*parser).callonFromEntity12,
 						expr: &seqExpr{
-							pos: position{line: 731, col: 5, offset: 17289},
+							pos: position{line: 731, col: 5, offset: 17291},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 731, col: 5, offset: 17289},
+									pos:  position{line: 731, col: 5, offset: 17291},
 									name: "EVAL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 731, col: 10, offset: 17294},
+									pos:  position{line: 731, col: 10, offset: 17296},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 731, col: 13, offset: 17297},
+									pos:        position{line: 731, col: 13, offset: 17299},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 731, col: 17, offset: 17301},
+									pos:  position{line: 731, col: 17, offset: 17303},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 731, col: 20, offset: 17304},
+									pos:   position{line: 731, col: 20, offset: 17306},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 731, col: 22, offset: 17306},
+										pos:  position{line: 731, col: 22, offset: 17308},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 731, col: 27, offset: 17311},
+									pos:  position{line: 731, col: 27, offset: 17313},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 731, col: 30, offset: 17314},
+									pos:        position{line: 731, col: 30, offset: 17316},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4887,35 +4891,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 738, col: 5, offset: 17450},
+						pos: position{line: 738, col: 5, offset: 17452},
 						run: (*parser).callonFromEntity22,
 						expr: &labeledExpr{
-							pos:   position{line: 738, col: 5, offset: 17450},
+							pos:   position{line: 738, col: 5, offset: 17452},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 738, col: 10, offset: 17455},
+								pos:  position{line: 738, col: 10, offset: 17457},
 								name: "PoolMeta",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 745, col: 5, offset: 17598},
+						pos: position{line: 745, col: 5, offset: 17600},
 						run: (*parser).callonFromEntity25,
 						expr: &seqExpr{
-							pos: position{line: 745, col: 5, offset: 17598},
+							pos: position{line: 745, col: 5, offset: 17600},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 745, col: 5, offset: 17598},
+									pos:   position{line: 745, col: 5, offset: 17600},
 									label: "join",
 									expr: &ruleRefExpr{
-										pos:  position{line: 745, col: 10, offset: 17603},
+										pos:  position{line: 745, col: 10, offset: 17605},
 										name: "JoinOperation",
 									},
 								},
 								&notExpr{
-									pos: position{line: 745, col: 24, offset: 17617},
+									pos: position{line: 745, col: 24, offset: 17619},
 									expr: &ruleRefExpr{
-										pos:  position{line: 745, col: 25, offset: 17618},
+										pos:  position{line: 745, col: 25, offset: 17620},
 										name: "AliasClause",
 									},
 								},
@@ -4923,35 +4927,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 746, col: 5, offset: 17653},
+						pos: position{line: 746, col: 5, offset: 17655},
 						run: (*parser).callonFromEntity31,
 						expr: &seqExpr{
-							pos: position{line: 746, col: 5, offset: 17653},
+							pos: position{line: 746, col: 5, offset: 17655},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 746, col: 5, offset: 17653},
+									pos:        position{line: 746, col: 5, offset: 17655},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 746, col: 9, offset: 17657},
+									pos:  position{line: 746, col: 9, offset: 17659},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 746, col: 12, offset: 17660},
+									pos:   position{line: 746, col: 12, offset: 17662},
 									label: "join",
 									expr: &ruleRefExpr{
-										pos:  position{line: 746, col: 17, offset: 17665},
+										pos:  position{line: 746, col: 17, offset: 17667},
 										name: "JoinOperation",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 746, col: 31, offset: 17679},
+									pos:  position{line: 746, col: 31, offset: 17681},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 746, col: 34, offset: 17682},
+									pos:        position{line: 746, col: 34, offset: 17684},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4960,35 +4964,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 747, col: 5, offset: 17711},
+						pos: position{line: 747, col: 5, offset: 17713},
 						run: (*parser).callonFromEntity39,
 						expr: &seqExpr{
-							pos: position{line: 747, col: 5, offset: 17711},
+							pos: position{line: 747, col: 5, offset: 17713},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 747, col: 5, offset: 17711},
+									pos:        position{line: 747, col: 5, offset: 17713},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 747, col: 9, offset: 17715},
+									pos:  position{line: 747, col: 9, offset: 17717},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 747, col: 12, offset: 17718},
+									pos:   position{line: 747, col: 12, offset: 17720},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 747, col: 14, offset: 17720},
+										pos:  position{line: 747, col: 14, offset: 17722},
 										name: "SQLPipe",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 747, col: 22, offset: 17728},
+									pos:  position{line: 747, col: 22, offset: 17730},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 747, col: 25, offset: 17731},
+									pos:        position{line: 747, col: 25, offset: 17733},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4997,13 +5001,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 750, col: 6, offset: 17768},
+						pos: position{line: 750, col: 6, offset: 17770},
 						run: (*parser).callonFromEntity47,
 						expr: &labeledExpr{
-							pos:   position{line: 750, col: 6, offset: 17768},
+							pos:   position{line: 750, col: 6, offset: 17770},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 750, col: 11, offset: 17773},
+								pos:  position{line: 750, col: 11, offset: 17775},
 								name: "Name",
 							},
 						},
@@ -5015,40 +5019,40 @@ var g = &grammar{
 		},
 		{
 			name: "FromArgs",
-			pos:  position{line: 753, col: 1, offset: 17871},
+			pos:  position{line: 753, col: 1, offset: 17873},
 			expr: &choiceExpr{
-				pos: position{line: 754, col: 5, offset: 17884},
+				pos: position{line: 754, col: 5, offset: 17886},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 754, col: 5, offset: 17884},
+						pos: position{line: 754, col: 5, offset: 17886},
 						run: (*parser).callonFromArgs2,
 						expr: &seqExpr{
-							pos: position{line: 754, col: 5, offset: 17884},
+							pos: position{line: 754, col: 5, offset: 17886},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 754, col: 5, offset: 17884},
+									pos:   position{line: 754, col: 5, offset: 17886},
 									label: "commit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 754, col: 12, offset: 17891},
+										pos:  position{line: 754, col: 12, offset: 17893},
 										name: "PoolCommit",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 754, col: 23, offset: 17902},
+									pos:   position{line: 754, col: 23, offset: 17904},
 									label: "meta",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 754, col: 28, offset: 17907},
+										pos: position{line: 754, col: 28, offset: 17909},
 										expr: &ruleRefExpr{
-											pos:  position{line: 754, col: 28, offset: 17907},
+											pos:  position{line: 754, col: 28, offset: 17909},
 											name: "PoolMeta",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 754, col: 38, offset: 17917},
+									pos:   position{line: 754, col: 38, offset: 17919},
 									label: "tap",
 									expr: &ruleRefExpr{
-										pos:  position{line: 754, col: 42, offset: 17921},
+										pos:  position{line: 754, col: 42, offset: 17923},
 										name: "TapArg",
 									},
 								},
@@ -5056,24 +5060,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 763, col: 5, offset: 18125},
+						pos: position{line: 763, col: 5, offset: 18127},
 						run: (*parser).callonFromArgs11,
 						expr: &seqExpr{
-							pos: position{line: 763, col: 5, offset: 18125},
+							pos: position{line: 763, col: 5, offset: 18127},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 763, col: 5, offset: 18125},
+									pos:   position{line: 763, col: 5, offset: 18127},
 									label: "meta",
 									expr: &ruleRefExpr{
-										pos:  position{line: 763, col: 10, offset: 18130},
+										pos:  position{line: 763, col: 10, offset: 18132},
 										name: "PoolMeta",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 763, col: 19, offset: 18139},
+									pos:   position{line: 763, col: 19, offset: 18141},
 									label: "tap",
 									expr: &ruleRefExpr{
-										pos:  position{line: 763, col: 23, offset: 18143},
+										pos:  position{line: 763, col: 23, offset: 18145},
 										name: "TapArg",
 									},
 								},
@@ -5081,41 +5085,41 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 771, col: 5, offset: 18309},
+						pos: position{line: 771, col: 5, offset: 18311},
 						run: (*parser).callonFromArgs17,
 						expr: &seqExpr{
-							pos: position{line: 771, col: 5, offset: 18309},
+							pos: position{line: 771, col: 5, offset: 18311},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 771, col: 5, offset: 18309},
+									pos:   position{line: 771, col: 5, offset: 18311},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 771, col: 12, offset: 18316},
+										pos:  position{line: 771, col: 12, offset: 18318},
 										name: "FormatArg",
 									},
 								},
 								&notExpr{
-									pos: position{line: 771, col: 22, offset: 18326},
+									pos: position{line: 771, col: 22, offset: 18328},
 									expr: &seqExpr{
-										pos: position{line: 771, col: 24, offset: 18328},
+										pos: position{line: 771, col: 24, offset: 18330},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 771, col: 24, offset: 18328},
+												pos:  position{line: 771, col: 24, offset: 18330},
 												name: "_",
 											},
 											&choiceExpr{
-												pos: position{line: 771, col: 27, offset: 18331},
+												pos: position{line: 771, col: 27, offset: 18333},
 												alternatives: []any{
 													&ruleRefExpr{
-														pos:  position{line: 771, col: 27, offset: 18331},
+														pos:  position{line: 771, col: 27, offset: 18333},
 														name: "METHOD",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 771, col: 36, offset: 18340},
+														pos:  position{line: 771, col: 36, offset: 18342},
 														name: "HEADERS",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 771, col: 46, offset: 18350},
+														pos:  position{line: 771, col: 46, offset: 18352},
 														name: "BODY",
 													},
 												},
@@ -5127,51 +5131,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 778, col: 5, offset: 18495},
+						pos: position{line: 778, col: 5, offset: 18497},
 						run: (*parser).callonFromArgs28,
 						expr: &seqExpr{
-							pos: position{line: 778, col: 5, offset: 18495},
+							pos: position{line: 778, col: 5, offset: 18497},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 778, col: 5, offset: 18495},
+									pos:   position{line: 778, col: 5, offset: 18497},
 									label: "format",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 778, col: 12, offset: 18502},
+										pos: position{line: 778, col: 12, offset: 18504},
 										expr: &ruleRefExpr{
-											pos:  position{line: 778, col: 12, offset: 18502},
+											pos:  position{line: 778, col: 12, offset: 18504},
 											name: "FormatArg",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 778, col: 23, offset: 18513},
+									pos:   position{line: 778, col: 23, offset: 18515},
 									label: "method",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 778, col: 30, offset: 18520},
+										pos: position{line: 778, col: 30, offset: 18522},
 										expr: &ruleRefExpr{
-											pos:  position{line: 778, col: 30, offset: 18520},
+											pos:  position{line: 778, col: 30, offset: 18522},
 											name: "MethodArg",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 778, col: 41, offset: 18531},
+									pos:   position{line: 778, col: 41, offset: 18533},
 									label: "headers",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 778, col: 49, offset: 18539},
+										pos: position{line: 778, col: 49, offset: 18541},
 										expr: &ruleRefExpr{
-											pos:  position{line: 778, col: 49, offset: 18539},
+											pos:  position{line: 778, col: 49, offset: 18541},
 											name: "HeadersArg",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 778, col: 61, offset: 18551},
+									pos:   position{line: 778, col: 61, offset: 18553},
 									label: "body",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 778, col: 66, offset: 18556},
+										pos: position{line: 778, col: 66, offset: 18558},
 										expr: &ruleRefExpr{
-											pos:  position{line: 778, col: 66, offset: 18556},
+											pos:  position{line: 778, col: 66, offset: 18558},
 											name: "BodyArg",
 										},
 									},
@@ -5186,30 +5190,30 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArg",
-			pos:  position{line: 795, col: 1, offset: 18972},
+			pos:  position{line: 795, col: 1, offset: 18974},
 			expr: &actionExpr{
-				pos: position{line: 795, col: 13, offset: 18984},
+				pos: position{line: 795, col: 13, offset: 18986},
 				run: (*parser).callonFormatArg1,
 				expr: &seqExpr{
-					pos: position{line: 795, col: 13, offset: 18984},
+					pos: position{line: 795, col: 13, offset: 18986},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 795, col: 13, offset: 18984},
+							pos:  position{line: 795, col: 13, offset: 18986},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 795, col: 15, offset: 18986},
+							pos:  position{line: 795, col: 15, offset: 18988},
 							name: "FORMAT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 795, col: 22, offset: 18993},
+							pos:  position{line: 795, col: 22, offset: 18995},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 795, col: 24, offset: 18995},
+							pos:   position{line: 795, col: 24, offset: 18997},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 795, col: 26, offset: 18997},
+								pos:  position{line: 795, col: 26, offset: 18999},
 								name: "Name",
 							},
 						},
@@ -5221,30 +5225,30 @@ var g = &grammar{
 		},
 		{
 			name: "MethodArg",
-			pos:  position{line: 797, col: 1, offset: 19021},
+			pos:  position{line: 797, col: 1, offset: 19023},
 			expr: &actionExpr{
-				pos: position{line: 797, col: 13, offset: 19033},
+				pos: position{line: 797, col: 13, offset: 19035},
 				run: (*parser).callonMethodArg1,
 				expr: &seqExpr{
-					pos: position{line: 797, col: 13, offset: 19033},
+					pos: position{line: 797, col: 13, offset: 19035},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 797, col: 13, offset: 19033},
+							pos:  position{line: 797, col: 13, offset: 19035},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 797, col: 15, offset: 19035},
+							pos:  position{line: 797, col: 15, offset: 19037},
 							name: "METHOD",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 797, col: 22, offset: 19042},
+							pos:  position{line: 797, col: 22, offset: 19044},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 797, col: 24, offset: 19044},
+							pos:   position{line: 797, col: 24, offset: 19046},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 797, col: 26, offset: 19046},
+								pos:  position{line: 797, col: 26, offset: 19048},
 								name: "Name",
 							},
 						},
@@ -5256,30 +5260,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadersArg",
-			pos:  position{line: 799, col: 1, offset: 19070},
+			pos:  position{line: 799, col: 1, offset: 19072},
 			expr: &actionExpr{
-				pos: position{line: 799, col: 14, offset: 19083},
+				pos: position{line: 799, col: 14, offset: 19085},
 				run: (*parser).callonHeadersArg1,
 				expr: &seqExpr{
-					pos: position{line: 799, col: 14, offset: 19083},
+					pos: position{line: 799, col: 14, offset: 19085},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 799, col: 14, offset: 19083},
+							pos:  position{line: 799, col: 14, offset: 19085},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 799, col: 16, offset: 19085},
+							pos:  position{line: 799, col: 16, offset: 19087},
 							name: "HEADERS",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 799, col: 24, offset: 19093},
+							pos:  position{line: 799, col: 24, offset: 19095},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 799, col: 26, offset: 19095},
+							pos:   position{line: 799, col: 26, offset: 19097},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 799, col: 28, offset: 19097},
+								pos:  position{line: 799, col: 28, offset: 19099},
 								name: "Record",
 							},
 						},
@@ -5291,30 +5295,30 @@ var g = &grammar{
 		},
 		{
 			name: "BodyArg",
-			pos:  position{line: 801, col: 1, offset: 19123},
+			pos:  position{line: 801, col: 1, offset: 19125},
 			expr: &actionExpr{
-				pos: position{line: 801, col: 11, offset: 19133},
+				pos: position{line: 801, col: 11, offset: 19135},
 				run: (*parser).callonBodyArg1,
 				expr: &seqExpr{
-					pos: position{line: 801, col: 11, offset: 19133},
+					pos: position{line: 801, col: 11, offset: 19135},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 801, col: 11, offset: 19133},
+							pos:  position{line: 801, col: 11, offset: 19135},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 801, col: 13, offset: 19135},
+							pos:  position{line: 801, col: 13, offset: 19137},
 							name: "BODY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 801, col: 18, offset: 19140},
+							pos:  position{line: 801, col: 18, offset: 19142},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 801, col: 20, offset: 19142},
+							pos:   position{line: 801, col: 20, offset: 19144},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 801, col: 22, offset: 19144},
+								pos:  position{line: 801, col: 22, offset: 19146},
 								name: "Name",
 							},
 						},
@@ -5326,24 +5330,24 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedURL",
-			pos:  position{line: 803, col: 1, offset: 19168},
+			pos:  position{line: 803, col: 1, offset: 19170},
 			expr: &actionExpr{
-				pos: position{line: 803, col: 15, offset: 19182},
+				pos: position{line: 803, col: 15, offset: 19184},
 				run: (*parser).callonUnquotedURL1,
 				expr: &seqExpr{
-					pos: position{line: 803, col: 15, offset: 19182},
+					pos: position{line: 803, col: 15, offset: 19184},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 803, col: 16, offset: 19183},
+							pos: position{line: 803, col: 16, offset: 19185},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 803, col: 16, offset: 19183},
+									pos:        position{line: 803, col: 16, offset: 19185},
 									val:        "http://",
 									ignoreCase: false,
 									want:       "\"http://\"",
 								},
 								&litMatcher{
-									pos:        position{line: 803, col: 28, offset: 19195},
+									pos:        position{line: 803, col: 28, offset: 19197},
 									val:        "https://",
 									ignoreCase: false,
 									want:       "\"https://\"",
@@ -5351,9 +5355,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 803, col: 40, offset: 19207},
+							pos: position{line: 803, col: 40, offset: 19209},
 							expr: &ruleRefExpr{
-								pos:  position{line: 803, col: 40, offset: 19207},
+								pos:  position{line: 803, col: 40, offset: 19209},
 								name: "URLChar",
 							},
 						},
@@ -5365,9 +5369,9 @@ var g = &grammar{
 		},
 		{
 			name: "URLChar",
-			pos:  position{line: 805, col: 1, offset: 19248},
+			pos:  position{line: 805, col: 1, offset: 19250},
 			expr: &charClassMatcher{
-				pos:        position{line: 805, col: 11, offset: 19258},
+				pos:        position{line: 805, col: 11, offset: 19260},
 				val:        "[0-9a-zA-Z!@$%&_=,./?:[\\]~+-]",
 				chars:      []rune{'!', '@', '$', '%', '&', '_', '=', ',', '.', '/', '?', ':', '[', ']', '~', '+', '-'},
 				ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
@@ -5379,30 +5383,30 @@ var g = &grammar{
 		},
 		{
 			name: "PoolAt",
-			pos:  position{line: 808, col: 1, offset: 19322},
+			pos:  position{line: 808, col: 1, offset: 19324},
 			expr: &actionExpr{
-				pos: position{line: 809, col: 5, offset: 19333},
+				pos: position{line: 809, col: 5, offset: 19335},
 				run: (*parser).callonPoolAt1,
 				expr: &seqExpr{
-					pos: position{line: 809, col: 5, offset: 19333},
+					pos: position{line: 809, col: 5, offset: 19335},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 809, col: 5, offset: 19333},
+							pos:  position{line: 809, col: 5, offset: 19335},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 809, col: 7, offset: 19335},
+							pos:  position{line: 809, col: 7, offset: 19337},
 							name: "AT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 809, col: 10, offset: 19338},
+							pos:  position{line: 809, col: 10, offset: 19340},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 809, col: 12, offset: 19340},
+							pos:   position{line: 809, col: 12, offset: 19342},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 809, col: 15, offset: 19343},
+								pos:  position{line: 809, col: 15, offset: 19345},
 								name: "KSUID",
 							},
 						},
@@ -5414,14 +5418,14 @@ var g = &grammar{
 		},
 		{
 			name: "KSUID",
-			pos:  position{line: 812, col: 1, offset: 19409},
+			pos:  position{line: 812, col: 1, offset: 19411},
 			expr: &actionExpr{
-				pos: position{line: 812, col: 9, offset: 19417},
+				pos: position{line: 812, col: 9, offset: 19419},
 				run: (*parser).callonKSUID1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 812, col: 9, offset: 19417},
+					pos: position{line: 812, col: 9, offset: 19419},
 					expr: &charClassMatcher{
-						pos:        position{line: 812, col: 10, offset: 19418},
+						pos:        position{line: 812, col: 10, offset: 19420},
 						val:        "[0-9a-zA-Z]",
 						ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
 						ignoreCase: false,
@@ -5434,24 +5438,24 @@ var g = &grammar{
 		},
 		{
 			name: "PoolCommit",
-			pos:  position{line: 814, col: 1, offset: 19464},
+			pos:  position{line: 814, col: 1, offset: 19466},
 			expr: &actionExpr{
-				pos: position{line: 815, col: 5, offset: 19479},
+				pos: position{line: 815, col: 5, offset: 19481},
 				run: (*parser).callonPoolCommit1,
 				expr: &seqExpr{
-					pos: position{line: 815, col: 5, offset: 19479},
+					pos: position{line: 815, col: 5, offset: 19481},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 815, col: 5, offset: 19479},
+							pos:        position{line: 815, col: 5, offset: 19481},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 815, col: 9, offset: 19483},
+							pos:   position{line: 815, col: 9, offset: 19485},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 815, col: 11, offset: 19485},
+								pos:  position{line: 815, col: 11, offset: 19487},
 								name: "Name",
 							},
 						},
@@ -5463,24 +5467,24 @@ var g = &grammar{
 		},
 		{
 			name: "PoolMeta",
-			pos:  position{line: 817, col: 1, offset: 19509},
+			pos:  position{line: 817, col: 1, offset: 19511},
 			expr: &actionExpr{
-				pos: position{line: 818, col: 5, offset: 19522},
+				pos: position{line: 818, col: 5, offset: 19524},
 				run: (*parser).callonPoolMeta1,
 				expr: &seqExpr{
-					pos: position{line: 818, col: 5, offset: 19522},
+					pos: position{line: 818, col: 5, offset: 19524},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 818, col: 5, offset: 19522},
+							pos:        position{line: 818, col: 5, offset: 19524},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 818, col: 9, offset: 19526},
+							pos:   position{line: 818, col: 9, offset: 19528},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 818, col: 11, offset: 19528},
+								pos:  position{line: 818, col: 11, offset: 19530},
 								name: "Name",
 							},
 						},
@@ -5492,32 +5496,32 @@ var g = &grammar{
 		},
 		{
 			name: "TapArg",
-			pos:  position{line: 820, col: 1, offset: 19552},
+			pos:  position{line: 820, col: 1, offset: 19554},
 			expr: &choiceExpr{
-				pos: position{line: 821, col: 5, offset: 19563},
+				pos: position{line: 821, col: 5, offset: 19565},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 821, col: 5, offset: 19563},
+						pos: position{line: 821, col: 5, offset: 19565},
 						run: (*parser).callonTapArg2,
 						expr: &seqExpr{
-							pos: position{line: 821, col: 5, offset: 19563},
+							pos: position{line: 821, col: 5, offset: 19565},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 821, col: 5, offset: 19563},
+									pos:  position{line: 821, col: 5, offset: 19565},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 821, col: 7, offset: 19565},
+									pos:  position{line: 821, col: 7, offset: 19567},
 									name: "TAP",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 822, col: 5, offset: 19594},
+						pos: position{line: 822, col: 5, offset: 19596},
 						run: (*parser).callonTapArg6,
 						expr: &litMatcher{
-							pos:        position{line: 822, col: 5, offset: 19594},
+							pos:        position{line: 822, col: 5, offset: 19596},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -5530,28 +5534,28 @@ var g = &grammar{
 		},
 		{
 			name: "PassOp",
-			pos:  position{line: 824, col: 1, offset: 19620},
+			pos:  position{line: 824, col: 1, offset: 19622},
 			expr: &actionExpr{
-				pos: position{line: 825, col: 5, offset: 19631},
+				pos: position{line: 825, col: 5, offset: 19633},
 				run: (*parser).callonPassOp1,
 				expr: &seqExpr{
-					pos: position{line: 825, col: 5, offset: 19631},
+					pos: position{line: 825, col: 5, offset: 19633},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 825, col: 5, offset: 19631},
+							pos:  position{line: 825, col: 5, offset: 19633},
 							name: "PASS",
 						},
 						&notExpr{
-							pos: position{line: 825, col: 10, offset: 19636},
+							pos: position{line: 825, col: 10, offset: 19638},
 							expr: &seqExpr{
-								pos: position{line: 825, col: 12, offset: 19638},
+								pos: position{line: 825, col: 12, offset: 19640},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 825, col: 12, offset: 19638},
+										pos:  position{line: 825, col: 12, offset: 19640},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 825, col: 15, offset: 19641},
+										pos:        position{line: 825, col: 15, offset: 19643},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -5560,9 +5564,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 825, col: 20, offset: 19646},
+							pos: position{line: 825, col: 20, offset: 19648},
 							expr: &ruleRefExpr{
-								pos:  position{line: 825, col: 21, offset: 19647},
+								pos:  position{line: 825, col: 21, offset: 19649},
 								name: "EOKW",
 							},
 						},
@@ -5574,44 +5578,44 @@ var g = &grammar{
 		},
 		{
 			name: "ExplodeOp",
-			pos:  position{line: 831, col: 1, offset: 19838},
+			pos:  position{line: 831, col: 1, offset: 19840},
 			expr: &actionExpr{
-				pos: position{line: 832, col: 5, offset: 19852},
+				pos: position{line: 832, col: 5, offset: 19854},
 				run: (*parser).callonExplodeOp1,
 				expr: &seqExpr{
-					pos: position{line: 832, col: 5, offset: 19852},
+					pos: position{line: 832, col: 5, offset: 19854},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 832, col: 5, offset: 19852},
+							pos:  position{line: 832, col: 5, offset: 19854},
 							name: "EXPLODE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 832, col: 13, offset: 19860},
+							pos:  position{line: 832, col: 13, offset: 19862},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 832, col: 15, offset: 19862},
+							pos:   position{line: 832, col: 15, offset: 19864},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 832, col: 20, offset: 19867},
+								pos:  position{line: 832, col: 20, offset: 19869},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 832, col: 26, offset: 19873},
+							pos:   position{line: 832, col: 26, offset: 19875},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 832, col: 30, offset: 19877},
+								pos:  position{line: 832, col: 30, offset: 19879},
 								name: "TypeArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 832, col: 38, offset: 19885},
+							pos:   position{line: 832, col: 38, offset: 19887},
 							label: "as",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 832, col: 41, offset: 19888},
+								pos: position{line: 832, col: 41, offset: 19890},
 								expr: &ruleRefExpr{
-									pos:  position{line: 832, col: 41, offset: 19888},
+									pos:  position{line: 832, col: 41, offset: 19890},
 									name: "AsArg",
 								},
 							},
@@ -5624,26 +5628,26 @@ var g = &grammar{
 		},
 		{
 			name: "MergeOp",
-			pos:  position{line: 845, col: 1, offset: 20130},
+			pos:  position{line: 845, col: 1, offset: 20132},
 			expr: &actionExpr{
-				pos: position{line: 846, col: 5, offset: 20142},
+				pos: position{line: 846, col: 5, offset: 20144},
 				run: (*parser).callonMergeOp1,
 				expr: &seqExpr{
-					pos: position{line: 846, col: 5, offset: 20142},
+					pos: position{line: 846, col: 5, offset: 20144},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 846, col: 5, offset: 20142},
+							pos:  position{line: 846, col: 5, offset: 20144},
 							name: "MERGE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 846, col: 11, offset: 20148},
+							pos:  position{line: 846, col: 11, offset: 20150},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 846, col: 13, offset: 20150},
+							pos:   position{line: 846, col: 13, offset: 20152},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 846, col: 19, offset: 20156},
+								pos:  position{line: 846, col: 19, offset: 20158},
 								name: "OrderByList",
 							},
 						},
@@ -5655,56 +5659,56 @@ var g = &grammar{
 		},
 		{
 			name: "OverOp",
-			pos:  position{line: 854, col: 1, offset: 20298},
+			pos:  position{line: 854, col: 1, offset: 20300},
 			expr: &actionExpr{
-				pos: position{line: 855, col: 5, offset: 20309},
+				pos: position{line: 855, col: 5, offset: 20311},
 				run: (*parser).callonOverOp1,
 				expr: &seqExpr{
-					pos: position{line: 855, col: 5, offset: 20309},
+					pos: position{line: 855, col: 5, offset: 20311},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 855, col: 6, offset: 20310},
+							pos: position{line: 855, col: 6, offset: 20312},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 855, col: 6, offset: 20310},
+									pos:  position{line: 855, col: 6, offset: 20312},
 									name: "OVER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 855, col: 13, offset: 20317},
+									pos:  position{line: 855, col: 13, offset: 20319},
 									name: "UNNEST",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 855, col: 21, offset: 20325},
+							pos:  position{line: 855, col: 21, offset: 20327},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 855, col: 23, offset: 20327},
+							pos:   position{line: 855, col: 23, offset: 20329},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 855, col: 29, offset: 20333},
+								pos:  position{line: 855, col: 29, offset: 20335},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 855, col: 35, offset: 20339},
+							pos:   position{line: 855, col: 35, offset: 20341},
 							label: "locals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 855, col: 42, offset: 20346},
+								pos: position{line: 855, col: 42, offset: 20348},
 								expr: &ruleRefExpr{
-									pos:  position{line: 855, col: 42, offset: 20346},
+									pos:  position{line: 855, col: 42, offset: 20348},
 									name: "Locals",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 855, col: 50, offset: 20354},
+							pos:   position{line: 855, col: 50, offset: 20356},
 							label: "body",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 855, col: 55, offset: 20359},
+								pos: position{line: 855, col: 55, offset: 20361},
 								expr: &ruleRefExpr{
-									pos:  position{line: 855, col: 55, offset: 20359},
+									pos:  position{line: 855, col: 55, offset: 20361},
 									name: "Lateral",
 								},
 							},
@@ -5717,54 +5721,54 @@ var g = &grammar{
 		},
 		{
 			name: "Lateral",
-			pos:  position{line: 870, col: 1, offset: 20684},
+			pos:  position{line: 870, col: 1, offset: 20686},
 			expr: &choiceExpr{
-				pos: position{line: 871, col: 5, offset: 20696},
+				pos: position{line: 871, col: 5, offset: 20698},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 871, col: 5, offset: 20696},
+						pos: position{line: 871, col: 5, offset: 20698},
 						run: (*parser).callonLateral2,
 						expr: &seqExpr{
-							pos: position{line: 871, col: 5, offset: 20696},
+							pos: position{line: 871, col: 5, offset: 20698},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 871, col: 5, offset: 20696},
+									pos:  position{line: 871, col: 5, offset: 20698},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 871, col: 8, offset: 20699},
+									pos:        position{line: 871, col: 8, offset: 20701},
 									val:        "=>",
 									ignoreCase: false,
 									want:       "\"=>\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 871, col: 13, offset: 20704},
+									pos:  position{line: 871, col: 13, offset: 20706},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 871, col: 16, offset: 20707},
+									pos:        position{line: 871, col: 16, offset: 20709},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 871, col: 20, offset: 20711},
+									pos:  position{line: 871, col: 20, offset: 20713},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 871, col: 23, offset: 20714},
+									pos:   position{line: 871, col: 23, offset: 20716},
 									label: "scope",
 									expr: &ruleRefExpr{
-										pos:  position{line: 871, col: 29, offset: 20720},
+										pos:  position{line: 871, col: 29, offset: 20722},
 										name: "Scope",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 871, col: 35, offset: 20726},
+									pos:  position{line: 871, col: 35, offset: 20728},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 871, col: 38, offset: 20729},
+									pos:        position{line: 871, col: 38, offset: 20731},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -5773,49 +5777,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 874, col: 5, offset: 20810},
+						pos: position{line: 874, col: 5, offset: 20812},
 						run: (*parser).callonLateral13,
 						expr: &seqExpr{
-							pos: position{line: 874, col: 5, offset: 20810},
+							pos: position{line: 874, col: 5, offset: 20812},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 874, col: 5, offset: 20810},
+									pos:  position{line: 874, col: 5, offset: 20812},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 874, col: 8, offset: 20813},
+									pos:        position{line: 874, col: 8, offset: 20815},
 									val:        "=>",
 									ignoreCase: false,
 									want:       "\"=>\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 874, col: 13, offset: 20818},
+									pos:  position{line: 874, col: 13, offset: 20820},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 874, col: 16, offset: 20821},
+									pos:        position{line: 874, col: 16, offset: 20823},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 874, col: 20, offset: 20825},
+									pos:  position{line: 874, col: 20, offset: 20827},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 874, col: 23, offset: 20828},
+									pos:   position{line: 874, col: 23, offset: 20830},
 									label: "seq",
 									expr: &ruleRefExpr{
-										pos:  position{line: 874, col: 27, offset: 20832},
+										pos:  position{line: 874, col: 27, offset: 20834},
 										name: "Seq",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 874, col: 31, offset: 20836},
+									pos:  position{line: 874, col: 31, offset: 20838},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 874, col: 34, offset: 20839},
+									pos:        position{line: 874, col: 34, offset: 20841},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -5830,63 +5834,63 @@ var g = &grammar{
 		},
 		{
 			name: "Locals",
-			pos:  position{line: 878, col: 1, offset: 20895},
+			pos:  position{line: 878, col: 1, offset: 20897},
 			expr: &actionExpr{
-				pos: position{line: 879, col: 5, offset: 20906},
+				pos: position{line: 879, col: 5, offset: 20908},
 				run: (*parser).callonLocals1,
 				expr: &seqExpr{
-					pos: position{line: 879, col: 5, offset: 20906},
+					pos: position{line: 879, col: 5, offset: 20908},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 879, col: 5, offset: 20906},
+							pos:  position{line: 879, col: 5, offset: 20908},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 879, col: 7, offset: 20908},
+							pos:  position{line: 879, col: 7, offset: 20910},
 							name: "WITH",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 879, col: 12, offset: 20913},
+							pos:  position{line: 879, col: 12, offset: 20915},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 879, col: 14, offset: 20915},
+							pos:   position{line: 879, col: 14, offset: 20917},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 879, col: 20, offset: 20921},
+								pos:  position{line: 879, col: 20, offset: 20923},
 								name: "LocalsAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 879, col: 37, offset: 20938},
+							pos:   position{line: 879, col: 37, offset: 20940},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 879, col: 42, offset: 20943},
+								pos: position{line: 879, col: 42, offset: 20945},
 								expr: &actionExpr{
-									pos: position{line: 879, col: 43, offset: 20944},
+									pos: position{line: 879, col: 43, offset: 20946},
 									run: (*parser).callonLocals10,
 									expr: &seqExpr{
-										pos: position{line: 879, col: 43, offset: 20944},
+										pos: position{line: 879, col: 43, offset: 20946},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 879, col: 43, offset: 20944},
+												pos:  position{line: 879, col: 43, offset: 20946},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 879, col: 46, offset: 20947},
+												pos:        position{line: 879, col: 46, offset: 20949},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 879, col: 50, offset: 20951},
+												pos:  position{line: 879, col: 50, offset: 20953},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 879, col: 53, offset: 20954},
+												pos:   position{line: 879, col: 53, offset: 20956},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 879, col: 55, offset: 20956},
+													pos:  position{line: 879, col: 55, offset: 20958},
 													name: "LocalsAssignment",
 												},
 											},
@@ -5903,45 +5907,45 @@ var g = &grammar{
 		},
 		{
 			name: "LocalsAssignment",
-			pos:  position{line: 883, col: 1, offset: 21041},
+			pos:  position{line: 883, col: 1, offset: 21043},
 			expr: &actionExpr{
-				pos: position{line: 884, col: 5, offset: 21062},
+				pos: position{line: 884, col: 5, offset: 21064},
 				run: (*parser).callonLocalsAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 884, col: 5, offset: 21062},
+					pos: position{line: 884, col: 5, offset: 21064},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 884, col: 5, offset: 21062},
+							pos:   position{line: 884, col: 5, offset: 21064},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 884, col: 10, offset: 21067},
+								pos:  position{line: 884, col: 10, offset: 21069},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 884, col: 21, offset: 21078},
+							pos:   position{line: 884, col: 21, offset: 21080},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 884, col: 25, offset: 21082},
+								pos: position{line: 884, col: 25, offset: 21084},
 								expr: &seqExpr{
-									pos: position{line: 884, col: 26, offset: 21083},
+									pos: position{line: 884, col: 26, offset: 21085},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 884, col: 26, offset: 21083},
+											pos:  position{line: 884, col: 26, offset: 21085},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 884, col: 29, offset: 21086},
+											pos:        position{line: 884, col: 29, offset: 21088},
 											val:        "=",
 											ignoreCase: false,
 											want:       "\"=\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 884, col: 33, offset: 21090},
+											pos:  position{line: 884, col: 33, offset: 21092},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 884, col: 36, offset: 21093},
+											pos:  position{line: 884, col: 36, offset: 21095},
 											name: "Expr",
 										},
 									},
@@ -5956,26 +5960,26 @@ var g = &grammar{
 		},
 		{
 			name: "YieldOp",
-			pos:  position{line: 896, col: 1, offset: 21317},
+			pos:  position{line: 896, col: 1, offset: 21319},
 			expr: &actionExpr{
-				pos: position{line: 897, col: 5, offset: 21329},
+				pos: position{line: 897, col: 5, offset: 21331},
 				run: (*parser).callonYieldOp1,
 				expr: &seqExpr{
-					pos: position{line: 897, col: 5, offset: 21329},
+					pos: position{line: 897, col: 5, offset: 21331},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 897, col: 5, offset: 21329},
+							pos:  position{line: 897, col: 5, offset: 21331},
 							name: "YIELD",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 897, col: 11, offset: 21335},
+							pos:  position{line: 897, col: 11, offset: 21337},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 897, col: 13, offset: 21337},
+							pos:   position{line: 897, col: 13, offset: 21339},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 897, col: 19, offset: 21343},
+								pos:  position{line: 897, col: 19, offset: 21345},
 								name: "Exprs",
 							},
 						},
@@ -5987,30 +5991,30 @@ var g = &grammar{
 		},
 		{
 			name: "TypeArg",
-			pos:  position{line: 905, col: 1, offset: 21487},
+			pos:  position{line: 905, col: 1, offset: 21489},
 			expr: &actionExpr{
-				pos: position{line: 906, col: 5, offset: 21499},
+				pos: position{line: 906, col: 5, offset: 21501},
 				run: (*parser).callonTypeArg1,
 				expr: &seqExpr{
-					pos: position{line: 906, col: 5, offset: 21499},
+					pos: position{line: 906, col: 5, offset: 21501},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 906, col: 5, offset: 21499},
+							pos:  position{line: 906, col: 5, offset: 21501},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 906, col: 7, offset: 21501},
+							pos:  position{line: 906, col: 7, offset: 21503},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 906, col: 10, offset: 21504},
+							pos:  position{line: 906, col: 10, offset: 21506},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 906, col: 12, offset: 21506},
+							pos:   position{line: 906, col: 12, offset: 21508},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 906, col: 16, offset: 21510},
+								pos:  position{line: 906, col: 16, offset: 21512},
 								name: "Type",
 							},
 						},
@@ -6022,30 +6026,30 @@ var g = &grammar{
 		},
 		{
 			name: "AsArg",
-			pos:  position{line: 908, col: 1, offset: 21536},
+			pos:  position{line: 908, col: 1, offset: 21538},
 			expr: &actionExpr{
-				pos: position{line: 909, col: 5, offset: 21546},
+				pos: position{line: 909, col: 5, offset: 21548},
 				run: (*parser).callonAsArg1,
 				expr: &seqExpr{
-					pos: position{line: 909, col: 5, offset: 21546},
+					pos: position{line: 909, col: 5, offset: 21548},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 909, col: 5, offset: 21546},
+							pos:  position{line: 909, col: 5, offset: 21548},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 909, col: 7, offset: 21548},
+							pos:  position{line: 909, col: 7, offset: 21550},
 							name: "AS",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 909, col: 10, offset: 21551},
+							pos:  position{line: 909, col: 10, offset: 21553},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 909, col: 12, offset: 21553},
+							pos:   position{line: 909, col: 12, offset: 21555},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 909, col: 16, offset: 21557},
+								pos:  position{line: 909, col: 16, offset: 21559},
 								name: "Lval",
 							},
 						},
@@ -6057,9 +6061,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 913, col: 1, offset: 21608},
+			pos:  position{line: 913, col: 1, offset: 21610},
 			expr: &ruleRefExpr{
-				pos:  position{line: 913, col: 8, offset: 21615},
+				pos:  position{line: 913, col: 8, offset: 21617},
 				name: "DerefExpr",
 			},
 			leader:        false,
@@ -6067,51 +6071,51 @@ var g = &grammar{
 		},
 		{
 			name: "Lvals",
-			pos:  position{line: 915, col: 1, offset: 21626},
+			pos:  position{line: 915, col: 1, offset: 21628},
 			expr: &actionExpr{
-				pos: position{line: 916, col: 5, offset: 21636},
+				pos: position{line: 916, col: 5, offset: 21638},
 				run: (*parser).callonLvals1,
 				expr: &seqExpr{
-					pos: position{line: 916, col: 5, offset: 21636},
+					pos: position{line: 916, col: 5, offset: 21638},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 916, col: 5, offset: 21636},
+							pos:   position{line: 916, col: 5, offset: 21638},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 916, col: 11, offset: 21642},
+								pos:  position{line: 916, col: 11, offset: 21644},
 								name: "Lval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 916, col: 16, offset: 21647},
+							pos:   position{line: 916, col: 16, offset: 21649},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 916, col: 21, offset: 21652},
+								pos: position{line: 916, col: 21, offset: 21654},
 								expr: &actionExpr{
-									pos: position{line: 916, col: 22, offset: 21653},
+									pos: position{line: 916, col: 22, offset: 21655},
 									run: (*parser).callonLvals7,
 									expr: &seqExpr{
-										pos: position{line: 916, col: 22, offset: 21653},
+										pos: position{line: 916, col: 22, offset: 21655},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 916, col: 22, offset: 21653},
+												pos:  position{line: 916, col: 22, offset: 21655},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 916, col: 25, offset: 21656},
+												pos:        position{line: 916, col: 25, offset: 21658},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 916, col: 29, offset: 21660},
+												pos:  position{line: 916, col: 29, offset: 21662},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 916, col: 32, offset: 21663},
+												pos:   position{line: 916, col: 32, offset: 21665},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 916, col: 37, offset: 21668},
+													pos:  position{line: 916, col: 37, offset: 21670},
 													name: "Lval",
 												},
 											},
@@ -6128,51 +6132,51 @@ var g = &grammar{
 		},
 		{
 			name: "Assignments",
-			pos:  position{line: 920, col: 1, offset: 21744},
+			pos:  position{line: 920, col: 1, offset: 21746},
 			expr: &actionExpr{
-				pos: position{line: 921, col: 5, offset: 21760},
+				pos: position{line: 921, col: 5, offset: 21762},
 				run: (*parser).callonAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 921, col: 5, offset: 21760},
+					pos: position{line: 921, col: 5, offset: 21762},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 921, col: 5, offset: 21760},
+							pos:   position{line: 921, col: 5, offset: 21762},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 921, col: 11, offset: 21766},
+								pos:  position{line: 921, col: 11, offset: 21768},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 921, col: 22, offset: 21777},
+							pos:   position{line: 921, col: 22, offset: 21779},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 921, col: 27, offset: 21782},
+								pos: position{line: 921, col: 27, offset: 21784},
 								expr: &actionExpr{
-									pos: position{line: 921, col: 28, offset: 21783},
+									pos: position{line: 921, col: 28, offset: 21785},
 									run: (*parser).callonAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 921, col: 28, offset: 21783},
+										pos: position{line: 921, col: 28, offset: 21785},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 921, col: 28, offset: 21783},
+												pos:  position{line: 921, col: 28, offset: 21785},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 921, col: 31, offset: 21786},
+												pos:        position{line: 921, col: 31, offset: 21788},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 921, col: 35, offset: 21790},
+												pos:  position{line: 921, col: 35, offset: 21792},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 921, col: 38, offset: 21793},
+												pos:   position{line: 921, col: 38, offset: 21795},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 921, col: 40, offset: 21795},
+													pos:  position{line: 921, col: 40, offset: 21797},
 													name: "Assignment",
 												},
 											},
@@ -6189,40 +6193,40 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 925, col: 1, offset: 21870},
+			pos:  position{line: 925, col: 1, offset: 21872},
 			expr: &actionExpr{
-				pos: position{line: 926, col: 5, offset: 21885},
+				pos: position{line: 926, col: 5, offset: 21887},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 926, col: 5, offset: 21885},
+					pos: position{line: 926, col: 5, offset: 21887},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 926, col: 5, offset: 21885},
+							pos:   position{line: 926, col: 5, offset: 21887},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 926, col: 9, offset: 21889},
+								pos:  position{line: 926, col: 9, offset: 21891},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 926, col: 14, offset: 21894},
+							pos:  position{line: 926, col: 14, offset: 21896},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 926, col: 17, offset: 21897},
+							pos:        position{line: 926, col: 17, offset: 21899},
 							val:        ":=",
 							ignoreCase: false,
 							want:       "\":=\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 926, col: 22, offset: 21902},
+							pos:  position{line: 926, col: 22, offset: 21904},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 926, col: 25, offset: 21905},
+							pos:   position{line: 926, col: 25, offset: 21907},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 926, col: 29, offset: 21909},
+								pos:  position{line: 926, col: 29, offset: 21911},
 								name: "Expr",
 							},
 						},
@@ -6234,9 +6238,9 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 935, col: 1, offset: 22080},
+			pos:  position{line: 935, col: 1, offset: 22082},
 			expr: &ruleRefExpr{
-				pos:  position{line: 935, col: 8, offset: 22087},
+				pos:  position{line: 935, col: 8, offset: 22089},
 				name: "ConditionalExpr",
 			},
 			leader:        false,
@@ -6244,63 +6248,63 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 937, col: 1, offset: 22104},
+			pos:  position{line: 937, col: 1, offset: 22106},
 			expr: &actionExpr{
-				pos: position{line: 938, col: 5, offset: 22124},
+				pos: position{line: 938, col: 5, offset: 22126},
 				run: (*parser).callonConditionalExpr1,
 				expr: &seqExpr{
-					pos: position{line: 938, col: 5, offset: 22124},
+					pos: position{line: 938, col: 5, offset: 22126},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 938, col: 5, offset: 22124},
+							pos:   position{line: 938, col: 5, offset: 22126},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 938, col: 10, offset: 22129},
+								pos:  position{line: 938, col: 10, offset: 22131},
 								name: "LogicalOrExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 938, col: 24, offset: 22143},
+							pos:   position{line: 938, col: 24, offset: 22145},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 938, col: 28, offset: 22147},
+								pos: position{line: 938, col: 28, offset: 22149},
 								expr: &seqExpr{
-									pos: position{line: 938, col: 29, offset: 22148},
+									pos: position{line: 938, col: 29, offset: 22150},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 938, col: 29, offset: 22148},
+											pos:  position{line: 938, col: 29, offset: 22150},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 938, col: 32, offset: 22151},
+											pos:        position{line: 938, col: 32, offset: 22153},
 											val:        "?",
 											ignoreCase: false,
 											want:       "\"?\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 938, col: 36, offset: 22155},
+											pos:  position{line: 938, col: 36, offset: 22157},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 938, col: 39, offset: 22158},
+											pos:  position{line: 938, col: 39, offset: 22160},
 											name: "Expr",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 938, col: 44, offset: 22163},
+											pos:  position{line: 938, col: 44, offset: 22165},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 938, col: 47, offset: 22166},
+											pos:        position{line: 938, col: 47, offset: 22168},
 											val:        ":",
 											ignoreCase: false,
 											want:       "\":\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 938, col: 51, offset: 22170},
+											pos:  position{line: 938, col: 51, offset: 22172},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 938, col: 54, offset: 22173},
+											pos:  position{line: 938, col: 54, offset: 22175},
 											name: "Expr",
 										},
 									},
@@ -6315,53 +6319,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 952, col: 1, offset: 22494},
+			pos:  position{line: 952, col: 1, offset: 22496},
 			expr: &actionExpr{
-				pos: position{line: 953, col: 5, offset: 22512},
+				pos: position{line: 953, col: 5, offset: 22514},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 953, col: 5, offset: 22512},
+					pos: position{line: 953, col: 5, offset: 22514},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 953, col: 5, offset: 22512},
+							pos:   position{line: 953, col: 5, offset: 22514},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 953, col: 11, offset: 22518},
+								pos:  position{line: 953, col: 11, offset: 22520},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 954, col: 5, offset: 22537},
+							pos:   position{line: 954, col: 5, offset: 22539},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 954, col: 10, offset: 22542},
+								pos: position{line: 954, col: 10, offset: 22544},
 								expr: &actionExpr{
-									pos: position{line: 954, col: 11, offset: 22543},
+									pos: position{line: 954, col: 11, offset: 22545},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 954, col: 11, offset: 22543},
+										pos: position{line: 954, col: 11, offset: 22545},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 954, col: 11, offset: 22543},
+												pos:  position{line: 954, col: 11, offset: 22545},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 954, col: 14, offset: 22546},
+												pos:   position{line: 954, col: 14, offset: 22548},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 954, col: 17, offset: 22549},
+													pos:  position{line: 954, col: 17, offset: 22551},
 													name: "OR",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 954, col: 20, offset: 22552},
+												pos:  position{line: 954, col: 20, offset: 22554},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 954, col: 23, offset: 22555},
+												pos:   position{line: 954, col: 23, offset: 22557},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 954, col: 28, offset: 22560},
+													pos:  position{line: 954, col: 28, offset: 22562},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -6378,53 +6382,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 958, col: 1, offset: 22674},
+			pos:  position{line: 958, col: 1, offset: 22676},
 			expr: &actionExpr{
-				pos: position{line: 959, col: 5, offset: 22693},
+				pos: position{line: 959, col: 5, offset: 22695},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 959, col: 5, offset: 22693},
+					pos: position{line: 959, col: 5, offset: 22695},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 959, col: 5, offset: 22693},
+							pos:   position{line: 959, col: 5, offset: 22695},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 959, col: 11, offset: 22699},
+								pos:  position{line: 959, col: 11, offset: 22701},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 960, col: 5, offset: 22711},
+							pos:   position{line: 960, col: 5, offset: 22713},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 960, col: 10, offset: 22716},
+								pos: position{line: 960, col: 10, offset: 22718},
 								expr: &actionExpr{
-									pos: position{line: 960, col: 11, offset: 22717},
+									pos: position{line: 960, col: 11, offset: 22719},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 960, col: 11, offset: 22717},
+										pos: position{line: 960, col: 11, offset: 22719},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 960, col: 11, offset: 22717},
+												pos:  position{line: 960, col: 11, offset: 22719},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 960, col: 14, offset: 22720},
+												pos:   position{line: 960, col: 14, offset: 22722},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 960, col: 17, offset: 22723},
+													pos:  position{line: 960, col: 17, offset: 22725},
 													name: "AND",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 960, col: 21, offset: 22727},
+												pos:  position{line: 960, col: 21, offset: 22729},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 960, col: 24, offset: 22730},
+												pos:   position{line: 960, col: 24, offset: 22732},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 960, col: 29, offset: 22735},
+													pos:  position{line: 960, col: 29, offset: 22737},
 													name: "NotExpr",
 												},
 											},
@@ -6441,43 +6445,43 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 964, col: 1, offset: 22842},
+			pos:  position{line: 964, col: 1, offset: 22844},
 			expr: &choiceExpr{
-				pos: position{line: 965, col: 5, offset: 22854},
+				pos: position{line: 965, col: 5, offset: 22856},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 965, col: 5, offset: 22854},
+						pos: position{line: 965, col: 5, offset: 22856},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 965, col: 5, offset: 22854},
+							pos: position{line: 965, col: 5, offset: 22856},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 965, col: 6, offset: 22855},
+									pos: position{line: 965, col: 6, offset: 22857},
 									alternatives: []any{
 										&seqExpr{
-											pos: position{line: 965, col: 6, offset: 22855},
+											pos: position{line: 965, col: 6, offset: 22857},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 965, col: 6, offset: 22855},
+													pos:  position{line: 965, col: 6, offset: 22857},
 													name: "NOT",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 965, col: 10, offset: 22859},
+													pos:  position{line: 965, col: 10, offset: 22861},
 													name: "_",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 965, col: 14, offset: 22863},
+											pos: position{line: 965, col: 14, offset: 22865},
 											exprs: []any{
 												&litMatcher{
-													pos:        position{line: 965, col: 14, offset: 22863},
+													pos:        position{line: 965, col: 14, offset: 22865},
 													val:        "!",
 													ignoreCase: false,
 													want:       "\"!\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 965, col: 18, offset: 22867},
+													pos:  position{line: 965, col: 18, offset: 22869},
 													name: "__",
 												},
 											},
@@ -6485,10 +6489,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 965, col: 22, offset: 22871},
+									pos:   position{line: 965, col: 22, offset: 22873},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 965, col: 24, offset: 22873},
+										pos:  position{line: 965, col: 24, offset: 22875},
 										name: "NotExpr",
 									},
 								},
@@ -6496,7 +6500,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 973, col: 5, offset: 23039},
+						pos:  position{line: 973, col: 5, offset: 23041},
 						name: "BetweenExpr",
 					},
 				},
@@ -6506,42 +6510,42 @@ var g = &grammar{
 		},
 		{
 			name: "BetweenExpr",
-			pos:  position{line: 975, col: 1, offset: 23054},
+			pos:  position{line: 975, col: 1, offset: 23056},
 			expr: &choiceExpr{
-				pos: position{line: 976, col: 5, offset: 23070},
+				pos: position{line: 976, col: 5, offset: 23072},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 976, col: 5, offset: 23070},
+						pos: position{line: 976, col: 5, offset: 23072},
 						run: (*parser).callonBetweenExpr2,
 						expr: &seqExpr{
-							pos: position{line: 976, col: 5, offset: 23070},
+							pos: position{line: 976, col: 5, offset: 23072},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 976, col: 5, offset: 23070},
+									pos:   position{line: 976, col: 5, offset: 23072},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 976, col: 10, offset: 23075},
+										pos:  position{line: 976, col: 10, offset: 23077},
 										name: "ComparisonExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 976, col: 25, offset: 23090},
+									pos:  position{line: 976, col: 25, offset: 23092},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 976, col: 27, offset: 23092},
+									pos:   position{line: 976, col: 27, offset: 23094},
 									label: "not",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 976, col: 31, offset: 23096},
+										pos: position{line: 976, col: 31, offset: 23098},
 										expr: &seqExpr{
-											pos: position{line: 976, col: 32, offset: 23097},
+											pos: position{line: 976, col: 32, offset: 23099},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 976, col: 32, offset: 23097},
+													pos:  position{line: 976, col: 32, offset: 23099},
 													name: "NOT",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 976, col: 36, offset: 23101},
+													pos:  position{line: 976, col: 36, offset: 23103},
 													name: "_",
 												},
 											},
@@ -6549,38 +6553,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 976, col: 40, offset: 23105},
+									pos:  position{line: 976, col: 40, offset: 23107},
 									name: "BETWEEN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 976, col: 48, offset: 23113},
+									pos:  position{line: 976, col: 48, offset: 23115},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 976, col: 50, offset: 23115},
+									pos:   position{line: 976, col: 50, offset: 23117},
 									label: "lower",
 									expr: &ruleRefExpr{
-										pos:  position{line: 976, col: 56, offset: 23121},
+										pos:  position{line: 976, col: 56, offset: 23123},
 										name: "BetweenExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 976, col: 68, offset: 23133},
+									pos:  position{line: 976, col: 68, offset: 23135},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 976, col: 70, offset: 23135},
+									pos:  position{line: 976, col: 70, offset: 23137},
 									name: "AND",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 976, col: 74, offset: 23139},
+									pos:  position{line: 976, col: 74, offset: 23141},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 976, col: 76, offset: 23141},
+									pos:   position{line: 976, col: 76, offset: 23143},
 									label: "upper",
 									expr: &ruleRefExpr{
-										pos:  position{line: 976, col: 82, offset: 23147},
+										pos:  position{line: 976, col: 82, offset: 23149},
 										name: "BetweenExpr",
 									},
 								},
@@ -6588,7 +6592,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 986, col: 5, offset: 23379},
+						pos:  position{line: 986, col: 5, offset: 23381},
 						name: "ComparisonExpr",
 					},
 				},
@@ -6598,46 +6602,46 @@ var g = &grammar{
 		},
 		{
 			name: "ComparisonExpr",
-			pos:  position{line: 988, col: 1, offset: 23395},
+			pos:  position{line: 988, col: 1, offset: 23397},
 			expr: &choiceExpr{
-				pos: position{line: 989, col: 5, offset: 23414},
+				pos: position{line: 989, col: 5, offset: 23416},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 989, col: 5, offset: 23414},
+						pos: position{line: 989, col: 5, offset: 23416},
 						run: (*parser).callonComparisonExpr2,
 						expr: &seqExpr{
-							pos: position{line: 989, col: 5, offset: 23414},
+							pos: position{line: 989, col: 5, offset: 23416},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 989, col: 5, offset: 23414},
+									pos:   position{line: 989, col: 5, offset: 23416},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 989, col: 10, offset: 23419},
+										pos:  position{line: 989, col: 10, offset: 23421},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 989, col: 23, offset: 23432},
+									pos:  position{line: 989, col: 23, offset: 23434},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 989, col: 25, offset: 23434},
+									pos:  position{line: 989, col: 25, offset: 23436},
 									name: "IS",
 								},
 								&labeledExpr{
-									pos:   position{line: 989, col: 28, offset: 23437},
+									pos:   position{line: 989, col: 28, offset: 23439},
 									label: "not",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 989, col: 32, offset: 23441},
+										pos: position{line: 989, col: 32, offset: 23443},
 										expr: &seqExpr{
-											pos: position{line: 989, col: 33, offset: 23442},
+											pos: position{line: 989, col: 33, offset: 23444},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 989, col: 33, offset: 23442},
+													pos:  position{line: 989, col: 33, offset: 23444},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 989, col: 35, offset: 23444},
+													pos:  position{line: 989, col: 35, offset: 23446},
 													name: "NOT",
 												},
 											},
@@ -6645,82 +6649,82 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 989, col: 41, offset: 23450},
+									pos:  position{line: 989, col: 41, offset: 23452},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 989, col: 43, offset: 23452},
+									pos:  position{line: 989, col: 43, offset: 23454},
 									name: "NULL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 997, col: 5, offset: 23620},
+						pos: position{line: 997, col: 5, offset: 23622},
 						run: (*parser).callonComparisonExpr15,
 						expr: &seqExpr{
-							pos: position{line: 997, col: 5, offset: 23620},
+							pos: position{line: 997, col: 5, offset: 23622},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 997, col: 5, offset: 23620},
+									pos:   position{line: 997, col: 5, offset: 23622},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 997, col: 9, offset: 23624},
+										pos:  position{line: 997, col: 9, offset: 23626},
 										name: "AdditiveExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 997, col: 22, offset: 23637},
+									pos:   position{line: 997, col: 22, offset: 23639},
 									label: "opAndRHS",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 997, col: 31, offset: 23646},
+										pos: position{line: 997, col: 31, offset: 23648},
 										expr: &choiceExpr{
-											pos: position{line: 997, col: 32, offset: 23647},
+											pos: position{line: 997, col: 32, offset: 23649},
 											alternatives: []any{
 												&seqExpr{
-													pos: position{line: 997, col: 32, offset: 23647},
+													pos: position{line: 997, col: 32, offset: 23649},
 													exprs: []any{
 														&ruleRefExpr{
-															pos:  position{line: 997, col: 32, offset: 23647},
+															pos:  position{line: 997, col: 32, offset: 23649},
 															name: "__",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 997, col: 35, offset: 23650},
+															pos:  position{line: 997, col: 35, offset: 23652},
 															name: "Comparator",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 997, col: 46, offset: 23661},
+															pos:  position{line: 997, col: 46, offset: 23663},
 															name: "__",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 997, col: 49, offset: 23664},
+															pos:  position{line: 997, col: 49, offset: 23666},
 															name: "AdditiveExpr",
 														},
 													},
 												},
 												&seqExpr{
-													pos: position{line: 997, col: 64, offset: 23679},
+													pos: position{line: 997, col: 64, offset: 23681},
 													exprs: []any{
 														&ruleRefExpr{
-															pos:  position{line: 997, col: 64, offset: 23679},
+															pos:  position{line: 997, col: 64, offset: 23681},
 															name: "__",
 														},
 														&actionExpr{
-															pos: position{line: 997, col: 68, offset: 23683},
+															pos: position{line: 997, col: 68, offset: 23685},
 															run: (*parser).callonComparisonExpr29,
 															expr: &litMatcher{
-																pos:        position{line: 997, col: 68, offset: 23683},
+																pos:        position{line: 997, col: 68, offset: 23685},
 																val:        "~",
 																ignoreCase: false,
 																want:       "\"~\"",
 															},
 														},
 														&ruleRefExpr{
-															pos:  position{line: 997, col: 104, offset: 23719},
+															pos:  position{line: 997, col: 104, offset: 23721},
 															name: "__",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 997, col: 107, offset: 23722},
+															pos:  position{line: 997, col: 107, offset: 23724},
 															name: "Regexp",
 														},
 													},
@@ -6739,53 +6743,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 1010, col: 1, offset: 24008},
+			pos:  position{line: 1010, col: 1, offset: 24010},
 			expr: &actionExpr{
-				pos: position{line: 1011, col: 5, offset: 24025},
+				pos: position{line: 1011, col: 5, offset: 24027},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1011, col: 5, offset: 24025},
+					pos: position{line: 1011, col: 5, offset: 24027},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1011, col: 5, offset: 24025},
+							pos:   position{line: 1011, col: 5, offset: 24027},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1011, col: 11, offset: 24031},
+								pos:  position{line: 1011, col: 11, offset: 24033},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1012, col: 5, offset: 24054},
+							pos:   position{line: 1012, col: 5, offset: 24056},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1012, col: 10, offset: 24059},
+								pos: position{line: 1012, col: 10, offset: 24061},
 								expr: &actionExpr{
-									pos: position{line: 1012, col: 11, offset: 24060},
+									pos: position{line: 1012, col: 11, offset: 24062},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 1012, col: 11, offset: 24060},
+										pos: position{line: 1012, col: 11, offset: 24062},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1012, col: 11, offset: 24060},
+												pos:  position{line: 1012, col: 11, offset: 24062},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1012, col: 14, offset: 24063},
+												pos:   position{line: 1012, col: 14, offset: 24065},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1012, col: 17, offset: 24066},
+													pos:  position{line: 1012, col: 17, offset: 24068},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1012, col: 34, offset: 24083},
+												pos:  position{line: 1012, col: 34, offset: 24085},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1012, col: 37, offset: 24086},
+												pos:   position{line: 1012, col: 37, offset: 24088},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1012, col: 42, offset: 24091},
+													pos:  position{line: 1012, col: 42, offset: 24093},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -6802,21 +6806,21 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 1016, col: 1, offset: 24209},
+			pos:  position{line: 1016, col: 1, offset: 24211},
 			expr: &actionExpr{
-				pos: position{line: 1016, col: 20, offset: 24228},
+				pos: position{line: 1016, col: 20, offset: 24230},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 1016, col: 21, offset: 24229},
+					pos: position{line: 1016, col: 21, offset: 24231},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1016, col: 21, offset: 24229},
+							pos:        position{line: 1016, col: 21, offset: 24231},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1016, col: 27, offset: 24235},
+							pos:        position{line: 1016, col: 27, offset: 24237},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
@@ -6829,53 +6833,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 1018, col: 1, offset: 24272},
+			pos:  position{line: 1018, col: 1, offset: 24274},
 			expr: &actionExpr{
-				pos: position{line: 1019, col: 5, offset: 24295},
+				pos: position{line: 1019, col: 5, offset: 24297},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1019, col: 5, offset: 24295},
+					pos: position{line: 1019, col: 5, offset: 24297},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1019, col: 5, offset: 24295},
+							pos:   position{line: 1019, col: 5, offset: 24297},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1019, col: 11, offset: 24301},
+								pos:  position{line: 1019, col: 11, offset: 24303},
 								name: "ConcatExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1020, col: 5, offset: 24316},
+							pos:   position{line: 1020, col: 5, offset: 24318},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1020, col: 10, offset: 24321},
+								pos: position{line: 1020, col: 10, offset: 24323},
 								expr: &actionExpr{
-									pos: position{line: 1020, col: 11, offset: 24322},
+									pos: position{line: 1020, col: 11, offset: 24324},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 1020, col: 11, offset: 24322},
+										pos: position{line: 1020, col: 11, offset: 24324},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1020, col: 11, offset: 24322},
+												pos:  position{line: 1020, col: 11, offset: 24324},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1020, col: 14, offset: 24325},
+												pos:   position{line: 1020, col: 14, offset: 24327},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1020, col: 17, offset: 24328},
+													pos:  position{line: 1020, col: 17, offset: 24330},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1020, col: 40, offset: 24351},
+												pos:  position{line: 1020, col: 40, offset: 24353},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1020, col: 43, offset: 24354},
+												pos:   position{line: 1020, col: 43, offset: 24356},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1020, col: 48, offset: 24359},
+													pos:  position{line: 1020, col: 48, offset: 24361},
 													name: "ConcatExpr",
 												},
 											},
@@ -6892,27 +6896,27 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 1024, col: 1, offset: 24469},
+			pos:  position{line: 1024, col: 1, offset: 24471},
 			expr: &actionExpr{
-				pos: position{line: 1024, col: 26, offset: 24494},
+				pos: position{line: 1024, col: 26, offset: 24496},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 1024, col: 27, offset: 24495},
+					pos: position{line: 1024, col: 27, offset: 24497},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1024, col: 27, offset: 24495},
+							pos:        position{line: 1024, col: 27, offset: 24497},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1024, col: 33, offset: 24501},
+							pos:        position{line: 1024, col: 33, offset: 24503},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1024, col: 39, offset: 24507},
+							pos:        position{line: 1024, col: 39, offset: 24509},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
@@ -6925,51 +6929,51 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatExpr",
-			pos:  position{line: 1026, col: 1, offset: 24544},
+			pos:  position{line: 1026, col: 1, offset: 24546},
 			expr: &actionExpr{
-				pos: position{line: 1027, col: 5, offset: 24560},
+				pos: position{line: 1027, col: 5, offset: 24562},
 				run: (*parser).callonConcatExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1027, col: 5, offset: 24560},
+					pos: position{line: 1027, col: 5, offset: 24562},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1027, col: 5, offset: 24560},
+							pos:   position{line: 1027, col: 5, offset: 24562},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1027, col: 11, offset: 24566},
+								pos:  position{line: 1027, col: 11, offset: 24568},
 								name: "UnaryPlusOrMinus",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1028, col: 5, offset: 24587},
+							pos:   position{line: 1028, col: 5, offset: 24589},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1028, col: 10, offset: 24592},
+								pos: position{line: 1028, col: 10, offset: 24594},
 								expr: &actionExpr{
-									pos: position{line: 1028, col: 11, offset: 24593},
+									pos: position{line: 1028, col: 11, offset: 24595},
 									run: (*parser).callonConcatExpr7,
 									expr: &seqExpr{
-										pos: position{line: 1028, col: 11, offset: 24593},
+										pos: position{line: 1028, col: 11, offset: 24595},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1028, col: 11, offset: 24593},
+												pos:  position{line: 1028, col: 11, offset: 24595},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1028, col: 14, offset: 24596},
+												pos:        position{line: 1028, col: 14, offset: 24598},
 												val:        "||",
 												ignoreCase: false,
 												want:       "\"||\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1028, col: 19, offset: 24601},
+												pos:  position{line: 1028, col: 19, offset: 24603},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1028, col: 22, offset: 24604},
+												pos:   position{line: 1028, col: 22, offset: 24606},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1028, col: 27, offset: 24609},
+													pos:  position{line: 1028, col: 27, offset: 24611},
 													name: "UnaryPlusOrMinus",
 												},
 											},
@@ -6986,40 +6990,40 @@ var g = &grammar{
 		},
 		{
 			name: "UnaryPlusOrMinus",
-			pos:  position{line: 1032, col: 1, offset: 24727},
+			pos:  position{line: 1032, col: 1, offset: 24729},
 			expr: &choiceExpr{
-				pos: position{line: 1033, col: 5, offset: 24748},
+				pos: position{line: 1033, col: 5, offset: 24750},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1033, col: 5, offset: 24748},
+						pos: position{line: 1033, col: 5, offset: 24750},
 						run: (*parser).callonUnaryPlusOrMinus2,
 						expr: &seqExpr{
-							pos: position{line: 1033, col: 5, offset: 24748},
+							pos: position{line: 1033, col: 5, offset: 24750},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1033, col: 5, offset: 24748},
+									pos: position{line: 1033, col: 5, offset: 24750},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1033, col: 6, offset: 24749},
+										pos:  position{line: 1033, col: 6, offset: 24751},
 										name: "Literal",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1033, col: 14, offset: 24757},
+									pos:   position{line: 1033, col: 14, offset: 24759},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1033, col: 17, offset: 24760},
+										pos:  position{line: 1033, col: 17, offset: 24762},
 										name: "PlusOrMinusOp",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1033, col: 31, offset: 24774},
+									pos:  position{line: 1033, col: 31, offset: 24776},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1033, col: 34, offset: 24777},
+									pos:   position{line: 1033, col: 34, offset: 24779},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1033, col: 36, offset: 24779},
+										pos:  position{line: 1033, col: 36, offset: 24781},
 										name: "UnaryPlusOrMinus",
 									},
 								},
@@ -7027,7 +7031,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1042, col: 5, offset: 24963},
+						pos:  position{line: 1042, col: 5, offset: 24965},
 						name: "DerefExpr",
 					},
 				},
@@ -7037,21 +7041,21 @@ var g = &grammar{
 		},
 		{
 			name: "PlusOrMinusOp",
-			pos:  position{line: 1044, col: 1, offset: 24974},
+			pos:  position{line: 1044, col: 1, offset: 24976},
 			expr: &actionExpr{
-				pos: position{line: 1044, col: 17, offset: 24990},
+				pos: position{line: 1044, col: 17, offset: 24992},
 				run: (*parser).callonPlusOrMinusOp1,
 				expr: &choiceExpr{
-					pos: position{line: 1044, col: 18, offset: 24991},
+					pos: position{line: 1044, col: 18, offset: 24993},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1044, col: 18, offset: 24991},
+							pos:        position{line: 1044, col: 18, offset: 24993},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1044, col: 24, offset: 24997},
+							pos:        position{line: 1044, col: 24, offset: 24999},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
@@ -7064,73 +7068,73 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 1046, col: 1, offset: 25034},
+			pos:  position{line: 1046, col: 1, offset: 25036},
 			expr: &choiceExpr{
-				pos: position{line: 1047, col: 5, offset: 25048},
+				pos: position{line: 1047, col: 5, offset: 25050},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1047, col: 5, offset: 25048},
+						pos: position{line: 1047, col: 5, offset: 25050},
 						run: (*parser).callonDerefExpr2,
 						expr: &seqExpr{
-							pos: position{line: 1047, col: 5, offset: 25048},
+							pos: position{line: 1047, col: 5, offset: 25050},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1047, col: 5, offset: 25048},
+									pos:   position{line: 1047, col: 5, offset: 25050},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1047, col: 10, offset: 25053},
+										pos:  position{line: 1047, col: 10, offset: 25055},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1047, col: 20, offset: 25063},
+									pos:        position{line: 1047, col: 20, offset: 25065},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1047, col: 24, offset: 25067},
+									pos:  position{line: 1047, col: 24, offset: 25069},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1047, col: 27, offset: 25070},
+									pos:   position{line: 1047, col: 27, offset: 25072},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1047, col: 32, offset: 25075},
+										pos:  position{line: 1047, col: 32, offset: 25077},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1047, col: 45, offset: 25088},
+									pos:  position{line: 1047, col: 45, offset: 25090},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1047, col: 48, offset: 25091},
+									pos:        position{line: 1047, col: 48, offset: 25093},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1047, col: 52, offset: 25095},
+									pos:  position{line: 1047, col: 52, offset: 25097},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1047, col: 55, offset: 25098},
+									pos:   position{line: 1047, col: 55, offset: 25100},
 									label: "to",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1047, col: 58, offset: 25101},
+										pos: position{line: 1047, col: 58, offset: 25103},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1047, col: 58, offset: 25101},
+											pos:  position{line: 1047, col: 58, offset: 25103},
 											name: "AdditiveExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1047, col: 72, offset: 25115},
+									pos:  position{line: 1047, col: 72, offset: 25117},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1047, col: 75, offset: 25118},
+									pos:        position{line: 1047, col: 75, offset: 25120},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -7139,49 +7143,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1059, col: 5, offset: 25357},
+						pos: position{line: 1059, col: 5, offset: 25359},
 						run: (*parser).callonDerefExpr18,
 						expr: &seqExpr{
-							pos: position{line: 1059, col: 5, offset: 25357},
+							pos: position{line: 1059, col: 5, offset: 25359},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1059, col: 5, offset: 25357},
+									pos:   position{line: 1059, col: 5, offset: 25359},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1059, col: 10, offset: 25362},
+										pos:  position{line: 1059, col: 10, offset: 25364},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1059, col: 20, offset: 25372},
+									pos:        position{line: 1059, col: 20, offset: 25374},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1059, col: 24, offset: 25376},
+									pos:  position{line: 1059, col: 24, offset: 25378},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1059, col: 27, offset: 25379},
+									pos:        position{line: 1059, col: 27, offset: 25381},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1059, col: 31, offset: 25383},
+									pos:  position{line: 1059, col: 31, offset: 25385},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1059, col: 34, offset: 25386},
+									pos:   position{line: 1059, col: 34, offset: 25388},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1059, col: 37, offset: 25389},
+										pos:  position{line: 1059, col: 37, offset: 25391},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1059, col: 50, offset: 25402},
+									pos:        position{line: 1059, col: 50, offset: 25404},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -7190,35 +7194,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1067, col: 5, offset: 25566},
+						pos: position{line: 1067, col: 5, offset: 25568},
 						run: (*parser).callonDerefExpr29,
 						expr: &seqExpr{
-							pos: position{line: 1067, col: 5, offset: 25566},
+							pos: position{line: 1067, col: 5, offset: 25568},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1067, col: 5, offset: 25566},
+									pos:   position{line: 1067, col: 5, offset: 25568},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1067, col: 10, offset: 25571},
+										pos:  position{line: 1067, col: 10, offset: 25573},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1067, col: 20, offset: 25581},
+									pos:        position{line: 1067, col: 20, offset: 25583},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1067, col: 24, offset: 25585},
+									pos:   position{line: 1067, col: 24, offset: 25587},
 									label: "index",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1067, col: 30, offset: 25591},
+										pos:  position{line: 1067, col: 30, offset: 25593},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1067, col: 35, offset: 25596},
+									pos:        position{line: 1067, col: 35, offset: 25598},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -7227,30 +7231,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1075, col: 5, offset: 25766},
+						pos: position{line: 1075, col: 5, offset: 25768},
 						run: (*parser).callonDerefExpr37,
 						expr: &seqExpr{
-							pos: position{line: 1075, col: 5, offset: 25766},
+							pos: position{line: 1075, col: 5, offset: 25768},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1075, col: 5, offset: 25766},
+									pos:   position{line: 1075, col: 5, offset: 25768},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1075, col: 10, offset: 25771},
+										pos:  position{line: 1075, col: 10, offset: 25773},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1075, col: 20, offset: 25781},
+									pos:        position{line: 1075, col: 20, offset: 25783},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1075, col: 24, offset: 25785},
+									pos:   position{line: 1075, col: 24, offset: 25787},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1075, col: 27, offset: 25788},
+										pos:  position{line: 1075, col: 27, offset: 25790},
 										name: "DerefKey",
 									},
 								},
@@ -7258,11 +7262,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1084, col: 5, offset: 25976},
+						pos:  position{line: 1084, col: 5, offset: 25978},
 						name: "FuncExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1085, col: 5, offset: 25989},
+						pos:  position{line: 1085, col: 5, offset: 25991},
 						name: "Primary",
 					},
 				},
@@ -7272,34 +7276,34 @@ var g = &grammar{
 		},
 		{
 			name: "DerefKey",
-			pos:  position{line: 1087, col: 1, offset: 25998},
+			pos:  position{line: 1087, col: 1, offset: 26000},
 			expr: &choiceExpr{
-				pos: position{line: 1088, col: 5, offset: 26011},
+				pos: position{line: 1088, col: 5, offset: 26013},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1088, col: 5, offset: 26011},
+						pos:  position{line: 1088, col: 5, offset: 26013},
 						name: "Identifier",
 					},
 					&actionExpr{
-						pos: position{line: 1089, col: 5, offset: 26027},
+						pos: position{line: 1089, col: 5, offset: 26029},
 						run: (*parser).callonDerefKey3,
 						expr: &labeledExpr{
-							pos:   position{line: 1089, col: 5, offset: 26027},
+							pos:   position{line: 1089, col: 5, offset: 26029},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1089, col: 7, offset: 26029},
+								pos:  position{line: 1089, col: 7, offset: 26031},
 								name: "DoubleQuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1090, col: 5, offset: 26121},
+						pos: position{line: 1090, col: 5, offset: 26123},
 						run: (*parser).callonDerefKey6,
 						expr: &labeledExpr{
-							pos:   position{line: 1090, col: 5, offset: 26121},
+							pos:   position{line: 1090, col: 5, offset: 26123},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1090, col: 7, offset: 26123},
+								pos:  position{line: 1090, col: 7, offset: 26125},
 								name: "BacktickString",
 							},
 						},
@@ -7311,16 +7315,16 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 1092, col: 1, offset: 26212},
+			pos:  position{line: 1092, col: 1, offset: 26214},
 			expr: &choiceExpr{
-				pos: position{line: 1093, col: 5, offset: 26225},
+				pos: position{line: 1093, col: 5, offset: 26227},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1093, col: 5, offset: 26225},
+						pos:  position{line: 1093, col: 5, offset: 26227},
 						name: "Cast",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1094, col: 5, offset: 26234},
+						pos:  position{line: 1094, col: 5, offset: 26236},
 						name: "Function",
 					},
 				},
@@ -7330,20 +7334,20 @@ var g = &grammar{
 		},
 		{
 			name: "FuncGuard",
-			pos:  position{line: 1096, col: 1, offset: 26244},
+			pos:  position{line: 1096, col: 1, offset: 26246},
 			expr: &seqExpr{
-				pos: position{line: 1096, col: 13, offset: 26256},
+				pos: position{line: 1096, col: 13, offset: 26258},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1096, col: 13, offset: 26256},
+						pos:  position{line: 1096, col: 13, offset: 26258},
 						name: "NotFuncs",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1096, col: 22, offset: 26265},
+						pos:  position{line: 1096, col: 22, offset: 26267},
 						name: "__",
 					},
 					&litMatcher{
-						pos:        position{line: 1096, col: 25, offset: 26268},
+						pos:        position{line: 1096, col: 25, offset: 26270},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
@@ -7355,16 +7359,16 @@ var g = &grammar{
 		},
 		{
 			name: "NotFuncs",
-			pos:  position{line: 1098, col: 1, offset: 26273},
+			pos:  position{line: 1098, col: 1, offset: 26275},
 			expr: &choiceExpr{
-				pos: position{line: 1099, col: 5, offset: 26286},
+				pos: position{line: 1099, col: 5, offset: 26288},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1099, col: 5, offset: 26286},
+						pos:  position{line: 1099, col: 5, offset: 26288},
 						name: "NOT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1100, col: 5, offset: 26294},
+						pos:  position{line: 1100, col: 5, offset: 26296},
 						name: "SELECT",
 					},
 				},
@@ -7374,58 +7378,58 @@ var g = &grammar{
 		},
 		{
 			name: "Cast",
-			pos:  position{line: 1102, col: 1, offset: 26302},
+			pos:  position{line: 1102, col: 1, offset: 26304},
 			expr: &actionExpr{
-				pos: position{line: 1103, col: 5, offset: 26311},
+				pos: position{line: 1103, col: 5, offset: 26313},
 				run: (*parser).callonCast1,
 				expr: &seqExpr{
-					pos: position{line: 1103, col: 5, offset: 26311},
+					pos: position{line: 1103, col: 5, offset: 26313},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1103, col: 5, offset: 26311},
+							pos:   position{line: 1103, col: 5, offset: 26313},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1103, col: 9, offset: 26315},
+								pos:  position{line: 1103, col: 9, offset: 26317},
 								name: "TypeLiteral",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1103, col: 21, offset: 26327},
+							pos:  position{line: 1103, col: 21, offset: 26329},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1103, col: 24, offset: 26330},
+							pos:        position{line: 1103, col: 24, offset: 26332},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1103, col: 28, offset: 26334},
+							pos:  position{line: 1103, col: 28, offset: 26336},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1103, col: 31, offset: 26337},
+							pos:   position{line: 1103, col: 31, offset: 26339},
 							label: "expr",
 							expr: &choiceExpr{
-								pos: position{line: 1103, col: 37, offset: 26343},
+								pos: position{line: 1103, col: 37, offset: 26345},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1103, col: 37, offset: 26343},
+										pos:  position{line: 1103, col: 37, offset: 26345},
 										name: "OverExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1103, col: 48, offset: 26354},
+										pos:  position{line: 1103, col: 48, offset: 26356},
 										name: "Expr",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1103, col: 54, offset: 26360},
+							pos:  position{line: 1103, col: 54, offset: 26362},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1103, col: 57, offset: 26363},
+							pos:        position{line: 1103, col: 57, offset: 26365},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -7438,85 +7442,85 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 1107, col: 1, offset: 26476},
+			pos:  position{line: 1107, col: 1, offset: 26478},
 			expr: &choiceExpr{
-				pos: position{line: 1108, col: 5, offset: 26489},
+				pos: position{line: 1108, col: 5, offset: 26491},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1108, col: 5, offset: 26489},
+						pos:  position{line: 1108, col: 5, offset: 26491},
 						name: "Grep",
 					},
 					&actionExpr{
-						pos: position{line: 1110, col: 5, offset: 26576},
+						pos: position{line: 1110, col: 5, offset: 26578},
 						run: (*parser).callonFunction3,
 						expr: &seqExpr{
-							pos: position{line: 1110, col: 5, offset: 26576},
+							pos: position{line: 1110, col: 5, offset: 26578},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1110, col: 5, offset: 26576},
+									pos:  position{line: 1110, col: 5, offset: 26578},
 									name: "REGEXP",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1110, col: 12, offset: 26583},
+									pos:  position{line: 1110, col: 12, offset: 26585},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1110, col: 15, offset: 26586},
+									pos:        position{line: 1110, col: 15, offset: 26588},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1110, col: 19, offset: 26590},
+									pos:  position{line: 1110, col: 19, offset: 26592},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1110, col: 22, offset: 26593},
+									pos:   position{line: 1110, col: 22, offset: 26595},
 									label: "arg0",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1110, col: 27, offset: 26598},
+										pos:  position{line: 1110, col: 27, offset: 26600},
 										name: "RegexpPrimitive",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1110, col: 43, offset: 26614},
+									pos:  position{line: 1110, col: 43, offset: 26616},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1110, col: 46, offset: 26617},
+									pos:        position{line: 1110, col: 46, offset: 26619},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1110, col: 50, offset: 26621},
+									pos:  position{line: 1110, col: 50, offset: 26623},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1110, col: 53, offset: 26624},
+									pos:   position{line: 1110, col: 53, offset: 26626},
 									label: "arg1",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1110, col: 58, offset: 26629},
+										pos:  position{line: 1110, col: 58, offset: 26631},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1110, col: 63, offset: 26634},
+									pos:  position{line: 1110, col: 63, offset: 26636},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1110, col: 66, offset: 26637},
+									pos:        position{line: 1110, col: 66, offset: 26639},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1110, col: 70, offset: 26641},
+									pos:   position{line: 1110, col: 70, offset: 26643},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1110, col: 76, offset: 26647},
+										pos: position{line: 1110, col: 76, offset: 26649},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1110, col: 76, offset: 26647},
+											pos:  position{line: 1110, col: 76, offset: 26649},
 											name: "WhereClause",
 										},
 									},
@@ -7525,98 +7529,98 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1114, col: 5, offset: 26826},
+						pos: position{line: 1114, col: 5, offset: 26828},
 						run: (*parser).callonFunction21,
 						expr: &seqExpr{
-							pos: position{line: 1114, col: 5, offset: 26826},
+							pos: position{line: 1114, col: 5, offset: 26828},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1114, col: 5, offset: 26826},
+									pos:  position{line: 1114, col: 5, offset: 26828},
 									name: "REGEXP_REPLACE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1114, col: 20, offset: 26841},
+									pos:  position{line: 1114, col: 20, offset: 26843},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1114, col: 23, offset: 26844},
+									pos:        position{line: 1114, col: 23, offset: 26846},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1114, col: 27, offset: 26848},
+									pos:  position{line: 1114, col: 27, offset: 26850},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1114, col: 30, offset: 26851},
+									pos:   position{line: 1114, col: 30, offset: 26853},
 									label: "arg0",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1114, col: 35, offset: 26856},
+										pos:  position{line: 1114, col: 35, offset: 26858},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1114, col: 40, offset: 26861},
+									pos:  position{line: 1114, col: 40, offset: 26863},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1114, col: 43, offset: 26864},
+									pos:        position{line: 1114, col: 43, offset: 26866},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1114, col: 47, offset: 26868},
+									pos:  position{line: 1114, col: 47, offset: 26870},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1114, col: 50, offset: 26871},
+									pos:   position{line: 1114, col: 50, offset: 26873},
 									label: "arg1",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1114, col: 55, offset: 26876},
+										pos:  position{line: 1114, col: 55, offset: 26878},
 										name: "RegexpPrimitive",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1114, col: 71, offset: 26892},
+									pos:  position{line: 1114, col: 71, offset: 26894},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1114, col: 74, offset: 26895},
+									pos:        position{line: 1114, col: 74, offset: 26897},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1114, col: 78, offset: 26899},
+									pos:  position{line: 1114, col: 78, offset: 26901},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1114, col: 81, offset: 26902},
+									pos:   position{line: 1114, col: 81, offset: 26904},
 									label: "arg2",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1114, col: 86, offset: 26907},
+										pos:  position{line: 1114, col: 86, offset: 26909},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1114, col: 91, offset: 26912},
+									pos:  position{line: 1114, col: 91, offset: 26914},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1114, col: 94, offset: 26915},
+									pos:        position{line: 1114, col: 94, offset: 26917},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1114, col: 98, offset: 26919},
+									pos:   position{line: 1114, col: 98, offset: 26921},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1114, col: 104, offset: 26925},
+										pos: position{line: 1114, col: 104, offset: 26927},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1114, col: 104, offset: 26925},
+											pos:  position{line: 1114, col: 104, offset: 26927},
 											name: "WhereClause",
 										},
 									},
@@ -7625,81 +7629,81 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1118, col: 5, offset: 27119},
+						pos: position{line: 1118, col: 5, offset: 27121},
 						run: (*parser).callonFunction44,
 						expr: &seqExpr{
-							pos: position{line: 1118, col: 5, offset: 27119},
+							pos: position{line: 1118, col: 5, offset: 27121},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1118, col: 5, offset: 27119},
+									pos: position{line: 1118, col: 5, offset: 27121},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1118, col: 6, offset: 27120},
+										pos:  position{line: 1118, col: 6, offset: 27122},
 										name: "FuncGuard",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1118, col: 16, offset: 27130},
+									pos:  position{line: 1118, col: 16, offset: 27132},
 									name: "EXTRACT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1118, col: 24, offset: 27138},
+									pos:  position{line: 1118, col: 24, offset: 27140},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1118, col: 27, offset: 27141},
+									pos:        position{line: 1118, col: 27, offset: 27143},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1118, col: 31, offset: 27145},
+									pos:  position{line: 1118, col: 31, offset: 27147},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1118, col: 34, offset: 27148},
+									pos:   position{line: 1118, col: 34, offset: 27150},
 									label: "part",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1118, col: 39, offset: 27153},
+										pos:  position{line: 1118, col: 39, offset: 27155},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1118, col: 44, offset: 27158},
+									pos:  position{line: 1118, col: 44, offset: 27160},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1118, col: 46, offset: 27160},
+									pos:  position{line: 1118, col: 46, offset: 27162},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1118, col: 51, offset: 27165},
+									pos:  position{line: 1118, col: 51, offset: 27167},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1118, col: 53, offset: 27167},
+									pos:   position{line: 1118, col: 53, offset: 27169},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1118, col: 55, offset: 27169},
+										pos:  position{line: 1118, col: 55, offset: 27171},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1118, col: 60, offset: 27174},
+									pos:  position{line: 1118, col: 60, offset: 27176},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1118, col: 63, offset: 27177},
+									pos:        position{line: 1118, col: 63, offset: 27179},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1118, col: 67, offset: 27181},
+									pos:   position{line: 1118, col: 67, offset: 27183},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1118, col: 73, offset: 27187},
+										pos: position{line: 1118, col: 73, offset: 27189},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1118, col: 73, offset: 27187},
+											pos:  position{line: 1118, col: 73, offset: 27189},
 											name: "WhereClause",
 										},
 									},
@@ -7708,70 +7712,70 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1126, col: 5, offset: 27366},
+						pos: position{line: 1126, col: 5, offset: 27368},
 						run: (*parser).callonFunction64,
 						expr: &seqExpr{
-							pos: position{line: 1126, col: 5, offset: 27366},
+							pos: position{line: 1126, col: 5, offset: 27368},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1126, col: 5, offset: 27366},
+									pos: position{line: 1126, col: 5, offset: 27368},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1126, col: 6, offset: 27367},
+										pos:  position{line: 1126, col: 6, offset: 27369},
 										name: "FuncGuard",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1126, col: 16, offset: 27377},
+									pos:  position{line: 1126, col: 16, offset: 27379},
 									name: "CAST",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1126, col: 21, offset: 27382},
+									pos:  position{line: 1126, col: 21, offset: 27384},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1126, col: 24, offset: 27385},
+									pos:        position{line: 1126, col: 24, offset: 27387},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1126, col: 28, offset: 27389},
+									pos:  position{line: 1126, col: 28, offset: 27391},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1126, col: 31, offset: 27392},
+									pos:   position{line: 1126, col: 31, offset: 27394},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1126, col: 33, offset: 27394},
+										pos:  position{line: 1126, col: 33, offset: 27396},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1126, col: 38, offset: 27399},
+									pos:  position{line: 1126, col: 38, offset: 27401},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1126, col: 40, offset: 27401},
+									pos:  position{line: 1126, col: 40, offset: 27403},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1126, col: 43, offset: 27404},
+									pos:  position{line: 1126, col: 43, offset: 27406},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1126, col: 45, offset: 27406},
+									pos:   position{line: 1126, col: 45, offset: 27408},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1126, col: 49, offset: 27410},
+										pos:  position{line: 1126, col: 49, offset: 27412},
 										name: "Identifier",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1126, col: 60, offset: 27421},
+									pos:  position{line: 1126, col: 60, offset: 27423},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1126, col: 63, offset: 27424},
+									pos:        position{line: 1126, col: 63, offset: 27426},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7780,72 +7784,72 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1134, col: 5, offset: 27583},
+						pos: position{line: 1134, col: 5, offset: 27585},
 						run: (*parser).callonFunction81,
 						expr: &seqExpr{
-							pos: position{line: 1134, col: 5, offset: 27583},
+							pos: position{line: 1134, col: 5, offset: 27585},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1134, col: 5, offset: 27583},
+									pos: position{line: 1134, col: 5, offset: 27585},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1134, col: 6, offset: 27584},
+										pos:  position{line: 1134, col: 6, offset: 27586},
 										name: "FuncGuard",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1134, col: 16, offset: 27594},
+									pos:  position{line: 1134, col: 16, offset: 27596},
 									name: "SUBSTRING",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1134, col: 26, offset: 27604},
+									pos:  position{line: 1134, col: 26, offset: 27606},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1134, col: 29, offset: 27607},
+									pos:        position{line: 1134, col: 29, offset: 27609},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1134, col: 33, offset: 27611},
+									pos:  position{line: 1134, col: 33, offset: 27613},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1134, col: 36, offset: 27614},
+									pos:   position{line: 1134, col: 36, offset: 27616},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1134, col: 41, offset: 27619},
+										pos:  position{line: 1134, col: 41, offset: 27621},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1134, col: 46, offset: 27624},
+									pos:   position{line: 1134, col: 46, offset: 27626},
 									label: "from",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1134, col: 51, offset: 27629},
+										pos: position{line: 1134, col: 51, offset: 27631},
 										expr: &actionExpr{
-											pos: position{line: 1134, col: 52, offset: 27630},
+											pos: position{line: 1134, col: 52, offset: 27632},
 											run: (*parser).callonFunction93,
 											expr: &seqExpr{
-												pos: position{line: 1134, col: 52, offset: 27630},
+												pos: position{line: 1134, col: 52, offset: 27632},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1134, col: 52, offset: 27630},
+														pos:  position{line: 1134, col: 52, offset: 27632},
 														name: "_",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1134, col: 54, offset: 27632},
+														pos:  position{line: 1134, col: 54, offset: 27634},
 														name: "FROM",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1134, col: 59, offset: 27637},
+														pos:  position{line: 1134, col: 59, offset: 27639},
 														name: "_",
 													},
 													&labeledExpr{
-														pos:   position{line: 1134, col: 61, offset: 27639},
+														pos:   position{line: 1134, col: 61, offset: 27641},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1134, col: 63, offset: 27641},
+															pos:  position{line: 1134, col: 63, offset: 27643},
 															name: "Expr",
 														},
 													},
@@ -7855,33 +7859,33 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1134, col: 88, offset: 27666},
+									pos:   position{line: 1134, col: 88, offset: 27668},
 									label: "for_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1134, col: 93, offset: 27671},
+										pos: position{line: 1134, col: 93, offset: 27673},
 										expr: &actionExpr{
-											pos: position{line: 1134, col: 94, offset: 27672},
+											pos: position{line: 1134, col: 94, offset: 27674},
 											run: (*parser).callonFunction102,
 											expr: &seqExpr{
-												pos: position{line: 1134, col: 94, offset: 27672},
+												pos: position{line: 1134, col: 94, offset: 27674},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1134, col: 94, offset: 27672},
+														pos:  position{line: 1134, col: 94, offset: 27674},
 														name: "_",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1134, col: 96, offset: 27674},
+														pos:  position{line: 1134, col: 96, offset: 27676},
 														name: "FOR",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1134, col: 100, offset: 27678},
+														pos:  position{line: 1134, col: 100, offset: 27680},
 														name: "_",
 													},
 													&labeledExpr{
-														pos:   position{line: 1134, col: 102, offset: 27680},
+														pos:   position{line: 1134, col: 102, offset: 27682},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1134, col: 104, offset: 27682},
+															pos:  position{line: 1134, col: 104, offset: 27684},
 															name: "Expr",
 														},
 													},
@@ -7891,7 +7895,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1134, col: 129, offset: 27707},
+									pos:        position{line: 1134, col: 129, offset: 27709},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7900,65 +7904,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1148, col: 5, offset: 27990},
+						pos: position{line: 1148, col: 5, offset: 27992},
 						run: (*parser).callonFunction110,
 						expr: &seqExpr{
-							pos: position{line: 1148, col: 5, offset: 27990},
+							pos: position{line: 1148, col: 5, offset: 27992},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1148, col: 5, offset: 27990},
+									pos: position{line: 1148, col: 5, offset: 27992},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1148, col: 6, offset: 27991},
+										pos:  position{line: 1148, col: 6, offset: 27993},
 										name: "FuncGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1148, col: 16, offset: 28001},
+									pos:   position{line: 1148, col: 16, offset: 28003},
 									label: "fn",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1148, col: 19, offset: 28004},
+										pos:  position{line: 1148, col: 19, offset: 28006},
 										name: "Identifier",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1148, col: 30, offset: 28015},
+									pos:  position{line: 1148, col: 30, offset: 28017},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1148, col: 33, offset: 28018},
+									pos:        position{line: 1148, col: 33, offset: 28020},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1148, col: 37, offset: 28022},
+									pos:  position{line: 1148, col: 37, offset: 28024},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1148, col: 40, offset: 28025},
+									pos:   position{line: 1148, col: 40, offset: 28027},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1148, col: 45, offset: 28030},
+										pos:  position{line: 1148, col: 45, offset: 28032},
 										name: "FunctionArgs",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1148, col: 58, offset: 28043},
+									pos:  position{line: 1148, col: 58, offset: 28045},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1148, col: 61, offset: 28046},
+									pos:        position{line: 1148, col: 61, offset: 28048},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1148, col: 65, offset: 28050},
+									pos:   position{line: 1148, col: 65, offset: 28052},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1148, col: 71, offset: 28056},
+										pos: position{line: 1148, col: 71, offset: 28058},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1148, col: 71, offset: 28056},
+											pos:  position{line: 1148, col: 71, offset: 28058},
 											name: "WhereClause",
 										},
 									},
@@ -7967,7 +7971,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1151, col: 5, offset: 28127},
+						pos:  position{line: 1151, col: 5, offset: 28129},
 						name: "CountStar",
 					},
 				},
@@ -7977,15 +7981,15 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPrimitive",
-			pos:  position{line: 1153, col: 1, offset: 28138},
+			pos:  position{line: 1153, col: 1, offset: 28140},
 			expr: &actionExpr{
-				pos: position{line: 1154, col: 5, offset: 28158},
+				pos: position{line: 1154, col: 5, offset: 28160},
 				run: (*parser).callonRegexpPrimitive1,
 				expr: &labeledExpr{
-					pos:   position{line: 1154, col: 5, offset: 28158},
+					pos:   position{line: 1154, col: 5, offset: 28160},
 					label: "pat",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1154, col: 9, offset: 28162},
+						pos:  position{line: 1154, col: 9, offset: 28164},
 						name: "RegexpPattern",
 					},
 				},
@@ -7995,24 +7999,24 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionArgs",
-			pos:  position{line: 1156, col: 1, offset: 28233},
+			pos:  position{line: 1156, col: 1, offset: 28235},
 			expr: &choiceExpr{
-				pos: position{line: 1157, col: 5, offset: 28250},
+				pos: position{line: 1157, col: 5, offset: 28252},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1157, col: 5, offset: 28250},
+						pos: position{line: 1157, col: 5, offset: 28252},
 						run: (*parser).callonFunctionArgs2,
 						expr: &labeledExpr{
-							pos:   position{line: 1157, col: 5, offset: 28250},
+							pos:   position{line: 1157, col: 5, offset: 28252},
 							label: "o",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1157, col: 7, offset: 28252},
+								pos:  position{line: 1157, col: 7, offset: 28254},
 								name: "OverExpr",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1158, col: 5, offset: 28290},
+						pos:  position{line: 1158, col: 5, offset: 28292},
 						name: "OptionalExprs",
 					},
 				},
@@ -8022,96 +8026,96 @@ var g = &grammar{
 		},
 		{
 			name: "Grep",
-			pos:  position{line: 1160, col: 1, offset: 28305},
+			pos:  position{line: 1160, col: 1, offset: 28307},
 			expr: &actionExpr{
-				pos: position{line: 1161, col: 5, offset: 28314},
+				pos: position{line: 1161, col: 5, offset: 28316},
 				run: (*parser).callonGrep1,
 				expr: &seqExpr{
-					pos: position{line: 1161, col: 5, offset: 28314},
+					pos: position{line: 1161, col: 5, offset: 28316},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1161, col: 5, offset: 28314},
+							pos:  position{line: 1161, col: 5, offset: 28316},
 							name: "GREP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1161, col: 10, offset: 28319},
+							pos:  position{line: 1161, col: 10, offset: 28321},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1161, col: 13, offset: 28322},
+							pos:        position{line: 1161, col: 13, offset: 28324},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1161, col: 17, offset: 28326},
+							pos:  position{line: 1161, col: 17, offset: 28328},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1161, col: 20, offset: 28329},
+							pos:   position{line: 1161, col: 20, offset: 28331},
 							label: "pattern",
 							expr: &choiceExpr{
-								pos: position{line: 1161, col: 29, offset: 28338},
+								pos: position{line: 1161, col: 29, offset: 28340},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1161, col: 29, offset: 28338},
+										pos:  position{line: 1161, col: 29, offset: 28340},
 										name: "Regexp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1161, col: 38, offset: 28347},
+										pos:  position{line: 1161, col: 38, offset: 28349},
 										name: "Glob",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1161, col: 45, offset: 28354},
+										pos:  position{line: 1161, col: 45, offset: 28356},
 										name: "Expr",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1161, col: 51, offset: 28360},
+							pos:  position{line: 1161, col: 51, offset: 28362},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1161, col: 54, offset: 28363},
+							pos:   position{line: 1161, col: 54, offset: 28365},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1161, col: 58, offset: 28367},
+								pos: position{line: 1161, col: 58, offset: 28369},
 								expr: &actionExpr{
-									pos: position{line: 1161, col: 59, offset: 28368},
+									pos: position{line: 1161, col: 59, offset: 28370},
 									run: (*parser).callonGrep15,
 									expr: &seqExpr{
-										pos: position{line: 1161, col: 59, offset: 28368},
+										pos: position{line: 1161, col: 59, offset: 28370},
 										exprs: []any{
 											&litMatcher{
-												pos:        position{line: 1161, col: 59, offset: 28368},
+												pos:        position{line: 1161, col: 59, offset: 28370},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1161, col: 63, offset: 28372},
+												pos:  position{line: 1161, col: 63, offset: 28374},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1161, col: 66, offset: 28375},
+												pos:   position{line: 1161, col: 66, offset: 28377},
 												label: "e",
 												expr: &choiceExpr{
-													pos: position{line: 1161, col: 69, offset: 28378},
+													pos: position{line: 1161, col: 69, offset: 28380},
 													alternatives: []any{
 														&ruleRefExpr{
-															pos:  position{line: 1161, col: 69, offset: 28378},
+															pos:  position{line: 1161, col: 69, offset: 28380},
 															name: "OverExpr",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 1161, col: 80, offset: 28389},
+															pos:  position{line: 1161, col: 80, offset: 28391},
 															name: "Expr",
 														},
 													},
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1161, col: 86, offset: 28395},
+												pos:  position{line: 1161, col: 86, offset: 28397},
 												name: "__",
 											},
 										},
@@ -8120,7 +8124,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1161, col: 109, offset: 28418},
+							pos:        position{line: 1161, col: 109, offset: 28420},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -8133,19 +8137,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptionalExprs",
-			pos:  position{line: 1173, col: 1, offset: 28631},
+			pos:  position{line: 1173, col: 1, offset: 28633},
 			expr: &choiceExpr{
-				pos: position{line: 1174, col: 5, offset: 28649},
+				pos: position{line: 1174, col: 5, offset: 28651},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1174, col: 5, offset: 28649},
+						pos:  position{line: 1174, col: 5, offset: 28651},
 						name: "Exprs",
 					},
 					&actionExpr{
-						pos: position{line: 1175, col: 5, offset: 28659},
+						pos: position{line: 1175, col: 5, offset: 28661},
 						run: (*parser).callonOptionalExprs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1175, col: 5, offset: 28659},
+							pos:  position{line: 1175, col: 5, offset: 28661},
 							name: "__",
 						},
 					},
@@ -8156,51 +8160,51 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 1177, col: 1, offset: 28687},
+			pos:  position{line: 1177, col: 1, offset: 28689},
 			expr: &actionExpr{
-				pos: position{line: 1178, col: 5, offset: 28697},
+				pos: position{line: 1178, col: 5, offset: 28699},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 1178, col: 5, offset: 28697},
+					pos: position{line: 1178, col: 5, offset: 28699},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1178, col: 5, offset: 28697},
+							pos:   position{line: 1178, col: 5, offset: 28699},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1178, col: 11, offset: 28703},
+								pos:  position{line: 1178, col: 11, offset: 28705},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1178, col: 16, offset: 28708},
+							pos:   position{line: 1178, col: 16, offset: 28710},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1178, col: 21, offset: 28713},
+								pos: position{line: 1178, col: 21, offset: 28715},
 								expr: &actionExpr{
-									pos: position{line: 1178, col: 22, offset: 28714},
+									pos: position{line: 1178, col: 22, offset: 28716},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 1178, col: 22, offset: 28714},
+										pos: position{line: 1178, col: 22, offset: 28716},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1178, col: 22, offset: 28714},
+												pos:  position{line: 1178, col: 22, offset: 28716},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1178, col: 25, offset: 28717},
+												pos:        position{line: 1178, col: 25, offset: 28719},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1178, col: 29, offset: 28721},
+												pos:  position{line: 1178, col: 29, offset: 28723},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1178, col: 32, offset: 28724},
+												pos:   position{line: 1178, col: 32, offset: 28726},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1178, col: 34, offset: 28726},
+													pos:  position{line: 1178, col: 34, offset: 28728},
 													name: "Expr",
 												},
 											},
@@ -8217,56 +8221,56 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 1182, col: 1, offset: 28799},
+			pos:  position{line: 1182, col: 1, offset: 28801},
 			expr: &choiceExpr{
-				pos: position{line: 1183, col: 5, offset: 28811},
+				pos: position{line: 1183, col: 5, offset: 28813},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1183, col: 5, offset: 28811},
+						pos:  position{line: 1183, col: 5, offset: 28813},
 						name: "CaseExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1184, col: 5, offset: 28824},
+						pos:  position{line: 1184, col: 5, offset: 28826},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1185, col: 5, offset: 28835},
+						pos:  position{line: 1185, col: 5, offset: 28837},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1186, col: 5, offset: 28845},
+						pos:  position{line: 1186, col: 5, offset: 28847},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1187, col: 5, offset: 28853},
+						pos:  position{line: 1187, col: 5, offset: 28855},
 						name: "Map",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1188, col: 5, offset: 28861},
+						pos:  position{line: 1188, col: 5, offset: 28863},
 						name: "SQLTimeValue",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1189, col: 5, offset: 28878},
+						pos:  position{line: 1189, col: 5, offset: 28880},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 1190, col: 5, offset: 28890},
+						pos: position{line: 1190, col: 5, offset: 28892},
 						run: (*parser).callonPrimary9,
 						expr: &seqExpr{
-							pos: position{line: 1190, col: 5, offset: 28890},
+							pos: position{line: 1190, col: 5, offset: 28892},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1190, col: 5, offset: 28890},
+									pos: position{line: 1190, col: 5, offset: 28892},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1190, col: 6, offset: 28891},
+										pos:  position{line: 1190, col: 6, offset: 28893},
 										name: "PipeKeyword",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1190, col: 18, offset: 28903},
+									pos:   position{line: 1190, col: 18, offset: 28905},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1190, col: 21, offset: 28906},
+										pos:  position{line: 1190, col: 21, offset: 28908},
 										name: "Identifier",
 									},
 								},
@@ -8274,39 +8278,39 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1191, col: 5, offset: 28940},
+						pos:  position{line: 1191, col: 5, offset: 28942},
 						name: "Tuple",
 					},
 					&actionExpr{
-						pos: position{line: 1192, col: 5, offset: 28950},
+						pos: position{line: 1192, col: 5, offset: 28952},
 						run: (*parser).callonPrimary16,
 						expr: &seqExpr{
-							pos: position{line: 1192, col: 5, offset: 28950},
+							pos: position{line: 1192, col: 5, offset: 28952},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1192, col: 5, offset: 28950},
+									pos:        position{line: 1192, col: 5, offset: 28952},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1192, col: 9, offset: 28954},
+									pos:  position{line: 1192, col: 9, offset: 28956},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1192, col: 12, offset: 28957},
+									pos:   position{line: 1192, col: 12, offset: 28959},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1192, col: 17, offset: 28962},
+										pos:  position{line: 1192, col: 17, offset: 28964},
 										name: "OverExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1192, col: 26, offset: 28971},
+									pos:  position{line: 1192, col: 26, offset: 28973},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1192, col: 29, offset: 28974},
+									pos:        position{line: 1192, col: 29, offset: 28976},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -8315,35 +8319,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1193, col: 5, offset: 29003},
+						pos: position{line: 1193, col: 5, offset: 29005},
 						run: (*parser).callonPrimary24,
 						expr: &seqExpr{
-							pos: position{line: 1193, col: 5, offset: 29003},
+							pos: position{line: 1193, col: 5, offset: 29005},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1193, col: 5, offset: 29003},
+									pos:        position{line: 1193, col: 5, offset: 29005},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1193, col: 9, offset: 29007},
+									pos:  position{line: 1193, col: 9, offset: 29009},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1193, col: 12, offset: 29010},
+									pos:   position{line: 1193, col: 12, offset: 29012},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1193, col: 17, offset: 29015},
+										pos:  position{line: 1193, col: 17, offset: 29017},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1193, col: 22, offset: 29020},
+									pos:  position{line: 1193, col: 22, offset: 29022},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1193, col: 25, offset: 29023},
+									pos:        position{line: 1193, col: 25, offset: 29025},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -8358,53 +8362,53 @@ var g = &grammar{
 		},
 		{
 			name: "CaseExpr",
-			pos:  position{line: 1195, col: 1, offset: 29049},
+			pos:  position{line: 1195, col: 1, offset: 29051},
 			expr: &choiceExpr{
-				pos: position{line: 1196, col: 5, offset: 29062},
+				pos: position{line: 1196, col: 5, offset: 29064},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1196, col: 5, offset: 29062},
+						pos: position{line: 1196, col: 5, offset: 29064},
 						run: (*parser).callonCaseExpr2,
 						expr: &seqExpr{
-							pos: position{line: 1196, col: 5, offset: 29062},
+							pos: position{line: 1196, col: 5, offset: 29064},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1196, col: 5, offset: 29062},
+									pos:  position{line: 1196, col: 5, offset: 29064},
 									name: "CASE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1196, col: 10, offset: 29067},
+									pos:   position{line: 1196, col: 10, offset: 29069},
 									label: "cases",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1196, col: 16, offset: 29073},
+										pos: position{line: 1196, col: 16, offset: 29075},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1196, col: 16, offset: 29073},
+											pos:  position{line: 1196, col: 16, offset: 29075},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1196, col: 22, offset: 29079},
+									pos:   position{line: 1196, col: 22, offset: 29081},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1196, col: 28, offset: 29085},
+										pos: position{line: 1196, col: 28, offset: 29087},
 										expr: &seqExpr{
-											pos: position{line: 1196, col: 29, offset: 29086},
+											pos: position{line: 1196, col: 29, offset: 29088},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1196, col: 29, offset: 29086},
+													pos:  position{line: 1196, col: 29, offset: 29088},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1196, col: 31, offset: 29088},
+													pos:  position{line: 1196, col: 31, offset: 29090},
 													name: "ELSE",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1196, col: 36, offset: 29093},
+													pos:  position{line: 1196, col: 36, offset: 29095},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1196, col: 38, offset: 29095},
+													pos:  position{line: 1196, col: 38, offset: 29097},
 													name: "Expr",
 												},
 											},
@@ -8412,24 +8416,24 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1196, col: 45, offset: 29102},
+									pos:  position{line: 1196, col: 45, offset: 29104},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1196, col: 47, offset: 29104},
+									pos:  position{line: 1196, col: 47, offset: 29106},
 									name: "END",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1196, col: 51, offset: 29108},
+									pos: position{line: 1196, col: 51, offset: 29110},
 									expr: &seqExpr{
-										pos: position{line: 1196, col: 52, offset: 29109},
+										pos: position{line: 1196, col: 52, offset: 29111},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1196, col: 52, offset: 29109},
+												pos:  position{line: 1196, col: 52, offset: 29111},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1196, col: 54, offset: 29111},
+												pos:  position{line: 1196, col: 54, offset: 29113},
 												name: "CASE",
 											},
 										},
@@ -8439,60 +8443,60 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1220, col: 5, offset: 29760},
+						pos: position{line: 1220, col: 5, offset: 29762},
 						run: (*parser).callonCaseExpr21,
 						expr: &seqExpr{
-							pos: position{line: 1220, col: 5, offset: 29760},
+							pos: position{line: 1220, col: 5, offset: 29762},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1220, col: 5, offset: 29760},
+									pos:  position{line: 1220, col: 5, offset: 29762},
 									name: "CASE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1220, col: 10, offset: 29765},
+									pos:  position{line: 1220, col: 10, offset: 29767},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1220, col: 12, offset: 29767},
+									pos:   position{line: 1220, col: 12, offset: 29769},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1220, col: 17, offset: 29772},
+										pos:  position{line: 1220, col: 17, offset: 29774},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1220, col: 22, offset: 29777},
+									pos:   position{line: 1220, col: 22, offset: 29779},
 									label: "whens",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1220, col: 28, offset: 29783},
+										pos: position{line: 1220, col: 28, offset: 29785},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1220, col: 28, offset: 29783},
+											pos:  position{line: 1220, col: 28, offset: 29785},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1220, col: 34, offset: 29789},
+									pos:   position{line: 1220, col: 34, offset: 29791},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1220, col: 40, offset: 29795},
+										pos: position{line: 1220, col: 40, offset: 29797},
 										expr: &seqExpr{
-											pos: position{line: 1220, col: 41, offset: 29796},
+											pos: position{line: 1220, col: 41, offset: 29798},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1220, col: 41, offset: 29796},
+													pos:  position{line: 1220, col: 41, offset: 29798},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1220, col: 43, offset: 29798},
+													pos:  position{line: 1220, col: 43, offset: 29800},
 													name: "ELSE",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1220, col: 48, offset: 29803},
+													pos:  position{line: 1220, col: 48, offset: 29805},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1220, col: 50, offset: 29805},
+													pos:  position{line: 1220, col: 50, offset: 29807},
 													name: "Expr",
 												},
 											},
@@ -8500,24 +8504,24 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1220, col: 57, offset: 29812},
+									pos:  position{line: 1220, col: 57, offset: 29814},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1220, col: 59, offset: 29814},
+									pos:  position{line: 1220, col: 59, offset: 29816},
 									name: "END",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1220, col: 63, offset: 29818},
+									pos: position{line: 1220, col: 63, offset: 29820},
 									expr: &seqExpr{
-										pos: position{line: 1220, col: 64, offset: 29819},
+										pos: position{line: 1220, col: 64, offset: 29821},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1220, col: 64, offset: 29819},
+												pos:  position{line: 1220, col: 64, offset: 29821},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1220, col: 66, offset: 29821},
+												pos:  position{line: 1220, col: 66, offset: 29823},
 												name: "CASE",
 											},
 										},
@@ -8533,50 +8537,50 @@ var g = &grammar{
 		},
 		{
 			name: "When",
-			pos:  position{line: 1233, col: 1, offset: 30127},
+			pos:  position{line: 1233, col: 1, offset: 30129},
 			expr: &actionExpr{
-				pos: position{line: 1234, col: 5, offset: 30136},
+				pos: position{line: 1234, col: 5, offset: 30138},
 				run: (*parser).callonWhen1,
 				expr: &seqExpr{
-					pos: position{line: 1234, col: 5, offset: 30136},
+					pos: position{line: 1234, col: 5, offset: 30138},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1234, col: 5, offset: 30136},
+							pos:  position{line: 1234, col: 5, offset: 30138},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1234, col: 7, offset: 30138},
+							pos:  position{line: 1234, col: 7, offset: 30140},
 							name: "WHEN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1234, col: 12, offset: 30143},
+							pos:  position{line: 1234, col: 12, offset: 30145},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1234, col: 14, offset: 30145},
+							pos:   position{line: 1234, col: 14, offset: 30147},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1234, col: 19, offset: 30150},
+								pos:  position{line: 1234, col: 19, offset: 30152},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1234, col: 24, offset: 30155},
+							pos:  position{line: 1234, col: 24, offset: 30157},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1234, col: 26, offset: 30157},
+							pos:  position{line: 1234, col: 26, offset: 30159},
 							name: "THEN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1234, col: 31, offset: 30162},
+							pos:  position{line: 1234, col: 31, offset: 30164},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1234, col: 33, offset: 30164},
+							pos:   position{line: 1234, col: 33, offset: 30166},
 							label: "then",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1234, col: 38, offset: 30169},
+								pos:  position{line: 1234, col: 38, offset: 30171},
 								name: "Expr",
 							},
 						},
@@ -8588,57 +8592,57 @@ var g = &grammar{
 		},
 		{
 			name: "OverExpr",
-			pos:  position{line: 1243, col: 1, offset: 30328},
+			pos:  position{line: 1243, col: 1, offset: 30330},
 			expr: &actionExpr{
-				pos: position{line: 1244, col: 5, offset: 30341},
+				pos: position{line: 1244, col: 5, offset: 30343},
 				run: (*parser).callonOverExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1244, col: 5, offset: 30341},
+					pos: position{line: 1244, col: 5, offset: 30343},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1244, col: 5, offset: 30341},
+							pos:  position{line: 1244, col: 5, offset: 30343},
 							name: "OVER",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1244, col: 10, offset: 30346},
+							pos:  position{line: 1244, col: 10, offset: 30348},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1244, col: 12, offset: 30348},
+							pos:   position{line: 1244, col: 12, offset: 30350},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1244, col: 18, offset: 30354},
+								pos:  position{line: 1244, col: 18, offset: 30356},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1244, col: 24, offset: 30360},
+							pos:   position{line: 1244, col: 24, offset: 30362},
 							label: "locals",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1244, col: 31, offset: 30367},
+								pos: position{line: 1244, col: 31, offset: 30369},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1244, col: 31, offset: 30367},
+									pos:  position{line: 1244, col: 31, offset: 30369},
 									name: "Locals",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1244, col: 39, offset: 30375},
+							pos:  position{line: 1244, col: 39, offset: 30377},
 							name: "__",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1244, col: 42, offset: 30378},
+							pos:  position{line: 1244, col: 42, offset: 30380},
 							name: "Pipe",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1244, col: 47, offset: 30383},
+							pos:  position{line: 1244, col: 47, offset: 30385},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1244, col: 50, offset: 30386},
+							pos:   position{line: 1244, col: 50, offset: 30388},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1244, col: 55, offset: 30391},
+								pos:  position{line: 1244, col: 55, offset: 30393},
 								name: "Seq",
 							},
 						},
@@ -8650,37 +8654,37 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 1254, col: 1, offset: 30622},
+			pos:  position{line: 1254, col: 1, offset: 30624},
 			expr: &actionExpr{
-				pos: position{line: 1255, col: 5, offset: 30633},
+				pos: position{line: 1255, col: 5, offset: 30635},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 1255, col: 5, offset: 30633},
+					pos: position{line: 1255, col: 5, offset: 30635},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1255, col: 5, offset: 30633},
+							pos:        position{line: 1255, col: 5, offset: 30635},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1255, col: 9, offset: 30637},
+							pos:  position{line: 1255, col: 9, offset: 30639},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1255, col: 12, offset: 30640},
+							pos:   position{line: 1255, col: 12, offset: 30642},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1255, col: 18, offset: 30646},
+								pos:  position{line: 1255, col: 18, offset: 30648},
 								name: "RecordElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1255, col: 30, offset: 30658},
+							pos:  position{line: 1255, col: 30, offset: 30660},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1255, col: 33, offset: 30661},
+							pos:        position{line: 1255, col: 33, offset: 30663},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -8693,31 +8697,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElems",
-			pos:  position{line: 1263, col: 1, offset: 30819},
+			pos:  position{line: 1263, col: 1, offset: 30821},
 			expr: &choiceExpr{
-				pos: position{line: 1264, col: 5, offset: 30835},
+				pos: position{line: 1264, col: 5, offset: 30837},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1264, col: 5, offset: 30835},
+						pos: position{line: 1264, col: 5, offset: 30837},
 						run: (*parser).callonRecordElems2,
 						expr: &seqExpr{
-							pos: position{line: 1264, col: 5, offset: 30835},
+							pos: position{line: 1264, col: 5, offset: 30837},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1264, col: 5, offset: 30835},
+									pos:   position{line: 1264, col: 5, offset: 30837},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1264, col: 11, offset: 30841},
+										pos:  position{line: 1264, col: 11, offset: 30843},
 										name: "RecordElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1264, col: 22, offset: 30852},
+									pos:   position{line: 1264, col: 22, offset: 30854},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1264, col: 27, offset: 30857},
+										pos: position{line: 1264, col: 27, offset: 30859},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1264, col: 27, offset: 30857},
+											pos:  position{line: 1264, col: 27, offset: 30859},
 											name: "RecordElemTail",
 										},
 									},
@@ -8726,10 +8730,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1267, col: 5, offset: 30920},
+						pos: position{line: 1267, col: 5, offset: 30922},
 						run: (*parser).callonRecordElems9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1267, col: 5, offset: 30920},
+							pos:  position{line: 1267, col: 5, offset: 30922},
 							name: "__",
 						},
 					},
@@ -8740,32 +8744,32 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElemTail",
-			pos:  position{line: 1269, col: 1, offset: 30944},
+			pos:  position{line: 1269, col: 1, offset: 30946},
 			expr: &actionExpr{
-				pos: position{line: 1269, col: 18, offset: 30961},
+				pos: position{line: 1269, col: 18, offset: 30963},
 				run: (*parser).callonRecordElemTail1,
 				expr: &seqExpr{
-					pos: position{line: 1269, col: 18, offset: 30961},
+					pos: position{line: 1269, col: 18, offset: 30963},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1269, col: 18, offset: 30961},
+							pos:  position{line: 1269, col: 18, offset: 30963},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1269, col: 21, offset: 30964},
+							pos:        position{line: 1269, col: 21, offset: 30966},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1269, col: 25, offset: 30968},
+							pos:  position{line: 1269, col: 25, offset: 30970},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1269, col: 28, offset: 30971},
+							pos:   position{line: 1269, col: 28, offset: 30973},
 							label: "elem",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1269, col: 33, offset: 30976},
+								pos:  position{line: 1269, col: 33, offset: 30978},
 								name: "RecordElem",
 							},
 						},
@@ -8777,20 +8781,20 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElem",
-			pos:  position{line: 1271, col: 1, offset: 31009},
+			pos:  position{line: 1271, col: 1, offset: 31011},
 			expr: &choiceExpr{
-				pos: position{line: 1272, col: 5, offset: 31024},
+				pos: position{line: 1272, col: 5, offset: 31026},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1272, col: 5, offset: 31024},
+						pos:  position{line: 1272, col: 5, offset: 31026},
 						name: "Spread",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1273, col: 5, offset: 31035},
+						pos:  position{line: 1273, col: 5, offset: 31037},
 						name: "FieldExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1274, col: 5, offset: 31049},
+						pos:  position{line: 1274, col: 5, offset: 31051},
 						name: "Identifier",
 					},
 				},
@@ -8800,28 +8804,28 @@ var g = &grammar{
 		},
 		{
 			name: "Spread",
-			pos:  position{line: 1276, col: 1, offset: 31061},
+			pos:  position{line: 1276, col: 1, offset: 31063},
 			expr: &actionExpr{
-				pos: position{line: 1277, col: 5, offset: 31072},
+				pos: position{line: 1277, col: 5, offset: 31074},
 				run: (*parser).callonSpread1,
 				expr: &seqExpr{
-					pos: position{line: 1277, col: 5, offset: 31072},
+					pos: position{line: 1277, col: 5, offset: 31074},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1277, col: 5, offset: 31072},
+							pos:        position{line: 1277, col: 5, offset: 31074},
 							val:        "...",
 							ignoreCase: false,
 							want:       "\"...\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1277, col: 11, offset: 31078},
+							pos:  position{line: 1277, col: 11, offset: 31080},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1277, col: 14, offset: 31081},
+							pos:   position{line: 1277, col: 14, offset: 31083},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1277, col: 19, offset: 31086},
+								pos:  position{line: 1277, col: 19, offset: 31088},
 								name: "Expr",
 							},
 						},
@@ -8833,40 +8837,40 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 1281, col: 1, offset: 31182},
+			pos:  position{line: 1281, col: 1, offset: 31184},
 			expr: &actionExpr{
-				pos: position{line: 1282, col: 5, offset: 31196},
+				pos: position{line: 1282, col: 5, offset: 31198},
 				run: (*parser).callonFieldExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1282, col: 5, offset: 31196},
+					pos: position{line: 1282, col: 5, offset: 31198},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1282, col: 5, offset: 31196},
+							pos:   position{line: 1282, col: 5, offset: 31198},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1282, col: 10, offset: 31201},
+								pos:  position{line: 1282, col: 10, offset: 31203},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1282, col: 15, offset: 31206},
+							pos:  position{line: 1282, col: 15, offset: 31208},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1282, col: 18, offset: 31209},
+							pos:        position{line: 1282, col: 18, offset: 31211},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1282, col: 22, offset: 31213},
+							pos:  position{line: 1282, col: 22, offset: 31215},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1282, col: 25, offset: 31216},
+							pos:   position{line: 1282, col: 25, offset: 31218},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1282, col: 31, offset: 31222},
+								pos:  position{line: 1282, col: 31, offset: 31224},
 								name: "Expr",
 							},
 						},
@@ -8878,37 +8882,37 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 1291, col: 1, offset: 31391},
+			pos:  position{line: 1291, col: 1, offset: 31393},
 			expr: &actionExpr{
-				pos: position{line: 1292, col: 5, offset: 31401},
+				pos: position{line: 1292, col: 5, offset: 31403},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 1292, col: 5, offset: 31401},
+					pos: position{line: 1292, col: 5, offset: 31403},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1292, col: 5, offset: 31401},
+							pos:        position{line: 1292, col: 5, offset: 31403},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1292, col: 9, offset: 31405},
+							pos:  position{line: 1292, col: 9, offset: 31407},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1292, col: 12, offset: 31408},
+							pos:   position{line: 1292, col: 12, offset: 31410},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1292, col: 18, offset: 31414},
+								pos:  position{line: 1292, col: 18, offset: 31416},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1292, col: 30, offset: 31426},
+							pos:  position{line: 1292, col: 30, offset: 31428},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1292, col: 33, offset: 31429},
+							pos:        position{line: 1292, col: 33, offset: 31431},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -8921,37 +8925,37 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 1300, col: 1, offset: 31585},
+			pos:  position{line: 1300, col: 1, offset: 31587},
 			expr: &actionExpr{
-				pos: position{line: 1301, col: 5, offset: 31593},
+				pos: position{line: 1301, col: 5, offset: 31595},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 1301, col: 5, offset: 31593},
+					pos: position{line: 1301, col: 5, offset: 31595},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1301, col: 5, offset: 31593},
+							pos:        position{line: 1301, col: 5, offset: 31595},
 							val:        "|[",
 							ignoreCase: false,
 							want:       "\"|[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1301, col: 10, offset: 31598},
+							pos:  position{line: 1301, col: 10, offset: 31600},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1301, col: 13, offset: 31601},
+							pos:   position{line: 1301, col: 13, offset: 31603},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1301, col: 19, offset: 31607},
+								pos:  position{line: 1301, col: 19, offset: 31609},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1301, col: 31, offset: 31619},
+							pos:  position{line: 1301, col: 31, offset: 31621},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1301, col: 34, offset: 31622},
+							pos:        position{line: 1301, col: 34, offset: 31624},
 							val:        "]|",
 							ignoreCase: false,
 							want:       "\"]|\"",
@@ -8964,54 +8968,54 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElems",
-			pos:  position{line: 1309, col: 1, offset: 31775},
+			pos:  position{line: 1309, col: 1, offset: 31777},
 			expr: &choiceExpr{
-				pos: position{line: 1310, col: 5, offset: 31791},
+				pos: position{line: 1310, col: 5, offset: 31793},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1310, col: 5, offset: 31791},
+						pos: position{line: 1310, col: 5, offset: 31793},
 						run: (*parser).callonVectorElems2,
 						expr: &seqExpr{
-							pos: position{line: 1310, col: 5, offset: 31791},
+							pos: position{line: 1310, col: 5, offset: 31793},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1310, col: 5, offset: 31791},
+									pos:   position{line: 1310, col: 5, offset: 31793},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1310, col: 11, offset: 31797},
+										pos:  position{line: 1310, col: 11, offset: 31799},
 										name: "VectorElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1310, col: 22, offset: 31808},
+									pos:   position{line: 1310, col: 22, offset: 31810},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1310, col: 27, offset: 31813},
+										pos: position{line: 1310, col: 27, offset: 31815},
 										expr: &actionExpr{
-											pos: position{line: 1310, col: 28, offset: 31814},
+											pos: position{line: 1310, col: 28, offset: 31816},
 											run: (*parser).callonVectorElems8,
 											expr: &seqExpr{
-												pos: position{line: 1310, col: 28, offset: 31814},
+												pos: position{line: 1310, col: 28, offset: 31816},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1310, col: 28, offset: 31814},
+														pos:  position{line: 1310, col: 28, offset: 31816},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 1310, col: 31, offset: 31817},
+														pos:        position{line: 1310, col: 31, offset: 31819},
 														val:        ",",
 														ignoreCase: false,
 														want:       "\",\"",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1310, col: 35, offset: 31821},
+														pos:  position{line: 1310, col: 35, offset: 31823},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 1310, col: 38, offset: 31824},
+														pos:   position{line: 1310, col: 38, offset: 31826},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1310, col: 40, offset: 31826},
+															pos:  position{line: 1310, col: 40, offset: 31828},
 															name: "VectorElem",
 														},
 													},
@@ -9024,10 +9028,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1313, col: 5, offset: 31908},
+						pos: position{line: 1313, col: 5, offset: 31910},
 						run: (*parser).callonVectorElems15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1313, col: 5, offset: 31908},
+							pos:  position{line: 1313, col: 5, offset: 31910},
 							name: "__",
 						},
 					},
@@ -9038,22 +9042,22 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElem",
-			pos:  position{line: 1315, col: 1, offset: 31932},
+			pos:  position{line: 1315, col: 1, offset: 31934},
 			expr: &choiceExpr{
-				pos: position{line: 1316, col: 5, offset: 31947},
+				pos: position{line: 1316, col: 5, offset: 31949},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1316, col: 5, offset: 31947},
+						pos:  position{line: 1316, col: 5, offset: 31949},
 						name: "Spread",
 					},
 					&actionExpr{
-						pos: position{line: 1317, col: 5, offset: 31958},
+						pos: position{line: 1317, col: 5, offset: 31960},
 						run: (*parser).callonVectorElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1317, col: 5, offset: 31958},
+							pos:   position{line: 1317, col: 5, offset: 31960},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1317, col: 7, offset: 31960},
+								pos:  position{line: 1317, col: 7, offset: 31962},
 								name: "Expr",
 							},
 						},
@@ -9065,37 +9069,37 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 1319, col: 1, offset: 32051},
+			pos:  position{line: 1319, col: 1, offset: 32053},
 			expr: &actionExpr{
-				pos: position{line: 1320, col: 5, offset: 32059},
+				pos: position{line: 1320, col: 5, offset: 32061},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 1320, col: 5, offset: 32059},
+					pos: position{line: 1320, col: 5, offset: 32061},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1320, col: 5, offset: 32059},
+							pos:        position{line: 1320, col: 5, offset: 32061},
 							val:        "|{",
 							ignoreCase: false,
 							want:       "\"|{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1320, col: 10, offset: 32064},
+							pos:  position{line: 1320, col: 10, offset: 32066},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1320, col: 13, offset: 32067},
+							pos:   position{line: 1320, col: 13, offset: 32069},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1320, col: 19, offset: 32073},
+								pos:  position{line: 1320, col: 19, offset: 32075},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1320, col: 27, offset: 32081},
+							pos:  position{line: 1320, col: 27, offset: 32083},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1320, col: 30, offset: 32084},
+							pos:        position{line: 1320, col: 30, offset: 32086},
 							val:        "}|",
 							ignoreCase: false,
 							want:       "\"}|\"",
@@ -9108,31 +9112,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 1328, col: 1, offset: 32238},
+			pos:  position{line: 1328, col: 1, offset: 32240},
 			expr: &choiceExpr{
-				pos: position{line: 1329, col: 5, offset: 32250},
+				pos: position{line: 1329, col: 5, offset: 32252},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1329, col: 5, offset: 32250},
+						pos: position{line: 1329, col: 5, offset: 32252},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 1329, col: 5, offset: 32250},
+							pos: position{line: 1329, col: 5, offset: 32252},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1329, col: 5, offset: 32250},
+									pos:   position{line: 1329, col: 5, offset: 32252},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1329, col: 11, offset: 32256},
+										pos:  position{line: 1329, col: 11, offset: 32258},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1329, col: 17, offset: 32262},
+									pos:   position{line: 1329, col: 17, offset: 32264},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1329, col: 22, offset: 32267},
+										pos: position{line: 1329, col: 22, offset: 32269},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1329, col: 22, offset: 32267},
+											pos:  position{line: 1329, col: 22, offset: 32269},
 											name: "EntryTail",
 										},
 									},
@@ -9141,10 +9145,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1332, col: 5, offset: 32325},
+						pos: position{line: 1332, col: 5, offset: 32327},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1332, col: 5, offset: 32325},
+							pos:  position{line: 1332, col: 5, offset: 32327},
 							name: "__",
 						},
 					},
@@ -9155,32 +9159,32 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 1335, col: 1, offset: 32350},
+			pos:  position{line: 1335, col: 1, offset: 32352},
 			expr: &actionExpr{
-				pos: position{line: 1335, col: 13, offset: 32362},
+				pos: position{line: 1335, col: 13, offset: 32364},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 1335, col: 13, offset: 32362},
+					pos: position{line: 1335, col: 13, offset: 32364},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1335, col: 13, offset: 32362},
+							pos:  position{line: 1335, col: 13, offset: 32364},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1335, col: 16, offset: 32365},
+							pos:        position{line: 1335, col: 16, offset: 32367},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1335, col: 20, offset: 32369},
+							pos:  position{line: 1335, col: 20, offset: 32371},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1335, col: 23, offset: 32372},
+							pos:   position{line: 1335, col: 23, offset: 32374},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1335, col: 25, offset: 32374},
+								pos:  position{line: 1335, col: 25, offset: 32376},
 								name: "Entry",
 							},
 						},
@@ -9192,40 +9196,40 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 1337, col: 1, offset: 32399},
+			pos:  position{line: 1337, col: 1, offset: 32401},
 			expr: &actionExpr{
-				pos: position{line: 1338, col: 5, offset: 32409},
+				pos: position{line: 1338, col: 5, offset: 32411},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 1338, col: 5, offset: 32409},
+					pos: position{line: 1338, col: 5, offset: 32411},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1338, col: 5, offset: 32409},
+							pos:   position{line: 1338, col: 5, offset: 32411},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1338, col: 9, offset: 32413},
+								pos:  position{line: 1338, col: 9, offset: 32415},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1338, col: 14, offset: 32418},
+							pos:  position{line: 1338, col: 14, offset: 32420},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1338, col: 17, offset: 32421},
+							pos:        position{line: 1338, col: 17, offset: 32423},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1338, col: 21, offset: 32425},
+							pos:  position{line: 1338, col: 21, offset: 32427},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1338, col: 24, offset: 32428},
+							pos:   position{line: 1338, col: 24, offset: 32430},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1338, col: 30, offset: 32434},
+								pos:  position{line: 1338, col: 30, offset: 32436},
 								name: "Expr",
 							},
 						},
@@ -9237,61 +9241,61 @@ var g = &grammar{
 		},
 		{
 			name: "Tuple",
-			pos:  position{line: 1342, col: 1, offset: 32537},
+			pos:  position{line: 1342, col: 1, offset: 32539},
 			expr: &actionExpr{
-				pos: position{line: 1343, col: 5, offset: 32547},
+				pos: position{line: 1343, col: 5, offset: 32549},
 				run: (*parser).callonTuple1,
 				expr: &seqExpr{
-					pos: position{line: 1343, col: 5, offset: 32547},
+					pos: position{line: 1343, col: 5, offset: 32549},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1343, col: 5, offset: 32547},
+							pos:        position{line: 1343, col: 5, offset: 32549},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1343, col: 9, offset: 32551},
+							pos:  position{line: 1343, col: 9, offset: 32553},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1343, col: 12, offset: 32554},
+							pos:   position{line: 1343, col: 12, offset: 32556},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1343, col: 18, offset: 32560},
+								pos:  position{line: 1343, col: 18, offset: 32562},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1343, col: 23, offset: 32565},
+							pos:   position{line: 1343, col: 23, offset: 32567},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1343, col: 28, offset: 32570},
+								pos: position{line: 1343, col: 28, offset: 32572},
 								expr: &actionExpr{
-									pos: position{line: 1343, col: 29, offset: 32571},
+									pos: position{line: 1343, col: 29, offset: 32573},
 									run: (*parser).callonTuple9,
 									expr: &seqExpr{
-										pos: position{line: 1343, col: 29, offset: 32571},
+										pos: position{line: 1343, col: 29, offset: 32573},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1343, col: 29, offset: 32571},
+												pos:  position{line: 1343, col: 29, offset: 32573},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1343, col: 32, offset: 32574},
+												pos:        position{line: 1343, col: 32, offset: 32576},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1343, col: 36, offset: 32578},
+												pos:  position{line: 1343, col: 36, offset: 32580},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1343, col: 39, offset: 32581},
+												pos:   position{line: 1343, col: 39, offset: 32583},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1343, col: 41, offset: 32583},
+													pos:  position{line: 1343, col: 41, offset: 32585},
 													name: "Expr",
 												},
 											},
@@ -9301,11 +9305,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1343, col: 66, offset: 32608},
+							pos:  position{line: 1343, col: 66, offset: 32610},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1343, col: 69, offset: 32611},
+							pos:        position{line: 1343, col: 69, offset: 32613},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -9318,39 +9322,39 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTimeValue",
-			pos:  position{line: 1351, col: 1, offset: 32770},
+			pos:  position{line: 1351, col: 1, offset: 32772},
 			expr: &actionExpr{
-				pos: position{line: 1352, col: 5, offset: 32787},
+				pos: position{line: 1352, col: 5, offset: 32789},
 				run: (*parser).callonSQLTimeValue1,
 				expr: &seqExpr{
-					pos: position{line: 1352, col: 5, offset: 32787},
+					pos: position{line: 1352, col: 5, offset: 32789},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1352, col: 5, offset: 32787},
+							pos:   position{line: 1352, col: 5, offset: 32789},
 							label: "typ",
 							expr: &choiceExpr{
-								pos: position{line: 1352, col: 10, offset: 32792},
+								pos: position{line: 1352, col: 10, offset: 32794},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1352, col: 10, offset: 32792},
+										pos:  position{line: 1352, col: 10, offset: 32794},
 										name: "DATE",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1352, col: 17, offset: 32799},
+										pos:  position{line: 1352, col: 17, offset: 32801},
 										name: "TIMESTAMP",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1352, col: 28, offset: 32810},
+							pos:  position{line: 1352, col: 28, offset: 32812},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1352, col: 30, offset: 32812},
+							pos:   position{line: 1352, col: 30, offset: 32814},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1352, col: 32, offset: 32814},
+								pos:  position{line: 1352, col: 32, offset: 32816},
 								name: "StringLiteral",
 							},
 						},
@@ -9362,56 +9366,56 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 1363, col: 1, offset: 33031},
+			pos:  position{line: 1363, col: 1, offset: 33033},
 			expr: &choiceExpr{
-				pos: position{line: 1364, col: 5, offset: 33043},
+				pos: position{line: 1364, col: 5, offset: 33045},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1364, col: 5, offset: 33043},
+						pos:  position{line: 1364, col: 5, offset: 33045},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1365, col: 5, offset: 33059},
+						pos:  position{line: 1365, col: 5, offset: 33061},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1366, col: 5, offset: 33077},
+						pos:  position{line: 1366, col: 5, offset: 33079},
 						name: "FString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1367, col: 5, offset: 33089},
+						pos:  position{line: 1367, col: 5, offset: 33091},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1368, col: 5, offset: 33107},
+						pos:  position{line: 1368, col: 5, offset: 33109},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1369, col: 5, offset: 33126},
+						pos:  position{line: 1369, col: 5, offset: 33128},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1370, col: 5, offset: 33143},
+						pos:  position{line: 1370, col: 5, offset: 33145},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1371, col: 5, offset: 33156},
+						pos:  position{line: 1371, col: 5, offset: 33158},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1372, col: 5, offset: 33165},
+						pos:  position{line: 1372, col: 5, offset: 33167},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1373, col: 5, offset: 33182},
+						pos:  position{line: 1373, col: 5, offset: 33184},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1374, col: 5, offset: 33201},
+						pos:  position{line: 1374, col: 5, offset: 33203},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1375, col: 5, offset: 33220},
+						pos:  position{line: 1375, col: 5, offset: 33222},
 						name: "NullLiteral",
 					},
 				},
@@ -9421,28 +9425,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 1377, col: 1, offset: 33233},
+			pos:  position{line: 1377, col: 1, offset: 33235},
 			expr: &choiceExpr{
-				pos: position{line: 1378, col: 5, offset: 33251},
+				pos: position{line: 1378, col: 5, offset: 33253},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1378, col: 5, offset: 33251},
+						pos: position{line: 1378, col: 5, offset: 33253},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1378, col: 5, offset: 33251},
+							pos: position{line: 1378, col: 5, offset: 33253},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1378, col: 5, offset: 33251},
+									pos:   position{line: 1378, col: 5, offset: 33253},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1378, col: 7, offset: 33253},
+										pos:  position{line: 1378, col: 7, offset: 33255},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1378, col: 14, offset: 33260},
+									pos: position{line: 1378, col: 14, offset: 33262},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1378, col: 15, offset: 33261},
+										pos:  position{line: 1378, col: 15, offset: 33263},
 										name: "IdentifierRest",
 									},
 								},
@@ -9450,13 +9454,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1381, col: 5, offset: 33341},
+						pos: position{line: 1381, col: 5, offset: 33343},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1381, col: 5, offset: 33341},
+							pos:   position{line: 1381, col: 5, offset: 33343},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1381, col: 7, offset: 33343},
+								pos:  position{line: 1381, col: 7, offset: 33345},
 								name: "IP4Net",
 							},
 						},
@@ -9468,28 +9472,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 1385, col: 1, offset: 33412},
+			pos:  position{line: 1385, col: 1, offset: 33414},
 			expr: &choiceExpr{
-				pos: position{line: 1386, col: 5, offset: 33431},
+				pos: position{line: 1386, col: 5, offset: 33433},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1386, col: 5, offset: 33431},
+						pos: position{line: 1386, col: 5, offset: 33433},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1386, col: 5, offset: 33431},
+							pos: position{line: 1386, col: 5, offset: 33433},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1386, col: 5, offset: 33431},
+									pos:   position{line: 1386, col: 5, offset: 33433},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1386, col: 7, offset: 33433},
+										pos:  position{line: 1386, col: 7, offset: 33435},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1386, col: 11, offset: 33437},
+									pos: position{line: 1386, col: 11, offset: 33439},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1386, col: 12, offset: 33438},
+										pos:  position{line: 1386, col: 12, offset: 33440},
 										name: "IdentifierRest",
 									},
 								},
@@ -9497,13 +9501,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1389, col: 5, offset: 33517},
+						pos: position{line: 1389, col: 5, offset: 33519},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1389, col: 5, offset: 33517},
+							pos:   position{line: 1389, col: 5, offset: 33519},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1389, col: 7, offset: 33519},
+								pos:  position{line: 1389, col: 7, offset: 33521},
 								name: "IP",
 							},
 						},
@@ -9515,15 +9519,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 1393, col: 1, offset: 33583},
+			pos:  position{line: 1393, col: 1, offset: 33585},
 			expr: &actionExpr{
-				pos: position{line: 1394, col: 5, offset: 33600},
+				pos: position{line: 1394, col: 5, offset: 33602},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1394, col: 5, offset: 33600},
+					pos:   position{line: 1394, col: 5, offset: 33602},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1394, col: 7, offset: 33602},
+						pos:  position{line: 1394, col: 7, offset: 33604},
 						name: "FloatString",
 					},
 				},
@@ -9533,15 +9537,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 1398, col: 1, offset: 33680},
+			pos:  position{line: 1398, col: 1, offset: 33682},
 			expr: &actionExpr{
-				pos: position{line: 1399, col: 5, offset: 33699},
+				pos: position{line: 1399, col: 5, offset: 33701},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1399, col: 5, offset: 33699},
+					pos:   position{line: 1399, col: 5, offset: 33701},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1399, col: 7, offset: 33701},
+						pos:  position{line: 1399, col: 7, offset: 33703},
 						name: "IntString",
 					},
 				},
@@ -9551,23 +9555,23 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 1403, col: 1, offset: 33775},
+			pos:  position{line: 1403, col: 1, offset: 33777},
 			expr: &choiceExpr{
-				pos: position{line: 1404, col: 5, offset: 33794},
+				pos: position{line: 1404, col: 5, offset: 33796},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1404, col: 5, offset: 33794},
+						pos: position{line: 1404, col: 5, offset: 33796},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1404, col: 5, offset: 33794},
+							pos:  position{line: 1404, col: 5, offset: 33796},
 							name: "TRUE",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1405, col: 5, offset: 33852},
+						pos: position{line: 1405, col: 5, offset: 33854},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1405, col: 5, offset: 33852},
+							pos:  position{line: 1405, col: 5, offset: 33854},
 							name: "FALSE",
 						},
 					},
@@ -9578,12 +9582,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 1407, col: 1, offset: 33908},
+			pos:  position{line: 1407, col: 1, offset: 33910},
 			expr: &actionExpr{
-				pos: position{line: 1408, col: 5, offset: 33924},
+				pos: position{line: 1408, col: 5, offset: 33926},
 				run: (*parser).callonNullLiteral1,
 				expr: &ruleRefExpr{
-					pos:  position{line: 1408, col: 5, offset: 33924},
+					pos:  position{line: 1408, col: 5, offset: 33926},
 					name: "NULL",
 				},
 			},
@@ -9592,23 +9596,23 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 1410, col: 1, offset: 33974},
+			pos:  position{line: 1410, col: 1, offset: 33976},
 			expr: &actionExpr{
-				pos: position{line: 1411, col: 5, offset: 33991},
+				pos: position{line: 1411, col: 5, offset: 33993},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1411, col: 5, offset: 33991},
+					pos: position{line: 1411, col: 5, offset: 33993},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1411, col: 5, offset: 33991},
+							pos:        position{line: 1411, col: 5, offset: 33993},
 							val:        "0x",
 							ignoreCase: false,
 							want:       "\"0x\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1411, col: 10, offset: 33996},
+							pos: position{line: 1411, col: 10, offset: 33998},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1411, col: 10, offset: 33996},
+								pos:  position{line: 1411, col: 10, offset: 33998},
 								name: "HexDigit",
 							},
 						},
@@ -9620,29 +9624,29 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 1415, col: 1, offset: 34070},
+			pos:  position{line: 1415, col: 1, offset: 34072},
 			expr: &actionExpr{
-				pos: position{line: 1416, col: 5, offset: 34086},
+				pos: position{line: 1416, col: 5, offset: 34088},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1416, col: 5, offset: 34086},
+					pos: position{line: 1416, col: 5, offset: 34088},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1416, col: 5, offset: 34086},
+							pos:        position{line: 1416, col: 5, offset: 34088},
 							val:        "<",
 							ignoreCase: false,
 							want:       "\"<\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1416, col: 9, offset: 34090},
+							pos:   position{line: 1416, col: 9, offset: 34092},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1416, col: 13, offset: 34094},
+								pos:  position{line: 1416, col: 13, offset: 34096},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1416, col: 18, offset: 34099},
+							pos:        position{line: 1416, col: 18, offset: 34101},
 							val:        ">",
 							ignoreCase: false,
 							want:       "\">\"",
@@ -9655,16 +9659,16 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1424, col: 1, offset: 34232},
+			pos:  position{line: 1424, col: 1, offset: 34234},
 			expr: &choiceExpr{
-				pos: position{line: 1425, col: 5, offset: 34241},
+				pos: position{line: 1425, col: 5, offset: 34243},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1425, col: 5, offset: 34241},
+						pos:  position{line: 1425, col: 5, offset: 34243},
 						name: "AmbiguousType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1426, col: 5, offset: 34259},
+						pos:  position{line: 1426, col: 5, offset: 34261},
 						name: "ComplexType",
 					},
 				},
@@ -9674,28 +9678,28 @@ var g = &grammar{
 		},
 		{
 			name: "AmbiguousType",
-			pos:  position{line: 1428, col: 1, offset: 34272},
+			pos:  position{line: 1428, col: 1, offset: 34274},
 			expr: &choiceExpr{
-				pos: position{line: 1429, col: 5, offset: 34290},
+				pos: position{line: 1429, col: 5, offset: 34292},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1429, col: 5, offset: 34290},
+						pos: position{line: 1429, col: 5, offset: 34292},
 						run: (*parser).callonAmbiguousType2,
 						expr: &seqExpr{
-							pos: position{line: 1429, col: 5, offset: 34290},
+							pos: position{line: 1429, col: 5, offset: 34292},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1429, col: 5, offset: 34290},
+									pos:   position{line: 1429, col: 5, offset: 34292},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1429, col: 10, offset: 34295},
+										pos:  position{line: 1429, col: 10, offset: 34297},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1429, col: 24, offset: 34309},
+									pos: position{line: 1429, col: 24, offset: 34311},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1429, col: 25, offset: 34310},
+										pos:  position{line: 1429, col: 25, offset: 34312},
 										name: "IdentifierRest",
 									},
 								},
@@ -9703,43 +9707,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1430, col: 5, offset: 34350},
+						pos: position{line: 1430, col: 5, offset: 34352},
 						run: (*parser).callonAmbiguousType8,
 						expr: &seqExpr{
-							pos: position{line: 1430, col: 5, offset: 34350},
+							pos: position{line: 1430, col: 5, offset: 34352},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1430, col: 5, offset: 34350},
+									pos:  position{line: 1430, col: 5, offset: 34352},
 									name: "ERROR",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1430, col: 11, offset: 34356},
+									pos:  position{line: 1430, col: 11, offset: 34358},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1430, col: 14, offset: 34359},
+									pos:        position{line: 1430, col: 14, offset: 34361},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1430, col: 18, offset: 34363},
+									pos:  position{line: 1430, col: 18, offset: 34365},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1430, col: 21, offset: 34366},
+									pos:   position{line: 1430, col: 21, offset: 34368},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1430, col: 23, offset: 34368},
+										pos:  position{line: 1430, col: 23, offset: 34370},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1430, col: 28, offset: 34373},
+									pos:  position{line: 1430, col: 28, offset: 34375},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1430, col: 31, offset: 34376},
+									pos:        position{line: 1430, col: 31, offset: 34378},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9748,43 +9752,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1437, col: 5, offset: 34516},
+						pos: position{line: 1437, col: 5, offset: 34518},
 						run: (*parser).callonAmbiguousType18,
 						expr: &seqExpr{
-							pos: position{line: 1437, col: 5, offset: 34516},
+							pos: position{line: 1437, col: 5, offset: 34518},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1437, col: 5, offset: 34516},
+									pos:   position{line: 1437, col: 5, offset: 34518},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1437, col: 10, offset: 34521},
+										pos:  position{line: 1437, col: 10, offset: 34523},
 										name: "Name",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1437, col: 15, offset: 34526},
+									pos:   position{line: 1437, col: 15, offset: 34528},
 									label: "opt",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1437, col: 19, offset: 34530},
+										pos: position{line: 1437, col: 19, offset: 34532},
 										expr: &seqExpr{
-											pos: position{line: 1437, col: 20, offset: 34531},
+											pos: position{line: 1437, col: 20, offset: 34533},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1437, col: 20, offset: 34531},
+													pos:  position{line: 1437, col: 20, offset: 34533},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1437, col: 23, offset: 34534},
+													pos:        position{line: 1437, col: 23, offset: 34536},
 													val:        "=",
 													ignoreCase: false,
 													want:       "\"=\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1437, col: 27, offset: 34538},
+													pos:  position{line: 1437, col: 27, offset: 34540},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1437, col: 30, offset: 34541},
+													pos:  position{line: 1437, col: 30, offset: 34543},
 													name: "Type",
 												},
 											},
@@ -9795,31 +9799,31 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1448, col: 5, offset: 34866},
+						pos: position{line: 1448, col: 5, offset: 34868},
 						run: (*parser).callonAmbiguousType29,
 						expr: &seqExpr{
-							pos: position{line: 1448, col: 5, offset: 34866},
+							pos: position{line: 1448, col: 5, offset: 34868},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1448, col: 5, offset: 34866},
+									pos:        position{line: 1448, col: 5, offset: 34868},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1448, col: 9, offset: 34870},
+									pos:  position{line: 1448, col: 9, offset: 34872},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1448, col: 12, offset: 34873},
+									pos:   position{line: 1448, col: 12, offset: 34875},
 									label: "types",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1448, col: 18, offset: 34879},
+										pos:  position{line: 1448, col: 18, offset: 34881},
 										name: "TypeList",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1448, col: 27, offset: 34888},
+									pos:        position{line: 1448, col: 27, offset: 34890},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9834,28 +9838,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1456, col: 1, offset: 35032},
+			pos:  position{line: 1456, col: 1, offset: 35034},
 			expr: &actionExpr{
-				pos: position{line: 1457, col: 5, offset: 35045},
+				pos: position{line: 1457, col: 5, offset: 35047},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1457, col: 5, offset: 35045},
+					pos: position{line: 1457, col: 5, offset: 35047},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1457, col: 5, offset: 35045},
+							pos:   position{line: 1457, col: 5, offset: 35047},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1457, col: 11, offset: 35051},
+								pos:  position{line: 1457, col: 11, offset: 35053},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1457, col: 16, offset: 35056},
+							pos:   position{line: 1457, col: 16, offset: 35058},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1457, col: 21, offset: 35061},
+								pos: position{line: 1457, col: 21, offset: 35063},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1457, col: 21, offset: 35061},
+									pos:  position{line: 1457, col: 21, offset: 35063},
 									name: "TypeListTail",
 								},
 							},
@@ -9868,32 +9872,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1461, col: 1, offset: 35119},
+			pos:  position{line: 1461, col: 1, offset: 35121},
 			expr: &actionExpr{
-				pos: position{line: 1461, col: 16, offset: 35134},
+				pos: position{line: 1461, col: 16, offset: 35136},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1461, col: 16, offset: 35134},
+					pos: position{line: 1461, col: 16, offset: 35136},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1461, col: 16, offset: 35134},
+							pos:  position{line: 1461, col: 16, offset: 35136},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1461, col: 19, offset: 35137},
+							pos:        position{line: 1461, col: 19, offset: 35139},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1461, col: 23, offset: 35141},
+							pos:  position{line: 1461, col: 23, offset: 35143},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1461, col: 26, offset: 35144},
+							pos:   position{line: 1461, col: 26, offset: 35146},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1461, col: 30, offset: 35148},
+								pos:  position{line: 1461, col: 30, offset: 35150},
 								name: "Type",
 							},
 						},
@@ -9905,40 +9909,40 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 1463, col: 1, offset: 35174},
+			pos:  position{line: 1463, col: 1, offset: 35176},
 			expr: &choiceExpr{
-				pos: position{line: 1464, col: 5, offset: 35190},
+				pos: position{line: 1464, col: 5, offset: 35192},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1464, col: 5, offset: 35190},
+						pos: position{line: 1464, col: 5, offset: 35192},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 1464, col: 5, offset: 35190},
+							pos: position{line: 1464, col: 5, offset: 35192},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1464, col: 5, offset: 35190},
+									pos:        position{line: 1464, col: 5, offset: 35192},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1464, col: 9, offset: 35194},
+									pos:  position{line: 1464, col: 9, offset: 35196},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1464, col: 12, offset: 35197},
+									pos:   position{line: 1464, col: 12, offset: 35199},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1464, col: 19, offset: 35204},
+										pos:  position{line: 1464, col: 19, offset: 35206},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1464, col: 33, offset: 35218},
+									pos:  position{line: 1464, col: 33, offset: 35220},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1464, col: 36, offset: 35221},
+									pos:        position{line: 1464, col: 36, offset: 35223},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -9947,35 +9951,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1471, col: 5, offset: 35383},
+						pos: position{line: 1471, col: 5, offset: 35385},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 1471, col: 5, offset: 35383},
+							pos: position{line: 1471, col: 5, offset: 35385},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1471, col: 5, offset: 35383},
+									pos:        position{line: 1471, col: 5, offset: 35385},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1471, col: 9, offset: 35387},
+									pos:  position{line: 1471, col: 9, offset: 35389},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1471, col: 12, offset: 35390},
+									pos:   position{line: 1471, col: 12, offset: 35392},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1471, col: 16, offset: 35394},
+										pos:  position{line: 1471, col: 16, offset: 35396},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1471, col: 21, offset: 35399},
+									pos:  position{line: 1471, col: 21, offset: 35401},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1471, col: 24, offset: 35402},
+									pos:        position{line: 1471, col: 24, offset: 35404},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -9984,35 +9988,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1478, col: 5, offset: 35544},
+						pos: position{line: 1478, col: 5, offset: 35546},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 1478, col: 5, offset: 35544},
+							pos: position{line: 1478, col: 5, offset: 35546},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1478, col: 5, offset: 35544},
+									pos:        position{line: 1478, col: 5, offset: 35546},
 									val:        "|[",
 									ignoreCase: false,
 									want:       "\"|[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1478, col: 10, offset: 35549},
+									pos:  position{line: 1478, col: 10, offset: 35551},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1478, col: 13, offset: 35552},
+									pos:   position{line: 1478, col: 13, offset: 35554},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1478, col: 17, offset: 35556},
+										pos:  position{line: 1478, col: 17, offset: 35558},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1478, col: 22, offset: 35561},
+									pos:  position{line: 1478, col: 22, offset: 35563},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1478, col: 25, offset: 35564},
+									pos:        position{line: 1478, col: 25, offset: 35566},
 									val:        "]|",
 									ignoreCase: false,
 									want:       "\"]|\"",
@@ -10021,57 +10025,57 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1485, col: 5, offset: 35703},
+						pos: position{line: 1485, col: 5, offset: 35705},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 1485, col: 5, offset: 35703},
+							pos: position{line: 1485, col: 5, offset: 35705},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1485, col: 5, offset: 35703},
+									pos:        position{line: 1485, col: 5, offset: 35705},
 									val:        "|{",
 									ignoreCase: false,
 									want:       "\"|{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1485, col: 10, offset: 35708},
+									pos:  position{line: 1485, col: 10, offset: 35710},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1485, col: 13, offset: 35711},
+									pos:   position{line: 1485, col: 13, offset: 35713},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1485, col: 21, offset: 35719},
+										pos:  position{line: 1485, col: 21, offset: 35721},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1485, col: 26, offset: 35724},
+									pos:  position{line: 1485, col: 26, offset: 35726},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1485, col: 29, offset: 35727},
+									pos:        position{line: 1485, col: 29, offset: 35729},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1485, col: 33, offset: 35731},
+									pos:  position{line: 1485, col: 33, offset: 35733},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1485, col: 36, offset: 35734},
+									pos:   position{line: 1485, col: 36, offset: 35736},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1485, col: 44, offset: 35742},
+										pos:  position{line: 1485, col: 44, offset: 35744},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1485, col: 49, offset: 35747},
+									pos:  position{line: 1485, col: 49, offset: 35749},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1485, col: 52, offset: 35750},
+									pos:        position{line: 1485, col: 52, offset: 35752},
 									val:        "}|",
 									ignoreCase: false,
 									want:       "\"}|\"",
@@ -10086,30 +10090,30 @@ var g = &grammar{
 		},
 		{
 			name: "StringLiteral",
-			pos:  position{line: 1494, col: 1, offset: 35924},
+			pos:  position{line: 1494, col: 1, offset: 35926},
 			expr: &choiceExpr{
-				pos: position{line: 1495, col: 5, offset: 35942},
+				pos: position{line: 1495, col: 5, offset: 35944},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1495, col: 5, offset: 35942},
+						pos: position{line: 1495, col: 5, offset: 35944},
 						run: (*parser).callonStringLiteral2,
 						expr: &labeledExpr{
-							pos:   position{line: 1495, col: 5, offset: 35942},
+							pos:   position{line: 1495, col: 5, offset: 35944},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1495, col: 7, offset: 35944},
+								pos:  position{line: 1495, col: 7, offset: 35946},
 								name: "DoubleQuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1496, col: 5, offset: 36051},
+						pos: position{line: 1496, col: 5, offset: 36053},
 						run: (*parser).callonStringLiteral5,
 						expr: &labeledExpr{
-							pos:   position{line: 1496, col: 5, offset: 36051},
+							pos:   position{line: 1496, col: 5, offset: 36053},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1496, col: 7, offset: 36053},
+								pos:  position{line: 1496, col: 7, offset: 36055},
 								name: "SingleQuotedString",
 							},
 						},
@@ -10121,35 +10125,35 @@ var g = &grammar{
 		},
 		{
 			name: "FString",
-			pos:  position{line: 1498, col: 1, offset: 36127},
+			pos:  position{line: 1498, col: 1, offset: 36129},
 			expr: &choiceExpr{
-				pos: position{line: 1499, col: 5, offset: 36139},
+				pos: position{line: 1499, col: 5, offset: 36141},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1499, col: 5, offset: 36139},
+						pos: position{line: 1499, col: 5, offset: 36141},
 						run: (*parser).callonFString2,
 						expr: &seqExpr{
-							pos: position{line: 1499, col: 5, offset: 36139},
+							pos: position{line: 1499, col: 5, offset: 36141},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1499, col: 5, offset: 36139},
+									pos:        position{line: 1499, col: 5, offset: 36141},
 									val:        "f\"",
 									ignoreCase: false,
 									want:       "\"f\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1499, col: 11, offset: 36145},
+									pos:   position{line: 1499, col: 11, offset: 36147},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1499, col: 13, offset: 36147},
+										pos: position{line: 1499, col: 13, offset: 36149},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1499, col: 13, offset: 36147},
+											pos:  position{line: 1499, col: 13, offset: 36149},
 											name: "FStringDoubleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1499, col: 38, offset: 36172},
+									pos:        position{line: 1499, col: 38, offset: 36174},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -10158,30 +10162,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1506, col: 5, offset: 36318},
+						pos: position{line: 1506, col: 5, offset: 36320},
 						run: (*parser).callonFString9,
 						expr: &seqExpr{
-							pos: position{line: 1506, col: 5, offset: 36318},
+							pos: position{line: 1506, col: 5, offset: 36320},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1506, col: 5, offset: 36318},
+									pos:        position{line: 1506, col: 5, offset: 36320},
 									val:        "f'",
 									ignoreCase: false,
 									want:       "\"f'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1506, col: 10, offset: 36323},
+									pos:   position{line: 1506, col: 10, offset: 36325},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1506, col: 12, offset: 36325},
+										pos: position{line: 1506, col: 12, offset: 36327},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1506, col: 12, offset: 36325},
+											pos:  position{line: 1506, col: 12, offset: 36327},
 											name: "FStringSingleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1506, col: 37, offset: 36350},
+									pos:        position{line: 1506, col: 37, offset: 36352},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -10196,24 +10200,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedElem",
-			pos:  position{line: 1514, col: 1, offset: 36493},
+			pos:  position{line: 1514, col: 1, offset: 36495},
 			expr: &choiceExpr{
-				pos: position{line: 1515, col: 5, offset: 36521},
+				pos: position{line: 1515, col: 5, offset: 36523},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1515, col: 5, offset: 36521},
+						pos:  position{line: 1515, col: 5, offset: 36523},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1516, col: 5, offset: 36537},
+						pos: position{line: 1516, col: 5, offset: 36539},
 						run: (*parser).callonFStringDoubleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1516, col: 5, offset: 36537},
+							pos:   position{line: 1516, col: 5, offset: 36539},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1516, col: 7, offset: 36539},
+								pos: position{line: 1516, col: 7, offset: 36541},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1516, col: 7, offset: 36539},
+									pos:  position{line: 1516, col: 7, offset: 36541},
 									name: "FStringDoubleQuotedChar",
 								},
 							},
@@ -10226,27 +10230,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedChar",
-			pos:  position{line: 1520, col: 1, offset: 36662},
+			pos:  position{line: 1520, col: 1, offset: 36664},
 			expr: &choiceExpr{
-				pos: position{line: 1521, col: 5, offset: 36690},
+				pos: position{line: 1521, col: 5, offset: 36692},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1521, col: 5, offset: 36690},
+						pos: position{line: 1521, col: 5, offset: 36692},
 						run: (*parser).callonFStringDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1521, col: 5, offset: 36690},
+							pos: position{line: 1521, col: 5, offset: 36692},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1521, col: 5, offset: 36690},
+									pos:        position{line: 1521, col: 5, offset: 36692},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1521, col: 10, offset: 36695},
+									pos:   position{line: 1521, col: 10, offset: 36697},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1521, col: 12, offset: 36697},
+										pos:        position{line: 1521, col: 12, offset: 36699},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -10256,25 +10260,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1522, col: 5, offset: 36723},
+						pos: position{line: 1522, col: 5, offset: 36725},
 						run: (*parser).callonFStringDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1522, col: 5, offset: 36723},
+							pos: position{line: 1522, col: 5, offset: 36725},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1522, col: 5, offset: 36723},
+									pos: position{line: 1522, col: 5, offset: 36725},
 									expr: &litMatcher{
-										pos:        position{line: 1522, col: 7, offset: 36725},
+										pos:        position{line: 1522, col: 7, offset: 36727},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1522, col: 12, offset: 36730},
+									pos:   position{line: 1522, col: 12, offset: 36732},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1522, col: 14, offset: 36732},
+										pos:  position{line: 1522, col: 14, offset: 36734},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -10288,24 +10292,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedElem",
-			pos:  position{line: 1524, col: 1, offset: 36768},
+			pos:  position{line: 1524, col: 1, offset: 36770},
 			expr: &choiceExpr{
-				pos: position{line: 1525, col: 5, offset: 36796},
+				pos: position{line: 1525, col: 5, offset: 36798},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1525, col: 5, offset: 36796},
+						pos:  position{line: 1525, col: 5, offset: 36798},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1526, col: 5, offset: 36812},
+						pos: position{line: 1526, col: 5, offset: 36814},
 						run: (*parser).callonFStringSingleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1526, col: 5, offset: 36812},
+							pos:   position{line: 1526, col: 5, offset: 36814},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1526, col: 7, offset: 36814},
+								pos: position{line: 1526, col: 7, offset: 36816},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1526, col: 7, offset: 36814},
+									pos:  position{line: 1526, col: 7, offset: 36816},
 									name: "FStringSingleQuotedChar",
 								},
 							},
@@ -10318,27 +10322,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedChar",
-			pos:  position{line: 1530, col: 1, offset: 36937},
+			pos:  position{line: 1530, col: 1, offset: 36939},
 			expr: &choiceExpr{
-				pos: position{line: 1531, col: 5, offset: 36965},
+				pos: position{line: 1531, col: 5, offset: 36967},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1531, col: 5, offset: 36965},
+						pos: position{line: 1531, col: 5, offset: 36967},
 						run: (*parser).callonFStringSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1531, col: 5, offset: 36965},
+							pos: position{line: 1531, col: 5, offset: 36967},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1531, col: 5, offset: 36965},
+									pos:        position{line: 1531, col: 5, offset: 36967},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1531, col: 10, offset: 36970},
+									pos:   position{line: 1531, col: 10, offset: 36972},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1531, col: 12, offset: 36972},
+										pos:        position{line: 1531, col: 12, offset: 36974},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -10348,25 +10352,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1532, col: 5, offset: 36998},
+						pos: position{line: 1532, col: 5, offset: 37000},
 						run: (*parser).callonFStringSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1532, col: 5, offset: 36998},
+							pos: position{line: 1532, col: 5, offset: 37000},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1532, col: 5, offset: 36998},
+									pos: position{line: 1532, col: 5, offset: 37000},
 									expr: &litMatcher{
-										pos:        position{line: 1532, col: 7, offset: 37000},
+										pos:        position{line: 1532, col: 7, offset: 37002},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1532, col: 12, offset: 37005},
+									pos:   position{line: 1532, col: 12, offset: 37007},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1532, col: 14, offset: 37007},
+										pos:  position{line: 1532, col: 14, offset: 37009},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -10380,37 +10384,37 @@ var g = &grammar{
 		},
 		{
 			name: "FStringExpr",
-			pos:  position{line: 1534, col: 1, offset: 37043},
+			pos:  position{line: 1534, col: 1, offset: 37045},
 			expr: &actionExpr{
-				pos: position{line: 1535, col: 5, offset: 37059},
+				pos: position{line: 1535, col: 5, offset: 37061},
 				run: (*parser).callonFStringExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1535, col: 5, offset: 37059},
+					pos: position{line: 1535, col: 5, offset: 37061},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1535, col: 5, offset: 37059},
+							pos:        position{line: 1535, col: 5, offset: 37061},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1535, col: 9, offset: 37063},
+							pos:  position{line: 1535, col: 9, offset: 37065},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1535, col: 12, offset: 37066},
+							pos:   position{line: 1535, col: 12, offset: 37068},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1535, col: 14, offset: 37068},
+								pos:  position{line: 1535, col: 14, offset: 37070},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1535, col: 19, offset: 37073},
+							pos:  position{line: 1535, col: 19, offset: 37075},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1535, col: 22, offset: 37076},
+							pos:        position{line: 1535, col: 22, offset: 37078},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -10423,129 +10427,129 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1543, col: 1, offset: 37211},
+			pos:  position{line: 1543, col: 1, offset: 37213},
 			expr: &actionExpr{
-				pos: position{line: 1544, col: 5, offset: 37229},
+				pos: position{line: 1544, col: 5, offset: 37231},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1544, col: 9, offset: 37233},
+					pos: position{line: 1544, col: 9, offset: 37235},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1544, col: 9, offset: 37233},
+							pos:        position{line: 1544, col: 9, offset: 37235},
 							val:        "uint8",
 							ignoreCase: false,
 							want:       "\"uint8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1544, col: 19, offset: 37243},
+							pos:        position{line: 1544, col: 19, offset: 37245},
 							val:        "uint16",
 							ignoreCase: false,
 							want:       "\"uint16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1544, col: 30, offset: 37254},
+							pos:        position{line: 1544, col: 30, offset: 37256},
 							val:        "uint32",
 							ignoreCase: false,
 							want:       "\"uint32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1544, col: 41, offset: 37265},
+							pos:        position{line: 1544, col: 41, offset: 37267},
 							val:        "uint64",
 							ignoreCase: false,
 							want:       "\"uint64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1545, col: 9, offset: 37282},
+							pos:        position{line: 1545, col: 9, offset: 37284},
 							val:        "int8",
 							ignoreCase: false,
 							want:       "\"int8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1545, col: 18, offset: 37291},
+							pos:        position{line: 1545, col: 18, offset: 37293},
 							val:        "int16",
 							ignoreCase: false,
 							want:       "\"int16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1545, col: 28, offset: 37301},
+							pos:        position{line: 1545, col: 28, offset: 37303},
 							val:        "int32",
 							ignoreCase: false,
 							want:       "\"int32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1545, col: 38, offset: 37311},
+							pos:        position{line: 1545, col: 38, offset: 37313},
 							val:        "int64",
 							ignoreCase: false,
 							want:       "\"int64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1546, col: 9, offset: 37327},
+							pos:        position{line: 1546, col: 9, offset: 37329},
 							val:        "float16",
 							ignoreCase: false,
 							want:       "\"float16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1546, col: 21, offset: 37339},
+							pos:        position{line: 1546, col: 21, offset: 37341},
 							val:        "float32",
 							ignoreCase: false,
 							want:       "\"float32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1546, col: 33, offset: 37351},
+							pos:        position{line: 1546, col: 33, offset: 37353},
 							val:        "float64",
 							ignoreCase: false,
 							want:       "\"float64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1547, col: 9, offset: 37369},
+							pos:        position{line: 1547, col: 9, offset: 37371},
 							val:        "bool",
 							ignoreCase: false,
 							want:       "\"bool\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1547, col: 18, offset: 37378},
+							pos:        position{line: 1547, col: 18, offset: 37380},
 							val:        "string",
 							ignoreCase: false,
 							want:       "\"string\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1548, col: 9, offset: 37395},
+							pos:        position{line: 1548, col: 9, offset: 37397},
 							val:        "duration",
 							ignoreCase: false,
 							want:       "\"duration\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1548, col: 22, offset: 37408},
+							pos:        position{line: 1548, col: 22, offset: 37410},
 							val:        "time",
 							ignoreCase: false,
 							want:       "\"time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1549, col: 9, offset: 37423},
+							pos:        position{line: 1549, col: 9, offset: 37425},
 							val:        "bytes",
 							ignoreCase: false,
 							want:       "\"bytes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1550, col: 9, offset: 37439},
+							pos:        position{line: 1550, col: 9, offset: 37441},
 							val:        "ip",
 							ignoreCase: false,
 							want:       "\"ip\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1550, col: 16, offset: 37446},
+							pos:        position{line: 1550, col: 16, offset: 37448},
 							val:        "net",
 							ignoreCase: false,
 							want:       "\"net\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1551, col: 9, offset: 37460},
+							pos:        position{line: 1551, col: 9, offset: 37462},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1551, col: 18, offset: 37469},
+							pos:        position{line: 1551, col: 18, offset: 37471},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
@@ -10558,31 +10562,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1559, col: 1, offset: 37654},
+			pos:  position{line: 1559, col: 1, offset: 37656},
 			expr: &choiceExpr{
-				pos: position{line: 1560, col: 5, offset: 37672},
+				pos: position{line: 1560, col: 5, offset: 37674},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1560, col: 5, offset: 37672},
+						pos: position{line: 1560, col: 5, offset: 37674},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1560, col: 5, offset: 37672},
+							pos: position{line: 1560, col: 5, offset: 37674},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1560, col: 5, offset: 37672},
+									pos:   position{line: 1560, col: 5, offset: 37674},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1560, col: 11, offset: 37678},
+										pos:  position{line: 1560, col: 11, offset: 37680},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1560, col: 21, offset: 37688},
+									pos:   position{line: 1560, col: 21, offset: 37690},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1560, col: 26, offset: 37693},
+										pos: position{line: 1560, col: 26, offset: 37695},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1560, col: 26, offset: 37693},
+											pos:  position{line: 1560, col: 26, offset: 37695},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -10591,10 +10595,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1563, col: 5, offset: 37759},
+						pos: position{line: 1563, col: 5, offset: 37761},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1563, col: 5, offset: 37759},
+							pos:        position{line: 1563, col: 5, offset: 37761},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -10607,32 +10611,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1565, col: 1, offset: 37783},
+			pos:  position{line: 1565, col: 1, offset: 37785},
 			expr: &actionExpr{
-				pos: position{line: 1565, col: 21, offset: 37803},
+				pos: position{line: 1565, col: 21, offset: 37805},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1565, col: 21, offset: 37803},
+					pos: position{line: 1565, col: 21, offset: 37805},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1565, col: 21, offset: 37803},
+							pos:  position{line: 1565, col: 21, offset: 37805},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1565, col: 24, offset: 37806},
+							pos:        position{line: 1565, col: 24, offset: 37808},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1565, col: 28, offset: 37810},
+							pos:  position{line: 1565, col: 28, offset: 37812},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1565, col: 31, offset: 37813},
+							pos:   position{line: 1565, col: 31, offset: 37815},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1565, col: 35, offset: 37817},
+								pos:  position{line: 1565, col: 35, offset: 37819},
 								name: "TypeField",
 							},
 						},
@@ -10644,40 +10648,40 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1567, col: 1, offset: 37848},
+			pos:  position{line: 1567, col: 1, offset: 37850},
 			expr: &actionExpr{
-				pos: position{line: 1568, col: 5, offset: 37862},
+				pos: position{line: 1568, col: 5, offset: 37864},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1568, col: 5, offset: 37862},
+					pos: position{line: 1568, col: 5, offset: 37864},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1568, col: 5, offset: 37862},
+							pos:   position{line: 1568, col: 5, offset: 37864},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1568, col: 10, offset: 37867},
+								pos:  position{line: 1568, col: 10, offset: 37869},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1568, col: 15, offset: 37872},
+							pos:  position{line: 1568, col: 15, offset: 37874},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1568, col: 18, offset: 37875},
+							pos:        position{line: 1568, col: 18, offset: 37877},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1568, col: 22, offset: 37879},
+							pos:  position{line: 1568, col: 22, offset: 37881},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1568, col: 25, offset: 37882},
+							pos:   position{line: 1568, col: 25, offset: 37884},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1568, col: 29, offset: 37886},
+								pos:  position{line: 1568, col: 29, offset: 37888},
 								name: "Type",
 							},
 						},
@@ -10689,66 +10693,66 @@ var g = &grammar{
 		},
 		{
 			name: "Name",
-			pos:  position{line: 1576, col: 1, offset: 38035},
+			pos:  position{line: 1576, col: 1, offset: 38037},
 			expr: &choiceExpr{
-				pos: position{line: 1577, col: 5, offset: 38044},
+				pos: position{line: 1577, col: 5, offset: 38046},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1577, col: 5, offset: 38044},
+						pos: position{line: 1577, col: 5, offset: 38046},
 						run: (*parser).callonName2,
 						expr: &labeledExpr{
-							pos:   position{line: 1577, col: 5, offset: 38044},
+							pos:   position{line: 1577, col: 5, offset: 38046},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1577, col: 7, offset: 38046},
+								pos:  position{line: 1577, col: 7, offset: 38048},
 								name: "DottedIDs",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1578, col: 5, offset: 38136},
+						pos: position{line: 1578, col: 5, offset: 38138},
 						run: (*parser).callonName5,
 						expr: &labeledExpr{
-							pos:   position{line: 1578, col: 5, offset: 38136},
+							pos:   position{line: 1578, col: 5, offset: 38138},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1578, col: 7, offset: 38138},
+								pos:  position{line: 1578, col: 7, offset: 38140},
 								name: "IdentifierName",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1579, col: 5, offset: 38228},
+						pos: position{line: 1579, col: 5, offset: 38230},
 						run: (*parser).callonName8,
 						expr: &labeledExpr{
-							pos:   position{line: 1579, col: 5, offset: 38228},
+							pos:   position{line: 1579, col: 5, offset: 38230},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1579, col: 7, offset: 38230},
+								pos:  position{line: 1579, col: 7, offset: 38232},
 								name: "DoubleQuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1580, col: 5, offset: 38320},
+						pos: position{line: 1580, col: 5, offset: 38322},
 						run: (*parser).callonName11,
 						expr: &labeledExpr{
-							pos:   position{line: 1580, col: 5, offset: 38320},
+							pos:   position{line: 1580, col: 5, offset: 38322},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1580, col: 7, offset: 38322},
+								pos:  position{line: 1580, col: 7, offset: 38324},
 								name: "SingleQuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1581, col: 5, offset: 38412},
+						pos: position{line: 1581, col: 5, offset: 38414},
 						run: (*parser).callonName14,
 						expr: &labeledExpr{
-							pos:   position{line: 1581, col: 5, offset: 38412},
+							pos:   position{line: 1581, col: 5, offset: 38414},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1581, col: 7, offset: 38414},
+								pos:  position{line: 1581, col: 7, offset: 38416},
 								name: "KSUID",
 							},
 						},
@@ -10760,22 +10764,22 @@ var g = &grammar{
 		},
 		{
 			name: "DottedIDs",
-			pos:  position{line: 1583, col: 1, offset: 38501},
+			pos:  position{line: 1583, col: 1, offset: 38503},
 			expr: &actionExpr{
-				pos: position{line: 1584, col: 5, offset: 38515},
+				pos: position{line: 1584, col: 5, offset: 38517},
 				run: (*parser).callonDottedIDs1,
 				expr: &seqExpr{
-					pos: position{line: 1584, col: 5, offset: 38515},
+					pos: position{line: 1584, col: 5, offset: 38517},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 1584, col: 6, offset: 38516},
+							pos: position{line: 1584, col: 6, offset: 38518},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1584, col: 6, offset: 38516},
+									pos:  position{line: 1584, col: 6, offset: 38518},
 									name: "IdentifierStart",
 								},
 								&litMatcher{
-									pos:        position{line: 1584, col: 24, offset: 38534},
+									pos:        position{line: 1584, col: 24, offset: 38536},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
@@ -10783,16 +10787,16 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1584, col: 29, offset: 38539},
+							pos: position{line: 1584, col: 29, offset: 38541},
 							expr: &choiceExpr{
-								pos: position{line: 1584, col: 30, offset: 38540},
+								pos: position{line: 1584, col: 30, offset: 38542},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1584, col: 30, offset: 38540},
+										pos:  position{line: 1584, col: 30, offset: 38542},
 										name: "IdentifierRest",
 									},
 									&litMatcher{
-										pos:        position{line: 1584, col: 47, offset: 38557},
+										pos:        position{line: 1584, col: 47, offset: 38559},
 										val:        ".",
 										ignoreCase: false,
 										want:       "\".\"",
@@ -10808,15 +10812,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1586, col: 1, offset: 38595},
+			pos:  position{line: 1586, col: 1, offset: 38597},
 			expr: &actionExpr{
-				pos: position{line: 1587, col: 5, offset: 38610},
+				pos: position{line: 1587, col: 5, offset: 38612},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1587, col: 5, offset: 38610},
+					pos:   position{line: 1587, col: 5, offset: 38612},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1587, col: 8, offset: 38613},
+						pos:  position{line: 1587, col: 8, offset: 38615},
 						name: "IdentifierName",
 					},
 				},
@@ -10826,51 +10830,51 @@ var g = &grammar{
 		},
 		{
 			name: "Identifiers",
-			pos:  position{line: 1595, col: 1, offset: 38746},
+			pos:  position{line: 1595, col: 1, offset: 38748},
 			expr: &actionExpr{
-				pos: position{line: 1596, col: 5, offset: 38762},
+				pos: position{line: 1596, col: 5, offset: 38764},
 				run: (*parser).callonIdentifiers1,
 				expr: &seqExpr{
-					pos: position{line: 1596, col: 5, offset: 38762},
+					pos: position{line: 1596, col: 5, offset: 38764},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1596, col: 5, offset: 38762},
+							pos:   position{line: 1596, col: 5, offset: 38764},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1596, col: 11, offset: 38768},
+								pos:  position{line: 1596, col: 11, offset: 38770},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1596, col: 22, offset: 38779},
+							pos:   position{line: 1596, col: 22, offset: 38781},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1596, col: 27, offset: 38784},
+								pos: position{line: 1596, col: 27, offset: 38786},
 								expr: &actionExpr{
-									pos: position{line: 1596, col: 28, offset: 38785},
+									pos: position{line: 1596, col: 28, offset: 38787},
 									run: (*parser).callonIdentifiers7,
 									expr: &seqExpr{
-										pos: position{line: 1596, col: 28, offset: 38785},
+										pos: position{line: 1596, col: 28, offset: 38787},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1596, col: 28, offset: 38785},
+												pos:  position{line: 1596, col: 28, offset: 38787},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1596, col: 31, offset: 38788},
+												pos:        position{line: 1596, col: 31, offset: 38790},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1596, col: 35, offset: 38792},
+												pos:  position{line: 1596, col: 35, offset: 38794},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1596, col: 38, offset: 38795},
+												pos:   position{line: 1596, col: 38, offset: 38797},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1596, col: 43, offset: 38800},
+													pos:  position{line: 1596, col: 43, offset: 38802},
 													name: "Identifier",
 												},
 											},
@@ -10887,34 +10891,34 @@ var g = &grammar{
 		},
 		{
 			name: "SQLIdentifier",
-			pos:  position{line: 1600, col: 1, offset: 38878},
+			pos:  position{line: 1600, col: 1, offset: 38880},
 			expr: &choiceExpr{
-				pos: position{line: 1601, col: 5, offset: 38896},
+				pos: position{line: 1601, col: 5, offset: 38898},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1601, col: 5, offset: 38896},
+						pos:  position{line: 1601, col: 5, offset: 38898},
 						name: "Identifier",
 					},
 					&actionExpr{
-						pos: position{line: 1602, col: 5, offset: 38911},
+						pos: position{line: 1602, col: 5, offset: 38913},
 						run: (*parser).callonSQLIdentifier3,
 						expr: &labeledExpr{
-							pos:   position{line: 1602, col: 5, offset: 38911},
+							pos:   position{line: 1602, col: 5, offset: 38913},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1602, col: 7, offset: 38913},
+								pos:  position{line: 1602, col: 7, offset: 38915},
 								name: "BacktickString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1603, col: 5, offset: 39001},
+						pos: position{line: 1603, col: 5, offset: 39003},
 						run: (*parser).callonSQLIdentifier6,
 						expr: &labeledExpr{
-							pos:   position{line: 1603, col: 5, offset: 39001},
+							pos:   position{line: 1603, col: 5, offset: 39003},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1603, col: 7, offset: 39003},
+								pos:  position{line: 1603, col: 7, offset: 39005},
 								name: "DoubleQuotedString",
 							},
 						},
@@ -10926,29 +10930,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1605, col: 1, offset: 39088},
+			pos:  position{line: 1605, col: 1, offset: 39090},
 			expr: &choiceExpr{
-				pos: position{line: 1606, col: 5, offset: 39107},
+				pos: position{line: 1606, col: 5, offset: 39109},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1606, col: 5, offset: 39107},
+						pos: position{line: 1606, col: 5, offset: 39109},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1606, col: 5, offset: 39107},
+							pos: position{line: 1606, col: 5, offset: 39109},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1606, col: 5, offset: 39107},
+									pos: position{line: 1606, col: 5, offset: 39109},
 									expr: &seqExpr{
-										pos: position{line: 1606, col: 7, offset: 39109},
+										pos: position{line: 1606, col: 7, offset: 39111},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1606, col: 7, offset: 39109},
+												pos:  position{line: 1606, col: 7, offset: 39111},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1606, col: 15, offset: 39117},
+												pos: position{line: 1606, col: 15, offset: 39119},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1606, col: 16, offset: 39118},
+													pos:  position{line: 1606, col: 16, offset: 39120},
 													name: "IdentifierRest",
 												},
 											},
@@ -10956,13 +10960,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1606, col: 32, offset: 39134},
+									pos:  position{line: 1606, col: 32, offset: 39136},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1606, col: 48, offset: 39150},
+									pos: position{line: 1606, col: 48, offset: 39152},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1606, col: 48, offset: 39150},
+										pos:  position{line: 1606, col: 48, offset: 39152},
 										name: "IdentifierRest",
 									},
 								},
@@ -10970,32 +10974,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1607, col: 5, offset: 39201},
+						pos: position{line: 1607, col: 5, offset: 39203},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 1607, col: 5, offset: 39201},
+							pos:        position{line: 1607, col: 5, offset: 39203},
 							val:        "$",
 							ignoreCase: false,
 							want:       "\"$\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1608, col: 5, offset: 39240},
+						pos: position{line: 1608, col: 5, offset: 39242},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 1608, col: 5, offset: 39240},
+							pos: position{line: 1608, col: 5, offset: 39242},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1608, col: 5, offset: 39240},
+									pos:        position{line: 1608, col: 5, offset: 39242},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1608, col: 10, offset: 39245},
+									pos:   position{line: 1608, col: 10, offset: 39247},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1608, col: 13, offset: 39248},
+										pos:  position{line: 1608, col: 13, offset: 39250},
 										name: "IDGuard",
 									},
 								},
@@ -11003,17 +11007,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1610, col: 5, offset: 39339},
+						pos: position{line: 1610, col: 5, offset: 39341},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 1610, col: 5, offset: 39339},
+							pos:        position{line: 1610, col: 5, offset: 39341},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1611, col: 5, offset: 39381},
+						pos:  position{line: 1611, col: 5, offset: 39383},
 						name: "BacktickString",
 					},
 				},
@@ -11023,22 +11027,22 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1613, col: 1, offset: 39398},
+			pos:  position{line: 1613, col: 1, offset: 39400},
 			expr: &choiceExpr{
-				pos: position{line: 1614, col: 5, offset: 39418},
+				pos: position{line: 1614, col: 5, offset: 39420},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1614, col: 5, offset: 39418},
+						pos:  position{line: 1614, col: 5, offset: 39420},
 						name: "UnicodeLetter",
 					},
 					&litMatcher{
-						pos:        position{line: 1615, col: 5, offset: 39436},
+						pos:        position{line: 1615, col: 5, offset: 39438},
 						val:        "$",
 						ignoreCase: false,
 						want:       "\"$\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1616, col: 5, offset: 39444},
+						pos:        position{line: 1616, col: 5, offset: 39446},
 						val:        "_",
 						ignoreCase: false,
 						want:       "\"_\"",
@@ -11050,24 +11054,24 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1618, col: 1, offset: 39449},
+			pos:  position{line: 1618, col: 1, offset: 39451},
 			expr: &choiceExpr{
-				pos: position{line: 1619, col: 5, offset: 39468},
+				pos: position{line: 1619, col: 5, offset: 39470},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1619, col: 5, offset: 39468},
+						pos:  position{line: 1619, col: 5, offset: 39470},
 						name: "IdentifierStart",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1620, col: 5, offset: 39488},
+						pos:  position{line: 1620, col: 5, offset: 39490},
 						name: "UnicodeCombiningMark",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1621, col: 5, offset: 39513},
+						pos:  position{line: 1621, col: 5, offset: 39515},
 						name: "UnicodeDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1622, col: 5, offset: 39530},
+						pos:  position{line: 1622, col: 5, offset: 39532},
 						name: "UnicodeConnectorPunctuation",
 					},
 				},
@@ -11077,24 +11081,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1624, col: 1, offset: 39559},
+			pos:  position{line: 1624, col: 1, offset: 39561},
 			expr: &choiceExpr{
-				pos: position{line: 1625, col: 5, offset: 39571},
+				pos: position{line: 1625, col: 5, offset: 39573},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1625, col: 5, offset: 39571},
+						pos:  position{line: 1625, col: 5, offset: 39573},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1626, col: 5, offset: 39590},
+						pos:  position{line: 1626, col: 5, offset: 39592},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1627, col: 5, offset: 39606},
+						pos:  position{line: 1627, col: 5, offset: 39608},
 						name: "NaN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1628, col: 5, offset: 39614},
+						pos:  position{line: 1628, col: 5, offset: 39616},
 						name: "Infinity",
 					},
 				},
@@ -11104,25 +11108,25 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1630, col: 1, offset: 39624},
+			pos:  position{line: 1630, col: 1, offset: 39626},
 			expr: &actionExpr{
-				pos: position{line: 1631, col: 5, offset: 39633},
+				pos: position{line: 1631, col: 5, offset: 39635},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1631, col: 5, offset: 39633},
+					pos: position{line: 1631, col: 5, offset: 39635},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1631, col: 5, offset: 39633},
+							pos:  position{line: 1631, col: 5, offset: 39635},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1631, col: 14, offset: 39642},
+							pos:        position{line: 1631, col: 14, offset: 39644},
 							val:        "T",
 							ignoreCase: false,
 							want:       "\"T\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1631, col: 18, offset: 39646},
+							pos:  position{line: 1631, col: 18, offset: 39648},
 							name: "FullTime",
 						},
 					},
@@ -11133,32 +11137,32 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1635, col: 1, offset: 39722},
+			pos:  position{line: 1635, col: 1, offset: 39724},
 			expr: &seqExpr{
-				pos: position{line: 1635, col: 12, offset: 39733},
+				pos: position{line: 1635, col: 12, offset: 39735},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1635, col: 12, offset: 39733},
+						pos:  position{line: 1635, col: 12, offset: 39735},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1635, col: 15, offset: 39736},
+						pos:        position{line: 1635, col: 15, offset: 39738},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1635, col: 19, offset: 39740},
+						pos:  position{line: 1635, col: 19, offset: 39742},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1635, col: 22, offset: 39743},
+						pos:        position{line: 1635, col: 22, offset: 39745},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1635, col: 26, offset: 39747},
+						pos:  position{line: 1635, col: 26, offset: 39749},
 						name: "D2",
 					},
 				},
@@ -11168,33 +11172,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1637, col: 1, offset: 39751},
+			pos:  position{line: 1637, col: 1, offset: 39753},
 			expr: &seqExpr{
-				pos: position{line: 1637, col: 6, offset: 39756},
+				pos: position{line: 1637, col: 6, offset: 39758},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1637, col: 6, offset: 39756},
+						pos:        position{line: 1637, col: 6, offset: 39758},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1637, col: 11, offset: 39761},
+						pos:        position{line: 1637, col: 11, offset: 39763},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1637, col: 16, offset: 39766},
+						pos:        position{line: 1637, col: 16, offset: 39768},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1637, col: 21, offset: 39771},
+						pos:        position{line: 1637, col: 21, offset: 39773},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11207,19 +11211,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1638, col: 1, offset: 39777},
+			pos:  position{line: 1638, col: 1, offset: 39779},
 			expr: &seqExpr{
-				pos: position{line: 1638, col: 6, offset: 39782},
+				pos: position{line: 1638, col: 6, offset: 39784},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1638, col: 6, offset: 39782},
+						pos:        position{line: 1638, col: 6, offset: 39784},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1638, col: 11, offset: 39787},
+						pos:        position{line: 1638, col: 11, offset: 39789},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11232,16 +11236,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1640, col: 1, offset: 39794},
+			pos:  position{line: 1640, col: 1, offset: 39796},
 			expr: &seqExpr{
-				pos: position{line: 1640, col: 12, offset: 39805},
+				pos: position{line: 1640, col: 12, offset: 39807},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1640, col: 12, offset: 39805},
+						pos:  position{line: 1640, col: 12, offset: 39807},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1640, col: 24, offset: 39817},
+						pos:  position{line: 1640, col: 24, offset: 39819},
 						name: "TimeOffset",
 					},
 				},
@@ -11251,49 +11255,49 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1642, col: 1, offset: 39829},
+			pos:  position{line: 1642, col: 1, offset: 39831},
 			expr: &seqExpr{
-				pos: position{line: 1642, col: 15, offset: 39843},
+				pos: position{line: 1642, col: 15, offset: 39845},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1642, col: 15, offset: 39843},
+						pos:  position{line: 1642, col: 15, offset: 39845},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1642, col: 18, offset: 39846},
+						pos:        position{line: 1642, col: 18, offset: 39848},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1642, col: 22, offset: 39850},
+						pos:  position{line: 1642, col: 22, offset: 39852},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1642, col: 25, offset: 39853},
+						pos:        position{line: 1642, col: 25, offset: 39855},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1642, col: 29, offset: 39857},
+						pos:  position{line: 1642, col: 29, offset: 39859},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1642, col: 32, offset: 39860},
+						pos: position{line: 1642, col: 32, offset: 39862},
 						expr: &seqExpr{
-							pos: position{line: 1642, col: 33, offset: 39861},
+							pos: position{line: 1642, col: 33, offset: 39863},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1642, col: 33, offset: 39861},
+									pos:        position{line: 1642, col: 33, offset: 39863},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1642, col: 37, offset: 39865},
+									pos: position{line: 1642, col: 37, offset: 39867},
 									expr: &charClassMatcher{
-										pos:        position{line: 1642, col: 37, offset: 39865},
+										pos:        position{line: 1642, col: 37, offset: 39867},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11310,30 +11314,30 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1644, col: 1, offset: 39875},
+			pos:  position{line: 1644, col: 1, offset: 39877},
 			expr: &choiceExpr{
-				pos: position{line: 1645, col: 5, offset: 39890},
+				pos: position{line: 1645, col: 5, offset: 39892},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1645, col: 5, offset: 39890},
+						pos:        position{line: 1645, col: 5, offset: 39892},
 						val:        "Z",
 						ignoreCase: false,
 						want:       "\"Z\"",
 					},
 					&seqExpr{
-						pos: position{line: 1646, col: 5, offset: 39898},
+						pos: position{line: 1646, col: 5, offset: 39900},
 						exprs: []any{
 							&choiceExpr{
-								pos: position{line: 1646, col: 6, offset: 39899},
+								pos: position{line: 1646, col: 6, offset: 39901},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 1646, col: 6, offset: 39899},
+										pos:        position{line: 1646, col: 6, offset: 39901},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 1646, col: 12, offset: 39905},
+										pos:        position{line: 1646, col: 12, offset: 39907},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
@@ -11341,34 +11345,34 @@ var g = &grammar{
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1646, col: 17, offset: 39910},
+								pos:  position{line: 1646, col: 17, offset: 39912},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1646, col: 20, offset: 39913},
+								pos:        position{line: 1646, col: 20, offset: 39915},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1646, col: 24, offset: 39917},
+								pos:  position{line: 1646, col: 24, offset: 39919},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1646, col: 27, offset: 39920},
+								pos: position{line: 1646, col: 27, offset: 39922},
 								expr: &seqExpr{
-									pos: position{line: 1646, col: 28, offset: 39921},
+									pos: position{line: 1646, col: 28, offset: 39923},
 									exprs: []any{
 										&litMatcher{
-											pos:        position{line: 1646, col: 28, offset: 39921},
+											pos:        position{line: 1646, col: 28, offset: 39923},
 											val:        ".",
 											ignoreCase: false,
 											want:       "\".\"",
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1646, col: 32, offset: 39925},
+											pos: position{line: 1646, col: 32, offset: 39927},
 											expr: &charClassMatcher{
-												pos:        position{line: 1646, col: 32, offset: 39925},
+												pos:        position{line: 1646, col: 32, offset: 39927},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -11387,33 +11391,33 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1648, col: 1, offset: 39935},
+			pos:  position{line: 1648, col: 1, offset: 39937},
 			expr: &actionExpr{
-				pos: position{line: 1649, col: 5, offset: 39948},
+				pos: position{line: 1649, col: 5, offset: 39950},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1649, col: 5, offset: 39948},
+					pos: position{line: 1649, col: 5, offset: 39950},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 1649, col: 5, offset: 39948},
+							pos: position{line: 1649, col: 5, offset: 39950},
 							expr: &litMatcher{
-								pos:        position{line: 1649, col: 5, offset: 39948},
+								pos:        position{line: 1649, col: 5, offset: 39950},
 								val:        "-",
 								ignoreCase: false,
 								want:       "\"-\"",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1649, col: 10, offset: 39953},
+							pos: position{line: 1649, col: 10, offset: 39955},
 							expr: &seqExpr{
-								pos: position{line: 1649, col: 11, offset: 39954},
+								pos: position{line: 1649, col: 11, offset: 39956},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1649, col: 11, offset: 39954},
+										pos:  position{line: 1649, col: 11, offset: 39956},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1649, col: 19, offset: 39962},
+										pos:  position{line: 1649, col: 19, offset: 39964},
 										name: "TimeUnit",
 									},
 								},
@@ -11427,27 +11431,27 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1653, col: 1, offset: 40044},
+			pos:  position{line: 1653, col: 1, offset: 40046},
 			expr: &seqExpr{
-				pos: position{line: 1653, col: 11, offset: 40054},
+				pos: position{line: 1653, col: 11, offset: 40056},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1653, col: 11, offset: 40054},
+						pos:  position{line: 1653, col: 11, offset: 40056},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1653, col: 16, offset: 40059},
+						pos: position{line: 1653, col: 16, offset: 40061},
 						expr: &seqExpr{
-							pos: position{line: 1653, col: 17, offset: 40060},
+							pos: position{line: 1653, col: 17, offset: 40062},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1653, col: 17, offset: 40060},
+									pos:        position{line: 1653, col: 17, offset: 40062},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1653, col: 21, offset: 40064},
+									pos:  position{line: 1653, col: 21, offset: 40066},
 									name: "UInt",
 								},
 							},
@@ -11460,60 +11464,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1655, col: 1, offset: 40072},
+			pos:  position{line: 1655, col: 1, offset: 40074},
 			expr: &choiceExpr{
-				pos: position{line: 1656, col: 5, offset: 40085},
+				pos: position{line: 1656, col: 5, offset: 40087},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1656, col: 5, offset: 40085},
+						pos:        position{line: 1656, col: 5, offset: 40087},
 						val:        "ns",
 						ignoreCase: false,
 						want:       "\"ns\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1657, col: 5, offset: 40094},
+						pos:        position{line: 1657, col: 5, offset: 40096},
 						val:        "us",
 						ignoreCase: false,
 						want:       "\"us\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1658, col: 5, offset: 40103},
+						pos:        position{line: 1658, col: 5, offset: 40105},
 						val:        "ms",
 						ignoreCase: false,
 						want:       "\"ms\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1659, col: 5, offset: 40112},
+						pos:        position{line: 1659, col: 5, offset: 40114},
 						val:        "s",
 						ignoreCase: false,
 						want:       "\"s\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1660, col: 5, offset: 40120},
+						pos:        position{line: 1660, col: 5, offset: 40122},
 						val:        "m",
 						ignoreCase: false,
 						want:       "\"m\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1661, col: 5, offset: 40128},
+						pos:        position{line: 1661, col: 5, offset: 40130},
 						val:        "h",
 						ignoreCase: false,
 						want:       "\"h\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1662, col: 5, offset: 40136},
+						pos:        position{line: 1662, col: 5, offset: 40138},
 						val:        "d",
 						ignoreCase: false,
 						want:       "\"d\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1663, col: 5, offset: 40144},
+						pos:        position{line: 1663, col: 5, offset: 40146},
 						val:        "w",
 						ignoreCase: false,
 						want:       "\"w\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1664, col: 5, offset: 40152},
+						pos:        position{line: 1664, col: 5, offset: 40154},
 						val:        "y",
 						ignoreCase: false,
 						want:       "\"y\"",
@@ -11525,45 +11529,45 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1666, col: 1, offset: 40157},
+			pos:  position{line: 1666, col: 1, offset: 40159},
 			expr: &actionExpr{
-				pos: position{line: 1667, col: 5, offset: 40164},
+				pos: position{line: 1667, col: 5, offset: 40166},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1667, col: 5, offset: 40164},
+					pos: position{line: 1667, col: 5, offset: 40166},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1667, col: 5, offset: 40164},
+							pos:  position{line: 1667, col: 5, offset: 40166},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1667, col: 10, offset: 40169},
+							pos:        position{line: 1667, col: 10, offset: 40171},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1667, col: 14, offset: 40173},
+							pos:  position{line: 1667, col: 14, offset: 40175},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1667, col: 19, offset: 40178},
+							pos:        position{line: 1667, col: 19, offset: 40180},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1667, col: 23, offset: 40182},
+							pos:  position{line: 1667, col: 23, offset: 40184},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1667, col: 28, offset: 40187},
+							pos:        position{line: 1667, col: 28, offset: 40189},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1667, col: 32, offset: 40191},
+							pos:  position{line: 1667, col: 32, offset: 40193},
 							name: "UInt",
 						},
 					},
@@ -11574,43 +11578,43 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1669, col: 1, offset: 40228},
+			pos:  position{line: 1669, col: 1, offset: 40230},
 			expr: &actionExpr{
-				pos: position{line: 1670, col: 5, offset: 40236},
+				pos: position{line: 1670, col: 5, offset: 40238},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1670, col: 5, offset: 40236},
+					pos: position{line: 1670, col: 5, offset: 40238},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1670, col: 5, offset: 40236},
+							pos: position{line: 1670, col: 5, offset: 40238},
 							expr: &seqExpr{
-								pos: position{line: 1670, col: 7, offset: 40238},
+								pos: position{line: 1670, col: 7, offset: 40240},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1670, col: 7, offset: 40238},
+										pos:  position{line: 1670, col: 7, offset: 40240},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1670, col: 11, offset: 40242},
+										pos:        position{line: 1670, col: 11, offset: 40244},
 										val:        ":",
 										ignoreCase: false,
 										want:       "\":\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1670, col: 15, offset: 40246},
+										pos:  position{line: 1670, col: 15, offset: 40248},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1670, col: 19, offset: 40250},
+										pos: position{line: 1670, col: 19, offset: 40252},
 										expr: &choiceExpr{
-											pos: position{line: 1670, col: 21, offset: 40252},
+											pos: position{line: 1670, col: 21, offset: 40254},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1670, col: 21, offset: 40252},
+													pos:  position{line: 1670, col: 21, offset: 40254},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1670, col: 32, offset: 40263},
+													pos:        position{line: 1670, col: 32, offset: 40265},
 													val:        ":",
 													ignoreCase: false,
 													want:       "\":\"",
@@ -11622,10 +11626,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1670, col: 38, offset: 40269},
+							pos:   position{line: 1670, col: 38, offset: 40271},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1670, col: 40, offset: 40271},
+								pos:  position{line: 1670, col: 40, offset: 40273},
 								name: "IP6Variations",
 							},
 						},
@@ -11637,32 +11641,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1674, col: 1, offset: 40435},
+			pos:  position{line: 1674, col: 1, offset: 40437},
 			expr: &choiceExpr{
-				pos: position{line: 1675, col: 5, offset: 40453},
+				pos: position{line: 1675, col: 5, offset: 40455},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1675, col: 5, offset: 40453},
+						pos: position{line: 1675, col: 5, offset: 40455},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1675, col: 5, offset: 40453},
+							pos: position{line: 1675, col: 5, offset: 40455},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1675, col: 5, offset: 40453},
+									pos:   position{line: 1675, col: 5, offset: 40455},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1675, col: 7, offset: 40455},
+										pos: position{line: 1675, col: 7, offset: 40457},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1675, col: 7, offset: 40455},
+											pos:  position{line: 1675, col: 7, offset: 40457},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1675, col: 17, offset: 40465},
+									pos:   position{line: 1675, col: 17, offset: 40467},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1675, col: 19, offset: 40467},
+										pos:  position{line: 1675, col: 19, offset: 40469},
 										name: "IP6Tail",
 									},
 								},
@@ -11670,52 +11674,52 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1678, col: 5, offset: 40531},
+						pos: position{line: 1678, col: 5, offset: 40533},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1678, col: 5, offset: 40531},
+							pos: position{line: 1678, col: 5, offset: 40533},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1678, col: 5, offset: 40531},
+									pos:   position{line: 1678, col: 5, offset: 40533},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1678, col: 7, offset: 40533},
+										pos:  position{line: 1678, col: 7, offset: 40535},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1678, col: 11, offset: 40537},
+									pos:   position{line: 1678, col: 11, offset: 40539},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1678, col: 13, offset: 40539},
+										pos: position{line: 1678, col: 13, offset: 40541},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1678, col: 13, offset: 40539},
+											pos:  position{line: 1678, col: 13, offset: 40541},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1678, col: 23, offset: 40549},
+									pos:        position{line: 1678, col: 23, offset: 40551},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1678, col: 28, offset: 40554},
+									pos:   position{line: 1678, col: 28, offset: 40556},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1678, col: 30, offset: 40556},
+										pos: position{line: 1678, col: 30, offset: 40558},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1678, col: 30, offset: 40556},
+											pos:  position{line: 1678, col: 30, offset: 40558},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1678, col: 40, offset: 40566},
+									pos:   position{line: 1678, col: 40, offset: 40568},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1678, col: 42, offset: 40568},
+										pos:  position{line: 1678, col: 42, offset: 40570},
 										name: "IP6Tail",
 									},
 								},
@@ -11723,33 +11727,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1681, col: 5, offset: 40667},
+						pos: position{line: 1681, col: 5, offset: 40669},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1681, col: 5, offset: 40667},
+							pos: position{line: 1681, col: 5, offset: 40669},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1681, col: 5, offset: 40667},
+									pos:        position{line: 1681, col: 5, offset: 40669},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1681, col: 10, offset: 40672},
+									pos:   position{line: 1681, col: 10, offset: 40674},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1681, col: 12, offset: 40674},
+										pos: position{line: 1681, col: 12, offset: 40676},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1681, col: 12, offset: 40674},
+											pos:  position{line: 1681, col: 12, offset: 40676},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1681, col: 22, offset: 40684},
+									pos:   position{line: 1681, col: 22, offset: 40686},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1681, col: 24, offset: 40686},
+										pos:  position{line: 1681, col: 24, offset: 40688},
 										name: "IP6Tail",
 									},
 								},
@@ -11757,32 +11761,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1684, col: 5, offset: 40757},
+						pos: position{line: 1684, col: 5, offset: 40759},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1684, col: 5, offset: 40757},
+							pos: position{line: 1684, col: 5, offset: 40759},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1684, col: 5, offset: 40757},
+									pos:   position{line: 1684, col: 5, offset: 40759},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1684, col: 7, offset: 40759},
+										pos:  position{line: 1684, col: 7, offset: 40761},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1684, col: 11, offset: 40763},
+									pos:   position{line: 1684, col: 11, offset: 40765},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1684, col: 13, offset: 40765},
+										pos: position{line: 1684, col: 13, offset: 40767},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1684, col: 13, offset: 40765},
+											pos:  position{line: 1684, col: 13, offset: 40767},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1684, col: 23, offset: 40775},
+									pos:        position{line: 1684, col: 23, offset: 40777},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
@@ -11791,10 +11795,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1687, col: 5, offset: 40843},
+						pos: position{line: 1687, col: 5, offset: 40845},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 1687, col: 5, offset: 40843},
+							pos:        position{line: 1687, col: 5, offset: 40845},
 							val:        "::",
 							ignoreCase: false,
 							want:       "\"::\"",
@@ -11807,16 +11811,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1691, col: 1, offset: 40880},
+			pos:  position{line: 1691, col: 1, offset: 40882},
 			expr: &choiceExpr{
-				pos: position{line: 1692, col: 5, offset: 40892},
+				pos: position{line: 1692, col: 5, offset: 40894},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1692, col: 5, offset: 40892},
+						pos:  position{line: 1692, col: 5, offset: 40894},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1693, col: 5, offset: 40899},
+						pos:  position{line: 1693, col: 5, offset: 40901},
 						name: "Hex",
 					},
 				},
@@ -11826,24 +11830,24 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1695, col: 1, offset: 40904},
+			pos:  position{line: 1695, col: 1, offset: 40906},
 			expr: &actionExpr{
-				pos: position{line: 1695, col: 12, offset: 40915},
+				pos: position{line: 1695, col: 12, offset: 40917},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1695, col: 12, offset: 40915},
+					pos: position{line: 1695, col: 12, offset: 40917},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1695, col: 12, offset: 40915},
+							pos:        position{line: 1695, col: 12, offset: 40917},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1695, col: 16, offset: 40919},
+							pos:   position{line: 1695, col: 16, offset: 40921},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1695, col: 18, offset: 40921},
+								pos:  position{line: 1695, col: 18, offset: 40923},
 								name: "Hex",
 							},
 						},
@@ -11855,23 +11859,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1697, col: 1, offset: 40959},
+			pos:  position{line: 1697, col: 1, offset: 40961},
 			expr: &actionExpr{
-				pos: position{line: 1697, col: 12, offset: 40970},
+				pos: position{line: 1697, col: 12, offset: 40972},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1697, col: 12, offset: 40970},
+					pos: position{line: 1697, col: 12, offset: 40972},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1697, col: 12, offset: 40970},
+							pos:   position{line: 1697, col: 12, offset: 40972},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1697, col: 14, offset: 40972},
+								pos:  position{line: 1697, col: 14, offset: 40974},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1697, col: 18, offset: 40976},
+							pos:        position{line: 1697, col: 18, offset: 40978},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
@@ -11884,32 +11888,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1699, col: 1, offset: 41014},
+			pos:  position{line: 1699, col: 1, offset: 41016},
 			expr: &actionExpr{
-				pos: position{line: 1700, col: 5, offset: 41025},
+				pos: position{line: 1700, col: 5, offset: 41027},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1700, col: 5, offset: 41025},
+					pos: position{line: 1700, col: 5, offset: 41027},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1700, col: 5, offset: 41025},
+							pos:   position{line: 1700, col: 5, offset: 41027},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1700, col: 7, offset: 41027},
+								pos:  position{line: 1700, col: 7, offset: 41029},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1700, col: 10, offset: 41030},
+							pos:        position{line: 1700, col: 10, offset: 41032},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1700, col: 14, offset: 41034},
+							pos:   position{line: 1700, col: 14, offset: 41036},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1700, col: 16, offset: 41036},
+								pos:  position{line: 1700, col: 16, offset: 41038},
 								name: "UIntString",
 							},
 						},
@@ -11921,32 +11925,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1704, col: 1, offset: 41104},
+			pos:  position{line: 1704, col: 1, offset: 41106},
 			expr: &actionExpr{
-				pos: position{line: 1705, col: 5, offset: 41115},
+				pos: position{line: 1705, col: 5, offset: 41117},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1705, col: 5, offset: 41115},
+					pos: position{line: 1705, col: 5, offset: 41117},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1705, col: 5, offset: 41115},
+							pos:   position{line: 1705, col: 5, offset: 41117},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1705, col: 7, offset: 41117},
+								pos:  position{line: 1705, col: 7, offset: 41119},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1705, col: 11, offset: 41121},
+							pos:        position{line: 1705, col: 11, offset: 41123},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1705, col: 15, offset: 41125},
+							pos:   position{line: 1705, col: 15, offset: 41127},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1705, col: 17, offset: 41127},
+								pos:  position{line: 1705, col: 17, offset: 41129},
 								name: "UIntString",
 							},
 						},
@@ -11958,15 +11962,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1709, col: 1, offset: 41195},
+			pos:  position{line: 1709, col: 1, offset: 41197},
 			expr: &actionExpr{
-				pos: position{line: 1710, col: 4, offset: 41203},
+				pos: position{line: 1710, col: 4, offset: 41205},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1710, col: 4, offset: 41203},
+					pos:   position{line: 1710, col: 4, offset: 41205},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1710, col: 6, offset: 41205},
+						pos:  position{line: 1710, col: 6, offset: 41207},
 						name: "UIntString",
 					},
 				},
@@ -11976,16 +11980,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1712, col: 1, offset: 41245},
+			pos:  position{line: 1712, col: 1, offset: 41247},
 			expr: &choiceExpr{
-				pos: position{line: 1713, col: 5, offset: 41259},
+				pos: position{line: 1713, col: 5, offset: 41261},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1713, col: 5, offset: 41259},
+						pos:  position{line: 1713, col: 5, offset: 41261},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1714, col: 5, offset: 41274},
+						pos:  position{line: 1714, col: 5, offset: 41276},
 						name: "MinusIntString",
 					},
 				},
@@ -11995,14 +11999,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1716, col: 1, offset: 41290},
+			pos:  position{line: 1716, col: 1, offset: 41292},
 			expr: &actionExpr{
-				pos: position{line: 1716, col: 14, offset: 41303},
+				pos: position{line: 1716, col: 14, offset: 41305},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1716, col: 14, offset: 41303},
+					pos: position{line: 1716, col: 14, offset: 41305},
 					expr: &charClassMatcher{
-						pos:        position{line: 1716, col: 14, offset: 41303},
+						pos:        position{line: 1716, col: 14, offset: 41305},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -12015,21 +12019,21 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1718, col: 1, offset: 41342},
+			pos:  position{line: 1718, col: 1, offset: 41344},
 			expr: &actionExpr{
-				pos: position{line: 1719, col: 5, offset: 41361},
+				pos: position{line: 1719, col: 5, offset: 41363},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1719, col: 5, offset: 41361},
+					pos: position{line: 1719, col: 5, offset: 41363},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1719, col: 5, offset: 41361},
+							pos:        position{line: 1719, col: 5, offset: 41363},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1719, col: 9, offset: 41365},
+							pos:  position{line: 1719, col: 9, offset: 41367},
 							name: "UIntString",
 						},
 					},
@@ -12040,29 +12044,29 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1721, col: 1, offset: 41408},
+			pos:  position{line: 1721, col: 1, offset: 41410},
 			expr: &choiceExpr{
-				pos: position{line: 1722, col: 5, offset: 41424},
+				pos: position{line: 1722, col: 5, offset: 41426},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1722, col: 5, offset: 41424},
+						pos: position{line: 1722, col: 5, offset: 41426},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1722, col: 5, offset: 41424},
+							pos: position{line: 1722, col: 5, offset: 41426},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1722, col: 5, offset: 41424},
+									pos: position{line: 1722, col: 5, offset: 41426},
 									expr: &litMatcher{
-										pos:        position{line: 1722, col: 5, offset: 41424},
+										pos:        position{line: 1722, col: 5, offset: 41426},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1722, col: 10, offset: 41429},
+									pos: position{line: 1722, col: 10, offset: 41431},
 									expr: &charClassMatcher{
-										pos:        position{line: 1722, col: 10, offset: 41429},
+										pos:        position{line: 1722, col: 10, offset: 41431},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -12070,15 +12074,15 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1722, col: 17, offset: 41436},
+									pos:        position{line: 1722, col: 17, offset: 41438},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1722, col: 21, offset: 41440},
+									pos: position{line: 1722, col: 21, offset: 41442},
 									expr: &charClassMatcher{
-										pos:        position{line: 1722, col: 21, offset: 41440},
+										pos:        position{line: 1722, col: 21, offset: 41442},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -12086,9 +12090,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1722, col: 28, offset: 41447},
+									pos: position{line: 1722, col: 28, offset: 41449},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1722, col: 28, offset: 41447},
+										pos:  position{line: 1722, col: 28, offset: 41449},
 										name: "ExponentPart",
 									},
 								},
@@ -12096,30 +12100,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1723, col: 5, offset: 41496},
+						pos: position{line: 1723, col: 5, offset: 41498},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1723, col: 5, offset: 41496},
+							pos: position{line: 1723, col: 5, offset: 41498},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1723, col: 5, offset: 41496},
+									pos: position{line: 1723, col: 5, offset: 41498},
 									expr: &litMatcher{
-										pos:        position{line: 1723, col: 5, offset: 41496},
+										pos:        position{line: 1723, col: 5, offset: 41498},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1723, col: 10, offset: 41501},
+									pos:        position{line: 1723, col: 10, offset: 41503},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1723, col: 14, offset: 41505},
+									pos: position{line: 1723, col: 14, offset: 41507},
 									expr: &charClassMatcher{
-										pos:        position{line: 1723, col: 14, offset: 41505},
+										pos:        position{line: 1723, col: 14, offset: 41507},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -12127,9 +12131,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1723, col: 21, offset: 41512},
+									pos: position{line: 1723, col: 21, offset: 41514},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1723, col: 21, offset: 41512},
+										pos:  position{line: 1723, col: 21, offset: 41514},
 										name: "ExponentPart",
 									},
 								},
@@ -12137,17 +12141,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1724, col: 5, offset: 41561},
+						pos: position{line: 1724, col: 5, offset: 41563},
 						run: (*parser).callonFloatString22,
 						expr: &choiceExpr{
-							pos: position{line: 1724, col: 6, offset: 41562},
+							pos: position{line: 1724, col: 6, offset: 41564},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1724, col: 6, offset: 41562},
+									pos:  position{line: 1724, col: 6, offset: 41564},
 									name: "NaN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1724, col: 12, offset: 41568},
+									pos:  position{line: 1724, col: 12, offset: 41570},
 									name: "Infinity",
 								},
 							},
@@ -12160,20 +12164,20 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1727, col: 1, offset: 41611},
+			pos:  position{line: 1727, col: 1, offset: 41613},
 			expr: &seqExpr{
-				pos: position{line: 1727, col: 16, offset: 41626},
+				pos: position{line: 1727, col: 16, offset: 41628},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1727, col: 16, offset: 41626},
+						pos:        position{line: 1727, col: 16, offset: 41628},
 						val:        "e",
 						ignoreCase: true,
 						want:       "\"e\"i",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1727, col: 21, offset: 41631},
+						pos: position{line: 1727, col: 21, offset: 41633},
 						expr: &charClassMatcher{
-							pos:        position{line: 1727, col: 21, offset: 41631},
+							pos:        position{line: 1727, col: 21, offset: 41633},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -12181,7 +12185,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1727, col: 27, offset: 41637},
+						pos:  position{line: 1727, col: 27, offset: 41639},
 						name: "UIntString",
 					},
 				},
@@ -12191,9 +12195,9 @@ var g = &grammar{
 		},
 		{
 			name: "NaN",
-			pos:  position{line: 1729, col: 1, offset: 41649},
+			pos:  position{line: 1729, col: 1, offset: 41651},
 			expr: &litMatcher{
-				pos:        position{line: 1729, col: 7, offset: 41655},
+				pos:        position{line: 1729, col: 7, offset: 41657},
 				val:        "NaN",
 				ignoreCase: false,
 				want:       "\"NaN\"",
@@ -12203,23 +12207,23 @@ var g = &grammar{
 		},
 		{
 			name: "Infinity",
-			pos:  position{line: 1731, col: 1, offset: 41662},
+			pos:  position{line: 1731, col: 1, offset: 41664},
 			expr: &seqExpr{
-				pos: position{line: 1731, col: 12, offset: 41673},
+				pos: position{line: 1731, col: 12, offset: 41675},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 1731, col: 12, offset: 41673},
+						pos: position{line: 1731, col: 12, offset: 41675},
 						expr: &choiceExpr{
-							pos: position{line: 1731, col: 13, offset: 41674},
+							pos: position{line: 1731, col: 13, offset: 41676},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1731, col: 13, offset: 41674},
+									pos:        position{line: 1731, col: 13, offset: 41676},
 									val:        "-",
 									ignoreCase: false,
 									want:       "\"-\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1731, col: 19, offset: 41680},
+									pos:        position{line: 1731, col: 19, offset: 41682},
 									val:        "+",
 									ignoreCase: false,
 									want:       "\"+\"",
@@ -12228,7 +12232,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1731, col: 25, offset: 41686},
+						pos:        position{line: 1731, col: 25, offset: 41688},
 						val:        "Inf",
 						ignoreCase: false,
 						want:       "\"Inf\"",
@@ -12240,14 +12244,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1733, col: 1, offset: 41693},
+			pos:  position{line: 1733, col: 1, offset: 41695},
 			expr: &actionExpr{
-				pos: position{line: 1733, col: 7, offset: 41699},
+				pos: position{line: 1733, col: 7, offset: 41701},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1733, col: 7, offset: 41699},
+					pos: position{line: 1733, col: 7, offset: 41701},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1733, col: 7, offset: 41699},
+						pos:  position{line: 1733, col: 7, offset: 41701},
 						name: "HexDigit",
 					},
 				},
@@ -12257,9 +12261,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1735, col: 1, offset: 41741},
+			pos:  position{line: 1735, col: 1, offset: 41743},
 			expr: &charClassMatcher{
-				pos:        position{line: 1735, col: 12, offset: 41752},
+				pos:        position{line: 1735, col: 12, offset: 41754},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -12270,32 +12274,32 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedString",
-			pos:  position{line: 1737, col: 1, offset: 41765},
+			pos:  position{line: 1737, col: 1, offset: 41767},
 			expr: &actionExpr{
-				pos: position{line: 1738, col: 5, offset: 41788},
+				pos: position{line: 1738, col: 5, offset: 41790},
 				run: (*parser).callonSingleQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 1738, col: 5, offset: 41788},
+					pos: position{line: 1738, col: 5, offset: 41790},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1738, col: 5, offset: 41788},
+							pos:        position{line: 1738, col: 5, offset: 41790},
 							val:        "'",
 							ignoreCase: false,
 							want:       "\"'\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1738, col: 9, offset: 41792},
+							pos:   position{line: 1738, col: 9, offset: 41794},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1738, col: 11, offset: 41794},
+								pos: position{line: 1738, col: 11, offset: 41796},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1738, col: 11, offset: 41794},
+									pos:  position{line: 1738, col: 11, offset: 41796},
 									name: "SingleQuotedChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1738, col: 29, offset: 41812},
+							pos:        position{line: 1738, col: 29, offset: 41814},
 							val:        "'",
 							ignoreCase: false,
 							want:       "\"'\"",
@@ -12308,32 +12312,32 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedString",
-			pos:  position{line: 1740, col: 1, offset: 41846},
+			pos:  position{line: 1740, col: 1, offset: 41848},
 			expr: &actionExpr{
-				pos: position{line: 1741, col: 5, offset: 41869},
+				pos: position{line: 1741, col: 5, offset: 41871},
 				run: (*parser).callonDoubleQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 1741, col: 5, offset: 41869},
+					pos: position{line: 1741, col: 5, offset: 41871},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1741, col: 5, offset: 41869},
+							pos:        position{line: 1741, col: 5, offset: 41871},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1741, col: 9, offset: 41873},
+							pos:   position{line: 1741, col: 9, offset: 41875},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1741, col: 11, offset: 41875},
+								pos: position{line: 1741, col: 11, offset: 41877},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1741, col: 11, offset: 41875},
+									pos:  position{line: 1741, col: 11, offset: 41877},
 									name: "DoubleQuotedChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1741, col: 29, offset: 41893},
+							pos:        position{line: 1741, col: 29, offset: 41895},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -12346,57 +12350,57 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1743, col: 1, offset: 41927},
+			pos:  position{line: 1743, col: 1, offset: 41929},
 			expr: &choiceExpr{
-				pos: position{line: 1744, col: 5, offset: 41948},
+				pos: position{line: 1744, col: 5, offset: 41950},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1744, col: 5, offset: 41948},
+						pos: position{line: 1744, col: 5, offset: 41950},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1744, col: 5, offset: 41948},
+							pos: position{line: 1744, col: 5, offset: 41950},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1744, col: 5, offset: 41948},
+									pos: position{line: 1744, col: 5, offset: 41950},
 									expr: &choiceExpr{
-										pos: position{line: 1744, col: 7, offset: 41950},
+										pos: position{line: 1744, col: 7, offset: 41952},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1744, col: 7, offset: 41950},
+												pos:        position{line: 1744, col: 7, offset: 41952},
 												val:        "\"",
 												ignoreCase: false,
 												want:       "\"\\\"\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1744, col: 13, offset: 41956},
+												pos:  position{line: 1744, col: 13, offset: 41958},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1744, col: 26, offset: 41969,
+									line: 1744, col: 26, offset: 41971,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1745, col: 5, offset: 42006},
+						pos: position{line: 1745, col: 5, offset: 42008},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1745, col: 5, offset: 42006},
+							pos: position{line: 1745, col: 5, offset: 42008},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1745, col: 5, offset: 42006},
+									pos:        position{line: 1745, col: 5, offset: 42008},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1745, col: 10, offset: 42011},
+									pos:   position{line: 1745, col: 10, offset: 42013},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1745, col: 12, offset: 42013},
+										pos:  position{line: 1745, col: 12, offset: 42015},
 										name: "EscapeSequence",
 									},
 								},
@@ -12410,32 +12414,32 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickString",
-			pos:  position{line: 1747, col: 1, offset: 42047},
+			pos:  position{line: 1747, col: 1, offset: 42049},
 			expr: &actionExpr{
-				pos: position{line: 1748, col: 5, offset: 42066},
+				pos: position{line: 1748, col: 5, offset: 42068},
 				run: (*parser).callonBacktickString1,
 				expr: &seqExpr{
-					pos: position{line: 1748, col: 5, offset: 42066},
+					pos: position{line: 1748, col: 5, offset: 42068},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1748, col: 5, offset: 42066},
+							pos:        position{line: 1748, col: 5, offset: 42068},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1748, col: 9, offset: 42070},
+							pos:   position{line: 1748, col: 9, offset: 42072},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1748, col: 11, offset: 42072},
+								pos: position{line: 1748, col: 11, offset: 42074},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1748, col: 11, offset: 42072},
+									pos:  position{line: 1748, col: 11, offset: 42074},
 									name: "BacktickChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1748, col: 25, offset: 42086},
+							pos:        position{line: 1748, col: 25, offset: 42088},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
@@ -12448,57 +12452,57 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickChar",
-			pos:  position{line: 1750, col: 1, offset: 42120},
+			pos:  position{line: 1750, col: 1, offset: 42122},
 			expr: &choiceExpr{
-				pos: position{line: 1751, col: 5, offset: 42137},
+				pos: position{line: 1751, col: 5, offset: 42139},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1751, col: 5, offset: 42137},
+						pos: position{line: 1751, col: 5, offset: 42139},
 						run: (*parser).callonBacktickChar2,
 						expr: &seqExpr{
-							pos: position{line: 1751, col: 5, offset: 42137},
+							pos: position{line: 1751, col: 5, offset: 42139},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1751, col: 5, offset: 42137},
+									pos: position{line: 1751, col: 5, offset: 42139},
 									expr: &choiceExpr{
-										pos: position{line: 1751, col: 7, offset: 42139},
+										pos: position{line: 1751, col: 7, offset: 42141},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1751, col: 7, offset: 42139},
+												pos:        position{line: 1751, col: 7, offset: 42141},
 												val:        "`",
 												ignoreCase: false,
 												want:       "\"`\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1751, col: 13, offset: 42145},
+												pos:  position{line: 1751, col: 13, offset: 42147},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1751, col: 26, offset: 42158,
+									line: 1751, col: 26, offset: 42160,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1752, col: 5, offset: 42195},
+						pos: position{line: 1752, col: 5, offset: 42197},
 						run: (*parser).callonBacktickChar9,
 						expr: &seqExpr{
-							pos: position{line: 1752, col: 5, offset: 42195},
+							pos: position{line: 1752, col: 5, offset: 42197},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1752, col: 5, offset: 42195},
+									pos:        position{line: 1752, col: 5, offset: 42197},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1752, col: 10, offset: 42200},
+									pos:   position{line: 1752, col: 10, offset: 42202},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1752, col: 12, offset: 42202},
+										pos:  position{line: 1752, col: 12, offset: 42204},
 										name: "EscapeSequence",
 									},
 								},
@@ -12512,28 +12516,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1754, col: 1, offset: 42236},
+			pos:  position{line: 1754, col: 1, offset: 42238},
 			expr: &actionExpr{
-				pos: position{line: 1755, col: 5, offset: 42248},
+				pos: position{line: 1755, col: 5, offset: 42250},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1755, col: 5, offset: 42248},
+					pos: position{line: 1755, col: 5, offset: 42250},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1755, col: 5, offset: 42248},
+							pos:   position{line: 1755, col: 5, offset: 42250},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1755, col: 10, offset: 42253},
+								pos:  position{line: 1755, col: 10, offset: 42255},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1755, col: 23, offset: 42266},
+							pos:   position{line: 1755, col: 23, offset: 42268},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1755, col: 28, offset: 42271},
+								pos: position{line: 1755, col: 28, offset: 42273},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1755, col: 28, offset: 42271},
+									pos:  position{line: 1755, col: 28, offset: 42273},
 									name: "KeyWordRest",
 								},
 							},
@@ -12546,16 +12550,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1757, col: 1, offset: 42333},
+			pos:  position{line: 1757, col: 1, offset: 42335},
 			expr: &choiceExpr{
-				pos: position{line: 1758, col: 5, offset: 42350},
+				pos: position{line: 1758, col: 5, offset: 42352},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1758, col: 5, offset: 42350},
+						pos:  position{line: 1758, col: 5, offset: 42352},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1759, col: 5, offset: 42367},
+						pos:  position{line: 1759, col: 5, offset: 42369},
 						name: "KeyWordEsc",
 					},
 				},
@@ -12565,16 +12569,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1761, col: 1, offset: 42379},
+			pos:  position{line: 1761, col: 1, offset: 42381},
 			expr: &choiceExpr{
-				pos: position{line: 1762, col: 5, offset: 42395},
+				pos: position{line: 1762, col: 5, offset: 42397},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1762, col: 5, offset: 42395},
+						pos:  position{line: 1762, col: 5, offset: 42397},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1763, col: 5, offset: 42412},
+						pos:        position{line: 1763, col: 5, offset: 42414},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -12587,19 +12591,19 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1765, col: 1, offset: 42419},
+			pos:  position{line: 1765, col: 1, offset: 42421},
 			expr: &actionExpr{
-				pos: position{line: 1765, col: 16, offset: 42434},
+				pos: position{line: 1765, col: 16, offset: 42436},
 				run: (*parser).callonKeyWordChars1,
 				expr: &choiceExpr{
-					pos: position{line: 1765, col: 17, offset: 42435},
+					pos: position{line: 1765, col: 17, offset: 42437},
 					alternatives: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1765, col: 17, offset: 42435},
+							pos:  position{line: 1765, col: 17, offset: 42437},
 							name: "UnicodeLetter",
 						},
 						&charClassMatcher{
-							pos:        position{line: 1765, col: 33, offset: 42451},
+							pos:        position{line: 1765, col: 33, offset: 42453},
 							val:        "[_.:/%#@~]",
 							chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 							ignoreCase: false,
@@ -12613,31 +12617,31 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1767, col: 1, offset: 42495},
+			pos:  position{line: 1767, col: 1, offset: 42497},
 			expr: &actionExpr{
-				pos: position{line: 1767, col: 14, offset: 42508},
+				pos: position{line: 1767, col: 14, offset: 42510},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1767, col: 14, offset: 42508},
+					pos: position{line: 1767, col: 14, offset: 42510},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1767, col: 14, offset: 42508},
+							pos:        position{line: 1767, col: 14, offset: 42510},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1767, col: 19, offset: 42513},
+							pos:   position{line: 1767, col: 19, offset: 42515},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1767, col: 22, offset: 42516},
+								pos: position{line: 1767, col: 22, offset: 42518},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1767, col: 22, offset: 42516},
+										pos:  position{line: 1767, col: 22, offset: 42518},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1767, col: 38, offset: 42532},
+										pos:  position{line: 1767, col: 38, offset: 42534},
 										name: "EscapeSequence",
 									},
 								},
@@ -12651,42 +12655,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1769, col: 1, offset: 42567},
+			pos:  position{line: 1769, col: 1, offset: 42569},
 			expr: &actionExpr{
-				pos: position{line: 1770, col: 5, offset: 42583},
+				pos: position{line: 1770, col: 5, offset: 42585},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1770, col: 5, offset: 42583},
+					pos: position{line: 1770, col: 5, offset: 42585},
 					exprs: []any{
 						&andExpr{
-							pos: position{line: 1770, col: 5, offset: 42583},
+							pos: position{line: 1770, col: 5, offset: 42585},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1770, col: 6, offset: 42584},
+								pos:  position{line: 1770, col: 6, offset: 42586},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1770, col: 22, offset: 42600},
+							pos: position{line: 1770, col: 22, offset: 42602},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1770, col: 23, offset: 42601},
+								pos:  position{line: 1770, col: 23, offset: 42603},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1770, col: 35, offset: 42613},
+							pos:   position{line: 1770, col: 35, offset: 42615},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1770, col: 40, offset: 42618},
+								pos:  position{line: 1770, col: 40, offset: 42620},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1770, col: 50, offset: 42628},
+							pos:   position{line: 1770, col: 50, offset: 42630},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1770, col: 55, offset: 42633},
+								pos: position{line: 1770, col: 55, offset: 42635},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1770, col: 55, offset: 42633},
+									pos:  position{line: 1770, col: 55, offset: 42635},
 									name: "GlobRest",
 								},
 							},
@@ -12699,28 +12703,28 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1774, col: 1, offset: 42702},
+			pos:  position{line: 1774, col: 1, offset: 42704},
 			expr: &choiceExpr{
-				pos: position{line: 1774, col: 19, offset: 42720},
+				pos: position{line: 1774, col: 19, offset: 42722},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1774, col: 19, offset: 42720},
+						pos:  position{line: 1774, col: 19, offset: 42722},
 						name: "KeyWordStart",
 					},
 					&seqExpr{
-						pos: position{line: 1774, col: 34, offset: 42735},
+						pos: position{line: 1774, col: 34, offset: 42737},
 						exprs: []any{
 							&oneOrMoreExpr{
-								pos: position{line: 1774, col: 34, offset: 42735},
+								pos: position{line: 1774, col: 34, offset: 42737},
 								expr: &litMatcher{
-									pos:        position{line: 1774, col: 34, offset: 42735},
+									pos:        position{line: 1774, col: 34, offset: 42737},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1774, col: 39, offset: 42740},
+								pos:  position{line: 1774, col: 39, offset: 42742},
 								name: "KeyWordRest",
 							},
 						},
@@ -12732,19 +12736,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1775, col: 1, offset: 42752},
+			pos:  position{line: 1775, col: 1, offset: 42754},
 			expr: &seqExpr{
-				pos: position{line: 1775, col: 15, offset: 42766},
+				pos: position{line: 1775, col: 15, offset: 42768},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1775, col: 15, offset: 42766},
+						pos: position{line: 1775, col: 15, offset: 42768},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1775, col: 15, offset: 42766},
+							pos:  position{line: 1775, col: 15, offset: 42768},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1775, col: 28, offset: 42779},
+						pos:        position{line: 1775, col: 28, offset: 42781},
 						val:        "*",
 						ignoreCase: false,
 						want:       "\"*\"",
@@ -12756,23 +12760,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1777, col: 1, offset: 42784},
+			pos:  position{line: 1777, col: 1, offset: 42786},
 			expr: &choiceExpr{
-				pos: position{line: 1778, col: 5, offset: 42798},
+				pos: position{line: 1778, col: 5, offset: 42800},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1778, col: 5, offset: 42798},
+						pos:  position{line: 1778, col: 5, offset: 42800},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1779, col: 5, offset: 42815},
+						pos:  position{line: 1779, col: 5, offset: 42817},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1780, col: 5, offset: 42827},
+						pos: position{line: 1780, col: 5, offset: 42829},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1780, col: 5, offset: 42827},
+							pos:        position{line: 1780, col: 5, offset: 42829},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -12785,16 +12789,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1782, col: 1, offset: 42852},
+			pos:  position{line: 1782, col: 1, offset: 42854},
 			expr: &choiceExpr{
-				pos: position{line: 1783, col: 5, offset: 42865},
+				pos: position{line: 1783, col: 5, offset: 42867},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1783, col: 5, offset: 42865},
+						pos:  position{line: 1783, col: 5, offset: 42867},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1784, col: 5, offset: 42879},
+						pos:        position{line: 1784, col: 5, offset: 42881},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -12807,31 +12811,31 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1786, col: 1, offset: 42886},
+			pos:  position{line: 1786, col: 1, offset: 42888},
 			expr: &actionExpr{
-				pos: position{line: 1786, col: 11, offset: 42896},
+				pos: position{line: 1786, col: 11, offset: 42898},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1786, col: 11, offset: 42896},
+					pos: position{line: 1786, col: 11, offset: 42898},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1786, col: 11, offset: 42896},
+							pos:        position{line: 1786, col: 11, offset: 42898},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1786, col: 16, offset: 42901},
+							pos:   position{line: 1786, col: 16, offset: 42903},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1786, col: 19, offset: 42904},
+								pos: position{line: 1786, col: 19, offset: 42906},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1786, col: 19, offset: 42904},
+										pos:  position{line: 1786, col: 19, offset: 42906},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1786, col: 32, offset: 42917},
+										pos:  position{line: 1786, col: 32, offset: 42919},
 										name: "EscapeSequence",
 									},
 								},
@@ -12845,32 +12849,32 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1788, col: 1, offset: 42952},
+			pos:  position{line: 1788, col: 1, offset: 42954},
 			expr: &choiceExpr{
-				pos: position{line: 1789, col: 5, offset: 42967},
+				pos: position{line: 1789, col: 5, offset: 42969},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1789, col: 5, offset: 42967},
+						pos: position{line: 1789, col: 5, offset: 42969},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1789, col: 5, offset: 42967},
+							pos:        position{line: 1789, col: 5, offset: 42969},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1790, col: 5, offset: 42995},
+						pos: position{line: 1790, col: 5, offset: 42997},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1790, col: 5, offset: 42995},
+							pos:        position{line: 1790, col: 5, offset: 42997},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1791, col: 5, offset: 43025},
+						pos:        position{line: 1791, col: 5, offset: 43027},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -12883,57 +12887,57 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1793, col: 1, offset: 43031},
+			pos:  position{line: 1793, col: 1, offset: 43033},
 			expr: &choiceExpr{
-				pos: position{line: 1794, col: 5, offset: 43052},
+				pos: position{line: 1794, col: 5, offset: 43054},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1794, col: 5, offset: 43052},
+						pos: position{line: 1794, col: 5, offset: 43054},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1794, col: 5, offset: 43052},
+							pos: position{line: 1794, col: 5, offset: 43054},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1794, col: 5, offset: 43052},
+									pos: position{line: 1794, col: 5, offset: 43054},
 									expr: &choiceExpr{
-										pos: position{line: 1794, col: 7, offset: 43054},
+										pos: position{line: 1794, col: 7, offset: 43056},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1794, col: 7, offset: 43054},
+												pos:        position{line: 1794, col: 7, offset: 43056},
 												val:        "'",
 												ignoreCase: false,
 												want:       "\"'\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1794, col: 13, offset: 43060},
+												pos:  position{line: 1794, col: 13, offset: 43062},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1794, col: 26, offset: 43073,
+									line: 1794, col: 26, offset: 43075,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1795, col: 5, offset: 43110},
+						pos: position{line: 1795, col: 5, offset: 43112},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1795, col: 5, offset: 43110},
+							pos: position{line: 1795, col: 5, offset: 43112},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1795, col: 5, offset: 43110},
+									pos:        position{line: 1795, col: 5, offset: 43112},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1795, col: 10, offset: 43115},
+									pos:   position{line: 1795, col: 10, offset: 43117},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1795, col: 12, offset: 43117},
+										pos:  position{line: 1795, col: 12, offset: 43119},
 										name: "EscapeSequence",
 									},
 								},
@@ -12947,16 +12951,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1797, col: 1, offset: 43151},
+			pos:  position{line: 1797, col: 1, offset: 43153},
 			expr: &choiceExpr{
-				pos: position{line: 1798, col: 5, offset: 43170},
+				pos: position{line: 1798, col: 5, offset: 43172},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1798, col: 5, offset: 43170},
+						pos:  position{line: 1798, col: 5, offset: 43172},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1799, col: 5, offset: 43191},
+						pos:  position{line: 1799, col: 5, offset: 43193},
 						name: "UnicodeEscape",
 					},
 				},
@@ -12966,87 +12970,87 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1801, col: 1, offset: 43206},
+			pos:  position{line: 1801, col: 1, offset: 43208},
 			expr: &choiceExpr{
-				pos: position{line: 1802, col: 5, offset: 43227},
+				pos: position{line: 1802, col: 5, offset: 43229},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1802, col: 5, offset: 43227},
+						pos:        position{line: 1802, col: 5, offset: 43229},
 						val:        "'",
 						ignoreCase: false,
 						want:       "\"'\"",
 					},
 					&actionExpr{
-						pos: position{line: 1803, col: 5, offset: 43235},
+						pos: position{line: 1803, col: 5, offset: 43237},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1803, col: 5, offset: 43235},
+							pos:        position{line: 1803, col: 5, offset: 43237},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1804, col: 5, offset: 43275},
+						pos:        position{line: 1804, col: 5, offset: 43277},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
 					},
 					&actionExpr{
-						pos: position{line: 1805, col: 5, offset: 43284},
+						pos: position{line: 1805, col: 5, offset: 43286},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1805, col: 5, offset: 43284},
+							pos:        position{line: 1805, col: 5, offset: 43286},
 							val:        "b",
 							ignoreCase: false,
 							want:       "\"b\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1806, col: 5, offset: 43313},
+						pos: position{line: 1806, col: 5, offset: 43315},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1806, col: 5, offset: 43313},
+							pos:        position{line: 1806, col: 5, offset: 43315},
 							val:        "f",
 							ignoreCase: false,
 							want:       "\"f\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1807, col: 5, offset: 43342},
+						pos: position{line: 1807, col: 5, offset: 43344},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1807, col: 5, offset: 43342},
+							pos:        position{line: 1807, col: 5, offset: 43344},
 							val:        "n",
 							ignoreCase: false,
 							want:       "\"n\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1808, col: 5, offset: 43371},
+						pos: position{line: 1808, col: 5, offset: 43373},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1808, col: 5, offset: 43371},
+							pos:        position{line: 1808, col: 5, offset: 43373},
 							val:        "r",
 							ignoreCase: false,
 							want:       "\"r\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1809, col: 5, offset: 43400},
+						pos: position{line: 1809, col: 5, offset: 43402},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1809, col: 5, offset: 43400},
+							pos:        position{line: 1809, col: 5, offset: 43402},
 							val:        "t",
 							ignoreCase: false,
 							want:       "\"t\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1810, col: 5, offset: 43429},
+						pos: position{line: 1810, col: 5, offset: 43431},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1810, col: 5, offset: 43429},
+							pos:        position{line: 1810, col: 5, offset: 43431},
 							val:        "v",
 							ignoreCase: false,
 							want:       "\"v\"",
@@ -13059,32 +13063,32 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1812, col: 1, offset: 43455},
+			pos:  position{line: 1812, col: 1, offset: 43457},
 			expr: &choiceExpr{
-				pos: position{line: 1813, col: 5, offset: 43473},
+				pos: position{line: 1813, col: 5, offset: 43475},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1813, col: 5, offset: 43473},
+						pos: position{line: 1813, col: 5, offset: 43475},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1813, col: 5, offset: 43473},
+							pos:        position{line: 1813, col: 5, offset: 43475},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1814, col: 5, offset: 43501},
+						pos: position{line: 1814, col: 5, offset: 43503},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1814, col: 5, offset: 43501},
+							pos:        position{line: 1814, col: 5, offset: 43503},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1815, col: 5, offset: 43529},
+						pos:        position{line: 1815, col: 5, offset: 43531},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -13097,42 +13101,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1817, col: 1, offset: 43535},
+			pos:  position{line: 1817, col: 1, offset: 43537},
 			expr: &choiceExpr{
-				pos: position{line: 1818, col: 5, offset: 43553},
+				pos: position{line: 1818, col: 5, offset: 43555},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1818, col: 5, offset: 43553},
+						pos: position{line: 1818, col: 5, offset: 43555},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1818, col: 5, offset: 43553},
+							pos: position{line: 1818, col: 5, offset: 43555},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1818, col: 5, offset: 43553},
+									pos:        position{line: 1818, col: 5, offset: 43555},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1818, col: 9, offset: 43557},
+									pos:   position{line: 1818, col: 9, offset: 43559},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1818, col: 16, offset: 43564},
+										pos: position{line: 1818, col: 16, offset: 43566},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1818, col: 16, offset: 43564},
+												pos:  position{line: 1818, col: 16, offset: 43566},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1818, col: 25, offset: 43573},
+												pos:  position{line: 1818, col: 25, offset: 43575},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1818, col: 34, offset: 43582},
+												pos:  position{line: 1818, col: 34, offset: 43584},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1818, col: 43, offset: 43591},
+												pos:  position{line: 1818, col: 43, offset: 43593},
 												name: "HexDigit",
 											},
 										},
@@ -13142,65 +13146,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1821, col: 5, offset: 43654},
+						pos: position{line: 1821, col: 5, offset: 43656},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1821, col: 5, offset: 43654},
+							pos: position{line: 1821, col: 5, offset: 43656},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1821, col: 5, offset: 43654},
+									pos:        position{line: 1821, col: 5, offset: 43656},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1821, col: 9, offset: 43658},
+									pos:        position{line: 1821, col: 9, offset: 43660},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1821, col: 13, offset: 43662},
+									pos:   position{line: 1821, col: 13, offset: 43664},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1821, col: 20, offset: 43669},
+										pos: position{line: 1821, col: 20, offset: 43671},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1821, col: 20, offset: 43669},
+												pos:  position{line: 1821, col: 20, offset: 43671},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1821, col: 29, offset: 43678},
+												pos: position{line: 1821, col: 29, offset: 43680},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1821, col: 29, offset: 43678},
+													pos:  position{line: 1821, col: 29, offset: 43680},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1821, col: 39, offset: 43688},
+												pos: position{line: 1821, col: 39, offset: 43690},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1821, col: 39, offset: 43688},
+													pos:  position{line: 1821, col: 39, offset: 43690},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1821, col: 49, offset: 43698},
+												pos: position{line: 1821, col: 49, offset: 43700},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1821, col: 49, offset: 43698},
+													pos:  position{line: 1821, col: 49, offset: 43700},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1821, col: 59, offset: 43708},
+												pos: position{line: 1821, col: 59, offset: 43710},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1821, col: 59, offset: 43708},
+													pos:  position{line: 1821, col: 59, offset: 43710},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1821, col: 69, offset: 43718},
+												pos: position{line: 1821, col: 69, offset: 43720},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1821, col: 69, offset: 43718},
+													pos:  position{line: 1821, col: 69, offset: 43720},
 													name: "HexDigit",
 												},
 											},
@@ -13208,7 +13212,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1821, col: 80, offset: 43729},
+									pos:        position{line: 1821, col: 80, offset: 43731},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -13223,37 +13227,37 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpPattern",
-			pos:  position{line: 1825, col: 1, offset: 43783},
+			pos:  position{line: 1825, col: 1, offset: 43785},
 			expr: &actionExpr{
-				pos: position{line: 1826, col: 5, offset: 43801},
+				pos: position{line: 1826, col: 5, offset: 43803},
 				run: (*parser).callonRegexpPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1826, col: 5, offset: 43801},
+					pos: position{line: 1826, col: 5, offset: 43803},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1826, col: 5, offset: 43801},
+							pos:        position{line: 1826, col: 5, offset: 43803},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1826, col: 9, offset: 43805},
+							pos:   position{line: 1826, col: 9, offset: 43807},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1826, col: 14, offset: 43810},
+								pos:  position{line: 1826, col: 14, offset: 43812},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1826, col: 25, offset: 43821},
+							pos:        position{line: 1826, col: 25, offset: 43823},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&notExpr{
-							pos: position{line: 1826, col: 29, offset: 43825},
+							pos: position{line: 1826, col: 29, offset: 43827},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1826, col: 30, offset: 43826},
+								pos:  position{line: 1826, col: 30, offset: 43828},
 								name: "KeyWordStart",
 							},
 						},
@@ -13265,33 +13269,33 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1828, col: 1, offset: 43861},
+			pos:  position{line: 1828, col: 1, offset: 43863},
 			expr: &actionExpr{
-				pos: position{line: 1829, col: 5, offset: 43876},
+				pos: position{line: 1829, col: 5, offset: 43878},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1829, col: 5, offset: 43876},
+					pos: position{line: 1829, col: 5, offset: 43878},
 					expr: &choiceExpr{
-						pos: position{line: 1829, col: 6, offset: 43877},
+						pos: position{line: 1829, col: 6, offset: 43879},
 						alternatives: []any{
 							&charClassMatcher{
-								pos:        position{line: 1829, col: 6, offset: 43877},
+								pos:        position{line: 1829, col: 6, offset: 43879},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&seqExpr{
-								pos: position{line: 1829, col: 15, offset: 43886},
+								pos: position{line: 1829, col: 15, offset: 43888},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 1829, col: 15, offset: 43886},
+										pos:        position{line: 1829, col: 15, offset: 43888},
 										val:        "\\",
 										ignoreCase: false,
 										want:       "\"\\\\\"",
 									},
 									&anyMatcher{
-										line: 1829, col: 20, offset: 43891,
+										line: 1829, col: 20, offset: 43893,
 									},
 								},
 							},
@@ -13304,9 +13308,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1831, col: 1, offset: 43927},
+			pos:  position{line: 1831, col: 1, offset: 43929},
 			expr: &charClassMatcher{
-				pos:        position{line: 1832, col: 5, offset: 43943},
+				pos:        position{line: 1832, col: 5, offset: 43945},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -13318,11 +13322,11 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1834, col: 1, offset: 43958},
+			pos:  position{line: 1834, col: 1, offset: 43960},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1834, col: 5, offset: 43962},
+				pos: position{line: 1834, col: 5, offset: 43964},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1834, col: 5, offset: 43962},
+					pos:  position{line: 1834, col: 5, offset: 43964},
 					name: "AnySpace",
 				},
 			},
@@ -13331,11 +13335,11 @@ var g = &grammar{
 		},
 		{
 			name: "__",
-			pos:  position{line: 1836, col: 1, offset: 43973},
+			pos:  position{line: 1836, col: 1, offset: 43975},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1836, col: 6, offset: 43978},
+				pos: position{line: 1836, col: 6, offset: 43980},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1836, col: 6, offset: 43978},
+					pos:  position{line: 1836, col: 6, offset: 43980},
 					name: "AnySpace",
 				},
 			},
@@ -13344,20 +13348,20 @@ var g = &grammar{
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1838, col: 1, offset: 43989},
+			pos:  position{line: 1838, col: 1, offset: 43991},
 			expr: &choiceExpr{
-				pos: position{line: 1839, col: 5, offset: 44002},
+				pos: position{line: 1839, col: 5, offset: 44004},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1839, col: 5, offset: 44002},
+						pos:  position{line: 1839, col: 5, offset: 44004},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1840, col: 5, offset: 44017},
+						pos:  position{line: 1840, col: 5, offset: 44019},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1841, col: 5, offset: 44036},
+						pos:  position{line: 1841, col: 5, offset: 44038},
 						name: "Comment",
 					},
 				},
@@ -13367,32 +13371,32 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeLetter",
-			pos:  position{line: 1843, col: 1, offset: 44045},
+			pos:  position{line: 1843, col: 1, offset: 44047},
 			expr: &choiceExpr{
-				pos: position{line: 1844, col: 5, offset: 44063},
+				pos: position{line: 1844, col: 5, offset: 44065},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1844, col: 5, offset: 44063},
+						pos:  position{line: 1844, col: 5, offset: 44065},
 						name: "Lu",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1845, col: 5, offset: 44070},
+						pos:  position{line: 1845, col: 5, offset: 44072},
 						name: "Ll",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1846, col: 5, offset: 44077},
+						pos:  position{line: 1846, col: 5, offset: 44079},
 						name: "Lt",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1847, col: 5, offset: 44084},
+						pos:  position{line: 1847, col: 5, offset: 44086},
 						name: "Lm",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1848, col: 5, offset: 44091},
+						pos:  position{line: 1848, col: 5, offset: 44093},
 						name: "Lo",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1849, col: 5, offset: 44098},
+						pos:  position{line: 1849, col: 5, offset: 44100},
 						name: "Nl",
 					},
 				},
@@ -13402,16 +13406,16 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeCombiningMark",
-			pos:  position{line: 1851, col: 1, offset: 44102},
+			pos:  position{line: 1851, col: 1, offset: 44104},
 			expr: &choiceExpr{
-				pos: position{line: 1852, col: 5, offset: 44127},
+				pos: position{line: 1852, col: 5, offset: 44129},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1852, col: 5, offset: 44127},
+						pos:  position{line: 1852, col: 5, offset: 44129},
 						name: "Mn",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1853, col: 5, offset: 44134},
+						pos:  position{line: 1853, col: 5, offset: 44136},
 						name: "Mc",
 					},
 				},
@@ -13421,9 +13425,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeDigit",
-			pos:  position{line: 1855, col: 1, offset: 44138},
+			pos:  position{line: 1855, col: 1, offset: 44140},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1856, col: 5, offset: 44155},
+				pos:  position{line: 1856, col: 5, offset: 44157},
 				name: "Nd",
 			},
 			leader:        false,
@@ -13431,9 +13435,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeConnectorPunctuation",
-			pos:  position{line: 1858, col: 1, offset: 44159},
+			pos:  position{line: 1858, col: 1, offset: 44161},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1859, col: 5, offset: 44191},
+				pos:  position{line: 1859, col: 5, offset: 44193},
 				name: "Pc",
 			},
 			leader:        false,
@@ -13441,9 +13445,9 @@ var g = &grammar{
 		},
 		{
 			name: "Ll",
-			pos:  position{line: 1865, col: 1, offset: 44372},
+			pos:  position{line: 1865, col: 1, offset: 44374},
 			expr: &charClassMatcher{
-				pos:        position{line: 1865, col: 6, offset: 44377},
+				pos:        position{line: 1865, col: 6, offset: 44379},
 				val:        "[\\u0061-\\u007A\\u00B5\\u00DF-\\u00F6\\u00F8-\\u00FF\\u0101\\u0103\\u0105\\u0107\\u0109\\u010B\\u010D\\u010F\\u0111\\u0113\\u0115\\u0117\\u0119\\u011B\\u011D\\u011F\\u0121\\u0123\\u0125\\u0127\\u0129\\u012B\\u012D\\u012F\\u0131\\u0133\\u0135\\u0137-\\u0138\\u013A\\u013C\\u013E\\u0140\\u0142\\u0144\\u0146\\u0148-\\u0149\\u014B\\u014D\\u014F\\u0151\\u0153\\u0155\\u0157\\u0159\\u015B\\u015D\\u015F\\u0161\\u0163\\u0165\\u0167\\u0169\\u016B\\u016D\\u016F\\u0171\\u0173\\u0175\\u0177\\u017A\\u017C\\u017E-\\u0180\\u0183\\u0185\\u0188\\u018C-\\u018D\\u0192\\u0195\\u0199-\\u019B\\u019E\\u01A1\\u01A3\\u01A5\\u01A8\\u01AA-\\u01AB\\u01AD\\u01B0\\u01B4\\u01B6\\u01B9-\\u01BA\\u01BD-\\u01BF\\u01C6\\u01C9\\u01CC\\u01CE\\u01D0\\u01D2\\u01D4\\u01D6\\u01D8\\u01DA\\u01DC-\\u01DD\\u01DF\\u01E1\\u01E3\\u01E5\\u01E7\\u01E9\\u01EB\\u01ED\\u01EF-\\u01F0\\u01F3\\u01F5\\u01F9\\u01FB\\u01FD\\u01FF\\u0201\\u0203\\u0205\\u0207\\u0209\\u020B\\u020D\\u020F\\u0211\\u0213\\u0215\\u0217\\u0219\\u021B\\u021D\\u021F\\u0221\\u0223\\u0225\\u0227\\u0229\\u022B\\u022D\\u022F\\u0231\\u0233-\\u0239\\u023C\\u023F-\\u0240\\u0242\\u0247\\u0249\\u024B\\u024D\\u024F-\\u0293\\u0295-\\u02AF\\u0371\\u0373\\u0377\\u037B-\\u037D\\u0390\\u03AC-\\u03CE\\u03D0-\\u03D1\\u03D5-\\u03D7\\u03D9\\u03DB\\u03DD\\u03DF\\u03E1\\u03E3\\u03E5\\u03E7\\u03E9\\u03EB\\u03ED\\u03EF-\\u03F3\\u03F5\\u03F8\\u03FB-\\u03FC\\u0430-\\u045F\\u0461\\u0463\\u0465\\u0467\\u0469\\u046B\\u046D\\u046F\\u0471\\u0473\\u0475\\u0477\\u0479\\u047B\\u047D\\u047F\\u0481\\u048B\\u048D\\u048F\\u0491\\u0493\\u0495\\u0497\\u0499\\u049B\\u049D\\u049F\\u04A1\\u04A3\\u04A5\\u04A7\\u04A9\\u04AB\\u04AD\\u04AF\\u04B1\\u04B3\\u04B5\\u04B7\\u04B9\\u04BB\\u04BD\\u04BF\\u04C2\\u04C4\\u04C6\\u04C8\\u04CA\\u04CC\\u04CE-\\u04CF\\u04D1\\u04D3\\u04D5\\u04D7\\u04D9\\u04DB\\u04DD\\u04DF\\u04E1\\u04E3\\u04E5\\u04E7\\u04E9\\u04EB\\u04ED\\u04EF\\u04F1\\u04F3\\u04F5\\u04F7\\u04F9\\u04FB\\u04FD\\u04FF\\u0501\\u0503\\u0505\\u0507\\u0509\\u050B\\u050D\\u050F\\u0511\\u0513\\u0515\\u0517\\u0519\\u051B\\u051D\\u051F\\u0521\\u0523\\u0525\\u0527\\u0529\\u052B\\u052D\\u052F\\u0560-\\u0588\\u10D0-\\u10FA\\u10FD-\\u10FF\\u13F8-\\u13FD\\u1C80-\\u1C88\\u1D00-\\u1D2B\\u1D6B-\\u1D77\\u1D79-\\u1D9A\\u1E01\\u1E03\\u1E05\\u1E07\\u1E09\\u1E0B\\u1E0D\\u1E0F\\u1E11\\u1E13\\u1E15\\u1E17\\u1E19\\u1E1B\\u1E1D\\u1E1F\\u1E21\\u1E23\\u1E25\\u1E27\\u1E29\\u1E2B\\u1E2D\\u1E2F\\u1E31\\u1E33\\u1E35\\u1E37\\u1E39\\u1E3B\\u1E3D\\u1E3F\\u1E41\\u1E43\\u1E45\\u1E47\\u1E49\\u1E4B\\u1E4D\\u1E4F\\u1E51\\u1E53\\u1E55\\u1E57\\u1E59\\u1E5B\\u1E5D\\u1E5F\\u1E61\\u1E63\\u1E65\\u1E67\\u1E69\\u1E6B\\u1E6D\\u1E6F\\u1E71\\u1E73\\u1E75\\u1E77\\u1E79\\u1E7B\\u1E7D\\u1E7F\\u1E81\\u1E83\\u1E85\\u1E87\\u1E89\\u1E8B\\u1E8D\\u1E8F\\u1E91\\u1E93\\u1E95-\\u1E9D\\u1E9F\\u1EA1\\u1EA3\\u1EA5\\u1EA7\\u1EA9\\u1EAB\\u1EAD\\u1EAF\\u1EB1\\u1EB3\\u1EB5\\u1EB7\\u1EB9\\u1EBB\\u1EBD\\u1EBF\\u1EC1\\u1EC3\\u1EC5\\u1EC7\\u1EC9\\u1ECB\\u1ECD\\u1ECF\\u1ED1\\u1ED3\\u1ED5\\u1ED7\\u1ED9\\u1EDB\\u1EDD\\u1EDF\\u1EE1\\u1EE3\\u1EE5\\u1EE7\\u1EE9\\u1EEB\\u1EED\\u1EEF\\u1EF1\\u1EF3\\u1EF5\\u1EF7\\u1EF9\\u1EFB\\u1EFD\\u1EFF-\\u1F07\\u1F10-\\u1F15\\u1F20-\\u1F27\\u1F30-\\u1F37\\u1F40-\\u1F45\\u1F50-\\u1F57\\u1F60-\\u1F67\\u1F70-\\u1F7D\\u1F80-\\u1F87\\u1F90-\\u1F97\\u1FA0-\\u1FA7\\u1FB0-\\u1FB4\\u1FB6-\\u1FB7\\u1FBE\\u1FC2-\\u1FC4\\u1FC6-\\u1FC7\\u1FD0-\\u1FD3\\u1FD6-\\u1FD7\\u1FE0-\\u1FE7\\u1FF2-\\u1FF4\\u1FF6-\\u1FF7\\u210A\\u210E-\\u210F\\u2113\\u212F\\u2134\\u2139\\u213C-\\u213D\\u2146-\\u2149\\u214E\\u2184\\u2C30-\\u2C5E\\u2C61\\u2C65-\\u2C66\\u2C68\\u2C6A\\u2C6C\\u2C71\\u2C73-\\u2C74\\u2C76-\\u2C7B\\u2C81\\u2C83\\u2C85\\u2C87\\u2C89\\u2C8B\\u2C8D\\u2C8F\\u2C91\\u2C93\\u2C95\\u2C97\\u2C99\\u2C9B\\u2C9D\\u2C9F\\u2CA1\\u2CA3\\u2CA5\\u2CA7\\u2CA9\\u2CAB\\u2CAD\\u2CAF\\u2CB1\\u2CB3\\u2CB5\\u2CB7\\u2CB9\\u2CBB\\u2CBD\\u2CBF\\u2CC1\\u2CC3\\u2CC5\\u2CC7\\u2CC9\\u2CCB\\u2CCD\\u2CCF\\u2CD1\\u2CD3\\u2CD5\\u2CD7\\u2CD9\\u2CDB\\u2CDD\\u2CDF\\u2CE1\\u2CE3-\\u2CE4\\u2CEC\\u2CEE\\u2CF3\\u2D00-\\u2D25\\u2D27\\u2D2D\\uA641\\uA643\\uA645\\uA647\\uA649\\uA64B\\uA64D\\uA64F\\uA651\\uA653\\uA655\\uA657\\uA659\\uA65B\\uA65D\\uA65F\\uA661\\uA663\\uA665\\uA667\\uA669\\uA66B\\uA66D\\uA681\\uA683\\uA685\\uA687\\uA689\\uA68B\\uA68D\\uA68F\\uA691\\uA693\\uA695\\uA697\\uA699\\uA69B\\uA723\\uA725\\uA727\\uA729\\uA72B\\uA72D\\uA72F-\\uA731\\uA733\\uA735\\uA737\\uA739\\uA73B\\uA73D\\uA73F\\uA741\\uA743\\uA745\\uA747\\uA749\\uA74B\\uA74D\\uA74F\\uA751\\uA753\\uA755\\uA757\\uA759\\uA75B\\uA75D\\uA75F\\uA761\\uA763\\uA765\\uA767\\uA769\\uA76B\\uA76D\\uA76F\\uA771-\\uA778\\uA77A\\uA77C\\uA77F\\uA781\\uA783\\uA785\\uA787\\uA78C\\uA78E\\uA791\\uA793-\\uA795\\uA797\\uA799\\uA79B\\uA79D\\uA79F\\uA7A1\\uA7A3\\uA7A5\\uA7A7\\uA7A9\\uA7AF\\uA7B5\\uA7B7\\uA7B9\\uA7FA\\uAB30-\\uAB5A\\uAB60-\\uAB65\\uAB70-\\uABBF\\uFB00-\\uFB06\\uFB13-\\uFB17\\uFF41-\\uFF5A]",
 				chars:      []rune{'µ', 'ā', 'ă', 'ą', 'ć', 'ĉ', 'ċ', 'č', 'ď', 'đ', 'ē', 'ĕ', 'ė', 'ę', 'ě', 'ĝ', 'ğ', 'ġ', 'ģ', 'ĥ', 'ħ', 'ĩ', 'ī', 'ĭ', 'į', 'ı', 'ĳ', 'ĵ', 'ĺ', 'ļ', 'ľ', 'ŀ', 'ł', 'ń', 'ņ', 'ŋ', 'ō', 'ŏ', 'ő', 'œ', 'ŕ', 'ŗ', 'ř', 'ś', 'ŝ', 'ş', 'š', 'ţ', 'ť', 'ŧ', 'ũ', 'ū', 'ŭ', 'ů', 'ű', 'ų', 'ŵ', 'ŷ', 'ź', 'ż', 'ƃ', 'ƅ', 'ƈ', 'ƒ', 'ƕ', 'ƞ', 'ơ', 'ƣ', 'ƥ', 'ƨ', 'ƭ', 'ư', 'ƴ', 'ƶ', 'ǆ', 'ǉ', 'ǌ', 'ǎ', 'ǐ', 'ǒ', 'ǔ', 'ǖ', 'ǘ', 'ǚ', 'ǟ', 'ǡ', 'ǣ', 'ǥ', 'ǧ', 'ǩ', 'ǫ', 'ǭ', 'ǳ', 'ǵ', 'ǹ', 'ǻ', 'ǽ', 'ǿ', 'ȁ', 'ȃ', 'ȅ', 'ȇ', 'ȉ', 'ȋ', 'ȍ', 'ȏ', 'ȑ', 'ȓ', 'ȕ', 'ȗ', 'ș', 'ț', 'ȝ', 'ȟ', 'ȡ', 'ȣ', 'ȥ', 'ȧ', 'ȩ', 'ȫ', 'ȭ', 'ȯ', 'ȱ', 'ȼ', 'ɂ', 'ɇ', 'ɉ', 'ɋ', 'ɍ', 'ͱ', 'ͳ', 'ͷ', 'ΐ', 'ϙ', 'ϛ', 'ϝ', 'ϟ', 'ϡ', 'ϣ', 'ϥ', 'ϧ', 'ϩ', 'ϫ', 'ϭ', 'ϵ', 'ϸ', 'ѡ', 'ѣ', 'ѥ', 'ѧ', 'ѩ', 'ѫ', 'ѭ', 'ѯ', 'ѱ', 'ѳ', 'ѵ', 'ѷ', 'ѹ', 'ѻ', 'ѽ', 'ѿ', 'ҁ', 'ҋ', 'ҍ', 'ҏ', 'ґ', 'ғ', 'ҕ', 'җ', 'ҙ', 'қ', 'ҝ', 'ҟ', 'ҡ', 'ң', 'ҥ', 'ҧ', 'ҩ', 'ҫ', 'ҭ', 'ү', 'ұ', 'ҳ', 'ҵ', 'ҷ', 'ҹ', 'һ', 'ҽ', 'ҿ', 'ӂ', 'ӄ', 'ӆ', 'ӈ', 'ӊ', 'ӌ', 'ӑ', 'ӓ', 'ӕ', 'ӗ', 'ә', 'ӛ', 'ӝ', 'ӟ', 'ӡ', 'ӣ', 'ӥ', 'ӧ', 'ө', 'ӫ', 'ӭ', 'ӯ', 'ӱ', 'ӳ', 'ӵ', 'ӷ', 'ӹ', 'ӻ', 'ӽ', 'ӿ', 'ԁ', 'ԃ', 'ԅ', 'ԇ', 'ԉ', 'ԋ', 'ԍ', 'ԏ', 'ԑ', 'ԓ', 'ԕ', 'ԗ', 'ԙ', 'ԛ', 'ԝ', 'ԟ', 'ԡ', 'ԣ', 'ԥ', 'ԧ', 'ԩ', 'ԫ', 'ԭ', 'ԯ', 'ḁ', 'ḃ', 'ḅ', 'ḇ', 'ḉ', 'ḋ', 'ḍ', 'ḏ', 'ḑ', 'ḓ', 'ḕ', 'ḗ', 'ḙ', 'ḛ', 'ḝ', 'ḟ', 'ḡ', 'ḣ', 'ḥ', 'ḧ', 'ḩ', 'ḫ', 'ḭ', 'ḯ', 'ḱ', 'ḳ', 'ḵ', 'ḷ', 'ḹ', 'ḻ', 'ḽ', 'ḿ', 'ṁ', 'ṃ', 'ṅ', 'ṇ', 'ṉ', 'ṋ', 'ṍ', 'ṏ', 'ṑ', 'ṓ', 'ṕ', 'ṗ', 'ṙ', 'ṛ', 'ṝ', 'ṟ', 'ṡ', 'ṣ', 'ṥ', 'ṧ', 'ṩ', 'ṫ', 'ṭ', 'ṯ', 'ṱ', 'ṳ', 'ṵ', 'ṷ', 'ṹ', 'ṻ', 'ṽ', 'ṿ', 'ẁ', 'ẃ', 'ẅ', 'ẇ', 'ẉ', 'ẋ', 'ẍ', 'ẏ', 'ẑ', 'ẓ', 'ẟ', 'ạ', 'ả', 'ấ', 'ầ', 'ẩ', 'ẫ', 'ậ', 'ắ', 'ằ', 'ẳ', 'ẵ', 'ặ', 'ẹ', 'ẻ', 'ẽ', 'ế', 'ề', 'ể', 'ễ', 'ệ', 'ỉ', 'ị', 'ọ', 'ỏ', 'ố', 'ồ', 'ổ', 'ỗ', 'ộ', 'ớ', 'ờ', 'ở', 'ỡ', 'ợ', 'ụ', 'ủ', 'ứ', 'ừ', 'ử', 'ữ', 'ự', 'ỳ', 'ỵ', 'ỷ', 'ỹ', 'ỻ', 'ỽ', 'ι', 'ℊ', 'ℓ', 'ℯ', 'ℴ', 'ℹ', 'ⅎ', 'ↄ', 'ⱡ', 'ⱨ', 'ⱪ', 'ⱬ', 'ⱱ', 'ⲁ', 'ⲃ', 'ⲅ', 'ⲇ', 'ⲉ', 'ⲋ', 'ⲍ', 'ⲏ', 'ⲑ', 'ⲓ', 'ⲕ', 'ⲗ', 'ⲙ', 'ⲛ', 'ⲝ', 'ⲟ', 'ⲡ', 'ⲣ', 'ⲥ', 'ⲧ', 'ⲩ', 'ⲫ', 'ⲭ', 'ⲯ', 'ⲱ', 'ⲳ', 'ⲵ', 'ⲷ', 'ⲹ', 'ⲻ', 'ⲽ', 'ⲿ', 'ⳁ', 'ⳃ', 'ⳅ', 'ⳇ', 'ⳉ', 'ⳋ', 'ⳍ', 'ⳏ', 'ⳑ', 'ⳓ', 'ⳕ', 'ⳗ', 'ⳙ', 'ⳛ', 'ⳝ', 'ⳟ', 'ⳡ', 'ⳬ', 'ⳮ', 'ⳳ', 'ⴧ', 'ⴭ', 'ꙁ', 'ꙃ', 'ꙅ', 'ꙇ', 'ꙉ', 'ꙋ', 'ꙍ', 'ꙏ', 'ꙑ', 'ꙓ', 'ꙕ', 'ꙗ', 'ꙙ', 'ꙛ', 'ꙝ', 'ꙟ', 'ꙡ', 'ꙣ', 'ꙥ', 'ꙧ', 'ꙩ', 'ꙫ', 'ꙭ', 'ꚁ', 'ꚃ', 'ꚅ', 'ꚇ', 'ꚉ', 'ꚋ', 'ꚍ', 'ꚏ', 'ꚑ', 'ꚓ', 'ꚕ', 'ꚗ', 'ꚙ', 'ꚛ', 'ꜣ', 'ꜥ', 'ꜧ', 'ꜩ', 'ꜫ', 'ꜭ', 'ꜳ', 'ꜵ', 'ꜷ', 'ꜹ', 'ꜻ', 'ꜽ', 'ꜿ', 'ꝁ', 'ꝃ', 'ꝅ', 'ꝇ', 'ꝉ', 'ꝋ', 'ꝍ', 'ꝏ', 'ꝑ', 'ꝓ', 'ꝕ', 'ꝗ', 'ꝙ', 'ꝛ', 'ꝝ', 'ꝟ', 'ꝡ', 'ꝣ', 'ꝥ', 'ꝧ', 'ꝩ', 'ꝫ', 'ꝭ', 'ꝯ', 'ꝺ', 'ꝼ', 'ꝿ', 'ꞁ', 'ꞃ', 'ꞅ', 'ꞇ', 'ꞌ', 'ꞎ', 'ꞑ', 'ꞗ', 'ꞙ', 'ꞛ', 'ꞝ', 'ꞟ', 'ꞡ', 'ꞣ', 'ꞥ', 'ꞧ', 'ꞩ', 'ꞯ', 'ꞵ', 'ꞷ', 'ꞹ', 'ꟺ'},
 				ranges:     []rune{'a', 'z', 'ß', 'ö', 'ø', 'ÿ', 'ķ', 'ĸ', 'ň', 'ŉ', 'ž', 'ƀ', 'ƌ', 'ƍ', 'ƙ', 'ƛ', 'ƪ', 'ƫ', 'ƹ', 'ƺ', 'ƽ', 'ƿ', 'ǜ', 'ǝ', 'ǯ', 'ǰ', 'ȳ', 'ȹ', 'ȿ', 'ɀ', 'ɏ', 'ʓ', 'ʕ', 'ʯ', 'ͻ', 'ͽ', 'ά', 'ώ', 'ϐ', 'ϑ', 'ϕ', 'ϗ', 'ϯ', 'ϳ', 'ϻ', 'ϼ', 'а', 'џ', 'ӎ', 'ӏ', 'ՠ', 'ֈ', 'ა', 'ჺ', 'ჽ', 'ჿ', 'ᏸ', 'ᏽ', 'ᲀ', 'ᲈ', 'ᴀ', 'ᴫ', 'ᵫ', 'ᵷ', 'ᵹ', 'ᶚ', 'ẕ', 'ẝ', 'ỿ', 'ἇ', 'ἐ', 'ἕ', 'ἠ', 'ἧ', 'ἰ', 'ἷ', 'ὀ', 'ὅ', 'ὐ', 'ὗ', 'ὠ', 'ὧ', 'ὰ', 'ώ', 'ᾀ', 'ᾇ', 'ᾐ', 'ᾗ', 'ᾠ', 'ᾧ', 'ᾰ', 'ᾴ', 'ᾶ', 'ᾷ', 'ῂ', 'ῄ', 'ῆ', 'ῇ', 'ῐ', 'ΐ', 'ῖ', 'ῗ', 'ῠ', 'ῧ', 'ῲ', 'ῴ', 'ῶ', 'ῷ', 'ℎ', 'ℏ', 'ℼ', 'ℽ', 'ⅆ', 'ⅉ', 'ⰰ', 'ⱞ', 'ⱥ', 'ⱦ', 'ⱳ', 'ⱴ', 'ⱶ', 'ⱻ', 'ⳣ', 'ⳤ', 'ⴀ', 'ⴥ', 'ꜯ', 'ꜱ', 'ꝱ', 'ꝸ', 'ꞓ', 'ꞕ', 'ꬰ', 'ꭚ', 'ꭠ', 'ꭥ', 'ꭰ', 'ꮿ', 'ﬀ', 'ﬆ', 'ﬓ', 'ﬗ', 'ａ', 'ｚ'},
@@ -13455,9 +13459,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lm",
-			pos:  position{line: 1868, col: 1, offset: 48529},
+			pos:  position{line: 1868, col: 1, offset: 48531},
 			expr: &charClassMatcher{
-				pos:        position{line: 1868, col: 6, offset: 48534},
+				pos:        position{line: 1868, col: 6, offset: 48536},
 				val:        "[\\u02B0-\\u02C1\\u02C6-\\u02D1\\u02E0-\\u02E4\\u02EC\\u02EE\\u0374\\u037A\\u0559\\u0640\\u06E5-\\u06E6\\u07F4-\\u07F5\\u07FA\\u081A\\u0824\\u0828\\u0971\\u0E46\\u0EC6\\u10FC\\u17D7\\u1843\\u1AA7\\u1C78-\\u1C7D\\u1D2C-\\u1D6A\\u1D78\\u1D9B-\\u1DBF\\u2071\\u207F\\u2090-\\u209C\\u2C7C-\\u2C7D\\u2D6F\\u2E2F\\u3005\\u3031-\\u3035\\u303B\\u309D-\\u309E\\u30FC-\\u30FE\\uA015\\uA4F8-\\uA4FD\\uA60C\\uA67F\\uA69C-\\uA69D\\uA717-\\uA71F\\uA770\\uA788\\uA7F8-\\uA7F9\\uA9CF\\uA9E6\\uAA70\\uAADD\\uAAF3-\\uAAF4\\uAB5C-\\uAB5F\\uFF70\\uFF9E-\\uFF9F]",
 				chars:      []rune{'ˬ', 'ˮ', 'ʹ', 'ͺ', 'ՙ', 'ـ', 'ߺ', 'ࠚ', 'ࠤ', 'ࠨ', 'ॱ', 'ๆ', 'ໆ', 'ჼ', 'ៗ', 'ᡃ', 'ᪧ', 'ᵸ', 'ⁱ', 'ⁿ', 'ⵯ', 'ⸯ', '々', '〻', 'ꀕ', 'ꘌ', 'ꙿ', 'ꝰ', 'ꞈ', 'ꧏ', 'ꧦ', 'ꩰ', 'ꫝ', 'ｰ'},
 				ranges:     []rune{'ʰ', 'ˁ', 'ˆ', 'ˑ', 'ˠ', 'ˤ', 'ۥ', 'ۦ', 'ߴ', 'ߵ', 'ᱸ', 'ᱽ', 'ᴬ', 'ᵪ', 'ᶛ', 'ᶿ', 'ₐ', 'ₜ', 'ⱼ', 'ⱽ', '〱', '〵', 'ゝ', 'ゞ', 'ー', 'ヾ', 'ꓸ', 'ꓽ', 'ꚜ', 'ꚝ', 'ꜗ', 'ꜟ', 'ꟸ', 'ꟹ', 'ꫳ', 'ꫴ', 'ꭜ', 'ꭟ', 'ﾞ', 'ﾟ'},
@@ -13469,9 +13473,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lo",
-			pos:  position{line: 1871, col: 1, offset: 49019},
+			pos:  position{line: 1871, col: 1, offset: 49021},
 			expr: &charClassMatcher{
-				pos:        position{line: 1871, col: 6, offset: 49024},
+				pos:        position{line: 1871, col: 6, offset: 49026},
 				val:        "[\\u00AA\\u00BA\\u01BB\\u01C0-\\u01C3\\u0294\\u05D0-\\u05EA\\u05EF-\\u05F2\\u0620-\\u063F\\u0641-\\u064A\\u066E-\\u066F\\u0671-\\u06D3\\u06D5\\u06EE-\\u06EF\\u06FA-\\u06FC\\u06FF\\u0710\\u0712-\\u072F\\u074D-\\u07A5\\u07B1\\u07CA-\\u07EA\\u0800-\\u0815\\u0840-\\u0858\\u0860-\\u086A\\u08A0-\\u08B4\\u08B6-\\u08BD\\u0904-\\u0939\\u093D\\u0950\\u0958-\\u0961\\u0972-\\u0980\\u0985-\\u098C\\u098F-\\u0990\\u0993-\\u09A8\\u09AA-\\u09B0\\u09B2\\u09B6-\\u09B9\\u09BD\\u09CE\\u09DC-\\u09DD\\u09DF-\\u09E1\\u09F0-\\u09F1\\u09FC\\u0A05-\\u0A0A\\u0A0F-\\u0A10\\u0A13-\\u0A28\\u0A2A-\\u0A30\\u0A32-\\u0A33\\u0A35-\\u0A36\\u0A38-\\u0A39\\u0A59-\\u0A5C\\u0A5E\\u0A72-\\u0A74\\u0A85-\\u0A8D\\u0A8F-\\u0A91\\u0A93-\\u0AA8\\u0AAA-\\u0AB0\\u0AB2-\\u0AB3\\u0AB5-\\u0AB9\\u0ABD\\u0AD0\\u0AE0-\\u0AE1\\u0AF9\\u0B05-\\u0B0C\\u0B0F-\\u0B10\\u0B13-\\u0B28\\u0B2A-\\u0B30\\u0B32-\\u0B33\\u0B35-\\u0B39\\u0B3D\\u0B5C-\\u0B5D\\u0B5F-\\u0B61\\u0B71\\u0B83\\u0B85-\\u0B8A\\u0B8E-\\u0B90\\u0B92-\\u0B95\\u0B99-\\u0B9A\\u0B9C\\u0B9E-\\u0B9F\\u0BA3-\\u0BA4\\u0BA8-\\u0BAA\\u0BAE-\\u0BB9\\u0BD0\\u0C05-\\u0C0C\\u0C0E-\\u0C10\\u0C12-\\u0C28\\u0C2A-\\u0C39\\u0C3D\\u0C58-\\u0C5A\\u0C60-\\u0C61\\u0C80\\u0C85-\\u0C8C\\u0C8E-\\u0C90\\u0C92-\\u0CA8\\u0CAA-\\u0CB3\\u0CB5-\\u0CB9\\u0CBD\\u0CDE\\u0CE0-\\u0CE1\\u0CF1-\\u0CF2\\u0D05-\\u0D0C\\u0D0E-\\u0D10\\u0D12-\\u0D3A\\u0D3D\\u0D4E\\u0D54-\\u0D56\\u0D5F-\\u0D61\\u0D7A-\\u0D7F\\u0D85-\\u0D96\\u0D9A-\\u0DB1\\u0DB3-\\u0DBB\\u0DBD\\u0DC0-\\u0DC6\\u0E01-\\u0E30\\u0E32-\\u0E33\\u0E40-\\u0E45\\u0E81-\\u0E82\\u0E84\\u0E87-\\u0E88\\u0E8A\\u0E8D\\u0E94-\\u0E97\\u0E99-\\u0E9F\\u0EA1-\\u0EA3\\u0EA5\\u0EA7\\u0EAA-\\u0EAB\\u0EAD-\\u0EB0\\u0EB2-\\u0EB3\\u0EBD\\u0EC0-\\u0EC4\\u0EDC-\\u0EDF\\u0F00\\u0F40-\\u0F47\\u0F49-\\u0F6C\\u0F88-\\u0F8C\\u1000-\\u102A\\u103F\\u1050-\\u1055\\u105A-\\u105D\\u1061\\u1065-\\u1066\\u106E-\\u1070\\u1075-\\u1081\\u108E\\u1100-\\u1248\\u124A-\\u124D\\u1250-\\u1256\\u1258\\u125A-\\u125D\\u1260-\\u1288\\u128A-\\u128D\\u1290-\\u12B0\\u12B2-\\u12B5\\u12B8-\\u12BE\\u12C0\\u12C2-\\u12C5\\u12C8-\\u12D6\\u12D8-\\u1310\\u1312-\\u1315\\u1318-\\u135A\\u1380-\\u138F\\u1401-\\u166C\\u166F-\\u167F\\u1681-\\u169A\\u16A0-\\u16EA\\u16F1-\\u16F8\\u1700-\\u170C\\u170E-\\u1711\\u1720-\\u1731\\u1740-\\u1751\\u1760-\\u176C\\u176E-\\u1770\\u1780-\\u17B3\\u17DC\\u1820-\\u1842\\u1844-\\u1878\\u1880-\\u1884\\u1887-\\u18A8\\u18AA\\u18B0-\\u18F5\\u1900-\\u191E\\u1950-\\u196D\\u1970-\\u1974\\u1980-\\u19AB\\u19B0-\\u19C9\\u1A00-\\u1A16\\u1A20-\\u1A54\\u1B05-\\u1B33\\u1B45-\\u1B4B\\u1B83-\\u1BA0\\u1BAE-\\u1BAF\\u1BBA-\\u1BE5\\u1C00-\\u1C23\\u1C4D-\\u1C4F\\u1C5A-\\u1C77\\u1CE9-\\u1CEC\\u1CEE-\\u1CF1\\u1CF5-\\u1CF6\\u2135-\\u2138\\u2D30-\\u2D67\\u2D80-\\u2D96\\u2DA0-\\u2DA6\\u2DA8-\\u2DAE\\u2DB0-\\u2DB6\\u2DB8-\\u2DBE\\u2DC0-\\u2DC6\\u2DC8-\\u2DCE\\u2DD0-\\u2DD6\\u2DD8-\\u2DDE\\u3006\\u303C\\u3041-\\u3096\\u309F\\u30A1-\\u30FA\\u30FF\\u3105-\\u312F\\u3131-\\u318E\\u31A0-\\u31BA\\u31F0-\\u31FF\\u3400-\\u4DB5\\u4E00-\\u9FEF\\uA000-\\uA014\\uA016-\\uA48C\\uA4D0-\\uA4F7\\uA500-\\uA60B\\uA610-\\uA61F\\uA62A-\\uA62B\\uA66E\\uA6A0-\\uA6E5\\uA78F\\uA7F7\\uA7FB-\\uA801\\uA803-\\uA805\\uA807-\\uA80A\\uA80C-\\uA822\\uA840-\\uA873\\uA882-\\uA8B3\\uA8F2-\\uA8F7\\uA8FB\\uA8FD-\\uA8FE\\uA90A-\\uA925\\uA930-\\uA946\\uA960-\\uA97C\\uA984-\\uA9B2\\uA9E0-\\uA9E4\\uA9E7-\\uA9EF\\uA9FA-\\uA9FE\\uAA00-\\uAA28\\uAA40-\\uAA42\\uAA44-\\uAA4B\\uAA60-\\uAA6F\\uAA71-\\uAA76\\uAA7A\\uAA7E-\\uAAAF\\uAAB1\\uAAB5-\\uAAB6\\uAAB9-\\uAABD\\uAAC0\\uAAC2\\uAADB-\\uAADC\\uAAE0-\\uAAEA\\uAAF2\\uAB01-\\uAB06\\uAB09-\\uAB0E\\uAB11-\\uAB16\\uAB20-\\uAB26\\uAB28-\\uAB2E\\uABC0-\\uABE2\\uAC00-\\uD7A3\\uD7B0-\\uD7C6\\uD7CB-\\uD7FB\\uF900-\\uFA6D\\uFA70-\\uFAD9\\uFB1D\\uFB1F-\\uFB28\\uFB2A-\\uFB36\\uFB38-\\uFB3C\\uFB3E\\uFB40-\\uFB41\\uFB43-\\uFB44\\uFB46-\\uFBB1\\uFBD3-\\uFD3D\\uFD50-\\uFD8F\\uFD92-\\uFDC7\\uFDF0-\\uFDFB\\uFE70-\\uFE74\\uFE76-\\uFEFC\\uFF66-\\uFF6F\\uFF71-\\uFF9D\\uFFA0-\\uFFBE\\uFFC2-\\uFFC7\\uFFCA-\\uFFCF\\uFFD2-\\uFFD7\\uFFDA-\\uFFDC]",
 				chars:      []rune{'ª', 'º', 'ƻ', 'ʔ', 'ە', 'ۿ', 'ܐ', 'ޱ', 'ऽ', 'ॐ', 'ল', 'ঽ', 'ৎ', 'ৼ', 'ਫ਼', 'ઽ', 'ૐ', 'ૹ', 'ଽ', 'ୱ', 'ஃ', 'ஜ', 'ௐ', 'ఽ', 'ಀ', 'ಽ', 'ೞ', 'ഽ', 'ൎ', 'ල', 'ຄ', 'ຊ', 'ຍ', 'ລ', 'ວ', 'ຽ', 'ༀ', 'ဿ', 'ၡ', 'ႎ', 'ቘ', 'ዀ', 'ៜ', 'ᢪ', '〆', '〼', 'ゟ', 'ヿ', 'ꙮ', 'ꞏ', 'ꟷ', 'ꣻ', 'ꩺ', 'ꪱ', 'ꫀ', 'ꫂ', 'ꫲ', 'יִ', 'מּ'},
 				ranges:     []rune{'ǀ', 'ǃ', 'א', 'ת', 'ׯ', 'ײ', 'ؠ', 'ؿ', 'ف', 'ي', 'ٮ', 'ٯ', 'ٱ', 'ۓ', 'ۮ', 'ۯ', 'ۺ', 'ۼ', 'ܒ', 'ܯ', 'ݍ', 'ޥ', 'ߊ', 'ߪ', 'ࠀ', 'ࠕ', 'ࡀ', 'ࡘ', 'ࡠ', 'ࡪ', 'ࢠ', 'ࢴ', 'ࢶ', 'ࢽ', 'ऄ', 'ह', 'क़', 'ॡ', 'ॲ', 'ঀ', 'অ', 'ঌ', 'এ', 'ঐ', 'ও', 'ন', 'প', 'র', 'শ', 'হ', 'ড়', 'ঢ়', 'য়', 'ৡ', 'ৰ', 'ৱ', 'ਅ', 'ਊ', 'ਏ', 'ਐ', 'ਓ', 'ਨ', 'ਪ', 'ਰ', 'ਲ', 'ਲ਼', 'ਵ', 'ਸ਼', 'ਸ', 'ਹ', 'ਖ਼', 'ੜ', 'ੲ', 'ੴ', 'અ', 'ઍ', 'એ', 'ઑ', 'ઓ', 'ન', 'પ', 'ર', 'લ', 'ળ', 'વ', 'હ', 'ૠ', 'ૡ', 'ଅ', 'ଌ', 'ଏ', 'ଐ', 'ଓ', 'ନ', 'ପ', 'ର', 'ଲ', 'ଳ', 'ଵ', 'ହ', 'ଡ଼', 'ଢ଼', 'ୟ', 'ୡ', 'அ', 'ஊ', 'எ', 'ஐ', 'ஒ', 'க', 'ங', 'ச', 'ஞ', 'ட', 'ண', 'த', 'ந', 'ப', 'ம', 'ஹ', 'అ', 'ఌ', 'ఎ', 'ఐ', 'ఒ', 'న', 'ప', 'హ', 'ౘ', 'ౚ', 'ౠ', 'ౡ', 'ಅ', 'ಌ', 'ಎ', 'ಐ', 'ಒ', 'ನ', 'ಪ', 'ಳ', 'ವ', 'ಹ', 'ೠ', 'ೡ', 'ೱ', 'ೲ', 'അ', 'ഌ', 'എ', 'ഐ', 'ഒ', 'ഺ', 'ൔ', 'ൖ', 'ൟ', 'ൡ', 'ൺ', 'ൿ', 'අ', 'ඖ', 'ක', 'න', 'ඳ', 'ර', 'ව', 'ෆ', 'ก', 'ะ', 'า', 'ำ', 'เ', 'ๅ', 'ກ', 'ຂ', 'ງ', 'ຈ', 'ດ', 'ທ', 'ນ', 'ຟ', 'ມ', 'ຣ', 'ສ', 'ຫ', 'ອ', 'ະ', 'າ', 'ຳ', 'ເ', 'ໄ', 'ໜ', 'ໟ', 'ཀ', 'ཇ', 'ཉ', 'ཬ', 'ྈ', 'ྌ', 'က', 'ဪ', 'ၐ', 'ၕ', 'ၚ', 'ၝ', 'ၥ', 'ၦ', 'ၮ', 'ၰ', 'ၵ', 'ႁ', 'ᄀ', 'ቈ', 'ቊ', 'ቍ', 'ቐ', 'ቖ', 'ቚ', 'ቝ', 'በ', 'ኈ', 'ኊ', 'ኍ', 'ነ', 'ኰ', 'ኲ', 'ኵ', 'ኸ', 'ኾ', 'ዂ', 'ዅ', 'ወ', 'ዖ', 'ዘ', 'ጐ', 'ጒ', 'ጕ', 'ጘ', 'ፚ', 'ᎀ', 'ᎏ', 'ᐁ', 'ᙬ', 'ᙯ', 'ᙿ', 'ᚁ', 'ᚚ', 'ᚠ', 'ᛪ', 'ᛱ', 'ᛸ', 'ᜀ', 'ᜌ', 'ᜎ', 'ᜑ', 'ᜠ', 'ᜱ', 'ᝀ', 'ᝑ', 'ᝠ', 'ᝬ', 'ᝮ', 'ᝰ', 'ក', 'ឳ', 'ᠠ', 'ᡂ', 'ᡄ', 'ᡸ', 'ᢀ', 'ᢄ', 'ᢇ', 'ᢨ', 'ᢰ', 'ᣵ', 'ᤀ', 'ᤞ', 'ᥐ', 'ᥭ', 'ᥰ', 'ᥴ', 'ᦀ', 'ᦫ', 'ᦰ', 'ᧉ', 'ᨀ', 'ᨖ', 'ᨠ', 'ᩔ', 'ᬅ', 'ᬳ', 'ᭅ', 'ᭋ', 'ᮃ', 'ᮠ', 'ᮮ', 'ᮯ', 'ᮺ', 'ᯥ', 'ᰀ', 'ᰣ', 'ᱍ', 'ᱏ', 'ᱚ', 'ᱷ', 'ᳩ', 'ᳬ', 'ᳮ', 'ᳱ', 'ᳵ', 'ᳶ', 'ℵ', 'ℸ', 'ⴰ', 'ⵧ', 'ⶀ', 'ⶖ', 'ⶠ', 'ⶦ', 'ⶨ', 'ⶮ', 'ⶰ', 'ⶶ', 'ⶸ', 'ⶾ', 'ⷀ', 'ⷆ', 'ⷈ', 'ⷎ', 'ⷐ', 'ⷖ', 'ⷘ', 'ⷞ', 'ぁ', 'ゖ', 'ァ', 'ヺ', 'ㄅ', 'ㄯ', 'ㄱ', 'ㆎ', 'ㆠ', 'ㆺ', 'ㇰ', 'ㇿ', '㐀', '䶵', '一', '鿯', 'ꀀ', 'ꀔ', 'ꀖ', 'ꒌ', 'ꓐ', 'ꓷ', 'ꔀ', 'ꘋ', 'ꘐ', 'ꘟ', 'ꘪ', 'ꘫ', 'ꚠ', 'ꛥ', 'ꟻ', 'ꠁ', 'ꠃ', 'ꠅ', 'ꠇ', 'ꠊ', 'ꠌ', 'ꠢ', 'ꡀ', 'ꡳ', 'ꢂ', 'ꢳ', 'ꣲ', 'ꣷ', 'ꣽ', 'ꣾ', 'ꤊ', 'ꤥ', 'ꤰ', 'ꥆ', 'ꥠ', 'ꥼ', 'ꦄ', 'ꦲ', 'ꧠ', 'ꧤ', 'ꧧ', 'ꧯ', 'ꧺ', 'ꧾ', 'ꨀ', 'ꨨ', 'ꩀ', 'ꩂ', 'ꩄ', 'ꩋ', 'ꩠ', 'ꩯ', 'ꩱ', 'ꩶ', 'ꩾ', 'ꪯ', 'ꪵ', 'ꪶ', 'ꪹ', 'ꪽ', 'ꫛ', 'ꫜ', 'ꫠ', 'ꫪ', 'ꬁ', 'ꬆ', 'ꬉ', 'ꬎ', 'ꬑ', 'ꬖ', 'ꬠ', 'ꬦ', 'ꬨ', 'ꬮ', 'ꯀ', 'ꯢ', '가', '힣', 'ힰ', 'ퟆ', 'ퟋ', 'ퟻ', '豈', '舘', '並', '龎', 'ײַ', 'ﬨ', 'שׁ', 'זּ', 'טּ', 'לּ', 'נּ', 'סּ', 'ףּ', 'פּ', 'צּ', 'ﮱ', 'ﯓ', 'ﴽ', 'ﵐ', 'ﶏ', 'ﶒ', 'ﷇ', 'ﷰ', 'ﷻ', 'ﹰ', 'ﹴ', 'ﹶ', 'ﻼ', 'ｦ', 'ｯ', 'ｱ', 'ﾝ', 'ﾠ', 'ﾾ', 'ￂ', 'ￇ', 'ￊ', 'ￏ', 'ￒ', 'ￗ', 'ￚ', 'ￜ'},
@@ -13483,9 +13487,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lt",
-			pos:  position{line: 1874, col: 1, offset: 52471},
+			pos:  position{line: 1874, col: 1, offset: 52473},
 			expr: &charClassMatcher{
-				pos:        position{line: 1874, col: 6, offset: 52476},
+				pos:        position{line: 1874, col: 6, offset: 52478},
 				val:        "[\\u01C5\\u01C8\\u01CB\\u01F2\\u1F88-\\u1F8F\\u1F98-\\u1F9F\\u1FA8-\\u1FAF\\u1FBC\\u1FCC\\u1FFC]",
 				chars:      []rune{'ǅ', 'ǈ', 'ǋ', 'ǲ', 'ᾼ', 'ῌ', 'ῼ'},
 				ranges:     []rune{'ᾈ', 'ᾏ', 'ᾘ', 'ᾟ', 'ᾨ', 'ᾯ'},
@@ -13497,9 +13501,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lu",
-			pos:  position{line: 1877, col: 1, offset: 52582},
+			pos:  position{line: 1877, col: 1, offset: 52584},
 			expr: &charClassMatcher{
-				pos:        position{line: 1877, col: 6, offset: 52587},
+				pos:        position{line: 1877, col: 6, offset: 52589},
 				val:        "[\\u0041-\\u005A\\u00C0-\\u00D6\\u00D8-\\u00DE\\u0100\\u0102\\u0104\\u0106\\u0108\\u010A\\u010C\\u010E\\u0110\\u0112\\u0114\\u0116\\u0118\\u011A\\u011C\\u011E\\u0120\\u0122\\u0124\\u0126\\u0128\\u012A\\u012C\\u012E\\u0130\\u0132\\u0134\\u0136\\u0139\\u013B\\u013D\\u013F\\u0141\\u0143\\u0145\\u0147\\u014A\\u014C\\u014E\\u0150\\u0152\\u0154\\u0156\\u0158\\u015A\\u015C\\u015E\\u0160\\u0162\\u0164\\u0166\\u0168\\u016A\\u016C\\u016E\\u0170\\u0172\\u0174\\u0176\\u0178-\\u0179\\u017B\\u017D\\u0181-\\u0182\\u0184\\u0186-\\u0187\\u0189-\\u018B\\u018E-\\u0191\\u0193-\\u0194\\u0196-\\u0198\\u019C-\\u019D\\u019F-\\u01A0\\u01A2\\u01A4\\u01A6-\\u01A7\\u01A9\\u01AC\\u01AE-\\u01AF\\u01B1-\\u01B3\\u01B5\\u01B7-\\u01B8\\u01BC\\u01C4\\u01C7\\u01CA\\u01CD\\u01CF\\u01D1\\u01D3\\u01D5\\u01D7\\u01D9\\u01DB\\u01DE\\u01E0\\u01E2\\u01E4\\u01E6\\u01E8\\u01EA\\u01EC\\u01EE\\u01F1\\u01F4\\u01F6-\\u01F8\\u01FA\\u01FC\\u01FE\\u0200\\u0202\\u0204\\u0206\\u0208\\u020A\\u020C\\u020E\\u0210\\u0212\\u0214\\u0216\\u0218\\u021A\\u021C\\u021E\\u0220\\u0222\\u0224\\u0226\\u0228\\u022A\\u022C\\u022E\\u0230\\u0232\\u023A-\\u023B\\u023D-\\u023E\\u0241\\u0243-\\u0246\\u0248\\u024A\\u024C\\u024E\\u0370\\u0372\\u0376\\u037F\\u0386\\u0388-\\u038A\\u038C\\u038E-\\u038F\\u0391-\\u03A1\\u03A3-\\u03AB\\u03CF\\u03D2-\\u03D4\\u03D8\\u03DA\\u03DC\\u03DE\\u03E0\\u03E2\\u03E4\\u03E6\\u03E8\\u03EA\\u03EC\\u03EE\\u03F4\\u03F7\\u03F9-\\u03FA\\u03FD-\\u042F\\u0460\\u0462\\u0464\\u0466\\u0468\\u046A\\u046C\\u046E\\u0470\\u0472\\u0474\\u0476\\u0478\\u047A\\u047C\\u047E\\u0480\\u048A\\u048C\\u048E\\u0490\\u0492\\u0494\\u0496\\u0498\\u049A\\u049C\\u049E\\u04A0\\u04A2\\u04A4\\u04A6\\u04A8\\u04AA\\u04AC\\u04AE\\u04B0\\u04B2\\u04B4\\u04B6\\u04B8\\u04BA\\u04BC\\u04BE\\u04C0-\\u04C1\\u04C3\\u04C5\\u04C7\\u04C9\\u04CB\\u04CD\\u04D0\\u04D2\\u04D4\\u04D6\\u04D8\\u04DA\\u04DC\\u04DE\\u04E0\\u04E2\\u04E4\\u04E6\\u04E8\\u04EA\\u04EC\\u04EE\\u04F0\\u04F2\\u04F4\\u04F6\\u04F8\\u04FA\\u04FC\\u04FE\\u0500\\u0502\\u0504\\u0506\\u0508\\u050A\\u050C\\u050E\\u0510\\u0512\\u0514\\u0516\\u0518\\u051A\\u051C\\u051E\\u0520\\u0522\\u0524\\u0526\\u0528\\u052A\\u052C\\u052E\\u0531-\\u0556\\u10A0-\\u10C5\\u10C7\\u10CD\\u13A0-\\u13F5\\u1C90-\\u1CBA\\u1CBD-\\u1CBF\\u1E00\\u1E02\\u1E04\\u1E06\\u1E08\\u1E0A\\u1E0C\\u1E0E\\u1E10\\u1E12\\u1E14\\u1E16\\u1E18\\u1E1A\\u1E1C\\u1E1E\\u1E20\\u1E22\\u1E24\\u1E26\\u1E28\\u1E2A\\u1E2C\\u1E2E\\u1E30\\u1E32\\u1E34\\u1E36\\u1E38\\u1E3A\\u1E3C\\u1E3E\\u1E40\\u1E42\\u1E44\\u1E46\\u1E48\\u1E4A\\u1E4C\\u1E4E\\u1E50\\u1E52\\u1E54\\u1E56\\u1E58\\u1E5A\\u1E5C\\u1E5E\\u1E60\\u1E62\\u1E64\\u1E66\\u1E68\\u1E6A\\u1E6C\\u1E6E\\u1E70\\u1E72\\u1E74\\u1E76\\u1E78\\u1E7A\\u1E7C\\u1E7E\\u1E80\\u1E82\\u1E84\\u1E86\\u1E88\\u1E8A\\u1E8C\\u1E8E\\u1E90\\u1E92\\u1E94\\u1E9E\\u1EA0\\u1EA2\\u1EA4\\u1EA6\\u1EA8\\u1EAA\\u1EAC\\u1EAE\\u1EB0\\u1EB2\\u1EB4\\u1EB6\\u1EB8\\u1EBA\\u1EBC\\u1EBE\\u1EC0\\u1EC2\\u1EC4\\u1EC6\\u1EC8\\u1ECA\\u1ECC\\u1ECE\\u1ED0\\u1ED2\\u1ED4\\u1ED6\\u1ED8\\u1EDA\\u1EDC\\u1EDE\\u1EE0\\u1EE2\\u1EE4\\u1EE6\\u1EE8\\u1EEA\\u1EEC\\u1EEE\\u1EF0\\u1EF2\\u1EF4\\u1EF6\\u1EF8\\u1EFA\\u1EFC\\u1EFE\\u1F08-\\u1F0F\\u1F18-\\u1F1D\\u1F28-\\u1F2F\\u1F38-\\u1F3F\\u1F48-\\u1F4D\\u1F59\\u1F5B\\u1F5D\\u1F5F\\u1F68-\\u1F6F\\u1FB8-\\u1FBB\\u1FC8-\\u1FCB\\u1FD8-\\u1FDB\\u1FE8-\\u1FEC\\u1FF8-\\u1FFB\\u2102\\u2107\\u210B-\\u210D\\u2110-\\u2112\\u2115\\u2119-\\u211D\\u2124\\u2126\\u2128\\u212A-\\u212D\\u2130-\\u2133\\u213E-\\u213F\\u2145\\u2183\\u2C00-\\u2C2E\\u2C60\\u2C62-\\u2C64\\u2C67\\u2C69\\u2C6B\\u2C6D-\\u2C70\\u2C72\\u2C75\\u2C7E-\\u2C80\\u2C82\\u2C84\\u2C86\\u2C88\\u2C8A\\u2C8C\\u2C8E\\u2C90\\u2C92\\u2C94\\u2C96\\u2C98\\u2C9A\\u2C9C\\u2C9E\\u2CA0\\u2CA2\\u2CA4\\u2CA6\\u2CA8\\u2CAA\\u2CAC\\u2CAE\\u2CB0\\u2CB2\\u2CB4\\u2CB6\\u2CB8\\u2CBA\\u2CBC\\u2CBE\\u2CC0\\u2CC2\\u2CC4\\u2CC6\\u2CC8\\u2CCA\\u2CCC\\u2CCE\\u2CD0\\u2CD2\\u2CD4\\u2CD6\\u2CD8\\u2CDA\\u2CDC\\u2CDE\\u2CE0\\u2CE2\\u2CEB\\u2CED\\u2CF2\\uA640\\uA642\\uA644\\uA646\\uA648\\uA64A\\uA64C\\uA64E\\uA650\\uA652\\uA654\\uA656\\uA658\\uA65A\\uA65C\\uA65E\\uA660\\uA662\\uA664\\uA666\\uA668\\uA66A\\uA66C\\uA680\\uA682\\uA684\\uA686\\uA688\\uA68A\\uA68C\\uA68E\\uA690\\uA692\\uA694\\uA696\\uA698\\uA69A\\uA722\\uA724\\uA726\\uA728\\uA72A\\uA72C\\uA72E\\uA732\\uA734\\uA736\\uA738\\uA73A\\uA73C\\uA73E\\uA740\\uA742\\uA744\\uA746\\uA748\\uA74A\\uA74C\\uA74E\\uA750\\uA752\\uA754\\uA756\\uA758\\uA75A\\uA75C\\uA75E\\uA760\\uA762\\uA764\\uA766\\uA768\\uA76A\\uA76C\\uA76E\\uA779\\uA77B\\uA77D-\\uA77E\\uA780\\uA782\\uA784\\uA786\\uA78B\\uA78D\\uA790\\uA792\\uA796\\uA798\\uA79A\\uA79C\\uA79E\\uA7A0\\uA7A2\\uA7A4\\uA7A6\\uA7A8\\uA7AA-\\uA7AE\\uA7B0-\\uA7B4\\uA7B6\\uA7B8\\uFF21-\\uFF3A]",
 				chars:      []rune{'Ā', 'Ă', 'Ą', 'Ć', 'Ĉ', 'Ċ', 'Č', 'Ď', 'Đ', 'Ē', 'Ĕ', 'Ė', 'Ę', 'Ě', 'Ĝ', 'Ğ', 'Ġ', 'Ģ', 'Ĥ', 'Ħ', 'Ĩ', 'Ī', 'Ĭ', 'Į', 'İ', 'Ĳ', 'Ĵ', 'Ķ', 'Ĺ', 'Ļ', 'Ľ', 'Ŀ', 'Ł', 'Ń', 'Ņ', 'Ň', 'Ŋ', 'Ō', 'Ŏ', 'Ő', 'Œ', 'Ŕ', 'Ŗ', 'Ř', 'Ś', 'Ŝ', 'Ş', 'Š', 'Ţ', 'Ť', 'Ŧ', 'Ũ', 'Ū', 'Ŭ', 'Ů', 'Ű', 'Ų', 'Ŵ', 'Ŷ', 'Ż', 'Ž', 'Ƅ', 'Ƣ', 'Ƥ', 'Ʃ', 'Ƭ', 'Ƶ', 'Ƽ', 'Ǆ', 'Ǉ', 'Ǌ', 'Ǎ', 'Ǐ', 'Ǒ', 'Ǔ', 'Ǖ', 'Ǘ', 'Ǚ', 'Ǜ', 'Ǟ', 'Ǡ', 'Ǣ', 'Ǥ', 'Ǧ', 'Ǩ', 'Ǫ', 'Ǭ', 'Ǯ', 'Ǳ', 'Ǵ', 'Ǻ', 'Ǽ', 'Ǿ', 'Ȁ', 'Ȃ', 'Ȅ', 'Ȇ', 'Ȉ', 'Ȋ', 'Ȍ', 'Ȏ', 'Ȑ', 'Ȓ', 'Ȕ', 'Ȗ', 'Ș', 'Ț', 'Ȝ', 'Ȟ', 'Ƞ', 'Ȣ', 'Ȥ', 'Ȧ', 'Ȩ', 'Ȫ', 'Ȭ', 'Ȯ', 'Ȱ', 'Ȳ', 'Ɂ', 'Ɉ', 'Ɋ', 'Ɍ', 'Ɏ', 'Ͱ', 'Ͳ', 'Ͷ', 'Ϳ', 'Ά', 'Ό', 'Ϗ', 'Ϙ', 'Ϛ', 'Ϝ', 'Ϟ', 'Ϡ', 'Ϣ', 'Ϥ', 'Ϧ', 'Ϩ', 'Ϫ', 'Ϭ', 'Ϯ', 'ϴ', 'Ϸ', 'Ѡ', 'Ѣ', 'Ѥ', 'Ѧ', 'Ѩ', 'Ѫ', 'Ѭ', 'Ѯ', 'Ѱ', 'Ѳ', 'Ѵ', 'Ѷ', 'Ѹ', 'Ѻ', 'Ѽ', 'Ѿ', 'Ҁ', 'Ҋ', 'Ҍ', 'Ҏ', 'Ґ', 'Ғ', 'Ҕ', 'Җ', 'Ҙ', 'Қ', 'Ҝ', 'Ҟ', 'Ҡ', 'Ң', 'Ҥ', 'Ҧ', 'Ҩ', 'Ҫ', 'Ҭ', 'Ү', 'Ұ', 'Ҳ', 'Ҵ', 'Ҷ', 'Ҹ', 'Һ', 'Ҽ', 'Ҿ', 'Ӄ', 'Ӆ', 'Ӈ', 'Ӊ', 'Ӌ', 'Ӎ', 'Ӑ', 'Ӓ', 'Ӕ', 'Ӗ', 'Ә', 'Ӛ', 'Ӝ', 'Ӟ', 'Ӡ', 'Ӣ', 'Ӥ', 'Ӧ', 'Ө', 'Ӫ', 'Ӭ', 'Ӯ', 'Ӱ', 'Ӳ', 'Ӵ', 'Ӷ', 'Ӹ', 'Ӻ', 'Ӽ', 'Ӿ', 'Ԁ', 'Ԃ', 'Ԅ', 'Ԇ', 'Ԉ', 'Ԋ', 'Ԍ', 'Ԏ', 'Ԑ', 'Ԓ', 'Ԕ', 'Ԗ', 'Ԙ', 'Ԛ', 'Ԝ', 'Ԟ', 'Ԡ', 'Ԣ', 'Ԥ', 'Ԧ', 'Ԩ', 'Ԫ', 'Ԭ', 'Ԯ', 'Ⴧ', 'Ⴭ', 'Ḁ', 'Ḃ', 'Ḅ', 'Ḇ', 'Ḉ', 'Ḋ', 'Ḍ', 'Ḏ', 'Ḑ', 'Ḓ', 'Ḕ', 'Ḗ', 'Ḙ', 'Ḛ', 'Ḝ', 'Ḟ', 'Ḡ', 'Ḣ', 'Ḥ', 'Ḧ', 'Ḩ', 'Ḫ', 'Ḭ', 'Ḯ', 'Ḱ', 'Ḳ', 'Ḵ', 'Ḷ', 'Ḹ', 'Ḻ', 'Ḽ', 'Ḿ', 'Ṁ', 'Ṃ', 'Ṅ', 'Ṇ', 'Ṉ', 'Ṋ', 'Ṍ', 'Ṏ', 'Ṑ', 'Ṓ', 'Ṕ', 'Ṗ', 'Ṙ', 'Ṛ', 'Ṝ', 'Ṟ', 'Ṡ', 'Ṣ', 'Ṥ', 'Ṧ', 'Ṩ', 'Ṫ', 'Ṭ', 'Ṯ', 'Ṱ', 'Ṳ', 'Ṵ', 'Ṷ', 'Ṹ', 'Ṻ', 'Ṽ', 'Ṿ', 'Ẁ', 'Ẃ', 'Ẅ', 'Ẇ', 'Ẉ', 'Ẋ', 'Ẍ', 'Ẏ', 'Ẑ', 'Ẓ', 'Ẕ', 'ẞ', 'Ạ', 'Ả', 'Ấ', 'Ầ', 'Ẩ', 'Ẫ', 'Ậ', 'Ắ', 'Ằ', 'Ẳ', 'Ẵ', 'Ặ', 'Ẹ', 'Ẻ', 'Ẽ', 'Ế', 'Ề', 'Ể', 'Ễ', 'Ệ', 'Ỉ', 'Ị', 'Ọ', 'Ỏ', 'Ố', 'Ồ', 'Ổ', 'Ỗ', 'Ộ', 'Ớ', 'Ờ', 'Ở', 'Ỡ', 'Ợ', 'Ụ', 'Ủ', 'Ứ', 'Ừ', 'Ử', 'Ữ', 'Ự', 'Ỳ', 'Ỵ', 'Ỷ', 'Ỹ', 'Ỻ', 'Ỽ', 'Ỿ', 'Ὑ', 'Ὓ', 'Ὕ', 'Ὗ', 'ℂ', 'ℇ', 'ℕ', 'ℤ', 'Ω', 'ℨ', 'ⅅ', 'Ↄ', 'Ⱡ', 'Ⱨ', 'Ⱪ', 'Ⱬ', 'Ⱳ', 'Ⱶ', 'Ⲃ', 'Ⲅ', 'Ⲇ', 'Ⲉ', 'Ⲋ', 'Ⲍ', 'Ⲏ', 'Ⲑ', 'Ⲓ', 'Ⲕ', 'Ⲗ', 'Ⲙ', 'Ⲛ', 'Ⲝ', 'Ⲟ', 'Ⲡ', 'Ⲣ', 'Ⲥ', 'Ⲧ', 'Ⲩ', 'Ⲫ', 'Ⲭ', 'Ⲯ', 'Ⲱ', 'Ⲳ', 'Ⲵ', 'Ⲷ', 'Ⲹ', 'Ⲻ', 'Ⲽ', 'Ⲿ', 'Ⳁ', 'Ⳃ', 'Ⳅ', 'Ⳇ', 'Ⳉ', 'Ⳋ', 'Ⳍ', 'Ⳏ', 'Ⳑ', 'Ⳓ', 'Ⳕ', 'Ⳗ', 'Ⳙ', 'Ⳛ', 'Ⳝ', 'Ⳟ', 'Ⳡ', 'Ⳣ', 'Ⳬ', 'Ⳮ', 'Ⳳ', 'Ꙁ', 'Ꙃ', 'Ꙅ', 'Ꙇ', 'Ꙉ', 'Ꙋ', 'Ꙍ', 'Ꙏ', 'Ꙑ', 'Ꙓ', 'Ꙕ', 'Ꙗ', 'Ꙙ', 'Ꙛ', 'Ꙝ', 'Ꙟ', 'Ꙡ', 'Ꙣ', 'Ꙥ', 'Ꙧ', 'Ꙩ', 'Ꙫ', 'Ꙭ', 'Ꚁ', 'Ꚃ', 'Ꚅ', 'Ꚇ', 'Ꚉ', 'Ꚋ', 'Ꚍ', 'Ꚏ', 'Ꚑ', 'Ꚓ', 'Ꚕ', 'Ꚗ', 'Ꚙ', 'Ꚛ', 'Ꜣ', 'Ꜥ', 'Ꜧ', 'Ꜩ', 'Ꜫ', 'Ꜭ', 'Ꜯ', 'Ꜳ', 'Ꜵ', 'Ꜷ', 'Ꜹ', 'Ꜻ', 'Ꜽ', 'Ꜿ', 'Ꝁ', 'Ꝃ', 'Ꝅ', 'Ꝇ', 'Ꝉ', 'Ꝋ', 'Ꝍ', 'Ꝏ', 'Ꝑ', 'Ꝓ', 'Ꝕ', 'Ꝗ', 'Ꝙ', 'Ꝛ', 'Ꝝ', 'Ꝟ', 'Ꝡ', 'Ꝣ', 'Ꝥ', 'Ꝧ', 'Ꝩ', 'Ꝫ', 'Ꝭ', 'Ꝯ', 'Ꝺ', 'Ꝼ', 'Ꞁ', 'Ꞃ', 'Ꞅ', 'Ꞇ', 'Ꞌ', 'Ɥ', 'Ꞑ', 'Ꞓ', 'Ꞗ', 'Ꞙ', 'Ꞛ', 'Ꞝ', 'Ꞟ', 'Ꞡ', 'Ꞣ', 'Ꞥ', 'Ꞧ', 'Ꞩ', 'Ꞷ', 'Ꞹ'},
 				ranges:     []rune{'A', 'Z', 'À', 'Ö', 'Ø', 'Þ', 'Ÿ', 'Ź', 'Ɓ', 'Ƃ', 'Ɔ', 'Ƈ', 'Ɖ', 'Ƌ', 'Ǝ', 'Ƒ', 'Ɠ', 'Ɣ', 'Ɩ', 'Ƙ', 'Ɯ', 'Ɲ', 'Ɵ', 'Ơ', 'Ʀ', 'Ƨ', 'Ʈ', 'Ư', 'Ʊ', 'Ƴ', 'Ʒ', 'Ƹ', 'Ƕ', 'Ǹ', 'Ⱥ', 'Ȼ', 'Ƚ', 'Ⱦ', 'Ƀ', 'Ɇ', 'Έ', 'Ί', 'Ύ', 'Ώ', 'Α', 'Ρ', 'Σ', 'Ϋ', 'ϒ', 'ϔ', 'Ϲ', 'Ϻ', 'Ͻ', 'Я', 'Ӏ', 'Ӂ', 'Ա', 'Ֆ', 'Ⴀ', 'Ⴥ', 'Ꭰ', 'Ᏽ', 'Ა', 'Ჺ', 'Ჽ', 'Ჿ', 'Ἀ', 'Ἇ', 'Ἐ', 'Ἕ', 'Ἠ', 'Ἧ', 'Ἰ', 'Ἷ', 'Ὀ', 'Ὅ', 'Ὠ', 'Ὧ', 'Ᾰ', 'Ά', 'Ὲ', 'Ή', 'Ῐ', 'Ί', 'Ῠ', 'Ῥ', 'Ὸ', 'Ώ', 'ℋ', 'ℍ', 'ℐ', 'ℒ', 'ℙ', 'ℝ', 'K', 'ℭ', 'ℰ', 'ℳ', 'ℾ', 'ℿ', 'Ⰰ', 'Ⱞ', 'Ɫ', 'Ɽ', 'Ɑ', 'Ɒ', 'Ȿ', 'Ⲁ', 'Ᵹ', 'Ꝿ', 'Ɦ', 'Ɪ', 'Ʞ', 'Ꞵ', 'Ａ', 'Ｚ'},
@@ -13511,9 +13515,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mc",
-			pos:  position{line: 1880, col: 1, offset: 56588},
+			pos:  position{line: 1880, col: 1, offset: 56590},
 			expr: &charClassMatcher{
-				pos:        position{line: 1880, col: 6, offset: 56593},
+				pos:        position{line: 1880, col: 6, offset: 56595},
 				val:        "[\\u0903\\u093B\\u093E-\\u0940\\u0949-\\u094C\\u094E-\\u094F\\u0982-\\u0983\\u09BE-\\u09C0\\u09C7-\\u09C8\\u09CB-\\u09CC\\u09D7\\u0A03\\u0A3E-\\u0A40\\u0A83\\u0ABE-\\u0AC0\\u0AC9\\u0ACB-\\u0ACC\\u0B02-\\u0B03\\u0B3E\\u0B40\\u0B47-\\u0B48\\u0B4B-\\u0B4C\\u0B57\\u0BBE-\\u0BBF\\u0BC1-\\u0BC2\\u0BC6-\\u0BC8\\u0BCA-\\u0BCC\\u0BD7\\u0C01-\\u0C03\\u0C41-\\u0C44\\u0C82-\\u0C83\\u0CBE\\u0CC0-\\u0CC4\\u0CC7-\\u0CC8\\u0CCA-\\u0CCB\\u0CD5-\\u0CD6\\u0D02-\\u0D03\\u0D3E-\\u0D40\\u0D46-\\u0D48\\u0D4A-\\u0D4C\\u0D57\\u0D82-\\u0D83\\u0DCF-\\u0DD1\\u0DD8-\\u0DDF\\u0DF2-\\u0DF3\\u0F3E-\\u0F3F\\u0F7F\\u102B-\\u102C\\u1031\\u1038\\u103B-\\u103C\\u1056-\\u1057\\u1062-\\u1064\\u1067-\\u106D\\u1083-\\u1084\\u1087-\\u108C\\u108F\\u109A-\\u109C\\u17B6\\u17BE-\\u17C5\\u17C7-\\u17C8\\u1923-\\u1926\\u1929-\\u192B\\u1930-\\u1931\\u1933-\\u1938\\u1A19-\\u1A1A\\u1A55\\u1A57\\u1A61\\u1A63-\\u1A64\\u1A6D-\\u1A72\\u1B04\\u1B35\\u1B3B\\u1B3D-\\u1B41\\u1B43-\\u1B44\\u1B82\\u1BA1\\u1BA6-\\u1BA7\\u1BAA\\u1BE7\\u1BEA-\\u1BEC\\u1BEE\\u1BF2-\\u1BF3\\u1C24-\\u1C2B\\u1C34-\\u1C35\\u1CE1\\u1CF2-\\u1CF3\\u1CF7\\u302E-\\u302F\\uA823-\\uA824\\uA827\\uA880-\\uA881\\uA8B4-\\uA8C3\\uA952-\\uA953\\uA983\\uA9B4-\\uA9B5\\uA9BA-\\uA9BB\\uA9BD-\\uA9C0\\uAA2F-\\uAA30\\uAA33-\\uAA34\\uAA4D\\uAA7B\\uAA7D\\uAAEB\\uAAEE-\\uAAEF\\uAAF5\\uABE3-\\uABE4\\uABE6-\\uABE7\\uABE9-\\uABEA\\uABEC]",
 				chars:      []rune{'ः', 'ऻ', 'ৗ', 'ਃ', 'ઃ', 'ૉ', 'ା', 'ୀ', 'ୗ', 'ௗ', 'ಾ', 'ൗ', 'ཿ', 'ေ', 'း', 'ႏ', 'ា', 'ᩕ', 'ᩗ', 'ᩡ', 'ᬄ', 'ᬵ', 'ᬻ', 'ᮂ', 'ᮡ', '᮪', 'ᯧ', 'ᯮ', '᳡', '᳷', 'ꠧ', 'ꦃ', 'ꩍ', 'ꩻ', 'ꩽ', 'ꫫ', 'ꫵ', '꯬'},
 				ranges:     []rune{'ा', 'ी', 'ॉ', 'ौ', 'ॎ', 'ॏ', 'ং', 'ঃ', 'া', 'ী', 'ে', 'ৈ', 'ো', 'ৌ', 'ਾ', 'ੀ', 'ા', 'ી', 'ો', 'ૌ', 'ଂ', 'ଃ', 'େ', 'ୈ', 'ୋ', 'ୌ', 'ா', 'ி', 'ு', 'ூ', 'ெ', 'ை', 'ொ', 'ௌ', 'ఁ', 'ః', 'ు', 'ౄ', 'ಂ', 'ಃ', 'ೀ', 'ೄ', 'ೇ', 'ೈ', 'ೊ', 'ೋ', 'ೕ', 'ೖ', 'ം', 'ഃ', 'ാ', 'ീ', 'െ', 'ൈ', 'ൊ', 'ൌ', 'ං', 'ඃ', 'ා', 'ෑ', 'ෘ', 'ෟ', 'ෲ', 'ෳ', '༾', '༿', 'ါ', 'ာ', 'ျ', 'ြ', 'ၖ', 'ၗ', 'ၢ', 'ၤ', 'ၧ', 'ၭ', 'ႃ', 'ႄ', 'ႇ', 'ႌ', 'ႚ', 'ႜ', 'ើ', 'ៅ', 'ះ', 'ៈ', 'ᤣ', 'ᤦ', 'ᤩ', 'ᤫ', 'ᤰ', 'ᤱ', 'ᤳ', 'ᤸ', 'ᨙ', 'ᨚ', 'ᩣ', 'ᩤ', 'ᩭ', 'ᩲ', 'ᬽ', 'ᭁ', 'ᭃ', '᭄', 'ᮦ', 'ᮧ', 'ᯪ', 'ᯬ', '᯲', '᯳', 'ᰤ', 'ᰫ', 'ᰴ', 'ᰵ', 'ᳲ', 'ᳳ', '〮', '〯', 'ꠣ', 'ꠤ', 'ꢀ', 'ꢁ', 'ꢴ', 'ꣃ', 'ꥒ', '꥓', 'ꦴ', 'ꦵ', 'ꦺ', 'ꦻ', 'ꦽ', '꧀', 'ꨯ', 'ꨰ', 'ꨳ', 'ꨴ', 'ꫮ', 'ꫯ', 'ꯣ', 'ꯤ', 'ꯦ', 'ꯧ', 'ꯩ', 'ꯪ'},
@@ -13525,9 +13529,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mn",
-			pos:  position{line: 1883, col: 1, offset: 57781},
+			pos:  position{line: 1883, col: 1, offset: 57783},
 			expr: &charClassMatcher{
-				pos:        position{line: 1883, col: 6, offset: 57786},
+				pos:        position{line: 1883, col: 6, offset: 57788},
 				val:        "[\\u0300-\\u036F\\u0483-\\u0487\\u0591-\\u05BD\\u05BF\\u05C1-\\u05C2\\u05C4-\\u05C5\\u05C7\\u0610-\\u061A\\u064B-\\u065F\\u0670\\u06D6-\\u06DC\\u06DF-\\u06E4\\u06E7-\\u06E8\\u06EA-\\u06ED\\u0711\\u0730-\\u074A\\u07A6-\\u07B0\\u07EB-\\u07F3\\u07FD\\u0816-\\u0819\\u081B-\\u0823\\u0825-\\u0827\\u0829-\\u082D\\u0859-\\u085B\\u08D3-\\u08E1\\u08E3-\\u0902\\u093A\\u093C\\u0941-\\u0948\\u094D\\u0951-\\u0957\\u0962-\\u0963\\u0981\\u09BC\\u09C1-\\u09C4\\u09CD\\u09E2-\\u09E3\\u09FE\\u0A01-\\u0A02\\u0A3C\\u0A41-\\u0A42\\u0A47-\\u0A48\\u0A4B-\\u0A4D\\u0A51\\u0A70-\\u0A71\\u0A75\\u0A81-\\u0A82\\u0ABC\\u0AC1-\\u0AC5\\u0AC7-\\u0AC8\\u0ACD\\u0AE2-\\u0AE3\\u0AFA-\\u0AFF\\u0B01\\u0B3C\\u0B3F\\u0B41-\\u0B44\\u0B4D\\u0B56\\u0B62-\\u0B63\\u0B82\\u0BC0\\u0BCD\\u0C00\\u0C04\\u0C3E-\\u0C40\\u0C46-\\u0C48\\u0C4A-\\u0C4D\\u0C55-\\u0C56\\u0C62-\\u0C63\\u0C81\\u0CBC\\u0CBF\\u0CC6\\u0CCC-\\u0CCD\\u0CE2-\\u0CE3\\u0D00-\\u0D01\\u0D3B-\\u0D3C\\u0D41-\\u0D44\\u0D4D\\u0D62-\\u0D63\\u0DCA\\u0DD2-\\u0DD4\\u0DD6\\u0E31\\u0E34-\\u0E3A\\u0E47-\\u0E4E\\u0EB1\\u0EB4-\\u0EB9\\u0EBB-\\u0EBC\\u0EC8-\\u0ECD\\u0F18-\\u0F19\\u0F35\\u0F37\\u0F39\\u0F71-\\u0F7E\\u0F80-\\u0F84\\u0F86-\\u0F87\\u0F8D-\\u0F97\\u0F99-\\u0FBC\\u0FC6\\u102D-\\u1030\\u1032-\\u1037\\u1039-\\u103A\\u103D-\\u103E\\u1058-\\u1059\\u105E-\\u1060\\u1071-\\u1074\\u1082\\u1085-\\u1086\\u108D\\u109D\\u135D-\\u135F\\u1712-\\u1714\\u1732-\\u1734\\u1752-\\u1753\\u1772-\\u1773\\u17B4-\\u17B5\\u17B7-\\u17BD\\u17C6\\u17C9-\\u17D3\\u17DD\\u180B-\\u180D\\u1885-\\u1886\\u18A9\\u1920-\\u1922\\u1927-\\u1928\\u1932\\u1939-\\u193B\\u1A17-\\u1A18\\u1A1B\\u1A56\\u1A58-\\u1A5E\\u1A60\\u1A62\\u1A65-\\u1A6C\\u1A73-\\u1A7C\\u1A7F\\u1AB0-\\u1ABD\\u1B00-\\u1B03\\u1B34\\u1B36-\\u1B3A\\u1B3C\\u1B42\\u1B6B-\\u1B73\\u1B80-\\u1B81\\u1BA2-\\u1BA5\\u1BA8-\\u1BA9\\u1BAB-\\u1BAD\\u1BE6\\u1BE8-\\u1BE9\\u1BED\\u1BEF-\\u1BF1\\u1C2C-\\u1C33\\u1C36-\\u1C37\\u1CD0-\\u1CD2\\u1CD4-\\u1CE0\\u1CE2-\\u1CE8\\u1CED\\u1CF4\\u1CF8-\\u1CF9\\u1DC0-\\u1DF9\\u1DFB-\\u1DFF\\u20D0-\\u20DC\\u20E1\\u20E5-\\u20F0\\u2CEF-\\u2CF1\\u2D7F\\u2DE0-\\u2DFF\\u302A-\\u302D\\u3099-\\u309A\\uA66F\\uA674-\\uA67D\\uA69E-\\uA69F\\uA6F0-\\uA6F1\\uA802\\uA806\\uA80B\\uA825-\\uA826\\uA8C4-\\uA8C5\\uA8E0-\\uA8F1\\uA8FF\\uA926-\\uA92D\\uA947-\\uA951\\uA980-\\uA982\\uA9B3\\uA9B6-\\uA9B9\\uA9BC\\uA9E5\\uAA29-\\uAA2E\\uAA31-\\uAA32\\uAA35-\\uAA36\\uAA43\\uAA4C\\uAA7C\\uAAB0\\uAAB2-\\uAAB4\\uAAB7-\\uAAB8\\uAABE-\\uAABF\\uAAC1\\uAAEC-\\uAAED\\uAAF6\\uABE5\\uABE8\\uABED\\uFB1E\\uFE00-\\uFE0F\\uFE20-\\uFE2F]",
 				chars:      []rune{'ֿ', 'ׇ', 'ٰ', 'ܑ', '߽', 'ऺ', '़', '्', 'ঁ', '়', '্', '৾', '਼', 'ੑ', 'ੵ', '઼', '્', 'ଁ', '଼', 'ି', '୍', 'ୖ', 'ஂ', 'ீ', '்', 'ఀ', 'ఄ', 'ಁ', '಼', 'ಿ', 'ೆ', '്', '්', 'ූ', 'ั', 'ັ', '༵', '༷', '༹', '࿆', 'ႂ', 'ႍ', 'ႝ', 'ំ', '៝', 'ᢩ', 'ᤲ', 'ᨛ', 'ᩖ', '᩠', 'ᩢ', '᩿', '᬴', 'ᬼ', 'ᭂ', '᯦', 'ᯭ', '᳭', '᳴', '⃡', '⵿', '꙯', 'ꠂ', '꠆', 'ꠋ', 'ꣿ', '꦳', 'ꦼ', 'ꧥ', 'ꩃ', 'ꩌ', 'ꩼ', 'ꪰ', '꫁', '꫶', 'ꯥ', 'ꯨ', '꯭', 'ﬞ'},
 				ranges:     []rune{'̀', 'ͯ', '҃', '҇', '֑', 'ֽ', 'ׁ', 'ׂ', 'ׄ', 'ׅ', 'ؐ', 'ؚ', 'ً', 'ٟ', 'ۖ', 'ۜ', '۟', 'ۤ', 'ۧ', 'ۨ', '۪', 'ۭ', 'ܰ', '݊', 'ަ', 'ް', '߫', '߳', 'ࠖ', '࠙', 'ࠛ', 'ࠣ', 'ࠥ', 'ࠧ', 'ࠩ', '࠭', '࡙', '࡛', '࣓', '࣡', 'ࣣ', 'ं', 'ु', 'ै', '॑', 'ॗ', 'ॢ', 'ॣ', 'ু', 'ৄ', 'ৢ', 'ৣ', 'ਁ', 'ਂ', 'ੁ', 'ੂ', 'ੇ', 'ੈ', 'ੋ', '੍', 'ੰ', 'ੱ', 'ઁ', 'ં', 'ુ', 'ૅ', 'ે', 'ૈ', 'ૢ', 'ૣ', 'ૺ', '૿', 'ୁ', 'ୄ', 'ୢ', 'ୣ', 'ా', 'ీ', 'ె', 'ై', 'ొ', '్', 'ౕ', 'ౖ', 'ౢ', 'ౣ', 'ೌ', '್', 'ೢ', 'ೣ', 'ഀ', 'ഁ', '഻', '഼', 'ു', 'ൄ', 'ൢ', 'ൣ', 'ි', 'ු', 'ิ', 'ฺ', '็', '๎', 'ິ', 'ູ', 'ົ', 'ຼ', '່', 'ໍ', '༘', '༙', 'ཱ', 'ཾ', 'ྀ', '྄', '྆', '྇', 'ྍ', 'ྗ', 'ྙ', 'ྼ', 'ိ', 'ူ', 'ဲ', '့', '္', '်', 'ွ', 'ှ', 'ၘ', 'ၙ', 'ၞ', 'ၠ', 'ၱ', 'ၴ', 'ႅ', 'ႆ', '፝', '፟', 'ᜒ', '᜔', 'ᜲ', '᜴', 'ᝒ', 'ᝓ', 'ᝲ', 'ᝳ', '឴', '឵', 'ិ', 'ួ', '៉', '៓', '᠋', '᠍', 'ᢅ', 'ᢆ', 'ᤠ', 'ᤢ', 'ᤧ', 'ᤨ', '᤹', '᤻', 'ᨗ', 'ᨘ', 'ᩘ', 'ᩞ', 'ᩥ', 'ᩬ', 'ᩳ', '᩼', '᪰', '᪽', 'ᬀ', 'ᬃ', 'ᬶ', 'ᬺ', '᭫', '᭳', 'ᮀ', 'ᮁ', 'ᮢ', 'ᮥ', 'ᮨ', 'ᮩ', '᮫', 'ᮭ', 'ᯨ', 'ᯩ', 'ᯯ', 'ᯱ', 'ᰬ', 'ᰳ', 'ᰶ', '᰷', '᳐', '᳒', '᳔', '᳠', '᳢', '᳨', '᳸', '᳹', '᷀', '᷹', '᷻', '᷿', '⃐', '⃜', '⃥', '⃰', '⳯', '⳱', 'ⷠ', 'ⷿ', '〪', '〭', '゙', '゚', 'ꙴ', '꙽', 'ꚞ', 'ꚟ', '꛰', '꛱', 'ꠥ', 'ꠦ', '꣄', 'ꣅ', '꣠', '꣱', 'ꤦ', '꤭', 'ꥇ', 'ꥑ', 'ꦀ', 'ꦂ', 'ꦶ', 'ꦹ', 'ꨩ', 'ꨮ', 'ꨱ', 'ꨲ', 'ꨵ', 'ꨶ', 'ꪲ', 'ꪴ', 'ꪷ', 'ꪸ', 'ꪾ', '꪿', 'ꫬ', 'ꫭ', '︀', '️', '︠', '︯'},
@@ -13539,9 +13543,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nd",
-			pos:  position{line: 1886, col: 1, offset: 59966},
+			pos:  position{line: 1886, col: 1, offset: 59968},
 			expr: &charClassMatcher{
-				pos:        position{line: 1886, col: 6, offset: 59971},
+				pos:        position{line: 1886, col: 6, offset: 59973},
 				val:        "[\\u0030-\\u0039\\u0660-\\u0669\\u06F0-\\u06F9\\u07C0-\\u07C9\\u0966-\\u096F\\u09E6-\\u09EF\\u0A66-\\u0A6F\\u0AE6-\\u0AEF\\u0B66-\\u0B6F\\u0BE6-\\u0BEF\\u0C66-\\u0C6F\\u0CE6-\\u0CEF\\u0D66-\\u0D6F\\u0DE6-\\u0DEF\\u0E50-\\u0E59\\u0ED0-\\u0ED9\\u0F20-\\u0F29\\u1040-\\u1049\\u1090-\\u1099\\u17E0-\\u17E9\\u1810-\\u1819\\u1946-\\u194F\\u19D0-\\u19D9\\u1A80-\\u1A89\\u1A90-\\u1A99\\u1B50-\\u1B59\\u1BB0-\\u1BB9\\u1C40-\\u1C49\\u1C50-\\u1C59\\uA620-\\uA629\\uA8D0-\\uA8D9\\uA900-\\uA909\\uA9D0-\\uA9D9\\uA9F0-\\uA9F9\\uAA50-\\uAA59\\uABF0-\\uABF9\\uFF10-\\uFF19]",
 				ranges:     []rune{'0', '9', '٠', '٩', '۰', '۹', '߀', '߉', '०', '९', '০', '৯', '੦', '੯', '૦', '૯', '୦', '୯', '௦', '௯', '౦', '౯', '೦', '೯', '൦', '൯', '෦', '෯', '๐', '๙', '໐', '໙', '༠', '༩', '၀', '၉', '႐', '႙', '០', '៩', '᠐', '᠙', '᥆', '᥏', '᧐', '᧙', '᪀', '᪉', '᪐', '᪙', '᭐', '᭙', '᮰', '᮹', '᱀', '᱉', '᱐', '᱙', '꘠', '꘩', '꣐', '꣙', '꤀', '꤉', '꧐', '꧙', '꧰', '꧹', '꩐', '꩙', '꯰', '꯹', '０', '９'},
 				ignoreCase: false,
@@ -13552,9 +13556,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nl",
-			pos:  position{line: 1889, col: 1, offset: 60474},
+			pos:  position{line: 1889, col: 1, offset: 60476},
 			expr: &charClassMatcher{
-				pos:        position{line: 1889, col: 6, offset: 60479},
+				pos:        position{line: 1889, col: 6, offset: 60481},
 				val:        "[\\u16EE-\\u16F0\\u2160-\\u2182\\u2185-\\u2188\\u3007\\u3021-\\u3029\\u3038-\\u303A\\uA6E6-\\uA6EF]",
 				chars:      []rune{'〇'},
 				ranges:     []rune{'ᛮ', 'ᛰ', 'Ⅰ', 'ↂ', 'ↅ', 'ↈ', '〡', '〩', '〸', '〺', 'ꛦ', 'ꛯ'},
@@ -13566,9 +13570,9 @@ var g = &grammar{
 		},
 		{
 			name: "Pc",
-			pos:  position{line: 1892, col: 1, offset: 60593},
+			pos:  position{line: 1892, col: 1, offset: 60595},
 			expr: &charClassMatcher{
-				pos:        position{line: 1892, col: 6, offset: 60598},
+				pos:        position{line: 1892, col: 6, offset: 60600},
 				val:        "[\\u005F\\u203F-\\u2040\\u2054\\uFE33-\\uFE34\\uFE4D-\\uFE4F\\uFF3F]",
 				chars:      []rune{'_', '⁔', '＿'},
 				ranges:     []rune{'‿', '⁀', '︳', '︴', '﹍', '﹏'},
@@ -13580,9 +13584,9 @@ var g = &grammar{
 		},
 		{
 			name: "Zs",
-			pos:  position{line: 1895, col: 1, offset: 60679},
+			pos:  position{line: 1895, col: 1, offset: 60681},
 			expr: &charClassMatcher{
-				pos:        position{line: 1895, col: 6, offset: 60684},
+				pos:        position{line: 1895, col: 6, offset: 60686},
 				val:        "[\\u0020\\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000]",
 				chars:      []rune{' ', '\u00a0', '\u1680', '\u202f', '\u205f', '\u3000'},
 				ranges:     []rune{'\u2000', '\u200a'},
@@ -13594,9 +13598,9 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1897, col: 1, offset: 60737},
+			pos:  position{line: 1897, col: 1, offset: 60739},
 			expr: &anyMatcher{
-				line: 1898, col: 5, offset: 60757,
+				line: 1898, col: 5, offset: 60759,
 			},
 			leader:        false,
 			leftRecursive: false,
@@ -13604,48 +13608,48 @@ var g = &grammar{
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1900, col: 1, offset: 60760},
+			pos:         position{line: 1900, col: 1, offset: 60762},
 			expr: &choiceExpr{
-				pos: position{line: 1901, col: 5, offset: 60788},
+				pos: position{line: 1901, col: 5, offset: 60790},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1901, col: 5, offset: 60788},
+						pos:        position{line: 1901, col: 5, offset: 60790},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1902, col: 5, offset: 60797},
+						pos:        position{line: 1902, col: 5, offset: 60799},
 						val:        "\v",
 						ignoreCase: false,
 						want:       "\"\\v\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1903, col: 5, offset: 60806},
+						pos:        position{line: 1903, col: 5, offset: 60808},
 						val:        "\f",
 						ignoreCase: false,
 						want:       "\"\\f\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1904, col: 5, offset: 60815},
+						pos:        position{line: 1904, col: 5, offset: 60817},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 1905, col: 5, offset: 60823},
+						pos:        position{line: 1905, col: 5, offset: 60825},
 						val:        "\u00a0",
 						ignoreCase: false,
 						want:       "\"\\u00a0\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1906, col: 5, offset: 60836},
+						pos:        position{line: 1906, col: 5, offset: 60838},
 						val:        "\ufeff",
 						ignoreCase: false,
 						want:       "\"\\ufeff\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1907, col: 5, offset: 60849},
+						pos:  position{line: 1907, col: 5, offset: 60851},
 						name: "Zs",
 					},
 				},
@@ -13655,9 +13659,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1909, col: 1, offset: 60853},
+			pos:  position{line: 1909, col: 1, offset: 60855},
 			expr: &charClassMatcher{
-				pos:        position{line: 1910, col: 5, offset: 60872},
+				pos:        position{line: 1910, col: 5, offset: 60874},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -13669,9 +13673,9 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1916, col: 1, offset: 61202},
+			pos:         position{line: 1916, col: 1, offset: 61204},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1919, col: 5, offset: 61273},
+				pos:  position{line: 1919, col: 5, offset: 61275},
 				name: "SingleLineComment",
 			},
 			leader:        false,
@@ -13679,39 +13683,39 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1921, col: 1, offset: 61292},
+			pos:  position{line: 1921, col: 1, offset: 61294},
 			expr: &seqExpr{
-				pos: position{line: 1922, col: 5, offset: 61313},
+				pos: position{line: 1922, col: 5, offset: 61315},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1922, col: 5, offset: 61313},
+						pos:        position{line: 1922, col: 5, offset: 61315},
 						val:        "/*",
 						ignoreCase: false,
 						want:       "\"/*\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1922, col: 10, offset: 61318},
+						pos: position{line: 1922, col: 10, offset: 61320},
 						expr: &seqExpr{
-							pos: position{line: 1922, col: 11, offset: 61319},
+							pos: position{line: 1922, col: 11, offset: 61321},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1922, col: 11, offset: 61319},
+									pos: position{line: 1922, col: 11, offset: 61321},
 									expr: &litMatcher{
-										pos:        position{line: 1922, col: 12, offset: 61320},
+										pos:        position{line: 1922, col: 12, offset: 61322},
 										val:        "*/",
 										ignoreCase: false,
 										want:       "\"*/\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1922, col: 17, offset: 61325},
+									pos:  position{line: 1922, col: 17, offset: 61327},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1922, col: 35, offset: 61343},
+						pos:        position{line: 1922, col: 35, offset: 61345},
 						val:        "*/",
 						ignoreCase: false,
 						want:       "\"*/\"",
@@ -13723,33 +13727,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1924, col: 1, offset: 61349},
+			pos:  position{line: 1924, col: 1, offset: 61351},
 			expr: &choiceExpr{
-				pos: position{line: 1925, col: 5, offset: 61371},
+				pos: position{line: 1925, col: 5, offset: 61373},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 1925, col: 5, offset: 61371},
+						pos: position{line: 1925, col: 5, offset: 61373},
 						exprs: []any{
 							&litMatcher{
-								pos:        position{line: 1925, col: 5, offset: 61371},
+								pos:        position{line: 1925, col: 5, offset: 61373},
 								val:        "//",
 								ignoreCase: false,
 								want:       "\"//\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1925, col: 10, offset: 61376},
+								pos: position{line: 1925, col: 10, offset: 61378},
 								expr: &seqExpr{
-									pos: position{line: 1925, col: 11, offset: 61377},
+									pos: position{line: 1925, col: 11, offset: 61379},
 									exprs: []any{
 										&notExpr{
-											pos: position{line: 1925, col: 11, offset: 61377},
+											pos: position{line: 1925, col: 11, offset: 61379},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1925, col: 12, offset: 61378},
+												pos:  position{line: 1925, col: 12, offset: 61380},
 												name: "LineTerminator",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1925, col: 27, offset: 61393},
+											pos:  position{line: 1925, col: 27, offset: 61395},
 											name: "SourceCharacter",
 										},
 									},
@@ -13758,28 +13762,28 @@ var g = &grammar{
 						},
 					},
 					&seqExpr{
-						pos: position{line: 1926, col: 5, offset: 61415},
+						pos: position{line: 1926, col: 5, offset: 61417},
 						exprs: []any{
 							&litMatcher{
-								pos:        position{line: 1926, col: 5, offset: 61415},
+								pos:        position{line: 1926, col: 5, offset: 61417},
 								val:        "--",
 								ignoreCase: false,
 								want:       "\"--\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1926, col: 10, offset: 61420},
+								pos: position{line: 1926, col: 10, offset: 61422},
 								expr: &seqExpr{
-									pos: position{line: 1926, col: 11, offset: 61421},
+									pos: position{line: 1926, col: 11, offset: 61423},
 									exprs: []any{
 										&notExpr{
-											pos: position{line: 1926, col: 11, offset: 61421},
+											pos: position{line: 1926, col: 11, offset: 61423},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1926, col: 12, offset: 61422},
+												pos:  position{line: 1926, col: 12, offset: 61424},
 												name: "LineTerminator",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1926, col: 27, offset: 61437},
+											pos:  position{line: 1926, col: 27, offset: 61439},
 											name: "SourceCharacter",
 										},
 									},
@@ -13794,19 +13798,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1928, col: 1, offset: 61456},
+			pos:  position{line: 1928, col: 1, offset: 61458},
 			expr: &seqExpr{
-				pos: position{line: 1928, col: 7, offset: 61462},
+				pos: position{line: 1928, col: 7, offset: 61464},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1928, col: 7, offset: 61462},
+						pos: position{line: 1928, col: 7, offset: 61464},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1928, col: 7, offset: 61462},
+							pos:  position{line: 1928, col: 7, offset: 61464},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1928, col: 19, offset: 61474},
+						pos:  position{line: 1928, col: 19, offset: 61476},
 						name: "LineTerminator",
 					},
 				},
@@ -13816,16 +13820,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1930, col: 1, offset: 61490},
+			pos:  position{line: 1930, col: 1, offset: 61492},
 			expr: &choiceExpr{
-				pos: position{line: 1930, col: 7, offset: 61496},
+				pos: position{line: 1930, col: 7, offset: 61498},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1930, col: 7, offset: 61496},
+						pos:  position{line: 1930, col: 7, offset: 61498},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1930, col: 11, offset: 61500},
+						pos:  position{line: 1930, col: 11, offset: 61502},
 						name: "EOF",
 					},
 				},
@@ -13835,11 +13839,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1932, col: 1, offset: 61505},
+			pos:  position{line: 1932, col: 1, offset: 61507},
 			expr: &notExpr{
-				pos: position{line: 1932, col: 7, offset: 61511},
+				pos: position{line: 1932, col: 7, offset: 61513},
 				expr: &anyMatcher{
-					line: 1932, col: 8, offset: 61512,
+					line: 1932, col: 8, offset: 61514,
 				},
 			},
 			leader:        false,
@@ -13847,11 +13851,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOKW",
-			pos:  position{line: 1934, col: 1, offset: 61515},
+			pos:  position{line: 1934, col: 1, offset: 61517},
 			expr: &notExpr{
-				pos: position{line: 1934, col: 8, offset: 61522},
+				pos: position{line: 1934, col: 8, offset: 61524},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1934, col: 9, offset: 61523},
+					pos:  position{line: 1934, col: 9, offset: 61525},
 					name: "KeyWordChars",
 				},
 			},
@@ -13860,15 +13864,15 @@ var g = &grammar{
 		},
 		{
 			name: "SQLPipe",
-			pos:  position{line: 1938, col: 1, offset: 61559},
+			pos:  position{line: 1938, col: 1, offset: 61561},
 			expr: &actionExpr{
-				pos: position{line: 1939, col: 5, offset: 61572},
+				pos: position{line: 1939, col: 5, offset: 61574},
 				run: (*parser).callonSQLPipe1,
 				expr: &labeledExpr{
-					pos:   position{line: 1939, col: 5, offset: 61572},
+					pos:   position{line: 1939, col: 5, offset: 61574},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1939, col: 7, offset: 61574},
+						pos:  position{line: 1939, col: 7, offset: 61576},
 						name: "Seq",
 					},
 				},
@@ -13878,27 +13882,27 @@ var g = &grammar{
 		},
 		{
 			name: "SelectOp",
-			pos:  position{line: 1947, col: 1, offset: 61720},
+			pos:  position{line: 1947, col: 1, offset: 61722},
 			expr: &actionExpr{
-				pos: position{line: 1947, col: 12, offset: 61731},
+				pos: position{line: 1947, col: 12, offset: 61733},
 				run: (*parser).callonSelectOp1,
 				expr: &seqExpr{
-					pos: position{line: 1947, col: 12, offset: 61731},
+					pos: position{line: 1947, col: 12, offset: 61733},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1947, col: 12, offset: 61731},
+							pos: position{line: 1947, col: 12, offset: 61733},
 							expr: &litMatcher{
-								pos:        position{line: 1947, col: 13, offset: 61732},
+								pos:        position{line: 1947, col: 13, offset: 61734},
 								val:        "(",
 								ignoreCase: false,
 								want:       "\"(\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1947, col: 17, offset: 61736},
+							pos:   position{line: 1947, col: 17, offset: 61738},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1947, col: 20, offset: 61739},
+								pos:  position{line: 1947, col: 20, offset: 61741},
 								name: "SelectExpr",
 							},
 						},
@@ -13910,73 +13914,73 @@ var g = &grammar{
 		},
 		{
 			name: "SelectExpr",
-			pos:  position{line: 1949, col: 1, offset: 61769},
+			pos:  position{line: 1949, col: 1, offset: 61771},
 			expr: &actionExpr{
-				pos: position{line: 1950, col: 5, offset: 61785},
+				pos: position{line: 1950, col: 5, offset: 61787},
 				run: (*parser).callonSelectExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1950, col: 5, offset: 61785},
+					pos: position{line: 1950, col: 5, offset: 61787},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1950, col: 5, offset: 61785},
+							pos:   position{line: 1950, col: 5, offset: 61787},
 							label: "with",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1950, col: 10, offset: 61790},
+								pos:  position{line: 1950, col: 10, offset: 61792},
 								name: "OptWithClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1951, col: 5, offset: 61808},
+							pos:   position{line: 1951, col: 5, offset: 61810},
 							label: "body",
 							expr: &choiceExpr{
-								pos: position{line: 1952, col: 9, offset: 61823},
+								pos: position{line: 1952, col: 9, offset: 61825},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1952, col: 9, offset: 61823},
+										pos:  position{line: 1952, col: 9, offset: 61825},
 										name: "SetOperation",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1953, col: 9, offset: 61844},
+										pos:  position{line: 1953, col: 9, offset: 61846},
 										name: "Select",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1954, col: 9, offset: 61859},
+										pos:  position{line: 1954, col: 9, offset: 61861},
 										name: "FromSelect",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1955, col: 9, offset: 61878},
+										pos:  position{line: 1955, col: 9, offset: 61880},
 										name: "Values",
 									},
 									&actionExpr{
-										pos: position{line: 1956, col: 9, offset: 61893},
+										pos: position{line: 1956, col: 9, offset: 61895},
 										run: (*parser).callonSelectExpr11,
 										expr: &seqExpr{
-											pos: position{line: 1956, col: 9, offset: 61893},
+											pos: position{line: 1956, col: 9, offset: 61895},
 											exprs: []any{
 												&litMatcher{
-													pos:        position{line: 1956, col: 9, offset: 61893},
+													pos:        position{line: 1956, col: 9, offset: 61895},
 													val:        "(",
 													ignoreCase: false,
 													want:       "\"(\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1956, col: 13, offset: 61897},
+													pos:  position{line: 1956, col: 13, offset: 61899},
 													name: "__",
 												},
 												&labeledExpr{
-													pos:   position{line: 1956, col: 16, offset: 61900},
+													pos:   position{line: 1956, col: 16, offset: 61902},
 													label: "s",
 													expr: &ruleRefExpr{
-														pos:  position{line: 1956, col: 18, offset: 61902},
+														pos:  position{line: 1956, col: 18, offset: 61904},
 														name: "SQLPipe",
 													},
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1956, col: 26, offset: 61910},
+													pos:  position{line: 1956, col: 26, offset: 61912},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1956, col: 28, offset: 61912},
+													pos:        position{line: 1956, col: 28, offset: 61914},
 													val:        ")",
 													ignoreCase: false,
 													want:       "\")\"",
@@ -13988,18 +13992,18 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1958, col: 5, offset: 61949},
+							pos:   position{line: 1958, col: 5, offset: 61951},
 							label: "orderby",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1958, col: 13, offset: 61957},
+								pos:  position{line: 1958, col: 13, offset: 61959},
 								name: "OptOrderByClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1959, col: 5, offset: 61978},
+							pos:   position{line: 1959, col: 5, offset: 61980},
 							label: "loff",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1959, col: 10, offset: 61983},
+								pos:  position{line: 1959, col: 10, offset: 61985},
 								name: "OptSQLLimitOffset",
 							},
 						},
@@ -14011,74 +14015,74 @@ var g = &grammar{
 		},
 		{
 			name: "Select",
-			pos:  position{line: 1979, col: 1, offset: 62379},
+			pos:  position{line: 1979, col: 1, offset: 62381},
 			expr: &actionExpr{
-				pos: position{line: 1980, col: 5, offset: 62391},
+				pos: position{line: 1980, col: 5, offset: 62393},
 				run: (*parser).callonSelect1,
 				expr: &seqExpr{
-					pos: position{line: 1980, col: 5, offset: 62391},
+					pos: position{line: 1980, col: 5, offset: 62393},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1980, col: 5, offset: 62391},
+							pos:  position{line: 1980, col: 5, offset: 62393},
 							name: "SELECT",
 						},
 						&labeledExpr{
-							pos:   position{line: 1981, col: 5, offset: 62403},
+							pos:   position{line: 1981, col: 5, offset: 62405},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1981, col: 14, offset: 62412},
+								pos:  position{line: 1981, col: 14, offset: 62414},
 								name: "OptDistinct",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1982, col: 5, offset: 62428},
+							pos:   position{line: 1982, col: 5, offset: 62430},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1982, col: 11, offset: 62434},
+								pos:  position{line: 1982, col: 11, offset: 62436},
 								name: "OptSelectValue",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1985, col: 5, offset: 62574},
+							pos:  position{line: 1985, col: 5, offset: 62576},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1985, col: 7, offset: 62576},
+							pos:   position{line: 1985, col: 7, offset: 62578},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1985, col: 17, offset: 62586},
+								pos:  position{line: 1985, col: 17, offset: 62588},
 								name: "Selection",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1986, col: 5, offset: 62600},
+							pos:   position{line: 1986, col: 5, offset: 62602},
 							label: "from",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1986, col: 10, offset: 62605},
+								pos:  position{line: 1986, col: 10, offset: 62607},
 								name: "OptFromClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1987, col: 5, offset: 62623},
+							pos:   position{line: 1987, col: 5, offset: 62625},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1987, col: 11, offset: 62629},
+								pos:  position{line: 1987, col: 11, offset: 62631},
 								name: "OptWhereClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1988, col: 5, offset: 62648},
+							pos:   position{line: 1988, col: 5, offset: 62650},
 							label: "group",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1988, col: 11, offset: 62654},
+								pos:  position{line: 1988, col: 11, offset: 62656},
 								name: "OptGroupClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1989, col: 5, offset: 62673},
+							pos:   position{line: 1989, col: 5, offset: 62675},
 							label: "having",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1989, col: 12, offset: 62680},
+								pos:  position{line: 1989, col: 12, offset: 62682},
 								name: "OptHavingClause",
 							},
 						},
@@ -14090,78 +14094,78 @@ var g = &grammar{
 		},
 		{
 			name: "FromSelect",
-			pos:  position{line: 2015, col: 1, offset: 63286},
+			pos:  position{line: 2015, col: 1, offset: 63288},
 			expr: &actionExpr{
-				pos: position{line: 2016, col: 5, offset: 63301},
+				pos: position{line: 2016, col: 5, offset: 63303},
 				run: (*parser).callonFromSelect1,
 				expr: &seqExpr{
-					pos: position{line: 2016, col: 5, offset: 63301},
+					pos: position{line: 2016, col: 5, offset: 63303},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2016, col: 5, offset: 63301},
+							pos:   position{line: 2016, col: 5, offset: 63303},
 							label: "from",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2016, col: 10, offset: 63306},
+								pos:  position{line: 2016, col: 10, offset: 63308},
 								name: "FromOp",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2016, col: 17, offset: 63313},
+							pos:  position{line: 2016, col: 17, offset: 63315},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2016, col: 19, offset: 63315},
+							pos:  position{line: 2016, col: 19, offset: 63317},
 							name: "SELECT",
 						},
 						&labeledExpr{
-							pos:   position{line: 2017, col: 5, offset: 63327},
+							pos:   position{line: 2017, col: 5, offset: 63329},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2017, col: 14, offset: 63336},
+								pos:  position{line: 2017, col: 14, offset: 63338},
 								name: "OptDistinct",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2018, col: 5, offset: 63352},
+							pos:   position{line: 2018, col: 5, offset: 63354},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2018, col: 11, offset: 63358},
+								pos:  position{line: 2018, col: 11, offset: 63360},
 								name: "OptSelectValue",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2021, col: 5, offset: 63498},
+							pos:  position{line: 2021, col: 5, offset: 63500},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2021, col: 7, offset: 63500},
+							pos:   position{line: 2021, col: 7, offset: 63502},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2021, col: 17, offset: 63510},
+								pos:  position{line: 2021, col: 17, offset: 63512},
 								name: "Selection",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2022, col: 5, offset: 63524},
+							pos:   position{line: 2022, col: 5, offset: 63526},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2022, col: 11, offset: 63530},
+								pos:  position{line: 2022, col: 11, offset: 63532},
 								name: "OptWhereClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2023, col: 5, offset: 63549},
+							pos:   position{line: 2023, col: 5, offset: 63551},
 							label: "group",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2023, col: 11, offset: 63555},
+								pos:  position{line: 2023, col: 11, offset: 63557},
 								name: "OptGroupClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2024, col: 5, offset: 63574},
+							pos:   position{line: 2024, col: 5, offset: 63576},
 							label: "having",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2024, col: 12, offset: 63581},
+								pos:  position{line: 2024, col: 12, offset: 63583},
 								name: "OptHavingClause",
 							},
 						},
@@ -14173,26 +14177,26 @@ var g = &grammar{
 		},
 		{
 			name: "Values",
-			pos:  position{line: 2048, col: 1, offset: 64154},
+			pos:  position{line: 2048, col: 1, offset: 64156},
 			expr: &actionExpr{
-				pos: position{line: 2049, col: 5, offset: 64165},
+				pos: position{line: 2049, col: 5, offset: 64167},
 				run: (*parser).callonValues1,
 				expr: &seqExpr{
-					pos: position{line: 2049, col: 5, offset: 64165},
+					pos: position{line: 2049, col: 5, offset: 64167},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2049, col: 5, offset: 64165},
+							pos:  position{line: 2049, col: 5, offset: 64167},
 							name: "VALUES",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2049, col: 12, offset: 64172},
+							pos:  position{line: 2049, col: 12, offset: 64174},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2049, col: 14, offset: 64174},
+							pos:   position{line: 2049, col: 14, offset: 64176},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2049, col: 20, offset: 64180},
+								pos:  position{line: 2049, col: 20, offset: 64182},
 								name: "Exprs",
 							},
 						},
@@ -14204,49 +14208,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptDistinct",
-			pos:  position{line: 2057, col: 1, offset: 64326},
+			pos:  position{line: 2057, col: 1, offset: 64328},
 			expr: &choiceExpr{
-				pos: position{line: 2058, col: 5, offset: 64342},
+				pos: position{line: 2058, col: 5, offset: 64344},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2058, col: 5, offset: 64342},
+						pos: position{line: 2058, col: 5, offset: 64344},
 						run: (*parser).callonOptDistinct2,
 						expr: &seqExpr{
-							pos: position{line: 2058, col: 5, offset: 64342},
+							pos: position{line: 2058, col: 5, offset: 64344},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2058, col: 5, offset: 64342},
+									pos:  position{line: 2058, col: 5, offset: 64344},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2058, col: 7, offset: 64344},
+									pos:  position{line: 2058, col: 7, offset: 64346},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2059, col: 5, offset: 64381},
+						pos: position{line: 2059, col: 5, offset: 64383},
 						run: (*parser).callonOptDistinct6,
 						expr: &seqExpr{
-							pos: position{line: 2059, col: 5, offset: 64381},
+							pos: position{line: 2059, col: 5, offset: 64383},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2059, col: 5, offset: 64381},
+									pos:  position{line: 2059, col: 5, offset: 64383},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2059, col: 7, offset: 64383},
+									pos:  position{line: 2059, col: 7, offset: 64385},
 									name: "DISTINCT",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2060, col: 5, offset: 64419},
+						pos: position{line: 2060, col: 5, offset: 64421},
 						run: (*parser).callonOptDistinct10,
 						expr: &litMatcher{
-							pos:        position{line: 2060, col: 5, offset: 64419},
+							pos:        position{line: 2060, col: 5, offset: 64421},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14259,57 +14263,57 @@ var g = &grammar{
 		},
 		{
 			name: "OptSelectValue",
-			pos:  position{line: 2062, col: 1, offset: 64458},
+			pos:  position{line: 2062, col: 1, offset: 64460},
 			expr: &choiceExpr{
-				pos: position{line: 2063, col: 5, offset: 64477},
+				pos: position{line: 2063, col: 5, offset: 64479},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2063, col: 5, offset: 64477},
+						pos: position{line: 2063, col: 5, offset: 64479},
 						run: (*parser).callonOptSelectValue2,
 						expr: &seqExpr{
-							pos: position{line: 2063, col: 5, offset: 64477},
+							pos: position{line: 2063, col: 5, offset: 64479},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2063, col: 5, offset: 64477},
+									pos:  position{line: 2063, col: 5, offset: 64479},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2063, col: 7, offset: 64479},
+									pos:  position{line: 2063, col: 7, offset: 64481},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2063, col: 10, offset: 64482},
+									pos:  position{line: 2063, col: 10, offset: 64484},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2063, col: 12, offset: 64484},
+									pos:  position{line: 2063, col: 12, offset: 64486},
 									name: "VALUE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2064, col: 5, offset: 64516},
+						pos: position{line: 2064, col: 5, offset: 64518},
 						run: (*parser).callonOptSelectValue8,
 						expr: &seqExpr{
-							pos: position{line: 2064, col: 5, offset: 64516},
+							pos: position{line: 2064, col: 5, offset: 64518},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2064, col: 5, offset: 64516},
+									pos:  position{line: 2064, col: 5, offset: 64518},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2064, col: 7, offset: 64518},
+									pos:  position{line: 2064, col: 7, offset: 64520},
 									name: "VALUE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2065, col: 5, offset: 64589},
+						pos: position{line: 2065, col: 5, offset: 64591},
 						run: (*parser).callonOptSelectValue12,
 						expr: &litMatcher{
-							pos:        position{line: 2065, col: 5, offset: 64589},
+							pos:        position{line: 2065, col: 5, offset: 64591},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14322,19 +14326,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptWithClause",
-			pos:  position{line: 2067, col: 1, offset: 64632},
+			pos:  position{line: 2067, col: 1, offset: 64634},
 			expr: &choiceExpr{
-				pos: position{line: 2068, col: 5, offset: 64651},
+				pos: position{line: 2068, col: 5, offset: 64653},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2068, col: 5, offset: 64651},
+						pos:  position{line: 2068, col: 5, offset: 64653},
 						name: "WithClause",
 					},
 					&actionExpr{
-						pos: position{line: 2069, col: 5, offset: 64666},
+						pos: position{line: 2069, col: 5, offset: 64668},
 						run: (*parser).callonOptWithClause3,
 						expr: &litMatcher{
-							pos:        position{line: 2069, col: 5, offset: 64666},
+							pos:        position{line: 2069, col: 5, offset: 64668},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14347,39 +14351,39 @@ var g = &grammar{
 		},
 		{
 			name: "WithClause",
-			pos:  position{line: 2071, col: 1, offset: 64699},
+			pos:  position{line: 2071, col: 1, offset: 64701},
 			expr: &actionExpr{
-				pos: position{line: 2072, col: 5, offset: 64715},
+				pos: position{line: 2072, col: 5, offset: 64717},
 				run: (*parser).callonWithClause1,
 				expr: &seqExpr{
-					pos: position{line: 2072, col: 5, offset: 64715},
+					pos: position{line: 2072, col: 5, offset: 64717},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2072, col: 5, offset: 64715},
+							pos:  position{line: 2072, col: 5, offset: 64717},
 							name: "WITH",
 						},
 						&labeledExpr{
-							pos:   position{line: 2072, col: 10, offset: 64720},
+							pos:   position{line: 2072, col: 10, offset: 64722},
 							label: "r",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2072, col: 12, offset: 64722},
+								pos:  position{line: 2072, col: 12, offset: 64724},
 								name: "OptRecursive",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2072, col: 25, offset: 64735},
+							pos:  position{line: 2072, col: 25, offset: 64737},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2072, col: 27, offset: 64737},
+							pos:   position{line: 2072, col: 27, offset: 64739},
 							label: "ctes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2072, col: 32, offset: 64742},
+								pos:  position{line: 2072, col: 32, offset: 64744},
 								name: "CteList",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2072, col: 40, offset: 64750},
+							pos:  position{line: 2072, col: 40, offset: 64752},
 							name: "__",
 						},
 					},
@@ -14390,32 +14394,32 @@ var g = &grammar{
 		},
 		{
 			name: "OptRecursive",
-			pos:  position{line: 2081, col: 1, offset: 64930},
+			pos:  position{line: 2081, col: 1, offset: 64932},
 			expr: &choiceExpr{
-				pos: position{line: 2082, col: 5, offset: 64948},
+				pos: position{line: 2082, col: 5, offset: 64950},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2082, col: 5, offset: 64948},
+						pos: position{line: 2082, col: 5, offset: 64950},
 						run: (*parser).callonOptRecursive2,
 						expr: &seqExpr{
-							pos: position{line: 2082, col: 5, offset: 64948},
+							pos: position{line: 2082, col: 5, offset: 64950},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2082, col: 5, offset: 64948},
+									pos:  position{line: 2082, col: 5, offset: 64950},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2082, col: 7, offset: 64950},
+									pos:  position{line: 2082, col: 7, offset: 64952},
 									name: "RECURSIVE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2083, col: 5, offset: 64986},
+						pos: position{line: 2083, col: 5, offset: 64988},
 						run: (*parser).callonOptRecursive6,
 						expr: &litMatcher{
-							pos:        position{line: 2083, col: 5, offset: 64986},
+							pos:        position{line: 2083, col: 5, offset: 64988},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14428,51 +14432,51 @@ var g = &grammar{
 		},
 		{
 			name: "CteList",
-			pos:  position{line: 2085, col: 1, offset: 65025},
+			pos:  position{line: 2085, col: 1, offset: 65027},
 			expr: &actionExpr{
-				pos: position{line: 2085, col: 11, offset: 65035},
+				pos: position{line: 2085, col: 11, offset: 65037},
 				run: (*parser).callonCteList1,
 				expr: &seqExpr{
-					pos: position{line: 2085, col: 11, offset: 65035},
+					pos: position{line: 2085, col: 11, offset: 65037},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2085, col: 11, offset: 65035},
+							pos:   position{line: 2085, col: 11, offset: 65037},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2085, col: 17, offset: 65041},
+								pos:  position{line: 2085, col: 17, offset: 65043},
 								name: "Cte",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2085, col: 21, offset: 65045},
+							pos:   position{line: 2085, col: 21, offset: 65047},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2085, col: 26, offset: 65050},
+								pos: position{line: 2085, col: 26, offset: 65052},
 								expr: &actionExpr{
-									pos: position{line: 2085, col: 28, offset: 65052},
+									pos: position{line: 2085, col: 28, offset: 65054},
 									run: (*parser).callonCteList7,
 									expr: &seqExpr{
-										pos: position{line: 2085, col: 28, offset: 65052},
+										pos: position{line: 2085, col: 28, offset: 65054},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2085, col: 28, offset: 65052},
+												pos:  position{line: 2085, col: 28, offset: 65054},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2085, col: 31, offset: 65055},
+												pos:        position{line: 2085, col: 31, offset: 65057},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2085, col: 35, offset: 65059},
+												pos:  position{line: 2085, col: 35, offset: 65061},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2085, col: 38, offset: 65062},
+												pos:   position{line: 2085, col: 38, offset: 65064},
 												label: "cte",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2085, col: 42, offset: 65066},
+													pos:  position{line: 2085, col: 42, offset: 65068},
 													name: "Cte",
 												},
 											},
@@ -14489,65 +14493,65 @@ var g = &grammar{
 		},
 		{
 			name: "Cte",
-			pos:  position{line: 2089, col: 1, offset: 65135},
+			pos:  position{line: 2089, col: 1, offset: 65137},
 			expr: &actionExpr{
-				pos: position{line: 2090, col: 5, offset: 65143},
+				pos: position{line: 2090, col: 5, offset: 65145},
 				run: (*parser).callonCte1,
 				expr: &seqExpr{
-					pos: position{line: 2090, col: 5, offset: 65143},
+					pos: position{line: 2090, col: 5, offset: 65145},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2090, col: 5, offset: 65143},
+							pos:   position{line: 2090, col: 5, offset: 65145},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2090, col: 10, offset: 65148},
+								pos:  position{line: 2090, col: 10, offset: 65150},
 								name: "SQLIdentifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2090, col: 24, offset: 65162},
+							pos:  position{line: 2090, col: 24, offset: 65164},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2090, col: 26, offset: 65164},
+							pos:  position{line: 2090, col: 26, offset: 65166},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 2090, col: 29, offset: 65167},
+							pos:   position{line: 2090, col: 29, offset: 65169},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2090, col: 31, offset: 65169},
+								pos:  position{line: 2090, col: 31, offset: 65171},
 								name: "OptMaterialized",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2090, col: 47, offset: 65185},
+							pos:  position{line: 2090, col: 47, offset: 65187},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2090, col: 50, offset: 65188},
+							pos:        position{line: 2090, col: 50, offset: 65190},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2090, col: 54, offset: 65192},
+							pos:  position{line: 2090, col: 54, offset: 65194},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2090, col: 57, offset: 65195},
+							pos:   position{line: 2090, col: 57, offset: 65197},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2090, col: 59, offset: 65197},
+								pos:  position{line: 2090, col: 59, offset: 65199},
 								name: "SQLPipe",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2090, col: 67, offset: 65205},
+							pos:  position{line: 2090, col: 67, offset: 65207},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2090, col: 70, offset: 65208},
+							pos:        position{line: 2090, col: 70, offset: 65210},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -14560,65 +14564,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptMaterialized",
-			pos:  position{line: 2099, col: 1, offset: 65391},
+			pos:  position{line: 2099, col: 1, offset: 65393},
 			expr: &choiceExpr{
-				pos: position{line: 2100, col: 5, offset: 65412},
+				pos: position{line: 2100, col: 5, offset: 65414},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2100, col: 5, offset: 65412},
+						pos: position{line: 2100, col: 5, offset: 65414},
 						run: (*parser).callonOptMaterialized2,
 						expr: &seqExpr{
-							pos: position{line: 2100, col: 5, offset: 65412},
+							pos: position{line: 2100, col: 5, offset: 65414},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2100, col: 5, offset: 65412},
+									pos:  position{line: 2100, col: 5, offset: 65414},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2100, col: 7, offset: 65414},
+									pos:  position{line: 2100, col: 7, offset: 65416},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2100, col: 20, offset: 65427},
+									pos:  position{line: 2100, col: 20, offset: 65429},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2101, col: 5, offset: 65466},
+						pos: position{line: 2101, col: 5, offset: 65468},
 						run: (*parser).callonOptMaterialized7,
 						expr: &seqExpr{
-							pos: position{line: 2101, col: 5, offset: 65466},
+							pos: position{line: 2101, col: 5, offset: 65468},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2101, col: 5, offset: 65466},
+									pos:  position{line: 2101, col: 5, offset: 65468},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2101, col: 7, offset: 65468},
+									pos:  position{line: 2101, col: 7, offset: 65470},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2101, col: 11, offset: 65472},
+									pos:  position{line: 2101, col: 11, offset: 65474},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2101, col: 13, offset: 65474},
+									pos:  position{line: 2101, col: 13, offset: 65476},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2101, col: 26, offset: 65487},
+									pos:  position{line: 2101, col: 26, offset: 65489},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2102, col: 5, offset: 65518},
+						pos: position{line: 2102, col: 5, offset: 65520},
 						run: (*parser).callonOptMaterialized14,
 						expr: &litMatcher{
-							pos:        position{line: 2102, col: 5, offset: 65518},
+							pos:        position{line: 2102, col: 5, offset: 65520},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14631,25 +14635,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAllClause",
-			pos:  position{line: 2104, col: 1, offset: 65573},
+			pos:  position{line: 2104, col: 1, offset: 65575},
 			expr: &choiceExpr{
-				pos: position{line: 2105, col: 5, offset: 65590},
+				pos: position{line: 2105, col: 5, offset: 65592},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 2105, col: 5, offset: 65590},
+						pos: position{line: 2105, col: 5, offset: 65592},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2105, col: 5, offset: 65590},
+								pos:  position{line: 2105, col: 5, offset: 65592},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2105, col: 7, offset: 65592},
+								pos:  position{line: 2105, col: 7, offset: 65594},
 								name: "ALL",
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 2106, col: 5, offset: 65601},
+						pos:        position{line: 2106, col: 5, offset: 65603},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -14661,25 +14665,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptFromClause",
-			pos:  position{line: 2108, col: 1, offset: 65605},
+			pos:  position{line: 2108, col: 1, offset: 65607},
 			expr: &choiceExpr{
-				pos: position{line: 2109, col: 5, offset: 65623},
+				pos: position{line: 2109, col: 5, offset: 65625},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2109, col: 5, offset: 65623},
+						pos: position{line: 2109, col: 5, offset: 65625},
 						run: (*parser).callonOptFromClause2,
 						expr: &seqExpr{
-							pos: position{line: 2109, col: 5, offset: 65623},
+							pos: position{line: 2109, col: 5, offset: 65625},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2109, col: 5, offset: 65623},
+									pos:  position{line: 2109, col: 5, offset: 65625},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2109, col: 7, offset: 65625},
+									pos:   position{line: 2109, col: 7, offset: 65627},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2109, col: 12, offset: 65630},
+										pos:  position{line: 2109, col: 12, offset: 65632},
 										name: "FromOp",
 									},
 								},
@@ -14687,10 +14691,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2112, col: 5, offset: 65672},
+						pos: position{line: 2112, col: 5, offset: 65674},
 						run: (*parser).callonOptFromClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2112, col: 5, offset: 65672},
+							pos:        position{line: 2112, col: 5, offset: 65674},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14703,27 +14707,27 @@ var g = &grammar{
 		},
 		{
 			name: "OptWhereClause",
-			pos:  position{line: 2114, col: 1, offset: 65713},
+			pos:  position{line: 2114, col: 1, offset: 65715},
 			expr: &choiceExpr{
-				pos: position{line: 2115, col: 5, offset: 65732},
+				pos: position{line: 2115, col: 5, offset: 65734},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2115, col: 5, offset: 65732},
+						pos: position{line: 2115, col: 5, offset: 65734},
 						run: (*parser).callonOptWhereClause2,
 						expr: &labeledExpr{
-							pos:   position{line: 2115, col: 5, offset: 65732},
+							pos:   position{line: 2115, col: 5, offset: 65734},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2115, col: 11, offset: 65738},
+								pos:  position{line: 2115, col: 11, offset: 65740},
 								name: "WhereClause",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2116, col: 5, offset: 65780},
+						pos: position{line: 2116, col: 5, offset: 65782},
 						run: (*parser).callonOptWhereClause5,
 						expr: &litMatcher{
-							pos:        position{line: 2116, col: 5, offset: 65780},
+							pos:        position{line: 2116, col: 5, offset: 65782},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14736,25 +14740,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptGroupClause",
-			pos:  position{line: 2118, col: 1, offset: 65825},
+			pos:  position{line: 2118, col: 1, offset: 65827},
 			expr: &choiceExpr{
-				pos: position{line: 2119, col: 5, offset: 65844},
+				pos: position{line: 2119, col: 5, offset: 65846},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2119, col: 5, offset: 65844},
+						pos: position{line: 2119, col: 5, offset: 65846},
 						run: (*parser).callonOptGroupClause2,
 						expr: &seqExpr{
-							pos: position{line: 2119, col: 5, offset: 65844},
+							pos: position{line: 2119, col: 5, offset: 65846},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2119, col: 5, offset: 65844},
+									pos:  position{line: 2119, col: 5, offset: 65846},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2119, col: 7, offset: 65846},
+									pos:   position{line: 2119, col: 7, offset: 65848},
 									label: "group",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2119, col: 13, offset: 65852},
+										pos:  position{line: 2119, col: 13, offset: 65854},
 										name: "GroupClause",
 									},
 								},
@@ -14762,10 +14766,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2120, col: 5, offset: 65890},
+						pos: position{line: 2120, col: 5, offset: 65892},
 						run: (*parser).callonOptGroupClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2120, col: 5, offset: 65890},
+							pos:        position{line: 2120, col: 5, offset: 65892},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14778,34 +14782,34 @@ var g = &grammar{
 		},
 		{
 			name: "GroupClause",
-			pos:  position{line: 2122, col: 1, offset: 65931},
+			pos:  position{line: 2122, col: 1, offset: 65933},
 			expr: &actionExpr{
-				pos: position{line: 2123, col: 5, offset: 65947},
+				pos: position{line: 2123, col: 5, offset: 65949},
 				run: (*parser).callonGroupClause1,
 				expr: &seqExpr{
-					pos: position{line: 2123, col: 5, offset: 65947},
+					pos: position{line: 2123, col: 5, offset: 65949},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2123, col: 5, offset: 65947},
+							pos:  position{line: 2123, col: 5, offset: 65949},
 							name: "GROUP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2123, col: 11, offset: 65953},
+							pos:  position{line: 2123, col: 11, offset: 65955},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2123, col: 13, offset: 65955},
+							pos:  position{line: 2123, col: 13, offset: 65957},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2123, col: 16, offset: 65958},
+							pos:  position{line: 2123, col: 16, offset: 65960},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2123, col: 18, offset: 65960},
+							pos:   position{line: 2123, col: 18, offset: 65962},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2123, col: 23, offset: 65965},
+								pos:  position{line: 2123, col: 23, offset: 65967},
 								name: "GroupByList",
 							},
 						},
@@ -14817,51 +14821,51 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByList",
-			pos:  position{line: 2125, col: 1, offset: 65999},
+			pos:  position{line: 2125, col: 1, offset: 66001},
 			expr: &actionExpr{
-				pos: position{line: 2126, col: 5, offset: 66016},
+				pos: position{line: 2126, col: 5, offset: 66018},
 				run: (*parser).callonGroupByList1,
 				expr: &seqExpr{
-					pos: position{line: 2126, col: 5, offset: 66016},
+					pos: position{line: 2126, col: 5, offset: 66018},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2126, col: 5, offset: 66016},
+							pos:   position{line: 2126, col: 5, offset: 66018},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2126, col: 11, offset: 66022},
+								pos:  position{line: 2126, col: 11, offset: 66024},
 								name: "GroupByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2126, col: 23, offset: 66034},
+							pos:   position{line: 2126, col: 23, offset: 66036},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2126, col: 28, offset: 66039},
+								pos: position{line: 2126, col: 28, offset: 66041},
 								expr: &actionExpr{
-									pos: position{line: 2126, col: 30, offset: 66041},
+									pos: position{line: 2126, col: 30, offset: 66043},
 									run: (*parser).callonGroupByList7,
 									expr: &seqExpr{
-										pos: position{line: 2126, col: 30, offset: 66041},
+										pos: position{line: 2126, col: 30, offset: 66043},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2126, col: 30, offset: 66041},
+												pos:  position{line: 2126, col: 30, offset: 66043},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2126, col: 33, offset: 66044},
+												pos:        position{line: 2126, col: 33, offset: 66046},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2126, col: 37, offset: 66048},
+												pos:  position{line: 2126, col: 37, offset: 66050},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2126, col: 40, offset: 66051},
+												pos:   position{line: 2126, col: 40, offset: 66053},
 												label: "g",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2126, col: 42, offset: 66053},
+													pos:  position{line: 2126, col: 42, offset: 66055},
 													name: "GroupByItem",
 												},
 											},
@@ -14878,9 +14882,9 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByItem",
-			pos:  position{line: 2130, col: 1, offset: 66134},
+			pos:  position{line: 2130, col: 1, offset: 66136},
 			expr: &ruleRefExpr{
-				pos:  position{line: 2130, col: 15, offset: 66148},
+				pos:  position{line: 2130, col: 15, offset: 66150},
 				name: "Expr",
 			},
 			leader:        false,
@@ -14888,25 +14892,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptHavingClause",
-			pos:  position{line: 2132, col: 1, offset: 66154},
+			pos:  position{line: 2132, col: 1, offset: 66156},
 			expr: &choiceExpr{
-				pos: position{line: 2133, col: 5, offset: 66174},
+				pos: position{line: 2133, col: 5, offset: 66176},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2133, col: 5, offset: 66174},
+						pos: position{line: 2133, col: 5, offset: 66176},
 						run: (*parser).callonOptHavingClause2,
 						expr: &seqExpr{
-							pos: position{line: 2133, col: 5, offset: 66174},
+							pos: position{line: 2133, col: 5, offset: 66176},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2133, col: 5, offset: 66174},
+									pos:  position{line: 2133, col: 5, offset: 66176},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2133, col: 7, offset: 66176},
+									pos:   position{line: 2133, col: 7, offset: 66178},
 									label: "h",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2133, col: 9, offset: 66178},
+										pos:  position{line: 2133, col: 9, offset: 66180},
 										name: "HavingClause",
 									},
 								},
@@ -14914,10 +14918,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2134, col: 5, offset: 66213},
+						pos: position{line: 2134, col: 5, offset: 66215},
 						run: (*parser).callonOptHavingClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2134, col: 5, offset: 66213},
+							pos:        position{line: 2134, col: 5, offset: 66215},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14930,26 +14934,26 @@ var g = &grammar{
 		},
 		{
 			name: "HavingClause",
-			pos:  position{line: 2136, col: 1, offset: 66237},
+			pos:  position{line: 2136, col: 1, offset: 66239},
 			expr: &actionExpr{
-				pos: position{line: 2137, col: 5, offset: 66254},
+				pos: position{line: 2137, col: 5, offset: 66256},
 				run: (*parser).callonHavingClause1,
 				expr: &seqExpr{
-					pos: position{line: 2137, col: 5, offset: 66254},
+					pos: position{line: 2137, col: 5, offset: 66256},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2137, col: 5, offset: 66254},
+							pos:  position{line: 2137, col: 5, offset: 66256},
 							name: "HAVING",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2137, col: 12, offset: 66261},
+							pos:  position{line: 2137, col: 12, offset: 66263},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2137, col: 14, offset: 66263},
+							pos:   position{line: 2137, col: 14, offset: 66265},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2137, col: 16, offset: 66265},
+								pos:  position{line: 2137, col: 16, offset: 66267},
 								name: "Expr",
 							},
 						},
@@ -14961,16 +14965,16 @@ var g = &grammar{
 		},
 		{
 			name: "JoinOperation",
-			pos:  position{line: 2139, col: 1, offset: 66289},
+			pos:  position{line: 2139, col: 1, offset: 66291},
 			expr: &choiceExpr{
-				pos: position{line: 2140, col: 5, offset: 66307},
+				pos: position{line: 2140, col: 5, offset: 66309},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2140, col: 5, offset: 66307},
+						pos:  position{line: 2140, col: 5, offset: 66309},
 						name: "CrossJoin",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2141, col: 5, offset: 66321},
+						pos:  position{line: 2141, col: 5, offset: 66323},
 						name: "ConditionJoin",
 					},
 				},
@@ -14980,30 +14984,30 @@ var g = &grammar{
 		},
 		{
 			name: "CrossJoin",
-			pos:  position{line: 2143, col: 1, offset: 66336},
+			pos:  position{line: 2143, col: 1, offset: 66338},
 			expr: &actionExpr{
-				pos: position{line: 2144, col: 5, offset: 66350},
+				pos: position{line: 2144, col: 5, offset: 66352},
 				run: (*parser).callonCrossJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2144, col: 5, offset: 66350},
+					pos: position{line: 2144, col: 5, offset: 66352},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2144, col: 5, offset: 66350},
+							pos:   position{line: 2144, col: 5, offset: 66352},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2144, col: 10, offset: 66355},
+								pos:  position{line: 2144, col: 10, offset: 66357},
 								name: "FromElem",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2144, col: 19, offset: 66364},
+							pos:  position{line: 2144, col: 19, offset: 66366},
 							name: "CrossJoinOp",
 						},
 						&labeledExpr{
-							pos:   position{line: 2144, col: 31, offset: 66376},
+							pos:   position{line: 2144, col: 31, offset: 66378},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2144, col: 37, offset: 66382},
+								pos:  position{line: 2144, col: 37, offset: 66384},
 								name: "FromElem",
 							},
 						},
@@ -15015,50 +15019,50 @@ var g = &grammar{
 		},
 		{
 			name: "CrossJoinOp",
-			pos:  position{line: 2153, col: 1, offset: 66584},
+			pos:  position{line: 2153, col: 1, offset: 66586},
 			expr: &choiceExpr{
-				pos: position{line: 2154, col: 5, offset: 66601},
+				pos: position{line: 2154, col: 5, offset: 66603},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 2154, col: 5, offset: 66601},
+						pos: position{line: 2154, col: 5, offset: 66603},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2154, col: 5, offset: 66601},
+								pos:  position{line: 2154, col: 5, offset: 66603},
 								name: "__",
 							},
 							&litMatcher{
-								pos:        position{line: 2154, col: 8, offset: 66604},
+								pos:        position{line: 2154, col: 8, offset: 66606},
 								val:        ",",
 								ignoreCase: false,
 								want:       "\",\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2154, col: 12, offset: 66608},
+								pos:  position{line: 2154, col: 12, offset: 66610},
 								name: "__",
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 2155, col: 5, offset: 66616},
+						pos: position{line: 2155, col: 5, offset: 66618},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2155, col: 5, offset: 66616},
+								pos:  position{line: 2155, col: 5, offset: 66618},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2155, col: 7, offset: 66618},
+								pos:  position{line: 2155, col: 7, offset: 66620},
 								name: "CROSS",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2155, col: 13, offset: 66624},
+								pos:  position{line: 2155, col: 13, offset: 66626},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2155, col: 15, offset: 66626},
+								pos:  position{line: 2155, col: 15, offset: 66628},
 								name: "JOIN",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2155, col: 20, offset: 66631},
+								pos:  position{line: 2155, col: 20, offset: 66633},
 								name: "_",
 							},
 						},
@@ -15070,46 +15074,50 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionJoin",
-			pos:  position{line: 2157, col: 1, offset: 66635},
+			pos:  position{line: 2157, col: 1, offset: 66637},
 			expr: &actionExpr{
-				pos: position{line: 2158, col: 5, offset: 66653},
+				pos: position{line: 2158, col: 5, offset: 66655},
 				run: (*parser).callonConditionJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2158, col: 5, offset: 66653},
+					pos: position{line: 2158, col: 5, offset: 66655},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2158, col: 5, offset: 66653},
+							pos:   position{line: 2158, col: 5, offset: 66655},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2158, col: 10, offset: 66658},
+								pos:  position{line: 2158, col: 10, offset: 66660},
 								name: "FromElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2158, col: 19, offset: 66667},
+							pos:   position{line: 2158, col: 19, offset: 66669},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2158, col: 25, offset: 66673},
+								pos:  position{line: 2158, col: 25, offset: 66675},
 								name: "SQLJoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2158, col: 38, offset: 66686},
+							pos:  position{line: 2158, col: 38, offset: 66688},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2158, col: 40, offset: 66688},
+							pos:   position{line: 2158, col: 40, offset: 66690},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2158, col: 46, offset: 66694},
+								pos:  position{line: 2158, col: 46, offset: 66696},
 								name: "FromElem",
 							},
 						},
+						&ruleRefExpr{
+							pos:  position{line: 2158, col: 55, offset: 66705},
+							name: "_",
+						},
 						&labeledExpr{
-							pos:   position{line: 2158, col: 55, offset: 66703},
+							pos:   position{line: 2158, col: 57, offset: 66707},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2158, col: 57, offset: 66705},
+								pos:  position{line: 2158, col: 59, offset: 66709},
 								name: "JoinExpr",
 							},
 						},
@@ -15121,161 +15129,161 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoinStyle",
-			pos:  position{line: 2169, col: 1, offset: 66974},
+			pos:  position{line: 2169, col: 1, offset: 66978},
 			expr: &choiceExpr{
-				pos: position{line: 2170, col: 5, offset: 66992},
+				pos: position{line: 2170, col: 5, offset: 66996},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2170, col: 5, offset: 66992},
+						pos: position{line: 2170, col: 5, offset: 66996},
 						run: (*parser).callonSQLJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 2170, col: 5, offset: 66992},
+							pos: position{line: 2170, col: 5, offset: 66996},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 2170, col: 5, offset: 66992},
+									pos: position{line: 2170, col: 5, offset: 66996},
 									expr: &seqExpr{
-										pos: position{line: 2170, col: 6, offset: 66993},
+										pos: position{line: 2170, col: 6, offset: 66997},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2170, col: 6, offset: 66993},
+												pos:  position{line: 2170, col: 6, offset: 66997},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2170, col: 8, offset: 66995},
+												pos:  position{line: 2170, col: 8, offset: 66999},
 												name: "INNER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2170, col: 16, offset: 67003},
+									pos:  position{line: 2170, col: 16, offset: 67007},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2170, col: 18, offset: 67005},
+									pos:  position{line: 2170, col: 18, offset: 67009},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2171, col: 5, offset: 67050},
+						pos: position{line: 2171, col: 5, offset: 67054},
 						run: (*parser).callonSQLJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 2171, col: 5, offset: 67050},
+							pos: position{line: 2171, col: 5, offset: 67054},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2171, col: 5, offset: 67050},
+									pos:  position{line: 2171, col: 5, offset: 67054},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2171, col: 7, offset: 67052},
+									pos:  position{line: 2171, col: 7, offset: 67056},
 									name: "FULL",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2171, col: 12, offset: 67057},
+									pos: position{line: 2171, col: 12, offset: 67061},
 									expr: &seqExpr{
-										pos: position{line: 2171, col: 13, offset: 67058},
+										pos: position{line: 2171, col: 13, offset: 67062},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2171, col: 13, offset: 67058},
+												pos:  position{line: 2171, col: 13, offset: 67062},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2171, col: 15, offset: 67060},
+												pos:  position{line: 2171, col: 15, offset: 67064},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2171, col: 23, offset: 67068},
+									pos:  position{line: 2171, col: 23, offset: 67072},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2171, col: 25, offset: 67070},
+									pos:  position{line: 2171, col: 25, offset: 67074},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2172, col: 5, offset: 67104},
+						pos: position{line: 2172, col: 5, offset: 67108},
 						run: (*parser).callonSQLJoinStyle20,
 						expr: &seqExpr{
-							pos: position{line: 2172, col: 5, offset: 67104},
+							pos: position{line: 2172, col: 5, offset: 67108},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2172, col: 5, offset: 67104},
+									pos:  position{line: 2172, col: 5, offset: 67108},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2172, col: 7, offset: 67106},
+									pos:  position{line: 2172, col: 7, offset: 67110},
 									name: "LEFT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2172, col: 12, offset: 67111},
+									pos: position{line: 2172, col: 12, offset: 67115},
 									expr: &seqExpr{
-										pos: position{line: 2172, col: 13, offset: 67112},
+										pos: position{line: 2172, col: 13, offset: 67116},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2172, col: 13, offset: 67112},
+												pos:  position{line: 2172, col: 13, offset: 67116},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2172, col: 15, offset: 67114},
+												pos:  position{line: 2172, col: 15, offset: 67118},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2172, col: 23, offset: 67122},
+									pos:  position{line: 2172, col: 23, offset: 67126},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2172, col: 25, offset: 67124},
+									pos:  position{line: 2172, col: 25, offset: 67128},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2173, col: 5, offset: 67158},
+						pos: position{line: 2173, col: 5, offset: 67162},
 						run: (*parser).callonSQLJoinStyle30,
 						expr: &seqExpr{
-							pos: position{line: 2173, col: 5, offset: 67158},
+							pos: position{line: 2173, col: 5, offset: 67162},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2173, col: 5, offset: 67158},
+									pos:  position{line: 2173, col: 5, offset: 67162},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2173, col: 7, offset: 67160},
+									pos:  position{line: 2173, col: 7, offset: 67164},
 									name: "RIGHT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2173, col: 13, offset: 67166},
+									pos: position{line: 2173, col: 13, offset: 67170},
 									expr: &seqExpr{
-										pos: position{line: 2173, col: 14, offset: 67167},
+										pos: position{line: 2173, col: 14, offset: 67171},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2173, col: 14, offset: 67167},
+												pos:  position{line: 2173, col: 14, offset: 67171},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2173, col: 16, offset: 67169},
+												pos:  position{line: 2173, col: 16, offset: 67173},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2173, col: 24, offset: 67177},
+									pos:  position{line: 2173, col: 24, offset: 67181},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2173, col: 26, offset: 67179},
+									pos:  position{line: 2173, col: 26, offset: 67183},
 									name: "JOIN",
 								},
 							},
@@ -15288,33 +15296,29 @@ var g = &grammar{
 		},
 		{
 			name: "JoinExpr",
-			pos:  position{line: 2175, col: 1, offset: 67211},
+			pos:  position{line: 2175, col: 1, offset: 67215},
 			expr: &choiceExpr{
-				pos: position{line: 2176, col: 5, offset: 67225},
+				pos: position{line: 2176, col: 5, offset: 67229},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2176, col: 5, offset: 67225},
+						pos: position{line: 2176, col: 5, offset: 67229},
 						run: (*parser).callonJoinExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2176, col: 5, offset: 67225},
+							pos: position{line: 2176, col: 5, offset: 67229},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2176, col: 5, offset: 67225},
-									name: "_",
-								},
-								&ruleRefExpr{
-									pos:  position{line: 2176, col: 7, offset: 67227},
+									pos:  position{line: 2176, col: 5, offset: 67229},
 									name: "ON",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2176, col: 10, offset: 67230},
+									pos:  position{line: 2176, col: 8, offset: 67232},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2176, col: 12, offset: 67232},
+									pos:   position{line: 2176, col: 10, offset: 67234},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2176, col: 14, offset: 67234},
+										pos:  position{line: 2176, col: 12, offset: 67236},
 										name: "Expr",
 									},
 								},
@@ -15322,47 +15326,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2183, col: 5, offset: 67389},
-						run: (*parser).callonJoinExpr9,
+						pos: position{line: 2183, col: 5, offset: 67391},
+						run: (*parser).callonJoinExpr8,
 						expr: &seqExpr{
-							pos: position{line: 2183, col: 5, offset: 67389},
+							pos: position{line: 2183, col: 5, offset: 67391},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2183, col: 5, offset: 67389},
-									name: "_",
-								},
-								&ruleRefExpr{
-									pos:  position{line: 2183, col: 7, offset: 67391},
+									pos:  position{line: 2183, col: 5, offset: 67391},
 									name: "USING",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2183, col: 13, offset: 67397},
+									pos:  position{line: 2183, col: 11, offset: 67397},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2183, col: 16, offset: 67400},
+									pos:        position{line: 2183, col: 14, offset: 67400},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2183, col: 20, offset: 67404},
+									pos:  position{line: 2183, col: 18, offset: 67404},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 2183, col: 23, offset: 67407},
+									pos:   position{line: 2183, col: 21, offset: 67407},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2183, col: 30, offset: 67414},
+										pos:  position{line: 2183, col: 28, offset: 67414},
 										name: "Lvals",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2183, col: 36, offset: 67420},
+									pos:  position{line: 2183, col: 34, offset: 67420},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2183, col: 39, offset: 67423},
+									pos:        position{line: 2183, col: 37, offset: 67423},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -23526,7 +23526,7 @@ func (p *parser) callonJoinExpr2() (any, error) {
 	return p.cur.onJoinExpr2(stack["e"])
 }
 
-func (c *current) onJoinExpr9(fields any) (any, error) {
+func (c *current) onJoinExpr8(fields any) (any, error) {
 	return &ast.JoinUsingExpr{
 		Kind:   "JoinUsingExpr",
 		Fields: sliceOf[ast.Expr](fields),
@@ -23535,10 +23535,10 @@ func (c *current) onJoinExpr9(fields any) (any, error) {
 
 }
 
-func (p *parser) callonJoinExpr9() (any, error) {
+func (p *parser) callonJoinExpr8() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onJoinExpr9(stack["fields"])
+	return p.cur.onJoinExpr8(stack["fields"])
 }
 
 func (c *current) onOptOrdinality2() (any, error) {

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -578,7 +578,7 @@ ShapeOp
     }
 
 JoinOp
-  = style:JoinStyle JOIN rightInput:JoinRightInput e:JoinExpr optArgs:(_ FlexAssignments)? {
+  = style:JoinStyle JOIN rightInput:JoinRightInput _ e:JoinExpr optArgs:(_ FlexAssignments)? {
       o := &ast.Join{
         Kind: "Join",
         Style: style.(string),
@@ -2155,7 +2155,7 @@ CrossJoinOp
   / _ CROSS _ JOIN _ 
 
 ConditionJoin
-  = left:FromElem style:SQLJoinStyle _ right:FromElem e:JoinExpr {
+  = left:FromElem style:SQLJoinStyle _ right:FromElem _ e:JoinExpr {
         return &ast.SQLJoin{
             Kind: "SQLJoin",
             Style: style.(string),
@@ -2173,14 +2173,14 @@ SQLJoinStyle
   / _ RIGHT (_ OUTER)? _ JOIN   { return "right", nil }
 
 JoinExpr 
-  = _ ON _ e:Expr { 
+  = ON _ e:Expr { 
         return &ast.JoinOnExpr{
             Kind: "JoinOnExpr", 
             Expr: e.(ast.Expr),
             Loc: loc(c),
         }, nil
     }
-  / _ USING __ "(" __ fields:Lvals __ ")" {
+  / USING __ "(" __ fields:Lvals __ ")" {
         return &ast.JoinUsingExpr{
             Kind: "JoinUsingExpr",
             Fields: sliceOf[ast.Expr](fields),


### PR DESCRIPTION
The JoinCond parse rules include a space prefix so reported errors include the space. Fix this.