### PR TITLE
compiler/semantic: try to resolve ast.DoubleQuote in schema

### DIFF
--- a/compiler/semantic/expr.go
+++ b/compiler/semantic/expr.go
@@ -399,7 +399,7 @@ func (a *analyzer) semDoubleQuote(d *ast.DoubleQuote) dag.Expr {
 	// as an identifier.  XXX we'll need to do something a bit more
 	// sophisticated to handle pipes inside SQL subqueries.
 	if a.scope.schema != nil {
-		return a.semID(&ast.ID{Kind: "ID", Name: d.Text, Loc: d.Loc})
+		return a.semExpr(&ast.ID{Kind: "ID", Name: d.Text, Loc: d.Loc})
 	}
 	return a.semExpr(&ast.Primitive{
 		Kind: "Primitive",


### PR DESCRIPTION
When a schema is available, analyzer.semDoubleQuote should try to resolve ast.DoubleQuote.Text in the schema.  It attempts to do this by creating an ast.ID and passing that to semID, but this is incorrect because schema resolution for an ast.ID happens in semExpr, not semID. Call semExpr instead.

This bug is masked by another bug in the optimizer.  Rather than add an explicit test for this bug, we should arrange to run the existing tests without the optimizer.