### PR TITLE
0-based index and slice expressions in pipes

### DIFF
--- a/book/src/super-sql/functions/records/unflatten.md
+++ b/book/src/super-sql/functions/records/unflatten.md
@@ -37,7 +37,7 @@ _Flatten to unflatten_
 ```mdtest-spq
 # spq
 unnest flatten(this) into (
-  key[1] != "rm"
+  key[0] != "rm"
   | values collect(this)
 )
 | values unflatten(this)

--- a/book/src/super-sql/functions/strings/upper.md
+++ b/book/src/super-sql/functions/strings/upper.md
@@ -31,7 +31,7 @@ values upper(this)
 ```mdtest-spq
 # spq
 fn capitalize(str): (
-  upper(str[1:2]) + str[2:]
+  upper(str[0:1]) + str[1:]
 )
 values capitalize(this)
 # input

--- a/book/src/super-sql/operators/unnest.md
+++ b/book/src/super-sql/operators/unnest.md
@@ -184,7 +184,7 @@ unnest {s,a} into ( sum(a) by s )
 _Unnested the elements of a record by flattening it_
 ```mdtest-spq
 # spq
-unnest {s,f:flatten(r)} into ( values {s,key:f.key[1],val:f.value} )
+unnest {s,f:flatten(r)} into ( values {s,key:f.key[0],val:f.value} )
 # input
 {s:"foo",r:{a:1,b:2}}
 {s:"bar",r:{a:3,b:4}}

--- a/compiler/dag/expr.go
+++ b/compiler/dag/expr.go
@@ -69,6 +69,7 @@ type (
 		Kind  string `json:"kind" unpack:""`
 		Expr  Expr   `json:"expr"`
 		Index Expr   `json:"index"`
+		SQL   bool   `json:"sql"`
 	}
 	IsNullExpr struct {
 		Kind string `json:"kind" unpack:""`
@@ -116,6 +117,7 @@ type (
 		Expr Expr   `json:"expr"`
 		From Expr   `json:"from"`
 		To   Expr   `json:"to"`
+		SQL  bool   `json:"sql"`
 	}
 	SortExpr struct {
 		Key   Expr        `json:"key"`

--- a/compiler/parser/ztests/in.yaml
+++ b/compiler/parser/ztests/in.yaml
@@ -1,5 +1,5 @@
 spq: |
-  values { x: 2 in a, y: b In a[2:], z: '1' IN a::[string]}
+  values { x: 2 in a, y: b In a[1:], z: '1' IN a::[string]}
 
 input: |
   {a:[1],b:2}

--- a/compiler/rungen/expr.go
+++ b/compiler/rungen/expr.go
@@ -223,7 +223,7 @@ func (b *Builder) compileSliceExpr(slice *dag.SliceExpr) (expr.Evaluator, error)
 	if err != nil {
 		return nil, err
 	}
-	return expr.NewSlice(b.sctx(), e, from, to), nil
+	return expr.NewSlice(b.sctx(), e, from, to, slice.SQL), nil
 }
 
 func (b *Builder) compileUnary(unary dag.UnaryExpr) (expr.Evaluator, error) {
@@ -379,7 +379,7 @@ func (b *Builder) compileIndexExpr(e *dag.IndexExpr) (expr.Evaluator, error) {
 	if err != nil {
 		return nil, err
 	}
-	return expr.NewIndexExpr(b.sctx(), container, index), nil
+	return expr.NewIndexExpr(b.sctx(), container, index, e.SQL), nil
 }
 
 func (b *Builder) compileIsNullExpr(e *dag.IsNullExpr) (expr.Evaluator, error) {

--- a/compiler/rungen/vexpr.go
+++ b/compiler/rungen/vexpr.go
@@ -164,7 +164,7 @@ func (b *Builder) compileVamIndexExpr(idx *dag.IndexExpr) (vamexpr.Evaluator, er
 	if err != nil {
 		return nil, err
 	}
-	return vamexpr.NewIndexExpr(b.sctx(), e, index), nil
+	return vamexpr.NewIndexExpr(b.sctx(), e, index, idx.SQL), nil
 }
 
 func (b *Builder) compileVamIsNullExpr(idx *dag.IsNullExpr) (vamexpr.Evaluator, error) {
@@ -343,7 +343,7 @@ func (b *Builder) compileVamSliceExpr(slice *dag.SliceExpr) (vamexpr.Evaluator, 
 	if err != nil {
 		return nil, err
 	}
-	return vamexpr.NewSliceExpr(b.sctx(), e, from, to), nil
+	return vamexpr.NewSliceExpr(b.sctx(), e, from, to, slice.SQL), nil
 }
 
 func (b *Builder) compileVamArrayExpr(e *dag.ArrayExpr) (vamexpr.Evaluator, error) {

--- a/compiler/semantic/dagen.go
+++ b/compiler/semantic/dagen.go
@@ -365,6 +365,7 @@ func (d *dagen) expr(e sem.Expr) dag.Expr {
 			Kind:  "IndexExpr",
 			Expr:  d.expr(e.Expr),
 			Index: d.expr(e.Index),
+			SQL:   e.SQL,
 		}
 	case *sem.IsNullExpr:
 		return &dag.IsNullExpr{
@@ -422,6 +423,7 @@ func (d *dagen) expr(e sem.Expr) dag.Expr {
 			Expr: d.expr(e.Expr),
 			From: d.expr(e.From),
 			To:   d.expr(e.To),
+			SQL:  e.SQL,
 		}
 	case *sem.SubqueryExpr:
 		return d.subquery(e)

--- a/compiler/semantic/expr.go
+++ b/compiler/semantic/expr.go
@@ -148,6 +148,7 @@ func (t *translator) expr(e ast.Expr) sem.Expr {
 			Node:  e,
 			Expr:  expr,
 			Index: index,
+			SQL:   t.scope.schema != nil,
 		}
 	case *ast.IsNullExpr:
 		expr := t.expr(e.Expr)
@@ -250,6 +251,7 @@ func (t *translator) expr(e ast.Expr) sem.Expr {
 			Expr: expr,
 			From: from,
 			To:   to,
+			SQL:  t.scope.schema != nil,
 		}
 	case *ast.SQLTimeExpr:
 		if e.Value.Type != "string" {
@@ -311,6 +313,7 @@ func (t *translator) expr(e ast.Expr) sem.Expr {
 			Node: e,
 			Expr: expr,
 			From: t.exprNullable(e.From),
+			SQL:  t.scope.schema != nil,
 		}
 		if e.For != nil {
 			to := t.expr(e.For)
@@ -1152,7 +1155,7 @@ func scalarSubqueryCheck(n ast.Node) *sem.ValuesOp {
 	indexExpr := &sem.IndexExpr{
 		Node:  n,
 		Expr:  sem.NewThis(n, nil),
-		Index: &sem.LiteralExpr{Node: n, Value: "1"},
+		Index: &sem.LiteralExpr{Node: n, Value: "0"},
 	}
 	innerCond := &sem.CondExpr{
 		Node: n,

--- a/compiler/semantic/sem/expr.go
+++ b/compiler/semantic/sem/expr.go
@@ -47,6 +47,7 @@ type (
 		ast.Node
 		Expr  Expr
 		Index Expr
+		SQL   bool
 	}
 	IsNullExpr struct {
 		ast.Node
@@ -94,6 +95,7 @@ type (
 		Expr Expr
 		From Expr
 		To   Expr
+		SQL  bool
 	}
 	SubqueryExpr struct {
 		ast.Node

--- a/compiler/ztests/par-pushdown.yaml
+++ b/compiler/ztests/par-pushdown.yaml
@@ -2,7 +2,7 @@ script: |
   export SUPER_DB=test
   super db init -q
   super db create -q -orderby ts test
-  super db compile -P 3 "from test | x==1" | super -s -c 'unnest body | kind=="ScatterOp" | unnest paths | values this[1].filter.kind' -
+  super db compile -P 3 "from test | x==1" | super -s -c 'unnest body | kind=="ScatterOp" | unnest paths | values this[0].filter.kind' -
 
 outputs:
   - name: stdout

--- a/compiler/ztests/sql/index.yaml
+++ b/compiler/ztests/sql/index.yaml
@@ -1,0 +1,32 @@
+spq: |
+  select a[i] as v
+
+vector: true
+
+input: |
+  {a:[1,2,3],i:1}
+  {a:[1,2,3],i:0}
+  {a:[1,2,3],i:-1}
+  {a:[1,2,3],i:"foo"}
+  {a:|[1,2,3]|,i:1}
+  {a:|[1,2,3]|,i:0}
+  {a:|[1,2,3]|,i:-1}
+  {a:|[1,2,3]|,i:"foo"}
+  {a:{c0:1,c1:2,c2:3},i:1}
+  {a:{c0:1,c1:2,c2:3},i:0}
+  {a:{c0:1,c1:2,c2:3},i:-1}
+  {a:{c0:1,c1:2,c2:3},i:"c1"}
+
+output: |
+  {v:1}
+  {v:error("missing")}
+  {v:3}
+  {v:error({message:"index is not an integer",on:"foo"})}
+  {v:1}
+  {v:error("missing")}
+  {v:3}
+  {v:error({message:"index is not an integer",on:"foo"})}
+  {v:1}
+  {v:error("missing")}
+  {v:3}
+  {v:2}

--- a/compiler/ztests/sql/slice.yaml
+++ b/compiler/ztests/sql/slice.yaml
@@ -1,0 +1,17 @@
+spq: |
+  select 
+    a[from:] as from,
+    a[:to] as to,
+    a[from:to] as both
+
+vector: true
+
+input: |
+  {a:[1,2,3],from:2,to:3}
+  {a:|[1,2,3]|,from:-2,to:-1}
+  {a:"123",from:2,to:3}
+
+output: |
+  {from:[2,3],to:[1,2],both:[2]}
+  {from:|[2,3]|,to:|[1,2]|,both:|[2]|}
+  {from:"23",to:"12",both:"2"}

--- a/compiler/ztests/sql/substring.yaml
+++ b/compiler/ztests/sql/substring.yaml
@@ -1,4 +1,4 @@
-spq: values SUBSTRING(this FROM 4 FOR 2), SUBSTRING(this FROM 4), SUBSTRING(this FOR 3)
+spq: select SUBSTRING(this FROM 4 FOR 2) as a, SUBSTRING(this FROM 4) as b, SUBSTRING(this FOR 3) as c
 
 vector: true
 
@@ -7,9 +7,5 @@ input: |
   [1,2]
 
 output: |
-  "ba"
-  "bar"
-  "foo"
-  error({message:"SUBSTRING: string value required",on:[1,2]})
-  error({message:"SUBSTRING: string value required",on:[1,2]})
-  error({message:"SUBSTRING: string value required",on:[1,2]})
+  {a:"ba",b:"bar",c:"foo"}
+  {a:error({message:"SUBSTRING: string value required",on:[1,2]}),b:error({message:"SUBSTRING: string value required",on:[1,2]}),c:error({message:"SUBSTRING: string value required",on:[1,2]})}

--- a/runtime/sam/expr/expr_test.go
+++ b/runtime/sam/expr/expr_test.go
@@ -461,13 +461,13 @@ func TestArithmetic(t *testing.T) {
 }
 
 func TestArrayIndex(t *testing.T) {
-	const record = `{x:[1,2,3],i:2::uint16}`
+	const record = `{x:[1,2,3],i:1::uint16}`
 
-	testSuccessful(t, "x[1]", record, "1")
-	testSuccessful(t, "x[2]", record, "2")
-	testSuccessful(t, "x[3]", record, "3")
+	testSuccessful(t, "x[0]", record, "1")
+	testSuccessful(t, "x[1]", record, "2")
+	testSuccessful(t, "x[2]", record, "3")
 	testSuccessful(t, "x[i]", record, "2")
-	testSuccessful(t, "i+1", record, "3")
+	testSuccessful(t, "i+1", record, "2")
 	testSuccessful(t, "x[i+1]", record, "3")
 }
 

--- a/runtime/sam/expr/filter_test.go
+++ b/runtime/sam/expr/filter_test.go
@@ -163,10 +163,10 @@ func TestFilters(t *testing.T) {
 
 	// Test array of records
 	runCases(t, "{nested:[{field:1::int32},{field:2}]}", []testcase{
-		{"nested[1].field == 1", true},
-		{"nested[2].field == 2", true},
-		{"nested[1].field == 2", false},
-		{"nested[3].field == 2", false},
+		{"nested[0].field == 1", true},
+		{"nested[1].field == 2", true},
+		{"nested[0].field == 2", false},
+		{"nested[2].field == 2", false},
 		{"nested.field == 2", false},
 	})
 
@@ -175,8 +175,8 @@ func TestFilters(t *testing.T) {
 		{"1 in nested.vec", true},
 		{"2 in nested.vec", true},
 		{"4 in nested.vec", false},
-		{"nested.vec[1] == 1", true},
-		{"nested.vec[2] == 1", false},
+		{"nested.vec[0] == 1", true},
+		{"nested.vec[1] == 1", false},
 		{"1 in nested", true},
 		{"?1", true},
 	})

--- a/runtime/sam/expr/ztests/index-named-complex.yaml
+++ b/runtime/sam/expr/ztests/index-named-complex.yaml
@@ -1,9 +1,9 @@
-spq: values this[2],this["x"]
+spq: values this[1],this["x"]
 
 input: |
   [1,2,3]::=foo
   |[4,5,6]|::=bar
-  |{2:"foo"}|::=baz
+  |{1:"foo"}|::=baz
   {"x":123}::=bap
   
 output: |

--- a/runtime/sam/expr/ztests/index.yaml
+++ b/runtime/sam/expr/ztests/index.yaml
@@ -1,9 +1,9 @@
 spq: |
   fn returnArray(): ([1])
-  values returnArray()[1],
-    cast(["1"],<[int64]>)[1],
-    [1][1],
-    |[1]|[1],
+  values returnArray()[0],
+    cast(["1"],<[int64]>)[0],
+    [1][0],
+    |[1]|[0],
     |{1:1}|[1],
     {x:1}["x"]
 

--- a/runtime/ztests/expr/array-bounds.yaml
+++ b/runtime/ztests/expr/array-bounds.yaml
@@ -1,4 +1,4 @@
-spq: put b:=missing(a[3])
+spq: put b:=missing(a[2])
 
 vector: true
 

--- a/runtime/ztests/expr/array-spread-union.yaml
+++ b/runtime/ztests/expr/array-spread-union.yaml
@@ -1,4 +1,4 @@
-spq: values [a[1],...b]
+spq: values [a[0],...b]
 
 vector: true
 

--- a/runtime/ztests/expr/function/cidr_match.yaml
+++ b/runtime/ztests/expr/function/cidr_match.yaml
@@ -1,5 +1,5 @@
 spq: |
-  values cidr_match(this[1], this[2])
+  values cidr_match(this[0], this[1])
 
 vector: true
 

--- a/runtime/ztests/expr/function/coalesce.yaml
+++ b/runtime/ztests/expr/function/coalesce.yaml
@@ -1,4 +1,4 @@
-spq: coalesce(this[1], this[2], this[3])
+spq: coalesce(this[0], this[1], this[2])
 
 vector: true
 

--- a/runtime/ztests/expr/index-deunion-vector.yaml
+++ b/runtime/ztests/expr/index-deunion-vector.yaml
@@ -1,4 +1,4 @@
-spq: values this[1], this[2], this[3]
+spq: values this[0], this[1], this[2]
 
 vector: true
 

--- a/runtime/ztests/expr/index.yaml
+++ b/runtime/ztests/expr/index.yaml
@@ -5,9 +5,9 @@ vector: true
 input: |
   // array
   {val:[1,2,3,"foo"],idx:-1}
-  {val:[1,2,3,"bar"],idx:2::uint8}
+  {val:[1,2,3,"bar"],idx:1::uint8}
   {val:[1,2,3,"foo"],idx:-4}
-  {val:[1,2,3,null],idx:4}
+  {val:[1,2,3,null],idx:3}
   {val:[1,2,3,"foo"],idx:-5}
   {val:null::[int64|string],idx:-5}
   {val:[1,2,3,"foo"],idx:null::int64}
@@ -15,16 +15,16 @@ input: |
   {val:[1,2,3,"foo"],idx:9223372036854775808::uint64}
   // set
   {val:|[1,2,3,"foo"]|,idx:-1}
-  {val:|[1,2,3,"bar"]|,idx:2}
+  {val:|[1,2,3,"bar"]|,idx:1}
   {val:|[1,2,3,"foo"]|,idx:-4}
-  {val:[1,2,3,null],idx:4}
+  {val:[1,2,3,null],idx:3}
   {val:|[1,2,3,"foo"]|,idx:-5}
   {val:|[1,2,3,"foo"]|,idx:"hi"}
   // record
   {val:{a:"foo",b:"bar"},idx:"a"}
   {val:{a:"bar",b:"baz"},idx:"b"}
   {val:{a:"bar",b:null},idx:"b"}
-  {val:{a:"foo",b:"bar"},idx:1}
+  {val:{a:"foo",b:"bar"},idx:0}
   {val:{a:"foo",b:"bar"},idx:-1}
   {val:{a:"foo",b:"bar"},idx:1.}
   {val:{a:"bar",b:"baz"},idx:"doesnotexist"}

--- a/runtime/ztests/expr/set-spread-union.yaml
+++ b/runtime/ztests/expr/set-spread-union.yaml
@@ -1,4 +1,4 @@
-spq: values |[a[1],...b]|
+spq: values |[a[0],...b]|
 
 vector: true
 

--- a/runtime/ztests/expr/slice-array.yaml
+++ b/runtime/ztests/expr/slice-array.yaml
@@ -3,12 +3,12 @@ spq: "values c[start:end]"
 vector: true
 
 input: |
-  {start:2,end:-1,c:null::[int64]}
-  {start:2,end:-1,c:[1,2,3,4]}
-  {start:-3,end:4,c:[5,7,8,9]}
-  {start:-5,end:4,c:[5,7,8,9]}
-  {start:1,end:6,c:[5,7,8,9]}
-  {start:5,end:4,c:[5,7,8,9]}
+  {start:1,end:-1,c:null::[int64]}
+  {start:1,end:-1,c:[1,2,3,4]}
+  {start:-3,end:3,c:[5,7,8,9]}
+  {start:-5,end:3,c:[5,7,8,9]}
+  {start:0,end:5,c:[5,7,8,9]}
+  {start:4,end:3,c:[5,7,8,9]}
 
 output: |
   null::[int64]

--- a/runtime/ztests/expr/slice-set.yaml
+++ b/runtime/ztests/expr/slice-set.yaml
@@ -3,12 +3,12 @@ spq: "values c[start:end]"
 vector: true
 
 input: |
-  {start:2,end:-1,c:null::|[int64]|}
-  {start:2,end:-1,c:|[1,2,3,4]|}
-  {start:-3,end:4,c:|[5,7,8,9]|}
-  {start:-5,end:4,c:|[5,7,8,9]|}
-  {start:0,end:6,c:|[5,7,8,9]|}
-  {start:5,end:4,c:|[5,7,8,9]|}
+  {start:1,end:-1,c:null::|[int64]|}
+  {start:1,end:-1,c:|[1,2,3,4]|}
+  {start:-3,end:3,c:|[5,7,8,9]|}
+  {start:-5,end:3,c:|[5,7,8,9]|}
+  {start:0,end:5,c:|[5,7,8,9]|}
+  {start:4,end:3,c:|[5,7,8,9]|}
 
 output: |
   null::|[int64]|

--- a/runtime/ztests/expr/slice.yaml
+++ b/runtime/ztests/expr/slice.yaml
@@ -1,4 +1,4 @@
-spq: "cut a1:=a[2:-1],a2:=a[2:],a3:=a[:2],a4:=a[:-1],a5:=a[:-100],a6:=a[-1:],a7:=a[-2:-1],a8:=(a IS NOT NULL and len(a)>0) ? a[:a[2]-8] : null"
+spq: "cut a1:=a[1:-1],a2:=a[1:],a3:=a[:1],a4:=a[:-1],a5:=a[:-100],a6:=a[-1:],a7:=a[-2:-1],a8:=(a IS NOT NULL and len(a)>0) ? a[:a[1]-9] : null"
 
 vector: true
 

--- a/runtime/ztests/expr/union-deref.yaml
+++ b/runtime/ztests/expr/union-deref.yaml
@@ -1,4 +1,4 @@
-spq: cut a:=r[1].a,b:=r[2].b
+spq: cut a:=r[0].a,b:=r[1].b
 
 vector: true
 

--- a/runtime/ztests/op/aggregate/missing.yaml
+++ b/runtime/ztests/op/aggregate/missing.yaml
@@ -1,5 +1,5 @@
 spq: |
-  by a:=a[1], b:=b.c | sort this
+  by a:=a[0], b:=b.c | sort this
 
 vector: true
 

--- a/service/ztests/curl-pool-rename.yaml
+++ b/service/ztests/curl-pool-rename.yaml
@@ -11,7 +11,7 @@ script: |
   curl -X POST \
     -H "Accept: application/json" \
     -d '{"query":"from :pools"}' \
-    $SUPER_DB/query | super -S -c "values this[1] | id:=0,ts:=0" -
+    $SUPER_DB/query | super -S -c "values this[0] | id:=0,ts:=0" -
 
 inputs:
   - name: service.sh


### PR DESCRIPTION
This commit changes the behavior of slice and index expressions so that slice and index expressions in pipe queries are 0-based while slice and index expression in SQL remain 1-based.