### PR TITLE
Point users at Homebrew Cask install

### DIFF
--- a/book/src/getting-started/install.md
+++ b/book/src/getting-started/install.md
@@ -19,7 +19,7 @@ To install the SuperDB Python client, see the
 On macOS and Linux, you can use [Homebrew](https://brew.sh/) to install `super`:
 
 ```bash
-brew install brimdata/tap/super
+brew install --cask brimdata/tap/super
 ```
 Once installed, run a [quick test](#quick-tests).
 


### PR DESCRIPTION
## tl;dr

Prerelease `super` builds are now updated nightly as Homebrew Casks (https://github.com/brimdata/homebrew-tap/pull/10) so this docs change on the `book` branch advises early users to install that way.

## Related Info

I'm still working on a way to nudge users off the old Homebrew Formula if they'd had it installed, either via auto migration (if I can get that working: https://github.com/Homebrew/brew/pull/20800#issuecomment-3387271679) or replacing the Formula with a shim that mentions the Cask install.

The long-term plan is to submit a Cask for `super` to be part of the ["official" set](https://formulae.brew.sh/cask/) but that happens after we tag a GA release.