### PR TITLE
Distrbute prerelease super via Homebrew Cask

### DIFF
--- a/.github/workflows/homebrew-update.yaml
+++ b/.github/workflows/homebrew-update.yaml
@@ -1,0 +1,60 @@
+name: "Update Homewbrew Cask"
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: closed
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Commit SHA to build'
+        required: true
+        default: 'main'
+        type: string
+
+jobs:
+  build-and-update:
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-22.04
+    steps:
+      - id: checkout-ref
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "ref=${{ github.event.inputs.ref }}" >> $GITHUB_OUTPUT
+          else
+            echo "ref=${{ github.event.pull_request.merge_commit_sha }}" >> $GITHUB_OUTPUT
+          fi
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.checkout-ref.outputs.ref }}
+          fetch-depth: 0    
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          args: release --snapshot --clean
+      - uses: aws-actions/configure-aws-credentials@v5
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+      - run: |
+          sha_hash=${{ steps.checkout-ref.outputs.ref }}
+          short_hash=${sha_hash:0:9}
+          for artifact in dist/super-${short_hash}*; do aws s3 cp $artifact s3://super-prereleases/${short_hash}/ ; done
+      - uses: actions/checkout@v4
+        with:
+          repository: brimdata/homebrew-tap
+          token: ${{ secrets.PAT_TOKEN }}
+          path: homebrew-tap
+      - run: |
+          mkdir -p homebrew-tap/Casks
+          cp dist/homebrew/Casks/super.rb homebrew-tap/Casks
+          cd homebrew-tap
+          git config --global user.name 'Brim Automation'
+          git config --global user.email 'automation@brimdata.com'
+          git add Casks/super.rb
+          git commit -am "update super Homebrew Cask to ${{ steps.checkout-ref.outputs.ref }}" || true
+          git push

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,7 +7,7 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -s -X github.com/brimdata/super/cli.version={{ .Tag }}
+      - -s -X github.com/brimdata/super/cli.version={{ .ShortCommit }}
     goarch:
       - amd64
       - arm64
@@ -16,7 +16,7 @@ builds:
       - windows
       - darwin
 archives:
-  - name_template: "{{ .ProjectName }}-{{ .Tag }}.{{ .Os }}-{{ .Arch }}"
+  - name_template: "{{ .ProjectName }}-{{ .ShortCommit }}.{{ .Os }}-{{ .Arch }}"
     format_overrides:
       - goos: windows
         formats: [ "zip" ]
@@ -36,9 +36,11 @@ homebrew_casks:
     homepage: https://github.com/brimdata/super
     description: |
       An analytics database that fuses structured and semi-structured data
+    url:
+      template: "https://super-prereleases.s3.us-east-2.amazonaws.com/{{ .ShortCommit }}/{{ .ArtifactName }}"
 checksum:
   name_template: 'super-checksums.txt'
 snapshot:
-  version_template: "{{ incpatch .Version }}-{{ .ShortCommit }}"
+  version_template: "{{ .ShortCommit }}"
 changelog:
   disable: true


### PR DESCRIPTION
## What's Changing

This builds on #6271 by creating artifacts as each PR merges and updating a Homebrew Cask to make those artifacts available on a public S3 bucket.

## Why

1. As described in #6271, GoReleaser is pushing us toward using Casks rather than Formulas, so this is is a step toward where we'll want to be at GA
2. I'd been updating the prerelease Formula manually on a "best effort" basis, but the approach here is automatic each time a PR merges to `main`, which should get us better user testing in this prerelease phase

## Details

Consensus has been that we don't want any artifacts on the [super Releases](https://github.com/brimdata/super/releases) page on GitHub until we're ready to tag a GA release. The approach here gets around that putting the artifacts on a public S3 bucket instead and having the Homebrew Cask point at those URLs.

Part of the goal here is to get prerelease users off the Formula and onto the Cask before GA. Based on my research there's no way to silently _force_ that transition, so when this merges, my next planned step will be to replace the old [`super.rb` Homebrew Formula](https://github.com/brimdata/homebrew-tap/blob/main/super.rb) with one that installs a shim that will advise users of the minimal steps to switch over to the Cask. At that point they'll start getting updated `super` binaries as part of every general `brew update` / `brew upgrade`. I'd plan to remove that `super.db` Formula entirely right before we tag the GA release.

I've tested this extensively in a [personal super fork](https://github.com/philrz/super) and [personal Homebrew tap](https://github.com/brimdata/homebrew-tap) so if you want to see proof it works run `brew install philrz/tap/super` on a scratch macOS system with Homebrew installed.