### PR TITLE
compiler/semantic: do not share dag.Expr for ast.Between

### DIFF
--- a/compiler/semantic/expr.go
+++ b/compiler/semantic/expr.go
@@ -53,9 +53,10 @@ func (a *analyzer) semExpr(e ast.Expr) dag.Expr {
 		val := a.semExpr(e.Expr)
 		lower := a.semExpr(e.Lower)
 		upper := a.semExpr(e.Upper)
+		// Copy val so an optimizer change to one instance doesn't affect the other.
 		expr := dag.NewBinaryExpr("and",
 			dag.NewBinaryExpr(">=", val, lower),
-			dag.NewBinaryExpr("<=", val, upper))
+			dag.NewBinaryExpr("<=", dag.CopyExpr(val), upper))
 		if e.Not {
 			return dag.NewUnaryExpr("!", expr)
 		}

--- a/compiler/ztests/lift-filters.yaml
+++ b/compiler/ztests/lift-filters.yaml
@@ -4,6 +4,9 @@ script: |
   super compile -C -O 'values {...a} | where b==1'
   echo ===
   super compile -C -O 'values {a:{b:c}} | where a.b==1'
+  echo ===
+  # https://github.com/brimdata/super/issues/6223
+  super compile -C -O 'values {a:b,c,d} | where a+1 between c and d'
 
 outputs:
   - name: stdout
@@ -21,4 +24,9 @@ outputs:
       null
       | where c==1
       | values {a:{b:c}}
+      | output main
+      ===
+      null
+      | where b+1>=c and b+1<=d
+      | values {a:b,c:c,d:d}
       | output main


### PR DESCRIPTION
semExpr creates a DAG for ast.Between that contains two references (in two different nodes) to a single dag.Expr.  This causes a bug in optimizer.liftFilterOps because a change through either reference is unexpectedly visible through the other.  Fix this in semExpr by creating two copies of the dag.Expr.

Fixes #6223.