### PR TITLE
add error check for multi-column SQL subquery results

### DIFF
--- a/compiler/semantic/sql.go
+++ b/compiler/semantic/sql.go
@@ -161,6 +161,12 @@ func unravel(n ast.Node, elems []sem.RecordElem, schema schema, prefix field.Pat
 	case *joinSchema:
 		elems = unravel(n, elems, schema.left, append(prefix, "left"))
 		return unravel(n, elems, schema.right, append(prefix, "right"))
+	case *subquerySchema:
+		// XXX we're currently using subquerySchema to detect correlated subqueries
+		// but not doing the unnest yet, so in this case here (e.g., (select * from...)),
+		// we just unravel the inner schema without a path extension. This will change
+		// when we implement proper SQL subqueries with correlated subquery support.
+		return unravel(n, elems, schema.inner, prefix)
 	default:
 		panic(schema)
 	}

--- a/compiler/ztests/sql/exists-empty.yaml
+++ b/compiler/ztests/sql/exists-empty.yaml
@@ -1,0 +1,5 @@
+spq: |
+  SELECT 1
+  WHERE EXISTS (SELECT * FROM (VALUES (1),(2)) limit 0)
+
+output: ""

--- a/compiler/ztests/sql/multi-column-subquery.yaml
+++ b/compiler/ztests/sql/multi-column-subquery.yaml
@@ -1,0 +1,4 @@
+spq: select (values {y:0,z:1}) as v
+
+output: |
+  {v:error({message:"subquery expression cannot have multiple columns",on:{y:0,z:1}})}

--- a/compiler/ztests/sql/subqueries.yaml
+++ b/compiler/ztests/sql/subqueries.yaml
@@ -1,8 +1,20 @@
 script: |
   super -s -c 'select 1+(select 1) as v'
-  echo // ===
-  # pipe values operator presents as relation (select 1+1 as y)
+  echo ===
+  # pipe subquery yields a value that is treated like a relation
+  super -s -c 'select (select {y:1+1}) as x'
+  echo ===
+  # pipe subquery yields a value that is treated like a relation
   super -s -c 'select (values {y:1+1}) as x'
+  echo ===
+  # ...as does select value
+  super -s -c 'select (values {y:1+1}) as x'
+  echo ===
+  # ...but array is a single value and need not be unraveled
+  super -s -c 'select [values {y:1+1}] as x'
+  echo ===
+  # pass errors through unmodified, i.e., do not turn into missing
+  super -s -c "select (values error('foo')) as e"
 
 vector: true
 
@@ -10,5 +22,13 @@ outputs:
   - name: stdout
     data: |
       {v:2}
-      // ===
+      ===
+      {x:{y:2}}
+      ===
       {x:2}
+      ===
+      {x:2}
+      ===
+      {x:[{y:2}]}
+      ===
+      {e:error("foo")}


### PR DESCRIPTION
This commit adds a dynamic error check for SQL subqueries to produce an error when the subquery result has multiple columns.  It passes through error values unmodified so that subquery errors are not mysteriously converted to error("missing").

We also fixed a bug in the semantic analyzer to unravel subquery schemas for select * and added test coverage for this.