### PR TITLE
remove sio/parquetio.TopLevelFieldNames in favor of Type

### DIFF
--- a/compiler/semantic/op.go
+++ b/compiler/semantic/op.go
@@ -161,9 +161,15 @@ func (t *translator) fileScanColumns(op *sem.FileScan) ([]string, bool) {
 		return nil, false
 	}
 	defer sr.Close()
-	cols, err := parquetio.TopLevelFieldNames(sr)
 	op.Type = parquetio.Type(t.sctx, sr)
-	return cols, err == nil
+	if op.Type == nil {
+		return nil, false
+	}
+	var cols []string
+	for _, f := range op.Type.(*super.TypeRecord).Fields {
+		cols = append(cols, f.Name)
+	}
+	return cols, true
 }
 
 func (t *translator) semFromExpr(entity *ast.ExprEntity, args []ast.OpArg, seq sem.Seq) (sem.Seq, string) {

--- a/sio/parquetio/reader.go
+++ b/sio/parquetio/reader.go
@@ -65,26 +65,3 @@ func Type(sctx *super.Context, r io.Reader) super.Type {
 	}
 	return nil
 }
-
-func TopLevelFieldNames(r io.Reader) ([]string, error) {
-	ras, ok := r.(parquet.ReaderAtSeeker)
-	if !ok {
-		return nil, errors.New("reader cannot seek")
-	}
-	pr, err := file.NewParquetReader(ras)
-	if err != nil {
-		return nil, err
-	}
-	var cols []string
-	var last string
-	schema := pr.MetaData().Schema
-	for i := range schema.NumColumns() {
-		name := schema.Column(i).ColumnPath()[0]
-		if name == last {
-			continue
-		}
-		cols = append(cols, name)
-		last = name
-	}
-	return cols, nil
-}


### PR DESCRIPTION
The Type function in the same package returns a super.Type containing the same information.