### PR TITLE
use existent files in SPQ in ztests

### DIFF
--- a/compiler/parser/ztests/ordinality.yaml
+++ b/compiler/parser/ztests/ordinality.yaml
@@ -1,9 +1,9 @@
 script: |
-  ! super compile -dag 'from x with ordinality'
+  ! super compile -dag 'from /dev/null with ordinality'
 
 outputs:
   - name: stderr
     data: |
-      WITH ORDINALITY clause is not yet supported at line 1, column 7:
-      from x with ordinality
-            ~~~~~~~~~~~~~~~~
+      WITH ORDINALITY clause is not yet supported at line 1, column 15:
+      from /dev/null with ordinality
+                    ~~~~~~~~~~~~~~~~

--- a/compiler/sfmt/ztests/parallel.yaml
+++ b/compiler/sfmt/ztests/parallel.yaml
@@ -1,10 +1,10 @@
 script: |
-  super compile -dag -C 'from bar | ?foo | fork ( count() by x:=this["@foo"] ) ( sum(x) ) ( put a:=b*c ) | cut cake | sort -r x'
+  super compile -dag -C 'from /dev/null | ?foo | fork ( count() by x:=this["@foo"] ) ( sum(x) ) ( put a:=b*c ) | cut cake | sort -r x'
 
 outputs:
   - name: stdout
     data: |
-      file bar
+      file /dev/null
       | where search("foo")
       | fork
         (

--- a/compiler/ztests/merge-filters.yaml
+++ b/compiler/ztests/merge-filters.yaml
@@ -1,7 +1,7 @@
 script: |
-  super compile -C -O 'from foo | where a | where b'
+  super compile -C -O 'from /dev/null | where a | where b'
   echo ===
-  super compile -C -O 'fork ( from a | where b | where c ) ( from d | where e | where f ) | where g'
+  super compile -C -O 'fork ( from /dev/null | where b | where c ) ( from /dev/zero | where e | where f ) | where g'
   echo ===
   super compile -C -O 'unnest [a] into ( where b | where c )'
   echo ===
@@ -10,15 +10,15 @@ script: |
 outputs:
   - name: stdout
     data: |
-      file foo filter (a and b)
+      file /dev/null filter (a and b)
       | output main
       ===
       fork
         (
-          file a unordered filter (b and c and g)
+          file /dev/null unordered filter (b and c and g)
         )
         (
-          file d unordered filter (e and f and g)
+          file /dev/zero unordered filter (e and f and g)
         )
       | output main
       ===

--- a/compiler/ztests/pushdown-sort.yaml
+++ b/compiler/ztests/pushdown-sort.yaml
@@ -1,29 +1,29 @@
 script: |
-  super compile -C -O 'from file1 | sort'
+  super compile -C -O 'from /dev/null | sort'
   echo ===
-  super compile -C -O 'from file1 | sort | values a'
+  super compile -C -O 'from /dev/null | sort | values a'
   echo ===
-  super compile -C -O 'from file1 | sort a'
+  super compile -C -O 'from /dev/null | sort a'
   echo ===
-  super compile -C -O 'from file1 | sort a | values b'
+  super compile -C -O 'from /dev/null | sort a | values b'
 
 outputs:
   - name: stdout
     data: |
-      file file1 unordered
+      file /dev/null unordered
       | sort
       | output main
       ===
-      file file1 unordered
+      file /dev/null unordered
       | sort
       | values a
       | output main
       ===
-      file file1 unordered
+      file /dev/null unordered
       | sort a asc nulls last
       | output main
       ===
-      file file1 unordered fields a,b
+      file /dev/null unordered fields a,b
       | sort a asc nulls last
       | values b
       | output main

--- a/compiler/ztests/pushdown-top.yaml
+++ b/compiler/ztests/pushdown-top.yaml
@@ -1,29 +1,29 @@
 script: |
-  super compile -C -O 'from file1 | top'
+  super compile -C -O 'from /dev/null | top'
   echo ===
-  super compile -C -O 'from file1 | top | values a'
+  super compile -C -O 'from /dev/null | top | values a'
   echo ===
-  super compile -C -O 'from file1 | top 2 a'
+  super compile -C -O 'from /dev/null | top 2 a'
   echo ===
-  super compile -C -O 'from file1 | top 2 a | values b'
+  super compile -C -O 'from /dev/null | top 2 a | values b'
 
 outputs:
   - name: stdout
     data: |
-      file file1 unordered
+      file /dev/null unordered
       | top 1
       | output main
       ===
-      file file1 unordered
+      file /dev/null unordered
       | top 1
       | values a
       | output main
       ===
-      file file1 unordered
+      file /dev/null unordered
       | top 2 a asc nulls last
       | output main
       ===
-      file file1 unordered fields a,b
+      file /dev/null unordered fields a,b
       | top 2 a asc nulls last
       | values b
       | output main

--- a/compiler/ztests/pushdown.yaml
+++ b/compiler/ztests/pushdown.yaml
@@ -1,22 +1,22 @@
 script: |
   echo === debug
-  super compile -C -O 'from file | debug a | values b'
+  super compile -C -O 'from /dev/null | debug a | values b'
   echo === distinct
-  super compile -C -O 'from file | distinct a | values b'
+  super compile -C -O 'from /dev/null | distinct a | values b'
   echo === fork into hash join
-  super compile -C -O 'fork ( from file1 ) ( from file2 ) | join on right.a=left.b | values left.c,right.d'
+  super compile -C -O 'fork ( from /dev/null ) ( from /dev/zero ) | join on right.a=left.b | values left.c,right.d'
   echo === fork into nested loop join
-  super compile -C -O 'fork ( from file1 ) ( from file2 ) | join on right.a>left.b | values left.c,right.d'
+  super compile -C -O 'fork ( from /dev/null ) ( from /dev/zero ) | join on right.a>left.b | values left.c,right.d'
   echo === hash join
-  super compile -C -O "from file1 | join (from file2) on left.a=right.b | values left.c,right.d"
+  super compile -C -O "from /dev/null | join (from /dev/zero) on left.a=right.b | values left.c,right.d"
   echo === nested loop join
-  super compile -C -O "from file1 | join (from file2) on left.a>right.b | values left.c,right.d"
+  super compile -C -O "from /dev/null | join (from /dev/zero) on left.a>right.b | values left.c,right.d"
   echo === switch into hash join
-  super compile -C -O 'from file | switch a case b ( put x:=c ) case d ( put x:=e ) | join on left.f=right.g | values left.h,right.i'
+  super compile -C -O 'from /dev/null | switch a case b ( put x:=c ) case d ( put x:=e ) | join on left.f=right.g | values left.h,right.i'
   echo === switch into nested loop join
-  super compile -C -O 'from file | switch a case b ( put x:=c ) case d ( put x:=e ) | join on left.f>right.g | values left.h,right.i'
+  super compile -C -O 'from /dev/null | switch a case b ( put x:=c ) case d ( put x:=e ) | join on left.f>right.g | values left.h,right.i'
   echo === where
-  super compile -C -O "from file | a==1 or e==2 | values c, b, d"
+  super compile -C -O "from /dev/null | a==1 or e==2 | values c, b, d"
   echo ===
   export SUPER_DB=test
   super db init -q
@@ -37,7 +37,7 @@ outputs:
   - name: stdout
     data: |
       === debug
-      file file fields a,b
+      file /dev/null fields a,b
       | mirror
         (
           values a
@@ -48,17 +48,17 @@ outputs:
           | output main
         )
       === distinct
-      file file unordered fields a,b
+      file /dev/null unordered fields a,b
       | distinct a
       | values b
       | output main
       === fork into hash join
       fork
         (
-          file file1 unordered fields b,c
+          file /dev/null unordered fields b,c
         )
         (
-          file file2 unordered fields a,d
+          file /dev/zero unordered fields a,d
         )
       | inner hashjoin as {left,right} on b==a
       | values left.c, right.d
@@ -66,10 +66,10 @@ outputs:
       === fork into nested loop join
       fork
         (
-          file file1 unordered fields b,c
+          file /dev/null unordered fields b,c
         )
         (
-          file file2 unordered fields a,d
+          file /dev/zero unordered fields a,d
         )
       | inner join as {left,right} on right.a>left.b
       | values left.c, right.d
@@ -77,10 +77,10 @@ outputs:
       === hash join
       fork
         (
-          file file1 unordered fields a,c
+          file /dev/null unordered fields a,c
         )
         (
-          file file2 unordered fields b,d
+          file /dev/zero unordered fields b,d
         )
       | inner hashjoin as {left,right} on a==b
       | values left.c, right.d
@@ -88,16 +88,16 @@ outputs:
       === nested loop join
       fork
         (
-          file file1 unordered fields a,c
+          file /dev/null unordered fields a,c
         )
         (
-          file file2 unordered fields b,d
+          file /dev/zero unordered fields b,d
         )
       | inner join as {left,right} on left.a>right.b
       | values left.c, right.d
       | output main
       === switch into hash join
-      file file unordered fields a,b,c,d,e,f,g,h,i
+      file /dev/null unordered fields a,b,c,d,e,f,g,h,i
       | switch a
         case b (
           put x:=c
@@ -109,7 +109,7 @@ outputs:
       | values left.h, right.i
       | output main
       === switch into nested loop join
-      file file unordered fields a,b,c,d,e,f,g,h,i
+      file /dev/null unordered fields a,b,c,d,e,f,g,h,i
       | switch a
         case b (
           put x:=c
@@ -121,7 +121,7 @@ outputs:
       | values left.h, right.i
       | output main
       === where
-      file file fields a,b,c,d,e filter (a==1 or e==2)
+      file /dev/null fields a,b,c,d,e filter (a==1 or e==2)
       | values c, b, d
       | output main
       ===

--- a/compiler/ztests/remove-passops.yaml
+++ b/compiler/ztests/remove-passops.yaml
@@ -1,7 +1,7 @@
-script: super compile -O -C 'from foo | x>1 | pass | pass | x>2 | pass'
+script: super compile -O -C 'from /dev/null | x>1 | pass | pass | x>2 | pass'
 
 outputs:
   - name: stdout
     data: |
-      file foo filter (x>1 and x>2)
+      file /dev/null filter (x>1 and x>2)
       | output main

--- a/compiler/ztests/sql/limit-offset.yaml
+++ b/compiler/ztests/sql/limit-offset.yaml
@@ -1,43 +1,43 @@
 script: |
-  super compile -C -O 'select * from test limit 1'
+  super compile -C -O 'select * from /dev/null limit 1'
   echo // ===
-  super compile -C -O 'select * from test limit all'
+  super compile -C -O 'select * from /dev/null limit all'
   echo // ===
-  super compile -C -O 'select * from test offset 1'
+  super compile -C -O 'select * from /dev/null offset 1'
   echo // ===
-  super compile -C -O 'select * from test limit 1 offset 1'
+  super compile -C -O 'select * from /dev/null limit 1 offset 1'
   echo // ===
-  super compile -C -O 'select * from test offset 1 limit 1'
+  super compile -C -O 'select * from /dev/null offset 1 limit 1'
   echo // ===
-  ! super compile -C -O 'select * from test offset -1 limit "foo"'
+  ! super compile -C -O 'select * from /dev/null offset -1 limit "foo"'
 
 outputs:
   - name: stdout
     data: |
-      file test
+      file /dev/null
       | values {in:this,out:{...this}}
       | head 1
       | values out
       | output main
       // ===
-      file test
+      file /dev/null
       | values {...this}
       | output main
       // ===
-      file test
+      file /dev/null
       | values {in:this,out:{...this}}
       | skip 1
       | values out
       | output main
       // ===
-      file test
+      file /dev/null
       | values {in:this,out:{...this}}
       | skip 1
       | head 1
       | values out
       | output main
       // ===
-      file test
+      file /dev/null
       | values {in:this,out:{...this}}
       | skip 1
       | head 1
@@ -46,9 +46,9 @@ outputs:
       // ===
   - name: stderr
     data: |
-      expression value must be a positive integer at line 1, column 27:
-      select * from test offset -1 limit "foo"
-                                ~~
-      expression value must be an integer value: "foo" at line 1, column 36:
-      select * from test offset -1 limit "foo"
-                                         ~~~~~
+      expression value must be a positive integer at line 1, column 32:
+      select * from /dev/null offset -1 limit "foo"
+                                     ~~
+      expression value must be an integer value: "foo" at line 1, column 41:
+      select * from /dev/null offset -1 limit "foo"
+                                              ~~~~~


### PR DESCRIPTION
Some ztests contain SPQ that refers to nonexistent files.  This is fine at present but a planned change to the semantic analyzer will break these tests.  Change them to use existent files in preparation.