### PR TITLE
pkg/storage: hide os.Stdin.Close again

### DIFF
--- a/pkg/storage/stdio.go
+++ b/pkg/storage/stdio.go
@@ -20,8 +20,12 @@ func (*StdioEngine) Get(_ context.Context, u *URI) (Reader, error) {
 	if u.Scheme != "stdio" || (u.Path != "stdin" && u.Path != "") {
 		return nil, fmt.Errorf("cannot read from %q", u)
 	}
-	return os.Stdin, nil
+	return &nopCloseFile{os.Stdin}, nil
 }
+
+type nopCloseFile struct{ *os.File }
+
+func (*nopCloseFile) Close() error { return nil }
 
 func (*StdioEngine) Put(ctx context.Context, u *URI) (io.WriteCloser, error) {
 	switch u.Path {

--- a/pkg/storage/stdio_test.go
+++ b/pkg/storage/stdio_test.go
@@ -1,0 +1,19 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStdinGetReturnsWorkingReaderAfterClose(t *testing.T) {
+	e := NewStdioEngine()
+	u := MustParseURI("stdio:stdin")
+	r, err := e.Get(t.Context(), u)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+	r, err = e.Get(t.Context(), u)
+	require.NoError(t, err)
+	_, err = r.Read(nil)
+	require.NoError(t, err, "zero-length read should succeed")
+}


### PR DESCRIPTION
Exposing os.Stdin.Close in #6338 was a mistake because opening stdio:stdin with pkg/storage, closing it, and opening it again now returns a reader on which reads always fail with "read /dev/stdin: file already closed".  Hide os.Stdin.Close again to prevent that error.