### PR TITLE
pkg/storage: expose os.Stdin's Close and ReadAt methods

### DIFF
--- a/pkg/storage/stdio.go
+++ b/pkg/storage/stdio.go
@@ -20,7 +20,7 @@ func (*StdioEngine) Get(_ context.Context, u *URI) (Reader, error) {
 	if u.Scheme != "stdio" || (u.Path != "stdin" && u.Path != "") {
 		return nil, fmt.Errorf("cannot read from %q", u)
 	}
-	return &notSupportedReaderAt{io.NopCloser(os.Stdin)}, nil
+	return os.Stdin, nil
 }
 
 func (*StdioEngine) Put(ctx context.Context, u *URI) (io.WriteCloser, error) {

--- a/sio/anyio/ztests/csup.yaml
+++ b/sio/anyio/ztests/csup.yaml
@@ -1,12 +1,17 @@
 script: |
   super -f csup -o f -
   super -s f
+  echo // standard input
+  super -s -c 'from "stdio:stdin"' < f
 
 inputs:
   - name: stdin
-    data: &stdin |
+    data: |
       {a:1}
 
 outputs:
   - name: stdout
-    data: *stdin
+    data: |
+      {a:1}
+      // standard input
+      {a:1}

--- a/sio/anyio/ztests/parquet.yaml
+++ b/sio/anyio/ztests/parquet.yaml
@@ -1,12 +1,17 @@
 script: |
   super -f parquet -o f -
   super -s f
+  echo // standard input
+  super -s -c 'from "stdio:stdin"' < f
 
 inputs:
   - name: stdin
-    data: &stdin |
+    data: |
       {a:1}
 
 outputs:
   - name: stdout
-    data: *stdin
+    data: |
+      {a:1}
+      // standard input
+      {a:1}


### PR DESCRIPTION
StdioEngine.Get wraps os.Stdin with io.NopCloser and notSupportedReaderAt to hide its Close and ReadAt methods.  This doesn't appear to be necessary, and exposing ReadAt enables reading CSUP and Parquet files from standard input.