### PR TITLE
remove /compiler/parser/deps/ from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /bin/
-/compiler/parser/deps/
 /dist/
 /zed-sample-data/
 


### PR DESCRIPTION
That directory hasn't been used since #5763.