### PR TITLE
join lift filter: Support const complex expressions

### DIFF
--- a/compiler/optimizer/pruner.go
+++ b/compiler/optimizer/pruner.go
@@ -246,10 +246,8 @@ func metaPrunerBinaryExpr(e *dag.BinaryExpr) dag.Expr {
 		}
 		var literals []*dag.LiteralExpr
 		switch e := e.RHS.(type) {
-		case *dag.ArrayExpr:
-			literals = literalsInArrayOrSet(e.Elems)
-		case *dag.SetExpr:
-			literals = literalsInArrayOrSet(e.Elems)
+		case *dag.ArrayExpr, *dag.SetExpr:
+			literals = literalsInArrayOrSet(vectorElems(e))
 		case *dag.RecordExpr:
 			for _, elem := range e.Elems {
 				f, ok := elem.(*dag.Field)
@@ -277,6 +275,17 @@ func metaPrunerBinaryExpr(e *dag.BinaryExpr) dag.Expr {
 		return ret
 	default:
 		return nil
+	}
+}
+
+func vectorElems(e dag.Expr) []dag.VectorElem {
+	switch e := e.(type) {
+	case *dag.ArrayExpr:
+		return e.Elems
+	case *dag.SetExpr:
+		return e.Elems
+	default:
+		panic(e)
 	}
 }
 

--- a/compiler/ztests/sql/join-filter-pullup.yaml
+++ b/compiler/ztests/sql/join-filter-pullup.yaml
@@ -9,7 +9,10 @@ script: |
   super compile -C -O "
     select *
     from (values (1)) as t1(a1), (values (1)) as t2(a2), (values (1)) as t3(a3)
-    where a1 == 1 and a3 == 1 and (1 == a2 or a2 == 2)
+    where a1 in [1,5,9]
+      and a1 in |[1,5,9]|
+      and a3 in (1,5,[9,11])
+      and (1 == a2 or a2 == 2)
   "
 
 outputs:
@@ -33,7 +36,7 @@ outputs:
       | fork
         (
           values {a1:1}
-          | where a1==1
+          | where a1 in [1,5,9] and a1 in |[1,5,9]|
         )
         (
           fork
@@ -43,7 +46,7 @@ outputs:
             )
             (
               values {a3:1}
-              | where a3==1
+              | where a3 in {c0:1,c1:5,c2:[9,11]}
             )
           | cross join as {left,right}
         )


### PR DESCRIPTION
This commits adds functionality to the optimizer to include constant record, array and set expressions when picking constant to path comparision to lift above join operators.

Partially fixes #6074