### PR TITLE
fix type checker bug with conditional expressions

### DIFF
--- a/compiler/semantic/ztests/checker-cond.yaml
+++ b/compiler/semantic/ztests/checker-cond.yaml
@@ -1,0 +1,6 @@
+spq: |
+  values {key:0,val:1}
+  | values key=0 ? val : val2
+
+output: |
+  1


### PR DESCRIPTION
This commit fixes a bug where a conditional expression was causing a fatal error if either branch of the conditional had a type error. The fix is to report an error only when both branches have errors.