### PR TITLE
compiler: add dag.NewUnaryExpr

### DIFF
--- a/compiler/dag/expr.go
+++ b/compiler/dag/expr.go
@@ -197,6 +197,10 @@ func NewBinaryExpr(op string, lhs, rhs Expr) *BinaryExpr {
 	}
 }
 
+func NewUnaryExpr(op string, e Expr) *UnaryExpr {
+	return &UnaryExpr{"UnaryExpr", op, e}
+}
+
 func NewValues(exprs ...Expr) *Values {
 	return &Values{"Values", exprs}
 }

--- a/compiler/rungen/pushdown.go
+++ b/compiler/rungen/pushdown.go
@@ -64,11 +64,7 @@ func (d *deleter) DataFilter() (expr.Evaluator, error) {
 	return d.builder.compileExpr(&dag.BinaryExpr{
 		Kind: "BinaryExpr",
 		Op:   "or",
-		LHS: &dag.UnaryExpr{
-			Kind:    "UnaryExpr",
-			Op:      "!",
-			Operand: d.dataFilter,
-		},
+		LHS:  dag.NewUnaryExpr("!", d.dataFilter),
 		RHS: &dag.BinaryExpr{
 			Kind: "BinaryExpr",
 			Op:   "or",

--- a/compiler/semantic/expr.go
+++ b/compiler/semantic/expr.go
@@ -67,11 +67,7 @@ func (a *analyzer) semExpr(e ast.Expr) dag.Expr {
 			},
 		}
 		if e.Not {
-			return &dag.UnaryExpr{
-				Kind:    "UnaryExpr",
-				Op:      "!",
-				Operand: expr,
-			}
+			return dag.NewUnaryExpr("!", expr)
 		}
 		return expr
 	case *ast.CaseExpr:
@@ -147,11 +143,7 @@ func (a *analyzer) semExpr(e ast.Expr) dag.Expr {
 		expr := a.semExpr(e.Expr)
 		var out dag.Expr = &dag.IsNullExpr{Kind: "IsNullExpr", Expr: expr}
 		if e.Not {
-			out = &dag.UnaryExpr{
-				Kind:    "UnaryExpr",
-				Op:      "!",
-				Operand: out,
-			}
+			out = dag.NewUnaryExpr("!", out)
 		}
 		return out
 	case *ast.MapExpr:
@@ -392,11 +384,7 @@ func (a *analyzer) semExpr(e ast.Expr) dag.Expr {
 		if e.Op == "+" {
 			return operand
 		}
-		return &dag.UnaryExpr{
-			Kind:    "UnaryExpr",
-			Op:      e.Op,
-			Operand: operand,
-		}
+		return dag.NewUnaryExpr(e.Op, operand)
 	case nil:
 		panic("semantic analysis: illegal null value encountered in AST")
 	}
@@ -553,11 +541,7 @@ func (a *analyzer) semBinary(e *ast.BinaryExpr) dag.Expr {
 			Expr:    lhs,
 		}
 		if op == "not like" {
-			return &dag.UnaryExpr{
-				Kind:    "UnaryExpr",
-				Op:      "!",
-				Operand: expr,
-			}
+			return dag.NewUnaryExpr("!", expr)
 		}
 		return expr
 	}
@@ -575,7 +559,7 @@ func (a *analyzer) semBinary(e *ast.BinaryExpr) dag.Expr {
 		op = "+"
 	case "not in":
 		expr := &dag.BinaryExpr{Kind: "BinaryExpr", Op: "in", LHS: lhs, RHS: rhs}
-		return &dag.UnaryExpr{Kind: "UnaryExpr", Op: "!", Operand: expr}
+		return dag.NewUnaryExpr("!", expr)
 	case "::":
 		return &dag.Call{
 			Kind: "Call",

--- a/compiler/semantic/op.go
+++ b/compiler/semantic/op.go
@@ -889,11 +889,7 @@ func (a *analyzer) semOp(o ast.Op, seq dag.Seq) dag.Seq {
 		}
 		seq = append(seq, &dag.Filter{
 			Kind: "Filter",
-			Expr: &dag.UnaryExpr{
-				Kind:    "UnaryExpr",
-				Op:      "!",
-				Operand: &dag.IsNullExpr{Kind: "IsNullExpr", Expr: e},
-			},
+			Expr: dag.NewUnaryExpr("!", &dag.IsNullExpr{Kind: "IsNullExpr", Expr: e}),
 		})
 		seq = append(seq, &dag.Aggregate{
 			Kind: "Aggregate",


### PR DESCRIPTION
It's more concise than a dag.UnaryExpr composite literal.