### PR TITLE
Enable book Git URL icon/link

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -12,11 +12,11 @@ enable = true
 [output.html]
 additional-css = ["super-example/super-example.css", "copy-button/copy-button.css", "theme/pagetoc.css"]
 additional-js = ["super-example.bundle.js", "copy-button/copy-button.js", "theme/pagetoc.js"]
+git-repository-url = "https://github.com/brimdata/super/tree/main/book"
 # This directive embeds content hashes in the certain asset file names 
 # to work around a problem where cached files cause the sidebar not to reflect
 # changes to SUMMARY.md.  See https://github.com/rust-lang/mdBook/issues/2547
 hash-files = true
-git-repository-url = "https://github.com/brimdata/super/tree/main/book"
 no-section-label = true
 
 [output.html.playground]


### PR DESCRIPTION
## What's Changing

An icon with hyperlink to the "book" directory in the super repo is added at the top of the rendered book docs pages.

<img width="951" height="496" alt="image" src="https://github.com/user-attachments/assets/e51516d0-7c10-4183-97ea-3302169f4ec2" />

## Why

It's a courtesy to users that might want to look at the source markdown of the docs for whatever reason, perhaps when filing issues or proposing enhancements.