### PR TITLE
simplify ::-cast and cast-as to use only types not expressions

### DIFF
--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -6582,7 +6582,7 @@ var g = &grammar{
 														},
 														&ruleRefExpr{
 															pos:  position{line: 995, col: 42, offset: 23826},
-															name: "DerefExpr",
+															name: "IDExpr",
 														},
 													},
 												},
@@ -6599,74 +6599,92 @@ var g = &grammar{
 			leftRecursive: false,
 		},
 		{
+			name: "IDExpr",
+			pos:  position{line: 999, col: 1, offset: 23933},
+			expr: &actionExpr{
+				pos: position{line: 999, col: 10, offset: 23942},
+				run: (*parser).callonIDExpr1,
+				expr: &labeledExpr{
+					pos:   position{line: 999, col: 10, offset: 23942},
+					label: "id",
+					expr: &ruleRefExpr{
+						pos:  position{line: 999, col: 13, offset: 23945},
+						name: "Identifier",
+					},
+				},
+			},
+			leader:        false,
+			leftRecursive: false,
+		},
+		{
 			name: "DerefExpr",
-			pos:  position{line: 999, col: 1, offset: 23936},
+			pos:  position{line: 1001, col: 1, offset: 24022},
 			expr: &choiceExpr{
-				pos: position{line: 1000, col: 5, offset: 23950},
+				pos: position{line: 1002, col: 5, offset: 24036},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1000, col: 5, offset: 23950},
+						pos: position{line: 1002, col: 5, offset: 24036},
 						run: (*parser).callonDerefExpr2,
 						expr: &seqExpr{
-							pos: position{line: 1000, col: 5, offset: 23950},
+							pos: position{line: 1002, col: 5, offset: 24036},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1000, col: 5, offset: 23950},
+									pos:   position{line: 1002, col: 5, offset: 24036},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1000, col: 10, offset: 23955},
+										pos:  position{line: 1002, col: 10, offset: 24041},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1000, col: 20, offset: 23965},
+									pos:        position{line: 1002, col: 20, offset: 24051},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1000, col: 24, offset: 23969},
+									pos:  position{line: 1002, col: 24, offset: 24055},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1000, col: 27, offset: 23972},
+									pos:   position{line: 1002, col: 27, offset: 24058},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1000, col: 32, offset: 23977},
+										pos:  position{line: 1002, col: 32, offset: 24063},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1000, col: 45, offset: 23990},
+									pos:  position{line: 1002, col: 45, offset: 24076},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1000, col: 48, offset: 23993},
+									pos:        position{line: 1002, col: 48, offset: 24079},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1000, col: 52, offset: 23997},
+									pos:  position{line: 1002, col: 52, offset: 24083},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1000, col: 55, offset: 24000},
+									pos:   position{line: 1002, col: 55, offset: 24086},
 									label: "to",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1000, col: 58, offset: 24003},
+										pos: position{line: 1002, col: 58, offset: 24089},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1000, col: 58, offset: 24003},
+											pos:  position{line: 1002, col: 58, offset: 24089},
 											name: "AdditiveExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1000, col: 72, offset: 24017},
+									pos:  position{line: 1002, col: 72, offset: 24103},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1000, col: 75, offset: 24020},
+									pos:        position{line: 1002, col: 75, offset: 24106},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6675,49 +6693,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1012, col: 5, offset: 24259},
+						pos: position{line: 1014, col: 5, offset: 24345},
 						run: (*parser).callonDerefExpr18,
 						expr: &seqExpr{
-							pos: position{line: 1012, col: 5, offset: 24259},
+							pos: position{line: 1014, col: 5, offset: 24345},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1012, col: 5, offset: 24259},
+									pos:   position{line: 1014, col: 5, offset: 24345},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1012, col: 10, offset: 24264},
+										pos:  position{line: 1014, col: 10, offset: 24350},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1012, col: 20, offset: 24274},
+									pos:        position{line: 1014, col: 20, offset: 24360},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1012, col: 24, offset: 24278},
+									pos:  position{line: 1014, col: 24, offset: 24364},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1012, col: 27, offset: 24281},
+									pos:        position{line: 1014, col: 27, offset: 24367},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1012, col: 31, offset: 24285},
+									pos:  position{line: 1014, col: 31, offset: 24371},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1012, col: 34, offset: 24288},
+									pos:   position{line: 1014, col: 34, offset: 24374},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1012, col: 37, offset: 24291},
+										pos:  position{line: 1014, col: 37, offset: 24377},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1012, col: 50, offset: 24304},
+									pos:        position{line: 1014, col: 50, offset: 24390},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6726,35 +6744,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1020, col: 5, offset: 24468},
+						pos: position{line: 1022, col: 5, offset: 24554},
 						run: (*parser).callonDerefExpr29,
 						expr: &seqExpr{
-							pos: position{line: 1020, col: 5, offset: 24468},
+							pos: position{line: 1022, col: 5, offset: 24554},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1020, col: 5, offset: 24468},
+									pos:   position{line: 1022, col: 5, offset: 24554},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1020, col: 10, offset: 24473},
+										pos:  position{line: 1022, col: 10, offset: 24559},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1020, col: 20, offset: 24483},
+									pos:        position{line: 1022, col: 20, offset: 24569},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1020, col: 24, offset: 24487},
+									pos:   position{line: 1022, col: 24, offset: 24573},
 									label: "index",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1020, col: 30, offset: 24493},
+										pos:  position{line: 1022, col: 30, offset: 24579},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1020, col: 35, offset: 24498},
+									pos:        position{line: 1022, col: 35, offset: 24584},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6763,30 +6781,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1028, col: 5, offset: 24668},
+						pos: position{line: 1030, col: 5, offset: 24754},
 						run: (*parser).callonDerefExpr37,
 						expr: &seqExpr{
-							pos: position{line: 1028, col: 5, offset: 24668},
+							pos: position{line: 1030, col: 5, offset: 24754},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1028, col: 5, offset: 24668},
+									pos:   position{line: 1030, col: 5, offset: 24754},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1028, col: 10, offset: 24673},
+										pos:  position{line: 1030, col: 10, offset: 24759},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1028, col: 20, offset: 24683},
+									pos:        position{line: 1030, col: 20, offset: 24769},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1028, col: 24, offset: 24687},
+									pos:   position{line: 1030, col: 24, offset: 24773},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1028, col: 27, offset: 24690},
+										pos:  position{line: 1030, col: 27, offset: 24776},
 										name: "DerefKey",
 									},
 								},
@@ -6794,11 +6812,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1037, col: 5, offset: 24878},
+						pos:  position{line: 1039, col: 5, offset: 24964},
 						name: "Function",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1038, col: 5, offset: 24891},
+						pos:  position{line: 1040, col: 5, offset: 24977},
 						name: "Primary",
 					},
 				},
@@ -6808,42 +6826,42 @@ var g = &grammar{
 		},
 		{
 			name: "DerefKey",
-			pos:  position{line: 1040, col: 1, offset: 24900},
+			pos:  position{line: 1042, col: 1, offset: 24986},
 			expr: &choiceExpr{
-				pos: position{line: 1041, col: 5, offset: 24913},
+				pos: position{line: 1043, col: 5, offset: 24999},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1041, col: 5, offset: 24913},
+						pos: position{line: 1043, col: 5, offset: 24999},
 						run: (*parser).callonDerefKey2,
 						expr: &labeledExpr{
-							pos:   position{line: 1041, col: 5, offset: 24913},
+							pos:   position{line: 1043, col: 5, offset: 24999},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1041, col: 8, offset: 24916},
+								pos:  position{line: 1043, col: 8, offset: 25002},
 								name: "Identifier",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1042, col: 5, offset: 25007},
+						pos: position{line: 1044, col: 5, offset: 25093},
 						run: (*parser).callonDerefKey5,
 						expr: &labeledExpr{
-							pos:   position{line: 1042, col: 5, offset: 25007},
+							pos:   position{line: 1044, col: 5, offset: 25093},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1042, col: 7, offset: 25009},
+								pos:  position{line: 1044, col: 7, offset: 25095},
 								name: "DoubleQuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1043, col: 5, offset: 25121},
+						pos: position{line: 1045, col: 5, offset: 25207},
 						run: (*parser).callonDerefKey8,
 						expr: &labeledExpr{
-							pos:   position{line: 1043, col: 5, offset: 25121},
+							pos:   position{line: 1045, col: 5, offset: 25207},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1043, col: 7, offset: 25123},
+								pos:  position{line: 1045, col: 7, offset: 25209},
 								name: "BacktickString",
 							},
 						},
@@ -6855,79 +6873,79 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 1045, col: 1, offset: 25232},
+			pos:  position{line: 1047, col: 1, offset: 25318},
 			expr: &choiceExpr{
-				pos: position{line: 1046, col: 5, offset: 25245},
+				pos: position{line: 1048, col: 5, offset: 25331},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1046, col: 5, offset: 25245},
+						pos: position{line: 1048, col: 5, offset: 25331},
 						run: (*parser).callonFunction2,
 						expr: &seqExpr{
-							pos: position{line: 1046, col: 5, offset: 25245},
+							pos: position{line: 1048, col: 5, offset: 25331},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1046, col: 5, offset: 25245},
+									pos:  position{line: 1048, col: 5, offset: 25331},
 									name: "EXTRACT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1046, col: 13, offset: 25253},
+									pos:  position{line: 1048, col: 13, offset: 25339},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1046, col: 16, offset: 25256},
+									pos:        position{line: 1048, col: 16, offset: 25342},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1046, col: 20, offset: 25260},
+									pos:  position{line: 1048, col: 20, offset: 25346},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1046, col: 23, offset: 25263},
+									pos:   position{line: 1048, col: 23, offset: 25349},
 									label: "part",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1046, col: 28, offset: 25268},
+										pos:  position{line: 1048, col: 28, offset: 25354},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1046, col: 33, offset: 25273},
+									pos:  position{line: 1048, col: 33, offset: 25359},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1046, col: 35, offset: 25275},
+									pos:  position{line: 1048, col: 35, offset: 25361},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1046, col: 40, offset: 25280},
+									pos:  position{line: 1048, col: 40, offset: 25366},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1046, col: 42, offset: 25282},
+									pos:   position{line: 1048, col: 42, offset: 25368},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1046, col: 44, offset: 25284},
+										pos:  position{line: 1048, col: 44, offset: 25370},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1046, col: 49, offset: 25289},
+									pos:  position{line: 1048, col: 49, offset: 25375},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1046, col: 52, offset: 25292},
+									pos:        position{line: 1048, col: 52, offset: 25378},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1046, col: 56, offset: 25296},
+									pos:   position{line: 1048, col: 56, offset: 25382},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1046, col: 62, offset: 25302},
+										pos: position{line: 1048, col: 62, offset: 25388},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1046, col: 62, offset: 25302},
+											pos:  position{line: 1048, col: 62, offset: 25388},
 											name: "WhereClause",
 										},
 									},
@@ -6936,43 +6954,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1054, col: 5, offset: 25480},
+						pos: position{line: 1056, col: 5, offset: 25566},
 						run: (*parser).callonFunction20,
 						expr: &seqExpr{
-							pos: position{line: 1054, col: 5, offset: 25480},
+							pos: position{line: 1056, col: 5, offset: 25566},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1054, col: 5, offset: 25480},
+									pos:  position{line: 1056, col: 5, offset: 25566},
 									name: "EXISTS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1054, col: 12, offset: 25487},
+									pos:  position{line: 1056, col: 12, offset: 25573},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1054, col: 15, offset: 25490},
+									pos:        position{line: 1056, col: 15, offset: 25576},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1054, col: 19, offset: 25494},
+									pos:  position{line: 1056, col: 19, offset: 25580},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1054, col: 22, offset: 25497},
+									pos:   position{line: 1056, col: 22, offset: 25583},
 									label: "body",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1054, col: 27, offset: 25502},
+										pos:  position{line: 1056, col: 27, offset: 25588},
 										name: "Seq",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1054, col: 31, offset: 25506},
+									pos:  position{line: 1056, col: 31, offset: 25592},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1054, col: 34, offset: 25509},
+									pos:        position{line: 1056, col: 34, offset: 25595},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -6981,72 +6999,72 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1061, col: 5, offset: 25654},
+						pos: position{line: 1063, col: 5, offset: 25740},
 						run: (*parser).callonFunction30,
 						expr: &seqExpr{
-							pos: position{line: 1061, col: 5, offset: 25654},
+							pos: position{line: 1063, col: 5, offset: 25740},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1061, col: 5, offset: 25654},
+									pos:  position{line: 1063, col: 5, offset: 25740},
 									name: "CAST",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1061, col: 10, offset: 25659},
+									pos:  position{line: 1063, col: 10, offset: 25745},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1061, col: 13, offset: 25662},
+									pos:        position{line: 1063, col: 13, offset: 25748},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1061, col: 17, offset: 25666},
+									pos:  position{line: 1063, col: 17, offset: 25752},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1061, col: 20, offset: 25669},
+									pos:   position{line: 1063, col: 20, offset: 25755},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1061, col: 22, offset: 25671},
+										pos:  position{line: 1063, col: 22, offset: 25757},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1061, col: 27, offset: 25676},
+									pos:  position{line: 1063, col: 27, offset: 25762},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1061, col: 29, offset: 25678},
+									pos:  position{line: 1063, col: 29, offset: 25764},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1061, col: 32, offset: 25681},
+									pos:  position{line: 1063, col: 32, offset: 25767},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1061, col: 34, offset: 25683},
+									pos:   position{line: 1063, col: 34, offset: 25769},
 									label: "typ",
 									expr: &choiceExpr{
-										pos: position{line: 1061, col: 39, offset: 25688},
+										pos: position{line: 1063, col: 39, offset: 25774},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1061, col: 39, offset: 25688},
+												pos:  position{line: 1063, col: 39, offset: 25774},
 												name: "DateTypeHack",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1061, col: 54, offset: 25703},
+												pos:  position{line: 1063, col: 54, offset: 25789},
 												name: "Type",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1061, col: 60, offset: 25709},
+									pos:  position{line: 1063, col: 60, offset: 25795},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1061, col: 63, offset: 25712},
+									pos:        position{line: 1063, col: 63, offset: 25798},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7055,65 +7073,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1069, col: 5, offset: 25874},
+						pos: position{line: 1071, col: 5, offset: 25960},
 						run: (*parser).callonFunction47,
 						expr: &seqExpr{
-							pos: position{line: 1069, col: 5, offset: 25874},
+							pos: position{line: 1071, col: 5, offset: 25960},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1069, col: 5, offset: 25874},
+									pos:  position{line: 1071, col: 5, offset: 25960},
 									name: "SUBSTRING",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1069, col: 15, offset: 25884},
+									pos:  position{line: 1071, col: 15, offset: 25970},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1069, col: 18, offset: 25887},
+									pos:        position{line: 1071, col: 18, offset: 25973},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1069, col: 22, offset: 25891},
+									pos:  position{line: 1071, col: 22, offset: 25977},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1069, col: 25, offset: 25894},
+									pos:   position{line: 1071, col: 25, offset: 25980},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1069, col: 30, offset: 25899},
+										pos:  position{line: 1071, col: 30, offset: 25985},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1069, col: 35, offset: 25904},
+									pos:   position{line: 1071, col: 35, offset: 25990},
 									label: "from",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1069, col: 40, offset: 25909},
+										pos: position{line: 1071, col: 40, offset: 25995},
 										expr: &actionExpr{
-											pos: position{line: 1069, col: 41, offset: 25910},
+											pos: position{line: 1071, col: 41, offset: 25996},
 											run: (*parser).callonFunction57,
 											expr: &seqExpr{
-												pos: position{line: 1069, col: 41, offset: 25910},
+												pos: position{line: 1071, col: 41, offset: 25996},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1069, col: 41, offset: 25910},
+														pos:  position{line: 1071, col: 41, offset: 25996},
 														name: "_",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1069, col: 43, offset: 25912},
+														pos:  position{line: 1071, col: 43, offset: 25998},
 														name: "FROM",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1069, col: 48, offset: 25917},
+														pos:  position{line: 1071, col: 48, offset: 26003},
 														name: "_",
 													},
 													&labeledExpr{
-														pos:   position{line: 1069, col: 50, offset: 25919},
+														pos:   position{line: 1071, col: 50, offset: 26005},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1069, col: 52, offset: 25921},
+															pos:  position{line: 1071, col: 52, offset: 26007},
 															name: "Expr",
 														},
 													},
@@ -7123,33 +7141,33 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1069, col: 77, offset: 25946},
+									pos:   position{line: 1071, col: 77, offset: 26032},
 									label: "for_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1069, col: 82, offset: 25951},
+										pos: position{line: 1071, col: 82, offset: 26037},
 										expr: &actionExpr{
-											pos: position{line: 1069, col: 83, offset: 25952},
+											pos: position{line: 1071, col: 83, offset: 26038},
 											run: (*parser).callonFunction66,
 											expr: &seqExpr{
-												pos: position{line: 1069, col: 83, offset: 25952},
+												pos: position{line: 1071, col: 83, offset: 26038},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1069, col: 83, offset: 25952},
+														pos:  position{line: 1071, col: 83, offset: 26038},
 														name: "_",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1069, col: 85, offset: 25954},
+														pos:  position{line: 1071, col: 85, offset: 26040},
 														name: "FOR",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1069, col: 89, offset: 25958},
+														pos:  position{line: 1071, col: 89, offset: 26044},
 														name: "_",
 													},
 													&labeledExpr{
-														pos:   position{line: 1069, col: 91, offset: 25960},
+														pos:   position{line: 1071, col: 91, offset: 26046},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1069, col: 93, offset: 25962},
+															pos:  position{line: 1071, col: 93, offset: 26048},
 															name: "Expr",
 														},
 													},
@@ -7159,7 +7177,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1069, col: 118, offset: 25987},
+									pos:        position{line: 1071, col: 118, offset: 26073},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7168,58 +7186,58 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1083, col: 5, offset: 26272},
+						pos: position{line: 1085, col: 5, offset: 26358},
 						run: (*parser).callonFunction74,
 						expr: &seqExpr{
-							pos: position{line: 1083, col: 5, offset: 26272},
+							pos: position{line: 1085, col: 5, offset: 26358},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1083, col: 5, offset: 26272},
+									pos:   position{line: 1085, col: 5, offset: 26358},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1083, col: 7, offset: 26274},
+										pos:  position{line: 1085, col: 7, offset: 26360},
 										name: "Callable",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1083, col: 16, offset: 26283},
+									pos:  position{line: 1085, col: 16, offset: 26369},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1083, col: 19, offset: 26286},
+									pos:        position{line: 1085, col: 19, offset: 26372},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1083, col: 23, offset: 26290},
+									pos:  position{line: 1085, col: 23, offset: 26376},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1083, col: 26, offset: 26293},
+									pos:   position{line: 1085, col: 26, offset: 26379},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1083, col: 31, offset: 26298},
+										pos:  position{line: 1085, col: 31, offset: 26384},
 										name: "FunctionArgs",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1083, col: 44, offset: 26311},
+									pos:  position{line: 1085, col: 44, offset: 26397},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1083, col: 47, offset: 26314},
+									pos:        position{line: 1085, col: 47, offset: 26400},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1083, col: 51, offset: 26318},
+									pos:   position{line: 1085, col: 51, offset: 26404},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1083, col: 57, offset: 26324},
+										pos: position{line: 1085, col: 57, offset: 26410},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1083, col: 57, offset: 26324},
+											pos:  position{line: 1085, col: 57, offset: 26410},
 											name: "WhereClause",
 										},
 									},
@@ -7228,7 +7246,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1086, col: 5, offset: 26394},
+						pos:  position{line: 1088, col: 5, offset: 26480},
 						name: "CountStar",
 					},
 				},
@@ -7238,22 +7256,22 @@ var g = &grammar{
 		},
 		{
 			name: "Callable",
-			pos:  position{line: 1088, col: 1, offset: 26405},
+			pos:  position{line: 1090, col: 1, offset: 26491},
 			expr: &choiceExpr{
-				pos: position{line: 1089, col: 5, offset: 26418},
+				pos: position{line: 1091, col: 5, offset: 26504},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1089, col: 5, offset: 26418},
+						pos:  position{line: 1091, col: 5, offset: 26504},
 						name: "LambdaExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1090, col: 5, offset: 26433},
+						pos: position{line: 1092, col: 5, offset: 26519},
 						run: (*parser).callonCallable3,
 						expr: &labeledExpr{
-							pos:   position{line: 1090, col: 5, offset: 26433},
+							pos:   position{line: 1092, col: 5, offset: 26519},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1090, col: 8, offset: 26436},
+								pos:  position{line: 1092, col: 8, offset: 26522},
 								name: "IdentifierName",
 							},
 						},
@@ -7265,27 +7283,27 @@ var g = &grammar{
 		},
 		{
 			name: "FuncValue",
-			pos:  position{line: 1098, col: 1, offset: 26583},
+			pos:  position{line: 1100, col: 1, offset: 26669},
 			expr: &choiceExpr{
-				pos: position{line: 1099, col: 5, offset: 26597},
+				pos: position{line: 1101, col: 5, offset: 26683},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1099, col: 5, offset: 26597},
+						pos: position{line: 1101, col: 5, offset: 26683},
 						run: (*parser).callonFuncValue2,
 						expr: &seqExpr{
-							pos: position{line: 1099, col: 5, offset: 26597},
+							pos: position{line: 1101, col: 5, offset: 26683},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1099, col: 5, offset: 26597},
+									pos:        position{line: 1101, col: 5, offset: 26683},
 									val:        "&",
 									ignoreCase: false,
 									want:       "\"&\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1099, col: 9, offset: 26601},
+									pos:   position{line: 1101, col: 9, offset: 26687},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1099, col: 12, offset: 26604},
+										pos:  position{line: 1101, col: 12, offset: 26690},
 										name: "IdentifierName",
 									},
 								},
@@ -7293,7 +7311,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1106, col: 5, offset: 26754},
+						pos:  position{line: 1108, col: 5, offset: 26840},
 						name: "LambdaExpr",
 					},
 				},
@@ -7303,12 +7321,12 @@ var g = &grammar{
 		},
 		{
 			name: "DateTypeHack",
-			pos:  position{line: 1108, col: 1, offset: 26766},
+			pos:  position{line: 1110, col: 1, offset: 26852},
 			expr: &actionExpr{
-				pos: position{line: 1109, col: 5, offset: 26783},
+				pos: position{line: 1111, col: 5, offset: 26869},
 				run: (*parser).callonDateTypeHack1,
 				expr: &litMatcher{
-					pos:        position{line: 1109, col: 5, offset: 26783},
+					pos:        position{line: 1111, col: 5, offset: 26869},
 					val:        "date",
 					ignoreCase: true,
 					want:       "\"date\"i",
@@ -7319,19 +7337,19 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionArgs",
-			pos:  position{line: 1116, col: 1, offset: 26895},
+			pos:  position{line: 1118, col: 1, offset: 26981},
 			expr: &choiceExpr{
-				pos: position{line: 1117, col: 5, offset: 26912},
+				pos: position{line: 1119, col: 5, offset: 26998},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1117, col: 5, offset: 26912},
+						pos:  position{line: 1119, col: 5, offset: 26998},
 						name: "FuncOrExprs",
 					},
 					&actionExpr{
-						pos: position{line: 1118, col: 5, offset: 26928},
+						pos: position{line: 1120, col: 5, offset: 27014},
 						run: (*parser).callonFunctionArgs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1118, col: 5, offset: 26928},
+							pos:  position{line: 1120, col: 5, offset: 27014},
 							name: "__",
 						},
 					},
@@ -7342,51 +7360,51 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 1120, col: 1, offset: 26956},
+			pos:  position{line: 1122, col: 1, offset: 27042},
 			expr: &actionExpr{
-				pos: position{line: 1121, col: 5, offset: 26966},
+				pos: position{line: 1123, col: 5, offset: 27052},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 1121, col: 5, offset: 26966},
+					pos: position{line: 1123, col: 5, offset: 27052},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1121, col: 5, offset: 26966},
+							pos:   position{line: 1123, col: 5, offset: 27052},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1121, col: 11, offset: 26972},
+								pos:  position{line: 1123, col: 11, offset: 27058},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1121, col: 16, offset: 26977},
+							pos:   position{line: 1123, col: 16, offset: 27063},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1121, col: 21, offset: 26982},
+								pos: position{line: 1123, col: 21, offset: 27068},
 								expr: &actionExpr{
-									pos: position{line: 1121, col: 22, offset: 26983},
+									pos: position{line: 1123, col: 22, offset: 27069},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 1121, col: 22, offset: 26983},
+										pos: position{line: 1123, col: 22, offset: 27069},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1121, col: 22, offset: 26983},
+												pos:  position{line: 1123, col: 22, offset: 27069},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1121, col: 25, offset: 26986},
+												pos:        position{line: 1123, col: 25, offset: 27072},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1121, col: 29, offset: 26990},
+												pos:  position{line: 1123, col: 29, offset: 27076},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1121, col: 32, offset: 26993},
+												pos:   position{line: 1123, col: 32, offset: 27079},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1121, col: 34, offset: 26995},
+													pos:  position{line: 1123, col: 34, offset: 27081},
 													name: "Expr",
 												},
 											},
@@ -7403,84 +7421,84 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 1125, col: 1, offset: 27068},
+			pos:  position{line: 1127, col: 1, offset: 27154},
 			expr: &choiceExpr{
-				pos: position{line: 1126, col: 5, offset: 27080},
+				pos: position{line: 1128, col: 5, offset: 27166},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1126, col: 5, offset: 27080},
+						pos:  position{line: 1128, col: 5, offset: 27166},
 						name: "CaseExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1127, col: 5, offset: 27093},
+						pos:  position{line: 1129, col: 5, offset: 27179},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1128, col: 5, offset: 27104},
+						pos:  position{line: 1130, col: 5, offset: 27190},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1129, col: 5, offset: 27114},
+						pos:  position{line: 1131, col: 5, offset: 27200},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1130, col: 5, offset: 27122},
+						pos:  position{line: 1132, col: 5, offset: 27208},
 						name: "Map",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1131, col: 5, offset: 27130},
+						pos:  position{line: 1133, col: 5, offset: 27216},
 						name: "SQLTimeExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1132, col: 5, offset: 27146},
+						pos:  position{line: 1134, col: 5, offset: 27232},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 1133, col: 5, offset: 27158},
+						pos: position{line: 1135, col: 5, offset: 27244},
 						run: (*parser).callonPrimary9,
 						expr: &labeledExpr{
-							pos:   position{line: 1133, col: 5, offset: 27158},
+							pos:   position{line: 1135, col: 5, offset: 27244},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1133, col: 8, offset: 27161},
+								pos:  position{line: 1135, col: 8, offset: 27247},
 								name: "Identifier",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1134, col: 5, offset: 27254},
+						pos:  position{line: 1136, col: 5, offset: 27340},
 						name: "Tuple",
 					},
 					&actionExpr{
-						pos: position{line: 1135, col: 5, offset: 27264},
+						pos: position{line: 1137, col: 5, offset: 27350},
 						run: (*parser).callonPrimary13,
 						expr: &seqExpr{
-							pos: position{line: 1135, col: 5, offset: 27264},
+							pos: position{line: 1137, col: 5, offset: 27350},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1135, col: 5, offset: 27264},
+									pos:        position{line: 1137, col: 5, offset: 27350},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1135, col: 9, offset: 27268},
+									pos:  position{line: 1137, col: 9, offset: 27354},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1135, col: 12, offset: 27271},
+									pos:   position{line: 1137, col: 12, offset: 27357},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1135, col: 17, offset: 27276},
+										pos:  position{line: 1137, col: 17, offset: 27362},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1135, col: 22, offset: 27281},
+									pos:  position{line: 1137, col: 22, offset: 27367},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1135, col: 25, offset: 27284},
+									pos:        position{line: 1137, col: 25, offset: 27370},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7489,35 +7507,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1136, col: 5, offset: 27313},
+						pos: position{line: 1138, col: 5, offset: 27399},
 						run: (*parser).callonPrimary21,
 						expr: &seqExpr{
-							pos: position{line: 1136, col: 5, offset: 27313},
+							pos: position{line: 1138, col: 5, offset: 27399},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1136, col: 5, offset: 27313},
+									pos:        position{line: 1138, col: 5, offset: 27399},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1136, col: 9, offset: 27317},
+									pos:  position{line: 1138, col: 9, offset: 27403},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1136, col: 12, offset: 27320},
+									pos:   position{line: 1138, col: 12, offset: 27406},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1136, col: 17, offset: 27325},
+										pos:  position{line: 1138, col: 17, offset: 27411},
 										name: "SubqueryExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1136, col: 30, offset: 27338},
+									pos:  position{line: 1138, col: 30, offset: 27424},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1136, col: 33, offset: 27341},
+									pos:        position{line: 1138, col: 33, offset: 27427},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7526,35 +7544,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1137, col: 5, offset: 27370},
+						pos: position{line: 1139, col: 5, offset: 27456},
 						run: (*parser).callonPrimary29,
 						expr: &seqExpr{
-							pos: position{line: 1137, col: 5, offset: 27370},
+							pos: position{line: 1139, col: 5, offset: 27456},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1137, col: 5, offset: 27370},
+									pos:        position{line: 1139, col: 5, offset: 27456},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1137, col: 9, offset: 27374},
+									pos:  position{line: 1139, col: 9, offset: 27460},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1137, col: 12, offset: 27377},
+									pos:   position{line: 1139, col: 12, offset: 27463},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1137, col: 17, offset: 27382},
+										pos:  position{line: 1139, col: 17, offset: 27468},
 										name: "SubqueryExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1137, col: 30, offset: 27395},
+									pos:  position{line: 1139, col: 30, offset: 27481},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1137, col: 33, offset: 27398},
+									pos:        position{line: 1139, col: 33, offset: 27484},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -7569,53 +7587,53 @@ var g = &grammar{
 		},
 		{
 			name: "CaseExpr",
-			pos:  position{line: 1142, col: 1, offset: 27480},
+			pos:  position{line: 1144, col: 1, offset: 27566},
 			expr: &choiceExpr{
-				pos: position{line: 1143, col: 5, offset: 27493},
+				pos: position{line: 1145, col: 5, offset: 27579},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1143, col: 5, offset: 27493},
+						pos: position{line: 1145, col: 5, offset: 27579},
 						run: (*parser).callonCaseExpr2,
 						expr: &seqExpr{
-							pos: position{line: 1143, col: 5, offset: 27493},
+							pos: position{line: 1145, col: 5, offset: 27579},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1143, col: 5, offset: 27493},
+									pos:  position{line: 1145, col: 5, offset: 27579},
 									name: "CASE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1143, col: 10, offset: 27498},
+									pos:   position{line: 1145, col: 10, offset: 27584},
 									label: "cases",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1143, col: 16, offset: 27504},
+										pos: position{line: 1145, col: 16, offset: 27590},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1143, col: 16, offset: 27504},
+											pos:  position{line: 1145, col: 16, offset: 27590},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1143, col: 22, offset: 27510},
+									pos:   position{line: 1145, col: 22, offset: 27596},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1143, col: 28, offset: 27516},
+										pos: position{line: 1145, col: 28, offset: 27602},
 										expr: &seqExpr{
-											pos: position{line: 1143, col: 29, offset: 27517},
+											pos: position{line: 1145, col: 29, offset: 27603},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1143, col: 29, offset: 27517},
+													pos:  position{line: 1145, col: 29, offset: 27603},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1143, col: 31, offset: 27519},
+													pos:  position{line: 1145, col: 31, offset: 27605},
 													name: "ELSE",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1143, col: 36, offset: 27524},
+													pos:  position{line: 1145, col: 36, offset: 27610},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1143, col: 38, offset: 27526},
+													pos:  position{line: 1145, col: 38, offset: 27612},
 													name: "Expr",
 												},
 											},
@@ -7623,24 +7641,24 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1143, col: 45, offset: 27533},
+									pos:  position{line: 1145, col: 45, offset: 27619},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1143, col: 47, offset: 27535},
+									pos:  position{line: 1145, col: 47, offset: 27621},
 									name: "END",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1143, col: 51, offset: 27539},
+									pos: position{line: 1145, col: 51, offset: 27625},
 									expr: &seqExpr{
-										pos: position{line: 1143, col: 52, offset: 27540},
+										pos: position{line: 1145, col: 52, offset: 27626},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1143, col: 52, offset: 27540},
+												pos:  position{line: 1145, col: 52, offset: 27626},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1143, col: 54, offset: 27542},
+												pos:  position{line: 1145, col: 54, offset: 27628},
 												name: "CASE",
 											},
 										},
@@ -7650,60 +7668,60 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1167, col: 5, offset: 28179},
+						pos: position{line: 1169, col: 5, offset: 28265},
 						run: (*parser).callonCaseExpr21,
 						expr: &seqExpr{
-							pos: position{line: 1167, col: 5, offset: 28179},
+							pos: position{line: 1169, col: 5, offset: 28265},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1167, col: 5, offset: 28179},
+									pos:  position{line: 1169, col: 5, offset: 28265},
 									name: "CASE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1167, col: 10, offset: 28184},
+									pos:  position{line: 1169, col: 10, offset: 28270},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1167, col: 12, offset: 28186},
+									pos:   position{line: 1169, col: 12, offset: 28272},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1167, col: 17, offset: 28191},
+										pos:  position{line: 1169, col: 17, offset: 28277},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1167, col: 22, offset: 28196},
+									pos:   position{line: 1169, col: 22, offset: 28282},
 									label: "whens",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1167, col: 28, offset: 28202},
+										pos: position{line: 1169, col: 28, offset: 28288},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1167, col: 28, offset: 28202},
+											pos:  position{line: 1169, col: 28, offset: 28288},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1167, col: 34, offset: 28208},
+									pos:   position{line: 1169, col: 34, offset: 28294},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1167, col: 40, offset: 28214},
+										pos: position{line: 1169, col: 40, offset: 28300},
 										expr: &seqExpr{
-											pos: position{line: 1167, col: 41, offset: 28215},
+											pos: position{line: 1169, col: 41, offset: 28301},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1167, col: 41, offset: 28215},
+													pos:  position{line: 1169, col: 41, offset: 28301},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1167, col: 43, offset: 28217},
+													pos:  position{line: 1169, col: 43, offset: 28303},
 													name: "ELSE",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1167, col: 48, offset: 28222},
+													pos:  position{line: 1169, col: 48, offset: 28308},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1167, col: 50, offset: 28224},
+													pos:  position{line: 1169, col: 50, offset: 28310},
 													name: "Expr",
 												},
 											},
@@ -7711,24 +7729,24 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1167, col: 57, offset: 28231},
+									pos:  position{line: 1169, col: 57, offset: 28317},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1167, col: 59, offset: 28233},
+									pos:  position{line: 1169, col: 59, offset: 28319},
 									name: "END",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1167, col: 63, offset: 28237},
+									pos: position{line: 1169, col: 63, offset: 28323},
 									expr: &seqExpr{
-										pos: position{line: 1167, col: 64, offset: 28238},
+										pos: position{line: 1169, col: 64, offset: 28324},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1167, col: 64, offset: 28238},
+												pos:  position{line: 1169, col: 64, offset: 28324},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1167, col: 66, offset: 28240},
+												pos:  position{line: 1169, col: 66, offset: 28326},
 												name: "CASE",
 											},
 										},
@@ -7744,50 +7762,50 @@ var g = &grammar{
 		},
 		{
 			name: "When",
-			pos:  position{line: 1180, col: 1, offset: 28546},
+			pos:  position{line: 1182, col: 1, offset: 28632},
 			expr: &actionExpr{
-				pos: position{line: 1181, col: 5, offset: 28555},
+				pos: position{line: 1183, col: 5, offset: 28641},
 				run: (*parser).callonWhen1,
 				expr: &seqExpr{
-					pos: position{line: 1181, col: 5, offset: 28555},
+					pos: position{line: 1183, col: 5, offset: 28641},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1181, col: 5, offset: 28555},
+							pos:  position{line: 1183, col: 5, offset: 28641},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1181, col: 7, offset: 28557},
+							pos:  position{line: 1183, col: 7, offset: 28643},
 							name: "WHEN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1181, col: 12, offset: 28562},
+							pos:  position{line: 1183, col: 12, offset: 28648},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1181, col: 14, offset: 28564},
+							pos:   position{line: 1183, col: 14, offset: 28650},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1181, col: 19, offset: 28569},
+								pos:  position{line: 1183, col: 19, offset: 28655},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1181, col: 24, offset: 28574},
+							pos:  position{line: 1183, col: 24, offset: 28660},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1181, col: 26, offset: 28576},
+							pos:  position{line: 1183, col: 26, offset: 28662},
 							name: "THEN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1181, col: 31, offset: 28581},
+							pos:  position{line: 1183, col: 31, offset: 28667},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1181, col: 33, offset: 28583},
+							pos:   position{line: 1183, col: 33, offset: 28669},
 							label: "then",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1181, col: 38, offset: 28588},
+								pos:  position{line: 1183, col: 38, offset: 28674},
 								name: "Expr",
 							},
 						},
@@ -7799,15 +7817,15 @@ var g = &grammar{
 		},
 		{
 			name: "SubqueryExpr",
-			pos:  position{line: 1189, col: 1, offset: 28721},
+			pos:  position{line: 1191, col: 1, offset: 28807},
 			expr: &actionExpr{
-				pos: position{line: 1190, col: 5, offset: 28738},
+				pos: position{line: 1192, col: 5, offset: 28824},
 				run: (*parser).callonSubqueryExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 1190, col: 5, offset: 28738},
+					pos:   position{line: 1192, col: 5, offset: 28824},
 					label: "body",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1190, col: 10, offset: 28743},
+						pos:  position{line: 1192, col: 10, offset: 28829},
 						name: "Seq",
 					},
 				},
@@ -7817,37 +7835,37 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 1198, col: 1, offset: 28887},
+			pos:  position{line: 1200, col: 1, offset: 28973},
 			expr: &actionExpr{
-				pos: position{line: 1199, col: 5, offset: 28898},
+				pos: position{line: 1201, col: 5, offset: 28984},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 1199, col: 5, offset: 28898},
+					pos: position{line: 1201, col: 5, offset: 28984},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1199, col: 5, offset: 28898},
+							pos:        position{line: 1201, col: 5, offset: 28984},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1199, col: 9, offset: 28902},
+							pos:  position{line: 1201, col: 9, offset: 28988},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1199, col: 12, offset: 28905},
+							pos:   position{line: 1201, col: 12, offset: 28991},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1199, col: 18, offset: 28911},
+								pos:  position{line: 1201, col: 18, offset: 28997},
 								name: "RecordElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1199, col: 30, offset: 28923},
+							pos:  position{line: 1201, col: 30, offset: 29009},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1199, col: 33, offset: 28926},
+							pos:        position{line: 1201, col: 33, offset: 29012},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -7860,31 +7878,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElems",
-			pos:  position{line: 1207, col: 1, offset: 29084},
+			pos:  position{line: 1209, col: 1, offset: 29170},
 			expr: &choiceExpr{
-				pos: position{line: 1208, col: 5, offset: 29100},
+				pos: position{line: 1210, col: 5, offset: 29186},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1208, col: 5, offset: 29100},
+						pos: position{line: 1210, col: 5, offset: 29186},
 						run: (*parser).callonRecordElems2,
 						expr: &seqExpr{
-							pos: position{line: 1208, col: 5, offset: 29100},
+							pos: position{line: 1210, col: 5, offset: 29186},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1208, col: 5, offset: 29100},
+									pos:   position{line: 1210, col: 5, offset: 29186},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1208, col: 11, offset: 29106},
+										pos:  position{line: 1210, col: 11, offset: 29192},
 										name: "RecordElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1208, col: 22, offset: 29117},
+									pos:   position{line: 1210, col: 22, offset: 29203},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1208, col: 27, offset: 29122},
+										pos: position{line: 1210, col: 27, offset: 29208},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1208, col: 27, offset: 29122},
+											pos:  position{line: 1210, col: 27, offset: 29208},
 											name: "RecordElemTail",
 										},
 									},
@@ -7893,10 +7911,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1211, col: 5, offset: 29185},
+						pos: position{line: 1213, col: 5, offset: 29271},
 						run: (*parser).callonRecordElems9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1211, col: 5, offset: 29185},
+							pos:  position{line: 1213, col: 5, offset: 29271},
 							name: "__",
 						},
 					},
@@ -7907,32 +7925,32 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElemTail",
-			pos:  position{line: 1213, col: 1, offset: 29209},
+			pos:  position{line: 1215, col: 1, offset: 29295},
 			expr: &actionExpr{
-				pos: position{line: 1213, col: 18, offset: 29226},
+				pos: position{line: 1215, col: 18, offset: 29312},
 				run: (*parser).callonRecordElemTail1,
 				expr: &seqExpr{
-					pos: position{line: 1213, col: 18, offset: 29226},
+					pos: position{line: 1215, col: 18, offset: 29312},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1213, col: 18, offset: 29226},
+							pos:  position{line: 1215, col: 18, offset: 29312},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1213, col: 21, offset: 29229},
+							pos:        position{line: 1215, col: 21, offset: 29315},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1213, col: 25, offset: 29233},
+							pos:  position{line: 1215, col: 25, offset: 29319},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1213, col: 28, offset: 29236},
+							pos:   position{line: 1215, col: 28, offset: 29322},
 							label: "elem",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1213, col: 33, offset: 29241},
+								pos:  position{line: 1215, col: 33, offset: 29327},
 								name: "RecordElem",
 							},
 						},
@@ -7944,20 +7962,20 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElem",
-			pos:  position{line: 1215, col: 1, offset: 29274},
+			pos:  position{line: 1217, col: 1, offset: 29360},
 			expr: &choiceExpr{
-				pos: position{line: 1215, col: 14, offset: 29287},
+				pos: position{line: 1217, col: 14, offset: 29373},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1215, col: 14, offset: 29287},
+						pos:  position{line: 1217, col: 14, offset: 29373},
 						name: "SpreadElem",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1215, col: 27, offset: 29300},
+						pos:  position{line: 1217, col: 27, offset: 29386},
 						name: "FieldElem",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1215, col: 39, offset: 29312},
+						pos:  position{line: 1217, col: 39, offset: 29398},
 						name: "ExprElem",
 					},
 				},
@@ -7967,28 +7985,28 @@ var g = &grammar{
 		},
 		{
 			name: "SpreadElem",
-			pos:  position{line: 1217, col: 1, offset: 29322},
+			pos:  position{line: 1219, col: 1, offset: 29408},
 			expr: &actionExpr{
-				pos: position{line: 1218, col: 5, offset: 29337},
+				pos: position{line: 1220, col: 5, offset: 29423},
 				run: (*parser).callonSpreadElem1,
 				expr: &seqExpr{
-					pos: position{line: 1218, col: 5, offset: 29337},
+					pos: position{line: 1220, col: 5, offset: 29423},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1218, col: 5, offset: 29337},
+							pos:        position{line: 1220, col: 5, offset: 29423},
 							val:        "...",
 							ignoreCase: false,
 							want:       "\"...\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1218, col: 11, offset: 29343},
+							pos:  position{line: 1220, col: 11, offset: 29429},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1218, col: 14, offset: 29346},
+							pos:   position{line: 1220, col: 14, offset: 29432},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1218, col: 19, offset: 29351},
+								pos:  position{line: 1220, col: 19, offset: 29437},
 								name: "Expr",
 							},
 						},
@@ -8000,40 +8018,40 @@ var g = &grammar{
 		},
 		{
 			name: "FieldElem",
-			pos:  position{line: 1222, col: 1, offset: 29455},
+			pos:  position{line: 1224, col: 1, offset: 29541},
 			expr: &actionExpr{
-				pos: position{line: 1223, col: 5, offset: 29469},
+				pos: position{line: 1225, col: 5, offset: 29555},
 				run: (*parser).callonFieldElem1,
 				expr: &seqExpr{
-					pos: position{line: 1223, col: 5, offset: 29469},
+					pos: position{line: 1225, col: 5, offset: 29555},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1223, col: 5, offset: 29469},
+							pos:   position{line: 1225, col: 5, offset: 29555},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1223, col: 10, offset: 29474},
+								pos:  position{line: 1225, col: 10, offset: 29560},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1223, col: 15, offset: 29479},
+							pos:  position{line: 1225, col: 15, offset: 29565},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1223, col: 18, offset: 29482},
+							pos:        position{line: 1225, col: 18, offset: 29568},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1223, col: 22, offset: 29486},
+							pos:  position{line: 1225, col: 22, offset: 29572},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1223, col: 25, offset: 29489},
+							pos:   position{line: 1225, col: 25, offset: 29575},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1223, col: 31, offset: 29495},
+								pos:  position{line: 1225, col: 31, offset: 29581},
 								name: "Expr",
 							},
 						},
@@ -8045,15 +8063,15 @@ var g = &grammar{
 		},
 		{
 			name: "ExprElem",
-			pos:  position{line: 1232, col: 1, offset: 29664},
+			pos:  position{line: 1234, col: 1, offset: 29750},
 			expr: &actionExpr{
-				pos: position{line: 1233, col: 5, offset: 29677},
+				pos: position{line: 1235, col: 5, offset: 29763},
 				run: (*parser).callonExprElem1,
 				expr: &labeledExpr{
-					pos:   position{line: 1233, col: 5, offset: 29677},
+					pos:   position{line: 1235, col: 5, offset: 29763},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1233, col: 10, offset: 29682},
+						pos:  position{line: 1235, col: 10, offset: 29768},
 						name: "Expr",
 					},
 				},
@@ -8063,37 +8081,37 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 1237, col: 1, offset: 29782},
+			pos:  position{line: 1239, col: 1, offset: 29868},
 			expr: &actionExpr{
-				pos: position{line: 1238, col: 5, offset: 29792},
+				pos: position{line: 1240, col: 5, offset: 29878},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 1238, col: 5, offset: 29792},
+					pos: position{line: 1240, col: 5, offset: 29878},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1238, col: 5, offset: 29792},
+							pos:        position{line: 1240, col: 5, offset: 29878},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1238, col: 9, offset: 29796},
+							pos:  position{line: 1240, col: 9, offset: 29882},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1238, col: 12, offset: 29799},
+							pos:   position{line: 1240, col: 12, offset: 29885},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1238, col: 18, offset: 29805},
+								pos:  position{line: 1240, col: 18, offset: 29891},
 								name: "ArrayElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1238, col: 29, offset: 29816},
+							pos:  position{line: 1240, col: 29, offset: 29902},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1238, col: 32, offset: 29819},
+							pos:        position{line: 1240, col: 32, offset: 29905},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -8106,37 +8124,37 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 1246, col: 1, offset: 29974},
+			pos:  position{line: 1248, col: 1, offset: 30060},
 			expr: &actionExpr{
-				pos: position{line: 1247, col: 5, offset: 29982},
+				pos: position{line: 1249, col: 5, offset: 30068},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 1247, col: 5, offset: 29982},
+					pos: position{line: 1249, col: 5, offset: 30068},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1247, col: 5, offset: 29982},
+							pos:        position{line: 1249, col: 5, offset: 30068},
 							val:        "|[",
 							ignoreCase: false,
 							want:       "\"|[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1247, col: 10, offset: 29987},
+							pos:  position{line: 1249, col: 10, offset: 30073},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1247, col: 13, offset: 29990},
+							pos:   position{line: 1249, col: 13, offset: 30076},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1247, col: 19, offset: 29996},
+								pos:  position{line: 1249, col: 19, offset: 30082},
 								name: "ArrayElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1247, col: 30, offset: 30007},
+							pos:  position{line: 1249, col: 30, offset: 30093},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1247, col: 33, offset: 30010},
+							pos:        position{line: 1249, col: 33, offset: 30096},
 							val:        "]|",
 							ignoreCase: false,
 							want:       "\"]|\"",
@@ -8149,54 +8167,54 @@ var g = &grammar{
 		},
 		{
 			name: "ArrayElems",
-			pos:  position{line: 1255, col: 1, offset: 30162},
+			pos:  position{line: 1257, col: 1, offset: 30248},
 			expr: &choiceExpr{
-				pos: position{line: 1256, col: 5, offset: 30177},
+				pos: position{line: 1258, col: 5, offset: 30263},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1256, col: 5, offset: 30177},
+						pos: position{line: 1258, col: 5, offset: 30263},
 						run: (*parser).callonArrayElems2,
 						expr: &seqExpr{
-							pos: position{line: 1256, col: 5, offset: 30177},
+							pos: position{line: 1258, col: 5, offset: 30263},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1256, col: 5, offset: 30177},
+									pos:   position{line: 1258, col: 5, offset: 30263},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1256, col: 11, offset: 30183},
+										pos:  position{line: 1258, col: 11, offset: 30269},
 										name: "ArrayElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1256, col: 21, offset: 30193},
+									pos:   position{line: 1258, col: 21, offset: 30279},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1256, col: 26, offset: 30198},
+										pos: position{line: 1258, col: 26, offset: 30284},
 										expr: &actionExpr{
-											pos: position{line: 1256, col: 27, offset: 30199},
+											pos: position{line: 1258, col: 27, offset: 30285},
 											run: (*parser).callonArrayElems8,
 											expr: &seqExpr{
-												pos: position{line: 1256, col: 27, offset: 30199},
+												pos: position{line: 1258, col: 27, offset: 30285},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1256, col: 27, offset: 30199},
+														pos:  position{line: 1258, col: 27, offset: 30285},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 1256, col: 30, offset: 30202},
+														pos:        position{line: 1258, col: 30, offset: 30288},
 														val:        ",",
 														ignoreCase: false,
 														want:       "\",\"",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1256, col: 34, offset: 30206},
+														pos:  position{line: 1258, col: 34, offset: 30292},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 1256, col: 37, offset: 30209},
+														pos:   position{line: 1258, col: 37, offset: 30295},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1256, col: 39, offset: 30211},
+															pos:  position{line: 1258, col: 39, offset: 30297},
 															name: "ArrayElem",
 														},
 													},
@@ -8209,10 +8227,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1259, col: 5, offset: 30292},
+						pos: position{line: 1261, col: 5, offset: 30378},
 						run: (*parser).callonArrayElems15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1259, col: 5, offset: 30292},
+							pos:  position{line: 1261, col: 5, offset: 30378},
 							name: "__",
 						},
 					},
@@ -8223,16 +8241,16 @@ var g = &grammar{
 		},
 		{
 			name: "ArrayElem",
-			pos:  position{line: 1261, col: 1, offset: 30316},
+			pos:  position{line: 1263, col: 1, offset: 30402},
 			expr: &choiceExpr{
-				pos: position{line: 1261, col: 13, offset: 30328},
+				pos: position{line: 1263, col: 13, offset: 30414},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1261, col: 13, offset: 30328},
+						pos:  position{line: 1263, col: 13, offset: 30414},
 						name: "SpreadElem",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1261, col: 26, offset: 30341},
+						pos:  position{line: 1263, col: 26, offset: 30427},
 						name: "ExprElem",
 					},
 				},
@@ -8242,37 +8260,37 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 1263, col: 1, offset: 30351},
+			pos:  position{line: 1265, col: 1, offset: 30437},
 			expr: &actionExpr{
-				pos: position{line: 1264, col: 5, offset: 30359},
+				pos: position{line: 1266, col: 5, offset: 30445},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 1264, col: 5, offset: 30359},
+					pos: position{line: 1266, col: 5, offset: 30445},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1264, col: 5, offset: 30359},
+							pos:        position{line: 1266, col: 5, offset: 30445},
 							val:        "|{",
 							ignoreCase: false,
 							want:       "\"|{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1264, col: 10, offset: 30364},
+							pos:  position{line: 1266, col: 10, offset: 30450},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1264, col: 13, offset: 30367},
+							pos:   position{line: 1266, col: 13, offset: 30453},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1264, col: 19, offset: 30373},
+								pos:  position{line: 1266, col: 19, offset: 30459},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1264, col: 27, offset: 30381},
+							pos:  position{line: 1266, col: 27, offset: 30467},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1264, col: 30, offset: 30384},
+							pos:        position{line: 1266, col: 30, offset: 30470},
 							val:        "}|",
 							ignoreCase: false,
 							want:       "\"}|\"",
@@ -8285,31 +8303,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 1272, col: 1, offset: 30537},
+			pos:  position{line: 1274, col: 1, offset: 30623},
 			expr: &choiceExpr{
-				pos: position{line: 1273, col: 5, offset: 30549},
+				pos: position{line: 1275, col: 5, offset: 30635},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1273, col: 5, offset: 30549},
+						pos: position{line: 1275, col: 5, offset: 30635},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 1273, col: 5, offset: 30549},
+							pos: position{line: 1275, col: 5, offset: 30635},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1273, col: 5, offset: 30549},
+									pos:   position{line: 1275, col: 5, offset: 30635},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1273, col: 11, offset: 30555},
+										pos:  position{line: 1275, col: 11, offset: 30641},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1273, col: 17, offset: 30561},
+									pos:   position{line: 1275, col: 17, offset: 30647},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1273, col: 22, offset: 30566},
+										pos: position{line: 1275, col: 22, offset: 30652},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1273, col: 22, offset: 30566},
+											pos:  position{line: 1275, col: 22, offset: 30652},
 											name: "EntryTail",
 										},
 									},
@@ -8318,10 +8336,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1276, col: 5, offset: 30624},
+						pos: position{line: 1278, col: 5, offset: 30710},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1276, col: 5, offset: 30624},
+							pos:  position{line: 1278, col: 5, offset: 30710},
 							name: "__",
 						},
 					},
@@ -8332,32 +8350,32 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 1279, col: 1, offset: 30649},
+			pos:  position{line: 1281, col: 1, offset: 30735},
 			expr: &actionExpr{
-				pos: position{line: 1279, col: 13, offset: 30661},
+				pos: position{line: 1281, col: 13, offset: 30747},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 1279, col: 13, offset: 30661},
+					pos: position{line: 1281, col: 13, offset: 30747},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1279, col: 13, offset: 30661},
+							pos:  position{line: 1281, col: 13, offset: 30747},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1279, col: 16, offset: 30664},
+							pos:        position{line: 1281, col: 16, offset: 30750},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1279, col: 20, offset: 30668},
+							pos:  position{line: 1281, col: 20, offset: 30754},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1279, col: 23, offset: 30671},
+							pos:   position{line: 1281, col: 23, offset: 30757},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1279, col: 25, offset: 30673},
+								pos:  position{line: 1281, col: 25, offset: 30759},
 								name: "Entry",
 							},
 						},
@@ -8369,40 +8387,40 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 1281, col: 1, offset: 30698},
+			pos:  position{line: 1283, col: 1, offset: 30784},
 			expr: &actionExpr{
-				pos: position{line: 1282, col: 5, offset: 30708},
+				pos: position{line: 1284, col: 5, offset: 30794},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 1282, col: 5, offset: 30708},
+					pos: position{line: 1284, col: 5, offset: 30794},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1282, col: 5, offset: 30708},
+							pos:   position{line: 1284, col: 5, offset: 30794},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1282, col: 9, offset: 30712},
+								pos:  position{line: 1284, col: 9, offset: 30798},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1282, col: 14, offset: 30717},
+							pos:  position{line: 1284, col: 14, offset: 30803},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1282, col: 17, offset: 30720},
+							pos:        position{line: 1284, col: 17, offset: 30806},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1282, col: 21, offset: 30724},
+							pos:  position{line: 1284, col: 21, offset: 30810},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1282, col: 24, offset: 30727},
+							pos:   position{line: 1284, col: 24, offset: 30813},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1282, col: 30, offset: 30733},
+								pos:  position{line: 1284, col: 30, offset: 30819},
 								name: "Expr",
 							},
 						},
@@ -8414,61 +8432,61 @@ var g = &grammar{
 		},
 		{
 			name: "Tuple",
-			pos:  position{line: 1286, col: 1, offset: 30835},
+			pos:  position{line: 1288, col: 1, offset: 30921},
 			expr: &actionExpr{
-				pos: position{line: 1287, col: 5, offset: 30845},
+				pos: position{line: 1289, col: 5, offset: 30931},
 				run: (*parser).callonTuple1,
 				expr: &seqExpr{
-					pos: position{line: 1287, col: 5, offset: 30845},
+					pos: position{line: 1289, col: 5, offset: 30931},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1287, col: 5, offset: 30845},
+							pos:        position{line: 1289, col: 5, offset: 30931},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1287, col: 9, offset: 30849},
+							pos:  position{line: 1289, col: 9, offset: 30935},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1287, col: 12, offset: 30852},
+							pos:   position{line: 1289, col: 12, offset: 30938},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1287, col: 18, offset: 30858},
+								pos:  position{line: 1289, col: 18, offset: 30944},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1287, col: 23, offset: 30863},
+							pos:   position{line: 1289, col: 23, offset: 30949},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1287, col: 28, offset: 30868},
+								pos: position{line: 1289, col: 28, offset: 30954},
 								expr: &actionExpr{
-									pos: position{line: 1287, col: 29, offset: 30869},
+									pos: position{line: 1289, col: 29, offset: 30955},
 									run: (*parser).callonTuple9,
 									expr: &seqExpr{
-										pos: position{line: 1287, col: 29, offset: 30869},
+										pos: position{line: 1289, col: 29, offset: 30955},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1287, col: 29, offset: 30869},
+												pos:  position{line: 1289, col: 29, offset: 30955},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1287, col: 32, offset: 30872},
+												pos:        position{line: 1289, col: 32, offset: 30958},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1287, col: 36, offset: 30876},
+												pos:  position{line: 1289, col: 36, offset: 30962},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1287, col: 39, offset: 30879},
+												pos:   position{line: 1289, col: 39, offset: 30965},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1287, col: 41, offset: 30881},
+													pos:  position{line: 1289, col: 41, offset: 30967},
 													name: "Expr",
 												},
 											},
@@ -8478,11 +8496,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1287, col: 66, offset: 30906},
+							pos:  position{line: 1289, col: 66, offset: 30992},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1287, col: 69, offset: 30909},
+							pos:        position{line: 1289, col: 69, offset: 30995},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -8495,39 +8513,39 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTimeExpr",
-			pos:  position{line: 1295, col: 1, offset: 31068},
+			pos:  position{line: 1297, col: 1, offset: 31154},
 			expr: &actionExpr{
-				pos: position{line: 1296, col: 5, offset: 31084},
+				pos: position{line: 1298, col: 5, offset: 31170},
 				run: (*parser).callonSQLTimeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1296, col: 5, offset: 31084},
+					pos: position{line: 1298, col: 5, offset: 31170},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1296, col: 5, offset: 31084},
+							pos:   position{line: 1298, col: 5, offset: 31170},
 							label: "typ",
 							expr: &choiceExpr{
-								pos: position{line: 1296, col: 10, offset: 31089},
+								pos: position{line: 1298, col: 10, offset: 31175},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1296, col: 10, offset: 31089},
+										pos:  position{line: 1298, col: 10, offset: 31175},
 										name: "DATE",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1296, col: 17, offset: 31096},
+										pos:  position{line: 1298, col: 17, offset: 31182},
 										name: "TIMESTAMP",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1296, col: 28, offset: 31107},
+							pos:  position{line: 1298, col: 28, offset: 31193},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1296, col: 30, offset: 31109},
+							pos:   position{line: 1298, col: 30, offset: 31195},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1296, col: 32, offset: 31111},
+								pos:  position{line: 1298, col: 32, offset: 31197},
 								name: "StringLiteral",
 							},
 						},
@@ -8539,56 +8557,56 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 1307, col: 1, offset: 31326},
+			pos:  position{line: 1309, col: 1, offset: 31412},
 			expr: &choiceExpr{
-				pos: position{line: 1308, col: 5, offset: 31338},
+				pos: position{line: 1310, col: 5, offset: 31424},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1308, col: 5, offset: 31338},
+						pos:  position{line: 1310, col: 5, offset: 31424},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1309, col: 5, offset: 31354},
+						pos:  position{line: 1311, col: 5, offset: 31440},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1310, col: 5, offset: 31372},
+						pos:  position{line: 1312, col: 5, offset: 31458},
 						name: "FString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1311, col: 5, offset: 31384},
+						pos:  position{line: 1313, col: 5, offset: 31470},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1312, col: 5, offset: 31402},
+						pos:  position{line: 1314, col: 5, offset: 31488},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1313, col: 5, offset: 31421},
+						pos:  position{line: 1315, col: 5, offset: 31507},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1314, col: 5, offset: 31438},
+						pos:  position{line: 1316, col: 5, offset: 31524},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1315, col: 5, offset: 31451},
+						pos:  position{line: 1317, col: 5, offset: 31537},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1316, col: 5, offset: 31460},
+						pos:  position{line: 1318, col: 5, offset: 31546},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1317, col: 5, offset: 31477},
+						pos:  position{line: 1319, col: 5, offset: 31563},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1318, col: 5, offset: 31496},
+						pos:  position{line: 1320, col: 5, offset: 31582},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1319, col: 5, offset: 31515},
+						pos:  position{line: 1321, col: 5, offset: 31601},
 						name: "NullLiteral",
 					},
 				},
@@ -8598,28 +8616,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 1321, col: 1, offset: 31528},
+			pos:  position{line: 1323, col: 1, offset: 31614},
 			expr: &choiceExpr{
-				pos: position{line: 1322, col: 5, offset: 31546},
+				pos: position{line: 1324, col: 5, offset: 31632},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1322, col: 5, offset: 31546},
+						pos: position{line: 1324, col: 5, offset: 31632},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1322, col: 5, offset: 31546},
+							pos: position{line: 1324, col: 5, offset: 31632},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1322, col: 5, offset: 31546},
+									pos:   position{line: 1324, col: 5, offset: 31632},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1322, col: 7, offset: 31548},
+										pos:  position{line: 1324, col: 7, offset: 31634},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1322, col: 14, offset: 31555},
+									pos: position{line: 1324, col: 14, offset: 31641},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1322, col: 15, offset: 31556},
+										pos:  position{line: 1324, col: 15, offset: 31642},
 										name: "IdentifierRest",
 									},
 								},
@@ -8627,13 +8645,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1325, col: 5, offset: 31636},
+						pos: position{line: 1327, col: 5, offset: 31722},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1325, col: 5, offset: 31636},
+							pos:   position{line: 1327, col: 5, offset: 31722},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1325, col: 7, offset: 31638},
+								pos:  position{line: 1327, col: 7, offset: 31724},
 								name: "IP4Net",
 							},
 						},
@@ -8645,35 +8663,35 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 1329, col: 1, offset: 31707},
+			pos:  position{line: 1331, col: 1, offset: 31793},
 			expr: &choiceExpr{
-				pos: position{line: 1330, col: 5, offset: 31726},
+				pos: position{line: 1332, col: 5, offset: 31812},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1330, col: 5, offset: 31726},
+						pos: position{line: 1332, col: 5, offset: 31812},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1330, col: 5, offset: 31726},
+							pos: position{line: 1332, col: 5, offset: 31812},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1330, col: 5, offset: 31726},
+									pos:   position{line: 1332, col: 5, offset: 31812},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1330, col: 7, offset: 31728},
+										pos:  position{line: 1332, col: 7, offset: 31814},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1330, col: 11, offset: 31732},
+									pos: position{line: 1332, col: 11, offset: 31818},
 									expr: &choiceExpr{
-										pos: position{line: 1330, col: 13, offset: 31734},
+										pos: position{line: 1332, col: 13, offset: 31820},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1330, col: 13, offset: 31734},
+												pos:  position{line: 1332, col: 13, offset: 31820},
 												name: "IdentifierRest",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1330, col: 30, offset: 31751},
+												pos:  position{line: 1332, col: 30, offset: 31837},
 												name: "TypeLiteral",
 											},
 										},
@@ -8683,13 +8701,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1333, col: 5, offset: 31828},
+						pos: position{line: 1335, col: 5, offset: 31914},
 						run: (*parser).callonAddressLiteral10,
 						expr: &labeledExpr{
-							pos:   position{line: 1333, col: 5, offset: 31828},
+							pos:   position{line: 1335, col: 5, offset: 31914},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1333, col: 7, offset: 31830},
+								pos:  position{line: 1335, col: 7, offset: 31916},
 								name: "IP",
 							},
 						},
@@ -8701,15 +8719,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 1337, col: 1, offset: 31894},
+			pos:  position{line: 1339, col: 1, offset: 31980},
 			expr: &actionExpr{
-				pos: position{line: 1338, col: 5, offset: 31911},
+				pos: position{line: 1340, col: 5, offset: 31997},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1338, col: 5, offset: 31911},
+					pos:   position{line: 1340, col: 5, offset: 31997},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1338, col: 7, offset: 31913},
+						pos:  position{line: 1340, col: 7, offset: 31999},
 						name: "FloatString",
 					},
 				},
@@ -8719,15 +8737,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 1342, col: 1, offset: 31991},
+			pos:  position{line: 1344, col: 1, offset: 32077},
 			expr: &actionExpr{
-				pos: position{line: 1343, col: 5, offset: 32010},
+				pos: position{line: 1345, col: 5, offset: 32096},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1343, col: 5, offset: 32010},
+					pos:   position{line: 1345, col: 5, offset: 32096},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1343, col: 7, offset: 32012},
+						pos:  position{line: 1345, col: 7, offset: 32098},
 						name: "IntString",
 					},
 				},
@@ -8737,23 +8755,23 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 1347, col: 1, offset: 32086},
+			pos:  position{line: 1349, col: 1, offset: 32172},
 			expr: &choiceExpr{
-				pos: position{line: 1348, col: 5, offset: 32105},
+				pos: position{line: 1350, col: 5, offset: 32191},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1348, col: 5, offset: 32105},
+						pos: position{line: 1350, col: 5, offset: 32191},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1348, col: 5, offset: 32105},
+							pos:  position{line: 1350, col: 5, offset: 32191},
 							name: "TRUE",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1349, col: 5, offset: 32163},
+						pos: position{line: 1351, col: 5, offset: 32249},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1349, col: 5, offset: 32163},
+							pos:  position{line: 1351, col: 5, offset: 32249},
 							name: "FALSE",
 						},
 					},
@@ -8764,12 +8782,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 1351, col: 1, offset: 32219},
+			pos:  position{line: 1353, col: 1, offset: 32305},
 			expr: &actionExpr{
-				pos: position{line: 1352, col: 5, offset: 32235},
+				pos: position{line: 1354, col: 5, offset: 32321},
 				run: (*parser).callonNullLiteral1,
 				expr: &ruleRefExpr{
-					pos:  position{line: 1352, col: 5, offset: 32235},
+					pos:  position{line: 1354, col: 5, offset: 32321},
 					name: "NULL",
 				},
 			},
@@ -8778,23 +8796,23 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 1354, col: 1, offset: 32285},
+			pos:  position{line: 1356, col: 1, offset: 32371},
 			expr: &actionExpr{
-				pos: position{line: 1355, col: 5, offset: 32302},
+				pos: position{line: 1357, col: 5, offset: 32388},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1355, col: 5, offset: 32302},
+					pos: position{line: 1357, col: 5, offset: 32388},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1355, col: 5, offset: 32302},
+							pos:        position{line: 1357, col: 5, offset: 32388},
 							val:        "0x",
 							ignoreCase: false,
 							want:       "\"0x\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1355, col: 10, offset: 32307},
+							pos: position{line: 1357, col: 10, offset: 32393},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1355, col: 10, offset: 32307},
+								pos:  position{line: 1357, col: 10, offset: 32393},
 								name: "HexDigit",
 							},
 						},
@@ -8806,29 +8824,29 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 1359, col: 1, offset: 32381},
+			pos:  position{line: 1361, col: 1, offset: 32467},
 			expr: &actionExpr{
-				pos: position{line: 1360, col: 5, offset: 32397},
+				pos: position{line: 1362, col: 5, offset: 32483},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1360, col: 5, offset: 32397},
+					pos: position{line: 1362, col: 5, offset: 32483},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1360, col: 5, offset: 32397},
+							pos:        position{line: 1362, col: 5, offset: 32483},
 							val:        "<",
 							ignoreCase: false,
 							want:       "\"<\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1360, col: 9, offset: 32401},
+							pos:   position{line: 1362, col: 9, offset: 32487},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1360, col: 13, offset: 32405},
+								pos:  position{line: 1362, col: 13, offset: 32491},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1360, col: 18, offset: 32410},
+							pos:        position{line: 1362, col: 18, offset: 32496},
 							val:        ">",
 							ignoreCase: false,
 							want:       "\">\"",
@@ -8841,27 +8859,27 @@ var g = &grammar{
 		},
 		{
 			name: "TypeAsValue",
-			pos:  position{line: 1368, col: 1, offset: 32543},
+			pos:  position{line: 1370, col: 1, offset: 32629},
 			expr: &choiceExpr{
-				pos: position{line: 1369, col: 5, offset: 32559},
+				pos: position{line: 1371, col: 5, offset: 32645},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1369, col: 5, offset: 32559},
+						pos: position{line: 1371, col: 5, offset: 32645},
 						run: (*parser).callonTypeAsValue2,
 						expr: &seqExpr{
-							pos: position{line: 1369, col: 5, offset: 32559},
+							pos: position{line: 1371, col: 5, offset: 32645},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1369, col: 5, offset: 32559},
+									pos:        position{line: 1371, col: 5, offset: 32645},
 									val:        "=",
 									ignoreCase: false,
 									want:       "\"=\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1369, col: 9, offset: 32563},
+									pos:   position{line: 1371, col: 9, offset: 32649},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1369, col: 14, offset: 32568},
+										pos:  position{line: 1371, col: 14, offset: 32654},
 										name: "Name",
 									},
 								},
@@ -8869,13 +8887,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1370, col: 5, offset: 32642},
+						pos: position{line: 1372, col: 5, offset: 32728},
 						run: (*parser).callonTypeAsValue7,
 						expr: &labeledExpr{
-							pos:   position{line: 1370, col: 5, offset: 32642},
+							pos:   position{line: 1372, col: 5, offset: 32728},
 							label: "t",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1370, col: 7, offset: 32644},
+								pos:  position{line: 1372, col: 7, offset: 32730},
 								name: "EasyType",
 							},
 						},
@@ -8887,16 +8905,16 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1378, col: 1, offset: 32780},
+			pos:  position{line: 1380, col: 1, offset: 32866},
 			expr: &choiceExpr{
-				pos: position{line: 1379, col: 5, offset: 32789},
+				pos: position{line: 1381, col: 5, offset: 32875},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1379, col: 5, offset: 32789},
+						pos:  position{line: 1381, col: 5, offset: 32875},
 						name: "TypeUnion",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1380, col: 5, offset: 32803},
+						pos:  position{line: 1382, col: 5, offset: 32889},
 						name: "ComponentType",
 					},
 				},
@@ -8906,52 +8924,52 @@ var g = &grammar{
 		},
 		{
 			name: "ComponentType",
-			pos:  position{line: 1382, col: 1, offset: 32818},
+			pos:  position{line: 1384, col: 1, offset: 32904},
 			expr: &choiceExpr{
-				pos: position{line: 1383, col: 5, offset: 32836},
+				pos: position{line: 1385, col: 5, offset: 32922},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1383, col: 5, offset: 32836},
+						pos:  position{line: 1385, col: 5, offset: 32922},
 						name: "EasyType",
 					},
 					&actionExpr{
-						pos: position{line: 1384, col: 5, offset: 32849},
+						pos: position{line: 1386, col: 5, offset: 32935},
 						run: (*parser).callonComponentType3,
 						expr: &seqExpr{
-							pos: position{line: 1384, col: 5, offset: 32849},
+							pos: position{line: 1386, col: 5, offset: 32935},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1384, col: 5, offset: 32849},
+									pos:   position{line: 1386, col: 5, offset: 32935},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1384, col: 10, offset: 32854},
+										pos:  position{line: 1386, col: 10, offset: 32940},
 										name: "Name",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1384, col: 15, offset: 32859},
+									pos:   position{line: 1386, col: 15, offset: 32945},
 									label: "opt",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1384, col: 19, offset: 32863},
+										pos: position{line: 1386, col: 19, offset: 32949},
 										expr: &seqExpr{
-											pos: position{line: 1384, col: 20, offset: 32864},
+											pos: position{line: 1386, col: 20, offset: 32950},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1384, col: 20, offset: 32864},
+													pos:  position{line: 1386, col: 20, offset: 32950},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1384, col: 23, offset: 32867},
+													pos:        position{line: 1386, col: 23, offset: 32953},
 													val:        "=",
 													ignoreCase: false,
 													want:       "\"=\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1384, col: 27, offset: 32871},
+													pos:  position{line: 1386, col: 27, offset: 32957},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1384, col: 30, offset: 32874},
+													pos:  position{line: 1386, col: 30, offset: 32960},
 													name: "Type",
 												},
 											},
@@ -8968,40 +8986,40 @@ var g = &grammar{
 		},
 		{
 			name: "EasyType",
-			pos:  position{line: 1396, col: 1, offset: 33196},
+			pos:  position{line: 1398, col: 1, offset: 33282},
 			expr: &choiceExpr{
-				pos: position{line: 1397, col: 5, offset: 33209},
+				pos: position{line: 1399, col: 5, offset: 33295},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1397, col: 5, offset: 33209},
+						pos: position{line: 1399, col: 5, offset: 33295},
 						run: (*parser).callonEasyType2,
 						expr: &seqExpr{
-							pos: position{line: 1397, col: 5, offset: 33209},
+							pos: position{line: 1399, col: 5, offset: 33295},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1397, col: 5, offset: 33209},
+									pos:        position{line: 1399, col: 5, offset: 33295},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1397, col: 9, offset: 33213},
+									pos:  position{line: 1399, col: 9, offset: 33299},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1397, col: 12, offset: 33216},
+									pos:   position{line: 1399, col: 12, offset: 33302},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1397, col: 16, offset: 33220},
+										pos:  position{line: 1399, col: 16, offset: 33306},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1397, col: 21, offset: 33225},
+									pos:  position{line: 1399, col: 21, offset: 33311},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1397, col: 24, offset: 33228},
+									pos:        position{line: 1399, col: 24, offset: 33314},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9010,23 +9028,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1398, col: 5, offset: 33255},
+						pos: position{line: 1400, col: 5, offset: 33341},
 						run: (*parser).callonEasyType10,
 						expr: &seqExpr{
-							pos: position{line: 1398, col: 5, offset: 33255},
+							pos: position{line: 1400, col: 5, offset: 33341},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1398, col: 5, offset: 33255},
+									pos:   position{line: 1400, col: 5, offset: 33341},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1398, col: 10, offset: 33260},
+										pos:  position{line: 1400, col: 10, offset: 33346},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1398, col: 24, offset: 33274},
+									pos: position{line: 1400, col: 24, offset: 33360},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1398, col: 25, offset: 33275},
+										pos:  position{line: 1400, col: 25, offset: 33361},
 										name: "IdentifierRest",
 									},
 								},
@@ -9034,43 +9052,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1399, col: 5, offset: 33315},
+						pos: position{line: 1401, col: 5, offset: 33401},
 						run: (*parser).callonEasyType16,
 						expr: &seqExpr{
-							pos: position{line: 1399, col: 5, offset: 33315},
+							pos: position{line: 1401, col: 5, offset: 33401},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1399, col: 5, offset: 33315},
+									pos:  position{line: 1401, col: 5, offset: 33401},
 									name: "ERROR",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1399, col: 11, offset: 33321},
+									pos:  position{line: 1401, col: 11, offset: 33407},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1399, col: 14, offset: 33324},
+									pos:        position{line: 1401, col: 14, offset: 33410},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1399, col: 18, offset: 33328},
+									pos:  position{line: 1401, col: 18, offset: 33414},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1399, col: 21, offset: 33331},
+									pos:   position{line: 1401, col: 21, offset: 33417},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1399, col: 23, offset: 33333},
+										pos:  position{line: 1401, col: 23, offset: 33419},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1399, col: 28, offset: 33338},
+									pos:  position{line: 1401, col: 28, offset: 33424},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1399, col: 31, offset: 33341},
+									pos:        position{line: 1401, col: 31, offset: 33427},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9079,43 +9097,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1406, col: 5, offset: 33481},
+						pos: position{line: 1408, col: 5, offset: 33567},
 						run: (*parser).callonEasyType26,
 						expr: &seqExpr{
-							pos: position{line: 1406, col: 5, offset: 33481},
+							pos: position{line: 1408, col: 5, offset: 33567},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1406, col: 5, offset: 33481},
+									pos:  position{line: 1408, col: 5, offset: 33567},
 									name: "ENUM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1406, col: 10, offset: 33486},
+									pos:  position{line: 1408, col: 10, offset: 33572},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1406, col: 13, offset: 33489},
+									pos:        position{line: 1408, col: 13, offset: 33575},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1406, col: 17, offset: 33493},
+									pos:  position{line: 1408, col: 17, offset: 33579},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1406, col: 20, offset: 33496},
+									pos:   position{line: 1408, col: 20, offset: 33582},
 									label: "names",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1406, col: 26, offset: 33502},
+										pos:  position{line: 1408, col: 26, offset: 33588},
 										name: "Names",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1406, col: 32, offset: 33508},
+									pos:  position{line: 1408, col: 32, offset: 33594},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1406, col: 35, offset: 33511},
+									pos:        position{line: 1408, col: 35, offset: 33597},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9124,35 +9142,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1413, col: 5, offset: 33665},
+						pos: position{line: 1415, col: 5, offset: 33751},
 						run: (*parser).callonEasyType36,
 						expr: &seqExpr{
-							pos: position{line: 1413, col: 5, offset: 33665},
+							pos: position{line: 1415, col: 5, offset: 33751},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1413, col: 5, offset: 33665},
+									pos:        position{line: 1415, col: 5, offset: 33751},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1413, col: 9, offset: 33669},
+									pos:  position{line: 1415, col: 9, offset: 33755},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1413, col: 12, offset: 33672},
+									pos:   position{line: 1415, col: 12, offset: 33758},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1413, col: 19, offset: 33679},
+										pos:  position{line: 1415, col: 19, offset: 33765},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1413, col: 33, offset: 33693},
+									pos:  position{line: 1415, col: 33, offset: 33779},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1413, col: 36, offset: 33696},
+									pos:        position{line: 1415, col: 36, offset: 33782},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -9161,35 +9179,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1420, col: 5, offset: 33858},
+						pos: position{line: 1422, col: 5, offset: 33944},
 						run: (*parser).callonEasyType44,
 						expr: &seqExpr{
-							pos: position{line: 1420, col: 5, offset: 33858},
+							pos: position{line: 1422, col: 5, offset: 33944},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1420, col: 5, offset: 33858},
+									pos:        position{line: 1422, col: 5, offset: 33944},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1420, col: 9, offset: 33862},
+									pos:  position{line: 1422, col: 9, offset: 33948},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1420, col: 12, offset: 33865},
+									pos:   position{line: 1422, col: 12, offset: 33951},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1420, col: 16, offset: 33869},
+										pos:  position{line: 1422, col: 16, offset: 33955},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1420, col: 21, offset: 33874},
+									pos:  position{line: 1422, col: 21, offset: 33960},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1420, col: 24, offset: 33877},
+									pos:        position{line: 1422, col: 24, offset: 33963},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -9198,35 +9216,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1427, col: 5, offset: 34019},
+						pos: position{line: 1429, col: 5, offset: 34105},
 						run: (*parser).callonEasyType52,
 						expr: &seqExpr{
-							pos: position{line: 1427, col: 5, offset: 34019},
+							pos: position{line: 1429, col: 5, offset: 34105},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1427, col: 5, offset: 34019},
+									pos:        position{line: 1429, col: 5, offset: 34105},
 									val:        "|[",
 									ignoreCase: false,
 									want:       "\"|[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1427, col: 10, offset: 34024},
+									pos:  position{line: 1429, col: 10, offset: 34110},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1427, col: 13, offset: 34027},
+									pos:   position{line: 1429, col: 13, offset: 34113},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1427, col: 17, offset: 34031},
+										pos:  position{line: 1429, col: 17, offset: 34117},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1427, col: 22, offset: 34036},
+									pos:  position{line: 1429, col: 22, offset: 34122},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1427, col: 25, offset: 34039},
+									pos:        position{line: 1429, col: 25, offset: 34125},
 									val:        "]|",
 									ignoreCase: false,
 									want:       "\"]|\"",
@@ -9235,57 +9253,57 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1434, col: 5, offset: 34178},
+						pos: position{line: 1436, col: 5, offset: 34264},
 						run: (*parser).callonEasyType60,
 						expr: &seqExpr{
-							pos: position{line: 1434, col: 5, offset: 34178},
+							pos: position{line: 1436, col: 5, offset: 34264},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1434, col: 5, offset: 34178},
+									pos:        position{line: 1436, col: 5, offset: 34264},
 									val:        "|{",
 									ignoreCase: false,
 									want:       "\"|{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1434, col: 10, offset: 34183},
+									pos:  position{line: 1436, col: 10, offset: 34269},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1434, col: 13, offset: 34186},
+									pos:   position{line: 1436, col: 13, offset: 34272},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1434, col: 21, offset: 34194},
+										pos:  position{line: 1436, col: 21, offset: 34280},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1434, col: 26, offset: 34199},
+									pos:  position{line: 1436, col: 26, offset: 34285},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1434, col: 29, offset: 34202},
+									pos:        position{line: 1436, col: 29, offset: 34288},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1434, col: 33, offset: 34206},
+									pos:  position{line: 1436, col: 33, offset: 34292},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1434, col: 36, offset: 34209},
+									pos:   position{line: 1436, col: 36, offset: 34295},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1434, col: 44, offset: 34217},
+										pos:  position{line: 1436, col: 44, offset: 34303},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1434, col: 49, offset: 34222},
+									pos:  position{line: 1436, col: 49, offset: 34308},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1434, col: 52, offset: 34225},
+									pos:        position{line: 1436, col: 52, offset: 34311},
 									val:        "}|",
 									ignoreCase: false,
 									want:       "\"}|\"",
@@ -9300,15 +9318,15 @@ var g = &grammar{
 		},
 		{
 			name: "TypeUnion",
-			pos:  position{line: 1443, col: 1, offset: 34399},
+			pos:  position{line: 1445, col: 1, offset: 34485},
 			expr: &actionExpr{
-				pos: position{line: 1444, col: 5, offset: 34413},
+				pos: position{line: 1446, col: 5, offset: 34499},
 				run: (*parser).callonTypeUnion1,
 				expr: &labeledExpr{
-					pos:   position{line: 1444, col: 5, offset: 34413},
+					pos:   position{line: 1446, col: 5, offset: 34499},
 					label: "types",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1444, col: 11, offset: 34419},
+						pos:  position{line: 1446, col: 11, offset: 34505},
 						name: "TypeList",
 					},
 				},
@@ -9318,28 +9336,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1452, col: 1, offset: 34556},
+			pos:  position{line: 1454, col: 1, offset: 34642},
 			expr: &actionExpr{
-				pos: position{line: 1453, col: 5, offset: 34569},
+				pos: position{line: 1455, col: 5, offset: 34655},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1453, col: 5, offset: 34569},
+					pos: position{line: 1455, col: 5, offset: 34655},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1453, col: 5, offset: 34569},
+							pos:   position{line: 1455, col: 5, offset: 34655},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1453, col: 11, offset: 34575},
+								pos:  position{line: 1455, col: 11, offset: 34661},
 								name: "ComponentType",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1453, col: 25, offset: 34589},
+							pos:   position{line: 1455, col: 25, offset: 34675},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1453, col: 30, offset: 34594},
+								pos: position{line: 1455, col: 30, offset: 34680},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1453, col: 30, offset: 34594},
+									pos:  position{line: 1455, col: 30, offset: 34680},
 									name: "TypeListTail",
 								},
 							},
@@ -9352,32 +9370,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1457, col: 1, offset: 34652},
+			pos:  position{line: 1459, col: 1, offset: 34738},
 			expr: &actionExpr{
-				pos: position{line: 1457, col: 16, offset: 34667},
+				pos: position{line: 1459, col: 16, offset: 34753},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1457, col: 16, offset: 34667},
+					pos: position{line: 1459, col: 16, offset: 34753},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1457, col: 16, offset: 34667},
+							pos:  position{line: 1459, col: 16, offset: 34753},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1457, col: 19, offset: 34670},
+							pos:        position{line: 1459, col: 19, offset: 34756},
 							val:        "|",
 							ignoreCase: false,
 							want:       "\"|\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1457, col: 23, offset: 34674},
+							pos:  position{line: 1459, col: 23, offset: 34760},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1457, col: 26, offset: 34677},
+							pos:   position{line: 1459, col: 26, offset: 34763},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1457, col: 30, offset: 34681},
+								pos:  position{line: 1459, col: 30, offset: 34767},
 								name: "ComponentType",
 							},
 						},
@@ -9389,42 +9407,42 @@ var g = &grammar{
 		},
 		{
 			name: "StringLiteral",
-			pos:  position{line: 1459, col: 1, offset: 34716},
+			pos:  position{line: 1461, col: 1, offset: 34802},
 			expr: &choiceExpr{
-				pos: position{line: 1460, col: 5, offset: 34734},
+				pos: position{line: 1462, col: 5, offset: 34820},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1460, col: 5, offset: 34734},
+						pos: position{line: 1462, col: 5, offset: 34820},
 						run: (*parser).callonStringLiteral2,
 						expr: &labeledExpr{
-							pos:   position{line: 1460, col: 5, offset: 34734},
+							pos:   position{line: 1462, col: 5, offset: 34820},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1460, col: 7, offset: 34736},
+								pos:  position{line: 1462, col: 7, offset: 34822},
 								name: "DoubleQuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1461, col: 5, offset: 34851},
+						pos: position{line: 1463, col: 5, offset: 34937},
 						run: (*parser).callonStringLiteral5,
 						expr: &labeledExpr{
-							pos:   position{line: 1461, col: 5, offset: 34851},
+							pos:   position{line: 1463, col: 5, offset: 34937},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1461, col: 7, offset: 34853},
+								pos:  position{line: 1463, col: 7, offset: 34939},
 								name: "SingleQuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1462, col: 5, offset: 34930},
+						pos: position{line: 1464, col: 5, offset: 35016},
 						run: (*parser).callonStringLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1462, col: 5, offset: 34930},
+							pos:   position{line: 1464, col: 5, offset: 35016},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1462, col: 7, offset: 34932},
+								pos:  position{line: 1464, col: 7, offset: 35018},
 								name: "RString",
 							},
 						},
@@ -9436,35 +9454,35 @@ var g = &grammar{
 		},
 		{
 			name: "FString",
-			pos:  position{line: 1464, col: 1, offset: 34995},
+			pos:  position{line: 1466, col: 1, offset: 35081},
 			expr: &choiceExpr{
-				pos: position{line: 1465, col: 5, offset: 35007},
+				pos: position{line: 1467, col: 5, offset: 35093},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1465, col: 5, offset: 35007},
+						pos: position{line: 1467, col: 5, offset: 35093},
 						run: (*parser).callonFString2,
 						expr: &seqExpr{
-							pos: position{line: 1465, col: 5, offset: 35007},
+							pos: position{line: 1467, col: 5, offset: 35093},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1465, col: 5, offset: 35007},
+									pos:        position{line: 1467, col: 5, offset: 35093},
 									val:        "f\"",
 									ignoreCase: false,
 									want:       "\"f\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1465, col: 11, offset: 35013},
+									pos:   position{line: 1467, col: 11, offset: 35099},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1465, col: 13, offset: 35015},
+										pos: position{line: 1467, col: 13, offset: 35101},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1465, col: 13, offset: 35015},
+											pos:  position{line: 1467, col: 13, offset: 35101},
 											name: "FStringDoubleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1465, col: 38, offset: 35040},
+									pos:        position{line: 1467, col: 38, offset: 35126},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -9473,30 +9491,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1472, col: 5, offset: 35194},
+						pos: position{line: 1474, col: 5, offset: 35280},
 						run: (*parser).callonFString9,
 						expr: &seqExpr{
-							pos: position{line: 1472, col: 5, offset: 35194},
+							pos: position{line: 1474, col: 5, offset: 35280},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1472, col: 5, offset: 35194},
+									pos:        position{line: 1474, col: 5, offset: 35280},
 									val:        "f'",
 									ignoreCase: false,
 									want:       "\"f'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1472, col: 10, offset: 35199},
+									pos:   position{line: 1474, col: 10, offset: 35285},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1472, col: 12, offset: 35201},
+										pos: position{line: 1474, col: 12, offset: 35287},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1472, col: 12, offset: 35201},
+											pos:  position{line: 1474, col: 12, offset: 35287},
 											name: "FStringSingleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1472, col: 37, offset: 35226},
+									pos:        position{line: 1474, col: 37, offset: 35312},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -9511,24 +9529,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedElem",
-			pos:  position{line: 1480, col: 1, offset: 35377},
+			pos:  position{line: 1482, col: 1, offset: 35463},
 			expr: &choiceExpr{
-				pos: position{line: 1481, col: 5, offset: 35405},
+				pos: position{line: 1483, col: 5, offset: 35491},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1481, col: 5, offset: 35405},
+						pos:  position{line: 1483, col: 5, offset: 35491},
 						name: "FStringExprElem",
 					},
 					&actionExpr{
-						pos: position{line: 1482, col: 5, offset: 35425},
+						pos: position{line: 1484, col: 5, offset: 35511},
 						run: (*parser).callonFStringDoubleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1482, col: 5, offset: 35425},
+							pos:   position{line: 1484, col: 5, offset: 35511},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1482, col: 7, offset: 35427},
+								pos: position{line: 1484, col: 7, offset: 35513},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1482, col: 7, offset: 35427},
+									pos:  position{line: 1484, col: 7, offset: 35513},
 									name: "FStringDoubleQuotedChar",
 								},
 							},
@@ -9541,27 +9559,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedChar",
-			pos:  position{line: 1486, col: 1, offset: 35558},
+			pos:  position{line: 1488, col: 1, offset: 35644},
 			expr: &choiceExpr{
-				pos: position{line: 1487, col: 5, offset: 35586},
+				pos: position{line: 1489, col: 5, offset: 35672},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1487, col: 5, offset: 35586},
+						pos: position{line: 1489, col: 5, offset: 35672},
 						run: (*parser).callonFStringDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1487, col: 5, offset: 35586},
+							pos: position{line: 1489, col: 5, offset: 35672},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1487, col: 5, offset: 35586},
+									pos:        position{line: 1489, col: 5, offset: 35672},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1487, col: 10, offset: 35591},
+									pos:   position{line: 1489, col: 10, offset: 35677},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1487, col: 12, offset: 35593},
+										pos:        position{line: 1489, col: 12, offset: 35679},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9571,25 +9589,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1488, col: 5, offset: 35619},
+						pos: position{line: 1490, col: 5, offset: 35705},
 						run: (*parser).callonFStringDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1488, col: 5, offset: 35619},
+							pos: position{line: 1490, col: 5, offset: 35705},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1488, col: 5, offset: 35619},
+									pos: position{line: 1490, col: 5, offset: 35705},
 									expr: &litMatcher{
-										pos:        position{line: 1488, col: 7, offset: 35621},
+										pos:        position{line: 1490, col: 7, offset: 35707},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1488, col: 12, offset: 35626},
+									pos:   position{line: 1490, col: 12, offset: 35712},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1488, col: 14, offset: 35628},
+										pos:  position{line: 1490, col: 14, offset: 35714},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -9603,24 +9621,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedElem",
-			pos:  position{line: 1490, col: 1, offset: 35664},
+			pos:  position{line: 1492, col: 1, offset: 35750},
 			expr: &choiceExpr{
-				pos: position{line: 1491, col: 5, offset: 35692},
+				pos: position{line: 1493, col: 5, offset: 35778},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1491, col: 5, offset: 35692},
+						pos:  position{line: 1493, col: 5, offset: 35778},
 						name: "FStringExprElem",
 					},
 					&actionExpr{
-						pos: position{line: 1492, col: 5, offset: 35712},
+						pos: position{line: 1494, col: 5, offset: 35798},
 						run: (*parser).callonFStringSingleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1492, col: 5, offset: 35712},
+							pos:   position{line: 1494, col: 5, offset: 35798},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1492, col: 7, offset: 35714},
+								pos: position{line: 1494, col: 7, offset: 35800},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1492, col: 7, offset: 35714},
+									pos:  position{line: 1494, col: 7, offset: 35800},
 									name: "FStringSingleQuotedChar",
 								},
 							},
@@ -9633,27 +9651,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedChar",
-			pos:  position{line: 1496, col: 1, offset: 35845},
+			pos:  position{line: 1498, col: 1, offset: 35931},
 			expr: &choiceExpr{
-				pos: position{line: 1497, col: 5, offset: 35873},
+				pos: position{line: 1499, col: 5, offset: 35959},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1497, col: 5, offset: 35873},
+						pos: position{line: 1499, col: 5, offset: 35959},
 						run: (*parser).callonFStringSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1497, col: 5, offset: 35873},
+							pos: position{line: 1499, col: 5, offset: 35959},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1497, col: 5, offset: 35873},
+									pos:        position{line: 1499, col: 5, offset: 35959},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1497, col: 10, offset: 35878},
+									pos:   position{line: 1499, col: 10, offset: 35964},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1497, col: 12, offset: 35880},
+										pos:        position{line: 1499, col: 12, offset: 35966},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9663,25 +9681,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1498, col: 5, offset: 35906},
+						pos: position{line: 1500, col: 5, offset: 35992},
 						run: (*parser).callonFStringSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1498, col: 5, offset: 35906},
+							pos: position{line: 1500, col: 5, offset: 35992},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1498, col: 5, offset: 35906},
+									pos: position{line: 1500, col: 5, offset: 35992},
 									expr: &litMatcher{
-										pos:        position{line: 1498, col: 7, offset: 35908},
+										pos:        position{line: 1500, col: 7, offset: 35994},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1498, col: 12, offset: 35913},
+									pos:   position{line: 1500, col: 12, offset: 35999},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1498, col: 14, offset: 35915},
+										pos:  position{line: 1500, col: 14, offset: 36001},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -9695,37 +9713,37 @@ var g = &grammar{
 		},
 		{
 			name: "FStringExprElem",
-			pos:  position{line: 1500, col: 1, offset: 35951},
+			pos:  position{line: 1502, col: 1, offset: 36037},
 			expr: &actionExpr{
-				pos: position{line: 1501, col: 5, offset: 35971},
+				pos: position{line: 1503, col: 5, offset: 36057},
 				run: (*parser).callonFStringExprElem1,
 				expr: &seqExpr{
-					pos: position{line: 1501, col: 5, offset: 35971},
+					pos: position{line: 1503, col: 5, offset: 36057},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1501, col: 5, offset: 35971},
+							pos:        position{line: 1503, col: 5, offset: 36057},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1501, col: 9, offset: 35975},
+							pos:  position{line: 1503, col: 9, offset: 36061},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1501, col: 12, offset: 35978},
+							pos:   position{line: 1503, col: 12, offset: 36064},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1501, col: 14, offset: 35980},
+								pos:  position{line: 1503, col: 14, offset: 36066},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1501, col: 19, offset: 35985},
+							pos:  position{line: 1503, col: 19, offset: 36071},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1501, col: 22, offset: 35988},
+							pos:        position{line: 1503, col: 22, offset: 36074},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -9738,129 +9756,129 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1509, col: 1, offset: 36131},
+			pos:  position{line: 1511, col: 1, offset: 36217},
 			expr: &actionExpr{
-				pos: position{line: 1510, col: 5, offset: 36149},
+				pos: position{line: 1512, col: 5, offset: 36235},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1510, col: 9, offset: 36153},
+					pos: position{line: 1512, col: 9, offset: 36239},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1510, col: 9, offset: 36153},
+							pos:        position{line: 1512, col: 9, offset: 36239},
 							val:        "uint8",
 							ignoreCase: false,
 							want:       "\"uint8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1510, col: 19, offset: 36163},
+							pos:        position{line: 1512, col: 19, offset: 36249},
 							val:        "uint16",
 							ignoreCase: false,
 							want:       "\"uint16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1510, col: 30, offset: 36174},
+							pos:        position{line: 1512, col: 30, offset: 36260},
 							val:        "uint32",
 							ignoreCase: false,
 							want:       "\"uint32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1510, col: 41, offset: 36185},
+							pos:        position{line: 1512, col: 41, offset: 36271},
 							val:        "uint64",
 							ignoreCase: false,
 							want:       "\"uint64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1511, col: 9, offset: 36202},
+							pos:        position{line: 1513, col: 9, offset: 36288},
 							val:        "int8",
 							ignoreCase: false,
 							want:       "\"int8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1511, col: 18, offset: 36211},
+							pos:        position{line: 1513, col: 18, offset: 36297},
 							val:        "int16",
 							ignoreCase: false,
 							want:       "\"int16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1511, col: 28, offset: 36221},
+							pos:        position{line: 1513, col: 28, offset: 36307},
 							val:        "int32",
 							ignoreCase: false,
 							want:       "\"int32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1511, col: 38, offset: 36231},
+							pos:        position{line: 1513, col: 38, offset: 36317},
 							val:        "int64",
 							ignoreCase: false,
 							want:       "\"int64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1512, col: 9, offset: 36247},
+							pos:        position{line: 1514, col: 9, offset: 36333},
 							val:        "float16",
 							ignoreCase: false,
 							want:       "\"float16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1512, col: 21, offset: 36259},
+							pos:        position{line: 1514, col: 21, offset: 36345},
 							val:        "float32",
 							ignoreCase: false,
 							want:       "\"float32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1512, col: 33, offset: 36271},
+							pos:        position{line: 1514, col: 33, offset: 36357},
 							val:        "float64",
 							ignoreCase: false,
 							want:       "\"float64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1513, col: 9, offset: 36289},
+							pos:        position{line: 1515, col: 9, offset: 36375},
 							val:        "bool",
 							ignoreCase: false,
 							want:       "\"bool\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1513, col: 18, offset: 36298},
+							pos:        position{line: 1515, col: 18, offset: 36384},
 							val:        "string",
 							ignoreCase: false,
 							want:       "\"string\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1514, col: 9, offset: 36315},
+							pos:        position{line: 1516, col: 9, offset: 36401},
 							val:        "duration",
 							ignoreCase: false,
 							want:       "\"duration\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1514, col: 22, offset: 36328},
+							pos:        position{line: 1516, col: 22, offset: 36414},
 							val:        "time",
 							ignoreCase: false,
 							want:       "\"time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1515, col: 9, offset: 36343},
+							pos:        position{line: 1517, col: 9, offset: 36429},
 							val:        "bytes",
 							ignoreCase: false,
 							want:       "\"bytes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1516, col: 9, offset: 36359},
+							pos:        position{line: 1518, col: 9, offset: 36445},
 							val:        "ip",
 							ignoreCase: false,
 							want:       "\"ip\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1516, col: 16, offset: 36366},
+							pos:        position{line: 1518, col: 16, offset: 36452},
 							val:        "net",
 							ignoreCase: false,
 							want:       "\"net\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1517, col: 9, offset: 36380},
+							pos:        position{line: 1519, col: 9, offset: 36466},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1517, col: 18, offset: 36389},
+							pos:        position{line: 1519, col: 18, offset: 36475},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
@@ -9873,31 +9891,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1525, col: 1, offset: 36574},
+			pos:  position{line: 1527, col: 1, offset: 36660},
 			expr: &choiceExpr{
-				pos: position{line: 1526, col: 5, offset: 36592},
+				pos: position{line: 1528, col: 5, offset: 36678},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1526, col: 5, offset: 36592},
+						pos: position{line: 1528, col: 5, offset: 36678},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1526, col: 5, offset: 36592},
+							pos: position{line: 1528, col: 5, offset: 36678},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1526, col: 5, offset: 36592},
+									pos:   position{line: 1528, col: 5, offset: 36678},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1526, col: 11, offset: 36598},
+										pos:  position{line: 1528, col: 11, offset: 36684},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1526, col: 21, offset: 36608},
+									pos:   position{line: 1528, col: 21, offset: 36694},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1526, col: 26, offset: 36613},
+										pos: position{line: 1528, col: 26, offset: 36699},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1526, col: 26, offset: 36613},
+											pos:  position{line: 1528, col: 26, offset: 36699},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -9906,10 +9924,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1529, col: 5, offset: 36679},
+						pos: position{line: 1531, col: 5, offset: 36765},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1529, col: 5, offset: 36679},
+							pos:        position{line: 1531, col: 5, offset: 36765},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -9922,32 +9940,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1531, col: 1, offset: 36703},
+			pos:  position{line: 1533, col: 1, offset: 36789},
 			expr: &actionExpr{
-				pos: position{line: 1531, col: 21, offset: 36723},
+				pos: position{line: 1533, col: 21, offset: 36809},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1531, col: 21, offset: 36723},
+					pos: position{line: 1533, col: 21, offset: 36809},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1531, col: 21, offset: 36723},
+							pos:  position{line: 1533, col: 21, offset: 36809},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1531, col: 24, offset: 36726},
+							pos:        position{line: 1533, col: 24, offset: 36812},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1531, col: 28, offset: 36730},
+							pos:  position{line: 1533, col: 28, offset: 36816},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1531, col: 31, offset: 36733},
+							pos:   position{line: 1533, col: 31, offset: 36819},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1531, col: 35, offset: 36737},
+								pos:  position{line: 1533, col: 35, offset: 36823},
 								name: "TypeField",
 							},
 						},
@@ -9959,40 +9977,40 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1533, col: 1, offset: 36768},
+			pos:  position{line: 1535, col: 1, offset: 36854},
 			expr: &actionExpr{
-				pos: position{line: 1534, col: 5, offset: 36782},
+				pos: position{line: 1536, col: 5, offset: 36868},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1534, col: 5, offset: 36782},
+					pos: position{line: 1536, col: 5, offset: 36868},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1534, col: 5, offset: 36782},
+							pos:   position{line: 1536, col: 5, offset: 36868},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1534, col: 10, offset: 36787},
+								pos:  position{line: 1536, col: 10, offset: 36873},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1534, col: 15, offset: 36792},
+							pos:  position{line: 1536, col: 15, offset: 36878},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1534, col: 18, offset: 36795},
+							pos:        position{line: 1536, col: 18, offset: 36881},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1534, col: 22, offset: 36799},
+							pos:  position{line: 1536, col: 22, offset: 36885},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1534, col: 25, offset: 36802},
+							pos:   position{line: 1536, col: 25, offset: 36888},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1534, col: 29, offset: 36806},
+								pos:  position{line: 1536, col: 29, offset: 36892},
 								name: "Type",
 							},
 						},
@@ -10004,26 +10022,26 @@ var g = &grammar{
 		},
 		{
 			name: "Name",
-			pos:  position{line: 1542, col: 1, offset: 36955},
+			pos:  position{line: 1544, col: 1, offset: 37041},
 			expr: &actionExpr{
-				pos: position{line: 1543, col: 4, offset: 36963},
+				pos: position{line: 1545, col: 4, offset: 37049},
 				run: (*parser).callonName1,
 				expr: &labeledExpr{
-					pos:   position{line: 1543, col: 4, offset: 36963},
+					pos:   position{line: 1545, col: 4, offset: 37049},
 					label: "s",
 					expr: &choiceExpr{
-						pos: position{line: 1543, col: 7, offset: 36966},
+						pos: position{line: 1545, col: 7, offset: 37052},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1543, col: 7, offset: 36966},
+								pos:  position{line: 1545, col: 7, offset: 37052},
 								name: "IdentifierName",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1543, col: 24, offset: 36983},
+								pos:  position{line: 1545, col: 24, offset: 37069},
 								name: "DoubleQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1543, col: 45, offset: 37004},
+								pos:  position{line: 1545, col: 45, offset: 37090},
 								name: "SingleQuotedString",
 							},
 						},
@@ -10035,51 +10053,51 @@ var g = &grammar{
 		},
 		{
 			name: "Names",
-			pos:  position{line: 1547, col: 1, offset: 37104},
+			pos:  position{line: 1549, col: 1, offset: 37190},
 			expr: &actionExpr{
-				pos: position{line: 1548, col: 5, offset: 37114},
+				pos: position{line: 1550, col: 5, offset: 37200},
 				run: (*parser).callonNames1,
 				expr: &seqExpr{
-					pos: position{line: 1548, col: 5, offset: 37114},
+					pos: position{line: 1550, col: 5, offset: 37200},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1548, col: 5, offset: 37114},
+							pos:   position{line: 1550, col: 5, offset: 37200},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1548, col: 11, offset: 37120},
+								pos:  position{line: 1550, col: 11, offset: 37206},
 								name: "Name",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1548, col: 16, offset: 37125},
+							pos:   position{line: 1550, col: 16, offset: 37211},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1548, col: 21, offset: 37130},
+								pos: position{line: 1550, col: 21, offset: 37216},
 								expr: &actionExpr{
-									pos: position{line: 1548, col: 22, offset: 37131},
+									pos: position{line: 1550, col: 22, offset: 37217},
 									run: (*parser).callonNames7,
 									expr: &seqExpr{
-										pos: position{line: 1548, col: 22, offset: 37131},
+										pos: position{line: 1550, col: 22, offset: 37217},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1548, col: 22, offset: 37131},
+												pos:  position{line: 1550, col: 22, offset: 37217},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1548, col: 25, offset: 37134},
+												pos:        position{line: 1550, col: 25, offset: 37220},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1548, col: 29, offset: 37138},
+												pos:  position{line: 1550, col: 29, offset: 37224},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1548, col: 32, offset: 37141},
+												pos:   position{line: 1550, col: 32, offset: 37227},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1548, col: 37, offset: 37146},
+													pos:  position{line: 1550, col: 37, offset: 37232},
 													name: "Name",
 												},
 											},
@@ -10096,15 +10114,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1552, col: 1, offset: 37218},
+			pos:  position{line: 1554, col: 1, offset: 37304},
 			expr: &actionExpr{
-				pos: position{line: 1553, col: 5, offset: 37233},
+				pos: position{line: 1555, col: 5, offset: 37319},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1553, col: 5, offset: 37233},
+					pos:   position{line: 1555, col: 5, offset: 37319},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1553, col: 8, offset: 37236},
+						pos:  position{line: 1555, col: 8, offset: 37322},
 						name: "IdentifierName",
 					},
 				},
@@ -10114,51 +10132,51 @@ var g = &grammar{
 		},
 		{
 			name: "Identifiers",
-			pos:  position{line: 1560, col: 1, offset: 37347},
+			pos:  position{line: 1562, col: 1, offset: 37433},
 			expr: &actionExpr{
-				pos: position{line: 1561, col: 5, offset: 37363},
+				pos: position{line: 1563, col: 5, offset: 37449},
 				run: (*parser).callonIdentifiers1,
 				expr: &seqExpr{
-					pos: position{line: 1561, col: 5, offset: 37363},
+					pos: position{line: 1563, col: 5, offset: 37449},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1561, col: 5, offset: 37363},
+							pos:   position{line: 1563, col: 5, offset: 37449},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1561, col: 11, offset: 37369},
+								pos:  position{line: 1563, col: 11, offset: 37455},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1561, col: 22, offset: 37380},
+							pos:   position{line: 1563, col: 22, offset: 37466},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1561, col: 27, offset: 37385},
+								pos: position{line: 1563, col: 27, offset: 37471},
 								expr: &actionExpr{
-									pos: position{line: 1561, col: 28, offset: 37386},
+									pos: position{line: 1563, col: 28, offset: 37472},
 									run: (*parser).callonIdentifiers7,
 									expr: &seqExpr{
-										pos: position{line: 1561, col: 28, offset: 37386},
+										pos: position{line: 1563, col: 28, offset: 37472},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1561, col: 28, offset: 37386},
+												pos:  position{line: 1563, col: 28, offset: 37472},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1561, col: 31, offset: 37389},
+												pos:        position{line: 1563, col: 31, offset: 37475},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1561, col: 35, offset: 37393},
+												pos:  position{line: 1563, col: 35, offset: 37479},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1561, col: 38, offset: 37396},
+												pos:   position{line: 1563, col: 38, offset: 37482},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1561, col: 43, offset: 37401},
+													pos:  position{line: 1563, col: 43, offset: 37487},
 													name: "Identifier",
 												},
 											},
@@ -10175,22 +10193,22 @@ var g = &grammar{
 		},
 		{
 			name: "SQLIdentifier",
-			pos:  position{line: 1565, col: 1, offset: 37479},
+			pos:  position{line: 1567, col: 1, offset: 37565},
 			expr: &choiceExpr{
-				pos: position{line: 1566, col: 5, offset: 37497},
+				pos: position{line: 1568, col: 5, offset: 37583},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1566, col: 5, offset: 37497},
+						pos:  position{line: 1568, col: 5, offset: 37583},
 						name: "Identifier",
 					},
 					&actionExpr{
-						pos: position{line: 1567, col: 5, offset: 37512},
+						pos: position{line: 1569, col: 5, offset: 37598},
 						run: (*parser).callonSQLIdentifier3,
 						expr: &labeledExpr{
-							pos:   position{line: 1567, col: 5, offset: 37512},
+							pos:   position{line: 1569, col: 5, offset: 37598},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1567, col: 7, offset: 37514},
+								pos:  position{line: 1569, col: 7, offset: 37600},
 								name: "DoubleQuotedString",
 							},
 						},
@@ -10202,29 +10220,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1569, col: 1, offset: 37588},
+			pos:  position{line: 1571, col: 1, offset: 37674},
 			expr: &choiceExpr{
-				pos: position{line: 1570, col: 5, offset: 37607},
+				pos: position{line: 1572, col: 5, offset: 37693},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1570, col: 5, offset: 37607},
+						pos: position{line: 1572, col: 5, offset: 37693},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1570, col: 5, offset: 37607},
+							pos: position{line: 1572, col: 5, offset: 37693},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1570, col: 5, offset: 37607},
+									pos: position{line: 1572, col: 5, offset: 37693},
 									expr: &seqExpr{
-										pos: position{line: 1570, col: 7, offset: 37609},
+										pos: position{line: 1572, col: 7, offset: 37695},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1570, col: 7, offset: 37609},
+												pos:  position{line: 1572, col: 7, offset: 37695},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1570, col: 15, offset: 37617},
+												pos: position{line: 1572, col: 15, offset: 37703},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1570, col: 16, offset: 37618},
+													pos:  position{line: 1572, col: 16, offset: 37704},
 													name: "IdentifierRest",
 												},
 											},
@@ -10232,13 +10250,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1570, col: 32, offset: 37634},
+									pos:  position{line: 1572, col: 32, offset: 37720},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1570, col: 48, offset: 37650},
+									pos: position{line: 1572, col: 48, offset: 37736},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1570, col: 48, offset: 37650},
+										pos:  position{line: 1572, col: 48, offset: 37736},
 										name: "IdentifierRest",
 									},
 								},
@@ -10246,7 +10264,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1571, col: 5, offset: 37701},
+						pos:  position{line: 1573, col: 5, offset: 37787},
 						name: "BacktickString",
 					},
 				},
@@ -10256,22 +10274,22 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1573, col: 1, offset: 37717},
+			pos:  position{line: 1575, col: 1, offset: 37803},
 			expr: &choiceExpr{
-				pos: position{line: 1574, col: 5, offset: 37737},
+				pos: position{line: 1576, col: 5, offset: 37823},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1574, col: 5, offset: 37737},
+						pos:  position{line: 1576, col: 5, offset: 37823},
 						name: "UnicodeLetter",
 					},
 					&litMatcher{
-						pos:        position{line: 1575, col: 5, offset: 37755},
+						pos:        position{line: 1577, col: 5, offset: 37841},
 						val:        "$",
 						ignoreCase: false,
 						want:       "\"$\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1576, col: 5, offset: 37763},
+						pos:        position{line: 1578, col: 5, offset: 37849},
 						val:        "_",
 						ignoreCase: false,
 						want:       "\"_\"",
@@ -10283,24 +10301,24 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1578, col: 1, offset: 37768},
+			pos:  position{line: 1580, col: 1, offset: 37854},
 			expr: &choiceExpr{
-				pos: position{line: 1579, col: 5, offset: 37787},
+				pos: position{line: 1581, col: 5, offset: 37873},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1579, col: 5, offset: 37787},
+						pos:  position{line: 1581, col: 5, offset: 37873},
 						name: "IdentifierStart",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1580, col: 5, offset: 37807},
+						pos:  position{line: 1582, col: 5, offset: 37893},
 						name: "UnicodeCombiningMark",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1581, col: 5, offset: 37832},
+						pos:  position{line: 1583, col: 5, offset: 37918},
 						name: "UnicodeDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1582, col: 5, offset: 37849},
+						pos:  position{line: 1584, col: 5, offset: 37935},
 						name: "UnicodeConnectorPunctuation",
 					},
 				},
@@ -10310,24 +10328,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1584, col: 1, offset: 37878},
+			pos:  position{line: 1586, col: 1, offset: 37964},
 			expr: &choiceExpr{
-				pos: position{line: 1585, col: 5, offset: 37890},
+				pos: position{line: 1587, col: 5, offset: 37976},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1585, col: 5, offset: 37890},
+						pos:  position{line: 1587, col: 5, offset: 37976},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1586, col: 5, offset: 37909},
+						pos:  position{line: 1588, col: 5, offset: 37995},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1587, col: 5, offset: 37925},
+						pos:  position{line: 1589, col: 5, offset: 38011},
 						name: "NaN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1588, col: 5, offset: 37933},
+						pos:  position{line: 1590, col: 5, offset: 38019},
 						name: "Infinity",
 					},
 				},
@@ -10337,25 +10355,25 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1590, col: 1, offset: 37943},
+			pos:  position{line: 1592, col: 1, offset: 38029},
 			expr: &actionExpr{
-				pos: position{line: 1591, col: 5, offset: 37952},
+				pos: position{line: 1593, col: 5, offset: 38038},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1591, col: 5, offset: 37952},
+					pos: position{line: 1593, col: 5, offset: 38038},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1591, col: 5, offset: 37952},
+							pos:  position{line: 1593, col: 5, offset: 38038},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1591, col: 14, offset: 37961},
+							pos:        position{line: 1593, col: 14, offset: 38047},
 							val:        "T",
 							ignoreCase: false,
 							want:       "\"T\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1591, col: 18, offset: 37965},
+							pos:  position{line: 1593, col: 18, offset: 38051},
 							name: "FullTime",
 						},
 					},
@@ -10366,32 +10384,32 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1595, col: 1, offset: 38041},
+			pos:  position{line: 1597, col: 1, offset: 38127},
 			expr: &seqExpr{
-				pos: position{line: 1595, col: 12, offset: 38052},
+				pos: position{line: 1597, col: 12, offset: 38138},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1595, col: 12, offset: 38052},
+						pos:  position{line: 1597, col: 12, offset: 38138},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1595, col: 15, offset: 38055},
+						pos:        position{line: 1597, col: 15, offset: 38141},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1595, col: 19, offset: 38059},
+						pos:  position{line: 1597, col: 19, offset: 38145},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1595, col: 22, offset: 38062},
+						pos:        position{line: 1597, col: 22, offset: 38148},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1595, col: 26, offset: 38066},
+						pos:  position{line: 1597, col: 26, offset: 38152},
 						name: "D2",
 					},
 				},
@@ -10401,33 +10419,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1597, col: 1, offset: 38070},
+			pos:  position{line: 1599, col: 1, offset: 38156},
 			expr: &seqExpr{
-				pos: position{line: 1597, col: 6, offset: 38075},
+				pos: position{line: 1599, col: 6, offset: 38161},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1597, col: 6, offset: 38075},
+						pos:        position{line: 1599, col: 6, offset: 38161},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1597, col: 11, offset: 38080},
+						pos:        position{line: 1599, col: 11, offset: 38166},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1597, col: 16, offset: 38085},
+						pos:        position{line: 1599, col: 16, offset: 38171},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1597, col: 21, offset: 38090},
+						pos:        position{line: 1599, col: 21, offset: 38176},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10440,19 +10458,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1598, col: 1, offset: 38096},
+			pos:  position{line: 1600, col: 1, offset: 38182},
 			expr: &seqExpr{
-				pos: position{line: 1598, col: 6, offset: 38101},
+				pos: position{line: 1600, col: 6, offset: 38187},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1598, col: 6, offset: 38101},
+						pos:        position{line: 1600, col: 6, offset: 38187},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1598, col: 11, offset: 38106},
+						pos:        position{line: 1600, col: 11, offset: 38192},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10465,16 +10483,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1600, col: 1, offset: 38113},
+			pos:  position{line: 1602, col: 1, offset: 38199},
 			expr: &seqExpr{
-				pos: position{line: 1600, col: 12, offset: 38124},
+				pos: position{line: 1602, col: 12, offset: 38210},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1600, col: 12, offset: 38124},
+						pos:  position{line: 1602, col: 12, offset: 38210},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1600, col: 24, offset: 38136},
+						pos:  position{line: 1602, col: 24, offset: 38222},
 						name: "TimeOffset",
 					},
 				},
@@ -10484,49 +10502,49 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1602, col: 1, offset: 38148},
+			pos:  position{line: 1604, col: 1, offset: 38234},
 			expr: &seqExpr{
-				pos: position{line: 1602, col: 15, offset: 38162},
+				pos: position{line: 1604, col: 15, offset: 38248},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1602, col: 15, offset: 38162},
+						pos:  position{line: 1604, col: 15, offset: 38248},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1602, col: 18, offset: 38165},
+						pos:        position{line: 1604, col: 18, offset: 38251},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1602, col: 22, offset: 38169},
+						pos:  position{line: 1604, col: 22, offset: 38255},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1602, col: 25, offset: 38172},
+						pos:        position{line: 1604, col: 25, offset: 38258},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1602, col: 29, offset: 38176},
+						pos:  position{line: 1604, col: 29, offset: 38262},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1602, col: 32, offset: 38179},
+						pos: position{line: 1604, col: 32, offset: 38265},
 						expr: &seqExpr{
-							pos: position{line: 1602, col: 33, offset: 38180},
+							pos: position{line: 1604, col: 33, offset: 38266},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1602, col: 33, offset: 38180},
+									pos:        position{line: 1604, col: 33, offset: 38266},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1602, col: 37, offset: 38184},
+									pos: position{line: 1604, col: 37, offset: 38270},
 									expr: &charClassMatcher{
-										pos:        position{line: 1602, col: 37, offset: 38184},
+										pos:        position{line: 1604, col: 37, offset: 38270},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10543,30 +10561,30 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1604, col: 1, offset: 38194},
+			pos:  position{line: 1606, col: 1, offset: 38280},
 			expr: &choiceExpr{
-				pos: position{line: 1605, col: 5, offset: 38209},
+				pos: position{line: 1607, col: 5, offset: 38295},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1605, col: 5, offset: 38209},
+						pos:        position{line: 1607, col: 5, offset: 38295},
 						val:        "Z",
 						ignoreCase: false,
 						want:       "\"Z\"",
 					},
 					&seqExpr{
-						pos: position{line: 1606, col: 5, offset: 38217},
+						pos: position{line: 1608, col: 5, offset: 38303},
 						exprs: []any{
 							&choiceExpr{
-								pos: position{line: 1606, col: 6, offset: 38218},
+								pos: position{line: 1608, col: 6, offset: 38304},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 1606, col: 6, offset: 38218},
+										pos:        position{line: 1608, col: 6, offset: 38304},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 1606, col: 12, offset: 38224},
+										pos:        position{line: 1608, col: 12, offset: 38310},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
@@ -10574,34 +10592,34 @@ var g = &grammar{
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1606, col: 17, offset: 38229},
+								pos:  position{line: 1608, col: 17, offset: 38315},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1606, col: 20, offset: 38232},
+								pos:        position{line: 1608, col: 20, offset: 38318},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1606, col: 24, offset: 38236},
+								pos:  position{line: 1608, col: 24, offset: 38322},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1606, col: 27, offset: 38239},
+								pos: position{line: 1608, col: 27, offset: 38325},
 								expr: &seqExpr{
-									pos: position{line: 1606, col: 28, offset: 38240},
+									pos: position{line: 1608, col: 28, offset: 38326},
 									exprs: []any{
 										&litMatcher{
-											pos:        position{line: 1606, col: 28, offset: 38240},
+											pos:        position{line: 1608, col: 28, offset: 38326},
 											val:        ".",
 											ignoreCase: false,
 											want:       "\".\"",
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1606, col: 32, offset: 38244},
+											pos: position{line: 1608, col: 32, offset: 38330},
 											expr: &charClassMatcher{
-												pos:        position{line: 1606, col: 32, offset: 38244},
+												pos:        position{line: 1608, col: 32, offset: 38330},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -10620,33 +10638,33 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1608, col: 1, offset: 38254},
+			pos:  position{line: 1610, col: 1, offset: 38340},
 			expr: &actionExpr{
-				pos: position{line: 1609, col: 5, offset: 38267},
+				pos: position{line: 1611, col: 5, offset: 38353},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1609, col: 5, offset: 38267},
+					pos: position{line: 1611, col: 5, offset: 38353},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 1609, col: 5, offset: 38267},
+							pos: position{line: 1611, col: 5, offset: 38353},
 							expr: &litMatcher{
-								pos:        position{line: 1609, col: 5, offset: 38267},
+								pos:        position{line: 1611, col: 5, offset: 38353},
 								val:        "-",
 								ignoreCase: false,
 								want:       "\"-\"",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1609, col: 10, offset: 38272},
+							pos: position{line: 1611, col: 10, offset: 38358},
 							expr: &seqExpr{
-								pos: position{line: 1609, col: 11, offset: 38273},
+								pos: position{line: 1611, col: 11, offset: 38359},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1609, col: 11, offset: 38273},
+										pos:  position{line: 1611, col: 11, offset: 38359},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1609, col: 19, offset: 38281},
+										pos:  position{line: 1611, col: 19, offset: 38367},
 										name: "TimeUnit",
 									},
 								},
@@ -10660,27 +10678,27 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1613, col: 1, offset: 38363},
+			pos:  position{line: 1615, col: 1, offset: 38449},
 			expr: &seqExpr{
-				pos: position{line: 1613, col: 11, offset: 38373},
+				pos: position{line: 1615, col: 11, offset: 38459},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1613, col: 11, offset: 38373},
+						pos:  position{line: 1615, col: 11, offset: 38459},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1613, col: 16, offset: 38378},
+						pos: position{line: 1615, col: 16, offset: 38464},
 						expr: &seqExpr{
-							pos: position{line: 1613, col: 17, offset: 38379},
+							pos: position{line: 1615, col: 17, offset: 38465},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1613, col: 17, offset: 38379},
+									pos:        position{line: 1615, col: 17, offset: 38465},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1613, col: 21, offset: 38383},
+									pos:  position{line: 1615, col: 21, offset: 38469},
 									name: "UInt",
 								},
 							},
@@ -10693,60 +10711,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1615, col: 1, offset: 38391},
+			pos:  position{line: 1617, col: 1, offset: 38477},
 			expr: &choiceExpr{
-				pos: position{line: 1616, col: 5, offset: 38404},
+				pos: position{line: 1618, col: 5, offset: 38490},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1616, col: 5, offset: 38404},
+						pos:        position{line: 1618, col: 5, offset: 38490},
 						val:        "ns",
 						ignoreCase: false,
 						want:       "\"ns\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1617, col: 5, offset: 38413},
+						pos:        position{line: 1619, col: 5, offset: 38499},
 						val:        "us",
 						ignoreCase: false,
 						want:       "\"us\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1618, col: 5, offset: 38422},
+						pos:        position{line: 1620, col: 5, offset: 38508},
 						val:        "ms",
 						ignoreCase: false,
 						want:       "\"ms\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1619, col: 5, offset: 38431},
+						pos:        position{line: 1621, col: 5, offset: 38517},
 						val:        "s",
 						ignoreCase: false,
 						want:       "\"s\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1620, col: 5, offset: 38439},
+						pos:        position{line: 1622, col: 5, offset: 38525},
 						val:        "m",
 						ignoreCase: false,
 						want:       "\"m\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1621, col: 5, offset: 38447},
+						pos:        position{line: 1623, col: 5, offset: 38533},
 						val:        "h",
 						ignoreCase: false,
 						want:       "\"h\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1622, col: 5, offset: 38455},
+						pos:        position{line: 1624, col: 5, offset: 38541},
 						val:        "d",
 						ignoreCase: false,
 						want:       "\"d\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1623, col: 5, offset: 38463},
+						pos:        position{line: 1625, col: 5, offset: 38549},
 						val:        "w",
 						ignoreCase: false,
 						want:       "\"w\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1624, col: 5, offset: 38471},
+						pos:        position{line: 1626, col: 5, offset: 38557},
 						val:        "y",
 						ignoreCase: false,
 						want:       "\"y\"",
@@ -10758,45 +10776,45 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1626, col: 1, offset: 38476},
+			pos:  position{line: 1628, col: 1, offset: 38562},
 			expr: &actionExpr{
-				pos: position{line: 1627, col: 5, offset: 38483},
+				pos: position{line: 1629, col: 5, offset: 38569},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1627, col: 5, offset: 38483},
+					pos: position{line: 1629, col: 5, offset: 38569},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1627, col: 5, offset: 38483},
+							pos:  position{line: 1629, col: 5, offset: 38569},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1627, col: 10, offset: 38488},
+							pos:        position{line: 1629, col: 10, offset: 38574},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1627, col: 14, offset: 38492},
+							pos:  position{line: 1629, col: 14, offset: 38578},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1627, col: 19, offset: 38497},
+							pos:        position{line: 1629, col: 19, offset: 38583},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1627, col: 23, offset: 38501},
+							pos:  position{line: 1629, col: 23, offset: 38587},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1627, col: 28, offset: 38506},
+							pos:        position{line: 1629, col: 28, offset: 38592},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1627, col: 32, offset: 38510},
+							pos:  position{line: 1629, col: 32, offset: 38596},
 							name: "UInt",
 						},
 					},
@@ -10807,43 +10825,43 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1629, col: 1, offset: 38547},
+			pos:  position{line: 1631, col: 1, offset: 38633},
 			expr: &actionExpr{
-				pos: position{line: 1630, col: 5, offset: 38555},
+				pos: position{line: 1632, col: 5, offset: 38641},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1630, col: 5, offset: 38555},
+					pos: position{line: 1632, col: 5, offset: 38641},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1630, col: 5, offset: 38555},
+							pos: position{line: 1632, col: 5, offset: 38641},
 							expr: &seqExpr{
-								pos: position{line: 1630, col: 7, offset: 38557},
+								pos: position{line: 1632, col: 7, offset: 38643},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1630, col: 7, offset: 38557},
+										pos:  position{line: 1632, col: 7, offset: 38643},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1630, col: 11, offset: 38561},
+										pos:        position{line: 1632, col: 11, offset: 38647},
 										val:        ":",
 										ignoreCase: false,
 										want:       "\":\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1630, col: 15, offset: 38565},
+										pos:  position{line: 1632, col: 15, offset: 38651},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1630, col: 19, offset: 38569},
+										pos: position{line: 1632, col: 19, offset: 38655},
 										expr: &choiceExpr{
-											pos: position{line: 1630, col: 21, offset: 38571},
+											pos: position{line: 1632, col: 21, offset: 38657},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1630, col: 21, offset: 38571},
+													pos:  position{line: 1632, col: 21, offset: 38657},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1630, col: 32, offset: 38582},
+													pos:        position{line: 1632, col: 32, offset: 38668},
 													val:        ":",
 													ignoreCase: false,
 													want:       "\":\"",
@@ -10855,10 +10873,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1630, col: 38, offset: 38588},
+							pos:   position{line: 1632, col: 38, offset: 38674},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1630, col: 40, offset: 38590},
+								pos:  position{line: 1632, col: 40, offset: 38676},
 								name: "IP6Variations",
 							},
 						},
@@ -10870,32 +10888,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1634, col: 1, offset: 38754},
+			pos:  position{line: 1636, col: 1, offset: 38840},
 			expr: &choiceExpr{
-				pos: position{line: 1635, col: 5, offset: 38772},
+				pos: position{line: 1637, col: 5, offset: 38858},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1635, col: 5, offset: 38772},
+						pos: position{line: 1637, col: 5, offset: 38858},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1635, col: 5, offset: 38772},
+							pos: position{line: 1637, col: 5, offset: 38858},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1635, col: 5, offset: 38772},
+									pos:   position{line: 1637, col: 5, offset: 38858},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1635, col: 7, offset: 38774},
+										pos: position{line: 1637, col: 7, offset: 38860},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1635, col: 7, offset: 38774},
+											pos:  position{line: 1637, col: 7, offset: 38860},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1635, col: 17, offset: 38784},
+									pos:   position{line: 1637, col: 17, offset: 38870},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1635, col: 19, offset: 38786},
+										pos:  position{line: 1637, col: 19, offset: 38872},
 										name: "IP6Tail",
 									},
 								},
@@ -10903,52 +10921,52 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1638, col: 5, offset: 38850},
+						pos: position{line: 1640, col: 5, offset: 38936},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1638, col: 5, offset: 38850},
+							pos: position{line: 1640, col: 5, offset: 38936},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1638, col: 5, offset: 38850},
+									pos:   position{line: 1640, col: 5, offset: 38936},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1638, col: 7, offset: 38852},
+										pos:  position{line: 1640, col: 7, offset: 38938},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1638, col: 11, offset: 38856},
+									pos:   position{line: 1640, col: 11, offset: 38942},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1638, col: 13, offset: 38858},
+										pos: position{line: 1640, col: 13, offset: 38944},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1638, col: 13, offset: 38858},
+											pos:  position{line: 1640, col: 13, offset: 38944},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1638, col: 23, offset: 38868},
+									pos:        position{line: 1640, col: 23, offset: 38954},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1638, col: 28, offset: 38873},
+									pos:   position{line: 1640, col: 28, offset: 38959},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1638, col: 30, offset: 38875},
+										pos: position{line: 1640, col: 30, offset: 38961},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1638, col: 30, offset: 38875},
+											pos:  position{line: 1640, col: 30, offset: 38961},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1638, col: 40, offset: 38885},
+									pos:   position{line: 1640, col: 40, offset: 38971},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1638, col: 42, offset: 38887},
+										pos:  position{line: 1640, col: 42, offset: 38973},
 										name: "IP6Tail",
 									},
 								},
@@ -10956,33 +10974,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1641, col: 5, offset: 38986},
+						pos: position{line: 1643, col: 5, offset: 39072},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1641, col: 5, offset: 38986},
+							pos: position{line: 1643, col: 5, offset: 39072},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1641, col: 5, offset: 38986},
+									pos:        position{line: 1643, col: 5, offset: 39072},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1641, col: 10, offset: 38991},
+									pos:   position{line: 1643, col: 10, offset: 39077},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1641, col: 12, offset: 38993},
+										pos: position{line: 1643, col: 12, offset: 39079},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1641, col: 12, offset: 38993},
+											pos:  position{line: 1643, col: 12, offset: 39079},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1641, col: 22, offset: 39003},
+									pos:   position{line: 1643, col: 22, offset: 39089},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1641, col: 24, offset: 39005},
+										pos:  position{line: 1643, col: 24, offset: 39091},
 										name: "IP6Tail",
 									},
 								},
@@ -10990,40 +11008,40 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1644, col: 5, offset: 39076},
+						pos: position{line: 1646, col: 5, offset: 39162},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1644, col: 5, offset: 39076},
+							pos: position{line: 1646, col: 5, offset: 39162},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1644, col: 5, offset: 39076},
+									pos:   position{line: 1646, col: 5, offset: 39162},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1644, col: 7, offset: 39078},
+										pos:  position{line: 1646, col: 7, offset: 39164},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1644, col: 11, offset: 39082},
+									pos:   position{line: 1646, col: 11, offset: 39168},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1644, col: 13, offset: 39084},
+										pos: position{line: 1646, col: 13, offset: 39170},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1644, col: 13, offset: 39084},
+											pos:  position{line: 1646, col: 13, offset: 39170},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1644, col: 23, offset: 39094},
+									pos:        position{line: 1646, col: 23, offset: 39180},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&notExpr{
-									pos: position{line: 1644, col: 28, offset: 39099},
+									pos: position{line: 1646, col: 28, offset: 39185},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1644, col: 29, offset: 39100},
+										pos:  position{line: 1646, col: 29, offset: 39186},
 										name: "TypeAsValue",
 									},
 								},
@@ -11031,10 +11049,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1647, col: 5, offset: 39175},
+						pos: position{line: 1649, col: 5, offset: 39261},
 						run: (*parser).callonIP6Variations40,
 						expr: &litMatcher{
-							pos:        position{line: 1647, col: 5, offset: 39175},
+							pos:        position{line: 1649, col: 5, offset: 39261},
 							val:        "::",
 							ignoreCase: false,
 							want:       "\"::\"",
@@ -11047,16 +11065,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1651, col: 1, offset: 39212},
+			pos:  position{line: 1653, col: 1, offset: 39298},
 			expr: &choiceExpr{
-				pos: position{line: 1652, col: 5, offset: 39224},
+				pos: position{line: 1654, col: 5, offset: 39310},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1652, col: 5, offset: 39224},
+						pos:  position{line: 1654, col: 5, offset: 39310},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1653, col: 5, offset: 39231},
+						pos:  position{line: 1655, col: 5, offset: 39317},
 						name: "Hex",
 					},
 				},
@@ -11066,24 +11084,24 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1655, col: 1, offset: 39236},
+			pos:  position{line: 1657, col: 1, offset: 39322},
 			expr: &actionExpr{
-				pos: position{line: 1655, col: 12, offset: 39247},
+				pos: position{line: 1657, col: 12, offset: 39333},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1655, col: 12, offset: 39247},
+					pos: position{line: 1657, col: 12, offset: 39333},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1655, col: 12, offset: 39247},
+							pos:        position{line: 1657, col: 12, offset: 39333},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1655, col: 16, offset: 39251},
+							pos:   position{line: 1657, col: 16, offset: 39337},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1655, col: 18, offset: 39253},
+								pos:  position{line: 1657, col: 18, offset: 39339},
 								name: "Hex",
 							},
 						},
@@ -11095,23 +11113,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1657, col: 1, offset: 39291},
+			pos:  position{line: 1659, col: 1, offset: 39377},
 			expr: &actionExpr{
-				pos: position{line: 1657, col: 12, offset: 39302},
+				pos: position{line: 1659, col: 12, offset: 39388},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1657, col: 12, offset: 39302},
+					pos: position{line: 1659, col: 12, offset: 39388},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1657, col: 12, offset: 39302},
+							pos:   position{line: 1659, col: 12, offset: 39388},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1657, col: 14, offset: 39304},
+								pos:  position{line: 1659, col: 14, offset: 39390},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1657, col: 18, offset: 39308},
+							pos:        position{line: 1659, col: 18, offset: 39394},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
@@ -11124,32 +11142,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1659, col: 1, offset: 39346},
+			pos:  position{line: 1661, col: 1, offset: 39432},
 			expr: &actionExpr{
-				pos: position{line: 1660, col: 5, offset: 39357},
+				pos: position{line: 1662, col: 5, offset: 39443},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1660, col: 5, offset: 39357},
+					pos: position{line: 1662, col: 5, offset: 39443},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1660, col: 5, offset: 39357},
+							pos:   position{line: 1662, col: 5, offset: 39443},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1660, col: 7, offset: 39359},
+								pos:  position{line: 1662, col: 7, offset: 39445},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1660, col: 10, offset: 39362},
+							pos:        position{line: 1662, col: 10, offset: 39448},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1660, col: 14, offset: 39366},
+							pos:   position{line: 1662, col: 14, offset: 39452},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1660, col: 16, offset: 39368},
+								pos:  position{line: 1662, col: 16, offset: 39454},
 								name: "UIntString",
 							},
 						},
@@ -11161,32 +11179,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1664, col: 1, offset: 39436},
+			pos:  position{line: 1666, col: 1, offset: 39522},
 			expr: &actionExpr{
-				pos: position{line: 1665, col: 5, offset: 39447},
+				pos: position{line: 1667, col: 5, offset: 39533},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1665, col: 5, offset: 39447},
+					pos: position{line: 1667, col: 5, offset: 39533},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1665, col: 5, offset: 39447},
+							pos:   position{line: 1667, col: 5, offset: 39533},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1665, col: 7, offset: 39449},
+								pos:  position{line: 1667, col: 7, offset: 39535},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1665, col: 11, offset: 39453},
+							pos:        position{line: 1667, col: 11, offset: 39539},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1665, col: 15, offset: 39457},
+							pos:   position{line: 1667, col: 15, offset: 39543},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1665, col: 17, offset: 39459},
+								pos:  position{line: 1667, col: 17, offset: 39545},
 								name: "UIntString",
 							},
 						},
@@ -11198,15 +11216,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1669, col: 1, offset: 39527},
+			pos:  position{line: 1671, col: 1, offset: 39613},
 			expr: &actionExpr{
-				pos: position{line: 1670, col: 4, offset: 39535},
+				pos: position{line: 1672, col: 4, offset: 39621},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1670, col: 4, offset: 39535},
+					pos:   position{line: 1672, col: 4, offset: 39621},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1670, col: 6, offset: 39537},
+						pos:  position{line: 1672, col: 6, offset: 39623},
 						name: "UIntString",
 					},
 				},
@@ -11216,16 +11234,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1672, col: 1, offset: 39577},
+			pos:  position{line: 1674, col: 1, offset: 39663},
 			expr: &choiceExpr{
-				pos: position{line: 1673, col: 5, offset: 39591},
+				pos: position{line: 1675, col: 5, offset: 39677},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1673, col: 5, offset: 39591},
+						pos:  position{line: 1675, col: 5, offset: 39677},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1674, col: 5, offset: 39606},
+						pos:  position{line: 1676, col: 5, offset: 39692},
 						name: "MinusIntString",
 					},
 				},
@@ -11235,14 +11253,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1676, col: 1, offset: 39622},
+			pos:  position{line: 1678, col: 1, offset: 39708},
 			expr: &actionExpr{
-				pos: position{line: 1676, col: 14, offset: 39635},
+				pos: position{line: 1678, col: 14, offset: 39721},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1676, col: 14, offset: 39635},
+					pos: position{line: 1678, col: 14, offset: 39721},
 					expr: &charClassMatcher{
-						pos:        position{line: 1676, col: 14, offset: 39635},
+						pos:        position{line: 1678, col: 14, offset: 39721},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11255,21 +11273,21 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1678, col: 1, offset: 39674},
+			pos:  position{line: 1680, col: 1, offset: 39760},
 			expr: &actionExpr{
-				pos: position{line: 1679, col: 5, offset: 39693},
+				pos: position{line: 1681, col: 5, offset: 39779},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1679, col: 5, offset: 39693},
+					pos: position{line: 1681, col: 5, offset: 39779},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1679, col: 5, offset: 39693},
+							pos:        position{line: 1681, col: 5, offset: 39779},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1679, col: 9, offset: 39697},
+							pos:  position{line: 1681, col: 9, offset: 39783},
 							name: "UIntString",
 						},
 					},
@@ -11280,29 +11298,29 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1681, col: 1, offset: 39740},
+			pos:  position{line: 1683, col: 1, offset: 39826},
 			expr: &choiceExpr{
-				pos: position{line: 1682, col: 5, offset: 39756},
+				pos: position{line: 1684, col: 5, offset: 39842},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1682, col: 5, offset: 39756},
+						pos: position{line: 1684, col: 5, offset: 39842},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1682, col: 5, offset: 39756},
+							pos: position{line: 1684, col: 5, offset: 39842},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1682, col: 5, offset: 39756},
+									pos: position{line: 1684, col: 5, offset: 39842},
 									expr: &litMatcher{
-										pos:        position{line: 1682, col: 5, offset: 39756},
+										pos:        position{line: 1684, col: 5, offset: 39842},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1682, col: 10, offset: 39761},
+									pos: position{line: 1684, col: 10, offset: 39847},
 									expr: &charClassMatcher{
-										pos:        position{line: 1682, col: 10, offset: 39761},
+										pos:        position{line: 1684, col: 10, offset: 39847},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11310,15 +11328,15 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1682, col: 17, offset: 39768},
+									pos:        position{line: 1684, col: 17, offset: 39854},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1682, col: 21, offset: 39772},
+									pos: position{line: 1684, col: 21, offset: 39858},
 									expr: &charClassMatcher{
-										pos:        position{line: 1682, col: 21, offset: 39772},
+										pos:        position{line: 1684, col: 21, offset: 39858},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11326,9 +11344,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1682, col: 28, offset: 39779},
+									pos: position{line: 1684, col: 28, offset: 39865},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1682, col: 28, offset: 39779},
+										pos:  position{line: 1684, col: 28, offset: 39865},
 										name: "ExponentPart",
 									},
 								},
@@ -11336,30 +11354,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1683, col: 5, offset: 39828},
+						pos: position{line: 1685, col: 5, offset: 39914},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1683, col: 5, offset: 39828},
+							pos: position{line: 1685, col: 5, offset: 39914},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1683, col: 5, offset: 39828},
+									pos: position{line: 1685, col: 5, offset: 39914},
 									expr: &litMatcher{
-										pos:        position{line: 1683, col: 5, offset: 39828},
+										pos:        position{line: 1685, col: 5, offset: 39914},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1683, col: 10, offset: 39833},
+									pos:        position{line: 1685, col: 10, offset: 39919},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1683, col: 14, offset: 39837},
+									pos: position{line: 1685, col: 14, offset: 39923},
 									expr: &charClassMatcher{
-										pos:        position{line: 1683, col: 14, offset: 39837},
+										pos:        position{line: 1685, col: 14, offset: 39923},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11367,9 +11385,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1683, col: 21, offset: 39844},
+									pos: position{line: 1685, col: 21, offset: 39930},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1683, col: 21, offset: 39844},
+										pos:  position{line: 1685, col: 21, offset: 39930},
 										name: "ExponentPart",
 									},
 								},
@@ -11377,17 +11395,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1684, col: 5, offset: 39893},
+						pos: position{line: 1686, col: 5, offset: 39979},
 						run: (*parser).callonFloatString22,
 						expr: &choiceExpr{
-							pos: position{line: 1684, col: 6, offset: 39894},
+							pos: position{line: 1686, col: 6, offset: 39980},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1684, col: 6, offset: 39894},
+									pos:  position{line: 1686, col: 6, offset: 39980},
 									name: "NaN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1684, col: 12, offset: 39900},
+									pos:  position{line: 1686, col: 12, offset: 39986},
 									name: "Infinity",
 								},
 							},
@@ -11400,20 +11418,20 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1687, col: 1, offset: 39943},
+			pos:  position{line: 1689, col: 1, offset: 40029},
 			expr: &seqExpr{
-				pos: position{line: 1687, col: 16, offset: 39958},
+				pos: position{line: 1689, col: 16, offset: 40044},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1687, col: 16, offset: 39958},
+						pos:        position{line: 1689, col: 16, offset: 40044},
 						val:        "e",
 						ignoreCase: true,
 						want:       "\"e\"i",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1687, col: 21, offset: 39963},
+						pos: position{line: 1689, col: 21, offset: 40049},
 						expr: &charClassMatcher{
-							pos:        position{line: 1687, col: 21, offset: 39963},
+							pos:        position{line: 1689, col: 21, offset: 40049},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -11421,7 +11439,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1687, col: 27, offset: 39969},
+						pos:  position{line: 1689, col: 27, offset: 40055},
 						name: "UIntString",
 					},
 				},
@@ -11431,9 +11449,9 @@ var g = &grammar{
 		},
 		{
 			name: "NaN",
-			pos:  position{line: 1689, col: 1, offset: 39981},
+			pos:  position{line: 1691, col: 1, offset: 40067},
 			expr: &litMatcher{
-				pos:        position{line: 1689, col: 7, offset: 39987},
+				pos:        position{line: 1691, col: 7, offset: 40073},
 				val:        "NaN",
 				ignoreCase: false,
 				want:       "\"NaN\"",
@@ -11443,23 +11461,23 @@ var g = &grammar{
 		},
 		{
 			name: "Infinity",
-			pos:  position{line: 1691, col: 1, offset: 39994},
+			pos:  position{line: 1693, col: 1, offset: 40080},
 			expr: &seqExpr{
-				pos: position{line: 1691, col: 12, offset: 40005},
+				pos: position{line: 1693, col: 12, offset: 40091},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 1691, col: 12, offset: 40005},
+						pos: position{line: 1693, col: 12, offset: 40091},
 						expr: &choiceExpr{
-							pos: position{line: 1691, col: 13, offset: 40006},
+							pos: position{line: 1693, col: 13, offset: 40092},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1691, col: 13, offset: 40006},
+									pos:        position{line: 1693, col: 13, offset: 40092},
 									val:        "-",
 									ignoreCase: false,
 									want:       "\"-\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1691, col: 19, offset: 40012},
+									pos:        position{line: 1693, col: 19, offset: 40098},
 									val:        "+",
 									ignoreCase: false,
 									want:       "\"+\"",
@@ -11468,7 +11486,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1691, col: 25, offset: 40018},
+						pos:        position{line: 1693, col: 25, offset: 40104},
 						val:        "Inf",
 						ignoreCase: false,
 						want:       "\"Inf\"",
@@ -11480,14 +11498,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1693, col: 1, offset: 40025},
+			pos:  position{line: 1695, col: 1, offset: 40111},
 			expr: &actionExpr{
-				pos: position{line: 1693, col: 7, offset: 40031},
+				pos: position{line: 1695, col: 7, offset: 40117},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1693, col: 7, offset: 40031},
+					pos: position{line: 1695, col: 7, offset: 40117},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1693, col: 7, offset: 40031},
+						pos:  position{line: 1695, col: 7, offset: 40117},
 						name: "HexDigit",
 					},
 				},
@@ -11497,9 +11515,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1695, col: 1, offset: 40073},
+			pos:  position{line: 1697, col: 1, offset: 40159},
 			expr: &charClassMatcher{
-				pos:        position{line: 1695, col: 12, offset: 40084},
+				pos:        position{line: 1697, col: 12, offset: 40170},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -11510,32 +11528,32 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedString",
-			pos:  position{line: 1697, col: 1, offset: 40097},
+			pos:  position{line: 1699, col: 1, offset: 40183},
 			expr: &actionExpr{
-				pos: position{line: 1698, col: 5, offset: 40120},
+				pos: position{line: 1700, col: 5, offset: 40206},
 				run: (*parser).callonSingleQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 1698, col: 5, offset: 40120},
+					pos: position{line: 1700, col: 5, offset: 40206},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1698, col: 5, offset: 40120},
+							pos:        position{line: 1700, col: 5, offset: 40206},
 							val:        "'",
 							ignoreCase: false,
 							want:       "\"'\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1698, col: 9, offset: 40124},
+							pos:   position{line: 1700, col: 9, offset: 40210},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1698, col: 11, offset: 40126},
+								pos: position{line: 1700, col: 11, offset: 40212},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1698, col: 11, offset: 40126},
+									pos:  position{line: 1700, col: 11, offset: 40212},
 									name: "SingleQuotedChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1698, col: 29, offset: 40144},
+							pos:        position{line: 1700, col: 29, offset: 40230},
 							val:        "'",
 							ignoreCase: false,
 							want:       "\"'\"",
@@ -11548,32 +11566,32 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedString",
-			pos:  position{line: 1700, col: 1, offset: 40178},
+			pos:  position{line: 1702, col: 1, offset: 40264},
 			expr: &actionExpr{
-				pos: position{line: 1701, col: 5, offset: 40201},
+				pos: position{line: 1703, col: 5, offset: 40287},
 				run: (*parser).callonDoubleQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 1701, col: 5, offset: 40201},
+					pos: position{line: 1703, col: 5, offset: 40287},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1701, col: 5, offset: 40201},
+							pos:        position{line: 1703, col: 5, offset: 40287},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1701, col: 9, offset: 40205},
+							pos:   position{line: 1703, col: 9, offset: 40291},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1701, col: 11, offset: 40207},
+								pos: position{line: 1703, col: 11, offset: 40293},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1701, col: 11, offset: 40207},
+									pos:  position{line: 1703, col: 11, offset: 40293},
 									name: "DoubleQuotedChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1701, col: 29, offset: 40225},
+							pos:        position{line: 1703, col: 29, offset: 40311},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11586,57 +11604,57 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1703, col: 1, offset: 40259},
+			pos:  position{line: 1705, col: 1, offset: 40345},
 			expr: &choiceExpr{
-				pos: position{line: 1704, col: 5, offset: 40280},
+				pos: position{line: 1706, col: 5, offset: 40366},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1704, col: 5, offset: 40280},
+						pos: position{line: 1706, col: 5, offset: 40366},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1704, col: 5, offset: 40280},
+							pos: position{line: 1706, col: 5, offset: 40366},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1704, col: 5, offset: 40280},
+									pos: position{line: 1706, col: 5, offset: 40366},
 									expr: &choiceExpr{
-										pos: position{line: 1704, col: 7, offset: 40282},
+										pos: position{line: 1706, col: 7, offset: 40368},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1704, col: 7, offset: 40282},
+												pos:        position{line: 1706, col: 7, offset: 40368},
 												val:        "\"",
 												ignoreCase: false,
 												want:       "\"\\\"\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1704, col: 13, offset: 40288},
+												pos:  position{line: 1706, col: 13, offset: 40374},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1704, col: 26, offset: 40301,
+									line: 1706, col: 26, offset: 40387,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1705, col: 5, offset: 40338},
+						pos: position{line: 1707, col: 5, offset: 40424},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1705, col: 5, offset: 40338},
+							pos: position{line: 1707, col: 5, offset: 40424},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1705, col: 5, offset: 40338},
+									pos:        position{line: 1707, col: 5, offset: 40424},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1705, col: 10, offset: 40343},
+									pos:   position{line: 1707, col: 10, offset: 40429},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1705, col: 12, offset: 40345},
+										pos:  position{line: 1707, col: 12, offset: 40431},
 										name: "EscapeSequence",
 									},
 								},
@@ -11650,32 +11668,32 @@ var g = &grammar{
 		},
 		{
 			name: "RString",
-			pos:  position{line: 1707, col: 1, offset: 40379},
+			pos:  position{line: 1709, col: 1, offset: 40465},
 			expr: &choiceExpr{
-				pos: position{line: 1708, col: 5, offset: 40391},
+				pos: position{line: 1710, col: 5, offset: 40477},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1708, col: 5, offset: 40391},
+						pos: position{line: 1710, col: 5, offset: 40477},
 						run: (*parser).callonRString2,
 						expr: &seqExpr{
-							pos: position{line: 1708, col: 5, offset: 40391},
+							pos: position{line: 1710, col: 5, offset: 40477},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1708, col: 5, offset: 40391},
+									pos:        position{line: 1710, col: 5, offset: 40477},
 									val:        "r'",
 									ignoreCase: false,
 									want:       "\"r'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1708, col: 10, offset: 40396},
+									pos:   position{line: 1710, col: 10, offset: 40482},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1708, col: 12, offset: 40398},
+										pos:  position{line: 1710, col: 12, offset: 40484},
 										name: "NoSingleQuotes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1708, col: 27, offset: 40413},
+									pos:        position{line: 1710, col: 27, offset: 40499},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -11684,33 +11702,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1709, col: 5, offset: 40448},
+						pos: position{line: 1711, col: 5, offset: 40534},
 						run: (*parser).callonRString8,
 						expr: &seqExpr{
-							pos: position{line: 1709, col: 5, offset: 40448},
+							pos: position{line: 1711, col: 5, offset: 40534},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1709, col: 5, offset: 40448},
+									pos:        position{line: 1711, col: 5, offset: 40534},
 									val:        "r",
 									ignoreCase: false,
 									want:       "\"r\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1709, col: 9, offset: 40452},
+									pos:        position{line: 1711, col: 9, offset: 40538},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1709, col: 13, offset: 40456},
+									pos:   position{line: 1711, col: 13, offset: 40542},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1709, col: 15, offset: 40458},
+										pos:  position{line: 1711, col: 15, offset: 40544},
 										name: "NoDoubleQuotes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1709, col: 30, offset: 40473},
+									pos:        position{line: 1711, col: 30, offset: 40559},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -11725,26 +11743,26 @@ var g = &grammar{
 		},
 		{
 			name: "NoSingleQuotes",
-			pos:  position{line: 1711, col: 1, offset: 40505},
+			pos:  position{line: 1713, col: 1, offset: 40591},
 			expr: &actionExpr{
-				pos: position{line: 1712, col: 5, offset: 40524},
+				pos: position{line: 1714, col: 5, offset: 40610},
 				run: (*parser).callonNoSingleQuotes1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 1712, col: 5, offset: 40524},
+					pos: position{line: 1714, col: 5, offset: 40610},
 					expr: &seqExpr{
-						pos: position{line: 1712, col: 6, offset: 40525},
+						pos: position{line: 1714, col: 6, offset: 40611},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 1712, col: 6, offset: 40525},
+								pos: position{line: 1714, col: 6, offset: 40611},
 								expr: &litMatcher{
-									pos:        position{line: 1712, col: 7, offset: 40526},
+									pos:        position{line: 1714, col: 7, offset: 40612},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 							},
 							&anyMatcher{
-								line: 1712, col: 11, offset: 40530,
+								line: 1714, col: 11, offset: 40616,
 							},
 						},
 					},
@@ -11755,26 +11773,26 @@ var g = &grammar{
 		},
 		{
 			name: "NoDoubleQuotes",
-			pos:  position{line: 1714, col: 1, offset: 40566},
+			pos:  position{line: 1716, col: 1, offset: 40652},
 			expr: &actionExpr{
-				pos: position{line: 1715, col: 5, offset: 40585},
+				pos: position{line: 1717, col: 5, offset: 40671},
 				run: (*parser).callonNoDoubleQuotes1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 1715, col: 5, offset: 40585},
+					pos: position{line: 1717, col: 5, offset: 40671},
 					expr: &seqExpr{
-						pos: position{line: 1715, col: 6, offset: 40586},
+						pos: position{line: 1717, col: 6, offset: 40672},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 1715, col: 6, offset: 40586},
+								pos: position{line: 1717, col: 6, offset: 40672},
 								expr: &litMatcher{
-									pos:        position{line: 1715, col: 7, offset: 40587},
+									pos:        position{line: 1717, col: 7, offset: 40673},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 							},
 							&anyMatcher{
-								line: 1715, col: 11, offset: 40591,
+								line: 1717, col: 11, offset: 40677,
 							},
 						},
 					},
@@ -11785,32 +11803,32 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickString",
-			pos:  position{line: 1717, col: 1, offset: 40627},
+			pos:  position{line: 1719, col: 1, offset: 40713},
 			expr: &actionExpr{
-				pos: position{line: 1718, col: 5, offset: 40646},
+				pos: position{line: 1720, col: 5, offset: 40732},
 				run: (*parser).callonBacktickString1,
 				expr: &seqExpr{
-					pos: position{line: 1718, col: 5, offset: 40646},
+					pos: position{line: 1720, col: 5, offset: 40732},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1718, col: 5, offset: 40646},
+							pos:        position{line: 1720, col: 5, offset: 40732},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1718, col: 9, offset: 40650},
+							pos:   position{line: 1720, col: 9, offset: 40736},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1718, col: 11, offset: 40652},
+								pos: position{line: 1720, col: 11, offset: 40738},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1718, col: 11, offset: 40652},
+									pos:  position{line: 1720, col: 11, offset: 40738},
 									name: "BacktickChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1718, col: 25, offset: 40666},
+							pos:        position{line: 1720, col: 25, offset: 40752},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
@@ -11823,57 +11841,57 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickChar",
-			pos:  position{line: 1720, col: 1, offset: 40700},
+			pos:  position{line: 1722, col: 1, offset: 40786},
 			expr: &choiceExpr{
-				pos: position{line: 1721, col: 5, offset: 40717},
+				pos: position{line: 1723, col: 5, offset: 40803},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1721, col: 5, offset: 40717},
+						pos: position{line: 1723, col: 5, offset: 40803},
 						run: (*parser).callonBacktickChar2,
 						expr: &seqExpr{
-							pos: position{line: 1721, col: 5, offset: 40717},
+							pos: position{line: 1723, col: 5, offset: 40803},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1721, col: 5, offset: 40717},
+									pos: position{line: 1723, col: 5, offset: 40803},
 									expr: &choiceExpr{
-										pos: position{line: 1721, col: 7, offset: 40719},
+										pos: position{line: 1723, col: 7, offset: 40805},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1721, col: 7, offset: 40719},
+												pos:        position{line: 1723, col: 7, offset: 40805},
 												val:        "`",
 												ignoreCase: false,
 												want:       "\"`\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1721, col: 13, offset: 40725},
+												pos:  position{line: 1723, col: 13, offset: 40811},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1721, col: 26, offset: 40738,
+									line: 1723, col: 26, offset: 40824,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1722, col: 5, offset: 40775},
+						pos: position{line: 1724, col: 5, offset: 40861},
 						run: (*parser).callonBacktickChar9,
 						expr: &seqExpr{
-							pos: position{line: 1722, col: 5, offset: 40775},
+							pos: position{line: 1724, col: 5, offset: 40861},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1722, col: 5, offset: 40775},
+									pos:        position{line: 1724, col: 5, offset: 40861},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1722, col: 10, offset: 40780},
+									pos:   position{line: 1724, col: 10, offset: 40866},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1722, col: 12, offset: 40782},
+										pos:  position{line: 1724, col: 12, offset: 40868},
 										name: "EscapeSequence",
 									},
 								},
@@ -11887,28 +11905,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1724, col: 1, offset: 40816},
+			pos:  position{line: 1726, col: 1, offset: 40902},
 			expr: &actionExpr{
-				pos: position{line: 1725, col: 5, offset: 40828},
+				pos: position{line: 1727, col: 5, offset: 40914},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1725, col: 5, offset: 40828},
+					pos: position{line: 1727, col: 5, offset: 40914},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1725, col: 5, offset: 40828},
+							pos:   position{line: 1727, col: 5, offset: 40914},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1725, col: 10, offset: 40833},
+								pos:  position{line: 1727, col: 10, offset: 40919},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1725, col: 23, offset: 40846},
+							pos:   position{line: 1727, col: 23, offset: 40932},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1725, col: 28, offset: 40851},
+								pos: position{line: 1727, col: 28, offset: 40937},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1725, col: 28, offset: 40851},
+									pos:  position{line: 1727, col: 28, offset: 40937},
 									name: "KeyWordRest",
 								},
 							},
@@ -11921,16 +11939,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1727, col: 1, offset: 40913},
+			pos:  position{line: 1729, col: 1, offset: 40999},
 			expr: &choiceExpr{
-				pos: position{line: 1728, col: 5, offset: 40930},
+				pos: position{line: 1730, col: 5, offset: 41016},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1728, col: 5, offset: 40930},
+						pos:  position{line: 1730, col: 5, offset: 41016},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1729, col: 5, offset: 40947},
+						pos:  position{line: 1731, col: 5, offset: 41033},
 						name: "KeyWordEsc",
 					},
 				},
@@ -11940,16 +11958,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1731, col: 1, offset: 40959},
+			pos:  position{line: 1733, col: 1, offset: 41045},
 			expr: &choiceExpr{
-				pos: position{line: 1732, col: 5, offset: 40975},
+				pos: position{line: 1734, col: 5, offset: 41061},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1732, col: 5, offset: 40975},
+						pos:  position{line: 1734, col: 5, offset: 41061},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1733, col: 5, offset: 40992},
+						pos:        position{line: 1735, col: 5, offset: 41078},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11962,19 +11980,19 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1735, col: 1, offset: 40999},
+			pos:  position{line: 1737, col: 1, offset: 41085},
 			expr: &actionExpr{
-				pos: position{line: 1735, col: 16, offset: 41014},
+				pos: position{line: 1737, col: 16, offset: 41100},
 				run: (*parser).callonKeyWordChars1,
 				expr: &choiceExpr{
-					pos: position{line: 1735, col: 17, offset: 41015},
+					pos: position{line: 1737, col: 17, offset: 41101},
 					alternatives: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1735, col: 17, offset: 41015},
+							pos:  position{line: 1737, col: 17, offset: 41101},
 							name: "UnicodeLetter",
 						},
 						&charClassMatcher{
-							pos:        position{line: 1735, col: 33, offset: 41031},
+							pos:        position{line: 1737, col: 33, offset: 41117},
 							val:        "[_.:/%#@~]",
 							chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 							ignoreCase: false,
@@ -11988,31 +12006,31 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1737, col: 1, offset: 41075},
+			pos:  position{line: 1739, col: 1, offset: 41161},
 			expr: &actionExpr{
-				pos: position{line: 1737, col: 14, offset: 41088},
+				pos: position{line: 1739, col: 14, offset: 41174},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1737, col: 14, offset: 41088},
+					pos: position{line: 1739, col: 14, offset: 41174},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1737, col: 14, offset: 41088},
+							pos:        position{line: 1739, col: 14, offset: 41174},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1737, col: 19, offset: 41093},
+							pos:   position{line: 1739, col: 19, offset: 41179},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1737, col: 22, offset: 41096},
+								pos: position{line: 1739, col: 22, offset: 41182},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1737, col: 22, offset: 41096},
+										pos:  position{line: 1739, col: 22, offset: 41182},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1737, col: 38, offset: 41112},
+										pos:  position{line: 1739, col: 38, offset: 41198},
 										name: "EscapeSequence",
 									},
 								},
@@ -12026,42 +12044,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1739, col: 1, offset: 41147},
+			pos:  position{line: 1741, col: 1, offset: 41233},
 			expr: &actionExpr{
-				pos: position{line: 1740, col: 5, offset: 41163},
+				pos: position{line: 1742, col: 5, offset: 41249},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1740, col: 5, offset: 41163},
+					pos: position{line: 1742, col: 5, offset: 41249},
 					exprs: []any{
 						&andExpr{
-							pos: position{line: 1740, col: 5, offset: 41163},
+							pos: position{line: 1742, col: 5, offset: 41249},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1740, col: 6, offset: 41164},
+								pos:  position{line: 1742, col: 6, offset: 41250},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1740, col: 22, offset: 41180},
+							pos: position{line: 1742, col: 22, offset: 41266},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1740, col: 23, offset: 41181},
+								pos:  position{line: 1742, col: 23, offset: 41267},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1740, col: 35, offset: 41193},
+							pos:   position{line: 1742, col: 35, offset: 41279},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1740, col: 40, offset: 41198},
+								pos:  position{line: 1742, col: 40, offset: 41284},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1740, col: 50, offset: 41208},
+							pos:   position{line: 1742, col: 50, offset: 41294},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1740, col: 55, offset: 41213},
+								pos: position{line: 1742, col: 55, offset: 41299},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1740, col: 55, offset: 41213},
+									pos:  position{line: 1742, col: 55, offset: 41299},
 									name: "GlobRest",
 								},
 							},
@@ -12074,28 +12092,28 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1744, col: 1, offset: 41282},
+			pos:  position{line: 1746, col: 1, offset: 41368},
 			expr: &choiceExpr{
-				pos: position{line: 1744, col: 19, offset: 41300},
+				pos: position{line: 1746, col: 19, offset: 41386},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1744, col: 19, offset: 41300},
+						pos:  position{line: 1746, col: 19, offset: 41386},
 						name: "KeyWordStart",
 					},
 					&seqExpr{
-						pos: position{line: 1744, col: 34, offset: 41315},
+						pos: position{line: 1746, col: 34, offset: 41401},
 						exprs: []any{
 							&oneOrMoreExpr{
-								pos: position{line: 1744, col: 34, offset: 41315},
+								pos: position{line: 1746, col: 34, offset: 41401},
 								expr: &litMatcher{
-									pos:        position{line: 1744, col: 34, offset: 41315},
+									pos:        position{line: 1746, col: 34, offset: 41401},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1744, col: 39, offset: 41320},
+								pos:  position{line: 1746, col: 39, offset: 41406},
 								name: "KeyWordRest",
 							},
 						},
@@ -12107,19 +12125,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1745, col: 1, offset: 41332},
+			pos:  position{line: 1747, col: 1, offset: 41418},
 			expr: &seqExpr{
-				pos: position{line: 1745, col: 15, offset: 41346},
+				pos: position{line: 1747, col: 15, offset: 41432},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1745, col: 15, offset: 41346},
+						pos: position{line: 1747, col: 15, offset: 41432},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1745, col: 15, offset: 41346},
+							pos:  position{line: 1747, col: 15, offset: 41432},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1745, col: 28, offset: 41359},
+						pos:        position{line: 1747, col: 28, offset: 41445},
 						val:        "*",
 						ignoreCase: false,
 						want:       "\"*\"",
@@ -12131,23 +12149,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1747, col: 1, offset: 41364},
+			pos:  position{line: 1749, col: 1, offset: 41450},
 			expr: &choiceExpr{
-				pos: position{line: 1748, col: 5, offset: 41378},
+				pos: position{line: 1750, col: 5, offset: 41464},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1748, col: 5, offset: 41378},
+						pos:  position{line: 1750, col: 5, offset: 41464},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1749, col: 5, offset: 41395},
+						pos:  position{line: 1751, col: 5, offset: 41481},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1750, col: 5, offset: 41407},
+						pos: position{line: 1752, col: 5, offset: 41493},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1750, col: 5, offset: 41407},
+							pos:        position{line: 1752, col: 5, offset: 41493},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -12160,16 +12178,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1752, col: 1, offset: 41432},
+			pos:  position{line: 1754, col: 1, offset: 41518},
 			expr: &choiceExpr{
-				pos: position{line: 1753, col: 5, offset: 41445},
+				pos: position{line: 1755, col: 5, offset: 41531},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1753, col: 5, offset: 41445},
+						pos:  position{line: 1755, col: 5, offset: 41531},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1754, col: 5, offset: 41459},
+						pos:        position{line: 1756, col: 5, offset: 41545},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -12182,31 +12200,31 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1756, col: 1, offset: 41466},
+			pos:  position{line: 1758, col: 1, offset: 41552},
 			expr: &actionExpr{
-				pos: position{line: 1756, col: 11, offset: 41476},
+				pos: position{line: 1758, col: 11, offset: 41562},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1756, col: 11, offset: 41476},
+					pos: position{line: 1758, col: 11, offset: 41562},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1756, col: 11, offset: 41476},
+							pos:        position{line: 1758, col: 11, offset: 41562},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1756, col: 16, offset: 41481},
+							pos:   position{line: 1758, col: 16, offset: 41567},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1756, col: 19, offset: 41484},
+								pos: position{line: 1758, col: 19, offset: 41570},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1756, col: 19, offset: 41484},
+										pos:  position{line: 1758, col: 19, offset: 41570},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1756, col: 32, offset: 41497},
+										pos:  position{line: 1758, col: 32, offset: 41583},
 										name: "EscapeSequence",
 									},
 								},
@@ -12220,32 +12238,32 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1758, col: 1, offset: 41532},
+			pos:  position{line: 1760, col: 1, offset: 41618},
 			expr: &choiceExpr{
-				pos: position{line: 1759, col: 5, offset: 41547},
+				pos: position{line: 1761, col: 5, offset: 41633},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1759, col: 5, offset: 41547},
+						pos: position{line: 1761, col: 5, offset: 41633},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1759, col: 5, offset: 41547},
+							pos:        position{line: 1761, col: 5, offset: 41633},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1760, col: 5, offset: 41575},
+						pos: position{line: 1762, col: 5, offset: 41661},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1760, col: 5, offset: 41575},
+							pos:        position{line: 1762, col: 5, offset: 41661},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1761, col: 5, offset: 41605},
+						pos:        position{line: 1763, col: 5, offset: 41691},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -12258,57 +12276,57 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1763, col: 1, offset: 41611},
+			pos:  position{line: 1765, col: 1, offset: 41697},
 			expr: &choiceExpr{
-				pos: position{line: 1764, col: 5, offset: 41632},
+				pos: position{line: 1766, col: 5, offset: 41718},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1764, col: 5, offset: 41632},
+						pos: position{line: 1766, col: 5, offset: 41718},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1764, col: 5, offset: 41632},
+							pos: position{line: 1766, col: 5, offset: 41718},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1764, col: 5, offset: 41632},
+									pos: position{line: 1766, col: 5, offset: 41718},
 									expr: &choiceExpr{
-										pos: position{line: 1764, col: 7, offset: 41634},
+										pos: position{line: 1766, col: 7, offset: 41720},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1764, col: 7, offset: 41634},
+												pos:        position{line: 1766, col: 7, offset: 41720},
 												val:        "'",
 												ignoreCase: false,
 												want:       "\"'\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1764, col: 13, offset: 41640},
+												pos:  position{line: 1766, col: 13, offset: 41726},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1764, col: 26, offset: 41653,
+									line: 1766, col: 26, offset: 41739,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1765, col: 5, offset: 41690},
+						pos: position{line: 1767, col: 5, offset: 41776},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1765, col: 5, offset: 41690},
+							pos: position{line: 1767, col: 5, offset: 41776},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1765, col: 5, offset: 41690},
+									pos:        position{line: 1767, col: 5, offset: 41776},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1765, col: 10, offset: 41695},
+									pos:   position{line: 1767, col: 10, offset: 41781},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1765, col: 12, offset: 41697},
+										pos:  position{line: 1767, col: 12, offset: 41783},
 										name: "EscapeSequence",
 									},
 								},
@@ -12322,16 +12340,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1767, col: 1, offset: 41731},
+			pos:  position{line: 1769, col: 1, offset: 41817},
 			expr: &choiceExpr{
-				pos: position{line: 1768, col: 5, offset: 41750},
+				pos: position{line: 1770, col: 5, offset: 41836},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1768, col: 5, offset: 41750},
+						pos:  position{line: 1770, col: 5, offset: 41836},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1769, col: 5, offset: 41771},
+						pos:  position{line: 1771, col: 5, offset: 41857},
 						name: "UnicodeEscape",
 					},
 				},
@@ -12341,87 +12359,87 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1771, col: 1, offset: 41786},
+			pos:  position{line: 1773, col: 1, offset: 41872},
 			expr: &choiceExpr{
-				pos: position{line: 1772, col: 5, offset: 41807},
+				pos: position{line: 1774, col: 5, offset: 41893},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1772, col: 5, offset: 41807},
+						pos:        position{line: 1774, col: 5, offset: 41893},
 						val:        "'",
 						ignoreCase: false,
 						want:       "\"'\"",
 					},
 					&actionExpr{
-						pos: position{line: 1773, col: 5, offset: 41815},
+						pos: position{line: 1775, col: 5, offset: 41901},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1773, col: 5, offset: 41815},
+							pos:        position{line: 1775, col: 5, offset: 41901},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1774, col: 5, offset: 41855},
+						pos:        position{line: 1776, col: 5, offset: 41941},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
 					},
 					&actionExpr{
-						pos: position{line: 1775, col: 5, offset: 41864},
+						pos: position{line: 1777, col: 5, offset: 41950},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1775, col: 5, offset: 41864},
+							pos:        position{line: 1777, col: 5, offset: 41950},
 							val:        "b",
 							ignoreCase: false,
 							want:       "\"b\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1776, col: 5, offset: 41893},
+						pos: position{line: 1778, col: 5, offset: 41979},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1776, col: 5, offset: 41893},
+							pos:        position{line: 1778, col: 5, offset: 41979},
 							val:        "f",
 							ignoreCase: false,
 							want:       "\"f\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1777, col: 5, offset: 41922},
+						pos: position{line: 1779, col: 5, offset: 42008},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1777, col: 5, offset: 41922},
+							pos:        position{line: 1779, col: 5, offset: 42008},
 							val:        "n",
 							ignoreCase: false,
 							want:       "\"n\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1778, col: 5, offset: 41951},
+						pos: position{line: 1780, col: 5, offset: 42037},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1778, col: 5, offset: 41951},
+							pos:        position{line: 1780, col: 5, offset: 42037},
 							val:        "r",
 							ignoreCase: false,
 							want:       "\"r\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1779, col: 5, offset: 41980},
+						pos: position{line: 1781, col: 5, offset: 42066},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1779, col: 5, offset: 41980},
+							pos:        position{line: 1781, col: 5, offset: 42066},
 							val:        "t",
 							ignoreCase: false,
 							want:       "\"t\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1780, col: 5, offset: 42009},
+						pos: position{line: 1782, col: 5, offset: 42095},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1780, col: 5, offset: 42009},
+							pos:        position{line: 1782, col: 5, offset: 42095},
 							val:        "v",
 							ignoreCase: false,
 							want:       "\"v\"",
@@ -12434,32 +12452,32 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1782, col: 1, offset: 42035},
+			pos:  position{line: 1784, col: 1, offset: 42121},
 			expr: &choiceExpr{
-				pos: position{line: 1783, col: 5, offset: 42053},
+				pos: position{line: 1785, col: 5, offset: 42139},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1783, col: 5, offset: 42053},
+						pos: position{line: 1785, col: 5, offset: 42139},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1783, col: 5, offset: 42053},
+							pos:        position{line: 1785, col: 5, offset: 42139},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1784, col: 5, offset: 42081},
+						pos: position{line: 1786, col: 5, offset: 42167},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1784, col: 5, offset: 42081},
+							pos:        position{line: 1786, col: 5, offset: 42167},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1785, col: 5, offset: 42109},
+						pos:        position{line: 1787, col: 5, offset: 42195},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -12472,42 +12490,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1787, col: 1, offset: 42115},
+			pos:  position{line: 1789, col: 1, offset: 42201},
 			expr: &choiceExpr{
-				pos: position{line: 1788, col: 5, offset: 42133},
+				pos: position{line: 1790, col: 5, offset: 42219},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1788, col: 5, offset: 42133},
+						pos: position{line: 1790, col: 5, offset: 42219},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1788, col: 5, offset: 42133},
+							pos: position{line: 1790, col: 5, offset: 42219},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1788, col: 5, offset: 42133},
+									pos:        position{line: 1790, col: 5, offset: 42219},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1788, col: 9, offset: 42137},
+									pos:   position{line: 1790, col: 9, offset: 42223},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1788, col: 16, offset: 42144},
+										pos: position{line: 1790, col: 16, offset: 42230},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1788, col: 16, offset: 42144},
+												pos:  position{line: 1790, col: 16, offset: 42230},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1788, col: 25, offset: 42153},
+												pos:  position{line: 1790, col: 25, offset: 42239},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1788, col: 34, offset: 42162},
+												pos:  position{line: 1790, col: 34, offset: 42248},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1788, col: 43, offset: 42171},
+												pos:  position{line: 1790, col: 43, offset: 42257},
 												name: "HexDigit",
 											},
 										},
@@ -12517,65 +12535,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1791, col: 5, offset: 42234},
+						pos: position{line: 1793, col: 5, offset: 42320},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1791, col: 5, offset: 42234},
+							pos: position{line: 1793, col: 5, offset: 42320},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1791, col: 5, offset: 42234},
+									pos:        position{line: 1793, col: 5, offset: 42320},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1791, col: 9, offset: 42238},
+									pos:        position{line: 1793, col: 9, offset: 42324},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1791, col: 13, offset: 42242},
+									pos:   position{line: 1793, col: 13, offset: 42328},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1791, col: 20, offset: 42249},
+										pos: position{line: 1793, col: 20, offset: 42335},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1791, col: 20, offset: 42249},
+												pos:  position{line: 1793, col: 20, offset: 42335},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1791, col: 29, offset: 42258},
+												pos: position{line: 1793, col: 29, offset: 42344},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1791, col: 29, offset: 42258},
+													pos:  position{line: 1793, col: 29, offset: 42344},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1791, col: 39, offset: 42268},
+												pos: position{line: 1793, col: 39, offset: 42354},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1791, col: 39, offset: 42268},
+													pos:  position{line: 1793, col: 39, offset: 42354},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1791, col: 49, offset: 42278},
+												pos: position{line: 1793, col: 49, offset: 42364},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1791, col: 49, offset: 42278},
+													pos:  position{line: 1793, col: 49, offset: 42364},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1791, col: 59, offset: 42288},
+												pos: position{line: 1793, col: 59, offset: 42374},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1791, col: 59, offset: 42288},
+													pos:  position{line: 1793, col: 59, offset: 42374},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1791, col: 69, offset: 42298},
+												pos: position{line: 1793, col: 69, offset: 42384},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1791, col: 69, offset: 42298},
+													pos:  position{line: 1793, col: 69, offset: 42384},
 													name: "HexDigit",
 												},
 											},
@@ -12583,7 +12601,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1791, col: 80, offset: 42309},
+									pos:        position{line: 1793, col: 80, offset: 42395},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -12598,9 +12616,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1796, col: 1, offset: 42364},
+			pos:  position{line: 1798, col: 1, offset: 42450},
 			expr: &charClassMatcher{
-				pos:        position{line: 1797, col: 5, offset: 42380},
+				pos:        position{line: 1799, col: 5, offset: 42466},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -12612,11 +12630,11 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1799, col: 1, offset: 42395},
+			pos:  position{line: 1801, col: 1, offset: 42481},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1799, col: 5, offset: 42399},
+				pos: position{line: 1801, col: 5, offset: 42485},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1799, col: 5, offset: 42399},
+					pos:  position{line: 1801, col: 5, offset: 42485},
 					name: "AnySpace",
 				},
 			},
@@ -12625,11 +12643,11 @@ var g = &grammar{
 		},
 		{
 			name: "__",
-			pos:  position{line: 1801, col: 1, offset: 42410},
+			pos:  position{line: 1803, col: 1, offset: 42496},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1801, col: 6, offset: 42415},
+				pos: position{line: 1803, col: 6, offset: 42501},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1801, col: 6, offset: 42415},
+					pos:  position{line: 1803, col: 6, offset: 42501},
 					name: "AnySpace",
 				},
 			},
@@ -12638,20 +12656,20 @@ var g = &grammar{
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1803, col: 1, offset: 42426},
+			pos:  position{line: 1805, col: 1, offset: 42512},
 			expr: &choiceExpr{
-				pos: position{line: 1804, col: 5, offset: 42439},
+				pos: position{line: 1806, col: 5, offset: 42525},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1804, col: 5, offset: 42439},
+						pos:  position{line: 1806, col: 5, offset: 42525},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1805, col: 5, offset: 42454},
+						pos:  position{line: 1807, col: 5, offset: 42540},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1806, col: 5, offset: 42473},
+						pos:  position{line: 1808, col: 5, offset: 42559},
 						name: "Comment",
 					},
 				},
@@ -12661,32 +12679,32 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeLetter",
-			pos:  position{line: 1808, col: 1, offset: 42482},
+			pos:  position{line: 1810, col: 1, offset: 42568},
 			expr: &choiceExpr{
-				pos: position{line: 1809, col: 5, offset: 42500},
+				pos: position{line: 1811, col: 5, offset: 42586},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1809, col: 5, offset: 42500},
+						pos:  position{line: 1811, col: 5, offset: 42586},
 						name: "Lu",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1810, col: 5, offset: 42507},
+						pos:  position{line: 1812, col: 5, offset: 42593},
 						name: "Ll",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1811, col: 5, offset: 42514},
+						pos:  position{line: 1813, col: 5, offset: 42600},
 						name: "Lt",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1812, col: 5, offset: 42521},
+						pos:  position{line: 1814, col: 5, offset: 42607},
 						name: "Lm",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1813, col: 5, offset: 42528},
+						pos:  position{line: 1815, col: 5, offset: 42614},
 						name: "Lo",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1814, col: 5, offset: 42535},
+						pos:  position{line: 1816, col: 5, offset: 42621},
 						name: "Nl",
 					},
 				},
@@ -12696,16 +12714,16 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeCombiningMark",
-			pos:  position{line: 1816, col: 1, offset: 42539},
+			pos:  position{line: 1818, col: 1, offset: 42625},
 			expr: &choiceExpr{
-				pos: position{line: 1817, col: 5, offset: 42564},
+				pos: position{line: 1819, col: 5, offset: 42650},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1817, col: 5, offset: 42564},
+						pos:  position{line: 1819, col: 5, offset: 42650},
 						name: "Mn",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1818, col: 5, offset: 42571},
+						pos:  position{line: 1820, col: 5, offset: 42657},
 						name: "Mc",
 					},
 				},
@@ -12715,9 +12733,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeDigit",
-			pos:  position{line: 1820, col: 1, offset: 42575},
+			pos:  position{line: 1822, col: 1, offset: 42661},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1821, col: 5, offset: 42592},
+				pos:  position{line: 1823, col: 5, offset: 42678},
 				name: "Nd",
 			},
 			leader:        false,
@@ -12725,9 +12743,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeConnectorPunctuation",
-			pos:  position{line: 1823, col: 1, offset: 42596},
+			pos:  position{line: 1825, col: 1, offset: 42682},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1824, col: 5, offset: 42628},
+				pos:  position{line: 1826, col: 5, offset: 42714},
 				name: "Pc",
 			},
 			leader:        false,
@@ -12735,9 +12753,9 @@ var g = &grammar{
 		},
 		{
 			name: "Ll",
-			pos:  position{line: 1830, col: 1, offset: 42809},
+			pos:  position{line: 1832, col: 1, offset: 42895},
 			expr: &charClassMatcher{
-				pos:        position{line: 1830, col: 6, offset: 42814},
+				pos:        position{line: 1832, col: 6, offset: 42900},
 				val:        "[\\u0061-\\u007A\\u00B5\\u00DF-\\u00F6\\u00F8-\\u00FF\\u0101\\u0103\\u0105\\u0107\\u0109\\u010B\\u010D\\u010F\\u0111\\u0113\\u0115\\u0117\\u0119\\u011B\\u011D\\u011F\\u0121\\u0123\\u0125\\u0127\\u0129\\u012B\\u012D\\u012F\\u0131\\u0133\\u0135\\u0137-\\u0138\\u013A\\u013C\\u013E\\u0140\\u0142\\u0144\\u0146\\u0148-\\u0149\\u014B\\u014D\\u014F\\u0151\\u0153\\u0155\\u0157\\u0159\\u015B\\u015D\\u015F\\u0161\\u0163\\u0165\\u0167\\u0169\\u016B\\u016D\\u016F\\u0171\\u0173\\u0175\\u0177\\u017A\\u017C\\u017E-\\u0180\\u0183\\u0185\\u0188\\u018C-\\u018D\\u0192\\u0195\\u0199-\\u019B\\u019E\\u01A1\\u01A3\\u01A5\\u01A8\\u01AA-\\u01AB\\u01AD\\u01B0\\u01B4\\u01B6\\u01B9-\\u01BA\\u01BD-\\u01BF\\u01C6\\u01C9\\u01CC\\u01CE\\u01D0\\u01D2\\u01D4\\u01D6\\u01D8\\u01DA\\u01DC-\\u01DD\\u01DF\\u01E1\\u01E3\\u01E5\\u01E7\\u01E9\\u01EB\\u01ED\\u01EF-\\u01F0\\u01F3\\u01F5\\u01F9\\u01FB\\u01FD\\u01FF\\u0201\\u0203\\u0205\\u0207\\u0209\\u020B\\u020D\\u020F\\u0211\\u0213\\u0215\\u0217\\u0219\\u021B\\u021D\\u021F\\u0221\\u0223\\u0225\\u0227\\u0229\\u022B\\u022D\\u022F\\u0231\\u0233-\\u0239\\u023C\\u023F-\\u0240\\u0242\\u0247\\u0249\\u024B\\u024D\\u024F-\\u0293\\u0295-\\u02AF\\u0371\\u0373\\u0377\\u037B-\\u037D\\u0390\\u03AC-\\u03CE\\u03D0-\\u03D1\\u03D5-\\u03D7\\u03D9\\u03DB\\u03DD\\u03DF\\u03E1\\u03E3\\u03E5\\u03E7\\u03E9\\u03EB\\u03ED\\u03EF-\\u03F3\\u03F5\\u03F8\\u03FB-\\u03FC\\u0430-\\u045F\\u0461\\u0463\\u0465\\u0467\\u0469\\u046B\\u046D\\u046F\\u0471\\u0473\\u0475\\u0477\\u0479\\u047B\\u047D\\u047F\\u0481\\u048B\\u048D\\u048F\\u0491\\u0493\\u0495\\u0497\\u0499\\u049B\\u049D\\u049F\\u04A1\\u04A3\\u04A5\\u04A7\\u04A9\\u04AB\\u04AD\\u04AF\\u04B1\\u04B3\\u04B5\\u04B7\\u04B9\\u04BB\\u04BD\\u04BF\\u04C2\\u04C4\\u04C6\\u04C8\\u04CA\\u04CC\\u04CE-\\u04CF\\u04D1\\u04D3\\u04D5\\u04D7\\u04D9\\u04DB\\u04DD\\u04DF\\u04E1\\u04E3\\u04E5\\u04E7\\u04E9\\u04EB\\u04ED\\u04EF\\u04F1\\u04F3\\u04F5\\u04F7\\u04F9\\u04FB\\u04FD\\u04FF\\u0501\\u0503\\u0505\\u0507\\u0509\\u050B\\u050D\\u050F\\u0511\\u0513\\u0515\\u0517\\u0519\\u051B\\u051D\\u051F\\u0521\\u0523\\u0525\\u0527\\u0529\\u052B\\u052D\\u052F\\u0560-\\u0588\\u10D0-\\u10FA\\u10FD-\\u10FF\\u13F8-\\u13FD\\u1C80-\\u1C88\\u1D00-\\u1D2B\\u1D6B-\\u1D77\\u1D79-\\u1D9A\\u1E01\\u1E03\\u1E05\\u1E07\\u1E09\\u1E0B\\u1E0D\\u1E0F\\u1E11\\u1E13\\u1E15\\u1E17\\u1E19\\u1E1B\\u1E1D\\u1E1F\\u1E21\\u1E23\\u1E25\\u1E27\\u1E29\\u1E2B\\u1E2D\\u1E2F\\u1E31\\u1E33\\u1E35\\u1E37\\u1E39\\u1E3B\\u1E3D\\u1E3F\\u1E41\\u1E43\\u1E45\\u1E47\\u1E49\\u1E4B\\u1E4D\\u1E4F\\u1E51\\u1E53\\u1E55\\u1E57\\u1E59\\u1E5B\\u1E5D\\u1E5F\\u1E61\\u1E63\\u1E65\\u1E67\\u1E69\\u1E6B\\u1E6D\\u1E6F\\u1E71\\u1E73\\u1E75\\u1E77\\u1E79\\u1E7B\\u1E7D\\u1E7F\\u1E81\\u1E83\\u1E85\\u1E87\\u1E89\\u1E8B\\u1E8D\\u1E8F\\u1E91\\u1E93\\u1E95-\\u1E9D\\u1E9F\\u1EA1\\u1EA3\\u1EA5\\u1EA7\\u1EA9\\u1EAB\\u1EAD\\u1EAF\\u1EB1\\u1EB3\\u1EB5\\u1EB7\\u1EB9\\u1EBB\\u1EBD\\u1EBF\\u1EC1\\u1EC3\\u1EC5\\u1EC7\\u1EC9\\u1ECB\\u1ECD\\u1ECF\\u1ED1\\u1ED3\\u1ED5\\u1ED7\\u1ED9\\u1EDB\\u1EDD\\u1EDF\\u1EE1\\u1EE3\\u1EE5\\u1EE7\\u1EE9\\u1EEB\\u1EED\\u1EEF\\u1EF1\\u1EF3\\u1EF5\\u1EF7\\u1EF9\\u1EFB\\u1EFD\\u1EFF-\\u1F07\\u1F10-\\u1F15\\u1F20-\\u1F27\\u1F30-\\u1F37\\u1F40-\\u1F45\\u1F50-\\u1F57\\u1F60-\\u1F67\\u1F70-\\u1F7D\\u1F80-\\u1F87\\u1F90-\\u1F97\\u1FA0-\\u1FA7\\u1FB0-\\u1FB4\\u1FB6-\\u1FB7\\u1FBE\\u1FC2-\\u1FC4\\u1FC6-\\u1FC7\\u1FD0-\\u1FD3\\u1FD6-\\u1FD7\\u1FE0-\\u1FE7\\u1FF2-\\u1FF4\\u1FF6-\\u1FF7\\u210A\\u210E-\\u210F\\u2113\\u212F\\u2134\\u2139\\u213C-\\u213D\\u2146-\\u2149\\u214E\\u2184\\u2C30-\\u2C5E\\u2C61\\u2C65-\\u2C66\\u2C68\\u2C6A\\u2C6C\\u2C71\\u2C73-\\u2C74\\u2C76-\\u2C7B\\u2C81\\u2C83\\u2C85\\u2C87\\u2C89\\u2C8B\\u2C8D\\u2C8F\\u2C91\\u2C93\\u2C95\\u2C97\\u2C99\\u2C9B\\u2C9D\\u2C9F\\u2CA1\\u2CA3\\u2CA5\\u2CA7\\u2CA9\\u2CAB\\u2CAD\\u2CAF\\u2CB1\\u2CB3\\u2CB5\\u2CB7\\u2CB9\\u2CBB\\u2CBD\\u2CBF\\u2CC1\\u2CC3\\u2CC5\\u2CC7\\u2CC9\\u2CCB\\u2CCD\\u2CCF\\u2CD1\\u2CD3\\u2CD5\\u2CD7\\u2CD9\\u2CDB\\u2CDD\\u2CDF\\u2CE1\\u2CE3-\\u2CE4\\u2CEC\\u2CEE\\u2CF3\\u2D00-\\u2D25\\u2D27\\u2D2D\\uA641\\uA643\\uA645\\uA647\\uA649\\uA64B\\uA64D\\uA64F\\uA651\\uA653\\uA655\\uA657\\uA659\\uA65B\\uA65D\\uA65F\\uA661\\uA663\\uA665\\uA667\\uA669\\uA66B\\uA66D\\uA681\\uA683\\uA685\\uA687\\uA689\\uA68B\\uA68D\\uA68F\\uA691\\uA693\\uA695\\uA697\\uA699\\uA69B\\uA723\\uA725\\uA727\\uA729\\uA72B\\uA72D\\uA72F-\\uA731\\uA733\\uA735\\uA737\\uA739\\uA73B\\uA73D\\uA73F\\uA741\\uA743\\uA745\\uA747\\uA749\\uA74B\\uA74D\\uA74F\\uA751\\uA753\\uA755\\uA757\\uA759\\uA75B\\uA75D\\uA75F\\uA761\\uA763\\uA765\\uA767\\uA769\\uA76B\\uA76D\\uA76F\\uA771-\\uA778\\uA77A\\uA77C\\uA77F\\uA781\\uA783\\uA785\\uA787\\uA78C\\uA78E\\uA791\\uA793-\\uA795\\uA797\\uA799\\uA79B\\uA79D\\uA79F\\uA7A1\\uA7A3\\uA7A5\\uA7A7\\uA7A9\\uA7AF\\uA7B5\\uA7B7\\uA7B9\\uA7FA\\uAB30-\\uAB5A\\uAB60-\\uAB65\\uAB70-\\uABBF\\uFB00-\\uFB06\\uFB13-\\uFB17\\uFF41-\\uFF5A]",
 				chars:      []rune{'µ', 'ā', 'ă', 'ą', 'ć', 'ĉ', 'ċ', 'č', 'ď', 'đ', 'ē', 'ĕ', 'ė', 'ę', 'ě', 'ĝ', 'ğ', 'ġ', 'ģ', 'ĥ', 'ħ', 'ĩ', 'ī', 'ĭ', 'į', 'ı', 'ĳ', 'ĵ', 'ĺ', 'ļ', 'ľ', 'ŀ', 'ł', 'ń', 'ņ', 'ŋ', 'ō', 'ŏ', 'ő', 'œ', 'ŕ', 'ŗ', 'ř', 'ś', 'ŝ', 'ş', 'š', 'ţ', 'ť', 'ŧ', 'ũ', 'ū', 'ŭ', 'ů', 'ű', 'ų', 'ŵ', 'ŷ', 'ź', 'ż', 'ƃ', 'ƅ', 'ƈ', 'ƒ', 'ƕ', 'ƞ', 'ơ', 'ƣ', 'ƥ', 'ƨ', 'ƭ', 'ư', 'ƴ', 'ƶ', 'ǆ', 'ǉ', 'ǌ', 'ǎ', 'ǐ', 'ǒ', 'ǔ', 'ǖ', 'ǘ', 'ǚ', 'ǟ', 'ǡ', 'ǣ', 'ǥ', 'ǧ', 'ǩ', 'ǫ', 'ǭ', 'ǳ', 'ǵ', 'ǹ', 'ǻ', 'ǽ', 'ǿ', 'ȁ', 'ȃ', 'ȅ', 'ȇ', 'ȉ', 'ȋ', 'ȍ', 'ȏ', 'ȑ', 'ȓ', 'ȕ', 'ȗ', 'ș', 'ț', 'ȝ', 'ȟ', 'ȡ', 'ȣ', 'ȥ', 'ȧ', 'ȩ', 'ȫ', 'ȭ', 'ȯ', 'ȱ', 'ȼ', 'ɂ', 'ɇ', 'ɉ', 'ɋ', 'ɍ', 'ͱ', 'ͳ', 'ͷ', 'ΐ', 'ϙ', 'ϛ', 'ϝ', 'ϟ', 'ϡ', 'ϣ', 'ϥ', 'ϧ', 'ϩ', 'ϫ', 'ϭ', 'ϵ', 'ϸ', 'ѡ', 'ѣ', 'ѥ', 'ѧ', 'ѩ', 'ѫ', 'ѭ', 'ѯ', 'ѱ', 'ѳ', 'ѵ', 'ѷ', 'ѹ', 'ѻ', 'ѽ', 'ѿ', 'ҁ', 'ҋ', 'ҍ', 'ҏ', 'ґ', 'ғ', 'ҕ', 'җ', 'ҙ', 'қ', 'ҝ', 'ҟ', 'ҡ', 'ң', 'ҥ', 'ҧ', 'ҩ', 'ҫ', 'ҭ', 'ү', 'ұ', 'ҳ', 'ҵ', 'ҷ', 'ҹ', 'һ', 'ҽ', 'ҿ', 'ӂ', 'ӄ', 'ӆ', 'ӈ', 'ӊ', 'ӌ', 'ӑ', 'ӓ', 'ӕ', 'ӗ', 'ә', 'ӛ', 'ӝ', 'ӟ', 'ӡ', 'ӣ', 'ӥ', 'ӧ', 'ө', 'ӫ', 'ӭ', 'ӯ', 'ӱ', 'ӳ', 'ӵ', 'ӷ', 'ӹ', 'ӻ', 'ӽ', 'ӿ', 'ԁ', 'ԃ', 'ԅ', 'ԇ', 'ԉ', 'ԋ', 'ԍ', 'ԏ', 'ԑ', 'ԓ', 'ԕ', 'ԗ', 'ԙ', 'ԛ', 'ԝ', 'ԟ', 'ԡ', 'ԣ', 'ԥ', 'ԧ', 'ԩ', 'ԫ', 'ԭ', 'ԯ', 'ḁ', 'ḃ', 'ḅ', 'ḇ', 'ḉ', 'ḋ', 'ḍ', 'ḏ', 'ḑ', 'ḓ', 'ḕ', 'ḗ', 'ḙ', 'ḛ', 'ḝ', 'ḟ', 'ḡ', 'ḣ', 'ḥ', 'ḧ', 'ḩ', 'ḫ', 'ḭ', 'ḯ', 'ḱ', 'ḳ', 'ḵ', 'ḷ', 'ḹ', 'ḻ', 'ḽ', 'ḿ', 'ṁ', 'ṃ', 'ṅ', 'ṇ', 'ṉ', 'ṋ', 'ṍ', 'ṏ', 'ṑ', 'ṓ', 'ṕ', 'ṗ', 'ṙ', 'ṛ', 'ṝ', 'ṟ', 'ṡ', 'ṣ', 'ṥ', 'ṧ', 'ṩ', 'ṫ', 'ṭ', 'ṯ', 'ṱ', 'ṳ', 'ṵ', 'ṷ', 'ṹ', 'ṻ', 'ṽ', 'ṿ', 'ẁ', 'ẃ', 'ẅ', 'ẇ', 'ẉ', 'ẋ', 'ẍ', 'ẏ', 'ẑ', 'ẓ', 'ẟ', 'ạ', 'ả', 'ấ', 'ầ', 'ẩ', 'ẫ', 'ậ', 'ắ', 'ằ', 'ẳ', 'ẵ', 'ặ', 'ẹ', 'ẻ', 'ẽ', 'ế', 'ề', 'ể', 'ễ', 'ệ', 'ỉ', 'ị', 'ọ', 'ỏ', 'ố', 'ồ', 'ổ', 'ỗ', 'ộ', 'ớ', 'ờ', 'ở', 'ỡ', 'ợ', 'ụ', 'ủ', 'ứ', 'ừ', 'ử', 'ữ', 'ự', 'ỳ', 'ỵ', 'ỷ', 'ỹ', 'ỻ', 'ỽ', 'ι', 'ℊ', 'ℓ', 'ℯ', 'ℴ', 'ℹ', 'ⅎ', 'ↄ', 'ⱡ', 'ⱨ', 'ⱪ', 'ⱬ', 'ⱱ', 'ⲁ', 'ⲃ', 'ⲅ', 'ⲇ', 'ⲉ', 'ⲋ', 'ⲍ', 'ⲏ', 'ⲑ', 'ⲓ', 'ⲕ', 'ⲗ', 'ⲙ', 'ⲛ', 'ⲝ', 'ⲟ', 'ⲡ', 'ⲣ', 'ⲥ', 'ⲧ', 'ⲩ', 'ⲫ', 'ⲭ', 'ⲯ', 'ⲱ', 'ⲳ', 'ⲵ', 'ⲷ', 'ⲹ', 'ⲻ', 'ⲽ', 'ⲿ', 'ⳁ', 'ⳃ', 'ⳅ', 'ⳇ', 'ⳉ', 'ⳋ', 'ⳍ', 'ⳏ', 'ⳑ', 'ⳓ', 'ⳕ', 'ⳗ', 'ⳙ', 'ⳛ', 'ⳝ', 'ⳟ', 'ⳡ', 'ⳬ', 'ⳮ', 'ⳳ', 'ⴧ', 'ⴭ', 'ꙁ', 'ꙃ', 'ꙅ', 'ꙇ', 'ꙉ', 'ꙋ', 'ꙍ', 'ꙏ', 'ꙑ', 'ꙓ', 'ꙕ', 'ꙗ', 'ꙙ', 'ꙛ', 'ꙝ', 'ꙟ', 'ꙡ', 'ꙣ', 'ꙥ', 'ꙧ', 'ꙩ', 'ꙫ', 'ꙭ', 'ꚁ', 'ꚃ', 'ꚅ', 'ꚇ', 'ꚉ', 'ꚋ', 'ꚍ', 'ꚏ', 'ꚑ', 'ꚓ', 'ꚕ', 'ꚗ', 'ꚙ', 'ꚛ', 'ꜣ', 'ꜥ', 'ꜧ', 'ꜩ', 'ꜫ', 'ꜭ', 'ꜳ', 'ꜵ', 'ꜷ', 'ꜹ', 'ꜻ', 'ꜽ', 'ꜿ', 'ꝁ', 'ꝃ', 'ꝅ', 'ꝇ', 'ꝉ', 'ꝋ', 'ꝍ', 'ꝏ', 'ꝑ', 'ꝓ', 'ꝕ', 'ꝗ', 'ꝙ', 'ꝛ', 'ꝝ', 'ꝟ', 'ꝡ', 'ꝣ', 'ꝥ', 'ꝧ', 'ꝩ', 'ꝫ', 'ꝭ', 'ꝯ', 'ꝺ', 'ꝼ', 'ꝿ', 'ꞁ', 'ꞃ', 'ꞅ', 'ꞇ', 'ꞌ', 'ꞎ', 'ꞑ', 'ꞗ', 'ꞙ', 'ꞛ', 'ꞝ', 'ꞟ', 'ꞡ', 'ꞣ', 'ꞥ', 'ꞧ', 'ꞩ', 'ꞯ', 'ꞵ', 'ꞷ', 'ꞹ', 'ꟺ'},
 				ranges:     []rune{'a', 'z', 'ß', 'ö', 'ø', 'ÿ', 'ķ', 'ĸ', 'ň', 'ŉ', 'ž', 'ƀ', 'ƌ', 'ƍ', 'ƙ', 'ƛ', 'ƪ', 'ƫ', 'ƹ', 'ƺ', 'ƽ', 'ƿ', 'ǜ', 'ǝ', 'ǯ', 'ǰ', 'ȳ', 'ȹ', 'ȿ', 'ɀ', 'ɏ', 'ʓ', 'ʕ', 'ʯ', 'ͻ', 'ͽ', 'ά', 'ώ', 'ϐ', 'ϑ', 'ϕ', 'ϗ', 'ϯ', 'ϳ', 'ϻ', 'ϼ', 'а', 'џ', 'ӎ', 'ӏ', 'ՠ', 'ֈ', 'ა', 'ჺ', 'ჽ', 'ჿ', 'ᏸ', 'ᏽ', 'ᲀ', 'ᲈ', 'ᴀ', 'ᴫ', 'ᵫ', 'ᵷ', 'ᵹ', 'ᶚ', 'ẕ', 'ẝ', 'ỿ', 'ἇ', 'ἐ', 'ἕ', 'ἠ', 'ἧ', 'ἰ', 'ἷ', 'ὀ', 'ὅ', 'ὐ', 'ὗ', 'ὠ', 'ὧ', 'ὰ', 'ώ', 'ᾀ', 'ᾇ', 'ᾐ', 'ᾗ', 'ᾠ', 'ᾧ', 'ᾰ', 'ᾴ', 'ᾶ', 'ᾷ', 'ῂ', 'ῄ', 'ῆ', 'ῇ', 'ῐ', 'ΐ', 'ῖ', 'ῗ', 'ῠ', 'ῧ', 'ῲ', 'ῴ', 'ῶ', 'ῷ', 'ℎ', 'ℏ', 'ℼ', 'ℽ', 'ⅆ', 'ⅉ', 'ⰰ', 'ⱞ', 'ⱥ', 'ⱦ', 'ⱳ', 'ⱴ', 'ⱶ', 'ⱻ', 'ⳣ', 'ⳤ', 'ⴀ', 'ⴥ', 'ꜯ', 'ꜱ', 'ꝱ', 'ꝸ', 'ꞓ', 'ꞕ', 'ꬰ', 'ꭚ', 'ꭠ', 'ꭥ', 'ꭰ', 'ꮿ', 'ﬀ', 'ﬆ', 'ﬓ', 'ﬗ', 'ａ', 'ｚ'},
@@ -12749,9 +12767,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lm",
-			pos:  position{line: 1833, col: 1, offset: 46966},
+			pos:  position{line: 1835, col: 1, offset: 47052},
 			expr: &charClassMatcher{
-				pos:        position{line: 1833, col: 6, offset: 46971},
+				pos:        position{line: 1835, col: 6, offset: 47057},
 				val:        "[\\u02B0-\\u02C1\\u02C6-\\u02D1\\u02E0-\\u02E4\\u02EC\\u02EE\\u0374\\u037A\\u0559\\u0640\\u06E5-\\u06E6\\u07F4-\\u07F5\\u07FA\\u081A\\u0824\\u0828\\u0971\\u0E46\\u0EC6\\u10FC\\u17D7\\u1843\\u1AA7\\u1C78-\\u1C7D\\u1D2C-\\u1D6A\\u1D78\\u1D9B-\\u1DBF\\u2071\\u207F\\u2090-\\u209C\\u2C7C-\\u2C7D\\u2D6F\\u2E2F\\u3005\\u3031-\\u3035\\u303B\\u309D-\\u309E\\u30FC-\\u30FE\\uA015\\uA4F8-\\uA4FD\\uA60C\\uA67F\\uA69C-\\uA69D\\uA717-\\uA71F\\uA770\\uA788\\uA7F8-\\uA7F9\\uA9CF\\uA9E6\\uAA70\\uAADD\\uAAF3-\\uAAF4\\uAB5C-\\uAB5F\\uFF70\\uFF9E-\\uFF9F]",
 				chars:      []rune{'ˬ', 'ˮ', 'ʹ', 'ͺ', 'ՙ', 'ـ', 'ߺ', 'ࠚ', 'ࠤ', 'ࠨ', 'ॱ', 'ๆ', 'ໆ', 'ჼ', 'ៗ', 'ᡃ', 'ᪧ', 'ᵸ', 'ⁱ', 'ⁿ', 'ⵯ', 'ⸯ', '々', '〻', 'ꀕ', 'ꘌ', 'ꙿ', 'ꝰ', 'ꞈ', 'ꧏ', 'ꧦ', 'ꩰ', 'ꫝ', 'ｰ'},
 				ranges:     []rune{'ʰ', 'ˁ', 'ˆ', 'ˑ', 'ˠ', 'ˤ', 'ۥ', 'ۦ', 'ߴ', 'ߵ', 'ᱸ', 'ᱽ', 'ᴬ', 'ᵪ', 'ᶛ', 'ᶿ', 'ₐ', 'ₜ', 'ⱼ', 'ⱽ', '〱', '〵', 'ゝ', 'ゞ', 'ー', 'ヾ', 'ꓸ', 'ꓽ', 'ꚜ', 'ꚝ', 'ꜗ', 'ꜟ', 'ꟸ', 'ꟹ', 'ꫳ', 'ꫴ', 'ꭜ', 'ꭟ', 'ﾞ', 'ﾟ'},
@@ -12763,9 +12781,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lo",
-			pos:  position{line: 1836, col: 1, offset: 47456},
+			pos:  position{line: 1838, col: 1, offset: 47542},
 			expr: &charClassMatcher{
-				pos:        position{line: 1836, col: 6, offset: 47461},
+				pos:        position{line: 1838, col: 6, offset: 47547},
 				val:        "[\\u00AA\\u00BA\\u01BB\\u01C0-\\u01C3\\u0294\\u05D0-\\u05EA\\u05EF-\\u05F2\\u0620-\\u063F\\u0641-\\u064A\\u066E-\\u066F\\u0671-\\u06D3\\u06D5\\u06EE-\\u06EF\\u06FA-\\u06FC\\u06FF\\u0710\\u0712-\\u072F\\u074D-\\u07A5\\u07B1\\u07CA-\\u07EA\\u0800-\\u0815\\u0840-\\u0858\\u0860-\\u086A\\u08A0-\\u08B4\\u08B6-\\u08BD\\u0904-\\u0939\\u093D\\u0950\\u0958-\\u0961\\u0972-\\u0980\\u0985-\\u098C\\u098F-\\u0990\\u0993-\\u09A8\\u09AA-\\u09B0\\u09B2\\u09B6-\\u09B9\\u09BD\\u09CE\\u09DC-\\u09DD\\u09DF-\\u09E1\\u09F0-\\u09F1\\u09FC\\u0A05-\\u0A0A\\u0A0F-\\u0A10\\u0A13-\\u0A28\\u0A2A-\\u0A30\\u0A32-\\u0A33\\u0A35-\\u0A36\\u0A38-\\u0A39\\u0A59-\\u0A5C\\u0A5E\\u0A72-\\u0A74\\u0A85-\\u0A8D\\u0A8F-\\u0A91\\u0A93-\\u0AA8\\u0AAA-\\u0AB0\\u0AB2-\\u0AB3\\u0AB5-\\u0AB9\\u0ABD\\u0AD0\\u0AE0-\\u0AE1\\u0AF9\\u0B05-\\u0B0C\\u0B0F-\\u0B10\\u0B13-\\u0B28\\u0B2A-\\u0B30\\u0B32-\\u0B33\\u0B35-\\u0B39\\u0B3D\\u0B5C-\\u0B5D\\u0B5F-\\u0B61\\u0B71\\u0B83\\u0B85-\\u0B8A\\u0B8E-\\u0B90\\u0B92-\\u0B95\\u0B99-\\u0B9A\\u0B9C\\u0B9E-\\u0B9F\\u0BA3-\\u0BA4\\u0BA8-\\u0BAA\\u0BAE-\\u0BB9\\u0BD0\\u0C05-\\u0C0C\\u0C0E-\\u0C10\\u0C12-\\u0C28\\u0C2A-\\u0C39\\u0C3D\\u0C58-\\u0C5A\\u0C60-\\u0C61\\u0C80\\u0C85-\\u0C8C\\u0C8E-\\u0C90\\u0C92-\\u0CA8\\u0CAA-\\u0CB3\\u0CB5-\\u0CB9\\u0CBD\\u0CDE\\u0CE0-\\u0CE1\\u0CF1-\\u0CF2\\u0D05-\\u0D0C\\u0D0E-\\u0D10\\u0D12-\\u0D3A\\u0D3D\\u0D4E\\u0D54-\\u0D56\\u0D5F-\\u0D61\\u0D7A-\\u0D7F\\u0D85-\\u0D96\\u0D9A-\\u0DB1\\u0DB3-\\u0DBB\\u0DBD\\u0DC0-\\u0DC6\\u0E01-\\u0E30\\u0E32-\\u0E33\\u0E40-\\u0E45\\u0E81-\\u0E82\\u0E84\\u0E87-\\u0E88\\u0E8A\\u0E8D\\u0E94-\\u0E97\\u0E99-\\u0E9F\\u0EA1-\\u0EA3\\u0EA5\\u0EA7\\u0EAA-\\u0EAB\\u0EAD-\\u0EB0\\u0EB2-\\u0EB3\\u0EBD\\u0EC0-\\u0EC4\\u0EDC-\\u0EDF\\u0F00\\u0F40-\\u0F47\\u0F49-\\u0F6C\\u0F88-\\u0F8C\\u1000-\\u102A\\u103F\\u1050-\\u1055\\u105A-\\u105D\\u1061\\u1065-\\u1066\\u106E-\\u1070\\u1075-\\u1081\\u108E\\u1100-\\u1248\\u124A-\\u124D\\u1250-\\u1256\\u1258\\u125A-\\u125D\\u1260-\\u1288\\u128A-\\u128D\\u1290-\\u12B0\\u12B2-\\u12B5\\u12B8-\\u12BE\\u12C0\\u12C2-\\u12C5\\u12C8-\\u12D6\\u12D8-\\u1310\\u1312-\\u1315\\u1318-\\u135A\\u1380-\\u138F\\u1401-\\u166C\\u166F-\\u167F\\u1681-\\u169A\\u16A0-\\u16EA\\u16F1-\\u16F8\\u1700-\\u170C\\u170E-\\u1711\\u1720-\\u1731\\u1740-\\u1751\\u1760-\\u176C\\u176E-\\u1770\\u1780-\\u17B3\\u17DC\\u1820-\\u1842\\u1844-\\u1878\\u1880-\\u1884\\u1887-\\u18A8\\u18AA\\u18B0-\\u18F5\\u1900-\\u191E\\u1950-\\u196D\\u1970-\\u1974\\u1980-\\u19AB\\u19B0-\\u19C9\\u1A00-\\u1A16\\u1A20-\\u1A54\\u1B05-\\u1B33\\u1B45-\\u1B4B\\u1B83-\\u1BA0\\u1BAE-\\u1BAF\\u1BBA-\\u1BE5\\u1C00-\\u1C23\\u1C4D-\\u1C4F\\u1C5A-\\u1C77\\u1CE9-\\u1CEC\\u1CEE-\\u1CF1\\u1CF5-\\u1CF6\\u2135-\\u2138\\u2D30-\\u2D67\\u2D80-\\u2D96\\u2DA0-\\u2DA6\\u2DA8-\\u2DAE\\u2DB0-\\u2DB6\\u2DB8-\\u2DBE\\u2DC0-\\u2DC6\\u2DC8-\\u2DCE\\u2DD0-\\u2DD6\\u2DD8-\\u2DDE\\u3006\\u303C\\u3041-\\u3096\\u309F\\u30A1-\\u30FA\\u30FF\\u3105-\\u312F\\u3131-\\u318E\\u31A0-\\u31BA\\u31F0-\\u31FF\\u3400-\\u4DB5\\u4E00-\\u9FEF\\uA000-\\uA014\\uA016-\\uA48C\\uA4D0-\\uA4F7\\uA500-\\uA60B\\uA610-\\uA61F\\uA62A-\\uA62B\\uA66E\\uA6A0-\\uA6E5\\uA78F\\uA7F7\\uA7FB-\\uA801\\uA803-\\uA805\\uA807-\\uA80A\\uA80C-\\uA822\\uA840-\\uA873\\uA882-\\uA8B3\\uA8F2-\\uA8F7\\uA8FB\\uA8FD-\\uA8FE\\uA90A-\\uA925\\uA930-\\uA946\\uA960-\\uA97C\\uA984-\\uA9B2\\uA9E0-\\uA9E4\\uA9E7-\\uA9EF\\uA9FA-\\uA9FE\\uAA00-\\uAA28\\uAA40-\\uAA42\\uAA44-\\uAA4B\\uAA60-\\uAA6F\\uAA71-\\uAA76\\uAA7A\\uAA7E-\\uAAAF\\uAAB1\\uAAB5-\\uAAB6\\uAAB9-\\uAABD\\uAAC0\\uAAC2\\uAADB-\\uAADC\\uAAE0-\\uAAEA\\uAAF2\\uAB01-\\uAB06\\uAB09-\\uAB0E\\uAB11-\\uAB16\\uAB20-\\uAB26\\uAB28-\\uAB2E\\uABC0-\\uABE2\\uAC00-\\uD7A3\\uD7B0-\\uD7C6\\uD7CB-\\uD7FB\\uF900-\\uFA6D\\uFA70-\\uFAD9\\uFB1D\\uFB1F-\\uFB28\\uFB2A-\\uFB36\\uFB38-\\uFB3C\\uFB3E\\uFB40-\\uFB41\\uFB43-\\uFB44\\uFB46-\\uFBB1\\uFBD3-\\uFD3D\\uFD50-\\uFD8F\\uFD92-\\uFDC7\\uFDF0-\\uFDFB\\uFE70-\\uFE74\\uFE76-\\uFEFC\\uFF66-\\uFF6F\\uFF71-\\uFF9D\\uFFA0-\\uFFBE\\uFFC2-\\uFFC7\\uFFCA-\\uFFCF\\uFFD2-\\uFFD7\\uFFDA-\\uFFDC]",
 				chars:      []rune{'ª', 'º', 'ƻ', 'ʔ', 'ە', 'ۿ', 'ܐ', 'ޱ', 'ऽ', 'ॐ', 'ল', 'ঽ', 'ৎ', 'ৼ', 'ਫ਼', 'ઽ', 'ૐ', 'ૹ', 'ଽ', 'ୱ', 'ஃ', 'ஜ', 'ௐ', 'ఽ', 'ಀ', 'ಽ', 'ೞ', 'ഽ', 'ൎ', 'ල', 'ຄ', 'ຊ', 'ຍ', 'ລ', 'ວ', 'ຽ', 'ༀ', 'ဿ', 'ၡ', 'ႎ', 'ቘ', 'ዀ', 'ៜ', 'ᢪ', '〆', '〼', 'ゟ', 'ヿ', 'ꙮ', 'ꞏ', 'ꟷ', 'ꣻ', 'ꩺ', 'ꪱ', 'ꫀ', 'ꫂ', 'ꫲ', 'יִ', 'מּ'},
 				ranges:     []rune{'ǀ', 'ǃ', 'א', 'ת', 'ׯ', 'ײ', 'ؠ', 'ؿ', 'ف', 'ي', 'ٮ', 'ٯ', 'ٱ', 'ۓ', 'ۮ', 'ۯ', 'ۺ', 'ۼ', 'ܒ', 'ܯ', 'ݍ', 'ޥ', 'ߊ', 'ߪ', 'ࠀ', 'ࠕ', 'ࡀ', 'ࡘ', 'ࡠ', 'ࡪ', 'ࢠ', 'ࢴ', 'ࢶ', 'ࢽ', 'ऄ', 'ह', 'क़', 'ॡ', 'ॲ', 'ঀ', 'অ', 'ঌ', 'এ', 'ঐ', 'ও', 'ন', 'প', 'র', 'শ', 'হ', 'ড়', 'ঢ়', 'য়', 'ৡ', 'ৰ', 'ৱ', 'ਅ', 'ਊ', 'ਏ', 'ਐ', 'ਓ', 'ਨ', 'ਪ', 'ਰ', 'ਲ', 'ਲ਼', 'ਵ', 'ਸ਼', 'ਸ', 'ਹ', 'ਖ਼', 'ੜ', 'ੲ', 'ੴ', 'અ', 'ઍ', 'એ', 'ઑ', 'ઓ', 'ન', 'પ', 'ર', 'લ', 'ળ', 'વ', 'હ', 'ૠ', 'ૡ', 'ଅ', 'ଌ', 'ଏ', 'ଐ', 'ଓ', 'ନ', 'ପ', 'ର', 'ଲ', 'ଳ', 'ଵ', 'ହ', 'ଡ଼', 'ଢ଼', 'ୟ', 'ୡ', 'அ', 'ஊ', 'எ', 'ஐ', 'ஒ', 'க', 'ங', 'ச', 'ஞ', 'ட', 'ண', 'த', 'ந', 'ப', 'ம', 'ஹ', 'అ', 'ఌ', 'ఎ', 'ఐ', 'ఒ', 'న', 'ప', 'హ', 'ౘ', 'ౚ', 'ౠ', 'ౡ', 'ಅ', 'ಌ', 'ಎ', 'ಐ', 'ಒ', 'ನ', 'ಪ', 'ಳ', 'ವ', 'ಹ', 'ೠ', 'ೡ', 'ೱ', 'ೲ', 'അ', 'ഌ', 'എ', 'ഐ', 'ഒ', 'ഺ', 'ൔ', 'ൖ', 'ൟ', 'ൡ', 'ൺ', 'ൿ', 'අ', 'ඖ', 'ක', 'න', 'ඳ', 'ර', 'ව', 'ෆ', 'ก', 'ะ', 'า', 'ำ', 'เ', 'ๅ', 'ກ', 'ຂ', 'ງ', 'ຈ', 'ດ', 'ທ', 'ນ', 'ຟ', 'ມ', 'ຣ', 'ສ', 'ຫ', 'ອ', 'ະ', 'າ', 'ຳ', 'ເ', 'ໄ', 'ໜ', 'ໟ', 'ཀ', 'ཇ', 'ཉ', 'ཬ', 'ྈ', 'ྌ', 'က', 'ဪ', 'ၐ', 'ၕ', 'ၚ', 'ၝ', 'ၥ', 'ၦ', 'ၮ', 'ၰ', 'ၵ', 'ႁ', 'ᄀ', 'ቈ', 'ቊ', 'ቍ', 'ቐ', 'ቖ', 'ቚ', 'ቝ', 'በ', 'ኈ', 'ኊ', 'ኍ', 'ነ', 'ኰ', 'ኲ', 'ኵ', 'ኸ', 'ኾ', 'ዂ', 'ዅ', 'ወ', 'ዖ', 'ዘ', 'ጐ', 'ጒ', 'ጕ', 'ጘ', 'ፚ', 'ᎀ', 'ᎏ', 'ᐁ', 'ᙬ', 'ᙯ', 'ᙿ', 'ᚁ', 'ᚚ', 'ᚠ', 'ᛪ', 'ᛱ', 'ᛸ', 'ᜀ', 'ᜌ', 'ᜎ', 'ᜑ', 'ᜠ', 'ᜱ', 'ᝀ', 'ᝑ', 'ᝠ', 'ᝬ', 'ᝮ', 'ᝰ', 'ក', 'ឳ', 'ᠠ', 'ᡂ', 'ᡄ', 'ᡸ', 'ᢀ', 'ᢄ', 'ᢇ', 'ᢨ', 'ᢰ', 'ᣵ', 'ᤀ', 'ᤞ', 'ᥐ', 'ᥭ', 'ᥰ', 'ᥴ', 'ᦀ', 'ᦫ', 'ᦰ', 'ᧉ', 'ᨀ', 'ᨖ', 'ᨠ', 'ᩔ', 'ᬅ', 'ᬳ', 'ᭅ', 'ᭋ', 'ᮃ', 'ᮠ', 'ᮮ', 'ᮯ', 'ᮺ', 'ᯥ', 'ᰀ', 'ᰣ', 'ᱍ', 'ᱏ', 'ᱚ', 'ᱷ', 'ᳩ', 'ᳬ', 'ᳮ', 'ᳱ', 'ᳵ', 'ᳶ', 'ℵ', 'ℸ', 'ⴰ', 'ⵧ', 'ⶀ', 'ⶖ', 'ⶠ', 'ⶦ', 'ⶨ', 'ⶮ', 'ⶰ', 'ⶶ', 'ⶸ', 'ⶾ', 'ⷀ', 'ⷆ', 'ⷈ', 'ⷎ', 'ⷐ', 'ⷖ', 'ⷘ', 'ⷞ', 'ぁ', 'ゖ', 'ァ', 'ヺ', 'ㄅ', 'ㄯ', 'ㄱ', 'ㆎ', 'ㆠ', 'ㆺ', 'ㇰ', 'ㇿ', '㐀', '䶵', '一', '鿯', 'ꀀ', 'ꀔ', 'ꀖ', 'ꒌ', 'ꓐ', 'ꓷ', 'ꔀ', 'ꘋ', 'ꘐ', 'ꘟ', 'ꘪ', 'ꘫ', 'ꚠ', 'ꛥ', 'ꟻ', 'ꠁ', 'ꠃ', 'ꠅ', 'ꠇ', 'ꠊ', 'ꠌ', 'ꠢ', 'ꡀ', 'ꡳ', 'ꢂ', 'ꢳ', 'ꣲ', 'ꣷ', 'ꣽ', 'ꣾ', 'ꤊ', 'ꤥ', 'ꤰ', 'ꥆ', 'ꥠ', 'ꥼ', 'ꦄ', 'ꦲ', 'ꧠ', 'ꧤ', 'ꧧ', 'ꧯ', 'ꧺ', 'ꧾ', 'ꨀ', 'ꨨ', 'ꩀ', 'ꩂ', 'ꩄ', 'ꩋ', 'ꩠ', 'ꩯ', 'ꩱ', 'ꩶ', 'ꩾ', 'ꪯ', 'ꪵ', 'ꪶ', 'ꪹ', 'ꪽ', 'ꫛ', 'ꫜ', 'ꫠ', 'ꫪ', 'ꬁ', 'ꬆ', 'ꬉ', 'ꬎ', 'ꬑ', 'ꬖ', 'ꬠ', 'ꬦ', 'ꬨ', 'ꬮ', 'ꯀ', 'ꯢ', '가', '힣', 'ힰ', 'ퟆ', 'ퟋ', 'ퟻ', '豈', '舘', '並', '龎', 'ײַ', 'ﬨ', 'שׁ', 'זּ', 'טּ', 'לּ', 'נּ', 'סּ', 'ףּ', 'פּ', 'צּ', 'ﮱ', 'ﯓ', 'ﴽ', 'ﵐ', 'ﶏ', 'ﶒ', 'ﷇ', 'ﷰ', 'ﷻ', 'ﹰ', 'ﹴ', 'ﹶ', 'ﻼ', 'ｦ', 'ｯ', 'ｱ', 'ﾝ', 'ﾠ', 'ﾾ', 'ￂ', 'ￇ', 'ￊ', 'ￏ', 'ￒ', 'ￗ', 'ￚ', 'ￜ'},
@@ -12777,9 +12795,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lt",
-			pos:  position{line: 1839, col: 1, offset: 50908},
+			pos:  position{line: 1841, col: 1, offset: 50994},
 			expr: &charClassMatcher{
-				pos:        position{line: 1839, col: 6, offset: 50913},
+				pos:        position{line: 1841, col: 6, offset: 50999},
 				val:        "[\\u01C5\\u01C8\\u01CB\\u01F2\\u1F88-\\u1F8F\\u1F98-\\u1F9F\\u1FA8-\\u1FAF\\u1FBC\\u1FCC\\u1FFC]",
 				chars:      []rune{'ǅ', 'ǈ', 'ǋ', 'ǲ', 'ᾼ', 'ῌ', 'ῼ'},
 				ranges:     []rune{'ᾈ', 'ᾏ', 'ᾘ', 'ᾟ', 'ᾨ', 'ᾯ'},
@@ -12791,9 +12809,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lu",
-			pos:  position{line: 1842, col: 1, offset: 51019},
+			pos:  position{line: 1844, col: 1, offset: 51105},
 			expr: &charClassMatcher{
-				pos:        position{line: 1842, col: 6, offset: 51024},
+				pos:        position{line: 1844, col: 6, offset: 51110},
 				val:        "[\\u0041-\\u005A\\u00C0-\\u00D6\\u00D8-\\u00DE\\u0100\\u0102\\u0104\\u0106\\u0108\\u010A\\u010C\\u010E\\u0110\\u0112\\u0114\\u0116\\u0118\\u011A\\u011C\\u011E\\u0120\\u0122\\u0124\\u0126\\u0128\\u012A\\u012C\\u012E\\u0130\\u0132\\u0134\\u0136\\u0139\\u013B\\u013D\\u013F\\u0141\\u0143\\u0145\\u0147\\u014A\\u014C\\u014E\\u0150\\u0152\\u0154\\u0156\\u0158\\u015A\\u015C\\u015E\\u0160\\u0162\\u0164\\u0166\\u0168\\u016A\\u016C\\u016E\\u0170\\u0172\\u0174\\u0176\\u0178-\\u0179\\u017B\\u017D\\u0181-\\u0182\\u0184\\u0186-\\u0187\\u0189-\\u018B\\u018E-\\u0191\\u0193-\\u0194\\u0196-\\u0198\\u019C-\\u019D\\u019F-\\u01A0\\u01A2\\u01A4\\u01A6-\\u01A7\\u01A9\\u01AC\\u01AE-\\u01AF\\u01B1-\\u01B3\\u01B5\\u01B7-\\u01B8\\u01BC\\u01C4\\u01C7\\u01CA\\u01CD\\u01CF\\u01D1\\u01D3\\u01D5\\u01D7\\u01D9\\u01DB\\u01DE\\u01E0\\u01E2\\u01E4\\u01E6\\u01E8\\u01EA\\u01EC\\u01EE\\u01F1\\u01F4\\u01F6-\\u01F8\\u01FA\\u01FC\\u01FE\\u0200\\u0202\\u0204\\u0206\\u0208\\u020A\\u020C\\u020E\\u0210\\u0212\\u0214\\u0216\\u0218\\u021A\\u021C\\u021E\\u0220\\u0222\\u0224\\u0226\\u0228\\u022A\\u022C\\u022E\\u0230\\u0232\\u023A-\\u023B\\u023D-\\u023E\\u0241\\u0243-\\u0246\\u0248\\u024A\\u024C\\u024E\\u0370\\u0372\\u0376\\u037F\\u0386\\u0388-\\u038A\\u038C\\u038E-\\u038F\\u0391-\\u03A1\\u03A3-\\u03AB\\u03CF\\u03D2-\\u03D4\\u03D8\\u03DA\\u03DC\\u03DE\\u03E0\\u03E2\\u03E4\\u03E6\\u03E8\\u03EA\\u03EC\\u03EE\\u03F4\\u03F7\\u03F9-\\u03FA\\u03FD-\\u042F\\u0460\\u0462\\u0464\\u0466\\u0468\\u046A\\u046C\\u046E\\u0470\\u0472\\u0474\\u0476\\u0478\\u047A\\u047C\\u047E\\u0480\\u048A\\u048C\\u048E\\u0490\\u0492\\u0494\\u0496\\u0498\\u049A\\u049C\\u049E\\u04A0\\u04A2\\u04A4\\u04A6\\u04A8\\u04AA\\u04AC\\u04AE\\u04B0\\u04B2\\u04B4\\u04B6\\u04B8\\u04BA\\u04BC\\u04BE\\u04C0-\\u04C1\\u04C3\\u04C5\\u04C7\\u04C9\\u04CB\\u04CD\\u04D0\\u04D2\\u04D4\\u04D6\\u04D8\\u04DA\\u04DC\\u04DE\\u04E0\\u04E2\\u04E4\\u04E6\\u04E8\\u04EA\\u04EC\\u04EE\\u04F0\\u04F2\\u04F4\\u04F6\\u04F8\\u04FA\\u04FC\\u04FE\\u0500\\u0502\\u0504\\u0506\\u0508\\u050A\\u050C\\u050E\\u0510\\u0512\\u0514\\u0516\\u0518\\u051A\\u051C\\u051E\\u0520\\u0522\\u0524\\u0526\\u0528\\u052A\\u052C\\u052E\\u0531-\\u0556\\u10A0-\\u10C5\\u10C7\\u10CD\\u13A0-\\u13F5\\u1C90-\\u1CBA\\u1CBD-\\u1CBF\\u1E00\\u1E02\\u1E04\\u1E06\\u1E08\\u1E0A\\u1E0C\\u1E0E\\u1E10\\u1E12\\u1E14\\u1E16\\u1E18\\u1E1A\\u1E1C\\u1E1E\\u1E20\\u1E22\\u1E24\\u1E26\\u1E28\\u1E2A\\u1E2C\\u1E2E\\u1E30\\u1E32\\u1E34\\u1E36\\u1E38\\u1E3A\\u1E3C\\u1E3E\\u1E40\\u1E42\\u1E44\\u1E46\\u1E48\\u1E4A\\u1E4C\\u1E4E\\u1E50\\u1E52\\u1E54\\u1E56\\u1E58\\u1E5A\\u1E5C\\u1E5E\\u1E60\\u1E62\\u1E64\\u1E66\\u1E68\\u1E6A\\u1E6C\\u1E6E\\u1E70\\u1E72\\u1E74\\u1E76\\u1E78\\u1E7A\\u1E7C\\u1E7E\\u1E80\\u1E82\\u1E84\\u1E86\\u1E88\\u1E8A\\u1E8C\\u1E8E\\u1E90\\u1E92\\u1E94\\u1E9E\\u1EA0\\u1EA2\\u1EA4\\u1EA6\\u1EA8\\u1EAA\\u1EAC\\u1EAE\\u1EB0\\u1EB2\\u1EB4\\u1EB6\\u1EB8\\u1EBA\\u1EBC\\u1EBE\\u1EC0\\u1EC2\\u1EC4\\u1EC6\\u1EC8\\u1ECA\\u1ECC\\u1ECE\\u1ED0\\u1ED2\\u1ED4\\u1ED6\\u1ED8\\u1EDA\\u1EDC\\u1EDE\\u1EE0\\u1EE2\\u1EE4\\u1EE6\\u1EE8\\u1EEA\\u1EEC\\u1EEE\\u1EF0\\u1EF2\\u1EF4\\u1EF6\\u1EF8\\u1EFA\\u1EFC\\u1EFE\\u1F08-\\u1F0F\\u1F18-\\u1F1D\\u1F28-\\u1F2F\\u1F38-\\u1F3F\\u1F48-\\u1F4D\\u1F59\\u1F5B\\u1F5D\\u1F5F\\u1F68-\\u1F6F\\u1FB8-\\u1FBB\\u1FC8-\\u1FCB\\u1FD8-\\u1FDB\\u1FE8-\\u1FEC\\u1FF8-\\u1FFB\\u2102\\u2107\\u210B-\\u210D\\u2110-\\u2112\\u2115\\u2119-\\u211D\\u2124\\u2126\\u2128\\u212A-\\u212D\\u2130-\\u2133\\u213E-\\u213F\\u2145\\u2183\\u2C00-\\u2C2E\\u2C60\\u2C62-\\u2C64\\u2C67\\u2C69\\u2C6B\\u2C6D-\\u2C70\\u2C72\\u2C75\\u2C7E-\\u2C80\\u2C82\\u2C84\\u2C86\\u2C88\\u2C8A\\u2C8C\\u2C8E\\u2C90\\u2C92\\u2C94\\u2C96\\u2C98\\u2C9A\\u2C9C\\u2C9E\\u2CA0\\u2CA2\\u2CA4\\u2CA6\\u2CA8\\u2CAA\\u2CAC\\u2CAE\\u2CB0\\u2CB2\\u2CB4\\u2CB6\\u2CB8\\u2CBA\\u2CBC\\u2CBE\\u2CC0\\u2CC2\\u2CC4\\u2CC6\\u2CC8\\u2CCA\\u2CCC\\u2CCE\\u2CD0\\u2CD2\\u2CD4\\u2CD6\\u2CD8\\u2CDA\\u2CDC\\u2CDE\\u2CE0\\u2CE2\\u2CEB\\u2CED\\u2CF2\\uA640\\uA642\\uA644\\uA646\\uA648\\uA64A\\uA64C\\uA64E\\uA650\\uA652\\uA654\\uA656\\uA658\\uA65A\\uA65C\\uA65E\\uA660\\uA662\\uA664\\uA666\\uA668\\uA66A\\uA66C\\uA680\\uA682\\uA684\\uA686\\uA688\\uA68A\\uA68C\\uA68E\\uA690\\uA692\\uA694\\uA696\\uA698\\uA69A\\uA722\\uA724\\uA726\\uA728\\uA72A\\uA72C\\uA72E\\uA732\\uA734\\uA736\\uA738\\uA73A\\uA73C\\uA73E\\uA740\\uA742\\uA744\\uA746\\uA748\\uA74A\\uA74C\\uA74E\\uA750\\uA752\\uA754\\uA756\\uA758\\uA75A\\uA75C\\uA75E\\uA760\\uA762\\uA764\\uA766\\uA768\\uA76A\\uA76C\\uA76E\\uA779\\uA77B\\uA77D-\\uA77E\\uA780\\uA782\\uA784\\uA786\\uA78B\\uA78D\\uA790\\uA792\\uA796\\uA798\\uA79A\\uA79C\\uA79E\\uA7A0\\uA7A2\\uA7A4\\uA7A6\\uA7A8\\uA7AA-\\uA7AE\\uA7B0-\\uA7B4\\uA7B6\\uA7B8\\uFF21-\\uFF3A]",
 				chars:      []rune{'Ā', 'Ă', 'Ą', 'Ć', 'Ĉ', 'Ċ', 'Č', 'Ď', 'Đ', 'Ē', 'Ĕ', 'Ė', 'Ę', 'Ě', 'Ĝ', 'Ğ', 'Ġ', 'Ģ', 'Ĥ', 'Ħ', 'Ĩ', 'Ī', 'Ĭ', 'Į', 'İ', 'Ĳ', 'Ĵ', 'Ķ', 'Ĺ', 'Ļ', 'Ľ', 'Ŀ', 'Ł', 'Ń', 'Ņ', 'Ň', 'Ŋ', 'Ō', 'Ŏ', 'Ő', 'Œ', 'Ŕ', 'Ŗ', 'Ř', 'Ś', 'Ŝ', 'Ş', 'Š', 'Ţ', 'Ť', 'Ŧ', 'Ũ', 'Ū', 'Ŭ', 'Ů', 'Ű', 'Ų', 'Ŵ', 'Ŷ', 'Ż', 'Ž', 'Ƅ', 'Ƣ', 'Ƥ', 'Ʃ', 'Ƭ', 'Ƶ', 'Ƽ', 'Ǆ', 'Ǉ', 'Ǌ', 'Ǎ', 'Ǐ', 'Ǒ', 'Ǔ', 'Ǖ', 'Ǘ', 'Ǚ', 'Ǜ', 'Ǟ', 'Ǡ', 'Ǣ', 'Ǥ', 'Ǧ', 'Ǩ', 'Ǫ', 'Ǭ', 'Ǯ', 'Ǳ', 'Ǵ', 'Ǻ', 'Ǽ', 'Ǿ', 'Ȁ', 'Ȃ', 'Ȅ', 'Ȇ', 'Ȉ', 'Ȋ', 'Ȍ', 'Ȏ', 'Ȑ', 'Ȓ', 'Ȕ', 'Ȗ', 'Ș', 'Ț', 'Ȝ', 'Ȟ', 'Ƞ', 'Ȣ', 'Ȥ', 'Ȧ', 'Ȩ', 'Ȫ', 'Ȭ', 'Ȯ', 'Ȱ', 'Ȳ', 'Ɂ', 'Ɉ', 'Ɋ', 'Ɍ', 'Ɏ', 'Ͱ', 'Ͳ', 'Ͷ', 'Ϳ', 'Ά', 'Ό', 'Ϗ', 'Ϙ', 'Ϛ', 'Ϝ', 'Ϟ', 'Ϡ', 'Ϣ', 'Ϥ', 'Ϧ', 'Ϩ', 'Ϫ', 'Ϭ', 'Ϯ', 'ϴ', 'Ϸ', 'Ѡ', 'Ѣ', 'Ѥ', 'Ѧ', 'Ѩ', 'Ѫ', 'Ѭ', 'Ѯ', 'Ѱ', 'Ѳ', 'Ѵ', 'Ѷ', 'Ѹ', 'Ѻ', 'Ѽ', 'Ѿ', 'Ҁ', 'Ҋ', 'Ҍ', 'Ҏ', 'Ґ', 'Ғ', 'Ҕ', 'Җ', 'Ҙ', 'Қ', 'Ҝ', 'Ҟ', 'Ҡ', 'Ң', 'Ҥ', 'Ҧ', 'Ҩ', 'Ҫ', 'Ҭ', 'Ү', 'Ұ', 'Ҳ', 'Ҵ', 'Ҷ', 'Ҹ', 'Һ', 'Ҽ', 'Ҿ', 'Ӄ', 'Ӆ', 'Ӈ', 'Ӊ', 'Ӌ', 'Ӎ', 'Ӑ', 'Ӓ', 'Ӕ', 'Ӗ', 'Ә', 'Ӛ', 'Ӝ', 'Ӟ', 'Ӡ', 'Ӣ', 'Ӥ', 'Ӧ', 'Ө', 'Ӫ', 'Ӭ', 'Ӯ', 'Ӱ', 'Ӳ', 'Ӵ', 'Ӷ', 'Ӹ', 'Ӻ', 'Ӽ', 'Ӿ', 'Ԁ', 'Ԃ', 'Ԅ', 'Ԇ', 'Ԉ', 'Ԋ', 'Ԍ', 'Ԏ', 'Ԑ', 'Ԓ', 'Ԕ', 'Ԗ', 'Ԙ', 'Ԛ', 'Ԝ', 'Ԟ', 'Ԡ', 'Ԣ', 'Ԥ', 'Ԧ', 'Ԩ', 'Ԫ', 'Ԭ', 'Ԯ', 'Ⴧ', 'Ⴭ', 'Ḁ', 'Ḃ', 'Ḅ', 'Ḇ', 'Ḉ', 'Ḋ', 'Ḍ', 'Ḏ', 'Ḑ', 'Ḓ', 'Ḕ', 'Ḗ', 'Ḙ', 'Ḛ', 'Ḝ', 'Ḟ', 'Ḡ', 'Ḣ', 'Ḥ', 'Ḧ', 'Ḩ', 'Ḫ', 'Ḭ', 'Ḯ', 'Ḱ', 'Ḳ', 'Ḵ', 'Ḷ', 'Ḹ', 'Ḻ', 'Ḽ', 'Ḿ', 'Ṁ', 'Ṃ', 'Ṅ', 'Ṇ', 'Ṉ', 'Ṋ', 'Ṍ', 'Ṏ', 'Ṑ', 'Ṓ', 'Ṕ', 'Ṗ', 'Ṙ', 'Ṛ', 'Ṝ', 'Ṟ', 'Ṡ', 'Ṣ', 'Ṥ', 'Ṧ', 'Ṩ', 'Ṫ', 'Ṭ', 'Ṯ', 'Ṱ', 'Ṳ', 'Ṵ', 'Ṷ', 'Ṹ', 'Ṻ', 'Ṽ', 'Ṿ', 'Ẁ', 'Ẃ', 'Ẅ', 'Ẇ', 'Ẉ', 'Ẋ', 'Ẍ', 'Ẏ', 'Ẑ', 'Ẓ', 'Ẕ', 'ẞ', 'Ạ', 'Ả', 'Ấ', 'Ầ', 'Ẩ', 'Ẫ', 'Ậ', 'Ắ', 'Ằ', 'Ẳ', 'Ẵ', 'Ặ', 'Ẹ', 'Ẻ', 'Ẽ', 'Ế', 'Ề', 'Ể', 'Ễ', 'Ệ', 'Ỉ', 'Ị', 'Ọ', 'Ỏ', 'Ố', 'Ồ', 'Ổ', 'Ỗ', 'Ộ', 'Ớ', 'Ờ', 'Ở', 'Ỡ', 'Ợ', 'Ụ', 'Ủ', 'Ứ', 'Ừ', 'Ử', 'Ữ', 'Ự', 'Ỳ', 'Ỵ', 'Ỷ', 'Ỹ', 'Ỻ', 'Ỽ', 'Ỿ', 'Ὑ', 'Ὓ', 'Ὕ', 'Ὗ', 'ℂ', 'ℇ', 'ℕ', 'ℤ', 'Ω', 'ℨ', 'ⅅ', 'Ↄ', 'Ⱡ', 'Ⱨ', 'Ⱪ', 'Ⱬ', 'Ⱳ', 'Ⱶ', 'Ⲃ', 'Ⲅ', 'Ⲇ', 'Ⲉ', 'Ⲋ', 'Ⲍ', 'Ⲏ', 'Ⲑ', 'Ⲓ', 'Ⲕ', 'Ⲗ', 'Ⲙ', 'Ⲛ', 'Ⲝ', 'Ⲟ', 'Ⲡ', 'Ⲣ', 'Ⲥ', 'Ⲧ', 'Ⲩ', 'Ⲫ', 'Ⲭ', 'Ⲯ', 'Ⲱ', 'Ⲳ', 'Ⲵ', 'Ⲷ', 'Ⲹ', 'Ⲻ', 'Ⲽ', 'Ⲿ', 'Ⳁ', 'Ⳃ', 'Ⳅ', 'Ⳇ', 'Ⳉ', 'Ⳋ', 'Ⳍ', 'Ⳏ', 'Ⳑ', 'Ⳓ', 'Ⳕ', 'Ⳗ', 'Ⳙ', 'Ⳛ', 'Ⳝ', 'Ⳟ', 'Ⳡ', 'Ⳣ', 'Ⳬ', 'Ⳮ', 'Ⳳ', 'Ꙁ', 'Ꙃ', 'Ꙅ', 'Ꙇ', 'Ꙉ', 'Ꙋ', 'Ꙍ', 'Ꙏ', 'Ꙑ', 'Ꙓ', 'Ꙕ', 'Ꙗ', 'Ꙙ', 'Ꙛ', 'Ꙝ', 'Ꙟ', 'Ꙡ', 'Ꙣ', 'Ꙥ', 'Ꙧ', 'Ꙩ', 'Ꙫ', 'Ꙭ', 'Ꚁ', 'Ꚃ', 'Ꚅ', 'Ꚇ', 'Ꚉ', 'Ꚋ', 'Ꚍ', 'Ꚏ', 'Ꚑ', 'Ꚓ', 'Ꚕ', 'Ꚗ', 'Ꚙ', 'Ꚛ', 'Ꜣ', 'Ꜥ', 'Ꜧ', 'Ꜩ', 'Ꜫ', 'Ꜭ', 'Ꜯ', 'Ꜳ', 'Ꜵ', 'Ꜷ', 'Ꜹ', 'Ꜻ', 'Ꜽ', 'Ꜿ', 'Ꝁ', 'Ꝃ', 'Ꝅ', 'Ꝇ', 'Ꝉ', 'Ꝋ', 'Ꝍ', 'Ꝏ', 'Ꝑ', 'Ꝓ', 'Ꝕ', 'Ꝗ', 'Ꝙ', 'Ꝛ', 'Ꝝ', 'Ꝟ', 'Ꝡ', 'Ꝣ', 'Ꝥ', 'Ꝧ', 'Ꝩ', 'Ꝫ', 'Ꝭ', 'Ꝯ', 'Ꝺ', 'Ꝼ', 'Ꞁ', 'Ꞃ', 'Ꞅ', 'Ꞇ', 'Ꞌ', 'Ɥ', 'Ꞑ', 'Ꞓ', 'Ꞗ', 'Ꞙ', 'Ꞛ', 'Ꞝ', 'Ꞟ', 'Ꞡ', 'Ꞣ', 'Ꞥ', 'Ꞧ', 'Ꞩ', 'Ꞷ', 'Ꞹ'},
 				ranges:     []rune{'A', 'Z', 'À', 'Ö', 'Ø', 'Þ', 'Ÿ', 'Ź', 'Ɓ', 'Ƃ', 'Ɔ', 'Ƈ', 'Ɖ', 'Ƌ', 'Ǝ', 'Ƒ', 'Ɠ', 'Ɣ', 'Ɩ', 'Ƙ', 'Ɯ', 'Ɲ', 'Ɵ', 'Ơ', 'Ʀ', 'Ƨ', 'Ʈ', 'Ư', 'Ʊ', 'Ƴ', 'Ʒ', 'Ƹ', 'Ƕ', 'Ǹ', 'Ⱥ', 'Ȼ', 'Ƚ', 'Ⱦ', 'Ƀ', 'Ɇ', 'Έ', 'Ί', 'Ύ', 'Ώ', 'Α', 'Ρ', 'Σ', 'Ϋ', 'ϒ', 'ϔ', 'Ϲ', 'Ϻ', 'Ͻ', 'Я', 'Ӏ', 'Ӂ', 'Ա', 'Ֆ', 'Ⴀ', 'Ⴥ', 'Ꭰ', 'Ᏽ', 'Ა', 'Ჺ', 'Ჽ', 'Ჿ', 'Ἀ', 'Ἇ', 'Ἐ', 'Ἕ', 'Ἠ', 'Ἧ', 'Ἰ', 'Ἷ', 'Ὀ', 'Ὅ', 'Ὠ', 'Ὧ', 'Ᾰ', 'Ά', 'Ὲ', 'Ή', 'Ῐ', 'Ί', 'Ῠ', 'Ῥ', 'Ὸ', 'Ώ', 'ℋ', 'ℍ', 'ℐ', 'ℒ', 'ℙ', 'ℝ', 'K', 'ℭ', 'ℰ', 'ℳ', 'ℾ', 'ℿ', 'Ⰰ', 'Ⱞ', 'Ɫ', 'Ɽ', 'Ɑ', 'Ɒ', 'Ȿ', 'Ⲁ', 'Ᵹ', 'Ꝿ', 'Ɦ', 'Ɪ', 'Ʞ', 'Ꞵ', 'Ａ', 'Ｚ'},
@@ -12805,9 +12823,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mc",
-			pos:  position{line: 1845, col: 1, offset: 55025},
+			pos:  position{line: 1847, col: 1, offset: 55111},
 			expr: &charClassMatcher{
-				pos:        position{line: 1845, col: 6, offset: 55030},
+				pos:        position{line: 1847, col: 6, offset: 55116},
 				val:        "[\\u0903\\u093B\\u093E-\\u0940\\u0949-\\u094C\\u094E-\\u094F\\u0982-\\u0983\\u09BE-\\u09C0\\u09C7-\\u09C8\\u09CB-\\u09CC\\u09D7\\u0A03\\u0A3E-\\u0A40\\u0A83\\u0ABE-\\u0AC0\\u0AC9\\u0ACB-\\u0ACC\\u0B02-\\u0B03\\u0B3E\\u0B40\\u0B47-\\u0B48\\u0B4B-\\u0B4C\\u0B57\\u0BBE-\\u0BBF\\u0BC1-\\u0BC2\\u0BC6-\\u0BC8\\u0BCA-\\u0BCC\\u0BD7\\u0C01-\\u0C03\\u0C41-\\u0C44\\u0C82-\\u0C83\\u0CBE\\u0CC0-\\u0CC4\\u0CC7-\\u0CC8\\u0CCA-\\u0CCB\\u0CD5-\\u0CD6\\u0D02-\\u0D03\\u0D3E-\\u0D40\\u0D46-\\u0D48\\u0D4A-\\u0D4C\\u0D57\\u0D82-\\u0D83\\u0DCF-\\u0DD1\\u0DD8-\\u0DDF\\u0DF2-\\u0DF3\\u0F3E-\\u0F3F\\u0F7F\\u102B-\\u102C\\u1031\\u1038\\u103B-\\u103C\\u1056-\\u1057\\u1062-\\u1064\\u1067-\\u106D\\u1083-\\u1084\\u1087-\\u108C\\u108F\\u109A-\\u109C\\u17B6\\u17BE-\\u17C5\\u17C7-\\u17C8\\u1923-\\u1926\\u1929-\\u192B\\u1930-\\u1931\\u1933-\\u1938\\u1A19-\\u1A1A\\u1A55\\u1A57\\u1A61\\u1A63-\\u1A64\\u1A6D-\\u1A72\\u1B04\\u1B35\\u1B3B\\u1B3D-\\u1B41\\u1B43-\\u1B44\\u1B82\\u1BA1\\u1BA6-\\u1BA7\\u1BAA\\u1BE7\\u1BEA-\\u1BEC\\u1BEE\\u1BF2-\\u1BF3\\u1C24-\\u1C2B\\u1C34-\\u1C35\\u1CE1\\u1CF2-\\u1CF3\\u1CF7\\u302E-\\u302F\\uA823-\\uA824\\uA827\\uA880-\\uA881\\uA8B4-\\uA8C3\\uA952-\\uA953\\uA983\\uA9B4-\\uA9B5\\uA9BA-\\uA9BB\\uA9BD-\\uA9C0\\uAA2F-\\uAA30\\uAA33-\\uAA34\\uAA4D\\uAA7B\\uAA7D\\uAAEB\\uAAEE-\\uAAEF\\uAAF5\\uABE3-\\uABE4\\uABE6-\\uABE7\\uABE9-\\uABEA\\uABEC]",
 				chars:      []rune{'ः', 'ऻ', 'ৗ', 'ਃ', 'ઃ', 'ૉ', 'ା', 'ୀ', 'ୗ', 'ௗ', 'ಾ', 'ൗ', 'ཿ', 'ေ', 'း', 'ႏ', 'ា', 'ᩕ', 'ᩗ', 'ᩡ', 'ᬄ', 'ᬵ', 'ᬻ', 'ᮂ', 'ᮡ', '᮪', 'ᯧ', 'ᯮ', '᳡', '᳷', 'ꠧ', 'ꦃ', 'ꩍ', 'ꩻ', 'ꩽ', 'ꫫ', 'ꫵ', '꯬'},
 				ranges:     []rune{'ा', 'ी', 'ॉ', 'ौ', 'ॎ', 'ॏ', 'ং', 'ঃ', 'া', 'ী', 'ে', 'ৈ', 'ো', 'ৌ', 'ਾ', 'ੀ', 'ા', 'ી', 'ો', 'ૌ', 'ଂ', 'ଃ', 'େ', 'ୈ', 'ୋ', 'ୌ', 'ா', 'ி', 'ு', 'ூ', 'ெ', 'ை', 'ொ', 'ௌ', 'ఁ', 'ః', 'ు', 'ౄ', 'ಂ', 'ಃ', 'ೀ', 'ೄ', 'ೇ', 'ೈ', 'ೊ', 'ೋ', 'ೕ', 'ೖ', 'ം', 'ഃ', 'ാ', 'ീ', 'െ', 'ൈ', 'ൊ', 'ൌ', 'ං', 'ඃ', 'ා', 'ෑ', 'ෘ', 'ෟ', 'ෲ', 'ෳ', '༾', '༿', 'ါ', 'ာ', 'ျ', 'ြ', 'ၖ', 'ၗ', 'ၢ', 'ၤ', 'ၧ', 'ၭ', 'ႃ', 'ႄ', 'ႇ', 'ႌ', 'ႚ', 'ႜ', 'ើ', 'ៅ', 'ះ', 'ៈ', 'ᤣ', 'ᤦ', 'ᤩ', 'ᤫ', 'ᤰ', 'ᤱ', 'ᤳ', 'ᤸ', 'ᨙ', 'ᨚ', 'ᩣ', 'ᩤ', 'ᩭ', 'ᩲ', 'ᬽ', 'ᭁ', 'ᭃ', '᭄', 'ᮦ', 'ᮧ', 'ᯪ', 'ᯬ', '᯲', '᯳', 'ᰤ', 'ᰫ', 'ᰴ', 'ᰵ', 'ᳲ', 'ᳳ', '〮', '〯', 'ꠣ', 'ꠤ', 'ꢀ', 'ꢁ', 'ꢴ', 'ꣃ', 'ꥒ', '꥓', 'ꦴ', 'ꦵ', 'ꦺ', 'ꦻ', 'ꦽ', '꧀', 'ꨯ', 'ꨰ', 'ꨳ', 'ꨴ', 'ꫮ', 'ꫯ', 'ꯣ', 'ꯤ', 'ꯦ', 'ꯧ', 'ꯩ', 'ꯪ'},
@@ -12819,9 +12837,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mn",
-			pos:  position{line: 1848, col: 1, offset: 56218},
+			pos:  position{line: 1850, col: 1, offset: 56304},
 			expr: &charClassMatcher{
-				pos:        position{line: 1848, col: 6, offset: 56223},
+				pos:        position{line: 1850, col: 6, offset: 56309},
 				val:        "[\\u0300-\\u036F\\u0483-\\u0487\\u0591-\\u05BD\\u05BF\\u05C1-\\u05C2\\u05C4-\\u05C5\\u05C7\\u0610-\\u061A\\u064B-\\u065F\\u0670\\u06D6-\\u06DC\\u06DF-\\u06E4\\u06E7-\\u06E8\\u06EA-\\u06ED\\u0711\\u0730-\\u074A\\u07A6-\\u07B0\\u07EB-\\u07F3\\u07FD\\u0816-\\u0819\\u081B-\\u0823\\u0825-\\u0827\\u0829-\\u082D\\u0859-\\u085B\\u08D3-\\u08E1\\u08E3-\\u0902\\u093A\\u093C\\u0941-\\u0948\\u094D\\u0951-\\u0957\\u0962-\\u0963\\u0981\\u09BC\\u09C1-\\u09C4\\u09CD\\u09E2-\\u09E3\\u09FE\\u0A01-\\u0A02\\u0A3C\\u0A41-\\u0A42\\u0A47-\\u0A48\\u0A4B-\\u0A4D\\u0A51\\u0A70-\\u0A71\\u0A75\\u0A81-\\u0A82\\u0ABC\\u0AC1-\\u0AC5\\u0AC7-\\u0AC8\\u0ACD\\u0AE2-\\u0AE3\\u0AFA-\\u0AFF\\u0B01\\u0B3C\\u0B3F\\u0B41-\\u0B44\\u0B4D\\u0B56\\u0B62-\\u0B63\\u0B82\\u0BC0\\u0BCD\\u0C00\\u0C04\\u0C3E-\\u0C40\\u0C46-\\u0C48\\u0C4A-\\u0C4D\\u0C55-\\u0C56\\u0C62-\\u0C63\\u0C81\\u0CBC\\u0CBF\\u0CC6\\u0CCC-\\u0CCD\\u0CE2-\\u0CE3\\u0D00-\\u0D01\\u0D3B-\\u0D3C\\u0D41-\\u0D44\\u0D4D\\u0D62-\\u0D63\\u0DCA\\u0DD2-\\u0DD4\\u0DD6\\u0E31\\u0E34-\\u0E3A\\u0E47-\\u0E4E\\u0EB1\\u0EB4-\\u0EB9\\u0EBB-\\u0EBC\\u0EC8-\\u0ECD\\u0F18-\\u0F19\\u0F35\\u0F37\\u0F39\\u0F71-\\u0F7E\\u0F80-\\u0F84\\u0F86-\\u0F87\\u0F8D-\\u0F97\\u0F99-\\u0FBC\\u0FC6\\u102D-\\u1030\\u1032-\\u1037\\u1039-\\u103A\\u103D-\\u103E\\u1058-\\u1059\\u105E-\\u1060\\u1071-\\u1074\\u1082\\u1085-\\u1086\\u108D\\u109D\\u135D-\\u135F\\u1712-\\u1714\\u1732-\\u1734\\u1752-\\u1753\\u1772-\\u1773\\u17B4-\\u17B5\\u17B7-\\u17BD\\u17C6\\u17C9-\\u17D3\\u17DD\\u180B-\\u180D\\u1885-\\u1886\\u18A9\\u1920-\\u1922\\u1927-\\u1928\\u1932\\u1939-\\u193B\\u1A17-\\u1A18\\u1A1B\\u1A56\\u1A58-\\u1A5E\\u1A60\\u1A62\\u1A65-\\u1A6C\\u1A73-\\u1A7C\\u1A7F\\u1AB0-\\u1ABD\\u1B00-\\u1B03\\u1B34\\u1B36-\\u1B3A\\u1B3C\\u1B42\\u1B6B-\\u1B73\\u1B80-\\u1B81\\u1BA2-\\u1BA5\\u1BA8-\\u1BA9\\u1BAB-\\u1BAD\\u1BE6\\u1BE8-\\u1BE9\\u1BED\\u1BEF-\\u1BF1\\u1C2C-\\u1C33\\u1C36-\\u1C37\\u1CD0-\\u1CD2\\u1CD4-\\u1CE0\\u1CE2-\\u1CE8\\u1CED\\u1CF4\\u1CF8-\\u1CF9\\u1DC0-\\u1DF9\\u1DFB-\\u1DFF\\u20D0-\\u20DC\\u20E1\\u20E5-\\u20F0\\u2CEF-\\u2CF1\\u2D7F\\u2DE0-\\u2DFF\\u302A-\\u302D\\u3099-\\u309A\\uA66F\\uA674-\\uA67D\\uA69E-\\uA69F\\uA6F0-\\uA6F1\\uA802\\uA806\\uA80B\\uA825-\\uA826\\uA8C4-\\uA8C5\\uA8E0-\\uA8F1\\uA8FF\\uA926-\\uA92D\\uA947-\\uA951\\uA980-\\uA982\\uA9B3\\uA9B6-\\uA9B9\\uA9BC\\uA9E5\\uAA29-\\uAA2E\\uAA31-\\uAA32\\uAA35-\\uAA36\\uAA43\\uAA4C\\uAA7C\\uAAB0\\uAAB2-\\uAAB4\\uAAB7-\\uAAB8\\uAABE-\\uAABF\\uAAC1\\uAAEC-\\uAAED\\uAAF6\\uABE5\\uABE8\\uABED\\uFB1E\\uFE00-\\uFE0F\\uFE20-\\uFE2F]",
 				chars:      []rune{'ֿ', 'ׇ', 'ٰ', 'ܑ', '߽', 'ऺ', '़', '्', 'ঁ', '়', '্', '৾', '਼', 'ੑ', 'ੵ', '઼', '્', 'ଁ', '଼', 'ି', '୍', 'ୖ', 'ஂ', 'ீ', '்', 'ఀ', 'ఄ', 'ಁ', '಼', 'ಿ', 'ೆ', '്', '්', 'ූ', 'ั', 'ັ', '༵', '༷', '༹', '࿆', 'ႂ', 'ႍ', 'ႝ', 'ំ', '៝', 'ᢩ', 'ᤲ', 'ᨛ', 'ᩖ', '᩠', 'ᩢ', '᩿', '᬴', 'ᬼ', 'ᭂ', '᯦', 'ᯭ', '᳭', '᳴', '⃡', '⵿', '꙯', 'ꠂ', '꠆', 'ꠋ', 'ꣿ', '꦳', 'ꦼ', 'ꧥ', 'ꩃ', 'ꩌ', 'ꩼ', 'ꪰ', '꫁', '꫶', 'ꯥ', 'ꯨ', '꯭', 'ﬞ'},
 				ranges:     []rune{'̀', 'ͯ', '҃', '҇', '֑', 'ֽ', 'ׁ', 'ׂ', 'ׄ', 'ׅ', 'ؐ', 'ؚ', 'ً', 'ٟ', 'ۖ', 'ۜ', '۟', 'ۤ', 'ۧ', 'ۨ', '۪', 'ۭ', 'ܰ', '݊', 'ަ', 'ް', '߫', '߳', 'ࠖ', '࠙', 'ࠛ', 'ࠣ', 'ࠥ', 'ࠧ', 'ࠩ', '࠭', '࡙', '࡛', '࣓', '࣡', 'ࣣ', 'ं', 'ु', 'ै', '॑', 'ॗ', 'ॢ', 'ॣ', 'ু', 'ৄ', 'ৢ', 'ৣ', 'ਁ', 'ਂ', 'ੁ', 'ੂ', 'ੇ', 'ੈ', 'ੋ', '੍', 'ੰ', 'ੱ', 'ઁ', 'ં', 'ુ', 'ૅ', 'ે', 'ૈ', 'ૢ', 'ૣ', 'ૺ', '૿', 'ୁ', 'ୄ', 'ୢ', 'ୣ', 'ా', 'ీ', 'ె', 'ై', 'ొ', '్', 'ౕ', 'ౖ', 'ౢ', 'ౣ', 'ೌ', '್', 'ೢ', 'ೣ', 'ഀ', 'ഁ', '഻', '഼', 'ു', 'ൄ', 'ൢ', 'ൣ', 'ි', 'ු', 'ิ', 'ฺ', '็', '๎', 'ິ', 'ູ', 'ົ', 'ຼ', '່', 'ໍ', '༘', '༙', 'ཱ', 'ཾ', 'ྀ', '྄', '྆', '྇', 'ྍ', 'ྗ', 'ྙ', 'ྼ', 'ိ', 'ူ', 'ဲ', '့', '္', '်', 'ွ', 'ှ', 'ၘ', 'ၙ', 'ၞ', 'ၠ', 'ၱ', 'ၴ', 'ႅ', 'ႆ', '፝', '፟', 'ᜒ', '᜔', 'ᜲ', '᜴', 'ᝒ', 'ᝓ', 'ᝲ', 'ᝳ', '឴', '឵', 'ិ', 'ួ', '៉', '៓', '᠋', '᠍', 'ᢅ', 'ᢆ', 'ᤠ', 'ᤢ', 'ᤧ', 'ᤨ', '᤹', '᤻', 'ᨗ', 'ᨘ', 'ᩘ', 'ᩞ', 'ᩥ', 'ᩬ', 'ᩳ', '᩼', '᪰', '᪽', 'ᬀ', 'ᬃ', 'ᬶ', 'ᬺ', '᭫', '᭳', 'ᮀ', 'ᮁ', 'ᮢ', 'ᮥ', 'ᮨ', 'ᮩ', '᮫', 'ᮭ', 'ᯨ', 'ᯩ', 'ᯯ', 'ᯱ', 'ᰬ', 'ᰳ', 'ᰶ', '᰷', '᳐', '᳒', '᳔', '᳠', '᳢', '᳨', '᳸', '᳹', '᷀', '᷹', '᷻', '᷿', '⃐', '⃜', '⃥', '⃰', '⳯', '⳱', 'ⷠ', 'ⷿ', '〪', '〭', '゙', '゚', 'ꙴ', '꙽', 'ꚞ', 'ꚟ', '꛰', '꛱', 'ꠥ', 'ꠦ', '꣄', 'ꣅ', '꣠', '꣱', 'ꤦ', '꤭', 'ꥇ', 'ꥑ', 'ꦀ', 'ꦂ', 'ꦶ', 'ꦹ', 'ꨩ', 'ꨮ', 'ꨱ', 'ꨲ', 'ꨵ', 'ꨶ', 'ꪲ', 'ꪴ', 'ꪷ', 'ꪸ', 'ꪾ', '꪿', 'ꫬ', 'ꫭ', '︀', '️', '︠', '︯'},
@@ -12833,9 +12851,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nd",
-			pos:  position{line: 1851, col: 1, offset: 58403},
+			pos:  position{line: 1853, col: 1, offset: 58489},
 			expr: &charClassMatcher{
-				pos:        position{line: 1851, col: 6, offset: 58408},
+				pos:        position{line: 1853, col: 6, offset: 58494},
 				val:        "[\\u0030-\\u0039\\u0660-\\u0669\\u06F0-\\u06F9\\u07C0-\\u07C9\\u0966-\\u096F\\u09E6-\\u09EF\\u0A66-\\u0A6F\\u0AE6-\\u0AEF\\u0B66-\\u0B6F\\u0BE6-\\u0BEF\\u0C66-\\u0C6F\\u0CE6-\\u0CEF\\u0D66-\\u0D6F\\u0DE6-\\u0DEF\\u0E50-\\u0E59\\u0ED0-\\u0ED9\\u0F20-\\u0F29\\u1040-\\u1049\\u1090-\\u1099\\u17E0-\\u17E9\\u1810-\\u1819\\u1946-\\u194F\\u19D0-\\u19D9\\u1A80-\\u1A89\\u1A90-\\u1A99\\u1B50-\\u1B59\\u1BB0-\\u1BB9\\u1C40-\\u1C49\\u1C50-\\u1C59\\uA620-\\uA629\\uA8D0-\\uA8D9\\uA900-\\uA909\\uA9D0-\\uA9D9\\uA9F0-\\uA9F9\\uAA50-\\uAA59\\uABF0-\\uABF9\\uFF10-\\uFF19]",
 				ranges:     []rune{'0', '9', '٠', '٩', '۰', '۹', '߀', '߉', '०', '९', '০', '৯', '੦', '੯', '૦', '૯', '୦', '୯', '௦', '௯', '౦', '౯', '೦', '೯', '൦', '൯', '෦', '෯', '๐', '๙', '໐', '໙', '༠', '༩', '၀', '၉', '႐', '႙', '០', '៩', '᠐', '᠙', '᥆', '᥏', '᧐', '᧙', '᪀', '᪉', '᪐', '᪙', '᭐', '᭙', '᮰', '᮹', '᱀', '᱉', '᱐', '᱙', '꘠', '꘩', '꣐', '꣙', '꤀', '꤉', '꧐', '꧙', '꧰', '꧹', '꩐', '꩙', '꯰', '꯹', '０', '９'},
 				ignoreCase: false,
@@ -12846,9 +12864,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nl",
-			pos:  position{line: 1854, col: 1, offset: 58911},
+			pos:  position{line: 1856, col: 1, offset: 58997},
 			expr: &charClassMatcher{
-				pos:        position{line: 1854, col: 6, offset: 58916},
+				pos:        position{line: 1856, col: 6, offset: 59002},
 				val:        "[\\u16EE-\\u16F0\\u2160-\\u2182\\u2185-\\u2188\\u3007\\u3021-\\u3029\\u3038-\\u303A\\uA6E6-\\uA6EF]",
 				chars:      []rune{'〇'},
 				ranges:     []rune{'ᛮ', 'ᛰ', 'Ⅰ', 'ↂ', 'ↅ', 'ↈ', '〡', '〩', '〸', '〺', 'ꛦ', 'ꛯ'},
@@ -12860,9 +12878,9 @@ var g = &grammar{
 		},
 		{
 			name: "Pc",
-			pos:  position{line: 1857, col: 1, offset: 59030},
+			pos:  position{line: 1859, col: 1, offset: 59116},
 			expr: &charClassMatcher{
-				pos:        position{line: 1857, col: 6, offset: 59035},
+				pos:        position{line: 1859, col: 6, offset: 59121},
 				val:        "[\\u005F\\u203F-\\u2040\\u2054\\uFE33-\\uFE34\\uFE4D-\\uFE4F\\uFF3F]",
 				chars:      []rune{'_', '⁔', '＿'},
 				ranges:     []rune{'‿', '⁀', '︳', '︴', '﹍', '﹏'},
@@ -12874,9 +12892,9 @@ var g = &grammar{
 		},
 		{
 			name: "Zs",
-			pos:  position{line: 1860, col: 1, offset: 59116},
+			pos:  position{line: 1862, col: 1, offset: 59202},
 			expr: &charClassMatcher{
-				pos:        position{line: 1860, col: 6, offset: 59121},
+				pos:        position{line: 1862, col: 6, offset: 59207},
 				val:        "[\\u0020\\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000]",
 				chars:      []rune{' ', '\u00a0', '\u1680', '\u202f', '\u205f', '\u3000'},
 				ranges:     []rune{'\u2000', '\u200a'},
@@ -12888,9 +12906,9 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1862, col: 1, offset: 59174},
+			pos:  position{line: 1864, col: 1, offset: 59260},
 			expr: &anyMatcher{
-				line: 1863, col: 5, offset: 59194,
+				line: 1865, col: 5, offset: 59280,
 			},
 			leader:        false,
 			leftRecursive: false,
@@ -12898,48 +12916,48 @@ var g = &grammar{
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1865, col: 1, offset: 59197},
+			pos:         position{line: 1867, col: 1, offset: 59283},
 			expr: &choiceExpr{
-				pos: position{line: 1866, col: 5, offset: 59225},
+				pos: position{line: 1868, col: 5, offset: 59311},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1866, col: 5, offset: 59225},
+						pos:        position{line: 1868, col: 5, offset: 59311},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1867, col: 5, offset: 59234},
+						pos:        position{line: 1869, col: 5, offset: 59320},
 						val:        "\v",
 						ignoreCase: false,
 						want:       "\"\\v\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1868, col: 5, offset: 59243},
+						pos:        position{line: 1870, col: 5, offset: 59329},
 						val:        "\f",
 						ignoreCase: false,
 						want:       "\"\\f\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1869, col: 5, offset: 59252},
+						pos:        position{line: 1871, col: 5, offset: 59338},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 1870, col: 5, offset: 59260},
+						pos:        position{line: 1872, col: 5, offset: 59346},
 						val:        "\u00a0",
 						ignoreCase: false,
 						want:       "\"\\u00a0\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1871, col: 5, offset: 59273},
+						pos:        position{line: 1873, col: 5, offset: 59359},
 						val:        "\ufeff",
 						ignoreCase: false,
 						want:       "\"\\ufeff\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1872, col: 5, offset: 59286},
+						pos:  position{line: 1874, col: 5, offset: 59372},
 						name: "Zs",
 					},
 				},
@@ -12949,9 +12967,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1874, col: 1, offset: 59290},
+			pos:  position{line: 1876, col: 1, offset: 59376},
 			expr: &charClassMatcher{
-				pos:        position{line: 1875, col: 5, offset: 59309},
+				pos:        position{line: 1877, col: 5, offset: 59395},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -12963,16 +12981,16 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1877, col: 1, offset: 59329},
+			pos:         position{line: 1879, col: 1, offset: 59415},
 			expr: &choiceExpr{
-				pos: position{line: 1878, col: 5, offset: 59351},
+				pos: position{line: 1880, col: 5, offset: 59437},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1878, col: 5, offset: 59351},
+						pos:  position{line: 1880, col: 5, offset: 59437},
 						name: "MultiLineComment",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1879, col: 5, offset: 59372},
+						pos:  position{line: 1881, col: 5, offset: 59458},
 						name: "SingleLineComment",
 					},
 				},
@@ -12982,39 +13000,39 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1881, col: 1, offset: 59391},
+			pos:  position{line: 1883, col: 1, offset: 59477},
 			expr: &seqExpr{
-				pos: position{line: 1882, col: 5, offset: 59412},
+				pos: position{line: 1884, col: 5, offset: 59498},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1882, col: 5, offset: 59412},
+						pos:        position{line: 1884, col: 5, offset: 59498},
 						val:        "/*",
 						ignoreCase: false,
 						want:       "\"/*\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1882, col: 10, offset: 59417},
+						pos: position{line: 1884, col: 10, offset: 59503},
 						expr: &seqExpr{
-							pos: position{line: 1882, col: 11, offset: 59418},
+							pos: position{line: 1884, col: 11, offset: 59504},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1882, col: 11, offset: 59418},
+									pos: position{line: 1884, col: 11, offset: 59504},
 									expr: &litMatcher{
-										pos:        position{line: 1882, col: 12, offset: 59419},
+										pos:        position{line: 1884, col: 12, offset: 59505},
 										val:        "*/",
 										ignoreCase: false,
 										want:       "\"*/\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1882, col: 17, offset: 59424},
+									pos:  position{line: 1884, col: 17, offset: 59510},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1882, col: 35, offset: 59442},
+						pos:        position{line: 1884, col: 35, offset: 59528},
 						val:        "*/",
 						ignoreCase: false,
 						want:       "\"*/\"",
@@ -13026,30 +13044,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1884, col: 1, offset: 59448},
+			pos:  position{line: 1886, col: 1, offset: 59534},
 			expr: &seqExpr{
-				pos: position{line: 1885, col: 5, offset: 59470},
+				pos: position{line: 1887, col: 5, offset: 59556},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1885, col: 5, offset: 59470},
+						pos:        position{line: 1887, col: 5, offset: 59556},
 						val:        "--",
 						ignoreCase: false,
 						want:       "\"--\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1885, col: 10, offset: 59475},
+						pos: position{line: 1887, col: 10, offset: 59561},
 						expr: &seqExpr{
-							pos: position{line: 1885, col: 11, offset: 59476},
+							pos: position{line: 1887, col: 11, offset: 59562},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1885, col: 11, offset: 59476},
+									pos: position{line: 1887, col: 11, offset: 59562},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1885, col: 12, offset: 59477},
+										pos:  position{line: 1887, col: 12, offset: 59563},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1885, col: 27, offset: 59492},
+									pos:  position{line: 1887, col: 27, offset: 59578},
 									name: "SourceCharacter",
 								},
 							},
@@ -13062,19 +13080,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1887, col: 1, offset: 59511},
+			pos:  position{line: 1889, col: 1, offset: 59597},
 			expr: &seqExpr{
-				pos: position{line: 1887, col: 7, offset: 59517},
+				pos: position{line: 1889, col: 7, offset: 59603},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1887, col: 7, offset: 59517},
+						pos: position{line: 1889, col: 7, offset: 59603},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1887, col: 7, offset: 59517},
+							pos:  position{line: 1889, col: 7, offset: 59603},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1887, col: 19, offset: 59529},
+						pos:  position{line: 1889, col: 19, offset: 59615},
 						name: "LineTerminator",
 					},
 				},
@@ -13084,16 +13102,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1889, col: 1, offset: 59545},
+			pos:  position{line: 1891, col: 1, offset: 59631},
 			expr: &choiceExpr{
-				pos: position{line: 1889, col: 7, offset: 59551},
+				pos: position{line: 1891, col: 7, offset: 59637},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1889, col: 7, offset: 59551},
+						pos:  position{line: 1891, col: 7, offset: 59637},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1889, col: 11, offset: 59555},
+						pos:  position{line: 1891, col: 11, offset: 59641},
 						name: "EOF",
 					},
 				},
@@ -13103,11 +13121,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1891, col: 1, offset: 59560},
+			pos:  position{line: 1893, col: 1, offset: 59646},
 			expr: &notExpr{
-				pos: position{line: 1891, col: 7, offset: 59566},
+				pos: position{line: 1893, col: 7, offset: 59652},
 				expr: &anyMatcher{
-					line: 1891, col: 8, offset: 59567,
+					line: 1893, col: 8, offset: 59653,
 				},
 			},
 			leader:        false,
@@ -13115,15 +13133,15 @@ var g = &grammar{
 		},
 		{
 			name: "SQLPipe",
-			pos:  position{line: 1895, col: 1, offset: 59592},
+			pos:  position{line: 1897, col: 1, offset: 59678},
 			expr: &actionExpr{
-				pos: position{line: 1896, col: 5, offset: 59604},
+				pos: position{line: 1898, col: 5, offset: 59690},
 				run: (*parser).callonSQLPipe1,
 				expr: &labeledExpr{
-					pos:   position{line: 1896, col: 5, offset: 59604},
+					pos:   position{line: 1898, col: 5, offset: 59690},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1896, col: 7, offset: 59606},
+						pos:  position{line: 1898, col: 7, offset: 59692},
 						name: "Seq",
 					},
 				},
@@ -13133,15 +13151,15 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOp",
-			pos:  position{line: 1904, col: 1, offset: 59753},
+			pos:  position{line: 1906, col: 1, offset: 59839},
 			expr: &actionExpr{
-				pos: position{line: 1905, col: 5, offset: 59763},
+				pos: position{line: 1907, col: 5, offset: 59849},
 				run: (*parser).callonSQLOp1,
 				expr: &labeledExpr{
-					pos:   position{line: 1905, col: 5, offset: 59763},
+					pos:   position{line: 1907, col: 5, offset: 59849},
 					label: "query",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1905, col: 11, offset: 59769},
+						pos:  position{line: 1907, col: 11, offset: 59855},
 						name: "SQLQuery",
 					},
 				},
@@ -13151,42 +13169,42 @@ var g = &grammar{
 		},
 		{
 			name: "SQLQuery",
-			pos:  position{line: 1913, col: 1, offset: 59906},
+			pos:  position{line: 1915, col: 1, offset: 59992},
 			expr: &actionExpr{
-				pos: position{line: 1914, col: 5, offset: 59919},
+				pos: position{line: 1916, col: 5, offset: 60005},
 				run: (*parser).callonSQLQuery1,
 				expr: &seqExpr{
-					pos: position{line: 1914, col: 5, offset: 59919},
+					pos: position{line: 1916, col: 5, offset: 60005},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1914, col: 5, offset: 59919},
+							pos:   position{line: 1916, col: 5, offset: 60005},
 							label: "with",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1914, col: 10, offset: 59924},
+								pos:  position{line: 1916, col: 10, offset: 60010},
 								name: "OptWithClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1915, col: 5, offset: 59942},
+							pos:   position{line: 1917, col: 5, offset: 60028},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1915, col: 10, offset: 59947},
+								pos:  position{line: 1917, col: 10, offset: 60033},
 								name: "SQLBodySetOp",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1916, col: 5, offset: 59964},
+							pos:   position{line: 1918, col: 5, offset: 60050},
 							label: "orderby",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1916, col: 13, offset: 59972},
+								pos:  position{line: 1918, col: 13, offset: 60058},
 								name: "OptOrderByClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1917, col: 5, offset: 59993},
+							pos:   position{line: 1919, col: 5, offset: 60079},
 							label: "loff",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1917, col: 10, offset: 59998},
+								pos:  position{line: 1919, col: 10, offset: 60084},
 								name: "OptSQLLimitOffset",
 							},
 						},
@@ -13198,39 +13216,39 @@ var g = &grammar{
 		},
 		{
 			name: "SQLBodySetOp",
-			pos:  position{line: 1935, col: 1, offset: 60415},
+			pos:  position{line: 1937, col: 1, offset: 60501},
 			expr: &actionExpr{
-				pos: position{line: 1936, col: 5, offset: 60432},
+				pos: position{line: 1938, col: 5, offset: 60518},
 				run: (*parser).callonSQLBodySetOp1,
 				expr: &seqExpr{
-					pos: position{line: 1936, col: 5, offset: 60432},
+					pos: position{line: 1938, col: 5, offset: 60518},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1936, col: 5, offset: 60432},
+							pos:   position{line: 1938, col: 5, offset: 60518},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1936, col: 11, offset: 60438},
+								pos:  position{line: 1938, col: 11, offset: 60524},
 								name: "SQLQueryBody",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1936, col: 24, offset: 60451},
+							pos:   position{line: 1938, col: 24, offset: 60537},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1936, col: 29, offset: 60456},
+								pos: position{line: 1938, col: 29, offset: 60542},
 								expr: &seqExpr{
-									pos: position{line: 1936, col: 30, offset: 60457},
+									pos: position{line: 1938, col: 30, offset: 60543},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1936, col: 30, offset: 60457},
+											pos:  position{line: 1938, col: 30, offset: 60543},
 											name: "SetOp",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1936, col: 36, offset: 60463},
+											pos:  position{line: 1938, col: 36, offset: 60549},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1936, col: 38, offset: 60465},
+											pos:  position{line: 1938, col: 38, offset: 60551},
 											name: "SQLQueryBody",
 										},
 									},
@@ -13245,52 +13263,52 @@ var g = &grammar{
 		},
 		{
 			name: "SQLQueryBody",
-			pos:  position{line: 1950, col: 1, offset: 60782},
+			pos:  position{line: 1952, col: 1, offset: 60868},
 			expr: &choiceExpr{
-				pos: position{line: 1951, col: 5, offset: 60799},
+				pos: position{line: 1953, col: 5, offset: 60885},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1951, col: 5, offset: 60799},
+						pos:  position{line: 1953, col: 5, offset: 60885},
 						name: "Select",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1952, col: 5, offset: 60810},
+						pos:  position{line: 1954, col: 5, offset: 60896},
 						name: "FromSelect",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1953, col: 5, offset: 60825},
+						pos:  position{line: 1955, col: 5, offset: 60911},
 						name: "SQLValues",
 					},
 					&actionExpr{
-						pos: position{line: 1954, col: 5, offset: 60839},
+						pos: position{line: 1956, col: 5, offset: 60925},
 						run: (*parser).callonSQLQueryBody5,
 						expr: &seqExpr{
-							pos: position{line: 1954, col: 5, offset: 60839},
+							pos: position{line: 1956, col: 5, offset: 60925},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1954, col: 5, offset: 60839},
+									pos:        position{line: 1956, col: 5, offset: 60925},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1954, col: 9, offset: 60843},
+									pos:  position{line: 1956, col: 9, offset: 60929},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1954, col: 12, offset: 60846},
+									pos:   position{line: 1956, col: 12, offset: 60932},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1954, col: 14, offset: 60848},
+										pos:  position{line: 1956, col: 14, offset: 60934},
 										name: "SQLQueryOrSetExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1954, col: 32, offset: 60866},
+									pos:  position{line: 1956, col: 32, offset: 60952},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1954, col: 34, offset: 60868},
+									pos:        position{line: 1956, col: 34, offset: 60954},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -13305,16 +13323,16 @@ var g = &grammar{
 		},
 		{
 			name: "SQLQueryOrSetExpr",
-			pos:  position{line: 1956, col: 1, offset: 60891},
+			pos:  position{line: 1958, col: 1, offset: 60977},
 			expr: &choiceExpr{
-				pos: position{line: 1956, col: 21, offset: 60911},
+				pos: position{line: 1958, col: 21, offset: 60997},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1956, col: 21, offset: 60911},
+						pos:  position{line: 1958, col: 21, offset: 60997},
 						name: "SQLQuery",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1956, col: 32, offset: 60922},
+						pos:  position{line: 1958, col: 32, offset: 61008},
 						name: "SQLBodySetOp",
 					},
 				},
@@ -13324,74 +13342,74 @@ var g = &grammar{
 		},
 		{
 			name: "Select",
-			pos:  position{line: 1958, col: 1, offset: 60936},
+			pos:  position{line: 1960, col: 1, offset: 61022},
 			expr: &actionExpr{
-				pos: position{line: 1959, col: 5, offset: 60947},
+				pos: position{line: 1961, col: 5, offset: 61033},
 				run: (*parser).callonSelect1,
 				expr: &seqExpr{
-					pos: position{line: 1959, col: 5, offset: 60947},
+					pos: position{line: 1961, col: 5, offset: 61033},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1959, col: 5, offset: 60947},
+							pos:  position{line: 1961, col: 5, offset: 61033},
 							name: "SELECT",
 						},
 						&labeledExpr{
-							pos:   position{line: 1960, col: 5, offset: 60958},
+							pos:   position{line: 1962, col: 5, offset: 61044},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1960, col: 14, offset: 60967},
+								pos:  position{line: 1962, col: 14, offset: 61053},
 								name: "OptDistinct",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1961, col: 5, offset: 60983},
+							pos:   position{line: 1963, col: 5, offset: 61069},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1961, col: 11, offset: 60989},
+								pos:  position{line: 1963, col: 11, offset: 61075},
 								name: "OptSelectValue",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1964, col: 5, offset: 61128},
+							pos:  position{line: 1966, col: 5, offset: 61214},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1964, col: 7, offset: 61130},
+							pos:   position{line: 1966, col: 7, offset: 61216},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1964, col: 17, offset: 61140},
+								pos:  position{line: 1966, col: 17, offset: 61226},
 								name: "Selection",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1965, col: 5, offset: 61154},
+							pos:   position{line: 1967, col: 5, offset: 61240},
 							label: "from",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1965, col: 10, offset: 61159},
+								pos:  position{line: 1967, col: 10, offset: 61245},
 								name: "OptFromClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1966, col: 5, offset: 61177},
+							pos:   position{line: 1968, col: 5, offset: 61263},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1966, col: 11, offset: 61183},
+								pos:  position{line: 1968, col: 11, offset: 61269},
 								name: "OptWhereClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1967, col: 5, offset: 61202},
+							pos:   position{line: 1969, col: 5, offset: 61288},
 							label: "group",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1967, col: 11, offset: 61208},
+								pos:  position{line: 1969, col: 11, offset: 61294},
 								name: "OptGroupClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1968, col: 5, offset: 61227},
+							pos:   position{line: 1970, col: 5, offset: 61313},
 							label: "having",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1968, col: 12, offset: 61234},
+								pos:  position{line: 1970, col: 12, offset: 61320},
 								name: "OptHavingClause",
 							},
 						},
@@ -13403,78 +13421,78 @@ var g = &grammar{
 		},
 		{
 			name: "FromSelect",
-			pos:  position{line: 1994, col: 1, offset: 61851},
+			pos:  position{line: 1996, col: 1, offset: 61937},
 			expr: &actionExpr{
-				pos: position{line: 1995, col: 5, offset: 61866},
+				pos: position{line: 1997, col: 5, offset: 61952},
 				run: (*parser).callonFromSelect1,
 				expr: &seqExpr{
-					pos: position{line: 1995, col: 5, offset: 61866},
+					pos: position{line: 1997, col: 5, offset: 61952},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1995, col: 5, offset: 61866},
+							pos:   position{line: 1997, col: 5, offset: 61952},
 							label: "from",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1995, col: 10, offset: 61871},
+								pos:  position{line: 1997, col: 10, offset: 61957},
 								name: "FromOp",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1995, col: 17, offset: 61878},
+							pos:  position{line: 1997, col: 17, offset: 61964},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1995, col: 19, offset: 61880},
+							pos:  position{line: 1997, col: 19, offset: 61966},
 							name: "SELECT",
 						},
 						&labeledExpr{
-							pos:   position{line: 1996, col: 5, offset: 61891},
+							pos:   position{line: 1998, col: 5, offset: 61977},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1996, col: 14, offset: 61900},
+								pos:  position{line: 1998, col: 14, offset: 61986},
 								name: "OptDistinct",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1997, col: 5, offset: 61916},
+							pos:   position{line: 1999, col: 5, offset: 62002},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1997, col: 11, offset: 61922},
+								pos:  position{line: 1999, col: 11, offset: 62008},
 								name: "OptSelectValue",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2000, col: 5, offset: 62061},
+							pos:  position{line: 2002, col: 5, offset: 62147},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2000, col: 7, offset: 62063},
+							pos:   position{line: 2002, col: 7, offset: 62149},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2000, col: 17, offset: 62073},
+								pos:  position{line: 2002, col: 17, offset: 62159},
 								name: "Selection",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2001, col: 5, offset: 62087},
+							pos:   position{line: 2003, col: 5, offset: 62173},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2001, col: 11, offset: 62093},
+								pos:  position{line: 2003, col: 11, offset: 62179},
 								name: "OptWhereClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2002, col: 5, offset: 62112},
+							pos:   position{line: 2004, col: 5, offset: 62198},
 							label: "group",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2002, col: 11, offset: 62118},
+								pos:  position{line: 2004, col: 11, offset: 62204},
 								name: "OptGroupClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2003, col: 5, offset: 62137},
+							pos:   position{line: 2005, col: 5, offset: 62223},
 							label: "having",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2003, col: 12, offset: 62144},
+								pos:  position{line: 2005, col: 12, offset: 62230},
 								name: "OptHavingClause",
 							},
 						},
@@ -13486,26 +13504,26 @@ var g = &grammar{
 		},
 		{
 			name: "SQLValues",
-			pos:  position{line: 2027, col: 1, offset: 62728},
+			pos:  position{line: 2029, col: 1, offset: 62814},
 			expr: &actionExpr{
-				pos: position{line: 2028, col: 5, offset: 62742},
+				pos: position{line: 2030, col: 5, offset: 62828},
 				run: (*parser).callonSQLValues1,
 				expr: &seqExpr{
-					pos: position{line: 2028, col: 5, offset: 62742},
+					pos: position{line: 2030, col: 5, offset: 62828},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2028, col: 5, offset: 62742},
+							pos:  position{line: 2030, col: 5, offset: 62828},
 							name: "VALUES",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2028, col: 12, offset: 62749},
+							pos:  position{line: 2030, col: 12, offset: 62835},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2028, col: 15, offset: 62752},
+							pos:   position{line: 2030, col: 15, offset: 62838},
 							label: "tuples",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2028, col: 22, offset: 62759},
+								pos:  position{line: 2030, col: 22, offset: 62845},
 								name: "SQLTuples",
 							},
 						},
@@ -13517,26 +13535,26 @@ var g = &grammar{
 		},
 		{
 			name: "ValuesOp",
-			pos:  position{line: 2036, col: 1, offset: 62916},
+			pos:  position{line: 2038, col: 1, offset: 63002},
 			expr: &actionExpr{
-				pos: position{line: 2037, col: 5, offset: 62929},
+				pos: position{line: 2039, col: 5, offset: 63015},
 				run: (*parser).callonValuesOp1,
 				expr: &seqExpr{
-					pos: position{line: 2037, col: 5, offset: 62929},
+					pos: position{line: 2039, col: 5, offset: 63015},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2037, col: 5, offset: 62929},
+							pos:  position{line: 2039, col: 5, offset: 63015},
 							name: "VALUES",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2037, col: 12, offset: 62936},
+							pos:  position{line: 2039, col: 12, offset: 63022},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2037, col: 14, offset: 62938},
+							pos:   position{line: 2039, col: 14, offset: 63024},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2037, col: 20, offset: 62944},
+								pos:  position{line: 2039, col: 20, offset: 63030},
 								name: "Exprs",
 							},
 						},
@@ -13548,51 +13566,51 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTuples",
-			pos:  position{line: 2046, col: 1, offset: 63095},
+			pos:  position{line: 2048, col: 1, offset: 63181},
 			expr: &actionExpr{
-				pos: position{line: 2047, col: 5, offset: 63109},
+				pos: position{line: 2049, col: 5, offset: 63195},
 				run: (*parser).callonSQLTuples1,
 				expr: &seqExpr{
-					pos: position{line: 2047, col: 5, offset: 63109},
+					pos: position{line: 2049, col: 5, offset: 63195},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2047, col: 5, offset: 63109},
+							pos:   position{line: 2049, col: 5, offset: 63195},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2047, col: 11, offset: 63115},
+								pos:  position{line: 2049, col: 11, offset: 63201},
 								name: "SQLTuple",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2047, col: 20, offset: 63124},
+							pos:   position{line: 2049, col: 20, offset: 63210},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2047, col: 25, offset: 63129},
+								pos: position{line: 2049, col: 25, offset: 63215},
 								expr: &actionExpr{
-									pos: position{line: 2047, col: 26, offset: 63130},
+									pos: position{line: 2049, col: 26, offset: 63216},
 									run: (*parser).callonSQLTuples7,
 									expr: &seqExpr{
-										pos: position{line: 2047, col: 26, offset: 63130},
+										pos: position{line: 2049, col: 26, offset: 63216},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2047, col: 26, offset: 63130},
+												pos:  position{line: 2049, col: 26, offset: 63216},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2047, col: 29, offset: 63133},
+												pos:        position{line: 2049, col: 29, offset: 63219},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2047, col: 33, offset: 63137},
+												pos:  position{line: 2049, col: 33, offset: 63223},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2047, col: 36, offset: 63140},
+												pos:   position{line: 2049, col: 36, offset: 63226},
 												label: "t",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2047, col: 38, offset: 63142},
+													pos:  position{line: 2049, col: 38, offset: 63228},
 													name: "SQLTuple",
 												},
 											},
@@ -13609,37 +13627,37 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTuple",
-			pos:  position{line: 2051, col: 1, offset: 63219},
+			pos:  position{line: 2053, col: 1, offset: 63305},
 			expr: &actionExpr{
-				pos: position{line: 2052, col: 5, offset: 63232},
+				pos: position{line: 2054, col: 5, offset: 63318},
 				run: (*parser).callonSQLTuple1,
 				expr: &seqExpr{
-					pos: position{line: 2052, col: 5, offset: 63232},
+					pos: position{line: 2054, col: 5, offset: 63318},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2052, col: 5, offset: 63232},
+							pos:        position{line: 2054, col: 5, offset: 63318},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2052, col: 9, offset: 63236},
+							pos:  position{line: 2054, col: 9, offset: 63322},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2052, col: 12, offset: 63239},
+							pos:   position{line: 2054, col: 12, offset: 63325},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2052, col: 18, offset: 63245},
+								pos:  position{line: 2054, col: 18, offset: 63331},
 								name: "Exprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2052, col: 24, offset: 63251},
+							pos:  position{line: 2054, col: 24, offset: 63337},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2052, col: 27, offset: 63254},
+							pos:        position{line: 2054, col: 27, offset: 63340},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -13652,49 +13670,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptDistinct",
-			pos:  position{line: 2060, col: 1, offset: 63398},
+			pos:  position{line: 2062, col: 1, offset: 63484},
 			expr: &choiceExpr{
-				pos: position{line: 2061, col: 5, offset: 63414},
+				pos: position{line: 2063, col: 5, offset: 63500},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2061, col: 5, offset: 63414},
+						pos: position{line: 2063, col: 5, offset: 63500},
 						run: (*parser).callonOptDistinct2,
 						expr: &seqExpr{
-							pos: position{line: 2061, col: 5, offset: 63414},
+							pos: position{line: 2063, col: 5, offset: 63500},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2061, col: 5, offset: 63414},
+									pos:  position{line: 2063, col: 5, offset: 63500},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2061, col: 7, offset: 63416},
+									pos:  position{line: 2063, col: 7, offset: 63502},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2062, col: 5, offset: 63453},
+						pos: position{line: 2064, col: 5, offset: 63539},
 						run: (*parser).callonOptDistinct6,
 						expr: &seqExpr{
-							pos: position{line: 2062, col: 5, offset: 63453},
+							pos: position{line: 2064, col: 5, offset: 63539},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2062, col: 5, offset: 63453},
+									pos:  position{line: 2064, col: 5, offset: 63539},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2062, col: 7, offset: 63455},
+									pos:  position{line: 2064, col: 7, offset: 63541},
 									name: "DISTINCT",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2063, col: 5, offset: 63491},
+						pos: position{line: 2065, col: 5, offset: 63577},
 						run: (*parser).callonOptDistinct10,
 						expr: &litMatcher{
-							pos:        position{line: 2063, col: 5, offset: 63491},
+							pos:        position{line: 2065, col: 5, offset: 63577},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13707,57 +13725,57 @@ var g = &grammar{
 		},
 		{
 			name: "OptSelectValue",
-			pos:  position{line: 2065, col: 1, offset: 63530},
+			pos:  position{line: 2067, col: 1, offset: 63616},
 			expr: &choiceExpr{
-				pos: position{line: 2066, col: 5, offset: 63549},
+				pos: position{line: 2068, col: 5, offset: 63635},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2066, col: 5, offset: 63549},
+						pos: position{line: 2068, col: 5, offset: 63635},
 						run: (*parser).callonOptSelectValue2,
 						expr: &seqExpr{
-							pos: position{line: 2066, col: 5, offset: 63549},
+							pos: position{line: 2068, col: 5, offset: 63635},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2066, col: 5, offset: 63549},
+									pos:  position{line: 2068, col: 5, offset: 63635},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2066, col: 7, offset: 63551},
+									pos:  position{line: 2068, col: 7, offset: 63637},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2066, col: 10, offset: 63554},
+									pos:  position{line: 2068, col: 10, offset: 63640},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2066, col: 12, offset: 63556},
+									pos:  position{line: 2068, col: 12, offset: 63642},
 									name: "VALUE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2067, col: 5, offset: 63588},
+						pos: position{line: 2069, col: 5, offset: 63674},
 						run: (*parser).callonOptSelectValue8,
 						expr: &seqExpr{
-							pos: position{line: 2067, col: 5, offset: 63588},
+							pos: position{line: 2069, col: 5, offset: 63674},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2067, col: 5, offset: 63588},
+									pos:  position{line: 2069, col: 5, offset: 63674},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2067, col: 7, offset: 63590},
+									pos:  position{line: 2069, col: 7, offset: 63676},
 									name: "VALUE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2068, col: 5, offset: 63661},
+						pos: position{line: 2070, col: 5, offset: 63747},
 						run: (*parser).callonOptSelectValue12,
 						expr: &litMatcher{
-							pos:        position{line: 2068, col: 5, offset: 63661},
+							pos:        position{line: 2070, col: 5, offset: 63747},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13770,19 +13788,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptWithClause",
-			pos:  position{line: 2070, col: 1, offset: 63704},
+			pos:  position{line: 2072, col: 1, offset: 63790},
 			expr: &choiceExpr{
-				pos: position{line: 2071, col: 5, offset: 63722},
+				pos: position{line: 2073, col: 5, offset: 63808},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2071, col: 5, offset: 63722},
+						pos:  position{line: 2073, col: 5, offset: 63808},
 						name: "WithClause",
 					},
 					&actionExpr{
-						pos: position{line: 2072, col: 5, offset: 63737},
+						pos: position{line: 2074, col: 5, offset: 63823},
 						run: (*parser).callonOptWithClause3,
 						expr: &litMatcher{
-							pos:        position{line: 2072, col: 5, offset: 63737},
+							pos:        position{line: 2074, col: 5, offset: 63823},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13795,39 +13813,39 @@ var g = &grammar{
 		},
 		{
 			name: "WithClause",
-			pos:  position{line: 2074, col: 1, offset: 63770},
+			pos:  position{line: 2076, col: 1, offset: 63856},
 			expr: &actionExpr{
-				pos: position{line: 2075, col: 5, offset: 63785},
+				pos: position{line: 2077, col: 5, offset: 63871},
 				run: (*parser).callonWithClause1,
 				expr: &seqExpr{
-					pos: position{line: 2075, col: 5, offset: 63785},
+					pos: position{line: 2077, col: 5, offset: 63871},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2075, col: 5, offset: 63785},
+							pos:  position{line: 2077, col: 5, offset: 63871},
 							name: "WITH",
 						},
 						&labeledExpr{
-							pos:   position{line: 2075, col: 10, offset: 63790},
+							pos:   position{line: 2077, col: 10, offset: 63876},
 							label: "r",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2075, col: 12, offset: 63792},
+								pos:  position{line: 2077, col: 12, offset: 63878},
 								name: "OptRecursive",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2075, col: 25, offset: 63805},
+							pos:  position{line: 2077, col: 25, offset: 63891},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2075, col: 27, offset: 63807},
+							pos:   position{line: 2077, col: 27, offset: 63893},
 							label: "ctes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2075, col: 32, offset: 63812},
+								pos:  position{line: 2077, col: 32, offset: 63898},
 								name: "CteList",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2075, col: 40, offset: 63820},
+							pos:  position{line: 2077, col: 40, offset: 63906},
 							name: "__",
 						},
 					},
@@ -13838,32 +13856,32 @@ var g = &grammar{
 		},
 		{
 			name: "OptRecursive",
-			pos:  position{line: 2083, col: 1, offset: 63979},
+			pos:  position{line: 2085, col: 1, offset: 64065},
 			expr: &choiceExpr{
-				pos: position{line: 2084, col: 5, offset: 63996},
+				pos: position{line: 2086, col: 5, offset: 64082},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2084, col: 5, offset: 63996},
+						pos: position{line: 2086, col: 5, offset: 64082},
 						run: (*parser).callonOptRecursive2,
 						expr: &seqExpr{
-							pos: position{line: 2084, col: 5, offset: 63996},
+							pos: position{line: 2086, col: 5, offset: 64082},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2084, col: 5, offset: 63996},
+									pos:  position{line: 2086, col: 5, offset: 64082},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2084, col: 7, offset: 63998},
+									pos:  position{line: 2086, col: 7, offset: 64084},
 									name: "RECURSIVE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2085, col: 5, offset: 64034},
+						pos: position{line: 2087, col: 5, offset: 64120},
 						run: (*parser).callonOptRecursive6,
 						expr: &litMatcher{
-							pos:        position{line: 2085, col: 5, offset: 64034},
+							pos:        position{line: 2087, col: 5, offset: 64120},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13876,51 +13894,51 @@ var g = &grammar{
 		},
 		{
 			name: "CteList",
-			pos:  position{line: 2087, col: 1, offset: 64073},
+			pos:  position{line: 2089, col: 1, offset: 64159},
 			expr: &actionExpr{
-				pos: position{line: 2087, col: 11, offset: 64083},
+				pos: position{line: 2089, col: 11, offset: 64169},
 				run: (*parser).callonCteList1,
 				expr: &seqExpr{
-					pos: position{line: 2087, col: 11, offset: 64083},
+					pos: position{line: 2089, col: 11, offset: 64169},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2087, col: 11, offset: 64083},
+							pos:   position{line: 2089, col: 11, offset: 64169},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2087, col: 17, offset: 64089},
+								pos:  position{line: 2089, col: 17, offset: 64175},
 								name: "Cte",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2087, col: 21, offset: 64093},
+							pos:   position{line: 2089, col: 21, offset: 64179},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2087, col: 26, offset: 64098},
+								pos: position{line: 2089, col: 26, offset: 64184},
 								expr: &actionExpr{
-									pos: position{line: 2087, col: 28, offset: 64100},
+									pos: position{line: 2089, col: 28, offset: 64186},
 									run: (*parser).callonCteList7,
 									expr: &seqExpr{
-										pos: position{line: 2087, col: 28, offset: 64100},
+										pos: position{line: 2089, col: 28, offset: 64186},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2087, col: 28, offset: 64100},
+												pos:  position{line: 2089, col: 28, offset: 64186},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2087, col: 31, offset: 64103},
+												pos:        position{line: 2089, col: 31, offset: 64189},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2087, col: 35, offset: 64107},
+												pos:  position{line: 2089, col: 35, offset: 64193},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2087, col: 38, offset: 64110},
+												pos:   position{line: 2089, col: 38, offset: 64196},
 												label: "cte",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2087, col: 42, offset: 64114},
+													pos:  position{line: 2089, col: 42, offset: 64200},
 													name: "Cte",
 												},
 											},
@@ -13937,65 +13955,65 @@ var g = &grammar{
 		},
 		{
 			name: "Cte",
-			pos:  position{line: 2091, col: 1, offset: 64182},
+			pos:  position{line: 2093, col: 1, offset: 64268},
 			expr: &actionExpr{
-				pos: position{line: 2092, col: 5, offset: 64190},
+				pos: position{line: 2094, col: 5, offset: 64276},
 				run: (*parser).callonCte1,
 				expr: &seqExpr{
-					pos: position{line: 2092, col: 5, offset: 64190},
+					pos: position{line: 2094, col: 5, offset: 64276},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2092, col: 5, offset: 64190},
+							pos:   position{line: 2094, col: 5, offset: 64276},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2092, col: 10, offset: 64195},
+								pos:  position{line: 2094, col: 10, offset: 64281},
 								name: "SQLIdentifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2092, col: 24, offset: 64209},
+							pos:  position{line: 2094, col: 24, offset: 64295},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2092, col: 26, offset: 64211},
+							pos:  position{line: 2094, col: 26, offset: 64297},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 2092, col: 29, offset: 64214},
+							pos:   position{line: 2094, col: 29, offset: 64300},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2092, col: 31, offset: 64216},
+								pos:  position{line: 2094, col: 31, offset: 64302},
 								name: "OptMaterialized",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2092, col: 47, offset: 64232},
+							pos:  position{line: 2094, col: 47, offset: 64318},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2092, col: 50, offset: 64235},
+							pos:        position{line: 2094, col: 50, offset: 64321},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2092, col: 54, offset: 64239},
+							pos:  position{line: 2094, col: 54, offset: 64325},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2092, col: 57, offset: 64242},
+							pos:   position{line: 2094, col: 57, offset: 64328},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2092, col: 59, offset: 64244},
+								pos:  position{line: 2094, col: 59, offset: 64330},
 								name: "SQLQueryOrSetExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2092, col: 77, offset: 64262},
+							pos:  position{line: 2094, col: 77, offset: 64348},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2092, col: 80, offset: 64265},
+							pos:        position{line: 2094, col: 80, offset: 64351},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -14008,65 +14026,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptMaterialized",
-			pos:  position{line: 2101, col: 1, offset: 64455},
+			pos:  position{line: 2103, col: 1, offset: 64541},
 			expr: &choiceExpr{
-				pos: position{line: 2102, col: 5, offset: 64475},
+				pos: position{line: 2104, col: 5, offset: 64561},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2102, col: 5, offset: 64475},
+						pos: position{line: 2104, col: 5, offset: 64561},
 						run: (*parser).callonOptMaterialized2,
 						expr: &seqExpr{
-							pos: position{line: 2102, col: 5, offset: 64475},
+							pos: position{line: 2104, col: 5, offset: 64561},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2102, col: 5, offset: 64475},
+									pos:  position{line: 2104, col: 5, offset: 64561},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2102, col: 7, offset: 64477},
+									pos:  position{line: 2104, col: 7, offset: 64563},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2102, col: 20, offset: 64490},
+									pos:  position{line: 2104, col: 20, offset: 64576},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2103, col: 5, offset: 64529},
+						pos: position{line: 2105, col: 5, offset: 64615},
 						run: (*parser).callonOptMaterialized7,
 						expr: &seqExpr{
-							pos: position{line: 2103, col: 5, offset: 64529},
+							pos: position{line: 2105, col: 5, offset: 64615},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2103, col: 5, offset: 64529},
+									pos:  position{line: 2105, col: 5, offset: 64615},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2103, col: 7, offset: 64531},
+									pos:  position{line: 2105, col: 7, offset: 64617},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2103, col: 11, offset: 64535},
+									pos:  position{line: 2105, col: 11, offset: 64621},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2103, col: 13, offset: 64537},
+									pos:  position{line: 2105, col: 13, offset: 64623},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2103, col: 26, offset: 64550},
+									pos:  position{line: 2105, col: 26, offset: 64636},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2104, col: 5, offset: 64581},
+						pos: position{line: 2106, col: 5, offset: 64667},
 						run: (*parser).callonOptMaterialized14,
 						expr: &litMatcher{
-							pos:        position{line: 2104, col: 5, offset: 64581},
+							pos:        position{line: 2106, col: 5, offset: 64667},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14079,25 +14097,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAllClause",
-			pos:  position{line: 2106, col: 1, offset: 64636},
+			pos:  position{line: 2108, col: 1, offset: 64722},
 			expr: &choiceExpr{
-				pos: position{line: 2107, col: 5, offset: 64653},
+				pos: position{line: 2109, col: 5, offset: 64739},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 2107, col: 5, offset: 64653},
+						pos: position{line: 2109, col: 5, offset: 64739},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2107, col: 5, offset: 64653},
+								pos:  position{line: 2109, col: 5, offset: 64739},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2107, col: 7, offset: 64655},
+								pos:  position{line: 2109, col: 7, offset: 64741},
 								name: "ALL",
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 2108, col: 5, offset: 64663},
+						pos:        position{line: 2110, col: 5, offset: 64749},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -14109,25 +14127,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptFromClause",
-			pos:  position{line: 2110, col: 1, offset: 64667},
+			pos:  position{line: 2112, col: 1, offset: 64753},
 			expr: &choiceExpr{
-				pos: position{line: 2111, col: 5, offset: 64685},
+				pos: position{line: 2113, col: 5, offset: 64771},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2111, col: 5, offset: 64685},
+						pos: position{line: 2113, col: 5, offset: 64771},
 						run: (*parser).callonOptFromClause2,
 						expr: &seqExpr{
-							pos: position{line: 2111, col: 5, offset: 64685},
+							pos: position{line: 2113, col: 5, offset: 64771},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2111, col: 5, offset: 64685},
+									pos:  position{line: 2113, col: 5, offset: 64771},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2111, col: 7, offset: 64687},
+									pos:   position{line: 2113, col: 7, offset: 64773},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2111, col: 12, offset: 64692},
+										pos:  position{line: 2113, col: 12, offset: 64778},
 										name: "FromOp",
 									},
 								},
@@ -14135,10 +14153,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2114, col: 5, offset: 64734},
+						pos: position{line: 2116, col: 5, offset: 64820},
 						run: (*parser).callonOptFromClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2114, col: 5, offset: 64734},
+							pos:        position{line: 2116, col: 5, offset: 64820},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14151,27 +14169,27 @@ var g = &grammar{
 		},
 		{
 			name: "OptWhereClause",
-			pos:  position{line: 2116, col: 1, offset: 64775},
+			pos:  position{line: 2118, col: 1, offset: 64861},
 			expr: &choiceExpr{
-				pos: position{line: 2117, col: 5, offset: 64794},
+				pos: position{line: 2119, col: 5, offset: 64880},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2117, col: 5, offset: 64794},
+						pos: position{line: 2119, col: 5, offset: 64880},
 						run: (*parser).callonOptWhereClause2,
 						expr: &labeledExpr{
-							pos:   position{line: 2117, col: 5, offset: 64794},
+							pos:   position{line: 2119, col: 5, offset: 64880},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2117, col: 11, offset: 64800},
+								pos:  position{line: 2119, col: 11, offset: 64886},
 								name: "WhereClause",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2118, col: 5, offset: 64842},
+						pos: position{line: 2120, col: 5, offset: 64928},
 						run: (*parser).callonOptWhereClause5,
 						expr: &litMatcher{
-							pos:        position{line: 2118, col: 5, offset: 64842},
+							pos:        position{line: 2120, col: 5, offset: 64928},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14184,25 +14202,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptGroupClause",
-			pos:  position{line: 2120, col: 1, offset: 64887},
+			pos:  position{line: 2122, col: 1, offset: 64973},
 			expr: &choiceExpr{
-				pos: position{line: 2121, col: 5, offset: 64906},
+				pos: position{line: 2123, col: 5, offset: 64992},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2121, col: 5, offset: 64906},
+						pos: position{line: 2123, col: 5, offset: 64992},
 						run: (*parser).callonOptGroupClause2,
 						expr: &seqExpr{
-							pos: position{line: 2121, col: 5, offset: 64906},
+							pos: position{line: 2123, col: 5, offset: 64992},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2121, col: 5, offset: 64906},
+									pos:  position{line: 2123, col: 5, offset: 64992},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2121, col: 7, offset: 64908},
+									pos:   position{line: 2123, col: 7, offset: 64994},
 									label: "group",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2121, col: 13, offset: 64914},
+										pos:  position{line: 2123, col: 13, offset: 65000},
 										name: "GroupClause",
 									},
 								},
@@ -14210,10 +14228,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2122, col: 5, offset: 64952},
+						pos: position{line: 2124, col: 5, offset: 65038},
 						run: (*parser).callonOptGroupClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2122, col: 5, offset: 64952},
+							pos:        position{line: 2124, col: 5, offset: 65038},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14226,34 +14244,34 @@ var g = &grammar{
 		},
 		{
 			name: "GroupClause",
-			pos:  position{line: 2124, col: 1, offset: 64993},
+			pos:  position{line: 2126, col: 1, offset: 65079},
 			expr: &actionExpr{
-				pos: position{line: 2125, col: 5, offset: 65009},
+				pos: position{line: 2127, col: 5, offset: 65095},
 				run: (*parser).callonGroupClause1,
 				expr: &seqExpr{
-					pos: position{line: 2125, col: 5, offset: 65009},
+					pos: position{line: 2127, col: 5, offset: 65095},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2125, col: 5, offset: 65009},
+							pos:  position{line: 2127, col: 5, offset: 65095},
 							name: "GROUP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2125, col: 11, offset: 65015},
+							pos:  position{line: 2127, col: 11, offset: 65101},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2125, col: 13, offset: 65017},
+							pos:  position{line: 2127, col: 13, offset: 65103},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2125, col: 16, offset: 65020},
+							pos:  position{line: 2127, col: 16, offset: 65106},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2125, col: 18, offset: 65022},
+							pos:   position{line: 2127, col: 18, offset: 65108},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2125, col: 23, offset: 65027},
+								pos:  position{line: 2127, col: 23, offset: 65113},
 								name: "GroupByList",
 							},
 						},
@@ -14265,51 +14283,51 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByList",
-			pos:  position{line: 2127, col: 1, offset: 65061},
+			pos:  position{line: 2129, col: 1, offset: 65147},
 			expr: &actionExpr{
-				pos: position{line: 2128, col: 5, offset: 65077},
+				pos: position{line: 2130, col: 5, offset: 65163},
 				run: (*parser).callonGroupByList1,
 				expr: &seqExpr{
-					pos: position{line: 2128, col: 5, offset: 65077},
+					pos: position{line: 2130, col: 5, offset: 65163},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2128, col: 5, offset: 65077},
+							pos:   position{line: 2130, col: 5, offset: 65163},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2128, col: 11, offset: 65083},
+								pos:  position{line: 2130, col: 11, offset: 65169},
 								name: "GroupByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2128, col: 23, offset: 65095},
+							pos:   position{line: 2130, col: 23, offset: 65181},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2128, col: 28, offset: 65100},
+								pos: position{line: 2130, col: 28, offset: 65186},
 								expr: &actionExpr{
-									pos: position{line: 2128, col: 30, offset: 65102},
+									pos: position{line: 2130, col: 30, offset: 65188},
 									run: (*parser).callonGroupByList7,
 									expr: &seqExpr{
-										pos: position{line: 2128, col: 30, offset: 65102},
+										pos: position{line: 2130, col: 30, offset: 65188},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2128, col: 30, offset: 65102},
+												pos:  position{line: 2130, col: 30, offset: 65188},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2128, col: 33, offset: 65105},
+												pos:        position{line: 2130, col: 33, offset: 65191},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2128, col: 37, offset: 65109},
+												pos:  position{line: 2130, col: 37, offset: 65195},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2128, col: 40, offset: 65112},
+												pos:   position{line: 2130, col: 40, offset: 65198},
 												label: "g",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2128, col: 42, offset: 65114},
+													pos:  position{line: 2130, col: 42, offset: 65200},
 													name: "GroupByItem",
 												},
 											},
@@ -14326,9 +14344,9 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByItem",
-			pos:  position{line: 2132, col: 1, offset: 65195},
+			pos:  position{line: 2134, col: 1, offset: 65281},
 			expr: &ruleRefExpr{
-				pos:  position{line: 2132, col: 15, offset: 65209},
+				pos:  position{line: 2134, col: 15, offset: 65295},
 				name: "Expr",
 			},
 			leader:        false,
@@ -14336,25 +14354,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptHavingClause",
-			pos:  position{line: 2134, col: 1, offset: 65215},
+			pos:  position{line: 2136, col: 1, offset: 65301},
 			expr: &choiceExpr{
-				pos: position{line: 2135, col: 5, offset: 65235},
+				pos: position{line: 2137, col: 5, offset: 65321},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2135, col: 5, offset: 65235},
+						pos: position{line: 2137, col: 5, offset: 65321},
 						run: (*parser).callonOptHavingClause2,
 						expr: &seqExpr{
-							pos: position{line: 2135, col: 5, offset: 65235},
+							pos: position{line: 2137, col: 5, offset: 65321},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2135, col: 5, offset: 65235},
+									pos:  position{line: 2137, col: 5, offset: 65321},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2135, col: 7, offset: 65237},
+									pos:   position{line: 2137, col: 7, offset: 65323},
 									label: "h",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2135, col: 9, offset: 65239},
+										pos:  position{line: 2137, col: 9, offset: 65325},
 										name: "HavingClause",
 									},
 								},
@@ -14362,10 +14380,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2136, col: 5, offset: 65274},
+						pos: position{line: 2138, col: 5, offset: 65360},
 						run: (*parser).callonOptHavingClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2136, col: 5, offset: 65274},
+							pos:        position{line: 2138, col: 5, offset: 65360},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14378,26 +14396,26 @@ var g = &grammar{
 		},
 		{
 			name: "HavingClause",
-			pos:  position{line: 2138, col: 1, offset: 65298},
+			pos:  position{line: 2140, col: 1, offset: 65384},
 			expr: &actionExpr{
-				pos: position{line: 2139, col: 5, offset: 65315},
+				pos: position{line: 2141, col: 5, offset: 65401},
 				run: (*parser).callonHavingClause1,
 				expr: &seqExpr{
-					pos: position{line: 2139, col: 5, offset: 65315},
+					pos: position{line: 2141, col: 5, offset: 65401},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2139, col: 5, offset: 65315},
+							pos:  position{line: 2141, col: 5, offset: 65401},
 							name: "HAVING",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2139, col: 12, offset: 65322},
+							pos:  position{line: 2141, col: 12, offset: 65408},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2139, col: 14, offset: 65324},
+							pos:   position{line: 2141, col: 14, offset: 65410},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2139, col: 16, offset: 65326},
+								pos:  position{line: 2141, col: 16, offset: 65412},
 								name: "Expr",
 							},
 						},
@@ -14409,16 +14427,16 @@ var g = &grammar{
 		},
 		{
 			name: "JoinOperation",
-			pos:  position{line: 2141, col: 1, offset: 65350},
+			pos:  position{line: 2143, col: 1, offset: 65436},
 			expr: &choiceExpr{
-				pos: position{line: 2142, col: 5, offset: 65368},
+				pos: position{line: 2144, col: 5, offset: 65454},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2142, col: 5, offset: 65368},
+						pos:  position{line: 2144, col: 5, offset: 65454},
 						name: "CrossJoin",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2143, col: 5, offset: 65382},
+						pos:  position{line: 2145, col: 5, offset: 65468},
 						name: "ConditionJoin",
 					},
 				},
@@ -14428,30 +14446,30 @@ var g = &grammar{
 		},
 		{
 			name: "CrossJoin",
-			pos:  position{line: 2145, col: 1, offset: 65397},
+			pos:  position{line: 2147, col: 1, offset: 65483},
 			expr: &actionExpr{
-				pos: position{line: 2146, col: 5, offset: 65411},
+				pos: position{line: 2148, col: 5, offset: 65497},
 				run: (*parser).callonCrossJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2146, col: 5, offset: 65411},
+					pos: position{line: 2148, col: 5, offset: 65497},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2146, col: 5, offset: 65411},
+							pos:   position{line: 2148, col: 5, offset: 65497},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2146, col: 10, offset: 65416},
+								pos:  position{line: 2148, col: 10, offset: 65502},
 								name: "FromElem",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2146, col: 19, offset: 65425},
+							pos:  position{line: 2148, col: 19, offset: 65511},
 							name: "CrossJoinOp",
 						},
 						&labeledExpr{
-							pos:   position{line: 2146, col: 31, offset: 65437},
+							pos:   position{line: 2148, col: 31, offset: 65523},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2146, col: 37, offset: 65443},
+								pos:  position{line: 2148, col: 37, offset: 65529},
 								name: "FromElem",
 							},
 						},
@@ -14463,50 +14481,50 @@ var g = &grammar{
 		},
 		{
 			name: "CrossJoinOp",
-			pos:  position{line: 2155, col: 1, offset: 65651},
+			pos:  position{line: 2157, col: 1, offset: 65737},
 			expr: &choiceExpr{
-				pos: position{line: 2156, col: 5, offset: 65667},
+				pos: position{line: 2158, col: 5, offset: 65753},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 2156, col: 5, offset: 65667},
+						pos: position{line: 2158, col: 5, offset: 65753},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2156, col: 5, offset: 65667},
+								pos:  position{line: 2158, col: 5, offset: 65753},
 								name: "__",
 							},
 							&litMatcher{
-								pos:        position{line: 2156, col: 8, offset: 65670},
+								pos:        position{line: 2158, col: 8, offset: 65756},
 								val:        ",",
 								ignoreCase: false,
 								want:       "\",\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2156, col: 12, offset: 65674},
+								pos:  position{line: 2158, col: 12, offset: 65760},
 								name: "__",
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 2157, col: 5, offset: 65681},
+						pos: position{line: 2159, col: 5, offset: 65767},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2157, col: 5, offset: 65681},
+								pos:  position{line: 2159, col: 5, offset: 65767},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2157, col: 7, offset: 65683},
+								pos:  position{line: 2159, col: 7, offset: 65769},
 								name: "CROSS",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2157, col: 13, offset: 65689},
+								pos:  position{line: 2159, col: 13, offset: 65775},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2157, col: 15, offset: 65691},
+								pos:  position{line: 2159, col: 15, offset: 65777},
 								name: "JOIN",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2157, col: 20, offset: 65696},
+								pos:  position{line: 2159, col: 20, offset: 65782},
 								name: "_",
 							},
 						},
@@ -14518,50 +14536,50 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionJoin",
-			pos:  position{line: 2159, col: 1, offset: 65699},
+			pos:  position{line: 2161, col: 1, offset: 65785},
 			expr: &actionExpr{
-				pos: position{line: 2160, col: 5, offset: 65717},
+				pos: position{line: 2162, col: 5, offset: 65803},
 				run: (*parser).callonConditionJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2160, col: 5, offset: 65717},
+					pos: position{line: 2162, col: 5, offset: 65803},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2160, col: 5, offset: 65717},
+							pos:   position{line: 2162, col: 5, offset: 65803},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2160, col: 10, offset: 65722},
+								pos:  position{line: 2162, col: 10, offset: 65808},
 								name: "FromElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2160, col: 19, offset: 65731},
+							pos:   position{line: 2162, col: 19, offset: 65817},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2160, col: 25, offset: 65737},
+								pos:  position{line: 2162, col: 25, offset: 65823},
 								name: "SQLJoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2160, col: 38, offset: 65750},
+							pos:  position{line: 2162, col: 38, offset: 65836},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2160, col: 40, offset: 65752},
+							pos:   position{line: 2162, col: 40, offset: 65838},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2160, col: 46, offset: 65758},
+								pos:  position{line: 2162, col: 46, offset: 65844},
 								name: "FromElem",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2160, col: 55, offset: 65767},
+							pos:  position{line: 2162, col: 55, offset: 65853},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2160, col: 57, offset: 65769},
+							pos:   position{line: 2162, col: 57, offset: 65855},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2160, col: 59, offset: 65771},
+								pos:  position{line: 2162, col: 59, offset: 65857},
 								name: "JoinCond",
 							},
 						},
@@ -14573,186 +14591,186 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoinStyle",
-			pos:  position{line: 2171, col: 1, offset: 66040},
+			pos:  position{line: 2173, col: 1, offset: 66126},
 			expr: &choiceExpr{
-				pos: position{line: 2172, col: 5, offset: 66057},
+				pos: position{line: 2174, col: 5, offset: 66143},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2172, col: 5, offset: 66057},
+						pos: position{line: 2174, col: 5, offset: 66143},
 						run: (*parser).callonSQLJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 2172, col: 5, offset: 66057},
+							pos: position{line: 2174, col: 5, offset: 66143},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 2172, col: 5, offset: 66057},
+									pos: position{line: 2174, col: 5, offset: 66143},
 									expr: &seqExpr{
-										pos: position{line: 2172, col: 6, offset: 66058},
+										pos: position{line: 2174, col: 6, offset: 66144},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2172, col: 6, offset: 66058},
+												pos:  position{line: 2174, col: 6, offset: 66144},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2172, col: 8, offset: 66060},
+												pos:  position{line: 2174, col: 8, offset: 66146},
 												name: "INNER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2172, col: 16, offset: 66068},
+									pos:  position{line: 2174, col: 16, offset: 66154},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2172, col: 18, offset: 66070},
+									pos:  position{line: 2174, col: 18, offset: 66156},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2173, col: 5, offset: 66115},
+						pos: position{line: 2175, col: 5, offset: 66201},
 						run: (*parser).callonSQLJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 2173, col: 5, offset: 66115},
+							pos: position{line: 2175, col: 5, offset: 66201},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2173, col: 5, offset: 66115},
+									pos:  position{line: 2175, col: 5, offset: 66201},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2173, col: 7, offset: 66117},
+									pos:  position{line: 2175, col: 7, offset: 66203},
 									name: "ANTI",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2173, col: 12, offset: 66122},
+									pos:  position{line: 2175, col: 12, offset: 66208},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2173, col: 14, offset: 66124},
+									pos:  position{line: 2175, col: 14, offset: 66210},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2174, col: 5, offset: 66156},
+						pos: position{line: 2176, col: 5, offset: 66242},
 						run: (*parser).callonSQLJoinStyle16,
 						expr: &seqExpr{
-							pos: position{line: 2174, col: 5, offset: 66156},
+							pos: position{line: 2176, col: 5, offset: 66242},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2174, col: 5, offset: 66156},
+									pos:  position{line: 2176, col: 5, offset: 66242},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2174, col: 7, offset: 66158},
+									pos:  position{line: 2176, col: 7, offset: 66244},
 									name: "FULL",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2174, col: 12, offset: 66163},
+									pos: position{line: 2176, col: 12, offset: 66249},
 									expr: &seqExpr{
-										pos: position{line: 2174, col: 13, offset: 66164},
+										pos: position{line: 2176, col: 13, offset: 66250},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2174, col: 13, offset: 66164},
+												pos:  position{line: 2176, col: 13, offset: 66250},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2174, col: 15, offset: 66166},
+												pos:  position{line: 2176, col: 15, offset: 66252},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2174, col: 23, offset: 66174},
+									pos:  position{line: 2176, col: 23, offset: 66260},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2174, col: 25, offset: 66176},
+									pos:  position{line: 2176, col: 25, offset: 66262},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2175, col: 5, offset: 66210},
+						pos: position{line: 2177, col: 5, offset: 66296},
 						run: (*parser).callonSQLJoinStyle26,
 						expr: &seqExpr{
-							pos: position{line: 2175, col: 5, offset: 66210},
+							pos: position{line: 2177, col: 5, offset: 66296},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2175, col: 5, offset: 66210},
+									pos:  position{line: 2177, col: 5, offset: 66296},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2175, col: 7, offset: 66212},
+									pos:  position{line: 2177, col: 7, offset: 66298},
 									name: "LEFT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2175, col: 12, offset: 66217},
+									pos: position{line: 2177, col: 12, offset: 66303},
 									expr: &seqExpr{
-										pos: position{line: 2175, col: 13, offset: 66218},
+										pos: position{line: 2177, col: 13, offset: 66304},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2175, col: 13, offset: 66218},
+												pos:  position{line: 2177, col: 13, offset: 66304},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2175, col: 15, offset: 66220},
+												pos:  position{line: 2177, col: 15, offset: 66306},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2175, col: 23, offset: 66228},
+									pos:  position{line: 2177, col: 23, offset: 66314},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2175, col: 25, offset: 66230},
+									pos:  position{line: 2177, col: 25, offset: 66316},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2176, col: 5, offset: 66264},
+						pos: position{line: 2178, col: 5, offset: 66350},
 						run: (*parser).callonSQLJoinStyle36,
 						expr: &seqExpr{
-							pos: position{line: 2176, col: 5, offset: 66264},
+							pos: position{line: 2178, col: 5, offset: 66350},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2176, col: 5, offset: 66264},
+									pos:  position{line: 2178, col: 5, offset: 66350},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2176, col: 7, offset: 66266},
+									pos:  position{line: 2178, col: 7, offset: 66352},
 									name: "RIGHT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2176, col: 13, offset: 66272},
+									pos: position{line: 2178, col: 13, offset: 66358},
 									expr: &seqExpr{
-										pos: position{line: 2176, col: 14, offset: 66273},
+										pos: position{line: 2178, col: 14, offset: 66359},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2176, col: 14, offset: 66273},
+												pos:  position{line: 2178, col: 14, offset: 66359},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2176, col: 16, offset: 66275},
+												pos:  position{line: 2178, col: 16, offset: 66361},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2176, col: 24, offset: 66283},
+									pos:  position{line: 2178, col: 24, offset: 66369},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2176, col: 26, offset: 66285},
+									pos:  position{line: 2178, col: 26, offset: 66371},
 									name: "JOIN",
 								},
 							},
@@ -14765,29 +14783,29 @@ var g = &grammar{
 		},
 		{
 			name: "JoinCond",
-			pos:  position{line: 2178, col: 1, offset: 66317},
+			pos:  position{line: 2180, col: 1, offset: 66403},
 			expr: &choiceExpr{
-				pos: position{line: 2179, col: 5, offset: 66330},
+				pos: position{line: 2181, col: 5, offset: 66416},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2179, col: 5, offset: 66330},
+						pos: position{line: 2181, col: 5, offset: 66416},
 						run: (*parser).callonJoinCond2,
 						expr: &seqExpr{
-							pos: position{line: 2179, col: 5, offset: 66330},
+							pos: position{line: 2181, col: 5, offset: 66416},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2179, col: 5, offset: 66330},
+									pos:  position{line: 2181, col: 5, offset: 66416},
 									name: "ON",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2179, col: 8, offset: 66333},
+									pos:  position{line: 2181, col: 8, offset: 66419},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2179, col: 10, offset: 66335},
+									pos:   position{line: 2181, col: 10, offset: 66421},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2179, col: 12, offset: 66337},
+										pos:  position{line: 2181, col: 12, offset: 66423},
 										name: "Expr",
 									},
 								},
@@ -14795,43 +14813,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2186, col: 5, offset: 66490},
+						pos: position{line: 2188, col: 5, offset: 66576},
 						run: (*parser).callonJoinCond8,
 						expr: &seqExpr{
-							pos: position{line: 2186, col: 5, offset: 66490},
+							pos: position{line: 2188, col: 5, offset: 66576},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2186, col: 5, offset: 66490},
+									pos:  position{line: 2188, col: 5, offset: 66576},
 									name: "USING",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2186, col: 11, offset: 66496},
+									pos:  position{line: 2188, col: 11, offset: 66582},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2186, col: 14, offset: 66499},
+									pos:        position{line: 2188, col: 14, offset: 66585},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2186, col: 18, offset: 66503},
+									pos:  position{line: 2188, col: 18, offset: 66589},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 2186, col: 21, offset: 66506},
+									pos:   position{line: 2188, col: 21, offset: 66592},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2186, col: 28, offset: 66513},
+										pos:  position{line: 2188, col: 28, offset: 66599},
 										name: "Lvals",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2186, col: 34, offset: 66519},
+									pos:  position{line: 2188, col: 34, offset: 66605},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2186, col: 37, offset: 66522},
+									pos:        position{line: 2188, col: 37, offset: 66608},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -14846,40 +14864,40 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrdinality",
-			pos:  position{line: 2194, col: 1, offset: 66692},
+			pos:  position{line: 2196, col: 1, offset: 66778},
 			expr: &choiceExpr{
-				pos: position{line: 2195, col: 5, offset: 66710},
+				pos: position{line: 2197, col: 5, offset: 66796},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2195, col: 5, offset: 66710},
+						pos: position{line: 2197, col: 5, offset: 66796},
 						run: (*parser).callonOptOrdinality2,
 						expr: &seqExpr{
-							pos: position{line: 2195, col: 5, offset: 66710},
+							pos: position{line: 2197, col: 5, offset: 66796},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2195, col: 5, offset: 66710},
+									pos:  position{line: 2197, col: 5, offset: 66796},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2195, col: 7, offset: 66712},
+									pos:  position{line: 2197, col: 7, offset: 66798},
 									name: "WITH",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2195, col: 12, offset: 66717},
+									pos:  position{line: 2197, col: 12, offset: 66803},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2195, col: 14, offset: 66719},
+									pos:  position{line: 2197, col: 14, offset: 66805},
 									name: "ORDINALITY",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2200, col: 5, offset: 66816},
+						pos: position{line: 2202, col: 5, offset: 66902},
 						run: (*parser).callonOptOrdinality8,
 						expr: &litMatcher{
-							pos:        position{line: 2200, col: 5, offset: 66816},
+							pos:        position{line: 2202, col: 5, offset: 66902},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14892,25 +14910,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAlias",
-			pos:  position{line: 2202, col: 1, offset: 66865},
+			pos:  position{line: 2204, col: 1, offset: 66951},
 			expr: &choiceExpr{
-				pos: position{line: 2203, col: 5, offset: 66878},
+				pos: position{line: 2205, col: 5, offset: 66964},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2203, col: 5, offset: 66878},
+						pos: position{line: 2205, col: 5, offset: 66964},
 						run: (*parser).callonOptAlias2,
 						expr: &seqExpr{
-							pos: position{line: 2203, col: 5, offset: 66878},
+							pos: position{line: 2205, col: 5, offset: 66964},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2203, col: 5, offset: 66878},
+									pos:  position{line: 2205, col: 5, offset: 66964},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2203, col: 7, offset: 66880},
+									pos:   position{line: 2205, col: 7, offset: 66966},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2203, col: 9, offset: 66882},
+										pos:  position{line: 2205, col: 9, offset: 66968},
 										name: "AliasClause",
 									},
 								},
@@ -14918,10 +14936,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2204, col: 5, offset: 66916},
+						pos: position{line: 2206, col: 5, offset: 67002},
 						run: (*parser).callonOptAlias7,
 						expr: &litMatcher{
-							pos:        position{line: 2204, col: 5, offset: 66916},
+							pos:        position{line: 2206, col: 5, offset: 67002},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14934,51 +14952,51 @@ var g = &grammar{
 		},
 		{
 			name: "AliasClause",
-			pos:  position{line: 2206, col: 1, offset: 66953},
+			pos:  position{line: 2208, col: 1, offset: 67039},
 			expr: &actionExpr{
-				pos: position{line: 2207, col: 4, offset: 66968},
+				pos: position{line: 2209, col: 4, offset: 67054},
 				run: (*parser).callonAliasClause1,
 				expr: &seqExpr{
-					pos: position{line: 2207, col: 4, offset: 66968},
+					pos: position{line: 2209, col: 4, offset: 67054},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2207, col: 4, offset: 66968},
+							pos: position{line: 2209, col: 4, offset: 67054},
 							expr: &seqExpr{
-								pos: position{line: 2207, col: 5, offset: 66969},
+								pos: position{line: 2209, col: 5, offset: 67055},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2207, col: 5, offset: 66969},
+										pos:  position{line: 2209, col: 5, offset: 67055},
 										name: "AS",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2207, col: 8, offset: 66972},
+										pos:  position{line: 2209, col: 8, offset: 67058},
 										name: "_",
 									},
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 2207, col: 12, offset: 66976},
+							pos: position{line: 2209, col: 12, offset: 67062},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2207, col: 13, offset: 66977},
+								pos:  position{line: 2209, col: 13, offset: 67063},
 								name: "SQLGuard",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2207, col: 22, offset: 66986},
+							pos:   position{line: 2209, col: 22, offset: 67072},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2207, col: 27, offset: 66991},
+								pos:  position{line: 2209, col: 27, offset: 67077},
 								name: "IdentifierName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2207, col: 42, offset: 67006},
+							pos:   position{line: 2209, col: 42, offset: 67092},
 							label: "cols",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2207, col: 47, offset: 67011},
+								pos: position{line: 2209, col: 47, offset: 67097},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2207, col: 47, offset: 67011},
+									pos:  position{line: 2209, col: 47, offset: 67097},
 									name: "Columns",
 								},
 							},
@@ -14991,65 +15009,65 @@ var g = &grammar{
 		},
 		{
 			name: "Columns",
-			pos:  position{line: 2215, col: 1, offset: 67190},
+			pos:  position{line: 2217, col: 1, offset: 67276},
 			expr: &actionExpr{
-				pos: position{line: 2216, col: 5, offset: 67202},
+				pos: position{line: 2218, col: 5, offset: 67288},
 				run: (*parser).callonColumns1,
 				expr: &seqExpr{
-					pos: position{line: 2216, col: 5, offset: 67202},
+					pos: position{line: 2218, col: 5, offset: 67288},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2216, col: 5, offset: 67202},
+							pos:  position{line: 2218, col: 5, offset: 67288},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2216, col: 8, offset: 67205},
+							pos:        position{line: 2218, col: 8, offset: 67291},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2216, col: 12, offset: 67209},
+							pos:  position{line: 2218, col: 12, offset: 67295},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2216, col: 15, offset: 67212},
+							pos:   position{line: 2218, col: 15, offset: 67298},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2216, col: 21, offset: 67218},
+								pos:  position{line: 2218, col: 21, offset: 67304},
 								name: "SQLIdentifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2216, col: 35, offset: 67232},
+							pos:   position{line: 2218, col: 35, offset: 67318},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2216, col: 40, offset: 67237},
+								pos: position{line: 2218, col: 40, offset: 67323},
 								expr: &actionExpr{
-									pos: position{line: 2216, col: 42, offset: 67239},
+									pos: position{line: 2218, col: 42, offset: 67325},
 									run: (*parser).callonColumns10,
 									expr: &seqExpr{
-										pos: position{line: 2216, col: 42, offset: 67239},
+										pos: position{line: 2218, col: 42, offset: 67325},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2216, col: 42, offset: 67239},
+												pos:  position{line: 2218, col: 42, offset: 67325},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2216, col: 45, offset: 67242},
+												pos:        position{line: 2218, col: 45, offset: 67328},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2216, col: 49, offset: 67246},
+												pos:  position{line: 2218, col: 49, offset: 67332},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2216, col: 52, offset: 67249},
+												pos:   position{line: 2218, col: 52, offset: 67335},
 												label: "s",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2216, col: 54, offset: 67251},
+													pos:  position{line: 2218, col: 54, offset: 67337},
 													name: "SQLIdentifier",
 												},
 											},
@@ -15059,11 +15077,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2216, col: 87, offset: 67284},
+							pos:  position{line: 2218, col: 87, offset: 67370},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2216, col: 90, offset: 67287},
+							pos:        position{line: 2218, col: 90, offset: 67373},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -15076,51 +15094,51 @@ var g = &grammar{
 		},
 		{
 			name: "Selection",
-			pos:  position{line: 2220, col: 1, offset: 67358},
+			pos:  position{line: 2222, col: 1, offset: 67444},
 			expr: &actionExpr{
-				pos: position{line: 2221, col: 5, offset: 67372},
+				pos: position{line: 2223, col: 5, offset: 67458},
 				run: (*parser).callonSelection1,
 				expr: &seqExpr{
-					pos: position{line: 2221, col: 5, offset: 67372},
+					pos: position{line: 2223, col: 5, offset: 67458},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2221, col: 5, offset: 67372},
+							pos:   position{line: 2223, col: 5, offset: 67458},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2221, col: 11, offset: 67378},
+								pos:  position{line: 2223, col: 11, offset: 67464},
 								name: "SelectElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2221, col: 22, offset: 67389},
+							pos:   position{line: 2223, col: 22, offset: 67475},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2221, col: 27, offset: 67394},
+								pos: position{line: 2223, col: 27, offset: 67480},
 								expr: &actionExpr{
-									pos: position{line: 2221, col: 29, offset: 67396},
+									pos: position{line: 2223, col: 29, offset: 67482},
 									run: (*parser).callonSelection7,
 									expr: &seqExpr{
-										pos: position{line: 2221, col: 29, offset: 67396},
+										pos: position{line: 2223, col: 29, offset: 67482},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2221, col: 29, offset: 67396},
+												pos:  position{line: 2223, col: 29, offset: 67482},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2221, col: 32, offset: 67399},
+												pos:        position{line: 2223, col: 32, offset: 67485},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2221, col: 36, offset: 67403},
+												pos:  position{line: 2223, col: 36, offset: 67489},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2221, col: 39, offset: 67406},
+												pos:   position{line: 2223, col: 39, offset: 67492},
 												label: "s",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2221, col: 41, offset: 67408},
+													pos:  position{line: 2223, col: 41, offset: 67494},
 													name: "SelectElem",
 												},
 											},
@@ -15137,38 +15155,38 @@ var g = &grammar{
 		},
 		{
 			name: "SelectElem",
-			pos:  position{line: 2229, col: 1, offset: 67613},
+			pos:  position{line: 2231, col: 1, offset: 67699},
 			expr: &choiceExpr{
-				pos: position{line: 2230, col: 5, offset: 67628},
+				pos: position{line: 2232, col: 5, offset: 67714},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2230, col: 5, offset: 67628},
+						pos: position{line: 2232, col: 5, offset: 67714},
 						run: (*parser).callonSelectElem2,
 						expr: &seqExpr{
-							pos: position{line: 2230, col: 5, offset: 67628},
+							pos: position{line: 2232, col: 5, offset: 67714},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2230, col: 5, offset: 67628},
+									pos:   position{line: 2232, col: 5, offset: 67714},
 									label: "expr",
 									expr: &choiceExpr{
-										pos: position{line: 2230, col: 11, offset: 67634},
+										pos: position{line: 2232, col: 11, offset: 67720},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2230, col: 11, offset: 67634},
+												pos:  position{line: 2232, col: 11, offset: 67720},
 												name: "AggDistinct",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2230, col: 25, offset: 67648},
+												pos:  position{line: 2232, col: 25, offset: 67734},
 												name: "Expr",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2230, col: 31, offset: 67654},
+									pos:   position{line: 2232, col: 31, offset: 67740},
 									label: "as",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2230, col: 34, offset: 67657},
+										pos:  position{line: 2232, col: 34, offset: 67743},
 										name: "OptAsClause",
 									},
 								},
@@ -15176,10 +15194,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2241, col: 5, offset: 67885},
+						pos: position{line: 2243, col: 5, offset: 67971},
 						run: (*parser).callonSelectElem10,
 						expr: &litMatcher{
-							pos:        position{line: 2241, col: 5, offset: 67885},
+							pos:        position{line: 2243, col: 5, offset: 67971},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -15192,33 +15210,33 @@ var g = &grammar{
 		},
 		{
 			name: "OptAsClause",
-			pos:  position{line: 2246, col: 1, offset: 67990},
+			pos:  position{line: 2248, col: 1, offset: 68076},
 			expr: &choiceExpr{
-				pos: position{line: 2247, col: 5, offset: 68006},
+				pos: position{line: 2249, col: 5, offset: 68092},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2247, col: 5, offset: 68006},
+						pos: position{line: 2249, col: 5, offset: 68092},
 						run: (*parser).callonOptAsClause2,
 						expr: &seqExpr{
-							pos: position{line: 2247, col: 5, offset: 68006},
+							pos: position{line: 2249, col: 5, offset: 68092},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2247, col: 5, offset: 68006},
+									pos:  position{line: 2249, col: 5, offset: 68092},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2247, col: 7, offset: 68008},
+									pos:  position{line: 2249, col: 7, offset: 68094},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2247, col: 10, offset: 68011},
+									pos:  position{line: 2249, col: 10, offset: 68097},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2247, col: 12, offset: 68013},
+									pos:   position{line: 2249, col: 12, offset: 68099},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2247, col: 15, offset: 68016},
+										pos:  position{line: 2249, col: 15, offset: 68102},
 										name: "SQLIdentifier",
 									},
 								},
@@ -15226,27 +15244,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2248, col: 5, offset: 68053},
+						pos: position{line: 2250, col: 5, offset: 68139},
 						run: (*parser).callonOptAsClause9,
 						expr: &seqExpr{
-							pos: position{line: 2248, col: 5, offset: 68053},
+							pos: position{line: 2250, col: 5, offset: 68139},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2248, col: 5, offset: 68053},
+									pos:  position{line: 2250, col: 5, offset: 68139},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 2248, col: 7, offset: 68055},
+									pos: position{line: 2250, col: 7, offset: 68141},
 									expr: &ruleRefExpr{
-										pos:  position{line: 2248, col: 8, offset: 68056},
+										pos:  position{line: 2250, col: 8, offset: 68142},
 										name: "SQLGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2248, col: 17, offset: 68065},
+									pos:   position{line: 2250, col: 17, offset: 68151},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2248, col: 20, offset: 68068},
+										pos:  position{line: 2250, col: 20, offset: 68154},
 										name: "SQLIdentifier",
 									},
 								},
@@ -15254,10 +15272,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2249, col: 5, offset: 68105},
+						pos: position{line: 2251, col: 5, offset: 68191},
 						run: (*parser).callonOptAsClause16,
 						expr: &litMatcher{
-							pos:        position{line: 2249, col: 5, offset: 68105},
+							pos:        position{line: 2251, col: 5, offset: 68191},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15270,41 +15288,41 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrderByClause",
-			pos:  position{line: 2251, col: 1, offset: 68130},
+			pos:  position{line: 2253, col: 1, offset: 68216},
 			expr: &choiceExpr{
-				pos: position{line: 2252, col: 5, offset: 68151},
+				pos: position{line: 2254, col: 5, offset: 68237},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2252, col: 5, offset: 68151},
+						pos: position{line: 2254, col: 5, offset: 68237},
 						run: (*parser).callonOptOrderByClause2,
 						expr: &seqExpr{
-							pos: position{line: 2252, col: 5, offset: 68151},
+							pos: position{line: 2254, col: 5, offset: 68237},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2252, col: 5, offset: 68151},
+									pos:  position{line: 2254, col: 5, offset: 68237},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2252, col: 7, offset: 68153},
+									pos:  position{line: 2254, col: 7, offset: 68239},
 									name: "ORDER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2252, col: 13, offset: 68159},
+									pos:  position{line: 2254, col: 13, offset: 68245},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2252, col: 15, offset: 68161},
+									pos:  position{line: 2254, col: 15, offset: 68247},
 									name: "BY",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2252, col: 18, offset: 68164},
+									pos:  position{line: 2254, col: 18, offset: 68250},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2252, col: 20, offset: 68166},
+									pos:   position{line: 2254, col: 20, offset: 68252},
 									label: "list",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2252, col: 25, offset: 68171},
+										pos:  position{line: 2254, col: 25, offset: 68257},
 										name: "OrderByList",
 									},
 								},
@@ -15312,10 +15330,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2258, col: 5, offset: 68305},
+						pos: position{line: 2260, col: 5, offset: 68391},
 						run: (*parser).callonOptOrderByClause11,
 						expr: &litMatcher{
-							pos:        position{line: 2258, col: 5, offset: 68305},
+							pos:        position{line: 2260, col: 5, offset: 68391},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15328,51 +15346,51 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByList",
-			pos:  position{line: 2260, col: 1, offset: 68338},
+			pos:  position{line: 2262, col: 1, offset: 68424},
 			expr: &actionExpr{
-				pos: position{line: 2261, col: 5, offset: 68354},
+				pos: position{line: 2263, col: 5, offset: 68440},
 				run: (*parser).callonOrderByList1,
 				expr: &seqExpr{
-					pos: position{line: 2261, col: 5, offset: 68354},
+					pos: position{line: 2263, col: 5, offset: 68440},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2261, col: 5, offset: 68354},
+							pos:   position{line: 2263, col: 5, offset: 68440},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2261, col: 11, offset: 68360},
+								pos:  position{line: 2263, col: 11, offset: 68446},
 								name: "OrderByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2261, col: 23, offset: 68372},
+							pos:   position{line: 2263, col: 23, offset: 68458},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2261, col: 28, offset: 68377},
+								pos: position{line: 2263, col: 28, offset: 68463},
 								expr: &actionExpr{
-									pos: position{line: 2261, col: 30, offset: 68379},
+									pos: position{line: 2263, col: 30, offset: 68465},
 									run: (*parser).callonOrderByList7,
 									expr: &seqExpr{
-										pos: position{line: 2261, col: 30, offset: 68379},
+										pos: position{line: 2263, col: 30, offset: 68465},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2261, col: 30, offset: 68379},
+												pos:  position{line: 2263, col: 30, offset: 68465},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2261, col: 33, offset: 68382},
+												pos:        position{line: 2263, col: 33, offset: 68468},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2261, col: 37, offset: 68386},
+												pos:  position{line: 2263, col: 37, offset: 68472},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2261, col: 40, offset: 68389},
+												pos:   position{line: 2263, col: 40, offset: 68475},
 												label: "o",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2261, col: 42, offset: 68391},
+													pos:  position{line: 2263, col: 42, offset: 68477},
 													name: "OrderByItem",
 												},
 											},
@@ -15389,34 +15407,34 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByItem",
-			pos:  position{line: 2265, col: 1, offset: 68492},
+			pos:  position{line: 2267, col: 1, offset: 68578},
 			expr: &actionExpr{
-				pos: position{line: 2266, col: 5, offset: 68508},
+				pos: position{line: 2268, col: 5, offset: 68594},
 				run: (*parser).callonOrderByItem1,
 				expr: &seqExpr{
-					pos: position{line: 2266, col: 5, offset: 68508},
+					pos: position{line: 2268, col: 5, offset: 68594},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2266, col: 5, offset: 68508},
+							pos:   position{line: 2268, col: 5, offset: 68594},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2266, col: 7, offset: 68510},
+								pos:  position{line: 2268, col: 7, offset: 68596},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2266, col: 12, offset: 68515},
+							pos:   position{line: 2268, col: 12, offset: 68601},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2266, col: 18, offset: 68521},
+								pos:  position{line: 2268, col: 18, offset: 68607},
 								name: "OptAscDesc",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2266, col: 29, offset: 68532},
+							pos:   position{line: 2268, col: 29, offset: 68618},
 							label: "nulls",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2266, col: 35, offset: 68538},
+								pos:  position{line: 2268, col: 35, offset: 68624},
 								name: "OptNullsOrder",
 							},
 						},
@@ -15428,49 +15446,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptAscDesc",
-			pos:  position{line: 2277, col: 1, offset: 68770},
+			pos:  position{line: 2279, col: 1, offset: 68856},
 			expr: &choiceExpr{
-				pos: position{line: 2278, col: 5, offset: 68785},
+				pos: position{line: 2280, col: 5, offset: 68871},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2278, col: 5, offset: 68785},
+						pos: position{line: 2280, col: 5, offset: 68871},
 						run: (*parser).callonOptAscDesc2,
 						expr: &seqExpr{
-							pos: position{line: 2278, col: 5, offset: 68785},
+							pos: position{line: 2280, col: 5, offset: 68871},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2278, col: 5, offset: 68785},
+									pos:  position{line: 2280, col: 5, offset: 68871},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2278, col: 7, offset: 68787},
+									pos:  position{line: 2280, col: 7, offset: 68873},
 									name: "ASC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2279, col: 5, offset: 68847},
+						pos: position{line: 2281, col: 5, offset: 68933},
 						run: (*parser).callonOptAscDesc6,
 						expr: &seqExpr{
-							pos: position{line: 2279, col: 5, offset: 68847},
+							pos: position{line: 2281, col: 5, offset: 68933},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2279, col: 5, offset: 68847},
+									pos:  position{line: 2281, col: 5, offset: 68933},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2279, col: 7, offset: 68849},
+									pos:  position{line: 2281, col: 7, offset: 68935},
 									name: "DESC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2280, col: 5, offset: 68909},
+						pos: position{line: 2282, col: 5, offset: 68995},
 						run: (*parser).callonOptAscDesc10,
 						expr: &litMatcher{
-							pos:        position{line: 2280, col: 5, offset: 68909},
+							pos:        position{line: 2282, col: 5, offset: 68995},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15483,65 +15501,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptNullsOrder",
-			pos:  position{line: 2282, col: 1, offset: 68941},
+			pos:  position{line: 2284, col: 1, offset: 69027},
 			expr: &choiceExpr{
-				pos: position{line: 2283, col: 5, offset: 68959},
+				pos: position{line: 2285, col: 5, offset: 69045},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2283, col: 5, offset: 68959},
+						pos: position{line: 2285, col: 5, offset: 69045},
 						run: (*parser).callonOptNullsOrder2,
 						expr: &seqExpr{
-							pos: position{line: 2283, col: 5, offset: 68959},
+							pos: position{line: 2285, col: 5, offset: 69045},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2283, col: 5, offset: 68959},
+									pos:  position{line: 2285, col: 5, offset: 69045},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2283, col: 7, offset: 68961},
+									pos:  position{line: 2285, col: 7, offset: 69047},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2283, col: 13, offset: 68967},
+									pos:  position{line: 2285, col: 13, offset: 69053},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2283, col: 15, offset: 68969},
+									pos:  position{line: 2285, col: 15, offset: 69055},
 									name: "FIRST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2284, col: 5, offset: 69033},
+						pos: position{line: 2286, col: 5, offset: 69119},
 						run: (*parser).callonOptNullsOrder8,
 						expr: &seqExpr{
-							pos: position{line: 2284, col: 5, offset: 69033},
+							pos: position{line: 2286, col: 5, offset: 69119},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2284, col: 5, offset: 69033},
+									pos:  position{line: 2286, col: 5, offset: 69119},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2284, col: 7, offset: 69035},
+									pos:  position{line: 2286, col: 7, offset: 69121},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2284, col: 13, offset: 69041},
+									pos:  position{line: 2286, col: 13, offset: 69127},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2284, col: 15, offset: 69043},
+									pos:  position{line: 2286, col: 15, offset: 69129},
 									name: "LAST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2285, col: 5, offset: 69106},
+						pos: position{line: 2287, col: 5, offset: 69192},
 						run: (*parser).callonOptNullsOrder14,
 						expr: &litMatcher{
-							pos:        position{line: 2285, col: 5, offset: 69106},
+							pos:        position{line: 2287, col: 5, offset: 69192},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15554,25 +15572,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptSQLLimitOffset",
-			pos:  position{line: 2287, col: 1, offset: 69151},
+			pos:  position{line: 2289, col: 1, offset: 69237},
 			expr: &choiceExpr{
-				pos: position{line: 2288, col: 5, offset: 69173},
+				pos: position{line: 2290, col: 5, offset: 69259},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2288, col: 5, offset: 69173},
+						pos: position{line: 2290, col: 5, offset: 69259},
 						run: (*parser).callonOptSQLLimitOffset2,
 						expr: &seqExpr{
-							pos: position{line: 2288, col: 5, offset: 69173},
+							pos: position{line: 2290, col: 5, offset: 69259},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2288, col: 5, offset: 69173},
+									pos:  position{line: 2290, col: 5, offset: 69259},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2288, col: 7, offset: 69175},
+									pos:   position{line: 2290, col: 7, offset: 69261},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2288, col: 10, offset: 69178},
+										pos:  position{line: 2290, col: 10, offset: 69264},
 										name: "SQLLimitOffset",
 									},
 								},
@@ -15580,10 +15598,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2289, col: 5, offset: 69216},
+						pos: position{line: 2291, col: 5, offset: 69302},
 						run: (*parser).callonOptSQLLimitOffset7,
 						expr: &litMatcher{
-							pos:        position{line: 2289, col: 5, offset: 69216},
+							pos:        position{line: 2291, col: 5, offset: 69302},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15596,29 +15614,29 @@ var g = &grammar{
 		},
 		{
 			name: "SQLLimitOffset",
-			pos:  position{line: 2291, col: 1, offset: 69257},
+			pos:  position{line: 2293, col: 1, offset: 69343},
 			expr: &choiceExpr{
-				pos: position{line: 2292, col: 5, offset: 69276},
+				pos: position{line: 2294, col: 5, offset: 69362},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2292, col: 5, offset: 69276},
+						pos: position{line: 2294, col: 5, offset: 69362},
 						run: (*parser).callonSQLLimitOffset2,
 						expr: &seqExpr{
-							pos: position{line: 2292, col: 5, offset: 69276},
+							pos: position{line: 2294, col: 5, offset: 69362},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2292, col: 5, offset: 69276},
+									pos:   position{line: 2294, col: 5, offset: 69362},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2292, col: 7, offset: 69278},
+										pos:  position{line: 2294, col: 7, offset: 69364},
 										name: "LimitClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2292, col: 19, offset: 69290},
+									pos:   position{line: 2294, col: 19, offset: 69376},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2292, col: 21, offset: 69292},
+										pos:  position{line: 2294, col: 21, offset: 69378},
 										name: "OptOffsetClause",
 									},
 								},
@@ -15626,24 +15644,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2304, col: 5, offset: 69524},
+						pos: position{line: 2306, col: 5, offset: 69610},
 						run: (*parser).callonSQLLimitOffset8,
 						expr: &seqExpr{
-							pos: position{line: 2304, col: 5, offset: 69524},
+							pos: position{line: 2306, col: 5, offset: 69610},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2304, col: 5, offset: 69524},
+									pos:   position{line: 2306, col: 5, offset: 69610},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2304, col: 7, offset: 69526},
+										pos:  position{line: 2306, col: 7, offset: 69612},
 										name: "OffsetClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2304, col: 20, offset: 69539},
+									pos:   position{line: 2306, col: 20, offset: 69625},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2304, col: 22, offset: 69541},
+										pos:  position{line: 2306, col: 22, offset: 69627},
 										name: "OptLimitClause",
 									},
 								},
@@ -15657,25 +15675,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptLimitClause",
-			pos:  position{line: 2315, col: 1, offset: 69738},
+			pos:  position{line: 2317, col: 1, offset: 69824},
 			expr: &choiceExpr{
-				pos: position{line: 2316, col: 5, offset: 69757},
+				pos: position{line: 2318, col: 5, offset: 69843},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2316, col: 5, offset: 69757},
+						pos: position{line: 2318, col: 5, offset: 69843},
 						run: (*parser).callonOptLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2316, col: 5, offset: 69757},
+							pos: position{line: 2318, col: 5, offset: 69843},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2316, col: 5, offset: 69757},
+									pos:  position{line: 2318, col: 5, offset: 69843},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2316, col: 7, offset: 69759},
+									pos:   position{line: 2318, col: 7, offset: 69845},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2316, col: 9, offset: 69761},
+										pos:  position{line: 2318, col: 9, offset: 69847},
 										name: "LimitClause",
 									},
 								},
@@ -15683,10 +15701,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2317, col: 5, offset: 69795},
+						pos: position{line: 2319, col: 5, offset: 69881},
 						run: (*parser).callonOptLimitClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2317, col: 5, offset: 69795},
+							pos:        position{line: 2319, col: 5, offset: 69881},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15699,50 +15717,50 @@ var g = &grammar{
 		},
 		{
 			name: "LimitClause",
-			pos:  position{line: 2319, col: 1, offset: 69832},
+			pos:  position{line: 2321, col: 1, offset: 69918},
 			expr: &choiceExpr{
-				pos: position{line: 2320, col: 5, offset: 69848},
+				pos: position{line: 2322, col: 5, offset: 69934},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2320, col: 5, offset: 69848},
+						pos: position{line: 2322, col: 5, offset: 69934},
 						run: (*parser).callonLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2320, col: 5, offset: 69848},
+							pos: position{line: 2322, col: 5, offset: 69934},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2320, col: 5, offset: 69848},
+									pos:  position{line: 2322, col: 5, offset: 69934},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2320, col: 11, offset: 69854},
+									pos:  position{line: 2322, col: 11, offset: 69940},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2320, col: 13, offset: 69856},
+									pos:  position{line: 2322, col: 13, offset: 69942},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2321, col: 5, offset: 69884},
+						pos: position{line: 2323, col: 5, offset: 69970},
 						run: (*parser).callonLimitClause7,
 						expr: &seqExpr{
-							pos: position{line: 2321, col: 5, offset: 69884},
+							pos: position{line: 2323, col: 5, offset: 69970},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2321, col: 5, offset: 69884},
+									pos:  position{line: 2323, col: 5, offset: 69970},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2321, col: 11, offset: 69890},
+									pos:  position{line: 2323, col: 11, offset: 69976},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2321, col: 13, offset: 69892},
+									pos:   position{line: 2323, col: 13, offset: 69978},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2321, col: 15, offset: 69894},
+										pos:  position{line: 2323, col: 15, offset: 69980},
 										name: "Expr",
 									},
 								},
@@ -15756,25 +15774,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptOffsetClause",
-			pos:  position{line: 2323, col: 1, offset: 69918},
+			pos:  position{line: 2325, col: 1, offset: 70004},
 			expr: &choiceExpr{
-				pos: position{line: 2324, col: 5, offset: 69938},
+				pos: position{line: 2326, col: 5, offset: 70024},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2324, col: 5, offset: 69938},
+						pos: position{line: 2326, col: 5, offset: 70024},
 						run: (*parser).callonOptOffsetClause2,
 						expr: &seqExpr{
-							pos: position{line: 2324, col: 5, offset: 69938},
+							pos: position{line: 2326, col: 5, offset: 70024},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2324, col: 5, offset: 69938},
+									pos:  position{line: 2326, col: 5, offset: 70024},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2324, col: 7, offset: 69940},
+									pos:   position{line: 2326, col: 7, offset: 70026},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2324, col: 9, offset: 69942},
+										pos:  position{line: 2326, col: 9, offset: 70028},
 										name: "OffsetClause",
 									},
 								},
@@ -15782,10 +15800,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2325, col: 5, offset: 69978},
+						pos: position{line: 2327, col: 5, offset: 70064},
 						run: (*parser).callonOptOffsetClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2325, col: 5, offset: 69978},
+							pos:        position{line: 2327, col: 5, offset: 70064},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15798,26 +15816,26 @@ var g = &grammar{
 		},
 		{
 			name: "OffsetClause",
-			pos:  position{line: 2327, col: 1, offset: 70003},
+			pos:  position{line: 2329, col: 1, offset: 70089},
 			expr: &actionExpr{
-				pos: position{line: 2328, col: 5, offset: 70020},
+				pos: position{line: 2330, col: 5, offset: 70106},
 				run: (*parser).callonOffsetClause1,
 				expr: &seqExpr{
-					pos: position{line: 2328, col: 5, offset: 70020},
+					pos: position{line: 2330, col: 5, offset: 70106},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2328, col: 5, offset: 70020},
+							pos:  position{line: 2330, col: 5, offset: 70106},
 							name: "OFFSET",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2328, col: 12, offset: 70027},
+							pos:  position{line: 2330, col: 12, offset: 70113},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2328, col: 14, offset: 70029},
+							pos:   position{line: 2330, col: 14, offset: 70115},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2328, col: 16, offset: 70031},
+								pos:  position{line: 2330, col: 16, offset: 70117},
 								name: "Expr",
 							},
 						},
@@ -15829,60 +15847,60 @@ var g = &grammar{
 		},
 		{
 			name: "SetOp",
-			pos:  position{line: 2330, col: 1, offset: 70056},
+			pos:  position{line: 2332, col: 1, offset: 70142},
 			expr: &choiceExpr{
-				pos: position{line: 2331, col: 5, offset: 70066},
+				pos: position{line: 2333, col: 5, offset: 70152},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2331, col: 5, offset: 70066},
+						pos: position{line: 2333, col: 5, offset: 70152},
 						run: (*parser).callonSetOp2,
 						expr: &seqExpr{
-							pos: position{line: 2331, col: 5, offset: 70066},
+							pos: position{line: 2333, col: 5, offset: 70152},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2331, col: 5, offset: 70066},
+									pos:  position{line: 2333, col: 5, offset: 70152},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2331, col: 7, offset: 70068},
+									pos:  position{line: 2333, col: 7, offset: 70154},
 									name: "UNION",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2331, col: 13, offset: 70074},
+									pos:  position{line: 2333, col: 13, offset: 70160},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2331, col: 15, offset: 70076},
+									pos:  position{line: 2333, col: 15, offset: 70162},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2332, col: 5, offset: 70112},
+						pos: position{line: 2334, col: 5, offset: 70198},
 						run: (*parser).callonSetOp8,
 						expr: &seqExpr{
-							pos: position{line: 2332, col: 5, offset: 70112},
+							pos: position{line: 2334, col: 5, offset: 70198},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2332, col: 5, offset: 70112},
+									pos:  position{line: 2334, col: 5, offset: 70198},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2332, col: 7, offset: 70114},
+									pos:  position{line: 2334, col: 7, offset: 70200},
 									name: "UNION",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2332, col: 13, offset: 70120},
+									pos: position{line: 2334, col: 13, offset: 70206},
 									expr: &seqExpr{
-										pos: position{line: 2332, col: 14, offset: 70121},
+										pos: position{line: 2334, col: 14, offset: 70207},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2332, col: 14, offset: 70121},
+												pos:  position{line: 2334, col: 14, offset: 70207},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2332, col: 16, offset: 70123},
+												pos:  position{line: 2334, col: 16, offset: 70209},
 												name: "DISTINCT",
 											},
 										},
@@ -15898,88 +15916,88 @@ var g = &grammar{
 		},
 		{
 			name: "SQLGuard",
-			pos:  position{line: 2335, col: 1, offset: 70175},
+			pos:  position{line: 2337, col: 1, offset: 70261},
 			expr: &choiceExpr{
-				pos: position{line: 2336, col: 5, offset: 70190},
+				pos: position{line: 2338, col: 5, offset: 70276},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2336, col: 5, offset: 70190},
+						pos:  position{line: 2338, col: 5, offset: 70276},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2336, col: 12, offset: 70197},
+						pos:  position{line: 2338, col: 12, offset: 70283},
 						name: "GROUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2336, col: 20, offset: 70205},
+						pos:  position{line: 2338, col: 20, offset: 70291},
 						name: "HAVING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2336, col: 29, offset: 70214},
+						pos:  position{line: 2338, col: 29, offset: 70300},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2336, col: 38, offset: 70223},
+						pos:  position{line: 2338, col: 38, offset: 70309},
 						name: "RECURSIVE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2337, col: 5, offset: 70237},
+						pos:  position{line: 2339, col: 5, offset: 70323},
 						name: "ANTI",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2337, col: 12, offset: 70244},
+						pos:  position{line: 2339, col: 12, offset: 70330},
 						name: "INNER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2337, col: 20, offset: 70252},
+						pos:  position{line: 2339, col: 20, offset: 70338},
 						name: "LEFT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2337, col: 27, offset: 70259},
+						pos:  position{line: 2339, col: 27, offset: 70345},
 						name: "RIGHT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2337, col: 35, offset: 70267},
+						pos:  position{line: 2339, col: 35, offset: 70353},
 						name: "OUTER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2337, col: 43, offset: 70275},
+						pos:  position{line: 2339, col: 43, offset: 70361},
 						name: "CROSS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2337, col: 51, offset: 70283},
+						pos:  position{line: 2339, col: 51, offset: 70369},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2338, col: 5, offset: 70292},
+						pos:  position{line: 2340, col: 5, offset: 70378},
 						name: "UNION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2339, col: 5, offset: 70302},
+						pos:  position{line: 2341, col: 5, offset: 70388},
 						name: "ORDER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2340, col: 5, offset: 70312},
+						pos:  position{line: 2342, col: 5, offset: 70398},
 						name: "OFFSET",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2341, col: 5, offset: 70323},
+						pos:  position{line: 2343, col: 5, offset: 70409},
 						name: "LIMIT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2342, col: 5, offset: 70333},
+						pos:  position{line: 2344, col: 5, offset: 70419},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2343, col: 5, offset: 70343},
+						pos:  position{line: 2345, col: 5, offset: 70429},
 						name: "WITH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2344, col: 5, offset: 70352},
+						pos:  position{line: 2346, col: 5, offset: 70438},
 						name: "USING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2345, col: 5, offset: 70362},
+						pos:  position{line: 2347, col: 5, offset: 70448},
 						name: "ON",
 					},
 				},
@@ -15989,20 +16007,20 @@ var g = &grammar{
 		},
 		{
 			name: "AGGREGATE",
-			pos:  position{line: 2347, col: 1, offset: 70366},
+			pos:  position{line: 2349, col: 1, offset: 70452},
 			expr: &seqExpr{
-				pos: position{line: 2347, col: 14, offset: 70379},
+				pos: position{line: 2349, col: 14, offset: 70465},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2347, col: 14, offset: 70379},
+						pos:        position{line: 2349, col: 14, offset: 70465},
 						val:        "aggregate",
 						ignoreCase: true,
 						want:       "\"AGGREGATE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2347, col: 33, offset: 70398},
+						pos: position{line: 2349, col: 33, offset: 70484},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2347, col: 34, offset: 70399},
+							pos:  position{line: 2349, col: 34, offset: 70485},
 							name: "IdentifierRest",
 						},
 					},
@@ -16013,20 +16031,20 @@ var g = &grammar{
 		},
 		{
 			name: "ALL",
-			pos:  position{line: 2348, col: 1, offset: 70414},
+			pos:  position{line: 2350, col: 1, offset: 70500},
 			expr: &seqExpr{
-				pos: position{line: 2348, col: 14, offset: 70427},
+				pos: position{line: 2350, col: 14, offset: 70513},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2348, col: 14, offset: 70427},
+						pos:        position{line: 2350, col: 14, offset: 70513},
 						val:        "all",
 						ignoreCase: true,
 						want:       "\"ALL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2348, col: 33, offset: 70446},
+						pos: position{line: 2350, col: 33, offset: 70532},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2348, col: 34, offset: 70447},
+							pos:  position{line: 2350, col: 34, offset: 70533},
 							name: "IdentifierRest",
 						},
 					},
@@ -16037,23 +16055,23 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 2349, col: 1, offset: 70462},
+			pos:  position{line: 2351, col: 1, offset: 70548},
 			expr: &actionExpr{
-				pos: position{line: 2349, col: 14, offset: 70475},
+				pos: position{line: 2351, col: 14, offset: 70561},
 				run: (*parser).callonAND1,
 				expr: &seqExpr{
-					pos: position{line: 2349, col: 14, offset: 70475},
+					pos: position{line: 2351, col: 14, offset: 70561},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2349, col: 14, offset: 70475},
+							pos:        position{line: 2351, col: 14, offset: 70561},
 							val:        "and",
 							ignoreCase: true,
 							want:       "\"AND\"i",
 						},
 						&notExpr{
-							pos: position{line: 2349, col: 33, offset: 70494},
+							pos: position{line: 2351, col: 33, offset: 70580},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2349, col: 34, offset: 70495},
+								pos:  position{line: 2351, col: 34, offset: 70581},
 								name: "IdentifierRest",
 							},
 						},
@@ -16065,20 +16083,20 @@ var g = &grammar{
 		},
 		{
 			name: "ANTI",
-			pos:  position{line: 2350, col: 1, offset: 70532},
+			pos:  position{line: 2352, col: 1, offset: 70618},
 			expr: &seqExpr{
-				pos: position{line: 2350, col: 14, offset: 70545},
+				pos: position{line: 2352, col: 14, offset: 70631},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2350, col: 14, offset: 70545},
+						pos:        position{line: 2352, col: 14, offset: 70631},
 						val:        "anti",
 						ignoreCase: true,
 						want:       "\"ANTI\"i",
 					},
 					&notExpr{
-						pos: position{line: 2350, col: 33, offset: 70564},
+						pos: position{line: 2352, col: 33, offset: 70650},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2350, col: 34, offset: 70565},
+							pos:  position{line: 2352, col: 34, offset: 70651},
 							name: "IdentifierRest",
 						},
 					},
@@ -16089,20 +16107,20 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 2351, col: 1, offset: 70580},
+			pos:  position{line: 2353, col: 1, offset: 70666},
 			expr: &seqExpr{
-				pos: position{line: 2351, col: 14, offset: 70593},
+				pos: position{line: 2353, col: 14, offset: 70679},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2351, col: 14, offset: 70593},
+						pos:        position{line: 2353, col: 14, offset: 70679},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2351, col: 33, offset: 70612},
+						pos: position{line: 2353, col: 33, offset: 70698},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2351, col: 34, offset: 70613},
+							pos:  position{line: 2353, col: 34, offset: 70699},
 							name: "IdentifierRest",
 						},
 					},
@@ -16113,23 +16131,23 @@ var g = &grammar{
 		},
 		{
 			name: "ASC",
-			pos:  position{line: 2352, col: 1, offset: 70628},
+			pos:  position{line: 2354, col: 1, offset: 70714},
 			expr: &actionExpr{
-				pos: position{line: 2352, col: 14, offset: 70641},
+				pos: position{line: 2354, col: 14, offset: 70727},
 				run: (*parser).callonASC1,
 				expr: &seqExpr{
-					pos: position{line: 2352, col: 14, offset: 70641},
+					pos: position{line: 2354, col: 14, offset: 70727},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2352, col: 14, offset: 70641},
+							pos:        position{line: 2354, col: 14, offset: 70727},
 							val:        "asc",
 							ignoreCase: true,
 							want:       "\"ASC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2352, col: 33, offset: 70660},
+							pos: position{line: 2354, col: 33, offset: 70746},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2352, col: 34, offset: 70661},
+								pos:  position{line: 2354, col: 34, offset: 70747},
 								name: "IdentifierRest",
 							},
 						},
@@ -16141,20 +16159,20 @@ var g = &grammar{
 		},
 		{
 			name: "ASSERT",
-			pos:  position{line: 2353, col: 1, offset: 70698},
+			pos:  position{line: 2355, col: 1, offset: 70784},
 			expr: &seqExpr{
-				pos: position{line: 2353, col: 14, offset: 70711},
+				pos: position{line: 2355, col: 14, offset: 70797},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2353, col: 14, offset: 70711},
+						pos:        position{line: 2355, col: 14, offset: 70797},
 						val:        "assert",
 						ignoreCase: true,
 						want:       "\"ASSERT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2353, col: 33, offset: 70730},
+						pos: position{line: 2355, col: 33, offset: 70816},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2353, col: 34, offset: 70731},
+							pos:  position{line: 2355, col: 34, offset: 70817},
 							name: "IdentifierRest",
 						},
 					},
@@ -16165,20 +16183,20 @@ var g = &grammar{
 		},
 		{
 			name: "AT",
-			pos:  position{line: 2354, col: 1, offset: 70746},
+			pos:  position{line: 2356, col: 1, offset: 70832},
 			expr: &seqExpr{
-				pos: position{line: 2354, col: 14, offset: 70759},
+				pos: position{line: 2356, col: 14, offset: 70845},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2354, col: 14, offset: 70759},
+						pos:        position{line: 2356, col: 14, offset: 70845},
 						val:        "at",
 						ignoreCase: true,
 						want:       "\"AT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2354, col: 33, offset: 70778},
+						pos: position{line: 2356, col: 33, offset: 70864},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2354, col: 34, offset: 70779},
+							pos:  position{line: 2356, col: 34, offset: 70865},
 							name: "IdentifierRest",
 						},
 					},
@@ -16189,20 +16207,20 @@ var g = &grammar{
 		},
 		{
 			name: "BETWEEN",
-			pos:  position{line: 2355, col: 1, offset: 70794},
+			pos:  position{line: 2357, col: 1, offset: 70880},
 			expr: &seqExpr{
-				pos: position{line: 2355, col: 14, offset: 70807},
+				pos: position{line: 2357, col: 14, offset: 70893},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2355, col: 14, offset: 70807},
+						pos:        position{line: 2357, col: 14, offset: 70893},
 						val:        "between",
 						ignoreCase: true,
 						want:       "\"BETWEEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2355, col: 33, offset: 70826},
+						pos: position{line: 2357, col: 33, offset: 70912},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2355, col: 34, offset: 70827},
+							pos:  position{line: 2357, col: 34, offset: 70913},
 							name: "IdentifierRest",
 						},
 					},
@@ -16213,20 +16231,20 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 2356, col: 1, offset: 70842},
+			pos:  position{line: 2358, col: 1, offset: 70928},
 			expr: &seqExpr{
-				pos: position{line: 2356, col: 14, offset: 70855},
+				pos: position{line: 2358, col: 14, offset: 70941},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2356, col: 14, offset: 70855},
+						pos:        position{line: 2358, col: 14, offset: 70941},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2356, col: 33, offset: 70874},
+						pos: position{line: 2358, col: 33, offset: 70960},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2356, col: 34, offset: 70875},
+							pos:  position{line: 2358, col: 34, offset: 70961},
 							name: "IdentifierRest",
 						},
 					},
@@ -16237,20 +16255,20 @@ var g = &grammar{
 		},
 		{
 			name: "CALL",
-			pos:  position{line: 2357, col: 1, offset: 70890},
+			pos:  position{line: 2359, col: 1, offset: 70976},
 			expr: &seqExpr{
-				pos: position{line: 2357, col: 14, offset: 70903},
+				pos: position{line: 2359, col: 14, offset: 70989},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2357, col: 14, offset: 70903},
+						pos:        position{line: 2359, col: 14, offset: 70989},
 						val:        "call",
 						ignoreCase: true,
 						want:       "\"CALL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2357, col: 33, offset: 70922},
+						pos: position{line: 2359, col: 33, offset: 71008},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2357, col: 34, offset: 70923},
+							pos:  position{line: 2359, col: 34, offset: 71009},
 							name: "IdentifierRest",
 						},
 					},
@@ -16261,20 +16279,20 @@ var g = &grammar{
 		},
 		{
 			name: "CASE",
-			pos:  position{line: 2358, col: 1, offset: 70938},
+			pos:  position{line: 2360, col: 1, offset: 71024},
 			expr: &seqExpr{
-				pos: position{line: 2358, col: 14, offset: 70951},
+				pos: position{line: 2360, col: 14, offset: 71037},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2358, col: 14, offset: 70951},
+						pos:        position{line: 2360, col: 14, offset: 71037},
 						val:        "case",
 						ignoreCase: true,
 						want:       "\"CASE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2358, col: 33, offset: 70970},
+						pos: position{line: 2360, col: 33, offset: 71056},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2358, col: 34, offset: 70971},
+							pos:  position{line: 2360, col: 34, offset: 71057},
 							name: "IdentifierRest",
 						},
 					},
@@ -16285,20 +16303,20 @@ var g = &grammar{
 		},
 		{
 			name: "CAST",
-			pos:  position{line: 2359, col: 1, offset: 70986},
+			pos:  position{line: 2361, col: 1, offset: 71072},
 			expr: &seqExpr{
-				pos: position{line: 2359, col: 14, offset: 70999},
+				pos: position{line: 2361, col: 14, offset: 71085},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2359, col: 14, offset: 70999},
+						pos:        position{line: 2361, col: 14, offset: 71085},
 						val:        "cast",
 						ignoreCase: true,
 						want:       "\"CAST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2359, col: 33, offset: 71018},
+						pos: position{line: 2361, col: 33, offset: 71104},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2359, col: 34, offset: 71019},
+							pos:  position{line: 2361, col: 34, offset: 71105},
 							name: "IdentifierRest",
 						},
 					},
@@ -16309,20 +16327,20 @@ var g = &grammar{
 		},
 		{
 			name: "CONST",
-			pos:  position{line: 2360, col: 1, offset: 71034},
+			pos:  position{line: 2362, col: 1, offset: 71120},
 			expr: &seqExpr{
-				pos: position{line: 2360, col: 14, offset: 71047},
+				pos: position{line: 2362, col: 14, offset: 71133},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2360, col: 14, offset: 71047},
+						pos:        position{line: 2362, col: 14, offset: 71133},
 						val:        "const",
 						ignoreCase: true,
 						want:       "\"CONST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2360, col: 33, offset: 71066},
+						pos: position{line: 2362, col: 33, offset: 71152},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2360, col: 34, offset: 71067},
+							pos:  position{line: 2362, col: 34, offset: 71153},
 							name: "IdentifierRest",
 						},
 					},
@@ -16333,20 +16351,20 @@ var g = &grammar{
 		},
 		{
 			name: "COUNT",
-			pos:  position{line: 2361, col: 1, offset: 71082},
+			pos:  position{line: 2363, col: 1, offset: 71168},
 			expr: &seqExpr{
-				pos: position{line: 2361, col: 14, offset: 71095},
+				pos: position{line: 2363, col: 14, offset: 71181},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2361, col: 14, offset: 71095},
+						pos:        position{line: 2363, col: 14, offset: 71181},
 						val:        "count",
 						ignoreCase: true,
 						want:       "\"COUNT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2361, col: 33, offset: 71114},
+						pos: position{line: 2363, col: 33, offset: 71200},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2361, col: 34, offset: 71115},
+							pos:  position{line: 2363, col: 34, offset: 71201},
 							name: "IdentifierRest",
 						},
 					},
@@ -16357,20 +16375,20 @@ var g = &grammar{
 		},
 		{
 			name: "CROSS",
-			pos:  position{line: 2362, col: 1, offset: 71130},
+			pos:  position{line: 2364, col: 1, offset: 71216},
 			expr: &seqExpr{
-				pos: position{line: 2362, col: 14, offset: 71143},
+				pos: position{line: 2364, col: 14, offset: 71229},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2362, col: 14, offset: 71143},
+						pos:        position{line: 2364, col: 14, offset: 71229},
 						val:        "cross",
 						ignoreCase: true,
 						want:       "\"CROSS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2362, col: 33, offset: 71162},
+						pos: position{line: 2364, col: 33, offset: 71248},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2362, col: 34, offset: 71163},
+							pos:  position{line: 2364, col: 34, offset: 71249},
 							name: "IdentifierRest",
 						},
 					},
@@ -16381,20 +16399,20 @@ var g = &grammar{
 		},
 		{
 			name: "CUT",
-			pos:  position{line: 2363, col: 1, offset: 71178},
+			pos:  position{line: 2365, col: 1, offset: 71264},
 			expr: &seqExpr{
-				pos: position{line: 2363, col: 14, offset: 71191},
+				pos: position{line: 2365, col: 14, offset: 71277},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2363, col: 14, offset: 71191},
+						pos:        position{line: 2365, col: 14, offset: 71277},
 						val:        "cut",
 						ignoreCase: true,
 						want:       "\"CUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2363, col: 33, offset: 71210},
+						pos: position{line: 2365, col: 33, offset: 71296},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2363, col: 34, offset: 71211},
+							pos:  position{line: 2365, col: 34, offset: 71297},
 							name: "IdentifierRest",
 						},
 					},
@@ -16405,23 +16423,23 @@ var g = &grammar{
 		},
 		{
 			name: "DATE",
-			pos:  position{line: 2364, col: 1, offset: 71226},
+			pos:  position{line: 2366, col: 1, offset: 71312},
 			expr: &actionExpr{
-				pos: position{line: 2364, col: 14, offset: 71239},
+				pos: position{line: 2366, col: 14, offset: 71325},
 				run: (*parser).callonDATE1,
 				expr: &seqExpr{
-					pos: position{line: 2364, col: 14, offset: 71239},
+					pos: position{line: 2366, col: 14, offset: 71325},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2364, col: 14, offset: 71239},
+							pos:        position{line: 2366, col: 14, offset: 71325},
 							val:        "date",
 							ignoreCase: true,
 							want:       "\"DATE\"i",
 						},
 						&notExpr{
-							pos: position{line: 2364, col: 33, offset: 71258},
+							pos: position{line: 2366, col: 33, offset: 71344},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2364, col: 34, offset: 71259},
+								pos:  position{line: 2366, col: 34, offset: 71345},
 								name: "IdentifierRest",
 							},
 						},
@@ -16433,20 +16451,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEBUG",
-			pos:  position{line: 2365, col: 1, offset: 71297},
+			pos:  position{line: 2367, col: 1, offset: 71383},
 			expr: &seqExpr{
-				pos: position{line: 2365, col: 14, offset: 71310},
+				pos: position{line: 2367, col: 14, offset: 71396},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2365, col: 14, offset: 71310},
+						pos:        position{line: 2367, col: 14, offset: 71396},
 						val:        "debug",
 						ignoreCase: true,
 						want:       "\"DEBUG\"i",
 					},
 					&notExpr{
-						pos: position{line: 2365, col: 33, offset: 71329},
+						pos: position{line: 2367, col: 33, offset: 71415},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2365, col: 34, offset: 71330},
+							pos:  position{line: 2367, col: 34, offset: 71416},
 							name: "IdentifierRest",
 						},
 					},
@@ -16457,20 +16475,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEFAULT",
-			pos:  position{line: 2366, col: 1, offset: 71345},
+			pos:  position{line: 2368, col: 1, offset: 71431},
 			expr: &seqExpr{
-				pos: position{line: 2366, col: 14, offset: 71358},
+				pos: position{line: 2368, col: 14, offset: 71444},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2366, col: 14, offset: 71358},
+						pos:        position{line: 2368, col: 14, offset: 71444},
 						val:        "default",
 						ignoreCase: true,
 						want:       "\"DEFAULT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2366, col: 33, offset: 71377},
+						pos: position{line: 2368, col: 33, offset: 71463},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2366, col: 34, offset: 71378},
+							pos:  position{line: 2368, col: 34, offset: 71464},
 							name: "IdentifierRest",
 						},
 					},
@@ -16481,23 +16499,23 @@ var g = &grammar{
 		},
 		{
 			name: "DESC",
-			pos:  position{line: 2367, col: 1, offset: 71393},
+			pos:  position{line: 2369, col: 1, offset: 71479},
 			expr: &actionExpr{
-				pos: position{line: 2367, col: 14, offset: 71406},
+				pos: position{line: 2369, col: 14, offset: 71492},
 				run: (*parser).callonDESC1,
 				expr: &seqExpr{
-					pos: position{line: 2367, col: 14, offset: 71406},
+					pos: position{line: 2369, col: 14, offset: 71492},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2367, col: 14, offset: 71406},
+							pos:        position{line: 2369, col: 14, offset: 71492},
 							val:        "desc",
 							ignoreCase: true,
 							want:       "\"DESC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2367, col: 33, offset: 71425},
+							pos: position{line: 2369, col: 33, offset: 71511},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2367, col: 34, offset: 71426},
+								pos:  position{line: 2369, col: 34, offset: 71512},
 								name: "IdentifierRest",
 							},
 						},
@@ -16509,20 +16527,20 @@ var g = &grammar{
 		},
 		{
 			name: "DISTINCT",
-			pos:  position{line: 2368, col: 1, offset: 71464},
+			pos:  position{line: 2370, col: 1, offset: 71550},
 			expr: &seqExpr{
-				pos: position{line: 2368, col: 14, offset: 71477},
+				pos: position{line: 2370, col: 14, offset: 71563},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2368, col: 14, offset: 71477},
+						pos:        position{line: 2370, col: 14, offset: 71563},
 						val:        "distinct",
 						ignoreCase: true,
 						want:       "\"DISTINCT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2368, col: 33, offset: 71496},
+						pos: position{line: 2370, col: 33, offset: 71582},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2368, col: 34, offset: 71497},
+							pos:  position{line: 2370, col: 34, offset: 71583},
 							name: "IdentifierRest",
 						},
 					},
@@ -16533,20 +16551,20 @@ var g = &grammar{
 		},
 		{
 			name: "DROP",
-			pos:  position{line: 2369, col: 1, offset: 71512},
+			pos:  position{line: 2371, col: 1, offset: 71598},
 			expr: &seqExpr{
-				pos: position{line: 2369, col: 14, offset: 71525},
+				pos: position{line: 2371, col: 14, offset: 71611},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2369, col: 14, offset: 71525},
+						pos:        position{line: 2371, col: 14, offset: 71611},
 						val:        "drop",
 						ignoreCase: true,
 						want:       "\"DROP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2369, col: 33, offset: 71544},
+						pos: position{line: 2371, col: 33, offset: 71630},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2369, col: 34, offset: 71545},
+							pos:  position{line: 2371, col: 34, offset: 71631},
 							name: "IdentifierRest",
 						},
 					},
@@ -16557,20 +16575,20 @@ var g = &grammar{
 		},
 		{
 			name: "ELSE",
-			pos:  position{line: 2370, col: 1, offset: 71560},
+			pos:  position{line: 2372, col: 1, offset: 71646},
 			expr: &seqExpr{
-				pos: position{line: 2370, col: 14, offset: 71573},
+				pos: position{line: 2372, col: 14, offset: 71659},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2370, col: 14, offset: 71573},
+						pos:        position{line: 2372, col: 14, offset: 71659},
 						val:        "else",
 						ignoreCase: true,
 						want:       "\"ELSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2370, col: 33, offset: 71592},
+						pos: position{line: 2372, col: 33, offset: 71678},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2370, col: 34, offset: 71593},
+							pos:  position{line: 2372, col: 34, offset: 71679},
 							name: "IdentifierRest",
 						},
 					},
@@ -16581,20 +16599,20 @@ var g = &grammar{
 		},
 		{
 			name: "END",
-			pos:  position{line: 2371, col: 1, offset: 71608},
+			pos:  position{line: 2373, col: 1, offset: 71694},
 			expr: &seqExpr{
-				pos: position{line: 2371, col: 14, offset: 71621},
+				pos: position{line: 2373, col: 14, offset: 71707},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2371, col: 14, offset: 71621},
+						pos:        position{line: 2373, col: 14, offset: 71707},
 						val:        "end",
 						ignoreCase: true,
 						want:       "\"END\"i",
 					},
 					&notExpr{
-						pos: position{line: 2371, col: 33, offset: 71640},
+						pos: position{line: 2373, col: 33, offset: 71726},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2371, col: 34, offset: 71641},
+							pos:  position{line: 2373, col: 34, offset: 71727},
 							name: "IdentifierRest",
 						},
 					},
@@ -16605,20 +16623,20 @@ var g = &grammar{
 		},
 		{
 			name: "ENUM",
-			pos:  position{line: 2372, col: 1, offset: 71656},
+			pos:  position{line: 2374, col: 1, offset: 71742},
 			expr: &seqExpr{
-				pos: position{line: 2372, col: 14, offset: 71669},
+				pos: position{line: 2374, col: 14, offset: 71755},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2372, col: 14, offset: 71669},
+						pos:        position{line: 2374, col: 14, offset: 71755},
 						val:        "enum",
 						ignoreCase: true,
 						want:       "\"ENUM\"i",
 					},
 					&notExpr{
-						pos: position{line: 2372, col: 33, offset: 71688},
+						pos: position{line: 2374, col: 33, offset: 71774},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2372, col: 34, offset: 71689},
+							pos:  position{line: 2374, col: 34, offset: 71775},
 							name: "IdentifierRest",
 						},
 					},
@@ -16629,20 +16647,20 @@ var g = &grammar{
 		},
 		{
 			name: "ERROR",
-			pos:  position{line: 2373, col: 1, offset: 71704},
+			pos:  position{line: 2375, col: 1, offset: 71790},
 			expr: &seqExpr{
-				pos: position{line: 2373, col: 14, offset: 71717},
+				pos: position{line: 2375, col: 14, offset: 71803},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2373, col: 14, offset: 71717},
+						pos:        position{line: 2375, col: 14, offset: 71803},
 						val:        "error",
 						ignoreCase: true,
 						want:       "\"ERROR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2373, col: 33, offset: 71736},
+						pos: position{line: 2375, col: 33, offset: 71822},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2373, col: 34, offset: 71737},
+							pos:  position{line: 2375, col: 34, offset: 71823},
 							name: "IdentifierRest",
 						},
 					},
@@ -16653,20 +16671,20 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL",
-			pos:  position{line: 2374, col: 1, offset: 71752},
+			pos:  position{line: 2376, col: 1, offset: 71838},
 			expr: &seqExpr{
-				pos: position{line: 2374, col: 14, offset: 71765},
+				pos: position{line: 2376, col: 14, offset: 71851},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2374, col: 14, offset: 71765},
+						pos:        position{line: 2376, col: 14, offset: 71851},
 						val:        "eval",
 						ignoreCase: true,
 						want:       "\"EVAL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2374, col: 33, offset: 71784},
+						pos: position{line: 2376, col: 33, offset: 71870},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2374, col: 34, offset: 71785},
+							pos:  position{line: 2376, col: 34, offset: 71871},
 							name: "IdentifierRest",
 						},
 					},
@@ -16677,20 +16695,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXISTS",
-			pos:  position{line: 2375, col: 1, offset: 71800},
+			pos:  position{line: 2377, col: 1, offset: 71886},
 			expr: &seqExpr{
-				pos: position{line: 2375, col: 14, offset: 71813},
+				pos: position{line: 2377, col: 14, offset: 71899},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2375, col: 14, offset: 71813},
+						pos:        position{line: 2377, col: 14, offset: 71899},
 						val:        "exists",
 						ignoreCase: true,
 						want:       "\"EXISTS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2375, col: 33, offset: 71832},
+						pos: position{line: 2377, col: 33, offset: 71918},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2375, col: 34, offset: 71833},
+							pos:  position{line: 2377, col: 34, offset: 71919},
 							name: "IdentifierRest",
 						},
 					},
@@ -16701,20 +16719,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXPLODE",
-			pos:  position{line: 2376, col: 1, offset: 71848},
+			pos:  position{line: 2378, col: 1, offset: 71934},
 			expr: &seqExpr{
-				pos: position{line: 2376, col: 14, offset: 71861},
+				pos: position{line: 2378, col: 14, offset: 71947},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2376, col: 14, offset: 71861},
+						pos:        position{line: 2378, col: 14, offset: 71947},
 						val:        "explode",
 						ignoreCase: true,
 						want:       "\"EXPLODE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2376, col: 33, offset: 71880},
+						pos: position{line: 2378, col: 33, offset: 71966},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2376, col: 34, offset: 71881},
+							pos:  position{line: 2378, col: 34, offset: 71967},
 							name: "IdentifierRest",
 						},
 					},
@@ -16725,20 +16743,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXTRACT",
-			pos:  position{line: 2377, col: 1, offset: 71896},
+			pos:  position{line: 2379, col: 1, offset: 71982},
 			expr: &seqExpr{
-				pos: position{line: 2377, col: 14, offset: 71909},
+				pos: position{line: 2379, col: 14, offset: 71995},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2377, col: 14, offset: 71909},
+						pos:        position{line: 2379, col: 14, offset: 71995},
 						val:        "extract",
 						ignoreCase: true,
 						want:       "\"EXTRACT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2377, col: 33, offset: 71928},
+						pos: position{line: 2379, col: 33, offset: 72014},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2377, col: 34, offset: 71929},
+							pos:  position{line: 2379, col: 34, offset: 72015},
 							name: "IdentifierRest",
 						},
 					},
@@ -16749,20 +16767,20 @@ var g = &grammar{
 		},
 		{
 			name: "FALSE",
-			pos:  position{line: 2378, col: 1, offset: 71944},
+			pos:  position{line: 2380, col: 1, offset: 72030},
 			expr: &seqExpr{
-				pos: position{line: 2378, col: 14, offset: 71957},
+				pos: position{line: 2380, col: 14, offset: 72043},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2378, col: 14, offset: 71957},
+						pos:        position{line: 2380, col: 14, offset: 72043},
 						val:        "false",
 						ignoreCase: true,
 						want:       "\"FALSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2378, col: 33, offset: 71976},
+						pos: position{line: 2380, col: 33, offset: 72062},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2378, col: 34, offset: 71977},
+							pos:  position{line: 2380, col: 34, offset: 72063},
 							name: "IdentifierRest",
 						},
 					},
@@ -16773,20 +16791,20 @@ var g = &grammar{
 		},
 		{
 			name: "FIRST",
-			pos:  position{line: 2379, col: 1, offset: 71992},
+			pos:  position{line: 2381, col: 1, offset: 72078},
 			expr: &seqExpr{
-				pos: position{line: 2379, col: 14, offset: 72005},
+				pos: position{line: 2381, col: 14, offset: 72091},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2379, col: 14, offset: 72005},
+						pos:        position{line: 2381, col: 14, offset: 72091},
 						val:        "first",
 						ignoreCase: true,
 						want:       "\"FIRST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2379, col: 33, offset: 72024},
+						pos: position{line: 2381, col: 33, offset: 72110},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2379, col: 34, offset: 72025},
+							pos:  position{line: 2381, col: 34, offset: 72111},
 							name: "IdentifierRest",
 						},
 					},
@@ -16797,20 +16815,20 @@ var g = &grammar{
 		},
 		{
 			name: "FN",
-			pos:  position{line: 2380, col: 1, offset: 72040},
+			pos:  position{line: 2382, col: 1, offset: 72126},
 			expr: &seqExpr{
-				pos: position{line: 2380, col: 14, offset: 72053},
+				pos: position{line: 2382, col: 14, offset: 72139},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2380, col: 14, offset: 72053},
+						pos:        position{line: 2382, col: 14, offset: 72139},
 						val:        "fn",
 						ignoreCase: true,
 						want:       "\"FN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2380, col: 33, offset: 72072},
+						pos: position{line: 2382, col: 33, offset: 72158},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2380, col: 34, offset: 72073},
+							pos:  position{line: 2382, col: 34, offset: 72159},
 							name: "IdentifierRest",
 						},
 					},
@@ -16821,20 +16839,20 @@ var g = &grammar{
 		},
 		{
 			name: "FOR",
-			pos:  position{line: 2381, col: 1, offset: 72088},
+			pos:  position{line: 2383, col: 1, offset: 72174},
 			expr: &seqExpr{
-				pos: position{line: 2381, col: 14, offset: 72101},
+				pos: position{line: 2383, col: 14, offset: 72187},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2381, col: 14, offset: 72101},
+						pos:        position{line: 2383, col: 14, offset: 72187},
 						val:        "for",
 						ignoreCase: true,
 						want:       "\"FOR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2381, col: 33, offset: 72120},
+						pos: position{line: 2383, col: 33, offset: 72206},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2381, col: 34, offset: 72121},
+							pos:  position{line: 2383, col: 34, offset: 72207},
 							name: "IdentifierRest",
 						},
 					},
@@ -16845,20 +16863,20 @@ var g = &grammar{
 		},
 		{
 			name: "FORK",
-			pos:  position{line: 2382, col: 1, offset: 72136},
+			pos:  position{line: 2384, col: 1, offset: 72222},
 			expr: &seqExpr{
-				pos: position{line: 2382, col: 14, offset: 72149},
+				pos: position{line: 2384, col: 14, offset: 72235},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2382, col: 14, offset: 72149},
+						pos:        position{line: 2384, col: 14, offset: 72235},
 						val:        "fork",
 						ignoreCase: true,
 						want:       "\"FORK\"i",
 					},
 					&notExpr{
-						pos: position{line: 2382, col: 33, offset: 72168},
+						pos: position{line: 2384, col: 33, offset: 72254},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2382, col: 34, offset: 72169},
+							pos:  position{line: 2384, col: 34, offset: 72255},
 							name: "IdentifierRest",
 						},
 					},
@@ -16869,20 +16887,20 @@ var g = &grammar{
 		},
 		{
 			name: "FROM",
-			pos:  position{line: 2383, col: 1, offset: 72184},
+			pos:  position{line: 2385, col: 1, offset: 72270},
 			expr: &seqExpr{
-				pos: position{line: 2383, col: 14, offset: 72197},
+				pos: position{line: 2385, col: 14, offset: 72283},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2383, col: 14, offset: 72197},
+						pos:        position{line: 2385, col: 14, offset: 72283},
 						val:        "from",
 						ignoreCase: true,
 						want:       "\"FROM\"i",
 					},
 					&notExpr{
-						pos: position{line: 2383, col: 33, offset: 72216},
+						pos: position{line: 2385, col: 33, offset: 72302},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2383, col: 34, offset: 72217},
+							pos:  position{line: 2385, col: 34, offset: 72303},
 							name: "IdentifierRest",
 						},
 					},
@@ -16893,20 +16911,20 @@ var g = &grammar{
 		},
 		{
 			name: "FULL",
-			pos:  position{line: 2384, col: 1, offset: 72232},
+			pos:  position{line: 2386, col: 1, offset: 72318},
 			expr: &seqExpr{
-				pos: position{line: 2384, col: 14, offset: 72245},
+				pos: position{line: 2386, col: 14, offset: 72331},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2384, col: 14, offset: 72245},
+						pos:        position{line: 2386, col: 14, offset: 72331},
 						val:        "full",
 						ignoreCase: true,
 						want:       "\"FULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2384, col: 33, offset: 72264},
+						pos: position{line: 2386, col: 33, offset: 72350},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2384, col: 34, offset: 72265},
+							pos:  position{line: 2386, col: 34, offset: 72351},
 							name: "IdentifierRest",
 						},
 					},
@@ -16917,20 +16935,20 @@ var g = &grammar{
 		},
 		{
 			name: "FUSE",
-			pos:  position{line: 2385, col: 1, offset: 72280},
+			pos:  position{line: 2387, col: 1, offset: 72366},
 			expr: &seqExpr{
-				pos: position{line: 2385, col: 14, offset: 72293},
+				pos: position{line: 2387, col: 14, offset: 72379},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2385, col: 14, offset: 72293},
+						pos:        position{line: 2387, col: 14, offset: 72379},
 						val:        "fuse",
 						ignoreCase: true,
 						want:       "\"FUSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2385, col: 33, offset: 72312},
+						pos: position{line: 2387, col: 33, offset: 72398},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2385, col: 34, offset: 72313},
+							pos:  position{line: 2387, col: 34, offset: 72399},
 							name: "IdentifierRest",
 						},
 					},
@@ -16941,20 +16959,20 @@ var g = &grammar{
 		},
 		{
 			name: "GROUP",
-			pos:  position{line: 2386, col: 1, offset: 72328},
+			pos:  position{line: 2388, col: 1, offset: 72414},
 			expr: &seqExpr{
-				pos: position{line: 2386, col: 14, offset: 72341},
+				pos: position{line: 2388, col: 14, offset: 72427},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2386, col: 14, offset: 72341},
+						pos:        position{line: 2388, col: 14, offset: 72427},
 						val:        "group",
 						ignoreCase: true,
 						want:       "\"GROUP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2386, col: 33, offset: 72360},
+						pos: position{line: 2388, col: 33, offset: 72446},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2386, col: 34, offset: 72361},
+							pos:  position{line: 2388, col: 34, offset: 72447},
 							name: "IdentifierRest",
 						},
 					},
@@ -16965,20 +16983,20 @@ var g = &grammar{
 		},
 		{
 			name: "HAVING",
-			pos:  position{line: 2387, col: 1, offset: 72376},
+			pos:  position{line: 2389, col: 1, offset: 72462},
 			expr: &seqExpr{
-				pos: position{line: 2387, col: 14, offset: 72389},
+				pos: position{line: 2389, col: 14, offset: 72475},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2387, col: 14, offset: 72389},
+						pos:        position{line: 2389, col: 14, offset: 72475},
 						val:        "having",
 						ignoreCase: true,
 						want:       "\"HAVING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2387, col: 33, offset: 72408},
+						pos: position{line: 2389, col: 33, offset: 72494},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2387, col: 34, offset: 72409},
+							pos:  position{line: 2389, col: 34, offset: 72495},
 							name: "IdentifierRest",
 						},
 					},
@@ -16989,20 +17007,20 @@ var g = &grammar{
 		},
 		{
 			name: "HEAD",
-			pos:  position{line: 2388, col: 1, offset: 72424},
+			pos:  position{line: 2390, col: 1, offset: 72510},
 			expr: &seqExpr{
-				pos: position{line: 2388, col: 14, offset: 72437},
+				pos: position{line: 2390, col: 14, offset: 72523},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2388, col: 14, offset: 72437},
+						pos:        position{line: 2390, col: 14, offset: 72523},
 						val:        "head",
 						ignoreCase: true,
 						want:       "\"HEAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2388, col: 33, offset: 72456},
+						pos: position{line: 2390, col: 33, offset: 72542},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2388, col: 34, offset: 72457},
+							pos:  position{line: 2390, col: 34, offset: 72543},
 							name: "IdentifierRest",
 						},
 					},
@@ -17013,20 +17031,20 @@ var g = &grammar{
 		},
 		{
 			name: "IN",
-			pos:  position{line: 2389, col: 1, offset: 72472},
+			pos:  position{line: 2391, col: 1, offset: 72558},
 			expr: &seqExpr{
-				pos: position{line: 2389, col: 14, offset: 72485},
+				pos: position{line: 2391, col: 14, offset: 72571},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2389, col: 14, offset: 72485},
+						pos:        position{line: 2391, col: 14, offset: 72571},
 						val:        "in",
 						ignoreCase: true,
 						want:       "\"IN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2389, col: 33, offset: 72504},
+						pos: position{line: 2391, col: 33, offset: 72590},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2389, col: 34, offset: 72505},
+							pos:  position{line: 2391, col: 34, offset: 72591},
 							name: "IdentifierRest",
 						},
 					},
@@ -17037,20 +17055,20 @@ var g = &grammar{
 		},
 		{
 			name: "INNER",
-			pos:  position{line: 2390, col: 1, offset: 72520},
+			pos:  position{line: 2392, col: 1, offset: 72606},
 			expr: &seqExpr{
-				pos: position{line: 2390, col: 14, offset: 72533},
+				pos: position{line: 2392, col: 14, offset: 72619},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2390, col: 14, offset: 72533},
+						pos:        position{line: 2392, col: 14, offset: 72619},
 						val:        "inner",
 						ignoreCase: true,
 						want:       "\"INNER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2390, col: 33, offset: 72552},
+						pos: position{line: 2392, col: 33, offset: 72638},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2390, col: 34, offset: 72553},
+							pos:  position{line: 2392, col: 34, offset: 72639},
 							name: "IdentifierRest",
 						},
 					},
@@ -17061,20 +17079,20 @@ var g = &grammar{
 		},
 		{
 			name: "IS",
-			pos:  position{line: 2391, col: 1, offset: 72568},
+			pos:  position{line: 2393, col: 1, offset: 72654},
 			expr: &seqExpr{
-				pos: position{line: 2391, col: 14, offset: 72581},
+				pos: position{line: 2393, col: 14, offset: 72667},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2391, col: 14, offset: 72581},
+						pos:        position{line: 2393, col: 14, offset: 72667},
 						val:        "is",
 						ignoreCase: true,
 						want:       "\"IS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2391, col: 33, offset: 72600},
+						pos: position{line: 2393, col: 33, offset: 72686},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2391, col: 34, offset: 72601},
+							pos:  position{line: 2393, col: 34, offset: 72687},
 							name: "IdentifierRest",
 						},
 					},
@@ -17085,20 +17103,20 @@ var g = &grammar{
 		},
 		{
 			name: "JOIN",
-			pos:  position{line: 2392, col: 1, offset: 72616},
+			pos:  position{line: 2394, col: 1, offset: 72702},
 			expr: &seqExpr{
-				pos: position{line: 2392, col: 14, offset: 72629},
+				pos: position{line: 2394, col: 14, offset: 72715},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2392, col: 14, offset: 72629},
+						pos:        position{line: 2394, col: 14, offset: 72715},
 						val:        "join",
 						ignoreCase: true,
 						want:       "\"JOIN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2392, col: 33, offset: 72648},
+						pos: position{line: 2394, col: 33, offset: 72734},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2392, col: 34, offset: 72649},
+							pos:  position{line: 2394, col: 34, offset: 72735},
 							name: "IdentifierRest",
 						},
 					},
@@ -17109,20 +17127,20 @@ var g = &grammar{
 		},
 		{
 			name: "LAMBDA",
-			pos:  position{line: 2393, col: 1, offset: 72664},
+			pos:  position{line: 2395, col: 1, offset: 72750},
 			expr: &seqExpr{
-				pos: position{line: 2393, col: 14, offset: 72677},
+				pos: position{line: 2395, col: 14, offset: 72763},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2393, col: 14, offset: 72677},
+						pos:        position{line: 2395, col: 14, offset: 72763},
 						val:        "lambda",
 						ignoreCase: true,
 						want:       "\"LAMBDA\"i",
 					},
 					&notExpr{
-						pos: position{line: 2393, col: 33, offset: 72696},
+						pos: position{line: 2395, col: 33, offset: 72782},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2393, col: 34, offset: 72697},
+							pos:  position{line: 2395, col: 34, offset: 72783},
 							name: "IdentifierRest",
 						},
 					},
@@ -17133,20 +17151,20 @@ var g = &grammar{
 		},
 		{
 			name: "LAST",
-			pos:  position{line: 2394, col: 1, offset: 72712},
+			pos:  position{line: 2396, col: 1, offset: 72798},
 			expr: &seqExpr{
-				pos: position{line: 2394, col: 14, offset: 72725},
+				pos: position{line: 2396, col: 14, offset: 72811},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2394, col: 14, offset: 72725},
+						pos:        position{line: 2396, col: 14, offset: 72811},
 						val:        "last",
 						ignoreCase: true,
 						want:       "\"LAST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2394, col: 33, offset: 72744},
+						pos: position{line: 2396, col: 33, offset: 72830},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2394, col: 34, offset: 72745},
+							pos:  position{line: 2396, col: 34, offset: 72831},
 							name: "IdentifierRest",
 						},
 					},
@@ -17157,20 +17175,20 @@ var g = &grammar{
 		},
 		{
 			name: "LEFT",
-			pos:  position{line: 2395, col: 1, offset: 72760},
+			pos:  position{line: 2397, col: 1, offset: 72846},
 			expr: &seqExpr{
-				pos: position{line: 2395, col: 14, offset: 72773},
+				pos: position{line: 2397, col: 14, offset: 72859},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2395, col: 14, offset: 72773},
+						pos:        position{line: 2397, col: 14, offset: 72859},
 						val:        "left",
 						ignoreCase: true,
 						want:       "\"LEFT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2395, col: 33, offset: 72792},
+						pos: position{line: 2397, col: 33, offset: 72878},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2395, col: 34, offset: 72793},
+							pos:  position{line: 2397, col: 34, offset: 72879},
 							name: "IdentifierRest",
 						},
 					},
@@ -17181,20 +17199,20 @@ var g = &grammar{
 		},
 		{
 			name: "LET",
-			pos:  position{line: 2396, col: 1, offset: 72808},
+			pos:  position{line: 2398, col: 1, offset: 72894},
 			expr: &seqExpr{
-				pos: position{line: 2396, col: 14, offset: 72821},
+				pos: position{line: 2398, col: 14, offset: 72907},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2396, col: 14, offset: 72821},
+						pos:        position{line: 2398, col: 14, offset: 72907},
 						val:        "let",
 						ignoreCase: true,
 						want:       "\"LET\"i",
 					},
 					&notExpr{
-						pos: position{line: 2396, col: 33, offset: 72840},
+						pos: position{line: 2398, col: 33, offset: 72926},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2396, col: 34, offset: 72841},
+							pos:  position{line: 2398, col: 34, offset: 72927},
 							name: "IdentifierRest",
 						},
 					},
@@ -17205,20 +17223,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIKE",
-			pos:  position{line: 2397, col: 1, offset: 72856},
+			pos:  position{line: 2399, col: 1, offset: 72942},
 			expr: &seqExpr{
-				pos: position{line: 2397, col: 14, offset: 72869},
+				pos: position{line: 2399, col: 14, offset: 72955},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2397, col: 14, offset: 72869},
+						pos:        position{line: 2399, col: 14, offset: 72955},
 						val:        "like",
 						ignoreCase: true,
 						want:       "\"LIKE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2397, col: 33, offset: 72888},
+						pos: position{line: 2399, col: 33, offset: 72974},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2397, col: 34, offset: 72889},
+							pos:  position{line: 2399, col: 34, offset: 72975},
 							name: "IdentifierRest",
 						},
 					},
@@ -17229,20 +17247,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIMIT",
-			pos:  position{line: 2398, col: 1, offset: 72904},
+			pos:  position{line: 2400, col: 1, offset: 72990},
 			expr: &seqExpr{
-				pos: position{line: 2398, col: 14, offset: 72917},
+				pos: position{line: 2400, col: 14, offset: 73003},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2398, col: 14, offset: 72917},
+						pos:        position{line: 2400, col: 14, offset: 73003},
 						val:        "limit",
 						ignoreCase: true,
 						want:       "\"LIMIT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2398, col: 33, offset: 72936},
+						pos: position{line: 2400, col: 33, offset: 73022},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2398, col: 34, offset: 72937},
+							pos:  position{line: 2400, col: 34, offset: 73023},
 							name: "IdentifierRest",
 						},
 					},
@@ -17253,20 +17271,20 @@ var g = &grammar{
 		},
 		{
 			name: "LOAD",
-			pos:  position{line: 2399, col: 1, offset: 72952},
+			pos:  position{line: 2401, col: 1, offset: 73038},
 			expr: &seqExpr{
-				pos: position{line: 2399, col: 14, offset: 72965},
+				pos: position{line: 2401, col: 14, offset: 73051},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2399, col: 14, offset: 72965},
+						pos:        position{line: 2401, col: 14, offset: 73051},
 						val:        "load",
 						ignoreCase: true,
 						want:       "\"LOAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2399, col: 33, offset: 72984},
+						pos: position{line: 2401, col: 33, offset: 73070},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2399, col: 34, offset: 72985},
+							pos:  position{line: 2401, col: 34, offset: 73071},
 							name: "IdentifierRest",
 						},
 					},
@@ -17277,20 +17295,20 @@ var g = &grammar{
 		},
 		{
 			name: "MATERIALIZED",
-			pos:  position{line: 2400, col: 1, offset: 73000},
+			pos:  position{line: 2402, col: 1, offset: 73086},
 			expr: &seqExpr{
-				pos: position{line: 2400, col: 16, offset: 73015},
+				pos: position{line: 2402, col: 16, offset: 73101},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2400, col: 16, offset: 73015},
+						pos:        position{line: 2402, col: 16, offset: 73101},
 						val:        "materialized",
 						ignoreCase: true,
 						want:       "\"MATERIALIZED\"i",
 					},
 					&notExpr{
-						pos: position{line: 2400, col: 33, offset: 73032},
+						pos: position{line: 2402, col: 33, offset: 73118},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2400, col: 34, offset: 73033},
+							pos:  position{line: 2402, col: 34, offset: 73119},
 							name: "IdentifierRest",
 						},
 					},
@@ -17301,20 +17319,20 @@ var g = &grammar{
 		},
 		{
 			name: "MAP",
-			pos:  position{line: 2401, col: 1, offset: 73048},
+			pos:  position{line: 2403, col: 1, offset: 73134},
 			expr: &seqExpr{
-				pos: position{line: 2401, col: 14, offset: 73061},
+				pos: position{line: 2403, col: 14, offset: 73147},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2401, col: 14, offset: 73061},
+						pos:        position{line: 2403, col: 14, offset: 73147},
 						val:        "map",
 						ignoreCase: true,
 						want:       "\"MAP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2401, col: 33, offset: 73080},
+						pos: position{line: 2403, col: 33, offset: 73166},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2401, col: 34, offset: 73081},
+							pos:  position{line: 2403, col: 34, offset: 73167},
 							name: "IdentifierRest",
 						},
 					},
@@ -17325,20 +17343,20 @@ var g = &grammar{
 		},
 		{
 			name: "MERGE",
-			pos:  position{line: 2402, col: 1, offset: 73096},
+			pos:  position{line: 2404, col: 1, offset: 73182},
 			expr: &seqExpr{
-				pos: position{line: 2402, col: 14, offset: 73109},
+				pos: position{line: 2404, col: 14, offset: 73195},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2402, col: 14, offset: 73109},
+						pos:        position{line: 2404, col: 14, offset: 73195},
 						val:        "merge",
 						ignoreCase: true,
 						want:       "\"MERGE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2402, col: 33, offset: 73128},
+						pos: position{line: 2404, col: 33, offset: 73214},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2402, col: 34, offset: 73129},
+							pos:  position{line: 2404, col: 34, offset: 73215},
 							name: "IdentifierRest",
 						},
 					},
@@ -17349,20 +17367,20 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 2403, col: 1, offset: 73144},
+			pos:  position{line: 2405, col: 1, offset: 73230},
 			expr: &seqExpr{
-				pos: position{line: 2403, col: 14, offset: 73157},
+				pos: position{line: 2405, col: 14, offset: 73243},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2403, col: 14, offset: 73157},
+						pos:        position{line: 2405, col: 14, offset: 73243},
 						val:        "not",
 						ignoreCase: true,
 						want:       "\"NOT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2403, col: 33, offset: 73176},
+						pos: position{line: 2405, col: 33, offset: 73262},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2403, col: 34, offset: 73177},
+							pos:  position{line: 2405, col: 34, offset: 73263},
 							name: "IdentifierRest",
 						},
 					},
@@ -17373,20 +17391,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULL",
-			pos:  position{line: 2404, col: 1, offset: 73192},
+			pos:  position{line: 2406, col: 1, offset: 73278},
 			expr: &seqExpr{
-				pos: position{line: 2404, col: 14, offset: 73205},
+				pos: position{line: 2406, col: 14, offset: 73291},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2404, col: 14, offset: 73205},
+						pos:        position{line: 2406, col: 14, offset: 73291},
 						val:        "null",
 						ignoreCase: true,
 						want:       "\"NULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2404, col: 33, offset: 73224},
+						pos: position{line: 2406, col: 33, offset: 73310},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2404, col: 34, offset: 73225},
+							pos:  position{line: 2406, col: 34, offset: 73311},
 							name: "IdentifierRest",
 						},
 					},
@@ -17397,20 +17415,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULLS",
-			pos:  position{line: 2405, col: 1, offset: 73240},
+			pos:  position{line: 2407, col: 1, offset: 73326},
 			expr: &seqExpr{
-				pos: position{line: 2405, col: 14, offset: 73253},
+				pos: position{line: 2407, col: 14, offset: 73339},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2405, col: 14, offset: 73253},
+						pos:        position{line: 2407, col: 14, offset: 73339},
 						val:        "nulls",
 						ignoreCase: true,
 						want:       "\"NULLS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2405, col: 33, offset: 73272},
+						pos: position{line: 2407, col: 33, offset: 73358},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2405, col: 34, offset: 73273},
+							pos:  position{line: 2407, col: 34, offset: 73359},
 							name: "IdentifierRest",
 						},
 					},
@@ -17421,20 +17439,20 @@ var g = &grammar{
 		},
 		{
 			name: "OFFSET",
-			pos:  position{line: 2406, col: 1, offset: 73288},
+			pos:  position{line: 2408, col: 1, offset: 73374},
 			expr: &seqExpr{
-				pos: position{line: 2406, col: 14, offset: 73301},
+				pos: position{line: 2408, col: 14, offset: 73387},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2406, col: 14, offset: 73301},
+						pos:        position{line: 2408, col: 14, offset: 73387},
 						val:        "offset",
 						ignoreCase: true,
 						want:       "\"OFFSET\"i",
 					},
 					&notExpr{
-						pos: position{line: 2406, col: 33, offset: 73320},
+						pos: position{line: 2408, col: 33, offset: 73406},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2406, col: 34, offset: 73321},
+							pos:  position{line: 2408, col: 34, offset: 73407},
 							name: "IdentifierRest",
 						},
 					},
@@ -17445,20 +17463,20 @@ var g = &grammar{
 		},
 		{
 			name: "ON",
-			pos:  position{line: 2407, col: 1, offset: 73336},
+			pos:  position{line: 2409, col: 1, offset: 73422},
 			expr: &seqExpr{
-				pos: position{line: 2407, col: 14, offset: 73349},
+				pos: position{line: 2409, col: 14, offset: 73435},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2407, col: 14, offset: 73349},
+						pos:        position{line: 2409, col: 14, offset: 73435},
 						val:        "on",
 						ignoreCase: true,
 						want:       "\"ON\"i",
 					},
 					&notExpr{
-						pos: position{line: 2407, col: 33, offset: 73368},
+						pos: position{line: 2409, col: 33, offset: 73454},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2407, col: 34, offset: 73369},
+							pos:  position{line: 2409, col: 34, offset: 73455},
 							name: "IdentifierRest",
 						},
 					},
@@ -17469,20 +17487,20 @@ var g = &grammar{
 		},
 		{
 			name: "OP",
-			pos:  position{line: 2408, col: 1, offset: 73384},
+			pos:  position{line: 2410, col: 1, offset: 73470},
 			expr: &seqExpr{
-				pos: position{line: 2408, col: 14, offset: 73397},
+				pos: position{line: 2410, col: 14, offset: 73483},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2408, col: 14, offset: 73397},
+						pos:        position{line: 2410, col: 14, offset: 73483},
 						val:        "op",
 						ignoreCase: true,
 						want:       "\"OP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2408, col: 33, offset: 73416},
+						pos: position{line: 2410, col: 33, offset: 73502},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2408, col: 34, offset: 73417},
+							pos:  position{line: 2410, col: 34, offset: 73503},
 							name: "IdentifierRest",
 						},
 					},
@@ -17493,23 +17511,23 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 2409, col: 1, offset: 73432},
+			pos:  position{line: 2411, col: 1, offset: 73518},
 			expr: &actionExpr{
-				pos: position{line: 2409, col: 14, offset: 73445},
+				pos: position{line: 2411, col: 14, offset: 73531},
 				run: (*parser).callonOR1,
 				expr: &seqExpr{
-					pos: position{line: 2409, col: 14, offset: 73445},
+					pos: position{line: 2411, col: 14, offset: 73531},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2409, col: 14, offset: 73445},
+							pos:        position{line: 2411, col: 14, offset: 73531},
 							val:        "or",
 							ignoreCase: true,
 							want:       "\"OR\"i",
 						},
 						&notExpr{
-							pos: position{line: 2409, col: 33, offset: 73464},
+							pos: position{line: 2411, col: 33, offset: 73550},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2409, col: 34, offset: 73465},
+								pos:  position{line: 2411, col: 34, offset: 73551},
 								name: "IdentifierRest",
 							},
 						},
@@ -17521,20 +17539,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDER",
-			pos:  position{line: 2410, col: 1, offset: 73501},
+			pos:  position{line: 2412, col: 1, offset: 73587},
 			expr: &seqExpr{
-				pos: position{line: 2410, col: 14, offset: 73514},
+				pos: position{line: 2412, col: 14, offset: 73600},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2410, col: 14, offset: 73514},
+						pos:        position{line: 2412, col: 14, offset: 73600},
 						val:        "order",
 						ignoreCase: true,
 						want:       "\"ORDER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2410, col: 33, offset: 73533},
+						pos: position{line: 2412, col: 33, offset: 73619},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2410, col: 34, offset: 73534},
+							pos:  position{line: 2412, col: 34, offset: 73620},
 							name: "IdentifierRest",
 						},
 					},
@@ -17545,20 +17563,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDINALITY",
-			pos:  position{line: 2411, col: 1, offset: 73549},
+			pos:  position{line: 2413, col: 1, offset: 73635},
 			expr: &seqExpr{
-				pos: position{line: 2411, col: 14, offset: 73562},
+				pos: position{line: 2413, col: 14, offset: 73648},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2411, col: 14, offset: 73562},
+						pos:        position{line: 2413, col: 14, offset: 73648},
 						val:        "ordinality",
 						ignoreCase: true,
 						want:       "\"ORDINALITY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2411, col: 33, offset: 73581},
+						pos: position{line: 2413, col: 33, offset: 73667},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2411, col: 34, offset: 73582},
+							pos:  position{line: 2413, col: 34, offset: 73668},
 							name: "IdentifierRest",
 						},
 					},
@@ -17569,20 +17587,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTER",
-			pos:  position{line: 2412, col: 1, offset: 73597},
+			pos:  position{line: 2414, col: 1, offset: 73683},
 			expr: &seqExpr{
-				pos: position{line: 2412, col: 14, offset: 73610},
+				pos: position{line: 2414, col: 14, offset: 73696},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2412, col: 14, offset: 73610},
+						pos:        position{line: 2414, col: 14, offset: 73696},
 						val:        "outer",
 						ignoreCase: true,
 						want:       "\"OUTER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2412, col: 33, offset: 73629},
+						pos: position{line: 2414, col: 33, offset: 73715},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2412, col: 34, offset: 73630},
+							pos:  position{line: 2414, col: 34, offset: 73716},
 							name: "IdentifierRest",
 						},
 					},
@@ -17593,20 +17611,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTPUT",
-			pos:  position{line: 2413, col: 1, offset: 73645},
+			pos:  position{line: 2415, col: 1, offset: 73731},
 			expr: &seqExpr{
-				pos: position{line: 2413, col: 14, offset: 73658},
+				pos: position{line: 2415, col: 14, offset: 73744},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2413, col: 14, offset: 73658},
+						pos:        position{line: 2415, col: 14, offset: 73744},
 						val:        "output",
 						ignoreCase: true,
 						want:       "\"OUTPUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2413, col: 33, offset: 73677},
+						pos: position{line: 2415, col: 33, offset: 73763},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2413, col: 34, offset: 73678},
+							pos:  position{line: 2415, col: 34, offset: 73764},
 							name: "IdentifierRest",
 						},
 					},
@@ -17617,20 +17635,20 @@ var g = &grammar{
 		},
 		{
 			name: "PASS",
-			pos:  position{line: 2414, col: 1, offset: 73693},
+			pos:  position{line: 2416, col: 1, offset: 73779},
 			expr: &seqExpr{
-				pos: position{line: 2414, col: 14, offset: 73706},
+				pos: position{line: 2416, col: 14, offset: 73792},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2414, col: 14, offset: 73706},
+						pos:        position{line: 2416, col: 14, offset: 73792},
 						val:        "pass",
 						ignoreCase: true,
 						want:       "\"PASS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2414, col: 33, offset: 73725},
+						pos: position{line: 2416, col: 33, offset: 73811},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2414, col: 34, offset: 73726},
+							pos:  position{line: 2416, col: 34, offset: 73812},
 							name: "IdentifierRest",
 						},
 					},
@@ -17641,20 +17659,20 @@ var g = &grammar{
 		},
 		{
 			name: "PUT",
-			pos:  position{line: 2415, col: 1, offset: 73741},
+			pos:  position{line: 2417, col: 1, offset: 73827},
 			expr: &seqExpr{
-				pos: position{line: 2415, col: 14, offset: 73754},
+				pos: position{line: 2417, col: 14, offset: 73840},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2415, col: 14, offset: 73754},
+						pos:        position{line: 2417, col: 14, offset: 73840},
 						val:        "put",
 						ignoreCase: true,
 						want:       "\"PUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2415, col: 33, offset: 73773},
+						pos: position{line: 2417, col: 33, offset: 73859},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2415, col: 34, offset: 73774},
+							pos:  position{line: 2417, col: 34, offset: 73860},
 							name: "IdentifierRest",
 						},
 					},
@@ -17665,20 +17683,20 @@ var g = &grammar{
 		},
 		{
 			name: "RECURSIVE",
-			pos:  position{line: 2416, col: 1, offset: 73789},
+			pos:  position{line: 2418, col: 1, offset: 73875},
 			expr: &seqExpr{
-				pos: position{line: 2416, col: 14, offset: 73802},
+				pos: position{line: 2418, col: 14, offset: 73888},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2416, col: 14, offset: 73802},
+						pos:        position{line: 2418, col: 14, offset: 73888},
 						val:        "recursive",
 						ignoreCase: true,
 						want:       "\"RECURSIVE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2416, col: 33, offset: 73821},
+						pos: position{line: 2418, col: 33, offset: 73907},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2416, col: 34, offset: 73822},
+							pos:  position{line: 2418, col: 34, offset: 73908},
 							name: "IdentifierRest",
 						},
 					},
@@ -17689,20 +17707,20 @@ var g = &grammar{
 		},
 		{
 			name: "RENAME",
-			pos:  position{line: 2417, col: 1, offset: 73837},
+			pos:  position{line: 2419, col: 1, offset: 73923},
 			expr: &seqExpr{
-				pos: position{line: 2417, col: 14, offset: 73850},
+				pos: position{line: 2419, col: 14, offset: 73936},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2417, col: 14, offset: 73850},
+						pos:        position{line: 2419, col: 14, offset: 73936},
 						val:        "rename",
 						ignoreCase: true,
 						want:       "\"RENAME\"i",
 					},
 					&notExpr{
-						pos: position{line: 2417, col: 33, offset: 73869},
+						pos: position{line: 2419, col: 33, offset: 73955},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2417, col: 34, offset: 73870},
+							pos:  position{line: 2419, col: 34, offset: 73956},
 							name: "IdentifierRest",
 						},
 					},
@@ -17713,20 +17731,20 @@ var g = &grammar{
 		},
 		{
 			name: "RIGHT",
-			pos:  position{line: 2418, col: 1, offset: 73885},
+			pos:  position{line: 2420, col: 1, offset: 73971},
 			expr: &seqExpr{
-				pos: position{line: 2418, col: 14, offset: 73898},
+				pos: position{line: 2420, col: 14, offset: 73984},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2418, col: 14, offset: 73898},
+						pos:        position{line: 2420, col: 14, offset: 73984},
 						val:        "right",
 						ignoreCase: true,
 						want:       "\"RIGHT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2418, col: 33, offset: 73917},
+						pos: position{line: 2420, col: 33, offset: 74003},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2418, col: 34, offset: 73918},
+							pos:  position{line: 2420, col: 34, offset: 74004},
 							name: "IdentifierRest",
 						},
 					},
@@ -17737,20 +17755,20 @@ var g = &grammar{
 		},
 		{
 			name: "SHAPES",
-			pos:  position{line: 2419, col: 1, offset: 73933},
+			pos:  position{line: 2421, col: 1, offset: 74019},
 			expr: &seqExpr{
-				pos: position{line: 2419, col: 14, offset: 73946},
+				pos: position{line: 2421, col: 14, offset: 74032},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2419, col: 14, offset: 73946},
+						pos:        position{line: 2421, col: 14, offset: 74032},
 						val:        "shapes",
 						ignoreCase: true,
 						want:       "\"SHAPES\"i",
 					},
 					&notExpr{
-						pos: position{line: 2419, col: 33, offset: 73965},
+						pos: position{line: 2421, col: 33, offset: 74051},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2419, col: 34, offset: 73966},
+							pos:  position{line: 2421, col: 34, offset: 74052},
 							name: "IdentifierRest",
 						},
 					},
@@ -17761,20 +17779,20 @@ var g = &grammar{
 		},
 		{
 			name: "SEARCH",
-			pos:  position{line: 2420, col: 1, offset: 73981},
+			pos:  position{line: 2422, col: 1, offset: 74067},
 			expr: &seqExpr{
-				pos: position{line: 2420, col: 14, offset: 73994},
+				pos: position{line: 2422, col: 14, offset: 74080},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2420, col: 14, offset: 73994},
+						pos:        position{line: 2422, col: 14, offset: 74080},
 						val:        "search",
 						ignoreCase: true,
 						want:       "\"SEARCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2420, col: 33, offset: 74013},
+						pos: position{line: 2422, col: 33, offset: 74099},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2420, col: 34, offset: 74014},
+							pos:  position{line: 2422, col: 34, offset: 74100},
 							name: "IdentifierRest",
 						},
 					},
@@ -17785,20 +17803,20 @@ var g = &grammar{
 		},
 		{
 			name: "SELECT",
-			pos:  position{line: 2421, col: 1, offset: 74029},
+			pos:  position{line: 2423, col: 1, offset: 74115},
 			expr: &seqExpr{
-				pos: position{line: 2421, col: 14, offset: 74042},
+				pos: position{line: 2423, col: 14, offset: 74128},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2421, col: 14, offset: 74042},
+						pos:        position{line: 2423, col: 14, offset: 74128},
 						val:        "select",
 						ignoreCase: true,
 						want:       "\"SELECT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2421, col: 33, offset: 74061},
+						pos: position{line: 2423, col: 33, offset: 74147},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2421, col: 34, offset: 74062},
+							pos:  position{line: 2423, col: 34, offset: 74148},
 							name: "IdentifierRest",
 						},
 					},
@@ -17809,20 +17827,20 @@ var g = &grammar{
 		},
 		{
 			name: "SHAPE",
-			pos:  position{line: 2422, col: 1, offset: 74077},
+			pos:  position{line: 2424, col: 1, offset: 74163},
 			expr: &seqExpr{
-				pos: position{line: 2422, col: 14, offset: 74090},
+				pos: position{line: 2424, col: 14, offset: 74176},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2422, col: 14, offset: 74090},
+						pos:        position{line: 2424, col: 14, offset: 74176},
 						val:        "shape",
 						ignoreCase: true,
 						want:       "\"SHAPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2422, col: 33, offset: 74109},
+						pos: position{line: 2424, col: 33, offset: 74195},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2422, col: 34, offset: 74110},
+							pos:  position{line: 2424, col: 34, offset: 74196},
 							name: "IdentifierRest",
 						},
 					},
@@ -17833,20 +17851,20 @@ var g = &grammar{
 		},
 		{
 			name: "SKIP",
-			pos:  position{line: 2423, col: 1, offset: 74125},
+			pos:  position{line: 2425, col: 1, offset: 74211},
 			expr: &seqExpr{
-				pos: position{line: 2423, col: 14, offset: 74138},
+				pos: position{line: 2425, col: 14, offset: 74224},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2423, col: 14, offset: 74138},
+						pos:        position{line: 2425, col: 14, offset: 74224},
 						val:        "skip",
 						ignoreCase: true,
 						want:       "\"SKIP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2423, col: 33, offset: 74157},
+						pos: position{line: 2425, col: 33, offset: 74243},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2423, col: 34, offset: 74158},
+							pos:  position{line: 2425, col: 34, offset: 74244},
 							name: "IdentifierRest",
 						},
 					},
@@ -17857,20 +17875,20 @@ var g = &grammar{
 		},
 		{
 			name: "SORT",
-			pos:  position{line: 2424, col: 1, offset: 74173},
+			pos:  position{line: 2426, col: 1, offset: 74259},
 			expr: &seqExpr{
-				pos: position{line: 2424, col: 14, offset: 74186},
+				pos: position{line: 2426, col: 14, offset: 74272},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2424, col: 14, offset: 74186},
+						pos:        position{line: 2426, col: 14, offset: 74272},
 						val:        "sort",
 						ignoreCase: true,
 						want:       "\"SORT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2424, col: 33, offset: 74205},
+						pos: position{line: 2426, col: 33, offset: 74291},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2424, col: 34, offset: 74206},
+							pos:  position{line: 2426, col: 34, offset: 74292},
 							name: "IdentifierRest",
 						},
 					},
@@ -17881,20 +17899,20 @@ var g = &grammar{
 		},
 		{
 			name: "SUBSTRING",
-			pos:  position{line: 2425, col: 1, offset: 74221},
+			pos:  position{line: 2427, col: 1, offset: 74307},
 			expr: &seqExpr{
-				pos: position{line: 2425, col: 14, offset: 74234},
+				pos: position{line: 2427, col: 14, offset: 74320},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2425, col: 14, offset: 74234},
+						pos:        position{line: 2427, col: 14, offset: 74320},
 						val:        "substring",
 						ignoreCase: true,
 						want:       "\"SUBSTRING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2425, col: 33, offset: 74253},
+						pos: position{line: 2427, col: 33, offset: 74339},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2425, col: 34, offset: 74254},
+							pos:  position{line: 2427, col: 34, offset: 74340},
 							name: "IdentifierRest",
 						},
 					},
@@ -17905,20 +17923,20 @@ var g = &grammar{
 		},
 		{
 			name: "SUMMARIZE",
-			pos:  position{line: 2426, col: 1, offset: 74269},
+			pos:  position{line: 2428, col: 1, offset: 74355},
 			expr: &seqExpr{
-				pos: position{line: 2426, col: 14, offset: 74282},
+				pos: position{line: 2428, col: 14, offset: 74368},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2426, col: 14, offset: 74282},
+						pos:        position{line: 2428, col: 14, offset: 74368},
 						val:        "summarize",
 						ignoreCase: true,
 						want:       "\"SUMMARIZE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2426, col: 33, offset: 74301},
+						pos: position{line: 2428, col: 33, offset: 74387},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2426, col: 34, offset: 74302},
+							pos:  position{line: 2428, col: 34, offset: 74388},
 							name: "IdentifierRest",
 						},
 					},
@@ -17929,20 +17947,20 @@ var g = &grammar{
 		},
 		{
 			name: "SWITCH",
-			pos:  position{line: 2427, col: 1, offset: 74317},
+			pos:  position{line: 2429, col: 1, offset: 74403},
 			expr: &seqExpr{
-				pos: position{line: 2427, col: 14, offset: 74330},
+				pos: position{line: 2429, col: 14, offset: 74416},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2427, col: 14, offset: 74330},
+						pos:        position{line: 2429, col: 14, offset: 74416},
 						val:        "switch",
 						ignoreCase: true,
 						want:       "\"SWITCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2427, col: 33, offset: 74349},
+						pos: position{line: 2429, col: 33, offset: 74435},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2427, col: 34, offset: 74350},
+							pos:  position{line: 2429, col: 34, offset: 74436},
 							name: "IdentifierRest",
 						},
 					},
@@ -17953,20 +17971,20 @@ var g = &grammar{
 		},
 		{
 			name: "TAIL",
-			pos:  position{line: 2428, col: 1, offset: 74365},
+			pos:  position{line: 2430, col: 1, offset: 74451},
 			expr: &seqExpr{
-				pos: position{line: 2428, col: 14, offset: 74378},
+				pos: position{line: 2430, col: 14, offset: 74464},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2428, col: 14, offset: 74378},
+						pos:        position{line: 2430, col: 14, offset: 74464},
 						val:        "tail",
 						ignoreCase: true,
 						want:       "\"TAIL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2428, col: 33, offset: 74397},
+						pos: position{line: 2430, col: 33, offset: 74483},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2428, col: 34, offset: 74398},
+							pos:  position{line: 2430, col: 34, offset: 74484},
 							name: "IdentifierRest",
 						},
 					},
@@ -17977,20 +17995,20 @@ var g = &grammar{
 		},
 		{
 			name: "THEN",
-			pos:  position{line: 2429, col: 1, offset: 74413},
+			pos:  position{line: 2431, col: 1, offset: 74499},
 			expr: &seqExpr{
-				pos: position{line: 2429, col: 14, offset: 74426},
+				pos: position{line: 2431, col: 14, offset: 74512},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2429, col: 14, offset: 74426},
+						pos:        position{line: 2431, col: 14, offset: 74512},
 						val:        "then",
 						ignoreCase: true,
 						want:       "\"THEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2429, col: 33, offset: 74445},
+						pos: position{line: 2431, col: 33, offset: 74531},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2429, col: 34, offset: 74446},
+							pos:  position{line: 2431, col: 34, offset: 74532},
 							name: "IdentifierRest",
 						},
 					},
@@ -18001,23 +18019,23 @@ var g = &grammar{
 		},
 		{
 			name: "TIMESTAMP",
-			pos:  position{line: 2430, col: 1, offset: 74461},
+			pos:  position{line: 2432, col: 1, offset: 74547},
 			expr: &actionExpr{
-				pos: position{line: 2430, col: 14, offset: 74474},
+				pos: position{line: 2432, col: 14, offset: 74560},
 				run: (*parser).callonTIMESTAMP1,
 				expr: &seqExpr{
-					pos: position{line: 2430, col: 14, offset: 74474},
+					pos: position{line: 2432, col: 14, offset: 74560},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2430, col: 14, offset: 74474},
+							pos:        position{line: 2432, col: 14, offset: 74560},
 							val:        "timestamp",
 							ignoreCase: true,
 							want:       "\"TIMESTAMP\"i",
 						},
 						&notExpr{
-							pos: position{line: 2430, col: 33, offset: 74493},
+							pos: position{line: 2432, col: 33, offset: 74579},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2430, col: 34, offset: 74494},
+								pos:  position{line: 2432, col: 34, offset: 74580},
 								name: "IdentifierRest",
 							},
 						},
@@ -18029,20 +18047,20 @@ var g = &grammar{
 		},
 		{
 			name: "TOP",
-			pos:  position{line: 2431, col: 1, offset: 74537},
+			pos:  position{line: 2433, col: 1, offset: 74623},
 			expr: &seqExpr{
-				pos: position{line: 2431, col: 14, offset: 74550},
+				pos: position{line: 2433, col: 14, offset: 74636},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2431, col: 14, offset: 74550},
+						pos:        position{line: 2433, col: 14, offset: 74636},
 						val:        "top",
 						ignoreCase: true,
 						want:       "\"TOP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2431, col: 33, offset: 74569},
+						pos: position{line: 2433, col: 33, offset: 74655},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2431, col: 34, offset: 74570},
+							pos:  position{line: 2433, col: 34, offset: 74656},
 							name: "IdentifierRest",
 						},
 					},
@@ -18053,20 +18071,20 @@ var g = &grammar{
 		},
 		{
 			name: "TRUE",
-			pos:  position{line: 2432, col: 1, offset: 74585},
+			pos:  position{line: 2434, col: 1, offset: 74671},
 			expr: &seqExpr{
-				pos: position{line: 2432, col: 14, offset: 74598},
+				pos: position{line: 2434, col: 14, offset: 74684},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2432, col: 14, offset: 74598},
+						pos:        position{line: 2434, col: 14, offset: 74684},
 						val:        "true",
 						ignoreCase: true,
 						want:       "\"TRUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2432, col: 33, offset: 74617},
+						pos: position{line: 2434, col: 33, offset: 74703},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2432, col: 34, offset: 74618},
+							pos:  position{line: 2434, col: 34, offset: 74704},
 							name: "IdentifierRest",
 						},
 					},
@@ -18077,20 +18095,20 @@ var g = &grammar{
 		},
 		{
 			name: "TYPE",
-			pos:  position{line: 2433, col: 1, offset: 74633},
+			pos:  position{line: 2435, col: 1, offset: 74719},
 			expr: &seqExpr{
-				pos: position{line: 2433, col: 14, offset: 74646},
+				pos: position{line: 2435, col: 14, offset: 74732},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2433, col: 14, offset: 74646},
+						pos:        position{line: 2435, col: 14, offset: 74732},
 						val:        "type",
 						ignoreCase: true,
 						want:       "\"TYPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2433, col: 33, offset: 74665},
+						pos: position{line: 2435, col: 33, offset: 74751},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2433, col: 34, offset: 74666},
+							pos:  position{line: 2435, col: 34, offset: 74752},
 							name: "IdentifierRest",
 						},
 					},
@@ -18101,20 +18119,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNION",
-			pos:  position{line: 2434, col: 1, offset: 74681},
+			pos:  position{line: 2436, col: 1, offset: 74767},
 			expr: &seqExpr{
-				pos: position{line: 2434, col: 14, offset: 74694},
+				pos: position{line: 2436, col: 14, offset: 74780},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2434, col: 14, offset: 74694},
+						pos:        position{line: 2436, col: 14, offset: 74780},
 						val:        "union",
 						ignoreCase: true,
 						want:       "\"UNION\"i",
 					},
 					&notExpr{
-						pos: position{line: 2434, col: 33, offset: 74713},
+						pos: position{line: 2436, col: 33, offset: 74799},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2434, col: 34, offset: 74714},
+							pos:  position{line: 2436, col: 34, offset: 74800},
 							name: "IdentifierRest",
 						},
 					},
@@ -18125,20 +18143,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNIQ",
-			pos:  position{line: 2435, col: 1, offset: 74729},
+			pos:  position{line: 2437, col: 1, offset: 74815},
 			expr: &seqExpr{
-				pos: position{line: 2435, col: 14, offset: 74742},
+				pos: position{line: 2437, col: 14, offset: 74828},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2435, col: 14, offset: 74742},
+						pos:        position{line: 2437, col: 14, offset: 74828},
 						val:        "uniq",
 						ignoreCase: true,
 						want:       "\"UNIQ\"i",
 					},
 					&notExpr{
-						pos: position{line: 2435, col: 33, offset: 74761},
+						pos: position{line: 2437, col: 33, offset: 74847},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2435, col: 34, offset: 74762},
+							pos:  position{line: 2437, col: 34, offset: 74848},
 							name: "IdentifierRest",
 						},
 					},
@@ -18149,20 +18167,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNNEST",
-			pos:  position{line: 2436, col: 1, offset: 74777},
+			pos:  position{line: 2438, col: 1, offset: 74863},
 			expr: &seqExpr{
-				pos: position{line: 2436, col: 14, offset: 74790},
+				pos: position{line: 2438, col: 14, offset: 74876},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2436, col: 14, offset: 74790},
+						pos:        position{line: 2438, col: 14, offset: 74876},
 						val:        "unnest",
 						ignoreCase: true,
 						want:       "\"UNNEST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2436, col: 33, offset: 74809},
+						pos: position{line: 2438, col: 33, offset: 74895},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2436, col: 34, offset: 74810},
+							pos:  position{line: 2438, col: 34, offset: 74896},
 							name: "IdentifierRest",
 						},
 					},
@@ -18173,20 +18191,20 @@ var g = &grammar{
 		},
 		{
 			name: "USING",
-			pos:  position{line: 2437, col: 1, offset: 74825},
+			pos:  position{line: 2439, col: 1, offset: 74911},
 			expr: &seqExpr{
-				pos: position{line: 2437, col: 14, offset: 74838},
+				pos: position{line: 2439, col: 14, offset: 74924},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2437, col: 14, offset: 74838},
+						pos:        position{line: 2439, col: 14, offset: 74924},
 						val:        "using",
 						ignoreCase: true,
 						want:       "\"USING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2437, col: 33, offset: 74857},
+						pos: position{line: 2439, col: 33, offset: 74943},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2437, col: 34, offset: 74858},
+							pos:  position{line: 2439, col: 34, offset: 74944},
 							name: "IdentifierRest",
 						},
 					},
@@ -18197,20 +18215,20 @@ var g = &grammar{
 		},
 		{
 			name: "VALUE",
-			pos:  position{line: 2438, col: 1, offset: 74873},
+			pos:  position{line: 2440, col: 1, offset: 74959},
 			expr: &seqExpr{
-				pos: position{line: 2438, col: 14, offset: 74886},
+				pos: position{line: 2440, col: 14, offset: 74972},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2438, col: 14, offset: 74886},
+						pos:        position{line: 2440, col: 14, offset: 74972},
 						val:        "value",
 						ignoreCase: true,
 						want:       "\"VALUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2438, col: 33, offset: 74905},
+						pos: position{line: 2440, col: 33, offset: 74991},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2438, col: 34, offset: 74906},
+							pos:  position{line: 2440, col: 34, offset: 74992},
 							name: "IdentifierRest",
 						},
 					},
@@ -18221,20 +18239,20 @@ var g = &grammar{
 		},
 		{
 			name: "VALUES",
-			pos:  position{line: 2439, col: 1, offset: 74921},
+			pos:  position{line: 2441, col: 1, offset: 75007},
 			expr: &seqExpr{
-				pos: position{line: 2439, col: 14, offset: 74934},
+				pos: position{line: 2441, col: 14, offset: 75020},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2439, col: 14, offset: 74934},
+						pos:        position{line: 2441, col: 14, offset: 75020},
 						val:        "values",
 						ignoreCase: true,
 						want:       "\"VALUES\"i",
 					},
 					&notExpr{
-						pos: position{line: 2439, col: 33, offset: 74953},
+						pos: position{line: 2441, col: 33, offset: 75039},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2439, col: 34, offset: 74954},
+							pos:  position{line: 2441, col: 34, offset: 75040},
 							name: "IdentifierRest",
 						},
 					},
@@ -18245,20 +18263,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHEN",
-			pos:  position{line: 2440, col: 1, offset: 74969},
+			pos:  position{line: 2442, col: 1, offset: 75055},
 			expr: &seqExpr{
-				pos: position{line: 2440, col: 14, offset: 74982},
+				pos: position{line: 2442, col: 14, offset: 75068},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2440, col: 14, offset: 74982},
+						pos:        position{line: 2442, col: 14, offset: 75068},
 						val:        "when",
 						ignoreCase: true,
 						want:       "\"WHEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2440, col: 33, offset: 75001},
+						pos: position{line: 2442, col: 33, offset: 75087},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2440, col: 34, offset: 75002},
+							pos:  position{line: 2442, col: 34, offset: 75088},
 							name: "IdentifierRest",
 						},
 					},
@@ -18269,20 +18287,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHERE",
-			pos:  position{line: 2441, col: 1, offset: 75017},
+			pos:  position{line: 2443, col: 1, offset: 75103},
 			expr: &seqExpr{
-				pos: position{line: 2441, col: 14, offset: 75030},
+				pos: position{line: 2443, col: 14, offset: 75116},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2441, col: 14, offset: 75030},
+						pos:        position{line: 2443, col: 14, offset: 75116},
 						val:        "where",
 						ignoreCase: true,
 						want:       "\"WHERE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2441, col: 33, offset: 75049},
+						pos: position{line: 2443, col: 33, offset: 75135},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2441, col: 34, offset: 75050},
+							pos:  position{line: 2443, col: 34, offset: 75136},
 							name: "IdentifierRest",
 						},
 					},
@@ -18293,20 +18311,20 @@ var g = &grammar{
 		},
 		{
 			name: "WITH",
-			pos:  position{line: 2442, col: 1, offset: 75065},
+			pos:  position{line: 2444, col: 1, offset: 75151},
 			expr: &seqExpr{
-				pos: position{line: 2442, col: 14, offset: 75078},
+				pos: position{line: 2444, col: 14, offset: 75164},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2442, col: 14, offset: 75078},
+						pos:        position{line: 2444, col: 14, offset: 75164},
 						val:        "with",
 						ignoreCase: true,
 						want:       "\"WITH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2442, col: 33, offset: 75097},
+						pos: position{line: 2444, col: 33, offset: 75183},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2442, col: 34, offset: 75098},
+							pos:  position{line: 2444, col: 34, offset: 75184},
 							name: "IdentifierRest",
 						},
 					},
@@ -20479,6 +20497,16 @@ func (p *parser) callonColonCast1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onColonCast1(stack["first"], stack["rest"])
+}
+
+func (c *current) onIDExpr1(id any) (any, error) {
+	return &ast.IDExpr{Kind: "IDExpr", ID: *(id.(*ast.ID))}, nil
+}
+
+func (p *parser) callonIDExpr1() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onIDExpr1(stack["id"])
 }
 
 func (c *current) onDerefExpr2(expr, from, to any) (any, error) {

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -992,9 +992,11 @@ PlusOrMinusOp = ("+" / "-") { return string(c.text), nil }
 
 ColonCast
   = first:DerefExpr
-    rest:(__ "::" __ expr:(TypeAsValue / DerefExpr) { return []any{"::", expr}, nil })* {
+    rest:(__ "::" __ expr:(TypeAsValue / IDExpr) { return []any{"::", expr}, nil })* {
       return makeBinaryExprChain(first, rest, c), nil
     }
+
+IDExpr = id:Identifier { return &ast.IDExpr{Kind:"IDExpr", ID: *(id.(*ast.ID)) }, nil }
 
 DerefExpr
   = expr:DerefExpr "[" __ from:AdditiveExpr __ ":" __ to:AdditiveExpr? __ "]" {

--- a/compiler/parser/ztests/colon-cast-sfmt.yaml
+++ b/compiler/parser/ztests/colon-cast-sfmt.yaml
@@ -4,23 +4,15 @@ script: |
   super compile -C "values {x:1,s:'foo'}::{x:string,s:string}"
   super compile -C "values 3.3.3.0/24::net, ::1/128::net, 2::/16::net"
   super compile -C "values 3.3.3.3::ip, ::::ip, 2::::ip, (::)::ip, (2::)::ip"
-  super compile -C "values 80::<port=uint16>"
+  super compile -C "values 80::(port=uint16)"
   super compile -C "values 123::uint16::(uint16|float64)"
-  echo ===
-  super compile -C "values 1::<uint8>, 2::<int32>, 3::<float64>, '2025-07-01T21:53:23.26504Z'::<time>"
-  super compile -C "values [1,2,3]::<[string]>"
-  super compile -C "values {x:1,s:'foo'}::<{x:string,s:string}>"
-  super compile -C "values 3.3.3.0/24::<net>, ::1/128::<net>, 2::/16::<net>"
-  super compile -C "values 3.3.3.3::<ip>, ::::<ip>, 2::::<ip>, (::)::<ip>, (2::)::<ip>"
-  super compile -C "values 80::<port=uint16>"
-  super compile -C "values 123::<uint16>::<(uint16|float64)>"
   echo ===
   # IP6 addresses can collide with type names that happen to be hex strings 
   # but you can use the type literal syntax or put the value in parens
   # to disambiguate.  IP6 literal has precedence over the cast syntax.
-  super compile -C "type ff=int64 values 1::ff, 1::<ff>, (1)::ff"
+  super compile -C "type ff=int64 values 1::ff, 1::(ff), (1)::ff"
   echo ===
-  super compile -C "values x::typeof(y)"
+  super compile -C "values cast(x, typeof(y))"
 
 outputs:
   - name: stdout
@@ -33,15 +25,7 @@ outputs:
       values 80::<port=(uint16)>
       values 123::<uint16>::<(uint16|float64)>
       ===
-      values 1::<uint8>, 2::<int32>, 3::<float64>, "2025-07-01T21:53:23.26504Z"::<time>
-      values [1,2,3]::<[string]>
-      values {x:1,s:"foo"}::<{x:string,s:string}>
-      values 3.3.3.0/24::<net>, ::1/128::<net>, 2::/16::<net>
-      values 3.3.3.3::<ip>, ::::<ip>, 2::::<ip>, ::::<ip>, 2::::<ip>
-      values 80::<port=(uint16)>
-      values 123::<uint16>::<(uint16|float64)>
-      ===
       type ff = int64
       values 1::ff, 1::<ff>, 1::ff
       ===
-      values x::typeof(y)
+      values cast(x, typeof(y))

--- a/compiler/parser/ztests/colon-cast.yaml
+++ b/compiler/parser/ztests/colon-cast.yaml
@@ -7,41 +7,16 @@ script: |
   super -s -c "values 80::(port=uint16)"
   super -s -c "values 123::uint16::(uint16|float64)"
   echo ===
-  super -s -c "values 1::<uint8>, 2::<int32>, 3::<float64>, '2025-07-01T21:53:23.26504Z'::<time>"
-  super -s -c "values [1,2,3]::<[string]>"
-  super -s -c "values {x:1,s:'foo'}::<{x:string,s:string}>"
-  super -s -c "values 3.3.3.0/24::<net>, ::1/128::<net>, 2::/16::<net>"
-  super -s -c "values 3.3.3.3::<ip>, ::::<ip>, 2::::<ip>, (::)::<ip>, (2::)::<ip>"
-  super -s -c "values 80::<port=uint16>"
-  super -s -c "values 123::<uint16>::<uint16|float64>"
-  echo ===
   # IP6 addresses can collide with type names that happen to be hex strings 
   # but you can use the type literal syntax or put the value in parens
   # to disambiguate.  IP6 literal has precedence over the cast syntax.
-  super -s -c 'type ff=int64 values 1::ff, 1::(ff), 1::<ff>'
+  super -s -c 'type ff=int64 values 1::ff, 1::(ff), cast(1, ff)'
   echo ===
-  echo '{x:1,y:2::int8}' | super -s -c "values x::typeof(y)" -
+  echo '{x:1,y:2::int8}' | super -s -c "values cast(x, typeof(y))" -
 
 outputs:
   - name: stdout
     data: |
-      1::uint8
-      2::int32
-      3.
-      2025-07-01T21:53:23.26504Z
-      ["1","2","3"]
-      {x:"1",s:"foo"}
-      3.3.3.0/24
-      ::1/128
-      2::/16
-      3.3.3.3
-      ::
-      2::
-      ::
-      2::
-      80::(port=uint16)
-      123::uint16::(uint16|float64)
-      ===
       1::uint8
       2::int32
       3.

--- a/compiler/ztests/const-redefined-error.yaml
+++ b/compiler/ztests/const-redefined-error.yaml
@@ -1,7 +1,7 @@
 spq: |
   type myport=int16 
   type myport=int32 
-  put b:=this::'myport'
+  put b:=this::('myport')
 
 error: |
   symbol "myport" redefined at line 2, column 6:

--- a/sup/ztests/named-in-union-ambiguous.yaml
+++ b/sup/ztests/named-in-union-ambiguous.yaml
@@ -1,6 +1,6 @@
 script: |
   super -s -c "typeof(this)" in.sup
-  super -s -c 'typeof([1::<foo=int64>,"bar"])'
+  super -s -c 'typeof([1::(foo=int64),"bar"])'
 
 inputs:
   - name: in.sup


### PR DESCRIPTION
This commit simplifies the :: and SQL "cast as" syntax to allow only types (not expressions that result in type values) on the RHS. We wanted to get rid of the cast() function but are retaining it for casting to types resulting from expressions.  This is because we could not resolve the ambiguity between arbitrary parenthesized types with type names and generic expressions with names as field references.  These changes will simplify the docs regarding casts that are coming in a subsequent PR.