### PR TITLE
enable runtime/ztests/op/join-union.yaml on vector runtime

### DIFF
--- a/runtime/ztests/op/join-union.yaml
+++ b/runtime/ztests/op/join-union.yaml
@@ -1,7 +1,7 @@
 script: |
   super -s -c 'inner join (from b.sup) on left.a=right.b | values left | sort' a.sup
 
-#vector: true
+vector: true
 
 inputs:
   - name: a.sup
@@ -14,6 +14,7 @@ inputs:
       {b:1}
       {b:3}
       {b:"bar"}
+
 outputs:
   - name: stdout
     data: |


### PR DESCRIPTION
This test was disabled on the vector runtime in #5962 even though it passes on the vector runtime with that change.