### PR TITLE
fix "super compile -dag/-O" panic on from op with Parquet file

### DIFF
--- a/cmd/super/compile/shared.go
+++ b/cmd/super/compile/shared.go
@@ -77,7 +77,7 @@ func (s *Shared) Run(ctx context.Context, args []string, dbFlags *dbflags.Flags,
 		return s.writeValue(ctx, ast.Parsed())
 	}
 	rctx := runtime.DefaultContext()
-	env := exec.NewEnvironment(nil, root)
+	env := exec.NewEnvironment(storage.NewLocalEngine(), root)
 	dag, err := compiler.Analyze(rctx, ast, env, extInput)
 	if err != nil {
 		return err


### PR DESCRIPTION
When the semantic analyzer encounters a from operator with a Parquet file as its argument, it tries to build a list of top-level fields in that file.  For "super compile", this causes a panic because the file is accessed through compiler/semantic.analyzer.env, which is nil.  Fix that.

Note that if a Parquet file is missing or otherwise inaccessible, its schema won't be available.

Fixes #6222.