### PR TITLE
compiler/semantic: add missing slices.Clone in unravel

### DIFF
--- a/compiler/semantic/sql.go
+++ b/compiler/semantic/sql.go
@@ -146,7 +146,7 @@ func unravel(n ast.Node, elems []sem.RecordElem, schema schema, prefix field.Pat
 	case *dynamicSchema:
 		return append(elems, &sem.SpreadElem{
 			Node: n,
-			Expr: sem.NewThis(n, prefix),
+			Expr: sem.NewThis(n, slices.Clone(prefix)),
 		})
 	case *staticSchema:
 		for _, col := range schema.columns {


### PR DESCRIPTION
Recursive calls to unravel can modify the prefix parameter's underlying storage, so clone prefix with slices.Clone when capturing its current value.