### PR TITLE
parser: Add back left recursion for DerefExpr

### DIFF
--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -6737,254 +6737,241 @@ var g = &grammar{
 		{
 			name: "DerefExpr",
 			pos:  position{line: 998, col: 1, offset: 24039},
-			expr: &actionExpr{
+			expr: &choiceExpr{
 				pos: position{line: 999, col: 5, offset: 24053},
-				run: (*parser).callonDerefExpr1,
-				expr: &seqExpr{
-					pos: position{line: 999, col: 5, offset: 24053},
-					exprs: []any{
-						&labeledExpr{
-							pos:   position{line: 999, col: 5, offset: 24053},
-							label: "head",
-							expr: &choiceExpr{
-								pos: position{line: 999, col: 11, offset: 24059},
-								alternatives: []any{
-									&ruleRefExpr{
-										pos:  position{line: 999, col: 11, offset: 24059},
-										name: "Function",
+				alternatives: []any{
+					&actionExpr{
+						pos: position{line: 999, col: 5, offset: 24053},
+						run: (*parser).callonDerefExpr2,
+						expr: &seqExpr{
+							pos: position{line: 999, col: 5, offset: 24053},
+							exprs: []any{
+								&labeledExpr{
+									pos:   position{line: 999, col: 5, offset: 24053},
+									label: "expr",
+									expr: &ruleRefExpr{
+										pos:  position{line: 999, col: 10, offset: 24058},
+										name: "DerefExpr",
 									},
-									&ruleRefExpr{
-										pos:  position{line: 999, col: 22, offset: 24070},
-										name: "Primary",
+								},
+								&litMatcher{
+									pos:        position{line: 999, col: 20, offset: 24068},
+									val:        "[",
+									ignoreCase: false,
+									want:       "\"[\"",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 999, col: 24, offset: 24072},
+									name: "__",
+								},
+								&labeledExpr{
+									pos:   position{line: 999, col: 27, offset: 24075},
+									label: "from",
+									expr: &ruleRefExpr{
+										pos:  position{line: 999, col: 32, offset: 24080},
+										name: "AdditiveExpr",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 999, col: 45, offset: 24093},
+									name: "__",
+								},
+								&litMatcher{
+									pos:        position{line: 999, col: 48, offset: 24096},
+									val:        ":",
+									ignoreCase: false,
+									want:       "\":\"",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 999, col: 52, offset: 24100},
+									name: "__",
+								},
+								&labeledExpr{
+									pos:   position{line: 999, col: 55, offset: 24103},
+									label: "to",
+									expr: &zeroOrOneExpr{
+										pos: position{line: 999, col: 58, offset: 24106},
+										expr: &ruleRefExpr{
+											pos:  position{line: 999, col: 58, offset: 24106},
+											name: "AdditiveExpr",
+										},
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 999, col: 72, offset: 24120},
+									name: "__",
+								},
+								&litMatcher{
+									pos:        position{line: 999, col: 75, offset: 24123},
+									val:        "]",
+									ignoreCase: false,
+									want:       "\"]\"",
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 1011, col: 5, offset: 24362},
+						run: (*parser).callonDerefExpr18,
+						expr: &seqExpr{
+							pos: position{line: 1011, col: 5, offset: 24362},
+							exprs: []any{
+								&labeledExpr{
+									pos:   position{line: 1011, col: 5, offset: 24362},
+									label: "expr",
+									expr: &ruleRefExpr{
+										pos:  position{line: 1011, col: 10, offset: 24367},
+										name: "DerefExpr",
+									},
+								},
+								&litMatcher{
+									pos:        position{line: 1011, col: 20, offset: 24377},
+									val:        "[",
+									ignoreCase: false,
+									want:       "\"[\"",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 1011, col: 24, offset: 24381},
+									name: "__",
+								},
+								&litMatcher{
+									pos:        position{line: 1011, col: 27, offset: 24384},
+									val:        ":",
+									ignoreCase: false,
+									want:       "\":\"",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 1011, col: 31, offset: 24388},
+									name: "__",
+								},
+								&labeledExpr{
+									pos:   position{line: 1011, col: 34, offset: 24391},
+									label: "to",
+									expr: &ruleRefExpr{
+										pos:  position{line: 1011, col: 37, offset: 24394},
+										name: "AdditiveExpr",
+									},
+								},
+								&litMatcher{
+									pos:        position{line: 1011, col: 50, offset: 24407},
+									val:        "]",
+									ignoreCase: false,
+									want:       "\"]\"",
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 1019, col: 5, offset: 24571},
+						run: (*parser).callonDerefExpr29,
+						expr: &seqExpr{
+							pos: position{line: 1019, col: 5, offset: 24571},
+							exprs: []any{
+								&labeledExpr{
+									pos:   position{line: 1019, col: 5, offset: 24571},
+									label: "expr",
+									expr: &ruleRefExpr{
+										pos:  position{line: 1019, col: 10, offset: 24576},
+										name: "DerefExpr",
+									},
+								},
+								&litMatcher{
+									pos:        position{line: 1019, col: 20, offset: 24586},
+									val:        "[",
+									ignoreCase: false,
+									want:       "\"[\"",
+								},
+								&labeledExpr{
+									pos:   position{line: 1019, col: 24, offset: 24590},
+									label: "index",
+									expr: &ruleRefExpr{
+										pos:  position{line: 1019, col: 30, offset: 24596},
+										name: "Expr",
+									},
+								},
+								&litMatcher{
+									pos:        position{line: 1019, col: 35, offset: 24601},
+									val:        "]",
+									ignoreCase: false,
+									want:       "\"]\"",
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 1027, col: 5, offset: 24771},
+						run: (*parser).callonDerefExpr37,
+						expr: &seqExpr{
+							pos: position{line: 1027, col: 5, offset: 24771},
+							exprs: []any{
+								&labeledExpr{
+									pos:   position{line: 1027, col: 5, offset: 24771},
+									label: "expr",
+									expr: &ruleRefExpr{
+										pos:  position{line: 1027, col: 10, offset: 24776},
+										name: "DerefExpr",
+									},
+								},
+								&litMatcher{
+									pos:        position{line: 1027, col: 20, offset: 24786},
+									val:        ".",
+									ignoreCase: false,
+									want:       "\".\"",
+								},
+								&labeledExpr{
+									pos:   position{line: 1027, col: 24, offset: 24790},
+									label: "id",
+									expr: &ruleRefExpr{
+										pos:  position{line: 1027, col: 27, offset: 24793},
+										name: "DerefKey",
 									},
 								},
 							},
 						},
-						&labeledExpr{
-							pos:   position{line: 999, col: 31, offset: 24079},
-							label: "tail",
-							expr: &zeroOrMoreExpr{
-								pos: position{line: 999, col: 36, offset: 24084},
-								expr: &choiceExpr{
-									pos: position{line: 1000, col: 9, offset: 24094},
-									alternatives: []any{
-										&actionExpr{
-											pos: position{line: 1000, col: 9, offset: 24094},
-											run: (*parser).callonDerefExpr10,
-											expr: &seqExpr{
-												pos: position{line: 1000, col: 9, offset: 24094},
-												exprs: []any{
-													&ruleRefExpr{
-														pos:  position{line: 1000, col: 9, offset: 24094},
-														name: "__",
-													},
-													&litMatcher{
-														pos:        position{line: 1000, col: 12, offset: 24097},
-														val:        "[",
-														ignoreCase: false,
-														want:       "\"[\"",
-													},
-													&ruleRefExpr{
-														pos:  position{line: 1000, col: 16, offset: 24101},
-														name: "__",
-													},
-													&labeledExpr{
-														pos:   position{line: 1000, col: 19, offset: 24104},
-														label: "from",
-														expr: &ruleRefExpr{
-															pos:  position{line: 1000, col: 24, offset: 24109},
-															name: "AdditiveExpr",
-														},
-													},
-													&ruleRefExpr{
-														pos:  position{line: 1000, col: 37, offset: 24122},
-														name: "__",
-													},
-													&litMatcher{
-														pos:        position{line: 1000, col: 40, offset: 24125},
-														val:        ":",
-														ignoreCase: false,
-														want:       "\":\"",
-													},
-													&ruleRefExpr{
-														pos:  position{line: 1000, col: 44, offset: 24129},
-														name: "__",
-													},
-													&labeledExpr{
-														pos:   position{line: 1000, col: 47, offset: 24132},
-														label: "to",
-														expr: &zeroOrOneExpr{
-															pos: position{line: 1000, col: 50, offset: 24135},
-															expr: &ruleRefExpr{
-																pos:  position{line: 1000, col: 50, offset: 24135},
-																name: "AdditiveExpr",
-															},
-														},
-													},
-													&ruleRefExpr{
-														pos:  position{line: 1000, col: 64, offset: 24149},
-														name: "__",
-													},
-													&litMatcher{
-														pos:        position{line: 1000, col: 67, offset: 24152},
-														val:        "]",
-														ignoreCase: false,
-														want:       "\"]\"",
-													},
-												},
-											},
-										},
-										&actionExpr{
-											pos: position{line: 1011, col: 9, offset: 24405},
-											run: (*parser).callonDerefExpr25,
-											expr: &seqExpr{
-												pos: position{line: 1011, col: 9, offset: 24405},
-												exprs: []any{
-													&ruleRefExpr{
-														pos:  position{line: 1011, col: 9, offset: 24405},
-														name: "__",
-													},
-													&litMatcher{
-														pos:        position{line: 1011, col: 12, offset: 24408},
-														val:        "[",
-														ignoreCase: false,
-														want:       "\"[\"",
-													},
-													&ruleRefExpr{
-														pos:  position{line: 1011, col: 16, offset: 24412},
-														name: "__",
-													},
-													&litMatcher{
-														pos:        position{line: 1011, col: 19, offset: 24415},
-														val:        ":",
-														ignoreCase: false,
-														want:       "\":\"",
-													},
-													&ruleRefExpr{
-														pos:  position{line: 1011, col: 23, offset: 24419},
-														name: "__",
-													},
-													&labeledExpr{
-														pos:   position{line: 1011, col: 26, offset: 24422},
-														label: "to",
-														expr: &ruleRefExpr{
-															pos:  position{line: 1011, col: 29, offset: 24425},
-															name: "AdditiveExpr",
-														},
-													},
-													&litMatcher{
-														pos:        position{line: 1011, col: 42, offset: 24438},
-														val:        "]",
-														ignoreCase: false,
-														want:       "\"]\"",
-													},
-												},
-											},
-										},
-										&actionExpr{
-											pos: position{line: 1018, col: 9, offset: 24599},
-											run: (*parser).callonDerefExpr35,
-											expr: &seqExpr{
-												pos: position{line: 1018, col: 9, offset: 24599},
-												exprs: []any{
-													&ruleRefExpr{
-														pos:  position{line: 1018, col: 9, offset: 24599},
-														name: "__",
-													},
-													&litMatcher{
-														pos:        position{line: 1018, col: 12, offset: 24602},
-														val:        "[",
-														ignoreCase: false,
-														want:       "\"[\"",
-													},
-													&ruleRefExpr{
-														pos:  position{line: 1018, col: 16, offset: 24606},
-														name: "__",
-													},
-													&labeledExpr{
-														pos:   position{line: 1018, col: 19, offset: 24609},
-														label: "index",
-														expr: &ruleRefExpr{
-															pos:  position{line: 1018, col: 25, offset: 24615},
-															name: "Expr",
-														},
-													},
-													&ruleRefExpr{
-														pos:  position{line: 1018, col: 30, offset: 24620},
-														name: "__",
-													},
-													&litMatcher{
-														pos:        position{line: 1018, col: 33, offset: 24623},
-														val:        "]",
-														ignoreCase: false,
-														want:       "\"]\"",
-													},
-												},
-											},
-										},
-										&actionExpr{
-											pos: position{line: 1025, col: 9, offset: 24790},
-											run: (*parser).callonDerefExpr44,
-											expr: &seqExpr{
-												pos: position{line: 1025, col: 9, offset: 24790},
-												exprs: []any{
-													&litMatcher{
-														pos:        position{line: 1025, col: 9, offset: 24790},
-														val:        ".",
-														ignoreCase: false,
-														want:       "\".\"",
-													},
-													&labeledExpr{
-														pos:   position{line: 1025, col: 13, offset: 24794},
-														label: "id",
-														expr: &ruleRefExpr{
-															pos:  position{line: 1025, col: 16, offset: 24797},
-															name: "DerefKey",
-														},
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
+					},
+					&ruleRefExpr{
+						pos:  position{line: 1036, col: 5, offset: 24981},
+						name: "Function",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 1037, col: 5, offset: 24994},
+						name: "Primary",
 					},
 				},
 			},
-			leader:        false,
-			leftRecursive: false,
+			leader:        true,
+			leftRecursive: true,
 		},
 		{
 			name: "DerefKey",
-			pos:  position{line: 1037, col: 1, offset: 25039},
+			pos:  position{line: 1039, col: 1, offset: 25003},
 			expr: &choiceExpr{
-				pos: position{line: 1038, col: 5, offset: 25052},
+				pos: position{line: 1040, col: 5, offset: 25016},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1038, col: 5, offset: 25052},
+						pos:  position{line: 1040, col: 5, offset: 25016},
 						name: "Identifier",
 					},
 					&actionExpr{
-						pos: position{line: 1039, col: 5, offset: 25067},
+						pos: position{line: 1041, col: 5, offset: 25031},
 						run: (*parser).callonDerefKey3,
 						expr: &labeledExpr{
-							pos:   position{line: 1039, col: 5, offset: 25067},
+							pos:   position{line: 1041, col: 5, offset: 25031},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1039, col: 7, offset: 25069},
+								pos:  position{line: 1041, col: 7, offset: 25033},
 								name: "DoubleQuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1040, col: 5, offset: 25161},
+						pos: position{line: 1042, col: 5, offset: 25125},
 						run: (*parser).callonDerefKey6,
 						expr: &labeledExpr{
-							pos:   position{line: 1040, col: 5, offset: 25161},
+							pos:   position{line: 1042, col: 5, offset: 25125},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1040, col: 7, offset: 25163},
+								pos:  position{line: 1042, col: 7, offset: 25127},
 								name: "BacktickString",
 							},
 						},
@@ -6996,79 +6983,79 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 1042, col: 1, offset: 25252},
+			pos:  position{line: 1044, col: 1, offset: 25216},
 			expr: &choiceExpr{
-				pos: position{line: 1043, col: 5, offset: 25265},
+				pos: position{line: 1045, col: 5, offset: 25229},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1043, col: 5, offset: 25265},
+						pos: position{line: 1045, col: 5, offset: 25229},
 						run: (*parser).callonFunction2,
 						expr: &seqExpr{
-							pos: position{line: 1043, col: 5, offset: 25265},
+							pos: position{line: 1045, col: 5, offset: 25229},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1043, col: 5, offset: 25265},
+									pos:  position{line: 1045, col: 5, offset: 25229},
 									name: "EXTRACT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1043, col: 13, offset: 25273},
+									pos:  position{line: 1045, col: 13, offset: 25237},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1043, col: 16, offset: 25276},
+									pos:        position{line: 1045, col: 16, offset: 25240},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1043, col: 20, offset: 25280},
+									pos:  position{line: 1045, col: 20, offset: 25244},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1043, col: 23, offset: 25283},
+									pos:   position{line: 1045, col: 23, offset: 25247},
 									label: "part",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1043, col: 28, offset: 25288},
+										pos:  position{line: 1045, col: 28, offset: 25252},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1043, col: 33, offset: 25293},
+									pos:  position{line: 1045, col: 33, offset: 25257},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1043, col: 35, offset: 25295},
+									pos:  position{line: 1045, col: 35, offset: 25259},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1043, col: 40, offset: 25300},
+									pos:  position{line: 1045, col: 40, offset: 25264},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1043, col: 42, offset: 25302},
+									pos:   position{line: 1045, col: 42, offset: 25266},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1043, col: 44, offset: 25304},
+										pos:  position{line: 1045, col: 44, offset: 25268},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1043, col: 49, offset: 25309},
+									pos:  position{line: 1045, col: 49, offset: 25273},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1043, col: 52, offset: 25312},
+									pos:        position{line: 1045, col: 52, offset: 25276},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1043, col: 56, offset: 25316},
+									pos:   position{line: 1045, col: 56, offset: 25280},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1043, col: 62, offset: 25322},
+										pos: position{line: 1045, col: 62, offset: 25286},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1043, col: 62, offset: 25322},
+											pos:  position{line: 1045, col: 62, offset: 25286},
 											name: "WhereClause",
 										},
 									},
@@ -7077,43 +7064,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1051, col: 5, offset: 25500},
+						pos: position{line: 1053, col: 5, offset: 25464},
 						run: (*parser).callonFunction20,
 						expr: &seqExpr{
-							pos: position{line: 1051, col: 5, offset: 25500},
+							pos: position{line: 1053, col: 5, offset: 25464},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1051, col: 5, offset: 25500},
+									pos:  position{line: 1053, col: 5, offset: 25464},
 									name: "EXISTS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1051, col: 12, offset: 25507},
+									pos:  position{line: 1053, col: 12, offset: 25471},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1051, col: 15, offset: 25510},
+									pos:        position{line: 1053, col: 15, offset: 25474},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1051, col: 19, offset: 25514},
+									pos:  position{line: 1053, col: 19, offset: 25478},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1051, col: 22, offset: 25517},
+									pos:   position{line: 1053, col: 22, offset: 25481},
 									label: "body",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1051, col: 27, offset: 25522},
+										pos:  position{line: 1053, col: 27, offset: 25486},
 										name: "Seq",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1051, col: 31, offset: 25526},
+									pos:  position{line: 1053, col: 31, offset: 25490},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1051, col: 34, offset: 25529},
+									pos:        position{line: 1053, col: 34, offset: 25493},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7122,72 +7109,72 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1058, col: 5, offset: 25666},
+						pos: position{line: 1060, col: 5, offset: 25630},
 						run: (*parser).callonFunction30,
 						expr: &seqExpr{
-							pos: position{line: 1058, col: 5, offset: 25666},
+							pos: position{line: 1060, col: 5, offset: 25630},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1058, col: 5, offset: 25666},
+									pos:  position{line: 1060, col: 5, offset: 25630},
 									name: "CAST",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1058, col: 10, offset: 25671},
+									pos:  position{line: 1060, col: 10, offset: 25635},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1058, col: 13, offset: 25674},
+									pos:        position{line: 1060, col: 13, offset: 25638},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1058, col: 17, offset: 25678},
+									pos:  position{line: 1060, col: 17, offset: 25642},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1058, col: 20, offset: 25681},
+									pos:   position{line: 1060, col: 20, offset: 25645},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1058, col: 22, offset: 25683},
+										pos:  position{line: 1060, col: 22, offset: 25647},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1058, col: 27, offset: 25688},
+									pos:  position{line: 1060, col: 27, offset: 25652},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1058, col: 29, offset: 25690},
+									pos:  position{line: 1060, col: 29, offset: 25654},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1058, col: 32, offset: 25693},
+									pos:  position{line: 1060, col: 32, offset: 25657},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1058, col: 34, offset: 25695},
+									pos:   position{line: 1060, col: 34, offset: 25659},
 									label: "typ",
 									expr: &choiceExpr{
-										pos: position{line: 1058, col: 39, offset: 25700},
+										pos: position{line: 1060, col: 39, offset: 25664},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1058, col: 39, offset: 25700},
+												pos:  position{line: 1060, col: 39, offset: 25664},
 												name: "DateTypeHack",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1058, col: 54, offset: 25715},
+												pos:  position{line: 1060, col: 54, offset: 25679},
 												name: "Type",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1058, col: 60, offset: 25721},
+									pos:  position{line: 1060, col: 60, offset: 25685},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1058, col: 63, offset: 25724},
+									pos:        position{line: 1060, col: 63, offset: 25688},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7196,61 +7183,61 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1066, col: 5, offset: 25884},
+						pos: position{line: 1068, col: 5, offset: 25848},
 						run: (*parser).callonFunction47,
 						expr: &seqExpr{
-							pos: position{line: 1066, col: 5, offset: 25884},
+							pos: position{line: 1068, col: 5, offset: 25848},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1066, col: 5, offset: 25884},
+									pos:  position{line: 1068, col: 5, offset: 25848},
 									name: "MAP",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1066, col: 9, offset: 25888},
+									pos:  position{line: 1068, col: 9, offset: 25852},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1066, col: 12, offset: 25891},
+									pos:        position{line: 1068, col: 12, offset: 25855},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1066, col: 16, offset: 25895},
+									pos:  position{line: 1068, col: 16, offset: 25859},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1066, col: 19, offset: 25898},
+									pos:   position{line: 1068, col: 19, offset: 25862},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1066, col: 21, offset: 25900},
+										pos:  position{line: 1068, col: 21, offset: 25864},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1066, col: 26, offset: 25905},
+									pos:  position{line: 1068, col: 26, offset: 25869},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1066, col: 29, offset: 25908},
+									pos:        position{line: 1068, col: 29, offset: 25872},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1066, col: 33, offset: 25912},
+									pos:  position{line: 1068, col: 33, offset: 25876},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1066, col: 36, offset: 25915},
+									pos:   position{line: 1068, col: 36, offset: 25879},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1066, col: 38, offset: 25917},
+										pos:  position{line: 1068, col: 38, offset: 25881},
 										name: "FuncValue",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1066, col: 48, offset: 25927},
+									pos:        position{line: 1068, col: 48, offset: 25891},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7259,65 +7246,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1074, col: 5, offset: 26088},
+						pos: position{line: 1076, col: 5, offset: 26052},
 						run: (*parser).callonFunction61,
 						expr: &seqExpr{
-							pos: position{line: 1074, col: 5, offset: 26088},
+							pos: position{line: 1076, col: 5, offset: 26052},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1074, col: 5, offset: 26088},
+									pos:  position{line: 1076, col: 5, offset: 26052},
 									name: "SUBSTRING",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1074, col: 15, offset: 26098},
+									pos:  position{line: 1076, col: 15, offset: 26062},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1074, col: 18, offset: 26101},
+									pos:        position{line: 1076, col: 18, offset: 26065},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1074, col: 22, offset: 26105},
+									pos:  position{line: 1076, col: 22, offset: 26069},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1074, col: 25, offset: 26108},
+									pos:   position{line: 1076, col: 25, offset: 26072},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1074, col: 30, offset: 26113},
+										pos:  position{line: 1076, col: 30, offset: 26077},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1074, col: 35, offset: 26118},
+									pos:   position{line: 1076, col: 35, offset: 26082},
 									label: "from",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1074, col: 40, offset: 26123},
+										pos: position{line: 1076, col: 40, offset: 26087},
 										expr: &actionExpr{
-											pos: position{line: 1074, col: 41, offset: 26124},
+											pos: position{line: 1076, col: 41, offset: 26088},
 											run: (*parser).callonFunction71,
 											expr: &seqExpr{
-												pos: position{line: 1074, col: 41, offset: 26124},
+												pos: position{line: 1076, col: 41, offset: 26088},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1074, col: 41, offset: 26124},
+														pos:  position{line: 1076, col: 41, offset: 26088},
 														name: "_",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1074, col: 43, offset: 26126},
+														pos:  position{line: 1076, col: 43, offset: 26090},
 														name: "FROM",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1074, col: 48, offset: 26131},
+														pos:  position{line: 1076, col: 48, offset: 26095},
 														name: "_",
 													},
 													&labeledExpr{
-														pos:   position{line: 1074, col: 50, offset: 26133},
+														pos:   position{line: 1076, col: 50, offset: 26097},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1074, col: 52, offset: 26135},
+															pos:  position{line: 1076, col: 52, offset: 26099},
 															name: "Expr",
 														},
 													},
@@ -7327,33 +7314,33 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1074, col: 77, offset: 26160},
+									pos:   position{line: 1076, col: 77, offset: 26124},
 									label: "for_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1074, col: 82, offset: 26165},
+										pos: position{line: 1076, col: 82, offset: 26129},
 										expr: &actionExpr{
-											pos: position{line: 1074, col: 83, offset: 26166},
+											pos: position{line: 1076, col: 83, offset: 26130},
 											run: (*parser).callonFunction80,
 											expr: &seqExpr{
-												pos: position{line: 1074, col: 83, offset: 26166},
+												pos: position{line: 1076, col: 83, offset: 26130},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1074, col: 83, offset: 26166},
+														pos:  position{line: 1076, col: 83, offset: 26130},
 														name: "_",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1074, col: 85, offset: 26168},
+														pos:  position{line: 1076, col: 85, offset: 26132},
 														name: "FOR",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1074, col: 89, offset: 26172},
+														pos:  position{line: 1076, col: 89, offset: 26136},
 														name: "_",
 													},
 													&labeledExpr{
-														pos:   position{line: 1074, col: 91, offset: 26174},
+														pos:   position{line: 1076, col: 91, offset: 26138},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1074, col: 93, offset: 26176},
+															pos:  position{line: 1076, col: 93, offset: 26140},
 															name: "Expr",
 														},
 													},
@@ -7363,7 +7350,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1074, col: 118, offset: 26201},
+									pos:        position{line: 1076, col: 118, offset: 26165},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7372,58 +7359,58 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1088, col: 5, offset: 26484},
+						pos: position{line: 1090, col: 5, offset: 26448},
 						run: (*parser).callonFunction88,
 						expr: &seqExpr{
-							pos: position{line: 1088, col: 5, offset: 26484},
+							pos: position{line: 1090, col: 5, offset: 26448},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1088, col: 5, offset: 26484},
+									pos:   position{line: 1090, col: 5, offset: 26448},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1088, col: 7, offset: 26486},
+										pos:  position{line: 1090, col: 7, offset: 26450},
 										name: "Callable",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1088, col: 16, offset: 26495},
+									pos:  position{line: 1090, col: 16, offset: 26459},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1088, col: 19, offset: 26498},
+									pos:        position{line: 1090, col: 19, offset: 26462},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1088, col: 23, offset: 26502},
+									pos:  position{line: 1090, col: 23, offset: 26466},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1088, col: 26, offset: 26505},
+									pos:   position{line: 1090, col: 26, offset: 26469},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1088, col: 31, offset: 26510},
+										pos:  position{line: 1090, col: 31, offset: 26474},
 										name: "FunctionArgs",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1088, col: 44, offset: 26523},
+									pos:  position{line: 1090, col: 44, offset: 26487},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1088, col: 47, offset: 26526},
+									pos:        position{line: 1090, col: 47, offset: 26490},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1088, col: 51, offset: 26530},
+									pos:   position{line: 1090, col: 51, offset: 26494},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1088, col: 57, offset: 26536},
+										pos: position{line: 1090, col: 57, offset: 26500},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1088, col: 57, offset: 26536},
+											pos:  position{line: 1090, col: 57, offset: 26500},
 											name: "WhereClause",
 										},
 									},
@@ -7432,7 +7419,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1091, col: 5, offset: 26606},
+						pos:  position{line: 1093, col: 5, offset: 26570},
 						name: "CountStar",
 					},
 				},
@@ -7442,22 +7429,22 @@ var g = &grammar{
 		},
 		{
 			name: "Callable",
-			pos:  position{line: 1093, col: 1, offset: 26617},
+			pos:  position{line: 1095, col: 1, offset: 26581},
 			expr: &choiceExpr{
-				pos: position{line: 1094, col: 5, offset: 26630},
+				pos: position{line: 1096, col: 5, offset: 26594},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1094, col: 5, offset: 26630},
+						pos:  position{line: 1096, col: 5, offset: 26594},
 						name: "LambdaExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1095, col: 5, offset: 26645},
+						pos: position{line: 1097, col: 5, offset: 26609},
 						run: (*parser).callonCallable3,
 						expr: &labeledExpr{
-							pos:   position{line: 1095, col: 5, offset: 26645},
+							pos:   position{line: 1097, col: 5, offset: 26609},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1095, col: 8, offset: 26648},
+								pos:  position{line: 1097, col: 8, offset: 26612},
 								name: "IdentifierName",
 							},
 						},
@@ -7469,27 +7456,27 @@ var g = &grammar{
 		},
 		{
 			name: "FuncValue",
-			pos:  position{line: 1102, col: 1, offset: 26761},
+			pos:  position{line: 1104, col: 1, offset: 26725},
 			expr: &choiceExpr{
-				pos: position{line: 1103, col: 5, offset: 26775},
+				pos: position{line: 1105, col: 5, offset: 26739},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1103, col: 5, offset: 26775},
+						pos: position{line: 1105, col: 5, offset: 26739},
 						run: (*parser).callonFuncValue2,
 						expr: &seqExpr{
-							pos: position{line: 1103, col: 5, offset: 26775},
+							pos: position{line: 1105, col: 5, offset: 26739},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1103, col: 5, offset: 26775},
+									pos:        position{line: 1105, col: 5, offset: 26739},
 									val:        "&",
 									ignoreCase: false,
 									want:       "\"&\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1103, col: 9, offset: 26779},
+									pos:   position{line: 1105, col: 9, offset: 26743},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1103, col: 12, offset: 26782},
+										pos:  position{line: 1105, col: 12, offset: 26746},
 										name: "IdentifierName",
 									},
 								},
@@ -7497,7 +7484,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1110, col: 5, offset: 26924},
+						pos:  position{line: 1112, col: 5, offset: 26888},
 						name: "LambdaExpr",
 					},
 				},
@@ -7507,12 +7494,12 @@ var g = &grammar{
 		},
 		{
 			name: "DateTypeHack",
-			pos:  position{line: 1112, col: 1, offset: 26936},
+			pos:  position{line: 1114, col: 1, offset: 26900},
 			expr: &actionExpr{
-				pos: position{line: 1113, col: 5, offset: 26953},
+				pos: position{line: 1115, col: 5, offset: 26917},
 				run: (*parser).callonDateTypeHack1,
 				expr: &litMatcher{
-					pos:        position{line: 1113, col: 5, offset: 26953},
+					pos:        position{line: 1115, col: 5, offset: 26917},
 					val:        "date",
 					ignoreCase: true,
 					want:       "\"date\"i",
@@ -7523,19 +7510,19 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionArgs",
-			pos:  position{line: 1120, col: 1, offset: 27065},
+			pos:  position{line: 1122, col: 1, offset: 27029},
 			expr: &choiceExpr{
-				pos: position{line: 1121, col: 5, offset: 27082},
+				pos: position{line: 1123, col: 5, offset: 27046},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1121, col: 5, offset: 27082},
+						pos:  position{line: 1123, col: 5, offset: 27046},
 						name: "Exprs",
 					},
 					&actionExpr{
-						pos: position{line: 1122, col: 5, offset: 27092},
+						pos: position{line: 1124, col: 5, offset: 27056},
 						run: (*parser).callonFunctionArgs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1122, col: 5, offset: 27092},
+							pos:  position{line: 1124, col: 5, offset: 27056},
 							name: "__",
 						},
 					},
@@ -7546,51 +7533,51 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 1124, col: 1, offset: 27120},
+			pos:  position{line: 1126, col: 1, offset: 27084},
 			expr: &actionExpr{
-				pos: position{line: 1125, col: 5, offset: 27130},
+				pos: position{line: 1127, col: 5, offset: 27094},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 1125, col: 5, offset: 27130},
+					pos: position{line: 1127, col: 5, offset: 27094},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1125, col: 5, offset: 27130},
+							pos:   position{line: 1127, col: 5, offset: 27094},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1125, col: 11, offset: 27136},
+								pos:  position{line: 1127, col: 11, offset: 27100},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1125, col: 16, offset: 27141},
+							pos:   position{line: 1127, col: 16, offset: 27105},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1125, col: 21, offset: 27146},
+								pos: position{line: 1127, col: 21, offset: 27110},
 								expr: &actionExpr{
-									pos: position{line: 1125, col: 22, offset: 27147},
+									pos: position{line: 1127, col: 22, offset: 27111},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 1125, col: 22, offset: 27147},
+										pos: position{line: 1127, col: 22, offset: 27111},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1125, col: 22, offset: 27147},
+												pos:  position{line: 1127, col: 22, offset: 27111},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1125, col: 25, offset: 27150},
+												pos:        position{line: 1127, col: 25, offset: 27114},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1125, col: 29, offset: 27154},
+												pos:  position{line: 1127, col: 29, offset: 27118},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1125, col: 32, offset: 27157},
+												pos:   position{line: 1127, col: 32, offset: 27121},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1125, col: 34, offset: 27159},
+													pos:  position{line: 1127, col: 34, offset: 27123},
 													name: "Expr",
 												},
 											},
@@ -7607,76 +7594,76 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 1129, col: 1, offset: 27232},
+			pos:  position{line: 1131, col: 1, offset: 27196},
 			expr: &choiceExpr{
-				pos: position{line: 1130, col: 5, offset: 27244},
+				pos: position{line: 1132, col: 5, offset: 27208},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1130, col: 5, offset: 27244},
+						pos:  position{line: 1132, col: 5, offset: 27208},
 						name: "CaseExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1131, col: 5, offset: 27257},
+						pos:  position{line: 1133, col: 5, offset: 27221},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1132, col: 5, offset: 27268},
+						pos:  position{line: 1134, col: 5, offset: 27232},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1133, col: 5, offset: 27278},
+						pos:  position{line: 1135, col: 5, offset: 27242},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1134, col: 5, offset: 27286},
+						pos:  position{line: 1136, col: 5, offset: 27250},
 						name: "Map",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1135, col: 5, offset: 27294},
+						pos:  position{line: 1137, col: 5, offset: 27258},
 						name: "SQLTimeValue",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1136, col: 5, offset: 27311},
+						pos:  position{line: 1138, col: 5, offset: 27275},
 						name: "Literal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1137, col: 5, offset: 27323},
+						pos:  position{line: 1139, col: 5, offset: 27287},
 						name: "Identifier",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1138, col: 5, offset: 27338},
+						pos:  position{line: 1140, col: 5, offset: 27302},
 						name: "Tuple",
 					},
 					&actionExpr{
-						pos: position{line: 1139, col: 5, offset: 27348},
+						pos: position{line: 1141, col: 5, offset: 27312},
 						run: (*parser).callonPrimary11,
 						expr: &seqExpr{
-							pos: position{line: 1139, col: 5, offset: 27348},
+							pos: position{line: 1141, col: 5, offset: 27312},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1139, col: 5, offset: 27348},
+									pos:        position{line: 1141, col: 5, offset: 27312},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1139, col: 9, offset: 27352},
+									pos:  position{line: 1141, col: 9, offset: 27316},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1139, col: 12, offset: 27355},
+									pos:   position{line: 1141, col: 12, offset: 27319},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1139, col: 17, offset: 27360},
+										pos:  position{line: 1141, col: 17, offset: 27324},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1139, col: 22, offset: 27365},
+									pos:  position{line: 1141, col: 22, offset: 27329},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1139, col: 25, offset: 27368},
+									pos:        position{line: 1141, col: 25, offset: 27332},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7685,35 +7672,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1140, col: 5, offset: 27397},
+						pos: position{line: 1142, col: 5, offset: 27361},
 						run: (*parser).callonPrimary19,
 						expr: &seqExpr{
-							pos: position{line: 1140, col: 5, offset: 27397},
+							pos: position{line: 1142, col: 5, offset: 27361},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1140, col: 5, offset: 27397},
+									pos:        position{line: 1142, col: 5, offset: 27361},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1140, col: 9, offset: 27401},
+									pos:  position{line: 1142, col: 9, offset: 27365},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1140, col: 12, offset: 27404},
+									pos:   position{line: 1142, col: 12, offset: 27368},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1140, col: 17, offset: 27409},
+										pos:  position{line: 1142, col: 17, offset: 27373},
 										name: "Subquery",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1140, col: 26, offset: 27418},
+									pos:  position{line: 1142, col: 26, offset: 27382},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1140, col: 29, offset: 27421},
+									pos:        position{line: 1142, col: 29, offset: 27385},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7728,53 +7715,53 @@ var g = &grammar{
 		},
 		{
 			name: "CaseExpr",
-			pos:  position{line: 1142, col: 1, offset: 27447},
+			pos:  position{line: 1144, col: 1, offset: 27411},
 			expr: &choiceExpr{
-				pos: position{line: 1143, col: 5, offset: 27460},
+				pos: position{line: 1145, col: 5, offset: 27424},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1143, col: 5, offset: 27460},
+						pos: position{line: 1145, col: 5, offset: 27424},
 						run: (*parser).callonCaseExpr2,
 						expr: &seqExpr{
-							pos: position{line: 1143, col: 5, offset: 27460},
+							pos: position{line: 1145, col: 5, offset: 27424},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1143, col: 5, offset: 27460},
+									pos:  position{line: 1145, col: 5, offset: 27424},
 									name: "CASE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1143, col: 10, offset: 27465},
+									pos:   position{line: 1145, col: 10, offset: 27429},
 									label: "cases",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1143, col: 16, offset: 27471},
+										pos: position{line: 1145, col: 16, offset: 27435},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1143, col: 16, offset: 27471},
+											pos:  position{line: 1145, col: 16, offset: 27435},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1143, col: 22, offset: 27477},
+									pos:   position{line: 1145, col: 22, offset: 27441},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1143, col: 28, offset: 27483},
+										pos: position{line: 1145, col: 28, offset: 27447},
 										expr: &seqExpr{
-											pos: position{line: 1143, col: 29, offset: 27484},
+											pos: position{line: 1145, col: 29, offset: 27448},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1143, col: 29, offset: 27484},
+													pos:  position{line: 1145, col: 29, offset: 27448},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1143, col: 31, offset: 27486},
+													pos:  position{line: 1145, col: 31, offset: 27450},
 													name: "ELSE",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1143, col: 36, offset: 27491},
+													pos:  position{line: 1145, col: 36, offset: 27455},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1143, col: 38, offset: 27493},
+													pos:  position{line: 1145, col: 38, offset: 27457},
 													name: "Expr",
 												},
 											},
@@ -7782,24 +7769,24 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1143, col: 45, offset: 27500},
+									pos:  position{line: 1145, col: 45, offset: 27464},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1143, col: 47, offset: 27502},
+									pos:  position{line: 1145, col: 47, offset: 27466},
 									name: "END",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1143, col: 51, offset: 27506},
+									pos: position{line: 1145, col: 51, offset: 27470},
 									expr: &seqExpr{
-										pos: position{line: 1143, col: 52, offset: 27507},
+										pos: position{line: 1145, col: 52, offset: 27471},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1143, col: 52, offset: 27507},
+												pos:  position{line: 1145, col: 52, offset: 27471},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1143, col: 54, offset: 27509},
+												pos:  position{line: 1145, col: 54, offset: 27473},
 												name: "CASE",
 											},
 										},
@@ -7809,60 +7796,60 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1167, col: 5, offset: 28158},
+						pos: position{line: 1169, col: 5, offset: 28122},
 						run: (*parser).callonCaseExpr21,
 						expr: &seqExpr{
-							pos: position{line: 1167, col: 5, offset: 28158},
+							pos: position{line: 1169, col: 5, offset: 28122},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1167, col: 5, offset: 28158},
+									pos:  position{line: 1169, col: 5, offset: 28122},
 									name: "CASE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1167, col: 10, offset: 28163},
+									pos:  position{line: 1169, col: 10, offset: 28127},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1167, col: 12, offset: 28165},
+									pos:   position{line: 1169, col: 12, offset: 28129},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1167, col: 17, offset: 28170},
+										pos:  position{line: 1169, col: 17, offset: 28134},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1167, col: 22, offset: 28175},
+									pos:   position{line: 1169, col: 22, offset: 28139},
 									label: "whens",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1167, col: 28, offset: 28181},
+										pos: position{line: 1169, col: 28, offset: 28145},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1167, col: 28, offset: 28181},
+											pos:  position{line: 1169, col: 28, offset: 28145},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1167, col: 34, offset: 28187},
+									pos:   position{line: 1169, col: 34, offset: 28151},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1167, col: 40, offset: 28193},
+										pos: position{line: 1169, col: 40, offset: 28157},
 										expr: &seqExpr{
-											pos: position{line: 1167, col: 41, offset: 28194},
+											pos: position{line: 1169, col: 41, offset: 28158},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1167, col: 41, offset: 28194},
+													pos:  position{line: 1169, col: 41, offset: 28158},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1167, col: 43, offset: 28196},
+													pos:  position{line: 1169, col: 43, offset: 28160},
 													name: "ELSE",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1167, col: 48, offset: 28201},
+													pos:  position{line: 1169, col: 48, offset: 28165},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1167, col: 50, offset: 28203},
+													pos:  position{line: 1169, col: 50, offset: 28167},
 													name: "Expr",
 												},
 											},
@@ -7870,24 +7857,24 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1167, col: 57, offset: 28210},
+									pos:  position{line: 1169, col: 57, offset: 28174},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1167, col: 59, offset: 28212},
+									pos:  position{line: 1169, col: 59, offset: 28176},
 									name: "END",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1167, col: 63, offset: 28216},
+									pos: position{line: 1169, col: 63, offset: 28180},
 									expr: &seqExpr{
-										pos: position{line: 1167, col: 64, offset: 28217},
+										pos: position{line: 1169, col: 64, offset: 28181},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1167, col: 64, offset: 28217},
+												pos:  position{line: 1169, col: 64, offset: 28181},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1167, col: 66, offset: 28219},
+												pos:  position{line: 1169, col: 66, offset: 28183},
 												name: "CASE",
 											},
 										},
@@ -7903,50 +7890,50 @@ var g = &grammar{
 		},
 		{
 			name: "When",
-			pos:  position{line: 1180, col: 1, offset: 28525},
+			pos:  position{line: 1182, col: 1, offset: 28489},
 			expr: &actionExpr{
-				pos: position{line: 1181, col: 5, offset: 28534},
+				pos: position{line: 1183, col: 5, offset: 28498},
 				run: (*parser).callonWhen1,
 				expr: &seqExpr{
-					pos: position{line: 1181, col: 5, offset: 28534},
+					pos: position{line: 1183, col: 5, offset: 28498},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1181, col: 5, offset: 28534},
+							pos:  position{line: 1183, col: 5, offset: 28498},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1181, col: 7, offset: 28536},
+							pos:  position{line: 1183, col: 7, offset: 28500},
 							name: "WHEN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1181, col: 12, offset: 28541},
+							pos:  position{line: 1183, col: 12, offset: 28505},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1181, col: 14, offset: 28543},
+							pos:   position{line: 1183, col: 14, offset: 28507},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1181, col: 19, offset: 28548},
+								pos:  position{line: 1183, col: 19, offset: 28512},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1181, col: 24, offset: 28553},
+							pos:  position{line: 1183, col: 24, offset: 28517},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1181, col: 26, offset: 28555},
+							pos:  position{line: 1183, col: 26, offset: 28519},
 							name: "THEN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1181, col: 31, offset: 28560},
+							pos:  position{line: 1183, col: 31, offset: 28524},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1181, col: 33, offset: 28562},
+							pos:   position{line: 1183, col: 33, offset: 28526},
 							label: "then",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1181, col: 38, offset: 28567},
+								pos:  position{line: 1183, col: 38, offset: 28531},
 								name: "Expr",
 							},
 						},
@@ -7958,15 +7945,15 @@ var g = &grammar{
 		},
 		{
 			name: "Subquery",
-			pos:  position{line: 1190, col: 1, offset: 28722},
+			pos:  position{line: 1192, col: 1, offset: 28686},
 			expr: &actionExpr{
-				pos: position{line: 1191, col: 5, offset: 28735},
+				pos: position{line: 1193, col: 5, offset: 28699},
 				run: (*parser).callonSubquery1,
 				expr: &labeledExpr{
-					pos:   position{line: 1191, col: 5, offset: 28735},
+					pos:   position{line: 1193, col: 5, offset: 28699},
 					label: "body",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1191, col: 10, offset: 28740},
+						pos:  position{line: 1193, col: 10, offset: 28704},
 						name: "Seq",
 					},
 				},
@@ -7976,37 +7963,37 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 1199, col: 1, offset: 28876},
+			pos:  position{line: 1201, col: 1, offset: 28840},
 			expr: &actionExpr{
-				pos: position{line: 1200, col: 5, offset: 28887},
+				pos: position{line: 1202, col: 5, offset: 28851},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 1200, col: 5, offset: 28887},
+					pos: position{line: 1202, col: 5, offset: 28851},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1200, col: 5, offset: 28887},
+							pos:        position{line: 1202, col: 5, offset: 28851},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1200, col: 9, offset: 28891},
+							pos:  position{line: 1202, col: 9, offset: 28855},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1200, col: 12, offset: 28894},
+							pos:   position{line: 1202, col: 12, offset: 28858},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1200, col: 18, offset: 28900},
+								pos:  position{line: 1202, col: 18, offset: 28864},
 								name: "RecordElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1200, col: 30, offset: 28912},
+							pos:  position{line: 1202, col: 30, offset: 28876},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1200, col: 33, offset: 28915},
+							pos:        position{line: 1202, col: 33, offset: 28879},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -8019,31 +8006,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElems",
-			pos:  position{line: 1208, col: 1, offset: 29073},
+			pos:  position{line: 1210, col: 1, offset: 29037},
 			expr: &choiceExpr{
-				pos: position{line: 1209, col: 5, offset: 29089},
+				pos: position{line: 1211, col: 5, offset: 29053},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1209, col: 5, offset: 29089},
+						pos: position{line: 1211, col: 5, offset: 29053},
 						run: (*parser).callonRecordElems2,
 						expr: &seqExpr{
-							pos: position{line: 1209, col: 5, offset: 29089},
+							pos: position{line: 1211, col: 5, offset: 29053},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1209, col: 5, offset: 29089},
+									pos:   position{line: 1211, col: 5, offset: 29053},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1209, col: 11, offset: 29095},
+										pos:  position{line: 1211, col: 11, offset: 29059},
 										name: "RecordElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1209, col: 22, offset: 29106},
+									pos:   position{line: 1211, col: 22, offset: 29070},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1209, col: 27, offset: 29111},
+										pos: position{line: 1211, col: 27, offset: 29075},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1209, col: 27, offset: 29111},
+											pos:  position{line: 1211, col: 27, offset: 29075},
 											name: "RecordElemTail",
 										},
 									},
@@ -8052,10 +8039,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1212, col: 5, offset: 29174},
+						pos: position{line: 1214, col: 5, offset: 29138},
 						run: (*parser).callonRecordElems9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1212, col: 5, offset: 29174},
+							pos:  position{line: 1214, col: 5, offset: 29138},
 							name: "__",
 						},
 					},
@@ -8066,32 +8053,32 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElemTail",
-			pos:  position{line: 1214, col: 1, offset: 29198},
+			pos:  position{line: 1216, col: 1, offset: 29162},
 			expr: &actionExpr{
-				pos: position{line: 1214, col: 18, offset: 29215},
+				pos: position{line: 1216, col: 18, offset: 29179},
 				run: (*parser).callonRecordElemTail1,
 				expr: &seqExpr{
-					pos: position{line: 1214, col: 18, offset: 29215},
+					pos: position{line: 1216, col: 18, offset: 29179},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1214, col: 18, offset: 29215},
+							pos:  position{line: 1216, col: 18, offset: 29179},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1214, col: 21, offset: 29218},
+							pos:        position{line: 1216, col: 21, offset: 29182},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1214, col: 25, offset: 29222},
+							pos:  position{line: 1216, col: 25, offset: 29186},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1214, col: 28, offset: 29225},
+							pos:   position{line: 1216, col: 28, offset: 29189},
 							label: "elem",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1214, col: 33, offset: 29230},
+								pos:  position{line: 1216, col: 33, offset: 29194},
 								name: "RecordElem",
 							},
 						},
@@ -8103,20 +8090,20 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElem",
-			pos:  position{line: 1216, col: 1, offset: 29263},
+			pos:  position{line: 1218, col: 1, offset: 29227},
 			expr: &choiceExpr{
-				pos: position{line: 1217, col: 5, offset: 29278},
+				pos: position{line: 1219, col: 5, offset: 29242},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1217, col: 5, offset: 29278},
+						pos:  position{line: 1219, col: 5, offset: 29242},
 						name: "Spread",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1218, col: 5, offset: 29289},
+						pos:  position{line: 1220, col: 5, offset: 29253},
 						name: "FieldExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1219, col: 5, offset: 29303},
+						pos:  position{line: 1221, col: 5, offset: 29267},
 						name: "Identifier",
 					},
 				},
@@ -8126,28 +8113,28 @@ var g = &grammar{
 		},
 		{
 			name: "Spread",
-			pos:  position{line: 1221, col: 1, offset: 29315},
+			pos:  position{line: 1223, col: 1, offset: 29279},
 			expr: &actionExpr{
-				pos: position{line: 1222, col: 5, offset: 29326},
+				pos: position{line: 1224, col: 5, offset: 29290},
 				run: (*parser).callonSpread1,
 				expr: &seqExpr{
-					pos: position{line: 1222, col: 5, offset: 29326},
+					pos: position{line: 1224, col: 5, offset: 29290},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1222, col: 5, offset: 29326},
+							pos:        position{line: 1224, col: 5, offset: 29290},
 							val:        "...",
 							ignoreCase: false,
 							want:       "\"...\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1222, col: 11, offset: 29332},
+							pos:  position{line: 1224, col: 11, offset: 29296},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1222, col: 14, offset: 29335},
+							pos:   position{line: 1224, col: 14, offset: 29299},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1222, col: 19, offset: 29340},
+								pos:  position{line: 1224, col: 19, offset: 29304},
 								name: "Expr",
 							},
 						},
@@ -8159,40 +8146,40 @@ var g = &grammar{
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 1226, col: 1, offset: 29436},
+			pos:  position{line: 1228, col: 1, offset: 29400},
 			expr: &actionExpr{
-				pos: position{line: 1227, col: 5, offset: 29450},
+				pos: position{line: 1229, col: 5, offset: 29414},
 				run: (*parser).callonFieldExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1227, col: 5, offset: 29450},
+					pos: position{line: 1229, col: 5, offset: 29414},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1227, col: 5, offset: 29450},
+							pos:   position{line: 1229, col: 5, offset: 29414},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1227, col: 10, offset: 29455},
+								pos:  position{line: 1229, col: 10, offset: 29419},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1227, col: 15, offset: 29460},
+							pos:  position{line: 1229, col: 15, offset: 29424},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1227, col: 18, offset: 29463},
+							pos:        position{line: 1229, col: 18, offset: 29427},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1227, col: 22, offset: 29467},
+							pos:  position{line: 1229, col: 22, offset: 29431},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1227, col: 25, offset: 29470},
+							pos:   position{line: 1229, col: 25, offset: 29434},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1227, col: 31, offset: 29476},
+								pos:  position{line: 1229, col: 31, offset: 29440},
 								name: "Expr",
 							},
 						},
@@ -8204,37 +8191,37 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 1236, col: 1, offset: 29645},
+			pos:  position{line: 1238, col: 1, offset: 29609},
 			expr: &actionExpr{
-				pos: position{line: 1237, col: 5, offset: 29655},
+				pos: position{line: 1239, col: 5, offset: 29619},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 1237, col: 5, offset: 29655},
+					pos: position{line: 1239, col: 5, offset: 29619},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1237, col: 5, offset: 29655},
+							pos:        position{line: 1239, col: 5, offset: 29619},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1237, col: 9, offset: 29659},
+							pos:  position{line: 1239, col: 9, offset: 29623},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1237, col: 12, offset: 29662},
+							pos:   position{line: 1239, col: 12, offset: 29626},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1237, col: 18, offset: 29668},
+								pos:  position{line: 1239, col: 18, offset: 29632},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1237, col: 30, offset: 29680},
+							pos:  position{line: 1239, col: 30, offset: 29644},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1237, col: 33, offset: 29683},
+							pos:        position{line: 1239, col: 33, offset: 29647},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -8247,37 +8234,37 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 1245, col: 1, offset: 29839},
+			pos:  position{line: 1247, col: 1, offset: 29803},
 			expr: &actionExpr{
-				pos: position{line: 1246, col: 5, offset: 29847},
+				pos: position{line: 1248, col: 5, offset: 29811},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 1246, col: 5, offset: 29847},
+					pos: position{line: 1248, col: 5, offset: 29811},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1246, col: 5, offset: 29847},
+							pos:        position{line: 1248, col: 5, offset: 29811},
 							val:        "|[",
 							ignoreCase: false,
 							want:       "\"|[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1246, col: 10, offset: 29852},
+							pos:  position{line: 1248, col: 10, offset: 29816},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1246, col: 13, offset: 29855},
+							pos:   position{line: 1248, col: 13, offset: 29819},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1246, col: 19, offset: 29861},
+								pos:  position{line: 1248, col: 19, offset: 29825},
 								name: "VectorElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1246, col: 31, offset: 29873},
+							pos:  position{line: 1248, col: 31, offset: 29837},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1246, col: 34, offset: 29876},
+							pos:        position{line: 1248, col: 34, offset: 29840},
 							val:        "]|",
 							ignoreCase: false,
 							want:       "\"]|\"",
@@ -8290,54 +8277,54 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElems",
-			pos:  position{line: 1254, col: 1, offset: 30029},
+			pos:  position{line: 1256, col: 1, offset: 29993},
 			expr: &choiceExpr{
-				pos: position{line: 1255, col: 5, offset: 30045},
+				pos: position{line: 1257, col: 5, offset: 30009},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1255, col: 5, offset: 30045},
+						pos: position{line: 1257, col: 5, offset: 30009},
 						run: (*parser).callonVectorElems2,
 						expr: &seqExpr{
-							pos: position{line: 1255, col: 5, offset: 30045},
+							pos: position{line: 1257, col: 5, offset: 30009},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1255, col: 5, offset: 30045},
+									pos:   position{line: 1257, col: 5, offset: 30009},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1255, col: 11, offset: 30051},
+										pos:  position{line: 1257, col: 11, offset: 30015},
 										name: "VectorElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1255, col: 22, offset: 30062},
+									pos:   position{line: 1257, col: 22, offset: 30026},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1255, col: 27, offset: 30067},
+										pos: position{line: 1257, col: 27, offset: 30031},
 										expr: &actionExpr{
-											pos: position{line: 1255, col: 28, offset: 30068},
+											pos: position{line: 1257, col: 28, offset: 30032},
 											run: (*parser).callonVectorElems8,
 											expr: &seqExpr{
-												pos: position{line: 1255, col: 28, offset: 30068},
+												pos: position{line: 1257, col: 28, offset: 30032},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1255, col: 28, offset: 30068},
+														pos:  position{line: 1257, col: 28, offset: 30032},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 1255, col: 31, offset: 30071},
+														pos:        position{line: 1257, col: 31, offset: 30035},
 														val:        ",",
 														ignoreCase: false,
 														want:       "\",\"",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1255, col: 35, offset: 30075},
+														pos:  position{line: 1257, col: 35, offset: 30039},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 1255, col: 38, offset: 30078},
+														pos:   position{line: 1257, col: 38, offset: 30042},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1255, col: 40, offset: 30080},
+															pos:  position{line: 1257, col: 40, offset: 30044},
 															name: "VectorElem",
 														},
 													},
@@ -8350,10 +8337,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1258, col: 5, offset: 30162},
+						pos: position{line: 1260, col: 5, offset: 30126},
 						run: (*parser).callonVectorElems15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1258, col: 5, offset: 30162},
+							pos:  position{line: 1260, col: 5, offset: 30126},
 							name: "__",
 						},
 					},
@@ -8364,22 +8351,22 @@ var g = &grammar{
 		},
 		{
 			name: "VectorElem",
-			pos:  position{line: 1260, col: 1, offset: 30186},
+			pos:  position{line: 1262, col: 1, offset: 30150},
 			expr: &choiceExpr{
-				pos: position{line: 1261, col: 5, offset: 30201},
+				pos: position{line: 1263, col: 5, offset: 30165},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1261, col: 5, offset: 30201},
+						pos:  position{line: 1263, col: 5, offset: 30165},
 						name: "Spread",
 					},
 					&actionExpr{
-						pos: position{line: 1262, col: 5, offset: 30212},
+						pos: position{line: 1264, col: 5, offset: 30176},
 						run: (*parser).callonVectorElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1262, col: 5, offset: 30212},
+							pos:   position{line: 1264, col: 5, offset: 30176},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1262, col: 7, offset: 30214},
+								pos:  position{line: 1264, col: 7, offset: 30178},
 								name: "Expr",
 							},
 						},
@@ -8391,37 +8378,37 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 1264, col: 1, offset: 30305},
+			pos:  position{line: 1266, col: 1, offset: 30269},
 			expr: &actionExpr{
-				pos: position{line: 1265, col: 5, offset: 30313},
+				pos: position{line: 1267, col: 5, offset: 30277},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 1265, col: 5, offset: 30313},
+					pos: position{line: 1267, col: 5, offset: 30277},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1265, col: 5, offset: 30313},
+							pos:        position{line: 1267, col: 5, offset: 30277},
 							val:        "|{",
 							ignoreCase: false,
 							want:       "\"|{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1265, col: 10, offset: 30318},
+							pos:  position{line: 1267, col: 10, offset: 30282},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1265, col: 13, offset: 30321},
+							pos:   position{line: 1267, col: 13, offset: 30285},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1265, col: 19, offset: 30327},
+								pos:  position{line: 1267, col: 19, offset: 30291},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1265, col: 27, offset: 30335},
+							pos:  position{line: 1267, col: 27, offset: 30299},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1265, col: 30, offset: 30338},
+							pos:        position{line: 1267, col: 30, offset: 30302},
 							val:        "}|",
 							ignoreCase: false,
 							want:       "\"}|\"",
@@ -8434,31 +8421,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 1273, col: 1, offset: 30492},
+			pos:  position{line: 1275, col: 1, offset: 30456},
 			expr: &choiceExpr{
-				pos: position{line: 1274, col: 5, offset: 30504},
+				pos: position{line: 1276, col: 5, offset: 30468},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1274, col: 5, offset: 30504},
+						pos: position{line: 1276, col: 5, offset: 30468},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 1274, col: 5, offset: 30504},
+							pos: position{line: 1276, col: 5, offset: 30468},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1274, col: 5, offset: 30504},
+									pos:   position{line: 1276, col: 5, offset: 30468},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1274, col: 11, offset: 30510},
+										pos:  position{line: 1276, col: 11, offset: 30474},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1274, col: 17, offset: 30516},
+									pos:   position{line: 1276, col: 17, offset: 30480},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1274, col: 22, offset: 30521},
+										pos: position{line: 1276, col: 22, offset: 30485},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1274, col: 22, offset: 30521},
+											pos:  position{line: 1276, col: 22, offset: 30485},
 											name: "EntryTail",
 										},
 									},
@@ -8467,10 +8454,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1277, col: 5, offset: 30579},
+						pos: position{line: 1279, col: 5, offset: 30543},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1277, col: 5, offset: 30579},
+							pos:  position{line: 1279, col: 5, offset: 30543},
 							name: "__",
 						},
 					},
@@ -8481,32 +8468,32 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 1280, col: 1, offset: 30604},
+			pos:  position{line: 1282, col: 1, offset: 30568},
 			expr: &actionExpr{
-				pos: position{line: 1280, col: 13, offset: 30616},
+				pos: position{line: 1282, col: 13, offset: 30580},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 1280, col: 13, offset: 30616},
+					pos: position{line: 1282, col: 13, offset: 30580},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1280, col: 13, offset: 30616},
+							pos:  position{line: 1282, col: 13, offset: 30580},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1280, col: 16, offset: 30619},
+							pos:        position{line: 1282, col: 16, offset: 30583},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1280, col: 20, offset: 30623},
+							pos:  position{line: 1282, col: 20, offset: 30587},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1280, col: 23, offset: 30626},
+							pos:   position{line: 1282, col: 23, offset: 30590},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1280, col: 25, offset: 30628},
+								pos:  position{line: 1282, col: 25, offset: 30592},
 								name: "Entry",
 							},
 						},
@@ -8518,40 +8505,40 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 1282, col: 1, offset: 30653},
+			pos:  position{line: 1284, col: 1, offset: 30617},
 			expr: &actionExpr{
-				pos: position{line: 1283, col: 5, offset: 30663},
+				pos: position{line: 1285, col: 5, offset: 30627},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 1283, col: 5, offset: 30663},
+					pos: position{line: 1285, col: 5, offset: 30627},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1283, col: 5, offset: 30663},
+							pos:   position{line: 1285, col: 5, offset: 30627},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1283, col: 9, offset: 30667},
+								pos:  position{line: 1285, col: 9, offset: 30631},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1283, col: 14, offset: 30672},
+							pos:  position{line: 1285, col: 14, offset: 30636},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1283, col: 17, offset: 30675},
+							pos:        position{line: 1285, col: 17, offset: 30639},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1283, col: 21, offset: 30679},
+							pos:  position{line: 1285, col: 21, offset: 30643},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1283, col: 24, offset: 30682},
+							pos:   position{line: 1285, col: 24, offset: 30646},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1283, col: 30, offset: 30688},
+								pos:  position{line: 1285, col: 30, offset: 30652},
 								name: "Expr",
 							},
 						},
@@ -8563,61 +8550,61 @@ var g = &grammar{
 		},
 		{
 			name: "Tuple",
-			pos:  position{line: 1287, col: 1, offset: 30791},
+			pos:  position{line: 1289, col: 1, offset: 30755},
 			expr: &actionExpr{
-				pos: position{line: 1288, col: 5, offset: 30801},
+				pos: position{line: 1290, col: 5, offset: 30765},
 				run: (*parser).callonTuple1,
 				expr: &seqExpr{
-					pos: position{line: 1288, col: 5, offset: 30801},
+					pos: position{line: 1290, col: 5, offset: 30765},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1288, col: 5, offset: 30801},
+							pos:        position{line: 1290, col: 5, offset: 30765},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1288, col: 9, offset: 30805},
+							pos:  position{line: 1290, col: 9, offset: 30769},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1288, col: 12, offset: 30808},
+							pos:   position{line: 1290, col: 12, offset: 30772},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1288, col: 18, offset: 30814},
+								pos:  position{line: 1290, col: 18, offset: 30778},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1288, col: 23, offset: 30819},
+							pos:   position{line: 1290, col: 23, offset: 30783},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1288, col: 28, offset: 30824},
+								pos: position{line: 1290, col: 28, offset: 30788},
 								expr: &actionExpr{
-									pos: position{line: 1288, col: 29, offset: 30825},
+									pos: position{line: 1290, col: 29, offset: 30789},
 									run: (*parser).callonTuple9,
 									expr: &seqExpr{
-										pos: position{line: 1288, col: 29, offset: 30825},
+										pos: position{line: 1290, col: 29, offset: 30789},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1288, col: 29, offset: 30825},
+												pos:  position{line: 1290, col: 29, offset: 30789},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1288, col: 32, offset: 30828},
+												pos:        position{line: 1290, col: 32, offset: 30792},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1288, col: 36, offset: 30832},
+												pos:  position{line: 1290, col: 36, offset: 30796},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1288, col: 39, offset: 30835},
+												pos:   position{line: 1290, col: 39, offset: 30799},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1288, col: 41, offset: 30837},
+													pos:  position{line: 1290, col: 41, offset: 30801},
 													name: "Expr",
 												},
 											},
@@ -8627,11 +8614,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1288, col: 66, offset: 30862},
+							pos:  position{line: 1290, col: 66, offset: 30826},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1288, col: 69, offset: 30865},
+							pos:        position{line: 1290, col: 69, offset: 30829},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -8644,39 +8631,39 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTimeValue",
-			pos:  position{line: 1296, col: 1, offset: 31024},
+			pos:  position{line: 1298, col: 1, offset: 30988},
 			expr: &actionExpr{
-				pos: position{line: 1297, col: 5, offset: 31041},
+				pos: position{line: 1299, col: 5, offset: 31005},
 				run: (*parser).callonSQLTimeValue1,
 				expr: &seqExpr{
-					pos: position{line: 1297, col: 5, offset: 31041},
+					pos: position{line: 1299, col: 5, offset: 31005},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1297, col: 5, offset: 31041},
+							pos:   position{line: 1299, col: 5, offset: 31005},
 							label: "typ",
 							expr: &choiceExpr{
-								pos: position{line: 1297, col: 10, offset: 31046},
+								pos: position{line: 1299, col: 10, offset: 31010},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1297, col: 10, offset: 31046},
+										pos:  position{line: 1299, col: 10, offset: 31010},
 										name: "DATE",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1297, col: 17, offset: 31053},
+										pos:  position{line: 1299, col: 17, offset: 31017},
 										name: "TIMESTAMP",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1297, col: 28, offset: 31064},
+							pos:  position{line: 1299, col: 28, offset: 31028},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1297, col: 30, offset: 31066},
+							pos:   position{line: 1299, col: 30, offset: 31030},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1297, col: 32, offset: 31068},
+								pos:  position{line: 1299, col: 32, offset: 31032},
 								name: "StringLiteral",
 							},
 						},
@@ -8688,56 +8675,56 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 1308, col: 1, offset: 31285},
+			pos:  position{line: 1310, col: 1, offset: 31249},
 			expr: &choiceExpr{
-				pos: position{line: 1309, col: 5, offset: 31297},
+				pos: position{line: 1311, col: 5, offset: 31261},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1309, col: 5, offset: 31297},
+						pos:  position{line: 1311, col: 5, offset: 31261},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1310, col: 5, offset: 31313},
+						pos:  position{line: 1312, col: 5, offset: 31277},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1311, col: 5, offset: 31331},
+						pos:  position{line: 1313, col: 5, offset: 31295},
 						name: "FString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1312, col: 5, offset: 31343},
+						pos:  position{line: 1314, col: 5, offset: 31307},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1313, col: 5, offset: 31361},
+						pos:  position{line: 1315, col: 5, offset: 31325},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1314, col: 5, offset: 31380},
+						pos:  position{line: 1316, col: 5, offset: 31344},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1315, col: 5, offset: 31397},
+						pos:  position{line: 1317, col: 5, offset: 31361},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1316, col: 5, offset: 31410},
+						pos:  position{line: 1318, col: 5, offset: 31374},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1317, col: 5, offset: 31419},
+						pos:  position{line: 1319, col: 5, offset: 31383},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1318, col: 5, offset: 31436},
+						pos:  position{line: 1320, col: 5, offset: 31400},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1319, col: 5, offset: 31455},
+						pos:  position{line: 1321, col: 5, offset: 31419},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1320, col: 5, offset: 31474},
+						pos:  position{line: 1322, col: 5, offset: 31438},
 						name: "NullLiteral",
 					},
 				},
@@ -8747,28 +8734,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 1322, col: 1, offset: 31487},
+			pos:  position{line: 1324, col: 1, offset: 31451},
 			expr: &choiceExpr{
-				pos: position{line: 1323, col: 5, offset: 31505},
+				pos: position{line: 1325, col: 5, offset: 31469},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1323, col: 5, offset: 31505},
+						pos: position{line: 1325, col: 5, offset: 31469},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1323, col: 5, offset: 31505},
+							pos: position{line: 1325, col: 5, offset: 31469},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1323, col: 5, offset: 31505},
+									pos:   position{line: 1325, col: 5, offset: 31469},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1323, col: 7, offset: 31507},
+										pos:  position{line: 1325, col: 7, offset: 31471},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1323, col: 14, offset: 31514},
+									pos: position{line: 1325, col: 14, offset: 31478},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1323, col: 15, offset: 31515},
+										pos:  position{line: 1325, col: 15, offset: 31479},
 										name: "IdentifierRest",
 									},
 								},
@@ -8776,13 +8763,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1326, col: 5, offset: 31595},
+						pos: position{line: 1328, col: 5, offset: 31559},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1326, col: 5, offset: 31595},
+							pos:   position{line: 1328, col: 5, offset: 31559},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1326, col: 7, offset: 31597},
+								pos:  position{line: 1328, col: 7, offset: 31561},
 								name: "IP4Net",
 							},
 						},
@@ -8794,35 +8781,35 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 1330, col: 1, offset: 31666},
+			pos:  position{line: 1332, col: 1, offset: 31630},
 			expr: &choiceExpr{
-				pos: position{line: 1331, col: 5, offset: 31685},
+				pos: position{line: 1333, col: 5, offset: 31649},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1331, col: 5, offset: 31685},
+						pos: position{line: 1333, col: 5, offset: 31649},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1331, col: 5, offset: 31685},
+							pos: position{line: 1333, col: 5, offset: 31649},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1331, col: 5, offset: 31685},
+									pos:   position{line: 1333, col: 5, offset: 31649},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1331, col: 7, offset: 31687},
+										pos:  position{line: 1333, col: 7, offset: 31651},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1331, col: 11, offset: 31691},
+									pos: position{line: 1333, col: 11, offset: 31655},
 									expr: &choiceExpr{
-										pos: position{line: 1331, col: 13, offset: 31693},
+										pos: position{line: 1333, col: 13, offset: 31657},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1331, col: 13, offset: 31693},
+												pos:  position{line: 1333, col: 13, offset: 31657},
 												name: "IdentifierRest",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1331, col: 30, offset: 31710},
+												pos:  position{line: 1333, col: 30, offset: 31674},
 												name: "TypeLiteral",
 											},
 										},
@@ -8832,13 +8819,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1334, col: 5, offset: 31787},
+						pos: position{line: 1336, col: 5, offset: 31751},
 						run: (*parser).callonAddressLiteral10,
 						expr: &labeledExpr{
-							pos:   position{line: 1334, col: 5, offset: 31787},
+							pos:   position{line: 1336, col: 5, offset: 31751},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1334, col: 7, offset: 31789},
+								pos:  position{line: 1336, col: 7, offset: 31753},
 								name: "IP",
 							},
 						},
@@ -8850,15 +8837,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 1338, col: 1, offset: 31853},
+			pos:  position{line: 1340, col: 1, offset: 31817},
 			expr: &actionExpr{
-				pos: position{line: 1339, col: 5, offset: 31870},
+				pos: position{line: 1341, col: 5, offset: 31834},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1339, col: 5, offset: 31870},
+					pos:   position{line: 1341, col: 5, offset: 31834},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1339, col: 7, offset: 31872},
+						pos:  position{line: 1341, col: 7, offset: 31836},
 						name: "FloatString",
 					},
 				},
@@ -8868,15 +8855,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 1343, col: 1, offset: 31950},
+			pos:  position{line: 1345, col: 1, offset: 31914},
 			expr: &actionExpr{
-				pos: position{line: 1344, col: 5, offset: 31969},
+				pos: position{line: 1346, col: 5, offset: 31933},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1344, col: 5, offset: 31969},
+					pos:   position{line: 1346, col: 5, offset: 31933},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1344, col: 7, offset: 31971},
+						pos:  position{line: 1346, col: 7, offset: 31935},
 						name: "IntString",
 					},
 				},
@@ -8886,23 +8873,23 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 1348, col: 1, offset: 32045},
+			pos:  position{line: 1350, col: 1, offset: 32009},
 			expr: &choiceExpr{
-				pos: position{line: 1349, col: 5, offset: 32064},
+				pos: position{line: 1351, col: 5, offset: 32028},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1349, col: 5, offset: 32064},
+						pos: position{line: 1351, col: 5, offset: 32028},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1349, col: 5, offset: 32064},
+							pos:  position{line: 1351, col: 5, offset: 32028},
 							name: "TRUE",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1350, col: 5, offset: 32122},
+						pos: position{line: 1352, col: 5, offset: 32086},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1350, col: 5, offset: 32122},
+							pos:  position{line: 1352, col: 5, offset: 32086},
 							name: "FALSE",
 						},
 					},
@@ -8913,12 +8900,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 1352, col: 1, offset: 32178},
+			pos:  position{line: 1354, col: 1, offset: 32142},
 			expr: &actionExpr{
-				pos: position{line: 1353, col: 5, offset: 32194},
+				pos: position{line: 1355, col: 5, offset: 32158},
 				run: (*parser).callonNullLiteral1,
 				expr: &ruleRefExpr{
-					pos:  position{line: 1353, col: 5, offset: 32194},
+					pos:  position{line: 1355, col: 5, offset: 32158},
 					name: "NULL",
 				},
 			},
@@ -8927,23 +8914,23 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 1355, col: 1, offset: 32244},
+			pos:  position{line: 1357, col: 1, offset: 32208},
 			expr: &actionExpr{
-				pos: position{line: 1356, col: 5, offset: 32261},
+				pos: position{line: 1358, col: 5, offset: 32225},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1356, col: 5, offset: 32261},
+					pos: position{line: 1358, col: 5, offset: 32225},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1356, col: 5, offset: 32261},
+							pos:        position{line: 1358, col: 5, offset: 32225},
 							val:        "0x",
 							ignoreCase: false,
 							want:       "\"0x\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1356, col: 10, offset: 32266},
+							pos: position{line: 1358, col: 10, offset: 32230},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1356, col: 10, offset: 32266},
+								pos:  position{line: 1358, col: 10, offset: 32230},
 								name: "HexDigit",
 							},
 						},
@@ -8955,29 +8942,29 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 1360, col: 1, offset: 32340},
+			pos:  position{line: 1362, col: 1, offset: 32304},
 			expr: &actionExpr{
-				pos: position{line: 1361, col: 5, offset: 32356},
+				pos: position{line: 1363, col: 5, offset: 32320},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1361, col: 5, offset: 32356},
+					pos: position{line: 1363, col: 5, offset: 32320},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1361, col: 5, offset: 32356},
+							pos:        position{line: 1363, col: 5, offset: 32320},
 							val:        "<",
 							ignoreCase: false,
 							want:       "\"<\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1361, col: 9, offset: 32360},
+							pos:   position{line: 1363, col: 9, offset: 32324},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1361, col: 13, offset: 32364},
+								pos:  position{line: 1363, col: 13, offset: 32328},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1361, col: 18, offset: 32369},
+							pos:        position{line: 1363, col: 18, offset: 32333},
 							val:        ">",
 							ignoreCase: false,
 							want:       "\">\"",
@@ -8990,27 +8977,27 @@ var g = &grammar{
 		},
 		{
 			name: "TypeAsValue",
-			pos:  position{line: 1369, col: 1, offset: 32502},
+			pos:  position{line: 1371, col: 1, offset: 32466},
 			expr: &choiceExpr{
-				pos: position{line: 1370, col: 5, offset: 32518},
+				pos: position{line: 1372, col: 5, offset: 32482},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1370, col: 5, offset: 32518},
+						pos: position{line: 1372, col: 5, offset: 32482},
 						run: (*parser).callonTypeAsValue2,
 						expr: &seqExpr{
-							pos: position{line: 1370, col: 5, offset: 32518},
+							pos: position{line: 1372, col: 5, offset: 32482},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1370, col: 5, offset: 32518},
+									pos:        position{line: 1372, col: 5, offset: 32482},
 									val:        "=",
 									ignoreCase: false,
 									want:       "\"=\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1370, col: 9, offset: 32522},
+									pos:   position{line: 1372, col: 9, offset: 32486},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1370, col: 14, offset: 32527},
+										pos:  position{line: 1372, col: 14, offset: 32491},
 										name: "Name",
 									},
 								},
@@ -9018,13 +9005,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1371, col: 5, offset: 32601},
+						pos: position{line: 1373, col: 5, offset: 32565},
 						run: (*parser).callonTypeAsValue7,
 						expr: &labeledExpr{
-							pos:   position{line: 1371, col: 5, offset: 32601},
+							pos:   position{line: 1373, col: 5, offset: 32565},
 							label: "t",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1371, col: 7, offset: 32603},
+								pos:  position{line: 1373, col: 7, offset: 32567},
 								name: "EasyType",
 							},
 						},
@@ -9036,16 +9023,16 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1379, col: 1, offset: 32739},
+			pos:  position{line: 1381, col: 1, offset: 32703},
 			expr: &choiceExpr{
-				pos: position{line: 1380, col: 5, offset: 32748},
+				pos: position{line: 1382, col: 5, offset: 32712},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1380, col: 5, offset: 32748},
+						pos:  position{line: 1382, col: 5, offset: 32712},
 						name: "TypeUnion",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1381, col: 5, offset: 32762},
+						pos:  position{line: 1383, col: 5, offset: 32726},
 						name: "ComponentType",
 					},
 				},
@@ -9055,52 +9042,52 @@ var g = &grammar{
 		},
 		{
 			name: "ComponentType",
-			pos:  position{line: 1383, col: 1, offset: 32777},
+			pos:  position{line: 1385, col: 1, offset: 32741},
 			expr: &choiceExpr{
-				pos: position{line: 1384, col: 5, offset: 32795},
+				pos: position{line: 1386, col: 5, offset: 32759},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1384, col: 5, offset: 32795},
+						pos:  position{line: 1386, col: 5, offset: 32759},
 						name: "EasyType",
 					},
 					&actionExpr{
-						pos: position{line: 1385, col: 5, offset: 32808},
+						pos: position{line: 1387, col: 5, offset: 32772},
 						run: (*parser).callonComponentType3,
 						expr: &seqExpr{
-							pos: position{line: 1385, col: 5, offset: 32808},
+							pos: position{line: 1387, col: 5, offset: 32772},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1385, col: 5, offset: 32808},
+									pos:   position{line: 1387, col: 5, offset: 32772},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1385, col: 10, offset: 32813},
+										pos:  position{line: 1387, col: 10, offset: 32777},
 										name: "Name",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1385, col: 15, offset: 32818},
+									pos:   position{line: 1387, col: 15, offset: 32782},
 									label: "opt",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1385, col: 19, offset: 32822},
+										pos: position{line: 1387, col: 19, offset: 32786},
 										expr: &seqExpr{
-											pos: position{line: 1385, col: 20, offset: 32823},
+											pos: position{line: 1387, col: 20, offset: 32787},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1385, col: 20, offset: 32823},
+													pos:  position{line: 1387, col: 20, offset: 32787},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1385, col: 23, offset: 32826},
+													pos:        position{line: 1387, col: 23, offset: 32790},
 													val:        "=",
 													ignoreCase: false,
 													want:       "\"=\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1385, col: 27, offset: 32830},
+													pos:  position{line: 1387, col: 27, offset: 32794},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1385, col: 30, offset: 32833},
+													pos:  position{line: 1387, col: 30, offset: 32797},
 													name: "Type",
 												},
 											},
@@ -9117,40 +9104,40 @@ var g = &grammar{
 		},
 		{
 			name: "EasyType",
-			pos:  position{line: 1397, col: 1, offset: 33155},
+			pos:  position{line: 1399, col: 1, offset: 33119},
 			expr: &choiceExpr{
-				pos: position{line: 1398, col: 5, offset: 33168},
+				pos: position{line: 1400, col: 5, offset: 33132},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1398, col: 5, offset: 33168},
+						pos: position{line: 1400, col: 5, offset: 33132},
 						run: (*parser).callonEasyType2,
 						expr: &seqExpr{
-							pos: position{line: 1398, col: 5, offset: 33168},
+							pos: position{line: 1400, col: 5, offset: 33132},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1398, col: 5, offset: 33168},
+									pos:        position{line: 1400, col: 5, offset: 33132},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1398, col: 9, offset: 33172},
+									pos:  position{line: 1400, col: 9, offset: 33136},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1398, col: 12, offset: 33175},
+									pos:   position{line: 1400, col: 12, offset: 33139},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1398, col: 16, offset: 33179},
+										pos:  position{line: 1400, col: 16, offset: 33143},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1398, col: 21, offset: 33184},
+									pos:  position{line: 1400, col: 21, offset: 33148},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1398, col: 24, offset: 33187},
+									pos:        position{line: 1400, col: 24, offset: 33151},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9159,23 +9146,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1399, col: 5, offset: 33214},
+						pos: position{line: 1401, col: 5, offset: 33178},
 						run: (*parser).callonEasyType10,
 						expr: &seqExpr{
-							pos: position{line: 1399, col: 5, offset: 33214},
+							pos: position{line: 1401, col: 5, offset: 33178},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1399, col: 5, offset: 33214},
+									pos:   position{line: 1401, col: 5, offset: 33178},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1399, col: 10, offset: 33219},
+										pos:  position{line: 1401, col: 10, offset: 33183},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1399, col: 24, offset: 33233},
+									pos: position{line: 1401, col: 24, offset: 33197},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1399, col: 25, offset: 33234},
+										pos:  position{line: 1401, col: 25, offset: 33198},
 										name: "IdentifierRest",
 									},
 								},
@@ -9183,43 +9170,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1400, col: 5, offset: 33274},
+						pos: position{line: 1402, col: 5, offset: 33238},
 						run: (*parser).callonEasyType16,
 						expr: &seqExpr{
-							pos: position{line: 1400, col: 5, offset: 33274},
+							pos: position{line: 1402, col: 5, offset: 33238},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1400, col: 5, offset: 33274},
+									pos:  position{line: 1402, col: 5, offset: 33238},
 									name: "ERROR",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1400, col: 11, offset: 33280},
+									pos:  position{line: 1402, col: 11, offset: 33244},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1400, col: 14, offset: 33283},
+									pos:        position{line: 1402, col: 14, offset: 33247},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1400, col: 18, offset: 33287},
+									pos:  position{line: 1402, col: 18, offset: 33251},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1400, col: 21, offset: 33290},
+									pos:   position{line: 1402, col: 21, offset: 33254},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1400, col: 23, offset: 33292},
+										pos:  position{line: 1402, col: 23, offset: 33256},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1400, col: 28, offset: 33297},
+									pos:  position{line: 1402, col: 28, offset: 33261},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1400, col: 31, offset: 33300},
+									pos:        position{line: 1402, col: 31, offset: 33264},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9228,43 +9215,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1407, col: 5, offset: 33440},
+						pos: position{line: 1409, col: 5, offset: 33404},
 						run: (*parser).callonEasyType26,
 						expr: &seqExpr{
-							pos: position{line: 1407, col: 5, offset: 33440},
+							pos: position{line: 1409, col: 5, offset: 33404},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1407, col: 5, offset: 33440},
+									pos:  position{line: 1409, col: 5, offset: 33404},
 									name: "ENUM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1407, col: 10, offset: 33445},
+									pos:  position{line: 1409, col: 10, offset: 33409},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1407, col: 13, offset: 33448},
+									pos:        position{line: 1409, col: 13, offset: 33412},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1407, col: 17, offset: 33452},
+									pos:  position{line: 1409, col: 17, offset: 33416},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1407, col: 20, offset: 33455},
+									pos:   position{line: 1409, col: 20, offset: 33419},
 									label: "names",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1407, col: 26, offset: 33461},
+										pos:  position{line: 1409, col: 26, offset: 33425},
 										name: "Names",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1407, col: 32, offset: 33467},
+									pos:  position{line: 1409, col: 32, offset: 33431},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1407, col: 35, offset: 33470},
+									pos:        position{line: 1409, col: 35, offset: 33434},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9273,35 +9260,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1414, col: 5, offset: 33624},
+						pos: position{line: 1416, col: 5, offset: 33588},
 						run: (*parser).callonEasyType36,
 						expr: &seqExpr{
-							pos: position{line: 1414, col: 5, offset: 33624},
+							pos: position{line: 1416, col: 5, offset: 33588},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1414, col: 5, offset: 33624},
+									pos:        position{line: 1416, col: 5, offset: 33588},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1414, col: 9, offset: 33628},
+									pos:  position{line: 1416, col: 9, offset: 33592},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1414, col: 12, offset: 33631},
+									pos:   position{line: 1416, col: 12, offset: 33595},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1414, col: 19, offset: 33638},
+										pos:  position{line: 1416, col: 19, offset: 33602},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1414, col: 33, offset: 33652},
+									pos:  position{line: 1416, col: 33, offset: 33616},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1414, col: 36, offset: 33655},
+									pos:        position{line: 1416, col: 36, offset: 33619},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -9310,35 +9297,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1421, col: 5, offset: 33817},
+						pos: position{line: 1423, col: 5, offset: 33781},
 						run: (*parser).callonEasyType44,
 						expr: &seqExpr{
-							pos: position{line: 1421, col: 5, offset: 33817},
+							pos: position{line: 1423, col: 5, offset: 33781},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1421, col: 5, offset: 33817},
+									pos:        position{line: 1423, col: 5, offset: 33781},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1421, col: 9, offset: 33821},
+									pos:  position{line: 1423, col: 9, offset: 33785},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1421, col: 12, offset: 33824},
+									pos:   position{line: 1423, col: 12, offset: 33788},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1421, col: 16, offset: 33828},
+										pos:  position{line: 1423, col: 16, offset: 33792},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1421, col: 21, offset: 33833},
+									pos:  position{line: 1423, col: 21, offset: 33797},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1421, col: 24, offset: 33836},
+									pos:        position{line: 1423, col: 24, offset: 33800},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -9347,35 +9334,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1428, col: 5, offset: 33978},
+						pos: position{line: 1430, col: 5, offset: 33942},
 						run: (*parser).callonEasyType52,
 						expr: &seqExpr{
-							pos: position{line: 1428, col: 5, offset: 33978},
+							pos: position{line: 1430, col: 5, offset: 33942},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1428, col: 5, offset: 33978},
+									pos:        position{line: 1430, col: 5, offset: 33942},
 									val:        "|[",
 									ignoreCase: false,
 									want:       "\"|[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1428, col: 10, offset: 33983},
+									pos:  position{line: 1430, col: 10, offset: 33947},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1428, col: 13, offset: 33986},
+									pos:   position{line: 1430, col: 13, offset: 33950},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1428, col: 17, offset: 33990},
+										pos:  position{line: 1430, col: 17, offset: 33954},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1428, col: 22, offset: 33995},
+									pos:  position{line: 1430, col: 22, offset: 33959},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1428, col: 25, offset: 33998},
+									pos:        position{line: 1430, col: 25, offset: 33962},
 									val:        "]|",
 									ignoreCase: false,
 									want:       "\"]|\"",
@@ -9384,57 +9371,57 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1435, col: 5, offset: 34137},
+						pos: position{line: 1437, col: 5, offset: 34101},
 						run: (*parser).callonEasyType60,
 						expr: &seqExpr{
-							pos: position{line: 1435, col: 5, offset: 34137},
+							pos: position{line: 1437, col: 5, offset: 34101},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1435, col: 5, offset: 34137},
+									pos:        position{line: 1437, col: 5, offset: 34101},
 									val:        "|{",
 									ignoreCase: false,
 									want:       "\"|{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1435, col: 10, offset: 34142},
+									pos:  position{line: 1437, col: 10, offset: 34106},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1435, col: 13, offset: 34145},
+									pos:   position{line: 1437, col: 13, offset: 34109},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1435, col: 21, offset: 34153},
+										pos:  position{line: 1437, col: 21, offset: 34117},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1435, col: 26, offset: 34158},
+									pos:  position{line: 1437, col: 26, offset: 34122},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1435, col: 29, offset: 34161},
+									pos:        position{line: 1437, col: 29, offset: 34125},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1435, col: 33, offset: 34165},
+									pos:  position{line: 1437, col: 33, offset: 34129},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1435, col: 36, offset: 34168},
+									pos:   position{line: 1437, col: 36, offset: 34132},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1435, col: 44, offset: 34176},
+										pos:  position{line: 1437, col: 44, offset: 34140},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1435, col: 49, offset: 34181},
+									pos:  position{line: 1437, col: 49, offset: 34145},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1435, col: 52, offset: 34184},
+									pos:        position{line: 1437, col: 52, offset: 34148},
 									val:        "}|",
 									ignoreCase: false,
 									want:       "\"}|\"",
@@ -9449,15 +9436,15 @@ var g = &grammar{
 		},
 		{
 			name: "TypeUnion",
-			pos:  position{line: 1444, col: 1, offset: 34358},
+			pos:  position{line: 1446, col: 1, offset: 34322},
 			expr: &actionExpr{
-				pos: position{line: 1445, col: 5, offset: 34372},
+				pos: position{line: 1447, col: 5, offset: 34336},
 				run: (*parser).callonTypeUnion1,
 				expr: &labeledExpr{
-					pos:   position{line: 1445, col: 5, offset: 34372},
+					pos:   position{line: 1447, col: 5, offset: 34336},
 					label: "types",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1445, col: 11, offset: 34378},
+						pos:  position{line: 1447, col: 11, offset: 34342},
 						name: "TypeList",
 					},
 				},
@@ -9467,28 +9454,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1453, col: 1, offset: 34515},
+			pos:  position{line: 1455, col: 1, offset: 34479},
 			expr: &actionExpr{
-				pos: position{line: 1454, col: 5, offset: 34528},
+				pos: position{line: 1456, col: 5, offset: 34492},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1454, col: 5, offset: 34528},
+					pos: position{line: 1456, col: 5, offset: 34492},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1454, col: 5, offset: 34528},
+							pos:   position{line: 1456, col: 5, offset: 34492},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1454, col: 11, offset: 34534},
+								pos:  position{line: 1456, col: 11, offset: 34498},
 								name: "ComponentType",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1454, col: 25, offset: 34548},
+							pos:   position{line: 1456, col: 25, offset: 34512},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1454, col: 30, offset: 34553},
+								pos: position{line: 1456, col: 30, offset: 34517},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1454, col: 30, offset: 34553},
+									pos:  position{line: 1456, col: 30, offset: 34517},
 									name: "TypeListTail",
 								},
 							},
@@ -9501,32 +9488,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1458, col: 1, offset: 34611},
+			pos:  position{line: 1460, col: 1, offset: 34575},
 			expr: &actionExpr{
-				pos: position{line: 1458, col: 16, offset: 34626},
+				pos: position{line: 1460, col: 16, offset: 34590},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1458, col: 16, offset: 34626},
+					pos: position{line: 1460, col: 16, offset: 34590},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1458, col: 16, offset: 34626},
+							pos:  position{line: 1460, col: 16, offset: 34590},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1458, col: 19, offset: 34629},
+							pos:        position{line: 1460, col: 19, offset: 34593},
 							val:        "|",
 							ignoreCase: false,
 							want:       "\"|\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1458, col: 23, offset: 34633},
+							pos:  position{line: 1460, col: 23, offset: 34597},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1458, col: 26, offset: 34636},
+							pos:   position{line: 1460, col: 26, offset: 34600},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1458, col: 30, offset: 34640},
+								pos:  position{line: 1460, col: 30, offset: 34604},
 								name: "ComponentType",
 							},
 						},
@@ -9538,42 +9525,42 @@ var g = &grammar{
 		},
 		{
 			name: "StringLiteral",
-			pos:  position{line: 1460, col: 1, offset: 34675},
+			pos:  position{line: 1462, col: 1, offset: 34639},
 			expr: &choiceExpr{
-				pos: position{line: 1461, col: 5, offset: 34693},
+				pos: position{line: 1463, col: 5, offset: 34657},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1461, col: 5, offset: 34693},
+						pos: position{line: 1463, col: 5, offset: 34657},
 						run: (*parser).callonStringLiteral2,
 						expr: &labeledExpr{
-							pos:   position{line: 1461, col: 5, offset: 34693},
+							pos:   position{line: 1463, col: 5, offset: 34657},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1461, col: 7, offset: 34695},
+								pos:  position{line: 1463, col: 7, offset: 34659},
 								name: "DoubleQuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1462, col: 5, offset: 34802},
+						pos: position{line: 1464, col: 5, offset: 34766},
 						run: (*parser).callonStringLiteral5,
 						expr: &labeledExpr{
-							pos:   position{line: 1462, col: 5, offset: 34802},
+							pos:   position{line: 1464, col: 5, offset: 34766},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1462, col: 7, offset: 34804},
+								pos:  position{line: 1464, col: 7, offset: 34768},
 								name: "SingleQuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1463, col: 5, offset: 34881},
+						pos: position{line: 1465, col: 5, offset: 34845},
 						run: (*parser).callonStringLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1463, col: 5, offset: 34881},
+							pos:   position{line: 1465, col: 5, offset: 34845},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1463, col: 7, offset: 34883},
+								pos:  position{line: 1465, col: 7, offset: 34847},
 								name: "RString",
 							},
 						},
@@ -9585,35 +9572,35 @@ var g = &grammar{
 		},
 		{
 			name: "FString",
-			pos:  position{line: 1465, col: 1, offset: 34946},
+			pos:  position{line: 1467, col: 1, offset: 34910},
 			expr: &choiceExpr{
-				pos: position{line: 1466, col: 5, offset: 34958},
+				pos: position{line: 1468, col: 5, offset: 34922},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1466, col: 5, offset: 34958},
+						pos: position{line: 1468, col: 5, offset: 34922},
 						run: (*parser).callonFString2,
 						expr: &seqExpr{
-							pos: position{line: 1466, col: 5, offset: 34958},
+							pos: position{line: 1468, col: 5, offset: 34922},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1466, col: 5, offset: 34958},
+									pos:        position{line: 1468, col: 5, offset: 34922},
 									val:        "f\"",
 									ignoreCase: false,
 									want:       "\"f\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1466, col: 11, offset: 34964},
+									pos:   position{line: 1468, col: 11, offset: 34928},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1466, col: 13, offset: 34966},
+										pos: position{line: 1468, col: 13, offset: 34930},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1466, col: 13, offset: 34966},
+											pos:  position{line: 1468, col: 13, offset: 34930},
 											name: "FStringDoubleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1466, col: 38, offset: 34991},
+									pos:        position{line: 1468, col: 38, offset: 34955},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -9622,30 +9609,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1473, col: 5, offset: 35137},
+						pos: position{line: 1475, col: 5, offset: 35101},
 						run: (*parser).callonFString9,
 						expr: &seqExpr{
-							pos: position{line: 1473, col: 5, offset: 35137},
+							pos: position{line: 1475, col: 5, offset: 35101},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1473, col: 5, offset: 35137},
+									pos:        position{line: 1475, col: 5, offset: 35101},
 									val:        "f'",
 									ignoreCase: false,
 									want:       "\"f'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1473, col: 10, offset: 35142},
+									pos:   position{line: 1475, col: 10, offset: 35106},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1473, col: 12, offset: 35144},
+										pos: position{line: 1475, col: 12, offset: 35108},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1473, col: 12, offset: 35144},
+											pos:  position{line: 1475, col: 12, offset: 35108},
 											name: "FStringSingleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1473, col: 37, offset: 35169},
+									pos:        position{line: 1475, col: 37, offset: 35133},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -9660,24 +9647,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedElem",
-			pos:  position{line: 1481, col: 1, offset: 35312},
+			pos:  position{line: 1483, col: 1, offset: 35276},
 			expr: &choiceExpr{
-				pos: position{line: 1482, col: 5, offset: 35340},
+				pos: position{line: 1484, col: 5, offset: 35304},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1482, col: 5, offset: 35340},
+						pos:  position{line: 1484, col: 5, offset: 35304},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1483, col: 5, offset: 35356},
+						pos: position{line: 1485, col: 5, offset: 35320},
 						run: (*parser).callonFStringDoubleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1483, col: 5, offset: 35356},
+							pos:   position{line: 1485, col: 5, offset: 35320},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1483, col: 7, offset: 35358},
+								pos: position{line: 1485, col: 7, offset: 35322},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1483, col: 7, offset: 35358},
+									pos:  position{line: 1485, col: 7, offset: 35322},
 									name: "FStringDoubleQuotedChar",
 								},
 							},
@@ -9690,27 +9677,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedChar",
-			pos:  position{line: 1487, col: 1, offset: 35481},
+			pos:  position{line: 1489, col: 1, offset: 35445},
 			expr: &choiceExpr{
-				pos: position{line: 1488, col: 5, offset: 35509},
+				pos: position{line: 1490, col: 5, offset: 35473},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1488, col: 5, offset: 35509},
+						pos: position{line: 1490, col: 5, offset: 35473},
 						run: (*parser).callonFStringDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1488, col: 5, offset: 35509},
+							pos: position{line: 1490, col: 5, offset: 35473},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1488, col: 5, offset: 35509},
+									pos:        position{line: 1490, col: 5, offset: 35473},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1488, col: 10, offset: 35514},
+									pos:   position{line: 1490, col: 10, offset: 35478},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1488, col: 12, offset: 35516},
+										pos:        position{line: 1490, col: 12, offset: 35480},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9720,25 +9707,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1489, col: 5, offset: 35542},
+						pos: position{line: 1491, col: 5, offset: 35506},
 						run: (*parser).callonFStringDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1489, col: 5, offset: 35542},
+							pos: position{line: 1491, col: 5, offset: 35506},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1489, col: 5, offset: 35542},
+									pos: position{line: 1491, col: 5, offset: 35506},
 									expr: &litMatcher{
-										pos:        position{line: 1489, col: 7, offset: 35544},
+										pos:        position{line: 1491, col: 7, offset: 35508},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1489, col: 12, offset: 35549},
+									pos:   position{line: 1491, col: 12, offset: 35513},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1489, col: 14, offset: 35551},
+										pos:  position{line: 1491, col: 14, offset: 35515},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -9752,24 +9739,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedElem",
-			pos:  position{line: 1491, col: 1, offset: 35587},
+			pos:  position{line: 1493, col: 1, offset: 35551},
 			expr: &choiceExpr{
-				pos: position{line: 1492, col: 5, offset: 35615},
+				pos: position{line: 1494, col: 5, offset: 35579},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1492, col: 5, offset: 35615},
+						pos:  position{line: 1494, col: 5, offset: 35579},
 						name: "FStringExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1493, col: 5, offset: 35631},
+						pos: position{line: 1495, col: 5, offset: 35595},
 						run: (*parser).callonFStringSingleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1493, col: 5, offset: 35631},
+							pos:   position{line: 1495, col: 5, offset: 35595},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1493, col: 7, offset: 35633},
+								pos: position{line: 1495, col: 7, offset: 35597},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1493, col: 7, offset: 35633},
+									pos:  position{line: 1495, col: 7, offset: 35597},
 									name: "FStringSingleQuotedChar",
 								},
 							},
@@ -9782,27 +9769,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedChar",
-			pos:  position{line: 1497, col: 1, offset: 35756},
+			pos:  position{line: 1499, col: 1, offset: 35720},
 			expr: &choiceExpr{
-				pos: position{line: 1498, col: 5, offset: 35784},
+				pos: position{line: 1500, col: 5, offset: 35748},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1498, col: 5, offset: 35784},
+						pos: position{line: 1500, col: 5, offset: 35748},
 						run: (*parser).callonFStringSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1498, col: 5, offset: 35784},
+							pos: position{line: 1500, col: 5, offset: 35748},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1498, col: 5, offset: 35784},
+									pos:        position{line: 1500, col: 5, offset: 35748},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1498, col: 10, offset: 35789},
+									pos:   position{line: 1500, col: 10, offset: 35753},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1498, col: 12, offset: 35791},
+										pos:        position{line: 1500, col: 12, offset: 35755},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9812,25 +9799,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1499, col: 5, offset: 35817},
+						pos: position{line: 1501, col: 5, offset: 35781},
 						run: (*parser).callonFStringSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1499, col: 5, offset: 35817},
+							pos: position{line: 1501, col: 5, offset: 35781},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1499, col: 5, offset: 35817},
+									pos: position{line: 1501, col: 5, offset: 35781},
 									expr: &litMatcher{
-										pos:        position{line: 1499, col: 7, offset: 35819},
+										pos:        position{line: 1501, col: 7, offset: 35783},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1499, col: 12, offset: 35824},
+									pos:   position{line: 1501, col: 12, offset: 35788},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1499, col: 14, offset: 35826},
+										pos:  position{line: 1501, col: 14, offset: 35790},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -9844,37 +9831,37 @@ var g = &grammar{
 		},
 		{
 			name: "FStringExpr",
-			pos:  position{line: 1501, col: 1, offset: 35862},
+			pos:  position{line: 1503, col: 1, offset: 35826},
 			expr: &actionExpr{
-				pos: position{line: 1502, col: 5, offset: 35878},
+				pos: position{line: 1504, col: 5, offset: 35842},
 				run: (*parser).callonFStringExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1502, col: 5, offset: 35878},
+					pos: position{line: 1504, col: 5, offset: 35842},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1502, col: 5, offset: 35878},
+							pos:        position{line: 1504, col: 5, offset: 35842},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1502, col: 9, offset: 35882},
+							pos:  position{line: 1504, col: 9, offset: 35846},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1502, col: 12, offset: 35885},
+							pos:   position{line: 1504, col: 12, offset: 35849},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1502, col: 14, offset: 35887},
+								pos:  position{line: 1504, col: 14, offset: 35851},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1502, col: 19, offset: 35892},
+							pos:  position{line: 1504, col: 19, offset: 35856},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1502, col: 22, offset: 35895},
+							pos:        position{line: 1504, col: 22, offset: 35859},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -9887,129 +9874,129 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1510, col: 1, offset: 36030},
+			pos:  position{line: 1512, col: 1, offset: 35994},
 			expr: &actionExpr{
-				pos: position{line: 1511, col: 5, offset: 36048},
+				pos: position{line: 1513, col: 5, offset: 36012},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1511, col: 9, offset: 36052},
+					pos: position{line: 1513, col: 9, offset: 36016},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1511, col: 9, offset: 36052},
+							pos:        position{line: 1513, col: 9, offset: 36016},
 							val:        "uint8",
 							ignoreCase: false,
 							want:       "\"uint8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1511, col: 19, offset: 36062},
+							pos:        position{line: 1513, col: 19, offset: 36026},
 							val:        "uint16",
 							ignoreCase: false,
 							want:       "\"uint16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1511, col: 30, offset: 36073},
+							pos:        position{line: 1513, col: 30, offset: 36037},
 							val:        "uint32",
 							ignoreCase: false,
 							want:       "\"uint32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1511, col: 41, offset: 36084},
+							pos:        position{line: 1513, col: 41, offset: 36048},
 							val:        "uint64",
 							ignoreCase: false,
 							want:       "\"uint64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1512, col: 9, offset: 36101},
+							pos:        position{line: 1514, col: 9, offset: 36065},
 							val:        "int8",
 							ignoreCase: false,
 							want:       "\"int8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1512, col: 18, offset: 36110},
+							pos:        position{line: 1514, col: 18, offset: 36074},
 							val:        "int16",
 							ignoreCase: false,
 							want:       "\"int16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1512, col: 28, offset: 36120},
+							pos:        position{line: 1514, col: 28, offset: 36084},
 							val:        "int32",
 							ignoreCase: false,
 							want:       "\"int32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1512, col: 38, offset: 36130},
+							pos:        position{line: 1514, col: 38, offset: 36094},
 							val:        "int64",
 							ignoreCase: false,
 							want:       "\"int64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1513, col: 9, offset: 36146},
+							pos:        position{line: 1515, col: 9, offset: 36110},
 							val:        "float16",
 							ignoreCase: false,
 							want:       "\"float16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1513, col: 21, offset: 36158},
+							pos:        position{line: 1515, col: 21, offset: 36122},
 							val:        "float32",
 							ignoreCase: false,
 							want:       "\"float32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1513, col: 33, offset: 36170},
+							pos:        position{line: 1515, col: 33, offset: 36134},
 							val:        "float64",
 							ignoreCase: false,
 							want:       "\"float64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1514, col: 9, offset: 36188},
+							pos:        position{line: 1516, col: 9, offset: 36152},
 							val:        "bool",
 							ignoreCase: false,
 							want:       "\"bool\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1514, col: 18, offset: 36197},
+							pos:        position{line: 1516, col: 18, offset: 36161},
 							val:        "string",
 							ignoreCase: false,
 							want:       "\"string\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1515, col: 9, offset: 36214},
+							pos:        position{line: 1517, col: 9, offset: 36178},
 							val:        "duration",
 							ignoreCase: false,
 							want:       "\"duration\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1515, col: 22, offset: 36227},
+							pos:        position{line: 1517, col: 22, offset: 36191},
 							val:        "time",
 							ignoreCase: false,
 							want:       "\"time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1516, col: 9, offset: 36242},
+							pos:        position{line: 1518, col: 9, offset: 36206},
 							val:        "bytes",
 							ignoreCase: false,
 							want:       "\"bytes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1517, col: 9, offset: 36258},
+							pos:        position{line: 1519, col: 9, offset: 36222},
 							val:        "ip",
 							ignoreCase: false,
 							want:       "\"ip\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1517, col: 16, offset: 36265},
+							pos:        position{line: 1519, col: 16, offset: 36229},
 							val:        "net",
 							ignoreCase: false,
 							want:       "\"net\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1518, col: 9, offset: 36279},
+							pos:        position{line: 1520, col: 9, offset: 36243},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1518, col: 18, offset: 36288},
+							pos:        position{line: 1520, col: 18, offset: 36252},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
@@ -10022,31 +10009,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1526, col: 1, offset: 36473},
+			pos:  position{line: 1528, col: 1, offset: 36437},
 			expr: &choiceExpr{
-				pos: position{line: 1527, col: 5, offset: 36491},
+				pos: position{line: 1529, col: 5, offset: 36455},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1527, col: 5, offset: 36491},
+						pos: position{line: 1529, col: 5, offset: 36455},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1527, col: 5, offset: 36491},
+							pos: position{line: 1529, col: 5, offset: 36455},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1527, col: 5, offset: 36491},
+									pos:   position{line: 1529, col: 5, offset: 36455},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1527, col: 11, offset: 36497},
+										pos:  position{line: 1529, col: 11, offset: 36461},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1527, col: 21, offset: 36507},
+									pos:   position{line: 1529, col: 21, offset: 36471},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1527, col: 26, offset: 36512},
+										pos: position{line: 1529, col: 26, offset: 36476},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1527, col: 26, offset: 36512},
+											pos:  position{line: 1529, col: 26, offset: 36476},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -10055,10 +10042,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1530, col: 5, offset: 36578},
+						pos: position{line: 1532, col: 5, offset: 36542},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1530, col: 5, offset: 36578},
+							pos:        position{line: 1532, col: 5, offset: 36542},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -10071,32 +10058,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1532, col: 1, offset: 36602},
+			pos:  position{line: 1534, col: 1, offset: 36566},
 			expr: &actionExpr{
-				pos: position{line: 1532, col: 21, offset: 36622},
+				pos: position{line: 1534, col: 21, offset: 36586},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1532, col: 21, offset: 36622},
+					pos: position{line: 1534, col: 21, offset: 36586},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1532, col: 21, offset: 36622},
+							pos:  position{line: 1534, col: 21, offset: 36586},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1532, col: 24, offset: 36625},
+							pos:        position{line: 1534, col: 24, offset: 36589},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1532, col: 28, offset: 36629},
+							pos:  position{line: 1534, col: 28, offset: 36593},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1532, col: 31, offset: 36632},
+							pos:   position{line: 1534, col: 31, offset: 36596},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1532, col: 35, offset: 36636},
+								pos:  position{line: 1534, col: 35, offset: 36600},
 								name: "TypeField",
 							},
 						},
@@ -10108,40 +10095,40 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1534, col: 1, offset: 36667},
+			pos:  position{line: 1536, col: 1, offset: 36631},
 			expr: &actionExpr{
-				pos: position{line: 1535, col: 5, offset: 36681},
+				pos: position{line: 1537, col: 5, offset: 36645},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1535, col: 5, offset: 36681},
+					pos: position{line: 1537, col: 5, offset: 36645},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1535, col: 5, offset: 36681},
+							pos:   position{line: 1537, col: 5, offset: 36645},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1535, col: 10, offset: 36686},
+								pos:  position{line: 1537, col: 10, offset: 36650},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1535, col: 15, offset: 36691},
+							pos:  position{line: 1537, col: 15, offset: 36655},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1535, col: 18, offset: 36694},
+							pos:        position{line: 1537, col: 18, offset: 36658},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1535, col: 22, offset: 36698},
+							pos:  position{line: 1537, col: 22, offset: 36662},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1535, col: 25, offset: 36701},
+							pos:   position{line: 1537, col: 25, offset: 36665},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1535, col: 29, offset: 36705},
+								pos:  position{line: 1537, col: 29, offset: 36669},
 								name: "Type",
 							},
 						},
@@ -10153,26 +10140,26 @@ var g = &grammar{
 		},
 		{
 			name: "Name",
-			pos:  position{line: 1543, col: 1, offset: 36854},
+			pos:  position{line: 1545, col: 1, offset: 36818},
 			expr: &actionExpr{
-				pos: position{line: 1544, col: 4, offset: 36862},
+				pos: position{line: 1546, col: 4, offset: 36826},
 				run: (*parser).callonName1,
 				expr: &labeledExpr{
-					pos:   position{line: 1544, col: 4, offset: 36862},
+					pos:   position{line: 1546, col: 4, offset: 36826},
 					label: "s",
 					expr: &choiceExpr{
-						pos: position{line: 1544, col: 7, offset: 36865},
+						pos: position{line: 1546, col: 7, offset: 36829},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1544, col: 7, offset: 36865},
+								pos:  position{line: 1546, col: 7, offset: 36829},
 								name: "IdentifierName",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1544, col: 24, offset: 36882},
+								pos:  position{line: 1546, col: 24, offset: 36846},
 								name: "DoubleQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1544, col: 45, offset: 36903},
+								pos:  position{line: 1546, col: 45, offset: 36867},
 								name: "SingleQuotedString",
 							},
 						},
@@ -10184,51 +10171,51 @@ var g = &grammar{
 		},
 		{
 			name: "Names",
-			pos:  position{line: 1548, col: 1, offset: 37003},
+			pos:  position{line: 1550, col: 1, offset: 36967},
 			expr: &actionExpr{
-				pos: position{line: 1549, col: 5, offset: 37013},
+				pos: position{line: 1551, col: 5, offset: 36977},
 				run: (*parser).callonNames1,
 				expr: &seqExpr{
-					pos: position{line: 1549, col: 5, offset: 37013},
+					pos: position{line: 1551, col: 5, offset: 36977},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1549, col: 5, offset: 37013},
+							pos:   position{line: 1551, col: 5, offset: 36977},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1549, col: 11, offset: 37019},
+								pos:  position{line: 1551, col: 11, offset: 36983},
 								name: "Name",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1549, col: 16, offset: 37024},
+							pos:   position{line: 1551, col: 16, offset: 36988},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1549, col: 21, offset: 37029},
+								pos: position{line: 1551, col: 21, offset: 36993},
 								expr: &actionExpr{
-									pos: position{line: 1549, col: 22, offset: 37030},
+									pos: position{line: 1551, col: 22, offset: 36994},
 									run: (*parser).callonNames7,
 									expr: &seqExpr{
-										pos: position{line: 1549, col: 22, offset: 37030},
+										pos: position{line: 1551, col: 22, offset: 36994},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1549, col: 22, offset: 37030},
+												pos:  position{line: 1551, col: 22, offset: 36994},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1549, col: 25, offset: 37033},
+												pos:        position{line: 1551, col: 25, offset: 36997},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1549, col: 29, offset: 37037},
+												pos:  position{line: 1551, col: 29, offset: 37001},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1549, col: 32, offset: 37040},
+												pos:   position{line: 1551, col: 32, offset: 37004},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1549, col: 37, offset: 37045},
+													pos:  position{line: 1551, col: 37, offset: 37009},
 													name: "Name",
 												},
 											},
@@ -10245,15 +10232,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1553, col: 1, offset: 37117},
+			pos:  position{line: 1555, col: 1, offset: 37081},
 			expr: &actionExpr{
-				pos: position{line: 1554, col: 5, offset: 37132},
+				pos: position{line: 1556, col: 5, offset: 37096},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1554, col: 5, offset: 37132},
+					pos:   position{line: 1556, col: 5, offset: 37096},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1554, col: 8, offset: 37135},
+						pos:  position{line: 1556, col: 8, offset: 37099},
 						name: "IdentifierName",
 					},
 				},
@@ -10263,51 +10250,51 @@ var g = &grammar{
 		},
 		{
 			name: "Identifiers",
-			pos:  position{line: 1562, col: 1, offset: 37268},
+			pos:  position{line: 1564, col: 1, offset: 37232},
 			expr: &actionExpr{
-				pos: position{line: 1563, col: 5, offset: 37284},
+				pos: position{line: 1565, col: 5, offset: 37248},
 				run: (*parser).callonIdentifiers1,
 				expr: &seqExpr{
-					pos: position{line: 1563, col: 5, offset: 37284},
+					pos: position{line: 1565, col: 5, offset: 37248},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1563, col: 5, offset: 37284},
+							pos:   position{line: 1565, col: 5, offset: 37248},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1563, col: 11, offset: 37290},
+								pos:  position{line: 1565, col: 11, offset: 37254},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1563, col: 22, offset: 37301},
+							pos:   position{line: 1565, col: 22, offset: 37265},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1563, col: 27, offset: 37306},
+								pos: position{line: 1565, col: 27, offset: 37270},
 								expr: &actionExpr{
-									pos: position{line: 1563, col: 28, offset: 37307},
+									pos: position{line: 1565, col: 28, offset: 37271},
 									run: (*parser).callonIdentifiers7,
 									expr: &seqExpr{
-										pos: position{line: 1563, col: 28, offset: 37307},
+										pos: position{line: 1565, col: 28, offset: 37271},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1563, col: 28, offset: 37307},
+												pos:  position{line: 1565, col: 28, offset: 37271},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1563, col: 31, offset: 37310},
+												pos:        position{line: 1565, col: 31, offset: 37274},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1563, col: 35, offset: 37314},
+												pos:  position{line: 1565, col: 35, offset: 37278},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1563, col: 38, offset: 37317},
+												pos:   position{line: 1565, col: 38, offset: 37281},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1563, col: 43, offset: 37322},
+													pos:  position{line: 1565, col: 43, offset: 37286},
 													name: "Identifier",
 												},
 											},
@@ -10324,22 +10311,22 @@ var g = &grammar{
 		},
 		{
 			name: "SQLIdentifier",
-			pos:  position{line: 1567, col: 1, offset: 37400},
+			pos:  position{line: 1569, col: 1, offset: 37364},
 			expr: &choiceExpr{
-				pos: position{line: 1568, col: 5, offset: 37418},
+				pos: position{line: 1570, col: 5, offset: 37382},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1568, col: 5, offset: 37418},
+						pos:  position{line: 1570, col: 5, offset: 37382},
 						name: "Identifier",
 					},
 					&actionExpr{
-						pos: position{line: 1569, col: 5, offset: 37433},
+						pos: position{line: 1571, col: 5, offset: 37397},
 						run: (*parser).callonSQLIdentifier3,
 						expr: &labeledExpr{
-							pos:   position{line: 1569, col: 5, offset: 37433},
+							pos:   position{line: 1571, col: 5, offset: 37397},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1569, col: 7, offset: 37435},
+								pos:  position{line: 1571, col: 7, offset: 37399},
 								name: "DoubleQuotedString",
 							},
 						},
@@ -10351,29 +10338,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1571, col: 1, offset: 37520},
+			pos:  position{line: 1573, col: 1, offset: 37484},
 			expr: &choiceExpr{
-				pos: position{line: 1572, col: 5, offset: 37539},
+				pos: position{line: 1574, col: 5, offset: 37503},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1572, col: 5, offset: 37539},
+						pos: position{line: 1574, col: 5, offset: 37503},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1572, col: 5, offset: 37539},
+							pos: position{line: 1574, col: 5, offset: 37503},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1572, col: 5, offset: 37539},
+									pos: position{line: 1574, col: 5, offset: 37503},
 									expr: &seqExpr{
-										pos: position{line: 1572, col: 7, offset: 37541},
+										pos: position{line: 1574, col: 7, offset: 37505},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1572, col: 7, offset: 37541},
+												pos:  position{line: 1574, col: 7, offset: 37505},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1572, col: 15, offset: 37549},
+												pos: position{line: 1574, col: 15, offset: 37513},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1572, col: 16, offset: 37550},
+													pos:  position{line: 1574, col: 16, offset: 37514},
 													name: "IdentifierRest",
 												},
 											},
@@ -10381,13 +10368,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1572, col: 32, offset: 37566},
+									pos:  position{line: 1574, col: 32, offset: 37530},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1572, col: 48, offset: 37582},
+									pos: position{line: 1574, col: 48, offset: 37546},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1572, col: 48, offset: 37582},
+										pos:  position{line: 1574, col: 48, offset: 37546},
 										name: "IdentifierRest",
 									},
 								},
@@ -10395,7 +10382,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1573, col: 5, offset: 37633},
+						pos:  position{line: 1575, col: 5, offset: 37597},
 						name: "BacktickString",
 					},
 				},
@@ -10405,22 +10392,22 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1575, col: 1, offset: 37649},
+			pos:  position{line: 1577, col: 1, offset: 37613},
 			expr: &choiceExpr{
-				pos: position{line: 1576, col: 5, offset: 37669},
+				pos: position{line: 1578, col: 5, offset: 37633},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1576, col: 5, offset: 37669},
+						pos:  position{line: 1578, col: 5, offset: 37633},
 						name: "UnicodeLetter",
 					},
 					&litMatcher{
-						pos:        position{line: 1577, col: 5, offset: 37687},
+						pos:        position{line: 1579, col: 5, offset: 37651},
 						val:        "$",
 						ignoreCase: false,
 						want:       "\"$\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1578, col: 5, offset: 37695},
+						pos:        position{line: 1580, col: 5, offset: 37659},
 						val:        "_",
 						ignoreCase: false,
 						want:       "\"_\"",
@@ -10432,24 +10419,24 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1580, col: 1, offset: 37700},
+			pos:  position{line: 1582, col: 1, offset: 37664},
 			expr: &choiceExpr{
-				pos: position{line: 1581, col: 5, offset: 37719},
+				pos: position{line: 1583, col: 5, offset: 37683},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1581, col: 5, offset: 37719},
+						pos:  position{line: 1583, col: 5, offset: 37683},
 						name: "IdentifierStart",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1582, col: 5, offset: 37739},
+						pos:  position{line: 1584, col: 5, offset: 37703},
 						name: "UnicodeCombiningMark",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1583, col: 5, offset: 37764},
+						pos:  position{line: 1585, col: 5, offset: 37728},
 						name: "UnicodeDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1584, col: 5, offset: 37781},
+						pos:  position{line: 1586, col: 5, offset: 37745},
 						name: "UnicodeConnectorPunctuation",
 					},
 				},
@@ -10459,24 +10446,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1586, col: 1, offset: 37810},
+			pos:  position{line: 1588, col: 1, offset: 37774},
 			expr: &choiceExpr{
-				pos: position{line: 1587, col: 5, offset: 37822},
+				pos: position{line: 1589, col: 5, offset: 37786},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1587, col: 5, offset: 37822},
+						pos:  position{line: 1589, col: 5, offset: 37786},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1588, col: 5, offset: 37841},
+						pos:  position{line: 1590, col: 5, offset: 37805},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1589, col: 5, offset: 37857},
+						pos:  position{line: 1591, col: 5, offset: 37821},
 						name: "NaN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1590, col: 5, offset: 37865},
+						pos:  position{line: 1592, col: 5, offset: 37829},
 						name: "Infinity",
 					},
 				},
@@ -10486,25 +10473,25 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1592, col: 1, offset: 37875},
+			pos:  position{line: 1594, col: 1, offset: 37839},
 			expr: &actionExpr{
-				pos: position{line: 1593, col: 5, offset: 37884},
+				pos: position{line: 1595, col: 5, offset: 37848},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1593, col: 5, offset: 37884},
+					pos: position{line: 1595, col: 5, offset: 37848},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1593, col: 5, offset: 37884},
+							pos:  position{line: 1595, col: 5, offset: 37848},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1593, col: 14, offset: 37893},
+							pos:        position{line: 1595, col: 14, offset: 37857},
 							val:        "T",
 							ignoreCase: false,
 							want:       "\"T\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1593, col: 18, offset: 37897},
+							pos:  position{line: 1595, col: 18, offset: 37861},
 							name: "FullTime",
 						},
 					},
@@ -10515,32 +10502,32 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1597, col: 1, offset: 37973},
+			pos:  position{line: 1599, col: 1, offset: 37937},
 			expr: &seqExpr{
-				pos: position{line: 1597, col: 12, offset: 37984},
+				pos: position{line: 1599, col: 12, offset: 37948},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1597, col: 12, offset: 37984},
+						pos:  position{line: 1599, col: 12, offset: 37948},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1597, col: 15, offset: 37987},
+						pos:        position{line: 1599, col: 15, offset: 37951},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1597, col: 19, offset: 37991},
+						pos:  position{line: 1599, col: 19, offset: 37955},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1597, col: 22, offset: 37994},
+						pos:        position{line: 1599, col: 22, offset: 37958},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1597, col: 26, offset: 37998},
+						pos:  position{line: 1599, col: 26, offset: 37962},
 						name: "D2",
 					},
 				},
@@ -10550,33 +10537,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1599, col: 1, offset: 38002},
+			pos:  position{line: 1601, col: 1, offset: 37966},
 			expr: &seqExpr{
-				pos: position{line: 1599, col: 6, offset: 38007},
+				pos: position{line: 1601, col: 6, offset: 37971},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1599, col: 6, offset: 38007},
+						pos:        position{line: 1601, col: 6, offset: 37971},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1599, col: 11, offset: 38012},
+						pos:        position{line: 1601, col: 11, offset: 37976},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1599, col: 16, offset: 38017},
+						pos:        position{line: 1601, col: 16, offset: 37981},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1599, col: 21, offset: 38022},
+						pos:        position{line: 1601, col: 21, offset: 37986},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10589,19 +10576,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1600, col: 1, offset: 38028},
+			pos:  position{line: 1602, col: 1, offset: 37992},
 			expr: &seqExpr{
-				pos: position{line: 1600, col: 6, offset: 38033},
+				pos: position{line: 1602, col: 6, offset: 37997},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1600, col: 6, offset: 38033},
+						pos:        position{line: 1602, col: 6, offset: 37997},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1600, col: 11, offset: 38038},
+						pos:        position{line: 1602, col: 11, offset: 38002},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10614,16 +10601,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1602, col: 1, offset: 38045},
+			pos:  position{line: 1604, col: 1, offset: 38009},
 			expr: &seqExpr{
-				pos: position{line: 1602, col: 12, offset: 38056},
+				pos: position{line: 1604, col: 12, offset: 38020},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1602, col: 12, offset: 38056},
+						pos:  position{line: 1604, col: 12, offset: 38020},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1602, col: 24, offset: 38068},
+						pos:  position{line: 1604, col: 24, offset: 38032},
 						name: "TimeOffset",
 					},
 				},
@@ -10633,49 +10620,49 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1604, col: 1, offset: 38080},
+			pos:  position{line: 1606, col: 1, offset: 38044},
 			expr: &seqExpr{
-				pos: position{line: 1604, col: 15, offset: 38094},
+				pos: position{line: 1606, col: 15, offset: 38058},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1604, col: 15, offset: 38094},
+						pos:  position{line: 1606, col: 15, offset: 38058},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1604, col: 18, offset: 38097},
+						pos:        position{line: 1606, col: 18, offset: 38061},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1604, col: 22, offset: 38101},
+						pos:  position{line: 1606, col: 22, offset: 38065},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1604, col: 25, offset: 38104},
+						pos:        position{line: 1606, col: 25, offset: 38068},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1604, col: 29, offset: 38108},
+						pos:  position{line: 1606, col: 29, offset: 38072},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1604, col: 32, offset: 38111},
+						pos: position{line: 1606, col: 32, offset: 38075},
 						expr: &seqExpr{
-							pos: position{line: 1604, col: 33, offset: 38112},
+							pos: position{line: 1606, col: 33, offset: 38076},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1604, col: 33, offset: 38112},
+									pos:        position{line: 1606, col: 33, offset: 38076},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1604, col: 37, offset: 38116},
+									pos: position{line: 1606, col: 37, offset: 38080},
 									expr: &charClassMatcher{
-										pos:        position{line: 1604, col: 37, offset: 38116},
+										pos:        position{line: 1606, col: 37, offset: 38080},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10692,30 +10679,30 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1606, col: 1, offset: 38126},
+			pos:  position{line: 1608, col: 1, offset: 38090},
 			expr: &choiceExpr{
-				pos: position{line: 1607, col: 5, offset: 38141},
+				pos: position{line: 1609, col: 5, offset: 38105},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1607, col: 5, offset: 38141},
+						pos:        position{line: 1609, col: 5, offset: 38105},
 						val:        "Z",
 						ignoreCase: false,
 						want:       "\"Z\"",
 					},
 					&seqExpr{
-						pos: position{line: 1608, col: 5, offset: 38149},
+						pos: position{line: 1610, col: 5, offset: 38113},
 						exprs: []any{
 							&choiceExpr{
-								pos: position{line: 1608, col: 6, offset: 38150},
+								pos: position{line: 1610, col: 6, offset: 38114},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 1608, col: 6, offset: 38150},
+										pos:        position{line: 1610, col: 6, offset: 38114},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 1608, col: 12, offset: 38156},
+										pos:        position{line: 1610, col: 12, offset: 38120},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
@@ -10723,34 +10710,34 @@ var g = &grammar{
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1608, col: 17, offset: 38161},
+								pos:  position{line: 1610, col: 17, offset: 38125},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1608, col: 20, offset: 38164},
+								pos:        position{line: 1610, col: 20, offset: 38128},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1608, col: 24, offset: 38168},
+								pos:  position{line: 1610, col: 24, offset: 38132},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1608, col: 27, offset: 38171},
+								pos: position{line: 1610, col: 27, offset: 38135},
 								expr: &seqExpr{
-									pos: position{line: 1608, col: 28, offset: 38172},
+									pos: position{line: 1610, col: 28, offset: 38136},
 									exprs: []any{
 										&litMatcher{
-											pos:        position{line: 1608, col: 28, offset: 38172},
+											pos:        position{line: 1610, col: 28, offset: 38136},
 											val:        ".",
 											ignoreCase: false,
 											want:       "\".\"",
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1608, col: 32, offset: 38176},
+											pos: position{line: 1610, col: 32, offset: 38140},
 											expr: &charClassMatcher{
-												pos:        position{line: 1608, col: 32, offset: 38176},
+												pos:        position{line: 1610, col: 32, offset: 38140},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -10769,33 +10756,33 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1610, col: 1, offset: 38186},
+			pos:  position{line: 1612, col: 1, offset: 38150},
 			expr: &actionExpr{
-				pos: position{line: 1611, col: 5, offset: 38199},
+				pos: position{line: 1613, col: 5, offset: 38163},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1611, col: 5, offset: 38199},
+					pos: position{line: 1613, col: 5, offset: 38163},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 1611, col: 5, offset: 38199},
+							pos: position{line: 1613, col: 5, offset: 38163},
 							expr: &litMatcher{
-								pos:        position{line: 1611, col: 5, offset: 38199},
+								pos:        position{line: 1613, col: 5, offset: 38163},
 								val:        "-",
 								ignoreCase: false,
 								want:       "\"-\"",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1611, col: 10, offset: 38204},
+							pos: position{line: 1613, col: 10, offset: 38168},
 							expr: &seqExpr{
-								pos: position{line: 1611, col: 11, offset: 38205},
+								pos: position{line: 1613, col: 11, offset: 38169},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1611, col: 11, offset: 38205},
+										pos:  position{line: 1613, col: 11, offset: 38169},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1611, col: 19, offset: 38213},
+										pos:  position{line: 1613, col: 19, offset: 38177},
 										name: "TimeUnit",
 									},
 								},
@@ -10809,27 +10796,27 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1615, col: 1, offset: 38295},
+			pos:  position{line: 1617, col: 1, offset: 38259},
 			expr: &seqExpr{
-				pos: position{line: 1615, col: 11, offset: 38305},
+				pos: position{line: 1617, col: 11, offset: 38269},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1615, col: 11, offset: 38305},
+						pos:  position{line: 1617, col: 11, offset: 38269},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1615, col: 16, offset: 38310},
+						pos: position{line: 1617, col: 16, offset: 38274},
 						expr: &seqExpr{
-							pos: position{line: 1615, col: 17, offset: 38311},
+							pos: position{line: 1617, col: 17, offset: 38275},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1615, col: 17, offset: 38311},
+									pos:        position{line: 1617, col: 17, offset: 38275},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1615, col: 21, offset: 38315},
+									pos:  position{line: 1617, col: 21, offset: 38279},
 									name: "UInt",
 								},
 							},
@@ -10842,60 +10829,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1617, col: 1, offset: 38323},
+			pos:  position{line: 1619, col: 1, offset: 38287},
 			expr: &choiceExpr{
-				pos: position{line: 1618, col: 5, offset: 38336},
+				pos: position{line: 1620, col: 5, offset: 38300},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1618, col: 5, offset: 38336},
+						pos:        position{line: 1620, col: 5, offset: 38300},
 						val:        "ns",
 						ignoreCase: false,
 						want:       "\"ns\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1619, col: 5, offset: 38345},
+						pos:        position{line: 1621, col: 5, offset: 38309},
 						val:        "us",
 						ignoreCase: false,
 						want:       "\"us\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1620, col: 5, offset: 38354},
+						pos:        position{line: 1622, col: 5, offset: 38318},
 						val:        "ms",
 						ignoreCase: false,
 						want:       "\"ms\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1621, col: 5, offset: 38363},
+						pos:        position{line: 1623, col: 5, offset: 38327},
 						val:        "s",
 						ignoreCase: false,
 						want:       "\"s\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1622, col: 5, offset: 38371},
+						pos:        position{line: 1624, col: 5, offset: 38335},
 						val:        "m",
 						ignoreCase: false,
 						want:       "\"m\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1623, col: 5, offset: 38379},
+						pos:        position{line: 1625, col: 5, offset: 38343},
 						val:        "h",
 						ignoreCase: false,
 						want:       "\"h\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1624, col: 5, offset: 38387},
+						pos:        position{line: 1626, col: 5, offset: 38351},
 						val:        "d",
 						ignoreCase: false,
 						want:       "\"d\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1625, col: 5, offset: 38395},
+						pos:        position{line: 1627, col: 5, offset: 38359},
 						val:        "w",
 						ignoreCase: false,
 						want:       "\"w\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1626, col: 5, offset: 38403},
+						pos:        position{line: 1628, col: 5, offset: 38367},
 						val:        "y",
 						ignoreCase: false,
 						want:       "\"y\"",
@@ -10907,45 +10894,45 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1628, col: 1, offset: 38408},
+			pos:  position{line: 1630, col: 1, offset: 38372},
 			expr: &actionExpr{
-				pos: position{line: 1629, col: 5, offset: 38415},
+				pos: position{line: 1631, col: 5, offset: 38379},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1629, col: 5, offset: 38415},
+					pos: position{line: 1631, col: 5, offset: 38379},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1629, col: 5, offset: 38415},
+							pos:  position{line: 1631, col: 5, offset: 38379},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1629, col: 10, offset: 38420},
+							pos:        position{line: 1631, col: 10, offset: 38384},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1629, col: 14, offset: 38424},
+							pos:  position{line: 1631, col: 14, offset: 38388},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1629, col: 19, offset: 38429},
+							pos:        position{line: 1631, col: 19, offset: 38393},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1629, col: 23, offset: 38433},
+							pos:  position{line: 1631, col: 23, offset: 38397},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1629, col: 28, offset: 38438},
+							pos:        position{line: 1631, col: 28, offset: 38402},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1629, col: 32, offset: 38442},
+							pos:  position{line: 1631, col: 32, offset: 38406},
 							name: "UInt",
 						},
 					},
@@ -10956,43 +10943,43 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1631, col: 1, offset: 38479},
+			pos:  position{line: 1633, col: 1, offset: 38443},
 			expr: &actionExpr{
-				pos: position{line: 1632, col: 5, offset: 38487},
+				pos: position{line: 1634, col: 5, offset: 38451},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1632, col: 5, offset: 38487},
+					pos: position{line: 1634, col: 5, offset: 38451},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1632, col: 5, offset: 38487},
+							pos: position{line: 1634, col: 5, offset: 38451},
 							expr: &seqExpr{
-								pos: position{line: 1632, col: 7, offset: 38489},
+								pos: position{line: 1634, col: 7, offset: 38453},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1632, col: 7, offset: 38489},
+										pos:  position{line: 1634, col: 7, offset: 38453},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1632, col: 11, offset: 38493},
+										pos:        position{line: 1634, col: 11, offset: 38457},
 										val:        ":",
 										ignoreCase: false,
 										want:       "\":\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1632, col: 15, offset: 38497},
+										pos:  position{line: 1634, col: 15, offset: 38461},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1632, col: 19, offset: 38501},
+										pos: position{line: 1634, col: 19, offset: 38465},
 										expr: &choiceExpr{
-											pos: position{line: 1632, col: 21, offset: 38503},
+											pos: position{line: 1634, col: 21, offset: 38467},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1632, col: 21, offset: 38503},
+													pos:  position{line: 1634, col: 21, offset: 38467},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1632, col: 32, offset: 38514},
+													pos:        position{line: 1634, col: 32, offset: 38478},
 													val:        ":",
 													ignoreCase: false,
 													want:       "\":\"",
@@ -11004,10 +10991,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1632, col: 38, offset: 38520},
+							pos:   position{line: 1634, col: 38, offset: 38484},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1632, col: 40, offset: 38522},
+								pos:  position{line: 1634, col: 40, offset: 38486},
 								name: "IP6Variations",
 							},
 						},
@@ -11019,32 +11006,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1636, col: 1, offset: 38686},
+			pos:  position{line: 1638, col: 1, offset: 38650},
 			expr: &choiceExpr{
-				pos: position{line: 1637, col: 5, offset: 38704},
+				pos: position{line: 1639, col: 5, offset: 38668},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1637, col: 5, offset: 38704},
+						pos: position{line: 1639, col: 5, offset: 38668},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1637, col: 5, offset: 38704},
+							pos: position{line: 1639, col: 5, offset: 38668},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1637, col: 5, offset: 38704},
+									pos:   position{line: 1639, col: 5, offset: 38668},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1637, col: 7, offset: 38706},
+										pos: position{line: 1639, col: 7, offset: 38670},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1637, col: 7, offset: 38706},
+											pos:  position{line: 1639, col: 7, offset: 38670},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1637, col: 17, offset: 38716},
+									pos:   position{line: 1639, col: 17, offset: 38680},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1637, col: 19, offset: 38718},
+										pos:  position{line: 1639, col: 19, offset: 38682},
 										name: "IP6Tail",
 									},
 								},
@@ -11052,52 +11039,52 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1640, col: 5, offset: 38782},
+						pos: position{line: 1642, col: 5, offset: 38746},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1640, col: 5, offset: 38782},
+							pos: position{line: 1642, col: 5, offset: 38746},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1640, col: 5, offset: 38782},
+									pos:   position{line: 1642, col: 5, offset: 38746},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1640, col: 7, offset: 38784},
+										pos:  position{line: 1642, col: 7, offset: 38748},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1640, col: 11, offset: 38788},
+									pos:   position{line: 1642, col: 11, offset: 38752},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1640, col: 13, offset: 38790},
+										pos: position{line: 1642, col: 13, offset: 38754},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1640, col: 13, offset: 38790},
+											pos:  position{line: 1642, col: 13, offset: 38754},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1640, col: 23, offset: 38800},
+									pos:        position{line: 1642, col: 23, offset: 38764},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1640, col: 28, offset: 38805},
+									pos:   position{line: 1642, col: 28, offset: 38769},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1640, col: 30, offset: 38807},
+										pos: position{line: 1642, col: 30, offset: 38771},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1640, col: 30, offset: 38807},
+											pos:  position{line: 1642, col: 30, offset: 38771},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1640, col: 40, offset: 38817},
+									pos:   position{line: 1642, col: 40, offset: 38781},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1640, col: 42, offset: 38819},
+										pos:  position{line: 1642, col: 42, offset: 38783},
 										name: "IP6Tail",
 									},
 								},
@@ -11105,33 +11092,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1643, col: 5, offset: 38918},
+						pos: position{line: 1645, col: 5, offset: 38882},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1643, col: 5, offset: 38918},
+							pos: position{line: 1645, col: 5, offset: 38882},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1643, col: 5, offset: 38918},
+									pos:        position{line: 1645, col: 5, offset: 38882},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1643, col: 10, offset: 38923},
+									pos:   position{line: 1645, col: 10, offset: 38887},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1643, col: 12, offset: 38925},
+										pos: position{line: 1645, col: 12, offset: 38889},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1643, col: 12, offset: 38925},
+											pos:  position{line: 1645, col: 12, offset: 38889},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1643, col: 22, offset: 38935},
+									pos:   position{line: 1645, col: 22, offset: 38899},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1643, col: 24, offset: 38937},
+										pos:  position{line: 1645, col: 24, offset: 38901},
 										name: "IP6Tail",
 									},
 								},
@@ -11139,40 +11126,40 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1646, col: 5, offset: 39008},
+						pos: position{line: 1648, col: 5, offset: 38972},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1646, col: 5, offset: 39008},
+							pos: position{line: 1648, col: 5, offset: 38972},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1646, col: 5, offset: 39008},
+									pos:   position{line: 1648, col: 5, offset: 38972},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1646, col: 7, offset: 39010},
+										pos:  position{line: 1648, col: 7, offset: 38974},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1646, col: 11, offset: 39014},
+									pos:   position{line: 1648, col: 11, offset: 38978},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1646, col: 13, offset: 39016},
+										pos: position{line: 1648, col: 13, offset: 38980},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1646, col: 13, offset: 39016},
+											pos:  position{line: 1648, col: 13, offset: 38980},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1646, col: 23, offset: 39026},
+									pos:        position{line: 1648, col: 23, offset: 38990},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&notExpr{
-									pos: position{line: 1646, col: 28, offset: 39031},
+									pos: position{line: 1648, col: 28, offset: 38995},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1646, col: 29, offset: 39032},
+										pos:  position{line: 1648, col: 29, offset: 38996},
 										name: "TypeAsValue",
 									},
 								},
@@ -11180,10 +11167,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1649, col: 5, offset: 39107},
+						pos: position{line: 1651, col: 5, offset: 39071},
 						run: (*parser).callonIP6Variations40,
 						expr: &litMatcher{
-							pos:        position{line: 1649, col: 5, offset: 39107},
+							pos:        position{line: 1651, col: 5, offset: 39071},
 							val:        "::",
 							ignoreCase: false,
 							want:       "\"::\"",
@@ -11196,16 +11183,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1653, col: 1, offset: 39144},
+			pos:  position{line: 1655, col: 1, offset: 39108},
 			expr: &choiceExpr{
-				pos: position{line: 1654, col: 5, offset: 39156},
+				pos: position{line: 1656, col: 5, offset: 39120},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1654, col: 5, offset: 39156},
+						pos:  position{line: 1656, col: 5, offset: 39120},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1655, col: 5, offset: 39163},
+						pos:  position{line: 1657, col: 5, offset: 39127},
 						name: "Hex",
 					},
 				},
@@ -11215,24 +11202,24 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1657, col: 1, offset: 39168},
+			pos:  position{line: 1659, col: 1, offset: 39132},
 			expr: &actionExpr{
-				pos: position{line: 1657, col: 12, offset: 39179},
+				pos: position{line: 1659, col: 12, offset: 39143},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1657, col: 12, offset: 39179},
+					pos: position{line: 1659, col: 12, offset: 39143},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1657, col: 12, offset: 39179},
+							pos:        position{line: 1659, col: 12, offset: 39143},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1657, col: 16, offset: 39183},
+							pos:   position{line: 1659, col: 16, offset: 39147},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1657, col: 18, offset: 39185},
+								pos:  position{line: 1659, col: 18, offset: 39149},
 								name: "Hex",
 							},
 						},
@@ -11244,23 +11231,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1659, col: 1, offset: 39223},
+			pos:  position{line: 1661, col: 1, offset: 39187},
 			expr: &actionExpr{
-				pos: position{line: 1659, col: 12, offset: 39234},
+				pos: position{line: 1661, col: 12, offset: 39198},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1659, col: 12, offset: 39234},
+					pos: position{line: 1661, col: 12, offset: 39198},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1659, col: 12, offset: 39234},
+							pos:   position{line: 1661, col: 12, offset: 39198},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1659, col: 14, offset: 39236},
+								pos:  position{line: 1661, col: 14, offset: 39200},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1659, col: 18, offset: 39240},
+							pos:        position{line: 1661, col: 18, offset: 39204},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
@@ -11273,32 +11260,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1661, col: 1, offset: 39278},
+			pos:  position{line: 1663, col: 1, offset: 39242},
 			expr: &actionExpr{
-				pos: position{line: 1662, col: 5, offset: 39289},
+				pos: position{line: 1664, col: 5, offset: 39253},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1662, col: 5, offset: 39289},
+					pos: position{line: 1664, col: 5, offset: 39253},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1662, col: 5, offset: 39289},
+							pos:   position{line: 1664, col: 5, offset: 39253},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1662, col: 7, offset: 39291},
+								pos:  position{line: 1664, col: 7, offset: 39255},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1662, col: 10, offset: 39294},
+							pos:        position{line: 1664, col: 10, offset: 39258},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1662, col: 14, offset: 39298},
+							pos:   position{line: 1664, col: 14, offset: 39262},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1662, col: 16, offset: 39300},
+								pos:  position{line: 1664, col: 16, offset: 39264},
 								name: "UIntString",
 							},
 						},
@@ -11310,32 +11297,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1666, col: 1, offset: 39368},
+			pos:  position{line: 1668, col: 1, offset: 39332},
 			expr: &actionExpr{
-				pos: position{line: 1667, col: 5, offset: 39379},
+				pos: position{line: 1669, col: 5, offset: 39343},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1667, col: 5, offset: 39379},
+					pos: position{line: 1669, col: 5, offset: 39343},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1667, col: 5, offset: 39379},
+							pos:   position{line: 1669, col: 5, offset: 39343},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1667, col: 7, offset: 39381},
+								pos:  position{line: 1669, col: 7, offset: 39345},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1667, col: 11, offset: 39385},
+							pos:        position{line: 1669, col: 11, offset: 39349},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1667, col: 15, offset: 39389},
+							pos:   position{line: 1669, col: 15, offset: 39353},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1667, col: 17, offset: 39391},
+								pos:  position{line: 1669, col: 17, offset: 39355},
 								name: "UIntString",
 							},
 						},
@@ -11347,15 +11334,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1671, col: 1, offset: 39459},
+			pos:  position{line: 1673, col: 1, offset: 39423},
 			expr: &actionExpr{
-				pos: position{line: 1672, col: 4, offset: 39467},
+				pos: position{line: 1674, col: 4, offset: 39431},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1672, col: 4, offset: 39467},
+					pos:   position{line: 1674, col: 4, offset: 39431},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1672, col: 6, offset: 39469},
+						pos:  position{line: 1674, col: 6, offset: 39433},
 						name: "UIntString",
 					},
 				},
@@ -11365,16 +11352,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1674, col: 1, offset: 39509},
+			pos:  position{line: 1676, col: 1, offset: 39473},
 			expr: &choiceExpr{
-				pos: position{line: 1675, col: 5, offset: 39523},
+				pos: position{line: 1677, col: 5, offset: 39487},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1675, col: 5, offset: 39523},
+						pos:  position{line: 1677, col: 5, offset: 39487},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1676, col: 5, offset: 39538},
+						pos:  position{line: 1678, col: 5, offset: 39502},
 						name: "MinusIntString",
 					},
 				},
@@ -11384,14 +11371,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1678, col: 1, offset: 39554},
+			pos:  position{line: 1680, col: 1, offset: 39518},
 			expr: &actionExpr{
-				pos: position{line: 1678, col: 14, offset: 39567},
+				pos: position{line: 1680, col: 14, offset: 39531},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1678, col: 14, offset: 39567},
+					pos: position{line: 1680, col: 14, offset: 39531},
 					expr: &charClassMatcher{
-						pos:        position{line: 1678, col: 14, offset: 39567},
+						pos:        position{line: 1680, col: 14, offset: 39531},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11404,21 +11391,21 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1680, col: 1, offset: 39606},
+			pos:  position{line: 1682, col: 1, offset: 39570},
 			expr: &actionExpr{
-				pos: position{line: 1681, col: 5, offset: 39625},
+				pos: position{line: 1683, col: 5, offset: 39589},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1681, col: 5, offset: 39625},
+					pos: position{line: 1683, col: 5, offset: 39589},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1681, col: 5, offset: 39625},
+							pos:        position{line: 1683, col: 5, offset: 39589},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1681, col: 9, offset: 39629},
+							pos:  position{line: 1683, col: 9, offset: 39593},
 							name: "UIntString",
 						},
 					},
@@ -11429,29 +11416,29 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1683, col: 1, offset: 39672},
+			pos:  position{line: 1685, col: 1, offset: 39636},
 			expr: &choiceExpr{
-				pos: position{line: 1684, col: 5, offset: 39688},
+				pos: position{line: 1686, col: 5, offset: 39652},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1684, col: 5, offset: 39688},
+						pos: position{line: 1686, col: 5, offset: 39652},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1684, col: 5, offset: 39688},
+							pos: position{line: 1686, col: 5, offset: 39652},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1684, col: 5, offset: 39688},
+									pos: position{line: 1686, col: 5, offset: 39652},
 									expr: &litMatcher{
-										pos:        position{line: 1684, col: 5, offset: 39688},
+										pos:        position{line: 1686, col: 5, offset: 39652},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1684, col: 10, offset: 39693},
+									pos: position{line: 1686, col: 10, offset: 39657},
 									expr: &charClassMatcher{
-										pos:        position{line: 1684, col: 10, offset: 39693},
+										pos:        position{line: 1686, col: 10, offset: 39657},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11459,15 +11446,15 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1684, col: 17, offset: 39700},
+									pos:        position{line: 1686, col: 17, offset: 39664},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1684, col: 21, offset: 39704},
+									pos: position{line: 1686, col: 21, offset: 39668},
 									expr: &charClassMatcher{
-										pos:        position{line: 1684, col: 21, offset: 39704},
+										pos:        position{line: 1686, col: 21, offset: 39668},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11475,9 +11462,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1684, col: 28, offset: 39711},
+									pos: position{line: 1686, col: 28, offset: 39675},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1684, col: 28, offset: 39711},
+										pos:  position{line: 1686, col: 28, offset: 39675},
 										name: "ExponentPart",
 									},
 								},
@@ -11485,30 +11472,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1685, col: 5, offset: 39760},
+						pos: position{line: 1687, col: 5, offset: 39724},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1685, col: 5, offset: 39760},
+							pos: position{line: 1687, col: 5, offset: 39724},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1685, col: 5, offset: 39760},
+									pos: position{line: 1687, col: 5, offset: 39724},
 									expr: &litMatcher{
-										pos:        position{line: 1685, col: 5, offset: 39760},
+										pos:        position{line: 1687, col: 5, offset: 39724},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1685, col: 10, offset: 39765},
+									pos:        position{line: 1687, col: 10, offset: 39729},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1685, col: 14, offset: 39769},
+									pos: position{line: 1687, col: 14, offset: 39733},
 									expr: &charClassMatcher{
-										pos:        position{line: 1685, col: 14, offset: 39769},
+										pos:        position{line: 1687, col: 14, offset: 39733},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11516,9 +11503,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1685, col: 21, offset: 39776},
+									pos: position{line: 1687, col: 21, offset: 39740},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1685, col: 21, offset: 39776},
+										pos:  position{line: 1687, col: 21, offset: 39740},
 										name: "ExponentPart",
 									},
 								},
@@ -11526,17 +11513,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1686, col: 5, offset: 39825},
+						pos: position{line: 1688, col: 5, offset: 39789},
 						run: (*parser).callonFloatString22,
 						expr: &choiceExpr{
-							pos: position{line: 1686, col: 6, offset: 39826},
+							pos: position{line: 1688, col: 6, offset: 39790},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1686, col: 6, offset: 39826},
+									pos:  position{line: 1688, col: 6, offset: 39790},
 									name: "NaN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1686, col: 12, offset: 39832},
+									pos:  position{line: 1688, col: 12, offset: 39796},
 									name: "Infinity",
 								},
 							},
@@ -11549,20 +11536,20 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1689, col: 1, offset: 39875},
+			pos:  position{line: 1691, col: 1, offset: 39839},
 			expr: &seqExpr{
-				pos: position{line: 1689, col: 16, offset: 39890},
+				pos: position{line: 1691, col: 16, offset: 39854},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1689, col: 16, offset: 39890},
+						pos:        position{line: 1691, col: 16, offset: 39854},
 						val:        "e",
 						ignoreCase: true,
 						want:       "\"e\"i",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1689, col: 21, offset: 39895},
+						pos: position{line: 1691, col: 21, offset: 39859},
 						expr: &charClassMatcher{
-							pos:        position{line: 1689, col: 21, offset: 39895},
+							pos:        position{line: 1691, col: 21, offset: 39859},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -11570,7 +11557,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1689, col: 27, offset: 39901},
+						pos:  position{line: 1691, col: 27, offset: 39865},
 						name: "UIntString",
 					},
 				},
@@ -11580,9 +11567,9 @@ var g = &grammar{
 		},
 		{
 			name: "NaN",
-			pos:  position{line: 1691, col: 1, offset: 39913},
+			pos:  position{line: 1693, col: 1, offset: 39877},
 			expr: &litMatcher{
-				pos:        position{line: 1691, col: 7, offset: 39919},
+				pos:        position{line: 1693, col: 7, offset: 39883},
 				val:        "NaN",
 				ignoreCase: false,
 				want:       "\"NaN\"",
@@ -11592,23 +11579,23 @@ var g = &grammar{
 		},
 		{
 			name: "Infinity",
-			pos:  position{line: 1693, col: 1, offset: 39926},
+			pos:  position{line: 1695, col: 1, offset: 39890},
 			expr: &seqExpr{
-				pos: position{line: 1693, col: 12, offset: 39937},
+				pos: position{line: 1695, col: 12, offset: 39901},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 1693, col: 12, offset: 39937},
+						pos: position{line: 1695, col: 12, offset: 39901},
 						expr: &choiceExpr{
-							pos: position{line: 1693, col: 13, offset: 39938},
+							pos: position{line: 1695, col: 13, offset: 39902},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1693, col: 13, offset: 39938},
+									pos:        position{line: 1695, col: 13, offset: 39902},
 									val:        "-",
 									ignoreCase: false,
 									want:       "\"-\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1693, col: 19, offset: 39944},
+									pos:        position{line: 1695, col: 19, offset: 39908},
 									val:        "+",
 									ignoreCase: false,
 									want:       "\"+\"",
@@ -11617,7 +11604,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1693, col: 25, offset: 39950},
+						pos:        position{line: 1695, col: 25, offset: 39914},
 						val:        "Inf",
 						ignoreCase: false,
 						want:       "\"Inf\"",
@@ -11629,14 +11616,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1695, col: 1, offset: 39957},
+			pos:  position{line: 1697, col: 1, offset: 39921},
 			expr: &actionExpr{
-				pos: position{line: 1695, col: 7, offset: 39963},
+				pos: position{line: 1697, col: 7, offset: 39927},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1695, col: 7, offset: 39963},
+					pos: position{line: 1697, col: 7, offset: 39927},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1695, col: 7, offset: 39963},
+						pos:  position{line: 1697, col: 7, offset: 39927},
 						name: "HexDigit",
 					},
 				},
@@ -11646,9 +11633,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1697, col: 1, offset: 40005},
+			pos:  position{line: 1699, col: 1, offset: 39969},
 			expr: &charClassMatcher{
-				pos:        position{line: 1697, col: 12, offset: 40016},
+				pos:        position{line: 1699, col: 12, offset: 39980},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -11659,32 +11646,32 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedString",
-			pos:  position{line: 1699, col: 1, offset: 40029},
+			pos:  position{line: 1701, col: 1, offset: 39993},
 			expr: &actionExpr{
-				pos: position{line: 1700, col: 5, offset: 40052},
+				pos: position{line: 1702, col: 5, offset: 40016},
 				run: (*parser).callonSingleQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 1700, col: 5, offset: 40052},
+					pos: position{line: 1702, col: 5, offset: 40016},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1700, col: 5, offset: 40052},
+							pos:        position{line: 1702, col: 5, offset: 40016},
 							val:        "'",
 							ignoreCase: false,
 							want:       "\"'\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1700, col: 9, offset: 40056},
+							pos:   position{line: 1702, col: 9, offset: 40020},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1700, col: 11, offset: 40058},
+								pos: position{line: 1702, col: 11, offset: 40022},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1700, col: 11, offset: 40058},
+									pos:  position{line: 1702, col: 11, offset: 40022},
 									name: "SingleQuotedChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1700, col: 29, offset: 40076},
+							pos:        position{line: 1702, col: 29, offset: 40040},
 							val:        "'",
 							ignoreCase: false,
 							want:       "\"'\"",
@@ -11697,32 +11684,32 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedString",
-			pos:  position{line: 1702, col: 1, offset: 40110},
+			pos:  position{line: 1704, col: 1, offset: 40074},
 			expr: &actionExpr{
-				pos: position{line: 1703, col: 5, offset: 40133},
+				pos: position{line: 1705, col: 5, offset: 40097},
 				run: (*parser).callonDoubleQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 1703, col: 5, offset: 40133},
+					pos: position{line: 1705, col: 5, offset: 40097},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1703, col: 5, offset: 40133},
+							pos:        position{line: 1705, col: 5, offset: 40097},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1703, col: 9, offset: 40137},
+							pos:   position{line: 1705, col: 9, offset: 40101},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1703, col: 11, offset: 40139},
+								pos: position{line: 1705, col: 11, offset: 40103},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1703, col: 11, offset: 40139},
+									pos:  position{line: 1705, col: 11, offset: 40103},
 									name: "DoubleQuotedChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1703, col: 29, offset: 40157},
+							pos:        position{line: 1705, col: 29, offset: 40121},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11735,57 +11722,57 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1705, col: 1, offset: 40191},
+			pos:  position{line: 1707, col: 1, offset: 40155},
 			expr: &choiceExpr{
-				pos: position{line: 1706, col: 5, offset: 40212},
+				pos: position{line: 1708, col: 5, offset: 40176},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1706, col: 5, offset: 40212},
+						pos: position{line: 1708, col: 5, offset: 40176},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1706, col: 5, offset: 40212},
+							pos: position{line: 1708, col: 5, offset: 40176},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1706, col: 5, offset: 40212},
+									pos: position{line: 1708, col: 5, offset: 40176},
 									expr: &choiceExpr{
-										pos: position{line: 1706, col: 7, offset: 40214},
+										pos: position{line: 1708, col: 7, offset: 40178},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1706, col: 7, offset: 40214},
+												pos:        position{line: 1708, col: 7, offset: 40178},
 												val:        "\"",
 												ignoreCase: false,
 												want:       "\"\\\"\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1706, col: 13, offset: 40220},
+												pos:  position{line: 1708, col: 13, offset: 40184},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1706, col: 26, offset: 40233,
+									line: 1708, col: 26, offset: 40197,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1707, col: 5, offset: 40270},
+						pos: position{line: 1709, col: 5, offset: 40234},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1707, col: 5, offset: 40270},
+							pos: position{line: 1709, col: 5, offset: 40234},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1707, col: 5, offset: 40270},
+									pos:        position{line: 1709, col: 5, offset: 40234},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1707, col: 10, offset: 40275},
+									pos:   position{line: 1709, col: 10, offset: 40239},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1707, col: 12, offset: 40277},
+										pos:  position{line: 1709, col: 12, offset: 40241},
 										name: "EscapeSequence",
 									},
 								},
@@ -11799,32 +11786,32 @@ var g = &grammar{
 		},
 		{
 			name: "RString",
-			pos:  position{line: 1709, col: 1, offset: 40311},
+			pos:  position{line: 1711, col: 1, offset: 40275},
 			expr: &choiceExpr{
-				pos: position{line: 1710, col: 5, offset: 40323},
+				pos: position{line: 1712, col: 5, offset: 40287},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1710, col: 5, offset: 40323},
+						pos: position{line: 1712, col: 5, offset: 40287},
 						run: (*parser).callonRString2,
 						expr: &seqExpr{
-							pos: position{line: 1710, col: 5, offset: 40323},
+							pos: position{line: 1712, col: 5, offset: 40287},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1710, col: 5, offset: 40323},
+									pos:        position{line: 1712, col: 5, offset: 40287},
 									val:        "r'",
 									ignoreCase: false,
 									want:       "\"r'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1710, col: 10, offset: 40328},
+									pos:   position{line: 1712, col: 10, offset: 40292},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1710, col: 12, offset: 40330},
+										pos:  position{line: 1712, col: 12, offset: 40294},
 										name: "NoSingleQuotes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1710, col: 27, offset: 40345},
+									pos:        position{line: 1712, col: 27, offset: 40309},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -11833,33 +11820,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1711, col: 5, offset: 40380},
+						pos: position{line: 1713, col: 5, offset: 40344},
 						run: (*parser).callonRString8,
 						expr: &seqExpr{
-							pos: position{line: 1711, col: 5, offset: 40380},
+							pos: position{line: 1713, col: 5, offset: 40344},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1711, col: 5, offset: 40380},
+									pos:        position{line: 1713, col: 5, offset: 40344},
 									val:        "r",
 									ignoreCase: false,
 									want:       "\"r\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1711, col: 9, offset: 40384},
+									pos:        position{line: 1713, col: 9, offset: 40348},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1711, col: 13, offset: 40388},
+									pos:   position{line: 1713, col: 13, offset: 40352},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1711, col: 15, offset: 40390},
+										pos:  position{line: 1713, col: 15, offset: 40354},
 										name: "NoDoubleQuotes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1711, col: 30, offset: 40405},
+									pos:        position{line: 1713, col: 30, offset: 40369},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -11874,26 +11861,26 @@ var g = &grammar{
 		},
 		{
 			name: "NoSingleQuotes",
-			pos:  position{line: 1713, col: 1, offset: 40437},
+			pos:  position{line: 1715, col: 1, offset: 40401},
 			expr: &actionExpr{
-				pos: position{line: 1714, col: 5, offset: 40456},
+				pos: position{line: 1716, col: 5, offset: 40420},
 				run: (*parser).callonNoSingleQuotes1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 1714, col: 5, offset: 40456},
+					pos: position{line: 1716, col: 5, offset: 40420},
 					expr: &seqExpr{
-						pos: position{line: 1714, col: 6, offset: 40457},
+						pos: position{line: 1716, col: 6, offset: 40421},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 1714, col: 6, offset: 40457},
+								pos: position{line: 1716, col: 6, offset: 40421},
 								expr: &litMatcher{
-									pos:        position{line: 1714, col: 7, offset: 40458},
+									pos:        position{line: 1716, col: 7, offset: 40422},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 							},
 							&anyMatcher{
-								line: 1714, col: 11, offset: 40462,
+								line: 1716, col: 11, offset: 40426,
 							},
 						},
 					},
@@ -11904,26 +11891,26 @@ var g = &grammar{
 		},
 		{
 			name: "NoDoubleQuotes",
-			pos:  position{line: 1716, col: 1, offset: 40498},
+			pos:  position{line: 1718, col: 1, offset: 40462},
 			expr: &actionExpr{
-				pos: position{line: 1717, col: 5, offset: 40517},
+				pos: position{line: 1719, col: 5, offset: 40481},
 				run: (*parser).callonNoDoubleQuotes1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 1717, col: 5, offset: 40517},
+					pos: position{line: 1719, col: 5, offset: 40481},
 					expr: &seqExpr{
-						pos: position{line: 1717, col: 6, offset: 40518},
+						pos: position{line: 1719, col: 6, offset: 40482},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 1717, col: 6, offset: 40518},
+								pos: position{line: 1719, col: 6, offset: 40482},
 								expr: &litMatcher{
-									pos:        position{line: 1717, col: 7, offset: 40519},
+									pos:        position{line: 1719, col: 7, offset: 40483},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 							},
 							&anyMatcher{
-								line: 1717, col: 11, offset: 40523,
+								line: 1719, col: 11, offset: 40487,
 							},
 						},
 					},
@@ -11934,32 +11921,32 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickString",
-			pos:  position{line: 1719, col: 1, offset: 40559},
+			pos:  position{line: 1721, col: 1, offset: 40523},
 			expr: &actionExpr{
-				pos: position{line: 1720, col: 5, offset: 40578},
+				pos: position{line: 1722, col: 5, offset: 40542},
 				run: (*parser).callonBacktickString1,
 				expr: &seqExpr{
-					pos: position{line: 1720, col: 5, offset: 40578},
+					pos: position{line: 1722, col: 5, offset: 40542},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1720, col: 5, offset: 40578},
+							pos:        position{line: 1722, col: 5, offset: 40542},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1720, col: 9, offset: 40582},
+							pos:   position{line: 1722, col: 9, offset: 40546},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1720, col: 11, offset: 40584},
+								pos: position{line: 1722, col: 11, offset: 40548},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1720, col: 11, offset: 40584},
+									pos:  position{line: 1722, col: 11, offset: 40548},
 									name: "BacktickChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1720, col: 25, offset: 40598},
+							pos:        position{line: 1722, col: 25, offset: 40562},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
@@ -11972,57 +11959,57 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickChar",
-			pos:  position{line: 1722, col: 1, offset: 40632},
+			pos:  position{line: 1724, col: 1, offset: 40596},
 			expr: &choiceExpr{
-				pos: position{line: 1723, col: 5, offset: 40649},
+				pos: position{line: 1725, col: 5, offset: 40613},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1723, col: 5, offset: 40649},
+						pos: position{line: 1725, col: 5, offset: 40613},
 						run: (*parser).callonBacktickChar2,
 						expr: &seqExpr{
-							pos: position{line: 1723, col: 5, offset: 40649},
+							pos: position{line: 1725, col: 5, offset: 40613},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1723, col: 5, offset: 40649},
+									pos: position{line: 1725, col: 5, offset: 40613},
 									expr: &choiceExpr{
-										pos: position{line: 1723, col: 7, offset: 40651},
+										pos: position{line: 1725, col: 7, offset: 40615},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1723, col: 7, offset: 40651},
+												pos:        position{line: 1725, col: 7, offset: 40615},
 												val:        "`",
 												ignoreCase: false,
 												want:       "\"`\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1723, col: 13, offset: 40657},
+												pos:  position{line: 1725, col: 13, offset: 40621},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1723, col: 26, offset: 40670,
+									line: 1725, col: 26, offset: 40634,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1724, col: 5, offset: 40707},
+						pos: position{line: 1726, col: 5, offset: 40671},
 						run: (*parser).callonBacktickChar9,
 						expr: &seqExpr{
-							pos: position{line: 1724, col: 5, offset: 40707},
+							pos: position{line: 1726, col: 5, offset: 40671},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1724, col: 5, offset: 40707},
+									pos:        position{line: 1726, col: 5, offset: 40671},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1724, col: 10, offset: 40712},
+									pos:   position{line: 1726, col: 10, offset: 40676},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1724, col: 12, offset: 40714},
+										pos:  position{line: 1726, col: 12, offset: 40678},
 										name: "EscapeSequence",
 									},
 								},
@@ -12036,28 +12023,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1726, col: 1, offset: 40748},
+			pos:  position{line: 1728, col: 1, offset: 40712},
 			expr: &actionExpr{
-				pos: position{line: 1727, col: 5, offset: 40760},
+				pos: position{line: 1729, col: 5, offset: 40724},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1727, col: 5, offset: 40760},
+					pos: position{line: 1729, col: 5, offset: 40724},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1727, col: 5, offset: 40760},
+							pos:   position{line: 1729, col: 5, offset: 40724},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1727, col: 10, offset: 40765},
+								pos:  position{line: 1729, col: 10, offset: 40729},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1727, col: 23, offset: 40778},
+							pos:   position{line: 1729, col: 23, offset: 40742},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1727, col: 28, offset: 40783},
+								pos: position{line: 1729, col: 28, offset: 40747},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1727, col: 28, offset: 40783},
+									pos:  position{line: 1729, col: 28, offset: 40747},
 									name: "KeyWordRest",
 								},
 							},
@@ -12070,16 +12057,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1729, col: 1, offset: 40845},
+			pos:  position{line: 1731, col: 1, offset: 40809},
 			expr: &choiceExpr{
-				pos: position{line: 1730, col: 5, offset: 40862},
+				pos: position{line: 1732, col: 5, offset: 40826},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1730, col: 5, offset: 40862},
+						pos:  position{line: 1732, col: 5, offset: 40826},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1731, col: 5, offset: 40879},
+						pos:  position{line: 1733, col: 5, offset: 40843},
 						name: "KeyWordEsc",
 					},
 				},
@@ -12089,16 +12076,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1733, col: 1, offset: 40891},
+			pos:  position{line: 1735, col: 1, offset: 40855},
 			expr: &choiceExpr{
-				pos: position{line: 1734, col: 5, offset: 40907},
+				pos: position{line: 1736, col: 5, offset: 40871},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1734, col: 5, offset: 40907},
+						pos:  position{line: 1736, col: 5, offset: 40871},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1735, col: 5, offset: 40924},
+						pos:        position{line: 1737, col: 5, offset: 40888},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -12111,19 +12098,19 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1737, col: 1, offset: 40931},
+			pos:  position{line: 1739, col: 1, offset: 40895},
 			expr: &actionExpr{
-				pos: position{line: 1737, col: 16, offset: 40946},
+				pos: position{line: 1739, col: 16, offset: 40910},
 				run: (*parser).callonKeyWordChars1,
 				expr: &choiceExpr{
-					pos: position{line: 1737, col: 17, offset: 40947},
+					pos: position{line: 1739, col: 17, offset: 40911},
 					alternatives: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1737, col: 17, offset: 40947},
+							pos:  position{line: 1739, col: 17, offset: 40911},
 							name: "UnicodeLetter",
 						},
 						&charClassMatcher{
-							pos:        position{line: 1737, col: 33, offset: 40963},
+							pos:        position{line: 1739, col: 33, offset: 40927},
 							val:        "[_.:/%#@~]",
 							chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 							ignoreCase: false,
@@ -12137,31 +12124,31 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1739, col: 1, offset: 41007},
+			pos:  position{line: 1741, col: 1, offset: 40971},
 			expr: &actionExpr{
-				pos: position{line: 1739, col: 14, offset: 41020},
+				pos: position{line: 1741, col: 14, offset: 40984},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1739, col: 14, offset: 41020},
+					pos: position{line: 1741, col: 14, offset: 40984},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1739, col: 14, offset: 41020},
+							pos:        position{line: 1741, col: 14, offset: 40984},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1739, col: 19, offset: 41025},
+							pos:   position{line: 1741, col: 19, offset: 40989},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1739, col: 22, offset: 41028},
+								pos: position{line: 1741, col: 22, offset: 40992},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1739, col: 22, offset: 41028},
+										pos:  position{line: 1741, col: 22, offset: 40992},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1739, col: 38, offset: 41044},
+										pos:  position{line: 1741, col: 38, offset: 41008},
 										name: "EscapeSequence",
 									},
 								},
@@ -12175,42 +12162,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1741, col: 1, offset: 41079},
+			pos:  position{line: 1743, col: 1, offset: 41043},
 			expr: &actionExpr{
-				pos: position{line: 1742, col: 5, offset: 41095},
+				pos: position{line: 1744, col: 5, offset: 41059},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1742, col: 5, offset: 41095},
+					pos: position{line: 1744, col: 5, offset: 41059},
 					exprs: []any{
 						&andExpr{
-							pos: position{line: 1742, col: 5, offset: 41095},
+							pos: position{line: 1744, col: 5, offset: 41059},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1742, col: 6, offset: 41096},
+								pos:  position{line: 1744, col: 6, offset: 41060},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1742, col: 22, offset: 41112},
+							pos: position{line: 1744, col: 22, offset: 41076},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1742, col: 23, offset: 41113},
+								pos:  position{line: 1744, col: 23, offset: 41077},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1742, col: 35, offset: 41125},
+							pos:   position{line: 1744, col: 35, offset: 41089},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1742, col: 40, offset: 41130},
+								pos:  position{line: 1744, col: 40, offset: 41094},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1742, col: 50, offset: 41140},
+							pos:   position{line: 1744, col: 50, offset: 41104},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1742, col: 55, offset: 41145},
+								pos: position{line: 1744, col: 55, offset: 41109},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1742, col: 55, offset: 41145},
+									pos:  position{line: 1744, col: 55, offset: 41109},
 									name: "GlobRest",
 								},
 							},
@@ -12223,28 +12210,28 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1746, col: 1, offset: 41214},
+			pos:  position{line: 1748, col: 1, offset: 41178},
 			expr: &choiceExpr{
-				pos: position{line: 1746, col: 19, offset: 41232},
+				pos: position{line: 1748, col: 19, offset: 41196},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1746, col: 19, offset: 41232},
+						pos:  position{line: 1748, col: 19, offset: 41196},
 						name: "KeyWordStart",
 					},
 					&seqExpr{
-						pos: position{line: 1746, col: 34, offset: 41247},
+						pos: position{line: 1748, col: 34, offset: 41211},
 						exprs: []any{
 							&oneOrMoreExpr{
-								pos: position{line: 1746, col: 34, offset: 41247},
+								pos: position{line: 1748, col: 34, offset: 41211},
 								expr: &litMatcher{
-									pos:        position{line: 1746, col: 34, offset: 41247},
+									pos:        position{line: 1748, col: 34, offset: 41211},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1746, col: 39, offset: 41252},
+								pos:  position{line: 1748, col: 39, offset: 41216},
 								name: "KeyWordRest",
 							},
 						},
@@ -12256,19 +12243,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1747, col: 1, offset: 41264},
+			pos:  position{line: 1749, col: 1, offset: 41228},
 			expr: &seqExpr{
-				pos: position{line: 1747, col: 15, offset: 41278},
+				pos: position{line: 1749, col: 15, offset: 41242},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1747, col: 15, offset: 41278},
+						pos: position{line: 1749, col: 15, offset: 41242},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1747, col: 15, offset: 41278},
+							pos:  position{line: 1749, col: 15, offset: 41242},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1747, col: 28, offset: 41291},
+						pos:        position{line: 1749, col: 28, offset: 41255},
 						val:        "*",
 						ignoreCase: false,
 						want:       "\"*\"",
@@ -12280,23 +12267,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1749, col: 1, offset: 41296},
+			pos:  position{line: 1751, col: 1, offset: 41260},
 			expr: &choiceExpr{
-				pos: position{line: 1750, col: 5, offset: 41310},
+				pos: position{line: 1752, col: 5, offset: 41274},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1750, col: 5, offset: 41310},
+						pos:  position{line: 1752, col: 5, offset: 41274},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1751, col: 5, offset: 41327},
+						pos:  position{line: 1753, col: 5, offset: 41291},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1752, col: 5, offset: 41339},
+						pos: position{line: 1754, col: 5, offset: 41303},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1752, col: 5, offset: 41339},
+							pos:        position{line: 1754, col: 5, offset: 41303},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -12309,16 +12296,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1754, col: 1, offset: 41364},
+			pos:  position{line: 1756, col: 1, offset: 41328},
 			expr: &choiceExpr{
-				pos: position{line: 1755, col: 5, offset: 41377},
+				pos: position{line: 1757, col: 5, offset: 41341},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1755, col: 5, offset: 41377},
+						pos:  position{line: 1757, col: 5, offset: 41341},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1756, col: 5, offset: 41391},
+						pos:        position{line: 1758, col: 5, offset: 41355},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -12331,31 +12318,31 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1758, col: 1, offset: 41398},
+			pos:  position{line: 1760, col: 1, offset: 41362},
 			expr: &actionExpr{
-				pos: position{line: 1758, col: 11, offset: 41408},
+				pos: position{line: 1760, col: 11, offset: 41372},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1758, col: 11, offset: 41408},
+					pos: position{line: 1760, col: 11, offset: 41372},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1758, col: 11, offset: 41408},
+							pos:        position{line: 1760, col: 11, offset: 41372},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1758, col: 16, offset: 41413},
+							pos:   position{line: 1760, col: 16, offset: 41377},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1758, col: 19, offset: 41416},
+								pos: position{line: 1760, col: 19, offset: 41380},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1758, col: 19, offset: 41416},
+										pos:  position{line: 1760, col: 19, offset: 41380},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1758, col: 32, offset: 41429},
+										pos:  position{line: 1760, col: 32, offset: 41393},
 										name: "EscapeSequence",
 									},
 								},
@@ -12369,32 +12356,32 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1760, col: 1, offset: 41464},
+			pos:  position{line: 1762, col: 1, offset: 41428},
 			expr: &choiceExpr{
-				pos: position{line: 1761, col: 5, offset: 41479},
+				pos: position{line: 1763, col: 5, offset: 41443},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1761, col: 5, offset: 41479},
+						pos: position{line: 1763, col: 5, offset: 41443},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1761, col: 5, offset: 41479},
+							pos:        position{line: 1763, col: 5, offset: 41443},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1762, col: 5, offset: 41507},
+						pos: position{line: 1764, col: 5, offset: 41471},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1762, col: 5, offset: 41507},
+							pos:        position{line: 1764, col: 5, offset: 41471},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1763, col: 5, offset: 41537},
+						pos:        position{line: 1765, col: 5, offset: 41501},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -12407,57 +12394,57 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1765, col: 1, offset: 41543},
+			pos:  position{line: 1767, col: 1, offset: 41507},
 			expr: &choiceExpr{
-				pos: position{line: 1766, col: 5, offset: 41564},
+				pos: position{line: 1768, col: 5, offset: 41528},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1766, col: 5, offset: 41564},
+						pos: position{line: 1768, col: 5, offset: 41528},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1766, col: 5, offset: 41564},
+							pos: position{line: 1768, col: 5, offset: 41528},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1766, col: 5, offset: 41564},
+									pos: position{line: 1768, col: 5, offset: 41528},
 									expr: &choiceExpr{
-										pos: position{line: 1766, col: 7, offset: 41566},
+										pos: position{line: 1768, col: 7, offset: 41530},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1766, col: 7, offset: 41566},
+												pos:        position{line: 1768, col: 7, offset: 41530},
 												val:        "'",
 												ignoreCase: false,
 												want:       "\"'\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1766, col: 13, offset: 41572},
+												pos:  position{line: 1768, col: 13, offset: 41536},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1766, col: 26, offset: 41585,
+									line: 1768, col: 26, offset: 41549,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1767, col: 5, offset: 41622},
+						pos: position{line: 1769, col: 5, offset: 41586},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1767, col: 5, offset: 41622},
+							pos: position{line: 1769, col: 5, offset: 41586},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1767, col: 5, offset: 41622},
+									pos:        position{line: 1769, col: 5, offset: 41586},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1767, col: 10, offset: 41627},
+									pos:   position{line: 1769, col: 10, offset: 41591},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1767, col: 12, offset: 41629},
+										pos:  position{line: 1769, col: 12, offset: 41593},
 										name: "EscapeSequence",
 									},
 								},
@@ -12471,16 +12458,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1769, col: 1, offset: 41663},
+			pos:  position{line: 1771, col: 1, offset: 41627},
 			expr: &choiceExpr{
-				pos: position{line: 1770, col: 5, offset: 41682},
+				pos: position{line: 1772, col: 5, offset: 41646},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1770, col: 5, offset: 41682},
+						pos:  position{line: 1772, col: 5, offset: 41646},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1771, col: 5, offset: 41703},
+						pos:  position{line: 1773, col: 5, offset: 41667},
 						name: "UnicodeEscape",
 					},
 				},
@@ -12490,87 +12477,87 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1773, col: 1, offset: 41718},
+			pos:  position{line: 1775, col: 1, offset: 41682},
 			expr: &choiceExpr{
-				pos: position{line: 1774, col: 5, offset: 41739},
+				pos: position{line: 1776, col: 5, offset: 41703},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1774, col: 5, offset: 41739},
+						pos:        position{line: 1776, col: 5, offset: 41703},
 						val:        "'",
 						ignoreCase: false,
 						want:       "\"'\"",
 					},
 					&actionExpr{
-						pos: position{line: 1775, col: 5, offset: 41747},
+						pos: position{line: 1777, col: 5, offset: 41711},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1775, col: 5, offset: 41747},
+							pos:        position{line: 1777, col: 5, offset: 41711},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1776, col: 5, offset: 41787},
+						pos:        position{line: 1778, col: 5, offset: 41751},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
 					},
 					&actionExpr{
-						pos: position{line: 1777, col: 5, offset: 41796},
+						pos: position{line: 1779, col: 5, offset: 41760},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1777, col: 5, offset: 41796},
+							pos:        position{line: 1779, col: 5, offset: 41760},
 							val:        "b",
 							ignoreCase: false,
 							want:       "\"b\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1778, col: 5, offset: 41825},
+						pos: position{line: 1780, col: 5, offset: 41789},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1778, col: 5, offset: 41825},
+							pos:        position{line: 1780, col: 5, offset: 41789},
 							val:        "f",
 							ignoreCase: false,
 							want:       "\"f\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1779, col: 5, offset: 41854},
+						pos: position{line: 1781, col: 5, offset: 41818},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1779, col: 5, offset: 41854},
+							pos:        position{line: 1781, col: 5, offset: 41818},
 							val:        "n",
 							ignoreCase: false,
 							want:       "\"n\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1780, col: 5, offset: 41883},
+						pos: position{line: 1782, col: 5, offset: 41847},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1780, col: 5, offset: 41883},
+							pos:        position{line: 1782, col: 5, offset: 41847},
 							val:        "r",
 							ignoreCase: false,
 							want:       "\"r\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1781, col: 5, offset: 41912},
+						pos: position{line: 1783, col: 5, offset: 41876},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1781, col: 5, offset: 41912},
+							pos:        position{line: 1783, col: 5, offset: 41876},
 							val:        "t",
 							ignoreCase: false,
 							want:       "\"t\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1782, col: 5, offset: 41941},
+						pos: position{line: 1784, col: 5, offset: 41905},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1782, col: 5, offset: 41941},
+							pos:        position{line: 1784, col: 5, offset: 41905},
 							val:        "v",
 							ignoreCase: false,
 							want:       "\"v\"",
@@ -12583,32 +12570,32 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1784, col: 1, offset: 41967},
+			pos:  position{line: 1786, col: 1, offset: 41931},
 			expr: &choiceExpr{
-				pos: position{line: 1785, col: 5, offset: 41985},
+				pos: position{line: 1787, col: 5, offset: 41949},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1785, col: 5, offset: 41985},
+						pos: position{line: 1787, col: 5, offset: 41949},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1785, col: 5, offset: 41985},
+							pos:        position{line: 1787, col: 5, offset: 41949},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1786, col: 5, offset: 42013},
+						pos: position{line: 1788, col: 5, offset: 41977},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1786, col: 5, offset: 42013},
+							pos:        position{line: 1788, col: 5, offset: 41977},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1787, col: 5, offset: 42041},
+						pos:        position{line: 1789, col: 5, offset: 42005},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -12621,42 +12608,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1789, col: 1, offset: 42047},
+			pos:  position{line: 1791, col: 1, offset: 42011},
 			expr: &choiceExpr{
-				pos: position{line: 1790, col: 5, offset: 42065},
+				pos: position{line: 1792, col: 5, offset: 42029},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1790, col: 5, offset: 42065},
+						pos: position{line: 1792, col: 5, offset: 42029},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1790, col: 5, offset: 42065},
+							pos: position{line: 1792, col: 5, offset: 42029},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1790, col: 5, offset: 42065},
+									pos:        position{line: 1792, col: 5, offset: 42029},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1790, col: 9, offset: 42069},
+									pos:   position{line: 1792, col: 9, offset: 42033},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1790, col: 16, offset: 42076},
+										pos: position{line: 1792, col: 16, offset: 42040},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1790, col: 16, offset: 42076},
+												pos:  position{line: 1792, col: 16, offset: 42040},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1790, col: 25, offset: 42085},
+												pos:  position{line: 1792, col: 25, offset: 42049},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1790, col: 34, offset: 42094},
+												pos:  position{line: 1792, col: 34, offset: 42058},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1790, col: 43, offset: 42103},
+												pos:  position{line: 1792, col: 43, offset: 42067},
 												name: "HexDigit",
 											},
 										},
@@ -12666,65 +12653,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1793, col: 5, offset: 42166},
+						pos: position{line: 1795, col: 5, offset: 42130},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1793, col: 5, offset: 42166},
+							pos: position{line: 1795, col: 5, offset: 42130},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1793, col: 5, offset: 42166},
+									pos:        position{line: 1795, col: 5, offset: 42130},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1793, col: 9, offset: 42170},
+									pos:        position{line: 1795, col: 9, offset: 42134},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1793, col: 13, offset: 42174},
+									pos:   position{line: 1795, col: 13, offset: 42138},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1793, col: 20, offset: 42181},
+										pos: position{line: 1795, col: 20, offset: 42145},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1793, col: 20, offset: 42181},
+												pos:  position{line: 1795, col: 20, offset: 42145},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1793, col: 29, offset: 42190},
+												pos: position{line: 1795, col: 29, offset: 42154},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1793, col: 29, offset: 42190},
+													pos:  position{line: 1795, col: 29, offset: 42154},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1793, col: 39, offset: 42200},
+												pos: position{line: 1795, col: 39, offset: 42164},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1793, col: 39, offset: 42200},
+													pos:  position{line: 1795, col: 39, offset: 42164},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1793, col: 49, offset: 42210},
+												pos: position{line: 1795, col: 49, offset: 42174},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1793, col: 49, offset: 42210},
+													pos:  position{line: 1795, col: 49, offset: 42174},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1793, col: 59, offset: 42220},
+												pos: position{line: 1795, col: 59, offset: 42184},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1793, col: 59, offset: 42220},
+													pos:  position{line: 1795, col: 59, offset: 42184},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1793, col: 69, offset: 42230},
+												pos: position{line: 1795, col: 69, offset: 42194},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1793, col: 69, offset: 42230},
+													pos:  position{line: 1795, col: 69, offset: 42194},
 													name: "HexDigit",
 												},
 											},
@@ -12732,7 +12719,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1793, col: 80, offset: 42241},
+									pos:        position{line: 1795, col: 80, offset: 42205},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -12747,9 +12734,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1798, col: 1, offset: 42296},
+			pos:  position{line: 1800, col: 1, offset: 42260},
 			expr: &charClassMatcher{
-				pos:        position{line: 1799, col: 5, offset: 42312},
+				pos:        position{line: 1801, col: 5, offset: 42276},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -12761,11 +12748,11 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1801, col: 1, offset: 42327},
+			pos:  position{line: 1803, col: 1, offset: 42291},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1801, col: 5, offset: 42331},
+				pos: position{line: 1803, col: 5, offset: 42295},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1801, col: 5, offset: 42331},
+					pos:  position{line: 1803, col: 5, offset: 42295},
 					name: "AnySpace",
 				},
 			},
@@ -12774,11 +12761,11 @@ var g = &grammar{
 		},
 		{
 			name: "__",
-			pos:  position{line: 1803, col: 1, offset: 42342},
+			pos:  position{line: 1805, col: 1, offset: 42306},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1803, col: 6, offset: 42347},
+				pos: position{line: 1805, col: 6, offset: 42311},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1803, col: 6, offset: 42347},
+					pos:  position{line: 1805, col: 6, offset: 42311},
 					name: "AnySpace",
 				},
 			},
@@ -12787,20 +12774,20 @@ var g = &grammar{
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1805, col: 1, offset: 42358},
+			pos:  position{line: 1807, col: 1, offset: 42322},
 			expr: &choiceExpr{
-				pos: position{line: 1806, col: 5, offset: 42371},
+				pos: position{line: 1808, col: 5, offset: 42335},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1806, col: 5, offset: 42371},
+						pos:  position{line: 1808, col: 5, offset: 42335},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1807, col: 5, offset: 42386},
+						pos:  position{line: 1809, col: 5, offset: 42350},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1808, col: 5, offset: 42405},
+						pos:  position{line: 1810, col: 5, offset: 42369},
 						name: "Comment",
 					},
 				},
@@ -12810,32 +12797,32 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeLetter",
-			pos:  position{line: 1810, col: 1, offset: 42414},
+			pos:  position{line: 1812, col: 1, offset: 42378},
 			expr: &choiceExpr{
-				pos: position{line: 1811, col: 5, offset: 42432},
+				pos: position{line: 1813, col: 5, offset: 42396},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1811, col: 5, offset: 42432},
+						pos:  position{line: 1813, col: 5, offset: 42396},
 						name: "Lu",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1812, col: 5, offset: 42439},
+						pos:  position{line: 1814, col: 5, offset: 42403},
 						name: "Ll",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1813, col: 5, offset: 42446},
+						pos:  position{line: 1815, col: 5, offset: 42410},
 						name: "Lt",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1814, col: 5, offset: 42453},
+						pos:  position{line: 1816, col: 5, offset: 42417},
 						name: "Lm",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1815, col: 5, offset: 42460},
+						pos:  position{line: 1817, col: 5, offset: 42424},
 						name: "Lo",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1816, col: 5, offset: 42467},
+						pos:  position{line: 1818, col: 5, offset: 42431},
 						name: "Nl",
 					},
 				},
@@ -12845,16 +12832,16 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeCombiningMark",
-			pos:  position{line: 1818, col: 1, offset: 42471},
+			pos:  position{line: 1820, col: 1, offset: 42435},
 			expr: &choiceExpr{
-				pos: position{line: 1819, col: 5, offset: 42496},
+				pos: position{line: 1821, col: 5, offset: 42460},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1819, col: 5, offset: 42496},
+						pos:  position{line: 1821, col: 5, offset: 42460},
 						name: "Mn",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1820, col: 5, offset: 42503},
+						pos:  position{line: 1822, col: 5, offset: 42467},
 						name: "Mc",
 					},
 				},
@@ -12864,9 +12851,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeDigit",
-			pos:  position{line: 1822, col: 1, offset: 42507},
+			pos:  position{line: 1824, col: 1, offset: 42471},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1823, col: 5, offset: 42524},
+				pos:  position{line: 1825, col: 5, offset: 42488},
 				name: "Nd",
 			},
 			leader:        false,
@@ -12874,9 +12861,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeConnectorPunctuation",
-			pos:  position{line: 1825, col: 1, offset: 42528},
+			pos:  position{line: 1827, col: 1, offset: 42492},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1826, col: 5, offset: 42560},
+				pos:  position{line: 1828, col: 5, offset: 42524},
 				name: "Pc",
 			},
 			leader:        false,
@@ -12884,9 +12871,9 @@ var g = &grammar{
 		},
 		{
 			name: "Ll",
-			pos:  position{line: 1832, col: 1, offset: 42741},
+			pos:  position{line: 1834, col: 1, offset: 42705},
 			expr: &charClassMatcher{
-				pos:        position{line: 1832, col: 6, offset: 42746},
+				pos:        position{line: 1834, col: 6, offset: 42710},
 				val:        "[\\u0061-\\u007A\\u00B5\\u00DF-\\u00F6\\u00F8-\\u00FF\\u0101\\u0103\\u0105\\u0107\\u0109\\u010B\\u010D\\u010F\\u0111\\u0113\\u0115\\u0117\\u0119\\u011B\\u011D\\u011F\\u0121\\u0123\\u0125\\u0127\\u0129\\u012B\\u012D\\u012F\\u0131\\u0133\\u0135\\u0137-\\u0138\\u013A\\u013C\\u013E\\u0140\\u0142\\u0144\\u0146\\u0148-\\u0149\\u014B\\u014D\\u014F\\u0151\\u0153\\u0155\\u0157\\u0159\\u015B\\u015D\\u015F\\u0161\\u0163\\u0165\\u0167\\u0169\\u016B\\u016D\\u016F\\u0171\\u0173\\u0175\\u0177\\u017A\\u017C\\u017E-\\u0180\\u0183\\u0185\\u0188\\u018C-\\u018D\\u0192\\u0195\\u0199-\\u019B\\u019E\\u01A1\\u01A3\\u01A5\\u01A8\\u01AA-\\u01AB\\u01AD\\u01B0\\u01B4\\u01B6\\u01B9-\\u01BA\\u01BD-\\u01BF\\u01C6\\u01C9\\u01CC\\u01CE\\u01D0\\u01D2\\u01D4\\u01D6\\u01D8\\u01DA\\u01DC-\\u01DD\\u01DF\\u01E1\\u01E3\\u01E5\\u01E7\\u01E9\\u01EB\\u01ED\\u01EF-\\u01F0\\u01F3\\u01F5\\u01F9\\u01FB\\u01FD\\u01FF\\u0201\\u0203\\u0205\\u0207\\u0209\\u020B\\u020D\\u020F\\u0211\\u0213\\u0215\\u0217\\u0219\\u021B\\u021D\\u021F\\u0221\\u0223\\u0225\\u0227\\u0229\\u022B\\u022D\\u022F\\u0231\\u0233-\\u0239\\u023C\\u023F-\\u0240\\u0242\\u0247\\u0249\\u024B\\u024D\\u024F-\\u0293\\u0295-\\u02AF\\u0371\\u0373\\u0377\\u037B-\\u037D\\u0390\\u03AC-\\u03CE\\u03D0-\\u03D1\\u03D5-\\u03D7\\u03D9\\u03DB\\u03DD\\u03DF\\u03E1\\u03E3\\u03E5\\u03E7\\u03E9\\u03EB\\u03ED\\u03EF-\\u03F3\\u03F5\\u03F8\\u03FB-\\u03FC\\u0430-\\u045F\\u0461\\u0463\\u0465\\u0467\\u0469\\u046B\\u046D\\u046F\\u0471\\u0473\\u0475\\u0477\\u0479\\u047B\\u047D\\u047F\\u0481\\u048B\\u048D\\u048F\\u0491\\u0493\\u0495\\u0497\\u0499\\u049B\\u049D\\u049F\\u04A1\\u04A3\\u04A5\\u04A7\\u04A9\\u04AB\\u04AD\\u04AF\\u04B1\\u04B3\\u04B5\\u04B7\\u04B9\\u04BB\\u04BD\\u04BF\\u04C2\\u04C4\\u04C6\\u04C8\\u04CA\\u04CC\\u04CE-\\u04CF\\u04D1\\u04D3\\u04D5\\u04D7\\u04D9\\u04DB\\u04DD\\u04DF\\u04E1\\u04E3\\u04E5\\u04E7\\u04E9\\u04EB\\u04ED\\u04EF\\u04F1\\u04F3\\u04F5\\u04F7\\u04F9\\u04FB\\u04FD\\u04FF\\u0501\\u0503\\u0505\\u0507\\u0509\\u050B\\u050D\\u050F\\u0511\\u0513\\u0515\\u0517\\u0519\\u051B\\u051D\\u051F\\u0521\\u0523\\u0525\\u0527\\u0529\\u052B\\u052D\\u052F\\u0560-\\u0588\\u10D0-\\u10FA\\u10FD-\\u10FF\\u13F8-\\u13FD\\u1C80-\\u1C88\\u1D00-\\u1D2B\\u1D6B-\\u1D77\\u1D79-\\u1D9A\\u1E01\\u1E03\\u1E05\\u1E07\\u1E09\\u1E0B\\u1E0D\\u1E0F\\u1E11\\u1E13\\u1E15\\u1E17\\u1E19\\u1E1B\\u1E1D\\u1E1F\\u1E21\\u1E23\\u1E25\\u1E27\\u1E29\\u1E2B\\u1E2D\\u1E2F\\u1E31\\u1E33\\u1E35\\u1E37\\u1E39\\u1E3B\\u1E3D\\u1E3F\\u1E41\\u1E43\\u1E45\\u1E47\\u1E49\\u1E4B\\u1E4D\\u1E4F\\u1E51\\u1E53\\u1E55\\u1E57\\u1E59\\u1E5B\\u1E5D\\u1E5F\\u1E61\\u1E63\\u1E65\\u1E67\\u1E69\\u1E6B\\u1E6D\\u1E6F\\u1E71\\u1E73\\u1E75\\u1E77\\u1E79\\u1E7B\\u1E7D\\u1E7F\\u1E81\\u1E83\\u1E85\\u1E87\\u1E89\\u1E8B\\u1E8D\\u1E8F\\u1E91\\u1E93\\u1E95-\\u1E9D\\u1E9F\\u1EA1\\u1EA3\\u1EA5\\u1EA7\\u1EA9\\u1EAB\\u1EAD\\u1EAF\\u1EB1\\u1EB3\\u1EB5\\u1EB7\\u1EB9\\u1EBB\\u1EBD\\u1EBF\\u1EC1\\u1EC3\\u1EC5\\u1EC7\\u1EC9\\u1ECB\\u1ECD\\u1ECF\\u1ED1\\u1ED3\\u1ED5\\u1ED7\\u1ED9\\u1EDB\\u1EDD\\u1EDF\\u1EE1\\u1EE3\\u1EE5\\u1EE7\\u1EE9\\u1EEB\\u1EED\\u1EEF\\u1EF1\\u1EF3\\u1EF5\\u1EF7\\u1EF9\\u1EFB\\u1EFD\\u1EFF-\\u1F07\\u1F10-\\u1F15\\u1F20-\\u1F27\\u1F30-\\u1F37\\u1F40-\\u1F45\\u1F50-\\u1F57\\u1F60-\\u1F67\\u1F70-\\u1F7D\\u1F80-\\u1F87\\u1F90-\\u1F97\\u1FA0-\\u1FA7\\u1FB0-\\u1FB4\\u1FB6-\\u1FB7\\u1FBE\\u1FC2-\\u1FC4\\u1FC6-\\u1FC7\\u1FD0-\\u1FD3\\u1FD6-\\u1FD7\\u1FE0-\\u1FE7\\u1FF2-\\u1FF4\\u1FF6-\\u1FF7\\u210A\\u210E-\\u210F\\u2113\\u212F\\u2134\\u2139\\u213C-\\u213D\\u2146-\\u2149\\u214E\\u2184\\u2C30-\\u2C5E\\u2C61\\u2C65-\\u2C66\\u2C68\\u2C6A\\u2C6C\\u2C71\\u2C73-\\u2C74\\u2C76-\\u2C7B\\u2C81\\u2C83\\u2C85\\u2C87\\u2C89\\u2C8B\\u2C8D\\u2C8F\\u2C91\\u2C93\\u2C95\\u2C97\\u2C99\\u2C9B\\u2C9D\\u2C9F\\u2CA1\\u2CA3\\u2CA5\\u2CA7\\u2CA9\\u2CAB\\u2CAD\\u2CAF\\u2CB1\\u2CB3\\u2CB5\\u2CB7\\u2CB9\\u2CBB\\u2CBD\\u2CBF\\u2CC1\\u2CC3\\u2CC5\\u2CC7\\u2CC9\\u2CCB\\u2CCD\\u2CCF\\u2CD1\\u2CD3\\u2CD5\\u2CD7\\u2CD9\\u2CDB\\u2CDD\\u2CDF\\u2CE1\\u2CE3-\\u2CE4\\u2CEC\\u2CEE\\u2CF3\\u2D00-\\u2D25\\u2D27\\u2D2D\\uA641\\uA643\\uA645\\uA647\\uA649\\uA64B\\uA64D\\uA64F\\uA651\\uA653\\uA655\\uA657\\uA659\\uA65B\\uA65D\\uA65F\\uA661\\uA663\\uA665\\uA667\\uA669\\uA66B\\uA66D\\uA681\\uA683\\uA685\\uA687\\uA689\\uA68B\\uA68D\\uA68F\\uA691\\uA693\\uA695\\uA697\\uA699\\uA69B\\uA723\\uA725\\uA727\\uA729\\uA72B\\uA72D\\uA72F-\\uA731\\uA733\\uA735\\uA737\\uA739\\uA73B\\uA73D\\uA73F\\uA741\\uA743\\uA745\\uA747\\uA749\\uA74B\\uA74D\\uA74F\\uA751\\uA753\\uA755\\uA757\\uA759\\uA75B\\uA75D\\uA75F\\uA761\\uA763\\uA765\\uA767\\uA769\\uA76B\\uA76D\\uA76F\\uA771-\\uA778\\uA77A\\uA77C\\uA77F\\uA781\\uA783\\uA785\\uA787\\uA78C\\uA78E\\uA791\\uA793-\\uA795\\uA797\\uA799\\uA79B\\uA79D\\uA79F\\uA7A1\\uA7A3\\uA7A5\\uA7A7\\uA7A9\\uA7AF\\uA7B5\\uA7B7\\uA7B9\\uA7FA\\uAB30-\\uAB5A\\uAB60-\\uAB65\\uAB70-\\uABBF\\uFB00-\\uFB06\\uFB13-\\uFB17\\uFF41-\\uFF5A]",
 				chars:      []rune{'µ', 'ā', 'ă', 'ą', 'ć', 'ĉ', 'ċ', 'č', 'ď', 'đ', 'ē', 'ĕ', 'ė', 'ę', 'ě', 'ĝ', 'ğ', 'ġ', 'ģ', 'ĥ', 'ħ', 'ĩ', 'ī', 'ĭ', 'į', 'ı', 'ĳ', 'ĵ', 'ĺ', 'ļ', 'ľ', 'ŀ', 'ł', 'ń', 'ņ', 'ŋ', 'ō', 'ŏ', 'ő', 'œ', 'ŕ', 'ŗ', 'ř', 'ś', 'ŝ', 'ş', 'š', 'ţ', 'ť', 'ŧ', 'ũ', 'ū', 'ŭ', 'ů', 'ű', 'ų', 'ŵ', 'ŷ', 'ź', 'ż', 'ƃ', 'ƅ', 'ƈ', 'ƒ', 'ƕ', 'ƞ', 'ơ', 'ƣ', 'ƥ', 'ƨ', 'ƭ', 'ư', 'ƴ', 'ƶ', 'ǆ', 'ǉ', 'ǌ', 'ǎ', 'ǐ', 'ǒ', 'ǔ', 'ǖ', 'ǘ', 'ǚ', 'ǟ', 'ǡ', 'ǣ', 'ǥ', 'ǧ', 'ǩ', 'ǫ', 'ǭ', 'ǳ', 'ǵ', 'ǹ', 'ǻ', 'ǽ', 'ǿ', 'ȁ', 'ȃ', 'ȅ', 'ȇ', 'ȉ', 'ȋ', 'ȍ', 'ȏ', 'ȑ', 'ȓ', 'ȕ', 'ȗ', 'ș', 'ț', 'ȝ', 'ȟ', 'ȡ', 'ȣ', 'ȥ', 'ȧ', 'ȩ', 'ȫ', 'ȭ', 'ȯ', 'ȱ', 'ȼ', 'ɂ', 'ɇ', 'ɉ', 'ɋ', 'ɍ', 'ͱ', 'ͳ', 'ͷ', 'ΐ', 'ϙ', 'ϛ', 'ϝ', 'ϟ', 'ϡ', 'ϣ', 'ϥ', 'ϧ', 'ϩ', 'ϫ', 'ϭ', 'ϵ', 'ϸ', 'ѡ', 'ѣ', 'ѥ', 'ѧ', 'ѩ', 'ѫ', 'ѭ', 'ѯ', 'ѱ', 'ѳ', 'ѵ', 'ѷ', 'ѹ', 'ѻ', 'ѽ', 'ѿ', 'ҁ', 'ҋ', 'ҍ', 'ҏ', 'ґ', 'ғ', 'ҕ', 'җ', 'ҙ', 'қ', 'ҝ', 'ҟ', 'ҡ', 'ң', 'ҥ', 'ҧ', 'ҩ', 'ҫ', 'ҭ', 'ү', 'ұ', 'ҳ', 'ҵ', 'ҷ', 'ҹ', 'һ', 'ҽ', 'ҿ', 'ӂ', 'ӄ', 'ӆ', 'ӈ', 'ӊ', 'ӌ', 'ӑ', 'ӓ', 'ӕ', 'ӗ', 'ә', 'ӛ', 'ӝ', 'ӟ', 'ӡ', 'ӣ', 'ӥ', 'ӧ', 'ө', 'ӫ', 'ӭ', 'ӯ', 'ӱ', 'ӳ', 'ӵ', 'ӷ', 'ӹ', 'ӻ', 'ӽ', 'ӿ', 'ԁ', 'ԃ', 'ԅ', 'ԇ', 'ԉ', 'ԋ', 'ԍ', 'ԏ', 'ԑ', 'ԓ', 'ԕ', 'ԗ', 'ԙ', 'ԛ', 'ԝ', 'ԟ', 'ԡ', 'ԣ', 'ԥ', 'ԧ', 'ԩ', 'ԫ', 'ԭ', 'ԯ', 'ḁ', 'ḃ', 'ḅ', 'ḇ', 'ḉ', 'ḋ', 'ḍ', 'ḏ', 'ḑ', 'ḓ', 'ḕ', 'ḗ', 'ḙ', 'ḛ', 'ḝ', 'ḟ', 'ḡ', 'ḣ', 'ḥ', 'ḧ', 'ḩ', 'ḫ', 'ḭ', 'ḯ', 'ḱ', 'ḳ', 'ḵ', 'ḷ', 'ḹ', 'ḻ', 'ḽ', 'ḿ', 'ṁ', 'ṃ', 'ṅ', 'ṇ', 'ṉ', 'ṋ', 'ṍ', 'ṏ', 'ṑ', 'ṓ', 'ṕ', 'ṗ', 'ṙ', 'ṛ', 'ṝ', 'ṟ', 'ṡ', 'ṣ', 'ṥ', 'ṧ', 'ṩ', 'ṫ', 'ṭ', 'ṯ', 'ṱ', 'ṳ', 'ṵ', 'ṷ', 'ṹ', 'ṻ', 'ṽ', 'ṿ', 'ẁ', 'ẃ', 'ẅ', 'ẇ', 'ẉ', 'ẋ', 'ẍ', 'ẏ', 'ẑ', 'ẓ', 'ẟ', 'ạ', 'ả', 'ấ', 'ầ', 'ẩ', 'ẫ', 'ậ', 'ắ', 'ằ', 'ẳ', 'ẵ', 'ặ', 'ẹ', 'ẻ', 'ẽ', 'ế', 'ề', 'ể', 'ễ', 'ệ', 'ỉ', 'ị', 'ọ', 'ỏ', 'ố', 'ồ', 'ổ', 'ỗ', 'ộ', 'ớ', 'ờ', 'ở', 'ỡ', 'ợ', 'ụ', 'ủ', 'ứ', 'ừ', 'ử', 'ữ', 'ự', 'ỳ', 'ỵ', 'ỷ', 'ỹ', 'ỻ', 'ỽ', 'ι', 'ℊ', 'ℓ', 'ℯ', 'ℴ', 'ℹ', 'ⅎ', 'ↄ', 'ⱡ', 'ⱨ', 'ⱪ', 'ⱬ', 'ⱱ', 'ⲁ', 'ⲃ', 'ⲅ', 'ⲇ', 'ⲉ', 'ⲋ', 'ⲍ', 'ⲏ', 'ⲑ', 'ⲓ', 'ⲕ', 'ⲗ', 'ⲙ', 'ⲛ', 'ⲝ', 'ⲟ', 'ⲡ', 'ⲣ', 'ⲥ', 'ⲧ', 'ⲩ', 'ⲫ', 'ⲭ', 'ⲯ', 'ⲱ', 'ⲳ', 'ⲵ', 'ⲷ', 'ⲹ', 'ⲻ', 'ⲽ', 'ⲿ', 'ⳁ', 'ⳃ', 'ⳅ', 'ⳇ', 'ⳉ', 'ⳋ', 'ⳍ', 'ⳏ', 'ⳑ', 'ⳓ', 'ⳕ', 'ⳗ', 'ⳙ', 'ⳛ', 'ⳝ', 'ⳟ', 'ⳡ', 'ⳬ', 'ⳮ', 'ⳳ', 'ⴧ', 'ⴭ', 'ꙁ', 'ꙃ', 'ꙅ', 'ꙇ', 'ꙉ', 'ꙋ', 'ꙍ', 'ꙏ', 'ꙑ', 'ꙓ', 'ꙕ', 'ꙗ', 'ꙙ', 'ꙛ', 'ꙝ', 'ꙟ', 'ꙡ', 'ꙣ', 'ꙥ', 'ꙧ', 'ꙩ', 'ꙫ', 'ꙭ', 'ꚁ', 'ꚃ', 'ꚅ', 'ꚇ', 'ꚉ', 'ꚋ', 'ꚍ', 'ꚏ', 'ꚑ', 'ꚓ', 'ꚕ', 'ꚗ', 'ꚙ', 'ꚛ', 'ꜣ', 'ꜥ', 'ꜧ', 'ꜩ', 'ꜫ', 'ꜭ', 'ꜳ', 'ꜵ', 'ꜷ', 'ꜹ', 'ꜻ', 'ꜽ', 'ꜿ', 'ꝁ', 'ꝃ', 'ꝅ', 'ꝇ', 'ꝉ', 'ꝋ', 'ꝍ', 'ꝏ', 'ꝑ', 'ꝓ', 'ꝕ', 'ꝗ', 'ꝙ', 'ꝛ', 'ꝝ', 'ꝟ', 'ꝡ', 'ꝣ', 'ꝥ', 'ꝧ', 'ꝩ', 'ꝫ', 'ꝭ', 'ꝯ', 'ꝺ', 'ꝼ', 'ꝿ', 'ꞁ', 'ꞃ', 'ꞅ', 'ꞇ', 'ꞌ', 'ꞎ', 'ꞑ', 'ꞗ', 'ꞙ', 'ꞛ', 'ꞝ', 'ꞟ', 'ꞡ', 'ꞣ', 'ꞥ', 'ꞧ', 'ꞩ', 'ꞯ', 'ꞵ', 'ꞷ', 'ꞹ', 'ꟺ'},
 				ranges:     []rune{'a', 'z', 'ß', 'ö', 'ø', 'ÿ', 'ķ', 'ĸ', 'ň', 'ŉ', 'ž', 'ƀ', 'ƌ', 'ƍ', 'ƙ', 'ƛ', 'ƪ', 'ƫ', 'ƹ', 'ƺ', 'ƽ', 'ƿ', 'ǜ', 'ǝ', 'ǯ', 'ǰ', 'ȳ', 'ȹ', 'ȿ', 'ɀ', 'ɏ', 'ʓ', 'ʕ', 'ʯ', 'ͻ', 'ͽ', 'ά', 'ώ', 'ϐ', 'ϑ', 'ϕ', 'ϗ', 'ϯ', 'ϳ', 'ϻ', 'ϼ', 'а', 'џ', 'ӎ', 'ӏ', 'ՠ', 'ֈ', 'ა', 'ჺ', 'ჽ', 'ჿ', 'ᏸ', 'ᏽ', 'ᲀ', 'ᲈ', 'ᴀ', 'ᴫ', 'ᵫ', 'ᵷ', 'ᵹ', 'ᶚ', 'ẕ', 'ẝ', 'ỿ', 'ἇ', 'ἐ', 'ἕ', 'ἠ', 'ἧ', 'ἰ', 'ἷ', 'ὀ', 'ὅ', 'ὐ', 'ὗ', 'ὠ', 'ὧ', 'ὰ', 'ώ', 'ᾀ', 'ᾇ', 'ᾐ', 'ᾗ', 'ᾠ', 'ᾧ', 'ᾰ', 'ᾴ', 'ᾶ', 'ᾷ', 'ῂ', 'ῄ', 'ῆ', 'ῇ', 'ῐ', 'ΐ', 'ῖ', 'ῗ', 'ῠ', 'ῧ', 'ῲ', 'ῴ', 'ῶ', 'ῷ', 'ℎ', 'ℏ', 'ℼ', 'ℽ', 'ⅆ', 'ⅉ', 'ⰰ', 'ⱞ', 'ⱥ', 'ⱦ', 'ⱳ', 'ⱴ', 'ⱶ', 'ⱻ', 'ⳣ', 'ⳤ', 'ⴀ', 'ⴥ', 'ꜯ', 'ꜱ', 'ꝱ', 'ꝸ', 'ꞓ', 'ꞕ', 'ꬰ', 'ꭚ', 'ꭠ', 'ꭥ', 'ꭰ', 'ꮿ', 'ﬀ', 'ﬆ', 'ﬓ', 'ﬗ', 'ａ', 'ｚ'},
@@ -12898,9 +12885,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lm",
-			pos:  position{line: 1835, col: 1, offset: 46898},
+			pos:  position{line: 1837, col: 1, offset: 46862},
 			expr: &charClassMatcher{
-				pos:        position{line: 1835, col: 6, offset: 46903},
+				pos:        position{line: 1837, col: 6, offset: 46867},
 				val:        "[\\u02B0-\\u02C1\\u02C6-\\u02D1\\u02E0-\\u02E4\\u02EC\\u02EE\\u0374\\u037A\\u0559\\u0640\\u06E5-\\u06E6\\u07F4-\\u07F5\\u07FA\\u081A\\u0824\\u0828\\u0971\\u0E46\\u0EC6\\u10FC\\u17D7\\u1843\\u1AA7\\u1C78-\\u1C7D\\u1D2C-\\u1D6A\\u1D78\\u1D9B-\\u1DBF\\u2071\\u207F\\u2090-\\u209C\\u2C7C-\\u2C7D\\u2D6F\\u2E2F\\u3005\\u3031-\\u3035\\u303B\\u309D-\\u309E\\u30FC-\\u30FE\\uA015\\uA4F8-\\uA4FD\\uA60C\\uA67F\\uA69C-\\uA69D\\uA717-\\uA71F\\uA770\\uA788\\uA7F8-\\uA7F9\\uA9CF\\uA9E6\\uAA70\\uAADD\\uAAF3-\\uAAF4\\uAB5C-\\uAB5F\\uFF70\\uFF9E-\\uFF9F]",
 				chars:      []rune{'ˬ', 'ˮ', 'ʹ', 'ͺ', 'ՙ', 'ـ', 'ߺ', 'ࠚ', 'ࠤ', 'ࠨ', 'ॱ', 'ๆ', 'ໆ', 'ჼ', 'ៗ', 'ᡃ', 'ᪧ', 'ᵸ', 'ⁱ', 'ⁿ', 'ⵯ', 'ⸯ', '々', '〻', 'ꀕ', 'ꘌ', 'ꙿ', 'ꝰ', 'ꞈ', 'ꧏ', 'ꧦ', 'ꩰ', 'ꫝ', 'ｰ'},
 				ranges:     []rune{'ʰ', 'ˁ', 'ˆ', 'ˑ', 'ˠ', 'ˤ', 'ۥ', 'ۦ', 'ߴ', 'ߵ', 'ᱸ', 'ᱽ', 'ᴬ', 'ᵪ', 'ᶛ', 'ᶿ', 'ₐ', 'ₜ', 'ⱼ', 'ⱽ', '〱', '〵', 'ゝ', 'ゞ', 'ー', 'ヾ', 'ꓸ', 'ꓽ', 'ꚜ', 'ꚝ', 'ꜗ', 'ꜟ', 'ꟸ', 'ꟹ', 'ꫳ', 'ꫴ', 'ꭜ', 'ꭟ', 'ﾞ', 'ﾟ'},
@@ -12912,9 +12899,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lo",
-			pos:  position{line: 1838, col: 1, offset: 47388},
+			pos:  position{line: 1840, col: 1, offset: 47352},
 			expr: &charClassMatcher{
-				pos:        position{line: 1838, col: 6, offset: 47393},
+				pos:        position{line: 1840, col: 6, offset: 47357},
 				val:        "[\\u00AA\\u00BA\\u01BB\\u01C0-\\u01C3\\u0294\\u05D0-\\u05EA\\u05EF-\\u05F2\\u0620-\\u063F\\u0641-\\u064A\\u066E-\\u066F\\u0671-\\u06D3\\u06D5\\u06EE-\\u06EF\\u06FA-\\u06FC\\u06FF\\u0710\\u0712-\\u072F\\u074D-\\u07A5\\u07B1\\u07CA-\\u07EA\\u0800-\\u0815\\u0840-\\u0858\\u0860-\\u086A\\u08A0-\\u08B4\\u08B6-\\u08BD\\u0904-\\u0939\\u093D\\u0950\\u0958-\\u0961\\u0972-\\u0980\\u0985-\\u098C\\u098F-\\u0990\\u0993-\\u09A8\\u09AA-\\u09B0\\u09B2\\u09B6-\\u09B9\\u09BD\\u09CE\\u09DC-\\u09DD\\u09DF-\\u09E1\\u09F0-\\u09F1\\u09FC\\u0A05-\\u0A0A\\u0A0F-\\u0A10\\u0A13-\\u0A28\\u0A2A-\\u0A30\\u0A32-\\u0A33\\u0A35-\\u0A36\\u0A38-\\u0A39\\u0A59-\\u0A5C\\u0A5E\\u0A72-\\u0A74\\u0A85-\\u0A8D\\u0A8F-\\u0A91\\u0A93-\\u0AA8\\u0AAA-\\u0AB0\\u0AB2-\\u0AB3\\u0AB5-\\u0AB9\\u0ABD\\u0AD0\\u0AE0-\\u0AE1\\u0AF9\\u0B05-\\u0B0C\\u0B0F-\\u0B10\\u0B13-\\u0B28\\u0B2A-\\u0B30\\u0B32-\\u0B33\\u0B35-\\u0B39\\u0B3D\\u0B5C-\\u0B5D\\u0B5F-\\u0B61\\u0B71\\u0B83\\u0B85-\\u0B8A\\u0B8E-\\u0B90\\u0B92-\\u0B95\\u0B99-\\u0B9A\\u0B9C\\u0B9E-\\u0B9F\\u0BA3-\\u0BA4\\u0BA8-\\u0BAA\\u0BAE-\\u0BB9\\u0BD0\\u0C05-\\u0C0C\\u0C0E-\\u0C10\\u0C12-\\u0C28\\u0C2A-\\u0C39\\u0C3D\\u0C58-\\u0C5A\\u0C60-\\u0C61\\u0C80\\u0C85-\\u0C8C\\u0C8E-\\u0C90\\u0C92-\\u0CA8\\u0CAA-\\u0CB3\\u0CB5-\\u0CB9\\u0CBD\\u0CDE\\u0CE0-\\u0CE1\\u0CF1-\\u0CF2\\u0D05-\\u0D0C\\u0D0E-\\u0D10\\u0D12-\\u0D3A\\u0D3D\\u0D4E\\u0D54-\\u0D56\\u0D5F-\\u0D61\\u0D7A-\\u0D7F\\u0D85-\\u0D96\\u0D9A-\\u0DB1\\u0DB3-\\u0DBB\\u0DBD\\u0DC0-\\u0DC6\\u0E01-\\u0E30\\u0E32-\\u0E33\\u0E40-\\u0E45\\u0E81-\\u0E82\\u0E84\\u0E87-\\u0E88\\u0E8A\\u0E8D\\u0E94-\\u0E97\\u0E99-\\u0E9F\\u0EA1-\\u0EA3\\u0EA5\\u0EA7\\u0EAA-\\u0EAB\\u0EAD-\\u0EB0\\u0EB2-\\u0EB3\\u0EBD\\u0EC0-\\u0EC4\\u0EDC-\\u0EDF\\u0F00\\u0F40-\\u0F47\\u0F49-\\u0F6C\\u0F88-\\u0F8C\\u1000-\\u102A\\u103F\\u1050-\\u1055\\u105A-\\u105D\\u1061\\u1065-\\u1066\\u106E-\\u1070\\u1075-\\u1081\\u108E\\u1100-\\u1248\\u124A-\\u124D\\u1250-\\u1256\\u1258\\u125A-\\u125D\\u1260-\\u1288\\u128A-\\u128D\\u1290-\\u12B0\\u12B2-\\u12B5\\u12B8-\\u12BE\\u12C0\\u12C2-\\u12C5\\u12C8-\\u12D6\\u12D8-\\u1310\\u1312-\\u1315\\u1318-\\u135A\\u1380-\\u138F\\u1401-\\u166C\\u166F-\\u167F\\u1681-\\u169A\\u16A0-\\u16EA\\u16F1-\\u16F8\\u1700-\\u170C\\u170E-\\u1711\\u1720-\\u1731\\u1740-\\u1751\\u1760-\\u176C\\u176E-\\u1770\\u1780-\\u17B3\\u17DC\\u1820-\\u1842\\u1844-\\u1878\\u1880-\\u1884\\u1887-\\u18A8\\u18AA\\u18B0-\\u18F5\\u1900-\\u191E\\u1950-\\u196D\\u1970-\\u1974\\u1980-\\u19AB\\u19B0-\\u19C9\\u1A00-\\u1A16\\u1A20-\\u1A54\\u1B05-\\u1B33\\u1B45-\\u1B4B\\u1B83-\\u1BA0\\u1BAE-\\u1BAF\\u1BBA-\\u1BE5\\u1C00-\\u1C23\\u1C4D-\\u1C4F\\u1C5A-\\u1C77\\u1CE9-\\u1CEC\\u1CEE-\\u1CF1\\u1CF5-\\u1CF6\\u2135-\\u2138\\u2D30-\\u2D67\\u2D80-\\u2D96\\u2DA0-\\u2DA6\\u2DA8-\\u2DAE\\u2DB0-\\u2DB6\\u2DB8-\\u2DBE\\u2DC0-\\u2DC6\\u2DC8-\\u2DCE\\u2DD0-\\u2DD6\\u2DD8-\\u2DDE\\u3006\\u303C\\u3041-\\u3096\\u309F\\u30A1-\\u30FA\\u30FF\\u3105-\\u312F\\u3131-\\u318E\\u31A0-\\u31BA\\u31F0-\\u31FF\\u3400-\\u4DB5\\u4E00-\\u9FEF\\uA000-\\uA014\\uA016-\\uA48C\\uA4D0-\\uA4F7\\uA500-\\uA60B\\uA610-\\uA61F\\uA62A-\\uA62B\\uA66E\\uA6A0-\\uA6E5\\uA78F\\uA7F7\\uA7FB-\\uA801\\uA803-\\uA805\\uA807-\\uA80A\\uA80C-\\uA822\\uA840-\\uA873\\uA882-\\uA8B3\\uA8F2-\\uA8F7\\uA8FB\\uA8FD-\\uA8FE\\uA90A-\\uA925\\uA930-\\uA946\\uA960-\\uA97C\\uA984-\\uA9B2\\uA9E0-\\uA9E4\\uA9E7-\\uA9EF\\uA9FA-\\uA9FE\\uAA00-\\uAA28\\uAA40-\\uAA42\\uAA44-\\uAA4B\\uAA60-\\uAA6F\\uAA71-\\uAA76\\uAA7A\\uAA7E-\\uAAAF\\uAAB1\\uAAB5-\\uAAB6\\uAAB9-\\uAABD\\uAAC0\\uAAC2\\uAADB-\\uAADC\\uAAE0-\\uAAEA\\uAAF2\\uAB01-\\uAB06\\uAB09-\\uAB0E\\uAB11-\\uAB16\\uAB20-\\uAB26\\uAB28-\\uAB2E\\uABC0-\\uABE2\\uAC00-\\uD7A3\\uD7B0-\\uD7C6\\uD7CB-\\uD7FB\\uF900-\\uFA6D\\uFA70-\\uFAD9\\uFB1D\\uFB1F-\\uFB28\\uFB2A-\\uFB36\\uFB38-\\uFB3C\\uFB3E\\uFB40-\\uFB41\\uFB43-\\uFB44\\uFB46-\\uFBB1\\uFBD3-\\uFD3D\\uFD50-\\uFD8F\\uFD92-\\uFDC7\\uFDF0-\\uFDFB\\uFE70-\\uFE74\\uFE76-\\uFEFC\\uFF66-\\uFF6F\\uFF71-\\uFF9D\\uFFA0-\\uFFBE\\uFFC2-\\uFFC7\\uFFCA-\\uFFCF\\uFFD2-\\uFFD7\\uFFDA-\\uFFDC]",
 				chars:      []rune{'ª', 'º', 'ƻ', 'ʔ', 'ە', 'ۿ', 'ܐ', 'ޱ', 'ऽ', 'ॐ', 'ল', 'ঽ', 'ৎ', 'ৼ', 'ਫ਼', 'ઽ', 'ૐ', 'ૹ', 'ଽ', 'ୱ', 'ஃ', 'ஜ', 'ௐ', 'ఽ', 'ಀ', 'ಽ', 'ೞ', 'ഽ', 'ൎ', 'ල', 'ຄ', 'ຊ', 'ຍ', 'ລ', 'ວ', 'ຽ', 'ༀ', 'ဿ', 'ၡ', 'ႎ', 'ቘ', 'ዀ', 'ៜ', 'ᢪ', '〆', '〼', 'ゟ', 'ヿ', 'ꙮ', 'ꞏ', 'ꟷ', 'ꣻ', 'ꩺ', 'ꪱ', 'ꫀ', 'ꫂ', 'ꫲ', 'יִ', 'מּ'},
 				ranges:     []rune{'ǀ', 'ǃ', 'א', 'ת', 'ׯ', 'ײ', 'ؠ', 'ؿ', 'ف', 'ي', 'ٮ', 'ٯ', 'ٱ', 'ۓ', 'ۮ', 'ۯ', 'ۺ', 'ۼ', 'ܒ', 'ܯ', 'ݍ', 'ޥ', 'ߊ', 'ߪ', 'ࠀ', 'ࠕ', 'ࡀ', 'ࡘ', 'ࡠ', 'ࡪ', 'ࢠ', 'ࢴ', 'ࢶ', 'ࢽ', 'ऄ', 'ह', 'क़', 'ॡ', 'ॲ', 'ঀ', 'অ', 'ঌ', 'এ', 'ঐ', 'ও', 'ন', 'প', 'র', 'শ', 'হ', 'ড়', 'ঢ়', 'য়', 'ৡ', 'ৰ', 'ৱ', 'ਅ', 'ਊ', 'ਏ', 'ਐ', 'ਓ', 'ਨ', 'ਪ', 'ਰ', 'ਲ', 'ਲ਼', 'ਵ', 'ਸ਼', 'ਸ', 'ਹ', 'ਖ਼', 'ੜ', 'ੲ', 'ੴ', 'અ', 'ઍ', 'એ', 'ઑ', 'ઓ', 'ન', 'પ', 'ર', 'લ', 'ળ', 'વ', 'હ', 'ૠ', 'ૡ', 'ଅ', 'ଌ', 'ଏ', 'ଐ', 'ଓ', 'ନ', 'ପ', 'ର', 'ଲ', 'ଳ', 'ଵ', 'ହ', 'ଡ଼', 'ଢ଼', 'ୟ', 'ୡ', 'அ', 'ஊ', 'எ', 'ஐ', 'ஒ', 'க', 'ங', 'ச', 'ஞ', 'ட', 'ண', 'த', 'ந', 'ப', 'ம', 'ஹ', 'అ', 'ఌ', 'ఎ', 'ఐ', 'ఒ', 'న', 'ప', 'హ', 'ౘ', 'ౚ', 'ౠ', 'ౡ', 'ಅ', 'ಌ', 'ಎ', 'ಐ', 'ಒ', 'ನ', 'ಪ', 'ಳ', 'ವ', 'ಹ', 'ೠ', 'ೡ', 'ೱ', 'ೲ', 'അ', 'ഌ', 'എ', 'ഐ', 'ഒ', 'ഺ', 'ൔ', 'ൖ', 'ൟ', 'ൡ', 'ൺ', 'ൿ', 'අ', 'ඖ', 'ක', 'න', 'ඳ', 'ර', 'ව', 'ෆ', 'ก', 'ะ', 'า', 'ำ', 'เ', 'ๅ', 'ກ', 'ຂ', 'ງ', 'ຈ', 'ດ', 'ທ', 'ນ', 'ຟ', 'ມ', 'ຣ', 'ສ', 'ຫ', 'ອ', 'ະ', 'າ', 'ຳ', 'ເ', 'ໄ', 'ໜ', 'ໟ', 'ཀ', 'ཇ', 'ཉ', 'ཬ', 'ྈ', 'ྌ', 'က', 'ဪ', 'ၐ', 'ၕ', 'ၚ', 'ၝ', 'ၥ', 'ၦ', 'ၮ', 'ၰ', 'ၵ', 'ႁ', 'ᄀ', 'ቈ', 'ቊ', 'ቍ', 'ቐ', 'ቖ', 'ቚ', 'ቝ', 'በ', 'ኈ', 'ኊ', 'ኍ', 'ነ', 'ኰ', 'ኲ', 'ኵ', 'ኸ', 'ኾ', 'ዂ', 'ዅ', 'ወ', 'ዖ', 'ዘ', 'ጐ', 'ጒ', 'ጕ', 'ጘ', 'ፚ', 'ᎀ', 'ᎏ', 'ᐁ', 'ᙬ', 'ᙯ', 'ᙿ', 'ᚁ', 'ᚚ', 'ᚠ', 'ᛪ', 'ᛱ', 'ᛸ', 'ᜀ', 'ᜌ', 'ᜎ', 'ᜑ', 'ᜠ', 'ᜱ', 'ᝀ', 'ᝑ', 'ᝠ', 'ᝬ', 'ᝮ', 'ᝰ', 'ក', 'ឳ', 'ᠠ', 'ᡂ', 'ᡄ', 'ᡸ', 'ᢀ', 'ᢄ', 'ᢇ', 'ᢨ', 'ᢰ', 'ᣵ', 'ᤀ', 'ᤞ', 'ᥐ', 'ᥭ', 'ᥰ', 'ᥴ', 'ᦀ', 'ᦫ', 'ᦰ', 'ᧉ', 'ᨀ', 'ᨖ', 'ᨠ', 'ᩔ', 'ᬅ', 'ᬳ', 'ᭅ', 'ᭋ', 'ᮃ', 'ᮠ', 'ᮮ', 'ᮯ', 'ᮺ', 'ᯥ', 'ᰀ', 'ᰣ', 'ᱍ', 'ᱏ', 'ᱚ', 'ᱷ', 'ᳩ', 'ᳬ', 'ᳮ', 'ᳱ', 'ᳵ', 'ᳶ', 'ℵ', 'ℸ', 'ⴰ', 'ⵧ', 'ⶀ', 'ⶖ', 'ⶠ', 'ⶦ', 'ⶨ', 'ⶮ', 'ⶰ', 'ⶶ', 'ⶸ', 'ⶾ', 'ⷀ', 'ⷆ', 'ⷈ', 'ⷎ', 'ⷐ', 'ⷖ', 'ⷘ', 'ⷞ', 'ぁ', 'ゖ', 'ァ', 'ヺ', 'ㄅ', 'ㄯ', 'ㄱ', 'ㆎ', 'ㆠ', 'ㆺ', 'ㇰ', 'ㇿ', '㐀', '䶵', '一', '鿯', 'ꀀ', 'ꀔ', 'ꀖ', 'ꒌ', 'ꓐ', 'ꓷ', 'ꔀ', 'ꘋ', 'ꘐ', 'ꘟ', 'ꘪ', 'ꘫ', 'ꚠ', 'ꛥ', 'ꟻ', 'ꠁ', 'ꠃ', 'ꠅ', 'ꠇ', 'ꠊ', 'ꠌ', 'ꠢ', 'ꡀ', 'ꡳ', 'ꢂ', 'ꢳ', 'ꣲ', 'ꣷ', 'ꣽ', 'ꣾ', 'ꤊ', 'ꤥ', 'ꤰ', 'ꥆ', 'ꥠ', 'ꥼ', 'ꦄ', 'ꦲ', 'ꧠ', 'ꧤ', 'ꧧ', 'ꧯ', 'ꧺ', 'ꧾ', 'ꨀ', 'ꨨ', 'ꩀ', 'ꩂ', 'ꩄ', 'ꩋ', 'ꩠ', 'ꩯ', 'ꩱ', 'ꩶ', 'ꩾ', 'ꪯ', 'ꪵ', 'ꪶ', 'ꪹ', 'ꪽ', 'ꫛ', 'ꫜ', 'ꫠ', 'ꫪ', 'ꬁ', 'ꬆ', 'ꬉ', 'ꬎ', 'ꬑ', 'ꬖ', 'ꬠ', 'ꬦ', 'ꬨ', 'ꬮ', 'ꯀ', 'ꯢ', '가', '힣', 'ힰ', 'ퟆ', 'ퟋ', 'ퟻ', '豈', '舘', '並', '龎', 'ײַ', 'ﬨ', 'שׁ', 'זּ', 'טּ', 'לּ', 'נּ', 'סּ', 'ףּ', 'פּ', 'צּ', 'ﮱ', 'ﯓ', 'ﴽ', 'ﵐ', 'ﶏ', 'ﶒ', 'ﷇ', 'ﷰ', 'ﷻ', 'ﹰ', 'ﹴ', 'ﹶ', 'ﻼ', 'ｦ', 'ｯ', 'ｱ', 'ﾝ', 'ﾠ', 'ﾾ', 'ￂ', 'ￇ', 'ￊ', 'ￏ', 'ￒ', 'ￗ', 'ￚ', 'ￜ'},
@@ -12926,9 +12913,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lt",
-			pos:  position{line: 1841, col: 1, offset: 50840},
+			pos:  position{line: 1843, col: 1, offset: 50804},
 			expr: &charClassMatcher{
-				pos:        position{line: 1841, col: 6, offset: 50845},
+				pos:        position{line: 1843, col: 6, offset: 50809},
 				val:        "[\\u01C5\\u01C8\\u01CB\\u01F2\\u1F88-\\u1F8F\\u1F98-\\u1F9F\\u1FA8-\\u1FAF\\u1FBC\\u1FCC\\u1FFC]",
 				chars:      []rune{'ǅ', 'ǈ', 'ǋ', 'ǲ', 'ᾼ', 'ῌ', 'ῼ'},
 				ranges:     []rune{'ᾈ', 'ᾏ', 'ᾘ', 'ᾟ', 'ᾨ', 'ᾯ'},
@@ -12940,9 +12927,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lu",
-			pos:  position{line: 1844, col: 1, offset: 50951},
+			pos:  position{line: 1846, col: 1, offset: 50915},
 			expr: &charClassMatcher{
-				pos:        position{line: 1844, col: 6, offset: 50956},
+				pos:        position{line: 1846, col: 6, offset: 50920},
 				val:        "[\\u0041-\\u005A\\u00C0-\\u00D6\\u00D8-\\u00DE\\u0100\\u0102\\u0104\\u0106\\u0108\\u010A\\u010C\\u010E\\u0110\\u0112\\u0114\\u0116\\u0118\\u011A\\u011C\\u011E\\u0120\\u0122\\u0124\\u0126\\u0128\\u012A\\u012C\\u012E\\u0130\\u0132\\u0134\\u0136\\u0139\\u013B\\u013D\\u013F\\u0141\\u0143\\u0145\\u0147\\u014A\\u014C\\u014E\\u0150\\u0152\\u0154\\u0156\\u0158\\u015A\\u015C\\u015E\\u0160\\u0162\\u0164\\u0166\\u0168\\u016A\\u016C\\u016E\\u0170\\u0172\\u0174\\u0176\\u0178-\\u0179\\u017B\\u017D\\u0181-\\u0182\\u0184\\u0186-\\u0187\\u0189-\\u018B\\u018E-\\u0191\\u0193-\\u0194\\u0196-\\u0198\\u019C-\\u019D\\u019F-\\u01A0\\u01A2\\u01A4\\u01A6-\\u01A7\\u01A9\\u01AC\\u01AE-\\u01AF\\u01B1-\\u01B3\\u01B5\\u01B7-\\u01B8\\u01BC\\u01C4\\u01C7\\u01CA\\u01CD\\u01CF\\u01D1\\u01D3\\u01D5\\u01D7\\u01D9\\u01DB\\u01DE\\u01E0\\u01E2\\u01E4\\u01E6\\u01E8\\u01EA\\u01EC\\u01EE\\u01F1\\u01F4\\u01F6-\\u01F8\\u01FA\\u01FC\\u01FE\\u0200\\u0202\\u0204\\u0206\\u0208\\u020A\\u020C\\u020E\\u0210\\u0212\\u0214\\u0216\\u0218\\u021A\\u021C\\u021E\\u0220\\u0222\\u0224\\u0226\\u0228\\u022A\\u022C\\u022E\\u0230\\u0232\\u023A-\\u023B\\u023D-\\u023E\\u0241\\u0243-\\u0246\\u0248\\u024A\\u024C\\u024E\\u0370\\u0372\\u0376\\u037F\\u0386\\u0388-\\u038A\\u038C\\u038E-\\u038F\\u0391-\\u03A1\\u03A3-\\u03AB\\u03CF\\u03D2-\\u03D4\\u03D8\\u03DA\\u03DC\\u03DE\\u03E0\\u03E2\\u03E4\\u03E6\\u03E8\\u03EA\\u03EC\\u03EE\\u03F4\\u03F7\\u03F9-\\u03FA\\u03FD-\\u042F\\u0460\\u0462\\u0464\\u0466\\u0468\\u046A\\u046C\\u046E\\u0470\\u0472\\u0474\\u0476\\u0478\\u047A\\u047C\\u047E\\u0480\\u048A\\u048C\\u048E\\u0490\\u0492\\u0494\\u0496\\u0498\\u049A\\u049C\\u049E\\u04A0\\u04A2\\u04A4\\u04A6\\u04A8\\u04AA\\u04AC\\u04AE\\u04B0\\u04B2\\u04B4\\u04B6\\u04B8\\u04BA\\u04BC\\u04BE\\u04C0-\\u04C1\\u04C3\\u04C5\\u04C7\\u04C9\\u04CB\\u04CD\\u04D0\\u04D2\\u04D4\\u04D6\\u04D8\\u04DA\\u04DC\\u04DE\\u04E0\\u04E2\\u04E4\\u04E6\\u04E8\\u04EA\\u04EC\\u04EE\\u04F0\\u04F2\\u04F4\\u04F6\\u04F8\\u04FA\\u04FC\\u04FE\\u0500\\u0502\\u0504\\u0506\\u0508\\u050A\\u050C\\u050E\\u0510\\u0512\\u0514\\u0516\\u0518\\u051A\\u051C\\u051E\\u0520\\u0522\\u0524\\u0526\\u0528\\u052A\\u052C\\u052E\\u0531-\\u0556\\u10A0-\\u10C5\\u10C7\\u10CD\\u13A0-\\u13F5\\u1C90-\\u1CBA\\u1CBD-\\u1CBF\\u1E00\\u1E02\\u1E04\\u1E06\\u1E08\\u1E0A\\u1E0C\\u1E0E\\u1E10\\u1E12\\u1E14\\u1E16\\u1E18\\u1E1A\\u1E1C\\u1E1E\\u1E20\\u1E22\\u1E24\\u1E26\\u1E28\\u1E2A\\u1E2C\\u1E2E\\u1E30\\u1E32\\u1E34\\u1E36\\u1E38\\u1E3A\\u1E3C\\u1E3E\\u1E40\\u1E42\\u1E44\\u1E46\\u1E48\\u1E4A\\u1E4C\\u1E4E\\u1E50\\u1E52\\u1E54\\u1E56\\u1E58\\u1E5A\\u1E5C\\u1E5E\\u1E60\\u1E62\\u1E64\\u1E66\\u1E68\\u1E6A\\u1E6C\\u1E6E\\u1E70\\u1E72\\u1E74\\u1E76\\u1E78\\u1E7A\\u1E7C\\u1E7E\\u1E80\\u1E82\\u1E84\\u1E86\\u1E88\\u1E8A\\u1E8C\\u1E8E\\u1E90\\u1E92\\u1E94\\u1E9E\\u1EA0\\u1EA2\\u1EA4\\u1EA6\\u1EA8\\u1EAA\\u1EAC\\u1EAE\\u1EB0\\u1EB2\\u1EB4\\u1EB6\\u1EB8\\u1EBA\\u1EBC\\u1EBE\\u1EC0\\u1EC2\\u1EC4\\u1EC6\\u1EC8\\u1ECA\\u1ECC\\u1ECE\\u1ED0\\u1ED2\\u1ED4\\u1ED6\\u1ED8\\u1EDA\\u1EDC\\u1EDE\\u1EE0\\u1EE2\\u1EE4\\u1EE6\\u1EE8\\u1EEA\\u1EEC\\u1EEE\\u1EF0\\u1EF2\\u1EF4\\u1EF6\\u1EF8\\u1EFA\\u1EFC\\u1EFE\\u1F08-\\u1F0F\\u1F18-\\u1F1D\\u1F28-\\u1F2F\\u1F38-\\u1F3F\\u1F48-\\u1F4D\\u1F59\\u1F5B\\u1F5D\\u1F5F\\u1F68-\\u1F6F\\u1FB8-\\u1FBB\\u1FC8-\\u1FCB\\u1FD8-\\u1FDB\\u1FE8-\\u1FEC\\u1FF8-\\u1FFB\\u2102\\u2107\\u210B-\\u210D\\u2110-\\u2112\\u2115\\u2119-\\u211D\\u2124\\u2126\\u2128\\u212A-\\u212D\\u2130-\\u2133\\u213E-\\u213F\\u2145\\u2183\\u2C00-\\u2C2E\\u2C60\\u2C62-\\u2C64\\u2C67\\u2C69\\u2C6B\\u2C6D-\\u2C70\\u2C72\\u2C75\\u2C7E-\\u2C80\\u2C82\\u2C84\\u2C86\\u2C88\\u2C8A\\u2C8C\\u2C8E\\u2C90\\u2C92\\u2C94\\u2C96\\u2C98\\u2C9A\\u2C9C\\u2C9E\\u2CA0\\u2CA2\\u2CA4\\u2CA6\\u2CA8\\u2CAA\\u2CAC\\u2CAE\\u2CB0\\u2CB2\\u2CB4\\u2CB6\\u2CB8\\u2CBA\\u2CBC\\u2CBE\\u2CC0\\u2CC2\\u2CC4\\u2CC6\\u2CC8\\u2CCA\\u2CCC\\u2CCE\\u2CD0\\u2CD2\\u2CD4\\u2CD6\\u2CD8\\u2CDA\\u2CDC\\u2CDE\\u2CE0\\u2CE2\\u2CEB\\u2CED\\u2CF2\\uA640\\uA642\\uA644\\uA646\\uA648\\uA64A\\uA64C\\uA64E\\uA650\\uA652\\uA654\\uA656\\uA658\\uA65A\\uA65C\\uA65E\\uA660\\uA662\\uA664\\uA666\\uA668\\uA66A\\uA66C\\uA680\\uA682\\uA684\\uA686\\uA688\\uA68A\\uA68C\\uA68E\\uA690\\uA692\\uA694\\uA696\\uA698\\uA69A\\uA722\\uA724\\uA726\\uA728\\uA72A\\uA72C\\uA72E\\uA732\\uA734\\uA736\\uA738\\uA73A\\uA73C\\uA73E\\uA740\\uA742\\uA744\\uA746\\uA748\\uA74A\\uA74C\\uA74E\\uA750\\uA752\\uA754\\uA756\\uA758\\uA75A\\uA75C\\uA75E\\uA760\\uA762\\uA764\\uA766\\uA768\\uA76A\\uA76C\\uA76E\\uA779\\uA77B\\uA77D-\\uA77E\\uA780\\uA782\\uA784\\uA786\\uA78B\\uA78D\\uA790\\uA792\\uA796\\uA798\\uA79A\\uA79C\\uA79E\\uA7A0\\uA7A2\\uA7A4\\uA7A6\\uA7A8\\uA7AA-\\uA7AE\\uA7B0-\\uA7B4\\uA7B6\\uA7B8\\uFF21-\\uFF3A]",
 				chars:      []rune{'Ā', 'Ă', 'Ą', 'Ć', 'Ĉ', 'Ċ', 'Č', 'Ď', 'Đ', 'Ē', 'Ĕ', 'Ė', 'Ę', 'Ě', 'Ĝ', 'Ğ', 'Ġ', 'Ģ', 'Ĥ', 'Ħ', 'Ĩ', 'Ī', 'Ĭ', 'Į', 'İ', 'Ĳ', 'Ĵ', 'Ķ', 'Ĺ', 'Ļ', 'Ľ', 'Ŀ', 'Ł', 'Ń', 'Ņ', 'Ň', 'Ŋ', 'Ō', 'Ŏ', 'Ő', 'Œ', 'Ŕ', 'Ŗ', 'Ř', 'Ś', 'Ŝ', 'Ş', 'Š', 'Ţ', 'Ť', 'Ŧ', 'Ũ', 'Ū', 'Ŭ', 'Ů', 'Ű', 'Ų', 'Ŵ', 'Ŷ', 'Ż', 'Ž', 'Ƅ', 'Ƣ', 'Ƥ', 'Ʃ', 'Ƭ', 'Ƶ', 'Ƽ', 'Ǆ', 'Ǉ', 'Ǌ', 'Ǎ', 'Ǐ', 'Ǒ', 'Ǔ', 'Ǖ', 'Ǘ', 'Ǚ', 'Ǜ', 'Ǟ', 'Ǡ', 'Ǣ', 'Ǥ', 'Ǧ', 'Ǩ', 'Ǫ', 'Ǭ', 'Ǯ', 'Ǳ', 'Ǵ', 'Ǻ', 'Ǽ', 'Ǿ', 'Ȁ', 'Ȃ', 'Ȅ', 'Ȇ', 'Ȉ', 'Ȋ', 'Ȍ', 'Ȏ', 'Ȑ', 'Ȓ', 'Ȕ', 'Ȗ', 'Ș', 'Ț', 'Ȝ', 'Ȟ', 'Ƞ', 'Ȣ', 'Ȥ', 'Ȧ', 'Ȩ', 'Ȫ', 'Ȭ', 'Ȯ', 'Ȱ', 'Ȳ', 'Ɂ', 'Ɉ', 'Ɋ', 'Ɍ', 'Ɏ', 'Ͱ', 'Ͳ', 'Ͷ', 'Ϳ', 'Ά', 'Ό', 'Ϗ', 'Ϙ', 'Ϛ', 'Ϝ', 'Ϟ', 'Ϡ', 'Ϣ', 'Ϥ', 'Ϧ', 'Ϩ', 'Ϫ', 'Ϭ', 'Ϯ', 'ϴ', 'Ϸ', 'Ѡ', 'Ѣ', 'Ѥ', 'Ѧ', 'Ѩ', 'Ѫ', 'Ѭ', 'Ѯ', 'Ѱ', 'Ѳ', 'Ѵ', 'Ѷ', 'Ѹ', 'Ѻ', 'Ѽ', 'Ѿ', 'Ҁ', 'Ҋ', 'Ҍ', 'Ҏ', 'Ґ', 'Ғ', 'Ҕ', 'Җ', 'Ҙ', 'Қ', 'Ҝ', 'Ҟ', 'Ҡ', 'Ң', 'Ҥ', 'Ҧ', 'Ҩ', 'Ҫ', 'Ҭ', 'Ү', 'Ұ', 'Ҳ', 'Ҵ', 'Ҷ', 'Ҹ', 'Һ', 'Ҽ', 'Ҿ', 'Ӄ', 'Ӆ', 'Ӈ', 'Ӊ', 'Ӌ', 'Ӎ', 'Ӑ', 'Ӓ', 'Ӕ', 'Ӗ', 'Ә', 'Ӛ', 'Ӝ', 'Ӟ', 'Ӡ', 'Ӣ', 'Ӥ', 'Ӧ', 'Ө', 'Ӫ', 'Ӭ', 'Ӯ', 'Ӱ', 'Ӳ', 'Ӵ', 'Ӷ', 'Ӹ', 'Ӻ', 'Ӽ', 'Ӿ', 'Ԁ', 'Ԃ', 'Ԅ', 'Ԇ', 'Ԉ', 'Ԋ', 'Ԍ', 'Ԏ', 'Ԑ', 'Ԓ', 'Ԕ', 'Ԗ', 'Ԙ', 'Ԛ', 'Ԝ', 'Ԟ', 'Ԡ', 'Ԣ', 'Ԥ', 'Ԧ', 'Ԩ', 'Ԫ', 'Ԭ', 'Ԯ', 'Ⴧ', 'Ⴭ', 'Ḁ', 'Ḃ', 'Ḅ', 'Ḇ', 'Ḉ', 'Ḋ', 'Ḍ', 'Ḏ', 'Ḑ', 'Ḓ', 'Ḕ', 'Ḗ', 'Ḙ', 'Ḛ', 'Ḝ', 'Ḟ', 'Ḡ', 'Ḣ', 'Ḥ', 'Ḧ', 'Ḩ', 'Ḫ', 'Ḭ', 'Ḯ', 'Ḱ', 'Ḳ', 'Ḵ', 'Ḷ', 'Ḹ', 'Ḻ', 'Ḽ', 'Ḿ', 'Ṁ', 'Ṃ', 'Ṅ', 'Ṇ', 'Ṉ', 'Ṋ', 'Ṍ', 'Ṏ', 'Ṑ', 'Ṓ', 'Ṕ', 'Ṗ', 'Ṙ', 'Ṛ', 'Ṝ', 'Ṟ', 'Ṡ', 'Ṣ', 'Ṥ', 'Ṧ', 'Ṩ', 'Ṫ', 'Ṭ', 'Ṯ', 'Ṱ', 'Ṳ', 'Ṵ', 'Ṷ', 'Ṹ', 'Ṻ', 'Ṽ', 'Ṿ', 'Ẁ', 'Ẃ', 'Ẅ', 'Ẇ', 'Ẉ', 'Ẋ', 'Ẍ', 'Ẏ', 'Ẑ', 'Ẓ', 'Ẕ', 'ẞ', 'Ạ', 'Ả', 'Ấ', 'Ầ', 'Ẩ', 'Ẫ', 'Ậ', 'Ắ', 'Ằ', 'Ẳ', 'Ẵ', 'Ặ', 'Ẹ', 'Ẻ', 'Ẽ', 'Ế', 'Ề', 'Ể', 'Ễ', 'Ệ', 'Ỉ', 'Ị', 'Ọ', 'Ỏ', 'Ố', 'Ồ', 'Ổ', 'Ỗ', 'Ộ', 'Ớ', 'Ờ', 'Ở', 'Ỡ', 'Ợ', 'Ụ', 'Ủ', 'Ứ', 'Ừ', 'Ử', 'Ữ', 'Ự', 'Ỳ', 'Ỵ', 'Ỷ', 'Ỹ', 'Ỻ', 'Ỽ', 'Ỿ', 'Ὑ', 'Ὓ', 'Ὕ', 'Ὗ', 'ℂ', 'ℇ', 'ℕ', 'ℤ', 'Ω', 'ℨ', 'ⅅ', 'Ↄ', 'Ⱡ', 'Ⱨ', 'Ⱪ', 'Ⱬ', 'Ⱳ', 'Ⱶ', 'Ⲃ', 'Ⲅ', 'Ⲇ', 'Ⲉ', 'Ⲋ', 'Ⲍ', 'Ⲏ', 'Ⲑ', 'Ⲓ', 'Ⲕ', 'Ⲗ', 'Ⲙ', 'Ⲛ', 'Ⲝ', 'Ⲟ', 'Ⲡ', 'Ⲣ', 'Ⲥ', 'Ⲧ', 'Ⲩ', 'Ⲫ', 'Ⲭ', 'Ⲯ', 'Ⲱ', 'Ⲳ', 'Ⲵ', 'Ⲷ', 'Ⲹ', 'Ⲻ', 'Ⲽ', 'Ⲿ', 'Ⳁ', 'Ⳃ', 'Ⳅ', 'Ⳇ', 'Ⳉ', 'Ⳋ', 'Ⳍ', 'Ⳏ', 'Ⳑ', 'Ⳓ', 'Ⳕ', 'Ⳗ', 'Ⳙ', 'Ⳛ', 'Ⳝ', 'Ⳟ', 'Ⳡ', 'Ⳣ', 'Ⳬ', 'Ⳮ', 'Ⳳ', 'Ꙁ', 'Ꙃ', 'Ꙅ', 'Ꙇ', 'Ꙉ', 'Ꙋ', 'Ꙍ', 'Ꙏ', 'Ꙑ', 'Ꙓ', 'Ꙕ', 'Ꙗ', 'Ꙙ', 'Ꙛ', 'Ꙝ', 'Ꙟ', 'Ꙡ', 'Ꙣ', 'Ꙥ', 'Ꙧ', 'Ꙩ', 'Ꙫ', 'Ꙭ', 'Ꚁ', 'Ꚃ', 'Ꚅ', 'Ꚇ', 'Ꚉ', 'Ꚋ', 'Ꚍ', 'Ꚏ', 'Ꚑ', 'Ꚓ', 'Ꚕ', 'Ꚗ', 'Ꚙ', 'Ꚛ', 'Ꜣ', 'Ꜥ', 'Ꜧ', 'Ꜩ', 'Ꜫ', 'Ꜭ', 'Ꜯ', 'Ꜳ', 'Ꜵ', 'Ꜷ', 'Ꜹ', 'Ꜻ', 'Ꜽ', 'Ꜿ', 'Ꝁ', 'Ꝃ', 'Ꝅ', 'Ꝇ', 'Ꝉ', 'Ꝋ', 'Ꝍ', 'Ꝏ', 'Ꝑ', 'Ꝓ', 'Ꝕ', 'Ꝗ', 'Ꝙ', 'Ꝛ', 'Ꝝ', 'Ꝟ', 'Ꝡ', 'Ꝣ', 'Ꝥ', 'Ꝧ', 'Ꝩ', 'Ꝫ', 'Ꝭ', 'Ꝯ', 'Ꝺ', 'Ꝼ', 'Ꞁ', 'Ꞃ', 'Ꞅ', 'Ꞇ', 'Ꞌ', 'Ɥ', 'Ꞑ', 'Ꞓ', 'Ꞗ', 'Ꞙ', 'Ꞛ', 'Ꞝ', 'Ꞟ', 'Ꞡ', 'Ꞣ', 'Ꞥ', 'Ꞧ', 'Ꞩ', 'Ꞷ', 'Ꞹ'},
 				ranges:     []rune{'A', 'Z', 'À', 'Ö', 'Ø', 'Þ', 'Ÿ', 'Ź', 'Ɓ', 'Ƃ', 'Ɔ', 'Ƈ', 'Ɖ', 'Ƌ', 'Ǝ', 'Ƒ', 'Ɠ', 'Ɣ', 'Ɩ', 'Ƙ', 'Ɯ', 'Ɲ', 'Ɵ', 'Ơ', 'Ʀ', 'Ƨ', 'Ʈ', 'Ư', 'Ʊ', 'Ƴ', 'Ʒ', 'Ƹ', 'Ƕ', 'Ǹ', 'Ⱥ', 'Ȼ', 'Ƚ', 'Ⱦ', 'Ƀ', 'Ɇ', 'Έ', 'Ί', 'Ύ', 'Ώ', 'Α', 'Ρ', 'Σ', 'Ϋ', 'ϒ', 'ϔ', 'Ϲ', 'Ϻ', 'Ͻ', 'Я', 'Ӏ', 'Ӂ', 'Ա', 'Ֆ', 'Ⴀ', 'Ⴥ', 'Ꭰ', 'Ᏽ', 'Ა', 'Ჺ', 'Ჽ', 'Ჿ', 'Ἀ', 'Ἇ', 'Ἐ', 'Ἕ', 'Ἠ', 'Ἧ', 'Ἰ', 'Ἷ', 'Ὀ', 'Ὅ', 'Ὠ', 'Ὧ', 'Ᾰ', 'Ά', 'Ὲ', 'Ή', 'Ῐ', 'Ί', 'Ῠ', 'Ῥ', 'Ὸ', 'Ώ', 'ℋ', 'ℍ', 'ℐ', 'ℒ', 'ℙ', 'ℝ', 'K', 'ℭ', 'ℰ', 'ℳ', 'ℾ', 'ℿ', 'Ⰰ', 'Ⱞ', 'Ɫ', 'Ɽ', 'Ɑ', 'Ɒ', 'Ȿ', 'Ⲁ', 'Ᵹ', 'Ꝿ', 'Ɦ', 'Ɪ', 'Ʞ', 'Ꞵ', 'Ａ', 'Ｚ'},
@@ -12954,9 +12941,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mc",
-			pos:  position{line: 1847, col: 1, offset: 54957},
+			pos:  position{line: 1849, col: 1, offset: 54921},
 			expr: &charClassMatcher{
-				pos:        position{line: 1847, col: 6, offset: 54962},
+				pos:        position{line: 1849, col: 6, offset: 54926},
 				val:        "[\\u0903\\u093B\\u093E-\\u0940\\u0949-\\u094C\\u094E-\\u094F\\u0982-\\u0983\\u09BE-\\u09C0\\u09C7-\\u09C8\\u09CB-\\u09CC\\u09D7\\u0A03\\u0A3E-\\u0A40\\u0A83\\u0ABE-\\u0AC0\\u0AC9\\u0ACB-\\u0ACC\\u0B02-\\u0B03\\u0B3E\\u0B40\\u0B47-\\u0B48\\u0B4B-\\u0B4C\\u0B57\\u0BBE-\\u0BBF\\u0BC1-\\u0BC2\\u0BC6-\\u0BC8\\u0BCA-\\u0BCC\\u0BD7\\u0C01-\\u0C03\\u0C41-\\u0C44\\u0C82-\\u0C83\\u0CBE\\u0CC0-\\u0CC4\\u0CC7-\\u0CC8\\u0CCA-\\u0CCB\\u0CD5-\\u0CD6\\u0D02-\\u0D03\\u0D3E-\\u0D40\\u0D46-\\u0D48\\u0D4A-\\u0D4C\\u0D57\\u0D82-\\u0D83\\u0DCF-\\u0DD1\\u0DD8-\\u0DDF\\u0DF2-\\u0DF3\\u0F3E-\\u0F3F\\u0F7F\\u102B-\\u102C\\u1031\\u1038\\u103B-\\u103C\\u1056-\\u1057\\u1062-\\u1064\\u1067-\\u106D\\u1083-\\u1084\\u1087-\\u108C\\u108F\\u109A-\\u109C\\u17B6\\u17BE-\\u17C5\\u17C7-\\u17C8\\u1923-\\u1926\\u1929-\\u192B\\u1930-\\u1931\\u1933-\\u1938\\u1A19-\\u1A1A\\u1A55\\u1A57\\u1A61\\u1A63-\\u1A64\\u1A6D-\\u1A72\\u1B04\\u1B35\\u1B3B\\u1B3D-\\u1B41\\u1B43-\\u1B44\\u1B82\\u1BA1\\u1BA6-\\u1BA7\\u1BAA\\u1BE7\\u1BEA-\\u1BEC\\u1BEE\\u1BF2-\\u1BF3\\u1C24-\\u1C2B\\u1C34-\\u1C35\\u1CE1\\u1CF2-\\u1CF3\\u1CF7\\u302E-\\u302F\\uA823-\\uA824\\uA827\\uA880-\\uA881\\uA8B4-\\uA8C3\\uA952-\\uA953\\uA983\\uA9B4-\\uA9B5\\uA9BA-\\uA9BB\\uA9BD-\\uA9C0\\uAA2F-\\uAA30\\uAA33-\\uAA34\\uAA4D\\uAA7B\\uAA7D\\uAAEB\\uAAEE-\\uAAEF\\uAAF5\\uABE3-\\uABE4\\uABE6-\\uABE7\\uABE9-\\uABEA\\uABEC]",
 				chars:      []rune{'ः', 'ऻ', 'ৗ', 'ਃ', 'ઃ', 'ૉ', 'ା', 'ୀ', 'ୗ', 'ௗ', 'ಾ', 'ൗ', 'ཿ', 'ေ', 'း', 'ႏ', 'ា', 'ᩕ', 'ᩗ', 'ᩡ', 'ᬄ', 'ᬵ', 'ᬻ', 'ᮂ', 'ᮡ', '᮪', 'ᯧ', 'ᯮ', '᳡', '᳷', 'ꠧ', 'ꦃ', 'ꩍ', 'ꩻ', 'ꩽ', 'ꫫ', 'ꫵ', '꯬'},
 				ranges:     []rune{'ा', 'ी', 'ॉ', 'ौ', 'ॎ', 'ॏ', 'ং', 'ঃ', 'া', 'ী', 'ে', 'ৈ', 'ো', 'ৌ', 'ਾ', 'ੀ', 'ા', 'ી', 'ો', 'ૌ', 'ଂ', 'ଃ', 'େ', 'ୈ', 'ୋ', 'ୌ', 'ா', 'ி', 'ு', 'ூ', 'ெ', 'ை', 'ொ', 'ௌ', 'ఁ', 'ః', 'ు', 'ౄ', 'ಂ', 'ಃ', 'ೀ', 'ೄ', 'ೇ', 'ೈ', 'ೊ', 'ೋ', 'ೕ', 'ೖ', 'ം', 'ഃ', 'ാ', 'ീ', 'െ', 'ൈ', 'ൊ', 'ൌ', 'ං', 'ඃ', 'ා', 'ෑ', 'ෘ', 'ෟ', 'ෲ', 'ෳ', '༾', '༿', 'ါ', 'ာ', 'ျ', 'ြ', 'ၖ', 'ၗ', 'ၢ', 'ၤ', 'ၧ', 'ၭ', 'ႃ', 'ႄ', 'ႇ', 'ႌ', 'ႚ', 'ႜ', 'ើ', 'ៅ', 'ះ', 'ៈ', 'ᤣ', 'ᤦ', 'ᤩ', 'ᤫ', 'ᤰ', 'ᤱ', 'ᤳ', 'ᤸ', 'ᨙ', 'ᨚ', 'ᩣ', 'ᩤ', 'ᩭ', 'ᩲ', 'ᬽ', 'ᭁ', 'ᭃ', '᭄', 'ᮦ', 'ᮧ', 'ᯪ', 'ᯬ', '᯲', '᯳', 'ᰤ', 'ᰫ', 'ᰴ', 'ᰵ', 'ᳲ', 'ᳳ', '〮', '〯', 'ꠣ', 'ꠤ', 'ꢀ', 'ꢁ', 'ꢴ', 'ꣃ', 'ꥒ', '꥓', 'ꦴ', 'ꦵ', 'ꦺ', 'ꦻ', 'ꦽ', '꧀', 'ꨯ', 'ꨰ', 'ꨳ', 'ꨴ', 'ꫮ', 'ꫯ', 'ꯣ', 'ꯤ', 'ꯦ', 'ꯧ', 'ꯩ', 'ꯪ'},
@@ -12968,9 +12955,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mn",
-			pos:  position{line: 1850, col: 1, offset: 56150},
+			pos:  position{line: 1852, col: 1, offset: 56114},
 			expr: &charClassMatcher{
-				pos:        position{line: 1850, col: 6, offset: 56155},
+				pos:        position{line: 1852, col: 6, offset: 56119},
 				val:        "[\\u0300-\\u036F\\u0483-\\u0487\\u0591-\\u05BD\\u05BF\\u05C1-\\u05C2\\u05C4-\\u05C5\\u05C7\\u0610-\\u061A\\u064B-\\u065F\\u0670\\u06D6-\\u06DC\\u06DF-\\u06E4\\u06E7-\\u06E8\\u06EA-\\u06ED\\u0711\\u0730-\\u074A\\u07A6-\\u07B0\\u07EB-\\u07F3\\u07FD\\u0816-\\u0819\\u081B-\\u0823\\u0825-\\u0827\\u0829-\\u082D\\u0859-\\u085B\\u08D3-\\u08E1\\u08E3-\\u0902\\u093A\\u093C\\u0941-\\u0948\\u094D\\u0951-\\u0957\\u0962-\\u0963\\u0981\\u09BC\\u09C1-\\u09C4\\u09CD\\u09E2-\\u09E3\\u09FE\\u0A01-\\u0A02\\u0A3C\\u0A41-\\u0A42\\u0A47-\\u0A48\\u0A4B-\\u0A4D\\u0A51\\u0A70-\\u0A71\\u0A75\\u0A81-\\u0A82\\u0ABC\\u0AC1-\\u0AC5\\u0AC7-\\u0AC8\\u0ACD\\u0AE2-\\u0AE3\\u0AFA-\\u0AFF\\u0B01\\u0B3C\\u0B3F\\u0B41-\\u0B44\\u0B4D\\u0B56\\u0B62-\\u0B63\\u0B82\\u0BC0\\u0BCD\\u0C00\\u0C04\\u0C3E-\\u0C40\\u0C46-\\u0C48\\u0C4A-\\u0C4D\\u0C55-\\u0C56\\u0C62-\\u0C63\\u0C81\\u0CBC\\u0CBF\\u0CC6\\u0CCC-\\u0CCD\\u0CE2-\\u0CE3\\u0D00-\\u0D01\\u0D3B-\\u0D3C\\u0D41-\\u0D44\\u0D4D\\u0D62-\\u0D63\\u0DCA\\u0DD2-\\u0DD4\\u0DD6\\u0E31\\u0E34-\\u0E3A\\u0E47-\\u0E4E\\u0EB1\\u0EB4-\\u0EB9\\u0EBB-\\u0EBC\\u0EC8-\\u0ECD\\u0F18-\\u0F19\\u0F35\\u0F37\\u0F39\\u0F71-\\u0F7E\\u0F80-\\u0F84\\u0F86-\\u0F87\\u0F8D-\\u0F97\\u0F99-\\u0FBC\\u0FC6\\u102D-\\u1030\\u1032-\\u1037\\u1039-\\u103A\\u103D-\\u103E\\u1058-\\u1059\\u105E-\\u1060\\u1071-\\u1074\\u1082\\u1085-\\u1086\\u108D\\u109D\\u135D-\\u135F\\u1712-\\u1714\\u1732-\\u1734\\u1752-\\u1753\\u1772-\\u1773\\u17B4-\\u17B5\\u17B7-\\u17BD\\u17C6\\u17C9-\\u17D3\\u17DD\\u180B-\\u180D\\u1885-\\u1886\\u18A9\\u1920-\\u1922\\u1927-\\u1928\\u1932\\u1939-\\u193B\\u1A17-\\u1A18\\u1A1B\\u1A56\\u1A58-\\u1A5E\\u1A60\\u1A62\\u1A65-\\u1A6C\\u1A73-\\u1A7C\\u1A7F\\u1AB0-\\u1ABD\\u1B00-\\u1B03\\u1B34\\u1B36-\\u1B3A\\u1B3C\\u1B42\\u1B6B-\\u1B73\\u1B80-\\u1B81\\u1BA2-\\u1BA5\\u1BA8-\\u1BA9\\u1BAB-\\u1BAD\\u1BE6\\u1BE8-\\u1BE9\\u1BED\\u1BEF-\\u1BF1\\u1C2C-\\u1C33\\u1C36-\\u1C37\\u1CD0-\\u1CD2\\u1CD4-\\u1CE0\\u1CE2-\\u1CE8\\u1CED\\u1CF4\\u1CF8-\\u1CF9\\u1DC0-\\u1DF9\\u1DFB-\\u1DFF\\u20D0-\\u20DC\\u20E1\\u20E5-\\u20F0\\u2CEF-\\u2CF1\\u2D7F\\u2DE0-\\u2DFF\\u302A-\\u302D\\u3099-\\u309A\\uA66F\\uA674-\\uA67D\\uA69E-\\uA69F\\uA6F0-\\uA6F1\\uA802\\uA806\\uA80B\\uA825-\\uA826\\uA8C4-\\uA8C5\\uA8E0-\\uA8F1\\uA8FF\\uA926-\\uA92D\\uA947-\\uA951\\uA980-\\uA982\\uA9B3\\uA9B6-\\uA9B9\\uA9BC\\uA9E5\\uAA29-\\uAA2E\\uAA31-\\uAA32\\uAA35-\\uAA36\\uAA43\\uAA4C\\uAA7C\\uAAB0\\uAAB2-\\uAAB4\\uAAB7-\\uAAB8\\uAABE-\\uAABF\\uAAC1\\uAAEC-\\uAAED\\uAAF6\\uABE5\\uABE8\\uABED\\uFB1E\\uFE00-\\uFE0F\\uFE20-\\uFE2F]",
 				chars:      []rune{'ֿ', 'ׇ', 'ٰ', 'ܑ', '߽', 'ऺ', '़', '्', 'ঁ', '়', '্', '৾', '਼', 'ੑ', 'ੵ', '઼', '્', 'ଁ', '଼', 'ି', '୍', 'ୖ', 'ஂ', 'ீ', '்', 'ఀ', 'ఄ', 'ಁ', '಼', 'ಿ', 'ೆ', '്', '්', 'ූ', 'ั', 'ັ', '༵', '༷', '༹', '࿆', 'ႂ', 'ႍ', 'ႝ', 'ំ', '៝', 'ᢩ', 'ᤲ', 'ᨛ', 'ᩖ', '᩠', 'ᩢ', '᩿', '᬴', 'ᬼ', 'ᭂ', '᯦', 'ᯭ', '᳭', '᳴', '⃡', '⵿', '꙯', 'ꠂ', '꠆', 'ꠋ', 'ꣿ', '꦳', 'ꦼ', 'ꧥ', 'ꩃ', 'ꩌ', 'ꩼ', 'ꪰ', '꫁', '꫶', 'ꯥ', 'ꯨ', '꯭', 'ﬞ'},
 				ranges:     []rune{'̀', 'ͯ', '҃', '҇', '֑', 'ֽ', 'ׁ', 'ׂ', 'ׄ', 'ׅ', 'ؐ', 'ؚ', 'ً', 'ٟ', 'ۖ', 'ۜ', '۟', 'ۤ', 'ۧ', 'ۨ', '۪', 'ۭ', 'ܰ', '݊', 'ަ', 'ް', '߫', '߳', 'ࠖ', '࠙', 'ࠛ', 'ࠣ', 'ࠥ', 'ࠧ', 'ࠩ', '࠭', '࡙', '࡛', '࣓', '࣡', 'ࣣ', 'ं', 'ु', 'ै', '॑', 'ॗ', 'ॢ', 'ॣ', 'ু', 'ৄ', 'ৢ', 'ৣ', 'ਁ', 'ਂ', 'ੁ', 'ੂ', 'ੇ', 'ੈ', 'ੋ', '੍', 'ੰ', 'ੱ', 'ઁ', 'ં', 'ુ', 'ૅ', 'ે', 'ૈ', 'ૢ', 'ૣ', 'ૺ', '૿', 'ୁ', 'ୄ', 'ୢ', 'ୣ', 'ా', 'ీ', 'ె', 'ై', 'ొ', '్', 'ౕ', 'ౖ', 'ౢ', 'ౣ', 'ೌ', '್', 'ೢ', 'ೣ', 'ഀ', 'ഁ', '഻', '഼', 'ു', 'ൄ', 'ൢ', 'ൣ', 'ි', 'ු', 'ิ', 'ฺ', '็', '๎', 'ິ', 'ູ', 'ົ', 'ຼ', '່', 'ໍ', '༘', '༙', 'ཱ', 'ཾ', 'ྀ', '྄', '྆', '྇', 'ྍ', 'ྗ', 'ྙ', 'ྼ', 'ိ', 'ူ', 'ဲ', '့', '္', '်', 'ွ', 'ှ', 'ၘ', 'ၙ', 'ၞ', 'ၠ', 'ၱ', 'ၴ', 'ႅ', 'ႆ', '፝', '፟', 'ᜒ', '᜔', 'ᜲ', '᜴', 'ᝒ', 'ᝓ', 'ᝲ', 'ᝳ', '឴', '឵', 'ិ', 'ួ', '៉', '៓', '᠋', '᠍', 'ᢅ', 'ᢆ', 'ᤠ', 'ᤢ', 'ᤧ', 'ᤨ', '᤹', '᤻', 'ᨗ', 'ᨘ', 'ᩘ', 'ᩞ', 'ᩥ', 'ᩬ', 'ᩳ', '᩼', '᪰', '᪽', 'ᬀ', 'ᬃ', 'ᬶ', 'ᬺ', '᭫', '᭳', 'ᮀ', 'ᮁ', 'ᮢ', 'ᮥ', 'ᮨ', 'ᮩ', '᮫', 'ᮭ', 'ᯨ', 'ᯩ', 'ᯯ', 'ᯱ', 'ᰬ', 'ᰳ', 'ᰶ', '᰷', '᳐', '᳒', '᳔', '᳠', '᳢', '᳨', '᳸', '᳹', '᷀', '᷹', '᷻', '᷿', '⃐', '⃜', '⃥', '⃰', '⳯', '⳱', 'ⷠ', 'ⷿ', '〪', '〭', '゙', '゚', 'ꙴ', '꙽', 'ꚞ', 'ꚟ', '꛰', '꛱', 'ꠥ', 'ꠦ', '꣄', 'ꣅ', '꣠', '꣱', 'ꤦ', '꤭', 'ꥇ', 'ꥑ', 'ꦀ', 'ꦂ', 'ꦶ', 'ꦹ', 'ꨩ', 'ꨮ', 'ꨱ', 'ꨲ', 'ꨵ', 'ꨶ', 'ꪲ', 'ꪴ', 'ꪷ', 'ꪸ', 'ꪾ', '꪿', 'ꫬ', 'ꫭ', '︀', '️', '︠', '︯'},
@@ -12982,9 +12969,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nd",
-			pos:  position{line: 1853, col: 1, offset: 58335},
+			pos:  position{line: 1855, col: 1, offset: 58299},
 			expr: &charClassMatcher{
-				pos:        position{line: 1853, col: 6, offset: 58340},
+				pos:        position{line: 1855, col: 6, offset: 58304},
 				val:        "[\\u0030-\\u0039\\u0660-\\u0669\\u06F0-\\u06F9\\u07C0-\\u07C9\\u0966-\\u096F\\u09E6-\\u09EF\\u0A66-\\u0A6F\\u0AE6-\\u0AEF\\u0B66-\\u0B6F\\u0BE6-\\u0BEF\\u0C66-\\u0C6F\\u0CE6-\\u0CEF\\u0D66-\\u0D6F\\u0DE6-\\u0DEF\\u0E50-\\u0E59\\u0ED0-\\u0ED9\\u0F20-\\u0F29\\u1040-\\u1049\\u1090-\\u1099\\u17E0-\\u17E9\\u1810-\\u1819\\u1946-\\u194F\\u19D0-\\u19D9\\u1A80-\\u1A89\\u1A90-\\u1A99\\u1B50-\\u1B59\\u1BB0-\\u1BB9\\u1C40-\\u1C49\\u1C50-\\u1C59\\uA620-\\uA629\\uA8D0-\\uA8D9\\uA900-\\uA909\\uA9D0-\\uA9D9\\uA9F0-\\uA9F9\\uAA50-\\uAA59\\uABF0-\\uABF9\\uFF10-\\uFF19]",
 				ranges:     []rune{'0', '9', '٠', '٩', '۰', '۹', '߀', '߉', '०', '९', '০', '৯', '੦', '੯', '૦', '૯', '୦', '୯', '௦', '௯', '౦', '౯', '೦', '೯', '൦', '൯', '෦', '෯', '๐', '๙', '໐', '໙', '༠', '༩', '၀', '၉', '႐', '႙', '០', '៩', '᠐', '᠙', '᥆', '᥏', '᧐', '᧙', '᪀', '᪉', '᪐', '᪙', '᭐', '᭙', '᮰', '᮹', '᱀', '᱉', '᱐', '᱙', '꘠', '꘩', '꣐', '꣙', '꤀', '꤉', '꧐', '꧙', '꧰', '꧹', '꩐', '꩙', '꯰', '꯹', '０', '９'},
 				ignoreCase: false,
@@ -12995,9 +12982,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nl",
-			pos:  position{line: 1856, col: 1, offset: 58843},
+			pos:  position{line: 1858, col: 1, offset: 58807},
 			expr: &charClassMatcher{
-				pos:        position{line: 1856, col: 6, offset: 58848},
+				pos:        position{line: 1858, col: 6, offset: 58812},
 				val:        "[\\u16EE-\\u16F0\\u2160-\\u2182\\u2185-\\u2188\\u3007\\u3021-\\u3029\\u3038-\\u303A\\uA6E6-\\uA6EF]",
 				chars:      []rune{'〇'},
 				ranges:     []rune{'ᛮ', 'ᛰ', 'Ⅰ', 'ↂ', 'ↅ', 'ↈ', '〡', '〩', '〸', '〺', 'ꛦ', 'ꛯ'},
@@ -13009,9 +12996,9 @@ var g = &grammar{
 		},
 		{
 			name: "Pc",
-			pos:  position{line: 1859, col: 1, offset: 58962},
+			pos:  position{line: 1861, col: 1, offset: 58926},
 			expr: &charClassMatcher{
-				pos:        position{line: 1859, col: 6, offset: 58967},
+				pos:        position{line: 1861, col: 6, offset: 58931},
 				val:        "[\\u005F\\u203F-\\u2040\\u2054\\uFE33-\\uFE34\\uFE4D-\\uFE4F\\uFF3F]",
 				chars:      []rune{'_', '⁔', '＿'},
 				ranges:     []rune{'‿', '⁀', '︳', '︴', '﹍', '﹏'},
@@ -13023,9 +13010,9 @@ var g = &grammar{
 		},
 		{
 			name: "Zs",
-			pos:  position{line: 1862, col: 1, offset: 59048},
+			pos:  position{line: 1864, col: 1, offset: 59012},
 			expr: &charClassMatcher{
-				pos:        position{line: 1862, col: 6, offset: 59053},
+				pos:        position{line: 1864, col: 6, offset: 59017},
 				val:        "[\\u0020\\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000]",
 				chars:      []rune{' ', '\u00a0', '\u1680', '\u202f', '\u205f', '\u3000'},
 				ranges:     []rune{'\u2000', '\u200a'},
@@ -13037,9 +13024,9 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1864, col: 1, offset: 59106},
+			pos:  position{line: 1866, col: 1, offset: 59070},
 			expr: &anyMatcher{
-				line: 1865, col: 5, offset: 59126,
+				line: 1867, col: 5, offset: 59090,
 			},
 			leader:        false,
 			leftRecursive: false,
@@ -13047,48 +13034,48 @@ var g = &grammar{
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1867, col: 1, offset: 59129},
+			pos:         position{line: 1869, col: 1, offset: 59093},
 			expr: &choiceExpr{
-				pos: position{line: 1868, col: 5, offset: 59157},
+				pos: position{line: 1870, col: 5, offset: 59121},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1868, col: 5, offset: 59157},
+						pos:        position{line: 1870, col: 5, offset: 59121},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1869, col: 5, offset: 59166},
+						pos:        position{line: 1871, col: 5, offset: 59130},
 						val:        "\v",
 						ignoreCase: false,
 						want:       "\"\\v\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1870, col: 5, offset: 59175},
+						pos:        position{line: 1872, col: 5, offset: 59139},
 						val:        "\f",
 						ignoreCase: false,
 						want:       "\"\\f\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1871, col: 5, offset: 59184},
+						pos:        position{line: 1873, col: 5, offset: 59148},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 1872, col: 5, offset: 59192},
+						pos:        position{line: 1874, col: 5, offset: 59156},
 						val:        "\u00a0",
 						ignoreCase: false,
 						want:       "\"\\u00a0\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1873, col: 5, offset: 59205},
+						pos:        position{line: 1875, col: 5, offset: 59169},
 						val:        "\ufeff",
 						ignoreCase: false,
 						want:       "\"\\ufeff\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1874, col: 5, offset: 59218},
+						pos:  position{line: 1876, col: 5, offset: 59182},
 						name: "Zs",
 					},
 				},
@@ -13098,9 +13085,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1876, col: 1, offset: 59222},
+			pos:  position{line: 1878, col: 1, offset: 59186},
 			expr: &charClassMatcher{
-				pos:        position{line: 1877, col: 5, offset: 59241},
+				pos:        position{line: 1879, col: 5, offset: 59205},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -13112,16 +13099,16 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1879, col: 1, offset: 59261},
+			pos:         position{line: 1881, col: 1, offset: 59225},
 			expr: &choiceExpr{
-				pos: position{line: 1880, col: 5, offset: 59283},
+				pos: position{line: 1882, col: 5, offset: 59247},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1880, col: 5, offset: 59283},
+						pos:  position{line: 1882, col: 5, offset: 59247},
 						name: "MultiLineComment",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1881, col: 5, offset: 59304},
+						pos:  position{line: 1883, col: 5, offset: 59268},
 						name: "SingleLineComment",
 					},
 				},
@@ -13131,39 +13118,39 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1883, col: 1, offset: 59323},
+			pos:  position{line: 1885, col: 1, offset: 59287},
 			expr: &seqExpr{
-				pos: position{line: 1884, col: 5, offset: 59344},
+				pos: position{line: 1886, col: 5, offset: 59308},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1884, col: 5, offset: 59344},
+						pos:        position{line: 1886, col: 5, offset: 59308},
 						val:        "/*",
 						ignoreCase: false,
 						want:       "\"/*\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1884, col: 10, offset: 59349},
+						pos: position{line: 1886, col: 10, offset: 59313},
 						expr: &seqExpr{
-							pos: position{line: 1884, col: 11, offset: 59350},
+							pos: position{line: 1886, col: 11, offset: 59314},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1884, col: 11, offset: 59350},
+									pos: position{line: 1886, col: 11, offset: 59314},
 									expr: &litMatcher{
-										pos:        position{line: 1884, col: 12, offset: 59351},
+										pos:        position{line: 1886, col: 12, offset: 59315},
 										val:        "*/",
 										ignoreCase: false,
 										want:       "\"*/\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1884, col: 17, offset: 59356},
+									pos:  position{line: 1886, col: 17, offset: 59320},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1884, col: 35, offset: 59374},
+						pos:        position{line: 1886, col: 35, offset: 59338},
 						val:        "*/",
 						ignoreCase: false,
 						want:       "\"*/\"",
@@ -13175,30 +13162,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1886, col: 1, offset: 59380},
+			pos:  position{line: 1888, col: 1, offset: 59344},
 			expr: &seqExpr{
-				pos: position{line: 1887, col: 5, offset: 59402},
+				pos: position{line: 1889, col: 5, offset: 59366},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1887, col: 5, offset: 59402},
+						pos:        position{line: 1889, col: 5, offset: 59366},
 						val:        "--",
 						ignoreCase: false,
 						want:       "\"--\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1887, col: 10, offset: 59407},
+						pos: position{line: 1889, col: 10, offset: 59371},
 						expr: &seqExpr{
-							pos: position{line: 1887, col: 11, offset: 59408},
+							pos: position{line: 1889, col: 11, offset: 59372},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1887, col: 11, offset: 59408},
+									pos: position{line: 1889, col: 11, offset: 59372},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1887, col: 12, offset: 59409},
+										pos:  position{line: 1889, col: 12, offset: 59373},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1887, col: 27, offset: 59424},
+									pos:  position{line: 1889, col: 27, offset: 59388},
 									name: "SourceCharacter",
 								},
 							},
@@ -13211,19 +13198,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1889, col: 1, offset: 59443},
+			pos:  position{line: 1891, col: 1, offset: 59407},
 			expr: &seqExpr{
-				pos: position{line: 1889, col: 7, offset: 59449},
+				pos: position{line: 1891, col: 7, offset: 59413},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1889, col: 7, offset: 59449},
+						pos: position{line: 1891, col: 7, offset: 59413},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1889, col: 7, offset: 59449},
+							pos:  position{line: 1891, col: 7, offset: 59413},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1889, col: 19, offset: 59461},
+						pos:  position{line: 1891, col: 19, offset: 59425},
 						name: "LineTerminator",
 					},
 				},
@@ -13233,16 +13220,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1891, col: 1, offset: 59477},
+			pos:  position{line: 1893, col: 1, offset: 59441},
 			expr: &choiceExpr{
-				pos: position{line: 1891, col: 7, offset: 59483},
+				pos: position{line: 1893, col: 7, offset: 59447},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1891, col: 7, offset: 59483},
+						pos:  position{line: 1893, col: 7, offset: 59447},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1891, col: 11, offset: 59487},
+						pos:  position{line: 1893, col: 11, offset: 59451},
 						name: "EOF",
 					},
 				},
@@ -13252,11 +13239,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1893, col: 1, offset: 59492},
+			pos:  position{line: 1895, col: 1, offset: 59456},
 			expr: &notExpr{
-				pos: position{line: 1893, col: 7, offset: 59498},
+				pos: position{line: 1895, col: 7, offset: 59462},
 				expr: &anyMatcher{
-					line: 1893, col: 8, offset: 59499,
+					line: 1895, col: 8, offset: 59463,
 				},
 			},
 			leader:        false,
@@ -13264,11 +13251,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOKW",
-			pos:  position{line: 1895, col: 1, offset: 59502},
+			pos:  position{line: 1897, col: 1, offset: 59466},
 			expr: &notExpr{
-				pos: position{line: 1895, col: 8, offset: 59509},
+				pos: position{line: 1897, col: 8, offset: 59473},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1895, col: 9, offset: 59510},
+					pos:  position{line: 1897, col: 9, offset: 59474},
 					name: "KeyWordChars",
 				},
 			},
@@ -13277,15 +13264,15 @@ var g = &grammar{
 		},
 		{
 			name: "SQLPipe",
-			pos:  position{line: 1899, col: 1, offset: 59546},
+			pos:  position{line: 1901, col: 1, offset: 59510},
 			expr: &actionExpr{
-				pos: position{line: 1900, col: 5, offset: 59558},
+				pos: position{line: 1902, col: 5, offset: 59522},
 				run: (*parser).callonSQLPipe1,
 				expr: &labeledExpr{
-					pos:   position{line: 1900, col: 5, offset: 59558},
+					pos:   position{line: 1902, col: 5, offset: 59522},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1900, col: 7, offset: 59560},
+						pos:  position{line: 1902, col: 7, offset: 59524},
 						name: "Seq",
 					},
 				},
@@ -13295,42 +13282,42 @@ var g = &grammar{
 		},
 		{
 			name: "SelectOp",
-			pos:  position{line: 1908, col: 1, offset: 59706},
+			pos:  position{line: 1910, col: 1, offset: 59670},
 			expr: &actionExpr{
-				pos: position{line: 1909, col: 5, offset: 59719},
+				pos: position{line: 1911, col: 5, offset: 59683},
 				run: (*parser).callonSelectOp1,
 				expr: &seqExpr{
-					pos: position{line: 1909, col: 5, offset: 59719},
+					pos: position{line: 1911, col: 5, offset: 59683},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1909, col: 5, offset: 59719},
+							pos:   position{line: 1911, col: 5, offset: 59683},
 							label: "with",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1909, col: 10, offset: 59724},
+								pos:  position{line: 1911, col: 10, offset: 59688},
 								name: "OptWithClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1910, col: 5, offset: 59742},
+							pos:   position{line: 1912, col: 5, offset: 59706},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1910, col: 10, offset: 59747},
+								pos:  position{line: 1912, col: 10, offset: 59711},
 								name: "SelectSetOperation",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1911, col: 5, offset: 59770},
+							pos:   position{line: 1913, col: 5, offset: 59734},
 							label: "orderby",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1911, col: 13, offset: 59778},
+								pos:  position{line: 1913, col: 13, offset: 59742},
 								name: "OptOrderByClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1912, col: 5, offset: 59799},
+							pos:   position{line: 1914, col: 5, offset: 59763},
 							label: "loff",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1912, col: 10, offset: 59804},
+								pos:  position{line: 1914, col: 10, offset: 59768},
 								name: "OptSQLLimitOffset",
 							},
 						},
@@ -13342,39 +13329,39 @@ var g = &grammar{
 		},
 		{
 			name: "SelectSetOperation",
-			pos:  position{line: 1932, col: 1, offset: 60205},
+			pos:  position{line: 1934, col: 1, offset: 60169},
 			expr: &actionExpr{
-				pos: position{line: 1933, col: 5, offset: 60228},
+				pos: position{line: 1935, col: 5, offset: 60192},
 				run: (*parser).callonSelectSetOperation1,
 				expr: &seqExpr{
-					pos: position{line: 1933, col: 5, offset: 60228},
+					pos: position{line: 1935, col: 5, offset: 60192},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1933, col: 5, offset: 60228},
+							pos:   position{line: 1935, col: 5, offset: 60192},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1933, col: 11, offset: 60234},
+								pos:  position{line: 1935, col: 11, offset: 60198},
 								name: "SimpleSelect",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1933, col: 24, offset: 60247},
+							pos:   position{line: 1935, col: 24, offset: 60211},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1933, col: 29, offset: 60252},
+								pos: position{line: 1935, col: 29, offset: 60216},
 								expr: &seqExpr{
-									pos: position{line: 1933, col: 30, offset: 60253},
+									pos: position{line: 1935, col: 30, offset: 60217},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1933, col: 30, offset: 60253},
+											pos:  position{line: 1935, col: 30, offset: 60217},
 											name: "SetOp",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1933, col: 36, offset: 60259},
+											pos:  position{line: 1935, col: 36, offset: 60223},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1933, col: 38, offset: 60261},
+											pos:  position{line: 1935, col: 38, offset: 60225},
 											name: "SimpleSelect",
 										},
 									},
@@ -13389,52 +13376,52 @@ var g = &grammar{
 		},
 		{
 			name: "SimpleSelect",
-			pos:  position{line: 1947, col: 1, offset: 60558},
+			pos:  position{line: 1949, col: 1, offset: 60522},
 			expr: &choiceExpr{
-				pos: position{line: 1948, col: 5, offset: 60575},
+				pos: position{line: 1950, col: 5, offset: 60539},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1948, col: 5, offset: 60575},
+						pos:  position{line: 1950, col: 5, offset: 60539},
 						name: "Select",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1949, col: 5, offset: 60586},
+						pos:  position{line: 1951, col: 5, offset: 60550},
 						name: "FromSelect",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1950, col: 5, offset: 60601},
+						pos:  position{line: 1952, col: 5, offset: 60565},
 						name: "SQLValues",
 					},
 					&actionExpr{
-						pos: position{line: 1951, col: 5, offset: 60615},
+						pos: position{line: 1953, col: 5, offset: 60579},
 						run: (*parser).callonSimpleSelect5,
 						expr: &seqExpr{
-							pos: position{line: 1951, col: 5, offset: 60615},
+							pos: position{line: 1953, col: 5, offset: 60579},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1951, col: 5, offset: 60615},
+									pos:        position{line: 1953, col: 5, offset: 60579},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1951, col: 9, offset: 60619},
+									pos:  position{line: 1953, col: 9, offset: 60583},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1951, col: 12, offset: 60622},
+									pos:   position{line: 1953, col: 12, offset: 60586},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1951, col: 14, offset: 60624},
+										pos:  position{line: 1953, col: 14, offset: 60588},
 										name: "SQLPipe",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1951, col: 22, offset: 60632},
+									pos:  position{line: 1953, col: 22, offset: 60596},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1951, col: 24, offset: 60634},
+									pos:        position{line: 1953, col: 24, offset: 60598},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -13449,74 +13436,74 @@ var g = &grammar{
 		},
 		{
 			name: "Select",
-			pos:  position{line: 1953, col: 1, offset: 60657},
+			pos:  position{line: 1955, col: 1, offset: 60621},
 			expr: &actionExpr{
-				pos: position{line: 1954, col: 5, offset: 60668},
+				pos: position{line: 1956, col: 5, offset: 60632},
 				run: (*parser).callonSelect1,
 				expr: &seqExpr{
-					pos: position{line: 1954, col: 5, offset: 60668},
+					pos: position{line: 1956, col: 5, offset: 60632},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1954, col: 5, offset: 60668},
+							pos:  position{line: 1956, col: 5, offset: 60632},
 							name: "SELECT",
 						},
 						&labeledExpr{
-							pos:   position{line: 1955, col: 5, offset: 60679},
+							pos:   position{line: 1957, col: 5, offset: 60643},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1955, col: 14, offset: 60688},
+								pos:  position{line: 1957, col: 14, offset: 60652},
 								name: "OptDistinct",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1956, col: 5, offset: 60704},
+							pos:   position{line: 1958, col: 5, offset: 60668},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1956, col: 11, offset: 60710},
+								pos:  position{line: 1958, col: 11, offset: 60674},
 								name: "OptSelectValue",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1959, col: 5, offset: 60849},
+							pos:  position{line: 1961, col: 5, offset: 60813},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1959, col: 7, offset: 60851},
+							pos:   position{line: 1961, col: 7, offset: 60815},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1959, col: 17, offset: 60861},
+								pos:  position{line: 1961, col: 17, offset: 60825},
 								name: "Selection",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1960, col: 5, offset: 60875},
+							pos:   position{line: 1962, col: 5, offset: 60839},
 							label: "from",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1960, col: 10, offset: 60880},
+								pos:  position{line: 1962, col: 10, offset: 60844},
 								name: "OptFromClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1961, col: 5, offset: 60898},
+							pos:   position{line: 1963, col: 5, offset: 60862},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1961, col: 11, offset: 60904},
+								pos:  position{line: 1963, col: 11, offset: 60868},
 								name: "OptWhereClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1962, col: 5, offset: 60923},
+							pos:   position{line: 1964, col: 5, offset: 60887},
 							label: "group",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1962, col: 11, offset: 60929},
+								pos:  position{line: 1964, col: 11, offset: 60893},
 								name: "OptGroupClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1963, col: 5, offset: 60948},
+							pos:   position{line: 1965, col: 5, offset: 60912},
 							label: "having",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1963, col: 12, offset: 60955},
+								pos:  position{line: 1965, col: 12, offset: 60919},
 								name: "OptHavingClause",
 							},
 						},
@@ -13528,78 +13515,78 @@ var g = &grammar{
 		},
 		{
 			name: "FromSelect",
-			pos:  position{line: 1989, col: 1, offset: 61570},
+			pos:  position{line: 1991, col: 1, offset: 61534},
 			expr: &actionExpr{
-				pos: position{line: 1990, col: 5, offset: 61585},
+				pos: position{line: 1992, col: 5, offset: 61549},
 				run: (*parser).callonFromSelect1,
 				expr: &seqExpr{
-					pos: position{line: 1990, col: 5, offset: 61585},
+					pos: position{line: 1992, col: 5, offset: 61549},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1990, col: 5, offset: 61585},
+							pos:   position{line: 1992, col: 5, offset: 61549},
 							label: "from",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1990, col: 10, offset: 61590},
+								pos:  position{line: 1992, col: 10, offset: 61554},
 								name: "FromOp",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1990, col: 17, offset: 61597},
+							pos:  position{line: 1992, col: 17, offset: 61561},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1990, col: 19, offset: 61599},
+							pos:  position{line: 1992, col: 19, offset: 61563},
 							name: "SELECT",
 						},
 						&labeledExpr{
-							pos:   position{line: 1991, col: 5, offset: 61610},
+							pos:   position{line: 1993, col: 5, offset: 61574},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1991, col: 14, offset: 61619},
+								pos:  position{line: 1993, col: 14, offset: 61583},
 								name: "OptDistinct",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1992, col: 5, offset: 61635},
+							pos:   position{line: 1994, col: 5, offset: 61599},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1992, col: 11, offset: 61641},
+								pos:  position{line: 1994, col: 11, offset: 61605},
 								name: "OptSelectValue",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1995, col: 5, offset: 61780},
+							pos:  position{line: 1997, col: 5, offset: 61744},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1995, col: 7, offset: 61782},
+							pos:   position{line: 1997, col: 7, offset: 61746},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1995, col: 17, offset: 61792},
+								pos:  position{line: 1997, col: 17, offset: 61756},
 								name: "Selection",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1996, col: 5, offset: 61806},
+							pos:   position{line: 1998, col: 5, offset: 61770},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1996, col: 11, offset: 61812},
+								pos:  position{line: 1998, col: 11, offset: 61776},
 								name: "OptWhereClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1997, col: 5, offset: 61831},
+							pos:   position{line: 1999, col: 5, offset: 61795},
 							label: "group",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1997, col: 11, offset: 61837},
+								pos:  position{line: 1999, col: 11, offset: 61801},
 								name: "OptGroupClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1998, col: 5, offset: 61856},
+							pos:   position{line: 2000, col: 5, offset: 61820},
 							label: "having",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1998, col: 12, offset: 61863},
+								pos:  position{line: 2000, col: 12, offset: 61827},
 								name: "OptHavingClause",
 							},
 						},
@@ -13611,26 +13598,26 @@ var g = &grammar{
 		},
 		{
 			name: "SQLValues",
-			pos:  position{line: 2022, col: 1, offset: 62445},
+			pos:  position{line: 2024, col: 1, offset: 62409},
 			expr: &actionExpr{
-				pos: position{line: 2023, col: 5, offset: 62459},
+				pos: position{line: 2025, col: 5, offset: 62423},
 				run: (*parser).callonSQLValues1,
 				expr: &seqExpr{
-					pos: position{line: 2023, col: 5, offset: 62459},
+					pos: position{line: 2025, col: 5, offset: 62423},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2023, col: 5, offset: 62459},
+							pos:  position{line: 2025, col: 5, offset: 62423},
 							name: "VALUES",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2023, col: 12, offset: 62466},
+							pos:  position{line: 2025, col: 12, offset: 62430},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2023, col: 15, offset: 62469},
+							pos:   position{line: 2025, col: 15, offset: 62433},
 							label: "tuples",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2023, col: 22, offset: 62476},
+								pos:  position{line: 2025, col: 22, offset: 62440},
 								name: "SQLTuples",
 							},
 						},
@@ -13642,26 +13629,26 @@ var g = &grammar{
 		},
 		{
 			name: "ValuesOp",
-			pos:  position{line: 2031, col: 1, offset: 62633},
+			pos:  position{line: 2033, col: 1, offset: 62597},
 			expr: &actionExpr{
-				pos: position{line: 2032, col: 5, offset: 62646},
+				pos: position{line: 2034, col: 5, offset: 62610},
 				run: (*parser).callonValuesOp1,
 				expr: &seqExpr{
-					pos: position{line: 2032, col: 5, offset: 62646},
+					pos: position{line: 2034, col: 5, offset: 62610},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2032, col: 5, offset: 62646},
+							pos:  position{line: 2034, col: 5, offset: 62610},
 							name: "VALUES",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2032, col: 12, offset: 62653},
+							pos:  position{line: 2034, col: 12, offset: 62617},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2032, col: 14, offset: 62655},
+							pos:   position{line: 2034, col: 14, offset: 62619},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2032, col: 20, offset: 62661},
+								pos:  position{line: 2034, col: 20, offset: 62625},
 								name: "Exprs",
 							},
 						},
@@ -13673,51 +13660,51 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTuples",
-			pos:  position{line: 2041, col: 1, offset: 62808},
+			pos:  position{line: 2043, col: 1, offset: 62772},
 			expr: &actionExpr{
-				pos: position{line: 2042, col: 5, offset: 62822},
+				pos: position{line: 2044, col: 5, offset: 62786},
 				run: (*parser).callonSQLTuples1,
 				expr: &seqExpr{
-					pos: position{line: 2042, col: 5, offset: 62822},
+					pos: position{line: 2044, col: 5, offset: 62786},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2042, col: 5, offset: 62822},
+							pos:   position{line: 2044, col: 5, offset: 62786},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2042, col: 11, offset: 62828},
+								pos:  position{line: 2044, col: 11, offset: 62792},
 								name: "SQLTuple",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2042, col: 20, offset: 62837},
+							pos:   position{line: 2044, col: 20, offset: 62801},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2042, col: 25, offset: 62842},
+								pos: position{line: 2044, col: 25, offset: 62806},
 								expr: &actionExpr{
-									pos: position{line: 2042, col: 26, offset: 62843},
+									pos: position{line: 2044, col: 26, offset: 62807},
 									run: (*parser).callonSQLTuples7,
 									expr: &seqExpr{
-										pos: position{line: 2042, col: 26, offset: 62843},
+										pos: position{line: 2044, col: 26, offset: 62807},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2042, col: 26, offset: 62843},
+												pos:  position{line: 2044, col: 26, offset: 62807},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2042, col: 29, offset: 62846},
+												pos:        position{line: 2044, col: 29, offset: 62810},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2042, col: 33, offset: 62850},
+												pos:  position{line: 2044, col: 33, offset: 62814},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2042, col: 36, offset: 62853},
+												pos:   position{line: 2044, col: 36, offset: 62817},
 												label: "t",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2042, col: 38, offset: 62855},
+													pos:  position{line: 2044, col: 38, offset: 62819},
 													name: "SQLTuple",
 												},
 											},
@@ -13734,37 +13721,37 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTuple",
-			pos:  position{line: 2046, col: 1, offset: 62932},
+			pos:  position{line: 2048, col: 1, offset: 62896},
 			expr: &actionExpr{
-				pos: position{line: 2047, col: 5, offset: 62945},
+				pos: position{line: 2049, col: 5, offset: 62909},
 				run: (*parser).callonSQLTuple1,
 				expr: &seqExpr{
-					pos: position{line: 2047, col: 5, offset: 62945},
+					pos: position{line: 2049, col: 5, offset: 62909},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2047, col: 5, offset: 62945},
+							pos:        position{line: 2049, col: 5, offset: 62909},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2047, col: 9, offset: 62949},
+							pos:  position{line: 2049, col: 9, offset: 62913},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2047, col: 12, offset: 62952},
+							pos:   position{line: 2049, col: 12, offset: 62916},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2047, col: 18, offset: 62958},
+								pos:  position{line: 2049, col: 18, offset: 62922},
 								name: "Exprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2047, col: 24, offset: 62964},
+							pos:  position{line: 2049, col: 24, offset: 62928},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2047, col: 27, offset: 62967},
+							pos:        position{line: 2049, col: 27, offset: 62931},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -13777,49 +13764,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptDistinct",
-			pos:  position{line: 2055, col: 1, offset: 63111},
+			pos:  position{line: 2057, col: 1, offset: 63075},
 			expr: &choiceExpr{
-				pos: position{line: 2056, col: 5, offset: 63127},
+				pos: position{line: 2058, col: 5, offset: 63091},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2056, col: 5, offset: 63127},
+						pos: position{line: 2058, col: 5, offset: 63091},
 						run: (*parser).callonOptDistinct2,
 						expr: &seqExpr{
-							pos: position{line: 2056, col: 5, offset: 63127},
+							pos: position{line: 2058, col: 5, offset: 63091},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2056, col: 5, offset: 63127},
+									pos:  position{line: 2058, col: 5, offset: 63091},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2056, col: 7, offset: 63129},
+									pos:  position{line: 2058, col: 7, offset: 63093},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2057, col: 5, offset: 63166},
+						pos: position{line: 2059, col: 5, offset: 63130},
 						run: (*parser).callonOptDistinct6,
 						expr: &seqExpr{
-							pos: position{line: 2057, col: 5, offset: 63166},
+							pos: position{line: 2059, col: 5, offset: 63130},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2057, col: 5, offset: 63166},
+									pos:  position{line: 2059, col: 5, offset: 63130},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2057, col: 7, offset: 63168},
+									pos:  position{line: 2059, col: 7, offset: 63132},
 									name: "DISTINCT",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2058, col: 5, offset: 63204},
+						pos: position{line: 2060, col: 5, offset: 63168},
 						run: (*parser).callonOptDistinct10,
 						expr: &litMatcher{
-							pos:        position{line: 2058, col: 5, offset: 63204},
+							pos:        position{line: 2060, col: 5, offset: 63168},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13832,57 +13819,57 @@ var g = &grammar{
 		},
 		{
 			name: "OptSelectValue",
-			pos:  position{line: 2060, col: 1, offset: 63243},
+			pos:  position{line: 2062, col: 1, offset: 63207},
 			expr: &choiceExpr{
-				pos: position{line: 2061, col: 5, offset: 63262},
+				pos: position{line: 2063, col: 5, offset: 63226},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2061, col: 5, offset: 63262},
+						pos: position{line: 2063, col: 5, offset: 63226},
 						run: (*parser).callonOptSelectValue2,
 						expr: &seqExpr{
-							pos: position{line: 2061, col: 5, offset: 63262},
+							pos: position{line: 2063, col: 5, offset: 63226},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2061, col: 5, offset: 63262},
+									pos:  position{line: 2063, col: 5, offset: 63226},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2061, col: 7, offset: 63264},
+									pos:  position{line: 2063, col: 7, offset: 63228},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2061, col: 10, offset: 63267},
+									pos:  position{line: 2063, col: 10, offset: 63231},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2061, col: 12, offset: 63269},
+									pos:  position{line: 2063, col: 12, offset: 63233},
 									name: "VALUE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2062, col: 5, offset: 63301},
+						pos: position{line: 2064, col: 5, offset: 63265},
 						run: (*parser).callonOptSelectValue8,
 						expr: &seqExpr{
-							pos: position{line: 2062, col: 5, offset: 63301},
+							pos: position{line: 2064, col: 5, offset: 63265},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2062, col: 5, offset: 63301},
+									pos:  position{line: 2064, col: 5, offset: 63265},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2062, col: 7, offset: 63303},
+									pos:  position{line: 2064, col: 7, offset: 63267},
 									name: "VALUE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2063, col: 5, offset: 63374},
+						pos: position{line: 2065, col: 5, offset: 63338},
 						run: (*parser).callonOptSelectValue12,
 						expr: &litMatcher{
-							pos:        position{line: 2063, col: 5, offset: 63374},
+							pos:        position{line: 2065, col: 5, offset: 63338},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13895,19 +13882,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptWithClause",
-			pos:  position{line: 2065, col: 1, offset: 63417},
+			pos:  position{line: 2067, col: 1, offset: 63381},
 			expr: &choiceExpr{
-				pos: position{line: 2066, col: 5, offset: 63435},
+				pos: position{line: 2068, col: 5, offset: 63399},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2066, col: 5, offset: 63435},
+						pos:  position{line: 2068, col: 5, offset: 63399},
 						name: "WithClause",
 					},
 					&actionExpr{
-						pos: position{line: 2067, col: 5, offset: 63450},
+						pos: position{line: 2069, col: 5, offset: 63414},
 						run: (*parser).callonOptWithClause3,
 						expr: &litMatcher{
-							pos:        position{line: 2067, col: 5, offset: 63450},
+							pos:        position{line: 2069, col: 5, offset: 63414},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13920,39 +13907,39 @@ var g = &grammar{
 		},
 		{
 			name: "WithClause",
-			pos:  position{line: 2069, col: 1, offset: 63483},
+			pos:  position{line: 2071, col: 1, offset: 63447},
 			expr: &actionExpr{
-				pos: position{line: 2070, col: 5, offset: 63498},
+				pos: position{line: 2072, col: 5, offset: 63462},
 				run: (*parser).callonWithClause1,
 				expr: &seqExpr{
-					pos: position{line: 2070, col: 5, offset: 63498},
+					pos: position{line: 2072, col: 5, offset: 63462},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2070, col: 5, offset: 63498},
+							pos:  position{line: 2072, col: 5, offset: 63462},
 							name: "WITH",
 						},
 						&labeledExpr{
-							pos:   position{line: 2070, col: 10, offset: 63503},
+							pos:   position{line: 2072, col: 10, offset: 63467},
 							label: "r",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2070, col: 12, offset: 63505},
+								pos:  position{line: 2072, col: 12, offset: 63469},
 								name: "OptRecursive",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2070, col: 25, offset: 63518},
+							pos:  position{line: 2072, col: 25, offset: 63482},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2070, col: 27, offset: 63520},
+							pos:   position{line: 2072, col: 27, offset: 63484},
 							label: "ctes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2070, col: 32, offset: 63525},
+								pos:  position{line: 2072, col: 32, offset: 63489},
 								name: "CteList",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2070, col: 40, offset: 63533},
+							pos:  position{line: 2072, col: 40, offset: 63497},
 							name: "__",
 						},
 					},
@@ -13963,32 +13950,32 @@ var g = &grammar{
 		},
 		{
 			name: "OptRecursive",
-			pos:  position{line: 2079, col: 1, offset: 63721},
+			pos:  position{line: 2081, col: 1, offset: 63685},
 			expr: &choiceExpr{
-				pos: position{line: 2080, col: 5, offset: 63738},
+				pos: position{line: 2082, col: 5, offset: 63702},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2080, col: 5, offset: 63738},
+						pos: position{line: 2082, col: 5, offset: 63702},
 						run: (*parser).callonOptRecursive2,
 						expr: &seqExpr{
-							pos: position{line: 2080, col: 5, offset: 63738},
+							pos: position{line: 2082, col: 5, offset: 63702},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2080, col: 5, offset: 63738},
+									pos:  position{line: 2082, col: 5, offset: 63702},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2080, col: 7, offset: 63740},
+									pos:  position{line: 2082, col: 7, offset: 63704},
 									name: "RECURSIVE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2081, col: 5, offset: 63776},
+						pos: position{line: 2083, col: 5, offset: 63740},
 						run: (*parser).callonOptRecursive6,
 						expr: &litMatcher{
-							pos:        position{line: 2081, col: 5, offset: 63776},
+							pos:        position{line: 2083, col: 5, offset: 63740},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14001,51 +13988,51 @@ var g = &grammar{
 		},
 		{
 			name: "CteList",
-			pos:  position{line: 2083, col: 1, offset: 63815},
+			pos:  position{line: 2085, col: 1, offset: 63779},
 			expr: &actionExpr{
-				pos: position{line: 2083, col: 11, offset: 63825},
+				pos: position{line: 2085, col: 11, offset: 63789},
 				run: (*parser).callonCteList1,
 				expr: &seqExpr{
-					pos: position{line: 2083, col: 11, offset: 63825},
+					pos: position{line: 2085, col: 11, offset: 63789},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2083, col: 11, offset: 63825},
+							pos:   position{line: 2085, col: 11, offset: 63789},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2083, col: 17, offset: 63831},
+								pos:  position{line: 2085, col: 17, offset: 63795},
 								name: "Cte",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2083, col: 21, offset: 63835},
+							pos:   position{line: 2085, col: 21, offset: 63799},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2083, col: 26, offset: 63840},
+								pos: position{line: 2085, col: 26, offset: 63804},
 								expr: &actionExpr{
-									pos: position{line: 2083, col: 28, offset: 63842},
+									pos: position{line: 2085, col: 28, offset: 63806},
 									run: (*parser).callonCteList7,
 									expr: &seqExpr{
-										pos: position{line: 2083, col: 28, offset: 63842},
+										pos: position{line: 2085, col: 28, offset: 63806},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2083, col: 28, offset: 63842},
+												pos:  position{line: 2085, col: 28, offset: 63806},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2083, col: 31, offset: 63845},
+												pos:        position{line: 2085, col: 31, offset: 63809},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2083, col: 35, offset: 63849},
+												pos:  position{line: 2085, col: 35, offset: 63813},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2083, col: 38, offset: 63852},
+												pos:   position{line: 2085, col: 38, offset: 63816},
 												label: "cte",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2083, col: 42, offset: 63856},
+													pos:  position{line: 2085, col: 42, offset: 63820},
 													name: "Cte",
 												},
 											},
@@ -14062,65 +14049,65 @@ var g = &grammar{
 		},
 		{
 			name: "Cte",
-			pos:  position{line: 2087, col: 1, offset: 63924},
+			pos:  position{line: 2089, col: 1, offset: 63888},
 			expr: &actionExpr{
-				pos: position{line: 2088, col: 5, offset: 63932},
+				pos: position{line: 2090, col: 5, offset: 63896},
 				run: (*parser).callonCte1,
 				expr: &seqExpr{
-					pos: position{line: 2088, col: 5, offset: 63932},
+					pos: position{line: 2090, col: 5, offset: 63896},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2088, col: 5, offset: 63932},
+							pos:   position{line: 2090, col: 5, offset: 63896},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2088, col: 10, offset: 63937},
+								pos:  position{line: 2090, col: 10, offset: 63901},
 								name: "SQLIdentifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2088, col: 24, offset: 63951},
+							pos:  position{line: 2090, col: 24, offset: 63915},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2088, col: 26, offset: 63953},
+							pos:  position{line: 2090, col: 26, offset: 63917},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 2088, col: 29, offset: 63956},
+							pos:   position{line: 2090, col: 29, offset: 63920},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2088, col: 31, offset: 63958},
+								pos:  position{line: 2090, col: 31, offset: 63922},
 								name: "OptMaterialized",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2088, col: 47, offset: 63974},
+							pos:  position{line: 2090, col: 47, offset: 63938},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2088, col: 50, offset: 63977},
+							pos:        position{line: 2090, col: 50, offset: 63941},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2088, col: 54, offset: 63981},
+							pos:  position{line: 2090, col: 54, offset: 63945},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2088, col: 57, offset: 63984},
+							pos:   position{line: 2090, col: 57, offset: 63948},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2088, col: 59, offset: 63986},
+								pos:  position{line: 2090, col: 59, offset: 63950},
 								name: "SQLPipe",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2088, col: 67, offset: 63994},
+							pos:  position{line: 2090, col: 67, offset: 63958},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2088, col: 70, offset: 63997},
+							pos:        position{line: 2090, col: 70, offset: 63961},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -14133,65 +14120,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptMaterialized",
-			pos:  position{line: 2097, col: 1, offset: 64183},
+			pos:  position{line: 2099, col: 1, offset: 64147},
 			expr: &choiceExpr{
-				pos: position{line: 2098, col: 5, offset: 64203},
+				pos: position{line: 2100, col: 5, offset: 64167},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2098, col: 5, offset: 64203},
+						pos: position{line: 2100, col: 5, offset: 64167},
 						run: (*parser).callonOptMaterialized2,
 						expr: &seqExpr{
-							pos: position{line: 2098, col: 5, offset: 64203},
+							pos: position{line: 2100, col: 5, offset: 64167},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2098, col: 5, offset: 64203},
+									pos:  position{line: 2100, col: 5, offset: 64167},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2098, col: 7, offset: 64205},
+									pos:  position{line: 2100, col: 7, offset: 64169},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2098, col: 20, offset: 64218},
+									pos:  position{line: 2100, col: 20, offset: 64182},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2099, col: 5, offset: 64257},
+						pos: position{line: 2101, col: 5, offset: 64221},
 						run: (*parser).callonOptMaterialized7,
 						expr: &seqExpr{
-							pos: position{line: 2099, col: 5, offset: 64257},
+							pos: position{line: 2101, col: 5, offset: 64221},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2099, col: 5, offset: 64257},
+									pos:  position{line: 2101, col: 5, offset: 64221},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2099, col: 7, offset: 64259},
+									pos:  position{line: 2101, col: 7, offset: 64223},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2099, col: 11, offset: 64263},
+									pos:  position{line: 2101, col: 11, offset: 64227},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2099, col: 13, offset: 64265},
+									pos:  position{line: 2101, col: 13, offset: 64229},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2099, col: 26, offset: 64278},
+									pos:  position{line: 2101, col: 26, offset: 64242},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2100, col: 5, offset: 64309},
+						pos: position{line: 2102, col: 5, offset: 64273},
 						run: (*parser).callonOptMaterialized14,
 						expr: &litMatcher{
-							pos:        position{line: 2100, col: 5, offset: 64309},
+							pos:        position{line: 2102, col: 5, offset: 64273},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14204,25 +14191,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAllClause",
-			pos:  position{line: 2102, col: 1, offset: 64364},
+			pos:  position{line: 2104, col: 1, offset: 64328},
 			expr: &choiceExpr{
-				pos: position{line: 2103, col: 5, offset: 64381},
+				pos: position{line: 2105, col: 5, offset: 64345},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 2103, col: 5, offset: 64381},
+						pos: position{line: 2105, col: 5, offset: 64345},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2103, col: 5, offset: 64381},
+								pos:  position{line: 2105, col: 5, offset: 64345},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2103, col: 7, offset: 64383},
+								pos:  position{line: 2105, col: 7, offset: 64347},
 								name: "ALL",
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 2104, col: 5, offset: 64391},
+						pos:        position{line: 2106, col: 5, offset: 64355},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -14234,25 +14221,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptFromClause",
-			pos:  position{line: 2106, col: 1, offset: 64395},
+			pos:  position{line: 2108, col: 1, offset: 64359},
 			expr: &choiceExpr{
-				pos: position{line: 2107, col: 5, offset: 64413},
+				pos: position{line: 2109, col: 5, offset: 64377},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2107, col: 5, offset: 64413},
+						pos: position{line: 2109, col: 5, offset: 64377},
 						run: (*parser).callonOptFromClause2,
 						expr: &seqExpr{
-							pos: position{line: 2107, col: 5, offset: 64413},
+							pos: position{line: 2109, col: 5, offset: 64377},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2107, col: 5, offset: 64413},
+									pos:  position{line: 2109, col: 5, offset: 64377},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2107, col: 7, offset: 64415},
+									pos:   position{line: 2109, col: 7, offset: 64379},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2107, col: 12, offset: 64420},
+										pos:  position{line: 2109, col: 12, offset: 64384},
 										name: "FromOp",
 									},
 								},
@@ -14260,10 +14247,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2110, col: 5, offset: 64462},
+						pos: position{line: 2112, col: 5, offset: 64426},
 						run: (*parser).callonOptFromClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2110, col: 5, offset: 64462},
+							pos:        position{line: 2112, col: 5, offset: 64426},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14276,27 +14263,27 @@ var g = &grammar{
 		},
 		{
 			name: "OptWhereClause",
-			pos:  position{line: 2112, col: 1, offset: 64503},
+			pos:  position{line: 2114, col: 1, offset: 64467},
 			expr: &choiceExpr{
-				pos: position{line: 2113, col: 5, offset: 64522},
+				pos: position{line: 2115, col: 5, offset: 64486},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2113, col: 5, offset: 64522},
+						pos: position{line: 2115, col: 5, offset: 64486},
 						run: (*parser).callonOptWhereClause2,
 						expr: &labeledExpr{
-							pos:   position{line: 2113, col: 5, offset: 64522},
+							pos:   position{line: 2115, col: 5, offset: 64486},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2113, col: 11, offset: 64528},
+								pos:  position{line: 2115, col: 11, offset: 64492},
 								name: "WhereClause",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2114, col: 5, offset: 64570},
+						pos: position{line: 2116, col: 5, offset: 64534},
 						run: (*parser).callonOptWhereClause5,
 						expr: &litMatcher{
-							pos:        position{line: 2114, col: 5, offset: 64570},
+							pos:        position{line: 2116, col: 5, offset: 64534},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14309,25 +14296,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptGroupClause",
-			pos:  position{line: 2116, col: 1, offset: 64615},
+			pos:  position{line: 2118, col: 1, offset: 64579},
 			expr: &choiceExpr{
-				pos: position{line: 2117, col: 5, offset: 64634},
+				pos: position{line: 2119, col: 5, offset: 64598},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2117, col: 5, offset: 64634},
+						pos: position{line: 2119, col: 5, offset: 64598},
 						run: (*parser).callonOptGroupClause2,
 						expr: &seqExpr{
-							pos: position{line: 2117, col: 5, offset: 64634},
+							pos: position{line: 2119, col: 5, offset: 64598},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2117, col: 5, offset: 64634},
+									pos:  position{line: 2119, col: 5, offset: 64598},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2117, col: 7, offset: 64636},
+									pos:   position{line: 2119, col: 7, offset: 64600},
 									label: "group",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2117, col: 13, offset: 64642},
+										pos:  position{line: 2119, col: 13, offset: 64606},
 										name: "GroupClause",
 									},
 								},
@@ -14335,10 +14322,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2118, col: 5, offset: 64680},
+						pos: position{line: 2120, col: 5, offset: 64644},
 						run: (*parser).callonOptGroupClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2118, col: 5, offset: 64680},
+							pos:        position{line: 2120, col: 5, offset: 64644},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14351,34 +14338,34 @@ var g = &grammar{
 		},
 		{
 			name: "GroupClause",
-			pos:  position{line: 2120, col: 1, offset: 64721},
+			pos:  position{line: 2122, col: 1, offset: 64685},
 			expr: &actionExpr{
-				pos: position{line: 2121, col: 5, offset: 64737},
+				pos: position{line: 2123, col: 5, offset: 64701},
 				run: (*parser).callonGroupClause1,
 				expr: &seqExpr{
-					pos: position{line: 2121, col: 5, offset: 64737},
+					pos: position{line: 2123, col: 5, offset: 64701},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2121, col: 5, offset: 64737},
+							pos:  position{line: 2123, col: 5, offset: 64701},
 							name: "GROUP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2121, col: 11, offset: 64743},
+							pos:  position{line: 2123, col: 11, offset: 64707},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2121, col: 13, offset: 64745},
+							pos:  position{line: 2123, col: 13, offset: 64709},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2121, col: 16, offset: 64748},
+							pos:  position{line: 2123, col: 16, offset: 64712},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2121, col: 18, offset: 64750},
+							pos:   position{line: 2123, col: 18, offset: 64714},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2121, col: 23, offset: 64755},
+								pos:  position{line: 2123, col: 23, offset: 64719},
 								name: "GroupByList",
 							},
 						},
@@ -14390,51 +14377,51 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByList",
-			pos:  position{line: 2123, col: 1, offset: 64789},
+			pos:  position{line: 2125, col: 1, offset: 64753},
 			expr: &actionExpr{
-				pos: position{line: 2124, col: 5, offset: 64805},
+				pos: position{line: 2126, col: 5, offset: 64769},
 				run: (*parser).callonGroupByList1,
 				expr: &seqExpr{
-					pos: position{line: 2124, col: 5, offset: 64805},
+					pos: position{line: 2126, col: 5, offset: 64769},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2124, col: 5, offset: 64805},
+							pos:   position{line: 2126, col: 5, offset: 64769},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2124, col: 11, offset: 64811},
+								pos:  position{line: 2126, col: 11, offset: 64775},
 								name: "GroupByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2124, col: 23, offset: 64823},
+							pos:   position{line: 2126, col: 23, offset: 64787},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2124, col: 28, offset: 64828},
+								pos: position{line: 2126, col: 28, offset: 64792},
 								expr: &actionExpr{
-									pos: position{line: 2124, col: 30, offset: 64830},
+									pos: position{line: 2126, col: 30, offset: 64794},
 									run: (*parser).callonGroupByList7,
 									expr: &seqExpr{
-										pos: position{line: 2124, col: 30, offset: 64830},
+										pos: position{line: 2126, col: 30, offset: 64794},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2124, col: 30, offset: 64830},
+												pos:  position{line: 2126, col: 30, offset: 64794},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2124, col: 33, offset: 64833},
+												pos:        position{line: 2126, col: 33, offset: 64797},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2124, col: 37, offset: 64837},
+												pos:  position{line: 2126, col: 37, offset: 64801},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2124, col: 40, offset: 64840},
+												pos:   position{line: 2126, col: 40, offset: 64804},
 												label: "g",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2124, col: 42, offset: 64842},
+													pos:  position{line: 2126, col: 42, offset: 64806},
 													name: "GroupByItem",
 												},
 											},
@@ -14451,9 +14438,9 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByItem",
-			pos:  position{line: 2128, col: 1, offset: 64923},
+			pos:  position{line: 2130, col: 1, offset: 64887},
 			expr: &ruleRefExpr{
-				pos:  position{line: 2128, col: 15, offset: 64937},
+				pos:  position{line: 2130, col: 15, offset: 64901},
 				name: "Expr",
 			},
 			leader:        false,
@@ -14461,25 +14448,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptHavingClause",
-			pos:  position{line: 2130, col: 1, offset: 64943},
+			pos:  position{line: 2132, col: 1, offset: 64907},
 			expr: &choiceExpr{
-				pos: position{line: 2131, col: 5, offset: 64963},
+				pos: position{line: 2133, col: 5, offset: 64927},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2131, col: 5, offset: 64963},
+						pos: position{line: 2133, col: 5, offset: 64927},
 						run: (*parser).callonOptHavingClause2,
 						expr: &seqExpr{
-							pos: position{line: 2131, col: 5, offset: 64963},
+							pos: position{line: 2133, col: 5, offset: 64927},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2131, col: 5, offset: 64963},
+									pos:  position{line: 2133, col: 5, offset: 64927},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2131, col: 7, offset: 64965},
+									pos:   position{line: 2133, col: 7, offset: 64929},
 									label: "h",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2131, col: 9, offset: 64967},
+										pos:  position{line: 2133, col: 9, offset: 64931},
 										name: "HavingClause",
 									},
 								},
@@ -14487,10 +14474,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2132, col: 5, offset: 65002},
+						pos: position{line: 2134, col: 5, offset: 64966},
 						run: (*parser).callonOptHavingClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2132, col: 5, offset: 65002},
+							pos:        position{line: 2134, col: 5, offset: 64966},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14503,26 +14490,26 @@ var g = &grammar{
 		},
 		{
 			name: "HavingClause",
-			pos:  position{line: 2134, col: 1, offset: 65026},
+			pos:  position{line: 2136, col: 1, offset: 64990},
 			expr: &actionExpr{
-				pos: position{line: 2135, col: 5, offset: 65043},
+				pos: position{line: 2137, col: 5, offset: 65007},
 				run: (*parser).callonHavingClause1,
 				expr: &seqExpr{
-					pos: position{line: 2135, col: 5, offset: 65043},
+					pos: position{line: 2137, col: 5, offset: 65007},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2135, col: 5, offset: 65043},
+							pos:  position{line: 2137, col: 5, offset: 65007},
 							name: "HAVING",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2135, col: 12, offset: 65050},
+							pos:  position{line: 2137, col: 12, offset: 65014},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2135, col: 14, offset: 65052},
+							pos:   position{line: 2137, col: 14, offset: 65016},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2135, col: 16, offset: 65054},
+								pos:  position{line: 2137, col: 16, offset: 65018},
 								name: "Expr",
 							},
 						},
@@ -14534,16 +14521,16 @@ var g = &grammar{
 		},
 		{
 			name: "JoinOperation",
-			pos:  position{line: 2137, col: 1, offset: 65078},
+			pos:  position{line: 2139, col: 1, offset: 65042},
 			expr: &choiceExpr{
-				pos: position{line: 2138, col: 5, offset: 65096},
+				pos: position{line: 2140, col: 5, offset: 65060},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2138, col: 5, offset: 65096},
+						pos:  position{line: 2140, col: 5, offset: 65060},
 						name: "CrossJoin",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2139, col: 5, offset: 65110},
+						pos:  position{line: 2141, col: 5, offset: 65074},
 						name: "ConditionJoin",
 					},
 				},
@@ -14553,30 +14540,30 @@ var g = &grammar{
 		},
 		{
 			name: "CrossJoin",
-			pos:  position{line: 2141, col: 1, offset: 65125},
+			pos:  position{line: 2143, col: 1, offset: 65089},
 			expr: &actionExpr{
-				pos: position{line: 2142, col: 5, offset: 65139},
+				pos: position{line: 2144, col: 5, offset: 65103},
 				run: (*parser).callonCrossJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2142, col: 5, offset: 65139},
+					pos: position{line: 2144, col: 5, offset: 65103},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2142, col: 5, offset: 65139},
+							pos:   position{line: 2144, col: 5, offset: 65103},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2142, col: 10, offset: 65144},
+								pos:  position{line: 2144, col: 10, offset: 65108},
 								name: "FromElem",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2142, col: 19, offset: 65153},
+							pos:  position{line: 2144, col: 19, offset: 65117},
 							name: "CrossJoinOp",
 						},
 						&labeledExpr{
-							pos:   position{line: 2142, col: 31, offset: 65165},
+							pos:   position{line: 2144, col: 31, offset: 65129},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2142, col: 37, offset: 65171},
+								pos:  position{line: 2144, col: 37, offset: 65135},
 								name: "FromElem",
 							},
 						},
@@ -14588,50 +14575,50 @@ var g = &grammar{
 		},
 		{
 			name: "CrossJoinOp",
-			pos:  position{line: 2151, col: 1, offset: 65379},
+			pos:  position{line: 2153, col: 1, offset: 65343},
 			expr: &choiceExpr{
-				pos: position{line: 2152, col: 5, offset: 65395},
+				pos: position{line: 2154, col: 5, offset: 65359},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 2152, col: 5, offset: 65395},
+						pos: position{line: 2154, col: 5, offset: 65359},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2152, col: 5, offset: 65395},
+								pos:  position{line: 2154, col: 5, offset: 65359},
 								name: "__",
 							},
 							&litMatcher{
-								pos:        position{line: 2152, col: 8, offset: 65398},
+								pos:        position{line: 2154, col: 8, offset: 65362},
 								val:        ",",
 								ignoreCase: false,
 								want:       "\",\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2152, col: 12, offset: 65402},
+								pos:  position{line: 2154, col: 12, offset: 65366},
 								name: "__",
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 2153, col: 5, offset: 65409},
+						pos: position{line: 2155, col: 5, offset: 65373},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2153, col: 5, offset: 65409},
+								pos:  position{line: 2155, col: 5, offset: 65373},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2153, col: 7, offset: 65411},
+								pos:  position{line: 2155, col: 7, offset: 65375},
 								name: "CROSS",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2153, col: 13, offset: 65417},
+								pos:  position{line: 2155, col: 13, offset: 65381},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2153, col: 15, offset: 65419},
+								pos:  position{line: 2155, col: 15, offset: 65383},
 								name: "JOIN",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2153, col: 20, offset: 65424},
+								pos:  position{line: 2155, col: 20, offset: 65388},
 								name: "_",
 							},
 						},
@@ -14643,50 +14630,50 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionJoin",
-			pos:  position{line: 2155, col: 1, offset: 65427},
+			pos:  position{line: 2157, col: 1, offset: 65391},
 			expr: &actionExpr{
-				pos: position{line: 2156, col: 5, offset: 65445},
+				pos: position{line: 2158, col: 5, offset: 65409},
 				run: (*parser).callonConditionJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2156, col: 5, offset: 65445},
+					pos: position{line: 2158, col: 5, offset: 65409},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2156, col: 5, offset: 65445},
+							pos:   position{line: 2158, col: 5, offset: 65409},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2156, col: 10, offset: 65450},
+								pos:  position{line: 2158, col: 10, offset: 65414},
 								name: "FromElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2156, col: 19, offset: 65459},
+							pos:   position{line: 2158, col: 19, offset: 65423},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2156, col: 25, offset: 65465},
+								pos:  position{line: 2158, col: 25, offset: 65429},
 								name: "SQLJoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2156, col: 38, offset: 65478},
+							pos:  position{line: 2158, col: 38, offset: 65442},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2156, col: 40, offset: 65480},
+							pos:   position{line: 2158, col: 40, offset: 65444},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2156, col: 46, offset: 65486},
+								pos:  position{line: 2158, col: 46, offset: 65450},
 								name: "FromElem",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2156, col: 55, offset: 65495},
+							pos:  position{line: 2158, col: 55, offset: 65459},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2156, col: 57, offset: 65497},
+							pos:   position{line: 2158, col: 57, offset: 65461},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2156, col: 59, offset: 65499},
+								pos:  position{line: 2158, col: 59, offset: 65463},
 								name: "JoinCond",
 							},
 						},
@@ -14698,161 +14685,161 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoinStyle",
-			pos:  position{line: 2167, col: 1, offset: 65768},
+			pos:  position{line: 2169, col: 1, offset: 65732},
 			expr: &choiceExpr{
-				pos: position{line: 2168, col: 5, offset: 65785},
+				pos: position{line: 2170, col: 5, offset: 65749},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2168, col: 5, offset: 65785},
+						pos: position{line: 2170, col: 5, offset: 65749},
 						run: (*parser).callonSQLJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 2168, col: 5, offset: 65785},
+							pos: position{line: 2170, col: 5, offset: 65749},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 2168, col: 5, offset: 65785},
+									pos: position{line: 2170, col: 5, offset: 65749},
 									expr: &seqExpr{
-										pos: position{line: 2168, col: 6, offset: 65786},
+										pos: position{line: 2170, col: 6, offset: 65750},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2168, col: 6, offset: 65786},
+												pos:  position{line: 2170, col: 6, offset: 65750},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2168, col: 8, offset: 65788},
+												pos:  position{line: 2170, col: 8, offset: 65752},
 												name: "INNER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2168, col: 16, offset: 65796},
+									pos:  position{line: 2170, col: 16, offset: 65760},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2168, col: 18, offset: 65798},
+									pos:  position{line: 2170, col: 18, offset: 65762},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2169, col: 5, offset: 65843},
+						pos: position{line: 2171, col: 5, offset: 65807},
 						run: (*parser).callonSQLJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 2169, col: 5, offset: 65843},
+							pos: position{line: 2171, col: 5, offset: 65807},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2169, col: 5, offset: 65843},
+									pos:  position{line: 2171, col: 5, offset: 65807},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2169, col: 7, offset: 65845},
+									pos:  position{line: 2171, col: 7, offset: 65809},
 									name: "FULL",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2169, col: 12, offset: 65850},
+									pos: position{line: 2171, col: 12, offset: 65814},
 									expr: &seqExpr{
-										pos: position{line: 2169, col: 13, offset: 65851},
+										pos: position{line: 2171, col: 13, offset: 65815},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2169, col: 13, offset: 65851},
+												pos:  position{line: 2171, col: 13, offset: 65815},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2169, col: 15, offset: 65853},
+												pos:  position{line: 2171, col: 15, offset: 65817},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2169, col: 23, offset: 65861},
+									pos:  position{line: 2171, col: 23, offset: 65825},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2169, col: 25, offset: 65863},
+									pos:  position{line: 2171, col: 25, offset: 65827},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2170, col: 5, offset: 65897},
+						pos: position{line: 2172, col: 5, offset: 65861},
 						run: (*parser).callonSQLJoinStyle20,
 						expr: &seqExpr{
-							pos: position{line: 2170, col: 5, offset: 65897},
+							pos: position{line: 2172, col: 5, offset: 65861},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2170, col: 5, offset: 65897},
+									pos:  position{line: 2172, col: 5, offset: 65861},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2170, col: 7, offset: 65899},
+									pos:  position{line: 2172, col: 7, offset: 65863},
 									name: "LEFT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2170, col: 12, offset: 65904},
+									pos: position{line: 2172, col: 12, offset: 65868},
 									expr: &seqExpr{
-										pos: position{line: 2170, col: 13, offset: 65905},
+										pos: position{line: 2172, col: 13, offset: 65869},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2170, col: 13, offset: 65905},
+												pos:  position{line: 2172, col: 13, offset: 65869},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2170, col: 15, offset: 65907},
+												pos:  position{line: 2172, col: 15, offset: 65871},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2170, col: 23, offset: 65915},
+									pos:  position{line: 2172, col: 23, offset: 65879},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2170, col: 25, offset: 65917},
+									pos:  position{line: 2172, col: 25, offset: 65881},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2171, col: 5, offset: 65951},
+						pos: position{line: 2173, col: 5, offset: 65915},
 						run: (*parser).callonSQLJoinStyle30,
 						expr: &seqExpr{
-							pos: position{line: 2171, col: 5, offset: 65951},
+							pos: position{line: 2173, col: 5, offset: 65915},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2171, col: 5, offset: 65951},
+									pos:  position{line: 2173, col: 5, offset: 65915},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2171, col: 7, offset: 65953},
+									pos:  position{line: 2173, col: 7, offset: 65917},
 									name: "RIGHT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2171, col: 13, offset: 65959},
+									pos: position{line: 2173, col: 13, offset: 65923},
 									expr: &seqExpr{
-										pos: position{line: 2171, col: 14, offset: 65960},
+										pos: position{line: 2173, col: 14, offset: 65924},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2171, col: 14, offset: 65960},
+												pos:  position{line: 2173, col: 14, offset: 65924},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2171, col: 16, offset: 65962},
+												pos:  position{line: 2173, col: 16, offset: 65926},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2171, col: 24, offset: 65970},
+									pos:  position{line: 2173, col: 24, offset: 65934},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2171, col: 26, offset: 65972},
+									pos:  position{line: 2173, col: 26, offset: 65936},
 									name: "JOIN",
 								},
 							},
@@ -14865,29 +14852,29 @@ var g = &grammar{
 		},
 		{
 			name: "JoinCond",
-			pos:  position{line: 2173, col: 1, offset: 66004},
+			pos:  position{line: 2175, col: 1, offset: 65968},
 			expr: &choiceExpr{
-				pos: position{line: 2174, col: 5, offset: 66017},
+				pos: position{line: 2176, col: 5, offset: 65981},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2174, col: 5, offset: 66017},
+						pos: position{line: 2176, col: 5, offset: 65981},
 						run: (*parser).callonJoinCond2,
 						expr: &seqExpr{
-							pos: position{line: 2174, col: 5, offset: 66017},
+							pos: position{line: 2176, col: 5, offset: 65981},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2174, col: 5, offset: 66017},
+									pos:  position{line: 2176, col: 5, offset: 65981},
 									name: "ON",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2174, col: 8, offset: 66020},
+									pos:  position{line: 2176, col: 8, offset: 65984},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2174, col: 10, offset: 66022},
+									pos:   position{line: 2176, col: 10, offset: 65986},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2174, col: 12, offset: 66024},
+										pos:  position{line: 2176, col: 12, offset: 65988},
 										name: "Expr",
 									},
 								},
@@ -14895,43 +14882,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2181, col: 5, offset: 66177},
+						pos: position{line: 2183, col: 5, offset: 66141},
 						run: (*parser).callonJoinCond8,
 						expr: &seqExpr{
-							pos: position{line: 2181, col: 5, offset: 66177},
+							pos: position{line: 2183, col: 5, offset: 66141},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2181, col: 5, offset: 66177},
+									pos:  position{line: 2183, col: 5, offset: 66141},
 									name: "USING",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2181, col: 11, offset: 66183},
+									pos:  position{line: 2183, col: 11, offset: 66147},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2181, col: 14, offset: 66186},
+									pos:        position{line: 2183, col: 14, offset: 66150},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2181, col: 18, offset: 66190},
+									pos:  position{line: 2183, col: 18, offset: 66154},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 2181, col: 21, offset: 66193},
+									pos:   position{line: 2183, col: 21, offset: 66157},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2181, col: 28, offset: 66200},
+										pos:  position{line: 2183, col: 28, offset: 66164},
 										name: "Lvals",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2181, col: 34, offset: 66206},
+									pos:  position{line: 2183, col: 34, offset: 66170},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2181, col: 37, offset: 66209},
+									pos:        position{line: 2183, col: 37, offset: 66173},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -14946,40 +14933,40 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrdinality",
-			pos:  position{line: 2189, col: 1, offset: 66379},
+			pos:  position{line: 2191, col: 1, offset: 66343},
 			expr: &choiceExpr{
-				pos: position{line: 2190, col: 5, offset: 66397},
+				pos: position{line: 2192, col: 5, offset: 66361},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2190, col: 5, offset: 66397},
+						pos: position{line: 2192, col: 5, offset: 66361},
 						run: (*parser).callonOptOrdinality2,
 						expr: &seqExpr{
-							pos: position{line: 2190, col: 5, offset: 66397},
+							pos: position{line: 2192, col: 5, offset: 66361},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2190, col: 5, offset: 66397},
+									pos:  position{line: 2192, col: 5, offset: 66361},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2190, col: 7, offset: 66399},
+									pos:  position{line: 2192, col: 7, offset: 66363},
 									name: "WITH",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2190, col: 12, offset: 66404},
+									pos:  position{line: 2192, col: 12, offset: 66368},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2190, col: 14, offset: 66406},
+									pos:  position{line: 2192, col: 14, offset: 66370},
 									name: "ORDINALITY",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2196, col: 5, offset: 66535},
+						pos: position{line: 2198, col: 5, offset: 66499},
 						run: (*parser).callonOptOrdinality8,
 						expr: &litMatcher{
-							pos:        position{line: 2196, col: 5, offset: 66535},
+							pos:        position{line: 2198, col: 5, offset: 66499},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14992,25 +14979,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAlias",
-			pos:  position{line: 2198, col: 1, offset: 66584},
+			pos:  position{line: 2200, col: 1, offset: 66548},
 			expr: &choiceExpr{
-				pos: position{line: 2199, col: 5, offset: 66597},
+				pos: position{line: 2201, col: 5, offset: 66561},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2199, col: 5, offset: 66597},
+						pos: position{line: 2201, col: 5, offset: 66561},
 						run: (*parser).callonOptAlias2,
 						expr: &seqExpr{
-							pos: position{line: 2199, col: 5, offset: 66597},
+							pos: position{line: 2201, col: 5, offset: 66561},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2199, col: 5, offset: 66597},
+									pos:  position{line: 2201, col: 5, offset: 66561},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2199, col: 7, offset: 66599},
+									pos:   position{line: 2201, col: 7, offset: 66563},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2199, col: 9, offset: 66601},
+										pos:  position{line: 2201, col: 9, offset: 66565},
 										name: "AliasClause",
 									},
 								},
@@ -15018,10 +15005,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2200, col: 5, offset: 66635},
+						pos: position{line: 2202, col: 5, offset: 66599},
 						run: (*parser).callonOptAlias7,
 						expr: &litMatcher{
-							pos:        position{line: 2200, col: 5, offset: 66635},
+							pos:        position{line: 2202, col: 5, offset: 66599},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15034,51 +15021,51 @@ var g = &grammar{
 		},
 		{
 			name: "AliasClause",
-			pos:  position{line: 2202, col: 1, offset: 66672},
+			pos:  position{line: 2204, col: 1, offset: 66636},
 			expr: &actionExpr{
-				pos: position{line: 2203, col: 4, offset: 66687},
+				pos: position{line: 2205, col: 4, offset: 66651},
 				run: (*parser).callonAliasClause1,
 				expr: &seqExpr{
-					pos: position{line: 2203, col: 4, offset: 66687},
+					pos: position{line: 2205, col: 4, offset: 66651},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2203, col: 4, offset: 66687},
+							pos: position{line: 2205, col: 4, offset: 66651},
 							expr: &seqExpr{
-								pos: position{line: 2203, col: 5, offset: 66688},
+								pos: position{line: 2205, col: 5, offset: 66652},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2203, col: 5, offset: 66688},
+										pos:  position{line: 2205, col: 5, offset: 66652},
 										name: "AS",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2203, col: 8, offset: 66691},
+										pos:  position{line: 2205, col: 8, offset: 66655},
 										name: "_",
 									},
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 2203, col: 12, offset: 66695},
+							pos: position{line: 2205, col: 12, offset: 66659},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2203, col: 13, offset: 66696},
+								pos:  position{line: 2205, col: 13, offset: 66660},
 								name: "SQLGuard",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2203, col: 22, offset: 66705},
+							pos:   position{line: 2205, col: 22, offset: 66669},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2203, col: 27, offset: 66710},
+								pos:  position{line: 2205, col: 27, offset: 66674},
 								name: "IdentifierName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2203, col: 42, offset: 66725},
+							pos:   position{line: 2205, col: 42, offset: 66689},
 							label: "cols",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2203, col: 47, offset: 66730},
+								pos: position{line: 2205, col: 47, offset: 66694},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2203, col: 47, offset: 66730},
+									pos:  position{line: 2205, col: 47, offset: 66694},
 									name: "Columns",
 								},
 							},
@@ -15091,65 +15078,65 @@ var g = &grammar{
 		},
 		{
 			name: "Columns",
-			pos:  position{line: 2211, col: 1, offset: 66929},
+			pos:  position{line: 2213, col: 1, offset: 66893},
 			expr: &actionExpr{
-				pos: position{line: 2212, col: 5, offset: 66941},
+				pos: position{line: 2214, col: 5, offset: 66905},
 				run: (*parser).callonColumns1,
 				expr: &seqExpr{
-					pos: position{line: 2212, col: 5, offset: 66941},
+					pos: position{line: 2214, col: 5, offset: 66905},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2212, col: 5, offset: 66941},
+							pos:  position{line: 2214, col: 5, offset: 66905},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2212, col: 8, offset: 66944},
+							pos:        position{line: 2214, col: 8, offset: 66908},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2212, col: 12, offset: 66948},
+							pos:  position{line: 2214, col: 12, offset: 66912},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2212, col: 15, offset: 66951},
+							pos:   position{line: 2214, col: 15, offset: 66915},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2212, col: 21, offset: 66957},
+								pos:  position{line: 2214, col: 21, offset: 66921},
 								name: "SQLIdentifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2212, col: 35, offset: 66971},
+							pos:   position{line: 2214, col: 35, offset: 66935},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2212, col: 40, offset: 66976},
+								pos: position{line: 2214, col: 40, offset: 66940},
 								expr: &actionExpr{
-									pos: position{line: 2212, col: 42, offset: 66978},
+									pos: position{line: 2214, col: 42, offset: 66942},
 									run: (*parser).callonColumns10,
 									expr: &seqExpr{
-										pos: position{line: 2212, col: 42, offset: 66978},
+										pos: position{line: 2214, col: 42, offset: 66942},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2212, col: 42, offset: 66978},
+												pos:  position{line: 2214, col: 42, offset: 66942},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2212, col: 45, offset: 66981},
+												pos:        position{line: 2214, col: 45, offset: 66945},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2212, col: 49, offset: 66985},
+												pos:  position{line: 2214, col: 49, offset: 66949},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2212, col: 52, offset: 66988},
+												pos:   position{line: 2214, col: 52, offset: 66952},
 												label: "s",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2212, col: 54, offset: 66990},
+													pos:  position{line: 2214, col: 54, offset: 66954},
 													name: "SQLIdentifier",
 												},
 											},
@@ -15159,11 +15146,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2212, col: 87, offset: 67023},
+							pos:  position{line: 2214, col: 87, offset: 66987},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2212, col: 90, offset: 67026},
+							pos:        position{line: 2214, col: 90, offset: 66990},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -15176,51 +15163,51 @@ var g = &grammar{
 		},
 		{
 			name: "Selection",
-			pos:  position{line: 2216, col: 1, offset: 67097},
+			pos:  position{line: 2218, col: 1, offset: 67061},
 			expr: &actionExpr{
-				pos: position{line: 2217, col: 5, offset: 67111},
+				pos: position{line: 2219, col: 5, offset: 67075},
 				run: (*parser).callonSelection1,
 				expr: &seqExpr{
-					pos: position{line: 2217, col: 5, offset: 67111},
+					pos: position{line: 2219, col: 5, offset: 67075},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2217, col: 5, offset: 67111},
+							pos:   position{line: 2219, col: 5, offset: 67075},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2217, col: 11, offset: 67117},
+								pos:  position{line: 2219, col: 11, offset: 67081},
 								name: "SelectElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2217, col: 22, offset: 67128},
+							pos:   position{line: 2219, col: 22, offset: 67092},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2217, col: 27, offset: 67133},
+								pos: position{line: 2219, col: 27, offset: 67097},
 								expr: &actionExpr{
-									pos: position{line: 2217, col: 29, offset: 67135},
+									pos: position{line: 2219, col: 29, offset: 67099},
 									run: (*parser).callonSelection7,
 									expr: &seqExpr{
-										pos: position{line: 2217, col: 29, offset: 67135},
+										pos: position{line: 2219, col: 29, offset: 67099},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2217, col: 29, offset: 67135},
+												pos:  position{line: 2219, col: 29, offset: 67099},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2217, col: 32, offset: 67138},
+												pos:        position{line: 2219, col: 32, offset: 67102},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2217, col: 36, offset: 67142},
+												pos:  position{line: 2219, col: 36, offset: 67106},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2217, col: 39, offset: 67145},
+												pos:   position{line: 2219, col: 39, offset: 67109},
 												label: "s",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2217, col: 41, offset: 67147},
+													pos:  position{line: 2219, col: 41, offset: 67111},
 													name: "SelectElem",
 												},
 											},
@@ -15237,38 +15224,38 @@ var g = &grammar{
 		},
 		{
 			name: "SelectElem",
-			pos:  position{line: 2226, col: 1, offset: 67382},
+			pos:  position{line: 2228, col: 1, offset: 67346},
 			expr: &choiceExpr{
-				pos: position{line: 2227, col: 5, offset: 67397},
+				pos: position{line: 2229, col: 5, offset: 67361},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2227, col: 5, offset: 67397},
+						pos: position{line: 2229, col: 5, offset: 67361},
 						run: (*parser).callonSelectElem2,
 						expr: &seqExpr{
-							pos: position{line: 2227, col: 5, offset: 67397},
+							pos: position{line: 2229, col: 5, offset: 67361},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2227, col: 5, offset: 67397},
+									pos:   position{line: 2229, col: 5, offset: 67361},
 									label: "expr",
 									expr: &choiceExpr{
-										pos: position{line: 2227, col: 11, offset: 67403},
+										pos: position{line: 2229, col: 11, offset: 67367},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2227, col: 11, offset: 67403},
+												pos:  position{line: 2229, col: 11, offset: 67367},
 												name: "AggDistinct",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2227, col: 25, offset: 67417},
+												pos:  position{line: 2229, col: 25, offset: 67381},
 												name: "Expr",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2227, col: 31, offset: 67423},
+									pos:   position{line: 2229, col: 31, offset: 67387},
 									label: "as",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2227, col: 34, offset: 67426},
+										pos:  position{line: 2229, col: 34, offset: 67390},
 										name: "OptAsClause",
 									},
 								},
@@ -15276,10 +15263,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2238, col: 5, offset: 67654},
+						pos: position{line: 2240, col: 5, offset: 67618},
 						run: (*parser).callonSelectElem10,
 						expr: &litMatcher{
-							pos:        position{line: 2238, col: 5, offset: 67654},
+							pos:        position{line: 2240, col: 5, offset: 67618},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -15292,33 +15279,33 @@ var g = &grammar{
 		},
 		{
 			name: "OptAsClause",
-			pos:  position{line: 2243, col: 1, offset: 67759},
+			pos:  position{line: 2245, col: 1, offset: 67723},
 			expr: &choiceExpr{
-				pos: position{line: 2244, col: 5, offset: 67775},
+				pos: position{line: 2246, col: 5, offset: 67739},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2244, col: 5, offset: 67775},
+						pos: position{line: 2246, col: 5, offset: 67739},
 						run: (*parser).callonOptAsClause2,
 						expr: &seqExpr{
-							pos: position{line: 2244, col: 5, offset: 67775},
+							pos: position{line: 2246, col: 5, offset: 67739},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2244, col: 5, offset: 67775},
+									pos:  position{line: 2246, col: 5, offset: 67739},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2244, col: 7, offset: 67777},
+									pos:  position{line: 2246, col: 7, offset: 67741},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2244, col: 10, offset: 67780},
+									pos:  position{line: 2246, col: 10, offset: 67744},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2244, col: 12, offset: 67782},
+									pos:   position{line: 2246, col: 12, offset: 67746},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2244, col: 15, offset: 67785},
+										pos:  position{line: 2246, col: 15, offset: 67749},
 										name: "SQLIdentifier",
 									},
 								},
@@ -15326,27 +15313,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2245, col: 5, offset: 67822},
+						pos: position{line: 2247, col: 5, offset: 67786},
 						run: (*parser).callonOptAsClause9,
 						expr: &seqExpr{
-							pos: position{line: 2245, col: 5, offset: 67822},
+							pos: position{line: 2247, col: 5, offset: 67786},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2245, col: 5, offset: 67822},
+									pos:  position{line: 2247, col: 5, offset: 67786},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 2245, col: 7, offset: 67824},
+									pos: position{line: 2247, col: 7, offset: 67788},
 									expr: &ruleRefExpr{
-										pos:  position{line: 2245, col: 8, offset: 67825},
+										pos:  position{line: 2247, col: 8, offset: 67789},
 										name: "SQLGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2245, col: 17, offset: 67834},
+									pos:   position{line: 2247, col: 17, offset: 67798},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2245, col: 20, offset: 67837},
+										pos:  position{line: 2247, col: 20, offset: 67801},
 										name: "SQLIdentifier",
 									},
 								},
@@ -15354,10 +15341,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2246, col: 5, offset: 67874},
+						pos: position{line: 2248, col: 5, offset: 67838},
 						run: (*parser).callonOptAsClause16,
 						expr: &litMatcher{
-							pos:        position{line: 2246, col: 5, offset: 67874},
+							pos:        position{line: 2248, col: 5, offset: 67838},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15370,41 +15357,41 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrderByClause",
-			pos:  position{line: 2248, col: 1, offset: 67899},
+			pos:  position{line: 2250, col: 1, offset: 67863},
 			expr: &choiceExpr{
-				pos: position{line: 2249, col: 5, offset: 67920},
+				pos: position{line: 2251, col: 5, offset: 67884},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2249, col: 5, offset: 67920},
+						pos: position{line: 2251, col: 5, offset: 67884},
 						run: (*parser).callonOptOrderByClause2,
 						expr: &seqExpr{
-							pos: position{line: 2249, col: 5, offset: 67920},
+							pos: position{line: 2251, col: 5, offset: 67884},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2249, col: 5, offset: 67920},
+									pos:  position{line: 2251, col: 5, offset: 67884},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2249, col: 7, offset: 67922},
+									pos:  position{line: 2251, col: 7, offset: 67886},
 									name: "ORDER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2249, col: 13, offset: 67928},
+									pos:  position{line: 2251, col: 13, offset: 67892},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2249, col: 15, offset: 67930},
+									pos:  position{line: 2251, col: 15, offset: 67894},
 									name: "BY",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2249, col: 18, offset: 67933},
+									pos:  position{line: 2251, col: 18, offset: 67897},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2249, col: 20, offset: 67935},
+									pos:   position{line: 2251, col: 20, offset: 67899},
 									label: "list",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2249, col: 25, offset: 67940},
+										pos:  position{line: 2251, col: 25, offset: 67904},
 										name: "OrderByList",
 									},
 								},
@@ -15412,10 +15399,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2256, col: 5, offset: 68104},
+						pos: position{line: 2258, col: 5, offset: 68068},
 						run: (*parser).callonOptOrderByClause11,
 						expr: &litMatcher{
-							pos:        position{line: 2256, col: 5, offset: 68104},
+							pos:        position{line: 2258, col: 5, offset: 68068},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15428,51 +15415,51 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByList",
-			pos:  position{line: 2258, col: 1, offset: 68137},
+			pos:  position{line: 2260, col: 1, offset: 68101},
 			expr: &actionExpr{
-				pos: position{line: 2259, col: 5, offset: 68153},
+				pos: position{line: 2261, col: 5, offset: 68117},
 				run: (*parser).callonOrderByList1,
 				expr: &seqExpr{
-					pos: position{line: 2259, col: 5, offset: 68153},
+					pos: position{line: 2261, col: 5, offset: 68117},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2259, col: 5, offset: 68153},
+							pos:   position{line: 2261, col: 5, offset: 68117},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2259, col: 11, offset: 68159},
+								pos:  position{line: 2261, col: 11, offset: 68123},
 								name: "OrderByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2259, col: 23, offset: 68171},
+							pos:   position{line: 2261, col: 23, offset: 68135},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2259, col: 28, offset: 68176},
+								pos: position{line: 2261, col: 28, offset: 68140},
 								expr: &actionExpr{
-									pos: position{line: 2259, col: 30, offset: 68178},
+									pos: position{line: 2261, col: 30, offset: 68142},
 									run: (*parser).callonOrderByList7,
 									expr: &seqExpr{
-										pos: position{line: 2259, col: 30, offset: 68178},
+										pos: position{line: 2261, col: 30, offset: 68142},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2259, col: 30, offset: 68178},
+												pos:  position{line: 2261, col: 30, offset: 68142},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2259, col: 33, offset: 68181},
+												pos:        position{line: 2261, col: 33, offset: 68145},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2259, col: 37, offset: 68185},
+												pos:  position{line: 2261, col: 37, offset: 68149},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2259, col: 40, offset: 68188},
+												pos:   position{line: 2261, col: 40, offset: 68152},
 												label: "o",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2259, col: 42, offset: 68190},
+													pos:  position{line: 2261, col: 42, offset: 68154},
 													name: "OrderByItem",
 												},
 											},
@@ -15489,34 +15476,34 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByItem",
-			pos:  position{line: 2263, col: 1, offset: 68291},
+			pos:  position{line: 2265, col: 1, offset: 68255},
 			expr: &actionExpr{
-				pos: position{line: 2264, col: 5, offset: 68307},
+				pos: position{line: 2266, col: 5, offset: 68271},
 				run: (*parser).callonOrderByItem1,
 				expr: &seqExpr{
-					pos: position{line: 2264, col: 5, offset: 68307},
+					pos: position{line: 2266, col: 5, offset: 68271},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2264, col: 5, offset: 68307},
+							pos:   position{line: 2266, col: 5, offset: 68271},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2264, col: 7, offset: 68309},
+								pos:  position{line: 2266, col: 7, offset: 68273},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2264, col: 12, offset: 68314},
+							pos:   position{line: 2266, col: 12, offset: 68278},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2264, col: 18, offset: 68320},
+								pos:  position{line: 2266, col: 18, offset: 68284},
 								name: "OptAscDesc",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2264, col: 29, offset: 68331},
+							pos:   position{line: 2266, col: 29, offset: 68295},
 							label: "nulls",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2264, col: 35, offset: 68337},
+								pos:  position{line: 2266, col: 35, offset: 68301},
 								name: "OptNullsOrder",
 							},
 						},
@@ -15528,49 +15515,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptAscDesc",
-			pos:  position{line: 2275, col: 1, offset: 68587},
+			pos:  position{line: 2277, col: 1, offset: 68551},
 			expr: &choiceExpr{
-				pos: position{line: 2276, col: 5, offset: 68602},
+				pos: position{line: 2278, col: 5, offset: 68566},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2276, col: 5, offset: 68602},
+						pos: position{line: 2278, col: 5, offset: 68566},
 						run: (*parser).callonOptAscDesc2,
 						expr: &seqExpr{
-							pos: position{line: 2276, col: 5, offset: 68602},
+							pos: position{line: 2278, col: 5, offset: 68566},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2276, col: 5, offset: 68602},
+									pos:  position{line: 2278, col: 5, offset: 68566},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2276, col: 7, offset: 68604},
+									pos:  position{line: 2278, col: 7, offset: 68568},
 									name: "ASC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2277, col: 5, offset: 68676},
+						pos: position{line: 2279, col: 5, offset: 68640},
 						run: (*parser).callonOptAscDesc6,
 						expr: &seqExpr{
-							pos: position{line: 2277, col: 5, offset: 68676},
+							pos: position{line: 2279, col: 5, offset: 68640},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2277, col: 5, offset: 68676},
+									pos:  position{line: 2279, col: 5, offset: 68640},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2277, col: 7, offset: 68678},
+									pos:  position{line: 2279, col: 7, offset: 68642},
 									name: "DESC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2278, col: 5, offset: 68750},
+						pos: position{line: 2280, col: 5, offset: 68714},
 						run: (*parser).callonOptAscDesc10,
 						expr: &litMatcher{
-							pos:        position{line: 2278, col: 5, offset: 68750},
+							pos:        position{line: 2280, col: 5, offset: 68714},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15583,65 +15570,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptNullsOrder",
-			pos:  position{line: 2280, col: 1, offset: 68782},
+			pos:  position{line: 2282, col: 1, offset: 68746},
 			expr: &choiceExpr{
-				pos: position{line: 2281, col: 5, offset: 68800},
+				pos: position{line: 2283, col: 5, offset: 68764},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2281, col: 5, offset: 68800},
+						pos: position{line: 2283, col: 5, offset: 68764},
 						run: (*parser).callonOptNullsOrder2,
 						expr: &seqExpr{
-							pos: position{line: 2281, col: 5, offset: 68800},
+							pos: position{line: 2283, col: 5, offset: 68764},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2281, col: 5, offset: 68800},
+									pos:  position{line: 2283, col: 5, offset: 68764},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2281, col: 7, offset: 68802},
+									pos:  position{line: 2283, col: 7, offset: 68766},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2281, col: 13, offset: 68808},
+									pos:  position{line: 2283, col: 13, offset: 68772},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2281, col: 15, offset: 68810},
+									pos:  position{line: 2283, col: 15, offset: 68774},
 									name: "FIRST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2282, col: 5, offset: 68886},
+						pos: position{line: 2284, col: 5, offset: 68850},
 						run: (*parser).callonOptNullsOrder8,
 						expr: &seqExpr{
-							pos: position{line: 2282, col: 5, offset: 68886},
+							pos: position{line: 2284, col: 5, offset: 68850},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2282, col: 5, offset: 68886},
+									pos:  position{line: 2284, col: 5, offset: 68850},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2282, col: 7, offset: 68888},
+									pos:  position{line: 2284, col: 7, offset: 68852},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2282, col: 13, offset: 68894},
+									pos:  position{line: 2284, col: 13, offset: 68858},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2282, col: 15, offset: 68896},
+									pos:  position{line: 2284, col: 15, offset: 68860},
 									name: "LAST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2283, col: 5, offset: 68971},
+						pos: position{line: 2285, col: 5, offset: 68935},
 						run: (*parser).callonOptNullsOrder14,
 						expr: &litMatcher{
-							pos:        position{line: 2283, col: 5, offset: 68971},
+							pos:        position{line: 2285, col: 5, offset: 68935},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15654,25 +15641,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptSQLLimitOffset",
-			pos:  position{line: 2285, col: 1, offset: 69016},
+			pos:  position{line: 2287, col: 1, offset: 68980},
 			expr: &choiceExpr{
-				pos: position{line: 2286, col: 5, offset: 69038},
+				pos: position{line: 2288, col: 5, offset: 69002},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2286, col: 5, offset: 69038},
+						pos: position{line: 2288, col: 5, offset: 69002},
 						run: (*parser).callonOptSQLLimitOffset2,
 						expr: &seqExpr{
-							pos: position{line: 2286, col: 5, offset: 69038},
+							pos: position{line: 2288, col: 5, offset: 69002},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2286, col: 5, offset: 69038},
+									pos:  position{line: 2288, col: 5, offset: 69002},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2286, col: 7, offset: 69040},
+									pos:   position{line: 2288, col: 7, offset: 69004},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2286, col: 10, offset: 69043},
+										pos:  position{line: 2288, col: 10, offset: 69007},
 										name: "SQLLimitOffset",
 									},
 								},
@@ -15680,10 +15667,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2287, col: 5, offset: 69081},
+						pos: position{line: 2289, col: 5, offset: 69045},
 						run: (*parser).callonOptSQLLimitOffset7,
 						expr: &litMatcher{
-							pos:        position{line: 2287, col: 5, offset: 69081},
+							pos:        position{line: 2289, col: 5, offset: 69045},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15696,29 +15683,29 @@ var g = &grammar{
 		},
 		{
 			name: "SQLLimitOffset",
-			pos:  position{line: 2289, col: 1, offset: 69122},
+			pos:  position{line: 2291, col: 1, offset: 69086},
 			expr: &choiceExpr{
-				pos: position{line: 2290, col: 5, offset: 69141},
+				pos: position{line: 2292, col: 5, offset: 69105},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2290, col: 5, offset: 69141},
+						pos: position{line: 2292, col: 5, offset: 69105},
 						run: (*parser).callonSQLLimitOffset2,
 						expr: &seqExpr{
-							pos: position{line: 2290, col: 5, offset: 69141},
+							pos: position{line: 2292, col: 5, offset: 69105},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2290, col: 5, offset: 69141},
+									pos:   position{line: 2292, col: 5, offset: 69105},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2290, col: 7, offset: 69143},
+										pos:  position{line: 2292, col: 7, offset: 69107},
 										name: "LimitClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2290, col: 19, offset: 69155},
+									pos:   position{line: 2292, col: 19, offset: 69119},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2290, col: 21, offset: 69157},
+										pos:  position{line: 2292, col: 21, offset: 69121},
 										name: "OptOffsetClause",
 									},
 								},
@@ -15726,24 +15713,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2303, col: 5, offset: 69421},
+						pos: position{line: 2305, col: 5, offset: 69385},
 						run: (*parser).callonSQLLimitOffset8,
 						expr: &seqExpr{
-							pos: position{line: 2303, col: 5, offset: 69421},
+							pos: position{line: 2305, col: 5, offset: 69385},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2303, col: 5, offset: 69421},
+									pos:   position{line: 2305, col: 5, offset: 69385},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2303, col: 7, offset: 69423},
+										pos:  position{line: 2305, col: 7, offset: 69387},
 										name: "OffsetClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2303, col: 20, offset: 69436},
+									pos:   position{line: 2305, col: 20, offset: 69400},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2303, col: 22, offset: 69438},
+										pos:  position{line: 2305, col: 22, offset: 69402},
 										name: "OptLimitClause",
 									},
 								},
@@ -15757,25 +15744,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptLimitClause",
-			pos:  position{line: 2315, col: 1, offset: 69667},
+			pos:  position{line: 2317, col: 1, offset: 69631},
 			expr: &choiceExpr{
-				pos: position{line: 2316, col: 5, offset: 69686},
+				pos: position{line: 2318, col: 5, offset: 69650},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2316, col: 5, offset: 69686},
+						pos: position{line: 2318, col: 5, offset: 69650},
 						run: (*parser).callonOptLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2316, col: 5, offset: 69686},
+							pos: position{line: 2318, col: 5, offset: 69650},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2316, col: 5, offset: 69686},
+									pos:  position{line: 2318, col: 5, offset: 69650},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2316, col: 7, offset: 69688},
+									pos:   position{line: 2318, col: 7, offset: 69652},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2316, col: 9, offset: 69690},
+										pos:  position{line: 2318, col: 9, offset: 69654},
 										name: "LimitClause",
 									},
 								},
@@ -15783,10 +15770,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2317, col: 5, offset: 69724},
+						pos: position{line: 2319, col: 5, offset: 69688},
 						run: (*parser).callonOptLimitClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2317, col: 5, offset: 69724},
+							pos:        position{line: 2319, col: 5, offset: 69688},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15799,50 +15786,50 @@ var g = &grammar{
 		},
 		{
 			name: "LimitClause",
-			pos:  position{line: 2319, col: 1, offset: 69761},
+			pos:  position{line: 2321, col: 1, offset: 69725},
 			expr: &choiceExpr{
-				pos: position{line: 2320, col: 5, offset: 69777},
+				pos: position{line: 2322, col: 5, offset: 69741},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2320, col: 5, offset: 69777},
+						pos: position{line: 2322, col: 5, offset: 69741},
 						run: (*parser).callonLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2320, col: 5, offset: 69777},
+							pos: position{line: 2322, col: 5, offset: 69741},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2320, col: 5, offset: 69777},
+									pos:  position{line: 2322, col: 5, offset: 69741},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2320, col: 11, offset: 69783},
+									pos:  position{line: 2322, col: 11, offset: 69747},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2320, col: 13, offset: 69785},
+									pos:  position{line: 2322, col: 13, offset: 69749},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2321, col: 5, offset: 69813},
+						pos: position{line: 2323, col: 5, offset: 69777},
 						run: (*parser).callonLimitClause7,
 						expr: &seqExpr{
-							pos: position{line: 2321, col: 5, offset: 69813},
+							pos: position{line: 2323, col: 5, offset: 69777},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2321, col: 5, offset: 69813},
+									pos:  position{line: 2323, col: 5, offset: 69777},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2321, col: 11, offset: 69819},
+									pos:  position{line: 2323, col: 11, offset: 69783},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2321, col: 13, offset: 69821},
+									pos:   position{line: 2323, col: 13, offset: 69785},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2321, col: 15, offset: 69823},
+										pos:  position{line: 2323, col: 15, offset: 69787},
 										name: "Expr",
 									},
 								},
@@ -15856,25 +15843,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptOffsetClause",
-			pos:  position{line: 2323, col: 1, offset: 69847},
+			pos:  position{line: 2325, col: 1, offset: 69811},
 			expr: &choiceExpr{
-				pos: position{line: 2324, col: 5, offset: 69867},
+				pos: position{line: 2326, col: 5, offset: 69831},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2324, col: 5, offset: 69867},
+						pos: position{line: 2326, col: 5, offset: 69831},
 						run: (*parser).callonOptOffsetClause2,
 						expr: &seqExpr{
-							pos: position{line: 2324, col: 5, offset: 69867},
+							pos: position{line: 2326, col: 5, offset: 69831},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2324, col: 5, offset: 69867},
+									pos:  position{line: 2326, col: 5, offset: 69831},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2324, col: 7, offset: 69869},
+									pos:   position{line: 2326, col: 7, offset: 69833},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2324, col: 9, offset: 69871},
+										pos:  position{line: 2326, col: 9, offset: 69835},
 										name: "OffsetClause",
 									},
 								},
@@ -15882,10 +15869,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2325, col: 5, offset: 69907},
+						pos: position{line: 2327, col: 5, offset: 69871},
 						run: (*parser).callonOptOffsetClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2325, col: 5, offset: 69907},
+							pos:        position{line: 2327, col: 5, offset: 69871},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15898,26 +15885,26 @@ var g = &grammar{
 		},
 		{
 			name: "OffsetClause",
-			pos:  position{line: 2327, col: 1, offset: 69932},
+			pos:  position{line: 2329, col: 1, offset: 69896},
 			expr: &actionExpr{
-				pos: position{line: 2328, col: 5, offset: 69949},
+				pos: position{line: 2330, col: 5, offset: 69913},
 				run: (*parser).callonOffsetClause1,
 				expr: &seqExpr{
-					pos: position{line: 2328, col: 5, offset: 69949},
+					pos: position{line: 2330, col: 5, offset: 69913},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2328, col: 5, offset: 69949},
+							pos:  position{line: 2330, col: 5, offset: 69913},
 							name: "OFFSET",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2328, col: 12, offset: 69956},
+							pos:  position{line: 2330, col: 12, offset: 69920},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2328, col: 14, offset: 69958},
+							pos:   position{line: 2330, col: 14, offset: 69922},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2328, col: 16, offset: 69960},
+								pos:  position{line: 2330, col: 16, offset: 69924},
 								name: "Expr",
 							},
 						},
@@ -15929,60 +15916,60 @@ var g = &grammar{
 		},
 		{
 			name: "SetOp",
-			pos:  position{line: 2330, col: 1, offset: 69985},
+			pos:  position{line: 2332, col: 1, offset: 69949},
 			expr: &choiceExpr{
-				pos: position{line: 2331, col: 5, offset: 69995},
+				pos: position{line: 2333, col: 5, offset: 69959},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2331, col: 5, offset: 69995},
+						pos: position{line: 2333, col: 5, offset: 69959},
 						run: (*parser).callonSetOp2,
 						expr: &seqExpr{
-							pos: position{line: 2331, col: 5, offset: 69995},
+							pos: position{line: 2333, col: 5, offset: 69959},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2331, col: 5, offset: 69995},
+									pos:  position{line: 2333, col: 5, offset: 69959},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2331, col: 7, offset: 69997},
+									pos:  position{line: 2333, col: 7, offset: 69961},
 									name: "UNION",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2331, col: 13, offset: 70003},
+									pos:  position{line: 2333, col: 13, offset: 69967},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2331, col: 15, offset: 70005},
+									pos:  position{line: 2333, col: 15, offset: 69969},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2332, col: 5, offset: 70041},
+						pos: position{line: 2334, col: 5, offset: 70005},
 						run: (*parser).callonSetOp8,
 						expr: &seqExpr{
-							pos: position{line: 2332, col: 5, offset: 70041},
+							pos: position{line: 2334, col: 5, offset: 70005},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2332, col: 5, offset: 70041},
+									pos:  position{line: 2334, col: 5, offset: 70005},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2332, col: 7, offset: 70043},
+									pos:  position{line: 2334, col: 7, offset: 70007},
 									name: "UNION",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2332, col: 13, offset: 70049},
+									pos: position{line: 2334, col: 13, offset: 70013},
 									expr: &seqExpr{
-										pos: position{line: 2332, col: 14, offset: 70050},
+										pos: position{line: 2334, col: 14, offset: 70014},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2332, col: 14, offset: 70050},
+												pos:  position{line: 2334, col: 14, offset: 70014},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2332, col: 16, offset: 70052},
+												pos:  position{line: 2334, col: 16, offset: 70016},
 												name: "DISTINCT",
 											},
 										},
@@ -15998,84 +15985,84 @@ var g = &grammar{
 		},
 		{
 			name: "SQLGuard",
-			pos:  position{line: 2335, col: 1, offset: 70104},
+			pos:  position{line: 2337, col: 1, offset: 70068},
 			expr: &choiceExpr{
-				pos: position{line: 2336, col: 5, offset: 70119},
+				pos: position{line: 2338, col: 5, offset: 70083},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2336, col: 5, offset: 70119},
+						pos:  position{line: 2338, col: 5, offset: 70083},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2336, col: 12, offset: 70126},
+						pos:  position{line: 2338, col: 12, offset: 70090},
 						name: "GROUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2336, col: 20, offset: 70134},
+						pos:  position{line: 2338, col: 20, offset: 70098},
 						name: "HAVING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2336, col: 29, offset: 70143},
+						pos:  position{line: 2338, col: 29, offset: 70107},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2336, col: 38, offset: 70152},
+						pos:  position{line: 2338, col: 38, offset: 70116},
 						name: "RECURSIVE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2337, col: 5, offset: 70166},
+						pos:  position{line: 2339, col: 5, offset: 70130},
 						name: "INNER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2337, col: 13, offset: 70174},
+						pos:  position{line: 2339, col: 13, offset: 70138},
 						name: "LEFT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2337, col: 20, offset: 70181},
+						pos:  position{line: 2339, col: 20, offset: 70145},
 						name: "RIGHT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2337, col: 28, offset: 70189},
+						pos:  position{line: 2339, col: 28, offset: 70153},
 						name: "OUTER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2337, col: 36, offset: 70197},
+						pos:  position{line: 2339, col: 36, offset: 70161},
 						name: "CROSS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2337, col: 44, offset: 70205},
+						pos:  position{line: 2339, col: 44, offset: 70169},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2338, col: 5, offset: 70214},
+						pos:  position{line: 2340, col: 5, offset: 70178},
 						name: "UNION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2339, col: 5, offset: 70224},
+						pos:  position{line: 2341, col: 5, offset: 70188},
 						name: "ORDER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2340, col: 5, offset: 70234},
+						pos:  position{line: 2342, col: 5, offset: 70198},
 						name: "OFFSET",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2341, col: 5, offset: 70245},
+						pos:  position{line: 2343, col: 5, offset: 70209},
 						name: "LIMIT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2342, col: 5, offset: 70255},
+						pos:  position{line: 2344, col: 5, offset: 70219},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2343, col: 5, offset: 70265},
+						pos:  position{line: 2345, col: 5, offset: 70229},
 						name: "WITH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2344, col: 5, offset: 70274},
+						pos:  position{line: 2346, col: 5, offset: 70238},
 						name: "USING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2345, col: 5, offset: 70284},
+						pos:  position{line: 2347, col: 5, offset: 70248},
 						name: "ON",
 					},
 				},
@@ -16085,20 +16072,20 @@ var g = &grammar{
 		},
 		{
 			name: "AGGREGATE",
-			pos:  position{line: 2347, col: 1, offset: 70288},
+			pos:  position{line: 2349, col: 1, offset: 70252},
 			expr: &seqExpr{
-				pos: position{line: 2347, col: 14, offset: 70301},
+				pos: position{line: 2349, col: 14, offset: 70265},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2347, col: 14, offset: 70301},
+						pos:        position{line: 2349, col: 14, offset: 70265},
 						val:        "aggregate",
 						ignoreCase: true,
 						want:       "\"AGGREGATE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2347, col: 33, offset: 70320},
+						pos: position{line: 2349, col: 33, offset: 70284},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2347, col: 34, offset: 70321},
+							pos:  position{line: 2349, col: 34, offset: 70285},
 							name: "IdentifierRest",
 						},
 					},
@@ -16109,20 +16096,20 @@ var g = &grammar{
 		},
 		{
 			name: "ALL",
-			pos:  position{line: 2348, col: 1, offset: 70336},
+			pos:  position{line: 2350, col: 1, offset: 70300},
 			expr: &seqExpr{
-				pos: position{line: 2348, col: 14, offset: 70349},
+				pos: position{line: 2350, col: 14, offset: 70313},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2348, col: 14, offset: 70349},
+						pos:        position{line: 2350, col: 14, offset: 70313},
 						val:        "all",
 						ignoreCase: true,
 						want:       "\"ALL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2348, col: 33, offset: 70368},
+						pos: position{line: 2350, col: 33, offset: 70332},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2348, col: 34, offset: 70369},
+							pos:  position{line: 2350, col: 34, offset: 70333},
 							name: "IdentifierRest",
 						},
 					},
@@ -16133,23 +16120,23 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 2349, col: 1, offset: 70384},
+			pos:  position{line: 2351, col: 1, offset: 70348},
 			expr: &actionExpr{
-				pos: position{line: 2349, col: 14, offset: 70397},
+				pos: position{line: 2351, col: 14, offset: 70361},
 				run: (*parser).callonAND1,
 				expr: &seqExpr{
-					pos: position{line: 2349, col: 14, offset: 70397},
+					pos: position{line: 2351, col: 14, offset: 70361},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2349, col: 14, offset: 70397},
+							pos:        position{line: 2351, col: 14, offset: 70361},
 							val:        "and",
 							ignoreCase: true,
 							want:       "\"AND\"i",
 						},
 						&notExpr{
-							pos: position{line: 2349, col: 33, offset: 70416},
+							pos: position{line: 2351, col: 33, offset: 70380},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2349, col: 34, offset: 70417},
+								pos:  position{line: 2351, col: 34, offset: 70381},
 								name: "IdentifierRest",
 							},
 						},
@@ -16161,20 +16148,20 @@ var g = &grammar{
 		},
 		{
 			name: "ANTI",
-			pos:  position{line: 2350, col: 1, offset: 70454},
+			pos:  position{line: 2352, col: 1, offset: 70418},
 			expr: &seqExpr{
-				pos: position{line: 2350, col: 14, offset: 70467},
+				pos: position{line: 2352, col: 14, offset: 70431},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2350, col: 14, offset: 70467},
+						pos:        position{line: 2352, col: 14, offset: 70431},
 						val:        "anti",
 						ignoreCase: true,
 						want:       "\"ANTI\"i",
 					},
 					&notExpr{
-						pos: position{line: 2350, col: 33, offset: 70486},
+						pos: position{line: 2352, col: 33, offset: 70450},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2350, col: 34, offset: 70487},
+							pos:  position{line: 2352, col: 34, offset: 70451},
 							name: "IdentifierRest",
 						},
 					},
@@ -16185,20 +16172,20 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 2351, col: 1, offset: 70502},
+			pos:  position{line: 2353, col: 1, offset: 70466},
 			expr: &seqExpr{
-				pos: position{line: 2351, col: 14, offset: 70515},
+				pos: position{line: 2353, col: 14, offset: 70479},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2351, col: 14, offset: 70515},
+						pos:        position{line: 2353, col: 14, offset: 70479},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2351, col: 33, offset: 70534},
+						pos: position{line: 2353, col: 33, offset: 70498},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2351, col: 34, offset: 70535},
+							pos:  position{line: 2353, col: 34, offset: 70499},
 							name: "IdentifierRest",
 						},
 					},
@@ -16209,23 +16196,23 @@ var g = &grammar{
 		},
 		{
 			name: "ASC",
-			pos:  position{line: 2352, col: 1, offset: 70550},
+			pos:  position{line: 2354, col: 1, offset: 70514},
 			expr: &actionExpr{
-				pos: position{line: 2352, col: 14, offset: 70563},
+				pos: position{line: 2354, col: 14, offset: 70527},
 				run: (*parser).callonASC1,
 				expr: &seqExpr{
-					pos: position{line: 2352, col: 14, offset: 70563},
+					pos: position{line: 2354, col: 14, offset: 70527},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2352, col: 14, offset: 70563},
+							pos:        position{line: 2354, col: 14, offset: 70527},
 							val:        "asc",
 							ignoreCase: true,
 							want:       "\"ASC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2352, col: 33, offset: 70582},
+							pos: position{line: 2354, col: 33, offset: 70546},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2352, col: 34, offset: 70583},
+								pos:  position{line: 2354, col: 34, offset: 70547},
 								name: "IdentifierRest",
 							},
 						},
@@ -16237,20 +16224,20 @@ var g = &grammar{
 		},
 		{
 			name: "ASSERT",
-			pos:  position{line: 2353, col: 1, offset: 70620},
+			pos:  position{line: 2355, col: 1, offset: 70584},
 			expr: &seqExpr{
-				pos: position{line: 2353, col: 14, offset: 70633},
+				pos: position{line: 2355, col: 14, offset: 70597},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2353, col: 14, offset: 70633},
+						pos:        position{line: 2355, col: 14, offset: 70597},
 						val:        "assert",
 						ignoreCase: true,
 						want:       "\"ASSERT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2353, col: 33, offset: 70652},
+						pos: position{line: 2355, col: 33, offset: 70616},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2353, col: 34, offset: 70653},
+							pos:  position{line: 2355, col: 34, offset: 70617},
 							name: "IdentifierRest",
 						},
 					},
@@ -16261,20 +16248,20 @@ var g = &grammar{
 		},
 		{
 			name: "AT",
-			pos:  position{line: 2354, col: 1, offset: 70668},
+			pos:  position{line: 2356, col: 1, offset: 70632},
 			expr: &seqExpr{
-				pos: position{line: 2354, col: 14, offset: 70681},
+				pos: position{line: 2356, col: 14, offset: 70645},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2354, col: 14, offset: 70681},
+						pos:        position{line: 2356, col: 14, offset: 70645},
 						val:        "at",
 						ignoreCase: true,
 						want:       "\"AT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2354, col: 33, offset: 70700},
+						pos: position{line: 2356, col: 33, offset: 70664},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2354, col: 34, offset: 70701},
+							pos:  position{line: 2356, col: 34, offset: 70665},
 							name: "IdentifierRest",
 						},
 					},
@@ -16285,20 +16272,20 @@ var g = &grammar{
 		},
 		{
 			name: "BETWEEN",
-			pos:  position{line: 2355, col: 1, offset: 70716},
+			pos:  position{line: 2357, col: 1, offset: 70680},
 			expr: &seqExpr{
-				pos: position{line: 2355, col: 14, offset: 70729},
+				pos: position{line: 2357, col: 14, offset: 70693},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2355, col: 14, offset: 70729},
+						pos:        position{line: 2357, col: 14, offset: 70693},
 						val:        "between",
 						ignoreCase: true,
 						want:       "\"BETWEEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2355, col: 33, offset: 70748},
+						pos: position{line: 2357, col: 33, offset: 70712},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2355, col: 34, offset: 70749},
+							pos:  position{line: 2357, col: 34, offset: 70713},
 							name: "IdentifierRest",
 						},
 					},
@@ -16309,20 +16296,20 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 2356, col: 1, offset: 70764},
+			pos:  position{line: 2358, col: 1, offset: 70728},
 			expr: &seqExpr{
-				pos: position{line: 2356, col: 14, offset: 70777},
+				pos: position{line: 2358, col: 14, offset: 70741},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2356, col: 14, offset: 70777},
+						pos:        position{line: 2358, col: 14, offset: 70741},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2356, col: 33, offset: 70796},
+						pos: position{line: 2358, col: 33, offset: 70760},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2356, col: 34, offset: 70797},
+							pos:  position{line: 2358, col: 34, offset: 70761},
 							name: "IdentifierRest",
 						},
 					},
@@ -16333,20 +16320,20 @@ var g = &grammar{
 		},
 		{
 			name: "CALL",
-			pos:  position{line: 2357, col: 1, offset: 70812},
+			pos:  position{line: 2359, col: 1, offset: 70776},
 			expr: &seqExpr{
-				pos: position{line: 2357, col: 14, offset: 70825},
+				pos: position{line: 2359, col: 14, offset: 70789},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2357, col: 14, offset: 70825},
+						pos:        position{line: 2359, col: 14, offset: 70789},
 						val:        "call",
 						ignoreCase: true,
 						want:       "\"CALL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2357, col: 33, offset: 70844},
+						pos: position{line: 2359, col: 33, offset: 70808},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2357, col: 34, offset: 70845},
+							pos:  position{line: 2359, col: 34, offset: 70809},
 							name: "IdentifierRest",
 						},
 					},
@@ -16357,20 +16344,20 @@ var g = &grammar{
 		},
 		{
 			name: "CASE",
-			pos:  position{line: 2358, col: 1, offset: 70860},
+			pos:  position{line: 2360, col: 1, offset: 70824},
 			expr: &seqExpr{
-				pos: position{line: 2358, col: 14, offset: 70873},
+				pos: position{line: 2360, col: 14, offset: 70837},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2358, col: 14, offset: 70873},
+						pos:        position{line: 2360, col: 14, offset: 70837},
 						val:        "case",
 						ignoreCase: true,
 						want:       "\"CASE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2358, col: 33, offset: 70892},
+						pos: position{line: 2360, col: 33, offset: 70856},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2358, col: 34, offset: 70893},
+							pos:  position{line: 2360, col: 34, offset: 70857},
 							name: "IdentifierRest",
 						},
 					},
@@ -16381,20 +16368,20 @@ var g = &grammar{
 		},
 		{
 			name: "CAST",
-			pos:  position{line: 2359, col: 1, offset: 70908},
+			pos:  position{line: 2361, col: 1, offset: 70872},
 			expr: &seqExpr{
-				pos: position{line: 2359, col: 14, offset: 70921},
+				pos: position{line: 2361, col: 14, offset: 70885},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2359, col: 14, offset: 70921},
+						pos:        position{line: 2361, col: 14, offset: 70885},
 						val:        "cast",
 						ignoreCase: true,
 						want:       "\"CAST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2359, col: 33, offset: 70940},
+						pos: position{line: 2361, col: 33, offset: 70904},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2359, col: 34, offset: 70941},
+							pos:  position{line: 2361, col: 34, offset: 70905},
 							name: "IdentifierRest",
 						},
 					},
@@ -16405,20 +16392,20 @@ var g = &grammar{
 		},
 		{
 			name: "CONST",
-			pos:  position{line: 2360, col: 1, offset: 70956},
+			pos:  position{line: 2362, col: 1, offset: 70920},
 			expr: &seqExpr{
-				pos: position{line: 2360, col: 14, offset: 70969},
+				pos: position{line: 2362, col: 14, offset: 70933},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2360, col: 14, offset: 70969},
+						pos:        position{line: 2362, col: 14, offset: 70933},
 						val:        "const",
 						ignoreCase: true,
 						want:       "\"CONST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2360, col: 33, offset: 70988},
+						pos: position{line: 2362, col: 33, offset: 70952},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2360, col: 34, offset: 70989},
+							pos:  position{line: 2362, col: 34, offset: 70953},
 							name: "IdentifierRest",
 						},
 					},
@@ -16429,20 +16416,20 @@ var g = &grammar{
 		},
 		{
 			name: "COUNT",
-			pos:  position{line: 2361, col: 1, offset: 71004},
+			pos:  position{line: 2363, col: 1, offset: 70968},
 			expr: &seqExpr{
-				pos: position{line: 2361, col: 14, offset: 71017},
+				pos: position{line: 2363, col: 14, offset: 70981},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2361, col: 14, offset: 71017},
+						pos:        position{line: 2363, col: 14, offset: 70981},
 						val:        "count",
 						ignoreCase: true,
 						want:       "\"COUNT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2361, col: 33, offset: 71036},
+						pos: position{line: 2363, col: 33, offset: 71000},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2361, col: 34, offset: 71037},
+							pos:  position{line: 2363, col: 34, offset: 71001},
 							name: "IdentifierRest",
 						},
 					},
@@ -16453,20 +16440,20 @@ var g = &grammar{
 		},
 		{
 			name: "CROSS",
-			pos:  position{line: 2362, col: 1, offset: 71052},
+			pos:  position{line: 2364, col: 1, offset: 71016},
 			expr: &seqExpr{
-				pos: position{line: 2362, col: 14, offset: 71065},
+				pos: position{line: 2364, col: 14, offset: 71029},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2362, col: 14, offset: 71065},
+						pos:        position{line: 2364, col: 14, offset: 71029},
 						val:        "cross",
 						ignoreCase: true,
 						want:       "\"CROSS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2362, col: 33, offset: 71084},
+						pos: position{line: 2364, col: 33, offset: 71048},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2362, col: 34, offset: 71085},
+							pos:  position{line: 2364, col: 34, offset: 71049},
 							name: "IdentifierRest",
 						},
 					},
@@ -16477,20 +16464,20 @@ var g = &grammar{
 		},
 		{
 			name: "CUT",
-			pos:  position{line: 2363, col: 1, offset: 71100},
+			pos:  position{line: 2365, col: 1, offset: 71064},
 			expr: &seqExpr{
-				pos: position{line: 2363, col: 14, offset: 71113},
+				pos: position{line: 2365, col: 14, offset: 71077},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2363, col: 14, offset: 71113},
+						pos:        position{line: 2365, col: 14, offset: 71077},
 						val:        "cut",
 						ignoreCase: true,
 						want:       "\"CUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2363, col: 33, offset: 71132},
+						pos: position{line: 2365, col: 33, offset: 71096},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2363, col: 34, offset: 71133},
+							pos:  position{line: 2365, col: 34, offset: 71097},
 							name: "IdentifierRest",
 						},
 					},
@@ -16501,23 +16488,23 @@ var g = &grammar{
 		},
 		{
 			name: "DATE",
-			pos:  position{line: 2364, col: 1, offset: 71148},
+			pos:  position{line: 2366, col: 1, offset: 71112},
 			expr: &actionExpr{
-				pos: position{line: 2364, col: 14, offset: 71161},
+				pos: position{line: 2366, col: 14, offset: 71125},
 				run: (*parser).callonDATE1,
 				expr: &seqExpr{
-					pos: position{line: 2364, col: 14, offset: 71161},
+					pos: position{line: 2366, col: 14, offset: 71125},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2364, col: 14, offset: 71161},
+							pos:        position{line: 2366, col: 14, offset: 71125},
 							val:        "date",
 							ignoreCase: true,
 							want:       "\"DATE\"i",
 						},
 						&notExpr{
-							pos: position{line: 2364, col: 33, offset: 71180},
+							pos: position{line: 2366, col: 33, offset: 71144},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2364, col: 34, offset: 71181},
+								pos:  position{line: 2366, col: 34, offset: 71145},
 								name: "IdentifierRest",
 							},
 						},
@@ -16529,20 +16516,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEBUG",
-			pos:  position{line: 2365, col: 1, offset: 71219},
+			pos:  position{line: 2367, col: 1, offset: 71183},
 			expr: &seqExpr{
-				pos: position{line: 2365, col: 14, offset: 71232},
+				pos: position{line: 2367, col: 14, offset: 71196},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2365, col: 14, offset: 71232},
+						pos:        position{line: 2367, col: 14, offset: 71196},
 						val:        "debug",
 						ignoreCase: true,
 						want:       "\"DEBUG\"i",
 					},
 					&notExpr{
-						pos: position{line: 2365, col: 33, offset: 71251},
+						pos: position{line: 2367, col: 33, offset: 71215},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2365, col: 34, offset: 71252},
+							pos:  position{line: 2367, col: 34, offset: 71216},
 							name: "IdentifierRest",
 						},
 					},
@@ -16553,20 +16540,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEFAULT",
-			pos:  position{line: 2366, col: 1, offset: 71267},
+			pos:  position{line: 2368, col: 1, offset: 71231},
 			expr: &seqExpr{
-				pos: position{line: 2366, col: 14, offset: 71280},
+				pos: position{line: 2368, col: 14, offset: 71244},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2366, col: 14, offset: 71280},
+						pos:        position{line: 2368, col: 14, offset: 71244},
 						val:        "default",
 						ignoreCase: true,
 						want:       "\"DEFAULT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2366, col: 33, offset: 71299},
+						pos: position{line: 2368, col: 33, offset: 71263},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2366, col: 34, offset: 71300},
+							pos:  position{line: 2368, col: 34, offset: 71264},
 							name: "IdentifierRest",
 						},
 					},
@@ -16577,23 +16564,23 @@ var g = &grammar{
 		},
 		{
 			name: "DESC",
-			pos:  position{line: 2367, col: 1, offset: 71315},
+			pos:  position{line: 2369, col: 1, offset: 71279},
 			expr: &actionExpr{
-				pos: position{line: 2367, col: 14, offset: 71328},
+				pos: position{line: 2369, col: 14, offset: 71292},
 				run: (*parser).callonDESC1,
 				expr: &seqExpr{
-					pos: position{line: 2367, col: 14, offset: 71328},
+					pos: position{line: 2369, col: 14, offset: 71292},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2367, col: 14, offset: 71328},
+							pos:        position{line: 2369, col: 14, offset: 71292},
 							val:        "desc",
 							ignoreCase: true,
 							want:       "\"DESC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2367, col: 33, offset: 71347},
+							pos: position{line: 2369, col: 33, offset: 71311},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2367, col: 34, offset: 71348},
+								pos:  position{line: 2369, col: 34, offset: 71312},
 								name: "IdentifierRest",
 							},
 						},
@@ -16605,20 +16592,20 @@ var g = &grammar{
 		},
 		{
 			name: "DISTINCT",
-			pos:  position{line: 2368, col: 1, offset: 71386},
+			pos:  position{line: 2370, col: 1, offset: 71350},
 			expr: &seqExpr{
-				pos: position{line: 2368, col: 14, offset: 71399},
+				pos: position{line: 2370, col: 14, offset: 71363},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2368, col: 14, offset: 71399},
+						pos:        position{line: 2370, col: 14, offset: 71363},
 						val:        "distinct",
 						ignoreCase: true,
 						want:       "\"DISTINCT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2368, col: 33, offset: 71418},
+						pos: position{line: 2370, col: 33, offset: 71382},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2368, col: 34, offset: 71419},
+							pos:  position{line: 2370, col: 34, offset: 71383},
 							name: "IdentifierRest",
 						},
 					},
@@ -16629,20 +16616,20 @@ var g = &grammar{
 		},
 		{
 			name: "DROP",
-			pos:  position{line: 2369, col: 1, offset: 71434},
+			pos:  position{line: 2371, col: 1, offset: 71398},
 			expr: &seqExpr{
-				pos: position{line: 2369, col: 14, offset: 71447},
+				pos: position{line: 2371, col: 14, offset: 71411},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2369, col: 14, offset: 71447},
+						pos:        position{line: 2371, col: 14, offset: 71411},
 						val:        "drop",
 						ignoreCase: true,
 						want:       "\"DROP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2369, col: 33, offset: 71466},
+						pos: position{line: 2371, col: 33, offset: 71430},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2369, col: 34, offset: 71467},
+							pos:  position{line: 2371, col: 34, offset: 71431},
 							name: "IdentifierRest",
 						},
 					},
@@ -16653,20 +16640,20 @@ var g = &grammar{
 		},
 		{
 			name: "ELSE",
-			pos:  position{line: 2370, col: 1, offset: 71482},
+			pos:  position{line: 2372, col: 1, offset: 71446},
 			expr: &seqExpr{
-				pos: position{line: 2370, col: 14, offset: 71495},
+				pos: position{line: 2372, col: 14, offset: 71459},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2370, col: 14, offset: 71495},
+						pos:        position{line: 2372, col: 14, offset: 71459},
 						val:        "else",
 						ignoreCase: true,
 						want:       "\"ELSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2370, col: 33, offset: 71514},
+						pos: position{line: 2372, col: 33, offset: 71478},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2370, col: 34, offset: 71515},
+							pos:  position{line: 2372, col: 34, offset: 71479},
 							name: "IdentifierRest",
 						},
 					},
@@ -16677,20 +16664,20 @@ var g = &grammar{
 		},
 		{
 			name: "END",
-			pos:  position{line: 2371, col: 1, offset: 71530},
+			pos:  position{line: 2373, col: 1, offset: 71494},
 			expr: &seqExpr{
-				pos: position{line: 2371, col: 14, offset: 71543},
+				pos: position{line: 2373, col: 14, offset: 71507},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2371, col: 14, offset: 71543},
+						pos:        position{line: 2373, col: 14, offset: 71507},
 						val:        "end",
 						ignoreCase: true,
 						want:       "\"END\"i",
 					},
 					&notExpr{
-						pos: position{line: 2371, col: 33, offset: 71562},
+						pos: position{line: 2373, col: 33, offset: 71526},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2371, col: 34, offset: 71563},
+							pos:  position{line: 2373, col: 34, offset: 71527},
 							name: "IdentifierRest",
 						},
 					},
@@ -16701,20 +16688,20 @@ var g = &grammar{
 		},
 		{
 			name: "ENUM",
-			pos:  position{line: 2372, col: 1, offset: 71578},
+			pos:  position{line: 2374, col: 1, offset: 71542},
 			expr: &seqExpr{
-				pos: position{line: 2372, col: 14, offset: 71591},
+				pos: position{line: 2374, col: 14, offset: 71555},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2372, col: 14, offset: 71591},
+						pos:        position{line: 2374, col: 14, offset: 71555},
 						val:        "enum",
 						ignoreCase: true,
 						want:       "\"ENUM\"i",
 					},
 					&notExpr{
-						pos: position{line: 2372, col: 33, offset: 71610},
+						pos: position{line: 2374, col: 33, offset: 71574},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2372, col: 34, offset: 71611},
+							pos:  position{line: 2374, col: 34, offset: 71575},
 							name: "IdentifierRest",
 						},
 					},
@@ -16725,20 +16712,20 @@ var g = &grammar{
 		},
 		{
 			name: "ERROR",
-			pos:  position{line: 2373, col: 1, offset: 71626},
+			pos:  position{line: 2375, col: 1, offset: 71590},
 			expr: &seqExpr{
-				pos: position{line: 2373, col: 14, offset: 71639},
+				pos: position{line: 2375, col: 14, offset: 71603},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2373, col: 14, offset: 71639},
+						pos:        position{line: 2375, col: 14, offset: 71603},
 						val:        "error",
 						ignoreCase: true,
 						want:       "\"ERROR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2373, col: 33, offset: 71658},
+						pos: position{line: 2375, col: 33, offset: 71622},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2373, col: 34, offset: 71659},
+							pos:  position{line: 2375, col: 34, offset: 71623},
 							name: "IdentifierRest",
 						},
 					},
@@ -16749,20 +16736,20 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL",
-			pos:  position{line: 2374, col: 1, offset: 71674},
+			pos:  position{line: 2376, col: 1, offset: 71638},
 			expr: &seqExpr{
-				pos: position{line: 2374, col: 14, offset: 71687},
+				pos: position{line: 2376, col: 14, offset: 71651},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2374, col: 14, offset: 71687},
+						pos:        position{line: 2376, col: 14, offset: 71651},
 						val:        "eval",
 						ignoreCase: true,
 						want:       "\"EVAL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2374, col: 33, offset: 71706},
+						pos: position{line: 2376, col: 33, offset: 71670},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2374, col: 34, offset: 71707},
+							pos:  position{line: 2376, col: 34, offset: 71671},
 							name: "IdentifierRest",
 						},
 					},
@@ -16773,20 +16760,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXISTS",
-			pos:  position{line: 2375, col: 1, offset: 71722},
+			pos:  position{line: 2377, col: 1, offset: 71686},
 			expr: &seqExpr{
-				pos: position{line: 2375, col: 14, offset: 71735},
+				pos: position{line: 2377, col: 14, offset: 71699},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2375, col: 14, offset: 71735},
+						pos:        position{line: 2377, col: 14, offset: 71699},
 						val:        "exists",
 						ignoreCase: true,
 						want:       "\"EXISTS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2375, col: 33, offset: 71754},
+						pos: position{line: 2377, col: 33, offset: 71718},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2375, col: 34, offset: 71755},
+							pos:  position{line: 2377, col: 34, offset: 71719},
 							name: "IdentifierRest",
 						},
 					},
@@ -16797,20 +16784,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXPLODE",
-			pos:  position{line: 2376, col: 1, offset: 71770},
+			pos:  position{line: 2378, col: 1, offset: 71734},
 			expr: &seqExpr{
-				pos: position{line: 2376, col: 14, offset: 71783},
+				pos: position{line: 2378, col: 14, offset: 71747},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2376, col: 14, offset: 71783},
+						pos:        position{line: 2378, col: 14, offset: 71747},
 						val:        "explode",
 						ignoreCase: true,
 						want:       "\"EXPLODE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2376, col: 33, offset: 71802},
+						pos: position{line: 2378, col: 33, offset: 71766},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2376, col: 34, offset: 71803},
+							pos:  position{line: 2378, col: 34, offset: 71767},
 							name: "IdentifierRest",
 						},
 					},
@@ -16821,20 +16808,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXTRACT",
-			pos:  position{line: 2377, col: 1, offset: 71818},
+			pos:  position{line: 2379, col: 1, offset: 71782},
 			expr: &seqExpr{
-				pos: position{line: 2377, col: 14, offset: 71831},
+				pos: position{line: 2379, col: 14, offset: 71795},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2377, col: 14, offset: 71831},
+						pos:        position{line: 2379, col: 14, offset: 71795},
 						val:        "extract",
 						ignoreCase: true,
 						want:       "\"EXTRACT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2377, col: 33, offset: 71850},
+						pos: position{line: 2379, col: 33, offset: 71814},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2377, col: 34, offset: 71851},
+							pos:  position{line: 2379, col: 34, offset: 71815},
 							name: "IdentifierRest",
 						},
 					},
@@ -16845,20 +16832,20 @@ var g = &grammar{
 		},
 		{
 			name: "FALSE",
-			pos:  position{line: 2378, col: 1, offset: 71866},
+			pos:  position{line: 2380, col: 1, offset: 71830},
 			expr: &seqExpr{
-				pos: position{line: 2378, col: 14, offset: 71879},
+				pos: position{line: 2380, col: 14, offset: 71843},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2378, col: 14, offset: 71879},
+						pos:        position{line: 2380, col: 14, offset: 71843},
 						val:        "false",
 						ignoreCase: true,
 						want:       "\"FALSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2378, col: 33, offset: 71898},
+						pos: position{line: 2380, col: 33, offset: 71862},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2378, col: 34, offset: 71899},
+							pos:  position{line: 2380, col: 34, offset: 71863},
 							name: "IdentifierRest",
 						},
 					},
@@ -16869,20 +16856,20 @@ var g = &grammar{
 		},
 		{
 			name: "FIRST",
-			pos:  position{line: 2379, col: 1, offset: 71914},
+			pos:  position{line: 2381, col: 1, offset: 71878},
 			expr: &seqExpr{
-				pos: position{line: 2379, col: 14, offset: 71927},
+				pos: position{line: 2381, col: 14, offset: 71891},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2379, col: 14, offset: 71927},
+						pos:        position{line: 2381, col: 14, offset: 71891},
 						val:        "first",
 						ignoreCase: true,
 						want:       "\"FIRST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2379, col: 33, offset: 71946},
+						pos: position{line: 2381, col: 33, offset: 71910},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2379, col: 34, offset: 71947},
+							pos:  position{line: 2381, col: 34, offset: 71911},
 							name: "IdentifierRest",
 						},
 					},
@@ -16893,20 +16880,20 @@ var g = &grammar{
 		},
 		{
 			name: "FN",
-			pos:  position{line: 2380, col: 1, offset: 71962},
+			pos:  position{line: 2382, col: 1, offset: 71926},
 			expr: &seqExpr{
-				pos: position{line: 2380, col: 14, offset: 71975},
+				pos: position{line: 2382, col: 14, offset: 71939},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2380, col: 14, offset: 71975},
+						pos:        position{line: 2382, col: 14, offset: 71939},
 						val:        "fn",
 						ignoreCase: true,
 						want:       "\"FN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2380, col: 33, offset: 71994},
+						pos: position{line: 2382, col: 33, offset: 71958},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2380, col: 34, offset: 71995},
+							pos:  position{line: 2382, col: 34, offset: 71959},
 							name: "IdentifierRest",
 						},
 					},
@@ -16917,20 +16904,20 @@ var g = &grammar{
 		},
 		{
 			name: "FOR",
-			pos:  position{line: 2381, col: 1, offset: 72010},
+			pos:  position{line: 2383, col: 1, offset: 71974},
 			expr: &seqExpr{
-				pos: position{line: 2381, col: 14, offset: 72023},
+				pos: position{line: 2383, col: 14, offset: 71987},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2381, col: 14, offset: 72023},
+						pos:        position{line: 2383, col: 14, offset: 71987},
 						val:        "for",
 						ignoreCase: true,
 						want:       "\"FOR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2381, col: 33, offset: 72042},
+						pos: position{line: 2383, col: 33, offset: 72006},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2381, col: 34, offset: 72043},
+							pos:  position{line: 2383, col: 34, offset: 72007},
 							name: "IdentifierRest",
 						},
 					},
@@ -16941,20 +16928,20 @@ var g = &grammar{
 		},
 		{
 			name: "FORK",
-			pos:  position{line: 2382, col: 1, offset: 72058},
+			pos:  position{line: 2384, col: 1, offset: 72022},
 			expr: &seqExpr{
-				pos: position{line: 2382, col: 14, offset: 72071},
+				pos: position{line: 2384, col: 14, offset: 72035},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2382, col: 14, offset: 72071},
+						pos:        position{line: 2384, col: 14, offset: 72035},
 						val:        "fork",
 						ignoreCase: true,
 						want:       "\"FORK\"i",
 					},
 					&notExpr{
-						pos: position{line: 2382, col: 33, offset: 72090},
+						pos: position{line: 2384, col: 33, offset: 72054},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2382, col: 34, offset: 72091},
+							pos:  position{line: 2384, col: 34, offset: 72055},
 							name: "IdentifierRest",
 						},
 					},
@@ -16965,20 +16952,20 @@ var g = &grammar{
 		},
 		{
 			name: "FROM",
-			pos:  position{line: 2383, col: 1, offset: 72106},
+			pos:  position{line: 2385, col: 1, offset: 72070},
 			expr: &seqExpr{
-				pos: position{line: 2383, col: 14, offset: 72119},
+				pos: position{line: 2385, col: 14, offset: 72083},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2383, col: 14, offset: 72119},
+						pos:        position{line: 2385, col: 14, offset: 72083},
 						val:        "from",
 						ignoreCase: true,
 						want:       "\"FROM\"i",
 					},
 					&notExpr{
-						pos: position{line: 2383, col: 33, offset: 72138},
+						pos: position{line: 2385, col: 33, offset: 72102},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2383, col: 34, offset: 72139},
+							pos:  position{line: 2385, col: 34, offset: 72103},
 							name: "IdentifierRest",
 						},
 					},
@@ -16989,20 +16976,20 @@ var g = &grammar{
 		},
 		{
 			name: "FULL",
-			pos:  position{line: 2384, col: 1, offset: 72154},
+			pos:  position{line: 2386, col: 1, offset: 72118},
 			expr: &seqExpr{
-				pos: position{line: 2384, col: 14, offset: 72167},
+				pos: position{line: 2386, col: 14, offset: 72131},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2384, col: 14, offset: 72167},
+						pos:        position{line: 2386, col: 14, offset: 72131},
 						val:        "full",
 						ignoreCase: true,
 						want:       "\"FULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2384, col: 33, offset: 72186},
+						pos: position{line: 2386, col: 33, offset: 72150},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2384, col: 34, offset: 72187},
+							pos:  position{line: 2386, col: 34, offset: 72151},
 							name: "IdentifierRest",
 						},
 					},
@@ -17013,20 +17000,20 @@ var g = &grammar{
 		},
 		{
 			name: "FUSE",
-			pos:  position{line: 2385, col: 1, offset: 72202},
+			pos:  position{line: 2387, col: 1, offset: 72166},
 			expr: &seqExpr{
-				pos: position{line: 2385, col: 14, offset: 72215},
+				pos: position{line: 2387, col: 14, offset: 72179},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2385, col: 14, offset: 72215},
+						pos:        position{line: 2387, col: 14, offset: 72179},
 						val:        "fuse",
 						ignoreCase: true,
 						want:       "\"FUSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2385, col: 33, offset: 72234},
+						pos: position{line: 2387, col: 33, offset: 72198},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2385, col: 34, offset: 72235},
+							pos:  position{line: 2387, col: 34, offset: 72199},
 							name: "IdentifierRest",
 						},
 					},
@@ -17037,20 +17024,20 @@ var g = &grammar{
 		},
 		{
 			name: "GROUP",
-			pos:  position{line: 2386, col: 1, offset: 72250},
+			pos:  position{line: 2388, col: 1, offset: 72214},
 			expr: &seqExpr{
-				pos: position{line: 2386, col: 14, offset: 72263},
+				pos: position{line: 2388, col: 14, offset: 72227},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2386, col: 14, offset: 72263},
+						pos:        position{line: 2388, col: 14, offset: 72227},
 						val:        "group",
 						ignoreCase: true,
 						want:       "\"GROUP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2386, col: 33, offset: 72282},
+						pos: position{line: 2388, col: 33, offset: 72246},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2386, col: 34, offset: 72283},
+							pos:  position{line: 2388, col: 34, offset: 72247},
 							name: "IdentifierRest",
 						},
 					},
@@ -17061,20 +17048,20 @@ var g = &grammar{
 		},
 		{
 			name: "HAVING",
-			pos:  position{line: 2387, col: 1, offset: 72298},
+			pos:  position{line: 2389, col: 1, offset: 72262},
 			expr: &seqExpr{
-				pos: position{line: 2387, col: 14, offset: 72311},
+				pos: position{line: 2389, col: 14, offset: 72275},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2387, col: 14, offset: 72311},
+						pos:        position{line: 2389, col: 14, offset: 72275},
 						val:        "having",
 						ignoreCase: true,
 						want:       "\"HAVING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2387, col: 33, offset: 72330},
+						pos: position{line: 2389, col: 33, offset: 72294},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2387, col: 34, offset: 72331},
+							pos:  position{line: 2389, col: 34, offset: 72295},
 							name: "IdentifierRest",
 						},
 					},
@@ -17085,20 +17072,20 @@ var g = &grammar{
 		},
 		{
 			name: "HEAD",
-			pos:  position{line: 2388, col: 1, offset: 72346},
+			pos:  position{line: 2390, col: 1, offset: 72310},
 			expr: &seqExpr{
-				pos: position{line: 2388, col: 14, offset: 72359},
+				pos: position{line: 2390, col: 14, offset: 72323},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2388, col: 14, offset: 72359},
+						pos:        position{line: 2390, col: 14, offset: 72323},
 						val:        "head",
 						ignoreCase: true,
 						want:       "\"HEAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2388, col: 33, offset: 72378},
+						pos: position{line: 2390, col: 33, offset: 72342},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2388, col: 34, offset: 72379},
+							pos:  position{line: 2390, col: 34, offset: 72343},
 							name: "IdentifierRest",
 						},
 					},
@@ -17109,20 +17096,20 @@ var g = &grammar{
 		},
 		{
 			name: "IN",
-			pos:  position{line: 2389, col: 1, offset: 72394},
+			pos:  position{line: 2391, col: 1, offset: 72358},
 			expr: &seqExpr{
-				pos: position{line: 2389, col: 14, offset: 72407},
+				pos: position{line: 2391, col: 14, offset: 72371},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2389, col: 14, offset: 72407},
+						pos:        position{line: 2391, col: 14, offset: 72371},
 						val:        "in",
 						ignoreCase: true,
 						want:       "\"IN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2389, col: 33, offset: 72426},
+						pos: position{line: 2391, col: 33, offset: 72390},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2389, col: 34, offset: 72427},
+							pos:  position{line: 2391, col: 34, offset: 72391},
 							name: "IdentifierRest",
 						},
 					},
@@ -17133,20 +17120,20 @@ var g = &grammar{
 		},
 		{
 			name: "INNER",
-			pos:  position{line: 2390, col: 1, offset: 72442},
+			pos:  position{line: 2392, col: 1, offset: 72406},
 			expr: &seqExpr{
-				pos: position{line: 2390, col: 14, offset: 72455},
+				pos: position{line: 2392, col: 14, offset: 72419},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2390, col: 14, offset: 72455},
+						pos:        position{line: 2392, col: 14, offset: 72419},
 						val:        "inner",
 						ignoreCase: true,
 						want:       "\"INNER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2390, col: 33, offset: 72474},
+						pos: position{line: 2392, col: 33, offset: 72438},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2390, col: 34, offset: 72475},
+							pos:  position{line: 2392, col: 34, offset: 72439},
 							name: "IdentifierRest",
 						},
 					},
@@ -17157,20 +17144,20 @@ var g = &grammar{
 		},
 		{
 			name: "IS",
-			pos:  position{line: 2391, col: 1, offset: 72490},
+			pos:  position{line: 2393, col: 1, offset: 72454},
 			expr: &seqExpr{
-				pos: position{line: 2391, col: 14, offset: 72503},
+				pos: position{line: 2393, col: 14, offset: 72467},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2391, col: 14, offset: 72503},
+						pos:        position{line: 2393, col: 14, offset: 72467},
 						val:        "is",
 						ignoreCase: true,
 						want:       "\"IS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2391, col: 33, offset: 72522},
+						pos: position{line: 2393, col: 33, offset: 72486},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2391, col: 34, offset: 72523},
+							pos:  position{line: 2393, col: 34, offset: 72487},
 							name: "IdentifierRest",
 						},
 					},
@@ -17181,20 +17168,20 @@ var g = &grammar{
 		},
 		{
 			name: "JOIN",
-			pos:  position{line: 2392, col: 1, offset: 72538},
+			pos:  position{line: 2394, col: 1, offset: 72502},
 			expr: &seqExpr{
-				pos: position{line: 2392, col: 14, offset: 72551},
+				pos: position{line: 2394, col: 14, offset: 72515},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2392, col: 14, offset: 72551},
+						pos:        position{line: 2394, col: 14, offset: 72515},
 						val:        "join",
 						ignoreCase: true,
 						want:       "\"JOIN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2392, col: 33, offset: 72570},
+						pos: position{line: 2394, col: 33, offset: 72534},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2392, col: 34, offset: 72571},
+							pos:  position{line: 2394, col: 34, offset: 72535},
 							name: "IdentifierRest",
 						},
 					},
@@ -17205,20 +17192,20 @@ var g = &grammar{
 		},
 		{
 			name: "LAMBDA",
-			pos:  position{line: 2393, col: 1, offset: 72586},
+			pos:  position{line: 2395, col: 1, offset: 72550},
 			expr: &seqExpr{
-				pos: position{line: 2393, col: 14, offset: 72599},
+				pos: position{line: 2395, col: 14, offset: 72563},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2393, col: 14, offset: 72599},
+						pos:        position{line: 2395, col: 14, offset: 72563},
 						val:        "lambda",
 						ignoreCase: true,
 						want:       "\"LAMBDA\"i",
 					},
 					&notExpr{
-						pos: position{line: 2393, col: 33, offset: 72618},
+						pos: position{line: 2395, col: 33, offset: 72582},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2393, col: 34, offset: 72619},
+							pos:  position{line: 2395, col: 34, offset: 72583},
 							name: "IdentifierRest",
 						},
 					},
@@ -17229,20 +17216,20 @@ var g = &grammar{
 		},
 		{
 			name: "LAST",
-			pos:  position{line: 2394, col: 1, offset: 72634},
+			pos:  position{line: 2396, col: 1, offset: 72598},
 			expr: &seqExpr{
-				pos: position{line: 2394, col: 14, offset: 72647},
+				pos: position{line: 2396, col: 14, offset: 72611},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2394, col: 14, offset: 72647},
+						pos:        position{line: 2396, col: 14, offset: 72611},
 						val:        "last",
 						ignoreCase: true,
 						want:       "\"LAST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2394, col: 33, offset: 72666},
+						pos: position{line: 2396, col: 33, offset: 72630},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2394, col: 34, offset: 72667},
+							pos:  position{line: 2396, col: 34, offset: 72631},
 							name: "IdentifierRest",
 						},
 					},
@@ -17253,20 +17240,20 @@ var g = &grammar{
 		},
 		{
 			name: "LEFT",
-			pos:  position{line: 2395, col: 1, offset: 72682},
+			pos:  position{line: 2397, col: 1, offset: 72646},
 			expr: &seqExpr{
-				pos: position{line: 2395, col: 14, offset: 72695},
+				pos: position{line: 2397, col: 14, offset: 72659},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2395, col: 14, offset: 72695},
+						pos:        position{line: 2397, col: 14, offset: 72659},
 						val:        "left",
 						ignoreCase: true,
 						want:       "\"LEFT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2395, col: 33, offset: 72714},
+						pos: position{line: 2397, col: 33, offset: 72678},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2395, col: 34, offset: 72715},
+							pos:  position{line: 2397, col: 34, offset: 72679},
 							name: "IdentifierRest",
 						},
 					},
@@ -17277,20 +17264,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIKE",
-			pos:  position{line: 2396, col: 1, offset: 72730},
+			pos:  position{line: 2398, col: 1, offset: 72694},
 			expr: &seqExpr{
-				pos: position{line: 2396, col: 14, offset: 72743},
+				pos: position{line: 2398, col: 14, offset: 72707},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2396, col: 14, offset: 72743},
+						pos:        position{line: 2398, col: 14, offset: 72707},
 						val:        "like",
 						ignoreCase: true,
 						want:       "\"LIKE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2396, col: 33, offset: 72762},
+						pos: position{line: 2398, col: 33, offset: 72726},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2396, col: 34, offset: 72763},
+							pos:  position{line: 2398, col: 34, offset: 72727},
 							name: "IdentifierRest",
 						},
 					},
@@ -17301,20 +17288,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIMIT",
-			pos:  position{line: 2397, col: 1, offset: 72778},
+			pos:  position{line: 2399, col: 1, offset: 72742},
 			expr: &seqExpr{
-				pos: position{line: 2397, col: 14, offset: 72791},
+				pos: position{line: 2399, col: 14, offset: 72755},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2397, col: 14, offset: 72791},
+						pos:        position{line: 2399, col: 14, offset: 72755},
 						val:        "limit",
 						ignoreCase: true,
 						want:       "\"LIMIT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2397, col: 33, offset: 72810},
+						pos: position{line: 2399, col: 33, offset: 72774},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2397, col: 34, offset: 72811},
+							pos:  position{line: 2399, col: 34, offset: 72775},
 							name: "IdentifierRest",
 						},
 					},
@@ -17325,20 +17312,20 @@ var g = &grammar{
 		},
 		{
 			name: "LOAD",
-			pos:  position{line: 2398, col: 1, offset: 72826},
+			pos:  position{line: 2400, col: 1, offset: 72790},
 			expr: &seqExpr{
-				pos: position{line: 2398, col: 14, offset: 72839},
+				pos: position{line: 2400, col: 14, offset: 72803},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2398, col: 14, offset: 72839},
+						pos:        position{line: 2400, col: 14, offset: 72803},
 						val:        "load",
 						ignoreCase: true,
 						want:       "\"LOAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2398, col: 33, offset: 72858},
+						pos: position{line: 2400, col: 33, offset: 72822},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2398, col: 34, offset: 72859},
+							pos:  position{line: 2400, col: 34, offset: 72823},
 							name: "IdentifierRest",
 						},
 					},
@@ -17349,20 +17336,20 @@ var g = &grammar{
 		},
 		{
 			name: "MATERIALIZED",
-			pos:  position{line: 2399, col: 1, offset: 72874},
+			pos:  position{line: 2401, col: 1, offset: 72838},
 			expr: &seqExpr{
-				pos: position{line: 2399, col: 16, offset: 72889},
+				pos: position{line: 2401, col: 16, offset: 72853},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2399, col: 16, offset: 72889},
+						pos:        position{line: 2401, col: 16, offset: 72853},
 						val:        "materialized",
 						ignoreCase: true,
 						want:       "\"MATERIALIZED\"i",
 					},
 					&notExpr{
-						pos: position{line: 2399, col: 33, offset: 72906},
+						pos: position{line: 2401, col: 33, offset: 72870},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2399, col: 34, offset: 72907},
+							pos:  position{line: 2401, col: 34, offset: 72871},
 							name: "IdentifierRest",
 						},
 					},
@@ -17373,20 +17360,20 @@ var g = &grammar{
 		},
 		{
 			name: "MAP",
-			pos:  position{line: 2400, col: 1, offset: 72922},
+			pos:  position{line: 2402, col: 1, offset: 72886},
 			expr: &seqExpr{
-				pos: position{line: 2400, col: 14, offset: 72935},
+				pos: position{line: 2402, col: 14, offset: 72899},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2400, col: 14, offset: 72935},
+						pos:        position{line: 2402, col: 14, offset: 72899},
 						val:        "map",
 						ignoreCase: true,
 						want:       "\"MAP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2400, col: 33, offset: 72954},
+						pos: position{line: 2402, col: 33, offset: 72918},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2400, col: 34, offset: 72955},
+							pos:  position{line: 2402, col: 34, offset: 72919},
 							name: "IdentifierRest",
 						},
 					},
@@ -17397,20 +17384,20 @@ var g = &grammar{
 		},
 		{
 			name: "MERGE",
-			pos:  position{line: 2401, col: 1, offset: 72970},
+			pos:  position{line: 2403, col: 1, offset: 72934},
 			expr: &seqExpr{
-				pos: position{line: 2401, col: 14, offset: 72983},
+				pos: position{line: 2403, col: 14, offset: 72947},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2401, col: 14, offset: 72983},
+						pos:        position{line: 2403, col: 14, offset: 72947},
 						val:        "merge",
 						ignoreCase: true,
 						want:       "\"MERGE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2401, col: 33, offset: 73002},
+						pos: position{line: 2403, col: 33, offset: 72966},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2401, col: 34, offset: 73003},
+							pos:  position{line: 2403, col: 34, offset: 72967},
 							name: "IdentifierRest",
 						},
 					},
@@ -17421,20 +17408,20 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 2402, col: 1, offset: 73018},
+			pos:  position{line: 2404, col: 1, offset: 72982},
 			expr: &seqExpr{
-				pos: position{line: 2402, col: 14, offset: 73031},
+				pos: position{line: 2404, col: 14, offset: 72995},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2402, col: 14, offset: 73031},
+						pos:        position{line: 2404, col: 14, offset: 72995},
 						val:        "not",
 						ignoreCase: true,
 						want:       "\"NOT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2402, col: 33, offset: 73050},
+						pos: position{line: 2404, col: 33, offset: 73014},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2402, col: 34, offset: 73051},
+							pos:  position{line: 2404, col: 34, offset: 73015},
 							name: "IdentifierRest",
 						},
 					},
@@ -17445,20 +17432,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULL",
-			pos:  position{line: 2403, col: 1, offset: 73066},
+			pos:  position{line: 2405, col: 1, offset: 73030},
 			expr: &seqExpr{
-				pos: position{line: 2403, col: 14, offset: 73079},
+				pos: position{line: 2405, col: 14, offset: 73043},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2403, col: 14, offset: 73079},
+						pos:        position{line: 2405, col: 14, offset: 73043},
 						val:        "null",
 						ignoreCase: true,
 						want:       "\"NULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2403, col: 33, offset: 73098},
+						pos: position{line: 2405, col: 33, offset: 73062},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2403, col: 34, offset: 73099},
+							pos:  position{line: 2405, col: 34, offset: 73063},
 							name: "IdentifierRest",
 						},
 					},
@@ -17469,20 +17456,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULLS",
-			pos:  position{line: 2404, col: 1, offset: 73114},
+			pos:  position{line: 2406, col: 1, offset: 73078},
 			expr: &seqExpr{
-				pos: position{line: 2404, col: 14, offset: 73127},
+				pos: position{line: 2406, col: 14, offset: 73091},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2404, col: 14, offset: 73127},
+						pos:        position{line: 2406, col: 14, offset: 73091},
 						val:        "nulls",
 						ignoreCase: true,
 						want:       "\"NULLS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2404, col: 33, offset: 73146},
+						pos: position{line: 2406, col: 33, offset: 73110},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2404, col: 34, offset: 73147},
+							pos:  position{line: 2406, col: 34, offset: 73111},
 							name: "IdentifierRest",
 						},
 					},
@@ -17493,20 +17480,20 @@ var g = &grammar{
 		},
 		{
 			name: "OFFSET",
-			pos:  position{line: 2405, col: 1, offset: 73162},
+			pos:  position{line: 2407, col: 1, offset: 73126},
 			expr: &seqExpr{
-				pos: position{line: 2405, col: 14, offset: 73175},
+				pos: position{line: 2407, col: 14, offset: 73139},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2405, col: 14, offset: 73175},
+						pos:        position{line: 2407, col: 14, offset: 73139},
 						val:        "offset",
 						ignoreCase: true,
 						want:       "\"OFFSET\"i",
 					},
 					&notExpr{
-						pos: position{line: 2405, col: 33, offset: 73194},
+						pos: position{line: 2407, col: 33, offset: 73158},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2405, col: 34, offset: 73195},
+							pos:  position{line: 2407, col: 34, offset: 73159},
 							name: "IdentifierRest",
 						},
 					},
@@ -17517,20 +17504,20 @@ var g = &grammar{
 		},
 		{
 			name: "ON",
-			pos:  position{line: 2406, col: 1, offset: 73210},
+			pos:  position{line: 2408, col: 1, offset: 73174},
 			expr: &seqExpr{
-				pos: position{line: 2406, col: 14, offset: 73223},
+				pos: position{line: 2408, col: 14, offset: 73187},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2406, col: 14, offset: 73223},
+						pos:        position{line: 2408, col: 14, offset: 73187},
 						val:        "on",
 						ignoreCase: true,
 						want:       "\"ON\"i",
 					},
 					&notExpr{
-						pos: position{line: 2406, col: 33, offset: 73242},
+						pos: position{line: 2408, col: 33, offset: 73206},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2406, col: 34, offset: 73243},
+							pos:  position{line: 2408, col: 34, offset: 73207},
 							name: "IdentifierRest",
 						},
 					},
@@ -17541,20 +17528,20 @@ var g = &grammar{
 		},
 		{
 			name: "OP",
-			pos:  position{line: 2407, col: 1, offset: 73258},
+			pos:  position{line: 2409, col: 1, offset: 73222},
 			expr: &seqExpr{
-				pos: position{line: 2407, col: 14, offset: 73271},
+				pos: position{line: 2409, col: 14, offset: 73235},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2407, col: 14, offset: 73271},
+						pos:        position{line: 2409, col: 14, offset: 73235},
 						val:        "op",
 						ignoreCase: true,
 						want:       "\"OP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2407, col: 33, offset: 73290},
+						pos: position{line: 2409, col: 33, offset: 73254},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2407, col: 34, offset: 73291},
+							pos:  position{line: 2409, col: 34, offset: 73255},
 							name: "IdentifierRest",
 						},
 					},
@@ -17565,23 +17552,23 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 2408, col: 1, offset: 73306},
+			pos:  position{line: 2410, col: 1, offset: 73270},
 			expr: &actionExpr{
-				pos: position{line: 2408, col: 14, offset: 73319},
+				pos: position{line: 2410, col: 14, offset: 73283},
 				run: (*parser).callonOR1,
 				expr: &seqExpr{
-					pos: position{line: 2408, col: 14, offset: 73319},
+					pos: position{line: 2410, col: 14, offset: 73283},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2408, col: 14, offset: 73319},
+							pos:        position{line: 2410, col: 14, offset: 73283},
 							val:        "or",
 							ignoreCase: true,
 							want:       "\"OR\"i",
 						},
 						&notExpr{
-							pos: position{line: 2408, col: 33, offset: 73338},
+							pos: position{line: 2410, col: 33, offset: 73302},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2408, col: 34, offset: 73339},
+								pos:  position{line: 2410, col: 34, offset: 73303},
 								name: "IdentifierRest",
 							},
 						},
@@ -17593,20 +17580,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDER",
-			pos:  position{line: 2409, col: 1, offset: 73375},
+			pos:  position{line: 2411, col: 1, offset: 73339},
 			expr: &seqExpr{
-				pos: position{line: 2409, col: 14, offset: 73388},
+				pos: position{line: 2411, col: 14, offset: 73352},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2409, col: 14, offset: 73388},
+						pos:        position{line: 2411, col: 14, offset: 73352},
 						val:        "order",
 						ignoreCase: true,
 						want:       "\"ORDER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2409, col: 33, offset: 73407},
+						pos: position{line: 2411, col: 33, offset: 73371},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2409, col: 34, offset: 73408},
+							pos:  position{line: 2411, col: 34, offset: 73372},
 							name: "IdentifierRest",
 						},
 					},
@@ -17617,20 +17604,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDINALITY",
-			pos:  position{line: 2410, col: 1, offset: 73423},
+			pos:  position{line: 2412, col: 1, offset: 73387},
 			expr: &seqExpr{
-				pos: position{line: 2410, col: 14, offset: 73436},
+				pos: position{line: 2412, col: 14, offset: 73400},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2410, col: 14, offset: 73436},
+						pos:        position{line: 2412, col: 14, offset: 73400},
 						val:        "ordinality",
 						ignoreCase: true,
 						want:       "\"ORDINALITY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2410, col: 33, offset: 73455},
+						pos: position{line: 2412, col: 33, offset: 73419},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2410, col: 34, offset: 73456},
+							pos:  position{line: 2412, col: 34, offset: 73420},
 							name: "IdentifierRest",
 						},
 					},
@@ -17641,20 +17628,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTER",
-			pos:  position{line: 2411, col: 1, offset: 73471},
+			pos:  position{line: 2413, col: 1, offset: 73435},
 			expr: &seqExpr{
-				pos: position{line: 2411, col: 14, offset: 73484},
+				pos: position{line: 2413, col: 14, offset: 73448},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2411, col: 14, offset: 73484},
+						pos:        position{line: 2413, col: 14, offset: 73448},
 						val:        "outer",
 						ignoreCase: true,
 						want:       "\"OUTER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2411, col: 33, offset: 73503},
+						pos: position{line: 2413, col: 33, offset: 73467},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2411, col: 34, offset: 73504},
+							pos:  position{line: 2413, col: 34, offset: 73468},
 							name: "IdentifierRest",
 						},
 					},
@@ -17665,20 +17652,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTPUT",
-			pos:  position{line: 2412, col: 1, offset: 73519},
+			pos:  position{line: 2414, col: 1, offset: 73483},
 			expr: &seqExpr{
-				pos: position{line: 2412, col: 14, offset: 73532},
+				pos: position{line: 2414, col: 14, offset: 73496},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2412, col: 14, offset: 73532},
+						pos:        position{line: 2414, col: 14, offset: 73496},
 						val:        "output",
 						ignoreCase: true,
 						want:       "\"OUTPUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2412, col: 33, offset: 73551},
+						pos: position{line: 2414, col: 33, offset: 73515},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2412, col: 34, offset: 73552},
+							pos:  position{line: 2414, col: 34, offset: 73516},
 							name: "IdentifierRest",
 						},
 					},
@@ -17689,20 +17676,20 @@ var g = &grammar{
 		},
 		{
 			name: "PASS",
-			pos:  position{line: 2413, col: 1, offset: 73567},
+			pos:  position{line: 2415, col: 1, offset: 73531},
 			expr: &seqExpr{
-				pos: position{line: 2413, col: 14, offset: 73580},
+				pos: position{line: 2415, col: 14, offset: 73544},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2413, col: 14, offset: 73580},
+						pos:        position{line: 2415, col: 14, offset: 73544},
 						val:        "pass",
 						ignoreCase: true,
 						want:       "\"PASS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2413, col: 33, offset: 73599},
+						pos: position{line: 2415, col: 33, offset: 73563},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2413, col: 34, offset: 73600},
+							pos:  position{line: 2415, col: 34, offset: 73564},
 							name: "IdentifierRest",
 						},
 					},
@@ -17713,20 +17700,20 @@ var g = &grammar{
 		},
 		{
 			name: "PUT",
-			pos:  position{line: 2414, col: 1, offset: 73615},
+			pos:  position{line: 2416, col: 1, offset: 73579},
 			expr: &seqExpr{
-				pos: position{line: 2414, col: 14, offset: 73628},
+				pos: position{line: 2416, col: 14, offset: 73592},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2414, col: 14, offset: 73628},
+						pos:        position{line: 2416, col: 14, offset: 73592},
 						val:        "put",
 						ignoreCase: true,
 						want:       "\"PUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2414, col: 33, offset: 73647},
+						pos: position{line: 2416, col: 33, offset: 73611},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2414, col: 34, offset: 73648},
+							pos:  position{line: 2416, col: 34, offset: 73612},
 							name: "IdentifierRest",
 						},
 					},
@@ -17737,20 +17724,20 @@ var g = &grammar{
 		},
 		{
 			name: "RECURSIVE",
-			pos:  position{line: 2415, col: 1, offset: 73663},
+			pos:  position{line: 2417, col: 1, offset: 73627},
 			expr: &seqExpr{
-				pos: position{line: 2415, col: 14, offset: 73676},
+				pos: position{line: 2417, col: 14, offset: 73640},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2415, col: 14, offset: 73676},
+						pos:        position{line: 2417, col: 14, offset: 73640},
 						val:        "recursive",
 						ignoreCase: true,
 						want:       "\"RECURSIVE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2415, col: 33, offset: 73695},
+						pos: position{line: 2417, col: 33, offset: 73659},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2415, col: 34, offset: 73696},
+							pos:  position{line: 2417, col: 34, offset: 73660},
 							name: "IdentifierRest",
 						},
 					},
@@ -17761,20 +17748,20 @@ var g = &grammar{
 		},
 		{
 			name: "RENAME",
-			pos:  position{line: 2416, col: 1, offset: 73711},
+			pos:  position{line: 2418, col: 1, offset: 73675},
 			expr: &seqExpr{
-				pos: position{line: 2416, col: 14, offset: 73724},
+				pos: position{line: 2418, col: 14, offset: 73688},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2416, col: 14, offset: 73724},
+						pos:        position{line: 2418, col: 14, offset: 73688},
 						val:        "rename",
 						ignoreCase: true,
 						want:       "\"RENAME\"i",
 					},
 					&notExpr{
-						pos: position{line: 2416, col: 33, offset: 73743},
+						pos: position{line: 2418, col: 33, offset: 73707},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2416, col: 34, offset: 73744},
+							pos:  position{line: 2418, col: 34, offset: 73708},
 							name: "IdentifierRest",
 						},
 					},
@@ -17785,20 +17772,20 @@ var g = &grammar{
 		},
 		{
 			name: "RIGHT",
-			pos:  position{line: 2417, col: 1, offset: 73759},
+			pos:  position{line: 2419, col: 1, offset: 73723},
 			expr: &seqExpr{
-				pos: position{line: 2417, col: 14, offset: 73772},
+				pos: position{line: 2419, col: 14, offset: 73736},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2417, col: 14, offset: 73772},
+						pos:        position{line: 2419, col: 14, offset: 73736},
 						val:        "right",
 						ignoreCase: true,
 						want:       "\"RIGHT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2417, col: 33, offset: 73791},
+						pos: position{line: 2419, col: 33, offset: 73755},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2417, col: 34, offset: 73792},
+							pos:  position{line: 2419, col: 34, offset: 73756},
 							name: "IdentifierRest",
 						},
 					},
@@ -17809,20 +17796,20 @@ var g = &grammar{
 		},
 		{
 			name: "SHAPES",
-			pos:  position{line: 2418, col: 1, offset: 73807},
+			pos:  position{line: 2420, col: 1, offset: 73771},
 			expr: &seqExpr{
-				pos: position{line: 2418, col: 14, offset: 73820},
+				pos: position{line: 2420, col: 14, offset: 73784},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2418, col: 14, offset: 73820},
+						pos:        position{line: 2420, col: 14, offset: 73784},
 						val:        "shapes",
 						ignoreCase: true,
 						want:       "\"SHAPES\"i",
 					},
 					&notExpr{
-						pos: position{line: 2418, col: 33, offset: 73839},
+						pos: position{line: 2420, col: 33, offset: 73803},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2418, col: 34, offset: 73840},
+							pos:  position{line: 2420, col: 34, offset: 73804},
 							name: "IdentifierRest",
 						},
 					},
@@ -17833,20 +17820,20 @@ var g = &grammar{
 		},
 		{
 			name: "SEARCH",
-			pos:  position{line: 2419, col: 1, offset: 73855},
+			pos:  position{line: 2421, col: 1, offset: 73819},
 			expr: &seqExpr{
-				pos: position{line: 2419, col: 14, offset: 73868},
+				pos: position{line: 2421, col: 14, offset: 73832},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2419, col: 14, offset: 73868},
+						pos:        position{line: 2421, col: 14, offset: 73832},
 						val:        "search",
 						ignoreCase: true,
 						want:       "\"SEARCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2419, col: 33, offset: 73887},
+						pos: position{line: 2421, col: 33, offset: 73851},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2419, col: 34, offset: 73888},
+							pos:  position{line: 2421, col: 34, offset: 73852},
 							name: "IdentifierRest",
 						},
 					},
@@ -17857,20 +17844,20 @@ var g = &grammar{
 		},
 		{
 			name: "SELECT",
-			pos:  position{line: 2420, col: 1, offset: 73903},
+			pos:  position{line: 2422, col: 1, offset: 73867},
 			expr: &seqExpr{
-				pos: position{line: 2420, col: 14, offset: 73916},
+				pos: position{line: 2422, col: 14, offset: 73880},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2420, col: 14, offset: 73916},
+						pos:        position{line: 2422, col: 14, offset: 73880},
 						val:        "select",
 						ignoreCase: true,
 						want:       "\"SELECT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2420, col: 33, offset: 73935},
+						pos: position{line: 2422, col: 33, offset: 73899},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2420, col: 34, offset: 73936},
+							pos:  position{line: 2422, col: 34, offset: 73900},
 							name: "IdentifierRest",
 						},
 					},
@@ -17881,20 +17868,20 @@ var g = &grammar{
 		},
 		{
 			name: "SHAPE",
-			pos:  position{line: 2421, col: 1, offset: 73951},
+			pos:  position{line: 2423, col: 1, offset: 73915},
 			expr: &seqExpr{
-				pos: position{line: 2421, col: 14, offset: 73964},
+				pos: position{line: 2423, col: 14, offset: 73928},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2421, col: 14, offset: 73964},
+						pos:        position{line: 2423, col: 14, offset: 73928},
 						val:        "shape",
 						ignoreCase: true,
 						want:       "\"SHAPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2421, col: 33, offset: 73983},
+						pos: position{line: 2423, col: 33, offset: 73947},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2421, col: 34, offset: 73984},
+							pos:  position{line: 2423, col: 34, offset: 73948},
 							name: "IdentifierRest",
 						},
 					},
@@ -17905,20 +17892,20 @@ var g = &grammar{
 		},
 		{
 			name: "SKIP",
-			pos:  position{line: 2422, col: 1, offset: 73999},
+			pos:  position{line: 2424, col: 1, offset: 73963},
 			expr: &seqExpr{
-				pos: position{line: 2422, col: 14, offset: 74012},
+				pos: position{line: 2424, col: 14, offset: 73976},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2422, col: 14, offset: 74012},
+						pos:        position{line: 2424, col: 14, offset: 73976},
 						val:        "skip",
 						ignoreCase: true,
 						want:       "\"SKIP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2422, col: 33, offset: 74031},
+						pos: position{line: 2424, col: 33, offset: 73995},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2422, col: 34, offset: 74032},
+							pos:  position{line: 2424, col: 34, offset: 73996},
 							name: "IdentifierRest",
 						},
 					},
@@ -17929,20 +17916,20 @@ var g = &grammar{
 		},
 		{
 			name: "SORT",
-			pos:  position{line: 2423, col: 1, offset: 74047},
+			pos:  position{line: 2425, col: 1, offset: 74011},
 			expr: &seqExpr{
-				pos: position{line: 2423, col: 14, offset: 74060},
+				pos: position{line: 2425, col: 14, offset: 74024},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2423, col: 14, offset: 74060},
+						pos:        position{line: 2425, col: 14, offset: 74024},
 						val:        "sort",
 						ignoreCase: true,
 						want:       "\"SORT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2423, col: 33, offset: 74079},
+						pos: position{line: 2425, col: 33, offset: 74043},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2423, col: 34, offset: 74080},
+							pos:  position{line: 2425, col: 34, offset: 74044},
 							name: "IdentifierRest",
 						},
 					},
@@ -17953,20 +17940,20 @@ var g = &grammar{
 		},
 		{
 			name: "SUBSTRING",
-			pos:  position{line: 2424, col: 1, offset: 74095},
+			pos:  position{line: 2426, col: 1, offset: 74059},
 			expr: &seqExpr{
-				pos: position{line: 2424, col: 14, offset: 74108},
+				pos: position{line: 2426, col: 14, offset: 74072},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2424, col: 14, offset: 74108},
+						pos:        position{line: 2426, col: 14, offset: 74072},
 						val:        "substring",
 						ignoreCase: true,
 						want:       "\"SUBSTRING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2424, col: 33, offset: 74127},
+						pos: position{line: 2426, col: 33, offset: 74091},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2424, col: 34, offset: 74128},
+							pos:  position{line: 2426, col: 34, offset: 74092},
 							name: "IdentifierRest",
 						},
 					},
@@ -17977,20 +17964,20 @@ var g = &grammar{
 		},
 		{
 			name: "SUMMARIZE",
-			pos:  position{line: 2425, col: 1, offset: 74143},
+			pos:  position{line: 2427, col: 1, offset: 74107},
 			expr: &seqExpr{
-				pos: position{line: 2425, col: 14, offset: 74156},
+				pos: position{line: 2427, col: 14, offset: 74120},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2425, col: 14, offset: 74156},
+						pos:        position{line: 2427, col: 14, offset: 74120},
 						val:        "summarize",
 						ignoreCase: true,
 						want:       "\"SUMMARIZE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2425, col: 33, offset: 74175},
+						pos: position{line: 2427, col: 33, offset: 74139},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2425, col: 34, offset: 74176},
+							pos:  position{line: 2427, col: 34, offset: 74140},
 							name: "IdentifierRest",
 						},
 					},
@@ -18001,20 +17988,20 @@ var g = &grammar{
 		},
 		{
 			name: "SWITCH",
-			pos:  position{line: 2426, col: 1, offset: 74191},
+			pos:  position{line: 2428, col: 1, offset: 74155},
 			expr: &seqExpr{
-				pos: position{line: 2426, col: 14, offset: 74204},
+				pos: position{line: 2428, col: 14, offset: 74168},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2426, col: 14, offset: 74204},
+						pos:        position{line: 2428, col: 14, offset: 74168},
 						val:        "switch",
 						ignoreCase: true,
 						want:       "\"SWITCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2426, col: 33, offset: 74223},
+						pos: position{line: 2428, col: 33, offset: 74187},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2426, col: 34, offset: 74224},
+							pos:  position{line: 2428, col: 34, offset: 74188},
 							name: "IdentifierRest",
 						},
 					},
@@ -18025,20 +18012,20 @@ var g = &grammar{
 		},
 		{
 			name: "TAIL",
-			pos:  position{line: 2427, col: 1, offset: 74239},
+			pos:  position{line: 2429, col: 1, offset: 74203},
 			expr: &seqExpr{
-				pos: position{line: 2427, col: 14, offset: 74252},
+				pos: position{line: 2429, col: 14, offset: 74216},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2427, col: 14, offset: 74252},
+						pos:        position{line: 2429, col: 14, offset: 74216},
 						val:        "tail",
 						ignoreCase: true,
 						want:       "\"TAIL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2427, col: 33, offset: 74271},
+						pos: position{line: 2429, col: 33, offset: 74235},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2427, col: 34, offset: 74272},
+							pos:  position{line: 2429, col: 34, offset: 74236},
 							name: "IdentifierRest",
 						},
 					},
@@ -18049,20 +18036,20 @@ var g = &grammar{
 		},
 		{
 			name: "THEN",
-			pos:  position{line: 2428, col: 1, offset: 74287},
+			pos:  position{line: 2430, col: 1, offset: 74251},
 			expr: &seqExpr{
-				pos: position{line: 2428, col: 14, offset: 74300},
+				pos: position{line: 2430, col: 14, offset: 74264},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2428, col: 14, offset: 74300},
+						pos:        position{line: 2430, col: 14, offset: 74264},
 						val:        "then",
 						ignoreCase: true,
 						want:       "\"THEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2428, col: 33, offset: 74319},
+						pos: position{line: 2430, col: 33, offset: 74283},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2428, col: 34, offset: 74320},
+							pos:  position{line: 2430, col: 34, offset: 74284},
 							name: "IdentifierRest",
 						},
 					},
@@ -18073,23 +18060,23 @@ var g = &grammar{
 		},
 		{
 			name: "TIMESTAMP",
-			pos:  position{line: 2429, col: 1, offset: 74335},
+			pos:  position{line: 2431, col: 1, offset: 74299},
 			expr: &actionExpr{
-				pos: position{line: 2429, col: 14, offset: 74348},
+				pos: position{line: 2431, col: 14, offset: 74312},
 				run: (*parser).callonTIMESTAMP1,
 				expr: &seqExpr{
-					pos: position{line: 2429, col: 14, offset: 74348},
+					pos: position{line: 2431, col: 14, offset: 74312},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2429, col: 14, offset: 74348},
+							pos:        position{line: 2431, col: 14, offset: 74312},
 							val:        "timestamp",
 							ignoreCase: true,
 							want:       "\"TIMESTAMP\"i",
 						},
 						&notExpr{
-							pos: position{line: 2429, col: 33, offset: 74367},
+							pos: position{line: 2431, col: 33, offset: 74331},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2429, col: 34, offset: 74368},
+								pos:  position{line: 2431, col: 34, offset: 74332},
 								name: "IdentifierRest",
 							},
 						},
@@ -18101,20 +18088,20 @@ var g = &grammar{
 		},
 		{
 			name: "TOP",
-			pos:  position{line: 2430, col: 1, offset: 74411},
+			pos:  position{line: 2432, col: 1, offset: 74375},
 			expr: &seqExpr{
-				pos: position{line: 2430, col: 14, offset: 74424},
+				pos: position{line: 2432, col: 14, offset: 74388},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2430, col: 14, offset: 74424},
+						pos:        position{line: 2432, col: 14, offset: 74388},
 						val:        "top",
 						ignoreCase: true,
 						want:       "\"TOP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2430, col: 33, offset: 74443},
+						pos: position{line: 2432, col: 33, offset: 74407},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2430, col: 34, offset: 74444},
+							pos:  position{line: 2432, col: 34, offset: 74408},
 							name: "IdentifierRest",
 						},
 					},
@@ -18125,20 +18112,20 @@ var g = &grammar{
 		},
 		{
 			name: "TRUE",
-			pos:  position{line: 2431, col: 1, offset: 74459},
+			pos:  position{line: 2433, col: 1, offset: 74423},
 			expr: &seqExpr{
-				pos: position{line: 2431, col: 14, offset: 74472},
+				pos: position{line: 2433, col: 14, offset: 74436},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2431, col: 14, offset: 74472},
+						pos:        position{line: 2433, col: 14, offset: 74436},
 						val:        "true",
 						ignoreCase: true,
 						want:       "\"TRUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2431, col: 33, offset: 74491},
+						pos: position{line: 2433, col: 33, offset: 74455},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2431, col: 34, offset: 74492},
+							pos:  position{line: 2433, col: 34, offset: 74456},
 							name: "IdentifierRest",
 						},
 					},
@@ -18149,20 +18136,20 @@ var g = &grammar{
 		},
 		{
 			name: "TYPE",
-			pos:  position{line: 2432, col: 1, offset: 74507},
+			pos:  position{line: 2434, col: 1, offset: 74471},
 			expr: &seqExpr{
-				pos: position{line: 2432, col: 14, offset: 74520},
+				pos: position{line: 2434, col: 14, offset: 74484},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2432, col: 14, offset: 74520},
+						pos:        position{line: 2434, col: 14, offset: 74484},
 						val:        "type",
 						ignoreCase: true,
 						want:       "\"TYPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2432, col: 33, offset: 74539},
+						pos: position{line: 2434, col: 33, offset: 74503},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2432, col: 34, offset: 74540},
+							pos:  position{line: 2434, col: 34, offset: 74504},
 							name: "IdentifierRest",
 						},
 					},
@@ -18173,20 +18160,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNION",
-			pos:  position{line: 2433, col: 1, offset: 74555},
+			pos:  position{line: 2435, col: 1, offset: 74519},
 			expr: &seqExpr{
-				pos: position{line: 2433, col: 14, offset: 74568},
+				pos: position{line: 2435, col: 14, offset: 74532},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2433, col: 14, offset: 74568},
+						pos:        position{line: 2435, col: 14, offset: 74532},
 						val:        "union",
 						ignoreCase: true,
 						want:       "\"UNION\"i",
 					},
 					&notExpr{
-						pos: position{line: 2433, col: 33, offset: 74587},
+						pos: position{line: 2435, col: 33, offset: 74551},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2433, col: 34, offset: 74588},
+							pos:  position{line: 2435, col: 34, offset: 74552},
 							name: "IdentifierRest",
 						},
 					},
@@ -18197,20 +18184,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNIQ",
-			pos:  position{line: 2434, col: 1, offset: 74603},
+			pos:  position{line: 2436, col: 1, offset: 74567},
 			expr: &seqExpr{
-				pos: position{line: 2434, col: 14, offset: 74616},
+				pos: position{line: 2436, col: 14, offset: 74580},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2434, col: 14, offset: 74616},
+						pos:        position{line: 2436, col: 14, offset: 74580},
 						val:        "uniq",
 						ignoreCase: true,
 						want:       "\"UNIQ\"i",
 					},
 					&notExpr{
-						pos: position{line: 2434, col: 33, offset: 74635},
+						pos: position{line: 2436, col: 33, offset: 74599},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2434, col: 34, offset: 74636},
+							pos:  position{line: 2436, col: 34, offset: 74600},
 							name: "IdentifierRest",
 						},
 					},
@@ -18221,20 +18208,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNNEST",
-			pos:  position{line: 2435, col: 1, offset: 74651},
+			pos:  position{line: 2437, col: 1, offset: 74615},
 			expr: &seqExpr{
-				pos: position{line: 2435, col: 14, offset: 74664},
+				pos: position{line: 2437, col: 14, offset: 74628},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2435, col: 14, offset: 74664},
+						pos:        position{line: 2437, col: 14, offset: 74628},
 						val:        "unnest",
 						ignoreCase: true,
 						want:       "\"UNNEST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2435, col: 33, offset: 74683},
+						pos: position{line: 2437, col: 33, offset: 74647},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2435, col: 34, offset: 74684},
+							pos:  position{line: 2437, col: 34, offset: 74648},
 							name: "IdentifierRest",
 						},
 					},
@@ -18245,20 +18232,20 @@ var g = &grammar{
 		},
 		{
 			name: "USING",
-			pos:  position{line: 2436, col: 1, offset: 74699},
+			pos:  position{line: 2438, col: 1, offset: 74663},
 			expr: &seqExpr{
-				pos: position{line: 2436, col: 14, offset: 74712},
+				pos: position{line: 2438, col: 14, offset: 74676},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2436, col: 14, offset: 74712},
+						pos:        position{line: 2438, col: 14, offset: 74676},
 						val:        "using",
 						ignoreCase: true,
 						want:       "\"USING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2436, col: 33, offset: 74731},
+						pos: position{line: 2438, col: 33, offset: 74695},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2436, col: 34, offset: 74732},
+							pos:  position{line: 2438, col: 34, offset: 74696},
 							name: "IdentifierRest",
 						},
 					},
@@ -18269,20 +18256,20 @@ var g = &grammar{
 		},
 		{
 			name: "VALUE",
-			pos:  position{line: 2437, col: 1, offset: 74747},
+			pos:  position{line: 2439, col: 1, offset: 74711},
 			expr: &seqExpr{
-				pos: position{line: 2437, col: 14, offset: 74760},
+				pos: position{line: 2439, col: 14, offset: 74724},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2437, col: 14, offset: 74760},
+						pos:        position{line: 2439, col: 14, offset: 74724},
 						val:        "value",
 						ignoreCase: true,
 						want:       "\"VALUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2437, col: 33, offset: 74779},
+						pos: position{line: 2439, col: 33, offset: 74743},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2437, col: 34, offset: 74780},
+							pos:  position{line: 2439, col: 34, offset: 74744},
 							name: "IdentifierRest",
 						},
 					},
@@ -18293,20 +18280,20 @@ var g = &grammar{
 		},
 		{
 			name: "VALUES",
-			pos:  position{line: 2438, col: 1, offset: 74795},
+			pos:  position{line: 2440, col: 1, offset: 74759},
 			expr: &seqExpr{
-				pos: position{line: 2438, col: 14, offset: 74808},
+				pos: position{line: 2440, col: 14, offset: 74772},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2438, col: 14, offset: 74808},
+						pos:        position{line: 2440, col: 14, offset: 74772},
 						val:        "values",
 						ignoreCase: true,
 						want:       "\"VALUES\"i",
 					},
 					&notExpr{
-						pos: position{line: 2438, col: 33, offset: 74827},
+						pos: position{line: 2440, col: 33, offset: 74791},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2438, col: 34, offset: 74828},
+							pos:  position{line: 2440, col: 34, offset: 74792},
 							name: "IdentifierRest",
 						},
 					},
@@ -18317,20 +18304,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHEN",
-			pos:  position{line: 2439, col: 1, offset: 74843},
+			pos:  position{line: 2441, col: 1, offset: 74807},
 			expr: &seqExpr{
-				pos: position{line: 2439, col: 14, offset: 74856},
+				pos: position{line: 2441, col: 14, offset: 74820},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2439, col: 14, offset: 74856},
+						pos:        position{line: 2441, col: 14, offset: 74820},
 						val:        "when",
 						ignoreCase: true,
 						want:       "\"WHEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2439, col: 33, offset: 74875},
+						pos: position{line: 2441, col: 33, offset: 74839},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2439, col: 34, offset: 74876},
+							pos:  position{line: 2441, col: 34, offset: 74840},
 							name: "IdentifierRest",
 						},
 					},
@@ -18341,20 +18328,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHERE",
-			pos:  position{line: 2440, col: 1, offset: 74891},
+			pos:  position{line: 2442, col: 1, offset: 74855},
 			expr: &seqExpr{
-				pos: position{line: 2440, col: 14, offset: 74904},
+				pos: position{line: 2442, col: 14, offset: 74868},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2440, col: 14, offset: 74904},
+						pos:        position{line: 2442, col: 14, offset: 74868},
 						val:        "where",
 						ignoreCase: true,
 						want:       "\"WHERE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2440, col: 33, offset: 74923},
+						pos: position{line: 2442, col: 33, offset: 74887},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2440, col: 34, offset: 74924},
+							pos:  position{line: 2442, col: 34, offset: 74888},
 							name: "IdentifierRest",
 						},
 					},
@@ -18365,20 +18352,20 @@ var g = &grammar{
 		},
 		{
 			name: "WITH",
-			pos:  position{line: 2441, col: 1, offset: 74939},
+			pos:  position{line: 2443, col: 1, offset: 74903},
 			expr: &seqExpr{
-				pos: position{line: 2441, col: 14, offset: 74952},
+				pos: position{line: 2443, col: 14, offset: 74916},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2441, col: 14, offset: 74952},
+						pos:        position{line: 2443, col: 14, offset: 74916},
 						val:        "with",
 						ignoreCase: true,
 						want:       "\"WITH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2441, col: 33, offset: 74971},
+						pos: position{line: 2443, col: 33, offset: 74935},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2441, col: 34, offset: 74972},
+							pos:  position{line: 2443, col: 34, offset: 74936},
 							name: "IdentifierRest",
 						},
 					},
@@ -20550,10 +20537,10 @@ func (p *parser) callonColonCast1() (any, error) {
 	return p.cur.onColonCast1(stack["first"], stack["rest"])
 }
 
-func (c *current) onDerefExpr10(from, to any) (any, error) {
-
+func (c *current) onDerefExpr2(expr, from, to any) (any, error) {
 	e := &ast.SliceExpr{
 		Kind: "SliceExpr",
+		Expr: expr.(ast.Expr),
 		From: from.(ast.Expr),
 		Loc:  loc(c),
 	}
@@ -20564,67 +20551,59 @@ func (c *current) onDerefExpr10(from, to any) (any, error) {
 
 }
 
-func (p *parser) callonDerefExpr10() (any, error) {
+func (p *parser) callonDerefExpr2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onDerefExpr10(stack["from"], stack["to"])
+	return p.cur.onDerefExpr2(stack["expr"], stack["from"], stack["to"])
 }
 
-func (c *current) onDerefExpr25(to any) (any, error) {
+func (c *current) onDerefExpr18(expr, to any) (any, error) {
 	return &ast.SliceExpr{
 		Kind: "SliceExpr",
+		Expr: expr.(ast.Expr),
 		To:   to.(ast.Expr),
 		Loc:  loc(c),
 	}, nil
 
 }
 
-func (p *parser) callonDerefExpr25() (any, error) {
+func (p *parser) callonDerefExpr18() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onDerefExpr25(stack["to"])
+	return p.cur.onDerefExpr18(stack["expr"], stack["to"])
 }
 
-func (c *current) onDerefExpr35(index any) (any, error) {
+func (c *current) onDerefExpr29(expr, index any) (any, error) {
 	return &ast.IndexExpr{
 		Kind:  "IndexExpr",
+		Expr:  expr.(ast.Expr),
 		Index: index.(ast.Expr),
 		Loc:   loc(c),
 	}, nil
 
 }
 
-func (p *parser) callonDerefExpr35() (any, error) {
+func (p *parser) callonDerefExpr29() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onDerefExpr35(stack["index"])
+	return p.cur.onDerefExpr29(stack["expr"], stack["index"])
 }
 
-func (c *current) onDerefExpr44(id any) (any, error) {
+func (c *current) onDerefExpr37(expr, id any) (any, error) {
 	return &ast.BinaryExpr{
 		Kind: "BinaryExpr",
 		Op:   ".",
+		LHS:  expr.(ast.Expr),
 		RHS:  id.(ast.Expr),
 		Loc:  loc(c),
 	}, nil
 
 }
 
-func (p *parser) callonDerefExpr44() (any, error) {
+func (p *parser) callonDerefExpr37() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onDerefExpr44(stack["id"])
-}
-
-func (c *current) onDerefExpr1(head, tail any) (any, error) {
-	return makeDerefExpr(head, tail), nil
-
-}
-
-func (p *parser) callonDerefExpr1() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onDerefExpr1(stack["head"], stack["tail"])
+	return p.cur.onDerefExpr37(stack["expr"], stack["id"])
 }
 
 func (c *current) onDerefKey3(s any) (any, error) {

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -996,43 +996,45 @@ ColonCast
     }
 
 DerefExpr
-  = head:(Function / Primary) tail:(
-        __ "[" __ from:AdditiveExpr __ ":" __ to:AdditiveExpr? __ "]" { 
-          e := &ast.SliceExpr{
-            Kind: "SliceExpr",
-            From: from.(ast.Expr),
-            Loc: loc(c),
-          }
-          if to != nil {
-            e.To = to.(ast.Expr)
-          }
-          return e, nil
-        }
-      / __ "[" __ ":" __ to:AdditiveExpr "]" {
-          return &ast.SliceExpr{
-            Kind: "SliceExpr",
-            To: to.(ast.Expr),
-            Loc: loc(c),
-          }, nil
-        }
-      / __ "[" __ index:Expr __ "]" {
-          return &ast.IndexExpr{
-            Kind: "IndexExpr",
-            Index: index.(ast.Expr),
-            Loc: loc(c),
-          }, nil
-        }
-      / "." id:DerefKey {
-          return &ast.BinaryExpr{
-            Kind: "BinaryExpr",
-            Op: ".",
-            RHS: id.(ast.Expr),
-            Loc: loc(c),
-          }, nil
-        }
-    )* {
-      return makeDerefExpr(head, tail), nil
+  = expr:DerefExpr "[" __ from:AdditiveExpr __ ":" __ to:AdditiveExpr? __ "]" {
+      e := &ast.SliceExpr{
+        Kind: "SliceExpr",
+        Expr: expr.(ast.Expr),
+        From: from.(ast.Expr),
+        Loc: loc(c),
+      }
+      if to != nil {
+        e.To = to.(ast.Expr)
+      }
+      return e, nil
     }
+  / expr:DerefExpr "[" __ ":" __ to:AdditiveExpr "]" {
+      return &ast.SliceExpr{
+        Kind: "SliceExpr",
+        Expr: expr.(ast.Expr),
+        To: to.(ast.Expr),
+        Loc: loc(c),
+      }, nil
+    }
+  / expr:DerefExpr "[" index:Expr "]" {
+      return &ast.IndexExpr{
+        Kind: "IndexExpr",
+        Expr: expr.(ast.Expr),
+        Index: index.(ast.Expr),
+        Loc: loc(c),
+      }, nil
+    }
+  / expr:DerefExpr "." id:DerefKey {
+      return &ast.BinaryExpr{
+        Kind: "BinaryExpr",
+        Op: ".",
+        LHS: expr.(ast.Expr),
+        RHS: id.(ast.Expr),
+        Loc: loc(c),
+      }, nil
+    }
+  / Function
+  / Primary
 
 DerefKey
   = Identifier

--- a/compiler/parser/support.go
+++ b/compiler/parser/support.go
@@ -44,29 +44,6 @@ func makeBinaryExprChain(first, rest any, c *current) any {
 	return ret
 }
 
-func makeDerefExpr(head, tail any) any {
-	out := head.(ast.Expr)
-	for _, d := range tail.([]any) {
-		switch d := d.(type) {
-		case *ast.SliceExpr:
-			d.Expr = out
-			d.First = out.Pos()
-			out = d
-		case *ast.IndexExpr:
-			d.Expr = out
-			d.First = out.Pos()
-			out = d
-		case *ast.BinaryExpr:
-			d.LHS = out
-			d.First = out.Pos()
-			out = d
-		default:
-			panic(d)
-		}
-	}
-	return out
-}
-
 func makeArgMap(args any) (any, error) {
 	m := make(map[string]any)
 	for _, a := range args.([]any) {


### PR DESCRIPTION
Pull-request #6162 attempted to get rid of dependence on the experiemental left-recursion feature of pigeon by not using left recursion for dereference expressions. The change had the unexpected side-effect of adversely affecting the parsing times of some queries. Rollback those changes and go back to using left recursion for dereference expressions.

Fixes #6170