### PR TITLE
runtime/vam/expr/agg: fix panic in mathReducer.ResultAsPartial

### DIFF
--- a/runtime/vam/expr/agg/math.go
+++ b/runtime/vam/expr/agg/math.go
@@ -112,8 +112,8 @@ func (m *mathReducer) ConsumeAsPartial(vec vector.Any) {
 	m.Consume(vec)
 }
 
-func (m *mathReducer) ResultAsPartial(*super.Context) super.Value {
-	return m.Result(nil)
+func (m *mathReducer) ResultAsPartial(sctx *super.Context) super.Value {
+	return m.Result(sctx)
 }
 
 func trimNulls(vec vector.Any) vector.Any {


### PR DESCRIPTION
ResultAsPartial passes a nil *super.Context to Result, which can dereference it.