### PR TITLE
Adopt new style conventions for mdbook docs

### DIFF
--- a/book/src/formats/bsup.md
+++ b/book/src/formats/bsup.md
@@ -93,12 +93,12 @@ of bytes of said length:
 ```
 The length encoding utilizes a variable-length unsigned integer called herein a `uvarint`:
 
-> Inspired by Protocol Buffers,
+> _Inspired by Protocol Buffers,
 > a `uvarint` is an unsigned, variable-length integer encoded as a sequence of
 > bytes consisting of N-1 bytes with bit 7 clear and the Nth byte with bit 7 set,
 > whose value is the base-128 number composed of the digits defined by the lower
 > 7 bits of each byte from least-significant digit (byte 0) to
-> most-significant digit (byte N-1).
+> most-significant digit (byte N-1)._
 
 The frame payload's length is equal to the value of the `uvarint` following the
 frame code times 16 plus the low 4-bit integer value `L` field in the frame code.
@@ -128,7 +128,7 @@ Of the 256 possible values for the `<format>` byte, only type `0` is currently
 defined and specifies that `<compressed payload>` contains an
 [LZ4 block](https://github.com/lz4/lz4/blob/master/doc/lz4_Block_format.md).
 
-> This arrangement of frames separating types and values allows
+> _This arrangement of frames separating types and values allows
 > for efficient scanning and parallelization.  In general, values depend
 > on type definitions but as long as all of the types are known when
 > values are used, decoding can be done in parallel.  Likewise, since
@@ -139,7 +139,7 @@ defined and specifies that `<compressed payload>` contains an
 > heuristics, e.g., knowing a filtering predicate can't be true based on a
 > quick scan of the data perhaps using the Boyer-Moore algorithm to determine
 > that a comparison with a string constant would not work for any
-> value in the buffer.
+> value in the buffer._
 
 Whether the payload was originally uncompressed or was decompressed, it is
 then interpreted according to the `T` bits of the frame code as a
@@ -177,7 +177,7 @@ The typedef codes are defined as follows:
 |   6  |  error type definition   |
 |   7  |  named type definition   |
 
-Any references to a type ID in the body of a typedef are encoded as a `uvarint`,
+Any references to a type ID in the body of a typedef are encoded as a `uvarint`.
 
 ##### 2.1.1 Record Typedef
 
@@ -207,10 +207,10 @@ is further encoded as a "counted string", which is the `uvarint` encoding
 of the length of the string followed by that many bytes of UTF-8 encoded
 string data.
 
-> As defined by [Super (SUP)](sup.md), a field name can be any valid UTF-8 string much like JSON
+> _As defined by [Super (SUP)](sup.md), a field name can be any valid UTF-8 string much like JSON
 > objects can be indexed with arbitrary string keys (via index operator)
 > even if the field names available to the dot operator are restricted
-> by language syntax for identifiers.
+> by language syntax for identifiers._
 
 The type ID follows the field name and is encoded as a `uvarint`.
 

--- a/book/src/formats/csup.md
+++ b/book/src/formats/csup.md
@@ -1,6 +1,6 @@
 ## Super Column (CSUP) Format
 
-> TODO: this is out of date and needs to be updated.
+> _TODO: this is out of date and needs to be updated._
 
 Super Columnar (CSUP) is a file format based on
 the [super-structured data model](model.md) where data is stacked to form columns.
@@ -62,10 +62,10 @@ then write the metadata into the reassembly section along with the trailer
 at the end.  This allows a stream to be converted to a CSUP file
 in a single pass.
 
-> That said, the layout is
+> _That said, the layout is
 > flexible enough that an implementation may optimize the data layout with
 > additional passes or by writing the output to multiple files then
-> merging them together (or even leaving the CSUP entity as separate files).
+> merging them together (or even leaving the CSUP entity as separate files)._
 
 #### The Data Section
 
@@ -81,15 +81,15 @@ There is no information in the data section for how segments relate
 to one another or how they are reconstructed into columns.  They are just
 blobs of BSUP data.
 
-> Unlike Parquet, there is no explicit arrangement of the column chunks into
+> _Unlike Parquet, there is no explicit arrangement of the column chunks into
 > row groups but rather they are allowed to grow at different rates so a
 > high-volume column might be comprised of many segments while a low-volume
 > column must just be one or several.  This allows scans of low-volume record types
 > (the "mice") to perform well amongst high-volume record types (the "elephants"),
 > i.e., there are not a bunch of seeks with tiny reads of mice data interspersed
-> throughout the elephants.
-
-> The mice/elephants model creates an interesting and challenging layout
+> throughout the elephants._
+>
+> _The mice/elephants model creates an interesting and challenging layout
 > problem.  If you let the row indexes get too far apart (call this "skew"), then
 > you have to buffer very large amounts of data to keep the column data aligned.
 > This is the point of row groups in Parquet, but the model here is to leave it
@@ -101,7 +101,7 @@ blobs of BSUP data.
 > if you use lots of buffering on ingest, you can write the mice in front of the
 > elephants so the read path requires less buffering to align columns.  Or you can
 > do two passes where you store segments in separate files then merge them at close
-> according to an optimization plan.
+> according to an optimization plan._
 
 #### The Reassembly Section
 
@@ -109,15 +109,15 @@ The reassembly section provides the information needed to reconstruct
 column streams from segments, and in turn, to reconstruct the original values
 from column streams, i.e., to map columns back to composite values.
 
-> Of course, the reassembly section also provides the ability to extract just subsets of columns
+> _Of course, the reassembly section also provides the ability to extract just subsets of columns
 > to be read and searched efficiently without ever needing to reconstruct
 > the original rows.  How well this performs is up to any particular
-> CSUP implementation.
+> CSUP implementation._
 > 
-> Also, the reassembly section is in general vastly smaller than the data section
+> _Also, the reassembly section is in general vastly smaller than the data section
 > so the goal here isn't to express information in cute and obscure compact forms
 > but rather to represent data in an easy-to-digest, programmer-friendly form that
-> leverages BSUP.
+> leverages BSUP._
 
 The reassembly section is a BSUP stream.  Unlike Parquet,
 which uses an externally described schema
@@ -137,7 +137,7 @@ A super type's integer position in this sequence defines its identifier
 encoded in the [super column](#the-super-column).  This identifier is called
 the super ID.
 
-> Change the first N values to type values instead of nulls?
+> _Change the first N values to type values instead of nulls?_
 
 The next N+1 records contain reassembly information for each of the N super types
 where each record defines the column streams needed to reconstruct the original
@@ -159,9 +159,9 @@ type signature:
 In the rest of this document, we will refer to this type as `<segmap>` for
 shorthand and refer to the concept as a "segmap".
 
-> We use the type name "segmap" to emphasize that this information represents
+> _We use the type name "segmap" to emphasize that this information represents
 > a set of byte ranges where data is stored and must be read from *rather than*
-> the data itself.
+> the data itself._
 
 ##### The Super Column
 
@@ -202,9 +202,9 @@ This simple top-down arrangement, along with the definition of the other
 column structures below, is all that is needed to reconstruct all of the
 original data.
 
-> Each row reassembly record has its own layout of columnar
+> _Each row reassembly record has its own layout of columnar
 > values and there is no attempt made to store like-typed columns from different
-> schemas in the same physical column.
+> schemas in the same physical column._
 
 
 The notation `<any_column>` refers to any instance of the five column types:
@@ -333,12 +333,12 @@ data in the file,
 it will typically fit comfortably in memory and it can be very fast to scan the
 entire reassembly structure for any purpose.
 
-> For a given query, a "scan planner" could traverse all the
+> _For a given query, a "scan planner" could traverse all the
 > reassembly records to figure out which segments will be needed, then construct
 > an intelligent plan for reading the needed segments and attempt to read them
 > in mostly sequential order, which could serve as
 > an optimizing intermediary between any underlying storage API and the
-> CSUP decoding logic.
+> CSUP decoding logic._
 
 To decode the "next" row, its schema index is read from the root reassembly
 column stream.

--- a/book/src/intro.md
+++ b/book/src/intro.md
@@ -77,8 +77,8 @@ super -c "SELECT 'hello, world'"
 To interact with a SuperDB database, the `super db` subcommands and/or
 its corresponding API can be utilized.
 
-> Note that the persistent database layer is still under development and not yet 
-> ready for turnkey production use.
+> _Note that the persistent database layer is still under development and not yet 
+> ready for turnkey production use._
 
 ## Why Not Relational?
 
@@ -105,9 +105,9 @@ consider this simple line of JSON data is in a file called `example.json`:
 {"a":[1,"foo"]}
 ```
 
-> The literal `[1,"foo"]` is a contrived example but it adequately
+> _The literal `[1,"foo"]` is a contrived example but it adequately
 > represents the challenge of mixed-type JSON values, e.g.,
-> an API returning an array of JSON objects with varying shape.
+> an API returning an array of JSON objects with varying shape._
 
 Surprisingly, this simple JSON input causes unpredictable schema inference
 across different SQL systems.
@@ -172,12 +172,12 @@ While the original conception of the relational data model anticipated
 "product types" &mdash; in fact, describing a relation's schema in terms of
 a product type &mdash; it unfortunately did not anticipate sum types.
 
-> Codd's original paper on the relational model has a footnote that
-> essentially describes as a product type:
+> _Codd's original paper on the relational model has a footnote that
+> essentially describes as a product type:_
 >
 > <center><img src="codd-footnote.png" alt="Codd's Footnote" title="Codd's Footnote" width="500"></center>
 >
-> But sum types were notably absent.
+> _But sum types were notably absent._
 
 Armed with both sum and product types, super-structured data provides a 
 comprehensive algebraic type system that can represent any
@@ -216,7 +216,7 @@ adapted for super-structured data called
 SuperSQL is particularly well suited for data-wrangling use cases like
 ETL and data exploration and discovery.
 [Syntactic shortcuts](super-sql/shortcuts.md),
-[keyword search](super-sql/search.md), and the
+[keyword search](super-sql/operators/search.md), and the
 [pipe syntax](super-sql/intro.md)
 make interactively querying data a breeze.
 
@@ -383,5 +383,5 @@ feel free to dive in deeper:
 [formats](formats/intro.md) underlying SuperDB, or
 * browse the [tutorials](tutorials/intro.md).
 
-> Once you've had a look at SuperDB, feel free to chat with us on
-> our [community Slack](https://www.brimdata.io/join-slack/).
+> _Once you've had a look at SuperDB, feel free to chat with us on
+> our [community Slack](https://www.brimdata.io/join-slack/)._

--- a/book/src/super-sql/operators/cut.md
+++ b/book/src/super-sql/operators/cut.md
@@ -101,9 +101,9 @@ cut a,b
 
 _Invoke a function while cutting to set a default value for a field_
 
-> This can be helpful to transform data into a uniform record type, such as if
+> _This can be helpful to transform data into a uniform record type, such as if
 > the output will be exported in formats such as `csv` or `parquet` (see also:
-> [`fuse`](fuse.md)).
+> [`fuse`](fuse.md))._
 
 ```mdtest-spq
 # spq

--- a/book/src/super-sql/operators/from.md
+++ b/book/src/super-sql/operators/from.md
@@ -100,8 +100,8 @@ branch of each pool is accessed.
 
 The format argument is not valid with a database source.
 
-> Metadata from database pools also may be sourced using `from`.
-> This will be documented in a future release of SuperDB.
+> _Metadata from database pools also may be sourced using `from`.
+> This will be documented in a future release of SuperDB._
 
 #### URL
 

--- a/book/src/super-sql/operators/search.md
+++ b/book/src/super-sql/operators/search.md
@@ -150,7 +150,7 @@ where (123 in this or grep("123", this))
 ```
 
 Complex values are not supported as search terms but may be queried with
-the ["in" operator](../expressions.md#containment), e.g.,
+the ["in"](../expressions.md#containment) operator, e.g.,
 ```
 {s:"foo"} in this
 ```

--- a/book/src/super-sql/types/map.md
+++ b/book/src/super-sql/types/map.md
@@ -44,7 +44,7 @@ zero or more comma-separated key-value pairs contained in pipe braces:
 where `<key>` and `<value>`
 may be any valid [expression](../expressions.md).
 
-> The map spread operator is not yet implemented.
+> _The map spread operator is not yet implemented._
 
 When the expressions result in values of non-uniform type of either the keys or
 the values, then their types become a sum type of the types present,

--- a/book/src/super-sql/types/numbers.md
+++ b/book/src/super-sql/types/numbers.md
@@ -20,7 +20,7 @@ These signed types include:
 * `int16`, and
 * `int32`.
 
-> The `int128` type is not yet implemented in SuperDB.
+> _The `int128` type is not yet implemented in SuperDB._
 
 For backward compatibility with SQL, syntactic aliases for signed integers
 are defined as follows:
@@ -41,7 +41,7 @@ These unsigned types include:
 * `uint16`, and
 * `uint32`.
 
-> The `uint128` type is not yet implemented in SuperDB.
+> _The `uint128` type is not yet implemented in SuperDB._
 
 
 #### Floating Point 
@@ -69,7 +69,7 @@ are defined as follows:
 
 #### Decimal 
 
-> _The decimal type is not yet implemented in SuperSQL._
+> _The `decimal` type is not yet implemented in SuperSQL._
 
 #### Coercion
 


### PR DESCRIPTION
I've taken a pass through the mdbook docs merged to `main` thus far and brought them more in line with the style conventions introduced in #6158. I also fixed a couple small glitches I found along the way.