### PR TITLE
simplify text entity syntax

### DIFF
--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -4274,7 +4274,7 @@ var g = &grammar{
 					},
 				},
 			},
-			leader:        true,
+			leader:        false,
 			leftRecursive: true,
 		},
 		{
@@ -4593,9 +4593,12 @@ var g = &grammar{
 										ignoreCase: false,
 										want:       "\"/\"",
 									},
-									&ruleRefExpr{
-										pos:  position{line: 704, col: 8, offset: 16476},
-										name: "TextChars",
+									&zeroOrOneExpr{
+										pos: position{line: 704, col: 8, offset: 16476},
+										expr: &ruleRefExpr{
+											pos:  position{line: 704, col: 8, offset: 16476},
+											name: "TextChars",
+										},
 									},
 								},
 							},
@@ -4608,27 +4611,27 @@ var g = &grammar{
 		},
 		{
 			name: "TextChars",
-			pos:  position{line: 706, col: 1, offset: 16520},
+			pos:  position{line: 706, col: 1, offset: 16521},
 			expr: &actionExpr{
-				pos: position{line: 707, col: 5, offset: 16534},
+				pos: position{line: 707, col: 5, offset: 16535},
 				run: (*parser).callonTextChars1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 707, col: 5, offset: 16534},
+					pos: position{line: 707, col: 5, offset: 16535},
 					expr: &choiceExpr{
-						pos: position{line: 707, col: 6, offset: 16535},
+						pos: position{line: 707, col: 6, offset: 16536},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 707, col: 6, offset: 16535},
+								pos:  position{line: 707, col: 6, offset: 16536},
 								name: "IdentifierRest",
 							},
 							&litMatcher{
-								pos:        position{line: 707, col: 23, offset: 16552},
+								pos:        position{line: 707, col: 23, offset: 16553},
 								val:        ".",
 								ignoreCase: false,
 								want:       "\".\"",
 							},
 							&litMatcher{
-								pos:        position{line: 707, col: 29, offset: 16558},
+								pos:        position{line: 707, col: 29, offset: 16559},
 								val:        "/",
 								ignoreCase: false,
 								want:       "\"/\"",
@@ -4642,40 +4645,40 @@ var g = &grammar{
 		},
 		{
 			name: "CommitishOpArgs",
-			pos:  position{line: 709, col: 1, offset: 16596},
+			pos:  position{line: 709, col: 1, offset: 16597},
 			expr: &choiceExpr{
-				pos: position{line: 710, col: 5, offset: 16616},
+				pos: position{line: 710, col: 5, offset: 16617},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 710, col: 5, offset: 16616},
+						pos: position{line: 710, col: 5, offset: 16617},
 						run: (*parser).callonCommitishOpArgs2,
 						expr: &seqExpr{
-							pos: position{line: 710, col: 5, offset: 16616},
+							pos: position{line: 710, col: 5, offset: 16617},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 710, col: 5, offset: 16616},
+									pos:  position{line: 710, col: 5, offset: 16617},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 710, col: 8, offset: 16619},
+									pos:   position{line: 710, col: 8, offset: 16620},
 									label: "commit",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 710, col: 15, offset: 16626},
+										pos: position{line: 710, col: 15, offset: 16627},
 										expr: &ruleRefExpr{
-											pos:  position{line: 710, col: 15, offset: 16626},
+											pos:  position{line: 710, col: 15, offset: 16627},
 											name: "MetaCommitish",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 710, col: 30, offset: 16641},
+									pos:  position{line: 710, col: 30, offset: 16642},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 710, col: 33, offset: 16644},
+									pos:   position{line: 710, col: 33, offset: 16645},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 710, col: 38, offset: 16649},
+										pos:  position{line: 710, col: 38, offset: 16650},
 										name: "OpArgs",
 									},
 								},
@@ -4683,20 +4686,20 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 716, col: 5, offset: 16779},
+						pos: position{line: 716, col: 5, offset: 16780},
 						run: (*parser).callonCommitishOpArgs11,
 						expr: &seqExpr{
-							pos: position{line: 716, col: 5, offset: 16779},
+							pos: position{line: 716, col: 5, offset: 16780},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 716, col: 5, offset: 16779},
+									pos:  position{line: 716, col: 5, offset: 16780},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 716, col: 8, offset: 16782},
+									pos:   position{line: 716, col: 8, offset: 16783},
 									label: "commit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 716, col: 15, offset: 16789},
+										pos:  position{line: 716, col: 15, offset: 16790},
 										name: "MetaCommitish",
 									},
 								},
@@ -4710,31 +4713,31 @@ var g = &grammar{
 		},
 		{
 			name: "MetaCommitish",
-			pos:  position{line: 718, col: 1, offset: 16827},
+			pos:  position{line: 718, col: 1, offset: 16828},
 			expr: &choiceExpr{
-				pos: position{line: 719, col: 5, offset: 16845},
+				pos: position{line: 719, col: 5, offset: 16846},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 719, col: 5, offset: 16845},
+						pos: position{line: 719, col: 5, offset: 16846},
 						run: (*parser).callonMetaCommitish2,
 						expr: &seqExpr{
-							pos: position{line: 719, col: 5, offset: 16845},
+							pos: position{line: 719, col: 5, offset: 16846},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 719, col: 5, offset: 16845},
+									pos:   position{line: 719, col: 5, offset: 16846},
 									label: "commit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 719, col: 12, offset: 16852},
+										pos:  position{line: 719, col: 12, offset: 16853},
 										name: "Commitish",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 719, col: 22, offset: 16862},
+									pos:   position{line: 719, col: 22, offset: 16863},
 									label: "meta",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 719, col: 27, offset: 16867},
+										pos: position{line: 719, col: 27, offset: 16868},
 										expr: &ruleRefExpr{
-											pos:  position{line: 719, col: 27, offset: 16867},
+											pos:  position{line: 719, col: 27, offset: 16868},
 											name: "ColonName",
 										},
 									},
@@ -4743,13 +4746,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 726, col: 5, offset: 17091},
+						pos: position{line: 726, col: 5, offset: 17092},
 						run: (*parser).callonMetaCommitish9,
 						expr: &labeledExpr{
-							pos:   position{line: 726, col: 5, offset: 17091},
+							pos:   position{line: 726, col: 5, offset: 17092},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 726, col: 10, offset: 17096},
+								pos:  position{line: 726, col: 10, offset: 17097},
 								name: "ColonName",
 							},
 						},
@@ -4761,24 +4764,24 @@ var g = &grammar{
 		},
 		{
 			name: "Commitish",
-			pos:  position{line: 730, col: 1, offset: 17220},
+			pos:  position{line: 730, col: 1, offset: 17221},
 			expr: &actionExpr{
-				pos: position{line: 731, col: 5, offset: 17234},
+				pos: position{line: 731, col: 5, offset: 17235},
 				run: (*parser).callonCommitish1,
 				expr: &seqExpr{
-					pos: position{line: 731, col: 5, offset: 17234},
+					pos: position{line: 731, col: 5, offset: 17235},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 731, col: 5, offset: 17234},
+							pos:        position{line: 731, col: 5, offset: 17235},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 731, col: 9, offset: 17238},
+							pos:   position{line: 731, col: 9, offset: 17239},
 							label: "text",
 							expr: &ruleRefExpr{
-								pos:  position{line: 731, col: 14, offset: 17243},
+								pos:  position{line: 731, col: 14, offset: 17244},
 								name: "CommitText",
 							},
 						},
@@ -4790,19 +4793,19 @@ var g = &grammar{
 		},
 		{
 			name: "CommitText",
-			pos:  position{line: 735, col: 1, offset: 17378},
+			pos:  position{line: 735, col: 1, offset: 17379},
 			expr: &choiceExpr{
-				pos: position{line: 736, col: 5, offset: 17393},
+				pos: position{line: 736, col: 5, offset: 17394},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 736, col: 5, offset: 17393},
+						pos:  position{line: 736, col: 5, offset: 17394},
 						name: "Name",
 					},
 					&actionExpr{
-						pos: position{line: 737, col: 5, offset: 17402},
+						pos: position{line: 737, col: 5, offset: 17403},
 						run: (*parser).callonCommitText3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 737, col: 5, offset: 17402},
+							pos:  position{line: 737, col: 5, offset: 17403},
 							name: "KSUID",
 						},
 					},
@@ -4813,11 +4816,11 @@ var g = &grammar{
 		},
 		{
 			name: "KSUID",
-			pos:  position{line: 739, col: 1, offset: 17480},
+			pos:  position{line: 739, col: 1, offset: 17481},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 739, col: 9, offset: 17488},
+				pos: position{line: 739, col: 9, offset: 17489},
 				expr: &charClassMatcher{
-					pos:        position{line: 739, col: 9, offset: 17488},
+					pos:        position{line: 739, col: 9, offset: 17489},
 					val:        "[0-9a-zA-Z]",
 					ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
 					ignoreCase: false,
@@ -4829,40 +4832,40 @@ var g = &grammar{
 		},
 		{
 			name: "OpArg",
-			pos:  position{line: 741, col: 1, offset: 17502},
+			pos:  position{line: 741, col: 1, offset: 17503},
 			expr: &choiceExpr{
-				pos: position{line: 742, col: 5, offset: 17512},
+				pos: position{line: 742, col: 5, offset: 17513},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 742, col: 5, offset: 17512},
+						pos: position{line: 742, col: 5, offset: 17513},
 						run: (*parser).callonOpArg2,
 						expr: &seqExpr{
-							pos: position{line: 742, col: 5, offset: 17512},
+							pos: position{line: 742, col: 5, offset: 17513},
 							exprs: []any{
 								&andExpr{
-									pos: position{line: 742, col: 5, offset: 17512},
+									pos: position{line: 742, col: 5, offset: 17513},
 									expr: &ruleRefExpr{
-										pos:  position{line: 742, col: 6, offset: 17513},
+										pos:  position{line: 742, col: 6, offset: 17514},
 										name: "ArgNameExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 742, col: 18, offset: 17525},
+									pos:   position{line: 742, col: 18, offset: 17526},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 742, col: 22, offset: 17529},
+										pos:  position{line: 742, col: 22, offset: 17530},
 										name: "ArgName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 742, col: 30, offset: 17537},
+									pos:  position{line: 742, col: 30, offset: 17538},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 742, col: 32, offset: 17539},
+									pos:   position{line: 742, col: 32, offset: 17540},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 742, col: 34, offset: 17541},
+										pos:  position{line: 742, col: 34, offset: 17542},
 										name: "Expr",
 									},
 								},
@@ -4870,28 +4873,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 743, col: 5, offset: 17648},
+						pos: position{line: 743, col: 5, offset: 17649},
 						run: (*parser).callonOpArg11,
 						expr: &seqExpr{
-							pos: position{line: 743, col: 5, offset: 17648},
+							pos: position{line: 743, col: 5, offset: 17649},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 743, col: 5, offset: 17648},
+									pos:   position{line: 743, col: 5, offset: 17649},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 743, col: 9, offset: 17652},
+										pos:  position{line: 743, col: 9, offset: 17653},
 										name: "ArgName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 743, col: 17, offset: 17660},
+									pos:  position{line: 743, col: 17, offset: 17661},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 743, col: 19, offset: 17662},
+									pos:   position{line: 743, col: 19, offset: 17663},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 743, col: 21, offset: 17664},
+										pos:  position{line: 743, col: 21, offset: 17665},
 										name: "Text",
 									},
 								},
@@ -4905,51 +4908,51 @@ var g = &grammar{
 		},
 		{
 			name: "OpArgs",
-			pos:  position{line: 745, col: 1, offset: 17769},
+			pos:  position{line: 745, col: 1, offset: 17770},
 			expr: &actionExpr{
-				pos: position{line: 746, col: 5, offset: 17780},
+				pos: position{line: 746, col: 5, offset: 17781},
 				run: (*parser).callonOpArgs1,
 				expr: &seqExpr{
-					pos: position{line: 746, col: 5, offset: 17780},
+					pos: position{line: 746, col: 5, offset: 17781},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 746, col: 5, offset: 17780},
+							pos:        position{line: 746, col: 5, offset: 17781},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 746, col: 9, offset: 17784},
+							pos:  position{line: 746, col: 9, offset: 17785},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 746, col: 12, offset: 17787},
+							pos:   position{line: 746, col: 12, offset: 17788},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 746, col: 18, offset: 17793},
+								pos:  position{line: 746, col: 18, offset: 17794},
 								name: "OpArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 746, col: 24, offset: 17799},
+							pos:   position{line: 746, col: 24, offset: 17800},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 746, col: 29, offset: 17804},
+								pos: position{line: 746, col: 29, offset: 17805},
 								expr: &actionExpr{
-									pos: position{line: 746, col: 30, offset: 17805},
+									pos: position{line: 746, col: 30, offset: 17806},
 									run: (*parser).callonOpArgs9,
 									expr: &seqExpr{
-										pos: position{line: 746, col: 30, offset: 17805},
+										pos: position{line: 746, col: 30, offset: 17806},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 746, col: 30, offset: 17805},
+												pos:  position{line: 746, col: 30, offset: 17806},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 746, col: 32, offset: 17807},
+												pos:   position{line: 746, col: 32, offset: 17808},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 746, col: 34, offset: 17809},
+													pos:  position{line: 746, col: 34, offset: 17810},
 													name: "OpArg",
 												},
 											},
@@ -4959,11 +4962,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 746, col: 60, offset: 17835},
+							pos:  position{line: 746, col: 60, offset: 17836},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 746, col: 63, offset: 17838},
+							pos:        position{line: 746, col: 63, offset: 17839},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -4976,14 +4979,14 @@ var g = &grammar{
 		},
 		{
 			name: "ArgName",
-			pos:  position{line: 750, col: 1, offset: 17890},
+			pos:  position{line: 750, col: 1, offset: 17891},
 			expr: &actionExpr{
-				pos: position{line: 750, col: 11, offset: 17900},
+				pos: position{line: 750, col: 11, offset: 17901},
 				run: (*parser).callonArgName1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 750, col: 11, offset: 17900},
+					pos: position{line: 750, col: 11, offset: 17901},
 					expr: &ruleRefExpr{
-						pos:  position{line: 750, col: 11, offset: 17900},
+						pos:  position{line: 750, col: 11, offset: 17901},
 						name: "UnicodeLetter",
 					},
 				},
@@ -4993,20 +4996,20 @@ var g = &grammar{
 		},
 		{
 			name: "ArgNameExpr",
-			pos:  position{line: 752, col: 1, offset: 17947},
+			pos:  position{line: 752, col: 1, offset: 17948},
 			expr: &seqExpr{
-				pos: position{line: 753, col: 5, offset: 17963},
+				pos: position{line: 753, col: 5, offset: 17964},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 753, col: 5, offset: 17963},
+						pos:        position{line: 753, col: 5, offset: 17964},
 						val:        "headers",
 						ignoreCase: true,
 						want:       "\"headers\"i",
 					},
 					&notExpr{
-						pos: position{line: 753, col: 16, offset: 17974},
+						pos: position{line: 753, col: 16, offset: 17975},
 						expr: &ruleRefExpr{
-							pos:  position{line: 753, col: 17, offset: 17975},
+							pos:  position{line: 753, col: 17, offset: 17976},
 							name: "UnicodeLetter",
 						},
 					},
@@ -5017,24 +5020,24 @@ var g = &grammar{
 		},
 		{
 			name: "ColonName",
-			pos:  position{line: 755, col: 1, offset: 17990},
+			pos:  position{line: 755, col: 1, offset: 17991},
 			expr: &actionExpr{
-				pos: position{line: 756, col: 5, offset: 18004},
+				pos: position{line: 756, col: 5, offset: 18005},
 				run: (*parser).callonColonName1,
 				expr: &seqExpr{
-					pos: position{line: 756, col: 5, offset: 18004},
+					pos: position{line: 756, col: 5, offset: 18005},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 756, col: 5, offset: 18004},
+							pos:        position{line: 756, col: 5, offset: 18005},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 756, col: 9, offset: 18008},
+							pos:   position{line: 756, col: 9, offset: 18009},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 756, col: 11, offset: 18010},
+								pos:  position{line: 756, col: 11, offset: 18011},
 								name: "Name",
 							},
 						},
@@ -5046,28 +5049,28 @@ var g = &grammar{
 		},
 		{
 			name: "PassOp",
-			pos:  position{line: 758, col: 1, offset: 18034},
+			pos:  position{line: 758, col: 1, offset: 18035},
 			expr: &actionExpr{
-				pos: position{line: 759, col: 5, offset: 18045},
+				pos: position{line: 759, col: 5, offset: 18046},
 				run: (*parser).callonPassOp1,
 				expr: &seqExpr{
-					pos: position{line: 759, col: 5, offset: 18045},
+					pos: position{line: 759, col: 5, offset: 18046},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 759, col: 5, offset: 18045},
+							pos:  position{line: 759, col: 5, offset: 18046},
 							name: "PASS",
 						},
 						&notExpr{
-							pos: position{line: 759, col: 10, offset: 18050},
+							pos: position{line: 759, col: 10, offset: 18051},
 							expr: &seqExpr{
-								pos: position{line: 759, col: 12, offset: 18052},
+								pos: position{line: 759, col: 12, offset: 18053},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 759, col: 12, offset: 18052},
+										pos:  position{line: 759, col: 12, offset: 18053},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 759, col: 15, offset: 18055},
+										pos:        position{line: 759, col: 15, offset: 18056},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -5076,9 +5079,9 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 759, col: 20, offset: 18060},
+							pos: position{line: 759, col: 20, offset: 18061},
 							expr: &ruleRefExpr{
-								pos:  position{line: 759, col: 21, offset: 18061},
+								pos:  position{line: 759, col: 21, offset: 18062},
 								name: "EOKW",
 							},
 						},
@@ -5090,44 +5093,44 @@ var g = &grammar{
 		},
 		{
 			name: "ExplodeOp",
-			pos:  position{line: 765, col: 1, offset: 18252},
+			pos:  position{line: 765, col: 1, offset: 18253},
 			expr: &actionExpr{
-				pos: position{line: 766, col: 5, offset: 18266},
+				pos: position{line: 766, col: 5, offset: 18267},
 				run: (*parser).callonExplodeOp1,
 				expr: &seqExpr{
-					pos: position{line: 766, col: 5, offset: 18266},
+					pos: position{line: 766, col: 5, offset: 18267},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 766, col: 5, offset: 18266},
+							pos:  position{line: 766, col: 5, offset: 18267},
 							name: "EXPLODE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 766, col: 13, offset: 18274},
+							pos:  position{line: 766, col: 13, offset: 18275},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 766, col: 15, offset: 18276},
+							pos:   position{line: 766, col: 15, offset: 18277},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 766, col: 20, offset: 18281},
+								pos:  position{line: 766, col: 20, offset: 18282},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 766, col: 26, offset: 18287},
+							pos:   position{line: 766, col: 26, offset: 18288},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 766, col: 30, offset: 18291},
+								pos:  position{line: 766, col: 30, offset: 18292},
 								name: "TypeArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 766, col: 38, offset: 18299},
+							pos:   position{line: 766, col: 38, offset: 18300},
 							label: "as",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 766, col: 41, offset: 18302},
+								pos: position{line: 766, col: 41, offset: 18303},
 								expr: &ruleRefExpr{
-									pos:  position{line: 766, col: 41, offset: 18302},
+									pos:  position{line: 766, col: 41, offset: 18303},
 									name: "AsArg",
 								},
 							},
@@ -5140,26 +5143,26 @@ var g = &grammar{
 		},
 		{
 			name: "MergeOp",
-			pos:  position{line: 779, col: 1, offset: 18544},
+			pos:  position{line: 779, col: 1, offset: 18545},
 			expr: &actionExpr{
-				pos: position{line: 780, col: 5, offset: 18556},
+				pos: position{line: 780, col: 5, offset: 18557},
 				run: (*parser).callonMergeOp1,
 				expr: &seqExpr{
-					pos: position{line: 780, col: 5, offset: 18556},
+					pos: position{line: 780, col: 5, offset: 18557},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 780, col: 5, offset: 18556},
+							pos:  position{line: 780, col: 5, offset: 18557},
 							name: "MERGE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 780, col: 11, offset: 18562},
+							pos:  position{line: 780, col: 11, offset: 18563},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 780, col: 13, offset: 18564},
+							pos:   position{line: 780, col: 13, offset: 18565},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 780, col: 19, offset: 18570},
+								pos:  position{line: 780, col: 19, offset: 18571},
 								name: "OrderByList",
 							},
 						},
@@ -5171,59 +5174,59 @@ var g = &grammar{
 		},
 		{
 			name: "UnnestOp",
-			pos:  position{line: 788, col: 1, offset: 18712},
+			pos:  position{line: 788, col: 1, offset: 18713},
 			expr: &actionExpr{
-				pos: position{line: 789, col: 6, offset: 18726},
+				pos: position{line: 789, col: 6, offset: 18727},
 				run: (*parser).callonUnnestOp1,
 				expr: &seqExpr{
-					pos: position{line: 789, col: 6, offset: 18726},
+					pos: position{line: 789, col: 6, offset: 18727},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 789, col: 6, offset: 18726},
+							pos:  position{line: 789, col: 6, offset: 18727},
 							name: "UNNEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 789, col: 13, offset: 18733},
+							pos:  position{line: 789, col: 13, offset: 18734},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 789, col: 15, offset: 18735},
+							pos:   position{line: 789, col: 15, offset: 18736},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 789, col: 17, offset: 18737},
+								pos:  position{line: 789, col: 17, offset: 18738},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 789, col: 22, offset: 18742},
+							pos:   position{line: 789, col: 22, offset: 18743},
 							label: "body",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 789, col: 27, offset: 18747},
+								pos: position{line: 789, col: 27, offset: 18748},
 								expr: &actionExpr{
-									pos: position{line: 789, col: 28, offset: 18748},
+									pos: position{line: 789, col: 28, offset: 18749},
 									run: (*parser).callonUnnestOp9,
 									expr: &seqExpr{
-										pos: position{line: 789, col: 28, offset: 18748},
+										pos: position{line: 789, col: 28, offset: 18749},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 789, col: 28, offset: 18748},
+												pos:  position{line: 789, col: 28, offset: 18749},
 												name: "_",
 											},
 											&litMatcher{
-												pos:        position{line: 789, col: 30, offset: 18750},
+												pos:        position{line: 789, col: 30, offset: 18751},
 												val:        "into",
 												ignoreCase: true,
 												want:       "\"into\"i",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 789, col: 38, offset: 18758},
+												pos:  position{line: 789, col: 38, offset: 18759},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 789, col: 40, offset: 18760},
+												pos:   position{line: 789, col: 40, offset: 18761},
 												label: "body",
 												expr: &ruleRefExpr{
-													pos:  position{line: 789, col: 45, offset: 18765},
+													pos:  position{line: 789, col: 45, offset: 18766},
 													name: "ScopeBody",
 												},
 											},
@@ -5240,30 +5243,30 @@ var g = &grammar{
 		},
 		{
 			name: "TypeArg",
-			pos:  position{line: 801, col: 1, offset: 19002},
+			pos:  position{line: 801, col: 1, offset: 19003},
 			expr: &actionExpr{
-				pos: position{line: 802, col: 5, offset: 19014},
+				pos: position{line: 802, col: 5, offset: 19015},
 				run: (*parser).callonTypeArg1,
 				expr: &seqExpr{
-					pos: position{line: 802, col: 5, offset: 19014},
+					pos: position{line: 802, col: 5, offset: 19015},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 802, col: 5, offset: 19014},
+							pos:  position{line: 802, col: 5, offset: 19015},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 802, col: 7, offset: 19016},
+							pos:  position{line: 802, col: 7, offset: 19017},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 802, col: 10, offset: 19019},
+							pos:  position{line: 802, col: 10, offset: 19020},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 802, col: 12, offset: 19021},
+							pos:   position{line: 802, col: 12, offset: 19022},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 802, col: 16, offset: 19025},
+								pos:  position{line: 802, col: 16, offset: 19026},
 								name: "Type",
 							},
 						},
@@ -5275,30 +5278,30 @@ var g = &grammar{
 		},
 		{
 			name: "AsArg",
-			pos:  position{line: 804, col: 1, offset: 19051},
+			pos:  position{line: 804, col: 1, offset: 19052},
 			expr: &actionExpr{
-				pos: position{line: 805, col: 5, offset: 19061},
+				pos: position{line: 805, col: 5, offset: 19062},
 				run: (*parser).callonAsArg1,
 				expr: &seqExpr{
-					pos: position{line: 805, col: 5, offset: 19061},
+					pos: position{line: 805, col: 5, offset: 19062},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 805, col: 5, offset: 19061},
+							pos:  position{line: 805, col: 5, offset: 19062},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 805, col: 7, offset: 19063},
+							pos:  position{line: 805, col: 7, offset: 19064},
 							name: "AS",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 805, col: 10, offset: 19066},
+							pos:  position{line: 805, col: 10, offset: 19067},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 805, col: 12, offset: 19068},
+							pos:   position{line: 805, col: 12, offset: 19069},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 805, col: 16, offset: 19072},
+								pos:  position{line: 805, col: 16, offset: 19073},
 								name: "Lval",
 							},
 						},
@@ -5310,9 +5313,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 809, col: 1, offset: 19123},
+			pos:  position{line: 809, col: 1, offset: 19124},
 			expr: &ruleRefExpr{
-				pos:  position{line: 809, col: 8, offset: 19130},
+				pos:  position{line: 809, col: 8, offset: 19131},
 				name: "DerefExpr",
 			},
 			leader:        false,
@@ -5320,51 +5323,51 @@ var g = &grammar{
 		},
 		{
 			name: "Lvals",
-			pos:  position{line: 811, col: 1, offset: 19141},
+			pos:  position{line: 811, col: 1, offset: 19142},
 			expr: &actionExpr{
-				pos: position{line: 812, col: 5, offset: 19151},
+				pos: position{line: 812, col: 5, offset: 19152},
 				run: (*parser).callonLvals1,
 				expr: &seqExpr{
-					pos: position{line: 812, col: 5, offset: 19151},
+					pos: position{line: 812, col: 5, offset: 19152},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 812, col: 5, offset: 19151},
+							pos:   position{line: 812, col: 5, offset: 19152},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 812, col: 11, offset: 19157},
+								pos:  position{line: 812, col: 11, offset: 19158},
 								name: "Lval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 812, col: 16, offset: 19162},
+							pos:   position{line: 812, col: 16, offset: 19163},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 812, col: 21, offset: 19167},
+								pos: position{line: 812, col: 21, offset: 19168},
 								expr: &actionExpr{
-									pos: position{line: 812, col: 22, offset: 19168},
+									pos: position{line: 812, col: 22, offset: 19169},
 									run: (*parser).callonLvals7,
 									expr: &seqExpr{
-										pos: position{line: 812, col: 22, offset: 19168},
+										pos: position{line: 812, col: 22, offset: 19169},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 812, col: 22, offset: 19168},
+												pos:  position{line: 812, col: 22, offset: 19169},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 812, col: 25, offset: 19171},
+												pos:        position{line: 812, col: 25, offset: 19172},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 812, col: 29, offset: 19175},
+												pos:  position{line: 812, col: 29, offset: 19176},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 812, col: 32, offset: 19178},
+												pos:   position{line: 812, col: 32, offset: 19179},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 812, col: 37, offset: 19183},
+													pos:  position{line: 812, col: 37, offset: 19184},
 													name: "Lval",
 												},
 											},
@@ -5381,51 +5384,51 @@ var g = &grammar{
 		},
 		{
 			name: "Assignments",
-			pos:  position{line: 816, col: 1, offset: 19259},
+			pos:  position{line: 816, col: 1, offset: 19260},
 			expr: &actionExpr{
-				pos: position{line: 817, col: 5, offset: 19275},
+				pos: position{line: 817, col: 5, offset: 19276},
 				run: (*parser).callonAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 817, col: 5, offset: 19275},
+					pos: position{line: 817, col: 5, offset: 19276},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 817, col: 5, offset: 19275},
+							pos:   position{line: 817, col: 5, offset: 19276},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 817, col: 11, offset: 19281},
+								pos:  position{line: 817, col: 11, offset: 19282},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 817, col: 22, offset: 19292},
+							pos:   position{line: 817, col: 22, offset: 19293},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 817, col: 27, offset: 19297},
+								pos: position{line: 817, col: 27, offset: 19298},
 								expr: &actionExpr{
-									pos: position{line: 817, col: 28, offset: 19298},
+									pos: position{line: 817, col: 28, offset: 19299},
 									run: (*parser).callonAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 817, col: 28, offset: 19298},
+										pos: position{line: 817, col: 28, offset: 19299},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 817, col: 28, offset: 19298},
+												pos:  position{line: 817, col: 28, offset: 19299},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 817, col: 31, offset: 19301},
+												pos:        position{line: 817, col: 31, offset: 19302},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 817, col: 35, offset: 19305},
+												pos:  position{line: 817, col: 35, offset: 19306},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 817, col: 38, offset: 19308},
+												pos:   position{line: 817, col: 38, offset: 19309},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 817, col: 40, offset: 19310},
+													pos:  position{line: 817, col: 40, offset: 19311},
 													name: "Assignment",
 												},
 											},
@@ -5442,38 +5445,38 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 821, col: 1, offset: 19385},
+			pos:  position{line: 821, col: 1, offset: 19386},
 			expr: &actionExpr{
-				pos: position{line: 822, col: 5, offset: 19400},
+				pos: position{line: 822, col: 5, offset: 19401},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 822, col: 5, offset: 19400},
+					pos: position{line: 822, col: 5, offset: 19401},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 822, col: 5, offset: 19400},
+							pos:   position{line: 822, col: 5, offset: 19401},
 							label: "lhs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 822, col: 9, offset: 19404},
+								pos: position{line: 822, col: 9, offset: 19405},
 								expr: &actionExpr{
-									pos: position{line: 822, col: 10, offset: 19405},
+									pos: position{line: 822, col: 10, offset: 19406},
 									run: (*parser).callonAssignment5,
 									expr: &seqExpr{
-										pos: position{line: 822, col: 10, offset: 19405},
+										pos: position{line: 822, col: 10, offset: 19406},
 										exprs: []any{
 											&labeledExpr{
-												pos:   position{line: 822, col: 10, offset: 19405},
+												pos:   position{line: 822, col: 10, offset: 19406},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 822, col: 15, offset: 19410},
+													pos:  position{line: 822, col: 15, offset: 19411},
 													name: "Lval",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 822, col: 20, offset: 19415},
+												pos:  position{line: 822, col: 20, offset: 19416},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 822, col: 23, offset: 19418},
+												pos:        position{line: 822, col: 23, offset: 19419},
 												val:        ":=",
 												ignoreCase: false,
 												want:       "\":=\"",
@@ -5484,14 +5487,14 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 822, col: 51, offset: 19446},
+							pos:  position{line: 822, col: 51, offset: 19447},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 822, col: 54, offset: 19449},
+							pos:   position{line: 822, col: 54, offset: 19450},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 822, col: 58, offset: 19453},
+								pos:  position{line: 822, col: 58, offset: 19454},
 								name: "Expr",
 							},
 						},
@@ -5503,9 +5506,9 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 834, col: 1, offset: 19667},
+			pos:  position{line: 834, col: 1, offset: 19668},
 			expr: &ruleRefExpr{
-				pos:  position{line: 834, col: 8, offset: 19674},
+				pos:  position{line: 834, col: 8, offset: 19675},
 				name: "ConditionalExpr",
 			},
 			leader:        false,
@@ -5513,63 +5516,63 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 836, col: 1, offset: 19691},
+			pos:  position{line: 836, col: 1, offset: 19692},
 			expr: &actionExpr{
-				pos: position{line: 837, col: 5, offset: 19711},
+				pos: position{line: 837, col: 5, offset: 19712},
 				run: (*parser).callonConditionalExpr1,
 				expr: &seqExpr{
-					pos: position{line: 837, col: 5, offset: 19711},
+					pos: position{line: 837, col: 5, offset: 19712},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 837, col: 5, offset: 19711},
+							pos:   position{line: 837, col: 5, offset: 19712},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 837, col: 10, offset: 19716},
+								pos:  position{line: 837, col: 10, offset: 19717},
 								name: "LogicalOrExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 837, col: 24, offset: 19730},
+							pos:   position{line: 837, col: 24, offset: 19731},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 837, col: 28, offset: 19734},
+								pos: position{line: 837, col: 28, offset: 19735},
 								expr: &seqExpr{
-									pos: position{line: 837, col: 29, offset: 19735},
+									pos: position{line: 837, col: 29, offset: 19736},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 837, col: 29, offset: 19735},
+											pos:  position{line: 837, col: 29, offset: 19736},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 837, col: 32, offset: 19738},
+											pos:        position{line: 837, col: 32, offset: 19739},
 											val:        "?",
 											ignoreCase: false,
 											want:       "\"?\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 837, col: 36, offset: 19742},
+											pos:  position{line: 837, col: 36, offset: 19743},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 837, col: 39, offset: 19745},
+											pos:  position{line: 837, col: 39, offset: 19746},
 											name: "Expr",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 837, col: 44, offset: 19750},
+											pos:  position{line: 837, col: 44, offset: 19751},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 837, col: 47, offset: 19753},
+											pos:        position{line: 837, col: 47, offset: 19754},
 											val:        ":",
 											ignoreCase: false,
 											want:       "\":\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 837, col: 51, offset: 19757},
+											pos:  position{line: 837, col: 51, offset: 19758},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 837, col: 54, offset: 19760},
+											pos:  position{line: 837, col: 54, offset: 19761},
 											name: "Expr",
 										},
 									},
@@ -5584,53 +5587,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 851, col: 1, offset: 20081},
+			pos:  position{line: 851, col: 1, offset: 20082},
 			expr: &actionExpr{
-				pos: position{line: 852, col: 5, offset: 20099},
+				pos: position{line: 852, col: 5, offset: 20100},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 852, col: 5, offset: 20099},
+					pos: position{line: 852, col: 5, offset: 20100},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 852, col: 5, offset: 20099},
+							pos:   position{line: 852, col: 5, offset: 20100},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 852, col: 11, offset: 20105},
+								pos:  position{line: 852, col: 11, offset: 20106},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 853, col: 5, offset: 20124},
+							pos:   position{line: 853, col: 5, offset: 20125},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 853, col: 10, offset: 20129},
+								pos: position{line: 853, col: 10, offset: 20130},
 								expr: &actionExpr{
-									pos: position{line: 853, col: 11, offset: 20130},
+									pos: position{line: 853, col: 11, offset: 20131},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 853, col: 11, offset: 20130},
+										pos: position{line: 853, col: 11, offset: 20131},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 853, col: 11, offset: 20130},
+												pos:  position{line: 853, col: 11, offset: 20131},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 853, col: 14, offset: 20133},
+												pos:   position{line: 853, col: 14, offset: 20134},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 853, col: 17, offset: 20136},
+													pos:  position{line: 853, col: 17, offset: 20137},
 													name: "OR",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 853, col: 20, offset: 20139},
+												pos:  position{line: 853, col: 20, offset: 20140},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 853, col: 23, offset: 20142},
+												pos:   position{line: 853, col: 23, offset: 20143},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 853, col: 28, offset: 20147},
+													pos:  position{line: 853, col: 28, offset: 20148},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -5647,53 +5650,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 857, col: 1, offset: 20261},
+			pos:  position{line: 857, col: 1, offset: 20262},
 			expr: &actionExpr{
-				pos: position{line: 858, col: 5, offset: 20280},
+				pos: position{line: 858, col: 5, offset: 20281},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 858, col: 5, offset: 20280},
+					pos: position{line: 858, col: 5, offset: 20281},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 858, col: 5, offset: 20280},
+							pos:   position{line: 858, col: 5, offset: 20281},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 858, col: 11, offset: 20286},
+								pos:  position{line: 858, col: 11, offset: 20287},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 859, col: 5, offset: 20298},
+							pos:   position{line: 859, col: 5, offset: 20299},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 859, col: 10, offset: 20303},
+								pos: position{line: 859, col: 10, offset: 20304},
 								expr: &actionExpr{
-									pos: position{line: 859, col: 11, offset: 20304},
+									pos: position{line: 859, col: 11, offset: 20305},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 859, col: 11, offset: 20304},
+										pos: position{line: 859, col: 11, offset: 20305},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 859, col: 11, offset: 20304},
+												pos:  position{line: 859, col: 11, offset: 20305},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 859, col: 14, offset: 20307},
+												pos:   position{line: 859, col: 14, offset: 20308},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 859, col: 17, offset: 20310},
+													pos:  position{line: 859, col: 17, offset: 20311},
 													name: "AND",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 859, col: 21, offset: 20314},
+												pos:  position{line: 859, col: 21, offset: 20315},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 859, col: 24, offset: 20317},
+												pos:   position{line: 859, col: 24, offset: 20318},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 859, col: 29, offset: 20322},
+													pos:  position{line: 859, col: 29, offset: 20323},
 													name: "NotExpr",
 												},
 											},
@@ -5710,43 +5713,43 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 863, col: 1, offset: 20429},
+			pos:  position{line: 863, col: 1, offset: 20430},
 			expr: &choiceExpr{
-				pos: position{line: 864, col: 5, offset: 20441},
+				pos: position{line: 864, col: 5, offset: 20442},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 864, col: 5, offset: 20441},
+						pos: position{line: 864, col: 5, offset: 20442},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 864, col: 5, offset: 20441},
+							pos: position{line: 864, col: 5, offset: 20442},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 864, col: 6, offset: 20442},
+									pos: position{line: 864, col: 6, offset: 20443},
 									alternatives: []any{
 										&seqExpr{
-											pos: position{line: 864, col: 6, offset: 20442},
+											pos: position{line: 864, col: 6, offset: 20443},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 864, col: 6, offset: 20442},
+													pos:  position{line: 864, col: 6, offset: 20443},
 													name: "NOT",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 864, col: 10, offset: 20446},
+													pos:  position{line: 864, col: 10, offset: 20447},
 													name: "_",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 864, col: 14, offset: 20450},
+											pos: position{line: 864, col: 14, offset: 20451},
 											exprs: []any{
 												&litMatcher{
-													pos:        position{line: 864, col: 14, offset: 20450},
+													pos:        position{line: 864, col: 14, offset: 20451},
 													val:        "!",
 													ignoreCase: false,
 													want:       "\"!\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 864, col: 18, offset: 20454},
+													pos:  position{line: 864, col: 18, offset: 20455},
 													name: "__",
 												},
 											},
@@ -5754,10 +5757,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 864, col: 22, offset: 20458},
+									pos:   position{line: 864, col: 22, offset: 20459},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 864, col: 24, offset: 20460},
+										pos:  position{line: 864, col: 24, offset: 20461},
 										name: "NotExpr",
 									},
 								},
@@ -5765,7 +5768,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 872, col: 5, offset: 20626},
+						pos:  position{line: 872, col: 5, offset: 20627},
 						name: "BetweenExpr",
 					},
 				},
@@ -5775,42 +5778,42 @@ var g = &grammar{
 		},
 		{
 			name: "BetweenExpr",
-			pos:  position{line: 874, col: 1, offset: 20639},
+			pos:  position{line: 874, col: 1, offset: 20640},
 			expr: &choiceExpr{
-				pos: position{line: 875, col: 5, offset: 20655},
+				pos: position{line: 875, col: 5, offset: 20656},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 875, col: 5, offset: 20655},
+						pos: position{line: 875, col: 5, offset: 20656},
 						run: (*parser).callonBetweenExpr2,
 						expr: &seqExpr{
-							pos: position{line: 875, col: 5, offset: 20655},
+							pos: position{line: 875, col: 5, offset: 20656},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 875, col: 5, offset: 20655},
+									pos:   position{line: 875, col: 5, offset: 20656},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 875, col: 10, offset: 20660},
+										pos:  position{line: 875, col: 10, offset: 20661},
 										name: "ComparisonExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 875, col: 25, offset: 20675},
+									pos:  position{line: 875, col: 25, offset: 20676},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 875, col: 27, offset: 20677},
+									pos:   position{line: 875, col: 27, offset: 20678},
 									label: "not",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 875, col: 31, offset: 20681},
+										pos: position{line: 875, col: 31, offset: 20682},
 										expr: &seqExpr{
-											pos: position{line: 875, col: 32, offset: 20682},
+											pos: position{line: 875, col: 32, offset: 20683},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 875, col: 32, offset: 20682},
+													pos:  position{line: 875, col: 32, offset: 20683},
 													name: "NOT",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 875, col: 36, offset: 20686},
+													pos:  position{line: 875, col: 36, offset: 20687},
 													name: "_",
 												},
 											},
@@ -5818,38 +5821,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 875, col: 40, offset: 20690},
+									pos:  position{line: 875, col: 40, offset: 20691},
 									name: "BETWEEN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 875, col: 48, offset: 20698},
+									pos:  position{line: 875, col: 48, offset: 20699},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 875, col: 50, offset: 20700},
+									pos:   position{line: 875, col: 50, offset: 20701},
 									label: "lower",
 									expr: &ruleRefExpr{
-										pos:  position{line: 875, col: 56, offset: 20706},
+										pos:  position{line: 875, col: 56, offset: 20707},
 										name: "BetweenExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 875, col: 68, offset: 20718},
+									pos:  position{line: 875, col: 68, offset: 20719},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 875, col: 70, offset: 20720},
+									pos:  position{line: 875, col: 70, offset: 20721},
 									name: "AND",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 875, col: 74, offset: 20724},
+									pos:  position{line: 875, col: 74, offset: 20725},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 875, col: 76, offset: 20726},
+									pos:   position{line: 875, col: 76, offset: 20727},
 									label: "upper",
 									expr: &ruleRefExpr{
-										pos:  position{line: 875, col: 82, offset: 20732},
+										pos:  position{line: 875, col: 82, offset: 20733},
 										name: "BetweenExpr",
 									},
 								},
@@ -5857,7 +5860,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 885, col: 5, offset: 20964},
+						pos:  position{line: 885, col: 5, offset: 20965},
 						name: "ComparisonExpr",
 					},
 				},
@@ -5867,46 +5870,46 @@ var g = &grammar{
 		},
 		{
 			name: "ComparisonExpr",
-			pos:  position{line: 887, col: 1, offset: 20980},
+			pos:  position{line: 887, col: 1, offset: 20981},
 			expr: &choiceExpr{
-				pos: position{line: 888, col: 5, offset: 20999},
+				pos: position{line: 888, col: 5, offset: 21000},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 888, col: 5, offset: 20999},
+						pos: position{line: 888, col: 5, offset: 21000},
 						run: (*parser).callonComparisonExpr2,
 						expr: &seqExpr{
-							pos: position{line: 888, col: 5, offset: 20999},
+							pos: position{line: 888, col: 5, offset: 21000},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 888, col: 5, offset: 20999},
+									pos:   position{line: 888, col: 5, offset: 21000},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 888, col: 10, offset: 21004},
+										pos:  position{line: 888, col: 10, offset: 21005},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 888, col: 23, offset: 21017},
+									pos:  position{line: 888, col: 23, offset: 21018},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 888, col: 25, offset: 21019},
+									pos:  position{line: 888, col: 25, offset: 21020},
 									name: "IS",
 								},
 								&labeledExpr{
-									pos:   position{line: 888, col: 28, offset: 21022},
+									pos:   position{line: 888, col: 28, offset: 21023},
 									label: "not",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 888, col: 32, offset: 21026},
+										pos: position{line: 888, col: 32, offset: 21027},
 										expr: &seqExpr{
-											pos: position{line: 888, col: 33, offset: 21027},
+											pos: position{line: 888, col: 33, offset: 21028},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 888, col: 33, offset: 21027},
+													pos:  position{line: 888, col: 33, offset: 21028},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 888, col: 35, offset: 21029},
+													pos:  position{line: 888, col: 35, offset: 21030},
 													name: "NOT",
 												},
 											},
@@ -5914,82 +5917,82 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 888, col: 41, offset: 21035},
+									pos:  position{line: 888, col: 41, offset: 21036},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 888, col: 43, offset: 21037},
+									pos:  position{line: 888, col: 43, offset: 21038},
 									name: "NULL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 896, col: 5, offset: 21202},
+						pos: position{line: 896, col: 5, offset: 21203},
 						run: (*parser).callonComparisonExpr15,
 						expr: &seqExpr{
-							pos: position{line: 896, col: 5, offset: 21202},
+							pos: position{line: 896, col: 5, offset: 21203},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 896, col: 5, offset: 21202},
+									pos:   position{line: 896, col: 5, offset: 21203},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 896, col: 9, offset: 21206},
+										pos:  position{line: 896, col: 9, offset: 21207},
 										name: "AdditiveExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 896, col: 22, offset: 21219},
+									pos:   position{line: 896, col: 22, offset: 21220},
 									label: "opAndRHS",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 896, col: 31, offset: 21228},
+										pos: position{line: 896, col: 31, offset: 21229},
 										expr: &choiceExpr{
-											pos: position{line: 896, col: 32, offset: 21229},
+											pos: position{line: 896, col: 32, offset: 21230},
 											alternatives: []any{
 												&seqExpr{
-													pos: position{line: 896, col: 32, offset: 21229},
+													pos: position{line: 896, col: 32, offset: 21230},
 													exprs: []any{
 														&ruleRefExpr{
-															pos:  position{line: 896, col: 32, offset: 21229},
+															pos:  position{line: 896, col: 32, offset: 21230},
 															name: "__",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 896, col: 35, offset: 21232},
+															pos:  position{line: 896, col: 35, offset: 21233},
 															name: "Comparator",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 896, col: 46, offset: 21243},
+															pos:  position{line: 896, col: 46, offset: 21244},
 															name: "__",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 896, col: 49, offset: 21246},
+															pos:  position{line: 896, col: 49, offset: 21247},
 															name: "AdditiveExpr",
 														},
 													},
 												},
 												&seqExpr{
-													pos: position{line: 896, col: 64, offset: 21261},
+													pos: position{line: 896, col: 64, offset: 21262},
 													exprs: []any{
 														&ruleRefExpr{
-															pos:  position{line: 896, col: 64, offset: 21261},
+															pos:  position{line: 896, col: 64, offset: 21262},
 															name: "__",
 														},
 														&actionExpr{
-															pos: position{line: 896, col: 68, offset: 21265},
+															pos: position{line: 896, col: 68, offset: 21266},
 															run: (*parser).callonComparisonExpr29,
 															expr: &litMatcher{
-																pos:        position{line: 896, col: 68, offset: 21265},
+																pos:        position{line: 896, col: 68, offset: 21266},
 																val:        "~",
 																ignoreCase: false,
 																want:       "\"~\"",
 															},
 														},
 														&ruleRefExpr{
-															pos:  position{line: 896, col: 104, offset: 21301},
+															pos:  position{line: 896, col: 104, offset: 21302},
 															name: "__",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 896, col: 107, offset: 21304},
+															pos:  position{line: 896, col: 107, offset: 21305},
 															name: "AdditiveExpr",
 														},
 													},
@@ -6008,53 +6011,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 909, col: 1, offset: 21595},
+			pos:  position{line: 909, col: 1, offset: 21596},
 			expr: &actionExpr{
-				pos: position{line: 910, col: 5, offset: 21612},
+				pos: position{line: 910, col: 5, offset: 21613},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 910, col: 5, offset: 21612},
+					pos: position{line: 910, col: 5, offset: 21613},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 910, col: 5, offset: 21612},
+							pos:   position{line: 910, col: 5, offset: 21613},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 910, col: 11, offset: 21618},
+								pos:  position{line: 910, col: 11, offset: 21619},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 911, col: 5, offset: 21641},
+							pos:   position{line: 911, col: 5, offset: 21642},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 911, col: 10, offset: 21646},
+								pos: position{line: 911, col: 10, offset: 21647},
 								expr: &actionExpr{
-									pos: position{line: 911, col: 11, offset: 21647},
+									pos: position{line: 911, col: 11, offset: 21648},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 911, col: 11, offset: 21647},
+										pos: position{line: 911, col: 11, offset: 21648},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 911, col: 11, offset: 21647},
+												pos:  position{line: 911, col: 11, offset: 21648},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 911, col: 14, offset: 21650},
+												pos:   position{line: 911, col: 14, offset: 21651},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 911, col: 17, offset: 21653},
+													pos:  position{line: 911, col: 17, offset: 21654},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 911, col: 34, offset: 21670},
+												pos:  position{line: 911, col: 34, offset: 21671},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 911, col: 37, offset: 21673},
+												pos:   position{line: 911, col: 37, offset: 21674},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 911, col: 42, offset: 21678},
+													pos:  position{line: 911, col: 42, offset: 21679},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -6071,21 +6074,21 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 915, col: 1, offset: 21796},
+			pos:  position{line: 915, col: 1, offset: 21797},
 			expr: &actionExpr{
-				pos: position{line: 915, col: 20, offset: 21815},
+				pos: position{line: 915, col: 20, offset: 21816},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 915, col: 21, offset: 21816},
+					pos: position{line: 915, col: 21, offset: 21817},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 915, col: 21, offset: 21816},
+							pos:        position{line: 915, col: 21, offset: 21817},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&litMatcher{
-							pos:        position{line: 915, col: 27, offset: 21822},
+							pos:        position{line: 915, col: 27, offset: 21823},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
@@ -6098,53 +6101,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 917, col: 1, offset: 21859},
+			pos:  position{line: 917, col: 1, offset: 21860},
 			expr: &actionExpr{
-				pos: position{line: 918, col: 5, offset: 21882},
+				pos: position{line: 918, col: 5, offset: 21883},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 918, col: 5, offset: 21882},
+					pos: position{line: 918, col: 5, offset: 21883},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 918, col: 5, offset: 21882},
+							pos:   position{line: 918, col: 5, offset: 21883},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 918, col: 11, offset: 21888},
+								pos:  position{line: 918, col: 11, offset: 21889},
 								name: "ConcatExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 919, col: 5, offset: 21903},
+							pos:   position{line: 919, col: 5, offset: 21904},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 919, col: 10, offset: 21908},
+								pos: position{line: 919, col: 10, offset: 21909},
 								expr: &actionExpr{
-									pos: position{line: 919, col: 11, offset: 21909},
+									pos: position{line: 919, col: 11, offset: 21910},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 919, col: 11, offset: 21909},
+										pos: position{line: 919, col: 11, offset: 21910},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 919, col: 11, offset: 21909},
+												pos:  position{line: 919, col: 11, offset: 21910},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 919, col: 14, offset: 21912},
+												pos:   position{line: 919, col: 14, offset: 21913},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 919, col: 17, offset: 21915},
+													pos:  position{line: 919, col: 17, offset: 21916},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 919, col: 40, offset: 21938},
+												pos:  position{line: 919, col: 40, offset: 21939},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 919, col: 43, offset: 21941},
+												pos:   position{line: 919, col: 43, offset: 21942},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 919, col: 48, offset: 21946},
+													pos:  position{line: 919, col: 48, offset: 21947},
 													name: "ConcatExpr",
 												},
 											},
@@ -6161,27 +6164,27 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 923, col: 1, offset: 22056},
+			pos:  position{line: 923, col: 1, offset: 22057},
 			expr: &actionExpr{
-				pos: position{line: 923, col: 26, offset: 22081},
+				pos: position{line: 923, col: 26, offset: 22082},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 923, col: 27, offset: 22082},
+					pos: position{line: 923, col: 27, offset: 22083},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 923, col: 27, offset: 22082},
+							pos:        position{line: 923, col: 27, offset: 22083},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&litMatcher{
-							pos:        position{line: 923, col: 33, offset: 22088},
+							pos:        position{line: 923, col: 33, offset: 22089},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&litMatcher{
-							pos:        position{line: 923, col: 39, offset: 22094},
+							pos:        position{line: 923, col: 39, offset: 22095},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
@@ -6194,51 +6197,51 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatExpr",
-			pos:  position{line: 925, col: 1, offset: 22131},
+			pos:  position{line: 925, col: 1, offset: 22132},
 			expr: &actionExpr{
-				pos: position{line: 926, col: 5, offset: 22146},
+				pos: position{line: 926, col: 5, offset: 22147},
 				run: (*parser).callonConcatExpr1,
 				expr: &seqExpr{
-					pos: position{line: 926, col: 5, offset: 22146},
+					pos: position{line: 926, col: 5, offset: 22147},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 926, col: 5, offset: 22146},
+							pos:   position{line: 926, col: 5, offset: 22147},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 926, col: 11, offset: 22152},
+								pos:  position{line: 926, col: 11, offset: 22153},
 								name: "UnaryPlusOrMinus",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 927, col: 5, offset: 22173},
+							pos:   position{line: 927, col: 5, offset: 22174},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 927, col: 10, offset: 22178},
+								pos: position{line: 927, col: 10, offset: 22179},
 								expr: &actionExpr{
-									pos: position{line: 927, col: 11, offset: 22179},
+									pos: position{line: 927, col: 11, offset: 22180},
 									run: (*parser).callonConcatExpr7,
 									expr: &seqExpr{
-										pos: position{line: 927, col: 11, offset: 22179},
+										pos: position{line: 927, col: 11, offset: 22180},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 927, col: 11, offset: 22179},
+												pos:  position{line: 927, col: 11, offset: 22180},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 927, col: 14, offset: 22182},
+												pos:        position{line: 927, col: 14, offset: 22183},
 												val:        "||",
 												ignoreCase: false,
 												want:       "\"||\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 927, col: 19, offset: 22187},
+												pos:  position{line: 927, col: 19, offset: 22188},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 927, col: 22, offset: 22190},
+												pos:   position{line: 927, col: 22, offset: 22191},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 927, col: 27, offset: 22195},
+													pos:  position{line: 927, col: 27, offset: 22196},
 													name: "UnaryPlusOrMinus",
 												},
 											},
@@ -6255,40 +6258,40 @@ var g = &grammar{
 		},
 		{
 			name: "UnaryPlusOrMinus",
-			pos:  position{line: 931, col: 1, offset: 22313},
+			pos:  position{line: 931, col: 1, offset: 22314},
 			expr: &choiceExpr{
-				pos: position{line: 932, col: 5, offset: 22334},
+				pos: position{line: 932, col: 5, offset: 22335},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 932, col: 5, offset: 22334},
+						pos: position{line: 932, col: 5, offset: 22335},
 						run: (*parser).callonUnaryPlusOrMinus2,
 						expr: &seqExpr{
-							pos: position{line: 932, col: 5, offset: 22334},
+							pos: position{line: 932, col: 5, offset: 22335},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 932, col: 5, offset: 22334},
+									pos: position{line: 932, col: 5, offset: 22335},
 									expr: &ruleRefExpr{
-										pos:  position{line: 932, col: 6, offset: 22335},
+										pos:  position{line: 932, col: 6, offset: 22336},
 										name: "Literal",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 932, col: 14, offset: 22343},
+									pos:   position{line: 932, col: 14, offset: 22344},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 932, col: 17, offset: 22346},
+										pos:  position{line: 932, col: 17, offset: 22347},
 										name: "PlusOrMinusOp",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 932, col: 31, offset: 22360},
+									pos:  position{line: 932, col: 31, offset: 22361},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 932, col: 34, offset: 22363},
+									pos:   position{line: 932, col: 34, offset: 22364},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 932, col: 36, offset: 22365},
+										pos:  position{line: 932, col: 36, offset: 22366},
 										name: "UnaryPlusOrMinus",
 									},
 								},
@@ -6296,7 +6299,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 941, col: 5, offset: 22549},
+						pos:  position{line: 941, col: 5, offset: 22550},
 						name: "ColonCast",
 					},
 				},
@@ -6306,21 +6309,21 @@ var g = &grammar{
 		},
 		{
 			name: "PlusOrMinusOp",
-			pos:  position{line: 943, col: 1, offset: 22560},
+			pos:  position{line: 943, col: 1, offset: 22561},
 			expr: &actionExpr{
-				pos: position{line: 943, col: 17, offset: 22576},
+				pos: position{line: 943, col: 17, offset: 22577},
 				run: (*parser).callonPlusOrMinusOp1,
 				expr: &choiceExpr{
-					pos: position{line: 943, col: 18, offset: 22577},
+					pos: position{line: 943, col: 18, offset: 22578},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 943, col: 18, offset: 22577},
+							pos:        position{line: 943, col: 18, offset: 22578},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&litMatcher{
-							pos:        position{line: 943, col: 24, offset: 22583},
+							pos:        position{line: 943, col: 24, offset: 22584},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
@@ -6333,58 +6336,58 @@ var g = &grammar{
 		},
 		{
 			name: "ColonCast",
-			pos:  position{line: 945, col: 1, offset: 22620},
+			pos:  position{line: 945, col: 1, offset: 22621},
 			expr: &actionExpr{
-				pos: position{line: 946, col: 5, offset: 22634},
+				pos: position{line: 946, col: 5, offset: 22635},
 				run: (*parser).callonColonCast1,
 				expr: &seqExpr{
-					pos: position{line: 946, col: 5, offset: 22634},
+					pos: position{line: 946, col: 5, offset: 22635},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 946, col: 5, offset: 22634},
+							pos:   position{line: 946, col: 5, offset: 22635},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 946, col: 11, offset: 22640},
+								pos:  position{line: 946, col: 11, offset: 22641},
 								name: "DerefExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 947, col: 5, offset: 22654},
+							pos:   position{line: 947, col: 5, offset: 22655},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 947, col: 10, offset: 22659},
+								pos: position{line: 947, col: 10, offset: 22660},
 								expr: &actionExpr{
-									pos: position{line: 947, col: 11, offset: 22660},
+									pos: position{line: 947, col: 11, offset: 22661},
 									run: (*parser).callonColonCast7,
 									expr: &seqExpr{
-										pos: position{line: 947, col: 11, offset: 22660},
+										pos: position{line: 947, col: 11, offset: 22661},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 947, col: 11, offset: 22660},
+												pos:  position{line: 947, col: 11, offset: 22661},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 947, col: 14, offset: 22663},
+												pos:        position{line: 947, col: 14, offset: 22664},
 												val:        "::",
 												ignoreCase: false,
 												want:       "\"::\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 947, col: 19, offset: 22668},
+												pos:  position{line: 947, col: 19, offset: 22669},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 947, col: 22, offset: 22671},
+												pos:   position{line: 947, col: 22, offset: 22672},
 												label: "expr",
 												expr: &choiceExpr{
-													pos: position{line: 947, col: 28, offset: 22677},
+													pos: position{line: 947, col: 28, offset: 22678},
 													alternatives: []any{
 														&ruleRefExpr{
-															pos:  position{line: 947, col: 28, offset: 22677},
+															pos:  position{line: 947, col: 28, offset: 22678},
 															name: "TypeAsValue",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 947, col: 42, offset: 22691},
+															pos:  position{line: 947, col: 42, offset: 22692},
 															name: "DerefExpr",
 														},
 													},
@@ -6403,73 +6406,73 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 951, col: 1, offset: 22801},
+			pos:  position{line: 951, col: 1, offset: 22802},
 			expr: &choiceExpr{
-				pos: position{line: 952, col: 5, offset: 22815},
+				pos: position{line: 952, col: 5, offset: 22816},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 952, col: 5, offset: 22815},
+						pos: position{line: 952, col: 5, offset: 22816},
 						run: (*parser).callonDerefExpr2,
 						expr: &seqExpr{
-							pos: position{line: 952, col: 5, offset: 22815},
+							pos: position{line: 952, col: 5, offset: 22816},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 952, col: 5, offset: 22815},
+									pos:   position{line: 952, col: 5, offset: 22816},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 952, col: 10, offset: 22820},
+										pos:  position{line: 952, col: 10, offset: 22821},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 952, col: 20, offset: 22830},
+									pos:        position{line: 952, col: 20, offset: 22831},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 952, col: 24, offset: 22834},
+									pos:  position{line: 952, col: 24, offset: 22835},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 952, col: 27, offset: 22837},
+									pos:   position{line: 952, col: 27, offset: 22838},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 952, col: 32, offset: 22842},
+										pos:  position{line: 952, col: 32, offset: 22843},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 952, col: 45, offset: 22855},
+									pos:  position{line: 952, col: 45, offset: 22856},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 952, col: 48, offset: 22858},
+									pos:        position{line: 952, col: 48, offset: 22859},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 952, col: 52, offset: 22862},
+									pos:  position{line: 952, col: 52, offset: 22863},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 952, col: 55, offset: 22865},
+									pos:   position{line: 952, col: 55, offset: 22866},
 									label: "to",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 952, col: 58, offset: 22868},
+										pos: position{line: 952, col: 58, offset: 22869},
 										expr: &ruleRefExpr{
-											pos:  position{line: 952, col: 58, offset: 22868},
+											pos:  position{line: 952, col: 58, offset: 22869},
 											name: "AdditiveExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 952, col: 72, offset: 22882},
+									pos:  position{line: 952, col: 72, offset: 22883},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 952, col: 75, offset: 22885},
+									pos:        position{line: 952, col: 75, offset: 22886},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6478,49 +6481,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 964, col: 5, offset: 23124},
+						pos: position{line: 964, col: 5, offset: 23125},
 						run: (*parser).callonDerefExpr18,
 						expr: &seqExpr{
-							pos: position{line: 964, col: 5, offset: 23124},
+							pos: position{line: 964, col: 5, offset: 23125},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 964, col: 5, offset: 23124},
+									pos:   position{line: 964, col: 5, offset: 23125},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 964, col: 10, offset: 23129},
+										pos:  position{line: 964, col: 10, offset: 23130},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 964, col: 20, offset: 23139},
+									pos:        position{line: 964, col: 20, offset: 23140},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 964, col: 24, offset: 23143},
+									pos:  position{line: 964, col: 24, offset: 23144},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 964, col: 27, offset: 23146},
+									pos:        position{line: 964, col: 27, offset: 23147},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 964, col: 31, offset: 23150},
+									pos:  position{line: 964, col: 31, offset: 23151},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 964, col: 34, offset: 23153},
+									pos:   position{line: 964, col: 34, offset: 23154},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 964, col: 37, offset: 23156},
+										pos:  position{line: 964, col: 37, offset: 23157},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 964, col: 50, offset: 23169},
+									pos:        position{line: 964, col: 50, offset: 23170},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6529,35 +6532,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 972, col: 5, offset: 23333},
+						pos: position{line: 972, col: 5, offset: 23334},
 						run: (*parser).callonDerefExpr29,
 						expr: &seqExpr{
-							pos: position{line: 972, col: 5, offset: 23333},
+							pos: position{line: 972, col: 5, offset: 23334},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 972, col: 5, offset: 23333},
+									pos:   position{line: 972, col: 5, offset: 23334},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 972, col: 10, offset: 23338},
+										pos:  position{line: 972, col: 10, offset: 23339},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 972, col: 20, offset: 23348},
+									pos:        position{line: 972, col: 20, offset: 23349},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 972, col: 24, offset: 23352},
+									pos:   position{line: 972, col: 24, offset: 23353},
 									label: "index",
 									expr: &ruleRefExpr{
-										pos:  position{line: 972, col: 30, offset: 23358},
+										pos:  position{line: 972, col: 30, offset: 23359},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 972, col: 35, offset: 23363},
+									pos:        position{line: 972, col: 35, offset: 23364},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6566,30 +6569,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 980, col: 5, offset: 23533},
+						pos: position{line: 980, col: 5, offset: 23534},
 						run: (*parser).callonDerefExpr37,
 						expr: &seqExpr{
-							pos: position{line: 980, col: 5, offset: 23533},
+							pos: position{line: 980, col: 5, offset: 23534},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 980, col: 5, offset: 23533},
+									pos:   position{line: 980, col: 5, offset: 23534},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 980, col: 10, offset: 23538},
+										pos:  position{line: 980, col: 10, offset: 23539},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 980, col: 20, offset: 23548},
+									pos:        position{line: 980, col: 20, offset: 23549},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 980, col: 24, offset: 23552},
+									pos:   position{line: 980, col: 24, offset: 23553},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 980, col: 27, offset: 23555},
+										pos:  position{line: 980, col: 27, offset: 23556},
 										name: "DerefKey",
 									},
 								},
@@ -6597,11 +6600,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 989, col: 5, offset: 23743},
+						pos:  position{line: 989, col: 5, offset: 23744},
 						name: "FuncExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 990, col: 5, offset: 23756},
+						pos:  position{line: 990, col: 5, offset: 23757},
 						name: "Primary",
 					},
 				},
@@ -6611,34 +6614,34 @@ var g = &grammar{
 		},
 		{
 			name: "DerefKey",
-			pos:  position{line: 992, col: 1, offset: 23765},
+			pos:  position{line: 992, col: 1, offset: 23766},
 			expr: &choiceExpr{
-				pos: position{line: 993, col: 5, offset: 23778},
+				pos: position{line: 993, col: 5, offset: 23779},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 993, col: 5, offset: 23778},
+						pos:  position{line: 993, col: 5, offset: 23779},
 						name: "Identifier",
 					},
 					&actionExpr{
-						pos: position{line: 994, col: 5, offset: 23793},
+						pos: position{line: 994, col: 5, offset: 23794},
 						run: (*parser).callonDerefKey3,
 						expr: &labeledExpr{
-							pos:   position{line: 994, col: 5, offset: 23793},
+							pos:   position{line: 994, col: 5, offset: 23794},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 994, col: 7, offset: 23795},
+								pos:  position{line: 994, col: 7, offset: 23796},
 								name: "DoubleQuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 995, col: 5, offset: 23887},
+						pos: position{line: 995, col: 5, offset: 23888},
 						run: (*parser).callonDerefKey6,
 						expr: &labeledExpr{
-							pos:   position{line: 995, col: 5, offset: 23887},
+							pos:   position{line: 995, col: 5, offset: 23888},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 995, col: 7, offset: 23889},
+								pos:  position{line: 995, col: 7, offset: 23890},
 								name: "BacktickString",
 							},
 						},
@@ -6650,16 +6653,16 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 997, col: 1, offset: 23978},
+			pos:  position{line: 997, col: 1, offset: 23979},
 			expr: &choiceExpr{
-				pos: position{line: 998, col: 5, offset: 23991},
+				pos: position{line: 998, col: 5, offset: 23992},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 998, col: 5, offset: 23991},
+						pos:  position{line: 998, col: 5, offset: 23992},
 						name: "Cast",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 999, col: 5, offset: 24000},
+						pos:  position{line: 999, col: 5, offset: 24001},
 						name: "Function",
 					},
 				},
@@ -6669,20 +6672,20 @@ var g = &grammar{
 		},
 		{
 			name: "FuncGuard",
-			pos:  position{line: 1001, col: 1, offset: 24010},
+			pos:  position{line: 1001, col: 1, offset: 24011},
 			expr: &seqExpr{
-				pos: position{line: 1001, col: 13, offset: 24022},
+				pos: position{line: 1001, col: 13, offset: 24023},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1001, col: 13, offset: 24022},
+						pos:  position{line: 1001, col: 13, offset: 24023},
 						name: "NotFuncs",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1001, col: 22, offset: 24031},
+						pos:  position{line: 1001, col: 22, offset: 24032},
 						name: "__",
 					},
 					&litMatcher{
-						pos:        position{line: 1001, col: 25, offset: 24034},
+						pos:        position{line: 1001, col: 25, offset: 24035},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
@@ -6694,16 +6697,16 @@ var g = &grammar{
 		},
 		{
 			name: "NotFuncs",
-			pos:  position{line: 1003, col: 1, offset: 24039},
+			pos:  position{line: 1003, col: 1, offset: 24040},
 			expr: &choiceExpr{
-				pos: position{line: 1004, col: 5, offset: 24052},
+				pos: position{line: 1004, col: 5, offset: 24053},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1004, col: 5, offset: 24052},
+						pos:  position{line: 1004, col: 5, offset: 24053},
 						name: "NOT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1005, col: 5, offset: 24060},
+						pos:  position{line: 1005, col: 5, offset: 24061},
 						name: "SELECT",
 					},
 				},
@@ -6713,49 +6716,49 @@ var g = &grammar{
 		},
 		{
 			name: "Cast",
-			pos:  position{line: 1007, col: 1, offset: 24068},
+			pos:  position{line: 1007, col: 1, offset: 24069},
 			expr: &actionExpr{
-				pos: position{line: 1008, col: 5, offset: 24077},
+				pos: position{line: 1008, col: 5, offset: 24078},
 				run: (*parser).callonCast1,
 				expr: &seqExpr{
-					pos: position{line: 1008, col: 5, offset: 24077},
+					pos: position{line: 1008, col: 5, offset: 24078},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1008, col: 5, offset: 24077},
+							pos:   position{line: 1008, col: 5, offset: 24078},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1008, col: 9, offset: 24081},
+								pos:  position{line: 1008, col: 9, offset: 24082},
 								name: "TypeLiteral",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1008, col: 21, offset: 24093},
+							pos:  position{line: 1008, col: 21, offset: 24094},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1008, col: 24, offset: 24096},
+							pos:        position{line: 1008, col: 24, offset: 24097},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1008, col: 28, offset: 24100},
+							pos:  position{line: 1008, col: 28, offset: 24101},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1008, col: 31, offset: 24103},
+							pos:   position{line: 1008, col: 31, offset: 24104},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1008, col: 36, offset: 24108},
+								pos:  position{line: 1008, col: 36, offset: 24109},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1008, col: 41, offset: 24113},
+							pos:  position{line: 1008, col: 41, offset: 24114},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1008, col: 44, offset: 24116},
+							pos:        position{line: 1008, col: 44, offset: 24117},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -6768,86 +6771,86 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 1012, col: 1, offset: 24229},
+			pos:  position{line: 1012, col: 1, offset: 24230},
 			expr: &choiceExpr{
-				pos: position{line: 1013, col: 5, offset: 24242},
+				pos: position{line: 1013, col: 5, offset: 24243},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1013, col: 5, offset: 24242},
+						pos: position{line: 1013, col: 5, offset: 24243},
 						run: (*parser).callonFunction2,
 						expr: &seqExpr{
-							pos: position{line: 1013, col: 5, offset: 24242},
+							pos: position{line: 1013, col: 5, offset: 24243},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1013, col: 5, offset: 24242},
+									pos: position{line: 1013, col: 5, offset: 24243},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1013, col: 6, offset: 24243},
+										pos:  position{line: 1013, col: 6, offset: 24244},
 										name: "FuncGuard",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1013, col: 16, offset: 24253},
+									pos:  position{line: 1013, col: 16, offset: 24254},
 									name: "EXTRACT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1013, col: 24, offset: 24261},
+									pos:  position{line: 1013, col: 24, offset: 24262},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1013, col: 27, offset: 24264},
+									pos:        position{line: 1013, col: 27, offset: 24265},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1013, col: 31, offset: 24268},
+									pos:  position{line: 1013, col: 31, offset: 24269},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1013, col: 34, offset: 24271},
+									pos:   position{line: 1013, col: 34, offset: 24272},
 									label: "part",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1013, col: 39, offset: 24276},
+										pos:  position{line: 1013, col: 39, offset: 24277},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1013, col: 44, offset: 24281},
+									pos:  position{line: 1013, col: 44, offset: 24282},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1013, col: 46, offset: 24283},
+									pos:  position{line: 1013, col: 46, offset: 24284},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1013, col: 51, offset: 24288},
+									pos:  position{line: 1013, col: 51, offset: 24289},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1013, col: 53, offset: 24290},
+									pos:   position{line: 1013, col: 53, offset: 24291},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1013, col: 55, offset: 24292},
+										pos:  position{line: 1013, col: 55, offset: 24293},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1013, col: 60, offset: 24297},
+									pos:  position{line: 1013, col: 60, offset: 24298},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1013, col: 63, offset: 24300},
+									pos:        position{line: 1013, col: 63, offset: 24301},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1013, col: 67, offset: 24304},
+									pos:   position{line: 1013, col: 67, offset: 24305},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1013, col: 73, offset: 24310},
+										pos: position{line: 1013, col: 73, offset: 24311},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1013, col: 73, offset: 24310},
+											pos:  position{line: 1013, col: 73, offset: 24311},
 											name: "WhereClause",
 										},
 									},
@@ -6856,50 +6859,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1021, col: 5, offset: 24488},
+						pos: position{line: 1021, col: 5, offset: 24489},
 						run: (*parser).callonFunction22,
 						expr: &seqExpr{
-							pos: position{line: 1021, col: 5, offset: 24488},
+							pos: position{line: 1021, col: 5, offset: 24489},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1021, col: 5, offset: 24488},
+									pos: position{line: 1021, col: 5, offset: 24489},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1021, col: 6, offset: 24489},
+										pos:  position{line: 1021, col: 6, offset: 24490},
 										name: "FuncGuard",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1021, col: 16, offset: 24499},
+									pos:  position{line: 1021, col: 16, offset: 24500},
 									name: "EXISTS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1021, col: 23, offset: 24506},
+									pos:  position{line: 1021, col: 23, offset: 24507},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1021, col: 26, offset: 24509},
+									pos:        position{line: 1021, col: 26, offset: 24510},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1021, col: 30, offset: 24513},
+									pos:  position{line: 1021, col: 30, offset: 24514},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1021, col: 33, offset: 24516},
+									pos:   position{line: 1021, col: 33, offset: 24517},
 									label: "body",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1021, col: 38, offset: 24521},
+										pos:  position{line: 1021, col: 38, offset: 24522},
 										name: "Seq",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1021, col: 42, offset: 24525},
+									pos:  position{line: 1021, col: 42, offset: 24526},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1021, col: 45, offset: 24528},
+									pos:        position{line: 1021, col: 45, offset: 24529},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -6908,70 +6911,70 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1028, col: 5, offset: 24665},
+						pos: position{line: 1028, col: 5, offset: 24666},
 						run: (*parser).callonFunction34,
 						expr: &seqExpr{
-							pos: position{line: 1028, col: 5, offset: 24665},
+							pos: position{line: 1028, col: 5, offset: 24666},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1028, col: 5, offset: 24665},
+									pos: position{line: 1028, col: 5, offset: 24666},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1028, col: 6, offset: 24666},
+										pos:  position{line: 1028, col: 6, offset: 24667},
 										name: "FuncGuard",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1028, col: 16, offset: 24676},
+									pos:  position{line: 1028, col: 16, offset: 24677},
 									name: "CAST",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1028, col: 21, offset: 24681},
+									pos:  position{line: 1028, col: 21, offset: 24682},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1028, col: 24, offset: 24684},
+									pos:        position{line: 1028, col: 24, offset: 24685},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1028, col: 28, offset: 24688},
+									pos:  position{line: 1028, col: 28, offset: 24689},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1028, col: 31, offset: 24691},
+									pos:   position{line: 1028, col: 31, offset: 24692},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1028, col: 33, offset: 24693},
+										pos:  position{line: 1028, col: 33, offset: 24694},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1028, col: 38, offset: 24698},
+									pos:  position{line: 1028, col: 38, offset: 24699},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1028, col: 40, offset: 24700},
+									pos:  position{line: 1028, col: 40, offset: 24701},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1028, col: 43, offset: 24703},
+									pos:  position{line: 1028, col: 43, offset: 24704},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1028, col: 45, offset: 24705},
+									pos:   position{line: 1028, col: 45, offset: 24706},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1028, col: 49, offset: 24709},
+										pos:  position{line: 1028, col: 49, offset: 24710},
 										name: "Identifier",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1028, col: 60, offset: 24720},
+									pos:  position{line: 1028, col: 60, offset: 24721},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1028, col: 63, offset: 24723},
+									pos:        position{line: 1028, col: 63, offset: 24724},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -6980,72 +6983,72 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1036, col: 5, offset: 24882},
+						pos: position{line: 1036, col: 5, offset: 24883},
 						run: (*parser).callonFunction51,
 						expr: &seqExpr{
-							pos: position{line: 1036, col: 5, offset: 24882},
+							pos: position{line: 1036, col: 5, offset: 24883},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1036, col: 5, offset: 24882},
+									pos: position{line: 1036, col: 5, offset: 24883},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1036, col: 6, offset: 24883},
+										pos:  position{line: 1036, col: 6, offset: 24884},
 										name: "FuncGuard",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1036, col: 16, offset: 24893},
+									pos:  position{line: 1036, col: 16, offset: 24894},
 									name: "SUBSTRING",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1036, col: 26, offset: 24903},
+									pos:  position{line: 1036, col: 26, offset: 24904},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1036, col: 29, offset: 24906},
+									pos:        position{line: 1036, col: 29, offset: 24907},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1036, col: 33, offset: 24910},
+									pos:  position{line: 1036, col: 33, offset: 24911},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1036, col: 36, offset: 24913},
+									pos:   position{line: 1036, col: 36, offset: 24914},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1036, col: 41, offset: 24918},
+										pos:  position{line: 1036, col: 41, offset: 24919},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1036, col: 46, offset: 24923},
+									pos:   position{line: 1036, col: 46, offset: 24924},
 									label: "from",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1036, col: 51, offset: 24928},
+										pos: position{line: 1036, col: 51, offset: 24929},
 										expr: &actionExpr{
-											pos: position{line: 1036, col: 52, offset: 24929},
+											pos: position{line: 1036, col: 52, offset: 24930},
 											run: (*parser).callonFunction63,
 											expr: &seqExpr{
-												pos: position{line: 1036, col: 52, offset: 24929},
+												pos: position{line: 1036, col: 52, offset: 24930},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1036, col: 52, offset: 24929},
+														pos:  position{line: 1036, col: 52, offset: 24930},
 														name: "_",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1036, col: 54, offset: 24931},
+														pos:  position{line: 1036, col: 54, offset: 24932},
 														name: "FROM",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1036, col: 59, offset: 24936},
+														pos:  position{line: 1036, col: 59, offset: 24937},
 														name: "_",
 													},
 													&labeledExpr{
-														pos:   position{line: 1036, col: 61, offset: 24938},
+														pos:   position{line: 1036, col: 61, offset: 24939},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1036, col: 63, offset: 24940},
+															pos:  position{line: 1036, col: 63, offset: 24941},
 															name: "Expr",
 														},
 													},
@@ -7055,33 +7058,33 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1036, col: 88, offset: 24965},
+									pos:   position{line: 1036, col: 88, offset: 24966},
 									label: "for_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1036, col: 93, offset: 24970},
+										pos: position{line: 1036, col: 93, offset: 24971},
 										expr: &actionExpr{
-											pos: position{line: 1036, col: 94, offset: 24971},
+											pos: position{line: 1036, col: 94, offset: 24972},
 											run: (*parser).callonFunction72,
 											expr: &seqExpr{
-												pos: position{line: 1036, col: 94, offset: 24971},
+												pos: position{line: 1036, col: 94, offset: 24972},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1036, col: 94, offset: 24971},
+														pos:  position{line: 1036, col: 94, offset: 24972},
 														name: "_",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1036, col: 96, offset: 24973},
+														pos:  position{line: 1036, col: 96, offset: 24974},
 														name: "FOR",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1036, col: 100, offset: 24977},
+														pos:  position{line: 1036, col: 100, offset: 24978},
 														name: "_",
 													},
 													&labeledExpr{
-														pos:   position{line: 1036, col: 102, offset: 24979},
+														pos:   position{line: 1036, col: 102, offset: 24980},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1036, col: 104, offset: 24981},
+															pos:  position{line: 1036, col: 104, offset: 24982},
 															name: "Expr",
 														},
 													},
@@ -7091,7 +7094,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1036, col: 129, offset: 25006},
+									pos:        position{line: 1036, col: 129, offset: 25007},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7100,65 +7103,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1050, col: 5, offset: 25289},
+						pos: position{line: 1050, col: 5, offset: 25290},
 						run: (*parser).callonFunction80,
 						expr: &seqExpr{
-							pos: position{line: 1050, col: 5, offset: 25289},
+							pos: position{line: 1050, col: 5, offset: 25290},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1050, col: 5, offset: 25289},
+									pos: position{line: 1050, col: 5, offset: 25290},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1050, col: 6, offset: 25290},
+										pos:  position{line: 1050, col: 6, offset: 25291},
 										name: "FuncGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1050, col: 16, offset: 25300},
+									pos:   position{line: 1050, col: 16, offset: 25301},
 									label: "fn",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1050, col: 19, offset: 25303},
+										pos:  position{line: 1050, col: 19, offset: 25304},
 										name: "Identifier",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1050, col: 30, offset: 25314},
+									pos:  position{line: 1050, col: 30, offset: 25315},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1050, col: 33, offset: 25317},
+									pos:        position{line: 1050, col: 33, offset: 25318},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1050, col: 37, offset: 25321},
+									pos:  position{line: 1050, col: 37, offset: 25322},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1050, col: 40, offset: 25324},
+									pos:   position{line: 1050, col: 40, offset: 25325},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1050, col: 45, offset: 25329},
+										pos:  position{line: 1050, col: 45, offset: 25330},
 										name: "FunctionArgs",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1050, col: 58, offset: 25342},
+									pos:  position{line: 1050, col: 58, offset: 25343},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1050, col: 61, offset: 25345},
+									pos:        position{line: 1050, col: 61, offset: 25346},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1050, col: 65, offset: 25349},
+									pos:   position{line: 1050, col: 65, offset: 25350},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1050, col: 71, offset: 25355},
+										pos: position{line: 1050, col: 71, offset: 25356},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1050, col: 71, offset: 25355},
+											pos:  position{line: 1050, col: 71, offset: 25356},
 											name: "WhereClause",
 										},
 									},
@@ -7167,7 +7170,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1053, col: 5, offset: 25426},
+						pos:  position{line: 1053, col: 5, offset: 25427},
 						name: "CountStar",
 					},
 				},
@@ -7177,19 +7180,19 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionArgs",
-			pos:  position{line: 1055, col: 1, offset: 25437},
+			pos:  position{line: 1055, col: 1, offset: 25438},
 			expr: &choiceExpr{
-				pos: position{line: 1056, col: 5, offset: 25454},
+				pos: position{line: 1056, col: 5, offset: 25455},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1056, col: 5, offset: 25454},
+						pos:  position{line: 1056, col: 5, offset: 25455},
 						name: "Exprs",
 					},
 					&actionExpr{
-						pos: position{line: 1057, col: 5, offset: 25464},
+						pos: position{line: 1057, col: 5, offset: 25465},
 						run: (*parser).callonFunctionArgs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1057, col: 5, offset: 25464},
+							pos:  position{line: 1057, col: 5, offset: 25465},
 							name: "__",
 						},
 					},
@@ -7200,51 +7203,51 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 1059, col: 1, offset: 25492},
+			pos:  position{line: 1059, col: 1, offset: 25493},
 			expr: &actionExpr{
-				pos: position{line: 1060, col: 5, offset: 25502},
+				pos: position{line: 1060, col: 5, offset: 25503},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 1060, col: 5, offset: 25502},
+					pos: position{line: 1060, col: 5, offset: 25503},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1060, col: 5, offset: 25502},
+							pos:   position{line: 1060, col: 5, offset: 25503},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1060, col: 11, offset: 25508},
+								pos:  position{line: 1060, col: 11, offset: 25509},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1060, col: 16, offset: 25513},
+							pos:   position{line: 1060, col: 16, offset: 25514},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1060, col: 21, offset: 25518},
+								pos: position{line: 1060, col: 21, offset: 25519},
 								expr: &actionExpr{
-									pos: position{line: 1060, col: 22, offset: 25519},
+									pos: position{line: 1060, col: 22, offset: 25520},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 1060, col: 22, offset: 25519},
+										pos: position{line: 1060, col: 22, offset: 25520},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1060, col: 22, offset: 25519},
+												pos:  position{line: 1060, col: 22, offset: 25520},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1060, col: 25, offset: 25522},
+												pos:        position{line: 1060, col: 25, offset: 25523},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1060, col: 29, offset: 25526},
+												pos:  position{line: 1060, col: 29, offset: 25527},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1060, col: 32, offset: 25529},
+												pos:   position{line: 1060, col: 32, offset: 25530},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1060, col: 34, offset: 25531},
+													pos:  position{line: 1060, col: 34, offset: 25532},
 													name: "Expr",
 												},
 											},
@@ -7261,83 +7264,83 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 1064, col: 1, offset: 25604},
+			pos:  position{line: 1064, col: 1, offset: 25605},
 			expr: &choiceExpr{
-				pos: position{line: 1065, col: 5, offset: 25616},
+				pos: position{line: 1065, col: 5, offset: 25617},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1065, col: 5, offset: 25616},
+						pos:  position{line: 1065, col: 5, offset: 25617},
 						name: "CaseExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1066, col: 5, offset: 25629},
+						pos:  position{line: 1066, col: 5, offset: 25630},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1067, col: 5, offset: 25640},
+						pos:  position{line: 1067, col: 5, offset: 25641},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1068, col: 5, offset: 25650},
+						pos:  position{line: 1068, col: 5, offset: 25651},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1069, col: 5, offset: 25658},
+						pos:  position{line: 1069, col: 5, offset: 25659},
 						name: "Map",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1070, col: 5, offset: 25666},
+						pos:  position{line: 1070, col: 5, offset: 25667},
 						name: "SQLTimeValue",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1071, col: 5, offset: 25683},
+						pos:  position{line: 1071, col: 5, offset: 25684},
 						name: "Literal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1072, col: 5, offset: 25695},
+						pos:  position{line: 1072, col: 5, offset: 25696},
 						name: "Identifier",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1073, col: 5, offset: 25710},
+						pos:  position{line: 1073, col: 5, offset: 25711},
 						name: "Tuple",
 					},
 					&actionExpr{
-						pos: position{line: 1074, col: 5, offset: 25720},
+						pos: position{line: 1074, col: 5, offset: 25721},
 						run: (*parser).callonPrimary11,
 						expr: &seqExpr{
-							pos: position{line: 1074, col: 5, offset: 25720},
+							pos: position{line: 1074, col: 5, offset: 25721},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1074, col: 5, offset: 25720},
+									pos:        position{line: 1074, col: 5, offset: 25721},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1074, col: 9, offset: 25724},
+									pos:  position{line: 1074, col: 9, offset: 25725},
 									name: "__",
 								},
 								&andExpr{
-									pos: position{line: 1074, col: 12, offset: 25727},
+									pos: position{line: 1074, col: 12, offset: 25728},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1074, col: 13, offset: 25728},
+										pos:  position{line: 1074, col: 13, offset: 25729},
 										name: "SubqueryOps",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1074, col: 25, offset: 25740},
+									pos:   position{line: 1074, col: 25, offset: 25741},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1074, col: 30, offset: 25745},
+										pos:  position{line: 1074, col: 30, offset: 25746},
 										name: "QueryExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1074, col: 40, offset: 25755},
+									pos:  position{line: 1074, col: 40, offset: 25756},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1074, col: 43, offset: 25758},
+									pos:        position{line: 1074, col: 43, offset: 25759},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7346,35 +7349,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1075, col: 5, offset: 25787},
+						pos: position{line: 1075, col: 5, offset: 25788},
 						run: (*parser).callonPrimary21,
 						expr: &seqExpr{
-							pos: position{line: 1075, col: 5, offset: 25787},
+							pos: position{line: 1075, col: 5, offset: 25788},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1075, col: 5, offset: 25787},
+									pos:        position{line: 1075, col: 5, offset: 25788},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1075, col: 9, offset: 25791},
+									pos:  position{line: 1075, col: 9, offset: 25792},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1075, col: 12, offset: 25794},
+									pos:   position{line: 1075, col: 12, offset: 25795},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1075, col: 17, offset: 25799},
+										pos:  position{line: 1075, col: 17, offset: 25800},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1075, col: 22, offset: 25804},
+									pos:  position{line: 1075, col: 22, offset: 25805},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1075, col: 25, offset: 25807},
+									pos:        position{line: 1075, col: 25, offset: 25808},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7389,24 +7392,24 @@ var g = &grammar{
 		},
 		{
 			name: "SubqueryOps",
-			pos:  position{line: 1077, col: 1, offset: 25833},
+			pos:  position{line: 1077, col: 1, offset: 25834},
 			expr: &choiceExpr{
-				pos: position{line: 1077, col: 15, offset: 25847},
+				pos: position{line: 1077, col: 15, offset: 25848},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1077, col: 15, offset: 25847},
+						pos:  position{line: 1077, col: 15, offset: 25848},
 						name: "UNNEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1077, col: 24, offset: 25856},
+						pos:  position{line: 1077, col: 24, offset: 25857},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1077, col: 31, offset: 25863},
+						pos:  position{line: 1077, col: 31, offset: 25864},
 						name: "VALUES",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1077, col: 40, offset: 25872},
+						pos:  position{line: 1077, col: 40, offset: 25873},
 						name: "SelectOp",
 					},
 				},
@@ -7416,53 +7419,53 @@ var g = &grammar{
 		},
 		{
 			name: "CaseExpr",
-			pos:  position{line: 1079, col: 1, offset: 25882},
+			pos:  position{line: 1079, col: 1, offset: 25883},
 			expr: &choiceExpr{
-				pos: position{line: 1080, col: 5, offset: 25895},
+				pos: position{line: 1080, col: 5, offset: 25896},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1080, col: 5, offset: 25895},
+						pos: position{line: 1080, col: 5, offset: 25896},
 						run: (*parser).callonCaseExpr2,
 						expr: &seqExpr{
-							pos: position{line: 1080, col: 5, offset: 25895},
+							pos: position{line: 1080, col: 5, offset: 25896},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1080, col: 5, offset: 25895},
+									pos:  position{line: 1080, col: 5, offset: 25896},
 									name: "CASE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1080, col: 10, offset: 25900},
+									pos:   position{line: 1080, col: 10, offset: 25901},
 									label: "cases",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1080, col: 16, offset: 25906},
+										pos: position{line: 1080, col: 16, offset: 25907},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1080, col: 16, offset: 25906},
+											pos:  position{line: 1080, col: 16, offset: 25907},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1080, col: 22, offset: 25912},
+									pos:   position{line: 1080, col: 22, offset: 25913},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1080, col: 28, offset: 25918},
+										pos: position{line: 1080, col: 28, offset: 25919},
 										expr: &seqExpr{
-											pos: position{line: 1080, col: 29, offset: 25919},
+											pos: position{line: 1080, col: 29, offset: 25920},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1080, col: 29, offset: 25919},
+													pos:  position{line: 1080, col: 29, offset: 25920},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1080, col: 31, offset: 25921},
+													pos:  position{line: 1080, col: 31, offset: 25922},
 													name: "ELSE",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1080, col: 36, offset: 25926},
+													pos:  position{line: 1080, col: 36, offset: 25927},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1080, col: 38, offset: 25928},
+													pos:  position{line: 1080, col: 38, offset: 25929},
 													name: "Expr",
 												},
 											},
@@ -7470,24 +7473,24 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1080, col: 45, offset: 25935},
+									pos:  position{line: 1080, col: 45, offset: 25936},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1080, col: 47, offset: 25937},
+									pos:  position{line: 1080, col: 47, offset: 25938},
 									name: "END",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1080, col: 51, offset: 25941},
+									pos: position{line: 1080, col: 51, offset: 25942},
 									expr: &seqExpr{
-										pos: position{line: 1080, col: 52, offset: 25942},
+										pos: position{line: 1080, col: 52, offset: 25943},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1080, col: 52, offset: 25942},
+												pos:  position{line: 1080, col: 52, offset: 25943},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1080, col: 54, offset: 25944},
+												pos:  position{line: 1080, col: 54, offset: 25945},
 												name: "CASE",
 											},
 										},
@@ -7497,60 +7500,60 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1104, col: 5, offset: 26593},
+						pos: position{line: 1104, col: 5, offset: 26594},
 						run: (*parser).callonCaseExpr21,
 						expr: &seqExpr{
-							pos: position{line: 1104, col: 5, offset: 26593},
+							pos: position{line: 1104, col: 5, offset: 26594},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1104, col: 5, offset: 26593},
+									pos:  position{line: 1104, col: 5, offset: 26594},
 									name: "CASE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1104, col: 10, offset: 26598},
+									pos:  position{line: 1104, col: 10, offset: 26599},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1104, col: 12, offset: 26600},
+									pos:   position{line: 1104, col: 12, offset: 26601},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1104, col: 17, offset: 26605},
+										pos:  position{line: 1104, col: 17, offset: 26606},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1104, col: 22, offset: 26610},
+									pos:   position{line: 1104, col: 22, offset: 26611},
 									label: "whens",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1104, col: 28, offset: 26616},
+										pos: position{line: 1104, col: 28, offset: 26617},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1104, col: 28, offset: 26616},
+											pos:  position{line: 1104, col: 28, offset: 26617},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1104, col: 34, offset: 26622},
+									pos:   position{line: 1104, col: 34, offset: 26623},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1104, col: 40, offset: 26628},
+										pos: position{line: 1104, col: 40, offset: 26629},
 										expr: &seqExpr{
-											pos: position{line: 1104, col: 41, offset: 26629},
+											pos: position{line: 1104, col: 41, offset: 26630},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1104, col: 41, offset: 26629},
+													pos:  position{line: 1104, col: 41, offset: 26630},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1104, col: 43, offset: 26631},
+													pos:  position{line: 1104, col: 43, offset: 26632},
 													name: "ELSE",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1104, col: 48, offset: 26636},
+													pos:  position{line: 1104, col: 48, offset: 26637},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1104, col: 50, offset: 26638},
+													pos:  position{line: 1104, col: 50, offset: 26639},
 													name: "Expr",
 												},
 											},
@@ -7558,24 +7561,24 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1104, col: 57, offset: 26645},
+									pos:  position{line: 1104, col: 57, offset: 26646},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1104, col: 59, offset: 26647},
+									pos:  position{line: 1104, col: 59, offset: 26648},
 									name: "END",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1104, col: 63, offset: 26651},
+									pos: position{line: 1104, col: 63, offset: 26652},
 									expr: &seqExpr{
-										pos: position{line: 1104, col: 64, offset: 26652},
+										pos: position{line: 1104, col: 64, offset: 26653},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1104, col: 64, offset: 26652},
+												pos:  position{line: 1104, col: 64, offset: 26653},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1104, col: 66, offset: 26654},
+												pos:  position{line: 1104, col: 66, offset: 26655},
 												name: "CASE",
 											},
 										},
@@ -7591,50 +7594,50 @@ var g = &grammar{
 		},
 		{
 			name: "When",
-			pos:  position{line: 1117, col: 1, offset: 26960},
+			pos:  position{line: 1117, col: 1, offset: 26961},
 			expr: &actionExpr{
-				pos: position{line: 1118, col: 5, offset: 26969},
+				pos: position{line: 1118, col: 5, offset: 26970},
 				run: (*parser).callonWhen1,
 				expr: &seqExpr{
-					pos: position{line: 1118, col: 5, offset: 26969},
+					pos: position{line: 1118, col: 5, offset: 26970},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1118, col: 5, offset: 26969},
+							pos:  position{line: 1118, col: 5, offset: 26970},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1118, col: 7, offset: 26971},
+							pos:  position{line: 1118, col: 7, offset: 26972},
 							name: "WHEN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1118, col: 12, offset: 26976},
+							pos:  position{line: 1118, col: 12, offset: 26977},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1118, col: 14, offset: 26978},
+							pos:   position{line: 1118, col: 14, offset: 26979},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1118, col: 19, offset: 26983},
+								pos:  position{line: 1118, col: 19, offset: 26984},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1118, col: 24, offset: 26988},
+							pos:  position{line: 1118, col: 24, offset: 26989},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1118, col: 26, offset: 26990},
+							pos:  position{line: 1118, col: 26, offset: 26991},
 							name: "THEN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1118, col: 31, offset: 26995},
+							pos:  position{line: 1118, col: 31, offset: 26996},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1118, col: 33, offset: 26997},
+							pos:   position{line: 1118, col: 33, offset: 26998},
 							label: "then",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1118, col: 38, offset: 27002},
+								pos:  position{line: 1118, col: 38, offset: 27003},
 								name: "Expr",
 							},
 						},
@@ -7646,15 +7649,15 @@ var g = &grammar{
 		},
 		{
 			name: "QueryExpr",
-			pos:  position{line: 1127, col: 1, offset: 27157},
+			pos:  position{line: 1127, col: 1, offset: 27158},
 			expr: &actionExpr{
-				pos: position{line: 1128, col: 5, offset: 27171},
+				pos: position{line: 1128, col: 5, offset: 27172},
 				run: (*parser).callonQueryExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 1128, col: 5, offset: 27171},
+					pos:   position{line: 1128, col: 5, offset: 27172},
 					label: "body",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1128, col: 10, offset: 27176},
+						pos:  position{line: 1128, col: 10, offset: 27177},
 						name: "Seq",
 					},
 				},
@@ -7664,37 +7667,37 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 1136, col: 1, offset: 27314},
+			pos:  position{line: 1136, col: 1, offset: 27315},
 			expr: &actionExpr{
-				pos: position{line: 1137, col: 5, offset: 27325},
+				pos: position{line: 1137, col: 5, offset: 27326},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 1137, col: 5, offset: 27325},
+					pos: position{line: 1137, col: 5, offset: 27326},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1137, col: 5, offset: 27325},
+							pos:        position{line: 1137, col: 5, offset: 27326},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1137, col: 9, offset: 27329},
+							pos:  position{line: 1137, col: 9, offset: 27330},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1137, col: 12, offset: 27332},
+							pos:   position{line: 1137, col: 12, offset: 27333},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1137, col: 18, offset: 27338},
+								pos:  position{line: 1137, col: 18, offset: 27339},
 								name: "RecordElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1137, col: 30, offset: 27350},
+							pos:  position{line: 1137, col: 30, offset: 27351},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1137, col: 33, offset: 27353},
+							pos:        position{line: 1137, col: 33, offset: 27354},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -7707,31 +7710,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElems",
-			pos:  position{line: 1145, col: 1, offset: 27511},
+			pos:  position{line: 1145, col: 1, offset: 27512},
 			expr: &choiceExpr{
-				pos: position{line: 1146, col: 5, offset: 27527},
+				pos: position{line: 1146, col: 5, offset: 27528},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1146, col: 5, offset: 27527},
+						pos: position{line: 1146, col: 5, offset: 27528},
 						run: (*parser).callonRecordElems2,
 						expr: &seqExpr{
-							pos: position{line: 1146, col: 5, offset: 27527},
+							pos: position{line: 1146, col: 5, offset: 27528},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1146, col: 5, offset: 27527},
+									pos:   position{line: 1146, col: 5, offset: 27528},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1146, col: 11, offset: 27533},
+										pos:  position{line: 1146, col: 11, offset: 27534},
 										name: "RecordElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1146, col: 22, offset: 27544},
+									pos:   position{line: 1146, col: 22, offset: 27545},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1146, col: 27, offset: 27549},
+										pos: position{line: 1146, col: 27, offset: 27550},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1146, col: 27, offset: 27549},
+											pos:  position{line: 1146, col: 27, offset: 27550},
 											name: "RecordElemTail",
 										},
 									},
@@ -7740,10 +7743,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1149, col: 5, offset: 27612},
+						pos: position{line: 1149, col: 5, offset: 27613},
 						run: (*parser).callonRecordElems9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1149, col: 5, offset: 27612},
+							pos:  position{line: 1149, col: 5, offset: 27613},
 							name: "__",
 						},
 					},
@@ -7754,32 +7757,32 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElemTail",
-			pos:  position{line: 1151, col: 1, offset: 27636},
+			pos:  position{line: 1151, col: 1, offset: 27637},
 			expr: &actionExpr{
-				pos: position{line: 1151, col: 18, offset: 27653},
+				pos: position{line: 1151, col: 18, offset: 27654},
 				run: (*parser).callonRecordElemTail1,
 				expr: &seqExpr{
-					pos: position{line: 1151, col: 18, offset: 27653},
+					pos: position{line: 1151, col: 18, offset: 27654},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1151, col: 18, offset: 27653},
+							pos:  position{line: 1151, col: 18, offset: 27654},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1151, col: 21, offset: 27656},
+							pos:        position{line: 1151, col: 21, offset: 27657},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1151, col: 25, offset: 27660},
+							pos:  position{line: 1151, col: 25, offset: 27661},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1151, col: 28, offset: 27663},
+							pos:   position{line: 1151, col: 28, offset: 27664},
 							label: "elem",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1151, col: 33, offset: 27668},
+								pos:  position{line: 1151, col: 33, offset: 27669},
 								name: "RecordElem",
 							},
 						},
@@ -7791,20 +7794,20 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElem",
-			pos:  position{line: 1153, col: 1, offset: 27701},
+			pos:  position{line: 1153, col: 1, offset: 27702},
 			expr: &choiceExpr{
-				pos: position{line: 1154, col: 5, offset: 27716},
+				pos: position{line: 1154, col: 5, offset: 27717},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1154, col: 5, offset: 27716},
+						pos:  position{line: 1154, col: 5, offset: 27717},
 						name: "Spread",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1155, col: 5, offset: 27727},
+						pos:  position{line: 1155, col: 5, offset: 27728},
 						name: "FieldExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1156, col: 5, offset: 27741},
+						pos:  position{line: 1156, col: 5, offset: 27742},
 						name: "Identifier",
 					},
 				},
@@ -7814,28 +7817,28 @@ var g = &grammar{
 		},
 		{
 			name: "Spread",
-			pos:  position{line: 1158, col: 1, offset: 27753},
+			pos:  position{line: 1158, col: 1, offset: 27754},
 			expr: &actionExpr{
-				pos: position{line: 1159, col: 5, offset: 27764},
+				pos: position{line: 1159, col: 5, offset: 27765},
 				run: (*parser).callonSpread1,
 				expr: &seqExpr{
-					pos: position{line: 1159, col: 5, offset: 27764},
+					pos: position{line: 1159, col: 5, offset: 27765},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1159, col: 5, offset: 27764},
+							pos:        position{line: 1159, col: 5, offset: 27765},
 							val:        "...",
 							ignoreCase: false,
 							want:       "\"...\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1159, col: 11, offset: 27770},
+							pos:  position{line: 1159, col: 11, offset: 27771},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1159, col: 14, offset: 27773},
+							pos:   position{line: 1159, col: 14, offset: 27774},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1159, col: 19, offset: 27778},
+								pos:  position{line: 1159, col: 19, offset: 27779},
 								name: "Expr",
 							},
 						},
@@ -7847,40 +7850,40 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 1163, col: 1, offset: 27874},
+			pos:  position{line: 1163, col: 1, offset: 27875},
 			expr: &actionExpr{
-				pos: position{line: 1164, col: 5, offset: 27888},
+				pos: position{line: 1164, col: 5, offset: 27889},
 				run: (*parser).callonFieldExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1164, col: 5, offset: 27888},
+					pos: position{line: 1164, col: 5, offset: 27889},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1164, col: 5, offset: 27888},
+							pos:   position{line: 1164, col: 5, offset: 27889},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1164, col: 10, offset: 27893},
+								pos:  position{line: 1164, col: 10, offset: 27894},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1164, col: 15, offset: 27898},
+							pos:  position{line: 1164, col: 15, offset: 27899},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1164, col: 18, offset: 27901},
+							pos:        position{line: 1164, col: 18, offset: 27902},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1164, col: 22, offset: 27905},
+							pos:  position{line: 1164, col: 22, offset: 27906},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1164, col: 25, offset: 27908},
+							pos:   position{line: 1164, col: 25, offset: 27909},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1164, col: 31, offset: 27914},
+								pos:  position{line: 1164, col: 31, offset: 27915},
 								name: "Expr",
 							},
 						},
@@ -7892,37 +7895,37 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 1173, col: 1, offset: 28083},
+			pos:  position{line: 1173, col: 1, offset: 28084},
 			expr: &actionExpr{
-				pos: position{line: 1174, col: 5, offset: 28093},
+				pos: position{line: 1174, col: 5, offset: 28094},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 1174, col: 5, offset: 28093},
+					pos: position{line: 1174, col: 5, offset: 28094},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1174, col: 5, offset: 28093},
+							pos:        position{line: 1174, col: 5, offset: 28094},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1174, col: 9, offset: 28097},
+							pos:  position{line: 1174, col: 9, offset: 28098},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1174, col: 12, offset: 28100},
+							pos:   position{line: 1174, col: 12, offset: 28101},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1174, col: 18, offset: 28106},
+								pos:  position{line: 1174, col: 18, offset: 28107},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1174, col: 30, offset: 28118},
+							pos:  position{line: 1174, col: 30, offset: 28119},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1174, col: 33, offset: 28121},
+							pos:        position{line: 1174, col: 33, offset: 28122},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -7935,37 +7938,37 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 1182, col: 1, offset: 28277},
+			pos:  position{line: 1182, col: 1, offset: 28278},
 			expr: &actionExpr{
-				pos: position{line: 1183, col: 5, offset: 28285},
+				pos: position{line: 1183, col: 5, offset: 28286},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 1183, col: 5, offset: 28285},
+					pos: position{line: 1183, col: 5, offset: 28286},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1183, col: 5, offset: 28285},
+							pos:        position{line: 1183, col: 5, offset: 28286},
 							val:        "|[",
 							ignoreCase: false,
 							want:       "\"|[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1183, col: 10, offset: 28290},
+							pos:  position{line: 1183, col: 10, offset: 28291},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1183, col: 13, offset: 28293},
+							pos:   position{line: 1183, col: 13, offset: 28294},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1183, col: 19, offset: 28299},
+								pos:  position{line: 1183, col: 19, offset: 28300},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1183, col: 31, offset: 28311},
+							pos:  position{line: 1183, col: 31, offset: 28312},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1183, col: 34, offset: 28314},
+							pos:        position{line: 1183, col: 34, offset: 28315},
 							val:        "]|",
 							ignoreCase: false,
 							want:       "\"]|\"",
@@ -7978,54 +7981,54 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElems",
-			pos:  position{line: 1191, col: 1, offset: 28467},
+			pos:  position{line: 1191, col: 1, offset: 28468},
 			expr: &choiceExpr{
-				pos: position{line: 1192, col: 5, offset: 28483},
+				pos: position{line: 1192, col: 5, offset: 28484},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1192, col: 5, offset: 28483},
+						pos: position{line: 1192, col: 5, offset: 28484},
 						run: (*parser).callonVectorElems2,
 						expr: &seqExpr{
-							pos: position{line: 1192, col: 5, offset: 28483},
+							pos: position{line: 1192, col: 5, offset: 28484},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1192, col: 5, offset: 28483},
+									pos:   position{line: 1192, col: 5, offset: 28484},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1192, col: 11, offset: 28489},
+										pos:  position{line: 1192, col: 11, offset: 28490},
 										name: "VectorElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1192, col: 22, offset: 28500},
+									pos:   position{line: 1192, col: 22, offset: 28501},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1192, col: 27, offset: 28505},
+										pos: position{line: 1192, col: 27, offset: 28506},
 										expr: &actionExpr{
-											pos: position{line: 1192, col: 28, offset: 28506},
+											pos: position{line: 1192, col: 28, offset: 28507},
 											run: (*parser).callonVectorElems8,
 											expr: &seqExpr{
-												pos: position{line: 1192, col: 28, offset: 28506},
+												pos: position{line: 1192, col: 28, offset: 28507},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1192, col: 28, offset: 28506},
+														pos:  position{line: 1192, col: 28, offset: 28507},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 1192, col: 31, offset: 28509},
+														pos:        position{line: 1192, col: 31, offset: 28510},
 														val:        ",",
 														ignoreCase: false,
 														want:       "\",\"",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1192, col: 35, offset: 28513},
+														pos:  position{line: 1192, col: 35, offset: 28514},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 1192, col: 38, offset: 28516},
+														pos:   position{line: 1192, col: 38, offset: 28517},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1192, col: 40, offset: 28518},
+															pos:  position{line: 1192, col: 40, offset: 28519},
 															name: "VectorElem",
 														},
 													},
@@ -8038,10 +8041,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1195, col: 5, offset: 28600},
+						pos: position{line: 1195, col: 5, offset: 28601},
 						run: (*parser).callonVectorElems15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1195, col: 5, offset: 28600},
+							pos:  position{line: 1195, col: 5, offset: 28601},
 							name: "__",
 						},
 					},
@@ -8052,22 +8055,22 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElem",
-			pos:  position{line: 1197, col: 1, offset: 28624},
+			pos:  position{line: 1197, col: 1, offset: 28625},
 			expr: &choiceExpr{
-				pos: position{line: 1198, col: 5, offset: 28639},
+				pos: position{line: 1198, col: 5, offset: 28640},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1198, col: 5, offset: 28639},
+						pos:  position{line: 1198, col: 5, offset: 28640},
 						name: "Spread",
 					},
 					&actionExpr{
-						pos: position{line: 1199, col: 5, offset: 28650},
+						pos: position{line: 1199, col: 5, offset: 28651},
 						run: (*parser).callonVectorElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1199, col: 5, offset: 28650},
+							pos:   position{line: 1199, col: 5, offset: 28651},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1199, col: 7, offset: 28652},
+								pos:  position{line: 1199, col: 7, offset: 28653},
 								name: "Expr",
 							},
 						},
@@ -8079,37 +8082,37 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 1201, col: 1, offset: 28743},
+			pos:  position{line: 1201, col: 1, offset: 28744},
 			expr: &actionExpr{
-				pos: position{line: 1202, col: 5, offset: 28751},
+				pos: position{line: 1202, col: 5, offset: 28752},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 1202, col: 5, offset: 28751},
+					pos: position{line: 1202, col: 5, offset: 28752},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1202, col: 5, offset: 28751},
+							pos:        position{line: 1202, col: 5, offset: 28752},
 							val:        "|{",
 							ignoreCase: false,
 							want:       "\"|{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1202, col: 10, offset: 28756},
+							pos:  position{line: 1202, col: 10, offset: 28757},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1202, col: 13, offset: 28759},
+							pos:   position{line: 1202, col: 13, offset: 28760},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1202, col: 19, offset: 28765},
+								pos:  position{line: 1202, col: 19, offset: 28766},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1202, col: 27, offset: 28773},
+							pos:  position{line: 1202, col: 27, offset: 28774},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1202, col: 30, offset: 28776},
+							pos:        position{line: 1202, col: 30, offset: 28777},
 							val:        "}|",
 							ignoreCase: false,
 							want:       "\"}|\"",
@@ -8122,31 +8125,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 1210, col: 1, offset: 28930},
+			pos:  position{line: 1210, col: 1, offset: 28931},
 			expr: &choiceExpr{
-				pos: position{line: 1211, col: 5, offset: 28942},
+				pos: position{line: 1211, col: 5, offset: 28943},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1211, col: 5, offset: 28942},
+						pos: position{line: 1211, col: 5, offset: 28943},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 1211, col: 5, offset: 28942},
+							pos: position{line: 1211, col: 5, offset: 28943},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1211, col: 5, offset: 28942},
+									pos:   position{line: 1211, col: 5, offset: 28943},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1211, col: 11, offset: 28948},
+										pos:  position{line: 1211, col: 11, offset: 28949},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1211, col: 17, offset: 28954},
+									pos:   position{line: 1211, col: 17, offset: 28955},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1211, col: 22, offset: 28959},
+										pos: position{line: 1211, col: 22, offset: 28960},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1211, col: 22, offset: 28959},
+											pos:  position{line: 1211, col: 22, offset: 28960},
 											name: "EntryTail",
 										},
 									},
@@ -8155,10 +8158,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1214, col: 5, offset: 29017},
+						pos: position{line: 1214, col: 5, offset: 29018},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1214, col: 5, offset: 29017},
+							pos:  position{line: 1214, col: 5, offset: 29018},
 							name: "__",
 						},
 					},
@@ -8169,32 +8172,32 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 1217, col: 1, offset: 29042},
+			pos:  position{line: 1217, col: 1, offset: 29043},
 			expr: &actionExpr{
-				pos: position{line: 1217, col: 13, offset: 29054},
+				pos: position{line: 1217, col: 13, offset: 29055},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 1217, col: 13, offset: 29054},
+					pos: position{line: 1217, col: 13, offset: 29055},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1217, col: 13, offset: 29054},
+							pos:  position{line: 1217, col: 13, offset: 29055},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1217, col: 16, offset: 29057},
+							pos:        position{line: 1217, col: 16, offset: 29058},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1217, col: 20, offset: 29061},
+							pos:  position{line: 1217, col: 20, offset: 29062},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1217, col: 23, offset: 29064},
+							pos:   position{line: 1217, col: 23, offset: 29065},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1217, col: 25, offset: 29066},
+								pos:  position{line: 1217, col: 25, offset: 29067},
 								name: "Entry",
 							},
 						},
@@ -8206,40 +8209,40 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 1219, col: 1, offset: 29091},
+			pos:  position{line: 1219, col: 1, offset: 29092},
 			expr: &actionExpr{
-				pos: position{line: 1220, col: 5, offset: 29101},
+				pos: position{line: 1220, col: 5, offset: 29102},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 1220, col: 5, offset: 29101},
+					pos: position{line: 1220, col: 5, offset: 29102},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1220, col: 5, offset: 29101},
+							pos:   position{line: 1220, col: 5, offset: 29102},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1220, col: 9, offset: 29105},
+								pos:  position{line: 1220, col: 9, offset: 29106},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1220, col: 14, offset: 29110},
+							pos:  position{line: 1220, col: 14, offset: 29111},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1220, col: 17, offset: 29113},
+							pos:        position{line: 1220, col: 17, offset: 29114},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1220, col: 21, offset: 29117},
+							pos:  position{line: 1220, col: 21, offset: 29118},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1220, col: 24, offset: 29120},
+							pos:   position{line: 1220, col: 24, offset: 29121},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1220, col: 30, offset: 29126},
+								pos:  position{line: 1220, col: 30, offset: 29127},
 								name: "Expr",
 							},
 						},
@@ -8251,61 +8254,61 @@ var g = &grammar{
 		},
 		{
 			name: "Tuple",
-			pos:  position{line: 1224, col: 1, offset: 29229},
+			pos:  position{line: 1224, col: 1, offset: 29230},
 			expr: &actionExpr{
-				pos: position{line: 1225, col: 5, offset: 29239},
+				pos: position{line: 1225, col: 5, offset: 29240},
 				run: (*parser).callonTuple1,
 				expr: &seqExpr{
-					pos: position{line: 1225, col: 5, offset: 29239},
+					pos: position{line: 1225, col: 5, offset: 29240},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1225, col: 5, offset: 29239},
+							pos:        position{line: 1225, col: 5, offset: 29240},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1225, col: 9, offset: 29243},
+							pos:  position{line: 1225, col: 9, offset: 29244},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1225, col: 12, offset: 29246},
+							pos:   position{line: 1225, col: 12, offset: 29247},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1225, col: 18, offset: 29252},
+								pos:  position{line: 1225, col: 18, offset: 29253},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1225, col: 23, offset: 29257},
+							pos:   position{line: 1225, col: 23, offset: 29258},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1225, col: 28, offset: 29262},
+								pos: position{line: 1225, col: 28, offset: 29263},
 								expr: &actionExpr{
-									pos: position{line: 1225, col: 29, offset: 29263},
+									pos: position{line: 1225, col: 29, offset: 29264},
 									run: (*parser).callonTuple9,
 									expr: &seqExpr{
-										pos: position{line: 1225, col: 29, offset: 29263},
+										pos: position{line: 1225, col: 29, offset: 29264},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1225, col: 29, offset: 29263},
+												pos:  position{line: 1225, col: 29, offset: 29264},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1225, col: 32, offset: 29266},
+												pos:        position{line: 1225, col: 32, offset: 29267},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1225, col: 36, offset: 29270},
+												pos:  position{line: 1225, col: 36, offset: 29271},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1225, col: 39, offset: 29273},
+												pos:   position{line: 1225, col: 39, offset: 29274},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1225, col: 41, offset: 29275},
+													pos:  position{line: 1225, col: 41, offset: 29276},
 													name: "Expr",
 												},
 											},
@@ -8315,11 +8318,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1225, col: 66, offset: 29300},
+							pos:  position{line: 1225, col: 66, offset: 29301},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1225, col: 69, offset: 29303},
+							pos:        position{line: 1225, col: 69, offset: 29304},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -8332,39 +8335,39 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTimeValue",
-			pos:  position{line: 1233, col: 1, offset: 29462},
+			pos:  position{line: 1233, col: 1, offset: 29463},
 			expr: &actionExpr{
-				pos: position{line: 1234, col: 5, offset: 29479},
+				pos: position{line: 1234, col: 5, offset: 29480},
 				run: (*parser).callonSQLTimeValue1,
 				expr: &seqExpr{
-					pos: position{line: 1234, col: 5, offset: 29479},
+					pos: position{line: 1234, col: 5, offset: 29480},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1234, col: 5, offset: 29479},
+							pos:   position{line: 1234, col: 5, offset: 29480},
 							label: "typ",
 							expr: &choiceExpr{
-								pos: position{line: 1234, col: 10, offset: 29484},
+								pos: position{line: 1234, col: 10, offset: 29485},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1234, col: 10, offset: 29484},
+										pos:  position{line: 1234, col: 10, offset: 29485},
 										name: "DATE",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1234, col: 17, offset: 29491},
+										pos:  position{line: 1234, col: 17, offset: 29492},
 										name: "TIMESTAMP",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1234, col: 28, offset: 29502},
+							pos:  position{line: 1234, col: 28, offset: 29503},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1234, col: 30, offset: 29504},
+							pos:   position{line: 1234, col: 30, offset: 29505},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1234, col: 32, offset: 29506},
+								pos:  position{line: 1234, col: 32, offset: 29507},
 								name: "StringLiteral",
 							},
 						},
@@ -8376,56 +8379,56 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 1245, col: 1, offset: 29723},
+			pos:  position{line: 1245, col: 1, offset: 29724},
 			expr: &choiceExpr{
-				pos: position{line: 1246, col: 5, offset: 29735},
+				pos: position{line: 1246, col: 5, offset: 29736},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1246, col: 5, offset: 29735},
+						pos:  position{line: 1246, col: 5, offset: 29736},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1247, col: 5, offset: 29751},
+						pos:  position{line: 1247, col: 5, offset: 29752},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1248, col: 5, offset: 29769},
+						pos:  position{line: 1248, col: 5, offset: 29770},
 						name: "FString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1249, col: 5, offset: 29781},
+						pos:  position{line: 1249, col: 5, offset: 29782},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1250, col: 5, offset: 29799},
+						pos:  position{line: 1250, col: 5, offset: 29800},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1251, col: 5, offset: 29818},
+						pos:  position{line: 1251, col: 5, offset: 29819},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1252, col: 5, offset: 29835},
+						pos:  position{line: 1252, col: 5, offset: 29836},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1253, col: 5, offset: 29848},
+						pos:  position{line: 1253, col: 5, offset: 29849},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1254, col: 5, offset: 29857},
+						pos:  position{line: 1254, col: 5, offset: 29858},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1255, col: 5, offset: 29874},
+						pos:  position{line: 1255, col: 5, offset: 29875},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1256, col: 5, offset: 29893},
+						pos:  position{line: 1256, col: 5, offset: 29894},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1257, col: 5, offset: 29912},
+						pos:  position{line: 1257, col: 5, offset: 29913},
 						name: "NullLiteral",
 					},
 				},
@@ -8435,28 +8438,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 1259, col: 1, offset: 29925},
+			pos:  position{line: 1259, col: 1, offset: 29926},
 			expr: &choiceExpr{
-				pos: position{line: 1260, col: 5, offset: 29943},
+				pos: position{line: 1260, col: 5, offset: 29944},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1260, col: 5, offset: 29943},
+						pos: position{line: 1260, col: 5, offset: 29944},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1260, col: 5, offset: 29943},
+							pos: position{line: 1260, col: 5, offset: 29944},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1260, col: 5, offset: 29943},
+									pos:   position{line: 1260, col: 5, offset: 29944},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1260, col: 7, offset: 29945},
+										pos:  position{line: 1260, col: 7, offset: 29946},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1260, col: 14, offset: 29952},
+									pos: position{line: 1260, col: 14, offset: 29953},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1260, col: 15, offset: 29953},
+										pos:  position{line: 1260, col: 15, offset: 29954},
 										name: "IdentifierRest",
 									},
 								},
@@ -8464,13 +8467,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1263, col: 5, offset: 30033},
+						pos: position{line: 1263, col: 5, offset: 30034},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1263, col: 5, offset: 30033},
+							pos:   position{line: 1263, col: 5, offset: 30034},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1263, col: 7, offset: 30035},
+								pos:  position{line: 1263, col: 7, offset: 30036},
 								name: "IP4Net",
 							},
 						},
@@ -8482,35 +8485,35 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 1267, col: 1, offset: 30104},
+			pos:  position{line: 1267, col: 1, offset: 30105},
 			expr: &choiceExpr{
-				pos: position{line: 1268, col: 5, offset: 30123},
+				pos: position{line: 1268, col: 5, offset: 30124},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1268, col: 5, offset: 30123},
+						pos: position{line: 1268, col: 5, offset: 30124},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1268, col: 5, offset: 30123},
+							pos: position{line: 1268, col: 5, offset: 30124},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1268, col: 5, offset: 30123},
+									pos:   position{line: 1268, col: 5, offset: 30124},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1268, col: 7, offset: 30125},
+										pos:  position{line: 1268, col: 7, offset: 30126},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1268, col: 11, offset: 30129},
+									pos: position{line: 1268, col: 11, offset: 30130},
 									expr: &choiceExpr{
-										pos: position{line: 1268, col: 13, offset: 30131},
+										pos: position{line: 1268, col: 13, offset: 30132},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1268, col: 13, offset: 30131},
+												pos:  position{line: 1268, col: 13, offset: 30132},
 												name: "IdentifierRest",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1268, col: 30, offset: 30148},
+												pos:  position{line: 1268, col: 30, offset: 30149},
 												name: "TypeLiteral",
 											},
 										},
@@ -8520,13 +8523,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1271, col: 5, offset: 30225},
+						pos: position{line: 1271, col: 5, offset: 30226},
 						run: (*parser).callonAddressLiteral10,
 						expr: &labeledExpr{
-							pos:   position{line: 1271, col: 5, offset: 30225},
+							pos:   position{line: 1271, col: 5, offset: 30226},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1271, col: 7, offset: 30227},
+								pos:  position{line: 1271, col: 7, offset: 30228},
 								name: "IP",
 							},
 						},
@@ -8538,15 +8541,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 1275, col: 1, offset: 30291},
+			pos:  position{line: 1275, col: 1, offset: 30292},
 			expr: &actionExpr{
-				pos: position{line: 1276, col: 5, offset: 30308},
+				pos: position{line: 1276, col: 5, offset: 30309},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1276, col: 5, offset: 30308},
+					pos:   position{line: 1276, col: 5, offset: 30309},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1276, col: 7, offset: 30310},
+						pos:  position{line: 1276, col: 7, offset: 30311},
 						name: "FloatString",
 					},
 				},
@@ -8556,15 +8559,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 1280, col: 1, offset: 30388},
+			pos:  position{line: 1280, col: 1, offset: 30389},
 			expr: &actionExpr{
-				pos: position{line: 1281, col: 5, offset: 30407},
+				pos: position{line: 1281, col: 5, offset: 30408},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1281, col: 5, offset: 30407},
+					pos:   position{line: 1281, col: 5, offset: 30408},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1281, col: 7, offset: 30409},
+						pos:  position{line: 1281, col: 7, offset: 30410},
 						name: "IntString",
 					},
 				},
@@ -8574,23 +8577,23 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 1285, col: 1, offset: 30483},
+			pos:  position{line: 1285, col: 1, offset: 30484},
 			expr: &choiceExpr{
-				pos: position{line: 1286, col: 5, offset: 30502},
+				pos: position{line: 1286, col: 5, offset: 30503},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1286, col: 5, offset: 30502},
+						pos: position{line: 1286, col: 5, offset: 30503},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1286, col: 5, offset: 30502},
+							pos:  position{line: 1286, col: 5, offset: 30503},
 							name: "TRUE",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1287, col: 5, offset: 30560},
+						pos: position{line: 1287, col: 5, offset: 30561},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1287, col: 5, offset: 30560},
+							pos:  position{line: 1287, col: 5, offset: 30561},
 							name: "FALSE",
 						},
 					},
@@ -8601,12 +8604,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 1289, col: 1, offset: 30616},
+			pos:  position{line: 1289, col: 1, offset: 30617},
 			expr: &actionExpr{
-				pos: position{line: 1290, col: 5, offset: 30632},
+				pos: position{line: 1290, col: 5, offset: 30633},
 				run: (*parser).callonNullLiteral1,
 				expr: &ruleRefExpr{
-					pos:  position{line: 1290, col: 5, offset: 30632},
+					pos:  position{line: 1290, col: 5, offset: 30633},
 					name: "NULL",
 				},
 			},
@@ -8615,23 +8618,23 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 1292, col: 1, offset: 30682},
+			pos:  position{line: 1292, col: 1, offset: 30683},
 			expr: &actionExpr{
-				pos: position{line: 1293, col: 5, offset: 30699},
+				pos: position{line: 1293, col: 5, offset: 30700},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1293, col: 5, offset: 30699},
+					pos: position{line: 1293, col: 5, offset: 30700},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1293, col: 5, offset: 30699},
+							pos:        position{line: 1293, col: 5, offset: 30700},
 							val:        "0x",
 							ignoreCase: false,
 							want:       "\"0x\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1293, col: 10, offset: 30704},
+							pos: position{line: 1293, col: 10, offset: 30705},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1293, col: 10, offset: 30704},
+								pos:  position{line: 1293, col: 10, offset: 30705},
 								name: "HexDigit",
 							},
 						},
@@ -8643,29 +8646,29 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 1297, col: 1, offset: 30778},
+			pos:  position{line: 1297, col: 1, offset: 30779},
 			expr: &actionExpr{
-				pos: position{line: 1298, col: 5, offset: 30794},
+				pos: position{line: 1298, col: 5, offset: 30795},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1298, col: 5, offset: 30794},
+					pos: position{line: 1298, col: 5, offset: 30795},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1298, col: 5, offset: 30794},
+							pos:        position{line: 1298, col: 5, offset: 30795},
 							val:        "<",
 							ignoreCase: false,
 							want:       "\"<\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1298, col: 9, offset: 30798},
+							pos:   position{line: 1298, col: 9, offset: 30799},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1298, col: 13, offset: 30802},
+								pos:  position{line: 1298, col: 13, offset: 30803},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1298, col: 18, offset: 30807},
+							pos:        position{line: 1298, col: 18, offset: 30808},
 							val:        ">",
 							ignoreCase: false,
 							want:       "\">\"",
@@ -8678,27 +8681,27 @@ var g = &grammar{
 		},
 		{
 			name: "TypeAsValue",
-			pos:  position{line: 1306, col: 1, offset: 30940},
+			pos:  position{line: 1306, col: 1, offset: 30941},
 			expr: &choiceExpr{
-				pos: position{line: 1307, col: 5, offset: 30956},
+				pos: position{line: 1307, col: 5, offset: 30957},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1307, col: 5, offset: 30956},
+						pos: position{line: 1307, col: 5, offset: 30957},
 						run: (*parser).callonTypeAsValue2,
 						expr: &seqExpr{
-							pos: position{line: 1307, col: 5, offset: 30956},
+							pos: position{line: 1307, col: 5, offset: 30957},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1307, col: 5, offset: 30956},
+									pos:        position{line: 1307, col: 5, offset: 30957},
 									val:        "=",
 									ignoreCase: false,
 									want:       "\"=\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1307, col: 9, offset: 30960},
+									pos:   position{line: 1307, col: 9, offset: 30961},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1307, col: 14, offset: 30965},
+										pos:  position{line: 1307, col: 14, offset: 30966},
 										name: "Name",
 									},
 								},
@@ -8706,13 +8709,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1308, col: 5, offset: 31039},
+						pos: position{line: 1308, col: 5, offset: 31040},
 						run: (*parser).callonTypeAsValue7,
 						expr: &labeledExpr{
-							pos:   position{line: 1308, col: 5, offset: 31039},
+							pos:   position{line: 1308, col: 5, offset: 31040},
 							label: "t",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1308, col: 7, offset: 31041},
+								pos:  position{line: 1308, col: 7, offset: 31042},
 								name: "EasyType",
 							},
 						},
@@ -8724,16 +8727,16 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1316, col: 1, offset: 31177},
+			pos:  position{line: 1316, col: 1, offset: 31178},
 			expr: &choiceExpr{
-				pos: position{line: 1317, col: 5, offset: 31186},
+				pos: position{line: 1317, col: 5, offset: 31187},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1317, col: 5, offset: 31186},
+						pos:  position{line: 1317, col: 5, offset: 31187},
 						name: "TypeUnion",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1318, col: 5, offset: 31200},
+						pos:  position{line: 1318, col: 5, offset: 31201},
 						name: "ComponentType",
 					},
 				},
@@ -8743,52 +8746,52 @@ var g = &grammar{
 		},
 		{
 			name: "ComponentType",
-			pos:  position{line: 1320, col: 1, offset: 31215},
+			pos:  position{line: 1320, col: 1, offset: 31216},
 			expr: &choiceExpr{
-				pos: position{line: 1321, col: 5, offset: 31233},
+				pos: position{line: 1321, col: 5, offset: 31234},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1321, col: 5, offset: 31233},
+						pos:  position{line: 1321, col: 5, offset: 31234},
 						name: "EasyType",
 					},
 					&actionExpr{
-						pos: position{line: 1322, col: 5, offset: 31246},
+						pos: position{line: 1322, col: 5, offset: 31247},
 						run: (*parser).callonComponentType3,
 						expr: &seqExpr{
-							pos: position{line: 1322, col: 5, offset: 31246},
+							pos: position{line: 1322, col: 5, offset: 31247},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1322, col: 5, offset: 31246},
+									pos:   position{line: 1322, col: 5, offset: 31247},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1322, col: 10, offset: 31251},
+										pos:  position{line: 1322, col: 10, offset: 31252},
 										name: "Name",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1322, col: 15, offset: 31256},
+									pos:   position{line: 1322, col: 15, offset: 31257},
 									label: "opt",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1322, col: 19, offset: 31260},
+										pos: position{line: 1322, col: 19, offset: 31261},
 										expr: &seqExpr{
-											pos: position{line: 1322, col: 20, offset: 31261},
+											pos: position{line: 1322, col: 20, offset: 31262},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1322, col: 20, offset: 31261},
+													pos:  position{line: 1322, col: 20, offset: 31262},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1322, col: 23, offset: 31264},
+													pos:        position{line: 1322, col: 23, offset: 31265},
 													val:        "=",
 													ignoreCase: false,
 													want:       "\"=\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1322, col: 27, offset: 31268},
+													pos:  position{line: 1322, col: 27, offset: 31269},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1322, col: 30, offset: 31271},
+													pos:  position{line: 1322, col: 30, offset: 31272},
 													name: "Type",
 												},
 											},
@@ -8805,40 +8808,40 @@ var g = &grammar{
 		},
 		{
 			name: "EasyType",
-			pos:  position{line: 1334, col: 1, offset: 31593},
+			pos:  position{line: 1334, col: 1, offset: 31594},
 			expr: &choiceExpr{
-				pos: position{line: 1335, col: 5, offset: 31606},
+				pos: position{line: 1335, col: 5, offset: 31607},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1335, col: 5, offset: 31606},
+						pos: position{line: 1335, col: 5, offset: 31607},
 						run: (*parser).callonEasyType2,
 						expr: &seqExpr{
-							pos: position{line: 1335, col: 5, offset: 31606},
+							pos: position{line: 1335, col: 5, offset: 31607},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1335, col: 5, offset: 31606},
+									pos:        position{line: 1335, col: 5, offset: 31607},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1335, col: 9, offset: 31610},
+									pos:  position{line: 1335, col: 9, offset: 31611},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1335, col: 12, offset: 31613},
+									pos:   position{line: 1335, col: 12, offset: 31614},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1335, col: 16, offset: 31617},
+										pos:  position{line: 1335, col: 16, offset: 31618},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1335, col: 21, offset: 31622},
+									pos:  position{line: 1335, col: 21, offset: 31623},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1335, col: 24, offset: 31625},
+									pos:        position{line: 1335, col: 24, offset: 31626},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -8847,23 +8850,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1336, col: 5, offset: 31652},
+						pos: position{line: 1336, col: 5, offset: 31653},
 						run: (*parser).callonEasyType10,
 						expr: &seqExpr{
-							pos: position{line: 1336, col: 5, offset: 31652},
+							pos: position{line: 1336, col: 5, offset: 31653},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1336, col: 5, offset: 31652},
+									pos:   position{line: 1336, col: 5, offset: 31653},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1336, col: 10, offset: 31657},
+										pos:  position{line: 1336, col: 10, offset: 31658},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1336, col: 24, offset: 31671},
+									pos: position{line: 1336, col: 24, offset: 31672},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1336, col: 25, offset: 31672},
+										pos:  position{line: 1336, col: 25, offset: 31673},
 										name: "IdentifierRest",
 									},
 								},
@@ -8871,43 +8874,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1337, col: 5, offset: 31712},
+						pos: position{line: 1337, col: 5, offset: 31713},
 						run: (*parser).callonEasyType16,
 						expr: &seqExpr{
-							pos: position{line: 1337, col: 5, offset: 31712},
+							pos: position{line: 1337, col: 5, offset: 31713},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1337, col: 5, offset: 31712},
+									pos:  position{line: 1337, col: 5, offset: 31713},
 									name: "ERROR",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1337, col: 11, offset: 31718},
+									pos:  position{line: 1337, col: 11, offset: 31719},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1337, col: 14, offset: 31721},
+									pos:        position{line: 1337, col: 14, offset: 31722},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1337, col: 18, offset: 31725},
+									pos:  position{line: 1337, col: 18, offset: 31726},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1337, col: 21, offset: 31728},
+									pos:   position{line: 1337, col: 21, offset: 31729},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1337, col: 23, offset: 31730},
+										pos:  position{line: 1337, col: 23, offset: 31731},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1337, col: 28, offset: 31735},
+									pos:  position{line: 1337, col: 28, offset: 31736},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1337, col: 31, offset: 31738},
+									pos:        position{line: 1337, col: 31, offset: 31739},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -8916,43 +8919,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1344, col: 5, offset: 31878},
+						pos: position{line: 1344, col: 5, offset: 31879},
 						run: (*parser).callonEasyType26,
 						expr: &seqExpr{
-							pos: position{line: 1344, col: 5, offset: 31878},
+							pos: position{line: 1344, col: 5, offset: 31879},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1344, col: 5, offset: 31878},
+									pos:  position{line: 1344, col: 5, offset: 31879},
 									name: "ENUM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1344, col: 10, offset: 31883},
+									pos:  position{line: 1344, col: 10, offset: 31884},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1344, col: 13, offset: 31886},
+									pos:        position{line: 1344, col: 13, offset: 31887},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1344, col: 17, offset: 31890},
+									pos:  position{line: 1344, col: 17, offset: 31891},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1344, col: 20, offset: 31893},
+									pos:   position{line: 1344, col: 20, offset: 31894},
 									label: "names",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1344, col: 26, offset: 31899},
+										pos:  position{line: 1344, col: 26, offset: 31900},
 										name: "Names",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1344, col: 32, offset: 31905},
+									pos:  position{line: 1344, col: 32, offset: 31906},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1344, col: 35, offset: 31908},
+									pos:        position{line: 1344, col: 35, offset: 31909},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -8961,35 +8964,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1351, col: 5, offset: 32062},
+						pos: position{line: 1351, col: 5, offset: 32063},
 						run: (*parser).callonEasyType36,
 						expr: &seqExpr{
-							pos: position{line: 1351, col: 5, offset: 32062},
+							pos: position{line: 1351, col: 5, offset: 32063},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1351, col: 5, offset: 32062},
+									pos:        position{line: 1351, col: 5, offset: 32063},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1351, col: 9, offset: 32066},
+									pos:  position{line: 1351, col: 9, offset: 32067},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1351, col: 12, offset: 32069},
+									pos:   position{line: 1351, col: 12, offset: 32070},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1351, col: 19, offset: 32076},
+										pos:  position{line: 1351, col: 19, offset: 32077},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1351, col: 33, offset: 32090},
+									pos:  position{line: 1351, col: 33, offset: 32091},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1351, col: 36, offset: 32093},
+									pos:        position{line: 1351, col: 36, offset: 32094},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -8998,35 +9001,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1358, col: 5, offset: 32255},
+						pos: position{line: 1358, col: 5, offset: 32256},
 						run: (*parser).callonEasyType44,
 						expr: &seqExpr{
-							pos: position{line: 1358, col: 5, offset: 32255},
+							pos: position{line: 1358, col: 5, offset: 32256},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1358, col: 5, offset: 32255},
+									pos:        position{line: 1358, col: 5, offset: 32256},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1358, col: 9, offset: 32259},
+									pos:  position{line: 1358, col: 9, offset: 32260},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1358, col: 12, offset: 32262},
+									pos:   position{line: 1358, col: 12, offset: 32263},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1358, col: 16, offset: 32266},
+										pos:  position{line: 1358, col: 16, offset: 32267},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1358, col: 21, offset: 32271},
+									pos:  position{line: 1358, col: 21, offset: 32272},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1358, col: 24, offset: 32274},
+									pos:        position{line: 1358, col: 24, offset: 32275},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -9035,35 +9038,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1365, col: 5, offset: 32416},
+						pos: position{line: 1365, col: 5, offset: 32417},
 						run: (*parser).callonEasyType52,
 						expr: &seqExpr{
-							pos: position{line: 1365, col: 5, offset: 32416},
+							pos: position{line: 1365, col: 5, offset: 32417},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1365, col: 5, offset: 32416},
+									pos:        position{line: 1365, col: 5, offset: 32417},
 									val:        "|[",
 									ignoreCase: false,
 									want:       "\"|[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1365, col: 10, offset: 32421},
+									pos:  position{line: 1365, col: 10, offset: 32422},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1365, col: 13, offset: 32424},
+									pos:   position{line: 1365, col: 13, offset: 32425},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1365, col: 17, offset: 32428},
+										pos:  position{line: 1365, col: 17, offset: 32429},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1365, col: 22, offset: 32433},
+									pos:  position{line: 1365, col: 22, offset: 32434},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1365, col: 25, offset: 32436},
+									pos:        position{line: 1365, col: 25, offset: 32437},
 									val:        "]|",
 									ignoreCase: false,
 									want:       "\"]|\"",
@@ -9072,57 +9075,57 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1372, col: 5, offset: 32575},
+						pos: position{line: 1372, col: 5, offset: 32576},
 						run: (*parser).callonEasyType60,
 						expr: &seqExpr{
-							pos: position{line: 1372, col: 5, offset: 32575},
+							pos: position{line: 1372, col: 5, offset: 32576},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1372, col: 5, offset: 32575},
+									pos:        position{line: 1372, col: 5, offset: 32576},
 									val:        "|{",
 									ignoreCase: false,
 									want:       "\"|{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1372, col: 10, offset: 32580},
+									pos:  position{line: 1372, col: 10, offset: 32581},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1372, col: 13, offset: 32583},
+									pos:   position{line: 1372, col: 13, offset: 32584},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1372, col: 21, offset: 32591},
+										pos:  position{line: 1372, col: 21, offset: 32592},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1372, col: 26, offset: 32596},
+									pos:  position{line: 1372, col: 26, offset: 32597},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1372, col: 29, offset: 32599},
+									pos:        position{line: 1372, col: 29, offset: 32600},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1372, col: 33, offset: 32603},
+									pos:  position{line: 1372, col: 33, offset: 32604},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1372, col: 36, offset: 32606},
+									pos:   position{line: 1372, col: 36, offset: 32607},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1372, col: 44, offset: 32614},
+										pos:  position{line: 1372, col: 44, offset: 32615},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1372, col: 49, offset: 32619},
+									pos:  position{line: 1372, col: 49, offset: 32620},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1372, col: 52, offset: 32622},
+									pos:        position{line: 1372, col: 52, offset: 32623},
 									val:        "}|",
 									ignoreCase: false,
 									want:       "\"}|\"",
@@ -9137,15 +9140,15 @@ var g = &grammar{
 		},
 		{
 			name: "TypeUnion",
-			pos:  position{line: 1381, col: 1, offset: 32796},
+			pos:  position{line: 1381, col: 1, offset: 32797},
 			expr: &actionExpr{
-				pos: position{line: 1382, col: 5, offset: 32810},
+				pos: position{line: 1382, col: 5, offset: 32811},
 				run: (*parser).callonTypeUnion1,
 				expr: &labeledExpr{
-					pos:   position{line: 1382, col: 5, offset: 32810},
+					pos:   position{line: 1382, col: 5, offset: 32811},
 					label: "types",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1382, col: 11, offset: 32816},
+						pos:  position{line: 1382, col: 11, offset: 32817},
 						name: "TypeList",
 					},
 				},
@@ -9155,28 +9158,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1390, col: 1, offset: 32953},
+			pos:  position{line: 1390, col: 1, offset: 32954},
 			expr: &actionExpr{
-				pos: position{line: 1391, col: 5, offset: 32966},
+				pos: position{line: 1391, col: 5, offset: 32967},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1391, col: 5, offset: 32966},
+					pos: position{line: 1391, col: 5, offset: 32967},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1391, col: 5, offset: 32966},
+							pos:   position{line: 1391, col: 5, offset: 32967},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1391, col: 11, offset: 32972},
+								pos:  position{line: 1391, col: 11, offset: 32973},
 								name: "ComponentType",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1391, col: 25, offset: 32986},
+							pos:   position{line: 1391, col: 25, offset: 32987},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1391, col: 30, offset: 32991},
+								pos: position{line: 1391, col: 30, offset: 32992},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1391, col: 30, offset: 32991},
+									pos:  position{line: 1391, col: 30, offset: 32992},
 									name: "TypeListTail",
 								},
 							},
@@ -9189,32 +9192,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1395, col: 1, offset: 33049},
+			pos:  position{line: 1395, col: 1, offset: 33050},
 			expr: &actionExpr{
-				pos: position{line: 1395, col: 16, offset: 33064},
+				pos: position{line: 1395, col: 16, offset: 33065},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1395, col: 16, offset: 33064},
+					pos: position{line: 1395, col: 16, offset: 33065},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1395, col: 16, offset: 33064},
+							pos:  position{line: 1395, col: 16, offset: 33065},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1395, col: 19, offset: 33067},
+							pos:        position{line: 1395, col: 19, offset: 33068},
 							val:        "|",
 							ignoreCase: false,
 							want:       "\"|\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1395, col: 23, offset: 33071},
+							pos:  position{line: 1395, col: 23, offset: 33072},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1395, col: 26, offset: 33074},
+							pos:   position{line: 1395, col: 26, offset: 33075},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1395, col: 30, offset: 33078},
+								pos:  position{line: 1395, col: 30, offset: 33079},
 								name: "ComponentType",
 							},
 						},
@@ -9226,42 +9229,42 @@ var g = &grammar{
 		},
 		{
 			name: "StringLiteral",
-			pos:  position{line: 1397, col: 1, offset: 33113},
+			pos:  position{line: 1397, col: 1, offset: 33114},
 			expr: &choiceExpr{
-				pos: position{line: 1398, col: 5, offset: 33131},
+				pos: position{line: 1398, col: 5, offset: 33132},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1398, col: 5, offset: 33131},
+						pos: position{line: 1398, col: 5, offset: 33132},
 						run: (*parser).callonStringLiteral2,
 						expr: &labeledExpr{
-							pos:   position{line: 1398, col: 5, offset: 33131},
+							pos:   position{line: 1398, col: 5, offset: 33132},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1398, col: 7, offset: 33133},
+								pos:  position{line: 1398, col: 7, offset: 33134},
 								name: "DoubleQuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1399, col: 5, offset: 33240},
+						pos: position{line: 1399, col: 5, offset: 33241},
 						run: (*parser).callonStringLiteral5,
 						expr: &labeledExpr{
-							pos:   position{line: 1399, col: 5, offset: 33240},
+							pos:   position{line: 1399, col: 5, offset: 33241},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1399, col: 7, offset: 33242},
+								pos:  position{line: 1399, col: 7, offset: 33243},
 								name: "SingleQuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1400, col: 5, offset: 33319},
+						pos: position{line: 1400, col: 5, offset: 33320},
 						run: (*parser).callonStringLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1400, col: 5, offset: 33319},
+							pos:   position{line: 1400, col: 5, offset: 33320},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1400, col: 7, offset: 33321},
+								pos:  position{line: 1400, col: 7, offset: 33322},
 								name: "RString",
 							},
 						},
@@ -9273,35 +9276,35 @@ var g = &grammar{
 		},
 		{
 			name: "FString",
-			pos:  position{line: 1402, col: 1, offset: 33384},
+			pos:  position{line: 1402, col: 1, offset: 33385},
 			expr: &choiceExpr{
-				pos: position{line: 1403, col: 5, offset: 33396},
+				pos: position{line: 1403, col: 5, offset: 33397},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1403, col: 5, offset: 33396},
+						pos: position{line: 1403, col: 5, offset: 33397},
 						run: (*parser).callonFString2,
 						expr: &seqExpr{
-							pos: position{line: 1403, col: 5, offset: 33396},
+							pos: position{line: 1403, col: 5, offset: 33397},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1403, col: 5, offset: 33396},
+									pos:        position{line: 1403, col: 5, offset: 33397},
 									val:        "f\"",
 									ignoreCase: false,
 									want:       "\"f\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1403, col: 11, offset: 33402},
+									pos:   position{line: 1403, col: 11, offset: 33403},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1403, col: 13, offset: 33404},
+										pos: position{line: 1403, col: 13, offset: 33405},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1403, col: 13, offset: 33404},
+											pos:  position{line: 1403, col: 13, offset: 33405},
 											name: "FStringDoubleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1403, col: 38, offset: 33429},
+									pos:        position{line: 1403, col: 38, offset: 33430},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -9310,30 +9313,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1410, col: 5, offset: 33575},
+						pos: position{line: 1410, col: 5, offset: 33576},
 						run: (*parser).callonFString9,
 						expr: &seqExpr{
-							pos: position{line: 1410, col: 5, offset: 33575},
+							pos: position{line: 1410, col: 5, offset: 33576},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1410, col: 5, offset: 33575},
+									pos:        position{line: 1410, col: 5, offset: 33576},
 									val:        "f'",
 									ignoreCase: false,
 									want:       "\"f'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1410, col: 10, offset: 33580},
+									pos:   position{line: 1410, col: 10, offset: 33581},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1410, col: 12, offset: 33582},
+										pos: position{line: 1410, col: 12, offset: 33583},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1410, col: 12, offset: 33582},
+											pos:  position{line: 1410, col: 12, offset: 33583},
 											name: "FStringSingleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1410, col: 37, offset: 33607},
+									pos:        position{line: 1410, col: 37, offset: 33608},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -9348,24 +9351,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedElem",
-			pos:  position{line: 1418, col: 1, offset: 33750},
+			pos:  position{line: 1418, col: 1, offset: 33751},
 			expr: &choiceExpr{
-				pos: position{line: 1419, col: 5, offset: 33778},
+				pos: position{line: 1419, col: 5, offset: 33779},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1419, col: 5, offset: 33778},
+						pos:  position{line: 1419, col: 5, offset: 33779},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1420, col: 5, offset: 33794},
+						pos: position{line: 1420, col: 5, offset: 33795},
 						run: (*parser).callonFStringDoubleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1420, col: 5, offset: 33794},
+							pos:   position{line: 1420, col: 5, offset: 33795},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1420, col: 7, offset: 33796},
+								pos: position{line: 1420, col: 7, offset: 33797},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1420, col: 7, offset: 33796},
+									pos:  position{line: 1420, col: 7, offset: 33797},
 									name: "FStringDoubleQuotedChar",
 								},
 							},
@@ -9378,27 +9381,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedChar",
-			pos:  position{line: 1424, col: 1, offset: 33919},
+			pos:  position{line: 1424, col: 1, offset: 33920},
 			expr: &choiceExpr{
-				pos: position{line: 1425, col: 5, offset: 33947},
+				pos: position{line: 1425, col: 5, offset: 33948},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1425, col: 5, offset: 33947},
+						pos: position{line: 1425, col: 5, offset: 33948},
 						run: (*parser).callonFStringDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1425, col: 5, offset: 33947},
+							pos: position{line: 1425, col: 5, offset: 33948},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1425, col: 5, offset: 33947},
+									pos:        position{line: 1425, col: 5, offset: 33948},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1425, col: 10, offset: 33952},
+									pos:   position{line: 1425, col: 10, offset: 33953},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1425, col: 12, offset: 33954},
+										pos:        position{line: 1425, col: 12, offset: 33955},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9408,25 +9411,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1426, col: 5, offset: 33980},
+						pos: position{line: 1426, col: 5, offset: 33981},
 						run: (*parser).callonFStringDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1426, col: 5, offset: 33980},
+							pos: position{line: 1426, col: 5, offset: 33981},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1426, col: 5, offset: 33980},
+									pos: position{line: 1426, col: 5, offset: 33981},
 									expr: &litMatcher{
-										pos:        position{line: 1426, col: 7, offset: 33982},
+										pos:        position{line: 1426, col: 7, offset: 33983},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1426, col: 12, offset: 33987},
+									pos:   position{line: 1426, col: 12, offset: 33988},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1426, col: 14, offset: 33989},
+										pos:  position{line: 1426, col: 14, offset: 33990},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -9440,24 +9443,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedElem",
-			pos:  position{line: 1428, col: 1, offset: 34025},
+			pos:  position{line: 1428, col: 1, offset: 34026},
 			expr: &choiceExpr{
-				pos: position{line: 1429, col: 5, offset: 34053},
+				pos: position{line: 1429, col: 5, offset: 34054},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1429, col: 5, offset: 34053},
+						pos:  position{line: 1429, col: 5, offset: 34054},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1430, col: 5, offset: 34069},
+						pos: position{line: 1430, col: 5, offset: 34070},
 						run: (*parser).callonFStringSingleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1430, col: 5, offset: 34069},
+							pos:   position{line: 1430, col: 5, offset: 34070},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1430, col: 7, offset: 34071},
+								pos: position{line: 1430, col: 7, offset: 34072},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1430, col: 7, offset: 34071},
+									pos:  position{line: 1430, col: 7, offset: 34072},
 									name: "FStringSingleQuotedChar",
 								},
 							},
@@ -9470,27 +9473,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedChar",
-			pos:  position{line: 1434, col: 1, offset: 34194},
+			pos:  position{line: 1434, col: 1, offset: 34195},
 			expr: &choiceExpr{
-				pos: position{line: 1435, col: 5, offset: 34222},
+				pos: position{line: 1435, col: 5, offset: 34223},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1435, col: 5, offset: 34222},
+						pos: position{line: 1435, col: 5, offset: 34223},
 						run: (*parser).callonFStringSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1435, col: 5, offset: 34222},
+							pos: position{line: 1435, col: 5, offset: 34223},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1435, col: 5, offset: 34222},
+									pos:        position{line: 1435, col: 5, offset: 34223},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1435, col: 10, offset: 34227},
+									pos:   position{line: 1435, col: 10, offset: 34228},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1435, col: 12, offset: 34229},
+										pos:        position{line: 1435, col: 12, offset: 34230},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9500,25 +9503,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1436, col: 5, offset: 34255},
+						pos: position{line: 1436, col: 5, offset: 34256},
 						run: (*parser).callonFStringSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1436, col: 5, offset: 34255},
+							pos: position{line: 1436, col: 5, offset: 34256},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1436, col: 5, offset: 34255},
+									pos: position{line: 1436, col: 5, offset: 34256},
 									expr: &litMatcher{
-										pos:        position{line: 1436, col: 7, offset: 34257},
+										pos:        position{line: 1436, col: 7, offset: 34258},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1436, col: 12, offset: 34262},
+									pos:   position{line: 1436, col: 12, offset: 34263},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1436, col: 14, offset: 34264},
+										pos:  position{line: 1436, col: 14, offset: 34265},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -9532,37 +9535,37 @@ var g = &grammar{
 		},
 		{
 			name: "FStringExpr",
-			pos:  position{line: 1438, col: 1, offset: 34300},
+			pos:  position{line: 1438, col: 1, offset: 34301},
 			expr: &actionExpr{
-				pos: position{line: 1439, col: 5, offset: 34316},
+				pos: position{line: 1439, col: 5, offset: 34317},
 				run: (*parser).callonFStringExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1439, col: 5, offset: 34316},
+					pos: position{line: 1439, col: 5, offset: 34317},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1439, col: 5, offset: 34316},
+							pos:        position{line: 1439, col: 5, offset: 34317},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1439, col: 9, offset: 34320},
+							pos:  position{line: 1439, col: 9, offset: 34321},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1439, col: 12, offset: 34323},
+							pos:   position{line: 1439, col: 12, offset: 34324},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1439, col: 14, offset: 34325},
+								pos:  position{line: 1439, col: 14, offset: 34326},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1439, col: 19, offset: 34330},
+							pos:  position{line: 1439, col: 19, offset: 34331},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1439, col: 22, offset: 34333},
+							pos:        position{line: 1439, col: 22, offset: 34334},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -9575,129 +9578,129 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1447, col: 1, offset: 34468},
+			pos:  position{line: 1447, col: 1, offset: 34469},
 			expr: &actionExpr{
-				pos: position{line: 1448, col: 5, offset: 34486},
+				pos: position{line: 1448, col: 5, offset: 34487},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1448, col: 9, offset: 34490},
+					pos: position{line: 1448, col: 9, offset: 34491},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1448, col: 9, offset: 34490},
+							pos:        position{line: 1448, col: 9, offset: 34491},
 							val:        "uint8",
 							ignoreCase: false,
 							want:       "\"uint8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1448, col: 19, offset: 34500},
+							pos:        position{line: 1448, col: 19, offset: 34501},
 							val:        "uint16",
 							ignoreCase: false,
 							want:       "\"uint16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1448, col: 30, offset: 34511},
+							pos:        position{line: 1448, col: 30, offset: 34512},
 							val:        "uint32",
 							ignoreCase: false,
 							want:       "\"uint32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1448, col: 41, offset: 34522},
+							pos:        position{line: 1448, col: 41, offset: 34523},
 							val:        "uint64",
 							ignoreCase: false,
 							want:       "\"uint64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1449, col: 9, offset: 34539},
+							pos:        position{line: 1449, col: 9, offset: 34540},
 							val:        "int8",
 							ignoreCase: false,
 							want:       "\"int8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1449, col: 18, offset: 34548},
+							pos:        position{line: 1449, col: 18, offset: 34549},
 							val:        "int16",
 							ignoreCase: false,
 							want:       "\"int16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1449, col: 28, offset: 34558},
+							pos:        position{line: 1449, col: 28, offset: 34559},
 							val:        "int32",
 							ignoreCase: false,
 							want:       "\"int32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1449, col: 38, offset: 34568},
+							pos:        position{line: 1449, col: 38, offset: 34569},
 							val:        "int64",
 							ignoreCase: false,
 							want:       "\"int64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1450, col: 9, offset: 34584},
+							pos:        position{line: 1450, col: 9, offset: 34585},
 							val:        "float16",
 							ignoreCase: false,
 							want:       "\"float16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1450, col: 21, offset: 34596},
+							pos:        position{line: 1450, col: 21, offset: 34597},
 							val:        "float32",
 							ignoreCase: false,
 							want:       "\"float32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1450, col: 33, offset: 34608},
+							pos:        position{line: 1450, col: 33, offset: 34609},
 							val:        "float64",
 							ignoreCase: false,
 							want:       "\"float64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1451, col: 9, offset: 34626},
+							pos:        position{line: 1451, col: 9, offset: 34627},
 							val:        "bool",
 							ignoreCase: false,
 							want:       "\"bool\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1451, col: 18, offset: 34635},
+							pos:        position{line: 1451, col: 18, offset: 34636},
 							val:        "string",
 							ignoreCase: false,
 							want:       "\"string\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1452, col: 9, offset: 34652},
+							pos:        position{line: 1452, col: 9, offset: 34653},
 							val:        "duration",
 							ignoreCase: false,
 							want:       "\"duration\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1452, col: 22, offset: 34665},
+							pos:        position{line: 1452, col: 22, offset: 34666},
 							val:        "time",
 							ignoreCase: false,
 							want:       "\"time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1453, col: 9, offset: 34680},
+							pos:        position{line: 1453, col: 9, offset: 34681},
 							val:        "bytes",
 							ignoreCase: false,
 							want:       "\"bytes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1454, col: 9, offset: 34696},
+							pos:        position{line: 1454, col: 9, offset: 34697},
 							val:        "ip",
 							ignoreCase: false,
 							want:       "\"ip\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1454, col: 16, offset: 34703},
+							pos:        position{line: 1454, col: 16, offset: 34704},
 							val:        "net",
 							ignoreCase: false,
 							want:       "\"net\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1455, col: 9, offset: 34717},
+							pos:        position{line: 1455, col: 9, offset: 34718},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1455, col: 18, offset: 34726},
+							pos:        position{line: 1455, col: 18, offset: 34727},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
@@ -9710,31 +9713,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1463, col: 1, offset: 34911},
+			pos:  position{line: 1463, col: 1, offset: 34912},
 			expr: &choiceExpr{
-				pos: position{line: 1464, col: 5, offset: 34929},
+				pos: position{line: 1464, col: 5, offset: 34930},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1464, col: 5, offset: 34929},
+						pos: position{line: 1464, col: 5, offset: 34930},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1464, col: 5, offset: 34929},
+							pos: position{line: 1464, col: 5, offset: 34930},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1464, col: 5, offset: 34929},
+									pos:   position{line: 1464, col: 5, offset: 34930},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1464, col: 11, offset: 34935},
+										pos:  position{line: 1464, col: 11, offset: 34936},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1464, col: 21, offset: 34945},
+									pos:   position{line: 1464, col: 21, offset: 34946},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1464, col: 26, offset: 34950},
+										pos: position{line: 1464, col: 26, offset: 34951},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1464, col: 26, offset: 34950},
+											pos:  position{line: 1464, col: 26, offset: 34951},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -9743,10 +9746,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1467, col: 5, offset: 35016},
+						pos: position{line: 1467, col: 5, offset: 35017},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1467, col: 5, offset: 35016},
+							pos:        position{line: 1467, col: 5, offset: 35017},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -9759,32 +9762,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1469, col: 1, offset: 35040},
+			pos:  position{line: 1469, col: 1, offset: 35041},
 			expr: &actionExpr{
-				pos: position{line: 1469, col: 21, offset: 35060},
+				pos: position{line: 1469, col: 21, offset: 35061},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1469, col: 21, offset: 35060},
+					pos: position{line: 1469, col: 21, offset: 35061},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1469, col: 21, offset: 35060},
+							pos:  position{line: 1469, col: 21, offset: 35061},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1469, col: 24, offset: 35063},
+							pos:        position{line: 1469, col: 24, offset: 35064},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1469, col: 28, offset: 35067},
+							pos:  position{line: 1469, col: 28, offset: 35068},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1469, col: 31, offset: 35070},
+							pos:   position{line: 1469, col: 31, offset: 35071},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1469, col: 35, offset: 35074},
+								pos:  position{line: 1469, col: 35, offset: 35075},
 								name: "TypeField",
 							},
 						},
@@ -9796,40 +9799,40 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1471, col: 1, offset: 35105},
+			pos:  position{line: 1471, col: 1, offset: 35106},
 			expr: &actionExpr{
-				pos: position{line: 1472, col: 5, offset: 35119},
+				pos: position{line: 1472, col: 5, offset: 35120},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1472, col: 5, offset: 35119},
+					pos: position{line: 1472, col: 5, offset: 35120},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1472, col: 5, offset: 35119},
+							pos:   position{line: 1472, col: 5, offset: 35120},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1472, col: 10, offset: 35124},
+								pos:  position{line: 1472, col: 10, offset: 35125},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1472, col: 15, offset: 35129},
+							pos:  position{line: 1472, col: 15, offset: 35130},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1472, col: 18, offset: 35132},
+							pos:        position{line: 1472, col: 18, offset: 35133},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1472, col: 22, offset: 35136},
+							pos:  position{line: 1472, col: 22, offset: 35137},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1472, col: 25, offset: 35139},
+							pos:   position{line: 1472, col: 25, offset: 35140},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1472, col: 29, offset: 35143},
+								pos:  position{line: 1472, col: 29, offset: 35144},
 								name: "Type",
 							},
 						},
@@ -9841,26 +9844,26 @@ var g = &grammar{
 		},
 		{
 			name: "Name",
-			pos:  position{line: 1480, col: 1, offset: 35292},
+			pos:  position{line: 1480, col: 1, offset: 35293},
 			expr: &actionExpr{
-				pos: position{line: 1481, col: 4, offset: 35300},
+				pos: position{line: 1481, col: 4, offset: 35301},
 				run: (*parser).callonName1,
 				expr: &labeledExpr{
-					pos:   position{line: 1481, col: 4, offset: 35300},
+					pos:   position{line: 1481, col: 4, offset: 35301},
 					label: "s",
 					expr: &choiceExpr{
-						pos: position{line: 1481, col: 7, offset: 35303},
+						pos: position{line: 1481, col: 7, offset: 35304},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1481, col: 7, offset: 35303},
+								pos:  position{line: 1481, col: 7, offset: 35304},
 								name: "IdentifierName",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1481, col: 24, offset: 35320},
+								pos:  position{line: 1481, col: 24, offset: 35321},
 								name: "DoubleQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1481, col: 45, offset: 35341},
+								pos:  position{line: 1481, col: 45, offset: 35342},
 								name: "SingleQuotedString",
 							},
 						},
@@ -9872,51 +9875,51 @@ var g = &grammar{
 		},
 		{
 			name: "Names",
-			pos:  position{line: 1485, col: 1, offset: 35441},
+			pos:  position{line: 1485, col: 1, offset: 35442},
 			expr: &actionExpr{
-				pos: position{line: 1486, col: 5, offset: 35451},
+				pos: position{line: 1486, col: 5, offset: 35452},
 				run: (*parser).callonNames1,
 				expr: &seqExpr{
-					pos: position{line: 1486, col: 5, offset: 35451},
+					pos: position{line: 1486, col: 5, offset: 35452},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1486, col: 5, offset: 35451},
+							pos:   position{line: 1486, col: 5, offset: 35452},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1486, col: 11, offset: 35457},
+								pos:  position{line: 1486, col: 11, offset: 35458},
 								name: "Name",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1486, col: 16, offset: 35462},
+							pos:   position{line: 1486, col: 16, offset: 35463},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1486, col: 21, offset: 35467},
+								pos: position{line: 1486, col: 21, offset: 35468},
 								expr: &actionExpr{
-									pos: position{line: 1486, col: 22, offset: 35468},
+									pos: position{line: 1486, col: 22, offset: 35469},
 									run: (*parser).callonNames7,
 									expr: &seqExpr{
-										pos: position{line: 1486, col: 22, offset: 35468},
+										pos: position{line: 1486, col: 22, offset: 35469},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1486, col: 22, offset: 35468},
+												pos:  position{line: 1486, col: 22, offset: 35469},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1486, col: 25, offset: 35471},
+												pos:        position{line: 1486, col: 25, offset: 35472},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1486, col: 29, offset: 35475},
+												pos:  position{line: 1486, col: 29, offset: 35476},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1486, col: 32, offset: 35478},
+												pos:   position{line: 1486, col: 32, offset: 35479},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1486, col: 37, offset: 35483},
+													pos:  position{line: 1486, col: 37, offset: 35484},
 													name: "Name",
 												},
 											},
@@ -9933,15 +9936,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1490, col: 1, offset: 35555},
+			pos:  position{line: 1490, col: 1, offset: 35556},
 			expr: &actionExpr{
-				pos: position{line: 1491, col: 5, offset: 35570},
+				pos: position{line: 1491, col: 5, offset: 35571},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1491, col: 5, offset: 35570},
+					pos:   position{line: 1491, col: 5, offset: 35571},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1491, col: 8, offset: 35573},
+						pos:  position{line: 1491, col: 8, offset: 35574},
 						name: "IdentifierName",
 					},
 				},
@@ -9951,51 +9954,51 @@ var g = &grammar{
 		},
 		{
 			name: "Identifiers",
-			pos:  position{line: 1499, col: 1, offset: 35706},
+			pos:  position{line: 1499, col: 1, offset: 35707},
 			expr: &actionExpr{
-				pos: position{line: 1500, col: 5, offset: 35722},
+				pos: position{line: 1500, col: 5, offset: 35723},
 				run: (*parser).callonIdentifiers1,
 				expr: &seqExpr{
-					pos: position{line: 1500, col: 5, offset: 35722},
+					pos: position{line: 1500, col: 5, offset: 35723},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1500, col: 5, offset: 35722},
+							pos:   position{line: 1500, col: 5, offset: 35723},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1500, col: 11, offset: 35728},
+								pos:  position{line: 1500, col: 11, offset: 35729},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1500, col: 22, offset: 35739},
+							pos:   position{line: 1500, col: 22, offset: 35740},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1500, col: 27, offset: 35744},
+								pos: position{line: 1500, col: 27, offset: 35745},
 								expr: &actionExpr{
-									pos: position{line: 1500, col: 28, offset: 35745},
+									pos: position{line: 1500, col: 28, offset: 35746},
 									run: (*parser).callonIdentifiers7,
 									expr: &seqExpr{
-										pos: position{line: 1500, col: 28, offset: 35745},
+										pos: position{line: 1500, col: 28, offset: 35746},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1500, col: 28, offset: 35745},
+												pos:  position{line: 1500, col: 28, offset: 35746},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1500, col: 31, offset: 35748},
+												pos:        position{line: 1500, col: 31, offset: 35749},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1500, col: 35, offset: 35752},
+												pos:  position{line: 1500, col: 35, offset: 35753},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1500, col: 38, offset: 35755},
+												pos:   position{line: 1500, col: 38, offset: 35756},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1500, col: 43, offset: 35760},
+													pos:  position{line: 1500, col: 43, offset: 35761},
 													name: "Identifier",
 												},
 											},
@@ -10012,22 +10015,22 @@ var g = &grammar{
 		},
 		{
 			name: "SQLIdentifier",
-			pos:  position{line: 1504, col: 1, offset: 35838},
+			pos:  position{line: 1504, col: 1, offset: 35839},
 			expr: &choiceExpr{
-				pos: position{line: 1505, col: 5, offset: 35856},
+				pos: position{line: 1505, col: 5, offset: 35857},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1505, col: 5, offset: 35856},
+						pos:  position{line: 1505, col: 5, offset: 35857},
 						name: "Identifier",
 					},
 					&actionExpr{
-						pos: position{line: 1506, col: 5, offset: 35871},
+						pos: position{line: 1506, col: 5, offset: 35872},
 						run: (*parser).callonSQLIdentifier3,
 						expr: &labeledExpr{
-							pos:   position{line: 1506, col: 5, offset: 35871},
+							pos:   position{line: 1506, col: 5, offset: 35872},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1506, col: 7, offset: 35873},
+								pos:  position{line: 1506, col: 7, offset: 35874},
 								name: "DoubleQuotedString",
 							},
 						},
@@ -10039,29 +10042,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1508, col: 1, offset: 35958},
+			pos:  position{line: 1508, col: 1, offset: 35959},
 			expr: &choiceExpr{
-				pos: position{line: 1509, col: 5, offset: 35977},
+				pos: position{line: 1509, col: 5, offset: 35978},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1509, col: 5, offset: 35977},
+						pos: position{line: 1509, col: 5, offset: 35978},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1509, col: 5, offset: 35977},
+							pos: position{line: 1509, col: 5, offset: 35978},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1509, col: 5, offset: 35977},
+									pos: position{line: 1509, col: 5, offset: 35978},
 									expr: &seqExpr{
-										pos: position{line: 1509, col: 7, offset: 35979},
+										pos: position{line: 1509, col: 7, offset: 35980},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1509, col: 7, offset: 35979},
+												pos:  position{line: 1509, col: 7, offset: 35980},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1509, col: 15, offset: 35987},
+												pos: position{line: 1509, col: 15, offset: 35988},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1509, col: 16, offset: 35988},
+													pos:  position{line: 1509, col: 16, offset: 35989},
 													name: "IdentifierRest",
 												},
 											},
@@ -10069,13 +10072,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1509, col: 32, offset: 36004},
+									pos:  position{line: 1509, col: 32, offset: 36005},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1509, col: 48, offset: 36020},
+									pos: position{line: 1509, col: 48, offset: 36021},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1509, col: 48, offset: 36020},
+										pos:  position{line: 1509, col: 48, offset: 36021},
 										name: "IdentifierRest",
 									},
 								},
@@ -10083,7 +10086,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1510, col: 5, offset: 36071},
+						pos:  position{line: 1510, col: 5, offset: 36072},
 						name: "BacktickString",
 					},
 				},
@@ -10093,22 +10096,22 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1512, col: 1, offset: 36087},
+			pos:  position{line: 1512, col: 1, offset: 36088},
 			expr: &choiceExpr{
-				pos: position{line: 1513, col: 5, offset: 36107},
+				pos: position{line: 1513, col: 5, offset: 36108},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1513, col: 5, offset: 36107},
+						pos:  position{line: 1513, col: 5, offset: 36108},
 						name: "UnicodeLetter",
 					},
 					&litMatcher{
-						pos:        position{line: 1514, col: 5, offset: 36125},
+						pos:        position{line: 1514, col: 5, offset: 36126},
 						val:        "$",
 						ignoreCase: false,
 						want:       "\"$\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1515, col: 5, offset: 36133},
+						pos:        position{line: 1515, col: 5, offset: 36134},
 						val:        "_",
 						ignoreCase: false,
 						want:       "\"_\"",
@@ -10120,24 +10123,24 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1517, col: 1, offset: 36138},
+			pos:  position{line: 1517, col: 1, offset: 36139},
 			expr: &choiceExpr{
-				pos: position{line: 1518, col: 5, offset: 36157},
+				pos: position{line: 1518, col: 5, offset: 36158},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1518, col: 5, offset: 36157},
+						pos:  position{line: 1518, col: 5, offset: 36158},
 						name: "IdentifierStart",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1519, col: 5, offset: 36177},
+						pos:  position{line: 1519, col: 5, offset: 36178},
 						name: "UnicodeCombiningMark",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1520, col: 5, offset: 36202},
+						pos:  position{line: 1520, col: 5, offset: 36203},
 						name: "UnicodeDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1521, col: 5, offset: 36219},
+						pos:  position{line: 1521, col: 5, offset: 36220},
 						name: "UnicodeConnectorPunctuation",
 					},
 				},
@@ -10147,24 +10150,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1523, col: 1, offset: 36248},
+			pos:  position{line: 1523, col: 1, offset: 36249},
 			expr: &choiceExpr{
-				pos: position{line: 1524, col: 5, offset: 36260},
+				pos: position{line: 1524, col: 5, offset: 36261},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1524, col: 5, offset: 36260},
+						pos:  position{line: 1524, col: 5, offset: 36261},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1525, col: 5, offset: 36279},
+						pos:  position{line: 1525, col: 5, offset: 36280},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1526, col: 5, offset: 36295},
+						pos:  position{line: 1526, col: 5, offset: 36296},
 						name: "NaN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1527, col: 5, offset: 36303},
+						pos:  position{line: 1527, col: 5, offset: 36304},
 						name: "Infinity",
 					},
 				},
@@ -10174,25 +10177,25 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1529, col: 1, offset: 36313},
+			pos:  position{line: 1529, col: 1, offset: 36314},
 			expr: &actionExpr{
-				pos: position{line: 1530, col: 5, offset: 36322},
+				pos: position{line: 1530, col: 5, offset: 36323},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1530, col: 5, offset: 36322},
+					pos: position{line: 1530, col: 5, offset: 36323},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1530, col: 5, offset: 36322},
+							pos:  position{line: 1530, col: 5, offset: 36323},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1530, col: 14, offset: 36331},
+							pos:        position{line: 1530, col: 14, offset: 36332},
 							val:        "T",
 							ignoreCase: false,
 							want:       "\"T\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1530, col: 18, offset: 36335},
+							pos:  position{line: 1530, col: 18, offset: 36336},
 							name: "FullTime",
 						},
 					},
@@ -10203,32 +10206,32 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1534, col: 1, offset: 36411},
+			pos:  position{line: 1534, col: 1, offset: 36412},
 			expr: &seqExpr{
-				pos: position{line: 1534, col: 12, offset: 36422},
+				pos: position{line: 1534, col: 12, offset: 36423},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1534, col: 12, offset: 36422},
+						pos:  position{line: 1534, col: 12, offset: 36423},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1534, col: 15, offset: 36425},
+						pos:        position{line: 1534, col: 15, offset: 36426},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1534, col: 19, offset: 36429},
+						pos:  position{line: 1534, col: 19, offset: 36430},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1534, col: 22, offset: 36432},
+						pos:        position{line: 1534, col: 22, offset: 36433},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1534, col: 26, offset: 36436},
+						pos:  position{line: 1534, col: 26, offset: 36437},
 						name: "D2",
 					},
 				},
@@ -10238,33 +10241,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1536, col: 1, offset: 36440},
+			pos:  position{line: 1536, col: 1, offset: 36441},
 			expr: &seqExpr{
-				pos: position{line: 1536, col: 6, offset: 36445},
+				pos: position{line: 1536, col: 6, offset: 36446},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1536, col: 6, offset: 36445},
+						pos:        position{line: 1536, col: 6, offset: 36446},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1536, col: 11, offset: 36450},
+						pos:        position{line: 1536, col: 11, offset: 36451},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1536, col: 16, offset: 36455},
+						pos:        position{line: 1536, col: 16, offset: 36456},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1536, col: 21, offset: 36460},
+						pos:        position{line: 1536, col: 21, offset: 36461},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10277,19 +10280,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1537, col: 1, offset: 36466},
+			pos:  position{line: 1537, col: 1, offset: 36467},
 			expr: &seqExpr{
-				pos: position{line: 1537, col: 6, offset: 36471},
+				pos: position{line: 1537, col: 6, offset: 36472},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1537, col: 6, offset: 36471},
+						pos:        position{line: 1537, col: 6, offset: 36472},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1537, col: 11, offset: 36476},
+						pos:        position{line: 1537, col: 11, offset: 36477},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10302,16 +10305,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1539, col: 1, offset: 36483},
+			pos:  position{line: 1539, col: 1, offset: 36484},
 			expr: &seqExpr{
-				pos: position{line: 1539, col: 12, offset: 36494},
+				pos: position{line: 1539, col: 12, offset: 36495},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1539, col: 12, offset: 36494},
+						pos:  position{line: 1539, col: 12, offset: 36495},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1539, col: 24, offset: 36506},
+						pos:  position{line: 1539, col: 24, offset: 36507},
 						name: "TimeOffset",
 					},
 				},
@@ -10321,49 +10324,49 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1541, col: 1, offset: 36518},
+			pos:  position{line: 1541, col: 1, offset: 36519},
 			expr: &seqExpr{
-				pos: position{line: 1541, col: 15, offset: 36532},
+				pos: position{line: 1541, col: 15, offset: 36533},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1541, col: 15, offset: 36532},
+						pos:  position{line: 1541, col: 15, offset: 36533},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1541, col: 18, offset: 36535},
+						pos:        position{line: 1541, col: 18, offset: 36536},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1541, col: 22, offset: 36539},
+						pos:  position{line: 1541, col: 22, offset: 36540},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1541, col: 25, offset: 36542},
+						pos:        position{line: 1541, col: 25, offset: 36543},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1541, col: 29, offset: 36546},
+						pos:  position{line: 1541, col: 29, offset: 36547},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1541, col: 32, offset: 36549},
+						pos: position{line: 1541, col: 32, offset: 36550},
 						expr: &seqExpr{
-							pos: position{line: 1541, col: 33, offset: 36550},
+							pos: position{line: 1541, col: 33, offset: 36551},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1541, col: 33, offset: 36550},
+									pos:        position{line: 1541, col: 33, offset: 36551},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1541, col: 37, offset: 36554},
+									pos: position{line: 1541, col: 37, offset: 36555},
 									expr: &charClassMatcher{
-										pos:        position{line: 1541, col: 37, offset: 36554},
+										pos:        position{line: 1541, col: 37, offset: 36555},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10380,30 +10383,30 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1543, col: 1, offset: 36564},
+			pos:  position{line: 1543, col: 1, offset: 36565},
 			expr: &choiceExpr{
-				pos: position{line: 1544, col: 5, offset: 36579},
+				pos: position{line: 1544, col: 5, offset: 36580},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1544, col: 5, offset: 36579},
+						pos:        position{line: 1544, col: 5, offset: 36580},
 						val:        "Z",
 						ignoreCase: false,
 						want:       "\"Z\"",
 					},
 					&seqExpr{
-						pos: position{line: 1545, col: 5, offset: 36587},
+						pos: position{line: 1545, col: 5, offset: 36588},
 						exprs: []any{
 							&choiceExpr{
-								pos: position{line: 1545, col: 6, offset: 36588},
+								pos: position{line: 1545, col: 6, offset: 36589},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 1545, col: 6, offset: 36588},
+										pos:        position{line: 1545, col: 6, offset: 36589},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 1545, col: 12, offset: 36594},
+										pos:        position{line: 1545, col: 12, offset: 36595},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
@@ -10411,34 +10414,34 @@ var g = &grammar{
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1545, col: 17, offset: 36599},
+								pos:  position{line: 1545, col: 17, offset: 36600},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1545, col: 20, offset: 36602},
+								pos:        position{line: 1545, col: 20, offset: 36603},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1545, col: 24, offset: 36606},
+								pos:  position{line: 1545, col: 24, offset: 36607},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1545, col: 27, offset: 36609},
+								pos: position{line: 1545, col: 27, offset: 36610},
 								expr: &seqExpr{
-									pos: position{line: 1545, col: 28, offset: 36610},
+									pos: position{line: 1545, col: 28, offset: 36611},
 									exprs: []any{
 										&litMatcher{
-											pos:        position{line: 1545, col: 28, offset: 36610},
+											pos:        position{line: 1545, col: 28, offset: 36611},
 											val:        ".",
 											ignoreCase: false,
 											want:       "\".\"",
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1545, col: 32, offset: 36614},
+											pos: position{line: 1545, col: 32, offset: 36615},
 											expr: &charClassMatcher{
-												pos:        position{line: 1545, col: 32, offset: 36614},
+												pos:        position{line: 1545, col: 32, offset: 36615},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -10457,33 +10460,33 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1547, col: 1, offset: 36624},
+			pos:  position{line: 1547, col: 1, offset: 36625},
 			expr: &actionExpr{
-				pos: position{line: 1548, col: 5, offset: 36637},
+				pos: position{line: 1548, col: 5, offset: 36638},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1548, col: 5, offset: 36637},
+					pos: position{line: 1548, col: 5, offset: 36638},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 1548, col: 5, offset: 36637},
+							pos: position{line: 1548, col: 5, offset: 36638},
 							expr: &litMatcher{
-								pos:        position{line: 1548, col: 5, offset: 36637},
+								pos:        position{line: 1548, col: 5, offset: 36638},
 								val:        "-",
 								ignoreCase: false,
 								want:       "\"-\"",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1548, col: 10, offset: 36642},
+							pos: position{line: 1548, col: 10, offset: 36643},
 							expr: &seqExpr{
-								pos: position{line: 1548, col: 11, offset: 36643},
+								pos: position{line: 1548, col: 11, offset: 36644},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1548, col: 11, offset: 36643},
+										pos:  position{line: 1548, col: 11, offset: 36644},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1548, col: 19, offset: 36651},
+										pos:  position{line: 1548, col: 19, offset: 36652},
 										name: "TimeUnit",
 									},
 								},
@@ -10497,27 +10500,27 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1552, col: 1, offset: 36733},
+			pos:  position{line: 1552, col: 1, offset: 36734},
 			expr: &seqExpr{
-				pos: position{line: 1552, col: 11, offset: 36743},
+				pos: position{line: 1552, col: 11, offset: 36744},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1552, col: 11, offset: 36743},
+						pos:  position{line: 1552, col: 11, offset: 36744},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1552, col: 16, offset: 36748},
+						pos: position{line: 1552, col: 16, offset: 36749},
 						expr: &seqExpr{
-							pos: position{line: 1552, col: 17, offset: 36749},
+							pos: position{line: 1552, col: 17, offset: 36750},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1552, col: 17, offset: 36749},
+									pos:        position{line: 1552, col: 17, offset: 36750},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1552, col: 21, offset: 36753},
+									pos:  position{line: 1552, col: 21, offset: 36754},
 									name: "UInt",
 								},
 							},
@@ -10530,60 +10533,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1554, col: 1, offset: 36761},
+			pos:  position{line: 1554, col: 1, offset: 36762},
 			expr: &choiceExpr{
-				pos: position{line: 1555, col: 5, offset: 36774},
+				pos: position{line: 1555, col: 5, offset: 36775},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1555, col: 5, offset: 36774},
+						pos:        position{line: 1555, col: 5, offset: 36775},
 						val:        "ns",
 						ignoreCase: false,
 						want:       "\"ns\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1556, col: 5, offset: 36783},
+						pos:        position{line: 1556, col: 5, offset: 36784},
 						val:        "us",
 						ignoreCase: false,
 						want:       "\"us\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1557, col: 5, offset: 36792},
+						pos:        position{line: 1557, col: 5, offset: 36793},
 						val:        "ms",
 						ignoreCase: false,
 						want:       "\"ms\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1558, col: 5, offset: 36801},
+						pos:        position{line: 1558, col: 5, offset: 36802},
 						val:        "s",
 						ignoreCase: false,
 						want:       "\"s\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1559, col: 5, offset: 36809},
+						pos:        position{line: 1559, col: 5, offset: 36810},
 						val:        "m",
 						ignoreCase: false,
 						want:       "\"m\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1560, col: 5, offset: 36817},
+						pos:        position{line: 1560, col: 5, offset: 36818},
 						val:        "h",
 						ignoreCase: false,
 						want:       "\"h\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1561, col: 5, offset: 36825},
+						pos:        position{line: 1561, col: 5, offset: 36826},
 						val:        "d",
 						ignoreCase: false,
 						want:       "\"d\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1562, col: 5, offset: 36833},
+						pos:        position{line: 1562, col: 5, offset: 36834},
 						val:        "w",
 						ignoreCase: false,
 						want:       "\"w\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1563, col: 5, offset: 36841},
+						pos:        position{line: 1563, col: 5, offset: 36842},
 						val:        "y",
 						ignoreCase: false,
 						want:       "\"y\"",
@@ -10595,45 +10598,45 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1565, col: 1, offset: 36846},
+			pos:  position{line: 1565, col: 1, offset: 36847},
 			expr: &actionExpr{
-				pos: position{line: 1566, col: 5, offset: 36853},
+				pos: position{line: 1566, col: 5, offset: 36854},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1566, col: 5, offset: 36853},
+					pos: position{line: 1566, col: 5, offset: 36854},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1566, col: 5, offset: 36853},
+							pos:  position{line: 1566, col: 5, offset: 36854},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1566, col: 10, offset: 36858},
+							pos:        position{line: 1566, col: 10, offset: 36859},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1566, col: 14, offset: 36862},
+							pos:  position{line: 1566, col: 14, offset: 36863},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1566, col: 19, offset: 36867},
+							pos:        position{line: 1566, col: 19, offset: 36868},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1566, col: 23, offset: 36871},
+							pos:  position{line: 1566, col: 23, offset: 36872},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1566, col: 28, offset: 36876},
+							pos:        position{line: 1566, col: 28, offset: 36877},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1566, col: 32, offset: 36880},
+							pos:  position{line: 1566, col: 32, offset: 36881},
 							name: "UInt",
 						},
 					},
@@ -10644,43 +10647,43 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1568, col: 1, offset: 36917},
+			pos:  position{line: 1568, col: 1, offset: 36918},
 			expr: &actionExpr{
-				pos: position{line: 1569, col: 5, offset: 36925},
+				pos: position{line: 1569, col: 5, offset: 36926},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1569, col: 5, offset: 36925},
+					pos: position{line: 1569, col: 5, offset: 36926},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1569, col: 5, offset: 36925},
+							pos: position{line: 1569, col: 5, offset: 36926},
 							expr: &seqExpr{
-								pos: position{line: 1569, col: 7, offset: 36927},
+								pos: position{line: 1569, col: 7, offset: 36928},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1569, col: 7, offset: 36927},
+										pos:  position{line: 1569, col: 7, offset: 36928},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1569, col: 11, offset: 36931},
+										pos:        position{line: 1569, col: 11, offset: 36932},
 										val:        ":",
 										ignoreCase: false,
 										want:       "\":\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1569, col: 15, offset: 36935},
+										pos:  position{line: 1569, col: 15, offset: 36936},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1569, col: 19, offset: 36939},
+										pos: position{line: 1569, col: 19, offset: 36940},
 										expr: &choiceExpr{
-											pos: position{line: 1569, col: 21, offset: 36941},
+											pos: position{line: 1569, col: 21, offset: 36942},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1569, col: 21, offset: 36941},
+													pos:  position{line: 1569, col: 21, offset: 36942},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1569, col: 32, offset: 36952},
+													pos:        position{line: 1569, col: 32, offset: 36953},
 													val:        ":",
 													ignoreCase: false,
 													want:       "\":\"",
@@ -10692,10 +10695,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1569, col: 38, offset: 36958},
+							pos:   position{line: 1569, col: 38, offset: 36959},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1569, col: 40, offset: 36960},
+								pos:  position{line: 1569, col: 40, offset: 36961},
 								name: "IP6Variations",
 							},
 						},
@@ -10707,32 +10710,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1573, col: 1, offset: 37124},
+			pos:  position{line: 1573, col: 1, offset: 37125},
 			expr: &choiceExpr{
-				pos: position{line: 1574, col: 5, offset: 37142},
+				pos: position{line: 1574, col: 5, offset: 37143},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1574, col: 5, offset: 37142},
+						pos: position{line: 1574, col: 5, offset: 37143},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1574, col: 5, offset: 37142},
+							pos: position{line: 1574, col: 5, offset: 37143},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1574, col: 5, offset: 37142},
+									pos:   position{line: 1574, col: 5, offset: 37143},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1574, col: 7, offset: 37144},
+										pos: position{line: 1574, col: 7, offset: 37145},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1574, col: 7, offset: 37144},
+											pos:  position{line: 1574, col: 7, offset: 37145},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1574, col: 17, offset: 37154},
+									pos:   position{line: 1574, col: 17, offset: 37155},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1574, col: 19, offset: 37156},
+										pos:  position{line: 1574, col: 19, offset: 37157},
 										name: "IP6Tail",
 									},
 								},
@@ -10740,52 +10743,52 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1577, col: 5, offset: 37220},
+						pos: position{line: 1577, col: 5, offset: 37221},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1577, col: 5, offset: 37220},
+							pos: position{line: 1577, col: 5, offset: 37221},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1577, col: 5, offset: 37220},
+									pos:   position{line: 1577, col: 5, offset: 37221},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1577, col: 7, offset: 37222},
+										pos:  position{line: 1577, col: 7, offset: 37223},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1577, col: 11, offset: 37226},
+									pos:   position{line: 1577, col: 11, offset: 37227},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1577, col: 13, offset: 37228},
+										pos: position{line: 1577, col: 13, offset: 37229},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1577, col: 13, offset: 37228},
+											pos:  position{line: 1577, col: 13, offset: 37229},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1577, col: 23, offset: 37238},
+									pos:        position{line: 1577, col: 23, offset: 37239},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1577, col: 28, offset: 37243},
+									pos:   position{line: 1577, col: 28, offset: 37244},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1577, col: 30, offset: 37245},
+										pos: position{line: 1577, col: 30, offset: 37246},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1577, col: 30, offset: 37245},
+											pos:  position{line: 1577, col: 30, offset: 37246},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1577, col: 40, offset: 37255},
+									pos:   position{line: 1577, col: 40, offset: 37256},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1577, col: 42, offset: 37257},
+										pos:  position{line: 1577, col: 42, offset: 37258},
 										name: "IP6Tail",
 									},
 								},
@@ -10793,33 +10796,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1580, col: 5, offset: 37356},
+						pos: position{line: 1580, col: 5, offset: 37357},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1580, col: 5, offset: 37356},
+							pos: position{line: 1580, col: 5, offset: 37357},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1580, col: 5, offset: 37356},
+									pos:        position{line: 1580, col: 5, offset: 37357},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1580, col: 10, offset: 37361},
+									pos:   position{line: 1580, col: 10, offset: 37362},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1580, col: 12, offset: 37363},
+										pos: position{line: 1580, col: 12, offset: 37364},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1580, col: 12, offset: 37363},
+											pos:  position{line: 1580, col: 12, offset: 37364},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1580, col: 22, offset: 37373},
+									pos:   position{line: 1580, col: 22, offset: 37374},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1580, col: 24, offset: 37375},
+										pos:  position{line: 1580, col: 24, offset: 37376},
 										name: "IP6Tail",
 									},
 								},
@@ -10827,40 +10830,40 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1583, col: 5, offset: 37446},
+						pos: position{line: 1583, col: 5, offset: 37447},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1583, col: 5, offset: 37446},
+							pos: position{line: 1583, col: 5, offset: 37447},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1583, col: 5, offset: 37446},
+									pos:   position{line: 1583, col: 5, offset: 37447},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1583, col: 7, offset: 37448},
+										pos:  position{line: 1583, col: 7, offset: 37449},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1583, col: 11, offset: 37452},
+									pos:   position{line: 1583, col: 11, offset: 37453},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1583, col: 13, offset: 37454},
+										pos: position{line: 1583, col: 13, offset: 37455},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1583, col: 13, offset: 37454},
+											pos:  position{line: 1583, col: 13, offset: 37455},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1583, col: 23, offset: 37464},
+									pos:        position{line: 1583, col: 23, offset: 37465},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&notExpr{
-									pos: position{line: 1583, col: 28, offset: 37469},
+									pos: position{line: 1583, col: 28, offset: 37470},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1583, col: 29, offset: 37470},
+										pos:  position{line: 1583, col: 29, offset: 37471},
 										name: "TypeAsValue",
 									},
 								},
@@ -10868,10 +10871,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1586, col: 5, offset: 37545},
+						pos: position{line: 1586, col: 5, offset: 37546},
 						run: (*parser).callonIP6Variations40,
 						expr: &litMatcher{
-							pos:        position{line: 1586, col: 5, offset: 37545},
+							pos:        position{line: 1586, col: 5, offset: 37546},
 							val:        "::",
 							ignoreCase: false,
 							want:       "\"::\"",
@@ -10884,16 +10887,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1590, col: 1, offset: 37582},
+			pos:  position{line: 1590, col: 1, offset: 37583},
 			expr: &choiceExpr{
-				pos: position{line: 1591, col: 5, offset: 37594},
+				pos: position{line: 1591, col: 5, offset: 37595},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1591, col: 5, offset: 37594},
+						pos:  position{line: 1591, col: 5, offset: 37595},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1592, col: 5, offset: 37601},
+						pos:  position{line: 1592, col: 5, offset: 37602},
 						name: "Hex",
 					},
 				},
@@ -10903,24 +10906,24 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1594, col: 1, offset: 37606},
+			pos:  position{line: 1594, col: 1, offset: 37607},
 			expr: &actionExpr{
-				pos: position{line: 1594, col: 12, offset: 37617},
+				pos: position{line: 1594, col: 12, offset: 37618},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1594, col: 12, offset: 37617},
+					pos: position{line: 1594, col: 12, offset: 37618},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1594, col: 12, offset: 37617},
+							pos:        position{line: 1594, col: 12, offset: 37618},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1594, col: 16, offset: 37621},
+							pos:   position{line: 1594, col: 16, offset: 37622},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1594, col: 18, offset: 37623},
+								pos:  position{line: 1594, col: 18, offset: 37624},
 								name: "Hex",
 							},
 						},
@@ -10932,23 +10935,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1596, col: 1, offset: 37661},
+			pos:  position{line: 1596, col: 1, offset: 37662},
 			expr: &actionExpr{
-				pos: position{line: 1596, col: 12, offset: 37672},
+				pos: position{line: 1596, col: 12, offset: 37673},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1596, col: 12, offset: 37672},
+					pos: position{line: 1596, col: 12, offset: 37673},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1596, col: 12, offset: 37672},
+							pos:   position{line: 1596, col: 12, offset: 37673},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1596, col: 14, offset: 37674},
+								pos:  position{line: 1596, col: 14, offset: 37675},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1596, col: 18, offset: 37678},
+							pos:        position{line: 1596, col: 18, offset: 37679},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
@@ -10961,32 +10964,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1598, col: 1, offset: 37716},
+			pos:  position{line: 1598, col: 1, offset: 37717},
 			expr: &actionExpr{
-				pos: position{line: 1599, col: 5, offset: 37727},
+				pos: position{line: 1599, col: 5, offset: 37728},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1599, col: 5, offset: 37727},
+					pos: position{line: 1599, col: 5, offset: 37728},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1599, col: 5, offset: 37727},
+							pos:   position{line: 1599, col: 5, offset: 37728},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1599, col: 7, offset: 37729},
+								pos:  position{line: 1599, col: 7, offset: 37730},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1599, col: 10, offset: 37732},
+							pos:        position{line: 1599, col: 10, offset: 37733},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1599, col: 14, offset: 37736},
+							pos:   position{line: 1599, col: 14, offset: 37737},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1599, col: 16, offset: 37738},
+								pos:  position{line: 1599, col: 16, offset: 37739},
 								name: "UIntString",
 							},
 						},
@@ -10998,32 +11001,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1603, col: 1, offset: 37806},
+			pos:  position{line: 1603, col: 1, offset: 37807},
 			expr: &actionExpr{
-				pos: position{line: 1604, col: 5, offset: 37817},
+				pos: position{line: 1604, col: 5, offset: 37818},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1604, col: 5, offset: 37817},
+					pos: position{line: 1604, col: 5, offset: 37818},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1604, col: 5, offset: 37817},
+							pos:   position{line: 1604, col: 5, offset: 37818},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1604, col: 7, offset: 37819},
+								pos:  position{line: 1604, col: 7, offset: 37820},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1604, col: 11, offset: 37823},
+							pos:        position{line: 1604, col: 11, offset: 37824},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1604, col: 15, offset: 37827},
+							pos:   position{line: 1604, col: 15, offset: 37828},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1604, col: 17, offset: 37829},
+								pos:  position{line: 1604, col: 17, offset: 37830},
 								name: "UIntString",
 							},
 						},
@@ -11035,15 +11038,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1608, col: 1, offset: 37897},
+			pos:  position{line: 1608, col: 1, offset: 37898},
 			expr: &actionExpr{
-				pos: position{line: 1609, col: 4, offset: 37905},
+				pos: position{line: 1609, col: 4, offset: 37906},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1609, col: 4, offset: 37905},
+					pos:   position{line: 1609, col: 4, offset: 37906},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1609, col: 6, offset: 37907},
+						pos:  position{line: 1609, col: 6, offset: 37908},
 						name: "UIntString",
 					},
 				},
@@ -11053,16 +11056,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1611, col: 1, offset: 37947},
+			pos:  position{line: 1611, col: 1, offset: 37948},
 			expr: &choiceExpr{
-				pos: position{line: 1612, col: 5, offset: 37961},
+				pos: position{line: 1612, col: 5, offset: 37962},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1612, col: 5, offset: 37961},
+						pos:  position{line: 1612, col: 5, offset: 37962},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1613, col: 5, offset: 37976},
+						pos:  position{line: 1613, col: 5, offset: 37977},
 						name: "MinusIntString",
 					},
 				},
@@ -11072,14 +11075,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1615, col: 1, offset: 37992},
+			pos:  position{line: 1615, col: 1, offset: 37993},
 			expr: &actionExpr{
-				pos: position{line: 1615, col: 14, offset: 38005},
+				pos: position{line: 1615, col: 14, offset: 38006},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1615, col: 14, offset: 38005},
+					pos: position{line: 1615, col: 14, offset: 38006},
 					expr: &charClassMatcher{
-						pos:        position{line: 1615, col: 14, offset: 38005},
+						pos:        position{line: 1615, col: 14, offset: 38006},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11092,21 +11095,21 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1617, col: 1, offset: 38044},
+			pos:  position{line: 1617, col: 1, offset: 38045},
 			expr: &actionExpr{
-				pos: position{line: 1618, col: 5, offset: 38063},
+				pos: position{line: 1618, col: 5, offset: 38064},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1618, col: 5, offset: 38063},
+					pos: position{line: 1618, col: 5, offset: 38064},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1618, col: 5, offset: 38063},
+							pos:        position{line: 1618, col: 5, offset: 38064},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1618, col: 9, offset: 38067},
+							pos:  position{line: 1618, col: 9, offset: 38068},
 							name: "UIntString",
 						},
 					},
@@ -11117,29 +11120,29 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1620, col: 1, offset: 38110},
+			pos:  position{line: 1620, col: 1, offset: 38111},
 			expr: &choiceExpr{
-				pos: position{line: 1621, col: 5, offset: 38126},
+				pos: position{line: 1621, col: 5, offset: 38127},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1621, col: 5, offset: 38126},
+						pos: position{line: 1621, col: 5, offset: 38127},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1621, col: 5, offset: 38126},
+							pos: position{line: 1621, col: 5, offset: 38127},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1621, col: 5, offset: 38126},
+									pos: position{line: 1621, col: 5, offset: 38127},
 									expr: &litMatcher{
-										pos:        position{line: 1621, col: 5, offset: 38126},
+										pos:        position{line: 1621, col: 5, offset: 38127},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1621, col: 10, offset: 38131},
+									pos: position{line: 1621, col: 10, offset: 38132},
 									expr: &charClassMatcher{
-										pos:        position{line: 1621, col: 10, offset: 38131},
+										pos:        position{line: 1621, col: 10, offset: 38132},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11147,15 +11150,15 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1621, col: 17, offset: 38138},
+									pos:        position{line: 1621, col: 17, offset: 38139},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1621, col: 21, offset: 38142},
+									pos: position{line: 1621, col: 21, offset: 38143},
 									expr: &charClassMatcher{
-										pos:        position{line: 1621, col: 21, offset: 38142},
+										pos:        position{line: 1621, col: 21, offset: 38143},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11163,9 +11166,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1621, col: 28, offset: 38149},
+									pos: position{line: 1621, col: 28, offset: 38150},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1621, col: 28, offset: 38149},
+										pos:  position{line: 1621, col: 28, offset: 38150},
 										name: "ExponentPart",
 									},
 								},
@@ -11173,30 +11176,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1622, col: 5, offset: 38198},
+						pos: position{line: 1622, col: 5, offset: 38199},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1622, col: 5, offset: 38198},
+							pos: position{line: 1622, col: 5, offset: 38199},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1622, col: 5, offset: 38198},
+									pos: position{line: 1622, col: 5, offset: 38199},
 									expr: &litMatcher{
-										pos:        position{line: 1622, col: 5, offset: 38198},
+										pos:        position{line: 1622, col: 5, offset: 38199},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1622, col: 10, offset: 38203},
+									pos:        position{line: 1622, col: 10, offset: 38204},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1622, col: 14, offset: 38207},
+									pos: position{line: 1622, col: 14, offset: 38208},
 									expr: &charClassMatcher{
-										pos:        position{line: 1622, col: 14, offset: 38207},
+										pos:        position{line: 1622, col: 14, offset: 38208},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11204,9 +11207,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1622, col: 21, offset: 38214},
+									pos: position{line: 1622, col: 21, offset: 38215},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1622, col: 21, offset: 38214},
+										pos:  position{line: 1622, col: 21, offset: 38215},
 										name: "ExponentPart",
 									},
 								},
@@ -11214,17 +11217,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1623, col: 5, offset: 38263},
+						pos: position{line: 1623, col: 5, offset: 38264},
 						run: (*parser).callonFloatString22,
 						expr: &choiceExpr{
-							pos: position{line: 1623, col: 6, offset: 38264},
+							pos: position{line: 1623, col: 6, offset: 38265},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1623, col: 6, offset: 38264},
+									pos:  position{line: 1623, col: 6, offset: 38265},
 									name: "NaN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1623, col: 12, offset: 38270},
+									pos:  position{line: 1623, col: 12, offset: 38271},
 									name: "Infinity",
 								},
 							},
@@ -11237,20 +11240,20 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1626, col: 1, offset: 38313},
+			pos:  position{line: 1626, col: 1, offset: 38314},
 			expr: &seqExpr{
-				pos: position{line: 1626, col: 16, offset: 38328},
+				pos: position{line: 1626, col: 16, offset: 38329},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1626, col: 16, offset: 38328},
+						pos:        position{line: 1626, col: 16, offset: 38329},
 						val:        "e",
 						ignoreCase: true,
 						want:       "\"e\"i",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1626, col: 21, offset: 38333},
+						pos: position{line: 1626, col: 21, offset: 38334},
 						expr: &charClassMatcher{
-							pos:        position{line: 1626, col: 21, offset: 38333},
+							pos:        position{line: 1626, col: 21, offset: 38334},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -11258,7 +11261,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1626, col: 27, offset: 38339},
+						pos:  position{line: 1626, col: 27, offset: 38340},
 						name: "UIntString",
 					},
 				},
@@ -11268,9 +11271,9 @@ var g = &grammar{
 		},
 		{
 			name: "NaN",
-			pos:  position{line: 1628, col: 1, offset: 38351},
+			pos:  position{line: 1628, col: 1, offset: 38352},
 			expr: &litMatcher{
-				pos:        position{line: 1628, col: 7, offset: 38357},
+				pos:        position{line: 1628, col: 7, offset: 38358},
 				val:        "NaN",
 				ignoreCase: false,
 				want:       "\"NaN\"",
@@ -11280,23 +11283,23 @@ var g = &grammar{
 		},
 		{
 			name: "Infinity",
-			pos:  position{line: 1630, col: 1, offset: 38364},
+			pos:  position{line: 1630, col: 1, offset: 38365},
 			expr: &seqExpr{
-				pos: position{line: 1630, col: 12, offset: 38375},
+				pos: position{line: 1630, col: 12, offset: 38376},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 1630, col: 12, offset: 38375},
+						pos: position{line: 1630, col: 12, offset: 38376},
 						expr: &choiceExpr{
-							pos: position{line: 1630, col: 13, offset: 38376},
+							pos: position{line: 1630, col: 13, offset: 38377},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1630, col: 13, offset: 38376},
+									pos:        position{line: 1630, col: 13, offset: 38377},
 									val:        "-",
 									ignoreCase: false,
 									want:       "\"-\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1630, col: 19, offset: 38382},
+									pos:        position{line: 1630, col: 19, offset: 38383},
 									val:        "+",
 									ignoreCase: false,
 									want:       "\"+\"",
@@ -11305,7 +11308,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1630, col: 25, offset: 38388},
+						pos:        position{line: 1630, col: 25, offset: 38389},
 						val:        "Inf",
 						ignoreCase: false,
 						want:       "\"Inf\"",
@@ -11317,14 +11320,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1632, col: 1, offset: 38395},
+			pos:  position{line: 1632, col: 1, offset: 38396},
 			expr: &actionExpr{
-				pos: position{line: 1632, col: 7, offset: 38401},
+				pos: position{line: 1632, col: 7, offset: 38402},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1632, col: 7, offset: 38401},
+					pos: position{line: 1632, col: 7, offset: 38402},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1632, col: 7, offset: 38401},
+						pos:  position{line: 1632, col: 7, offset: 38402},
 						name: "HexDigit",
 					},
 				},
@@ -11334,9 +11337,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1634, col: 1, offset: 38443},
+			pos:  position{line: 1634, col: 1, offset: 38444},
 			expr: &charClassMatcher{
-				pos:        position{line: 1634, col: 12, offset: 38454},
+				pos:        position{line: 1634, col: 12, offset: 38455},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -11347,32 +11350,32 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedString",
-			pos:  position{line: 1636, col: 1, offset: 38467},
+			pos:  position{line: 1636, col: 1, offset: 38468},
 			expr: &actionExpr{
-				pos: position{line: 1637, col: 5, offset: 38490},
+				pos: position{line: 1637, col: 5, offset: 38491},
 				run: (*parser).callonSingleQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 1637, col: 5, offset: 38490},
+					pos: position{line: 1637, col: 5, offset: 38491},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1637, col: 5, offset: 38490},
+							pos:        position{line: 1637, col: 5, offset: 38491},
 							val:        "'",
 							ignoreCase: false,
 							want:       "\"'\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1637, col: 9, offset: 38494},
+							pos:   position{line: 1637, col: 9, offset: 38495},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1637, col: 11, offset: 38496},
+								pos: position{line: 1637, col: 11, offset: 38497},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1637, col: 11, offset: 38496},
+									pos:  position{line: 1637, col: 11, offset: 38497},
 									name: "SingleQuotedChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1637, col: 29, offset: 38514},
+							pos:        position{line: 1637, col: 29, offset: 38515},
 							val:        "'",
 							ignoreCase: false,
 							want:       "\"'\"",
@@ -11385,32 +11388,32 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedString",
-			pos:  position{line: 1639, col: 1, offset: 38548},
+			pos:  position{line: 1639, col: 1, offset: 38549},
 			expr: &actionExpr{
-				pos: position{line: 1640, col: 5, offset: 38571},
+				pos: position{line: 1640, col: 5, offset: 38572},
 				run: (*parser).callonDoubleQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 1640, col: 5, offset: 38571},
+					pos: position{line: 1640, col: 5, offset: 38572},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1640, col: 5, offset: 38571},
+							pos:        position{line: 1640, col: 5, offset: 38572},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1640, col: 9, offset: 38575},
+							pos:   position{line: 1640, col: 9, offset: 38576},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1640, col: 11, offset: 38577},
+								pos: position{line: 1640, col: 11, offset: 38578},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1640, col: 11, offset: 38577},
+									pos:  position{line: 1640, col: 11, offset: 38578},
 									name: "DoubleQuotedChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1640, col: 29, offset: 38595},
+							pos:        position{line: 1640, col: 29, offset: 38596},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11423,57 +11426,57 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1642, col: 1, offset: 38629},
+			pos:  position{line: 1642, col: 1, offset: 38630},
 			expr: &choiceExpr{
-				pos: position{line: 1643, col: 5, offset: 38650},
+				pos: position{line: 1643, col: 5, offset: 38651},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1643, col: 5, offset: 38650},
+						pos: position{line: 1643, col: 5, offset: 38651},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1643, col: 5, offset: 38650},
+							pos: position{line: 1643, col: 5, offset: 38651},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1643, col: 5, offset: 38650},
+									pos: position{line: 1643, col: 5, offset: 38651},
 									expr: &choiceExpr{
-										pos: position{line: 1643, col: 7, offset: 38652},
+										pos: position{line: 1643, col: 7, offset: 38653},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1643, col: 7, offset: 38652},
+												pos:        position{line: 1643, col: 7, offset: 38653},
 												val:        "\"",
 												ignoreCase: false,
 												want:       "\"\\\"\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1643, col: 13, offset: 38658},
+												pos:  position{line: 1643, col: 13, offset: 38659},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1643, col: 26, offset: 38671,
+									line: 1643, col: 26, offset: 38672,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1644, col: 5, offset: 38708},
+						pos: position{line: 1644, col: 5, offset: 38709},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1644, col: 5, offset: 38708},
+							pos: position{line: 1644, col: 5, offset: 38709},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1644, col: 5, offset: 38708},
+									pos:        position{line: 1644, col: 5, offset: 38709},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1644, col: 10, offset: 38713},
+									pos:   position{line: 1644, col: 10, offset: 38714},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1644, col: 12, offset: 38715},
+										pos:  position{line: 1644, col: 12, offset: 38716},
 										name: "EscapeSequence",
 									},
 								},
@@ -11487,32 +11490,32 @@ var g = &grammar{
 		},
 		{
 			name: "RString",
-			pos:  position{line: 1646, col: 1, offset: 38749},
+			pos:  position{line: 1646, col: 1, offset: 38750},
 			expr: &choiceExpr{
-				pos: position{line: 1647, col: 5, offset: 38761},
+				pos: position{line: 1647, col: 5, offset: 38762},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1647, col: 5, offset: 38761},
+						pos: position{line: 1647, col: 5, offset: 38762},
 						run: (*parser).callonRString2,
 						expr: &seqExpr{
-							pos: position{line: 1647, col: 5, offset: 38761},
+							pos: position{line: 1647, col: 5, offset: 38762},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1647, col: 5, offset: 38761},
+									pos:        position{line: 1647, col: 5, offset: 38762},
 									val:        "r'",
 									ignoreCase: false,
 									want:       "\"r'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1647, col: 10, offset: 38766},
+									pos:   position{line: 1647, col: 10, offset: 38767},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1647, col: 12, offset: 38768},
+										pos:  position{line: 1647, col: 12, offset: 38769},
 										name: "NoSingleQuotes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1647, col: 27, offset: 38783},
+									pos:        position{line: 1647, col: 27, offset: 38784},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -11521,33 +11524,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1648, col: 5, offset: 38818},
+						pos: position{line: 1648, col: 5, offset: 38819},
 						run: (*parser).callonRString8,
 						expr: &seqExpr{
-							pos: position{line: 1648, col: 5, offset: 38818},
+							pos: position{line: 1648, col: 5, offset: 38819},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1648, col: 5, offset: 38818},
+									pos:        position{line: 1648, col: 5, offset: 38819},
 									val:        "r",
 									ignoreCase: false,
 									want:       "\"r\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1648, col: 9, offset: 38822},
+									pos:        position{line: 1648, col: 9, offset: 38823},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1648, col: 13, offset: 38826},
+									pos:   position{line: 1648, col: 13, offset: 38827},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1648, col: 15, offset: 38828},
+										pos:  position{line: 1648, col: 15, offset: 38829},
 										name: "NoDoubleQuotes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1648, col: 30, offset: 38843},
+									pos:        position{line: 1648, col: 30, offset: 38844},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -11562,26 +11565,26 @@ var g = &grammar{
 		},
 		{
 			name: "NoSingleQuotes",
-			pos:  position{line: 1650, col: 1, offset: 38875},
+			pos:  position{line: 1650, col: 1, offset: 38876},
 			expr: &actionExpr{
-				pos: position{line: 1651, col: 5, offset: 38894},
+				pos: position{line: 1651, col: 5, offset: 38895},
 				run: (*parser).callonNoSingleQuotes1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 1651, col: 5, offset: 38894},
+					pos: position{line: 1651, col: 5, offset: 38895},
 					expr: &seqExpr{
-						pos: position{line: 1651, col: 6, offset: 38895},
+						pos: position{line: 1651, col: 6, offset: 38896},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 1651, col: 6, offset: 38895},
+								pos: position{line: 1651, col: 6, offset: 38896},
 								expr: &litMatcher{
-									pos:        position{line: 1651, col: 7, offset: 38896},
+									pos:        position{line: 1651, col: 7, offset: 38897},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 							},
 							&anyMatcher{
-								line: 1651, col: 11, offset: 38900,
+								line: 1651, col: 11, offset: 38901,
 							},
 						},
 					},
@@ -11592,26 +11595,26 @@ var g = &grammar{
 		},
 		{
 			name: "NoDoubleQuotes",
-			pos:  position{line: 1653, col: 1, offset: 38936},
+			pos:  position{line: 1653, col: 1, offset: 38937},
 			expr: &actionExpr{
-				pos: position{line: 1654, col: 5, offset: 38955},
+				pos: position{line: 1654, col: 5, offset: 38956},
 				run: (*parser).callonNoDoubleQuotes1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 1654, col: 5, offset: 38955},
+					pos: position{line: 1654, col: 5, offset: 38956},
 					expr: &seqExpr{
-						pos: position{line: 1654, col: 6, offset: 38956},
+						pos: position{line: 1654, col: 6, offset: 38957},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 1654, col: 6, offset: 38956},
+								pos: position{line: 1654, col: 6, offset: 38957},
 								expr: &litMatcher{
-									pos:        position{line: 1654, col: 7, offset: 38957},
+									pos:        position{line: 1654, col: 7, offset: 38958},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 							},
 							&anyMatcher{
-								line: 1654, col: 11, offset: 38961,
+								line: 1654, col: 11, offset: 38962,
 							},
 						},
 					},
@@ -11622,32 +11625,32 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickString",
-			pos:  position{line: 1656, col: 1, offset: 38997},
+			pos:  position{line: 1656, col: 1, offset: 38998},
 			expr: &actionExpr{
-				pos: position{line: 1657, col: 5, offset: 39016},
+				pos: position{line: 1657, col: 5, offset: 39017},
 				run: (*parser).callonBacktickString1,
 				expr: &seqExpr{
-					pos: position{line: 1657, col: 5, offset: 39016},
+					pos: position{line: 1657, col: 5, offset: 39017},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1657, col: 5, offset: 39016},
+							pos:        position{line: 1657, col: 5, offset: 39017},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1657, col: 9, offset: 39020},
+							pos:   position{line: 1657, col: 9, offset: 39021},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1657, col: 11, offset: 39022},
+								pos: position{line: 1657, col: 11, offset: 39023},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1657, col: 11, offset: 39022},
+									pos:  position{line: 1657, col: 11, offset: 39023},
 									name: "BacktickChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1657, col: 25, offset: 39036},
+							pos:        position{line: 1657, col: 25, offset: 39037},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
@@ -11660,57 +11663,57 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickChar",
-			pos:  position{line: 1659, col: 1, offset: 39070},
+			pos:  position{line: 1659, col: 1, offset: 39071},
 			expr: &choiceExpr{
-				pos: position{line: 1660, col: 5, offset: 39087},
+				pos: position{line: 1660, col: 5, offset: 39088},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1660, col: 5, offset: 39087},
+						pos: position{line: 1660, col: 5, offset: 39088},
 						run: (*parser).callonBacktickChar2,
 						expr: &seqExpr{
-							pos: position{line: 1660, col: 5, offset: 39087},
+							pos: position{line: 1660, col: 5, offset: 39088},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1660, col: 5, offset: 39087},
+									pos: position{line: 1660, col: 5, offset: 39088},
 									expr: &choiceExpr{
-										pos: position{line: 1660, col: 7, offset: 39089},
+										pos: position{line: 1660, col: 7, offset: 39090},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1660, col: 7, offset: 39089},
+												pos:        position{line: 1660, col: 7, offset: 39090},
 												val:        "`",
 												ignoreCase: false,
 												want:       "\"`\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1660, col: 13, offset: 39095},
+												pos:  position{line: 1660, col: 13, offset: 39096},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1660, col: 26, offset: 39108,
+									line: 1660, col: 26, offset: 39109,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1661, col: 5, offset: 39145},
+						pos: position{line: 1661, col: 5, offset: 39146},
 						run: (*parser).callonBacktickChar9,
 						expr: &seqExpr{
-							pos: position{line: 1661, col: 5, offset: 39145},
+							pos: position{line: 1661, col: 5, offset: 39146},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1661, col: 5, offset: 39145},
+									pos:        position{line: 1661, col: 5, offset: 39146},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1661, col: 10, offset: 39150},
+									pos:   position{line: 1661, col: 10, offset: 39151},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1661, col: 12, offset: 39152},
+										pos:  position{line: 1661, col: 12, offset: 39153},
 										name: "EscapeSequence",
 									},
 								},
@@ -11724,28 +11727,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1663, col: 1, offset: 39186},
+			pos:  position{line: 1663, col: 1, offset: 39187},
 			expr: &actionExpr{
-				pos: position{line: 1664, col: 5, offset: 39198},
+				pos: position{line: 1664, col: 5, offset: 39199},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1664, col: 5, offset: 39198},
+					pos: position{line: 1664, col: 5, offset: 39199},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1664, col: 5, offset: 39198},
+							pos:   position{line: 1664, col: 5, offset: 39199},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1664, col: 10, offset: 39203},
+								pos:  position{line: 1664, col: 10, offset: 39204},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1664, col: 23, offset: 39216},
+							pos:   position{line: 1664, col: 23, offset: 39217},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1664, col: 28, offset: 39221},
+								pos: position{line: 1664, col: 28, offset: 39222},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1664, col: 28, offset: 39221},
+									pos:  position{line: 1664, col: 28, offset: 39222},
 									name: "KeyWordRest",
 								},
 							},
@@ -11758,16 +11761,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1666, col: 1, offset: 39283},
+			pos:  position{line: 1666, col: 1, offset: 39284},
 			expr: &choiceExpr{
-				pos: position{line: 1667, col: 5, offset: 39300},
+				pos: position{line: 1667, col: 5, offset: 39301},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1667, col: 5, offset: 39300},
+						pos:  position{line: 1667, col: 5, offset: 39301},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1668, col: 5, offset: 39317},
+						pos:  position{line: 1668, col: 5, offset: 39318},
 						name: "KeyWordEsc",
 					},
 				},
@@ -11777,16 +11780,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1670, col: 1, offset: 39329},
+			pos:  position{line: 1670, col: 1, offset: 39330},
 			expr: &choiceExpr{
-				pos: position{line: 1671, col: 5, offset: 39345},
+				pos: position{line: 1671, col: 5, offset: 39346},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1671, col: 5, offset: 39345},
+						pos:  position{line: 1671, col: 5, offset: 39346},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1672, col: 5, offset: 39362},
+						pos:        position{line: 1672, col: 5, offset: 39363},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11799,19 +11802,19 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1674, col: 1, offset: 39369},
+			pos:  position{line: 1674, col: 1, offset: 39370},
 			expr: &actionExpr{
-				pos: position{line: 1674, col: 16, offset: 39384},
+				pos: position{line: 1674, col: 16, offset: 39385},
 				run: (*parser).callonKeyWordChars1,
 				expr: &choiceExpr{
-					pos: position{line: 1674, col: 17, offset: 39385},
+					pos: position{line: 1674, col: 17, offset: 39386},
 					alternatives: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1674, col: 17, offset: 39385},
+							pos:  position{line: 1674, col: 17, offset: 39386},
 							name: "UnicodeLetter",
 						},
 						&charClassMatcher{
-							pos:        position{line: 1674, col: 33, offset: 39401},
+							pos:        position{line: 1674, col: 33, offset: 39402},
 							val:        "[_.:/%#@~]",
 							chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 							ignoreCase: false,
@@ -11825,31 +11828,31 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1676, col: 1, offset: 39445},
+			pos:  position{line: 1676, col: 1, offset: 39446},
 			expr: &actionExpr{
-				pos: position{line: 1676, col: 14, offset: 39458},
+				pos: position{line: 1676, col: 14, offset: 39459},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1676, col: 14, offset: 39458},
+					pos: position{line: 1676, col: 14, offset: 39459},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1676, col: 14, offset: 39458},
+							pos:        position{line: 1676, col: 14, offset: 39459},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1676, col: 19, offset: 39463},
+							pos:   position{line: 1676, col: 19, offset: 39464},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1676, col: 22, offset: 39466},
+								pos: position{line: 1676, col: 22, offset: 39467},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1676, col: 22, offset: 39466},
+										pos:  position{line: 1676, col: 22, offset: 39467},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1676, col: 38, offset: 39482},
+										pos:  position{line: 1676, col: 38, offset: 39483},
 										name: "EscapeSequence",
 									},
 								},
@@ -11863,42 +11866,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1678, col: 1, offset: 39517},
+			pos:  position{line: 1678, col: 1, offset: 39518},
 			expr: &actionExpr{
-				pos: position{line: 1679, col: 5, offset: 39533},
+				pos: position{line: 1679, col: 5, offset: 39534},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1679, col: 5, offset: 39533},
+					pos: position{line: 1679, col: 5, offset: 39534},
 					exprs: []any{
 						&andExpr{
-							pos: position{line: 1679, col: 5, offset: 39533},
+							pos: position{line: 1679, col: 5, offset: 39534},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1679, col: 6, offset: 39534},
+								pos:  position{line: 1679, col: 6, offset: 39535},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1679, col: 22, offset: 39550},
+							pos: position{line: 1679, col: 22, offset: 39551},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1679, col: 23, offset: 39551},
+								pos:  position{line: 1679, col: 23, offset: 39552},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1679, col: 35, offset: 39563},
+							pos:   position{line: 1679, col: 35, offset: 39564},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1679, col: 40, offset: 39568},
+								pos:  position{line: 1679, col: 40, offset: 39569},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1679, col: 50, offset: 39578},
+							pos:   position{line: 1679, col: 50, offset: 39579},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1679, col: 55, offset: 39583},
+								pos: position{line: 1679, col: 55, offset: 39584},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1679, col: 55, offset: 39583},
+									pos:  position{line: 1679, col: 55, offset: 39584},
 									name: "GlobRest",
 								},
 							},
@@ -11911,28 +11914,28 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1683, col: 1, offset: 39652},
+			pos:  position{line: 1683, col: 1, offset: 39653},
 			expr: &choiceExpr{
-				pos: position{line: 1683, col: 19, offset: 39670},
+				pos: position{line: 1683, col: 19, offset: 39671},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1683, col: 19, offset: 39670},
+						pos:  position{line: 1683, col: 19, offset: 39671},
 						name: "KeyWordStart",
 					},
 					&seqExpr{
-						pos: position{line: 1683, col: 34, offset: 39685},
+						pos: position{line: 1683, col: 34, offset: 39686},
 						exprs: []any{
 							&oneOrMoreExpr{
-								pos: position{line: 1683, col: 34, offset: 39685},
+								pos: position{line: 1683, col: 34, offset: 39686},
 								expr: &litMatcher{
-									pos:        position{line: 1683, col: 34, offset: 39685},
+									pos:        position{line: 1683, col: 34, offset: 39686},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1683, col: 39, offset: 39690},
+								pos:  position{line: 1683, col: 39, offset: 39691},
 								name: "KeyWordRest",
 							},
 						},
@@ -11944,19 +11947,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1684, col: 1, offset: 39702},
+			pos:  position{line: 1684, col: 1, offset: 39703},
 			expr: &seqExpr{
-				pos: position{line: 1684, col: 15, offset: 39716},
+				pos: position{line: 1684, col: 15, offset: 39717},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1684, col: 15, offset: 39716},
+						pos: position{line: 1684, col: 15, offset: 39717},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1684, col: 15, offset: 39716},
+							pos:  position{line: 1684, col: 15, offset: 39717},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1684, col: 28, offset: 39729},
+						pos:        position{line: 1684, col: 28, offset: 39730},
 						val:        "*",
 						ignoreCase: false,
 						want:       "\"*\"",
@@ -11968,23 +11971,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1686, col: 1, offset: 39734},
+			pos:  position{line: 1686, col: 1, offset: 39735},
 			expr: &choiceExpr{
-				pos: position{line: 1687, col: 5, offset: 39748},
+				pos: position{line: 1687, col: 5, offset: 39749},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1687, col: 5, offset: 39748},
+						pos:  position{line: 1687, col: 5, offset: 39749},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1688, col: 5, offset: 39765},
+						pos:  position{line: 1688, col: 5, offset: 39766},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1689, col: 5, offset: 39777},
+						pos: position{line: 1689, col: 5, offset: 39778},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1689, col: 5, offset: 39777},
+							pos:        position{line: 1689, col: 5, offset: 39778},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -11997,16 +12000,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1691, col: 1, offset: 39802},
+			pos:  position{line: 1691, col: 1, offset: 39803},
 			expr: &choiceExpr{
-				pos: position{line: 1692, col: 5, offset: 39815},
+				pos: position{line: 1692, col: 5, offset: 39816},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1692, col: 5, offset: 39815},
+						pos:  position{line: 1692, col: 5, offset: 39816},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1693, col: 5, offset: 39829},
+						pos:        position{line: 1693, col: 5, offset: 39830},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -12019,31 +12022,31 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1695, col: 1, offset: 39836},
+			pos:  position{line: 1695, col: 1, offset: 39837},
 			expr: &actionExpr{
-				pos: position{line: 1695, col: 11, offset: 39846},
+				pos: position{line: 1695, col: 11, offset: 39847},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1695, col: 11, offset: 39846},
+					pos: position{line: 1695, col: 11, offset: 39847},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1695, col: 11, offset: 39846},
+							pos:        position{line: 1695, col: 11, offset: 39847},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1695, col: 16, offset: 39851},
+							pos:   position{line: 1695, col: 16, offset: 39852},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1695, col: 19, offset: 39854},
+								pos: position{line: 1695, col: 19, offset: 39855},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1695, col: 19, offset: 39854},
+										pos:  position{line: 1695, col: 19, offset: 39855},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1695, col: 32, offset: 39867},
+										pos:  position{line: 1695, col: 32, offset: 39868},
 										name: "EscapeSequence",
 									},
 								},
@@ -12057,32 +12060,32 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1697, col: 1, offset: 39902},
+			pos:  position{line: 1697, col: 1, offset: 39903},
 			expr: &choiceExpr{
-				pos: position{line: 1698, col: 5, offset: 39917},
+				pos: position{line: 1698, col: 5, offset: 39918},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1698, col: 5, offset: 39917},
+						pos: position{line: 1698, col: 5, offset: 39918},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1698, col: 5, offset: 39917},
+							pos:        position{line: 1698, col: 5, offset: 39918},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1699, col: 5, offset: 39945},
+						pos: position{line: 1699, col: 5, offset: 39946},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1699, col: 5, offset: 39945},
+							pos:        position{line: 1699, col: 5, offset: 39946},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1700, col: 5, offset: 39975},
+						pos:        position{line: 1700, col: 5, offset: 39976},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -12095,57 +12098,57 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1702, col: 1, offset: 39981},
+			pos:  position{line: 1702, col: 1, offset: 39982},
 			expr: &choiceExpr{
-				pos: position{line: 1703, col: 5, offset: 40002},
+				pos: position{line: 1703, col: 5, offset: 40003},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1703, col: 5, offset: 40002},
+						pos: position{line: 1703, col: 5, offset: 40003},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1703, col: 5, offset: 40002},
+							pos: position{line: 1703, col: 5, offset: 40003},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1703, col: 5, offset: 40002},
+									pos: position{line: 1703, col: 5, offset: 40003},
 									expr: &choiceExpr{
-										pos: position{line: 1703, col: 7, offset: 40004},
+										pos: position{line: 1703, col: 7, offset: 40005},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1703, col: 7, offset: 40004},
+												pos:        position{line: 1703, col: 7, offset: 40005},
 												val:        "'",
 												ignoreCase: false,
 												want:       "\"'\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1703, col: 13, offset: 40010},
+												pos:  position{line: 1703, col: 13, offset: 40011},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1703, col: 26, offset: 40023,
+									line: 1703, col: 26, offset: 40024,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1704, col: 5, offset: 40060},
+						pos: position{line: 1704, col: 5, offset: 40061},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1704, col: 5, offset: 40060},
+							pos: position{line: 1704, col: 5, offset: 40061},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1704, col: 5, offset: 40060},
+									pos:        position{line: 1704, col: 5, offset: 40061},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1704, col: 10, offset: 40065},
+									pos:   position{line: 1704, col: 10, offset: 40066},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1704, col: 12, offset: 40067},
+										pos:  position{line: 1704, col: 12, offset: 40068},
 										name: "EscapeSequence",
 									},
 								},
@@ -12159,16 +12162,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1706, col: 1, offset: 40101},
+			pos:  position{line: 1706, col: 1, offset: 40102},
 			expr: &choiceExpr{
-				pos: position{line: 1707, col: 5, offset: 40120},
+				pos: position{line: 1707, col: 5, offset: 40121},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1707, col: 5, offset: 40120},
+						pos:  position{line: 1707, col: 5, offset: 40121},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1708, col: 5, offset: 40141},
+						pos:  position{line: 1708, col: 5, offset: 40142},
 						name: "UnicodeEscape",
 					},
 				},
@@ -12178,87 +12181,87 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1710, col: 1, offset: 40156},
+			pos:  position{line: 1710, col: 1, offset: 40157},
 			expr: &choiceExpr{
-				pos: position{line: 1711, col: 5, offset: 40177},
+				pos: position{line: 1711, col: 5, offset: 40178},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1711, col: 5, offset: 40177},
+						pos:        position{line: 1711, col: 5, offset: 40178},
 						val:        "'",
 						ignoreCase: false,
 						want:       "\"'\"",
 					},
 					&actionExpr{
-						pos: position{line: 1712, col: 5, offset: 40185},
+						pos: position{line: 1712, col: 5, offset: 40186},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1712, col: 5, offset: 40185},
+							pos:        position{line: 1712, col: 5, offset: 40186},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1713, col: 5, offset: 40225},
+						pos:        position{line: 1713, col: 5, offset: 40226},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
 					},
 					&actionExpr{
-						pos: position{line: 1714, col: 5, offset: 40234},
+						pos: position{line: 1714, col: 5, offset: 40235},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1714, col: 5, offset: 40234},
+							pos:        position{line: 1714, col: 5, offset: 40235},
 							val:        "b",
 							ignoreCase: false,
 							want:       "\"b\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1715, col: 5, offset: 40263},
+						pos: position{line: 1715, col: 5, offset: 40264},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1715, col: 5, offset: 40263},
+							pos:        position{line: 1715, col: 5, offset: 40264},
 							val:        "f",
 							ignoreCase: false,
 							want:       "\"f\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1716, col: 5, offset: 40292},
+						pos: position{line: 1716, col: 5, offset: 40293},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1716, col: 5, offset: 40292},
+							pos:        position{line: 1716, col: 5, offset: 40293},
 							val:        "n",
 							ignoreCase: false,
 							want:       "\"n\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1717, col: 5, offset: 40321},
+						pos: position{line: 1717, col: 5, offset: 40322},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1717, col: 5, offset: 40321},
+							pos:        position{line: 1717, col: 5, offset: 40322},
 							val:        "r",
 							ignoreCase: false,
 							want:       "\"r\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1718, col: 5, offset: 40350},
+						pos: position{line: 1718, col: 5, offset: 40351},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1718, col: 5, offset: 40350},
+							pos:        position{line: 1718, col: 5, offset: 40351},
 							val:        "t",
 							ignoreCase: false,
 							want:       "\"t\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1719, col: 5, offset: 40379},
+						pos: position{line: 1719, col: 5, offset: 40380},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1719, col: 5, offset: 40379},
+							pos:        position{line: 1719, col: 5, offset: 40380},
 							val:        "v",
 							ignoreCase: false,
 							want:       "\"v\"",
@@ -12271,32 +12274,32 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1721, col: 1, offset: 40405},
+			pos:  position{line: 1721, col: 1, offset: 40406},
 			expr: &choiceExpr{
-				pos: position{line: 1722, col: 5, offset: 40423},
+				pos: position{line: 1722, col: 5, offset: 40424},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1722, col: 5, offset: 40423},
+						pos: position{line: 1722, col: 5, offset: 40424},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1722, col: 5, offset: 40423},
+							pos:        position{line: 1722, col: 5, offset: 40424},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1723, col: 5, offset: 40451},
+						pos: position{line: 1723, col: 5, offset: 40452},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1723, col: 5, offset: 40451},
+							pos:        position{line: 1723, col: 5, offset: 40452},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1724, col: 5, offset: 40479},
+						pos:        position{line: 1724, col: 5, offset: 40480},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -12309,42 +12312,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1726, col: 1, offset: 40485},
+			pos:  position{line: 1726, col: 1, offset: 40486},
 			expr: &choiceExpr{
-				pos: position{line: 1727, col: 5, offset: 40503},
+				pos: position{line: 1727, col: 5, offset: 40504},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1727, col: 5, offset: 40503},
+						pos: position{line: 1727, col: 5, offset: 40504},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1727, col: 5, offset: 40503},
+							pos: position{line: 1727, col: 5, offset: 40504},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1727, col: 5, offset: 40503},
+									pos:        position{line: 1727, col: 5, offset: 40504},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1727, col: 9, offset: 40507},
+									pos:   position{line: 1727, col: 9, offset: 40508},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1727, col: 16, offset: 40514},
+										pos: position{line: 1727, col: 16, offset: 40515},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1727, col: 16, offset: 40514},
+												pos:  position{line: 1727, col: 16, offset: 40515},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1727, col: 25, offset: 40523},
+												pos:  position{line: 1727, col: 25, offset: 40524},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1727, col: 34, offset: 40532},
+												pos:  position{line: 1727, col: 34, offset: 40533},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1727, col: 43, offset: 40541},
+												pos:  position{line: 1727, col: 43, offset: 40542},
 												name: "HexDigit",
 											},
 										},
@@ -12354,65 +12357,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1730, col: 5, offset: 40604},
+						pos: position{line: 1730, col: 5, offset: 40605},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1730, col: 5, offset: 40604},
+							pos: position{line: 1730, col: 5, offset: 40605},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1730, col: 5, offset: 40604},
+									pos:        position{line: 1730, col: 5, offset: 40605},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1730, col: 9, offset: 40608},
+									pos:        position{line: 1730, col: 9, offset: 40609},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1730, col: 13, offset: 40612},
+									pos:   position{line: 1730, col: 13, offset: 40613},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1730, col: 20, offset: 40619},
+										pos: position{line: 1730, col: 20, offset: 40620},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1730, col: 20, offset: 40619},
+												pos:  position{line: 1730, col: 20, offset: 40620},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1730, col: 29, offset: 40628},
+												pos: position{line: 1730, col: 29, offset: 40629},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1730, col: 29, offset: 40628},
+													pos:  position{line: 1730, col: 29, offset: 40629},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1730, col: 39, offset: 40638},
+												pos: position{line: 1730, col: 39, offset: 40639},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1730, col: 39, offset: 40638},
+													pos:  position{line: 1730, col: 39, offset: 40639},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1730, col: 49, offset: 40648},
+												pos: position{line: 1730, col: 49, offset: 40649},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1730, col: 49, offset: 40648},
+													pos:  position{line: 1730, col: 49, offset: 40649},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1730, col: 59, offset: 40658},
+												pos: position{line: 1730, col: 59, offset: 40659},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1730, col: 59, offset: 40658},
+													pos:  position{line: 1730, col: 59, offset: 40659},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1730, col: 69, offset: 40668},
+												pos: position{line: 1730, col: 69, offset: 40669},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1730, col: 69, offset: 40668},
+													pos:  position{line: 1730, col: 69, offset: 40669},
 													name: "HexDigit",
 												},
 											},
@@ -12420,7 +12423,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1730, col: 80, offset: 40679},
+									pos:        position{line: 1730, col: 80, offset: 40680},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -12435,9 +12438,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1735, col: 1, offset: 40734},
+			pos:  position{line: 1735, col: 1, offset: 40735},
 			expr: &charClassMatcher{
-				pos:        position{line: 1736, col: 5, offset: 40750},
+				pos:        position{line: 1736, col: 5, offset: 40751},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -12449,11 +12452,11 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1738, col: 1, offset: 40765},
+			pos:  position{line: 1738, col: 1, offset: 40766},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1738, col: 5, offset: 40769},
+				pos: position{line: 1738, col: 5, offset: 40770},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1738, col: 5, offset: 40769},
+					pos:  position{line: 1738, col: 5, offset: 40770},
 					name: "AnySpace",
 				},
 			},
@@ -12462,11 +12465,11 @@ var g = &grammar{
 		},
 		{
 			name: "__",
-			pos:  position{line: 1740, col: 1, offset: 40780},
+			pos:  position{line: 1740, col: 1, offset: 40781},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1740, col: 6, offset: 40785},
+				pos: position{line: 1740, col: 6, offset: 40786},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1740, col: 6, offset: 40785},
+					pos:  position{line: 1740, col: 6, offset: 40786},
 					name: "AnySpace",
 				},
 			},
@@ -12475,20 +12478,20 @@ var g = &grammar{
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1742, col: 1, offset: 40796},
+			pos:  position{line: 1742, col: 1, offset: 40797},
 			expr: &choiceExpr{
-				pos: position{line: 1743, col: 5, offset: 40809},
+				pos: position{line: 1743, col: 5, offset: 40810},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1743, col: 5, offset: 40809},
+						pos:  position{line: 1743, col: 5, offset: 40810},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1744, col: 5, offset: 40824},
+						pos:  position{line: 1744, col: 5, offset: 40825},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1745, col: 5, offset: 40843},
+						pos:  position{line: 1745, col: 5, offset: 40844},
 						name: "Comment",
 					},
 				},
@@ -12498,32 +12501,32 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeLetter",
-			pos:  position{line: 1747, col: 1, offset: 40852},
+			pos:  position{line: 1747, col: 1, offset: 40853},
 			expr: &choiceExpr{
-				pos: position{line: 1748, col: 5, offset: 40870},
+				pos: position{line: 1748, col: 5, offset: 40871},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1748, col: 5, offset: 40870},
+						pos:  position{line: 1748, col: 5, offset: 40871},
 						name: "Lu",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1749, col: 5, offset: 40877},
+						pos:  position{line: 1749, col: 5, offset: 40878},
 						name: "Ll",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1750, col: 5, offset: 40884},
+						pos:  position{line: 1750, col: 5, offset: 40885},
 						name: "Lt",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1751, col: 5, offset: 40891},
+						pos:  position{line: 1751, col: 5, offset: 40892},
 						name: "Lm",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1752, col: 5, offset: 40898},
+						pos:  position{line: 1752, col: 5, offset: 40899},
 						name: "Lo",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1753, col: 5, offset: 40905},
+						pos:  position{line: 1753, col: 5, offset: 40906},
 						name: "Nl",
 					},
 				},
@@ -12533,16 +12536,16 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeCombiningMark",
-			pos:  position{line: 1755, col: 1, offset: 40909},
+			pos:  position{line: 1755, col: 1, offset: 40910},
 			expr: &choiceExpr{
-				pos: position{line: 1756, col: 5, offset: 40934},
+				pos: position{line: 1756, col: 5, offset: 40935},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1756, col: 5, offset: 40934},
+						pos:  position{line: 1756, col: 5, offset: 40935},
 						name: "Mn",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1757, col: 5, offset: 40941},
+						pos:  position{line: 1757, col: 5, offset: 40942},
 						name: "Mc",
 					},
 				},
@@ -12552,9 +12555,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeDigit",
-			pos:  position{line: 1759, col: 1, offset: 40945},
+			pos:  position{line: 1759, col: 1, offset: 40946},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1760, col: 5, offset: 40962},
+				pos:  position{line: 1760, col: 5, offset: 40963},
 				name: "Nd",
 			},
 			leader:        false,
@@ -12562,9 +12565,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeConnectorPunctuation",
-			pos:  position{line: 1762, col: 1, offset: 40966},
+			pos:  position{line: 1762, col: 1, offset: 40967},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1763, col: 5, offset: 40998},
+				pos:  position{line: 1763, col: 5, offset: 40999},
 				name: "Pc",
 			},
 			leader:        false,
@@ -12572,9 +12575,9 @@ var g = &grammar{
 		},
 		{
 			name: "Ll",
-			pos:  position{line: 1769, col: 1, offset: 41179},
+			pos:  position{line: 1769, col: 1, offset: 41180},
 			expr: &charClassMatcher{
-				pos:        position{line: 1769, col: 6, offset: 41184},
+				pos:        position{line: 1769, col: 6, offset: 41185},
 				val:        "[\\u0061-\\u007A\\u00B5\\u00DF-\\u00F6\\u00F8-\\u00FF\\u0101\\u0103\\u0105\\u0107\\u0109\\u010B\\u010D\\u010F\\u0111\\u0113\\u0115\\u0117\\u0119\\u011B\\u011D\\u011F\\u0121\\u0123\\u0125\\u0127\\u0129\\u012B\\u012D\\u012F\\u0131\\u0133\\u0135\\u0137-\\u0138\\u013A\\u013C\\u013E\\u0140\\u0142\\u0144\\u0146\\u0148-\\u0149\\u014B\\u014D\\u014F\\u0151\\u0153\\u0155\\u0157\\u0159\\u015B\\u015D\\u015F\\u0161\\u0163\\u0165\\u0167\\u0169\\u016B\\u016D\\u016F\\u0171\\u0173\\u0175\\u0177\\u017A\\u017C\\u017E-\\u0180\\u0183\\u0185\\u0188\\u018C-\\u018D\\u0192\\u0195\\u0199-\\u019B\\u019E\\u01A1\\u01A3\\u01A5\\u01A8\\u01AA-\\u01AB\\u01AD\\u01B0\\u01B4\\u01B6\\u01B9-\\u01BA\\u01BD-\\u01BF\\u01C6\\u01C9\\u01CC\\u01CE\\u01D0\\u01D2\\u01D4\\u01D6\\u01D8\\u01DA\\u01DC-\\u01DD\\u01DF\\u01E1\\u01E3\\u01E5\\u01E7\\u01E9\\u01EB\\u01ED\\u01EF-\\u01F0\\u01F3\\u01F5\\u01F9\\u01FB\\u01FD\\u01FF\\u0201\\u0203\\u0205\\u0207\\u0209\\u020B\\u020D\\u020F\\u0211\\u0213\\u0215\\u0217\\u0219\\u021B\\u021D\\u021F\\u0221\\u0223\\u0225\\u0227\\u0229\\u022B\\u022D\\u022F\\u0231\\u0233-\\u0239\\u023C\\u023F-\\u0240\\u0242\\u0247\\u0249\\u024B\\u024D\\u024F-\\u0293\\u0295-\\u02AF\\u0371\\u0373\\u0377\\u037B-\\u037D\\u0390\\u03AC-\\u03CE\\u03D0-\\u03D1\\u03D5-\\u03D7\\u03D9\\u03DB\\u03DD\\u03DF\\u03E1\\u03E3\\u03E5\\u03E7\\u03E9\\u03EB\\u03ED\\u03EF-\\u03F3\\u03F5\\u03F8\\u03FB-\\u03FC\\u0430-\\u045F\\u0461\\u0463\\u0465\\u0467\\u0469\\u046B\\u046D\\u046F\\u0471\\u0473\\u0475\\u0477\\u0479\\u047B\\u047D\\u047F\\u0481\\u048B\\u048D\\u048F\\u0491\\u0493\\u0495\\u0497\\u0499\\u049B\\u049D\\u049F\\u04A1\\u04A3\\u04A5\\u04A7\\u04A9\\u04AB\\u04AD\\u04AF\\u04B1\\u04B3\\u04B5\\u04B7\\u04B9\\u04BB\\u04BD\\u04BF\\u04C2\\u04C4\\u04C6\\u04C8\\u04CA\\u04CC\\u04CE-\\u04CF\\u04D1\\u04D3\\u04D5\\u04D7\\u04D9\\u04DB\\u04DD\\u04DF\\u04E1\\u04E3\\u04E5\\u04E7\\u04E9\\u04EB\\u04ED\\u04EF\\u04F1\\u04F3\\u04F5\\u04F7\\u04F9\\u04FB\\u04FD\\u04FF\\u0501\\u0503\\u0505\\u0507\\u0509\\u050B\\u050D\\u050F\\u0511\\u0513\\u0515\\u0517\\u0519\\u051B\\u051D\\u051F\\u0521\\u0523\\u0525\\u0527\\u0529\\u052B\\u052D\\u052F\\u0560-\\u0588\\u10D0-\\u10FA\\u10FD-\\u10FF\\u13F8-\\u13FD\\u1C80-\\u1C88\\u1D00-\\u1D2B\\u1D6B-\\u1D77\\u1D79-\\u1D9A\\u1E01\\u1E03\\u1E05\\u1E07\\u1E09\\u1E0B\\u1E0D\\u1E0F\\u1E11\\u1E13\\u1E15\\u1E17\\u1E19\\u1E1B\\u1E1D\\u1E1F\\u1E21\\u1E23\\u1E25\\u1E27\\u1E29\\u1E2B\\u1E2D\\u1E2F\\u1E31\\u1E33\\u1E35\\u1E37\\u1E39\\u1E3B\\u1E3D\\u1E3F\\u1E41\\u1E43\\u1E45\\u1E47\\u1E49\\u1E4B\\u1E4D\\u1E4F\\u1E51\\u1E53\\u1E55\\u1E57\\u1E59\\u1E5B\\u1E5D\\u1E5F\\u1E61\\u1E63\\u1E65\\u1E67\\u1E69\\u1E6B\\u1E6D\\u1E6F\\u1E71\\u1E73\\u1E75\\u1E77\\u1E79\\u1E7B\\u1E7D\\u1E7F\\u1E81\\u1E83\\u1E85\\u1E87\\u1E89\\u1E8B\\u1E8D\\u1E8F\\u1E91\\u1E93\\u1E95-\\u1E9D\\u1E9F\\u1EA1\\u1EA3\\u1EA5\\u1EA7\\u1EA9\\u1EAB\\u1EAD\\u1EAF\\u1EB1\\u1EB3\\u1EB5\\u1EB7\\u1EB9\\u1EBB\\u1EBD\\u1EBF\\u1EC1\\u1EC3\\u1EC5\\u1EC7\\u1EC9\\u1ECB\\u1ECD\\u1ECF\\u1ED1\\u1ED3\\u1ED5\\u1ED7\\u1ED9\\u1EDB\\u1EDD\\u1EDF\\u1EE1\\u1EE3\\u1EE5\\u1EE7\\u1EE9\\u1EEB\\u1EED\\u1EEF\\u1EF1\\u1EF3\\u1EF5\\u1EF7\\u1EF9\\u1EFB\\u1EFD\\u1EFF-\\u1F07\\u1F10-\\u1F15\\u1F20-\\u1F27\\u1F30-\\u1F37\\u1F40-\\u1F45\\u1F50-\\u1F57\\u1F60-\\u1F67\\u1F70-\\u1F7D\\u1F80-\\u1F87\\u1F90-\\u1F97\\u1FA0-\\u1FA7\\u1FB0-\\u1FB4\\u1FB6-\\u1FB7\\u1FBE\\u1FC2-\\u1FC4\\u1FC6-\\u1FC7\\u1FD0-\\u1FD3\\u1FD6-\\u1FD7\\u1FE0-\\u1FE7\\u1FF2-\\u1FF4\\u1FF6-\\u1FF7\\u210A\\u210E-\\u210F\\u2113\\u212F\\u2134\\u2139\\u213C-\\u213D\\u2146-\\u2149\\u214E\\u2184\\u2C30-\\u2C5E\\u2C61\\u2C65-\\u2C66\\u2C68\\u2C6A\\u2C6C\\u2C71\\u2C73-\\u2C74\\u2C76-\\u2C7B\\u2C81\\u2C83\\u2C85\\u2C87\\u2C89\\u2C8B\\u2C8D\\u2C8F\\u2C91\\u2C93\\u2C95\\u2C97\\u2C99\\u2C9B\\u2C9D\\u2C9F\\u2CA1\\u2CA3\\u2CA5\\u2CA7\\u2CA9\\u2CAB\\u2CAD\\u2CAF\\u2CB1\\u2CB3\\u2CB5\\u2CB7\\u2CB9\\u2CBB\\u2CBD\\u2CBF\\u2CC1\\u2CC3\\u2CC5\\u2CC7\\u2CC9\\u2CCB\\u2CCD\\u2CCF\\u2CD1\\u2CD3\\u2CD5\\u2CD7\\u2CD9\\u2CDB\\u2CDD\\u2CDF\\u2CE1\\u2CE3-\\u2CE4\\u2CEC\\u2CEE\\u2CF3\\u2D00-\\u2D25\\u2D27\\u2D2D\\uA641\\uA643\\uA645\\uA647\\uA649\\uA64B\\uA64D\\uA64F\\uA651\\uA653\\uA655\\uA657\\uA659\\uA65B\\uA65D\\uA65F\\uA661\\uA663\\uA665\\uA667\\uA669\\uA66B\\uA66D\\uA681\\uA683\\uA685\\uA687\\uA689\\uA68B\\uA68D\\uA68F\\uA691\\uA693\\uA695\\uA697\\uA699\\uA69B\\uA723\\uA725\\uA727\\uA729\\uA72B\\uA72D\\uA72F-\\uA731\\uA733\\uA735\\uA737\\uA739\\uA73B\\uA73D\\uA73F\\uA741\\uA743\\uA745\\uA747\\uA749\\uA74B\\uA74D\\uA74F\\uA751\\uA753\\uA755\\uA757\\uA759\\uA75B\\uA75D\\uA75F\\uA761\\uA763\\uA765\\uA767\\uA769\\uA76B\\uA76D\\uA76F\\uA771-\\uA778\\uA77A\\uA77C\\uA77F\\uA781\\uA783\\uA785\\uA787\\uA78C\\uA78E\\uA791\\uA793-\\uA795\\uA797\\uA799\\uA79B\\uA79D\\uA79F\\uA7A1\\uA7A3\\uA7A5\\uA7A7\\uA7A9\\uA7AF\\uA7B5\\uA7B7\\uA7B9\\uA7FA\\uAB30-\\uAB5A\\uAB60-\\uAB65\\uAB70-\\uABBF\\uFB00-\\uFB06\\uFB13-\\uFB17\\uFF41-\\uFF5A]",
 				chars:      []rune{'µ', 'ā', 'ă', 'ą', 'ć', 'ĉ', 'ċ', 'č', 'ď', 'đ', 'ē', 'ĕ', 'ė', 'ę', 'ě', 'ĝ', 'ğ', 'ġ', 'ģ', 'ĥ', 'ħ', 'ĩ', 'ī', 'ĭ', 'į', 'ı', 'ĳ', 'ĵ', 'ĺ', 'ļ', 'ľ', 'ŀ', 'ł', 'ń', 'ņ', 'ŋ', 'ō', 'ŏ', 'ő', 'œ', 'ŕ', 'ŗ', 'ř', 'ś', 'ŝ', 'ş', 'š', 'ţ', 'ť', 'ŧ', 'ũ', 'ū', 'ŭ', 'ů', 'ű', 'ų', 'ŵ', 'ŷ', 'ź', 'ż', 'ƃ', 'ƅ', 'ƈ', 'ƒ', 'ƕ', 'ƞ', 'ơ', 'ƣ', 'ƥ', 'ƨ', 'ƭ', 'ư', 'ƴ', 'ƶ', 'ǆ', 'ǉ', 'ǌ', 'ǎ', 'ǐ', 'ǒ', 'ǔ', 'ǖ', 'ǘ', 'ǚ', 'ǟ', 'ǡ', 'ǣ', 'ǥ', 'ǧ', 'ǩ', 'ǫ', 'ǭ', 'ǳ', 'ǵ', 'ǹ', 'ǻ', 'ǽ', 'ǿ', 'ȁ', 'ȃ', 'ȅ', 'ȇ', 'ȉ', 'ȋ', 'ȍ', 'ȏ', 'ȑ', 'ȓ', 'ȕ', 'ȗ', 'ș', 'ț', 'ȝ', 'ȟ', 'ȡ', 'ȣ', 'ȥ', 'ȧ', 'ȩ', 'ȫ', 'ȭ', 'ȯ', 'ȱ', 'ȼ', 'ɂ', 'ɇ', 'ɉ', 'ɋ', 'ɍ', 'ͱ', 'ͳ', 'ͷ', 'ΐ', 'ϙ', 'ϛ', 'ϝ', 'ϟ', 'ϡ', 'ϣ', 'ϥ', 'ϧ', 'ϩ', 'ϫ', 'ϭ', 'ϵ', 'ϸ', 'ѡ', 'ѣ', 'ѥ', 'ѧ', 'ѩ', 'ѫ', 'ѭ', 'ѯ', 'ѱ', 'ѳ', 'ѵ', 'ѷ', 'ѹ', 'ѻ', 'ѽ', 'ѿ', 'ҁ', 'ҋ', 'ҍ', 'ҏ', 'ґ', 'ғ', 'ҕ', 'җ', 'ҙ', 'қ', 'ҝ', 'ҟ', 'ҡ', 'ң', 'ҥ', 'ҧ', 'ҩ', 'ҫ', 'ҭ', 'ү', 'ұ', 'ҳ', 'ҵ', 'ҷ', 'ҹ', 'һ', 'ҽ', 'ҿ', 'ӂ', 'ӄ', 'ӆ', 'ӈ', 'ӊ', 'ӌ', 'ӑ', 'ӓ', 'ӕ', 'ӗ', 'ә', 'ӛ', 'ӝ', 'ӟ', 'ӡ', 'ӣ', 'ӥ', 'ӧ', 'ө', 'ӫ', 'ӭ', 'ӯ', 'ӱ', 'ӳ', 'ӵ', 'ӷ', 'ӹ', 'ӻ', 'ӽ', 'ӿ', 'ԁ', 'ԃ', 'ԅ', 'ԇ', 'ԉ', 'ԋ', 'ԍ', 'ԏ', 'ԑ', 'ԓ', 'ԕ', 'ԗ', 'ԙ', 'ԛ', 'ԝ', 'ԟ', 'ԡ', 'ԣ', 'ԥ', 'ԧ', 'ԩ', 'ԫ', 'ԭ', 'ԯ', 'ḁ', 'ḃ', 'ḅ', 'ḇ', 'ḉ', 'ḋ', 'ḍ', 'ḏ', 'ḑ', 'ḓ', 'ḕ', 'ḗ', 'ḙ', 'ḛ', 'ḝ', 'ḟ', 'ḡ', 'ḣ', 'ḥ', 'ḧ', 'ḩ', 'ḫ', 'ḭ', 'ḯ', 'ḱ', 'ḳ', 'ḵ', 'ḷ', 'ḹ', 'ḻ', 'ḽ', 'ḿ', 'ṁ', 'ṃ', 'ṅ', 'ṇ', 'ṉ', 'ṋ', 'ṍ', 'ṏ', 'ṑ', 'ṓ', 'ṕ', 'ṗ', 'ṙ', 'ṛ', 'ṝ', 'ṟ', 'ṡ', 'ṣ', 'ṥ', 'ṧ', 'ṩ', 'ṫ', 'ṭ', 'ṯ', 'ṱ', 'ṳ', 'ṵ', 'ṷ', 'ṹ', 'ṻ', 'ṽ', 'ṿ', 'ẁ', 'ẃ', 'ẅ', 'ẇ', 'ẉ', 'ẋ', 'ẍ', 'ẏ', 'ẑ', 'ẓ', 'ẟ', 'ạ', 'ả', 'ấ', 'ầ', 'ẩ', 'ẫ', 'ậ', 'ắ', 'ằ', 'ẳ', 'ẵ', 'ặ', 'ẹ', 'ẻ', 'ẽ', 'ế', 'ề', 'ể', 'ễ', 'ệ', 'ỉ', 'ị', 'ọ', 'ỏ', 'ố', 'ồ', 'ổ', 'ỗ', 'ộ', 'ớ', 'ờ', 'ở', 'ỡ', 'ợ', 'ụ', 'ủ', 'ứ', 'ừ', 'ử', 'ữ', 'ự', 'ỳ', 'ỵ', 'ỷ', 'ỹ', 'ỻ', 'ỽ', 'ι', 'ℊ', 'ℓ', 'ℯ', 'ℴ', 'ℹ', 'ⅎ', 'ↄ', 'ⱡ', 'ⱨ', 'ⱪ', 'ⱬ', 'ⱱ', 'ⲁ', 'ⲃ', 'ⲅ', 'ⲇ', 'ⲉ', 'ⲋ', 'ⲍ', 'ⲏ', 'ⲑ', 'ⲓ', 'ⲕ', 'ⲗ', 'ⲙ', 'ⲛ', 'ⲝ', 'ⲟ', 'ⲡ', 'ⲣ', 'ⲥ', 'ⲧ', 'ⲩ', 'ⲫ', 'ⲭ', 'ⲯ', 'ⲱ', 'ⲳ', 'ⲵ', 'ⲷ', 'ⲹ', 'ⲻ', 'ⲽ', 'ⲿ', 'ⳁ', 'ⳃ', 'ⳅ', 'ⳇ', 'ⳉ', 'ⳋ', 'ⳍ', 'ⳏ', 'ⳑ', 'ⳓ', 'ⳕ', 'ⳗ', 'ⳙ', 'ⳛ', 'ⳝ', 'ⳟ', 'ⳡ', 'ⳬ', 'ⳮ', 'ⳳ', 'ⴧ', 'ⴭ', 'ꙁ', 'ꙃ', 'ꙅ', 'ꙇ', 'ꙉ', 'ꙋ', 'ꙍ', 'ꙏ', 'ꙑ', 'ꙓ', 'ꙕ', 'ꙗ', 'ꙙ', 'ꙛ', 'ꙝ', 'ꙟ', 'ꙡ', 'ꙣ', 'ꙥ', 'ꙧ', 'ꙩ', 'ꙫ', 'ꙭ', 'ꚁ', 'ꚃ', 'ꚅ', 'ꚇ', 'ꚉ', 'ꚋ', 'ꚍ', 'ꚏ', 'ꚑ', 'ꚓ', 'ꚕ', 'ꚗ', 'ꚙ', 'ꚛ', 'ꜣ', 'ꜥ', 'ꜧ', 'ꜩ', 'ꜫ', 'ꜭ', 'ꜳ', 'ꜵ', 'ꜷ', 'ꜹ', 'ꜻ', 'ꜽ', 'ꜿ', 'ꝁ', 'ꝃ', 'ꝅ', 'ꝇ', 'ꝉ', 'ꝋ', 'ꝍ', 'ꝏ', 'ꝑ', 'ꝓ', 'ꝕ', 'ꝗ', 'ꝙ', 'ꝛ', 'ꝝ', 'ꝟ', 'ꝡ', 'ꝣ', 'ꝥ', 'ꝧ', 'ꝩ', 'ꝫ', 'ꝭ', 'ꝯ', 'ꝺ', 'ꝼ', 'ꝿ', 'ꞁ', 'ꞃ', 'ꞅ', 'ꞇ', 'ꞌ', 'ꞎ', 'ꞑ', 'ꞗ', 'ꞙ', 'ꞛ', 'ꞝ', 'ꞟ', 'ꞡ', 'ꞣ', 'ꞥ', 'ꞧ', 'ꞩ', 'ꞯ', 'ꞵ', 'ꞷ', 'ꞹ', 'ꟺ'},
 				ranges:     []rune{'a', 'z', 'ß', 'ö', 'ø', 'ÿ', 'ķ', 'ĸ', 'ň', 'ŉ', 'ž', 'ƀ', 'ƌ', 'ƍ', 'ƙ', 'ƛ', 'ƪ', 'ƫ', 'ƹ', 'ƺ', 'ƽ', 'ƿ', 'ǜ', 'ǝ', 'ǯ', 'ǰ', 'ȳ', 'ȹ', 'ȿ', 'ɀ', 'ɏ', 'ʓ', 'ʕ', 'ʯ', 'ͻ', 'ͽ', 'ά', 'ώ', 'ϐ', 'ϑ', 'ϕ', 'ϗ', 'ϯ', 'ϳ', 'ϻ', 'ϼ', 'а', 'џ', 'ӎ', 'ӏ', 'ՠ', 'ֈ', 'ა', 'ჺ', 'ჽ', 'ჿ', 'ᏸ', 'ᏽ', 'ᲀ', 'ᲈ', 'ᴀ', 'ᴫ', 'ᵫ', 'ᵷ', 'ᵹ', 'ᶚ', 'ẕ', 'ẝ', 'ỿ', 'ἇ', 'ἐ', 'ἕ', 'ἠ', 'ἧ', 'ἰ', 'ἷ', 'ὀ', 'ὅ', 'ὐ', 'ὗ', 'ὠ', 'ὧ', 'ὰ', 'ώ', 'ᾀ', 'ᾇ', 'ᾐ', 'ᾗ', 'ᾠ', 'ᾧ', 'ᾰ', 'ᾴ', 'ᾶ', 'ᾷ', 'ῂ', 'ῄ', 'ῆ', 'ῇ', 'ῐ', 'ΐ', 'ῖ', 'ῗ', 'ῠ', 'ῧ', 'ῲ', 'ῴ', 'ῶ', 'ῷ', 'ℎ', 'ℏ', 'ℼ', 'ℽ', 'ⅆ', 'ⅉ', 'ⰰ', 'ⱞ', 'ⱥ', 'ⱦ', 'ⱳ', 'ⱴ', 'ⱶ', 'ⱻ', 'ⳣ', 'ⳤ', 'ⴀ', 'ⴥ', 'ꜯ', 'ꜱ', 'ꝱ', 'ꝸ', 'ꞓ', 'ꞕ', 'ꬰ', 'ꭚ', 'ꭠ', 'ꭥ', 'ꭰ', 'ꮿ', 'ﬀ', 'ﬆ', 'ﬓ', 'ﬗ', 'ａ', 'ｚ'},
@@ -12586,9 +12589,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lm",
-			pos:  position{line: 1772, col: 1, offset: 45336},
+			pos:  position{line: 1772, col: 1, offset: 45337},
 			expr: &charClassMatcher{
-				pos:        position{line: 1772, col: 6, offset: 45341},
+				pos:        position{line: 1772, col: 6, offset: 45342},
 				val:        "[\\u02B0-\\u02C1\\u02C6-\\u02D1\\u02E0-\\u02E4\\u02EC\\u02EE\\u0374\\u037A\\u0559\\u0640\\u06E5-\\u06E6\\u07F4-\\u07F5\\u07FA\\u081A\\u0824\\u0828\\u0971\\u0E46\\u0EC6\\u10FC\\u17D7\\u1843\\u1AA7\\u1C78-\\u1C7D\\u1D2C-\\u1D6A\\u1D78\\u1D9B-\\u1DBF\\u2071\\u207F\\u2090-\\u209C\\u2C7C-\\u2C7D\\u2D6F\\u2E2F\\u3005\\u3031-\\u3035\\u303B\\u309D-\\u309E\\u30FC-\\u30FE\\uA015\\uA4F8-\\uA4FD\\uA60C\\uA67F\\uA69C-\\uA69D\\uA717-\\uA71F\\uA770\\uA788\\uA7F8-\\uA7F9\\uA9CF\\uA9E6\\uAA70\\uAADD\\uAAF3-\\uAAF4\\uAB5C-\\uAB5F\\uFF70\\uFF9E-\\uFF9F]",
 				chars:      []rune{'ˬ', 'ˮ', 'ʹ', 'ͺ', 'ՙ', 'ـ', 'ߺ', 'ࠚ', 'ࠤ', 'ࠨ', 'ॱ', 'ๆ', 'ໆ', 'ჼ', 'ៗ', 'ᡃ', 'ᪧ', 'ᵸ', 'ⁱ', 'ⁿ', 'ⵯ', 'ⸯ', '々', '〻', 'ꀕ', 'ꘌ', 'ꙿ', 'ꝰ', 'ꞈ', 'ꧏ', 'ꧦ', 'ꩰ', 'ꫝ', 'ｰ'},
 				ranges:     []rune{'ʰ', 'ˁ', 'ˆ', 'ˑ', 'ˠ', 'ˤ', 'ۥ', 'ۦ', 'ߴ', 'ߵ', 'ᱸ', 'ᱽ', 'ᴬ', 'ᵪ', 'ᶛ', 'ᶿ', 'ₐ', 'ₜ', 'ⱼ', 'ⱽ', '〱', '〵', 'ゝ', 'ゞ', 'ー', 'ヾ', 'ꓸ', 'ꓽ', 'ꚜ', 'ꚝ', 'ꜗ', 'ꜟ', 'ꟸ', 'ꟹ', 'ꫳ', 'ꫴ', 'ꭜ', 'ꭟ', 'ﾞ', 'ﾟ'},
@@ -12600,9 +12603,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lo",
-			pos:  position{line: 1775, col: 1, offset: 45826},
+			pos:  position{line: 1775, col: 1, offset: 45827},
 			expr: &charClassMatcher{
-				pos:        position{line: 1775, col: 6, offset: 45831},
+				pos:        position{line: 1775, col: 6, offset: 45832},
 				val:        "[\\u00AA\\u00BA\\u01BB\\u01C0-\\u01C3\\u0294\\u05D0-\\u05EA\\u05EF-\\u05F2\\u0620-\\u063F\\u0641-\\u064A\\u066E-\\u066F\\u0671-\\u06D3\\u06D5\\u06EE-\\u06EF\\u06FA-\\u06FC\\u06FF\\u0710\\u0712-\\u072F\\u074D-\\u07A5\\u07B1\\u07CA-\\u07EA\\u0800-\\u0815\\u0840-\\u0858\\u0860-\\u086A\\u08A0-\\u08B4\\u08B6-\\u08BD\\u0904-\\u0939\\u093D\\u0950\\u0958-\\u0961\\u0972-\\u0980\\u0985-\\u098C\\u098F-\\u0990\\u0993-\\u09A8\\u09AA-\\u09B0\\u09B2\\u09B6-\\u09B9\\u09BD\\u09CE\\u09DC-\\u09DD\\u09DF-\\u09E1\\u09F0-\\u09F1\\u09FC\\u0A05-\\u0A0A\\u0A0F-\\u0A10\\u0A13-\\u0A28\\u0A2A-\\u0A30\\u0A32-\\u0A33\\u0A35-\\u0A36\\u0A38-\\u0A39\\u0A59-\\u0A5C\\u0A5E\\u0A72-\\u0A74\\u0A85-\\u0A8D\\u0A8F-\\u0A91\\u0A93-\\u0AA8\\u0AAA-\\u0AB0\\u0AB2-\\u0AB3\\u0AB5-\\u0AB9\\u0ABD\\u0AD0\\u0AE0-\\u0AE1\\u0AF9\\u0B05-\\u0B0C\\u0B0F-\\u0B10\\u0B13-\\u0B28\\u0B2A-\\u0B30\\u0B32-\\u0B33\\u0B35-\\u0B39\\u0B3D\\u0B5C-\\u0B5D\\u0B5F-\\u0B61\\u0B71\\u0B83\\u0B85-\\u0B8A\\u0B8E-\\u0B90\\u0B92-\\u0B95\\u0B99-\\u0B9A\\u0B9C\\u0B9E-\\u0B9F\\u0BA3-\\u0BA4\\u0BA8-\\u0BAA\\u0BAE-\\u0BB9\\u0BD0\\u0C05-\\u0C0C\\u0C0E-\\u0C10\\u0C12-\\u0C28\\u0C2A-\\u0C39\\u0C3D\\u0C58-\\u0C5A\\u0C60-\\u0C61\\u0C80\\u0C85-\\u0C8C\\u0C8E-\\u0C90\\u0C92-\\u0CA8\\u0CAA-\\u0CB3\\u0CB5-\\u0CB9\\u0CBD\\u0CDE\\u0CE0-\\u0CE1\\u0CF1-\\u0CF2\\u0D05-\\u0D0C\\u0D0E-\\u0D10\\u0D12-\\u0D3A\\u0D3D\\u0D4E\\u0D54-\\u0D56\\u0D5F-\\u0D61\\u0D7A-\\u0D7F\\u0D85-\\u0D96\\u0D9A-\\u0DB1\\u0DB3-\\u0DBB\\u0DBD\\u0DC0-\\u0DC6\\u0E01-\\u0E30\\u0E32-\\u0E33\\u0E40-\\u0E45\\u0E81-\\u0E82\\u0E84\\u0E87-\\u0E88\\u0E8A\\u0E8D\\u0E94-\\u0E97\\u0E99-\\u0E9F\\u0EA1-\\u0EA3\\u0EA5\\u0EA7\\u0EAA-\\u0EAB\\u0EAD-\\u0EB0\\u0EB2-\\u0EB3\\u0EBD\\u0EC0-\\u0EC4\\u0EDC-\\u0EDF\\u0F00\\u0F40-\\u0F47\\u0F49-\\u0F6C\\u0F88-\\u0F8C\\u1000-\\u102A\\u103F\\u1050-\\u1055\\u105A-\\u105D\\u1061\\u1065-\\u1066\\u106E-\\u1070\\u1075-\\u1081\\u108E\\u1100-\\u1248\\u124A-\\u124D\\u1250-\\u1256\\u1258\\u125A-\\u125D\\u1260-\\u1288\\u128A-\\u128D\\u1290-\\u12B0\\u12B2-\\u12B5\\u12B8-\\u12BE\\u12C0\\u12C2-\\u12C5\\u12C8-\\u12D6\\u12D8-\\u1310\\u1312-\\u1315\\u1318-\\u135A\\u1380-\\u138F\\u1401-\\u166C\\u166F-\\u167F\\u1681-\\u169A\\u16A0-\\u16EA\\u16F1-\\u16F8\\u1700-\\u170C\\u170E-\\u1711\\u1720-\\u1731\\u1740-\\u1751\\u1760-\\u176C\\u176E-\\u1770\\u1780-\\u17B3\\u17DC\\u1820-\\u1842\\u1844-\\u1878\\u1880-\\u1884\\u1887-\\u18A8\\u18AA\\u18B0-\\u18F5\\u1900-\\u191E\\u1950-\\u196D\\u1970-\\u1974\\u1980-\\u19AB\\u19B0-\\u19C9\\u1A00-\\u1A16\\u1A20-\\u1A54\\u1B05-\\u1B33\\u1B45-\\u1B4B\\u1B83-\\u1BA0\\u1BAE-\\u1BAF\\u1BBA-\\u1BE5\\u1C00-\\u1C23\\u1C4D-\\u1C4F\\u1C5A-\\u1C77\\u1CE9-\\u1CEC\\u1CEE-\\u1CF1\\u1CF5-\\u1CF6\\u2135-\\u2138\\u2D30-\\u2D67\\u2D80-\\u2D96\\u2DA0-\\u2DA6\\u2DA8-\\u2DAE\\u2DB0-\\u2DB6\\u2DB8-\\u2DBE\\u2DC0-\\u2DC6\\u2DC8-\\u2DCE\\u2DD0-\\u2DD6\\u2DD8-\\u2DDE\\u3006\\u303C\\u3041-\\u3096\\u309F\\u30A1-\\u30FA\\u30FF\\u3105-\\u312F\\u3131-\\u318E\\u31A0-\\u31BA\\u31F0-\\u31FF\\u3400-\\u4DB5\\u4E00-\\u9FEF\\uA000-\\uA014\\uA016-\\uA48C\\uA4D0-\\uA4F7\\uA500-\\uA60B\\uA610-\\uA61F\\uA62A-\\uA62B\\uA66E\\uA6A0-\\uA6E5\\uA78F\\uA7F7\\uA7FB-\\uA801\\uA803-\\uA805\\uA807-\\uA80A\\uA80C-\\uA822\\uA840-\\uA873\\uA882-\\uA8B3\\uA8F2-\\uA8F7\\uA8FB\\uA8FD-\\uA8FE\\uA90A-\\uA925\\uA930-\\uA946\\uA960-\\uA97C\\uA984-\\uA9B2\\uA9E0-\\uA9E4\\uA9E7-\\uA9EF\\uA9FA-\\uA9FE\\uAA00-\\uAA28\\uAA40-\\uAA42\\uAA44-\\uAA4B\\uAA60-\\uAA6F\\uAA71-\\uAA76\\uAA7A\\uAA7E-\\uAAAF\\uAAB1\\uAAB5-\\uAAB6\\uAAB9-\\uAABD\\uAAC0\\uAAC2\\uAADB-\\uAADC\\uAAE0-\\uAAEA\\uAAF2\\uAB01-\\uAB06\\uAB09-\\uAB0E\\uAB11-\\uAB16\\uAB20-\\uAB26\\uAB28-\\uAB2E\\uABC0-\\uABE2\\uAC00-\\uD7A3\\uD7B0-\\uD7C6\\uD7CB-\\uD7FB\\uF900-\\uFA6D\\uFA70-\\uFAD9\\uFB1D\\uFB1F-\\uFB28\\uFB2A-\\uFB36\\uFB38-\\uFB3C\\uFB3E\\uFB40-\\uFB41\\uFB43-\\uFB44\\uFB46-\\uFBB1\\uFBD3-\\uFD3D\\uFD50-\\uFD8F\\uFD92-\\uFDC7\\uFDF0-\\uFDFB\\uFE70-\\uFE74\\uFE76-\\uFEFC\\uFF66-\\uFF6F\\uFF71-\\uFF9D\\uFFA0-\\uFFBE\\uFFC2-\\uFFC7\\uFFCA-\\uFFCF\\uFFD2-\\uFFD7\\uFFDA-\\uFFDC]",
 				chars:      []rune{'ª', 'º', 'ƻ', 'ʔ', 'ە', 'ۿ', 'ܐ', 'ޱ', 'ऽ', 'ॐ', 'ল', 'ঽ', 'ৎ', 'ৼ', 'ਫ਼', 'ઽ', 'ૐ', 'ૹ', 'ଽ', 'ୱ', 'ஃ', 'ஜ', 'ௐ', 'ఽ', 'ಀ', 'ಽ', 'ೞ', 'ഽ', 'ൎ', 'ල', 'ຄ', 'ຊ', 'ຍ', 'ລ', 'ວ', 'ຽ', 'ༀ', 'ဿ', 'ၡ', 'ႎ', 'ቘ', 'ዀ', 'ៜ', 'ᢪ', '〆', '〼', 'ゟ', 'ヿ', 'ꙮ', 'ꞏ', 'ꟷ', 'ꣻ', 'ꩺ', 'ꪱ', 'ꫀ', 'ꫂ', 'ꫲ', 'יִ', 'מּ'},
 				ranges:     []rune{'ǀ', 'ǃ', 'א', 'ת', 'ׯ', 'ײ', 'ؠ', 'ؿ', 'ف', 'ي', 'ٮ', 'ٯ', 'ٱ', 'ۓ', 'ۮ', 'ۯ', 'ۺ', 'ۼ', 'ܒ', 'ܯ', 'ݍ', 'ޥ', 'ߊ', 'ߪ', 'ࠀ', 'ࠕ', 'ࡀ', 'ࡘ', 'ࡠ', 'ࡪ', 'ࢠ', 'ࢴ', 'ࢶ', 'ࢽ', 'ऄ', 'ह', 'क़', 'ॡ', 'ॲ', 'ঀ', 'অ', 'ঌ', 'এ', 'ঐ', 'ও', 'ন', 'প', 'র', 'শ', 'হ', 'ড়', 'ঢ়', 'য়', 'ৡ', 'ৰ', 'ৱ', 'ਅ', 'ਊ', 'ਏ', 'ਐ', 'ਓ', 'ਨ', 'ਪ', 'ਰ', 'ਲ', 'ਲ਼', 'ਵ', 'ਸ਼', 'ਸ', 'ਹ', 'ਖ਼', 'ੜ', 'ੲ', 'ੴ', 'અ', 'ઍ', 'એ', 'ઑ', 'ઓ', 'ન', 'પ', 'ર', 'લ', 'ળ', 'વ', 'હ', 'ૠ', 'ૡ', 'ଅ', 'ଌ', 'ଏ', 'ଐ', 'ଓ', 'ନ', 'ପ', 'ର', 'ଲ', 'ଳ', 'ଵ', 'ହ', 'ଡ଼', 'ଢ଼', 'ୟ', 'ୡ', 'அ', 'ஊ', 'எ', 'ஐ', 'ஒ', 'க', 'ங', 'ச', 'ஞ', 'ட', 'ண', 'த', 'ந', 'ப', 'ம', 'ஹ', 'అ', 'ఌ', 'ఎ', 'ఐ', 'ఒ', 'న', 'ప', 'హ', 'ౘ', 'ౚ', 'ౠ', 'ౡ', 'ಅ', 'ಌ', 'ಎ', 'ಐ', 'ಒ', 'ನ', 'ಪ', 'ಳ', 'ವ', 'ಹ', 'ೠ', 'ೡ', 'ೱ', 'ೲ', 'അ', 'ഌ', 'എ', 'ഐ', 'ഒ', 'ഺ', 'ൔ', 'ൖ', 'ൟ', 'ൡ', 'ൺ', 'ൿ', 'අ', 'ඖ', 'ක', 'න', 'ඳ', 'ර', 'ව', 'ෆ', 'ก', 'ะ', 'า', 'ำ', 'เ', 'ๅ', 'ກ', 'ຂ', 'ງ', 'ຈ', 'ດ', 'ທ', 'ນ', 'ຟ', 'ມ', 'ຣ', 'ສ', 'ຫ', 'ອ', 'ະ', 'າ', 'ຳ', 'ເ', 'ໄ', 'ໜ', 'ໟ', 'ཀ', 'ཇ', 'ཉ', 'ཬ', 'ྈ', 'ྌ', 'က', 'ဪ', 'ၐ', 'ၕ', 'ၚ', 'ၝ', 'ၥ', 'ၦ', 'ၮ', 'ၰ', 'ၵ', 'ႁ', 'ᄀ', 'ቈ', 'ቊ', 'ቍ', 'ቐ', 'ቖ', 'ቚ', 'ቝ', 'በ', 'ኈ', 'ኊ', 'ኍ', 'ነ', 'ኰ', 'ኲ', 'ኵ', 'ኸ', 'ኾ', 'ዂ', 'ዅ', 'ወ', 'ዖ', 'ዘ', 'ጐ', 'ጒ', 'ጕ', 'ጘ', 'ፚ', 'ᎀ', 'ᎏ', 'ᐁ', 'ᙬ', 'ᙯ', 'ᙿ', 'ᚁ', 'ᚚ', 'ᚠ', 'ᛪ', 'ᛱ', 'ᛸ', 'ᜀ', 'ᜌ', 'ᜎ', 'ᜑ', 'ᜠ', 'ᜱ', 'ᝀ', 'ᝑ', 'ᝠ', 'ᝬ', 'ᝮ', 'ᝰ', 'ក', 'ឳ', 'ᠠ', 'ᡂ', 'ᡄ', 'ᡸ', 'ᢀ', 'ᢄ', 'ᢇ', 'ᢨ', 'ᢰ', 'ᣵ', 'ᤀ', 'ᤞ', 'ᥐ', 'ᥭ', 'ᥰ', 'ᥴ', 'ᦀ', 'ᦫ', 'ᦰ', 'ᧉ', 'ᨀ', 'ᨖ', 'ᨠ', 'ᩔ', 'ᬅ', 'ᬳ', 'ᭅ', 'ᭋ', 'ᮃ', 'ᮠ', 'ᮮ', 'ᮯ', 'ᮺ', 'ᯥ', 'ᰀ', 'ᰣ', 'ᱍ', 'ᱏ', 'ᱚ', 'ᱷ', 'ᳩ', 'ᳬ', 'ᳮ', 'ᳱ', 'ᳵ', 'ᳶ', 'ℵ', 'ℸ', 'ⴰ', 'ⵧ', 'ⶀ', 'ⶖ', 'ⶠ', 'ⶦ', 'ⶨ', 'ⶮ', 'ⶰ', 'ⶶ', 'ⶸ', 'ⶾ', 'ⷀ', 'ⷆ', 'ⷈ', 'ⷎ', 'ⷐ', 'ⷖ', 'ⷘ', 'ⷞ', 'ぁ', 'ゖ', 'ァ', 'ヺ', 'ㄅ', 'ㄯ', 'ㄱ', 'ㆎ', 'ㆠ', 'ㆺ', 'ㇰ', 'ㇿ', '㐀', '䶵', '一', '鿯', 'ꀀ', 'ꀔ', 'ꀖ', 'ꒌ', 'ꓐ', 'ꓷ', 'ꔀ', 'ꘋ', 'ꘐ', 'ꘟ', 'ꘪ', 'ꘫ', 'ꚠ', 'ꛥ', 'ꟻ', 'ꠁ', 'ꠃ', 'ꠅ', 'ꠇ', 'ꠊ', 'ꠌ', 'ꠢ', 'ꡀ', 'ꡳ', 'ꢂ', 'ꢳ', 'ꣲ', 'ꣷ', 'ꣽ', 'ꣾ', 'ꤊ', 'ꤥ', 'ꤰ', 'ꥆ', 'ꥠ', 'ꥼ', 'ꦄ', 'ꦲ', 'ꧠ', 'ꧤ', 'ꧧ', 'ꧯ', 'ꧺ', 'ꧾ', 'ꨀ', 'ꨨ', 'ꩀ', 'ꩂ', 'ꩄ', 'ꩋ', 'ꩠ', 'ꩯ', 'ꩱ', 'ꩶ', 'ꩾ', 'ꪯ', 'ꪵ', 'ꪶ', 'ꪹ', 'ꪽ', 'ꫛ', 'ꫜ', 'ꫠ', 'ꫪ', 'ꬁ', 'ꬆ', 'ꬉ', 'ꬎ', 'ꬑ', 'ꬖ', 'ꬠ', 'ꬦ', 'ꬨ', 'ꬮ', 'ꯀ', 'ꯢ', '가', '힣', 'ힰ', 'ퟆ', 'ퟋ', 'ퟻ', '豈', '舘', '並', '龎', 'ײַ', 'ﬨ', 'שׁ', 'זּ', 'טּ', 'לּ', 'נּ', 'סּ', 'ףּ', 'פּ', 'צּ', 'ﮱ', 'ﯓ', 'ﴽ', 'ﵐ', 'ﶏ', 'ﶒ', 'ﷇ', 'ﷰ', 'ﷻ', 'ﹰ', 'ﹴ', 'ﹶ', 'ﻼ', 'ｦ', 'ｯ', 'ｱ', 'ﾝ', 'ﾠ', 'ﾾ', 'ￂ', 'ￇ', 'ￊ', 'ￏ', 'ￒ', 'ￗ', 'ￚ', 'ￜ'},
@@ -12614,9 +12617,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lt",
-			pos:  position{line: 1778, col: 1, offset: 49278},
+			pos:  position{line: 1778, col: 1, offset: 49279},
 			expr: &charClassMatcher{
-				pos:        position{line: 1778, col: 6, offset: 49283},
+				pos:        position{line: 1778, col: 6, offset: 49284},
 				val:        "[\\u01C5\\u01C8\\u01CB\\u01F2\\u1F88-\\u1F8F\\u1F98-\\u1F9F\\u1FA8-\\u1FAF\\u1FBC\\u1FCC\\u1FFC]",
 				chars:      []rune{'ǅ', 'ǈ', 'ǋ', 'ǲ', 'ᾼ', 'ῌ', 'ῼ'},
 				ranges:     []rune{'ᾈ', 'ᾏ', 'ᾘ', 'ᾟ', 'ᾨ', 'ᾯ'},
@@ -12628,9 +12631,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lu",
-			pos:  position{line: 1781, col: 1, offset: 49389},
+			pos:  position{line: 1781, col: 1, offset: 49390},
 			expr: &charClassMatcher{
-				pos:        position{line: 1781, col: 6, offset: 49394},
+				pos:        position{line: 1781, col: 6, offset: 49395},
 				val:        "[\\u0041-\\u005A\\u00C0-\\u00D6\\u00D8-\\u00DE\\u0100\\u0102\\u0104\\u0106\\u0108\\u010A\\u010C\\u010E\\u0110\\u0112\\u0114\\u0116\\u0118\\u011A\\u011C\\u011E\\u0120\\u0122\\u0124\\u0126\\u0128\\u012A\\u012C\\u012E\\u0130\\u0132\\u0134\\u0136\\u0139\\u013B\\u013D\\u013F\\u0141\\u0143\\u0145\\u0147\\u014A\\u014C\\u014E\\u0150\\u0152\\u0154\\u0156\\u0158\\u015A\\u015C\\u015E\\u0160\\u0162\\u0164\\u0166\\u0168\\u016A\\u016C\\u016E\\u0170\\u0172\\u0174\\u0176\\u0178-\\u0179\\u017B\\u017D\\u0181-\\u0182\\u0184\\u0186-\\u0187\\u0189-\\u018B\\u018E-\\u0191\\u0193-\\u0194\\u0196-\\u0198\\u019C-\\u019D\\u019F-\\u01A0\\u01A2\\u01A4\\u01A6-\\u01A7\\u01A9\\u01AC\\u01AE-\\u01AF\\u01B1-\\u01B3\\u01B5\\u01B7-\\u01B8\\u01BC\\u01C4\\u01C7\\u01CA\\u01CD\\u01CF\\u01D1\\u01D3\\u01D5\\u01D7\\u01D9\\u01DB\\u01DE\\u01E0\\u01E2\\u01E4\\u01E6\\u01E8\\u01EA\\u01EC\\u01EE\\u01F1\\u01F4\\u01F6-\\u01F8\\u01FA\\u01FC\\u01FE\\u0200\\u0202\\u0204\\u0206\\u0208\\u020A\\u020C\\u020E\\u0210\\u0212\\u0214\\u0216\\u0218\\u021A\\u021C\\u021E\\u0220\\u0222\\u0224\\u0226\\u0228\\u022A\\u022C\\u022E\\u0230\\u0232\\u023A-\\u023B\\u023D-\\u023E\\u0241\\u0243-\\u0246\\u0248\\u024A\\u024C\\u024E\\u0370\\u0372\\u0376\\u037F\\u0386\\u0388-\\u038A\\u038C\\u038E-\\u038F\\u0391-\\u03A1\\u03A3-\\u03AB\\u03CF\\u03D2-\\u03D4\\u03D8\\u03DA\\u03DC\\u03DE\\u03E0\\u03E2\\u03E4\\u03E6\\u03E8\\u03EA\\u03EC\\u03EE\\u03F4\\u03F7\\u03F9-\\u03FA\\u03FD-\\u042F\\u0460\\u0462\\u0464\\u0466\\u0468\\u046A\\u046C\\u046E\\u0470\\u0472\\u0474\\u0476\\u0478\\u047A\\u047C\\u047E\\u0480\\u048A\\u048C\\u048E\\u0490\\u0492\\u0494\\u0496\\u0498\\u049A\\u049C\\u049E\\u04A0\\u04A2\\u04A4\\u04A6\\u04A8\\u04AA\\u04AC\\u04AE\\u04B0\\u04B2\\u04B4\\u04B6\\u04B8\\u04BA\\u04BC\\u04BE\\u04C0-\\u04C1\\u04C3\\u04C5\\u04C7\\u04C9\\u04CB\\u04CD\\u04D0\\u04D2\\u04D4\\u04D6\\u04D8\\u04DA\\u04DC\\u04DE\\u04E0\\u04E2\\u04E4\\u04E6\\u04E8\\u04EA\\u04EC\\u04EE\\u04F0\\u04F2\\u04F4\\u04F6\\u04F8\\u04FA\\u04FC\\u04FE\\u0500\\u0502\\u0504\\u0506\\u0508\\u050A\\u050C\\u050E\\u0510\\u0512\\u0514\\u0516\\u0518\\u051A\\u051C\\u051E\\u0520\\u0522\\u0524\\u0526\\u0528\\u052A\\u052C\\u052E\\u0531-\\u0556\\u10A0-\\u10C5\\u10C7\\u10CD\\u13A0-\\u13F5\\u1C90-\\u1CBA\\u1CBD-\\u1CBF\\u1E00\\u1E02\\u1E04\\u1E06\\u1E08\\u1E0A\\u1E0C\\u1E0E\\u1E10\\u1E12\\u1E14\\u1E16\\u1E18\\u1E1A\\u1E1C\\u1E1E\\u1E20\\u1E22\\u1E24\\u1E26\\u1E28\\u1E2A\\u1E2C\\u1E2E\\u1E30\\u1E32\\u1E34\\u1E36\\u1E38\\u1E3A\\u1E3C\\u1E3E\\u1E40\\u1E42\\u1E44\\u1E46\\u1E48\\u1E4A\\u1E4C\\u1E4E\\u1E50\\u1E52\\u1E54\\u1E56\\u1E58\\u1E5A\\u1E5C\\u1E5E\\u1E60\\u1E62\\u1E64\\u1E66\\u1E68\\u1E6A\\u1E6C\\u1E6E\\u1E70\\u1E72\\u1E74\\u1E76\\u1E78\\u1E7A\\u1E7C\\u1E7E\\u1E80\\u1E82\\u1E84\\u1E86\\u1E88\\u1E8A\\u1E8C\\u1E8E\\u1E90\\u1E92\\u1E94\\u1E9E\\u1EA0\\u1EA2\\u1EA4\\u1EA6\\u1EA8\\u1EAA\\u1EAC\\u1EAE\\u1EB0\\u1EB2\\u1EB4\\u1EB6\\u1EB8\\u1EBA\\u1EBC\\u1EBE\\u1EC0\\u1EC2\\u1EC4\\u1EC6\\u1EC8\\u1ECA\\u1ECC\\u1ECE\\u1ED0\\u1ED2\\u1ED4\\u1ED6\\u1ED8\\u1EDA\\u1EDC\\u1EDE\\u1EE0\\u1EE2\\u1EE4\\u1EE6\\u1EE8\\u1EEA\\u1EEC\\u1EEE\\u1EF0\\u1EF2\\u1EF4\\u1EF6\\u1EF8\\u1EFA\\u1EFC\\u1EFE\\u1F08-\\u1F0F\\u1F18-\\u1F1D\\u1F28-\\u1F2F\\u1F38-\\u1F3F\\u1F48-\\u1F4D\\u1F59\\u1F5B\\u1F5D\\u1F5F\\u1F68-\\u1F6F\\u1FB8-\\u1FBB\\u1FC8-\\u1FCB\\u1FD8-\\u1FDB\\u1FE8-\\u1FEC\\u1FF8-\\u1FFB\\u2102\\u2107\\u210B-\\u210D\\u2110-\\u2112\\u2115\\u2119-\\u211D\\u2124\\u2126\\u2128\\u212A-\\u212D\\u2130-\\u2133\\u213E-\\u213F\\u2145\\u2183\\u2C00-\\u2C2E\\u2C60\\u2C62-\\u2C64\\u2C67\\u2C69\\u2C6B\\u2C6D-\\u2C70\\u2C72\\u2C75\\u2C7E-\\u2C80\\u2C82\\u2C84\\u2C86\\u2C88\\u2C8A\\u2C8C\\u2C8E\\u2C90\\u2C92\\u2C94\\u2C96\\u2C98\\u2C9A\\u2C9C\\u2C9E\\u2CA0\\u2CA2\\u2CA4\\u2CA6\\u2CA8\\u2CAA\\u2CAC\\u2CAE\\u2CB0\\u2CB2\\u2CB4\\u2CB6\\u2CB8\\u2CBA\\u2CBC\\u2CBE\\u2CC0\\u2CC2\\u2CC4\\u2CC6\\u2CC8\\u2CCA\\u2CCC\\u2CCE\\u2CD0\\u2CD2\\u2CD4\\u2CD6\\u2CD8\\u2CDA\\u2CDC\\u2CDE\\u2CE0\\u2CE2\\u2CEB\\u2CED\\u2CF2\\uA640\\uA642\\uA644\\uA646\\uA648\\uA64A\\uA64C\\uA64E\\uA650\\uA652\\uA654\\uA656\\uA658\\uA65A\\uA65C\\uA65E\\uA660\\uA662\\uA664\\uA666\\uA668\\uA66A\\uA66C\\uA680\\uA682\\uA684\\uA686\\uA688\\uA68A\\uA68C\\uA68E\\uA690\\uA692\\uA694\\uA696\\uA698\\uA69A\\uA722\\uA724\\uA726\\uA728\\uA72A\\uA72C\\uA72E\\uA732\\uA734\\uA736\\uA738\\uA73A\\uA73C\\uA73E\\uA740\\uA742\\uA744\\uA746\\uA748\\uA74A\\uA74C\\uA74E\\uA750\\uA752\\uA754\\uA756\\uA758\\uA75A\\uA75C\\uA75E\\uA760\\uA762\\uA764\\uA766\\uA768\\uA76A\\uA76C\\uA76E\\uA779\\uA77B\\uA77D-\\uA77E\\uA780\\uA782\\uA784\\uA786\\uA78B\\uA78D\\uA790\\uA792\\uA796\\uA798\\uA79A\\uA79C\\uA79E\\uA7A0\\uA7A2\\uA7A4\\uA7A6\\uA7A8\\uA7AA-\\uA7AE\\uA7B0-\\uA7B4\\uA7B6\\uA7B8\\uFF21-\\uFF3A]",
 				chars:      []rune{'Ā', 'Ă', 'Ą', 'Ć', 'Ĉ', 'Ċ', 'Č', 'Ď', 'Đ', 'Ē', 'Ĕ', 'Ė', 'Ę', 'Ě', 'Ĝ', 'Ğ', 'Ġ', 'Ģ', 'Ĥ', 'Ħ', 'Ĩ', 'Ī', 'Ĭ', 'Į', 'İ', 'Ĳ', 'Ĵ', 'Ķ', 'Ĺ', 'Ļ', 'Ľ', 'Ŀ', 'Ł', 'Ń', 'Ņ', 'Ň', 'Ŋ', 'Ō', 'Ŏ', 'Ő', 'Œ', 'Ŕ', 'Ŗ', 'Ř', 'Ś', 'Ŝ', 'Ş', 'Š', 'Ţ', 'Ť', 'Ŧ', 'Ũ', 'Ū', 'Ŭ', 'Ů', 'Ű', 'Ų', 'Ŵ', 'Ŷ', 'Ż', 'Ž', 'Ƅ', 'Ƣ', 'Ƥ', 'Ʃ', 'Ƭ', 'Ƶ', 'Ƽ', 'Ǆ', 'Ǉ', 'Ǌ', 'Ǎ', 'Ǐ', 'Ǒ', 'Ǔ', 'Ǖ', 'Ǘ', 'Ǚ', 'Ǜ', 'Ǟ', 'Ǡ', 'Ǣ', 'Ǥ', 'Ǧ', 'Ǩ', 'Ǫ', 'Ǭ', 'Ǯ', 'Ǳ', 'Ǵ', 'Ǻ', 'Ǽ', 'Ǿ', 'Ȁ', 'Ȃ', 'Ȅ', 'Ȇ', 'Ȉ', 'Ȋ', 'Ȍ', 'Ȏ', 'Ȑ', 'Ȓ', 'Ȕ', 'Ȗ', 'Ș', 'Ț', 'Ȝ', 'Ȟ', 'Ƞ', 'Ȣ', 'Ȥ', 'Ȧ', 'Ȩ', 'Ȫ', 'Ȭ', 'Ȯ', 'Ȱ', 'Ȳ', 'Ɂ', 'Ɉ', 'Ɋ', 'Ɍ', 'Ɏ', 'Ͱ', 'Ͳ', 'Ͷ', 'Ϳ', 'Ά', 'Ό', 'Ϗ', 'Ϙ', 'Ϛ', 'Ϝ', 'Ϟ', 'Ϡ', 'Ϣ', 'Ϥ', 'Ϧ', 'Ϩ', 'Ϫ', 'Ϭ', 'Ϯ', 'ϴ', 'Ϸ', 'Ѡ', 'Ѣ', 'Ѥ', 'Ѧ', 'Ѩ', 'Ѫ', 'Ѭ', 'Ѯ', 'Ѱ', 'Ѳ', 'Ѵ', 'Ѷ', 'Ѹ', 'Ѻ', 'Ѽ', 'Ѿ', 'Ҁ', 'Ҋ', 'Ҍ', 'Ҏ', 'Ґ', 'Ғ', 'Ҕ', 'Җ', 'Ҙ', 'Қ', 'Ҝ', 'Ҟ', 'Ҡ', 'Ң', 'Ҥ', 'Ҧ', 'Ҩ', 'Ҫ', 'Ҭ', 'Ү', 'Ұ', 'Ҳ', 'Ҵ', 'Ҷ', 'Ҹ', 'Һ', 'Ҽ', 'Ҿ', 'Ӄ', 'Ӆ', 'Ӈ', 'Ӊ', 'Ӌ', 'Ӎ', 'Ӑ', 'Ӓ', 'Ӕ', 'Ӗ', 'Ә', 'Ӛ', 'Ӝ', 'Ӟ', 'Ӡ', 'Ӣ', 'Ӥ', 'Ӧ', 'Ө', 'Ӫ', 'Ӭ', 'Ӯ', 'Ӱ', 'Ӳ', 'Ӵ', 'Ӷ', 'Ӹ', 'Ӻ', 'Ӽ', 'Ӿ', 'Ԁ', 'Ԃ', 'Ԅ', 'Ԇ', 'Ԉ', 'Ԋ', 'Ԍ', 'Ԏ', 'Ԑ', 'Ԓ', 'Ԕ', 'Ԗ', 'Ԙ', 'Ԛ', 'Ԝ', 'Ԟ', 'Ԡ', 'Ԣ', 'Ԥ', 'Ԧ', 'Ԩ', 'Ԫ', 'Ԭ', 'Ԯ', 'Ⴧ', 'Ⴭ', 'Ḁ', 'Ḃ', 'Ḅ', 'Ḇ', 'Ḉ', 'Ḋ', 'Ḍ', 'Ḏ', 'Ḑ', 'Ḓ', 'Ḕ', 'Ḗ', 'Ḙ', 'Ḛ', 'Ḝ', 'Ḟ', 'Ḡ', 'Ḣ', 'Ḥ', 'Ḧ', 'Ḩ', 'Ḫ', 'Ḭ', 'Ḯ', 'Ḱ', 'Ḳ', 'Ḵ', 'Ḷ', 'Ḹ', 'Ḻ', 'Ḽ', 'Ḿ', 'Ṁ', 'Ṃ', 'Ṅ', 'Ṇ', 'Ṉ', 'Ṋ', 'Ṍ', 'Ṏ', 'Ṑ', 'Ṓ', 'Ṕ', 'Ṗ', 'Ṙ', 'Ṛ', 'Ṝ', 'Ṟ', 'Ṡ', 'Ṣ', 'Ṥ', 'Ṧ', 'Ṩ', 'Ṫ', 'Ṭ', 'Ṯ', 'Ṱ', 'Ṳ', 'Ṵ', 'Ṷ', 'Ṹ', 'Ṻ', 'Ṽ', 'Ṿ', 'Ẁ', 'Ẃ', 'Ẅ', 'Ẇ', 'Ẉ', 'Ẋ', 'Ẍ', 'Ẏ', 'Ẑ', 'Ẓ', 'Ẕ', 'ẞ', 'Ạ', 'Ả', 'Ấ', 'Ầ', 'Ẩ', 'Ẫ', 'Ậ', 'Ắ', 'Ằ', 'Ẳ', 'Ẵ', 'Ặ', 'Ẹ', 'Ẻ', 'Ẽ', 'Ế', 'Ề', 'Ể', 'Ễ', 'Ệ', 'Ỉ', 'Ị', 'Ọ', 'Ỏ', 'Ố', 'Ồ', 'Ổ', 'Ỗ', 'Ộ', 'Ớ', 'Ờ', 'Ở', 'Ỡ', 'Ợ', 'Ụ', 'Ủ', 'Ứ', 'Ừ', 'Ử', 'Ữ', 'Ự', 'Ỳ', 'Ỵ', 'Ỷ', 'Ỹ', 'Ỻ', 'Ỽ', 'Ỿ', 'Ὑ', 'Ὓ', 'Ὕ', 'Ὗ', 'ℂ', 'ℇ', 'ℕ', 'ℤ', 'Ω', 'ℨ', 'ⅅ', 'Ↄ', 'Ⱡ', 'Ⱨ', 'Ⱪ', 'Ⱬ', 'Ⱳ', 'Ⱶ', 'Ⲃ', 'Ⲅ', 'Ⲇ', 'Ⲉ', 'Ⲋ', 'Ⲍ', 'Ⲏ', 'Ⲑ', 'Ⲓ', 'Ⲕ', 'Ⲗ', 'Ⲙ', 'Ⲛ', 'Ⲝ', 'Ⲟ', 'Ⲡ', 'Ⲣ', 'Ⲥ', 'Ⲧ', 'Ⲩ', 'Ⲫ', 'Ⲭ', 'Ⲯ', 'Ⲱ', 'Ⲳ', 'Ⲵ', 'Ⲷ', 'Ⲹ', 'Ⲻ', 'Ⲽ', 'Ⲿ', 'Ⳁ', 'Ⳃ', 'Ⳅ', 'Ⳇ', 'Ⳉ', 'Ⳋ', 'Ⳍ', 'Ⳏ', 'Ⳑ', 'Ⳓ', 'Ⳕ', 'Ⳗ', 'Ⳙ', 'Ⳛ', 'Ⳝ', 'Ⳟ', 'Ⳡ', 'Ⳣ', 'Ⳬ', 'Ⳮ', 'Ⳳ', 'Ꙁ', 'Ꙃ', 'Ꙅ', 'Ꙇ', 'Ꙉ', 'Ꙋ', 'Ꙍ', 'Ꙏ', 'Ꙑ', 'Ꙓ', 'Ꙕ', 'Ꙗ', 'Ꙙ', 'Ꙛ', 'Ꙝ', 'Ꙟ', 'Ꙡ', 'Ꙣ', 'Ꙥ', 'Ꙧ', 'Ꙩ', 'Ꙫ', 'Ꙭ', 'Ꚁ', 'Ꚃ', 'Ꚅ', 'Ꚇ', 'Ꚉ', 'Ꚋ', 'Ꚍ', 'Ꚏ', 'Ꚑ', 'Ꚓ', 'Ꚕ', 'Ꚗ', 'Ꚙ', 'Ꚛ', 'Ꜣ', 'Ꜥ', 'Ꜧ', 'Ꜩ', 'Ꜫ', 'Ꜭ', 'Ꜯ', 'Ꜳ', 'Ꜵ', 'Ꜷ', 'Ꜹ', 'Ꜻ', 'Ꜽ', 'Ꜿ', 'Ꝁ', 'Ꝃ', 'Ꝅ', 'Ꝇ', 'Ꝉ', 'Ꝋ', 'Ꝍ', 'Ꝏ', 'Ꝑ', 'Ꝓ', 'Ꝕ', 'Ꝗ', 'Ꝙ', 'Ꝛ', 'Ꝝ', 'Ꝟ', 'Ꝡ', 'Ꝣ', 'Ꝥ', 'Ꝧ', 'Ꝩ', 'Ꝫ', 'Ꝭ', 'Ꝯ', 'Ꝺ', 'Ꝼ', 'Ꞁ', 'Ꞃ', 'Ꞅ', 'Ꞇ', 'Ꞌ', 'Ɥ', 'Ꞑ', 'Ꞓ', 'Ꞗ', 'Ꞙ', 'Ꞛ', 'Ꞝ', 'Ꞟ', 'Ꞡ', 'Ꞣ', 'Ꞥ', 'Ꞧ', 'Ꞩ', 'Ꞷ', 'Ꞹ'},
 				ranges:     []rune{'A', 'Z', 'À', 'Ö', 'Ø', 'Þ', 'Ÿ', 'Ź', 'Ɓ', 'Ƃ', 'Ɔ', 'Ƈ', 'Ɖ', 'Ƌ', 'Ǝ', 'Ƒ', 'Ɠ', 'Ɣ', 'Ɩ', 'Ƙ', 'Ɯ', 'Ɲ', 'Ɵ', 'Ơ', 'Ʀ', 'Ƨ', 'Ʈ', 'Ư', 'Ʊ', 'Ƴ', 'Ʒ', 'Ƹ', 'Ƕ', 'Ǹ', 'Ⱥ', 'Ȼ', 'Ƚ', 'Ⱦ', 'Ƀ', 'Ɇ', 'Έ', 'Ί', 'Ύ', 'Ώ', 'Α', 'Ρ', 'Σ', 'Ϋ', 'ϒ', 'ϔ', 'Ϲ', 'Ϻ', 'Ͻ', 'Я', 'Ӏ', 'Ӂ', 'Ա', 'Ֆ', 'Ⴀ', 'Ⴥ', 'Ꭰ', 'Ᏽ', 'Ა', 'Ჺ', 'Ჽ', 'Ჿ', 'Ἀ', 'Ἇ', 'Ἐ', 'Ἕ', 'Ἠ', 'Ἧ', 'Ἰ', 'Ἷ', 'Ὀ', 'Ὅ', 'Ὠ', 'Ὧ', 'Ᾰ', 'Ά', 'Ὲ', 'Ή', 'Ῐ', 'Ί', 'Ῠ', 'Ῥ', 'Ὸ', 'Ώ', 'ℋ', 'ℍ', 'ℐ', 'ℒ', 'ℙ', 'ℝ', 'K', 'ℭ', 'ℰ', 'ℳ', 'ℾ', 'ℿ', 'Ⰰ', 'Ⱞ', 'Ɫ', 'Ɽ', 'Ɑ', 'Ɒ', 'Ȿ', 'Ⲁ', 'Ᵹ', 'Ꝿ', 'Ɦ', 'Ɪ', 'Ʞ', 'Ꞵ', 'Ａ', 'Ｚ'},
@@ -12642,9 +12645,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mc",
-			pos:  position{line: 1784, col: 1, offset: 53395},
+			pos:  position{line: 1784, col: 1, offset: 53396},
 			expr: &charClassMatcher{
-				pos:        position{line: 1784, col: 6, offset: 53400},
+				pos:        position{line: 1784, col: 6, offset: 53401},
 				val:        "[\\u0903\\u093B\\u093E-\\u0940\\u0949-\\u094C\\u094E-\\u094F\\u0982-\\u0983\\u09BE-\\u09C0\\u09C7-\\u09C8\\u09CB-\\u09CC\\u09D7\\u0A03\\u0A3E-\\u0A40\\u0A83\\u0ABE-\\u0AC0\\u0AC9\\u0ACB-\\u0ACC\\u0B02-\\u0B03\\u0B3E\\u0B40\\u0B47-\\u0B48\\u0B4B-\\u0B4C\\u0B57\\u0BBE-\\u0BBF\\u0BC1-\\u0BC2\\u0BC6-\\u0BC8\\u0BCA-\\u0BCC\\u0BD7\\u0C01-\\u0C03\\u0C41-\\u0C44\\u0C82-\\u0C83\\u0CBE\\u0CC0-\\u0CC4\\u0CC7-\\u0CC8\\u0CCA-\\u0CCB\\u0CD5-\\u0CD6\\u0D02-\\u0D03\\u0D3E-\\u0D40\\u0D46-\\u0D48\\u0D4A-\\u0D4C\\u0D57\\u0D82-\\u0D83\\u0DCF-\\u0DD1\\u0DD8-\\u0DDF\\u0DF2-\\u0DF3\\u0F3E-\\u0F3F\\u0F7F\\u102B-\\u102C\\u1031\\u1038\\u103B-\\u103C\\u1056-\\u1057\\u1062-\\u1064\\u1067-\\u106D\\u1083-\\u1084\\u1087-\\u108C\\u108F\\u109A-\\u109C\\u17B6\\u17BE-\\u17C5\\u17C7-\\u17C8\\u1923-\\u1926\\u1929-\\u192B\\u1930-\\u1931\\u1933-\\u1938\\u1A19-\\u1A1A\\u1A55\\u1A57\\u1A61\\u1A63-\\u1A64\\u1A6D-\\u1A72\\u1B04\\u1B35\\u1B3B\\u1B3D-\\u1B41\\u1B43-\\u1B44\\u1B82\\u1BA1\\u1BA6-\\u1BA7\\u1BAA\\u1BE7\\u1BEA-\\u1BEC\\u1BEE\\u1BF2-\\u1BF3\\u1C24-\\u1C2B\\u1C34-\\u1C35\\u1CE1\\u1CF2-\\u1CF3\\u1CF7\\u302E-\\u302F\\uA823-\\uA824\\uA827\\uA880-\\uA881\\uA8B4-\\uA8C3\\uA952-\\uA953\\uA983\\uA9B4-\\uA9B5\\uA9BA-\\uA9BB\\uA9BD-\\uA9C0\\uAA2F-\\uAA30\\uAA33-\\uAA34\\uAA4D\\uAA7B\\uAA7D\\uAAEB\\uAAEE-\\uAAEF\\uAAF5\\uABE3-\\uABE4\\uABE6-\\uABE7\\uABE9-\\uABEA\\uABEC]",
 				chars:      []rune{'ः', 'ऻ', 'ৗ', 'ਃ', 'ઃ', 'ૉ', 'ା', 'ୀ', 'ୗ', 'ௗ', 'ಾ', 'ൗ', 'ཿ', 'ေ', 'း', 'ႏ', 'ា', 'ᩕ', 'ᩗ', 'ᩡ', 'ᬄ', 'ᬵ', 'ᬻ', 'ᮂ', 'ᮡ', '᮪', 'ᯧ', 'ᯮ', '᳡', '᳷', 'ꠧ', 'ꦃ', 'ꩍ', 'ꩻ', 'ꩽ', 'ꫫ', 'ꫵ', '꯬'},
 				ranges:     []rune{'ा', 'ी', 'ॉ', 'ौ', 'ॎ', 'ॏ', 'ং', 'ঃ', 'া', 'ী', 'ে', 'ৈ', 'ো', 'ৌ', 'ਾ', 'ੀ', 'ા', 'ી', 'ો', 'ૌ', 'ଂ', 'ଃ', 'େ', 'ୈ', 'ୋ', 'ୌ', 'ா', 'ி', 'ு', 'ூ', 'ெ', 'ை', 'ொ', 'ௌ', 'ఁ', 'ః', 'ు', 'ౄ', 'ಂ', 'ಃ', 'ೀ', 'ೄ', 'ೇ', 'ೈ', 'ೊ', 'ೋ', 'ೕ', 'ೖ', 'ം', 'ഃ', 'ാ', 'ീ', 'െ', 'ൈ', 'ൊ', 'ൌ', 'ං', 'ඃ', 'ා', 'ෑ', 'ෘ', 'ෟ', 'ෲ', 'ෳ', '༾', '༿', 'ါ', 'ာ', 'ျ', 'ြ', 'ၖ', 'ၗ', 'ၢ', 'ၤ', 'ၧ', 'ၭ', 'ႃ', 'ႄ', 'ႇ', 'ႌ', 'ႚ', 'ႜ', 'ើ', 'ៅ', 'ះ', 'ៈ', 'ᤣ', 'ᤦ', 'ᤩ', 'ᤫ', 'ᤰ', 'ᤱ', 'ᤳ', 'ᤸ', 'ᨙ', 'ᨚ', 'ᩣ', 'ᩤ', 'ᩭ', 'ᩲ', 'ᬽ', 'ᭁ', 'ᭃ', '᭄', 'ᮦ', 'ᮧ', 'ᯪ', 'ᯬ', '᯲', '᯳', 'ᰤ', 'ᰫ', 'ᰴ', 'ᰵ', 'ᳲ', 'ᳳ', '〮', '〯', 'ꠣ', 'ꠤ', 'ꢀ', 'ꢁ', 'ꢴ', 'ꣃ', 'ꥒ', '꥓', 'ꦴ', 'ꦵ', 'ꦺ', 'ꦻ', 'ꦽ', '꧀', 'ꨯ', 'ꨰ', 'ꨳ', 'ꨴ', 'ꫮ', 'ꫯ', 'ꯣ', 'ꯤ', 'ꯦ', 'ꯧ', 'ꯩ', 'ꯪ'},
@@ -12656,9 +12659,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mn",
-			pos:  position{line: 1787, col: 1, offset: 54588},
+			pos:  position{line: 1787, col: 1, offset: 54589},
 			expr: &charClassMatcher{
-				pos:        position{line: 1787, col: 6, offset: 54593},
+				pos:        position{line: 1787, col: 6, offset: 54594},
 				val:        "[\\u0300-\\u036F\\u0483-\\u0487\\u0591-\\u05BD\\u05BF\\u05C1-\\u05C2\\u05C4-\\u05C5\\u05C7\\u0610-\\u061A\\u064B-\\u065F\\u0670\\u06D6-\\u06DC\\u06DF-\\u06E4\\u06E7-\\u06E8\\u06EA-\\u06ED\\u0711\\u0730-\\u074A\\u07A6-\\u07B0\\u07EB-\\u07F3\\u07FD\\u0816-\\u0819\\u081B-\\u0823\\u0825-\\u0827\\u0829-\\u082D\\u0859-\\u085B\\u08D3-\\u08E1\\u08E3-\\u0902\\u093A\\u093C\\u0941-\\u0948\\u094D\\u0951-\\u0957\\u0962-\\u0963\\u0981\\u09BC\\u09C1-\\u09C4\\u09CD\\u09E2-\\u09E3\\u09FE\\u0A01-\\u0A02\\u0A3C\\u0A41-\\u0A42\\u0A47-\\u0A48\\u0A4B-\\u0A4D\\u0A51\\u0A70-\\u0A71\\u0A75\\u0A81-\\u0A82\\u0ABC\\u0AC1-\\u0AC5\\u0AC7-\\u0AC8\\u0ACD\\u0AE2-\\u0AE3\\u0AFA-\\u0AFF\\u0B01\\u0B3C\\u0B3F\\u0B41-\\u0B44\\u0B4D\\u0B56\\u0B62-\\u0B63\\u0B82\\u0BC0\\u0BCD\\u0C00\\u0C04\\u0C3E-\\u0C40\\u0C46-\\u0C48\\u0C4A-\\u0C4D\\u0C55-\\u0C56\\u0C62-\\u0C63\\u0C81\\u0CBC\\u0CBF\\u0CC6\\u0CCC-\\u0CCD\\u0CE2-\\u0CE3\\u0D00-\\u0D01\\u0D3B-\\u0D3C\\u0D41-\\u0D44\\u0D4D\\u0D62-\\u0D63\\u0DCA\\u0DD2-\\u0DD4\\u0DD6\\u0E31\\u0E34-\\u0E3A\\u0E47-\\u0E4E\\u0EB1\\u0EB4-\\u0EB9\\u0EBB-\\u0EBC\\u0EC8-\\u0ECD\\u0F18-\\u0F19\\u0F35\\u0F37\\u0F39\\u0F71-\\u0F7E\\u0F80-\\u0F84\\u0F86-\\u0F87\\u0F8D-\\u0F97\\u0F99-\\u0FBC\\u0FC6\\u102D-\\u1030\\u1032-\\u1037\\u1039-\\u103A\\u103D-\\u103E\\u1058-\\u1059\\u105E-\\u1060\\u1071-\\u1074\\u1082\\u1085-\\u1086\\u108D\\u109D\\u135D-\\u135F\\u1712-\\u1714\\u1732-\\u1734\\u1752-\\u1753\\u1772-\\u1773\\u17B4-\\u17B5\\u17B7-\\u17BD\\u17C6\\u17C9-\\u17D3\\u17DD\\u180B-\\u180D\\u1885-\\u1886\\u18A9\\u1920-\\u1922\\u1927-\\u1928\\u1932\\u1939-\\u193B\\u1A17-\\u1A18\\u1A1B\\u1A56\\u1A58-\\u1A5E\\u1A60\\u1A62\\u1A65-\\u1A6C\\u1A73-\\u1A7C\\u1A7F\\u1AB0-\\u1ABD\\u1B00-\\u1B03\\u1B34\\u1B36-\\u1B3A\\u1B3C\\u1B42\\u1B6B-\\u1B73\\u1B80-\\u1B81\\u1BA2-\\u1BA5\\u1BA8-\\u1BA9\\u1BAB-\\u1BAD\\u1BE6\\u1BE8-\\u1BE9\\u1BED\\u1BEF-\\u1BF1\\u1C2C-\\u1C33\\u1C36-\\u1C37\\u1CD0-\\u1CD2\\u1CD4-\\u1CE0\\u1CE2-\\u1CE8\\u1CED\\u1CF4\\u1CF8-\\u1CF9\\u1DC0-\\u1DF9\\u1DFB-\\u1DFF\\u20D0-\\u20DC\\u20E1\\u20E5-\\u20F0\\u2CEF-\\u2CF1\\u2D7F\\u2DE0-\\u2DFF\\u302A-\\u302D\\u3099-\\u309A\\uA66F\\uA674-\\uA67D\\uA69E-\\uA69F\\uA6F0-\\uA6F1\\uA802\\uA806\\uA80B\\uA825-\\uA826\\uA8C4-\\uA8C5\\uA8E0-\\uA8F1\\uA8FF\\uA926-\\uA92D\\uA947-\\uA951\\uA980-\\uA982\\uA9B3\\uA9B6-\\uA9B9\\uA9BC\\uA9E5\\uAA29-\\uAA2E\\uAA31-\\uAA32\\uAA35-\\uAA36\\uAA43\\uAA4C\\uAA7C\\uAAB0\\uAAB2-\\uAAB4\\uAAB7-\\uAAB8\\uAABE-\\uAABF\\uAAC1\\uAAEC-\\uAAED\\uAAF6\\uABE5\\uABE8\\uABED\\uFB1E\\uFE00-\\uFE0F\\uFE20-\\uFE2F]",
 				chars:      []rune{'ֿ', 'ׇ', 'ٰ', 'ܑ', '߽', 'ऺ', '़', '्', 'ঁ', '়', '্', '৾', '਼', 'ੑ', 'ੵ', '઼', '્', 'ଁ', '଼', 'ି', '୍', 'ୖ', 'ஂ', 'ீ', '்', 'ఀ', 'ఄ', 'ಁ', '಼', 'ಿ', 'ೆ', '്', '්', 'ූ', 'ั', 'ັ', '༵', '༷', '༹', '࿆', 'ႂ', 'ႍ', 'ႝ', 'ំ', '៝', 'ᢩ', 'ᤲ', 'ᨛ', 'ᩖ', '᩠', 'ᩢ', '᩿', '᬴', 'ᬼ', 'ᭂ', '᯦', 'ᯭ', '᳭', '᳴', '⃡', '⵿', '꙯', 'ꠂ', '꠆', 'ꠋ', 'ꣿ', '꦳', 'ꦼ', 'ꧥ', 'ꩃ', 'ꩌ', 'ꩼ', 'ꪰ', '꫁', '꫶', 'ꯥ', 'ꯨ', '꯭', 'ﬞ'},
 				ranges:     []rune{'̀', 'ͯ', '҃', '҇', '֑', 'ֽ', 'ׁ', 'ׂ', 'ׄ', 'ׅ', 'ؐ', 'ؚ', 'ً', 'ٟ', 'ۖ', 'ۜ', '۟', 'ۤ', 'ۧ', 'ۨ', '۪', 'ۭ', 'ܰ', '݊', 'ަ', 'ް', '߫', '߳', 'ࠖ', '࠙', 'ࠛ', 'ࠣ', 'ࠥ', 'ࠧ', 'ࠩ', '࠭', '࡙', '࡛', '࣓', '࣡', 'ࣣ', 'ं', 'ु', 'ै', '॑', 'ॗ', 'ॢ', 'ॣ', 'ু', 'ৄ', 'ৢ', 'ৣ', 'ਁ', 'ਂ', 'ੁ', 'ੂ', 'ੇ', 'ੈ', 'ੋ', '੍', 'ੰ', 'ੱ', 'ઁ', 'ં', 'ુ', 'ૅ', 'ે', 'ૈ', 'ૢ', 'ૣ', 'ૺ', '૿', 'ୁ', 'ୄ', 'ୢ', 'ୣ', 'ా', 'ీ', 'ె', 'ై', 'ొ', '్', 'ౕ', 'ౖ', 'ౢ', 'ౣ', 'ೌ', '್', 'ೢ', 'ೣ', 'ഀ', 'ഁ', '഻', '഼', 'ു', 'ൄ', 'ൢ', 'ൣ', 'ි', 'ු', 'ิ', 'ฺ', '็', '๎', 'ິ', 'ູ', 'ົ', 'ຼ', '່', 'ໍ', '༘', '༙', 'ཱ', 'ཾ', 'ྀ', '྄', '྆', '྇', 'ྍ', 'ྗ', 'ྙ', 'ྼ', 'ိ', 'ူ', 'ဲ', '့', '္', '်', 'ွ', 'ှ', 'ၘ', 'ၙ', 'ၞ', 'ၠ', 'ၱ', 'ၴ', 'ႅ', 'ႆ', '፝', '፟', 'ᜒ', '᜔', 'ᜲ', '᜴', 'ᝒ', 'ᝓ', 'ᝲ', 'ᝳ', '឴', '឵', 'ិ', 'ួ', '៉', '៓', '᠋', '᠍', 'ᢅ', 'ᢆ', 'ᤠ', 'ᤢ', 'ᤧ', 'ᤨ', '᤹', '᤻', 'ᨗ', 'ᨘ', 'ᩘ', 'ᩞ', 'ᩥ', 'ᩬ', 'ᩳ', '᩼', '᪰', '᪽', 'ᬀ', 'ᬃ', 'ᬶ', 'ᬺ', '᭫', '᭳', 'ᮀ', 'ᮁ', 'ᮢ', 'ᮥ', 'ᮨ', 'ᮩ', '᮫', 'ᮭ', 'ᯨ', 'ᯩ', 'ᯯ', 'ᯱ', 'ᰬ', 'ᰳ', 'ᰶ', '᰷', '᳐', '᳒', '᳔', '᳠', '᳢', '᳨', '᳸', '᳹', '᷀', '᷹', '᷻', '᷿', '⃐', '⃜', '⃥', '⃰', '⳯', '⳱', 'ⷠ', 'ⷿ', '〪', '〭', '゙', '゚', 'ꙴ', '꙽', 'ꚞ', 'ꚟ', '꛰', '꛱', 'ꠥ', 'ꠦ', '꣄', 'ꣅ', '꣠', '꣱', 'ꤦ', '꤭', 'ꥇ', 'ꥑ', 'ꦀ', 'ꦂ', 'ꦶ', 'ꦹ', 'ꨩ', 'ꨮ', 'ꨱ', 'ꨲ', 'ꨵ', 'ꨶ', 'ꪲ', 'ꪴ', 'ꪷ', 'ꪸ', 'ꪾ', '꪿', 'ꫬ', 'ꫭ', '︀', '️', '︠', '︯'},
@@ -12670,9 +12673,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nd",
-			pos:  position{line: 1790, col: 1, offset: 56773},
+			pos:  position{line: 1790, col: 1, offset: 56774},
 			expr: &charClassMatcher{
-				pos:        position{line: 1790, col: 6, offset: 56778},
+				pos:        position{line: 1790, col: 6, offset: 56779},
 				val:        "[\\u0030-\\u0039\\u0660-\\u0669\\u06F0-\\u06F9\\u07C0-\\u07C9\\u0966-\\u096F\\u09E6-\\u09EF\\u0A66-\\u0A6F\\u0AE6-\\u0AEF\\u0B66-\\u0B6F\\u0BE6-\\u0BEF\\u0C66-\\u0C6F\\u0CE6-\\u0CEF\\u0D66-\\u0D6F\\u0DE6-\\u0DEF\\u0E50-\\u0E59\\u0ED0-\\u0ED9\\u0F20-\\u0F29\\u1040-\\u1049\\u1090-\\u1099\\u17E0-\\u17E9\\u1810-\\u1819\\u1946-\\u194F\\u19D0-\\u19D9\\u1A80-\\u1A89\\u1A90-\\u1A99\\u1B50-\\u1B59\\u1BB0-\\u1BB9\\u1C40-\\u1C49\\u1C50-\\u1C59\\uA620-\\uA629\\uA8D0-\\uA8D9\\uA900-\\uA909\\uA9D0-\\uA9D9\\uA9F0-\\uA9F9\\uAA50-\\uAA59\\uABF0-\\uABF9\\uFF10-\\uFF19]",
 				ranges:     []rune{'0', '9', '٠', '٩', '۰', '۹', '߀', '߉', '०', '९', '০', '৯', '੦', '੯', '૦', '૯', '୦', '୯', '௦', '௯', '౦', '౯', '೦', '೯', '൦', '൯', '෦', '෯', '๐', '๙', '໐', '໙', '༠', '༩', '၀', '၉', '႐', '႙', '០', '៩', '᠐', '᠙', '᥆', '᥏', '᧐', '᧙', '᪀', '᪉', '᪐', '᪙', '᭐', '᭙', '᮰', '᮹', '᱀', '᱉', '᱐', '᱙', '꘠', '꘩', '꣐', '꣙', '꤀', '꤉', '꧐', '꧙', '꧰', '꧹', '꩐', '꩙', '꯰', '꯹', '０', '９'},
 				ignoreCase: false,
@@ -12683,9 +12686,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nl",
-			pos:  position{line: 1793, col: 1, offset: 57281},
+			pos:  position{line: 1793, col: 1, offset: 57282},
 			expr: &charClassMatcher{
-				pos:        position{line: 1793, col: 6, offset: 57286},
+				pos:        position{line: 1793, col: 6, offset: 57287},
 				val:        "[\\u16EE-\\u16F0\\u2160-\\u2182\\u2185-\\u2188\\u3007\\u3021-\\u3029\\u3038-\\u303A\\uA6E6-\\uA6EF]",
 				chars:      []rune{'〇'},
 				ranges:     []rune{'ᛮ', 'ᛰ', 'Ⅰ', 'ↂ', 'ↅ', 'ↈ', '〡', '〩', '〸', '〺', 'ꛦ', 'ꛯ'},
@@ -12697,9 +12700,9 @@ var g = &grammar{
 		},
 		{
 			name: "Pc",
-			pos:  position{line: 1796, col: 1, offset: 57400},
+			pos:  position{line: 1796, col: 1, offset: 57401},
 			expr: &charClassMatcher{
-				pos:        position{line: 1796, col: 6, offset: 57405},
+				pos:        position{line: 1796, col: 6, offset: 57406},
 				val:        "[\\u005F\\u203F-\\u2040\\u2054\\uFE33-\\uFE34\\uFE4D-\\uFE4F\\uFF3F]",
 				chars:      []rune{'_', '⁔', '＿'},
 				ranges:     []rune{'‿', '⁀', '︳', '︴', '﹍', '﹏'},
@@ -12711,9 +12714,9 @@ var g = &grammar{
 		},
 		{
 			name: "Zs",
-			pos:  position{line: 1799, col: 1, offset: 57486},
+			pos:  position{line: 1799, col: 1, offset: 57487},
 			expr: &charClassMatcher{
-				pos:        position{line: 1799, col: 6, offset: 57491},
+				pos:        position{line: 1799, col: 6, offset: 57492},
 				val:        "[\\u0020\\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000]",
 				chars:      []rune{' ', '\u00a0', '\u1680', '\u202f', '\u205f', '\u3000'},
 				ranges:     []rune{'\u2000', '\u200a'},
@@ -12725,9 +12728,9 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1801, col: 1, offset: 57544},
+			pos:  position{line: 1801, col: 1, offset: 57545},
 			expr: &anyMatcher{
-				line: 1802, col: 5, offset: 57564,
+				line: 1802, col: 5, offset: 57565,
 			},
 			leader:        false,
 			leftRecursive: false,
@@ -12735,48 +12738,48 @@ var g = &grammar{
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1804, col: 1, offset: 57567},
+			pos:         position{line: 1804, col: 1, offset: 57568},
 			expr: &choiceExpr{
-				pos: position{line: 1805, col: 5, offset: 57595},
+				pos: position{line: 1805, col: 5, offset: 57596},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1805, col: 5, offset: 57595},
+						pos:        position{line: 1805, col: 5, offset: 57596},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1806, col: 5, offset: 57604},
+						pos:        position{line: 1806, col: 5, offset: 57605},
 						val:        "\v",
 						ignoreCase: false,
 						want:       "\"\\v\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1807, col: 5, offset: 57613},
+						pos:        position{line: 1807, col: 5, offset: 57614},
 						val:        "\f",
 						ignoreCase: false,
 						want:       "\"\\f\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1808, col: 5, offset: 57622},
+						pos:        position{line: 1808, col: 5, offset: 57623},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 1809, col: 5, offset: 57630},
+						pos:        position{line: 1809, col: 5, offset: 57631},
 						val:        "\u00a0",
 						ignoreCase: false,
 						want:       "\"\\u00a0\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1810, col: 5, offset: 57643},
+						pos:        position{line: 1810, col: 5, offset: 57644},
 						val:        "\ufeff",
 						ignoreCase: false,
 						want:       "\"\\ufeff\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1811, col: 5, offset: 57656},
+						pos:  position{line: 1811, col: 5, offset: 57657},
 						name: "Zs",
 					},
 				},
@@ -12786,9 +12789,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1813, col: 1, offset: 57660},
+			pos:  position{line: 1813, col: 1, offset: 57661},
 			expr: &charClassMatcher{
-				pos:        position{line: 1814, col: 5, offset: 57679},
+				pos:        position{line: 1814, col: 5, offset: 57680},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -12800,16 +12803,16 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1816, col: 1, offset: 57699},
+			pos:         position{line: 1816, col: 1, offset: 57700},
 			expr: &choiceExpr{
-				pos: position{line: 1817, col: 5, offset: 57721},
+				pos: position{line: 1817, col: 5, offset: 57722},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1817, col: 5, offset: 57721},
+						pos:  position{line: 1817, col: 5, offset: 57722},
 						name: "MultiLineComment",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1818, col: 5, offset: 57742},
+						pos:  position{line: 1818, col: 5, offset: 57743},
 						name: "SingleLineComment",
 					},
 				},
@@ -12819,39 +12822,39 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1820, col: 1, offset: 57761},
+			pos:  position{line: 1820, col: 1, offset: 57762},
 			expr: &seqExpr{
-				pos: position{line: 1821, col: 5, offset: 57782},
+				pos: position{line: 1821, col: 5, offset: 57783},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1821, col: 5, offset: 57782},
+						pos:        position{line: 1821, col: 5, offset: 57783},
 						val:        "/*",
 						ignoreCase: false,
 						want:       "\"/*\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1821, col: 10, offset: 57787},
+						pos: position{line: 1821, col: 10, offset: 57788},
 						expr: &seqExpr{
-							pos: position{line: 1821, col: 11, offset: 57788},
+							pos: position{line: 1821, col: 11, offset: 57789},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1821, col: 11, offset: 57788},
+									pos: position{line: 1821, col: 11, offset: 57789},
 									expr: &litMatcher{
-										pos:        position{line: 1821, col: 12, offset: 57789},
+										pos:        position{line: 1821, col: 12, offset: 57790},
 										val:        "*/",
 										ignoreCase: false,
 										want:       "\"*/\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1821, col: 17, offset: 57794},
+									pos:  position{line: 1821, col: 17, offset: 57795},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1821, col: 35, offset: 57812},
+						pos:        position{line: 1821, col: 35, offset: 57813},
 						val:        "*/",
 						ignoreCase: false,
 						want:       "\"*/\"",
@@ -12863,30 +12866,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1823, col: 1, offset: 57818},
+			pos:  position{line: 1823, col: 1, offset: 57819},
 			expr: &seqExpr{
-				pos: position{line: 1824, col: 5, offset: 57840},
+				pos: position{line: 1824, col: 5, offset: 57841},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1824, col: 5, offset: 57840},
+						pos:        position{line: 1824, col: 5, offset: 57841},
 						val:        "--",
 						ignoreCase: false,
 						want:       "\"--\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1824, col: 10, offset: 57845},
+						pos: position{line: 1824, col: 10, offset: 57846},
 						expr: &seqExpr{
-							pos: position{line: 1824, col: 11, offset: 57846},
+							pos: position{line: 1824, col: 11, offset: 57847},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1824, col: 11, offset: 57846},
+									pos: position{line: 1824, col: 11, offset: 57847},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1824, col: 12, offset: 57847},
+										pos:  position{line: 1824, col: 12, offset: 57848},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1824, col: 27, offset: 57862},
+									pos:  position{line: 1824, col: 27, offset: 57863},
 									name: "SourceCharacter",
 								},
 							},
@@ -12899,19 +12902,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1826, col: 1, offset: 57881},
+			pos:  position{line: 1826, col: 1, offset: 57882},
 			expr: &seqExpr{
-				pos: position{line: 1826, col: 7, offset: 57887},
+				pos: position{line: 1826, col: 7, offset: 57888},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1826, col: 7, offset: 57887},
+						pos: position{line: 1826, col: 7, offset: 57888},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1826, col: 7, offset: 57887},
+							pos:  position{line: 1826, col: 7, offset: 57888},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1826, col: 19, offset: 57899},
+						pos:  position{line: 1826, col: 19, offset: 57900},
 						name: "LineTerminator",
 					},
 				},
@@ -12921,16 +12924,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1828, col: 1, offset: 57915},
+			pos:  position{line: 1828, col: 1, offset: 57916},
 			expr: &choiceExpr{
-				pos: position{line: 1828, col: 7, offset: 57921},
+				pos: position{line: 1828, col: 7, offset: 57922},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1828, col: 7, offset: 57921},
+						pos:  position{line: 1828, col: 7, offset: 57922},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1828, col: 11, offset: 57925},
+						pos:  position{line: 1828, col: 11, offset: 57926},
 						name: "EOF",
 					},
 				},
@@ -12940,11 +12943,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1830, col: 1, offset: 57930},
+			pos:  position{line: 1830, col: 1, offset: 57931},
 			expr: &notExpr{
-				pos: position{line: 1830, col: 7, offset: 57936},
+				pos: position{line: 1830, col: 7, offset: 57937},
 				expr: &anyMatcher{
-					line: 1830, col: 8, offset: 57937,
+					line: 1830, col: 8, offset: 57938,
 				},
 			},
 			leader:        false,
@@ -12952,11 +12955,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOKW",
-			pos:  position{line: 1832, col: 1, offset: 57940},
+			pos:  position{line: 1832, col: 1, offset: 57941},
 			expr: &notExpr{
-				pos: position{line: 1832, col: 8, offset: 57947},
+				pos: position{line: 1832, col: 8, offset: 57948},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1832, col: 9, offset: 57948},
+					pos:  position{line: 1832, col: 9, offset: 57949},
 					name: "KeyWordChars",
 				},
 			},
@@ -12965,15 +12968,15 @@ var g = &grammar{
 		},
 		{
 			name: "SQLPipe",
-			pos:  position{line: 1836, col: 1, offset: 57984},
+			pos:  position{line: 1836, col: 1, offset: 57985},
 			expr: &actionExpr{
-				pos: position{line: 1837, col: 5, offset: 57996},
+				pos: position{line: 1837, col: 5, offset: 57997},
 				run: (*parser).callonSQLPipe1,
 				expr: &labeledExpr{
-					pos:   position{line: 1837, col: 5, offset: 57996},
+					pos:   position{line: 1837, col: 5, offset: 57997},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1837, col: 7, offset: 57998},
+						pos:  position{line: 1837, col: 7, offset: 57999},
 						name: "Seq",
 					},
 				},
@@ -12983,9 +12986,9 @@ var g = &grammar{
 		},
 		{
 			name: "SelectOp",
-			pos:  position{line: 1845, col: 1, offset: 58144},
+			pos:  position{line: 1845, col: 1, offset: 58145},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1845, col: 12, offset: 58155},
+				pos:  position{line: 1845, col: 12, offset: 58156},
 				name: "SelectExpr",
 			},
 			leader:        false,
@@ -12993,73 +12996,73 @@ var g = &grammar{
 		},
 		{
 			name: "SelectExpr",
-			pos:  position{line: 1847, col: 1, offset: 58167},
+			pos:  position{line: 1847, col: 1, offset: 58168},
 			expr: &actionExpr{
-				pos: position{line: 1848, col: 5, offset: 58182},
+				pos: position{line: 1848, col: 5, offset: 58183},
 				run: (*parser).callonSelectExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1848, col: 5, offset: 58182},
+					pos: position{line: 1848, col: 5, offset: 58183},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1848, col: 5, offset: 58182},
+							pos:   position{line: 1848, col: 5, offset: 58183},
 							label: "with",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1848, col: 10, offset: 58187},
+								pos:  position{line: 1848, col: 10, offset: 58188},
 								name: "OptWithClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1849, col: 5, offset: 58205},
+							pos:   position{line: 1849, col: 5, offset: 58206},
 							label: "body",
 							expr: &choiceExpr{
-								pos: position{line: 1850, col: 9, offset: 58220},
+								pos: position{line: 1850, col: 9, offset: 58221},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1850, col: 9, offset: 58220},
+										pos:  position{line: 1850, col: 9, offset: 58221},
 										name: "SetOperation",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1851, col: 9, offset: 58241},
+										pos:  position{line: 1851, col: 9, offset: 58242},
 										name: "Select",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1852, col: 9, offset: 58256},
+										pos:  position{line: 1852, col: 9, offset: 58257},
 										name: "FromSelect",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1853, col: 9, offset: 58275},
+										pos:  position{line: 1853, col: 9, offset: 58276},
 										name: "SQLValues",
 									},
 									&actionExpr{
-										pos: position{line: 1854, col: 9, offset: 58293},
+										pos: position{line: 1854, col: 9, offset: 58294},
 										run: (*parser).callonSelectExpr11,
 										expr: &seqExpr{
-											pos: position{line: 1854, col: 9, offset: 58293},
+											pos: position{line: 1854, col: 9, offset: 58294},
 											exprs: []any{
 												&litMatcher{
-													pos:        position{line: 1854, col: 9, offset: 58293},
+													pos:        position{line: 1854, col: 9, offset: 58294},
 													val:        "(",
 													ignoreCase: false,
 													want:       "\"(\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1854, col: 13, offset: 58297},
+													pos:  position{line: 1854, col: 13, offset: 58298},
 													name: "__",
 												},
 												&labeledExpr{
-													pos:   position{line: 1854, col: 16, offset: 58300},
+													pos:   position{line: 1854, col: 16, offset: 58301},
 													label: "s",
 													expr: &ruleRefExpr{
-														pos:  position{line: 1854, col: 18, offset: 58302},
+														pos:  position{line: 1854, col: 18, offset: 58303},
 														name: "SQLPipe",
 													},
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1854, col: 26, offset: 58310},
+													pos:  position{line: 1854, col: 26, offset: 58311},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1854, col: 28, offset: 58312},
+													pos:        position{line: 1854, col: 28, offset: 58313},
 													val:        ")",
 													ignoreCase: false,
 													want:       "\")\"",
@@ -13071,18 +13074,18 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1856, col: 5, offset: 58349},
+							pos:   position{line: 1856, col: 5, offset: 58350},
 							label: "orderby",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1856, col: 13, offset: 58357},
+								pos:  position{line: 1856, col: 13, offset: 58358},
 								name: "OptOrderByClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1857, col: 5, offset: 58378},
+							pos:   position{line: 1857, col: 5, offset: 58379},
 							label: "loff",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1857, col: 10, offset: 58383},
+								pos:  position{line: 1857, col: 10, offset: 58384},
 								name: "OptSQLLimitOffset",
 							},
 						},
@@ -13094,74 +13097,74 @@ var g = &grammar{
 		},
 		{
 			name: "Select",
-			pos:  position{line: 1877, col: 1, offset: 58784},
+			pos:  position{line: 1877, col: 1, offset: 58785},
 			expr: &actionExpr{
-				pos: position{line: 1878, col: 5, offset: 58795},
+				pos: position{line: 1878, col: 5, offset: 58796},
 				run: (*parser).callonSelect1,
 				expr: &seqExpr{
-					pos: position{line: 1878, col: 5, offset: 58795},
+					pos: position{line: 1878, col: 5, offset: 58796},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1878, col: 5, offset: 58795},
+							pos:  position{line: 1878, col: 5, offset: 58796},
 							name: "SELECT",
 						},
 						&labeledExpr{
-							pos:   position{line: 1879, col: 5, offset: 58806},
+							pos:   position{line: 1879, col: 5, offset: 58807},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1879, col: 14, offset: 58815},
+								pos:  position{line: 1879, col: 14, offset: 58816},
 								name: "OptDistinct",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1880, col: 5, offset: 58831},
+							pos:   position{line: 1880, col: 5, offset: 58832},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1880, col: 11, offset: 58837},
+								pos:  position{line: 1880, col: 11, offset: 58838},
 								name: "OptSelectValue",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1883, col: 5, offset: 58976},
+							pos:  position{line: 1883, col: 5, offset: 58977},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1883, col: 7, offset: 58978},
+							pos:   position{line: 1883, col: 7, offset: 58979},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1883, col: 17, offset: 58988},
+								pos:  position{line: 1883, col: 17, offset: 58989},
 								name: "Selection",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1884, col: 5, offset: 59002},
+							pos:   position{line: 1884, col: 5, offset: 59003},
 							label: "from",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1884, col: 10, offset: 59007},
+								pos:  position{line: 1884, col: 10, offset: 59008},
 								name: "OptFromClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1885, col: 5, offset: 59025},
+							pos:   position{line: 1885, col: 5, offset: 59026},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1885, col: 11, offset: 59031},
+								pos:  position{line: 1885, col: 11, offset: 59032},
 								name: "OptWhereClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1886, col: 5, offset: 59050},
+							pos:   position{line: 1886, col: 5, offset: 59051},
 							label: "group",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1886, col: 11, offset: 59056},
+								pos:  position{line: 1886, col: 11, offset: 59057},
 								name: "OptGroupClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1887, col: 5, offset: 59075},
+							pos:   position{line: 1887, col: 5, offset: 59076},
 							label: "having",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1887, col: 12, offset: 59082},
+								pos:  position{line: 1887, col: 12, offset: 59083},
 								name: "OptHavingClause",
 							},
 						},
@@ -13173,78 +13176,78 @@ var g = &grammar{
 		},
 		{
 			name: "FromSelect",
-			pos:  position{line: 1913, col: 1, offset: 59697},
+			pos:  position{line: 1913, col: 1, offset: 59698},
 			expr: &actionExpr{
-				pos: position{line: 1914, col: 5, offset: 59712},
+				pos: position{line: 1914, col: 5, offset: 59713},
 				run: (*parser).callonFromSelect1,
 				expr: &seqExpr{
-					pos: position{line: 1914, col: 5, offset: 59712},
+					pos: position{line: 1914, col: 5, offset: 59713},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1914, col: 5, offset: 59712},
+							pos:   position{line: 1914, col: 5, offset: 59713},
 							label: "from",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1914, col: 10, offset: 59717},
+								pos:  position{line: 1914, col: 10, offset: 59718},
 								name: "FromOp",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1914, col: 17, offset: 59724},
+							pos:  position{line: 1914, col: 17, offset: 59725},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1914, col: 19, offset: 59726},
+							pos:  position{line: 1914, col: 19, offset: 59727},
 							name: "SELECT",
 						},
 						&labeledExpr{
-							pos:   position{line: 1915, col: 5, offset: 59737},
+							pos:   position{line: 1915, col: 5, offset: 59738},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1915, col: 14, offset: 59746},
+								pos:  position{line: 1915, col: 14, offset: 59747},
 								name: "OptDistinct",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1916, col: 5, offset: 59762},
+							pos:   position{line: 1916, col: 5, offset: 59763},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1916, col: 11, offset: 59768},
+								pos:  position{line: 1916, col: 11, offset: 59769},
 								name: "OptSelectValue",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1919, col: 5, offset: 59907},
+							pos:  position{line: 1919, col: 5, offset: 59908},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1919, col: 7, offset: 59909},
+							pos:   position{line: 1919, col: 7, offset: 59910},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1919, col: 17, offset: 59919},
+								pos:  position{line: 1919, col: 17, offset: 59920},
 								name: "Selection",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1920, col: 5, offset: 59933},
+							pos:   position{line: 1920, col: 5, offset: 59934},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1920, col: 11, offset: 59939},
+								pos:  position{line: 1920, col: 11, offset: 59940},
 								name: "OptWhereClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1921, col: 5, offset: 59958},
+							pos:   position{line: 1921, col: 5, offset: 59959},
 							label: "group",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1921, col: 11, offset: 59964},
+								pos:  position{line: 1921, col: 11, offset: 59965},
 								name: "OptGroupClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1922, col: 5, offset: 59983},
+							pos:   position{line: 1922, col: 5, offset: 59984},
 							label: "having",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1922, col: 12, offset: 59990},
+								pos:  position{line: 1922, col: 12, offset: 59991},
 								name: "OptHavingClause",
 							},
 						},
@@ -13256,26 +13259,26 @@ var g = &grammar{
 		},
 		{
 			name: "SQLValues",
-			pos:  position{line: 1946, col: 1, offset: 60572},
+			pos:  position{line: 1946, col: 1, offset: 60573},
 			expr: &actionExpr{
-				pos: position{line: 1947, col: 5, offset: 60586},
+				pos: position{line: 1947, col: 5, offset: 60587},
 				run: (*parser).callonSQLValues1,
 				expr: &seqExpr{
-					pos: position{line: 1947, col: 5, offset: 60586},
+					pos: position{line: 1947, col: 5, offset: 60587},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1947, col: 5, offset: 60586},
+							pos:  position{line: 1947, col: 5, offset: 60587},
 							name: "VALUES",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1947, col: 12, offset: 60593},
+							pos:  position{line: 1947, col: 12, offset: 60594},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1947, col: 15, offset: 60596},
+							pos:   position{line: 1947, col: 15, offset: 60597},
 							label: "tuples",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1947, col: 22, offset: 60603},
+								pos:  position{line: 1947, col: 22, offset: 60604},
 								name: "SQLTuples",
 							},
 						},
@@ -13287,26 +13290,26 @@ var g = &grammar{
 		},
 		{
 			name: "ValuesOp",
-			pos:  position{line: 1955, col: 1, offset: 60760},
+			pos:  position{line: 1955, col: 1, offset: 60761},
 			expr: &actionExpr{
-				pos: position{line: 1956, col: 5, offset: 60773},
+				pos: position{line: 1956, col: 5, offset: 60774},
 				run: (*parser).callonValuesOp1,
 				expr: &seqExpr{
-					pos: position{line: 1956, col: 5, offset: 60773},
+					pos: position{line: 1956, col: 5, offset: 60774},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1956, col: 5, offset: 60773},
+							pos:  position{line: 1956, col: 5, offset: 60774},
 							name: "VALUES",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1956, col: 12, offset: 60780},
+							pos:  position{line: 1956, col: 12, offset: 60781},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1956, col: 14, offset: 60782},
+							pos:   position{line: 1956, col: 14, offset: 60783},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1956, col: 20, offset: 60788},
+								pos:  position{line: 1956, col: 20, offset: 60789},
 								name: "Exprs",
 							},
 						},
@@ -13318,51 +13321,51 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTuples",
-			pos:  position{line: 1965, col: 1, offset: 60935},
+			pos:  position{line: 1965, col: 1, offset: 60936},
 			expr: &actionExpr{
-				pos: position{line: 1966, col: 5, offset: 60949},
+				pos: position{line: 1966, col: 5, offset: 60950},
 				run: (*parser).callonSQLTuples1,
 				expr: &seqExpr{
-					pos: position{line: 1966, col: 5, offset: 60949},
+					pos: position{line: 1966, col: 5, offset: 60950},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1966, col: 5, offset: 60949},
+							pos:   position{line: 1966, col: 5, offset: 60950},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1966, col: 11, offset: 60955},
+								pos:  position{line: 1966, col: 11, offset: 60956},
 								name: "SQLTuple",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1966, col: 20, offset: 60964},
+							pos:   position{line: 1966, col: 20, offset: 60965},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1966, col: 25, offset: 60969},
+								pos: position{line: 1966, col: 25, offset: 60970},
 								expr: &actionExpr{
-									pos: position{line: 1966, col: 26, offset: 60970},
+									pos: position{line: 1966, col: 26, offset: 60971},
 									run: (*parser).callonSQLTuples7,
 									expr: &seqExpr{
-										pos: position{line: 1966, col: 26, offset: 60970},
+										pos: position{line: 1966, col: 26, offset: 60971},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1966, col: 26, offset: 60970},
+												pos:  position{line: 1966, col: 26, offset: 60971},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1966, col: 29, offset: 60973},
+												pos:        position{line: 1966, col: 29, offset: 60974},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1966, col: 33, offset: 60977},
+												pos:  position{line: 1966, col: 33, offset: 60978},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1966, col: 36, offset: 60980},
+												pos:   position{line: 1966, col: 36, offset: 60981},
 												label: "t",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1966, col: 38, offset: 60982},
+													pos:  position{line: 1966, col: 38, offset: 60983},
 													name: "SQLTuple",
 												},
 											},
@@ -13379,37 +13382,37 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTuple",
-			pos:  position{line: 1970, col: 1, offset: 61059},
+			pos:  position{line: 1970, col: 1, offset: 61060},
 			expr: &actionExpr{
-				pos: position{line: 1971, col: 5, offset: 61072},
+				pos: position{line: 1971, col: 5, offset: 61073},
 				run: (*parser).callonSQLTuple1,
 				expr: &seqExpr{
-					pos: position{line: 1971, col: 5, offset: 61072},
+					pos: position{line: 1971, col: 5, offset: 61073},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1971, col: 5, offset: 61072},
+							pos:        position{line: 1971, col: 5, offset: 61073},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1971, col: 9, offset: 61076},
+							pos:  position{line: 1971, col: 9, offset: 61077},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1971, col: 12, offset: 61079},
+							pos:   position{line: 1971, col: 12, offset: 61080},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1971, col: 18, offset: 61085},
+								pos:  position{line: 1971, col: 18, offset: 61086},
 								name: "Exprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1971, col: 24, offset: 61091},
+							pos:  position{line: 1971, col: 24, offset: 61092},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1971, col: 27, offset: 61094},
+							pos:        position{line: 1971, col: 27, offset: 61095},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -13422,49 +13425,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptDistinct",
-			pos:  position{line: 1979, col: 1, offset: 61238},
+			pos:  position{line: 1979, col: 1, offset: 61239},
 			expr: &choiceExpr{
-				pos: position{line: 1980, col: 5, offset: 61254},
+				pos: position{line: 1980, col: 5, offset: 61255},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1980, col: 5, offset: 61254},
+						pos: position{line: 1980, col: 5, offset: 61255},
 						run: (*parser).callonOptDistinct2,
 						expr: &seqExpr{
-							pos: position{line: 1980, col: 5, offset: 61254},
+							pos: position{line: 1980, col: 5, offset: 61255},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1980, col: 5, offset: 61254},
+									pos:  position{line: 1980, col: 5, offset: 61255},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1980, col: 7, offset: 61256},
+									pos:  position{line: 1980, col: 7, offset: 61257},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1981, col: 5, offset: 61293},
+						pos: position{line: 1981, col: 5, offset: 61294},
 						run: (*parser).callonOptDistinct6,
 						expr: &seqExpr{
-							pos: position{line: 1981, col: 5, offset: 61293},
+							pos: position{line: 1981, col: 5, offset: 61294},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1981, col: 5, offset: 61293},
+									pos:  position{line: 1981, col: 5, offset: 61294},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1981, col: 7, offset: 61295},
+									pos:  position{line: 1981, col: 7, offset: 61296},
 									name: "DISTINCT",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1982, col: 5, offset: 61331},
+						pos: position{line: 1982, col: 5, offset: 61332},
 						run: (*parser).callonOptDistinct10,
 						expr: &litMatcher{
-							pos:        position{line: 1982, col: 5, offset: 61331},
+							pos:        position{line: 1982, col: 5, offset: 61332},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13477,57 +13480,57 @@ var g = &grammar{
 		},
 		{
 			name: "OptSelectValue",
-			pos:  position{line: 1984, col: 1, offset: 61370},
+			pos:  position{line: 1984, col: 1, offset: 61371},
 			expr: &choiceExpr{
-				pos: position{line: 1985, col: 5, offset: 61389},
+				pos: position{line: 1985, col: 5, offset: 61390},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1985, col: 5, offset: 61389},
+						pos: position{line: 1985, col: 5, offset: 61390},
 						run: (*parser).callonOptSelectValue2,
 						expr: &seqExpr{
-							pos: position{line: 1985, col: 5, offset: 61389},
+							pos: position{line: 1985, col: 5, offset: 61390},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1985, col: 5, offset: 61389},
+									pos:  position{line: 1985, col: 5, offset: 61390},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1985, col: 7, offset: 61391},
+									pos:  position{line: 1985, col: 7, offset: 61392},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1985, col: 10, offset: 61394},
+									pos:  position{line: 1985, col: 10, offset: 61395},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1985, col: 12, offset: 61396},
+									pos:  position{line: 1985, col: 12, offset: 61397},
 									name: "VALUE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1986, col: 5, offset: 61428},
+						pos: position{line: 1986, col: 5, offset: 61429},
 						run: (*parser).callonOptSelectValue8,
 						expr: &seqExpr{
-							pos: position{line: 1986, col: 5, offset: 61428},
+							pos: position{line: 1986, col: 5, offset: 61429},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1986, col: 5, offset: 61428},
+									pos:  position{line: 1986, col: 5, offset: 61429},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1986, col: 7, offset: 61430},
+									pos:  position{line: 1986, col: 7, offset: 61431},
 									name: "VALUE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1987, col: 5, offset: 61501},
+						pos: position{line: 1987, col: 5, offset: 61502},
 						run: (*parser).callonOptSelectValue12,
 						expr: &litMatcher{
-							pos:        position{line: 1987, col: 5, offset: 61501},
+							pos:        position{line: 1987, col: 5, offset: 61502},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13540,19 +13543,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptWithClause",
-			pos:  position{line: 1989, col: 1, offset: 61544},
+			pos:  position{line: 1989, col: 1, offset: 61545},
 			expr: &choiceExpr{
-				pos: position{line: 1990, col: 5, offset: 61562},
+				pos: position{line: 1990, col: 5, offset: 61563},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1990, col: 5, offset: 61562},
+						pos:  position{line: 1990, col: 5, offset: 61563},
 						name: "WithClause",
 					},
 					&actionExpr{
-						pos: position{line: 1991, col: 5, offset: 61577},
+						pos: position{line: 1991, col: 5, offset: 61578},
 						run: (*parser).callonOptWithClause3,
 						expr: &litMatcher{
-							pos:        position{line: 1991, col: 5, offset: 61577},
+							pos:        position{line: 1991, col: 5, offset: 61578},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13565,39 +13568,39 @@ var g = &grammar{
 		},
 		{
 			name: "WithClause",
-			pos:  position{line: 1993, col: 1, offset: 61610},
+			pos:  position{line: 1993, col: 1, offset: 61611},
 			expr: &actionExpr{
-				pos: position{line: 1994, col: 5, offset: 61625},
+				pos: position{line: 1994, col: 5, offset: 61626},
 				run: (*parser).callonWithClause1,
 				expr: &seqExpr{
-					pos: position{line: 1994, col: 5, offset: 61625},
+					pos: position{line: 1994, col: 5, offset: 61626},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1994, col: 5, offset: 61625},
+							pos:  position{line: 1994, col: 5, offset: 61626},
 							name: "WITH",
 						},
 						&labeledExpr{
-							pos:   position{line: 1994, col: 10, offset: 61630},
+							pos:   position{line: 1994, col: 10, offset: 61631},
 							label: "r",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1994, col: 12, offset: 61632},
+								pos:  position{line: 1994, col: 12, offset: 61633},
 								name: "OptRecursive",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1994, col: 25, offset: 61645},
+							pos:  position{line: 1994, col: 25, offset: 61646},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1994, col: 27, offset: 61647},
+							pos:   position{line: 1994, col: 27, offset: 61648},
 							label: "ctes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1994, col: 32, offset: 61652},
+								pos:  position{line: 1994, col: 32, offset: 61653},
 								name: "CteList",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1994, col: 40, offset: 61660},
+							pos:  position{line: 1994, col: 40, offset: 61661},
 							name: "__",
 						},
 					},
@@ -13608,32 +13611,32 @@ var g = &grammar{
 		},
 		{
 			name: "OptRecursive",
-			pos:  position{line: 2003, col: 1, offset: 61848},
+			pos:  position{line: 2003, col: 1, offset: 61849},
 			expr: &choiceExpr{
-				pos: position{line: 2004, col: 5, offset: 61865},
+				pos: position{line: 2004, col: 5, offset: 61866},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2004, col: 5, offset: 61865},
+						pos: position{line: 2004, col: 5, offset: 61866},
 						run: (*parser).callonOptRecursive2,
 						expr: &seqExpr{
-							pos: position{line: 2004, col: 5, offset: 61865},
+							pos: position{line: 2004, col: 5, offset: 61866},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2004, col: 5, offset: 61865},
+									pos:  position{line: 2004, col: 5, offset: 61866},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2004, col: 7, offset: 61867},
+									pos:  position{line: 2004, col: 7, offset: 61868},
 									name: "RECURSIVE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2005, col: 5, offset: 61903},
+						pos: position{line: 2005, col: 5, offset: 61904},
 						run: (*parser).callonOptRecursive6,
 						expr: &litMatcher{
-							pos:        position{line: 2005, col: 5, offset: 61903},
+							pos:        position{line: 2005, col: 5, offset: 61904},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13646,51 +13649,51 @@ var g = &grammar{
 		},
 		{
 			name: "CteList",
-			pos:  position{line: 2007, col: 1, offset: 61942},
+			pos:  position{line: 2007, col: 1, offset: 61943},
 			expr: &actionExpr{
-				pos: position{line: 2007, col: 11, offset: 61952},
+				pos: position{line: 2007, col: 11, offset: 61953},
 				run: (*parser).callonCteList1,
 				expr: &seqExpr{
-					pos: position{line: 2007, col: 11, offset: 61952},
+					pos: position{line: 2007, col: 11, offset: 61953},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2007, col: 11, offset: 61952},
+							pos:   position{line: 2007, col: 11, offset: 61953},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2007, col: 17, offset: 61958},
+								pos:  position{line: 2007, col: 17, offset: 61959},
 								name: "Cte",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2007, col: 21, offset: 61962},
+							pos:   position{line: 2007, col: 21, offset: 61963},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2007, col: 26, offset: 61967},
+								pos: position{line: 2007, col: 26, offset: 61968},
 								expr: &actionExpr{
-									pos: position{line: 2007, col: 28, offset: 61969},
+									pos: position{line: 2007, col: 28, offset: 61970},
 									run: (*parser).callonCteList7,
 									expr: &seqExpr{
-										pos: position{line: 2007, col: 28, offset: 61969},
+										pos: position{line: 2007, col: 28, offset: 61970},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2007, col: 28, offset: 61969},
+												pos:  position{line: 2007, col: 28, offset: 61970},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2007, col: 31, offset: 61972},
+												pos:        position{line: 2007, col: 31, offset: 61973},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2007, col: 35, offset: 61976},
+												pos:  position{line: 2007, col: 35, offset: 61977},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2007, col: 38, offset: 61979},
+												pos:   position{line: 2007, col: 38, offset: 61980},
 												label: "cte",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2007, col: 42, offset: 61983},
+													pos:  position{line: 2007, col: 42, offset: 61984},
 													name: "Cte",
 												},
 											},
@@ -13707,65 +13710,65 @@ var g = &grammar{
 		},
 		{
 			name: "Cte",
-			pos:  position{line: 2011, col: 1, offset: 62051},
+			pos:  position{line: 2011, col: 1, offset: 62052},
 			expr: &actionExpr{
-				pos: position{line: 2012, col: 5, offset: 62059},
+				pos: position{line: 2012, col: 5, offset: 62060},
 				run: (*parser).callonCte1,
 				expr: &seqExpr{
-					pos: position{line: 2012, col: 5, offset: 62059},
+					pos: position{line: 2012, col: 5, offset: 62060},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2012, col: 5, offset: 62059},
+							pos:   position{line: 2012, col: 5, offset: 62060},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2012, col: 10, offset: 62064},
+								pos:  position{line: 2012, col: 10, offset: 62065},
 								name: "SQLIdentifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2012, col: 24, offset: 62078},
+							pos:  position{line: 2012, col: 24, offset: 62079},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2012, col: 26, offset: 62080},
+							pos:  position{line: 2012, col: 26, offset: 62081},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 2012, col: 29, offset: 62083},
+							pos:   position{line: 2012, col: 29, offset: 62084},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2012, col: 31, offset: 62085},
+								pos:  position{line: 2012, col: 31, offset: 62086},
 								name: "OptMaterialized",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2012, col: 47, offset: 62101},
+							pos:  position{line: 2012, col: 47, offset: 62102},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2012, col: 50, offset: 62104},
+							pos:        position{line: 2012, col: 50, offset: 62105},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2012, col: 54, offset: 62108},
+							pos:  position{line: 2012, col: 54, offset: 62109},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2012, col: 57, offset: 62111},
+							pos:   position{line: 2012, col: 57, offset: 62112},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2012, col: 59, offset: 62113},
+								pos:  position{line: 2012, col: 59, offset: 62114},
 								name: "SQLPipe",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2012, col: 67, offset: 62121},
+							pos:  position{line: 2012, col: 67, offset: 62122},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2012, col: 70, offset: 62124},
+							pos:        position{line: 2012, col: 70, offset: 62125},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -13778,65 +13781,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptMaterialized",
-			pos:  position{line: 2021, col: 1, offset: 62310},
+			pos:  position{line: 2021, col: 1, offset: 62311},
 			expr: &choiceExpr{
-				pos: position{line: 2022, col: 5, offset: 62330},
+				pos: position{line: 2022, col: 5, offset: 62331},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2022, col: 5, offset: 62330},
+						pos: position{line: 2022, col: 5, offset: 62331},
 						run: (*parser).callonOptMaterialized2,
 						expr: &seqExpr{
-							pos: position{line: 2022, col: 5, offset: 62330},
+							pos: position{line: 2022, col: 5, offset: 62331},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2022, col: 5, offset: 62330},
+									pos:  position{line: 2022, col: 5, offset: 62331},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2022, col: 7, offset: 62332},
+									pos:  position{line: 2022, col: 7, offset: 62333},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2022, col: 20, offset: 62345},
+									pos:  position{line: 2022, col: 20, offset: 62346},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2023, col: 5, offset: 62384},
+						pos: position{line: 2023, col: 5, offset: 62385},
 						run: (*parser).callonOptMaterialized7,
 						expr: &seqExpr{
-							pos: position{line: 2023, col: 5, offset: 62384},
+							pos: position{line: 2023, col: 5, offset: 62385},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2023, col: 5, offset: 62384},
+									pos:  position{line: 2023, col: 5, offset: 62385},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2023, col: 7, offset: 62386},
+									pos:  position{line: 2023, col: 7, offset: 62387},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2023, col: 11, offset: 62390},
+									pos:  position{line: 2023, col: 11, offset: 62391},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2023, col: 13, offset: 62392},
+									pos:  position{line: 2023, col: 13, offset: 62393},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2023, col: 26, offset: 62405},
+									pos:  position{line: 2023, col: 26, offset: 62406},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2024, col: 5, offset: 62436},
+						pos: position{line: 2024, col: 5, offset: 62437},
 						run: (*parser).callonOptMaterialized14,
 						expr: &litMatcher{
-							pos:        position{line: 2024, col: 5, offset: 62436},
+							pos:        position{line: 2024, col: 5, offset: 62437},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13849,25 +13852,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAllClause",
-			pos:  position{line: 2026, col: 1, offset: 62491},
+			pos:  position{line: 2026, col: 1, offset: 62492},
 			expr: &choiceExpr{
-				pos: position{line: 2027, col: 5, offset: 62508},
+				pos: position{line: 2027, col: 5, offset: 62509},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 2027, col: 5, offset: 62508},
+						pos: position{line: 2027, col: 5, offset: 62509},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2027, col: 5, offset: 62508},
+								pos:  position{line: 2027, col: 5, offset: 62509},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2027, col: 7, offset: 62510},
+								pos:  position{line: 2027, col: 7, offset: 62511},
 								name: "ALL",
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 2028, col: 5, offset: 62518},
+						pos:        position{line: 2028, col: 5, offset: 62519},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -13879,25 +13882,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptFromClause",
-			pos:  position{line: 2030, col: 1, offset: 62522},
+			pos:  position{line: 2030, col: 1, offset: 62523},
 			expr: &choiceExpr{
-				pos: position{line: 2031, col: 5, offset: 62540},
+				pos: position{line: 2031, col: 5, offset: 62541},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2031, col: 5, offset: 62540},
+						pos: position{line: 2031, col: 5, offset: 62541},
 						run: (*parser).callonOptFromClause2,
 						expr: &seqExpr{
-							pos: position{line: 2031, col: 5, offset: 62540},
+							pos: position{line: 2031, col: 5, offset: 62541},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2031, col: 5, offset: 62540},
+									pos:  position{line: 2031, col: 5, offset: 62541},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2031, col: 7, offset: 62542},
+									pos:   position{line: 2031, col: 7, offset: 62543},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2031, col: 12, offset: 62547},
+										pos:  position{line: 2031, col: 12, offset: 62548},
 										name: "FromOp",
 									},
 								},
@@ -13905,10 +13908,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2034, col: 5, offset: 62589},
+						pos: position{line: 2034, col: 5, offset: 62590},
 						run: (*parser).callonOptFromClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2034, col: 5, offset: 62589},
+							pos:        position{line: 2034, col: 5, offset: 62590},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13921,27 +13924,27 @@ var g = &grammar{
 		},
 		{
 			name: "OptWhereClause",
-			pos:  position{line: 2036, col: 1, offset: 62630},
+			pos:  position{line: 2036, col: 1, offset: 62631},
 			expr: &choiceExpr{
-				pos: position{line: 2037, col: 5, offset: 62649},
+				pos: position{line: 2037, col: 5, offset: 62650},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2037, col: 5, offset: 62649},
+						pos: position{line: 2037, col: 5, offset: 62650},
 						run: (*parser).callonOptWhereClause2,
 						expr: &labeledExpr{
-							pos:   position{line: 2037, col: 5, offset: 62649},
+							pos:   position{line: 2037, col: 5, offset: 62650},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2037, col: 11, offset: 62655},
+								pos:  position{line: 2037, col: 11, offset: 62656},
 								name: "WhereClause",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2038, col: 5, offset: 62697},
+						pos: position{line: 2038, col: 5, offset: 62698},
 						run: (*parser).callonOptWhereClause5,
 						expr: &litMatcher{
-							pos:        position{line: 2038, col: 5, offset: 62697},
+							pos:        position{line: 2038, col: 5, offset: 62698},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13954,25 +13957,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptGroupClause",
-			pos:  position{line: 2040, col: 1, offset: 62742},
+			pos:  position{line: 2040, col: 1, offset: 62743},
 			expr: &choiceExpr{
-				pos: position{line: 2041, col: 5, offset: 62761},
+				pos: position{line: 2041, col: 5, offset: 62762},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2041, col: 5, offset: 62761},
+						pos: position{line: 2041, col: 5, offset: 62762},
 						run: (*parser).callonOptGroupClause2,
 						expr: &seqExpr{
-							pos: position{line: 2041, col: 5, offset: 62761},
+							pos: position{line: 2041, col: 5, offset: 62762},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2041, col: 5, offset: 62761},
+									pos:  position{line: 2041, col: 5, offset: 62762},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2041, col: 7, offset: 62763},
+									pos:   position{line: 2041, col: 7, offset: 62764},
 									label: "group",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2041, col: 13, offset: 62769},
+										pos:  position{line: 2041, col: 13, offset: 62770},
 										name: "GroupClause",
 									},
 								},
@@ -13980,10 +13983,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2042, col: 5, offset: 62807},
+						pos: position{line: 2042, col: 5, offset: 62808},
 						run: (*parser).callonOptGroupClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2042, col: 5, offset: 62807},
+							pos:        position{line: 2042, col: 5, offset: 62808},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13996,34 +13999,34 @@ var g = &grammar{
 		},
 		{
 			name: "GroupClause",
-			pos:  position{line: 2044, col: 1, offset: 62848},
+			pos:  position{line: 2044, col: 1, offset: 62849},
 			expr: &actionExpr{
-				pos: position{line: 2045, col: 5, offset: 62864},
+				pos: position{line: 2045, col: 5, offset: 62865},
 				run: (*parser).callonGroupClause1,
 				expr: &seqExpr{
-					pos: position{line: 2045, col: 5, offset: 62864},
+					pos: position{line: 2045, col: 5, offset: 62865},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2045, col: 5, offset: 62864},
+							pos:  position{line: 2045, col: 5, offset: 62865},
 							name: "GROUP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2045, col: 11, offset: 62870},
+							pos:  position{line: 2045, col: 11, offset: 62871},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2045, col: 13, offset: 62872},
+							pos:  position{line: 2045, col: 13, offset: 62873},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2045, col: 16, offset: 62875},
+							pos:  position{line: 2045, col: 16, offset: 62876},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2045, col: 18, offset: 62877},
+							pos:   position{line: 2045, col: 18, offset: 62878},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2045, col: 23, offset: 62882},
+								pos:  position{line: 2045, col: 23, offset: 62883},
 								name: "GroupByList",
 							},
 						},
@@ -14035,51 +14038,51 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByList",
-			pos:  position{line: 2047, col: 1, offset: 62916},
+			pos:  position{line: 2047, col: 1, offset: 62917},
 			expr: &actionExpr{
-				pos: position{line: 2048, col: 5, offset: 62932},
+				pos: position{line: 2048, col: 5, offset: 62933},
 				run: (*parser).callonGroupByList1,
 				expr: &seqExpr{
-					pos: position{line: 2048, col: 5, offset: 62932},
+					pos: position{line: 2048, col: 5, offset: 62933},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2048, col: 5, offset: 62932},
+							pos:   position{line: 2048, col: 5, offset: 62933},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2048, col: 11, offset: 62938},
+								pos:  position{line: 2048, col: 11, offset: 62939},
 								name: "GroupByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2048, col: 23, offset: 62950},
+							pos:   position{line: 2048, col: 23, offset: 62951},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2048, col: 28, offset: 62955},
+								pos: position{line: 2048, col: 28, offset: 62956},
 								expr: &actionExpr{
-									pos: position{line: 2048, col: 30, offset: 62957},
+									pos: position{line: 2048, col: 30, offset: 62958},
 									run: (*parser).callonGroupByList7,
 									expr: &seqExpr{
-										pos: position{line: 2048, col: 30, offset: 62957},
+										pos: position{line: 2048, col: 30, offset: 62958},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2048, col: 30, offset: 62957},
+												pos:  position{line: 2048, col: 30, offset: 62958},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2048, col: 33, offset: 62960},
+												pos:        position{line: 2048, col: 33, offset: 62961},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2048, col: 37, offset: 62964},
+												pos:  position{line: 2048, col: 37, offset: 62965},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2048, col: 40, offset: 62967},
+												pos:   position{line: 2048, col: 40, offset: 62968},
 												label: "g",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2048, col: 42, offset: 62969},
+													pos:  position{line: 2048, col: 42, offset: 62970},
 													name: "GroupByItem",
 												},
 											},
@@ -14096,9 +14099,9 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByItem",
-			pos:  position{line: 2052, col: 1, offset: 63050},
+			pos:  position{line: 2052, col: 1, offset: 63051},
 			expr: &ruleRefExpr{
-				pos:  position{line: 2052, col: 15, offset: 63064},
+				pos:  position{line: 2052, col: 15, offset: 63065},
 				name: "Expr",
 			},
 			leader:        false,
@@ -14106,25 +14109,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptHavingClause",
-			pos:  position{line: 2054, col: 1, offset: 63070},
+			pos:  position{line: 2054, col: 1, offset: 63071},
 			expr: &choiceExpr{
-				pos: position{line: 2055, col: 5, offset: 63090},
+				pos: position{line: 2055, col: 5, offset: 63091},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2055, col: 5, offset: 63090},
+						pos: position{line: 2055, col: 5, offset: 63091},
 						run: (*parser).callonOptHavingClause2,
 						expr: &seqExpr{
-							pos: position{line: 2055, col: 5, offset: 63090},
+							pos: position{line: 2055, col: 5, offset: 63091},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2055, col: 5, offset: 63090},
+									pos:  position{line: 2055, col: 5, offset: 63091},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2055, col: 7, offset: 63092},
+									pos:   position{line: 2055, col: 7, offset: 63093},
 									label: "h",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2055, col: 9, offset: 63094},
+										pos:  position{line: 2055, col: 9, offset: 63095},
 										name: "HavingClause",
 									},
 								},
@@ -14132,10 +14135,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2056, col: 5, offset: 63129},
+						pos: position{line: 2056, col: 5, offset: 63130},
 						run: (*parser).callonOptHavingClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2056, col: 5, offset: 63129},
+							pos:        position{line: 2056, col: 5, offset: 63130},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14148,26 +14151,26 @@ var g = &grammar{
 		},
 		{
 			name: "HavingClause",
-			pos:  position{line: 2058, col: 1, offset: 63153},
+			pos:  position{line: 2058, col: 1, offset: 63154},
 			expr: &actionExpr{
-				pos: position{line: 2059, col: 5, offset: 63170},
+				pos: position{line: 2059, col: 5, offset: 63171},
 				run: (*parser).callonHavingClause1,
 				expr: &seqExpr{
-					pos: position{line: 2059, col: 5, offset: 63170},
+					pos: position{line: 2059, col: 5, offset: 63171},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2059, col: 5, offset: 63170},
+							pos:  position{line: 2059, col: 5, offset: 63171},
 							name: "HAVING",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2059, col: 12, offset: 63177},
+							pos:  position{line: 2059, col: 12, offset: 63178},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2059, col: 14, offset: 63179},
+							pos:   position{line: 2059, col: 14, offset: 63180},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2059, col: 16, offset: 63181},
+								pos:  position{line: 2059, col: 16, offset: 63182},
 								name: "Expr",
 							},
 						},
@@ -14179,49 +14182,49 @@ var g = &grammar{
 		},
 		{
 			name: "JoinOperation",
-			pos:  position{line: 2061, col: 1, offset: 63205},
+			pos:  position{line: 2061, col: 1, offset: 63206},
 			expr: &choiceExpr{
-				pos: position{line: 2062, col: 5, offset: 63223},
+				pos: position{line: 2062, col: 5, offset: 63224},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2062, col: 5, offset: 63223},
+						pos:  position{line: 2062, col: 5, offset: 63224},
 						name: "CrossJoin",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2063, col: 5, offset: 63237},
+						pos:  position{line: 2063, col: 5, offset: 63238},
 						name: "ConditionJoin",
 					},
 				},
 			},
-			leader:        false,
+			leader:        true,
 			leftRecursive: true,
 		},
 		{
 			name: "CrossJoin",
-			pos:  position{line: 2065, col: 1, offset: 63252},
+			pos:  position{line: 2065, col: 1, offset: 63253},
 			expr: &actionExpr{
-				pos: position{line: 2066, col: 5, offset: 63266},
+				pos: position{line: 2066, col: 5, offset: 63267},
 				run: (*parser).callonCrossJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2066, col: 5, offset: 63266},
+					pos: position{line: 2066, col: 5, offset: 63267},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2066, col: 5, offset: 63266},
+							pos:   position{line: 2066, col: 5, offset: 63267},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2066, col: 10, offset: 63271},
+								pos:  position{line: 2066, col: 10, offset: 63272},
 								name: "FromElem",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2066, col: 19, offset: 63280},
+							pos:  position{line: 2066, col: 19, offset: 63281},
 							name: "CrossJoinOp",
 						},
 						&labeledExpr{
-							pos:   position{line: 2066, col: 31, offset: 63292},
+							pos:   position{line: 2066, col: 31, offset: 63293},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2066, col: 37, offset: 63298},
+								pos:  position{line: 2066, col: 37, offset: 63299},
 								name: "FromElem",
 							},
 						},
@@ -14233,50 +14236,50 @@ var g = &grammar{
 		},
 		{
 			name: "CrossJoinOp",
-			pos:  position{line: 2075, col: 1, offset: 63506},
+			pos:  position{line: 2075, col: 1, offset: 63507},
 			expr: &choiceExpr{
-				pos: position{line: 2076, col: 5, offset: 63522},
+				pos: position{line: 2076, col: 5, offset: 63523},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 2076, col: 5, offset: 63522},
+						pos: position{line: 2076, col: 5, offset: 63523},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2076, col: 5, offset: 63522},
+								pos:  position{line: 2076, col: 5, offset: 63523},
 								name: "__",
 							},
 							&litMatcher{
-								pos:        position{line: 2076, col: 8, offset: 63525},
+								pos:        position{line: 2076, col: 8, offset: 63526},
 								val:        ",",
 								ignoreCase: false,
 								want:       "\",\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2076, col: 12, offset: 63529},
+								pos:  position{line: 2076, col: 12, offset: 63530},
 								name: "__",
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 2077, col: 5, offset: 63536},
+						pos: position{line: 2077, col: 5, offset: 63537},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2077, col: 5, offset: 63536},
+								pos:  position{line: 2077, col: 5, offset: 63537},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2077, col: 7, offset: 63538},
+								pos:  position{line: 2077, col: 7, offset: 63539},
 								name: "CROSS",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2077, col: 13, offset: 63544},
+								pos:  position{line: 2077, col: 13, offset: 63545},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2077, col: 15, offset: 63546},
+								pos:  position{line: 2077, col: 15, offset: 63547},
 								name: "JOIN",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2077, col: 20, offset: 63551},
+								pos:  position{line: 2077, col: 20, offset: 63552},
 								name: "_",
 							},
 						},
@@ -14288,50 +14291,50 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionJoin",
-			pos:  position{line: 2079, col: 1, offset: 63554},
+			pos:  position{line: 2079, col: 1, offset: 63555},
 			expr: &actionExpr{
-				pos: position{line: 2080, col: 5, offset: 63572},
+				pos: position{line: 2080, col: 5, offset: 63573},
 				run: (*parser).callonConditionJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2080, col: 5, offset: 63572},
+					pos: position{line: 2080, col: 5, offset: 63573},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2080, col: 5, offset: 63572},
+							pos:   position{line: 2080, col: 5, offset: 63573},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2080, col: 10, offset: 63577},
+								pos:  position{line: 2080, col: 10, offset: 63578},
 								name: "FromElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2080, col: 19, offset: 63586},
+							pos:   position{line: 2080, col: 19, offset: 63587},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2080, col: 25, offset: 63592},
+								pos:  position{line: 2080, col: 25, offset: 63593},
 								name: "SQLJoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2080, col: 38, offset: 63605},
+							pos:  position{line: 2080, col: 38, offset: 63606},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2080, col: 40, offset: 63607},
+							pos:   position{line: 2080, col: 40, offset: 63608},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2080, col: 46, offset: 63613},
+								pos:  position{line: 2080, col: 46, offset: 63614},
 								name: "FromElem",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2080, col: 55, offset: 63622},
+							pos:  position{line: 2080, col: 55, offset: 63623},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2080, col: 57, offset: 63624},
+							pos:   position{line: 2080, col: 57, offset: 63625},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2080, col: 59, offset: 63626},
+								pos:  position{line: 2080, col: 59, offset: 63627},
 								name: "JoinCond",
 							},
 						},
@@ -14343,161 +14346,161 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoinStyle",
-			pos:  position{line: 2091, col: 1, offset: 63895},
+			pos:  position{line: 2091, col: 1, offset: 63896},
 			expr: &choiceExpr{
-				pos: position{line: 2092, col: 5, offset: 63912},
+				pos: position{line: 2092, col: 5, offset: 63913},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2092, col: 5, offset: 63912},
+						pos: position{line: 2092, col: 5, offset: 63913},
 						run: (*parser).callonSQLJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 2092, col: 5, offset: 63912},
+							pos: position{line: 2092, col: 5, offset: 63913},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 2092, col: 5, offset: 63912},
+									pos: position{line: 2092, col: 5, offset: 63913},
 									expr: &seqExpr{
-										pos: position{line: 2092, col: 6, offset: 63913},
+										pos: position{line: 2092, col: 6, offset: 63914},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2092, col: 6, offset: 63913},
+												pos:  position{line: 2092, col: 6, offset: 63914},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2092, col: 8, offset: 63915},
+												pos:  position{line: 2092, col: 8, offset: 63916},
 												name: "INNER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2092, col: 16, offset: 63923},
+									pos:  position{line: 2092, col: 16, offset: 63924},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2092, col: 18, offset: 63925},
+									pos:  position{line: 2092, col: 18, offset: 63926},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2093, col: 5, offset: 63970},
+						pos: position{line: 2093, col: 5, offset: 63971},
 						run: (*parser).callonSQLJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 2093, col: 5, offset: 63970},
+							pos: position{line: 2093, col: 5, offset: 63971},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2093, col: 5, offset: 63970},
+									pos:  position{line: 2093, col: 5, offset: 63971},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2093, col: 7, offset: 63972},
+									pos:  position{line: 2093, col: 7, offset: 63973},
 									name: "FULL",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2093, col: 12, offset: 63977},
+									pos: position{line: 2093, col: 12, offset: 63978},
 									expr: &seqExpr{
-										pos: position{line: 2093, col: 13, offset: 63978},
+										pos: position{line: 2093, col: 13, offset: 63979},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2093, col: 13, offset: 63978},
+												pos:  position{line: 2093, col: 13, offset: 63979},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2093, col: 15, offset: 63980},
+												pos:  position{line: 2093, col: 15, offset: 63981},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2093, col: 23, offset: 63988},
+									pos:  position{line: 2093, col: 23, offset: 63989},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2093, col: 25, offset: 63990},
+									pos:  position{line: 2093, col: 25, offset: 63991},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2094, col: 5, offset: 64024},
+						pos: position{line: 2094, col: 5, offset: 64025},
 						run: (*parser).callonSQLJoinStyle20,
 						expr: &seqExpr{
-							pos: position{line: 2094, col: 5, offset: 64024},
+							pos: position{line: 2094, col: 5, offset: 64025},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2094, col: 5, offset: 64024},
+									pos:  position{line: 2094, col: 5, offset: 64025},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2094, col: 7, offset: 64026},
+									pos:  position{line: 2094, col: 7, offset: 64027},
 									name: "LEFT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2094, col: 12, offset: 64031},
+									pos: position{line: 2094, col: 12, offset: 64032},
 									expr: &seqExpr{
-										pos: position{line: 2094, col: 13, offset: 64032},
+										pos: position{line: 2094, col: 13, offset: 64033},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2094, col: 13, offset: 64032},
+												pos:  position{line: 2094, col: 13, offset: 64033},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2094, col: 15, offset: 64034},
+												pos:  position{line: 2094, col: 15, offset: 64035},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2094, col: 23, offset: 64042},
+									pos:  position{line: 2094, col: 23, offset: 64043},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2094, col: 25, offset: 64044},
+									pos:  position{line: 2094, col: 25, offset: 64045},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2095, col: 5, offset: 64078},
+						pos: position{line: 2095, col: 5, offset: 64079},
 						run: (*parser).callonSQLJoinStyle30,
 						expr: &seqExpr{
-							pos: position{line: 2095, col: 5, offset: 64078},
+							pos: position{line: 2095, col: 5, offset: 64079},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2095, col: 5, offset: 64078},
+									pos:  position{line: 2095, col: 5, offset: 64079},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2095, col: 7, offset: 64080},
+									pos:  position{line: 2095, col: 7, offset: 64081},
 									name: "RIGHT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2095, col: 13, offset: 64086},
+									pos: position{line: 2095, col: 13, offset: 64087},
 									expr: &seqExpr{
-										pos: position{line: 2095, col: 14, offset: 64087},
+										pos: position{line: 2095, col: 14, offset: 64088},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2095, col: 14, offset: 64087},
+												pos:  position{line: 2095, col: 14, offset: 64088},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2095, col: 16, offset: 64089},
+												pos:  position{line: 2095, col: 16, offset: 64090},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2095, col: 24, offset: 64097},
+									pos:  position{line: 2095, col: 24, offset: 64098},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2095, col: 26, offset: 64099},
+									pos:  position{line: 2095, col: 26, offset: 64100},
 									name: "JOIN",
 								},
 							},
@@ -14510,29 +14513,29 @@ var g = &grammar{
 		},
 		{
 			name: "JoinCond",
-			pos:  position{line: 2097, col: 1, offset: 64131},
+			pos:  position{line: 2097, col: 1, offset: 64132},
 			expr: &choiceExpr{
-				pos: position{line: 2098, col: 5, offset: 64144},
+				pos: position{line: 2098, col: 5, offset: 64145},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2098, col: 5, offset: 64144},
+						pos: position{line: 2098, col: 5, offset: 64145},
 						run: (*parser).callonJoinCond2,
 						expr: &seqExpr{
-							pos: position{line: 2098, col: 5, offset: 64144},
+							pos: position{line: 2098, col: 5, offset: 64145},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2098, col: 5, offset: 64144},
+									pos:  position{line: 2098, col: 5, offset: 64145},
 									name: "ON",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2098, col: 8, offset: 64147},
+									pos:  position{line: 2098, col: 8, offset: 64148},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2098, col: 10, offset: 64149},
+									pos:   position{line: 2098, col: 10, offset: 64150},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2098, col: 12, offset: 64151},
+										pos:  position{line: 2098, col: 12, offset: 64152},
 										name: "Expr",
 									},
 								},
@@ -14540,43 +14543,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2105, col: 5, offset: 64304},
+						pos: position{line: 2105, col: 5, offset: 64305},
 						run: (*parser).callonJoinCond8,
 						expr: &seqExpr{
-							pos: position{line: 2105, col: 5, offset: 64304},
+							pos: position{line: 2105, col: 5, offset: 64305},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2105, col: 5, offset: 64304},
+									pos:  position{line: 2105, col: 5, offset: 64305},
 									name: "USING",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2105, col: 11, offset: 64310},
+									pos:  position{line: 2105, col: 11, offset: 64311},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2105, col: 14, offset: 64313},
+									pos:        position{line: 2105, col: 14, offset: 64314},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2105, col: 18, offset: 64317},
+									pos:  position{line: 2105, col: 18, offset: 64318},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 2105, col: 21, offset: 64320},
+									pos:   position{line: 2105, col: 21, offset: 64321},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2105, col: 28, offset: 64327},
+										pos:  position{line: 2105, col: 28, offset: 64328},
 										name: "Lvals",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2105, col: 34, offset: 64333},
+									pos:  position{line: 2105, col: 34, offset: 64334},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2105, col: 37, offset: 64336},
+									pos:        position{line: 2105, col: 37, offset: 64337},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -14591,40 +14594,40 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrdinality",
-			pos:  position{line: 2113, col: 1, offset: 64506},
+			pos:  position{line: 2113, col: 1, offset: 64507},
 			expr: &choiceExpr{
-				pos: position{line: 2114, col: 5, offset: 64524},
+				pos: position{line: 2114, col: 5, offset: 64525},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2114, col: 5, offset: 64524},
+						pos: position{line: 2114, col: 5, offset: 64525},
 						run: (*parser).callonOptOrdinality2,
 						expr: &seqExpr{
-							pos: position{line: 2114, col: 5, offset: 64524},
+							pos: position{line: 2114, col: 5, offset: 64525},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2114, col: 5, offset: 64524},
+									pos:  position{line: 2114, col: 5, offset: 64525},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2114, col: 7, offset: 64526},
+									pos:  position{line: 2114, col: 7, offset: 64527},
 									name: "WITH",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2114, col: 12, offset: 64531},
+									pos:  position{line: 2114, col: 12, offset: 64532},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2114, col: 14, offset: 64533},
+									pos:  position{line: 2114, col: 14, offset: 64534},
 									name: "ORDINALITY",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2120, col: 5, offset: 64662},
+						pos: position{line: 2120, col: 5, offset: 64663},
 						run: (*parser).callonOptOrdinality8,
 						expr: &litMatcher{
-							pos:        position{line: 2120, col: 5, offset: 64662},
+							pos:        position{line: 2120, col: 5, offset: 64663},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14637,25 +14640,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAlias",
-			pos:  position{line: 2122, col: 1, offset: 64711},
+			pos:  position{line: 2122, col: 1, offset: 64712},
 			expr: &choiceExpr{
-				pos: position{line: 2123, col: 5, offset: 64724},
+				pos: position{line: 2123, col: 5, offset: 64725},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2123, col: 5, offset: 64724},
+						pos: position{line: 2123, col: 5, offset: 64725},
 						run: (*parser).callonOptAlias2,
 						expr: &seqExpr{
-							pos: position{line: 2123, col: 5, offset: 64724},
+							pos: position{line: 2123, col: 5, offset: 64725},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2123, col: 5, offset: 64724},
+									pos:  position{line: 2123, col: 5, offset: 64725},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2123, col: 7, offset: 64726},
+									pos:   position{line: 2123, col: 7, offset: 64727},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2123, col: 9, offset: 64728},
+										pos:  position{line: 2123, col: 9, offset: 64729},
 										name: "AliasClause",
 									},
 								},
@@ -14663,10 +14666,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2124, col: 5, offset: 64762},
+						pos: position{line: 2124, col: 5, offset: 64763},
 						run: (*parser).callonOptAlias7,
 						expr: &litMatcher{
-							pos:        position{line: 2124, col: 5, offset: 64762},
+							pos:        position{line: 2124, col: 5, offset: 64763},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14679,51 +14682,51 @@ var g = &grammar{
 		},
 		{
 			name: "AliasClause",
-			pos:  position{line: 2126, col: 1, offset: 64799},
+			pos:  position{line: 2126, col: 1, offset: 64800},
 			expr: &actionExpr{
-				pos: position{line: 2127, col: 4, offset: 64814},
+				pos: position{line: 2127, col: 4, offset: 64815},
 				run: (*parser).callonAliasClause1,
 				expr: &seqExpr{
-					pos: position{line: 2127, col: 4, offset: 64814},
+					pos: position{line: 2127, col: 4, offset: 64815},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2127, col: 4, offset: 64814},
+							pos: position{line: 2127, col: 4, offset: 64815},
 							expr: &seqExpr{
-								pos: position{line: 2127, col: 5, offset: 64815},
+								pos: position{line: 2127, col: 5, offset: 64816},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2127, col: 5, offset: 64815},
+										pos:  position{line: 2127, col: 5, offset: 64816},
 										name: "AS",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2127, col: 8, offset: 64818},
+										pos:  position{line: 2127, col: 8, offset: 64819},
 										name: "_",
 									},
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 2127, col: 12, offset: 64822},
+							pos: position{line: 2127, col: 12, offset: 64823},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2127, col: 13, offset: 64823},
+								pos:  position{line: 2127, col: 13, offset: 64824},
 								name: "SQLGuard",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2127, col: 22, offset: 64832},
+							pos:   position{line: 2127, col: 22, offset: 64833},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2127, col: 27, offset: 64837},
+								pos:  position{line: 2127, col: 27, offset: 64838},
 								name: "IdentifierName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2127, col: 42, offset: 64852},
+							pos:   position{line: 2127, col: 42, offset: 64853},
 							label: "cols",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2127, col: 47, offset: 64857},
+								pos: position{line: 2127, col: 47, offset: 64858},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2127, col: 47, offset: 64857},
+									pos:  position{line: 2127, col: 47, offset: 64858},
 									name: "Columns",
 								},
 							},
@@ -14736,65 +14739,65 @@ var g = &grammar{
 		},
 		{
 			name: "Columns",
-			pos:  position{line: 2135, col: 1, offset: 65056},
+			pos:  position{line: 2135, col: 1, offset: 65057},
 			expr: &actionExpr{
-				pos: position{line: 2136, col: 5, offset: 65068},
+				pos: position{line: 2136, col: 5, offset: 65069},
 				run: (*parser).callonColumns1,
 				expr: &seqExpr{
-					pos: position{line: 2136, col: 5, offset: 65068},
+					pos: position{line: 2136, col: 5, offset: 65069},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2136, col: 5, offset: 65068},
+							pos:  position{line: 2136, col: 5, offset: 65069},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2136, col: 8, offset: 65071},
+							pos:        position{line: 2136, col: 8, offset: 65072},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2136, col: 12, offset: 65075},
+							pos:  position{line: 2136, col: 12, offset: 65076},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2136, col: 15, offset: 65078},
+							pos:   position{line: 2136, col: 15, offset: 65079},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2136, col: 21, offset: 65084},
+								pos:  position{line: 2136, col: 21, offset: 65085},
 								name: "SQLIdentifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2136, col: 35, offset: 65098},
+							pos:   position{line: 2136, col: 35, offset: 65099},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2136, col: 40, offset: 65103},
+								pos: position{line: 2136, col: 40, offset: 65104},
 								expr: &actionExpr{
-									pos: position{line: 2136, col: 42, offset: 65105},
+									pos: position{line: 2136, col: 42, offset: 65106},
 									run: (*parser).callonColumns10,
 									expr: &seqExpr{
-										pos: position{line: 2136, col: 42, offset: 65105},
+										pos: position{line: 2136, col: 42, offset: 65106},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2136, col: 42, offset: 65105},
+												pos:  position{line: 2136, col: 42, offset: 65106},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2136, col: 45, offset: 65108},
+												pos:        position{line: 2136, col: 45, offset: 65109},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2136, col: 49, offset: 65112},
+												pos:  position{line: 2136, col: 49, offset: 65113},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2136, col: 52, offset: 65115},
+												pos:   position{line: 2136, col: 52, offset: 65116},
 												label: "s",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2136, col: 54, offset: 65117},
+													pos:  position{line: 2136, col: 54, offset: 65118},
 													name: "SQLIdentifier",
 												},
 											},
@@ -14804,11 +14807,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2136, col: 87, offset: 65150},
+							pos:  position{line: 2136, col: 87, offset: 65151},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2136, col: 90, offset: 65153},
+							pos:        position{line: 2136, col: 90, offset: 65154},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -14821,51 +14824,51 @@ var g = &grammar{
 		},
 		{
 			name: "Selection",
-			pos:  position{line: 2140, col: 1, offset: 65224},
+			pos:  position{line: 2140, col: 1, offset: 65225},
 			expr: &actionExpr{
-				pos: position{line: 2141, col: 5, offset: 65238},
+				pos: position{line: 2141, col: 5, offset: 65239},
 				run: (*parser).callonSelection1,
 				expr: &seqExpr{
-					pos: position{line: 2141, col: 5, offset: 65238},
+					pos: position{line: 2141, col: 5, offset: 65239},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2141, col: 5, offset: 65238},
+							pos:   position{line: 2141, col: 5, offset: 65239},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2141, col: 11, offset: 65244},
+								pos:  position{line: 2141, col: 11, offset: 65245},
 								name: "SelectElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2141, col: 22, offset: 65255},
+							pos:   position{line: 2141, col: 22, offset: 65256},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2141, col: 27, offset: 65260},
+								pos: position{line: 2141, col: 27, offset: 65261},
 								expr: &actionExpr{
-									pos: position{line: 2141, col: 29, offset: 65262},
+									pos: position{line: 2141, col: 29, offset: 65263},
 									run: (*parser).callonSelection7,
 									expr: &seqExpr{
-										pos: position{line: 2141, col: 29, offset: 65262},
+										pos: position{line: 2141, col: 29, offset: 65263},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2141, col: 29, offset: 65262},
+												pos:  position{line: 2141, col: 29, offset: 65263},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2141, col: 32, offset: 65265},
+												pos:        position{line: 2141, col: 32, offset: 65266},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2141, col: 36, offset: 65269},
+												pos:  position{line: 2141, col: 36, offset: 65270},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2141, col: 39, offset: 65272},
+												pos:   position{line: 2141, col: 39, offset: 65273},
 												label: "s",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2141, col: 41, offset: 65274},
+													pos:  position{line: 2141, col: 41, offset: 65275},
 													name: "SelectElem",
 												},
 											},
@@ -14882,38 +14885,38 @@ var g = &grammar{
 		},
 		{
 			name: "SelectElem",
-			pos:  position{line: 2150, col: 1, offset: 65509},
+			pos:  position{line: 2150, col: 1, offset: 65510},
 			expr: &choiceExpr{
-				pos: position{line: 2151, col: 5, offset: 65524},
+				pos: position{line: 2151, col: 5, offset: 65525},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2151, col: 5, offset: 65524},
+						pos: position{line: 2151, col: 5, offset: 65525},
 						run: (*parser).callonSelectElem2,
 						expr: &seqExpr{
-							pos: position{line: 2151, col: 5, offset: 65524},
+							pos: position{line: 2151, col: 5, offset: 65525},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2151, col: 5, offset: 65524},
+									pos:   position{line: 2151, col: 5, offset: 65525},
 									label: "expr",
 									expr: &choiceExpr{
-										pos: position{line: 2151, col: 11, offset: 65530},
+										pos: position{line: 2151, col: 11, offset: 65531},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2151, col: 11, offset: 65530},
+												pos:  position{line: 2151, col: 11, offset: 65531},
 												name: "AggDistinct",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2151, col: 25, offset: 65544},
+												pos:  position{line: 2151, col: 25, offset: 65545},
 												name: "Expr",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2151, col: 31, offset: 65550},
+									pos:   position{line: 2151, col: 31, offset: 65551},
 									label: "as",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2151, col: 34, offset: 65553},
+										pos:  position{line: 2151, col: 34, offset: 65554},
 										name: "OptAsClause",
 									},
 								},
@@ -14921,10 +14924,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2162, col: 5, offset: 65781},
+						pos: position{line: 2162, col: 5, offset: 65782},
 						run: (*parser).callonSelectElem10,
 						expr: &litMatcher{
-							pos:        position{line: 2162, col: 5, offset: 65781},
+							pos:        position{line: 2162, col: 5, offset: 65782},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -14937,33 +14940,33 @@ var g = &grammar{
 		},
 		{
 			name: "OptAsClause",
-			pos:  position{line: 2167, col: 1, offset: 65886},
+			pos:  position{line: 2167, col: 1, offset: 65887},
 			expr: &choiceExpr{
-				pos: position{line: 2168, col: 5, offset: 65902},
+				pos: position{line: 2168, col: 5, offset: 65903},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2168, col: 5, offset: 65902},
+						pos: position{line: 2168, col: 5, offset: 65903},
 						run: (*parser).callonOptAsClause2,
 						expr: &seqExpr{
-							pos: position{line: 2168, col: 5, offset: 65902},
+							pos: position{line: 2168, col: 5, offset: 65903},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2168, col: 5, offset: 65902},
+									pos:  position{line: 2168, col: 5, offset: 65903},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2168, col: 7, offset: 65904},
+									pos:  position{line: 2168, col: 7, offset: 65905},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2168, col: 10, offset: 65907},
+									pos:  position{line: 2168, col: 10, offset: 65908},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2168, col: 12, offset: 65909},
+									pos:   position{line: 2168, col: 12, offset: 65910},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2168, col: 15, offset: 65912},
+										pos:  position{line: 2168, col: 15, offset: 65913},
 										name: "SQLIdentifier",
 									},
 								},
@@ -14971,27 +14974,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2169, col: 5, offset: 65949},
+						pos: position{line: 2169, col: 5, offset: 65950},
 						run: (*parser).callonOptAsClause9,
 						expr: &seqExpr{
-							pos: position{line: 2169, col: 5, offset: 65949},
+							pos: position{line: 2169, col: 5, offset: 65950},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2169, col: 5, offset: 65949},
+									pos:  position{line: 2169, col: 5, offset: 65950},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 2169, col: 7, offset: 65951},
+									pos: position{line: 2169, col: 7, offset: 65952},
 									expr: &ruleRefExpr{
-										pos:  position{line: 2169, col: 8, offset: 65952},
+										pos:  position{line: 2169, col: 8, offset: 65953},
 										name: "SQLGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2169, col: 17, offset: 65961},
+									pos:   position{line: 2169, col: 17, offset: 65962},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2169, col: 20, offset: 65964},
+										pos:  position{line: 2169, col: 20, offset: 65965},
 										name: "SQLIdentifier",
 									},
 								},
@@ -14999,10 +15002,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2170, col: 5, offset: 66001},
+						pos: position{line: 2170, col: 5, offset: 66002},
 						run: (*parser).callonOptAsClause16,
 						expr: &litMatcher{
-							pos:        position{line: 2170, col: 5, offset: 66001},
+							pos:        position{line: 2170, col: 5, offset: 66002},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15015,41 +15018,41 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrderByClause",
-			pos:  position{line: 2172, col: 1, offset: 66026},
+			pos:  position{line: 2172, col: 1, offset: 66027},
 			expr: &choiceExpr{
-				pos: position{line: 2173, col: 5, offset: 66047},
+				pos: position{line: 2173, col: 5, offset: 66048},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2173, col: 5, offset: 66047},
+						pos: position{line: 2173, col: 5, offset: 66048},
 						run: (*parser).callonOptOrderByClause2,
 						expr: &seqExpr{
-							pos: position{line: 2173, col: 5, offset: 66047},
+							pos: position{line: 2173, col: 5, offset: 66048},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2173, col: 5, offset: 66047},
+									pos:  position{line: 2173, col: 5, offset: 66048},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2173, col: 7, offset: 66049},
+									pos:  position{line: 2173, col: 7, offset: 66050},
 									name: "ORDER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2173, col: 13, offset: 66055},
+									pos:  position{line: 2173, col: 13, offset: 66056},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2173, col: 15, offset: 66057},
+									pos:  position{line: 2173, col: 15, offset: 66058},
 									name: "BY",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2173, col: 18, offset: 66060},
+									pos:  position{line: 2173, col: 18, offset: 66061},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2173, col: 20, offset: 66062},
+									pos:   position{line: 2173, col: 20, offset: 66063},
 									label: "list",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2173, col: 25, offset: 66067},
+										pos:  position{line: 2173, col: 25, offset: 66068},
 										name: "OrderByList",
 									},
 								},
@@ -15057,10 +15060,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2180, col: 5, offset: 66231},
+						pos: position{line: 2180, col: 5, offset: 66232},
 						run: (*parser).callonOptOrderByClause11,
 						expr: &litMatcher{
-							pos:        position{line: 2180, col: 5, offset: 66231},
+							pos:        position{line: 2180, col: 5, offset: 66232},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15073,51 +15076,51 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByList",
-			pos:  position{line: 2182, col: 1, offset: 66264},
+			pos:  position{line: 2182, col: 1, offset: 66265},
 			expr: &actionExpr{
-				pos: position{line: 2183, col: 5, offset: 66280},
+				pos: position{line: 2183, col: 5, offset: 66281},
 				run: (*parser).callonOrderByList1,
 				expr: &seqExpr{
-					pos: position{line: 2183, col: 5, offset: 66280},
+					pos: position{line: 2183, col: 5, offset: 66281},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2183, col: 5, offset: 66280},
+							pos:   position{line: 2183, col: 5, offset: 66281},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2183, col: 11, offset: 66286},
+								pos:  position{line: 2183, col: 11, offset: 66287},
 								name: "OrderByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2183, col: 23, offset: 66298},
+							pos:   position{line: 2183, col: 23, offset: 66299},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2183, col: 28, offset: 66303},
+								pos: position{line: 2183, col: 28, offset: 66304},
 								expr: &actionExpr{
-									pos: position{line: 2183, col: 30, offset: 66305},
+									pos: position{line: 2183, col: 30, offset: 66306},
 									run: (*parser).callonOrderByList7,
 									expr: &seqExpr{
-										pos: position{line: 2183, col: 30, offset: 66305},
+										pos: position{line: 2183, col: 30, offset: 66306},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2183, col: 30, offset: 66305},
+												pos:  position{line: 2183, col: 30, offset: 66306},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2183, col: 33, offset: 66308},
+												pos:        position{line: 2183, col: 33, offset: 66309},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2183, col: 37, offset: 66312},
+												pos:  position{line: 2183, col: 37, offset: 66313},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2183, col: 40, offset: 66315},
+												pos:   position{line: 2183, col: 40, offset: 66316},
 												label: "o",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2183, col: 42, offset: 66317},
+													pos:  position{line: 2183, col: 42, offset: 66318},
 													name: "OrderByItem",
 												},
 											},
@@ -15134,34 +15137,34 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByItem",
-			pos:  position{line: 2187, col: 1, offset: 66418},
+			pos:  position{line: 2187, col: 1, offset: 66419},
 			expr: &actionExpr{
-				pos: position{line: 2188, col: 5, offset: 66434},
+				pos: position{line: 2188, col: 5, offset: 66435},
 				run: (*parser).callonOrderByItem1,
 				expr: &seqExpr{
-					pos: position{line: 2188, col: 5, offset: 66434},
+					pos: position{line: 2188, col: 5, offset: 66435},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2188, col: 5, offset: 66434},
+							pos:   position{line: 2188, col: 5, offset: 66435},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2188, col: 7, offset: 66436},
+								pos:  position{line: 2188, col: 7, offset: 66437},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2188, col: 12, offset: 66441},
+							pos:   position{line: 2188, col: 12, offset: 66442},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2188, col: 18, offset: 66447},
+								pos:  position{line: 2188, col: 18, offset: 66448},
 								name: "OptAscDesc",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2188, col: 29, offset: 66458},
+							pos:   position{line: 2188, col: 29, offset: 66459},
 							label: "nulls",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2188, col: 35, offset: 66464},
+								pos:  position{line: 2188, col: 35, offset: 66465},
 								name: "OptNullsOrder",
 							},
 						},
@@ -15173,49 +15176,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptAscDesc",
-			pos:  position{line: 2199, col: 1, offset: 66714},
+			pos:  position{line: 2199, col: 1, offset: 66715},
 			expr: &choiceExpr{
-				pos: position{line: 2200, col: 5, offset: 66729},
+				pos: position{line: 2200, col: 5, offset: 66730},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2200, col: 5, offset: 66729},
+						pos: position{line: 2200, col: 5, offset: 66730},
 						run: (*parser).callonOptAscDesc2,
 						expr: &seqExpr{
-							pos: position{line: 2200, col: 5, offset: 66729},
+							pos: position{line: 2200, col: 5, offset: 66730},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2200, col: 5, offset: 66729},
+									pos:  position{line: 2200, col: 5, offset: 66730},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2200, col: 7, offset: 66731},
+									pos:  position{line: 2200, col: 7, offset: 66732},
 									name: "ASC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2201, col: 5, offset: 66803},
+						pos: position{line: 2201, col: 5, offset: 66804},
 						run: (*parser).callonOptAscDesc6,
 						expr: &seqExpr{
-							pos: position{line: 2201, col: 5, offset: 66803},
+							pos: position{line: 2201, col: 5, offset: 66804},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2201, col: 5, offset: 66803},
+									pos:  position{line: 2201, col: 5, offset: 66804},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2201, col: 7, offset: 66805},
+									pos:  position{line: 2201, col: 7, offset: 66806},
 									name: "DESC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2202, col: 5, offset: 66877},
+						pos: position{line: 2202, col: 5, offset: 66878},
 						run: (*parser).callonOptAscDesc10,
 						expr: &litMatcher{
-							pos:        position{line: 2202, col: 5, offset: 66877},
+							pos:        position{line: 2202, col: 5, offset: 66878},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15228,65 +15231,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptNullsOrder",
-			pos:  position{line: 2204, col: 1, offset: 66909},
+			pos:  position{line: 2204, col: 1, offset: 66910},
 			expr: &choiceExpr{
-				pos: position{line: 2205, col: 5, offset: 66927},
+				pos: position{line: 2205, col: 5, offset: 66928},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2205, col: 5, offset: 66927},
+						pos: position{line: 2205, col: 5, offset: 66928},
 						run: (*parser).callonOptNullsOrder2,
 						expr: &seqExpr{
-							pos: position{line: 2205, col: 5, offset: 66927},
+							pos: position{line: 2205, col: 5, offset: 66928},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2205, col: 5, offset: 66927},
+									pos:  position{line: 2205, col: 5, offset: 66928},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2205, col: 7, offset: 66929},
+									pos:  position{line: 2205, col: 7, offset: 66930},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2205, col: 13, offset: 66935},
+									pos:  position{line: 2205, col: 13, offset: 66936},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2205, col: 15, offset: 66937},
+									pos:  position{line: 2205, col: 15, offset: 66938},
 									name: "FIRST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2206, col: 5, offset: 67013},
+						pos: position{line: 2206, col: 5, offset: 67014},
 						run: (*parser).callonOptNullsOrder8,
 						expr: &seqExpr{
-							pos: position{line: 2206, col: 5, offset: 67013},
+							pos: position{line: 2206, col: 5, offset: 67014},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2206, col: 5, offset: 67013},
+									pos:  position{line: 2206, col: 5, offset: 67014},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2206, col: 7, offset: 67015},
+									pos:  position{line: 2206, col: 7, offset: 67016},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2206, col: 13, offset: 67021},
+									pos:  position{line: 2206, col: 13, offset: 67022},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2206, col: 15, offset: 67023},
+									pos:  position{line: 2206, col: 15, offset: 67024},
 									name: "LAST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2207, col: 5, offset: 67098},
+						pos: position{line: 2207, col: 5, offset: 67099},
 						run: (*parser).callonOptNullsOrder14,
 						expr: &litMatcher{
-							pos:        position{line: 2207, col: 5, offset: 67098},
+							pos:        position{line: 2207, col: 5, offset: 67099},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15299,25 +15302,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptSQLLimitOffset",
-			pos:  position{line: 2209, col: 1, offset: 67143},
+			pos:  position{line: 2209, col: 1, offset: 67144},
 			expr: &choiceExpr{
-				pos: position{line: 2210, col: 5, offset: 67165},
+				pos: position{line: 2210, col: 5, offset: 67166},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2210, col: 5, offset: 67165},
+						pos: position{line: 2210, col: 5, offset: 67166},
 						run: (*parser).callonOptSQLLimitOffset2,
 						expr: &seqExpr{
-							pos: position{line: 2210, col: 5, offset: 67165},
+							pos: position{line: 2210, col: 5, offset: 67166},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2210, col: 5, offset: 67165},
+									pos:  position{line: 2210, col: 5, offset: 67166},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2210, col: 7, offset: 67167},
+									pos:   position{line: 2210, col: 7, offset: 67168},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2210, col: 10, offset: 67170},
+										pos:  position{line: 2210, col: 10, offset: 67171},
 										name: "SQLLimitOffset",
 									},
 								},
@@ -15325,10 +15328,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2211, col: 5, offset: 67208},
+						pos: position{line: 2211, col: 5, offset: 67209},
 						run: (*parser).callonOptSQLLimitOffset7,
 						expr: &litMatcher{
-							pos:        position{line: 2211, col: 5, offset: 67208},
+							pos:        position{line: 2211, col: 5, offset: 67209},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15341,29 +15344,29 @@ var g = &grammar{
 		},
 		{
 			name: "SQLLimitOffset",
-			pos:  position{line: 2213, col: 1, offset: 67249},
+			pos:  position{line: 2213, col: 1, offset: 67250},
 			expr: &choiceExpr{
-				pos: position{line: 2214, col: 5, offset: 67268},
+				pos: position{line: 2214, col: 5, offset: 67269},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2214, col: 5, offset: 67268},
+						pos: position{line: 2214, col: 5, offset: 67269},
 						run: (*parser).callonSQLLimitOffset2,
 						expr: &seqExpr{
-							pos: position{line: 2214, col: 5, offset: 67268},
+							pos: position{line: 2214, col: 5, offset: 67269},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2214, col: 5, offset: 67268},
+									pos:   position{line: 2214, col: 5, offset: 67269},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2214, col: 7, offset: 67270},
+										pos:  position{line: 2214, col: 7, offset: 67271},
 										name: "LimitClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2214, col: 19, offset: 67282},
+									pos:   position{line: 2214, col: 19, offset: 67283},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2214, col: 21, offset: 67284},
+										pos:  position{line: 2214, col: 21, offset: 67285},
 										name: "OptOffsetClause",
 									},
 								},
@@ -15371,24 +15374,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2227, col: 5, offset: 67548},
+						pos: position{line: 2227, col: 5, offset: 67549},
 						run: (*parser).callonSQLLimitOffset8,
 						expr: &seqExpr{
-							pos: position{line: 2227, col: 5, offset: 67548},
+							pos: position{line: 2227, col: 5, offset: 67549},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2227, col: 5, offset: 67548},
+									pos:   position{line: 2227, col: 5, offset: 67549},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2227, col: 7, offset: 67550},
+										pos:  position{line: 2227, col: 7, offset: 67551},
 										name: "OffsetClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2227, col: 20, offset: 67563},
+									pos:   position{line: 2227, col: 20, offset: 67564},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2227, col: 22, offset: 67565},
+										pos:  position{line: 2227, col: 22, offset: 67566},
 										name: "OptLimitClause",
 									},
 								},
@@ -15402,25 +15405,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptLimitClause",
-			pos:  position{line: 2239, col: 1, offset: 67794},
+			pos:  position{line: 2239, col: 1, offset: 67795},
 			expr: &choiceExpr{
-				pos: position{line: 2240, col: 5, offset: 67813},
+				pos: position{line: 2240, col: 5, offset: 67814},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2240, col: 5, offset: 67813},
+						pos: position{line: 2240, col: 5, offset: 67814},
 						run: (*parser).callonOptLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2240, col: 5, offset: 67813},
+							pos: position{line: 2240, col: 5, offset: 67814},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2240, col: 5, offset: 67813},
+									pos:  position{line: 2240, col: 5, offset: 67814},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2240, col: 7, offset: 67815},
+									pos:   position{line: 2240, col: 7, offset: 67816},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2240, col: 9, offset: 67817},
+										pos:  position{line: 2240, col: 9, offset: 67818},
 										name: "LimitClause",
 									},
 								},
@@ -15428,10 +15431,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2241, col: 5, offset: 67851},
+						pos: position{line: 2241, col: 5, offset: 67852},
 						run: (*parser).callonOptLimitClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2241, col: 5, offset: 67851},
+							pos:        position{line: 2241, col: 5, offset: 67852},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15444,50 +15447,50 @@ var g = &grammar{
 		},
 		{
 			name: "LimitClause",
-			pos:  position{line: 2243, col: 1, offset: 67888},
+			pos:  position{line: 2243, col: 1, offset: 67889},
 			expr: &choiceExpr{
-				pos: position{line: 2244, col: 5, offset: 67904},
+				pos: position{line: 2244, col: 5, offset: 67905},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2244, col: 5, offset: 67904},
+						pos: position{line: 2244, col: 5, offset: 67905},
 						run: (*parser).callonLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2244, col: 5, offset: 67904},
+							pos: position{line: 2244, col: 5, offset: 67905},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2244, col: 5, offset: 67904},
+									pos:  position{line: 2244, col: 5, offset: 67905},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2244, col: 11, offset: 67910},
+									pos:  position{line: 2244, col: 11, offset: 67911},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2244, col: 13, offset: 67912},
+									pos:  position{line: 2244, col: 13, offset: 67913},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2245, col: 5, offset: 67940},
+						pos: position{line: 2245, col: 5, offset: 67941},
 						run: (*parser).callonLimitClause7,
 						expr: &seqExpr{
-							pos: position{line: 2245, col: 5, offset: 67940},
+							pos: position{line: 2245, col: 5, offset: 67941},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2245, col: 5, offset: 67940},
+									pos:  position{line: 2245, col: 5, offset: 67941},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2245, col: 11, offset: 67946},
+									pos:  position{line: 2245, col: 11, offset: 67947},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2245, col: 13, offset: 67948},
+									pos:   position{line: 2245, col: 13, offset: 67949},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2245, col: 15, offset: 67950},
+										pos:  position{line: 2245, col: 15, offset: 67951},
 										name: "Expr",
 									},
 								},
@@ -15501,25 +15504,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptOffsetClause",
-			pos:  position{line: 2247, col: 1, offset: 67974},
+			pos:  position{line: 2247, col: 1, offset: 67975},
 			expr: &choiceExpr{
-				pos: position{line: 2248, col: 5, offset: 67994},
+				pos: position{line: 2248, col: 5, offset: 67995},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2248, col: 5, offset: 67994},
+						pos: position{line: 2248, col: 5, offset: 67995},
 						run: (*parser).callonOptOffsetClause2,
 						expr: &seqExpr{
-							pos: position{line: 2248, col: 5, offset: 67994},
+							pos: position{line: 2248, col: 5, offset: 67995},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2248, col: 5, offset: 67994},
+									pos:  position{line: 2248, col: 5, offset: 67995},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2248, col: 7, offset: 67996},
+									pos:   position{line: 2248, col: 7, offset: 67997},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2248, col: 9, offset: 67998},
+										pos:  position{line: 2248, col: 9, offset: 67999},
 										name: "OffsetClause",
 									},
 								},
@@ -15527,10 +15530,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2249, col: 5, offset: 68034},
+						pos: position{line: 2249, col: 5, offset: 68035},
 						run: (*parser).callonOptOffsetClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2249, col: 5, offset: 68034},
+							pos:        position{line: 2249, col: 5, offset: 68035},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15543,26 +15546,26 @@ var g = &grammar{
 		},
 		{
 			name: "OffsetClause",
-			pos:  position{line: 2251, col: 1, offset: 68059},
+			pos:  position{line: 2251, col: 1, offset: 68060},
 			expr: &actionExpr{
-				pos: position{line: 2252, col: 5, offset: 68076},
+				pos: position{line: 2252, col: 5, offset: 68077},
 				run: (*parser).callonOffsetClause1,
 				expr: &seqExpr{
-					pos: position{line: 2252, col: 5, offset: 68076},
+					pos: position{line: 2252, col: 5, offset: 68077},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2252, col: 5, offset: 68076},
+							pos:  position{line: 2252, col: 5, offset: 68077},
 							name: "OFFSET",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2252, col: 12, offset: 68083},
+							pos:  position{line: 2252, col: 12, offset: 68084},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2252, col: 14, offset: 68085},
+							pos:   position{line: 2252, col: 14, offset: 68086},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2252, col: 16, offset: 68087},
+								pos:  position{line: 2252, col: 16, offset: 68088},
 								name: "Expr",
 							},
 						},
@@ -15574,38 +15577,38 @@ var g = &grammar{
 		},
 		{
 			name: "SetOperation",
-			pos:  position{line: 2254, col: 1, offset: 68112},
+			pos:  position{line: 2254, col: 1, offset: 68113},
 			expr: &actionExpr{
-				pos: position{line: 2255, col: 5, offset: 68129},
+				pos: position{line: 2255, col: 5, offset: 68130},
 				run: (*parser).callonSetOperation1,
 				expr: &seqExpr{
-					pos: position{line: 2255, col: 5, offset: 68129},
+					pos: position{line: 2255, col: 5, offset: 68130},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2255, col: 5, offset: 68129},
+							pos:   position{line: 2255, col: 5, offset: 68130},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2255, col: 10, offset: 68134},
+								pos:  position{line: 2255, col: 10, offset: 68135},
 								name: "SelectExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2255, col: 21, offset: 68145},
+							pos:   position{line: 2255, col: 21, offset: 68146},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2255, col: 30, offset: 68154},
+								pos:  position{line: 2255, col: 30, offset: 68155},
 								name: "SetOp",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2255, col: 36, offset: 68160},
+							pos:  position{line: 2255, col: 36, offset: 68161},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2255, col: 38, offset: 68162},
+							pos:   position{line: 2255, col: 38, offset: 68163},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2255, col: 44, offset: 68168},
+								pos:  position{line: 2255, col: 44, offset: 68169},
 								name: "SelectExpr",
 							},
 						},
@@ -15617,60 +15620,60 @@ var g = &grammar{
 		},
 		{
 			name: "SetOp",
-			pos:  position{line: 2265, col: 1, offset: 68395},
+			pos:  position{line: 2265, col: 1, offset: 68396},
 			expr: &choiceExpr{
-				pos: position{line: 2266, col: 5, offset: 68405},
+				pos: position{line: 2266, col: 5, offset: 68406},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2266, col: 5, offset: 68405},
+						pos: position{line: 2266, col: 5, offset: 68406},
 						run: (*parser).callonSetOp2,
 						expr: &seqExpr{
-							pos: position{line: 2266, col: 5, offset: 68405},
+							pos: position{line: 2266, col: 5, offset: 68406},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2266, col: 5, offset: 68405},
+									pos:  position{line: 2266, col: 5, offset: 68406},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2266, col: 7, offset: 68407},
+									pos:  position{line: 2266, col: 7, offset: 68408},
 									name: "UNION",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2266, col: 13, offset: 68413},
+									pos:  position{line: 2266, col: 13, offset: 68414},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2266, col: 15, offset: 68415},
+									pos:  position{line: 2266, col: 15, offset: 68416},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2267, col: 5, offset: 68451},
+						pos: position{line: 2267, col: 5, offset: 68452},
 						run: (*parser).callonSetOp8,
 						expr: &seqExpr{
-							pos: position{line: 2267, col: 5, offset: 68451},
+							pos: position{line: 2267, col: 5, offset: 68452},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2267, col: 5, offset: 68451},
+									pos:  position{line: 2267, col: 5, offset: 68452},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2267, col: 7, offset: 68453},
+									pos:  position{line: 2267, col: 7, offset: 68454},
 									name: "UNION",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2267, col: 13, offset: 68459},
+									pos: position{line: 2267, col: 13, offset: 68460},
 									expr: &seqExpr{
-										pos: position{line: 2267, col: 14, offset: 68460},
+										pos: position{line: 2267, col: 14, offset: 68461},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2267, col: 14, offset: 68460},
+												pos:  position{line: 2267, col: 14, offset: 68461},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2267, col: 16, offset: 68462},
+												pos:  position{line: 2267, col: 16, offset: 68463},
 												name: "DISTINCT",
 											},
 										},
@@ -15686,84 +15689,84 @@ var g = &grammar{
 		},
 		{
 			name: "SQLGuard",
-			pos:  position{line: 2270, col: 1, offset: 68514},
+			pos:  position{line: 2270, col: 1, offset: 68515},
 			expr: &choiceExpr{
-				pos: position{line: 2271, col: 5, offset: 68529},
+				pos: position{line: 2271, col: 5, offset: 68530},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2271, col: 5, offset: 68529},
+						pos:  position{line: 2271, col: 5, offset: 68530},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2271, col: 12, offset: 68536},
+						pos:  position{line: 2271, col: 12, offset: 68537},
 						name: "GROUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2271, col: 20, offset: 68544},
+						pos:  position{line: 2271, col: 20, offset: 68545},
 						name: "HAVING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2271, col: 29, offset: 68553},
+						pos:  position{line: 2271, col: 29, offset: 68554},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2271, col: 38, offset: 68562},
+						pos:  position{line: 2271, col: 38, offset: 68563},
 						name: "RECURSIVE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2272, col: 5, offset: 68576},
+						pos:  position{line: 2272, col: 5, offset: 68577},
 						name: "INNER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2272, col: 13, offset: 68584},
+						pos:  position{line: 2272, col: 13, offset: 68585},
 						name: "LEFT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2272, col: 20, offset: 68591},
+						pos:  position{line: 2272, col: 20, offset: 68592},
 						name: "RIGHT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2272, col: 28, offset: 68599},
+						pos:  position{line: 2272, col: 28, offset: 68600},
 						name: "OUTER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2272, col: 36, offset: 68607},
+						pos:  position{line: 2272, col: 36, offset: 68608},
 						name: "CROSS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2272, col: 44, offset: 68615},
+						pos:  position{line: 2272, col: 44, offset: 68616},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2273, col: 5, offset: 68624},
+						pos:  position{line: 2273, col: 5, offset: 68625},
 						name: "UNION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2274, col: 5, offset: 68634},
+						pos:  position{line: 2274, col: 5, offset: 68635},
 						name: "ORDER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2275, col: 5, offset: 68644},
+						pos:  position{line: 2275, col: 5, offset: 68645},
 						name: "OFFSET",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2276, col: 5, offset: 68655},
+						pos:  position{line: 2276, col: 5, offset: 68656},
 						name: "LIMIT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2277, col: 5, offset: 68665},
+						pos:  position{line: 2277, col: 5, offset: 68666},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2278, col: 5, offset: 68675},
+						pos:  position{line: 2278, col: 5, offset: 68676},
 						name: "WITH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2279, col: 5, offset: 68684},
+						pos:  position{line: 2279, col: 5, offset: 68685},
 						name: "USING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2280, col: 5, offset: 68694},
+						pos:  position{line: 2280, col: 5, offset: 68695},
 						name: "ON",
 					},
 				},
@@ -15773,20 +15776,20 @@ var g = &grammar{
 		},
 		{
 			name: "AGGREGATE",
-			pos:  position{line: 2282, col: 1, offset: 68698},
+			pos:  position{line: 2282, col: 1, offset: 68699},
 			expr: &seqExpr{
-				pos: position{line: 2282, col: 14, offset: 68711},
+				pos: position{line: 2282, col: 14, offset: 68712},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2282, col: 14, offset: 68711},
+						pos:        position{line: 2282, col: 14, offset: 68712},
 						val:        "aggregate",
 						ignoreCase: true,
 						want:       "\"AGGREGATE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2282, col: 33, offset: 68730},
+						pos: position{line: 2282, col: 33, offset: 68731},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2282, col: 34, offset: 68731},
+							pos:  position{line: 2282, col: 34, offset: 68732},
 							name: "IdentifierRest",
 						},
 					},
@@ -15797,20 +15800,20 @@ var g = &grammar{
 		},
 		{
 			name: "ALL",
-			pos:  position{line: 2283, col: 1, offset: 68746},
+			pos:  position{line: 2283, col: 1, offset: 68747},
 			expr: &seqExpr{
-				pos: position{line: 2283, col: 14, offset: 68759},
+				pos: position{line: 2283, col: 14, offset: 68760},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2283, col: 14, offset: 68759},
+						pos:        position{line: 2283, col: 14, offset: 68760},
 						val:        "all",
 						ignoreCase: true,
 						want:       "\"ALL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2283, col: 33, offset: 68778},
+						pos: position{line: 2283, col: 33, offset: 68779},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2283, col: 34, offset: 68779},
+							pos:  position{line: 2283, col: 34, offset: 68780},
 							name: "IdentifierRest",
 						},
 					},
@@ -15821,23 +15824,23 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 2284, col: 1, offset: 68794},
+			pos:  position{line: 2284, col: 1, offset: 68795},
 			expr: &actionExpr{
-				pos: position{line: 2284, col: 14, offset: 68807},
+				pos: position{line: 2284, col: 14, offset: 68808},
 				run: (*parser).callonAND1,
 				expr: &seqExpr{
-					pos: position{line: 2284, col: 14, offset: 68807},
+					pos: position{line: 2284, col: 14, offset: 68808},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2284, col: 14, offset: 68807},
+							pos:        position{line: 2284, col: 14, offset: 68808},
 							val:        "and",
 							ignoreCase: true,
 							want:       "\"AND\"i",
 						},
 						&notExpr{
-							pos: position{line: 2284, col: 33, offset: 68826},
+							pos: position{line: 2284, col: 33, offset: 68827},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2284, col: 34, offset: 68827},
+								pos:  position{line: 2284, col: 34, offset: 68828},
 								name: "IdentifierRest",
 							},
 						},
@@ -15849,20 +15852,20 @@ var g = &grammar{
 		},
 		{
 			name: "ANTI",
-			pos:  position{line: 2285, col: 1, offset: 68864},
+			pos:  position{line: 2285, col: 1, offset: 68865},
 			expr: &seqExpr{
-				pos: position{line: 2285, col: 14, offset: 68877},
+				pos: position{line: 2285, col: 14, offset: 68878},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2285, col: 14, offset: 68877},
+						pos:        position{line: 2285, col: 14, offset: 68878},
 						val:        "anti",
 						ignoreCase: true,
 						want:       "\"ANTI\"i",
 					},
 					&notExpr{
-						pos: position{line: 2285, col: 33, offset: 68896},
+						pos: position{line: 2285, col: 33, offset: 68897},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2285, col: 34, offset: 68897},
+							pos:  position{line: 2285, col: 34, offset: 68898},
 							name: "IdentifierRest",
 						},
 					},
@@ -15873,20 +15876,20 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 2286, col: 1, offset: 68912},
+			pos:  position{line: 2286, col: 1, offset: 68913},
 			expr: &seqExpr{
-				pos: position{line: 2286, col: 14, offset: 68925},
+				pos: position{line: 2286, col: 14, offset: 68926},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2286, col: 14, offset: 68925},
+						pos:        position{line: 2286, col: 14, offset: 68926},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2286, col: 33, offset: 68944},
+						pos: position{line: 2286, col: 33, offset: 68945},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2286, col: 34, offset: 68945},
+							pos:  position{line: 2286, col: 34, offset: 68946},
 							name: "IdentifierRest",
 						},
 					},
@@ -15897,23 +15900,23 @@ var g = &grammar{
 		},
 		{
 			name: "ASC",
-			pos:  position{line: 2287, col: 1, offset: 68960},
+			pos:  position{line: 2287, col: 1, offset: 68961},
 			expr: &actionExpr{
-				pos: position{line: 2287, col: 14, offset: 68973},
+				pos: position{line: 2287, col: 14, offset: 68974},
 				run: (*parser).callonASC1,
 				expr: &seqExpr{
-					pos: position{line: 2287, col: 14, offset: 68973},
+					pos: position{line: 2287, col: 14, offset: 68974},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2287, col: 14, offset: 68973},
+							pos:        position{line: 2287, col: 14, offset: 68974},
 							val:        "asc",
 							ignoreCase: true,
 							want:       "\"ASC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2287, col: 33, offset: 68992},
+							pos: position{line: 2287, col: 33, offset: 68993},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2287, col: 34, offset: 68993},
+								pos:  position{line: 2287, col: 34, offset: 68994},
 								name: "IdentifierRest",
 							},
 						},
@@ -15925,20 +15928,20 @@ var g = &grammar{
 		},
 		{
 			name: "ASSERT",
-			pos:  position{line: 2288, col: 1, offset: 69030},
+			pos:  position{line: 2288, col: 1, offset: 69031},
 			expr: &seqExpr{
-				pos: position{line: 2288, col: 14, offset: 69043},
+				pos: position{line: 2288, col: 14, offset: 69044},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2288, col: 14, offset: 69043},
+						pos:        position{line: 2288, col: 14, offset: 69044},
 						val:        "assert",
 						ignoreCase: true,
 						want:       "\"ASSERT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2288, col: 33, offset: 69062},
+						pos: position{line: 2288, col: 33, offset: 69063},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2288, col: 34, offset: 69063},
+							pos:  position{line: 2288, col: 34, offset: 69064},
 							name: "IdentifierRest",
 						},
 					},
@@ -15949,20 +15952,20 @@ var g = &grammar{
 		},
 		{
 			name: "AT",
-			pos:  position{line: 2289, col: 1, offset: 69078},
+			pos:  position{line: 2289, col: 1, offset: 69079},
 			expr: &seqExpr{
-				pos: position{line: 2289, col: 14, offset: 69091},
+				pos: position{line: 2289, col: 14, offset: 69092},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2289, col: 14, offset: 69091},
+						pos:        position{line: 2289, col: 14, offset: 69092},
 						val:        "at",
 						ignoreCase: true,
 						want:       "\"AT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2289, col: 33, offset: 69110},
+						pos: position{line: 2289, col: 33, offset: 69111},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2289, col: 34, offset: 69111},
+							pos:  position{line: 2289, col: 34, offset: 69112},
 							name: "IdentifierRest",
 						},
 					},
@@ -15973,20 +15976,20 @@ var g = &grammar{
 		},
 		{
 			name: "BETWEEN",
-			pos:  position{line: 2290, col: 1, offset: 69126},
+			pos:  position{line: 2290, col: 1, offset: 69127},
 			expr: &seqExpr{
-				pos: position{line: 2290, col: 14, offset: 69139},
+				pos: position{line: 2290, col: 14, offset: 69140},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2290, col: 14, offset: 69139},
+						pos:        position{line: 2290, col: 14, offset: 69140},
 						val:        "between",
 						ignoreCase: true,
 						want:       "\"BETWEEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2290, col: 33, offset: 69158},
+						pos: position{line: 2290, col: 33, offset: 69159},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2290, col: 34, offset: 69159},
+							pos:  position{line: 2290, col: 34, offset: 69160},
 							name: "IdentifierRest",
 						},
 					},
@@ -15997,20 +16000,20 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 2291, col: 1, offset: 69174},
+			pos:  position{line: 2291, col: 1, offset: 69175},
 			expr: &seqExpr{
-				pos: position{line: 2291, col: 14, offset: 69187},
+				pos: position{line: 2291, col: 14, offset: 69188},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2291, col: 14, offset: 69187},
+						pos:        position{line: 2291, col: 14, offset: 69188},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2291, col: 33, offset: 69206},
+						pos: position{line: 2291, col: 33, offset: 69207},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2291, col: 34, offset: 69207},
+							pos:  position{line: 2291, col: 34, offset: 69208},
 							name: "IdentifierRest",
 						},
 					},
@@ -16021,20 +16024,20 @@ var g = &grammar{
 		},
 		{
 			name: "CASE",
-			pos:  position{line: 2292, col: 1, offset: 69222},
+			pos:  position{line: 2292, col: 1, offset: 69223},
 			expr: &seqExpr{
-				pos: position{line: 2292, col: 14, offset: 69235},
+				pos: position{line: 2292, col: 14, offset: 69236},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2292, col: 14, offset: 69235},
+						pos:        position{line: 2292, col: 14, offset: 69236},
 						val:        "case",
 						ignoreCase: true,
 						want:       "\"CASE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2292, col: 33, offset: 69254},
+						pos: position{line: 2292, col: 33, offset: 69255},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2292, col: 34, offset: 69255},
+							pos:  position{line: 2292, col: 34, offset: 69256},
 							name: "IdentifierRest",
 						},
 					},
@@ -16045,20 +16048,20 @@ var g = &grammar{
 		},
 		{
 			name: "CAST",
-			pos:  position{line: 2293, col: 1, offset: 69270},
+			pos:  position{line: 2293, col: 1, offset: 69271},
 			expr: &seqExpr{
-				pos: position{line: 2293, col: 14, offset: 69283},
+				pos: position{line: 2293, col: 14, offset: 69284},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2293, col: 14, offset: 69283},
+						pos:        position{line: 2293, col: 14, offset: 69284},
 						val:        "cast",
 						ignoreCase: true,
 						want:       "\"CAST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2293, col: 33, offset: 69302},
+						pos: position{line: 2293, col: 33, offset: 69303},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2293, col: 34, offset: 69303},
+							pos:  position{line: 2293, col: 34, offset: 69304},
 							name: "IdentifierRest",
 						},
 					},
@@ -16069,20 +16072,20 @@ var g = &grammar{
 		},
 		{
 			name: "CONST",
-			pos:  position{line: 2294, col: 1, offset: 69318},
+			pos:  position{line: 2294, col: 1, offset: 69319},
 			expr: &seqExpr{
-				pos: position{line: 2294, col: 14, offset: 69331},
+				pos: position{line: 2294, col: 14, offset: 69332},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2294, col: 14, offset: 69331},
+						pos:        position{line: 2294, col: 14, offset: 69332},
 						val:        "const",
 						ignoreCase: true,
 						want:       "\"CONST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2294, col: 33, offset: 69350},
+						pos: position{line: 2294, col: 33, offset: 69351},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2294, col: 34, offset: 69351},
+							pos:  position{line: 2294, col: 34, offset: 69352},
 							name: "IdentifierRest",
 						},
 					},
@@ -16093,20 +16096,20 @@ var g = &grammar{
 		},
 		{
 			name: "COUNT",
-			pos:  position{line: 2295, col: 1, offset: 69366},
+			pos:  position{line: 2295, col: 1, offset: 69367},
 			expr: &seqExpr{
-				pos: position{line: 2295, col: 14, offset: 69379},
+				pos: position{line: 2295, col: 14, offset: 69380},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2295, col: 14, offset: 69379},
+						pos:        position{line: 2295, col: 14, offset: 69380},
 						val:        "count",
 						ignoreCase: true,
 						want:       "\"COUNT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2295, col: 33, offset: 69398},
+						pos: position{line: 2295, col: 33, offset: 69399},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2295, col: 34, offset: 69399},
+							pos:  position{line: 2295, col: 34, offset: 69400},
 							name: "IdentifierRest",
 						},
 					},
@@ -16117,20 +16120,20 @@ var g = &grammar{
 		},
 		{
 			name: "CROSS",
-			pos:  position{line: 2296, col: 1, offset: 69414},
+			pos:  position{line: 2296, col: 1, offset: 69415},
 			expr: &seqExpr{
-				pos: position{line: 2296, col: 14, offset: 69427},
+				pos: position{line: 2296, col: 14, offset: 69428},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2296, col: 14, offset: 69427},
+						pos:        position{line: 2296, col: 14, offset: 69428},
 						val:        "cross",
 						ignoreCase: true,
 						want:       "\"CROSS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2296, col: 33, offset: 69446},
+						pos: position{line: 2296, col: 33, offset: 69447},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2296, col: 34, offset: 69447},
+							pos:  position{line: 2296, col: 34, offset: 69448},
 							name: "IdentifierRest",
 						},
 					},
@@ -16141,20 +16144,20 @@ var g = &grammar{
 		},
 		{
 			name: "CUT",
-			pos:  position{line: 2297, col: 1, offset: 69462},
+			pos:  position{line: 2297, col: 1, offset: 69463},
 			expr: &seqExpr{
-				pos: position{line: 2297, col: 14, offset: 69475},
+				pos: position{line: 2297, col: 14, offset: 69476},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2297, col: 14, offset: 69475},
+						pos:        position{line: 2297, col: 14, offset: 69476},
 						val:        "cut",
 						ignoreCase: true,
 						want:       "\"CUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2297, col: 33, offset: 69494},
+						pos: position{line: 2297, col: 33, offset: 69495},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2297, col: 34, offset: 69495},
+							pos:  position{line: 2297, col: 34, offset: 69496},
 							name: "IdentifierRest",
 						},
 					},
@@ -16165,23 +16168,23 @@ var g = &grammar{
 		},
 		{
 			name: "DATE",
-			pos:  position{line: 2298, col: 1, offset: 69510},
+			pos:  position{line: 2298, col: 1, offset: 69511},
 			expr: &actionExpr{
-				pos: position{line: 2298, col: 14, offset: 69523},
+				pos: position{line: 2298, col: 14, offset: 69524},
 				run: (*parser).callonDATE1,
 				expr: &seqExpr{
-					pos: position{line: 2298, col: 14, offset: 69523},
+					pos: position{line: 2298, col: 14, offset: 69524},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2298, col: 14, offset: 69523},
+							pos:        position{line: 2298, col: 14, offset: 69524},
 							val:        "date",
 							ignoreCase: true,
 							want:       "\"DATE\"i",
 						},
 						&notExpr{
-							pos: position{line: 2298, col: 33, offset: 69542},
+							pos: position{line: 2298, col: 33, offset: 69543},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2298, col: 34, offset: 69543},
+								pos:  position{line: 2298, col: 34, offset: 69544},
 								name: "IdentifierRest",
 							},
 						},
@@ -16193,20 +16196,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEBUG",
-			pos:  position{line: 2299, col: 1, offset: 69581},
+			pos:  position{line: 2299, col: 1, offset: 69582},
 			expr: &seqExpr{
-				pos: position{line: 2299, col: 14, offset: 69594},
+				pos: position{line: 2299, col: 14, offset: 69595},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2299, col: 14, offset: 69594},
+						pos:        position{line: 2299, col: 14, offset: 69595},
 						val:        "debug",
 						ignoreCase: true,
 						want:       "\"DEBUG\"i",
 					},
 					&notExpr{
-						pos: position{line: 2299, col: 33, offset: 69613},
+						pos: position{line: 2299, col: 33, offset: 69614},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2299, col: 34, offset: 69614},
+							pos:  position{line: 2299, col: 34, offset: 69615},
 							name: "IdentifierRest",
 						},
 					},
@@ -16217,20 +16220,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEFAULT",
-			pos:  position{line: 2300, col: 1, offset: 69629},
+			pos:  position{line: 2300, col: 1, offset: 69630},
 			expr: &seqExpr{
-				pos: position{line: 2300, col: 14, offset: 69642},
+				pos: position{line: 2300, col: 14, offset: 69643},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2300, col: 14, offset: 69642},
+						pos:        position{line: 2300, col: 14, offset: 69643},
 						val:        "default",
 						ignoreCase: true,
 						want:       "\"DEFAULT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2300, col: 33, offset: 69661},
+						pos: position{line: 2300, col: 33, offset: 69662},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2300, col: 34, offset: 69662},
+							pos:  position{line: 2300, col: 34, offset: 69663},
 							name: "IdentifierRest",
 						},
 					},
@@ -16241,23 +16244,23 @@ var g = &grammar{
 		},
 		{
 			name: "DESC",
-			pos:  position{line: 2301, col: 1, offset: 69677},
+			pos:  position{line: 2301, col: 1, offset: 69678},
 			expr: &actionExpr{
-				pos: position{line: 2301, col: 14, offset: 69690},
+				pos: position{line: 2301, col: 14, offset: 69691},
 				run: (*parser).callonDESC1,
 				expr: &seqExpr{
-					pos: position{line: 2301, col: 14, offset: 69690},
+					pos: position{line: 2301, col: 14, offset: 69691},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2301, col: 14, offset: 69690},
+							pos:        position{line: 2301, col: 14, offset: 69691},
 							val:        "desc",
 							ignoreCase: true,
 							want:       "\"DESC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2301, col: 33, offset: 69709},
+							pos: position{line: 2301, col: 33, offset: 69710},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2301, col: 34, offset: 69710},
+								pos:  position{line: 2301, col: 34, offset: 69711},
 								name: "IdentifierRest",
 							},
 						},
@@ -16269,20 +16272,20 @@ var g = &grammar{
 		},
 		{
 			name: "DISTINCT",
-			pos:  position{line: 2302, col: 1, offset: 69748},
+			pos:  position{line: 2302, col: 1, offset: 69749},
 			expr: &seqExpr{
-				pos: position{line: 2302, col: 14, offset: 69761},
+				pos: position{line: 2302, col: 14, offset: 69762},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2302, col: 14, offset: 69761},
+						pos:        position{line: 2302, col: 14, offset: 69762},
 						val:        "distinct",
 						ignoreCase: true,
 						want:       "\"DISTINCT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2302, col: 33, offset: 69780},
+						pos: position{line: 2302, col: 33, offset: 69781},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2302, col: 34, offset: 69781},
+							pos:  position{line: 2302, col: 34, offset: 69782},
 							name: "IdentifierRest",
 						},
 					},
@@ -16293,20 +16296,20 @@ var g = &grammar{
 		},
 		{
 			name: "DROP",
-			pos:  position{line: 2303, col: 1, offset: 69796},
+			pos:  position{line: 2303, col: 1, offset: 69797},
 			expr: &seqExpr{
-				pos: position{line: 2303, col: 14, offset: 69809},
+				pos: position{line: 2303, col: 14, offset: 69810},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2303, col: 14, offset: 69809},
+						pos:        position{line: 2303, col: 14, offset: 69810},
 						val:        "drop",
 						ignoreCase: true,
 						want:       "\"DROP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2303, col: 33, offset: 69828},
+						pos: position{line: 2303, col: 33, offset: 69829},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2303, col: 34, offset: 69829},
+							pos:  position{line: 2303, col: 34, offset: 69830},
 							name: "IdentifierRest",
 						},
 					},
@@ -16317,20 +16320,20 @@ var g = &grammar{
 		},
 		{
 			name: "ELSE",
-			pos:  position{line: 2304, col: 1, offset: 69844},
+			pos:  position{line: 2304, col: 1, offset: 69845},
 			expr: &seqExpr{
-				pos: position{line: 2304, col: 14, offset: 69857},
+				pos: position{line: 2304, col: 14, offset: 69858},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2304, col: 14, offset: 69857},
+						pos:        position{line: 2304, col: 14, offset: 69858},
 						val:        "else",
 						ignoreCase: true,
 						want:       "\"ELSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2304, col: 33, offset: 69876},
+						pos: position{line: 2304, col: 33, offset: 69877},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2304, col: 34, offset: 69877},
+							pos:  position{line: 2304, col: 34, offset: 69878},
 							name: "IdentifierRest",
 						},
 					},
@@ -16341,20 +16344,20 @@ var g = &grammar{
 		},
 		{
 			name: "END",
-			pos:  position{line: 2305, col: 1, offset: 69892},
+			pos:  position{line: 2305, col: 1, offset: 69893},
 			expr: &seqExpr{
-				pos: position{line: 2305, col: 14, offset: 69905},
+				pos: position{line: 2305, col: 14, offset: 69906},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2305, col: 14, offset: 69905},
+						pos:        position{line: 2305, col: 14, offset: 69906},
 						val:        "end",
 						ignoreCase: true,
 						want:       "\"END\"i",
 					},
 					&notExpr{
-						pos: position{line: 2305, col: 33, offset: 69924},
+						pos: position{line: 2305, col: 33, offset: 69925},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2305, col: 34, offset: 69925},
+							pos:  position{line: 2305, col: 34, offset: 69926},
 							name: "IdentifierRest",
 						},
 					},
@@ -16365,20 +16368,20 @@ var g = &grammar{
 		},
 		{
 			name: "ENUM",
-			pos:  position{line: 2306, col: 1, offset: 69940},
+			pos:  position{line: 2306, col: 1, offset: 69941},
 			expr: &seqExpr{
-				pos: position{line: 2306, col: 14, offset: 69953},
+				pos: position{line: 2306, col: 14, offset: 69954},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2306, col: 14, offset: 69953},
+						pos:        position{line: 2306, col: 14, offset: 69954},
 						val:        "enum",
 						ignoreCase: true,
 						want:       "\"ENUM\"i",
 					},
 					&notExpr{
-						pos: position{line: 2306, col: 33, offset: 69972},
+						pos: position{line: 2306, col: 33, offset: 69973},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2306, col: 34, offset: 69973},
+							pos:  position{line: 2306, col: 34, offset: 69974},
 							name: "IdentifierRest",
 						},
 					},
@@ -16389,20 +16392,20 @@ var g = &grammar{
 		},
 		{
 			name: "ERROR",
-			pos:  position{line: 2307, col: 1, offset: 69988},
+			pos:  position{line: 2307, col: 1, offset: 69989},
 			expr: &seqExpr{
-				pos: position{line: 2307, col: 14, offset: 70001},
+				pos: position{line: 2307, col: 14, offset: 70002},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2307, col: 14, offset: 70001},
+						pos:        position{line: 2307, col: 14, offset: 70002},
 						val:        "error",
 						ignoreCase: true,
 						want:       "\"ERROR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2307, col: 33, offset: 70020},
+						pos: position{line: 2307, col: 33, offset: 70021},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2307, col: 34, offset: 70021},
+							pos:  position{line: 2307, col: 34, offset: 70022},
 							name: "IdentifierRest",
 						},
 					},
@@ -16413,20 +16416,20 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL",
-			pos:  position{line: 2308, col: 1, offset: 70036},
+			pos:  position{line: 2308, col: 1, offset: 70037},
 			expr: &seqExpr{
-				pos: position{line: 2308, col: 14, offset: 70049},
+				pos: position{line: 2308, col: 14, offset: 70050},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2308, col: 14, offset: 70049},
+						pos:        position{line: 2308, col: 14, offset: 70050},
 						val:        "eval",
 						ignoreCase: true,
 						want:       "\"EVAL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2308, col: 33, offset: 70068},
+						pos: position{line: 2308, col: 33, offset: 70069},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2308, col: 34, offset: 70069},
+							pos:  position{line: 2308, col: 34, offset: 70070},
 							name: "IdentifierRest",
 						},
 					},
@@ -16437,20 +16440,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXISTS",
-			pos:  position{line: 2309, col: 1, offset: 70084},
+			pos:  position{line: 2309, col: 1, offset: 70085},
 			expr: &seqExpr{
-				pos: position{line: 2309, col: 14, offset: 70097},
+				pos: position{line: 2309, col: 14, offset: 70098},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2309, col: 14, offset: 70097},
+						pos:        position{line: 2309, col: 14, offset: 70098},
 						val:        "exists",
 						ignoreCase: true,
 						want:       "\"EXISTS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2309, col: 33, offset: 70116},
+						pos: position{line: 2309, col: 33, offset: 70117},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2309, col: 34, offset: 70117},
+							pos:  position{line: 2309, col: 34, offset: 70118},
 							name: "IdentifierRest",
 						},
 					},
@@ -16461,20 +16464,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXPLODE",
-			pos:  position{line: 2310, col: 1, offset: 70132},
+			pos:  position{line: 2310, col: 1, offset: 70133},
 			expr: &seqExpr{
-				pos: position{line: 2310, col: 14, offset: 70145},
+				pos: position{line: 2310, col: 14, offset: 70146},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2310, col: 14, offset: 70145},
+						pos:        position{line: 2310, col: 14, offset: 70146},
 						val:        "explode",
 						ignoreCase: true,
 						want:       "\"EXPLODE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2310, col: 33, offset: 70164},
+						pos: position{line: 2310, col: 33, offset: 70165},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2310, col: 34, offset: 70165},
+							pos:  position{line: 2310, col: 34, offset: 70166},
 							name: "IdentifierRest",
 						},
 					},
@@ -16485,20 +16488,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXTRACT",
-			pos:  position{line: 2311, col: 1, offset: 70180},
+			pos:  position{line: 2311, col: 1, offset: 70181},
 			expr: &seqExpr{
-				pos: position{line: 2311, col: 14, offset: 70193},
+				pos: position{line: 2311, col: 14, offset: 70194},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2311, col: 14, offset: 70193},
+						pos:        position{line: 2311, col: 14, offset: 70194},
 						val:        "extract",
 						ignoreCase: true,
 						want:       "\"EXTRACT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2311, col: 33, offset: 70212},
+						pos: position{line: 2311, col: 33, offset: 70213},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2311, col: 34, offset: 70213},
+							pos:  position{line: 2311, col: 34, offset: 70214},
 							name: "IdentifierRest",
 						},
 					},
@@ -16509,20 +16512,20 @@ var g = &grammar{
 		},
 		{
 			name: "FALSE",
-			pos:  position{line: 2312, col: 1, offset: 70228},
+			pos:  position{line: 2312, col: 1, offset: 70229},
 			expr: &seqExpr{
-				pos: position{line: 2312, col: 14, offset: 70241},
+				pos: position{line: 2312, col: 14, offset: 70242},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2312, col: 14, offset: 70241},
+						pos:        position{line: 2312, col: 14, offset: 70242},
 						val:        "false",
 						ignoreCase: true,
 						want:       "\"FALSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2312, col: 33, offset: 70260},
+						pos: position{line: 2312, col: 33, offset: 70261},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2312, col: 34, offset: 70261},
+							pos:  position{line: 2312, col: 34, offset: 70262},
 							name: "IdentifierRest",
 						},
 					},
@@ -16533,20 +16536,20 @@ var g = &grammar{
 		},
 		{
 			name: "FIRST",
-			pos:  position{line: 2313, col: 1, offset: 70276},
+			pos:  position{line: 2313, col: 1, offset: 70277},
 			expr: &seqExpr{
-				pos: position{line: 2313, col: 14, offset: 70289},
+				pos: position{line: 2313, col: 14, offset: 70290},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2313, col: 14, offset: 70289},
+						pos:        position{line: 2313, col: 14, offset: 70290},
 						val:        "first",
 						ignoreCase: true,
 						want:       "\"FIRST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2313, col: 33, offset: 70308},
+						pos: position{line: 2313, col: 33, offset: 70309},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2313, col: 34, offset: 70309},
+							pos:  position{line: 2313, col: 34, offset: 70310},
 							name: "IdentifierRest",
 						},
 					},
@@ -16557,20 +16560,20 @@ var g = &grammar{
 		},
 		{
 			name: "FOR",
-			pos:  position{line: 2314, col: 1, offset: 70324},
+			pos:  position{line: 2314, col: 1, offset: 70325},
 			expr: &seqExpr{
-				pos: position{line: 2314, col: 14, offset: 70337},
+				pos: position{line: 2314, col: 14, offset: 70338},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2314, col: 14, offset: 70337},
+						pos:        position{line: 2314, col: 14, offset: 70338},
 						val:        "for",
 						ignoreCase: true,
 						want:       "\"FOR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2314, col: 33, offset: 70356},
+						pos: position{line: 2314, col: 33, offset: 70357},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2314, col: 34, offset: 70357},
+							pos:  position{line: 2314, col: 34, offset: 70358},
 							name: "IdentifierRest",
 						},
 					},
@@ -16581,20 +16584,20 @@ var g = &grammar{
 		},
 		{
 			name: "FORK",
-			pos:  position{line: 2315, col: 1, offset: 70372},
+			pos:  position{line: 2315, col: 1, offset: 70373},
 			expr: &seqExpr{
-				pos: position{line: 2315, col: 14, offset: 70385},
+				pos: position{line: 2315, col: 14, offset: 70386},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2315, col: 14, offset: 70385},
+						pos:        position{line: 2315, col: 14, offset: 70386},
 						val:        "fork",
 						ignoreCase: true,
 						want:       "\"FORK\"i",
 					},
 					&notExpr{
-						pos: position{line: 2315, col: 33, offset: 70404},
+						pos: position{line: 2315, col: 33, offset: 70405},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2315, col: 34, offset: 70405},
+							pos:  position{line: 2315, col: 34, offset: 70406},
 							name: "IdentifierRest",
 						},
 					},
@@ -16605,20 +16608,20 @@ var g = &grammar{
 		},
 		{
 			name: "FROM",
-			pos:  position{line: 2316, col: 1, offset: 70420},
+			pos:  position{line: 2316, col: 1, offset: 70421},
 			expr: &seqExpr{
-				pos: position{line: 2316, col: 14, offset: 70433},
+				pos: position{line: 2316, col: 14, offset: 70434},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2316, col: 14, offset: 70433},
+						pos:        position{line: 2316, col: 14, offset: 70434},
 						val:        "from",
 						ignoreCase: true,
 						want:       "\"FROM\"i",
 					},
 					&notExpr{
-						pos: position{line: 2316, col: 33, offset: 70452},
+						pos: position{line: 2316, col: 33, offset: 70453},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2316, col: 34, offset: 70453},
+							pos:  position{line: 2316, col: 34, offset: 70454},
 							name: "IdentifierRest",
 						},
 					},
@@ -16629,20 +16632,20 @@ var g = &grammar{
 		},
 		{
 			name: "FULL",
-			pos:  position{line: 2317, col: 1, offset: 70468},
+			pos:  position{line: 2317, col: 1, offset: 70469},
 			expr: &seqExpr{
-				pos: position{line: 2317, col: 14, offset: 70481},
+				pos: position{line: 2317, col: 14, offset: 70482},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2317, col: 14, offset: 70481},
+						pos:        position{line: 2317, col: 14, offset: 70482},
 						val:        "full",
 						ignoreCase: true,
 						want:       "\"FULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2317, col: 33, offset: 70500},
+						pos: position{line: 2317, col: 33, offset: 70501},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2317, col: 34, offset: 70501},
+							pos:  position{line: 2317, col: 34, offset: 70502},
 							name: "IdentifierRest",
 						},
 					},
@@ -16653,20 +16656,20 @@ var g = &grammar{
 		},
 		{
 			name: "FUNC",
-			pos:  position{line: 2318, col: 1, offset: 70516},
+			pos:  position{line: 2318, col: 1, offset: 70517},
 			expr: &seqExpr{
-				pos: position{line: 2318, col: 14, offset: 70529},
+				pos: position{line: 2318, col: 14, offset: 70530},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2318, col: 14, offset: 70529},
+						pos:        position{line: 2318, col: 14, offset: 70530},
 						val:        "func",
 						ignoreCase: true,
 						want:       "\"FUNC\"i",
 					},
 					&notExpr{
-						pos: position{line: 2318, col: 33, offset: 70548},
+						pos: position{line: 2318, col: 33, offset: 70549},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2318, col: 34, offset: 70549},
+							pos:  position{line: 2318, col: 34, offset: 70550},
 							name: "IdentifierRest",
 						},
 					},
@@ -16677,20 +16680,20 @@ var g = &grammar{
 		},
 		{
 			name: "FUSE",
-			pos:  position{line: 2319, col: 1, offset: 70564},
+			pos:  position{line: 2319, col: 1, offset: 70565},
 			expr: &seqExpr{
-				pos: position{line: 2319, col: 14, offset: 70577},
+				pos: position{line: 2319, col: 14, offset: 70578},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2319, col: 14, offset: 70577},
+						pos:        position{line: 2319, col: 14, offset: 70578},
 						val:        "fuse",
 						ignoreCase: true,
 						want:       "\"FUSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2319, col: 33, offset: 70596},
+						pos: position{line: 2319, col: 33, offset: 70597},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2319, col: 34, offset: 70597},
+							pos:  position{line: 2319, col: 34, offset: 70598},
 							name: "IdentifierRest",
 						},
 					},
@@ -16701,20 +16704,20 @@ var g = &grammar{
 		},
 		{
 			name: "GROUP",
-			pos:  position{line: 2320, col: 1, offset: 70612},
+			pos:  position{line: 2320, col: 1, offset: 70613},
 			expr: &seqExpr{
-				pos: position{line: 2320, col: 14, offset: 70625},
+				pos: position{line: 2320, col: 14, offset: 70626},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2320, col: 14, offset: 70625},
+						pos:        position{line: 2320, col: 14, offset: 70626},
 						val:        "group",
 						ignoreCase: true,
 						want:       "\"GROUP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2320, col: 33, offset: 70644},
+						pos: position{line: 2320, col: 33, offset: 70645},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2320, col: 34, offset: 70645},
+							pos:  position{line: 2320, col: 34, offset: 70646},
 							name: "IdentifierRest",
 						},
 					},
@@ -16725,20 +16728,20 @@ var g = &grammar{
 		},
 		{
 			name: "HAVING",
-			pos:  position{line: 2321, col: 1, offset: 70660},
+			pos:  position{line: 2321, col: 1, offset: 70661},
 			expr: &seqExpr{
-				pos: position{line: 2321, col: 14, offset: 70673},
+				pos: position{line: 2321, col: 14, offset: 70674},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2321, col: 14, offset: 70673},
+						pos:        position{line: 2321, col: 14, offset: 70674},
 						val:        "having",
 						ignoreCase: true,
 						want:       "\"HAVING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2321, col: 33, offset: 70692},
+						pos: position{line: 2321, col: 33, offset: 70693},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2321, col: 34, offset: 70693},
+							pos:  position{line: 2321, col: 34, offset: 70694},
 							name: "IdentifierRest",
 						},
 					},
@@ -16749,20 +16752,20 @@ var g = &grammar{
 		},
 		{
 			name: "HEAD",
-			pos:  position{line: 2322, col: 1, offset: 70708},
+			pos:  position{line: 2322, col: 1, offset: 70709},
 			expr: &seqExpr{
-				pos: position{line: 2322, col: 14, offset: 70721},
+				pos: position{line: 2322, col: 14, offset: 70722},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2322, col: 14, offset: 70721},
+						pos:        position{line: 2322, col: 14, offset: 70722},
 						val:        "head",
 						ignoreCase: true,
 						want:       "\"HEAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2322, col: 33, offset: 70740},
+						pos: position{line: 2322, col: 33, offset: 70741},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2322, col: 34, offset: 70741},
+							pos:  position{line: 2322, col: 34, offset: 70742},
 							name: "IdentifierRest",
 						},
 					},
@@ -16773,20 +16776,20 @@ var g = &grammar{
 		},
 		{
 			name: "IN",
-			pos:  position{line: 2323, col: 1, offset: 70756},
+			pos:  position{line: 2323, col: 1, offset: 70757},
 			expr: &seqExpr{
-				pos: position{line: 2323, col: 14, offset: 70769},
+				pos: position{line: 2323, col: 14, offset: 70770},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2323, col: 14, offset: 70769},
+						pos:        position{line: 2323, col: 14, offset: 70770},
 						val:        "in",
 						ignoreCase: true,
 						want:       "\"IN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2323, col: 33, offset: 70788},
+						pos: position{line: 2323, col: 33, offset: 70789},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2323, col: 34, offset: 70789},
+							pos:  position{line: 2323, col: 34, offset: 70790},
 							name: "IdentifierRest",
 						},
 					},
@@ -16797,20 +16800,20 @@ var g = &grammar{
 		},
 		{
 			name: "INNER",
-			pos:  position{line: 2324, col: 1, offset: 70804},
+			pos:  position{line: 2324, col: 1, offset: 70805},
 			expr: &seqExpr{
-				pos: position{line: 2324, col: 14, offset: 70817},
+				pos: position{line: 2324, col: 14, offset: 70818},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2324, col: 14, offset: 70817},
+						pos:        position{line: 2324, col: 14, offset: 70818},
 						val:        "inner",
 						ignoreCase: true,
 						want:       "\"INNER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2324, col: 33, offset: 70836},
+						pos: position{line: 2324, col: 33, offset: 70837},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2324, col: 34, offset: 70837},
+							pos:  position{line: 2324, col: 34, offset: 70838},
 							name: "IdentifierRest",
 						},
 					},
@@ -16821,20 +16824,20 @@ var g = &grammar{
 		},
 		{
 			name: "IS",
-			pos:  position{line: 2325, col: 1, offset: 70852},
+			pos:  position{line: 2325, col: 1, offset: 70853},
 			expr: &seqExpr{
-				pos: position{line: 2325, col: 14, offset: 70865},
+				pos: position{line: 2325, col: 14, offset: 70866},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2325, col: 14, offset: 70865},
+						pos:        position{line: 2325, col: 14, offset: 70866},
 						val:        "is",
 						ignoreCase: true,
 						want:       "\"IS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2325, col: 33, offset: 70884},
+						pos: position{line: 2325, col: 33, offset: 70885},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2325, col: 34, offset: 70885},
+							pos:  position{line: 2325, col: 34, offset: 70886},
 							name: "IdentifierRest",
 						},
 					},
@@ -16845,20 +16848,20 @@ var g = &grammar{
 		},
 		{
 			name: "JOIN",
-			pos:  position{line: 2326, col: 1, offset: 70900},
+			pos:  position{line: 2326, col: 1, offset: 70901},
 			expr: &seqExpr{
-				pos: position{line: 2326, col: 14, offset: 70913},
+				pos: position{line: 2326, col: 14, offset: 70914},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2326, col: 14, offset: 70913},
+						pos:        position{line: 2326, col: 14, offset: 70914},
 						val:        "join",
 						ignoreCase: true,
 						want:       "\"JOIN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2326, col: 33, offset: 70932},
+						pos: position{line: 2326, col: 33, offset: 70933},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2326, col: 34, offset: 70933},
+							pos:  position{line: 2326, col: 34, offset: 70934},
 							name: "IdentifierRest",
 						},
 					},
@@ -16869,20 +16872,20 @@ var g = &grammar{
 		},
 		{
 			name: "LAST",
-			pos:  position{line: 2327, col: 1, offset: 70948},
+			pos:  position{line: 2327, col: 1, offset: 70949},
 			expr: &seqExpr{
-				pos: position{line: 2327, col: 14, offset: 70961},
+				pos: position{line: 2327, col: 14, offset: 70962},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2327, col: 14, offset: 70961},
+						pos:        position{line: 2327, col: 14, offset: 70962},
 						val:        "last",
 						ignoreCase: true,
 						want:       "\"LAST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2327, col: 33, offset: 70980},
+						pos: position{line: 2327, col: 33, offset: 70981},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2327, col: 34, offset: 70981},
+							pos:  position{line: 2327, col: 34, offset: 70982},
 							name: "IdentifierRest",
 						},
 					},
@@ -16893,20 +16896,20 @@ var g = &grammar{
 		},
 		{
 			name: "LEFT",
-			pos:  position{line: 2328, col: 1, offset: 70996},
+			pos:  position{line: 2328, col: 1, offset: 70997},
 			expr: &seqExpr{
-				pos: position{line: 2328, col: 14, offset: 71009},
+				pos: position{line: 2328, col: 14, offset: 71010},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2328, col: 14, offset: 71009},
+						pos:        position{line: 2328, col: 14, offset: 71010},
 						val:        "left",
 						ignoreCase: true,
 						want:       "\"LEFT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2328, col: 33, offset: 71028},
+						pos: position{line: 2328, col: 33, offset: 71029},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2328, col: 34, offset: 71029},
+							pos:  position{line: 2328, col: 34, offset: 71030},
 							name: "IdentifierRest",
 						},
 					},
@@ -16917,20 +16920,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIKE",
-			pos:  position{line: 2329, col: 1, offset: 71044},
+			pos:  position{line: 2329, col: 1, offset: 71045},
 			expr: &seqExpr{
-				pos: position{line: 2329, col: 14, offset: 71057},
+				pos: position{line: 2329, col: 14, offset: 71058},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2329, col: 14, offset: 71057},
+						pos:        position{line: 2329, col: 14, offset: 71058},
 						val:        "like",
 						ignoreCase: true,
 						want:       "\"LIKE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2329, col: 33, offset: 71076},
+						pos: position{line: 2329, col: 33, offset: 71077},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2329, col: 34, offset: 71077},
+							pos:  position{line: 2329, col: 34, offset: 71078},
 							name: "IdentifierRest",
 						},
 					},
@@ -16941,20 +16944,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIMIT",
-			pos:  position{line: 2330, col: 1, offset: 71092},
+			pos:  position{line: 2330, col: 1, offset: 71093},
 			expr: &seqExpr{
-				pos: position{line: 2330, col: 14, offset: 71105},
+				pos: position{line: 2330, col: 14, offset: 71106},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2330, col: 14, offset: 71105},
+						pos:        position{line: 2330, col: 14, offset: 71106},
 						val:        "limit",
 						ignoreCase: true,
 						want:       "\"LIMIT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2330, col: 33, offset: 71124},
+						pos: position{line: 2330, col: 33, offset: 71125},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2330, col: 34, offset: 71125},
+							pos:  position{line: 2330, col: 34, offset: 71126},
 							name: "IdentifierRest",
 						},
 					},
@@ -16965,20 +16968,20 @@ var g = &grammar{
 		},
 		{
 			name: "LOAD",
-			pos:  position{line: 2331, col: 1, offset: 71140},
+			pos:  position{line: 2331, col: 1, offset: 71141},
 			expr: &seqExpr{
-				pos: position{line: 2331, col: 14, offset: 71153},
+				pos: position{line: 2331, col: 14, offset: 71154},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2331, col: 14, offset: 71153},
+						pos:        position{line: 2331, col: 14, offset: 71154},
 						val:        "load",
 						ignoreCase: true,
 						want:       "\"LOAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2331, col: 33, offset: 71172},
+						pos: position{line: 2331, col: 33, offset: 71173},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2331, col: 34, offset: 71173},
+							pos:  position{line: 2331, col: 34, offset: 71174},
 							name: "IdentifierRest",
 						},
 					},
@@ -16989,20 +16992,20 @@ var g = &grammar{
 		},
 		{
 			name: "MATERIALIZED",
-			pos:  position{line: 2332, col: 1, offset: 71188},
+			pos:  position{line: 2332, col: 1, offset: 71189},
 			expr: &seqExpr{
-				pos: position{line: 2332, col: 16, offset: 71203},
+				pos: position{line: 2332, col: 16, offset: 71204},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2332, col: 16, offset: 71203},
+						pos:        position{line: 2332, col: 16, offset: 71204},
 						val:        "materialized",
 						ignoreCase: true,
 						want:       "\"MATERIALIZED\"i",
 					},
 					&notExpr{
-						pos: position{line: 2332, col: 33, offset: 71220},
+						pos: position{line: 2332, col: 33, offset: 71221},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2332, col: 34, offset: 71221},
+							pos:  position{line: 2332, col: 34, offset: 71222},
 							name: "IdentifierRest",
 						},
 					},
@@ -17013,20 +17016,20 @@ var g = &grammar{
 		},
 		{
 			name: "MERGE",
-			pos:  position{line: 2333, col: 1, offset: 71236},
+			pos:  position{line: 2333, col: 1, offset: 71237},
 			expr: &seqExpr{
-				pos: position{line: 2333, col: 14, offset: 71249},
+				pos: position{line: 2333, col: 14, offset: 71250},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2333, col: 14, offset: 71249},
+						pos:        position{line: 2333, col: 14, offset: 71250},
 						val:        "merge",
 						ignoreCase: true,
 						want:       "\"MERGE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2333, col: 33, offset: 71268},
+						pos: position{line: 2333, col: 33, offset: 71269},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2333, col: 34, offset: 71269},
+							pos:  position{line: 2333, col: 34, offset: 71270},
 							name: "IdentifierRest",
 						},
 					},
@@ -17037,20 +17040,20 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 2334, col: 1, offset: 71284},
+			pos:  position{line: 2334, col: 1, offset: 71285},
 			expr: &seqExpr{
-				pos: position{line: 2334, col: 14, offset: 71297},
+				pos: position{line: 2334, col: 14, offset: 71298},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2334, col: 14, offset: 71297},
+						pos:        position{line: 2334, col: 14, offset: 71298},
 						val:        "not",
 						ignoreCase: true,
 						want:       "\"NOT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2334, col: 33, offset: 71316},
+						pos: position{line: 2334, col: 33, offset: 71317},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2334, col: 34, offset: 71317},
+							pos:  position{line: 2334, col: 34, offset: 71318},
 							name: "IdentifierRest",
 						},
 					},
@@ -17061,20 +17064,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULL",
-			pos:  position{line: 2335, col: 1, offset: 71332},
+			pos:  position{line: 2335, col: 1, offset: 71333},
 			expr: &seqExpr{
-				pos: position{line: 2335, col: 14, offset: 71345},
+				pos: position{line: 2335, col: 14, offset: 71346},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2335, col: 14, offset: 71345},
+						pos:        position{line: 2335, col: 14, offset: 71346},
 						val:        "null",
 						ignoreCase: true,
 						want:       "\"NULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2335, col: 33, offset: 71364},
+						pos: position{line: 2335, col: 33, offset: 71365},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2335, col: 34, offset: 71365},
+							pos:  position{line: 2335, col: 34, offset: 71366},
 							name: "IdentifierRest",
 						},
 					},
@@ -17085,20 +17088,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULLS",
-			pos:  position{line: 2336, col: 1, offset: 71380},
+			pos:  position{line: 2336, col: 1, offset: 71381},
 			expr: &seqExpr{
-				pos: position{line: 2336, col: 14, offset: 71393},
+				pos: position{line: 2336, col: 14, offset: 71394},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2336, col: 14, offset: 71393},
+						pos:        position{line: 2336, col: 14, offset: 71394},
 						val:        "nulls",
 						ignoreCase: true,
 						want:       "\"NULLS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2336, col: 33, offset: 71412},
+						pos: position{line: 2336, col: 33, offset: 71413},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2336, col: 34, offset: 71413},
+							pos:  position{line: 2336, col: 34, offset: 71414},
 							name: "IdentifierRest",
 						},
 					},
@@ -17109,20 +17112,20 @@ var g = &grammar{
 		},
 		{
 			name: "OFFSET",
-			pos:  position{line: 2337, col: 1, offset: 71428},
+			pos:  position{line: 2337, col: 1, offset: 71429},
 			expr: &seqExpr{
-				pos: position{line: 2337, col: 14, offset: 71441},
+				pos: position{line: 2337, col: 14, offset: 71442},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2337, col: 14, offset: 71441},
+						pos:        position{line: 2337, col: 14, offset: 71442},
 						val:        "offset",
 						ignoreCase: true,
 						want:       "\"OFFSET\"i",
 					},
 					&notExpr{
-						pos: position{line: 2337, col: 33, offset: 71460},
+						pos: position{line: 2337, col: 33, offset: 71461},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2337, col: 34, offset: 71461},
+							pos:  position{line: 2337, col: 34, offset: 71462},
 							name: "IdentifierRest",
 						},
 					},
@@ -17133,20 +17136,20 @@ var g = &grammar{
 		},
 		{
 			name: "ON",
-			pos:  position{line: 2338, col: 1, offset: 71476},
+			pos:  position{line: 2338, col: 1, offset: 71477},
 			expr: &seqExpr{
-				pos: position{line: 2338, col: 14, offset: 71489},
+				pos: position{line: 2338, col: 14, offset: 71490},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2338, col: 14, offset: 71489},
+						pos:        position{line: 2338, col: 14, offset: 71490},
 						val:        "on",
 						ignoreCase: true,
 						want:       "\"ON\"i",
 					},
 					&notExpr{
-						pos: position{line: 2338, col: 33, offset: 71508},
+						pos: position{line: 2338, col: 33, offset: 71509},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2338, col: 34, offset: 71509},
+							pos:  position{line: 2338, col: 34, offset: 71510},
 							name: "IdentifierRest",
 						},
 					},
@@ -17157,20 +17160,20 @@ var g = &grammar{
 		},
 		{
 			name: "OP",
-			pos:  position{line: 2339, col: 1, offset: 71524},
+			pos:  position{line: 2339, col: 1, offset: 71525},
 			expr: &seqExpr{
-				pos: position{line: 2339, col: 14, offset: 71537},
+				pos: position{line: 2339, col: 14, offset: 71538},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2339, col: 14, offset: 71537},
+						pos:        position{line: 2339, col: 14, offset: 71538},
 						val:        "op",
 						ignoreCase: true,
 						want:       "\"OP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2339, col: 33, offset: 71556},
+						pos: position{line: 2339, col: 33, offset: 71557},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2339, col: 34, offset: 71557},
+							pos:  position{line: 2339, col: 34, offset: 71558},
 							name: "IdentifierRest",
 						},
 					},
@@ -17181,23 +17184,23 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 2340, col: 1, offset: 71572},
+			pos:  position{line: 2340, col: 1, offset: 71573},
 			expr: &actionExpr{
-				pos: position{line: 2340, col: 14, offset: 71585},
+				pos: position{line: 2340, col: 14, offset: 71586},
 				run: (*parser).callonOR1,
 				expr: &seqExpr{
-					pos: position{line: 2340, col: 14, offset: 71585},
+					pos: position{line: 2340, col: 14, offset: 71586},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2340, col: 14, offset: 71585},
+							pos:        position{line: 2340, col: 14, offset: 71586},
 							val:        "or",
 							ignoreCase: true,
 							want:       "\"OR\"i",
 						},
 						&notExpr{
-							pos: position{line: 2340, col: 33, offset: 71604},
+							pos: position{line: 2340, col: 33, offset: 71605},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2340, col: 34, offset: 71605},
+								pos:  position{line: 2340, col: 34, offset: 71606},
 								name: "IdentifierRest",
 							},
 						},
@@ -17209,20 +17212,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDER",
-			pos:  position{line: 2341, col: 1, offset: 71641},
+			pos:  position{line: 2341, col: 1, offset: 71642},
 			expr: &seqExpr{
-				pos: position{line: 2341, col: 14, offset: 71654},
+				pos: position{line: 2341, col: 14, offset: 71655},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2341, col: 14, offset: 71654},
+						pos:        position{line: 2341, col: 14, offset: 71655},
 						val:        "order",
 						ignoreCase: true,
 						want:       "\"ORDER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2341, col: 33, offset: 71673},
+						pos: position{line: 2341, col: 33, offset: 71674},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2341, col: 34, offset: 71674},
+							pos:  position{line: 2341, col: 34, offset: 71675},
 							name: "IdentifierRest",
 						},
 					},
@@ -17233,20 +17236,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDINALITY",
-			pos:  position{line: 2342, col: 1, offset: 71689},
+			pos:  position{line: 2342, col: 1, offset: 71690},
 			expr: &seqExpr{
-				pos: position{line: 2342, col: 14, offset: 71702},
+				pos: position{line: 2342, col: 14, offset: 71703},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2342, col: 14, offset: 71702},
+						pos:        position{line: 2342, col: 14, offset: 71703},
 						val:        "ordinality",
 						ignoreCase: true,
 						want:       "\"ORDINALITY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2342, col: 33, offset: 71721},
+						pos: position{line: 2342, col: 33, offset: 71722},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2342, col: 34, offset: 71722},
+							pos:  position{line: 2342, col: 34, offset: 71723},
 							name: "IdentifierRest",
 						},
 					},
@@ -17257,20 +17260,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTER",
-			pos:  position{line: 2343, col: 1, offset: 71737},
+			pos:  position{line: 2343, col: 1, offset: 71738},
 			expr: &seqExpr{
-				pos: position{line: 2343, col: 14, offset: 71750},
+				pos: position{line: 2343, col: 14, offset: 71751},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2343, col: 14, offset: 71750},
+						pos:        position{line: 2343, col: 14, offset: 71751},
 						val:        "outer",
 						ignoreCase: true,
 						want:       "\"OUTER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2343, col: 33, offset: 71769},
+						pos: position{line: 2343, col: 33, offset: 71770},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2343, col: 34, offset: 71770},
+							pos:  position{line: 2343, col: 34, offset: 71771},
 							name: "IdentifierRest",
 						},
 					},
@@ -17281,20 +17284,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTPUT",
-			pos:  position{line: 2344, col: 1, offset: 71785},
+			pos:  position{line: 2344, col: 1, offset: 71786},
 			expr: &seqExpr{
-				pos: position{line: 2344, col: 14, offset: 71798},
+				pos: position{line: 2344, col: 14, offset: 71799},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2344, col: 14, offset: 71798},
+						pos:        position{line: 2344, col: 14, offset: 71799},
 						val:        "output",
 						ignoreCase: true,
 						want:       "\"OUTPUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2344, col: 33, offset: 71817},
+						pos: position{line: 2344, col: 33, offset: 71818},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2344, col: 34, offset: 71818},
+							pos:  position{line: 2344, col: 34, offset: 71819},
 							name: "IdentifierRest",
 						},
 					},
@@ -17305,20 +17308,20 @@ var g = &grammar{
 		},
 		{
 			name: "PASS",
-			pos:  position{line: 2345, col: 1, offset: 71833},
+			pos:  position{line: 2345, col: 1, offset: 71834},
 			expr: &seqExpr{
-				pos: position{line: 2345, col: 14, offset: 71846},
+				pos: position{line: 2345, col: 14, offset: 71847},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2345, col: 14, offset: 71846},
+						pos:        position{line: 2345, col: 14, offset: 71847},
 						val:        "pass",
 						ignoreCase: true,
 						want:       "\"PASS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2345, col: 33, offset: 71865},
+						pos: position{line: 2345, col: 33, offset: 71866},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2345, col: 34, offset: 71866},
+							pos:  position{line: 2345, col: 34, offset: 71867},
 							name: "IdentifierRest",
 						},
 					},
@@ -17329,20 +17332,20 @@ var g = &grammar{
 		},
 		{
 			name: "PUT",
-			pos:  position{line: 2346, col: 1, offset: 71881},
+			pos:  position{line: 2346, col: 1, offset: 71882},
 			expr: &seqExpr{
-				pos: position{line: 2346, col: 14, offset: 71894},
+				pos: position{line: 2346, col: 14, offset: 71895},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2346, col: 14, offset: 71894},
+						pos:        position{line: 2346, col: 14, offset: 71895},
 						val:        "put",
 						ignoreCase: true,
 						want:       "\"PUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2346, col: 33, offset: 71913},
+						pos: position{line: 2346, col: 33, offset: 71914},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2346, col: 34, offset: 71914},
+							pos:  position{line: 2346, col: 34, offset: 71915},
 							name: "IdentifierRest",
 						},
 					},
@@ -17353,20 +17356,20 @@ var g = &grammar{
 		},
 		{
 			name: "RECURSIVE",
-			pos:  position{line: 2347, col: 1, offset: 71929},
+			pos:  position{line: 2347, col: 1, offset: 71930},
 			expr: &seqExpr{
-				pos: position{line: 2347, col: 14, offset: 71942},
+				pos: position{line: 2347, col: 14, offset: 71943},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2347, col: 14, offset: 71942},
+						pos:        position{line: 2347, col: 14, offset: 71943},
 						val:        "recursive",
 						ignoreCase: true,
 						want:       "\"RECURSIVE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2347, col: 33, offset: 71961},
+						pos: position{line: 2347, col: 33, offset: 71962},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2347, col: 34, offset: 71962},
+							pos:  position{line: 2347, col: 34, offset: 71963},
 							name: "IdentifierRest",
 						},
 					},
@@ -17377,20 +17380,20 @@ var g = &grammar{
 		},
 		{
 			name: "RENAME",
-			pos:  position{line: 2348, col: 1, offset: 71977},
+			pos:  position{line: 2348, col: 1, offset: 71978},
 			expr: &seqExpr{
-				pos: position{line: 2348, col: 14, offset: 71990},
+				pos: position{line: 2348, col: 14, offset: 71991},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2348, col: 14, offset: 71990},
+						pos:        position{line: 2348, col: 14, offset: 71991},
 						val:        "rename",
 						ignoreCase: true,
 						want:       "\"RENAME\"i",
 					},
 					&notExpr{
-						pos: position{line: 2348, col: 33, offset: 72009},
+						pos: position{line: 2348, col: 33, offset: 72010},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2348, col: 34, offset: 72010},
+							pos:  position{line: 2348, col: 34, offset: 72011},
 							name: "IdentifierRest",
 						},
 					},
@@ -17401,20 +17404,20 @@ var g = &grammar{
 		},
 		{
 			name: "RIGHT",
-			pos:  position{line: 2349, col: 1, offset: 72025},
+			pos:  position{line: 2349, col: 1, offset: 72026},
 			expr: &seqExpr{
-				pos: position{line: 2349, col: 14, offset: 72038},
+				pos: position{line: 2349, col: 14, offset: 72039},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2349, col: 14, offset: 72038},
+						pos:        position{line: 2349, col: 14, offset: 72039},
 						val:        "right",
 						ignoreCase: true,
 						want:       "\"RIGHT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2349, col: 33, offset: 72057},
+						pos: position{line: 2349, col: 33, offset: 72058},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2349, col: 34, offset: 72058},
+							pos:  position{line: 2349, col: 34, offset: 72059},
 							name: "IdentifierRest",
 						},
 					},
@@ -17425,20 +17428,20 @@ var g = &grammar{
 		},
 		{
 			name: "SHAPES",
-			pos:  position{line: 2350, col: 1, offset: 72073},
+			pos:  position{line: 2350, col: 1, offset: 72074},
 			expr: &seqExpr{
-				pos: position{line: 2350, col: 14, offset: 72086},
+				pos: position{line: 2350, col: 14, offset: 72087},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2350, col: 14, offset: 72086},
+						pos:        position{line: 2350, col: 14, offset: 72087},
 						val:        "shapes",
 						ignoreCase: true,
 						want:       "\"SHAPES\"i",
 					},
 					&notExpr{
-						pos: position{line: 2350, col: 33, offset: 72105},
+						pos: position{line: 2350, col: 33, offset: 72106},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2350, col: 34, offset: 72106},
+							pos:  position{line: 2350, col: 34, offset: 72107},
 							name: "IdentifierRest",
 						},
 					},
@@ -17449,20 +17452,20 @@ var g = &grammar{
 		},
 		{
 			name: "SEARCH",
-			pos:  position{line: 2351, col: 1, offset: 72121},
+			pos:  position{line: 2351, col: 1, offset: 72122},
 			expr: &seqExpr{
-				pos: position{line: 2351, col: 14, offset: 72134},
+				pos: position{line: 2351, col: 14, offset: 72135},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2351, col: 14, offset: 72134},
+						pos:        position{line: 2351, col: 14, offset: 72135},
 						val:        "search",
 						ignoreCase: true,
 						want:       "\"SEARCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2351, col: 33, offset: 72153},
+						pos: position{line: 2351, col: 33, offset: 72154},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2351, col: 34, offset: 72154},
+							pos:  position{line: 2351, col: 34, offset: 72155},
 							name: "IdentifierRest",
 						},
 					},
@@ -17473,20 +17476,20 @@ var g = &grammar{
 		},
 		{
 			name: "SELECT",
-			pos:  position{line: 2352, col: 1, offset: 72169},
+			pos:  position{line: 2352, col: 1, offset: 72170},
 			expr: &seqExpr{
-				pos: position{line: 2352, col: 14, offset: 72182},
+				pos: position{line: 2352, col: 14, offset: 72183},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2352, col: 14, offset: 72182},
+						pos:        position{line: 2352, col: 14, offset: 72183},
 						val:        "select",
 						ignoreCase: true,
 						want:       "\"SELECT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2352, col: 33, offset: 72201},
+						pos: position{line: 2352, col: 33, offset: 72202},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2352, col: 34, offset: 72202},
+							pos:  position{line: 2352, col: 34, offset: 72203},
 							name: "IdentifierRest",
 						},
 					},
@@ -17497,20 +17500,20 @@ var g = &grammar{
 		},
 		{
 			name: "SHAPE",
-			pos:  position{line: 2353, col: 1, offset: 72217},
+			pos:  position{line: 2353, col: 1, offset: 72218},
 			expr: &seqExpr{
-				pos: position{line: 2353, col: 14, offset: 72230},
+				pos: position{line: 2353, col: 14, offset: 72231},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2353, col: 14, offset: 72230},
+						pos:        position{line: 2353, col: 14, offset: 72231},
 						val:        "shape",
 						ignoreCase: true,
 						want:       "\"SHAPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2353, col: 33, offset: 72249},
+						pos: position{line: 2353, col: 33, offset: 72250},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2353, col: 34, offset: 72250},
+							pos:  position{line: 2353, col: 34, offset: 72251},
 							name: "IdentifierRest",
 						},
 					},
@@ -17521,20 +17524,20 @@ var g = &grammar{
 		},
 		{
 			name: "SKIP",
-			pos:  position{line: 2354, col: 1, offset: 72265},
+			pos:  position{line: 2354, col: 1, offset: 72266},
 			expr: &seqExpr{
-				pos: position{line: 2354, col: 14, offset: 72278},
+				pos: position{line: 2354, col: 14, offset: 72279},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2354, col: 14, offset: 72278},
+						pos:        position{line: 2354, col: 14, offset: 72279},
 						val:        "skip",
 						ignoreCase: true,
 						want:       "\"SKIP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2354, col: 33, offset: 72297},
+						pos: position{line: 2354, col: 33, offset: 72298},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2354, col: 34, offset: 72298},
+							pos:  position{line: 2354, col: 34, offset: 72299},
 							name: "IdentifierRest",
 						},
 					},
@@ -17545,20 +17548,20 @@ var g = &grammar{
 		},
 		{
 			name: "SORT",
-			pos:  position{line: 2355, col: 1, offset: 72313},
+			pos:  position{line: 2355, col: 1, offset: 72314},
 			expr: &seqExpr{
-				pos: position{line: 2355, col: 14, offset: 72326},
+				pos: position{line: 2355, col: 14, offset: 72327},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2355, col: 14, offset: 72326},
+						pos:        position{line: 2355, col: 14, offset: 72327},
 						val:        "sort",
 						ignoreCase: true,
 						want:       "\"SORT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2355, col: 33, offset: 72345},
+						pos: position{line: 2355, col: 33, offset: 72346},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2355, col: 34, offset: 72346},
+							pos:  position{line: 2355, col: 34, offset: 72347},
 							name: "IdentifierRest",
 						},
 					},
@@ -17569,20 +17572,20 @@ var g = &grammar{
 		},
 		{
 			name: "SUBSTRING",
-			pos:  position{line: 2356, col: 1, offset: 72361},
+			pos:  position{line: 2356, col: 1, offset: 72362},
 			expr: &seqExpr{
-				pos: position{line: 2356, col: 14, offset: 72374},
+				pos: position{line: 2356, col: 14, offset: 72375},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2356, col: 14, offset: 72374},
+						pos:        position{line: 2356, col: 14, offset: 72375},
 						val:        "substring",
 						ignoreCase: true,
 						want:       "\"SUBSTRING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2356, col: 33, offset: 72393},
+						pos: position{line: 2356, col: 33, offset: 72394},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2356, col: 34, offset: 72394},
+							pos:  position{line: 2356, col: 34, offset: 72395},
 							name: "IdentifierRest",
 						},
 					},
@@ -17593,20 +17596,20 @@ var g = &grammar{
 		},
 		{
 			name: "SUMMARIZE",
-			pos:  position{line: 2357, col: 1, offset: 72409},
+			pos:  position{line: 2357, col: 1, offset: 72410},
 			expr: &seqExpr{
-				pos: position{line: 2357, col: 14, offset: 72422},
+				pos: position{line: 2357, col: 14, offset: 72423},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2357, col: 14, offset: 72422},
+						pos:        position{line: 2357, col: 14, offset: 72423},
 						val:        "summarize",
 						ignoreCase: true,
 						want:       "\"SUMMARIZE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2357, col: 33, offset: 72441},
+						pos: position{line: 2357, col: 33, offset: 72442},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2357, col: 34, offset: 72442},
+							pos:  position{line: 2357, col: 34, offset: 72443},
 							name: "IdentifierRest",
 						},
 					},
@@ -17617,20 +17620,20 @@ var g = &grammar{
 		},
 		{
 			name: "SWITCH",
-			pos:  position{line: 2358, col: 1, offset: 72457},
+			pos:  position{line: 2358, col: 1, offset: 72458},
 			expr: &seqExpr{
-				pos: position{line: 2358, col: 14, offset: 72470},
+				pos: position{line: 2358, col: 14, offset: 72471},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2358, col: 14, offset: 72470},
+						pos:        position{line: 2358, col: 14, offset: 72471},
 						val:        "switch",
 						ignoreCase: true,
 						want:       "\"SWITCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2358, col: 33, offset: 72489},
+						pos: position{line: 2358, col: 33, offset: 72490},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2358, col: 34, offset: 72490},
+							pos:  position{line: 2358, col: 34, offset: 72491},
 							name: "IdentifierRest",
 						},
 					},
@@ -17641,20 +17644,20 @@ var g = &grammar{
 		},
 		{
 			name: "TAIL",
-			pos:  position{line: 2359, col: 1, offset: 72505},
+			pos:  position{line: 2359, col: 1, offset: 72506},
 			expr: &seqExpr{
-				pos: position{line: 2359, col: 14, offset: 72518},
+				pos: position{line: 2359, col: 14, offset: 72519},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2359, col: 14, offset: 72518},
+						pos:        position{line: 2359, col: 14, offset: 72519},
 						val:        "tail",
 						ignoreCase: true,
 						want:       "\"TAIL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2359, col: 33, offset: 72537},
+						pos: position{line: 2359, col: 33, offset: 72538},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2359, col: 34, offset: 72538},
+							pos:  position{line: 2359, col: 34, offset: 72539},
 							name: "IdentifierRest",
 						},
 					},
@@ -17665,20 +17668,20 @@ var g = &grammar{
 		},
 		{
 			name: "THEN",
-			pos:  position{line: 2360, col: 1, offset: 72553},
+			pos:  position{line: 2360, col: 1, offset: 72554},
 			expr: &seqExpr{
-				pos: position{line: 2360, col: 14, offset: 72566},
+				pos: position{line: 2360, col: 14, offset: 72567},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2360, col: 14, offset: 72566},
+						pos:        position{line: 2360, col: 14, offset: 72567},
 						val:        "then",
 						ignoreCase: true,
 						want:       "\"THEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2360, col: 33, offset: 72585},
+						pos: position{line: 2360, col: 33, offset: 72586},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2360, col: 34, offset: 72586},
+							pos:  position{line: 2360, col: 34, offset: 72587},
 							name: "IdentifierRest",
 						},
 					},
@@ -17689,23 +17692,23 @@ var g = &grammar{
 		},
 		{
 			name: "TIMESTAMP",
-			pos:  position{line: 2361, col: 1, offset: 72601},
+			pos:  position{line: 2361, col: 1, offset: 72602},
 			expr: &actionExpr{
-				pos: position{line: 2361, col: 14, offset: 72614},
+				pos: position{line: 2361, col: 14, offset: 72615},
 				run: (*parser).callonTIMESTAMP1,
 				expr: &seqExpr{
-					pos: position{line: 2361, col: 14, offset: 72614},
+					pos: position{line: 2361, col: 14, offset: 72615},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2361, col: 14, offset: 72614},
+							pos:        position{line: 2361, col: 14, offset: 72615},
 							val:        "timestamp",
 							ignoreCase: true,
 							want:       "\"TIMESTAMP\"i",
 						},
 						&notExpr{
-							pos: position{line: 2361, col: 33, offset: 72633},
+							pos: position{line: 2361, col: 33, offset: 72634},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2361, col: 34, offset: 72634},
+								pos:  position{line: 2361, col: 34, offset: 72635},
 								name: "IdentifierRest",
 							},
 						},
@@ -17717,20 +17720,20 @@ var g = &grammar{
 		},
 		{
 			name: "TOP",
-			pos:  position{line: 2362, col: 1, offset: 72677},
+			pos:  position{line: 2362, col: 1, offset: 72678},
 			expr: &seqExpr{
-				pos: position{line: 2362, col: 14, offset: 72690},
+				pos: position{line: 2362, col: 14, offset: 72691},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2362, col: 14, offset: 72690},
+						pos:        position{line: 2362, col: 14, offset: 72691},
 						val:        "top",
 						ignoreCase: true,
 						want:       "\"TOP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2362, col: 33, offset: 72709},
+						pos: position{line: 2362, col: 33, offset: 72710},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2362, col: 34, offset: 72710},
+							pos:  position{line: 2362, col: 34, offset: 72711},
 							name: "IdentifierRest",
 						},
 					},
@@ -17741,20 +17744,20 @@ var g = &grammar{
 		},
 		{
 			name: "TRUE",
-			pos:  position{line: 2363, col: 1, offset: 72725},
+			pos:  position{line: 2363, col: 1, offset: 72726},
 			expr: &seqExpr{
-				pos: position{line: 2363, col: 14, offset: 72738},
+				pos: position{line: 2363, col: 14, offset: 72739},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2363, col: 14, offset: 72738},
+						pos:        position{line: 2363, col: 14, offset: 72739},
 						val:        "true",
 						ignoreCase: true,
 						want:       "\"TRUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2363, col: 33, offset: 72757},
+						pos: position{line: 2363, col: 33, offset: 72758},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2363, col: 34, offset: 72758},
+							pos:  position{line: 2363, col: 34, offset: 72759},
 							name: "IdentifierRest",
 						},
 					},
@@ -17765,20 +17768,20 @@ var g = &grammar{
 		},
 		{
 			name: "TYPE",
-			pos:  position{line: 2364, col: 1, offset: 72773},
+			pos:  position{line: 2364, col: 1, offset: 72774},
 			expr: &seqExpr{
-				pos: position{line: 2364, col: 14, offset: 72786},
+				pos: position{line: 2364, col: 14, offset: 72787},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2364, col: 14, offset: 72786},
+						pos:        position{line: 2364, col: 14, offset: 72787},
 						val:        "type",
 						ignoreCase: true,
 						want:       "\"TYPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2364, col: 33, offset: 72805},
+						pos: position{line: 2364, col: 33, offset: 72806},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2364, col: 34, offset: 72806},
+							pos:  position{line: 2364, col: 34, offset: 72807},
 							name: "IdentifierRest",
 						},
 					},
@@ -17789,20 +17792,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNION",
-			pos:  position{line: 2365, col: 1, offset: 72821},
+			pos:  position{line: 2365, col: 1, offset: 72822},
 			expr: &seqExpr{
-				pos: position{line: 2365, col: 14, offset: 72834},
+				pos: position{line: 2365, col: 14, offset: 72835},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2365, col: 14, offset: 72834},
+						pos:        position{line: 2365, col: 14, offset: 72835},
 						val:        "union",
 						ignoreCase: true,
 						want:       "\"UNION\"i",
 					},
 					&notExpr{
-						pos: position{line: 2365, col: 33, offset: 72853},
+						pos: position{line: 2365, col: 33, offset: 72854},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2365, col: 34, offset: 72854},
+							pos:  position{line: 2365, col: 34, offset: 72855},
 							name: "IdentifierRest",
 						},
 					},
@@ -17813,20 +17816,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNIQ",
-			pos:  position{line: 2366, col: 1, offset: 72869},
+			pos:  position{line: 2366, col: 1, offset: 72870},
 			expr: &seqExpr{
-				pos: position{line: 2366, col: 14, offset: 72882},
+				pos: position{line: 2366, col: 14, offset: 72883},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2366, col: 14, offset: 72882},
+						pos:        position{line: 2366, col: 14, offset: 72883},
 						val:        "uniq",
 						ignoreCase: true,
 						want:       "\"UNIQ\"i",
 					},
 					&notExpr{
-						pos: position{line: 2366, col: 33, offset: 72901},
+						pos: position{line: 2366, col: 33, offset: 72902},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2366, col: 34, offset: 72902},
+							pos:  position{line: 2366, col: 34, offset: 72903},
 							name: "IdentifierRest",
 						},
 					},
@@ -17837,20 +17840,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNNEST",
-			pos:  position{line: 2367, col: 1, offset: 72917},
+			pos:  position{line: 2367, col: 1, offset: 72918},
 			expr: &seqExpr{
-				pos: position{line: 2367, col: 14, offset: 72930},
+				pos: position{line: 2367, col: 14, offset: 72931},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2367, col: 14, offset: 72930},
+						pos:        position{line: 2367, col: 14, offset: 72931},
 						val:        "unnest",
 						ignoreCase: true,
 						want:       "\"UNNEST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2367, col: 33, offset: 72949},
+						pos: position{line: 2367, col: 33, offset: 72950},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2367, col: 34, offset: 72950},
+							pos:  position{line: 2367, col: 34, offset: 72951},
 							name: "IdentifierRest",
 						},
 					},
@@ -17861,20 +17864,20 @@ var g = &grammar{
 		},
 		{
 			name: "USING",
-			pos:  position{line: 2368, col: 1, offset: 72965},
+			pos:  position{line: 2368, col: 1, offset: 72966},
 			expr: &seqExpr{
-				pos: position{line: 2368, col: 14, offset: 72978},
+				pos: position{line: 2368, col: 14, offset: 72979},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2368, col: 14, offset: 72978},
+						pos:        position{line: 2368, col: 14, offset: 72979},
 						val:        "using",
 						ignoreCase: true,
 						want:       "\"USING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2368, col: 33, offset: 72997},
+						pos: position{line: 2368, col: 33, offset: 72998},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2368, col: 34, offset: 72998},
+							pos:  position{line: 2368, col: 34, offset: 72999},
 							name: "IdentifierRest",
 						},
 					},
@@ -17885,20 +17888,20 @@ var g = &grammar{
 		},
 		{
 			name: "VALUE",
-			pos:  position{line: 2369, col: 1, offset: 73013},
+			pos:  position{line: 2369, col: 1, offset: 73014},
 			expr: &seqExpr{
-				pos: position{line: 2369, col: 14, offset: 73026},
+				pos: position{line: 2369, col: 14, offset: 73027},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2369, col: 14, offset: 73026},
+						pos:        position{line: 2369, col: 14, offset: 73027},
 						val:        "value",
 						ignoreCase: true,
 						want:       "\"VALUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2369, col: 33, offset: 73045},
+						pos: position{line: 2369, col: 33, offset: 73046},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2369, col: 34, offset: 73046},
+							pos:  position{line: 2369, col: 34, offset: 73047},
 							name: "IdentifierRest",
 						},
 					},
@@ -17909,20 +17912,20 @@ var g = &grammar{
 		},
 		{
 			name: "VALUES",
-			pos:  position{line: 2370, col: 1, offset: 73061},
+			pos:  position{line: 2370, col: 1, offset: 73062},
 			expr: &seqExpr{
-				pos: position{line: 2370, col: 14, offset: 73074},
+				pos: position{line: 2370, col: 14, offset: 73075},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2370, col: 14, offset: 73074},
+						pos:        position{line: 2370, col: 14, offset: 73075},
 						val:        "values",
 						ignoreCase: true,
 						want:       "\"VALUES\"i",
 					},
 					&notExpr{
-						pos: position{line: 2370, col: 33, offset: 73093},
+						pos: position{line: 2370, col: 33, offset: 73094},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2370, col: 34, offset: 73094},
+							pos:  position{line: 2370, col: 34, offset: 73095},
 							name: "IdentifierRest",
 						},
 					},
@@ -17933,20 +17936,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHEN",
-			pos:  position{line: 2371, col: 1, offset: 73109},
+			pos:  position{line: 2371, col: 1, offset: 73110},
 			expr: &seqExpr{
-				pos: position{line: 2371, col: 14, offset: 73122},
+				pos: position{line: 2371, col: 14, offset: 73123},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2371, col: 14, offset: 73122},
+						pos:        position{line: 2371, col: 14, offset: 73123},
 						val:        "when",
 						ignoreCase: true,
 						want:       "\"WHEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2371, col: 33, offset: 73141},
+						pos: position{line: 2371, col: 33, offset: 73142},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2371, col: 34, offset: 73142},
+							pos:  position{line: 2371, col: 34, offset: 73143},
 							name: "IdentifierRest",
 						},
 					},
@@ -17957,20 +17960,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHERE",
-			pos:  position{line: 2372, col: 1, offset: 73157},
+			pos:  position{line: 2372, col: 1, offset: 73158},
 			expr: &seqExpr{
-				pos: position{line: 2372, col: 14, offset: 73170},
+				pos: position{line: 2372, col: 14, offset: 73171},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2372, col: 14, offset: 73170},
+						pos:        position{line: 2372, col: 14, offset: 73171},
 						val:        "where",
 						ignoreCase: true,
 						want:       "\"WHERE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2372, col: 33, offset: 73189},
+						pos: position{line: 2372, col: 33, offset: 73190},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2372, col: 34, offset: 73190},
+							pos:  position{line: 2372, col: 34, offset: 73191},
 							name: "IdentifierRest",
 						},
 					},
@@ -17981,20 +17984,20 @@ var g = &grammar{
 		},
 		{
 			name: "WITH",
-			pos:  position{line: 2373, col: 1, offset: 73205},
+			pos:  position{line: 2373, col: 1, offset: 73206},
 			expr: &seqExpr{
-				pos: position{line: 2373, col: 14, offset: 73218},
+				pos: position{line: 2373, col: 14, offset: 73219},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2373, col: 14, offset: 73218},
+						pos:        position{line: 2373, col: 14, offset: 73219},
 						val:        "with",
 						ignoreCase: true,
 						want:       "\"WITH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2373, col: 33, offset: 73237},
+						pos: position{line: 2373, col: 33, offset: 73238},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2373, col: 34, offset: 73238},
+							pos:  position{line: 2373, col: 34, offset: 73239},
 							name: "IdentifierRest",
 						},
 					},

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -701,7 +701,7 @@ Text
 SimpleURL =
   "http" "s"? "://"
   ([a-zA-Z0-9_-]+) ( "." [a-zA-Z0-9_-]+)*
-  ("/" TextChars)? { return string(c.text), nil }
+  ("/" TextChars?)? { return string(c.text), nil }
 
 TextChars
   = (IdentifierRest / "." / "/")+ { return string(c.text), nil }

--- a/compiler/parser/valid.zed
+++ b/compiler/parser/valid.zed
@@ -37,3 +37,4 @@ truevals()
 falsevals()
 values 2600:1901:101::/126, ::1/1, 2001:0db8:85a3:0000:0000:8a2e:0370:7334/55
 func head(): (1) func tail(): (1) func uniq(): (1) func pass(): (1) head() | tail() | uniq() | pass()
+from http://x/


### PR DESCRIPTION
This commit simplifies the syntax rules for text entites by creating a new grammar rule for a "simple URL".  This makes usage and documentation clearer.

While here, we changed the ":meta" meta-modifier syntax to a "name" (the same rules as field names), where the it can be anything if quoted and otherwise must have identifier syntax.

We also eliminated the unused PEG rule PoolAt and simplified the rule for KSUID as it's now used in just one place (KSUID overlaps with TextChars so it's not needed in the Text rule).

Documentation changes are forthcoming in the book branch.