### PR TITLE
compiler/optimizer: fix bug in liftFilterOps

### DIFF
--- a/compiler/optimizer/optimizer.go
+++ b/compiler/optimizer/optimizer.go
@@ -526,11 +526,13 @@ func liftFilterOps(seq dag.Seq) dag.Seq {
 				e1, ok := fields[this.Path[0]]
 				if !ok {
 					if spread != nil {
-						return addPathToExpr(spread, this.Path)
+						// Copy spread so f and y don't share dag.Exprs.
+						return addPathToExpr(dag.CopyExpr(spread), this.Path)
 					}
 					return e
 				}
-				return addPathToExpr(e1, this.Path[1:])
+				// Copy e1 so f and y don't share dag.Exprs.
+				return addPathToExpr(dag.CopyExpr(e1), this.Path[1:])
 			})
 			seq[i], seq[i+1] = seq[i+1], seq[i]
 		}


### PR DESCRIPTION
liftFilterOps can produce a DAG in which a dag.Filter and dag.Values share a dag.Expr.  If the shared Expr is later modified on behalf of one operator, the change will incorrectly affect the other.  Fix by coping any Expr from the dag.Values that is substituted into the dag.Filter.

I haven't been able to craft a test for this but need to fix it in order to fix a mergeValuesOps bug that transforms "values {a:this} | values b" to "values b" instead of "values error('missing')".