### PR TITLE
compiler/parser: accept "all" qualifier in aggregate function calls

### DIFF
--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -2265,19 +2265,19 @@ var g = &grammar{
 							exprs: []any{
 								&labeledExpr{
 									pos:   position{line: 259, col: 5, offset: 6704},
-									label: "aggDistinct",
+									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 259, col: 17, offset: 6716},
-										name: "AggDistinct",
+										pos:  position{line: 259, col: 7, offset: 6706},
+										name: "AggAllOrDistinct",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 259, col: 29, offset: 6728},
+									pos:   position{line: 259, col: 24, offset: 6723},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 259, col: 35, offset: 6734},
+										pos: position{line: 259, col: 30, offset: 6729},
 										expr: &ruleRefExpr{
-											pos:  position{line: 259, col: 35, offset: 6734},
+											pos:  position{line: 259, col: 30, offset: 6729},
 											name: "WhereClause",
 										},
 									},
@@ -2286,61 +2286,61 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 267, col: 5, offset: 6909},
+						pos: position{line: 267, col: 5, offset: 6894},
 						run: (*parser).callonAgg9,
 						expr: &seqExpr{
-							pos: position{line: 267, col: 5, offset: 6909},
+							pos: position{line: 267, col: 5, offset: 6894},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 267, col: 5, offset: 6909},
+									pos:   position{line: 267, col: 5, offset: 6894},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 267, col: 10, offset: 6914},
+										pos:  position{line: 267, col: 10, offset: 6899},
 										name: "AggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 267, col: 18, offset: 6922},
+									pos:  position{line: 267, col: 18, offset: 6907},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 267, col: 21, offset: 6925},
+									pos:        position{line: 267, col: 21, offset: 6910},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 267, col: 25, offset: 6929},
+									pos:  position{line: 267, col: 25, offset: 6914},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 267, col: 28, offset: 6932},
+									pos:   position{line: 267, col: 28, offset: 6917},
 									label: "expr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 267, col: 33, offset: 6937},
+										pos: position{line: 267, col: 33, offset: 6922},
 										expr: &ruleRefExpr{
-											pos:  position{line: 267, col: 33, offset: 6937},
+											pos:  position{line: 267, col: 33, offset: 6922},
 											name: "Expr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 267, col: 39, offset: 6943},
+									pos:  position{line: 267, col: 39, offset: 6928},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 267, col: 42, offset: 6946},
+									pos:        position{line: 267, col: 42, offset: 6931},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 267, col: 46, offset: 6950},
+									pos:   position{line: 267, col: 46, offset: 6935},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 267, col: 52, offset: 6956},
+										pos: position{line: 267, col: 52, offset: 6941},
 										expr: &ruleRefExpr{
-											pos:  position{line: 267, col: 52, offset: 6956},
+											pos:  position{line: 267, col: 52, offset: 6941},
 											name: "WhereClause",
 										},
 									},
@@ -2349,13 +2349,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 281, col: 5, offset: 7246},
+						pos: position{line: 281, col: 5, offset: 7231},
 						run: (*parser).callonAgg24,
 						expr: &labeledExpr{
-							pos:   position{line: 281, col: 5, offset: 7246},
+							pos:   position{line: 281, col: 5, offset: 7231},
 							label: "cs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 281, col: 8, offset: 7249},
+								pos:  position{line: 281, col: 8, offset: 7234},
 								name: "CountStar",
 							},
 						},
@@ -2366,58 +2366,71 @@ var g = &grammar{
 			leftRecursive: false,
 		},
 		{
-			name: "AggDistinct",
-			pos:  position{line: 289, col: 1, offset: 7391},
+			name: "AggAllOrDistinct",
+			pos:  position{line: 289, col: 1, offset: 7376},
 			expr: &actionExpr{
-				pos: position{line: 290, col: 5, offset: 7407},
-				run: (*parser).callonAggDistinct1,
+				pos: position{line: 290, col: 5, offset: 7397},
+				run: (*parser).callonAggAllOrDistinct1,
 				expr: &seqExpr{
-					pos: position{line: 290, col: 5, offset: 7407},
+					pos: position{line: 290, col: 5, offset: 7397},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 290, col: 5, offset: 7407},
+							pos:   position{line: 290, col: 5, offset: 7397},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 290, col: 10, offset: 7412},
+								pos:  position{line: 290, col: 10, offset: 7402},
 								name: "AggName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 290, col: 18, offset: 7420},
+							pos:  position{line: 290, col: 18, offset: 7410},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 290, col: 21, offset: 7423},
+							pos:        position{line: 290, col: 21, offset: 7413},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 290, col: 25, offset: 7427},
+							pos:  position{line: 290, col: 25, offset: 7417},
 							name: "__",
 						},
-						&ruleRefExpr{
-							pos:  position{line: 290, col: 28, offset: 7430},
-							name: "DISTINCT",
+						&labeledExpr{
+							pos:   position{line: 290, col: 28, offset: 7420},
+							label: "q",
+							expr: &choiceExpr{
+								pos: position{line: 290, col: 31, offset: 7423},
+								alternatives: []any{
+									&ruleRefExpr{
+										pos:  position{line: 290, col: 31, offset: 7423},
+										name: "ALL",
+									},
+									&ruleRefExpr{
+										pos:  position{line: 290, col: 37, offset: 7429},
+										name: "DISTINCT",
+									},
+								},
+							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 290, col: 37, offset: 7439},
+							pos:  position{line: 290, col: 48, offset: 7440},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 290, col: 39, offset: 7441},
+							pos:   position{line: 290, col: 50, offset: 7442},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 290, col: 44, offset: 7446},
+								pos:  position{line: 290, col: 55, offset: 7447},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 290, col: 49, offset: 7451},
+							pos:  position{line: 290, col: 60, offset: 7452},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 290, col: 52, offset: 7454},
+							pos:        position{line: 290, col: 63, offset: 7455},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -2430,20 +2443,20 @@ var g = &grammar{
 		},
 		{
 			name: "AggName",
-			pos:  position{line: 300, col: 1, offset: 7639},
+			pos:  position{line: 301, col: 1, offset: 7725},
 			expr: &choiceExpr{
-				pos: position{line: 301, col: 5, offset: 7651},
+				pos: position{line: 302, col: 5, offset: 7737},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 301, col: 5, offset: 7651},
+						pos:  position{line: 302, col: 5, offset: 7737},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 302, col: 5, offset: 7670},
+						pos:  position{line: 303, col: 5, offset: 7756},
 						name: "AND",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 303, col: 5, offset: 7678},
+						pos:  position{line: 304, col: 5, offset: 7764},
 						name: "OR",
 					},
 				},
@@ -2453,30 +2466,30 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 305, col: 1, offset: 7682},
+			pos:  position{line: 306, col: 1, offset: 7768},
 			expr: &actionExpr{
-				pos: position{line: 305, col: 15, offset: 7696},
+				pos: position{line: 306, col: 15, offset: 7782},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 305, col: 15, offset: 7696},
+					pos: position{line: 306, col: 15, offset: 7782},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 305, col: 15, offset: 7696},
+							pos:  position{line: 306, col: 15, offset: 7782},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 305, col: 17, offset: 7698},
+							pos:  position{line: 306, col: 17, offset: 7784},
 							name: "WHERE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 305, col: 23, offset: 7704},
+							pos:  position{line: 306, col: 23, offset: 7790},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 305, col: 25, offset: 7706},
+							pos:   position{line: 306, col: 25, offset: 7792},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 305, col: 30, offset: 7711},
+								pos:  position{line: 306, col: 30, offset: 7797},
 								name: "LogicalOrExpr",
 							},
 						},
@@ -2488,45 +2501,45 @@ var g = &grammar{
 		},
 		{
 			name: "AggAssignments",
-			pos:  position{line: 307, col: 1, offset: 7747},
+			pos:  position{line: 308, col: 1, offset: 7833},
 			expr: &actionExpr{
-				pos: position{line: 308, col: 5, offset: 7766},
+				pos: position{line: 309, col: 5, offset: 7852},
 				run: (*parser).callonAggAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 308, col: 5, offset: 7766},
+					pos: position{line: 309, col: 5, offset: 7852},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 308, col: 5, offset: 7766},
+							pos:   position{line: 309, col: 5, offset: 7852},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 308, col: 11, offset: 7772},
+								pos:  position{line: 309, col: 11, offset: 7858},
 								name: "AggAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 308, col: 25, offset: 7786},
+							pos:   position{line: 309, col: 25, offset: 7872},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 308, col: 30, offset: 7791},
+								pos: position{line: 309, col: 30, offset: 7877},
 								expr: &seqExpr{
-									pos: position{line: 308, col: 31, offset: 7792},
+									pos: position{line: 309, col: 31, offset: 7878},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 308, col: 31, offset: 7792},
+											pos:  position{line: 309, col: 31, offset: 7878},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 308, col: 34, offset: 7795},
+											pos:        position{line: 309, col: 34, offset: 7881},
 											val:        ",",
 											ignoreCase: false,
 											want:       "\",\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 308, col: 38, offset: 7799},
+											pos:  position{line: 309, col: 38, offset: 7885},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 308, col: 41, offset: 7802},
+											pos:  position{line: 309, col: 41, offset: 7888},
 											name: "AggAssignment",
 										},
 									},
@@ -2541,43 +2554,43 @@ var g = &grammar{
 		},
 		{
 			name: "CountStar",
-			pos:  position{line: 316, col: 1, offset: 7976},
+			pos:  position{line: 317, col: 1, offset: 8062},
 			expr: &actionExpr{
-				pos: position{line: 316, col: 13, offset: 7988},
+				pos: position{line: 317, col: 13, offset: 8074},
 				run: (*parser).callonCountStar1,
 				expr: &seqExpr{
-					pos: position{line: 316, col: 13, offset: 7988},
+					pos: position{line: 317, col: 13, offset: 8074},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 316, col: 13, offset: 7988},
+							pos:  position{line: 317, col: 13, offset: 8074},
 							name: "COUNT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 316, col: 19, offset: 7994},
+							pos:  position{line: 317, col: 19, offset: 8080},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 316, col: 22, offset: 7997},
+							pos:        position{line: 317, col: 22, offset: 8083},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 316, col: 26, offset: 8001},
+							pos:  position{line: 317, col: 26, offset: 8087},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 316, col: 29, offset: 8004},
+							pos:        position{line: 317, col: 29, offset: 8090},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 316, col: 33, offset: 8008},
+							pos:  position{line: 317, col: 33, offset: 8094},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 316, col: 36, offset: 8011},
+							pos:        position{line: 317, col: 36, offset: 8097},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -2590,28 +2603,28 @@ var g = &grammar{
 		},
 		{
 			name: "Operator",
-			pos:  position{line: 331, col: 1, offset: 8251},
+			pos:  position{line: 332, col: 1, offset: 8337},
 			expr: &choiceExpr{
-				pos: position{line: 332, col: 5, offset: 8264},
+				pos: position{line: 333, col: 5, offset: 8350},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 332, col: 5, offset: 8264},
+						pos: position{line: 333, col: 5, offset: 8350},
 						run: (*parser).callonOperator2,
 						expr: &seqExpr{
-							pos: position{line: 332, col: 5, offset: 8264},
+							pos: position{line: 333, col: 5, offset: 8350},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 332, col: 5, offset: 8264},
+									pos:   position{line: 333, col: 5, offset: 8350},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 332, col: 8, offset: 8267},
+										pos:  position{line: 333, col: 8, offset: 8353},
 										name: "SQLOp",
 									},
 								},
 								&andExpr{
-									pos: position{line: 332, col: 14, offset: 8273},
+									pos: position{line: 333, col: 14, offset: 8359},
 									expr: &ruleRefExpr{
-										pos:  position{line: 332, col: 15, offset: 8274},
+										pos:  position{line: 333, col: 15, offset: 8360},
 										name: "EndOfOp",
 									},
 								},
@@ -2619,119 +2632,119 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 333, col: 5, offset: 8305},
+						pos:  position{line: 334, col: 5, offset: 8391},
 						name: "ForkOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 334, col: 5, offset: 8316},
+						pos:  position{line: 335, col: 5, offset: 8402},
 						name: "SwitchOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 335, col: 5, offset: 8329},
+						pos:  position{line: 336, col: 5, offset: 8415},
 						name: "SearchOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 336, col: 5, offset: 8342},
+						pos:  position{line: 337, col: 5, offset: 8428},
 						name: "AssertOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 337, col: 5, offset: 8355},
+						pos:  position{line: 338, col: 5, offset: 8441},
 						name: "SortOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 338, col: 5, offset: 8366},
+						pos:  position{line: 339, col: 5, offset: 8452},
 						name: "TopOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 339, col: 5, offset: 8376},
+						pos:  position{line: 340, col: 5, offset: 8462},
 						name: "CallOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 340, col: 5, offset: 8387},
+						pos:  position{line: 341, col: 5, offset: 8473},
 						name: "CutOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 341, col: 5, offset: 8397},
+						pos:  position{line: 342, col: 5, offset: 8483},
 						name: "DistinctOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 342, col: 5, offset: 8412},
+						pos:  position{line: 343, col: 5, offset: 8498},
 						name: "DropOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 343, col: 5, offset: 8423},
+						pos:  position{line: 344, col: 5, offset: 8509},
 						name: "HeadOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 344, col: 5, offset: 8434},
+						pos:  position{line: 345, col: 5, offset: 8520},
 						name: "TailOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 345, col: 5, offset: 8445},
+						pos:  position{line: 346, col: 5, offset: 8531},
 						name: "SkipOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 346, col: 5, offset: 8456},
+						pos:  position{line: 347, col: 5, offset: 8542},
 						name: "WhereOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 347, col: 5, offset: 8468},
+						pos:  position{line: 348, col: 5, offset: 8554},
 						name: "UniqOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 348, col: 5, offset: 8479},
+						pos:  position{line: 349, col: 5, offset: 8565},
 						name: "PutOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 349, col: 5, offset: 8489},
+						pos:  position{line: 350, col: 5, offset: 8575},
 						name: "RenameOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 350, col: 5, offset: 8502},
+						pos:  position{line: 351, col: 5, offset: 8588},
 						name: "FuseOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 351, col: 5, offset: 8513},
+						pos:  position{line: 352, col: 5, offset: 8599},
 						name: "JoinOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 352, col: 5, offset: 8524},
+						pos:  position{line: 353, col: 5, offset: 8610},
 						name: "ShapesOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 353, col: 5, offset: 8537},
+						pos:  position{line: 354, col: 5, offset: 8623},
 						name: "FromOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 354, col: 5, offset: 8548},
+						pos:  position{line: 355, col: 5, offset: 8634},
 						name: "PassOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 355, col: 5, offset: 8559},
+						pos:  position{line: 356, col: 5, offset: 8645},
 						name: "ExplodeOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 356, col: 5, offset: 8573},
+						pos:  position{line: 357, col: 5, offset: 8659},
 						name: "MergeOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 357, col: 5, offset: 8585},
+						pos:  position{line: 358, col: 5, offset: 8671},
 						name: "UnnestOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 358, col: 5, offset: 8598},
+						pos:  position{line: 359, col: 5, offset: 8684},
 						name: "ValuesOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 359, col: 5, offset: 8611},
+						pos:  position{line: 360, col: 5, offset: 8697},
 						name: "LoadOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 360, col: 5, offset: 8622},
+						pos:  position{line: 361, col: 5, offset: 8708},
 						name: "OutputOp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 361, col: 5, offset: 8635},
+						pos:  position{line: 362, col: 5, offset: 8721},
 						name: "DebugOp",
 					},
 				},
@@ -2741,37 +2754,37 @@ var g = &grammar{
 		},
 		{
 			name: "ForkOp",
-			pos:  position{line: 363, col: 2, offset: 8645},
+			pos:  position{line: 364, col: 2, offset: 8731},
 			expr: &actionExpr{
-				pos: position{line: 364, col: 4, offset: 8657},
+				pos: position{line: 365, col: 4, offset: 8743},
 				run: (*parser).callonForkOp1,
 				expr: &seqExpr{
-					pos: position{line: 364, col: 4, offset: 8657},
+					pos: position{line: 365, col: 4, offset: 8743},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 364, col: 4, offset: 8657},
+							pos:  position{line: 365, col: 4, offset: 8743},
 							name: "FORK",
 						},
 						&labeledExpr{
-							pos:   position{line: 364, col: 9, offset: 8662},
+							pos:   position{line: 365, col: 9, offset: 8748},
 							label: "paths",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 364, col: 15, offset: 8668},
+								pos: position{line: 365, col: 15, offset: 8754},
 								expr: &actionExpr{
-									pos: position{line: 364, col: 17, offset: 8670},
+									pos: position{line: 365, col: 17, offset: 8756},
 									run: (*parser).callonForkOp6,
 									expr: &seqExpr{
-										pos: position{line: 364, col: 17, offset: 8670},
+										pos: position{line: 365, col: 17, offset: 8756},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 364, col: 17, offset: 8670},
+												pos:  position{line: 365, col: 17, offset: 8756},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 364, col: 20, offset: 8673},
+												pos:   position{line: 365, col: 20, offset: 8759},
 												label: "path",
 												expr: &ruleRefExpr{
-													pos:  position{line: 364, col: 25, offset: 8678},
+													pos:  position{line: 365, col: 25, offset: 8764},
 													name: "ScopeBody",
 												},
 											},
@@ -2788,31 +2801,31 @@ var g = &grammar{
 		},
 		{
 			name: "SwitchOp",
-			pos:  position{line: 376, col: 1, offset: 8952},
+			pos:  position{line: 377, col: 1, offset: 9038},
 			expr: &choiceExpr{
-				pos: position{line: 377, col: 5, offset: 8965},
+				pos: position{line: 378, col: 5, offset: 9051},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 377, col: 5, offset: 8965},
+						pos: position{line: 378, col: 5, offset: 9051},
 						run: (*parser).callonSwitchOp2,
 						expr: &seqExpr{
-							pos: position{line: 377, col: 5, offset: 8965},
+							pos: position{line: 378, col: 5, offset: 9051},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 377, col: 5, offset: 8965},
+									pos:  position{line: 378, col: 5, offset: 9051},
 									name: "SWITCH",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 377, col: 12, offset: 8972},
+									pos:  position{line: 378, col: 12, offset: 9058},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 377, col: 14, offset: 8974},
+									pos:   position{line: 378, col: 14, offset: 9060},
 									label: "cases",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 377, col: 20, offset: 8980},
+										pos: position{line: 378, col: 20, offset: 9066},
 										expr: &ruleRefExpr{
-											pos:  position{line: 377, col: 20, offset: 8980},
+											pos:  position{line: 378, col: 20, offset: 9066},
 											name: "SwitchPath",
 										},
 									},
@@ -2821,38 +2834,38 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 384, col: 5, offset: 9139},
+						pos: position{line: 385, col: 5, offset: 9225},
 						run: (*parser).callonSwitchOp9,
 						expr: &seqExpr{
-							pos: position{line: 384, col: 5, offset: 9139},
+							pos: position{line: 385, col: 5, offset: 9225},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 384, col: 5, offset: 9139},
+									pos:  position{line: 385, col: 5, offset: 9225},
 									name: "SWITCH",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 384, col: 12, offset: 9146},
+									pos:  position{line: 385, col: 12, offset: 9232},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 384, col: 14, offset: 9148},
+									pos:   position{line: 385, col: 14, offset: 9234},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 384, col: 19, offset: 9153},
+										pos:  position{line: 385, col: 19, offset: 9239},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 384, col: 24, offset: 9158},
+									pos:  position{line: 385, col: 24, offset: 9244},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 384, col: 26, offset: 9160},
+									pos:   position{line: 385, col: 26, offset: 9246},
 									label: "cases",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 384, col: 32, offset: 9166},
+										pos: position{line: 385, col: 32, offset: 9252},
 										expr: &ruleRefExpr{
-											pos:  position{line: 384, col: 32, offset: 9166},
+											pos:  position{line: 385, col: 32, offset: 9252},
 											name: "SwitchPath",
 										},
 									},
@@ -2867,34 +2880,34 @@ var g = &grammar{
 		},
 		{
 			name: "SwitchPath",
-			pos:  position{line: 393, col: 1, offset: 9355},
+			pos:  position{line: 394, col: 1, offset: 9441},
 			expr: &actionExpr{
-				pos: position{line: 394, col: 5, offset: 9370},
+				pos: position{line: 395, col: 5, offset: 9456},
 				run: (*parser).callonSwitchPath1,
 				expr: &seqExpr{
-					pos: position{line: 394, col: 5, offset: 9370},
+					pos: position{line: 395, col: 5, offset: 9456},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 394, col: 5, offset: 9370},
+							pos:  position{line: 395, col: 5, offset: 9456},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 394, col: 8, offset: 9373},
+							pos:   position{line: 395, col: 8, offset: 9459},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 394, col: 13, offset: 9378},
+								pos:  position{line: 395, col: 13, offset: 9464},
 								name: "Case",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 394, col: 18, offset: 9383},
+							pos:  position{line: 395, col: 18, offset: 9469},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 394, col: 21, offset: 9386},
+							pos:   position{line: 395, col: 21, offset: 9472},
 							label: "path",
 							expr: &ruleRefExpr{
-								pos:  position{line: 394, col: 26, offset: 9391},
+								pos:  position{line: 395, col: 26, offset: 9477},
 								name: "ScopeBody",
 							},
 						},
@@ -2906,29 +2919,29 @@ var g = &grammar{
 		},
 		{
 			name: "Case",
-			pos:  position{line: 402, col: 1, offset: 9543},
+			pos:  position{line: 403, col: 1, offset: 9629},
 			expr: &choiceExpr{
-				pos: position{line: 403, col: 5, offset: 9552},
+				pos: position{line: 404, col: 5, offset: 9638},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 403, col: 5, offset: 9552},
+						pos: position{line: 404, col: 5, offset: 9638},
 						run: (*parser).callonCase2,
 						expr: &seqExpr{
-							pos: position{line: 403, col: 5, offset: 9552},
+							pos: position{line: 404, col: 5, offset: 9638},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 403, col: 5, offset: 9552},
+									pos:  position{line: 404, col: 5, offset: 9638},
 									name: "CASE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 403, col: 10, offset: 9557},
+									pos:  position{line: 404, col: 10, offset: 9643},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 403, col: 12, offset: 9559},
+									pos:   position{line: 404, col: 12, offset: 9645},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 403, col: 17, offset: 9564},
+										pos:  position{line: 404, col: 17, offset: 9650},
 										name: "Expr",
 									},
 								},
@@ -2936,10 +2949,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 404, col: 5, offset: 9594},
+						pos: position{line: 405, col: 5, offset: 9680},
 						run: (*parser).callonCase8,
 						expr: &ruleRefExpr{
-							pos:  position{line: 404, col: 5, offset: 9594},
+							pos:  position{line: 405, col: 5, offset: 9680},
 							name: "DEFAULT",
 						},
 					},
@@ -2950,40 +2963,40 @@ var g = &grammar{
 		},
 		{
 			name: "SearchOp",
-			pos:  position{line: 406, col: 1, offset: 9623},
+			pos:  position{line: 407, col: 1, offset: 9709},
 			expr: &actionExpr{
-				pos: position{line: 407, col: 5, offset: 9636},
+				pos: position{line: 408, col: 5, offset: 9722},
 				run: (*parser).callonSearchOp1,
 				expr: &seqExpr{
-					pos: position{line: 407, col: 5, offset: 9636},
+					pos: position{line: 408, col: 5, offset: 9722},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 407, col: 6, offset: 9637},
+							pos: position{line: 408, col: 6, offset: 9723},
 							alternatives: []any{
 								&seqExpr{
-									pos: position{line: 407, col: 6, offset: 9637},
+									pos: position{line: 408, col: 6, offset: 9723},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 407, col: 6, offset: 9637},
+											pos:  position{line: 408, col: 6, offset: 9723},
 											name: "SEARCH",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 407, col: 13, offset: 9644},
+											pos:  position{line: 408, col: 13, offset: 9730},
 											name: "_",
 										},
 									},
 								},
 								&seqExpr{
-									pos: position{line: 407, col: 17, offset: 9648},
+									pos: position{line: 408, col: 17, offset: 9734},
 									exprs: []any{
 										&litMatcher{
-											pos:        position{line: 407, col: 17, offset: 9648},
+											pos:        position{line: 408, col: 17, offset: 9734},
 											val:        "?",
 											ignoreCase: false,
 											want:       "\"?\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 407, col: 21, offset: 9652},
+											pos:  position{line: 408, col: 21, offset: 9738},
 											name: "__",
 										},
 									},
@@ -2991,10 +3004,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 407, col: 25, offset: 9656},
+							pos:   position{line: 408, col: 25, offset: 9742},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 407, col: 30, offset: 9661},
+								pos:  position{line: 408, col: 30, offset: 9747},
 								name: "SearchBoolean",
 							},
 						},
@@ -3006,32 +3019,32 @@ var g = &grammar{
 		},
 		{
 			name: "AssertOp",
-			pos:  position{line: 411, col: 1, offset: 9765},
+			pos:  position{line: 412, col: 1, offset: 9851},
 			expr: &actionExpr{
-				pos: position{line: 412, col: 5, offset: 9778},
+				pos: position{line: 413, col: 5, offset: 9864},
 				run: (*parser).callonAssertOp1,
 				expr: &seqExpr{
-					pos: position{line: 412, col: 5, offset: 9778},
+					pos: position{line: 413, col: 5, offset: 9864},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 412, col: 5, offset: 9778},
+							pos:  position{line: 413, col: 5, offset: 9864},
 							name: "ASSERT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 412, col: 12, offset: 9785},
+							pos:  position{line: 413, col: 12, offset: 9871},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 412, col: 14, offset: 9787},
+							pos:   position{line: 413, col: 14, offset: 9873},
 							label: "expr",
 							expr: &actionExpr{
-								pos: position{line: 412, col: 20, offset: 9793},
+								pos: position{line: 413, col: 20, offset: 9879},
 								run: (*parser).callonAssertOp6,
 								expr: &labeledExpr{
-									pos:   position{line: 412, col: 20, offset: 9793},
+									pos:   position{line: 413, col: 20, offset: 9879},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 412, col: 22, offset: 9795},
+										pos:  position{line: 413, col: 22, offset: 9881},
 										name: "Expr",
 									},
 								},
@@ -3045,33 +3058,33 @@ var g = &grammar{
 		},
 		{
 			name: "SortOp",
-			pos:  position{line: 421, col: 1, offset: 10029},
+			pos:  position{line: 422, col: 1, offset: 10115},
 			expr: &actionExpr{
-				pos: position{line: 422, col: 5, offset: 10040},
+				pos: position{line: 423, col: 5, offset: 10126},
 				run: (*parser).callonSortOp1,
 				expr: &seqExpr{
-					pos: position{line: 422, col: 5, offset: 10040},
+					pos: position{line: 423, col: 5, offset: 10126},
 					exprs: []any{
 						&choiceExpr{
-							pos: position{line: 422, col: 6, offset: 10041},
+							pos: position{line: 423, col: 6, offset: 10127},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 422, col: 6, offset: 10041},
+									pos:  position{line: 423, col: 6, offset: 10127},
 									name: "SORT",
 								},
 								&seqExpr{
-									pos: position{line: 422, col: 13, offset: 10048},
+									pos: position{line: 423, col: 13, offset: 10134},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 422, col: 13, offset: 10048},
+											pos:  position{line: 423, col: 13, offset: 10134},
 											name: "ORDER",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 422, col: 19, offset: 10054},
+											pos:  position{line: 423, col: 19, offset: 10140},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 422, col: 21, offset: 10056},
+											pos:  position{line: 423, col: 21, offset: 10142},
 											name: "BY",
 										},
 									},
@@ -3079,33 +3092,33 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 422, col: 25, offset: 10060},
+							pos:   position{line: 423, col: 25, offset: 10146},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 422, col: 30, offset: 10065},
+								pos:  position{line: 423, col: 30, offset: 10151},
 								name: "SortArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 422, col: 39, offset: 10074},
+							pos:   position{line: 423, col: 39, offset: 10160},
 							label: "exprs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 422, col: 45, offset: 10080},
+								pos: position{line: 423, col: 45, offset: 10166},
 								expr: &actionExpr{
-									pos: position{line: 422, col: 46, offset: 10081},
+									pos: position{line: 423, col: 46, offset: 10167},
 									run: (*parser).callonSortOp13,
 									expr: &seqExpr{
-										pos: position{line: 422, col: 46, offset: 10081},
+										pos: position{line: 423, col: 46, offset: 10167},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 422, col: 46, offset: 10081},
+												pos:  position{line: 423, col: 46, offset: 10167},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 422, col: 49, offset: 10084},
+												pos:   position{line: 423, col: 49, offset: 10170},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 422, col: 51, offset: 10086},
+													pos:  position{line: 423, col: 51, offset: 10172},
 													name: "OrderByList",
 												},
 											},
@@ -3122,30 +3135,30 @@ var g = &grammar{
 		},
 		{
 			name: "SortArgs",
-			pos:  position{line: 437, col: 1, offset: 10400},
+			pos:  position{line: 438, col: 1, offset: 10486},
 			expr: &actionExpr{
-				pos: position{line: 437, col: 12, offset: 10411},
+				pos: position{line: 438, col: 12, offset: 10497},
 				run: (*parser).callonSortArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 437, col: 12, offset: 10411},
+					pos:   position{line: 438, col: 12, offset: 10497},
 					label: "args",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 437, col: 17, offset: 10416},
+						pos: position{line: 438, col: 17, offset: 10502},
 						expr: &actionExpr{
-							pos: position{line: 437, col: 18, offset: 10417},
+							pos: position{line: 438, col: 18, offset: 10503},
 							run: (*parser).callonSortArgs4,
 							expr: &seqExpr{
-								pos: position{line: 437, col: 18, offset: 10417},
+								pos: position{line: 438, col: 18, offset: 10503},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 437, col: 18, offset: 10417},
+										pos:  position{line: 438, col: 18, offset: 10503},
 										name: "_",
 									},
 									&labeledExpr{
-										pos:   position{line: 437, col: 20, offset: 10419},
+										pos:   position{line: 438, col: 20, offset: 10505},
 										label: "a",
 										expr: &ruleRefExpr{
-											pos:  position{line: 437, col: 22, offset: 10421},
+											pos:  position{line: 438, col: 22, offset: 10507},
 											name: "SortArg",
 										},
 									},
@@ -3160,12 +3173,12 @@ var g = &grammar{
 		},
 		{
 			name: "SortArg",
-			pos:  position{line: 439, col: 1, offset: 10478},
+			pos:  position{line: 440, col: 1, offset: 10564},
 			expr: &actionExpr{
-				pos: position{line: 440, col: 5, offset: 10490},
+				pos: position{line: 441, col: 5, offset: 10576},
 				run: (*parser).callonSortArg1,
 				expr: &litMatcher{
-					pos:        position{line: 440, col: 5, offset: 10490},
+					pos:        position{line: 441, col: 5, offset: 10576},
 					val:        "-r",
 					ignoreCase: false,
 					want:       "\"-r\"",
@@ -3176,45 +3189,45 @@ var g = &grammar{
 		},
 		{
 			name: "TopOp",
-			pos:  position{line: 442, col: 1, offset: 10554},
+			pos:  position{line: 443, col: 1, offset: 10640},
 			expr: &actionExpr{
-				pos: position{line: 443, col: 5, offset: 10564},
+				pos: position{line: 444, col: 5, offset: 10650},
 				run: (*parser).callonTopOp1,
 				expr: &seqExpr{
-					pos: position{line: 443, col: 5, offset: 10564},
+					pos: position{line: 444, col: 5, offset: 10650},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 443, col: 5, offset: 10564},
+							pos:  position{line: 444, col: 5, offset: 10650},
 							name: "TOP",
 						},
 						&labeledExpr{
-							pos:   position{line: 443, col: 9, offset: 10568},
+							pos:   position{line: 444, col: 9, offset: 10654},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 443, col: 14, offset: 10573},
+								pos:  position{line: 444, col: 14, offset: 10659},
 								name: "SortArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 443, col: 23, offset: 10582},
+							pos:   position{line: 444, col: 23, offset: 10668},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 443, col: 29, offset: 10588},
+								pos: position{line: 444, col: 29, offset: 10674},
 								expr: &actionExpr{
-									pos: position{line: 443, col: 30, offset: 10589},
+									pos: position{line: 444, col: 30, offset: 10675},
 									run: (*parser).callonTopOp8,
 									expr: &seqExpr{
-										pos: position{line: 443, col: 30, offset: 10589},
+										pos: position{line: 444, col: 30, offset: 10675},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 443, col: 30, offset: 10589},
+												pos:  position{line: 444, col: 30, offset: 10675},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 443, col: 32, offset: 10591},
+												pos:   position{line: 444, col: 32, offset: 10677},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 443, col: 34, offset: 10593},
+													pos:  position{line: 444, col: 34, offset: 10679},
 													name: "Expr",
 												},
 											},
@@ -3224,25 +3237,25 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 443, col: 59, offset: 10618},
+							pos:   position{line: 444, col: 59, offset: 10704},
 							label: "exprs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 443, col: 65, offset: 10624},
+								pos: position{line: 444, col: 65, offset: 10710},
 								expr: &actionExpr{
-									pos: position{line: 443, col: 66, offset: 10625},
+									pos: position{line: 444, col: 66, offset: 10711},
 									run: (*parser).callonTopOp15,
 									expr: &seqExpr{
-										pos: position{line: 443, col: 66, offset: 10625},
+										pos: position{line: 444, col: 66, offset: 10711},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 443, col: 66, offset: 10625},
+												pos:  position{line: 444, col: 66, offset: 10711},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 443, col: 68, offset: 10627},
+												pos:   position{line: 444, col: 68, offset: 10713},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 443, col: 70, offset: 10629},
+													pos:  position{line: 444, col: 70, offset: 10715},
 													name: "OrderByList",
 												},
 											},
@@ -3259,49 +3272,49 @@ var g = &grammar{
 		},
 		{
 			name: "CallOp",
-			pos:  position{line: 461, col: 1, offset: 11013},
+			pos:  position{line: 462, col: 1, offset: 11099},
 			expr: &actionExpr{
-				pos: position{line: 462, col: 5, offset: 11024},
+				pos: position{line: 463, col: 5, offset: 11110},
 				run: (*parser).callonCallOp1,
 				expr: &seqExpr{
-					pos: position{line: 462, col: 5, offset: 11024},
+					pos: position{line: 463, col: 5, offset: 11110},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 462, col: 5, offset: 11024},
+							pos:  position{line: 463, col: 5, offset: 11110},
 							name: "CALL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 462, col: 10, offset: 11029},
+							pos:  position{line: 463, col: 10, offset: 11115},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 462, col: 12, offset: 11031},
+							pos:   position{line: 463, col: 12, offset: 11117},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 462, col: 17, offset: 11036},
+								pos:  position{line: 463, col: 17, offset: 11122},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 462, col: 28, offset: 11047},
+							pos:   position{line: 463, col: 28, offset: 11133},
 							label: "args",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 462, col: 33, offset: 11052},
+								pos: position{line: 463, col: 33, offset: 11138},
 								expr: &actionExpr{
-									pos: position{line: 462, col: 34, offset: 11053},
+									pos: position{line: 463, col: 34, offset: 11139},
 									run: (*parser).callonCallOp9,
 									expr: &seqExpr{
-										pos: position{line: 462, col: 35, offset: 11054},
+										pos: position{line: 463, col: 35, offset: 11140},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 462, col: 35, offset: 11054},
+												pos:  position{line: 463, col: 35, offset: 11140},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 462, col: 37, offset: 11056},
+												pos:   position{line: 463, col: 37, offset: 11142},
 												label: "args",
 												expr: &ruleRefExpr{
-													pos:  position{line: 462, col: 42, offset: 11061},
+													pos:  position{line: 463, col: 42, offset: 11147},
 													name: "FuncOrExprs",
 												},
 											},
@@ -3318,26 +3331,26 @@ var g = &grammar{
 		},
 		{
 			name: "CutOp",
-			pos:  position{line: 471, col: 1, offset: 11263},
+			pos:  position{line: 472, col: 1, offset: 11349},
 			expr: &actionExpr{
-				pos: position{line: 472, col: 5, offset: 11273},
+				pos: position{line: 473, col: 5, offset: 11359},
 				run: (*parser).callonCutOp1,
 				expr: &seqExpr{
-					pos: position{line: 472, col: 5, offset: 11273},
+					pos: position{line: 473, col: 5, offset: 11359},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 472, col: 5, offset: 11273},
+							pos:  position{line: 473, col: 5, offset: 11359},
 							name: "CUT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 472, col: 9, offset: 11277},
+							pos:  position{line: 473, col: 9, offset: 11363},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 472, col: 11, offset: 11279},
+							pos:   position{line: 473, col: 11, offset: 11365},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 472, col: 16, offset: 11284},
+								pos:  position{line: 473, col: 16, offset: 11370},
 								name: "Assignments",
 							},
 						},
@@ -3349,26 +3362,26 @@ var g = &grammar{
 		},
 		{
 			name: "DistinctOp",
-			pos:  position{line: 480, col: 1, offset: 11432},
+			pos:  position{line: 481, col: 1, offset: 11518},
 			expr: &actionExpr{
-				pos: position{line: 481, col: 5, offset: 11447},
+				pos: position{line: 482, col: 5, offset: 11533},
 				run: (*parser).callonDistinctOp1,
 				expr: &seqExpr{
-					pos: position{line: 481, col: 5, offset: 11447},
+					pos: position{line: 482, col: 5, offset: 11533},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 481, col: 5, offset: 11447},
+							pos:  position{line: 482, col: 5, offset: 11533},
 							name: "DISTINCT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 481, col: 14, offset: 11456},
+							pos:  position{line: 482, col: 14, offset: 11542},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 481, col: 16, offset: 11458},
+							pos:   position{line: 482, col: 16, offset: 11544},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 481, col: 18, offset: 11460},
+								pos:  position{line: 482, col: 18, offset: 11546},
 								name: "Expr",
 							},
 						},
@@ -3380,26 +3393,26 @@ var g = &grammar{
 		},
 		{
 			name: "DropOp",
-			pos:  position{line: 489, col: 1, offset: 11600},
+			pos:  position{line: 490, col: 1, offset: 11686},
 			expr: &actionExpr{
-				pos: position{line: 490, col: 5, offset: 11611},
+				pos: position{line: 491, col: 5, offset: 11697},
 				run: (*parser).callonDropOp1,
 				expr: &seqExpr{
-					pos: position{line: 490, col: 5, offset: 11611},
+					pos: position{line: 491, col: 5, offset: 11697},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 490, col: 5, offset: 11611},
+							pos:  position{line: 491, col: 5, offset: 11697},
 							name: "DROP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 490, col: 10, offset: 11616},
+							pos:  position{line: 491, col: 10, offset: 11702},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 490, col: 12, offset: 11618},
+							pos:   position{line: 491, col: 12, offset: 11704},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 490, col: 17, offset: 11623},
+								pos:  position{line: 491, col: 17, offset: 11709},
 								name: "Lvals",
 							},
 						},
@@ -3411,38 +3424,38 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOp",
-			pos:  position{line: 498, col: 1, offset: 11767},
+			pos:  position{line: 499, col: 1, offset: 11853},
 			expr: &choiceExpr{
-				pos: position{line: 499, col: 5, offset: 11778},
+				pos: position{line: 500, col: 5, offset: 11864},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 499, col: 5, offset: 11778},
+						pos: position{line: 500, col: 5, offset: 11864},
 						run: (*parser).callonHeadOp2,
 						expr: &seqExpr{
-							pos: position{line: 499, col: 5, offset: 11778},
+							pos: position{line: 500, col: 5, offset: 11864},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 499, col: 6, offset: 11779},
+									pos: position{line: 500, col: 6, offset: 11865},
 									alternatives: []any{
 										&ruleRefExpr{
-											pos:  position{line: 499, col: 6, offset: 11779},
+											pos:  position{line: 500, col: 6, offset: 11865},
 											name: "HEAD",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 499, col: 13, offset: 11786},
+											pos:  position{line: 500, col: 13, offset: 11872},
 											name: "LIMIT",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 499, col: 20, offset: 11793},
+									pos:  position{line: 500, col: 20, offset: 11879},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 499, col: 22, offset: 11795},
+									pos:   position{line: 500, col: 22, offset: 11881},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 499, col: 28, offset: 11801},
+										pos:  position{line: 500, col: 28, offset: 11887},
 										name: "Expr",
 									},
 								},
@@ -3450,19 +3463,19 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 506, col: 5, offset: 11935},
+						pos: position{line: 507, col: 5, offset: 12021},
 						run: (*parser).callonHeadOp10,
 						expr: &seqExpr{
-							pos: position{line: 506, col: 5, offset: 11935},
+							pos: position{line: 507, col: 5, offset: 12021},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 506, col: 5, offset: 11935},
+									pos:  position{line: 507, col: 5, offset: 12021},
 									name: "HEAD",
 								},
 								&andExpr{
-									pos: position{line: 506, col: 10, offset: 11940},
+									pos: position{line: 507, col: 10, offset: 12026},
 									expr: &ruleRefExpr{
-										pos:  position{line: 506, col: 11, offset: 11941},
+										pos:  position{line: 507, col: 11, offset: 12027},
 										name: "EndOfOp",
 									},
 								},
@@ -3476,29 +3489,29 @@ var g = &grammar{
 		},
 		{
 			name: "TailOp",
-			pos:  position{line: 513, col: 1, offset: 12042},
+			pos:  position{line: 514, col: 1, offset: 12128},
 			expr: &choiceExpr{
-				pos: position{line: 514, col: 5, offset: 12053},
+				pos: position{line: 515, col: 5, offset: 12139},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 514, col: 5, offset: 12053},
+						pos: position{line: 515, col: 5, offset: 12139},
 						run: (*parser).callonTailOp2,
 						expr: &seqExpr{
-							pos: position{line: 514, col: 5, offset: 12053},
+							pos: position{line: 515, col: 5, offset: 12139},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 514, col: 5, offset: 12053},
+									pos:  position{line: 515, col: 5, offset: 12139},
 									name: "TAIL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 514, col: 10, offset: 12058},
+									pos:  position{line: 515, col: 10, offset: 12144},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 514, col: 12, offset: 12060},
+									pos:   position{line: 515, col: 12, offset: 12146},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 514, col: 18, offset: 12066},
+										pos:  position{line: 515, col: 18, offset: 12152},
 										name: "Expr",
 									},
 								},
@@ -3506,19 +3519,19 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 521, col: 5, offset: 12200},
+						pos: position{line: 522, col: 5, offset: 12286},
 						run: (*parser).callonTailOp8,
 						expr: &seqExpr{
-							pos: position{line: 521, col: 5, offset: 12200},
+							pos: position{line: 522, col: 5, offset: 12286},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 521, col: 5, offset: 12200},
+									pos:  position{line: 522, col: 5, offset: 12286},
 									name: "TAIL",
 								},
 								&andExpr{
-									pos: position{line: 521, col: 10, offset: 12205},
+									pos: position{line: 522, col: 10, offset: 12291},
 									expr: &ruleRefExpr{
-										pos:  position{line: 521, col: 11, offset: 12206},
+										pos:  position{line: 522, col: 11, offset: 12292},
 										name: "EndOfOp",
 									},
 								},
@@ -3532,26 +3545,26 @@ var g = &grammar{
 		},
 		{
 			name: "SkipOp",
-			pos:  position{line: 528, col: 1, offset: 12307},
+			pos:  position{line: 529, col: 1, offset: 12393},
 			expr: &actionExpr{
-				pos: position{line: 529, col: 5, offset: 12318},
+				pos: position{line: 530, col: 5, offset: 12404},
 				run: (*parser).callonSkipOp1,
 				expr: &seqExpr{
-					pos: position{line: 529, col: 5, offset: 12318},
+					pos: position{line: 530, col: 5, offset: 12404},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 529, col: 5, offset: 12318},
+							pos:  position{line: 530, col: 5, offset: 12404},
 							name: "SKIP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 529, col: 10, offset: 12323},
+							pos:  position{line: 530, col: 10, offset: 12409},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 529, col: 12, offset: 12325},
+							pos:   position{line: 530, col: 12, offset: 12411},
 							label: "count",
 							expr: &ruleRefExpr{
-								pos:  position{line: 529, col: 18, offset: 12331},
+								pos:  position{line: 530, col: 18, offset: 12417},
 								name: "Expr",
 							},
 						},
@@ -3563,26 +3576,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereOp",
-			pos:  position{line: 537, col: 1, offset: 12462},
+			pos:  position{line: 538, col: 1, offset: 12548},
 			expr: &actionExpr{
-				pos: position{line: 538, col: 5, offset: 12474},
+				pos: position{line: 539, col: 5, offset: 12560},
 				run: (*parser).callonWhereOp1,
 				expr: &seqExpr{
-					pos: position{line: 538, col: 5, offset: 12474},
+					pos: position{line: 539, col: 5, offset: 12560},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 538, col: 5, offset: 12474},
+							pos:  position{line: 539, col: 5, offset: 12560},
 							name: "WHERE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 538, col: 11, offset: 12480},
+							pos:  position{line: 539, col: 11, offset: 12566},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 538, col: 13, offset: 12482},
+							pos:   position{line: 539, col: 13, offset: 12568},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 538, col: 18, offset: 12487},
+								pos:  position{line: 539, col: 18, offset: 12573},
 								name: "Expr",
 							},
 						},
@@ -3594,26 +3607,26 @@ var g = &grammar{
 		},
 		{
 			name: "UniqOp",
-			pos:  position{line: 546, col: 1, offset: 12618},
+			pos:  position{line: 547, col: 1, offset: 12704},
 			expr: &choiceExpr{
-				pos: position{line: 547, col: 5, offset: 12629},
+				pos: position{line: 548, col: 5, offset: 12715},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 547, col: 5, offset: 12629},
+						pos: position{line: 548, col: 5, offset: 12715},
 						run: (*parser).callonUniqOp2,
 						expr: &seqExpr{
-							pos: position{line: 547, col: 5, offset: 12629},
+							pos: position{line: 548, col: 5, offset: 12715},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 547, col: 5, offset: 12629},
+									pos:  position{line: 548, col: 5, offset: 12715},
 									name: "UNIQ",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 547, col: 10, offset: 12634},
+									pos:  position{line: 548, col: 10, offset: 12720},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 547, col: 12, offset: 12636},
+									pos:        position{line: 548, col: 12, offset: 12722},
 									val:        "-c",
 									ignoreCase: false,
 									want:       "\"-c\"",
@@ -3622,19 +3635,19 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 550, col: 5, offset: 12725},
+						pos: position{line: 551, col: 5, offset: 12811},
 						run: (*parser).callonUniqOp7,
 						expr: &seqExpr{
-							pos: position{line: 550, col: 5, offset: 12725},
+							pos: position{line: 551, col: 5, offset: 12811},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 550, col: 5, offset: 12725},
+									pos:  position{line: 551, col: 5, offset: 12811},
 									name: "UNIQ",
 								},
 								&andExpr{
-									pos: position{line: 550, col: 10, offset: 12730},
+									pos: position{line: 551, col: 10, offset: 12816},
 									expr: &ruleRefExpr{
-										pos:  position{line: 550, col: 11, offset: 12731},
+										pos:  position{line: 551, col: 11, offset: 12817},
 										name: "EndOfOp",
 									},
 								},
@@ -3648,26 +3661,26 @@ var g = &grammar{
 		},
 		{
 			name: "PutOp",
-			pos:  position{line: 554, col: 1, offset: 12807},
+			pos:  position{line: 555, col: 1, offset: 12893},
 			expr: &actionExpr{
-				pos: position{line: 555, col: 5, offset: 12817},
+				pos: position{line: 556, col: 5, offset: 12903},
 				run: (*parser).callonPutOp1,
 				expr: &seqExpr{
-					pos: position{line: 555, col: 5, offset: 12817},
+					pos: position{line: 556, col: 5, offset: 12903},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 555, col: 5, offset: 12817},
+							pos:  position{line: 556, col: 5, offset: 12903},
 							name: "PUT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 555, col: 9, offset: 12821},
+							pos:  position{line: 556, col: 9, offset: 12907},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 555, col: 11, offset: 12823},
+							pos:   position{line: 556, col: 11, offset: 12909},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 555, col: 16, offset: 12828},
+								pos:  position{line: 556, col: 16, offset: 12914},
 								name: "Assignments",
 							},
 						},
@@ -3679,59 +3692,59 @@ var g = &grammar{
 		},
 		{
 			name: "RenameOp",
-			pos:  position{line: 563, col: 1, offset: 12982},
+			pos:  position{line: 564, col: 1, offset: 13068},
 			expr: &actionExpr{
-				pos: position{line: 564, col: 5, offset: 12995},
+				pos: position{line: 565, col: 5, offset: 13081},
 				run: (*parser).callonRenameOp1,
 				expr: &seqExpr{
-					pos: position{line: 564, col: 5, offset: 12995},
+					pos: position{line: 565, col: 5, offset: 13081},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 564, col: 5, offset: 12995},
+							pos:  position{line: 565, col: 5, offset: 13081},
 							name: "RENAME",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 564, col: 12, offset: 13002},
+							pos:  position{line: 565, col: 12, offset: 13088},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 564, col: 14, offset: 13004},
+							pos:   position{line: 565, col: 14, offset: 13090},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 564, col: 20, offset: 13010},
+								pos:  position{line: 565, col: 20, offset: 13096},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 564, col: 31, offset: 13021},
+							pos:   position{line: 565, col: 31, offset: 13107},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 564, col: 36, offset: 13026},
+								pos: position{line: 565, col: 36, offset: 13112},
 								expr: &actionExpr{
-									pos: position{line: 564, col: 37, offset: 13027},
+									pos: position{line: 565, col: 37, offset: 13113},
 									run: (*parser).callonRenameOp9,
 									expr: &seqExpr{
-										pos: position{line: 564, col: 37, offset: 13027},
+										pos: position{line: 565, col: 37, offset: 13113},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 564, col: 37, offset: 13027},
+												pos:  position{line: 565, col: 37, offset: 13113},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 564, col: 40, offset: 13030},
+												pos:        position{line: 565, col: 40, offset: 13116},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 564, col: 44, offset: 13034},
+												pos:  position{line: 565, col: 44, offset: 13120},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 564, col: 47, offset: 13037},
+												pos:   position{line: 565, col: 47, offset: 13123},
 												label: "cl",
 												expr: &ruleRefExpr{
-													pos:  position{line: 564, col: 50, offset: 13040},
+													pos:  position{line: 565, col: 50, offset: 13126},
 													name: "Assignment",
 												},
 											},
@@ -3748,21 +3761,21 @@ var g = &grammar{
 		},
 		{
 			name: "FuseOp",
-			pos:  position{line: 573, col: 1, offset: 13266},
+			pos:  position{line: 574, col: 1, offset: 13352},
 			expr: &actionExpr{
-				pos: position{line: 574, col: 5, offset: 13277},
+				pos: position{line: 575, col: 5, offset: 13363},
 				run: (*parser).callonFuseOp1,
 				expr: &seqExpr{
-					pos: position{line: 574, col: 5, offset: 13277},
+					pos: position{line: 575, col: 5, offset: 13363},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 574, col: 5, offset: 13277},
+							pos:  position{line: 575, col: 5, offset: 13363},
 							name: "FUSE",
 						},
 						&andExpr{
-							pos: position{line: 574, col: 10, offset: 13282},
+							pos: position{line: 575, col: 10, offset: 13368},
 							expr: &ruleRefExpr{
-								pos:  position{line: 574, col: 11, offset: 13283},
+								pos:  position{line: 575, col: 11, offset: 13369},
 								name: "EndOfOp",
 							},
 						},
@@ -3774,41 +3787,41 @@ var g = &grammar{
 		},
 		{
 			name: "JoinOp",
-			pos:  position{line: 578, col: 1, offset: 13359},
+			pos:  position{line: 579, col: 1, offset: 13445},
 			expr: &choiceExpr{
-				pos: position{line: 579, col: 5, offset: 13370},
+				pos: position{line: 580, col: 5, offset: 13456},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 579, col: 5, offset: 13370},
+						pos: position{line: 580, col: 5, offset: 13456},
 						run: (*parser).callonJoinOp2,
 						expr: &seqExpr{
-							pos: position{line: 579, col: 5, offset: 13370},
+							pos: position{line: 580, col: 5, offset: 13456},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 579, col: 5, offset: 13370},
+									pos:  position{line: 580, col: 5, offset: 13456},
 									name: "CROSS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 579, col: 11, offset: 13376},
+									pos:  position{line: 580, col: 11, offset: 13462},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 579, col: 13, offset: 13378},
+									pos:  position{line: 580, col: 13, offset: 13464},
 									name: "JOIN",
 								},
 								&labeledExpr{
-									pos:   position{line: 579, col: 18, offset: 13383},
+									pos:   position{line: 580, col: 18, offset: 13469},
 									label: "rightInput",
 									expr: &ruleRefExpr{
-										pos:  position{line: 579, col: 29, offset: 13394},
+										pos:  position{line: 580, col: 29, offset: 13480},
 										name: "JoinRightInput",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 579, col: 44, offset: 13409},
+									pos:   position{line: 580, col: 44, offset: 13495},
 									label: "alias",
 									expr: &ruleRefExpr{
-										pos:  position{line: 579, col: 50, offset: 13415},
+										pos:  position{line: 580, col: 50, offset: 13501},
 										name: "OptJoinAlias",
 									},
 								},
@@ -3816,48 +3829,48 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 593, col: 5, offset: 13722},
+						pos: position{line: 594, col: 5, offset: 13808},
 						run: (*parser).callonJoinOp11,
 						expr: &seqExpr{
-							pos: position{line: 593, col: 5, offset: 13722},
+							pos: position{line: 594, col: 5, offset: 13808},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 593, col: 5, offset: 13722},
+									pos:   position{line: 594, col: 5, offset: 13808},
 									label: "style",
 									expr: &ruleRefExpr{
-										pos:  position{line: 593, col: 11, offset: 13728},
+										pos:  position{line: 594, col: 11, offset: 13814},
 										name: "JoinStyle",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 593, col: 21, offset: 13738},
+									pos:  position{line: 594, col: 21, offset: 13824},
 									name: "JOIN",
 								},
 								&labeledExpr{
-									pos:   position{line: 593, col: 26, offset: 13743},
+									pos:   position{line: 594, col: 26, offset: 13829},
 									label: "rightInput",
 									expr: &ruleRefExpr{
-										pos:  position{line: 593, col: 37, offset: 13754},
+										pos:  position{line: 594, col: 37, offset: 13840},
 										name: "JoinRightInput",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 593, col: 52, offset: 13769},
+									pos:   position{line: 594, col: 52, offset: 13855},
 									label: "alias",
 									expr: &ruleRefExpr{
-										pos:  position{line: 593, col: 58, offset: 13775},
+										pos:  position{line: 594, col: 58, offset: 13861},
 										name: "OptJoinAlias",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 593, col: 71, offset: 13788},
+									pos:  position{line: 594, col: 71, offset: 13874},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 593, col: 73, offset: 13790},
+									pos:   position{line: 594, col: 73, offset: 13876},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 593, col: 75, offset: 13792},
+										pos:  position{line: 594, col: 75, offset: 13878},
 										name: "JoinCond",
 									},
 								},
@@ -3871,83 +3884,83 @@ var g = &grammar{
 		},
 		{
 			name: "JoinStyle",
-			pos:  position{line: 609, col: 1, offset: 14131},
+			pos:  position{line: 610, col: 1, offset: 14217},
 			expr: &choiceExpr{
-				pos: position{line: 610, col: 5, offset: 14145},
+				pos: position{line: 611, col: 5, offset: 14231},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 610, col: 5, offset: 14145},
+						pos: position{line: 611, col: 5, offset: 14231},
 						run: (*parser).callonJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 610, col: 5, offset: 14145},
+							pos: position{line: 611, col: 5, offset: 14231},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 610, col: 5, offset: 14145},
+									pos:  position{line: 611, col: 5, offset: 14231},
 									name: "ANTI",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 610, col: 10, offset: 14150},
+									pos:  position{line: 611, col: 10, offset: 14236},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 611, col: 5, offset: 14180},
+						pos: position{line: 612, col: 5, offset: 14266},
 						run: (*parser).callonJoinStyle6,
 						expr: &seqExpr{
-							pos: position{line: 611, col: 5, offset: 14180},
+							pos: position{line: 612, col: 5, offset: 14266},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 611, col: 5, offset: 14180},
+									pos:  position{line: 612, col: 5, offset: 14266},
 									name: "INNER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 611, col: 11, offset: 14186},
+									pos:  position{line: 612, col: 11, offset: 14272},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 612, col: 5, offset: 14216},
+						pos: position{line: 613, col: 5, offset: 14302},
 						run: (*parser).callonJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 612, col: 5, offset: 14216},
+							pos: position{line: 613, col: 5, offset: 14302},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 612, col: 5, offset: 14216},
+									pos:  position{line: 613, col: 5, offset: 14302},
 									name: "LEFT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 612, col: 11, offset: 14222},
+									pos:  position{line: 613, col: 11, offset: 14308},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 613, col: 5, offset: 14251},
+						pos: position{line: 614, col: 5, offset: 14337},
 						run: (*parser).callonJoinStyle14,
 						expr: &seqExpr{
-							pos: position{line: 613, col: 5, offset: 14251},
+							pos: position{line: 614, col: 5, offset: 14337},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 613, col: 5, offset: 14251},
+									pos:  position{line: 614, col: 5, offset: 14337},
 									name: "RIGHT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 613, col: 11, offset: 14257},
+									pos:  position{line: 614, col: 11, offset: 14343},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 614, col: 5, offset: 14287},
+						pos: position{line: 615, col: 5, offset: 14373},
 						run: (*parser).callonJoinStyle18,
 						expr: &litMatcher{
-							pos:        position{line: 614, col: 5, offset: 14287},
+							pos:        position{line: 615, col: 5, offset: 14373},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -3960,33 +3973,33 @@ var g = &grammar{
 		},
 		{
 			name: "OptJoinAlias",
-			pos:  position{line: 616, col: 1, offset: 14315},
+			pos:  position{line: 617, col: 1, offset: 14401},
 			expr: &choiceExpr{
-				pos: position{line: 617, col: 5, offset: 14332},
+				pos: position{line: 618, col: 5, offset: 14418},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 617, col: 5, offset: 14332},
+						pos: position{line: 618, col: 5, offset: 14418},
 						run: (*parser).callonOptJoinAlias2,
 						expr: &seqExpr{
-							pos: position{line: 617, col: 5, offset: 14332},
+							pos: position{line: 618, col: 5, offset: 14418},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 617, col: 5, offset: 14332},
+									pos:  position{line: 618, col: 5, offset: 14418},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 617, col: 7, offset: 14334},
+									pos:  position{line: 618, col: 7, offset: 14420},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 617, col: 10, offset: 14337},
+									pos:  position{line: 618, col: 10, offset: 14423},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 617, col: 12, offset: 14339},
+									pos:   position{line: 618, col: 12, offset: 14425},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 617, col: 14, offset: 14341},
+										pos:  position{line: 618, col: 14, offset: 14427},
 										name: "JoinAlias",
 									},
 								},
@@ -3994,10 +4007,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 618, col: 5, offset: 14373},
+						pos: position{line: 619, col: 5, offset: 14459},
 						run: (*parser).callonOptJoinAlias9,
 						expr: &litMatcher{
-							pos:        position{line: 618, col: 5, offset: 14373},
+							pos:        position{line: 619, col: 5, offset: 14459},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -4010,59 +4023,59 @@ var g = &grammar{
 		},
 		{
 			name: "JoinAlias",
-			pos:  position{line: 620, col: 1, offset: 14397},
+			pos:  position{line: 621, col: 1, offset: 14483},
 			expr: &actionExpr{
-				pos: position{line: 621, col: 5, offset: 14411},
+				pos: position{line: 622, col: 5, offset: 14497},
 				run: (*parser).callonJoinAlias1,
 				expr: &seqExpr{
-					pos: position{line: 621, col: 5, offset: 14411},
+					pos: position{line: 622, col: 5, offset: 14497},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 621, col: 5, offset: 14411},
+							pos:        position{line: 622, col: 5, offset: 14497},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 621, col: 9, offset: 14415},
+							pos:  position{line: 622, col: 9, offset: 14501},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 621, col: 12, offset: 14418},
+							pos:   position{line: 622, col: 12, offset: 14504},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 621, col: 17, offset: 14423},
+								pos:  position{line: 622, col: 17, offset: 14509},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 621, col: 28, offset: 14434},
+							pos:  position{line: 622, col: 28, offset: 14520},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 621, col: 31, offset: 14437},
+							pos:        position{line: 622, col: 31, offset: 14523},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 621, col: 35, offset: 14441},
+							pos:  position{line: 622, col: 35, offset: 14527},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 621, col: 38, offset: 14444},
+							pos:   position{line: 622, col: 38, offset: 14530},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 621, col: 44, offset: 14450},
+								pos:  position{line: 622, col: 44, offset: 14536},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 621, col: 55, offset: 14461},
+							pos:  position{line: 622, col: 55, offset: 14547},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 621, col: 58, offset: 14464},
+							pos:        position{line: 622, col: 58, offset: 14550},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -4075,44 +4088,44 @@ var g = &grammar{
 		},
 		{
 			name: "JoinRightInput",
-			pos:  position{line: 629, col: 1, offset: 14602},
+			pos:  position{line: 630, col: 1, offset: 14688},
 			expr: &choiceExpr{
-				pos: position{line: 630, col: 5, offset: 14621},
+				pos: position{line: 631, col: 5, offset: 14707},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 630, col: 5, offset: 14621},
+						pos: position{line: 631, col: 5, offset: 14707},
 						run: (*parser).callonJoinRightInput2,
 						expr: &seqExpr{
-							pos: position{line: 630, col: 5, offset: 14621},
+							pos: position{line: 631, col: 5, offset: 14707},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 630, col: 5, offset: 14621},
+									pos:  position{line: 631, col: 5, offset: 14707},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 630, col: 8, offset: 14624},
+									pos:        position{line: 631, col: 8, offset: 14710},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 630, col: 12, offset: 14628},
+									pos:  position{line: 631, col: 12, offset: 14714},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 630, col: 15, offset: 14631},
+									pos:   position{line: 631, col: 15, offset: 14717},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 630, col: 17, offset: 14633},
+										pos:  position{line: 631, col: 17, offset: 14719},
 										name: "Seq",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 630, col: 21, offset: 14637},
+									pos:  position{line: 631, col: 21, offset: 14723},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 630, col: 24, offset: 14640},
+									pos:        position{line: 631, col: 24, offset: 14726},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4121,10 +4134,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 631, col: 5, offset: 14666},
+						pos: position{line: 632, col: 5, offset: 14752},
 						run: (*parser).callonJoinRightInput11,
 						expr: &litMatcher{
-							pos:        position{line: 631, col: 5, offset: 14666},
+							pos:        position{line: 632, col: 5, offset: 14752},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -4137,37 +4150,37 @@ var g = &grammar{
 		},
 		{
 			name: "ShapesOp",
-			pos:  position{line: 633, col: 1, offset: 14690},
+			pos:  position{line: 634, col: 1, offset: 14776},
 			expr: &actionExpr{
-				pos: position{line: 634, col: 5, offset: 14703},
+				pos: position{line: 635, col: 5, offset: 14789},
 				run: (*parser).callonShapesOp1,
 				expr: &seqExpr{
-					pos: position{line: 634, col: 5, offset: 14703},
+					pos: position{line: 635, col: 5, offset: 14789},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 634, col: 5, offset: 14703},
+							pos:  position{line: 635, col: 5, offset: 14789},
 							name: "SHAPES",
 						},
 						&labeledExpr{
-							pos:   position{line: 634, col: 12, offset: 14710},
+							pos:   position{line: 635, col: 12, offset: 14796},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 634, col: 17, offset: 14715},
+								pos: position{line: 635, col: 17, offset: 14801},
 								expr: &actionExpr{
-									pos: position{line: 634, col: 18, offset: 14716},
+									pos: position{line: 635, col: 18, offset: 14802},
 									run: (*parser).callonShapesOp6,
 									expr: &seqExpr{
-										pos: position{line: 634, col: 18, offset: 14716},
+										pos: position{line: 635, col: 18, offset: 14802},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 634, col: 18, offset: 14716},
+												pos:  position{line: 635, col: 18, offset: 14802},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 634, col: 20, offset: 14718},
+												pos:   position{line: 635, col: 20, offset: 14804},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 634, col: 22, offset: 14720},
+													pos:  position{line: 635, col: 22, offset: 14806},
 													name: "Lval",
 												},
 											},
@@ -4184,28 +4197,28 @@ var g = &grammar{
 		},
 		{
 			name: "AssignmentOp",
-			pos:  position{line: 647, col: 1, offset: 15163},
+			pos:  position{line: 648, col: 1, offset: 15249},
 			expr: &actionExpr{
-				pos: position{line: 648, col: 5, offset: 15180},
+				pos: position{line: 649, col: 5, offset: 15266},
 				run: (*parser).callonAssignmentOp1,
 				expr: &seqExpr{
-					pos: position{line: 648, col: 5, offset: 15180},
+					pos: position{line: 649, col: 5, offset: 15266},
 					exprs: []any{
 						&andExpr{
-							pos: position{line: 648, col: 5, offset: 15180},
+							pos: position{line: 649, col: 5, offset: 15266},
 							expr: &seqExpr{
-								pos: position{line: 648, col: 7, offset: 15182},
+								pos: position{line: 649, col: 7, offset: 15268},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 648, col: 7, offset: 15182},
+										pos:  position{line: 649, col: 7, offset: 15268},
 										name: "Lval",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 648, col: 12, offset: 15187},
+										pos:  position{line: 649, col: 12, offset: 15273},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 648, col: 15, offset: 15190},
+										pos:        position{line: 649, col: 15, offset: 15276},
 										val:        ":=",
 										ignoreCase: false,
 										want:       "\":=\"",
@@ -4214,10 +4227,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 648, col: 21, offset: 15196},
+							pos:   position{line: 649, col: 21, offset: 15282},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 648, col: 23, offset: 15198},
+								pos:  position{line: 649, col: 23, offset: 15284},
 								name: "Assignments",
 							},
 						},
@@ -4229,36 +4242,36 @@ var g = &grammar{
 		},
 		{
 			name: "LoadOp",
-			pos:  position{line: 656, col: 1, offset: 15370},
+			pos:  position{line: 657, col: 1, offset: 15456},
 			expr: &actionExpr{
-				pos: position{line: 657, col: 5, offset: 15381},
+				pos: position{line: 658, col: 5, offset: 15467},
 				run: (*parser).callonLoadOp1,
 				expr: &seqExpr{
-					pos: position{line: 657, col: 5, offset: 15381},
+					pos: position{line: 658, col: 5, offset: 15467},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 657, col: 5, offset: 15381},
+							pos:  position{line: 658, col: 5, offset: 15467},
 							name: "LOAD",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 657, col: 10, offset: 15386},
+							pos:  position{line: 658, col: 10, offset: 15472},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 657, col: 12, offset: 15388},
+							pos:   position{line: 658, col: 12, offset: 15474},
 							label: "pool",
 							expr: &ruleRefExpr{
-								pos:  position{line: 657, col: 17, offset: 15393},
+								pos:  position{line: 658, col: 17, offset: 15479},
 								name: "Text",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 657, col: 22, offset: 15398},
+							pos:   position{line: 658, col: 22, offset: 15484},
 							label: "args",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 657, col: 27, offset: 15403},
+								pos: position{line: 658, col: 27, offset: 15489},
 								expr: &ruleRefExpr{
-									pos:  position{line: 657, col: 27, offset: 15403},
+									pos:  position{line: 658, col: 27, offset: 15489},
 									name: "CommitishOpArgs",
 								},
 							},
@@ -4271,26 +4284,26 @@ var g = &grammar{
 		},
 		{
 			name: "OutputOp",
-			pos:  position{line: 666, col: 1, offset: 15585},
+			pos:  position{line: 667, col: 1, offset: 15671},
 			expr: &actionExpr{
-				pos: position{line: 667, col: 5, offset: 15598},
+				pos: position{line: 668, col: 5, offset: 15684},
 				run: (*parser).callonOutputOp1,
 				expr: &seqExpr{
-					pos: position{line: 667, col: 5, offset: 15598},
+					pos: position{line: 668, col: 5, offset: 15684},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 667, col: 5, offset: 15598},
+							pos:  position{line: 668, col: 5, offset: 15684},
 							name: "OUTPUT",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 667, col: 12, offset: 15605},
+							pos:  position{line: 668, col: 12, offset: 15691},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 667, col: 14, offset: 15607},
+							pos:   position{line: 668, col: 14, offset: 15693},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 667, col: 19, offset: 15612},
+								pos:  position{line: 668, col: 19, offset: 15698},
 								name: "Identifier",
 							},
 						},
@@ -4302,37 +4315,37 @@ var g = &grammar{
 		},
 		{
 			name: "DebugOp",
-			pos:  position{line: 675, col: 1, offset: 15750},
+			pos:  position{line: 676, col: 1, offset: 15836},
 			expr: &actionExpr{
-				pos: position{line: 676, col: 5, offset: 15762},
+				pos: position{line: 677, col: 5, offset: 15848},
 				run: (*parser).callonDebugOp1,
 				expr: &seqExpr{
-					pos: position{line: 676, col: 5, offset: 15762},
+					pos: position{line: 677, col: 5, offset: 15848},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 676, col: 5, offset: 15762},
+							pos:  position{line: 677, col: 5, offset: 15848},
 							name: "DEBUG",
 						},
 						&labeledExpr{
-							pos:   position{line: 676, col: 11, offset: 15768},
+							pos:   position{line: 677, col: 11, offset: 15854},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 676, col: 16, offset: 15773},
+								pos: position{line: 677, col: 16, offset: 15859},
 								expr: &actionExpr{
-									pos: position{line: 676, col: 17, offset: 15774},
+									pos: position{line: 677, col: 17, offset: 15860},
 									run: (*parser).callonDebugOp6,
 									expr: &seqExpr{
-										pos: position{line: 676, col: 17, offset: 15774},
+										pos: position{line: 677, col: 17, offset: 15860},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 676, col: 17, offset: 15774},
+												pos:  position{line: 677, col: 17, offset: 15860},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 676, col: 19, offset: 15776},
+												pos:   position{line: 677, col: 19, offset: 15862},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 676, col: 21, offset: 15778},
+													pos:  position{line: 677, col: 21, offset: 15864},
 													name: "Expr",
 												},
 											},
@@ -4349,26 +4362,26 @@ var g = &grammar{
 		},
 		{
 			name: "FromOp",
-			pos:  position{line: 687, col: 1, offset: 15975},
+			pos:  position{line: 688, col: 1, offset: 16061},
 			expr: &actionExpr{
-				pos: position{line: 688, col: 5, offset: 15986},
+				pos: position{line: 689, col: 5, offset: 16072},
 				run: (*parser).callonFromOp1,
 				expr: &seqExpr{
-					pos: position{line: 688, col: 5, offset: 15986},
+					pos: position{line: 689, col: 5, offset: 16072},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 688, col: 5, offset: 15986},
+							pos:  position{line: 689, col: 5, offset: 16072},
 							name: "FROM",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 688, col: 10, offset: 15991},
+							pos:  position{line: 689, col: 10, offset: 16077},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 688, col: 12, offset: 15993},
+							pos:   position{line: 689, col: 12, offset: 16079},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 688, col: 18, offset: 15999},
+								pos:  position{line: 689, col: 18, offset: 16085},
 								name: "FromElems",
 							},
 						},
@@ -4380,51 +4393,51 @@ var g = &grammar{
 		},
 		{
 			name: "FromElems",
-			pos:  position{line: 696, col: 1, offset: 16146},
+			pos:  position{line: 697, col: 1, offset: 16232},
 			expr: &actionExpr{
-				pos: position{line: 697, col: 5, offset: 16160},
+				pos: position{line: 698, col: 5, offset: 16246},
 				run: (*parser).callonFromElems1,
 				expr: &seqExpr{
-					pos: position{line: 697, col: 5, offset: 16160},
+					pos: position{line: 698, col: 5, offset: 16246},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 697, col: 5, offset: 16160},
+							pos:   position{line: 698, col: 5, offset: 16246},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 697, col: 11, offset: 16166},
+								pos:  position{line: 698, col: 11, offset: 16252},
 								name: "FromElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 697, col: 20, offset: 16175},
+							pos:   position{line: 698, col: 20, offset: 16261},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 697, col: 25, offset: 16180},
+								pos: position{line: 698, col: 25, offset: 16266},
 								expr: &actionExpr{
-									pos: position{line: 697, col: 27, offset: 16182},
+									pos: position{line: 698, col: 27, offset: 16268},
 									run: (*parser).callonFromElems7,
 									expr: &seqExpr{
-										pos: position{line: 697, col: 27, offset: 16182},
+										pos: position{line: 698, col: 27, offset: 16268},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 697, col: 27, offset: 16182},
+												pos:  position{line: 698, col: 27, offset: 16268},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 697, col: 30, offset: 16185},
+												pos:        position{line: 698, col: 30, offset: 16271},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 697, col: 34, offset: 16189},
+												pos:  position{line: 698, col: 34, offset: 16275},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 697, col: 37, offset: 16192},
+												pos:   position{line: 698, col: 37, offset: 16278},
 												label: "elem",
 												expr: &ruleRefExpr{
-													pos:  position{line: 697, col: 42, offset: 16197},
+													pos:  position{line: 698, col: 42, offset: 16283},
 													name: "FromElem",
 												},
 											},
@@ -4441,45 +4454,45 @@ var g = &grammar{
 		},
 		{
 			name: "FromElem",
-			pos:  position{line: 701, col: 1, offset: 16277},
+			pos:  position{line: 702, col: 1, offset: 16363},
 			expr: &actionExpr{
-				pos: position{line: 702, col: 5, offset: 16290},
+				pos: position{line: 703, col: 5, offset: 16376},
 				run: (*parser).callonFromElem1,
 				expr: &seqExpr{
-					pos: position{line: 702, col: 5, offset: 16290},
+					pos: position{line: 703, col: 5, offset: 16376},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 702, col: 5, offset: 16290},
+							pos:   position{line: 703, col: 5, offset: 16376},
 							label: "entity",
 							expr: &ruleRefExpr{
-								pos:  position{line: 702, col: 12, offset: 16297},
+								pos:  position{line: 703, col: 12, offset: 16383},
 								name: "FromEntity",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 702, col: 23, offset: 16308},
+							pos:   position{line: 703, col: 23, offset: 16394},
 							label: "args",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 702, col: 28, offset: 16313},
+								pos: position{line: 703, col: 28, offset: 16399},
 								expr: &ruleRefExpr{
-									pos:  position{line: 702, col: 28, offset: 16313},
+									pos:  position{line: 703, col: 28, offset: 16399},
 									name: "CommitishOpArgs",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 702, col: 45, offset: 16330},
+							pos:   position{line: 703, col: 45, offset: 16416},
 							label: "o",
 							expr: &ruleRefExpr{
-								pos:  position{line: 702, col: 47, offset: 16332},
+								pos:  position{line: 703, col: 47, offset: 16418},
 								name: "OptOrdinality",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 702, col: 61, offset: 16346},
+							pos:   position{line: 703, col: 61, offset: 16432},
 							label: "alias",
 							expr: &ruleRefExpr{
-								pos:  position{line: 702, col: 67, offset: 16352},
+								pos:  position{line: 703, col: 67, offset: 16438},
 								name: "OptAlias",
 							},
 						},
@@ -4491,34 +4504,34 @@ var g = &grammar{
 		},
 		{
 			name: "FromEntity",
-			pos:  position{line: 719, col: 1, offset: 16719},
+			pos:  position{line: 720, col: 1, offset: 16805},
 			expr: &choiceExpr{
-				pos: position{line: 720, col: 5, offset: 16734},
+				pos: position{line: 721, col: 5, offset: 16820},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 720, col: 5, offset: 16734},
+						pos:  position{line: 721, col: 5, offset: 16820},
 						name: "Regexp",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 721, col: 5, offset: 16745},
+						pos:  position{line: 722, col: 5, offset: 16831},
 						name: "Glob",
 					},
 					&actionExpr{
-						pos: position{line: 722, col: 5, offset: 16754},
+						pos: position{line: 723, col: 5, offset: 16840},
 						run: (*parser).callonFromEntity4,
 						expr: &seqExpr{
-							pos: position{line: 722, col: 5, offset: 16754},
+							pos: position{line: 723, col: 5, offset: 16840},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 722, col: 5, offset: 16754},
+									pos:        position{line: 723, col: 5, offset: 16840},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 								&notExpr{
-									pos: position{line: 722, col: 9, offset: 16758},
+									pos: position{line: 723, col: 9, offset: 16844},
 									expr: &ruleRefExpr{
-										pos:  position{line: 722, col: 10, offset: 16759},
+										pos:  position{line: 723, col: 10, offset: 16845},
 										name: "ExprGuard",
 									},
 								},
@@ -4526,43 +4539,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 723, col: 5, offset: 16848},
+						pos: position{line: 724, col: 5, offset: 16934},
 						run: (*parser).callonFromEntity9,
 						expr: &seqExpr{
-							pos: position{line: 723, col: 5, offset: 16848},
+							pos: position{line: 724, col: 5, offset: 16934},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 723, col: 5, offset: 16848},
+									pos:  position{line: 724, col: 5, offset: 16934},
 									name: "EVAL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 723, col: 10, offset: 16853},
+									pos:  position{line: 724, col: 10, offset: 16939},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 723, col: 13, offset: 16856},
+									pos:        position{line: 724, col: 13, offset: 16942},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 723, col: 17, offset: 16860},
+									pos:  position{line: 724, col: 17, offset: 16946},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 723, col: 20, offset: 16863},
+									pos:   position{line: 724, col: 20, offset: 16949},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 723, col: 22, offset: 16865},
+										pos:  position{line: 724, col: 22, offset: 16951},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 723, col: 27, offset: 16870},
+									pos:  position{line: 724, col: 27, offset: 16956},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 723, col: 30, offset: 16873},
+									pos:        position{line: 724, col: 30, offset: 16959},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4571,35 +4584,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 730, col: 5, offset: 17009},
+						pos: position{line: 731, col: 5, offset: 17095},
 						run: (*parser).callonFromEntity19,
 						expr: &labeledExpr{
-							pos:   position{line: 730, col: 5, offset: 17009},
+							pos:   position{line: 731, col: 5, offset: 17095},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 730, col: 10, offset: 17014},
+								pos:  position{line: 731, col: 10, offset: 17100},
 								name: "ColonName",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 737, col: 5, offset: 17152},
+						pos: position{line: 738, col: 5, offset: 17238},
 						run: (*parser).callonFromEntity22,
 						expr: &seqExpr{
-							pos: position{line: 737, col: 5, offset: 17152},
+							pos: position{line: 738, col: 5, offset: 17238},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 737, col: 5, offset: 17152},
+									pos:   position{line: 738, col: 5, offset: 17238},
 									label: "join",
 									expr: &ruleRefExpr{
-										pos:  position{line: 737, col: 10, offset: 17157},
+										pos:  position{line: 738, col: 10, offset: 17243},
 										name: "JoinOperation",
 									},
 								},
 								&notExpr{
-									pos: position{line: 737, col: 24, offset: 17171},
+									pos: position{line: 738, col: 24, offset: 17257},
 									expr: &ruleRefExpr{
-										pos:  position{line: 737, col: 25, offset: 17172},
+										pos:  position{line: 738, col: 25, offset: 17258},
 										name: "AliasClause",
 									},
 								},
@@ -4607,35 +4620,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 738, col: 5, offset: 17207},
+						pos: position{line: 739, col: 5, offset: 17293},
 						run: (*parser).callonFromEntity28,
 						expr: &seqExpr{
-							pos: position{line: 738, col: 5, offset: 17207},
+							pos: position{line: 739, col: 5, offset: 17293},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 738, col: 5, offset: 17207},
+									pos:        position{line: 739, col: 5, offset: 17293},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 738, col: 9, offset: 17211},
+									pos:  position{line: 739, col: 9, offset: 17297},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 738, col: 12, offset: 17214},
+									pos:   position{line: 739, col: 12, offset: 17300},
 									label: "join",
 									expr: &ruleRefExpr{
-										pos:  position{line: 738, col: 17, offset: 17219},
+										pos:  position{line: 739, col: 17, offset: 17305},
 										name: "JoinOperation",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 738, col: 31, offset: 17233},
+									pos:  position{line: 739, col: 31, offset: 17319},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 738, col: 34, offset: 17236},
+									pos:        position{line: 739, col: 34, offset: 17322},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4644,35 +4657,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 739, col: 5, offset: 17265},
+						pos: position{line: 740, col: 5, offset: 17351},
 						run: (*parser).callonFromEntity36,
 						expr: &seqExpr{
-							pos: position{line: 739, col: 5, offset: 17265},
+							pos: position{line: 740, col: 5, offset: 17351},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 739, col: 5, offset: 17265},
+									pos:        position{line: 740, col: 5, offset: 17351},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 739, col: 9, offset: 17269},
+									pos:  position{line: 740, col: 9, offset: 17355},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 739, col: 12, offset: 17272},
+									pos:   position{line: 740, col: 12, offset: 17358},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 739, col: 14, offset: 17274},
+										pos:  position{line: 740, col: 14, offset: 17360},
 										name: "SQLPipe",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 739, col: 22, offset: 17282},
+									pos:  position{line: 740, col: 22, offset: 17368},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 739, col: 25, offset: 17285},
+									pos:        position{line: 740, col: 25, offset: 17371},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -4681,7 +4694,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 742, col: 5, offset: 17321},
+						pos:  position{line: 743, col: 5, offset: 17407},
 						name: "Text",
 					},
 				},
@@ -4691,34 +4704,34 @@ var g = &grammar{
 		},
 		{
 			name: "Text",
-			pos:  position{line: 745, col: 1, offset: 17395},
+			pos:  position{line: 746, col: 1, offset: 17481},
 			expr: &actionExpr{
-				pos: position{line: 746, col: 4, offset: 17403},
+				pos: position{line: 747, col: 4, offset: 17489},
 				run: (*parser).callonText1,
 				expr: &labeledExpr{
-					pos:   position{line: 746, col: 4, offset: 17403},
+					pos:   position{line: 747, col: 4, offset: 17489},
 					label: "s",
 					expr: &choiceExpr{
-						pos: position{line: 746, col: 7, offset: 17406},
+						pos: position{line: 747, col: 7, offset: 17492},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 746, col: 7, offset: 17406},
+								pos:  position{line: 747, col: 7, offset: 17492},
 								name: "SimpleURL",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 746, col: 19, offset: 17418},
+								pos:  position{line: 747, col: 19, offset: 17504},
 								name: "TextChars",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 746, col: 31, offset: 17430},
+								pos:  position{line: 747, col: 31, offset: 17516},
 								name: "DoubleQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 746, col: 52, offset: 17451},
+								pos:  position{line: 747, col: 52, offset: 17537},
 								name: "SingleQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 746, col: 73, offset: 17472},
+								pos:  position{line: 747, col: 73, offset: 17558},
 								name: "RString",
 							},
 						},
@@ -4730,38 +4743,38 @@ var g = &grammar{
 		},
 		{
 			name: "SimpleURL",
-			pos:  position{line: 750, col: 1, offset: 17561},
+			pos:  position{line: 751, col: 1, offset: 17647},
 			expr: &actionExpr{
-				pos: position{line: 751, col: 3, offset: 17575},
+				pos: position{line: 752, col: 3, offset: 17661},
 				run: (*parser).callonSimpleURL1,
 				expr: &seqExpr{
-					pos: position{line: 751, col: 3, offset: 17575},
+					pos: position{line: 752, col: 3, offset: 17661},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 751, col: 3, offset: 17575},
+							pos:        position{line: 752, col: 3, offset: 17661},
 							val:        "http",
 							ignoreCase: false,
 							want:       "\"http\"",
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 751, col: 10, offset: 17582},
+							pos: position{line: 752, col: 10, offset: 17668},
 							expr: &litMatcher{
-								pos:        position{line: 751, col: 10, offset: 17582},
+								pos:        position{line: 752, col: 10, offset: 17668},
 								val:        "s",
 								ignoreCase: false,
 								want:       "\"s\"",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 751, col: 15, offset: 17587},
+							pos:        position{line: 752, col: 15, offset: 17673},
 							val:        "://",
 							ignoreCase: false,
 							want:       "\"://\"",
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 752, col: 4, offset: 17596},
+							pos: position{line: 753, col: 4, offset: 17682},
 							expr: &charClassMatcher{
-								pos:        position{line: 752, col: 4, offset: 17596},
+								pos:        position{line: 753, col: 4, offset: 17682},
 								val:        "[a-zA-Z0-9_-]",
 								chars:      []rune{'_', '-'},
 								ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -4770,20 +4783,20 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 752, col: 20, offset: 17612},
+							pos: position{line: 753, col: 20, offset: 17698},
 							expr: &seqExpr{
-								pos: position{line: 752, col: 22, offset: 17614},
+								pos: position{line: 753, col: 22, offset: 17700},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 752, col: 22, offset: 17614},
+										pos:        position{line: 753, col: 22, offset: 17700},
 										val:        ".",
 										ignoreCase: false,
 										want:       "\".\"",
 									},
 									&oneOrMoreExpr{
-										pos: position{line: 752, col: 26, offset: 17618},
+										pos: position{line: 753, col: 26, offset: 17704},
 										expr: &charClassMatcher{
-											pos:        position{line: 752, col: 26, offset: 17618},
+											pos:        position{line: 753, col: 26, offset: 17704},
 											val:        "[a-zA-Z0-9_-]",
 											chars:      []rune{'_', '-'},
 											ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -4795,20 +4808,20 @@ var g = &grammar{
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 753, col: 3, offset: 17637},
+							pos: position{line: 754, col: 3, offset: 17723},
 							expr: &seqExpr{
-								pos: position{line: 753, col: 4, offset: 17638},
+								pos: position{line: 754, col: 4, offset: 17724},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 753, col: 4, offset: 17638},
+										pos:        position{line: 754, col: 4, offset: 17724},
 										val:        "/",
 										ignoreCase: false,
 										want:       "\"/\"",
 									},
 									&zeroOrOneExpr{
-										pos: position{line: 753, col: 8, offset: 17642},
+										pos: position{line: 754, col: 8, offset: 17728},
 										expr: &ruleRefExpr{
-											pos:  position{line: 753, col: 8, offset: 17642},
+											pos:  position{line: 754, col: 8, offset: 17728},
 											name: "TextChars",
 										},
 									},
@@ -4823,27 +4836,27 @@ var g = &grammar{
 		},
 		{
 			name: "TextChars",
-			pos:  position{line: 755, col: 1, offset: 17687},
+			pos:  position{line: 756, col: 1, offset: 17773},
 			expr: &actionExpr{
-				pos: position{line: 756, col: 5, offset: 17701},
+				pos: position{line: 757, col: 5, offset: 17787},
 				run: (*parser).callonTextChars1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 756, col: 5, offset: 17701},
+					pos: position{line: 757, col: 5, offset: 17787},
 					expr: &choiceExpr{
-						pos: position{line: 756, col: 6, offset: 17702},
+						pos: position{line: 757, col: 6, offset: 17788},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 756, col: 6, offset: 17702},
+								pos:  position{line: 757, col: 6, offset: 17788},
 								name: "IdentifierRest",
 							},
 							&litMatcher{
-								pos:        position{line: 756, col: 23, offset: 17719},
+								pos:        position{line: 757, col: 23, offset: 17805},
 								val:        ".",
 								ignoreCase: false,
 								want:       "\".\"",
 							},
 							&litMatcher{
-								pos:        position{line: 756, col: 29, offset: 17725},
+								pos:        position{line: 757, col: 29, offset: 17811},
 								val:        "/",
 								ignoreCase: false,
 								want:       "\"/\"",
@@ -4857,40 +4870,40 @@ var g = &grammar{
 		},
 		{
 			name: "CommitishOpArgs",
-			pos:  position{line: 758, col: 1, offset: 17763},
+			pos:  position{line: 759, col: 1, offset: 17849},
 			expr: &choiceExpr{
-				pos: position{line: 759, col: 5, offset: 17783},
+				pos: position{line: 760, col: 5, offset: 17869},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 759, col: 5, offset: 17783},
+						pos: position{line: 760, col: 5, offset: 17869},
 						run: (*parser).callonCommitishOpArgs2,
 						expr: &seqExpr{
-							pos: position{line: 759, col: 5, offset: 17783},
+							pos: position{line: 760, col: 5, offset: 17869},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 759, col: 5, offset: 17783},
+									pos:  position{line: 760, col: 5, offset: 17869},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 759, col: 8, offset: 17786},
+									pos:   position{line: 760, col: 8, offset: 17872},
 									label: "commit",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 759, col: 15, offset: 17793},
+										pos: position{line: 760, col: 15, offset: 17879},
 										expr: &ruleRefExpr{
-											pos:  position{line: 759, col: 15, offset: 17793},
+											pos:  position{line: 760, col: 15, offset: 17879},
 											name: "MetaCommitish",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 759, col: 30, offset: 17808},
+									pos:  position{line: 760, col: 30, offset: 17894},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 759, col: 33, offset: 17811},
+									pos:   position{line: 760, col: 33, offset: 17897},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 759, col: 38, offset: 17816},
+										pos:  position{line: 760, col: 38, offset: 17902},
 										name: "OpArgs",
 									},
 								},
@@ -4898,20 +4911,20 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 765, col: 5, offset: 17946},
+						pos: position{line: 766, col: 5, offset: 18032},
 						run: (*parser).callonCommitishOpArgs11,
 						expr: &seqExpr{
-							pos: position{line: 765, col: 5, offset: 17946},
+							pos: position{line: 766, col: 5, offset: 18032},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 765, col: 5, offset: 17946},
+									pos:  position{line: 766, col: 5, offset: 18032},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 765, col: 8, offset: 17949},
+									pos:   position{line: 766, col: 8, offset: 18035},
 									label: "commit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 765, col: 15, offset: 17956},
+										pos:  position{line: 766, col: 15, offset: 18042},
 										name: "MetaCommitish",
 									},
 								},
@@ -4925,31 +4938,31 @@ var g = &grammar{
 		},
 		{
 			name: "MetaCommitish",
-			pos:  position{line: 767, col: 1, offset: 17994},
+			pos:  position{line: 768, col: 1, offset: 18080},
 			expr: &choiceExpr{
-				pos: position{line: 768, col: 5, offset: 18012},
+				pos: position{line: 769, col: 5, offset: 18098},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 768, col: 5, offset: 18012},
+						pos: position{line: 769, col: 5, offset: 18098},
 						run: (*parser).callonMetaCommitish2,
 						expr: &seqExpr{
-							pos: position{line: 768, col: 5, offset: 18012},
+							pos: position{line: 769, col: 5, offset: 18098},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 768, col: 5, offset: 18012},
+									pos:   position{line: 769, col: 5, offset: 18098},
 									label: "commit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 768, col: 12, offset: 18019},
+										pos:  position{line: 769, col: 12, offset: 18105},
 										name: "Commitish",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 768, col: 22, offset: 18029},
+									pos:   position{line: 769, col: 22, offset: 18115},
 									label: "meta",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 768, col: 27, offset: 18034},
+										pos: position{line: 769, col: 27, offset: 18120},
 										expr: &ruleRefExpr{
-											pos:  position{line: 768, col: 27, offset: 18034},
+											pos:  position{line: 769, col: 27, offset: 18120},
 											name: "ColonName",
 										},
 									},
@@ -4958,13 +4971,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 775, col: 5, offset: 18258},
+						pos: position{line: 776, col: 5, offset: 18344},
 						run: (*parser).callonMetaCommitish9,
 						expr: &labeledExpr{
-							pos:   position{line: 775, col: 5, offset: 18258},
+							pos:   position{line: 776, col: 5, offset: 18344},
 							label: "meta",
 							expr: &ruleRefExpr{
-								pos:  position{line: 775, col: 10, offset: 18263},
+								pos:  position{line: 776, col: 10, offset: 18349},
 								name: "ColonName",
 							},
 						},
@@ -4976,24 +4989,24 @@ var g = &grammar{
 		},
 		{
 			name: "Commitish",
-			pos:  position{line: 779, col: 1, offset: 18387},
+			pos:  position{line: 780, col: 1, offset: 18473},
 			expr: &actionExpr{
-				pos: position{line: 780, col: 5, offset: 18401},
+				pos: position{line: 781, col: 5, offset: 18487},
 				run: (*parser).callonCommitish1,
 				expr: &seqExpr{
-					pos: position{line: 780, col: 5, offset: 18401},
+					pos: position{line: 781, col: 5, offset: 18487},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 780, col: 5, offset: 18401},
+							pos:        position{line: 781, col: 5, offset: 18487},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 780, col: 9, offset: 18405},
+							pos:   position{line: 781, col: 9, offset: 18491},
 							label: "text",
 							expr: &ruleRefExpr{
-								pos:  position{line: 780, col: 14, offset: 18410},
+								pos:  position{line: 781, col: 14, offset: 18496},
 								name: "CommitText",
 							},
 						},
@@ -5005,19 +5018,19 @@ var g = &grammar{
 		},
 		{
 			name: "CommitText",
-			pos:  position{line: 784, col: 1, offset: 18545},
+			pos:  position{line: 785, col: 1, offset: 18631},
 			expr: &choiceExpr{
-				pos: position{line: 785, col: 5, offset: 18560},
+				pos: position{line: 786, col: 5, offset: 18646},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 785, col: 5, offset: 18560},
+						pos:  position{line: 786, col: 5, offset: 18646},
 						name: "Name",
 					},
 					&actionExpr{
-						pos: position{line: 786, col: 5, offset: 18569},
+						pos: position{line: 787, col: 5, offset: 18655},
 						run: (*parser).callonCommitText3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 786, col: 5, offset: 18569},
+							pos:  position{line: 787, col: 5, offset: 18655},
 							name: "KSUID",
 						},
 					},
@@ -5028,11 +5041,11 @@ var g = &grammar{
 		},
 		{
 			name: "KSUID",
-			pos:  position{line: 788, col: 1, offset: 18647},
+			pos:  position{line: 789, col: 1, offset: 18733},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 788, col: 9, offset: 18655},
+				pos: position{line: 789, col: 9, offset: 18741},
 				expr: &charClassMatcher{
-					pos:        position{line: 788, col: 9, offset: 18655},
+					pos:        position{line: 789, col: 9, offset: 18741},
 					val:        "[0-9a-zA-Z]",
 					ranges:     []rune{'0', '9', 'a', 'z', 'A', 'Z'},
 					ignoreCase: false,
@@ -5044,40 +5057,40 @@ var g = &grammar{
 		},
 		{
 			name: "OpArg",
-			pos:  position{line: 790, col: 1, offset: 18669},
+			pos:  position{line: 791, col: 1, offset: 18755},
 			expr: &choiceExpr{
-				pos: position{line: 791, col: 5, offset: 18679},
+				pos: position{line: 792, col: 5, offset: 18765},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 791, col: 5, offset: 18679},
+						pos: position{line: 792, col: 5, offset: 18765},
 						run: (*parser).callonOpArg2,
 						expr: &seqExpr{
-							pos: position{line: 791, col: 5, offset: 18679},
+							pos: position{line: 792, col: 5, offset: 18765},
 							exprs: []any{
 								&andExpr{
-									pos: position{line: 791, col: 5, offset: 18679},
+									pos: position{line: 792, col: 5, offset: 18765},
 									expr: &ruleRefExpr{
-										pos:  position{line: 791, col: 6, offset: 18680},
+										pos:  position{line: 792, col: 6, offset: 18766},
 										name: "ArgNameExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 791, col: 18, offset: 18692},
+									pos:   position{line: 792, col: 18, offset: 18778},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 791, col: 22, offset: 18696},
+										pos:  position{line: 792, col: 22, offset: 18782},
 										name: "ArgName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 791, col: 30, offset: 18704},
+									pos:  position{line: 792, col: 30, offset: 18790},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 791, col: 32, offset: 18706},
+									pos:   position{line: 792, col: 32, offset: 18792},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 791, col: 34, offset: 18708},
+										pos:  position{line: 792, col: 34, offset: 18794},
 										name: "Expr",
 									},
 								},
@@ -5085,28 +5098,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 792, col: 5, offset: 18815},
+						pos: position{line: 793, col: 5, offset: 18901},
 						run: (*parser).callonOpArg11,
 						expr: &seqExpr{
-							pos: position{line: 792, col: 5, offset: 18815},
+							pos: position{line: 793, col: 5, offset: 18901},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 792, col: 5, offset: 18815},
+									pos:   position{line: 793, col: 5, offset: 18901},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 792, col: 9, offset: 18819},
+										pos:  position{line: 793, col: 9, offset: 18905},
 										name: "ArgName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 792, col: 17, offset: 18827},
+									pos:  position{line: 793, col: 17, offset: 18913},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 792, col: 19, offset: 18829},
+									pos:   position{line: 793, col: 19, offset: 18915},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 792, col: 21, offset: 18831},
+										pos:  position{line: 793, col: 21, offset: 18917},
 										name: "Text",
 									},
 								},
@@ -5120,51 +5133,51 @@ var g = &grammar{
 		},
 		{
 			name: "OpArgs",
-			pos:  position{line: 794, col: 1, offset: 18936},
+			pos:  position{line: 795, col: 1, offset: 19022},
 			expr: &actionExpr{
-				pos: position{line: 795, col: 5, offset: 18947},
+				pos: position{line: 796, col: 5, offset: 19033},
 				run: (*parser).callonOpArgs1,
 				expr: &seqExpr{
-					pos: position{line: 795, col: 5, offset: 18947},
+					pos: position{line: 796, col: 5, offset: 19033},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 795, col: 5, offset: 18947},
+							pos:        position{line: 796, col: 5, offset: 19033},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 795, col: 9, offset: 18951},
+							pos:  position{line: 796, col: 9, offset: 19037},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 795, col: 12, offset: 18954},
+							pos:   position{line: 796, col: 12, offset: 19040},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 795, col: 18, offset: 18960},
+								pos:  position{line: 796, col: 18, offset: 19046},
 								name: "OpArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 795, col: 24, offset: 18966},
+							pos:   position{line: 796, col: 24, offset: 19052},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 795, col: 29, offset: 18971},
+								pos: position{line: 796, col: 29, offset: 19057},
 								expr: &actionExpr{
-									pos: position{line: 795, col: 30, offset: 18972},
+									pos: position{line: 796, col: 30, offset: 19058},
 									run: (*parser).callonOpArgs9,
 									expr: &seqExpr{
-										pos: position{line: 795, col: 30, offset: 18972},
+										pos: position{line: 796, col: 30, offset: 19058},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 795, col: 30, offset: 18972},
+												pos:  position{line: 796, col: 30, offset: 19058},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 795, col: 32, offset: 18974},
+												pos:   position{line: 796, col: 32, offset: 19060},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 795, col: 34, offset: 18976},
+													pos:  position{line: 796, col: 34, offset: 19062},
 													name: "OpArg",
 												},
 											},
@@ -5174,11 +5187,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 795, col: 60, offset: 19002},
+							pos:  position{line: 796, col: 60, offset: 19088},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 795, col: 63, offset: 19005},
+							pos:        position{line: 796, col: 63, offset: 19091},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -5191,14 +5204,14 @@ var g = &grammar{
 		},
 		{
 			name: "ArgName",
-			pos:  position{line: 799, col: 1, offset: 19057},
+			pos:  position{line: 800, col: 1, offset: 19143},
 			expr: &actionExpr{
-				pos: position{line: 799, col: 11, offset: 19067},
+				pos: position{line: 800, col: 11, offset: 19153},
 				run: (*parser).callonArgName1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 799, col: 11, offset: 19067},
+					pos: position{line: 800, col: 11, offset: 19153},
 					expr: &ruleRefExpr{
-						pos:  position{line: 799, col: 11, offset: 19067},
+						pos:  position{line: 800, col: 11, offset: 19153},
 						name: "UnicodeLetter",
 					},
 				},
@@ -5208,20 +5221,20 @@ var g = &grammar{
 		},
 		{
 			name: "ArgNameExpr",
-			pos:  position{line: 801, col: 1, offset: 19114},
+			pos:  position{line: 802, col: 1, offset: 19200},
 			expr: &seqExpr{
-				pos: position{line: 802, col: 5, offset: 19130},
+				pos: position{line: 803, col: 5, offset: 19216},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 802, col: 5, offset: 19130},
+						pos:        position{line: 803, col: 5, offset: 19216},
 						val:        "headers",
 						ignoreCase: true,
 						want:       "\"headers\"i",
 					},
 					&notExpr{
-						pos: position{line: 802, col: 16, offset: 19141},
+						pos: position{line: 803, col: 16, offset: 19227},
 						expr: &ruleRefExpr{
-							pos:  position{line: 802, col: 17, offset: 19142},
+							pos:  position{line: 803, col: 17, offset: 19228},
 							name: "UnicodeLetter",
 						},
 					},
@@ -5232,24 +5245,24 @@ var g = &grammar{
 		},
 		{
 			name: "ColonName",
-			pos:  position{line: 804, col: 1, offset: 19157},
+			pos:  position{line: 805, col: 1, offset: 19243},
 			expr: &actionExpr{
-				pos: position{line: 805, col: 5, offset: 19171},
+				pos: position{line: 806, col: 5, offset: 19257},
 				run: (*parser).callonColonName1,
 				expr: &seqExpr{
-					pos: position{line: 805, col: 5, offset: 19171},
+					pos: position{line: 806, col: 5, offset: 19257},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 805, col: 5, offset: 19171},
+							pos:        position{line: 806, col: 5, offset: 19257},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 805, col: 9, offset: 19175},
+							pos:   position{line: 806, col: 9, offset: 19261},
 							label: "n",
 							expr: &ruleRefExpr{
-								pos:  position{line: 805, col: 11, offset: 19177},
+								pos:  position{line: 806, col: 11, offset: 19263},
 								name: "Name",
 							},
 						},
@@ -5261,21 +5274,21 @@ var g = &grammar{
 		},
 		{
 			name: "PassOp",
-			pos:  position{line: 807, col: 1, offset: 19201},
+			pos:  position{line: 808, col: 1, offset: 19287},
 			expr: &actionExpr{
-				pos: position{line: 808, col: 5, offset: 19212},
+				pos: position{line: 809, col: 5, offset: 19298},
 				run: (*parser).callonPassOp1,
 				expr: &seqExpr{
-					pos: position{line: 808, col: 5, offset: 19212},
+					pos: position{line: 809, col: 5, offset: 19298},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 808, col: 5, offset: 19212},
+							pos:  position{line: 809, col: 5, offset: 19298},
 							name: "PASS",
 						},
 						&andExpr{
-							pos: position{line: 808, col: 10, offset: 19217},
+							pos: position{line: 809, col: 10, offset: 19303},
 							expr: &ruleRefExpr{
-								pos:  position{line: 808, col: 11, offset: 19218},
+								pos:  position{line: 809, col: 11, offset: 19304},
 								name: "EndOfOp",
 							},
 						},
@@ -5287,44 +5300,44 @@ var g = &grammar{
 		},
 		{
 			name: "ExplodeOp",
-			pos:  position{line: 814, col: 1, offset: 19416},
+			pos:  position{line: 815, col: 1, offset: 19502},
 			expr: &actionExpr{
-				pos: position{line: 815, col: 5, offset: 19430},
+				pos: position{line: 816, col: 5, offset: 19516},
 				run: (*parser).callonExplodeOp1,
 				expr: &seqExpr{
-					pos: position{line: 815, col: 5, offset: 19430},
+					pos: position{line: 816, col: 5, offset: 19516},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 815, col: 5, offset: 19430},
+							pos:  position{line: 816, col: 5, offset: 19516},
 							name: "EXPLODE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 815, col: 13, offset: 19438},
+							pos:  position{line: 816, col: 13, offset: 19524},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 815, col: 15, offset: 19440},
+							pos:   position{line: 816, col: 15, offset: 19526},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 815, col: 20, offset: 19445},
+								pos:  position{line: 816, col: 20, offset: 19531},
 								name: "Exprs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 815, col: 26, offset: 19451},
+							pos:   position{line: 816, col: 26, offset: 19537},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 815, col: 30, offset: 19455},
+								pos:  position{line: 816, col: 30, offset: 19541},
 								name: "TypeArg",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 815, col: 38, offset: 19463},
+							pos:   position{line: 816, col: 38, offset: 19549},
 							label: "as",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 815, col: 41, offset: 19466},
+								pos: position{line: 816, col: 41, offset: 19552},
 								expr: &ruleRefExpr{
-									pos:  position{line: 815, col: 41, offset: 19466},
+									pos:  position{line: 816, col: 41, offset: 19552},
 									name: "AsArg",
 								},
 							},
@@ -5337,26 +5350,26 @@ var g = &grammar{
 		},
 		{
 			name: "MergeOp",
-			pos:  position{line: 828, col: 1, offset: 19712},
+			pos:  position{line: 829, col: 1, offset: 19798},
 			expr: &actionExpr{
-				pos: position{line: 829, col: 5, offset: 19724},
+				pos: position{line: 830, col: 5, offset: 19810},
 				run: (*parser).callonMergeOp1,
 				expr: &seqExpr{
-					pos: position{line: 829, col: 5, offset: 19724},
+					pos: position{line: 830, col: 5, offset: 19810},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 829, col: 5, offset: 19724},
+							pos:  position{line: 830, col: 5, offset: 19810},
 							name: "MERGE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 829, col: 11, offset: 19730},
+							pos:  position{line: 830, col: 11, offset: 19816},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 829, col: 13, offset: 19732},
+							pos:   position{line: 830, col: 13, offset: 19818},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 829, col: 19, offset: 19738},
+								pos:  position{line: 830, col: 19, offset: 19824},
 								name: "OrderByList",
 							},
 						},
@@ -5368,59 +5381,59 @@ var g = &grammar{
 		},
 		{
 			name: "UnnestOp",
-			pos:  position{line: 837, col: 1, offset: 19884},
+			pos:  position{line: 838, col: 1, offset: 19970},
 			expr: &actionExpr{
-				pos: position{line: 838, col: 6, offset: 19898},
+				pos: position{line: 839, col: 6, offset: 19984},
 				run: (*parser).callonUnnestOp1,
 				expr: &seqExpr{
-					pos: position{line: 838, col: 6, offset: 19898},
+					pos: position{line: 839, col: 6, offset: 19984},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 838, col: 6, offset: 19898},
+							pos:  position{line: 839, col: 6, offset: 19984},
 							name: "UNNEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 838, col: 13, offset: 19905},
+							pos:  position{line: 839, col: 13, offset: 19991},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 838, col: 15, offset: 19907},
+							pos:   position{line: 839, col: 15, offset: 19993},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 838, col: 17, offset: 19909},
+								pos:  position{line: 839, col: 17, offset: 19995},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 838, col: 22, offset: 19914},
+							pos:   position{line: 839, col: 22, offset: 20000},
 							label: "body",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 838, col: 27, offset: 19919},
+								pos: position{line: 839, col: 27, offset: 20005},
 								expr: &actionExpr{
-									pos: position{line: 838, col: 28, offset: 19920},
+									pos: position{line: 839, col: 28, offset: 20006},
 									run: (*parser).callonUnnestOp9,
 									expr: &seqExpr{
-										pos: position{line: 838, col: 28, offset: 19920},
+										pos: position{line: 839, col: 28, offset: 20006},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 838, col: 28, offset: 19920},
+												pos:  position{line: 839, col: 28, offset: 20006},
 												name: "_",
 											},
 											&litMatcher{
-												pos:        position{line: 838, col: 30, offset: 19922},
+												pos:        position{line: 839, col: 30, offset: 20008},
 												val:        "into",
 												ignoreCase: true,
 												want:       "\"into\"i",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 838, col: 38, offset: 19930},
+												pos:  position{line: 839, col: 38, offset: 20016},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 838, col: 40, offset: 19932},
+												pos:   position{line: 839, col: 40, offset: 20018},
 												label: "body",
 												expr: &ruleRefExpr{
-													pos:  position{line: 838, col: 45, offset: 19937},
+													pos:  position{line: 839, col: 45, offset: 20023},
 													name: "ScopeBody",
 												},
 											},
@@ -5437,30 +5450,30 @@ var g = &grammar{
 		},
 		{
 			name: "TypeArg",
-			pos:  position{line: 850, col: 1, offset: 20178},
+			pos:  position{line: 851, col: 1, offset: 20264},
 			expr: &actionExpr{
-				pos: position{line: 851, col: 5, offset: 20190},
+				pos: position{line: 852, col: 5, offset: 20276},
 				run: (*parser).callonTypeArg1,
 				expr: &seqExpr{
-					pos: position{line: 851, col: 5, offset: 20190},
+					pos: position{line: 852, col: 5, offset: 20276},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 851, col: 5, offset: 20190},
+							pos:  position{line: 852, col: 5, offset: 20276},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 851, col: 7, offset: 20192},
+							pos:  position{line: 852, col: 7, offset: 20278},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 851, col: 10, offset: 20195},
+							pos:  position{line: 852, col: 10, offset: 20281},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 851, col: 12, offset: 20197},
+							pos:   position{line: 852, col: 12, offset: 20283},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 851, col: 16, offset: 20201},
+								pos:  position{line: 852, col: 16, offset: 20287},
 								name: "Type",
 							},
 						},
@@ -5472,30 +5485,30 @@ var g = &grammar{
 		},
 		{
 			name: "AsArg",
-			pos:  position{line: 853, col: 1, offset: 20227},
+			pos:  position{line: 854, col: 1, offset: 20313},
 			expr: &actionExpr{
-				pos: position{line: 854, col: 5, offset: 20237},
+				pos: position{line: 855, col: 5, offset: 20323},
 				run: (*parser).callonAsArg1,
 				expr: &seqExpr{
-					pos: position{line: 854, col: 5, offset: 20237},
+					pos: position{line: 855, col: 5, offset: 20323},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 854, col: 5, offset: 20237},
+							pos:  position{line: 855, col: 5, offset: 20323},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 854, col: 7, offset: 20239},
+							pos:  position{line: 855, col: 7, offset: 20325},
 							name: "AS",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 854, col: 10, offset: 20242},
+							pos:  position{line: 855, col: 10, offset: 20328},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 854, col: 12, offset: 20244},
+							pos:   position{line: 855, col: 12, offset: 20330},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 854, col: 16, offset: 20248},
+								pos:  position{line: 855, col: 16, offset: 20334},
 								name: "Lval",
 							},
 						},
@@ -5507,9 +5520,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 858, col: 1, offset: 20299},
+			pos:  position{line: 859, col: 1, offset: 20385},
 			expr: &ruleRefExpr{
-				pos:  position{line: 858, col: 8, offset: 20306},
+				pos:  position{line: 859, col: 8, offset: 20392},
 				name: "DerefExpr",
 			},
 			leader:        false,
@@ -5517,51 +5530,51 @@ var g = &grammar{
 		},
 		{
 			name: "Lvals",
-			pos:  position{line: 860, col: 1, offset: 20317},
+			pos:  position{line: 861, col: 1, offset: 20403},
 			expr: &actionExpr{
-				pos: position{line: 861, col: 5, offset: 20327},
+				pos: position{line: 862, col: 5, offset: 20413},
 				run: (*parser).callonLvals1,
 				expr: &seqExpr{
-					pos: position{line: 861, col: 5, offset: 20327},
+					pos: position{line: 862, col: 5, offset: 20413},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 861, col: 5, offset: 20327},
+							pos:   position{line: 862, col: 5, offset: 20413},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 861, col: 11, offset: 20333},
+								pos:  position{line: 862, col: 11, offset: 20419},
 								name: "Lval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 861, col: 16, offset: 20338},
+							pos:   position{line: 862, col: 16, offset: 20424},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 861, col: 21, offset: 20343},
+								pos: position{line: 862, col: 21, offset: 20429},
 								expr: &actionExpr{
-									pos: position{line: 861, col: 22, offset: 20344},
+									pos: position{line: 862, col: 22, offset: 20430},
 									run: (*parser).callonLvals7,
 									expr: &seqExpr{
-										pos: position{line: 861, col: 22, offset: 20344},
+										pos: position{line: 862, col: 22, offset: 20430},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 861, col: 22, offset: 20344},
+												pos:  position{line: 862, col: 22, offset: 20430},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 861, col: 25, offset: 20347},
+												pos:        position{line: 862, col: 25, offset: 20433},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 861, col: 29, offset: 20351},
+												pos:  position{line: 862, col: 29, offset: 20437},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 861, col: 32, offset: 20354},
+												pos:   position{line: 862, col: 32, offset: 20440},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 861, col: 37, offset: 20359},
+													pos:  position{line: 862, col: 37, offset: 20445},
 													name: "Lval",
 												},
 											},
@@ -5578,51 +5591,51 @@ var g = &grammar{
 		},
 		{
 			name: "Assignments",
-			pos:  position{line: 865, col: 1, offset: 20435},
+			pos:  position{line: 866, col: 1, offset: 20521},
 			expr: &actionExpr{
-				pos: position{line: 866, col: 5, offset: 20451},
+				pos: position{line: 867, col: 5, offset: 20537},
 				run: (*parser).callonAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 866, col: 5, offset: 20451},
+					pos: position{line: 867, col: 5, offset: 20537},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 866, col: 5, offset: 20451},
+							pos:   position{line: 867, col: 5, offset: 20537},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 866, col: 11, offset: 20457},
+								pos:  position{line: 867, col: 11, offset: 20543},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 866, col: 22, offset: 20468},
+							pos:   position{line: 867, col: 22, offset: 20554},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 866, col: 27, offset: 20473},
+								pos: position{line: 867, col: 27, offset: 20559},
 								expr: &actionExpr{
-									pos: position{line: 866, col: 28, offset: 20474},
+									pos: position{line: 867, col: 28, offset: 20560},
 									run: (*parser).callonAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 866, col: 28, offset: 20474},
+										pos: position{line: 867, col: 28, offset: 20560},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 866, col: 28, offset: 20474},
+												pos:  position{line: 867, col: 28, offset: 20560},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 866, col: 31, offset: 20477},
+												pos:        position{line: 867, col: 31, offset: 20563},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 866, col: 35, offset: 20481},
+												pos:  position{line: 867, col: 35, offset: 20567},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 866, col: 38, offset: 20484},
+												pos:   position{line: 867, col: 38, offset: 20570},
 												label: "a",
 												expr: &ruleRefExpr{
-													pos:  position{line: 866, col: 40, offset: 20486},
+													pos:  position{line: 867, col: 40, offset: 20572},
 													name: "Assignment",
 												},
 											},
@@ -5639,38 +5652,38 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 870, col: 1, offset: 20561},
+			pos:  position{line: 871, col: 1, offset: 20647},
 			expr: &actionExpr{
-				pos: position{line: 871, col: 5, offset: 20576},
+				pos: position{line: 872, col: 5, offset: 20662},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 871, col: 5, offset: 20576},
+					pos: position{line: 872, col: 5, offset: 20662},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 871, col: 5, offset: 20576},
+							pos:   position{line: 872, col: 5, offset: 20662},
 							label: "lhs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 871, col: 9, offset: 20580},
+								pos: position{line: 872, col: 9, offset: 20666},
 								expr: &actionExpr{
-									pos: position{line: 871, col: 10, offset: 20581},
+									pos: position{line: 872, col: 10, offset: 20667},
 									run: (*parser).callonAssignment5,
 									expr: &seqExpr{
-										pos: position{line: 871, col: 10, offset: 20581},
+										pos: position{line: 872, col: 10, offset: 20667},
 										exprs: []any{
 											&labeledExpr{
-												pos:   position{line: 871, col: 10, offset: 20581},
+												pos:   position{line: 872, col: 10, offset: 20667},
 												label: "lval",
 												expr: &ruleRefExpr{
-													pos:  position{line: 871, col: 15, offset: 20586},
+													pos:  position{line: 872, col: 15, offset: 20672},
 													name: "Lval",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 871, col: 20, offset: 20591},
+												pos:  position{line: 872, col: 20, offset: 20677},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 871, col: 23, offset: 20594},
+												pos:        position{line: 872, col: 23, offset: 20680},
 												val:        ":=",
 												ignoreCase: false,
 												want:       "\":=\"",
@@ -5681,14 +5694,14 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 871, col: 51, offset: 20622},
+							pos:  position{line: 872, col: 51, offset: 20708},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 871, col: 54, offset: 20625},
+							pos:   position{line: 872, col: 54, offset: 20711},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 871, col: 58, offset: 20629},
+								pos:  position{line: 872, col: 58, offset: 20715},
 								name: "Expr",
 							},
 						},
@@ -5700,9 +5713,9 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 882, col: 1, offset: 20813},
+			pos:  position{line: 883, col: 1, offset: 20899},
 			expr: &ruleRefExpr{
-				pos:  position{line: 882, col: 8, offset: 20820},
+				pos:  position{line: 883, col: 8, offset: 20906},
 				name: "CondExpr",
 			},
 			leader:        false,
@@ -5710,63 +5723,63 @@ var g = &grammar{
 		},
 		{
 			name: "CondExpr",
-			pos:  position{line: 884, col: 1, offset: 20830},
+			pos:  position{line: 885, col: 1, offset: 20916},
 			expr: &actionExpr{
-				pos: position{line: 885, col: 5, offset: 20843},
+				pos: position{line: 886, col: 5, offset: 20929},
 				run: (*parser).callonCondExpr1,
 				expr: &seqExpr{
-					pos: position{line: 885, col: 5, offset: 20843},
+					pos: position{line: 886, col: 5, offset: 20929},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 885, col: 5, offset: 20843},
+							pos:   position{line: 886, col: 5, offset: 20929},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 885, col: 10, offset: 20848},
+								pos:  position{line: 886, col: 10, offset: 20934},
 								name: "LogicalOrExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 885, col: 24, offset: 20862},
+							pos:   position{line: 886, col: 24, offset: 20948},
 							label: "opt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 885, col: 28, offset: 20866},
+								pos: position{line: 886, col: 28, offset: 20952},
 								expr: &seqExpr{
-									pos: position{line: 885, col: 29, offset: 20867},
+									pos: position{line: 886, col: 29, offset: 20953},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 885, col: 29, offset: 20867},
+											pos:  position{line: 886, col: 29, offset: 20953},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 885, col: 32, offset: 20870},
+											pos:        position{line: 886, col: 32, offset: 20956},
 											val:        "?",
 											ignoreCase: false,
 											want:       "\"?\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 885, col: 36, offset: 20874},
+											pos:  position{line: 886, col: 36, offset: 20960},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 885, col: 39, offset: 20877},
+											pos:  position{line: 886, col: 39, offset: 20963},
 											name: "Expr",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 885, col: 44, offset: 20882},
+											pos:  position{line: 886, col: 44, offset: 20968},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 885, col: 47, offset: 20885},
+											pos:        position{line: 886, col: 47, offset: 20971},
 											val:        ":",
 											ignoreCase: false,
 											want:       "\":\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 885, col: 51, offset: 20889},
+											pos:  position{line: 886, col: 51, offset: 20975},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 885, col: 54, offset: 20892},
+											pos:  position{line: 886, col: 54, offset: 20978},
 											name: "Expr",
 										},
 									},
@@ -5781,53 +5794,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 899, col: 1, offset: 21207},
+			pos:  position{line: 900, col: 1, offset: 21293},
 			expr: &actionExpr{
-				pos: position{line: 900, col: 5, offset: 21225},
+				pos: position{line: 901, col: 5, offset: 21311},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 900, col: 5, offset: 21225},
+					pos: position{line: 901, col: 5, offset: 21311},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 900, col: 5, offset: 21225},
+							pos:   position{line: 901, col: 5, offset: 21311},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 900, col: 11, offset: 21231},
+								pos:  position{line: 901, col: 11, offset: 21317},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 901, col: 5, offset: 21250},
+							pos:   position{line: 902, col: 5, offset: 21336},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 901, col: 10, offset: 21255},
+								pos: position{line: 902, col: 10, offset: 21341},
 								expr: &actionExpr{
-									pos: position{line: 901, col: 11, offset: 21256},
+									pos: position{line: 902, col: 11, offset: 21342},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 901, col: 11, offset: 21256},
+										pos: position{line: 902, col: 11, offset: 21342},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 901, col: 11, offset: 21256},
+												pos:  position{line: 902, col: 11, offset: 21342},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 901, col: 14, offset: 21259},
+												pos:   position{line: 902, col: 14, offset: 21345},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 901, col: 17, offset: 21262},
+													pos:  position{line: 902, col: 17, offset: 21348},
 													name: "OR",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 901, col: 20, offset: 21265},
+												pos:  position{line: 902, col: 20, offset: 21351},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 901, col: 23, offset: 21268},
+												pos:   position{line: 902, col: 23, offset: 21354},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 901, col: 28, offset: 21273},
+													pos:  position{line: 902, col: 28, offset: 21359},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -5844,53 +5857,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 905, col: 1, offset: 21387},
+			pos:  position{line: 906, col: 1, offset: 21473},
 			expr: &actionExpr{
-				pos: position{line: 906, col: 5, offset: 21406},
+				pos: position{line: 907, col: 5, offset: 21492},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 906, col: 5, offset: 21406},
+					pos: position{line: 907, col: 5, offset: 21492},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 906, col: 5, offset: 21406},
+							pos:   position{line: 907, col: 5, offset: 21492},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 906, col: 11, offset: 21412},
+								pos:  position{line: 907, col: 11, offset: 21498},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 907, col: 5, offset: 21424},
+							pos:   position{line: 908, col: 5, offset: 21510},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 907, col: 10, offset: 21429},
+								pos: position{line: 908, col: 10, offset: 21515},
 								expr: &actionExpr{
-									pos: position{line: 907, col: 11, offset: 21430},
+									pos: position{line: 908, col: 11, offset: 21516},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 907, col: 11, offset: 21430},
+										pos: position{line: 908, col: 11, offset: 21516},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 907, col: 11, offset: 21430},
+												pos:  position{line: 908, col: 11, offset: 21516},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 907, col: 14, offset: 21433},
+												pos:   position{line: 908, col: 14, offset: 21519},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 907, col: 17, offset: 21436},
+													pos:  position{line: 908, col: 17, offset: 21522},
 													name: "AND",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 907, col: 21, offset: 21440},
+												pos:  position{line: 908, col: 21, offset: 21526},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 907, col: 24, offset: 21443},
+												pos:   position{line: 908, col: 24, offset: 21529},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 907, col: 29, offset: 21448},
+													pos:  position{line: 908, col: 29, offset: 21534},
 													name: "NotExpr",
 												},
 											},
@@ -5907,43 +5920,43 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 911, col: 1, offset: 21555},
+			pos:  position{line: 912, col: 1, offset: 21641},
 			expr: &choiceExpr{
-				pos: position{line: 912, col: 5, offset: 21567},
+				pos: position{line: 913, col: 5, offset: 21653},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 912, col: 5, offset: 21567},
+						pos: position{line: 913, col: 5, offset: 21653},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 912, col: 5, offset: 21567},
+							pos: position{line: 913, col: 5, offset: 21653},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 912, col: 6, offset: 21568},
+									pos: position{line: 913, col: 6, offset: 21654},
 									alternatives: []any{
 										&seqExpr{
-											pos: position{line: 912, col: 6, offset: 21568},
+											pos: position{line: 913, col: 6, offset: 21654},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 912, col: 6, offset: 21568},
+													pos:  position{line: 913, col: 6, offset: 21654},
 													name: "NOT",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 912, col: 10, offset: 21572},
+													pos:  position{line: 913, col: 10, offset: 21658},
 													name: "__",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 912, col: 15, offset: 21577},
+											pos: position{line: 913, col: 15, offset: 21663},
 											exprs: []any{
 												&litMatcher{
-													pos:        position{line: 912, col: 15, offset: 21577},
+													pos:        position{line: 913, col: 15, offset: 21663},
 													val:        "!",
 													ignoreCase: false,
 													want:       "\"!\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 912, col: 19, offset: 21581},
+													pos:  position{line: 913, col: 19, offset: 21667},
 													name: "__",
 												},
 											},
@@ -5951,10 +5964,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 912, col: 23, offset: 21585},
+									pos:   position{line: 913, col: 23, offset: 21671},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 912, col: 25, offset: 21587},
+										pos:  position{line: 913, col: 25, offset: 21673},
 										name: "NotExpr",
 									},
 								},
@@ -5962,7 +5975,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 920, col: 5, offset: 21753},
+						pos:  position{line: 921, col: 5, offset: 21839},
 						name: "BetweenExpr",
 					},
 				},
@@ -5972,42 +5985,42 @@ var g = &grammar{
 		},
 		{
 			name: "BetweenExpr",
-			pos:  position{line: 922, col: 1, offset: 21766},
+			pos:  position{line: 923, col: 1, offset: 21852},
 			expr: &choiceExpr{
-				pos: position{line: 923, col: 5, offset: 21782},
+				pos: position{line: 924, col: 5, offset: 21868},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 923, col: 5, offset: 21782},
+						pos: position{line: 924, col: 5, offset: 21868},
 						run: (*parser).callonBetweenExpr2,
 						expr: &seqExpr{
-							pos: position{line: 923, col: 5, offset: 21782},
+							pos: position{line: 924, col: 5, offset: 21868},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 923, col: 5, offset: 21782},
+									pos:   position{line: 924, col: 5, offset: 21868},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 923, col: 10, offset: 21787},
+										pos:  position{line: 924, col: 10, offset: 21873},
 										name: "ComparisonExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 923, col: 25, offset: 21802},
+									pos:  position{line: 924, col: 25, offset: 21888},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 923, col: 27, offset: 21804},
+									pos:   position{line: 924, col: 27, offset: 21890},
 									label: "not",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 923, col: 31, offset: 21808},
+										pos: position{line: 924, col: 31, offset: 21894},
 										expr: &seqExpr{
-											pos: position{line: 923, col: 32, offset: 21809},
+											pos: position{line: 924, col: 32, offset: 21895},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 923, col: 32, offset: 21809},
+													pos:  position{line: 924, col: 32, offset: 21895},
 													name: "NOT",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 923, col: 36, offset: 21813},
+													pos:  position{line: 924, col: 36, offset: 21899},
 													name: "_",
 												},
 											},
@@ -6015,38 +6028,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 923, col: 40, offset: 21817},
+									pos:  position{line: 924, col: 40, offset: 21903},
 									name: "BETWEEN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 923, col: 48, offset: 21825},
+									pos:  position{line: 924, col: 48, offset: 21911},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 923, col: 50, offset: 21827},
+									pos:   position{line: 924, col: 50, offset: 21913},
 									label: "lower",
 									expr: &ruleRefExpr{
-										pos:  position{line: 923, col: 56, offset: 21833},
+										pos:  position{line: 924, col: 56, offset: 21919},
 										name: "BetweenExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 923, col: 68, offset: 21845},
+									pos:  position{line: 924, col: 68, offset: 21931},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 923, col: 70, offset: 21847},
+									pos:  position{line: 924, col: 70, offset: 21933},
 									name: "AND",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 923, col: 74, offset: 21851},
+									pos:  position{line: 924, col: 74, offset: 21937},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 923, col: 76, offset: 21853},
+									pos:   position{line: 924, col: 76, offset: 21939},
 									label: "upper",
 									expr: &ruleRefExpr{
-										pos:  position{line: 923, col: 82, offset: 21859},
+										pos:  position{line: 924, col: 82, offset: 21945},
 										name: "BetweenExpr",
 									},
 								},
@@ -6054,7 +6067,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 933, col: 5, offset: 22099},
+						pos:  position{line: 934, col: 5, offset: 22185},
 						name: "ComparisonExpr",
 					},
 				},
@@ -6064,46 +6077,46 @@ var g = &grammar{
 		},
 		{
 			name: "ComparisonExpr",
-			pos:  position{line: 935, col: 1, offset: 22115},
+			pos:  position{line: 936, col: 1, offset: 22201},
 			expr: &choiceExpr{
-				pos: position{line: 936, col: 5, offset: 22134},
+				pos: position{line: 937, col: 5, offset: 22220},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 936, col: 5, offset: 22134},
+						pos: position{line: 937, col: 5, offset: 22220},
 						run: (*parser).callonComparisonExpr2,
 						expr: &seqExpr{
-							pos: position{line: 936, col: 5, offset: 22134},
+							pos: position{line: 937, col: 5, offset: 22220},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 936, col: 5, offset: 22134},
+									pos:   position{line: 937, col: 5, offset: 22220},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 936, col: 10, offset: 22139},
+										pos:  position{line: 937, col: 10, offset: 22225},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 936, col: 23, offset: 22152},
+									pos:  position{line: 937, col: 23, offset: 22238},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 936, col: 25, offset: 22154},
+									pos:  position{line: 937, col: 25, offset: 22240},
 									name: "IS",
 								},
 								&labeledExpr{
-									pos:   position{line: 936, col: 28, offset: 22157},
+									pos:   position{line: 937, col: 28, offset: 22243},
 									label: "not",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 936, col: 32, offset: 22161},
+										pos: position{line: 937, col: 32, offset: 22247},
 										expr: &seqExpr{
-											pos: position{line: 936, col: 33, offset: 22162},
+											pos: position{line: 937, col: 33, offset: 22248},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 936, col: 33, offset: 22162},
+													pos:  position{line: 937, col: 33, offset: 22248},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 936, col: 35, offset: 22164},
+													pos:  position{line: 937, col: 35, offset: 22250},
 													name: "NOT",
 												},
 											},
@@ -6111,82 +6124,82 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 936, col: 41, offset: 22170},
+									pos:  position{line: 937, col: 41, offset: 22256},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 936, col: 43, offset: 22172},
+									pos:  position{line: 937, col: 43, offset: 22258},
 									name: "NULL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 944, col: 5, offset: 22337},
+						pos: position{line: 945, col: 5, offset: 22423},
 						run: (*parser).callonComparisonExpr15,
 						expr: &seqExpr{
-							pos: position{line: 944, col: 5, offset: 22337},
+							pos: position{line: 945, col: 5, offset: 22423},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 944, col: 5, offset: 22337},
+									pos:   position{line: 945, col: 5, offset: 22423},
 									label: "lhs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 944, col: 9, offset: 22341},
+										pos:  position{line: 945, col: 9, offset: 22427},
 										name: "AdditiveExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 944, col: 22, offset: 22354},
+									pos:   position{line: 945, col: 22, offset: 22440},
 									label: "opAndRHS",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 944, col: 31, offset: 22363},
+										pos: position{line: 945, col: 31, offset: 22449},
 										expr: &choiceExpr{
-											pos: position{line: 944, col: 32, offset: 22364},
+											pos: position{line: 945, col: 32, offset: 22450},
 											alternatives: []any{
 												&seqExpr{
-													pos: position{line: 944, col: 32, offset: 22364},
+													pos: position{line: 945, col: 32, offset: 22450},
 													exprs: []any{
 														&ruleRefExpr{
-															pos:  position{line: 944, col: 32, offset: 22364},
+															pos:  position{line: 945, col: 32, offset: 22450},
 															name: "__",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 944, col: 35, offset: 22367},
+															pos:  position{line: 945, col: 35, offset: 22453},
 															name: "Comparator",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 944, col: 46, offset: 22378},
+															pos:  position{line: 945, col: 46, offset: 22464},
 															name: "__",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 944, col: 49, offset: 22381},
+															pos:  position{line: 945, col: 49, offset: 22467},
 															name: "AdditiveExpr",
 														},
 													},
 												},
 												&seqExpr{
-													pos: position{line: 944, col: 64, offset: 22396},
+													pos: position{line: 945, col: 64, offset: 22482},
 													exprs: []any{
 														&ruleRefExpr{
-															pos:  position{line: 944, col: 64, offset: 22396},
+															pos:  position{line: 945, col: 64, offset: 22482},
 															name: "__",
 														},
 														&actionExpr{
-															pos: position{line: 944, col: 68, offset: 22400},
+															pos: position{line: 945, col: 68, offset: 22486},
 															run: (*parser).callonComparisonExpr29,
 															expr: &litMatcher{
-																pos:        position{line: 944, col: 68, offset: 22400},
+																pos:        position{line: 945, col: 68, offset: 22486},
 																val:        "~",
 																ignoreCase: false,
 																want:       "\"~\"",
 															},
 														},
 														&ruleRefExpr{
-															pos:  position{line: 944, col: 104, offset: 22436},
+															pos:  position{line: 945, col: 104, offset: 22522},
 															name: "__",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 944, col: 107, offset: 22439},
+															pos:  position{line: 945, col: 107, offset: 22525},
 															name: "AdditiveExpr",
 														},
 													},
@@ -6205,53 +6218,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 957, col: 1, offset: 22730},
+			pos:  position{line: 958, col: 1, offset: 22816},
 			expr: &actionExpr{
-				pos: position{line: 958, col: 5, offset: 22747},
+				pos: position{line: 959, col: 5, offset: 22833},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 958, col: 5, offset: 22747},
+					pos: position{line: 959, col: 5, offset: 22833},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 958, col: 5, offset: 22747},
+							pos:   position{line: 959, col: 5, offset: 22833},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 958, col: 11, offset: 22753},
+								pos:  position{line: 959, col: 11, offset: 22839},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 959, col: 5, offset: 22776},
+							pos:   position{line: 960, col: 5, offset: 22862},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 959, col: 10, offset: 22781},
+								pos: position{line: 960, col: 10, offset: 22867},
 								expr: &actionExpr{
-									pos: position{line: 959, col: 11, offset: 22782},
+									pos: position{line: 960, col: 11, offset: 22868},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 959, col: 11, offset: 22782},
+										pos: position{line: 960, col: 11, offset: 22868},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 959, col: 11, offset: 22782},
+												pos:  position{line: 960, col: 11, offset: 22868},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 959, col: 14, offset: 22785},
+												pos:   position{line: 960, col: 14, offset: 22871},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 959, col: 17, offset: 22788},
+													pos:  position{line: 960, col: 17, offset: 22874},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 959, col: 34, offset: 22805},
+												pos:  position{line: 960, col: 34, offset: 22891},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 959, col: 37, offset: 22808},
+												pos:   position{line: 960, col: 37, offset: 22894},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 959, col: 42, offset: 22813},
+													pos:  position{line: 960, col: 42, offset: 22899},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -6268,21 +6281,21 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 963, col: 1, offset: 22931},
+			pos:  position{line: 964, col: 1, offset: 23017},
 			expr: &actionExpr{
-				pos: position{line: 963, col: 20, offset: 22950},
+				pos: position{line: 964, col: 20, offset: 23036},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 963, col: 21, offset: 22951},
+					pos: position{line: 964, col: 21, offset: 23037},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 963, col: 21, offset: 22951},
+							pos:        position{line: 964, col: 21, offset: 23037},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&litMatcher{
-							pos:        position{line: 963, col: 27, offset: 22957},
+							pos:        position{line: 964, col: 27, offset: 23043},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
@@ -6295,53 +6308,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 965, col: 1, offset: 22994},
+			pos:  position{line: 966, col: 1, offset: 23080},
 			expr: &actionExpr{
-				pos: position{line: 966, col: 5, offset: 23017},
+				pos: position{line: 967, col: 5, offset: 23103},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 966, col: 5, offset: 23017},
+					pos: position{line: 967, col: 5, offset: 23103},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 966, col: 5, offset: 23017},
+							pos:   position{line: 967, col: 5, offset: 23103},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 966, col: 11, offset: 23023},
+								pos:  position{line: 967, col: 11, offset: 23109},
 								name: "ConcatExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 967, col: 5, offset: 23038},
+							pos:   position{line: 968, col: 5, offset: 23124},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 967, col: 10, offset: 23043},
+								pos: position{line: 968, col: 10, offset: 23129},
 								expr: &actionExpr{
-									pos: position{line: 967, col: 11, offset: 23044},
+									pos: position{line: 968, col: 11, offset: 23130},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 967, col: 11, offset: 23044},
+										pos: position{line: 968, col: 11, offset: 23130},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 967, col: 11, offset: 23044},
+												pos:  position{line: 968, col: 11, offset: 23130},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 967, col: 14, offset: 23047},
+												pos:   position{line: 968, col: 14, offset: 23133},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 967, col: 17, offset: 23050},
+													pos:  position{line: 968, col: 17, offset: 23136},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 967, col: 40, offset: 23073},
+												pos:  position{line: 968, col: 40, offset: 23159},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 967, col: 43, offset: 23076},
+												pos:   position{line: 968, col: 43, offset: 23162},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 967, col: 48, offset: 23081},
+													pos:  position{line: 968, col: 48, offset: 23167},
 													name: "ConcatExpr",
 												},
 											},
@@ -6358,27 +6371,27 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 971, col: 1, offset: 23191},
+			pos:  position{line: 972, col: 1, offset: 23277},
 			expr: &actionExpr{
-				pos: position{line: 971, col: 26, offset: 23216},
+				pos: position{line: 972, col: 26, offset: 23302},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 971, col: 27, offset: 23217},
+					pos: position{line: 972, col: 27, offset: 23303},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 971, col: 27, offset: 23217},
+							pos:        position{line: 972, col: 27, offset: 23303},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&litMatcher{
-							pos:        position{line: 971, col: 33, offset: 23223},
+							pos:        position{line: 972, col: 33, offset: 23309},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&litMatcher{
-							pos:        position{line: 971, col: 39, offset: 23229},
+							pos:        position{line: 972, col: 39, offset: 23315},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
@@ -6391,51 +6404,51 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatExpr",
-			pos:  position{line: 973, col: 1, offset: 23266},
+			pos:  position{line: 974, col: 1, offset: 23352},
 			expr: &actionExpr{
-				pos: position{line: 974, col: 5, offset: 23281},
+				pos: position{line: 975, col: 5, offset: 23367},
 				run: (*parser).callonConcatExpr1,
 				expr: &seqExpr{
-					pos: position{line: 974, col: 5, offset: 23281},
+					pos: position{line: 975, col: 5, offset: 23367},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 974, col: 5, offset: 23281},
+							pos:   position{line: 975, col: 5, offset: 23367},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 974, col: 11, offset: 23287},
+								pos:  position{line: 975, col: 11, offset: 23373},
 								name: "UnaryPlusOrMinus",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 975, col: 5, offset: 23308},
+							pos:   position{line: 976, col: 5, offset: 23394},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 975, col: 10, offset: 23313},
+								pos: position{line: 976, col: 10, offset: 23399},
 								expr: &actionExpr{
-									pos: position{line: 975, col: 11, offset: 23314},
+									pos: position{line: 976, col: 11, offset: 23400},
 									run: (*parser).callonConcatExpr7,
 									expr: &seqExpr{
-										pos: position{line: 975, col: 11, offset: 23314},
+										pos: position{line: 976, col: 11, offset: 23400},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 975, col: 11, offset: 23314},
+												pos:  position{line: 976, col: 11, offset: 23400},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 975, col: 14, offset: 23317},
+												pos:        position{line: 976, col: 14, offset: 23403},
 												val:        "||",
 												ignoreCase: false,
 												want:       "\"||\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 975, col: 19, offset: 23322},
+												pos:  position{line: 976, col: 19, offset: 23408},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 975, col: 22, offset: 23325},
+												pos:   position{line: 976, col: 22, offset: 23411},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 975, col: 27, offset: 23330},
+													pos:  position{line: 976, col: 27, offset: 23416},
 													name: "UnaryPlusOrMinus",
 												},
 											},
@@ -6452,40 +6465,40 @@ var g = &grammar{
 		},
 		{
 			name: "UnaryPlusOrMinus",
-			pos:  position{line: 979, col: 1, offset: 23448},
+			pos:  position{line: 980, col: 1, offset: 23534},
 			expr: &choiceExpr{
-				pos: position{line: 980, col: 5, offset: 23469},
+				pos: position{line: 981, col: 5, offset: 23555},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 980, col: 5, offset: 23469},
+						pos: position{line: 981, col: 5, offset: 23555},
 						run: (*parser).callonUnaryPlusOrMinus2,
 						expr: &seqExpr{
-							pos: position{line: 980, col: 5, offset: 23469},
+							pos: position{line: 981, col: 5, offset: 23555},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 980, col: 5, offset: 23469},
+									pos: position{line: 981, col: 5, offset: 23555},
 									expr: &ruleRefExpr{
-										pos:  position{line: 980, col: 6, offset: 23470},
+										pos:  position{line: 981, col: 6, offset: 23556},
 										name: "Literal",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 980, col: 14, offset: 23478},
+									pos:   position{line: 981, col: 14, offset: 23564},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 980, col: 17, offset: 23481},
+										pos:  position{line: 981, col: 17, offset: 23567},
 										name: "PlusOrMinusOp",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 980, col: 31, offset: 23495},
+									pos:  position{line: 981, col: 31, offset: 23581},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 980, col: 34, offset: 23498},
+									pos:   position{line: 981, col: 34, offset: 23584},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 980, col: 36, offset: 23500},
+										pos:  position{line: 981, col: 36, offset: 23586},
 										name: "UnaryPlusOrMinus",
 									},
 								},
@@ -6493,7 +6506,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 989, col: 5, offset: 23684},
+						pos:  position{line: 990, col: 5, offset: 23770},
 						name: "ColonCast",
 					},
 				},
@@ -6503,21 +6516,21 @@ var g = &grammar{
 		},
 		{
 			name: "PlusOrMinusOp",
-			pos:  position{line: 991, col: 1, offset: 23695},
+			pos:  position{line: 992, col: 1, offset: 23781},
 			expr: &actionExpr{
-				pos: position{line: 991, col: 17, offset: 23711},
+				pos: position{line: 992, col: 17, offset: 23797},
 				run: (*parser).callonPlusOrMinusOp1,
 				expr: &choiceExpr{
-					pos: position{line: 991, col: 18, offset: 23712},
+					pos: position{line: 992, col: 18, offset: 23798},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 991, col: 18, offset: 23712},
+							pos:        position{line: 992, col: 18, offset: 23798},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&litMatcher{
-							pos:        position{line: 991, col: 24, offset: 23718},
+							pos:        position{line: 992, col: 24, offset: 23804},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
@@ -6530,58 +6543,58 @@ var g = &grammar{
 		},
 		{
 			name: "ColonCast",
-			pos:  position{line: 993, col: 1, offset: 23755},
+			pos:  position{line: 994, col: 1, offset: 23841},
 			expr: &actionExpr{
-				pos: position{line: 994, col: 5, offset: 23769},
+				pos: position{line: 995, col: 5, offset: 23855},
 				run: (*parser).callonColonCast1,
 				expr: &seqExpr{
-					pos: position{line: 994, col: 5, offset: 23769},
+					pos: position{line: 995, col: 5, offset: 23855},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 994, col: 5, offset: 23769},
+							pos:   position{line: 995, col: 5, offset: 23855},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 994, col: 11, offset: 23775},
+								pos:  position{line: 995, col: 11, offset: 23861},
 								name: "DerefExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 995, col: 5, offset: 23789},
+							pos:   position{line: 996, col: 5, offset: 23875},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 995, col: 10, offset: 23794},
+								pos: position{line: 996, col: 10, offset: 23880},
 								expr: &actionExpr{
-									pos: position{line: 995, col: 11, offset: 23795},
+									pos: position{line: 996, col: 11, offset: 23881},
 									run: (*parser).callonColonCast7,
 									expr: &seqExpr{
-										pos: position{line: 995, col: 11, offset: 23795},
+										pos: position{line: 996, col: 11, offset: 23881},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 995, col: 11, offset: 23795},
+												pos:  position{line: 996, col: 11, offset: 23881},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 995, col: 14, offset: 23798},
+												pos:        position{line: 996, col: 14, offset: 23884},
 												val:        "::",
 												ignoreCase: false,
 												want:       "\"::\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 995, col: 19, offset: 23803},
+												pos:  position{line: 996, col: 19, offset: 23889},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 995, col: 22, offset: 23806},
+												pos:   position{line: 996, col: 22, offset: 23892},
 												label: "expr",
 												expr: &choiceExpr{
-													pos: position{line: 995, col: 28, offset: 23812},
+													pos: position{line: 996, col: 28, offset: 23898},
 													alternatives: []any{
 														&ruleRefExpr{
-															pos:  position{line: 995, col: 28, offset: 23812},
+															pos:  position{line: 996, col: 28, offset: 23898},
 															name: "TypeAsValue",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 995, col: 42, offset: 23826},
+															pos:  position{line: 996, col: 42, offset: 23912},
 															name: "IDExpr",
 														},
 													},
@@ -6600,15 +6613,15 @@ var g = &grammar{
 		},
 		{
 			name: "IDExpr",
-			pos:  position{line: 999, col: 1, offset: 23933},
+			pos:  position{line: 1000, col: 1, offset: 24019},
 			expr: &actionExpr{
-				pos: position{line: 999, col: 10, offset: 23942},
+				pos: position{line: 1000, col: 10, offset: 24028},
 				run: (*parser).callonIDExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 999, col: 10, offset: 23942},
+					pos:   position{line: 1000, col: 10, offset: 24028},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 999, col: 13, offset: 23945},
+						pos:  position{line: 1000, col: 13, offset: 24031},
 						name: "Identifier",
 					},
 				},
@@ -6618,73 +6631,73 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 1001, col: 1, offset: 24022},
+			pos:  position{line: 1002, col: 1, offset: 24108},
 			expr: &choiceExpr{
-				pos: position{line: 1002, col: 5, offset: 24036},
+				pos: position{line: 1003, col: 5, offset: 24122},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1002, col: 5, offset: 24036},
+						pos: position{line: 1003, col: 5, offset: 24122},
 						run: (*parser).callonDerefExpr2,
 						expr: &seqExpr{
-							pos: position{line: 1002, col: 5, offset: 24036},
+							pos: position{line: 1003, col: 5, offset: 24122},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1002, col: 5, offset: 24036},
+									pos:   position{line: 1003, col: 5, offset: 24122},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1002, col: 10, offset: 24041},
+										pos:  position{line: 1003, col: 10, offset: 24127},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1002, col: 20, offset: 24051},
+									pos:        position{line: 1003, col: 20, offset: 24137},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1002, col: 24, offset: 24055},
+									pos:  position{line: 1003, col: 24, offset: 24141},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1002, col: 27, offset: 24058},
+									pos:   position{line: 1003, col: 27, offset: 24144},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1002, col: 32, offset: 24063},
+										pos:  position{line: 1003, col: 32, offset: 24149},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1002, col: 45, offset: 24076},
+									pos:  position{line: 1003, col: 45, offset: 24162},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1002, col: 48, offset: 24079},
+									pos:        position{line: 1003, col: 48, offset: 24165},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1002, col: 52, offset: 24083},
+									pos:  position{line: 1003, col: 52, offset: 24169},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1002, col: 55, offset: 24086},
+									pos:   position{line: 1003, col: 55, offset: 24172},
 									label: "to",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1002, col: 58, offset: 24089},
+										pos: position{line: 1003, col: 58, offset: 24175},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1002, col: 58, offset: 24089},
+											pos:  position{line: 1003, col: 58, offset: 24175},
 											name: "AdditiveExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1002, col: 72, offset: 24103},
+									pos:  position{line: 1003, col: 72, offset: 24189},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1002, col: 75, offset: 24106},
+									pos:        position{line: 1003, col: 75, offset: 24192},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6693,49 +6706,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1014, col: 5, offset: 24345},
+						pos: position{line: 1015, col: 5, offset: 24431},
 						run: (*parser).callonDerefExpr18,
 						expr: &seqExpr{
-							pos: position{line: 1014, col: 5, offset: 24345},
+							pos: position{line: 1015, col: 5, offset: 24431},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1014, col: 5, offset: 24345},
+									pos:   position{line: 1015, col: 5, offset: 24431},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1014, col: 10, offset: 24350},
+										pos:  position{line: 1015, col: 10, offset: 24436},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1014, col: 20, offset: 24360},
+									pos:        position{line: 1015, col: 20, offset: 24446},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1014, col: 24, offset: 24364},
+									pos:  position{line: 1015, col: 24, offset: 24450},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1014, col: 27, offset: 24367},
+									pos:        position{line: 1015, col: 27, offset: 24453},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1014, col: 31, offset: 24371},
+									pos:  position{line: 1015, col: 31, offset: 24457},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1014, col: 34, offset: 24374},
+									pos:   position{line: 1015, col: 34, offset: 24460},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1014, col: 37, offset: 24377},
+										pos:  position{line: 1015, col: 37, offset: 24463},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1014, col: 50, offset: 24390},
+									pos:        position{line: 1015, col: 50, offset: 24476},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6744,35 +6757,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1022, col: 5, offset: 24554},
+						pos: position{line: 1023, col: 5, offset: 24640},
 						run: (*parser).callonDerefExpr29,
 						expr: &seqExpr{
-							pos: position{line: 1022, col: 5, offset: 24554},
+							pos: position{line: 1023, col: 5, offset: 24640},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1022, col: 5, offset: 24554},
+									pos:   position{line: 1023, col: 5, offset: 24640},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1022, col: 10, offset: 24559},
+										pos:  position{line: 1023, col: 10, offset: 24645},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1022, col: 20, offset: 24569},
+									pos:        position{line: 1023, col: 20, offset: 24655},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1022, col: 24, offset: 24573},
+									pos:   position{line: 1023, col: 24, offset: 24659},
 									label: "index",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1022, col: 30, offset: 24579},
+										pos:  position{line: 1023, col: 30, offset: 24665},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1022, col: 35, offset: 24584},
+									pos:        position{line: 1023, col: 35, offset: 24670},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -6781,30 +6794,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1030, col: 5, offset: 24754},
+						pos: position{line: 1031, col: 5, offset: 24840},
 						run: (*parser).callonDerefExpr37,
 						expr: &seqExpr{
-							pos: position{line: 1030, col: 5, offset: 24754},
+							pos: position{line: 1031, col: 5, offset: 24840},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1030, col: 5, offset: 24754},
+									pos:   position{line: 1031, col: 5, offset: 24840},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1030, col: 10, offset: 24759},
+										pos:  position{line: 1031, col: 10, offset: 24845},
 										name: "DerefExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1030, col: 20, offset: 24769},
+									pos:        position{line: 1031, col: 20, offset: 24855},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1030, col: 24, offset: 24773},
+									pos:   position{line: 1031, col: 24, offset: 24859},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1030, col: 27, offset: 24776},
+										pos:  position{line: 1031, col: 27, offset: 24862},
 										name: "DerefKey",
 									},
 								},
@@ -6812,11 +6825,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1039, col: 5, offset: 24964},
+						pos:  position{line: 1040, col: 5, offset: 25050},
 						name: "Function",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1040, col: 5, offset: 24977},
+						pos:  position{line: 1041, col: 5, offset: 25063},
 						name: "Primary",
 					},
 				},
@@ -6826,42 +6839,42 @@ var g = &grammar{
 		},
 		{
 			name: "DerefKey",
-			pos:  position{line: 1042, col: 1, offset: 24986},
+			pos:  position{line: 1043, col: 1, offset: 25072},
 			expr: &choiceExpr{
-				pos: position{line: 1043, col: 5, offset: 24999},
+				pos: position{line: 1044, col: 5, offset: 25085},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1043, col: 5, offset: 24999},
+						pos: position{line: 1044, col: 5, offset: 25085},
 						run: (*parser).callonDerefKey2,
 						expr: &labeledExpr{
-							pos:   position{line: 1043, col: 5, offset: 24999},
+							pos:   position{line: 1044, col: 5, offset: 25085},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1043, col: 8, offset: 25002},
+								pos:  position{line: 1044, col: 8, offset: 25088},
 								name: "Identifier",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1044, col: 5, offset: 25093},
+						pos: position{line: 1045, col: 5, offset: 25179},
 						run: (*parser).callonDerefKey5,
 						expr: &labeledExpr{
-							pos:   position{line: 1044, col: 5, offset: 25093},
+							pos:   position{line: 1045, col: 5, offset: 25179},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1044, col: 7, offset: 25095},
+								pos:  position{line: 1045, col: 7, offset: 25181},
 								name: "DoubleQuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1045, col: 5, offset: 25207},
+						pos: position{line: 1046, col: 5, offset: 25293},
 						run: (*parser).callonDerefKey8,
 						expr: &labeledExpr{
-							pos:   position{line: 1045, col: 5, offset: 25207},
+							pos:   position{line: 1046, col: 5, offset: 25293},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1045, col: 7, offset: 25209},
+								pos:  position{line: 1046, col: 7, offset: 25295},
 								name: "BacktickString",
 							},
 						},
@@ -6873,79 +6886,79 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 1047, col: 1, offset: 25318},
+			pos:  position{line: 1048, col: 1, offset: 25404},
 			expr: &choiceExpr{
-				pos: position{line: 1048, col: 5, offset: 25331},
+				pos: position{line: 1049, col: 5, offset: 25417},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1048, col: 5, offset: 25331},
+						pos: position{line: 1049, col: 5, offset: 25417},
 						run: (*parser).callonFunction2,
 						expr: &seqExpr{
-							pos: position{line: 1048, col: 5, offset: 25331},
+							pos: position{line: 1049, col: 5, offset: 25417},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1048, col: 5, offset: 25331},
+									pos:  position{line: 1049, col: 5, offset: 25417},
 									name: "EXTRACT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1048, col: 13, offset: 25339},
+									pos:  position{line: 1049, col: 13, offset: 25425},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1048, col: 16, offset: 25342},
+									pos:        position{line: 1049, col: 16, offset: 25428},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1048, col: 20, offset: 25346},
+									pos:  position{line: 1049, col: 20, offset: 25432},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1048, col: 23, offset: 25349},
+									pos:   position{line: 1049, col: 23, offset: 25435},
 									label: "part",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1048, col: 28, offset: 25354},
+										pos:  position{line: 1049, col: 28, offset: 25440},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1048, col: 33, offset: 25359},
+									pos:  position{line: 1049, col: 33, offset: 25445},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1048, col: 35, offset: 25361},
+									pos:  position{line: 1049, col: 35, offset: 25447},
 									name: "FROM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1048, col: 40, offset: 25366},
+									pos:  position{line: 1049, col: 40, offset: 25452},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1048, col: 42, offset: 25368},
+									pos:   position{line: 1049, col: 42, offset: 25454},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1048, col: 44, offset: 25370},
+										pos:  position{line: 1049, col: 44, offset: 25456},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1048, col: 49, offset: 25375},
+									pos:  position{line: 1049, col: 49, offset: 25461},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1048, col: 52, offset: 25378},
+									pos:        position{line: 1049, col: 52, offset: 25464},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1048, col: 56, offset: 25382},
+									pos:   position{line: 1049, col: 56, offset: 25468},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1048, col: 62, offset: 25388},
+										pos: position{line: 1049, col: 62, offset: 25474},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1048, col: 62, offset: 25388},
+											pos:  position{line: 1049, col: 62, offset: 25474},
 											name: "WhereClause",
 										},
 									},
@@ -6954,43 +6967,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1056, col: 5, offset: 25566},
+						pos: position{line: 1057, col: 5, offset: 25652},
 						run: (*parser).callonFunction20,
 						expr: &seqExpr{
-							pos: position{line: 1056, col: 5, offset: 25566},
+							pos: position{line: 1057, col: 5, offset: 25652},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1056, col: 5, offset: 25566},
+									pos:  position{line: 1057, col: 5, offset: 25652},
 									name: "EXISTS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1056, col: 12, offset: 25573},
+									pos:  position{line: 1057, col: 12, offset: 25659},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1056, col: 15, offset: 25576},
+									pos:        position{line: 1057, col: 15, offset: 25662},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1056, col: 19, offset: 25580},
+									pos:  position{line: 1057, col: 19, offset: 25666},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1056, col: 22, offset: 25583},
+									pos:   position{line: 1057, col: 22, offset: 25669},
 									label: "body",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1056, col: 27, offset: 25588},
+										pos:  position{line: 1057, col: 27, offset: 25674},
 										name: "Seq",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1056, col: 31, offset: 25592},
+									pos:  position{line: 1057, col: 31, offset: 25678},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1056, col: 34, offset: 25595},
+									pos:        position{line: 1057, col: 34, offset: 25681},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -6999,72 +7012,72 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1063, col: 5, offset: 25740},
+						pos: position{line: 1064, col: 5, offset: 25826},
 						run: (*parser).callonFunction30,
 						expr: &seqExpr{
-							pos: position{line: 1063, col: 5, offset: 25740},
+							pos: position{line: 1064, col: 5, offset: 25826},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1063, col: 5, offset: 25740},
+									pos:  position{line: 1064, col: 5, offset: 25826},
 									name: "CAST",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1063, col: 10, offset: 25745},
+									pos:  position{line: 1064, col: 10, offset: 25831},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1063, col: 13, offset: 25748},
+									pos:        position{line: 1064, col: 13, offset: 25834},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1063, col: 17, offset: 25752},
+									pos:  position{line: 1064, col: 17, offset: 25838},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1063, col: 20, offset: 25755},
+									pos:   position{line: 1064, col: 20, offset: 25841},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1063, col: 22, offset: 25757},
+										pos:  position{line: 1064, col: 22, offset: 25843},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1063, col: 27, offset: 25762},
+									pos:  position{line: 1064, col: 27, offset: 25848},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1063, col: 29, offset: 25764},
+									pos:  position{line: 1064, col: 29, offset: 25850},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1063, col: 32, offset: 25767},
+									pos:  position{line: 1064, col: 32, offset: 25853},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1063, col: 34, offset: 25769},
+									pos:   position{line: 1064, col: 34, offset: 25855},
 									label: "typ",
 									expr: &choiceExpr{
-										pos: position{line: 1063, col: 39, offset: 25774},
+										pos: position{line: 1064, col: 39, offset: 25860},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1063, col: 39, offset: 25774},
+												pos:  position{line: 1064, col: 39, offset: 25860},
 												name: "DateTypeHack",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1063, col: 54, offset: 25789},
+												pos:  position{line: 1064, col: 54, offset: 25875},
 												name: "Type",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1063, col: 60, offset: 25795},
+									pos:  position{line: 1064, col: 60, offset: 25881},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1063, col: 63, offset: 25798},
+									pos:        position{line: 1064, col: 63, offset: 25884},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7073,65 +7086,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1071, col: 5, offset: 25960},
+						pos: position{line: 1072, col: 5, offset: 26046},
 						run: (*parser).callonFunction47,
 						expr: &seqExpr{
-							pos: position{line: 1071, col: 5, offset: 25960},
+							pos: position{line: 1072, col: 5, offset: 26046},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1071, col: 5, offset: 25960},
+									pos:  position{line: 1072, col: 5, offset: 26046},
 									name: "SUBSTRING",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1071, col: 15, offset: 25970},
+									pos:  position{line: 1072, col: 15, offset: 26056},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1071, col: 18, offset: 25973},
+									pos:        position{line: 1072, col: 18, offset: 26059},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1071, col: 22, offset: 25977},
+									pos:  position{line: 1072, col: 22, offset: 26063},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1071, col: 25, offset: 25980},
+									pos:   position{line: 1072, col: 25, offset: 26066},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1071, col: 30, offset: 25985},
+										pos:  position{line: 1072, col: 30, offset: 26071},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1071, col: 35, offset: 25990},
+									pos:   position{line: 1072, col: 35, offset: 26076},
 									label: "from",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1071, col: 40, offset: 25995},
+										pos: position{line: 1072, col: 40, offset: 26081},
 										expr: &actionExpr{
-											pos: position{line: 1071, col: 41, offset: 25996},
+											pos: position{line: 1072, col: 41, offset: 26082},
 											run: (*parser).callonFunction57,
 											expr: &seqExpr{
-												pos: position{line: 1071, col: 41, offset: 25996},
+												pos: position{line: 1072, col: 41, offset: 26082},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1071, col: 41, offset: 25996},
+														pos:  position{line: 1072, col: 41, offset: 26082},
 														name: "_",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1071, col: 43, offset: 25998},
+														pos:  position{line: 1072, col: 43, offset: 26084},
 														name: "FROM",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1071, col: 48, offset: 26003},
+														pos:  position{line: 1072, col: 48, offset: 26089},
 														name: "_",
 													},
 													&labeledExpr{
-														pos:   position{line: 1071, col: 50, offset: 26005},
+														pos:   position{line: 1072, col: 50, offset: 26091},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1071, col: 52, offset: 26007},
+															pos:  position{line: 1072, col: 52, offset: 26093},
 															name: "Expr",
 														},
 													},
@@ -7141,33 +7154,33 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1071, col: 77, offset: 26032},
+									pos:   position{line: 1072, col: 77, offset: 26118},
 									label: "for_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1071, col: 82, offset: 26037},
+										pos: position{line: 1072, col: 82, offset: 26123},
 										expr: &actionExpr{
-											pos: position{line: 1071, col: 83, offset: 26038},
+											pos: position{line: 1072, col: 83, offset: 26124},
 											run: (*parser).callonFunction66,
 											expr: &seqExpr{
-												pos: position{line: 1071, col: 83, offset: 26038},
+												pos: position{line: 1072, col: 83, offset: 26124},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1071, col: 83, offset: 26038},
+														pos:  position{line: 1072, col: 83, offset: 26124},
 														name: "_",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1071, col: 85, offset: 26040},
+														pos:  position{line: 1072, col: 85, offset: 26126},
 														name: "FOR",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1071, col: 89, offset: 26044},
+														pos:  position{line: 1072, col: 89, offset: 26130},
 														name: "_",
 													},
 													&labeledExpr{
-														pos:   position{line: 1071, col: 91, offset: 26046},
+														pos:   position{line: 1072, col: 91, offset: 26132},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1071, col: 93, offset: 26048},
+															pos:  position{line: 1072, col: 93, offset: 26134},
 															name: "Expr",
 														},
 													},
@@ -7177,7 +7190,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1071, col: 118, offset: 26073},
+									pos:        position{line: 1072, col: 118, offset: 26159},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7186,58 +7199,58 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1085, col: 5, offset: 26358},
+						pos: position{line: 1086, col: 5, offset: 26444},
 						run: (*parser).callonFunction74,
 						expr: &seqExpr{
-							pos: position{line: 1085, col: 5, offset: 26358},
+							pos: position{line: 1086, col: 5, offset: 26444},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1085, col: 5, offset: 26358},
+									pos:   position{line: 1086, col: 5, offset: 26444},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1085, col: 7, offset: 26360},
+										pos:  position{line: 1086, col: 7, offset: 26446},
 										name: "Callable",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1085, col: 16, offset: 26369},
+									pos:  position{line: 1086, col: 16, offset: 26455},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1085, col: 19, offset: 26372},
+									pos:        position{line: 1086, col: 19, offset: 26458},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1085, col: 23, offset: 26376},
+									pos:  position{line: 1086, col: 23, offset: 26462},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1085, col: 26, offset: 26379},
+									pos:   position{line: 1086, col: 26, offset: 26465},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1085, col: 31, offset: 26384},
+										pos:  position{line: 1086, col: 31, offset: 26470},
 										name: "FunctionArgs",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1085, col: 44, offset: 26397},
+									pos:  position{line: 1086, col: 44, offset: 26483},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1085, col: 47, offset: 26400},
+									pos:        position{line: 1086, col: 47, offset: 26486},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1085, col: 51, offset: 26404},
+									pos:   position{line: 1086, col: 51, offset: 26490},
 									label: "where",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1085, col: 57, offset: 26410},
+										pos: position{line: 1086, col: 57, offset: 26496},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1085, col: 57, offset: 26410},
+											pos:  position{line: 1086, col: 57, offset: 26496},
 											name: "WhereClause",
 										},
 									},
@@ -7246,7 +7259,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1088, col: 5, offset: 26480},
+						pos:  position{line: 1089, col: 5, offset: 26566},
 						name: "CountStar",
 					},
 				},
@@ -7256,22 +7269,22 @@ var g = &grammar{
 		},
 		{
 			name: "Callable",
-			pos:  position{line: 1090, col: 1, offset: 26491},
+			pos:  position{line: 1091, col: 1, offset: 26577},
 			expr: &choiceExpr{
-				pos: position{line: 1091, col: 5, offset: 26504},
+				pos: position{line: 1092, col: 5, offset: 26590},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1091, col: 5, offset: 26504},
+						pos:  position{line: 1092, col: 5, offset: 26590},
 						name: "LambdaExpr",
 					},
 					&actionExpr{
-						pos: position{line: 1092, col: 5, offset: 26519},
+						pos: position{line: 1093, col: 5, offset: 26605},
 						run: (*parser).callonCallable3,
 						expr: &labeledExpr{
-							pos:   position{line: 1092, col: 5, offset: 26519},
+							pos:   position{line: 1093, col: 5, offset: 26605},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1092, col: 8, offset: 26522},
+								pos:  position{line: 1093, col: 8, offset: 26608},
 								name: "IdentifierName",
 							},
 						},
@@ -7283,27 +7296,27 @@ var g = &grammar{
 		},
 		{
 			name: "FuncValue",
-			pos:  position{line: 1100, col: 1, offset: 26669},
+			pos:  position{line: 1101, col: 1, offset: 26755},
 			expr: &choiceExpr{
-				pos: position{line: 1101, col: 5, offset: 26683},
+				pos: position{line: 1102, col: 5, offset: 26769},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1101, col: 5, offset: 26683},
+						pos: position{line: 1102, col: 5, offset: 26769},
 						run: (*parser).callonFuncValue2,
 						expr: &seqExpr{
-							pos: position{line: 1101, col: 5, offset: 26683},
+							pos: position{line: 1102, col: 5, offset: 26769},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1101, col: 5, offset: 26683},
+									pos:        position{line: 1102, col: 5, offset: 26769},
 									val:        "&",
 									ignoreCase: false,
 									want:       "\"&\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1101, col: 9, offset: 26687},
+									pos:   position{line: 1102, col: 9, offset: 26773},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1101, col: 12, offset: 26690},
+										pos:  position{line: 1102, col: 12, offset: 26776},
 										name: "IdentifierName",
 									},
 								},
@@ -7311,7 +7324,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1108, col: 5, offset: 26840},
+						pos:  position{line: 1109, col: 5, offset: 26926},
 						name: "LambdaExpr",
 					},
 				},
@@ -7321,12 +7334,12 @@ var g = &grammar{
 		},
 		{
 			name: "DateTypeHack",
-			pos:  position{line: 1110, col: 1, offset: 26852},
+			pos:  position{line: 1111, col: 1, offset: 26938},
 			expr: &actionExpr{
-				pos: position{line: 1111, col: 5, offset: 26869},
+				pos: position{line: 1112, col: 5, offset: 26955},
 				run: (*parser).callonDateTypeHack1,
 				expr: &litMatcher{
-					pos:        position{line: 1111, col: 5, offset: 26869},
+					pos:        position{line: 1112, col: 5, offset: 26955},
 					val:        "date",
 					ignoreCase: true,
 					want:       "\"date\"i",
@@ -7337,19 +7350,19 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionArgs",
-			pos:  position{line: 1118, col: 1, offset: 26981},
+			pos:  position{line: 1119, col: 1, offset: 27067},
 			expr: &choiceExpr{
-				pos: position{line: 1119, col: 5, offset: 26998},
+				pos: position{line: 1120, col: 5, offset: 27084},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1119, col: 5, offset: 26998},
+						pos:  position{line: 1120, col: 5, offset: 27084},
 						name: "FuncOrExprs",
 					},
 					&actionExpr{
-						pos: position{line: 1120, col: 5, offset: 27014},
+						pos: position{line: 1121, col: 5, offset: 27100},
 						run: (*parser).callonFunctionArgs3,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1120, col: 5, offset: 27014},
+							pos:  position{line: 1121, col: 5, offset: 27100},
 							name: "__",
 						},
 					},
@@ -7360,51 +7373,51 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 1122, col: 1, offset: 27042},
+			pos:  position{line: 1123, col: 1, offset: 27128},
 			expr: &actionExpr{
-				pos: position{line: 1123, col: 5, offset: 27052},
+				pos: position{line: 1124, col: 5, offset: 27138},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 1123, col: 5, offset: 27052},
+					pos: position{line: 1124, col: 5, offset: 27138},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1123, col: 5, offset: 27052},
+							pos:   position{line: 1124, col: 5, offset: 27138},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1123, col: 11, offset: 27058},
+								pos:  position{line: 1124, col: 11, offset: 27144},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1123, col: 16, offset: 27063},
+							pos:   position{line: 1124, col: 16, offset: 27149},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1123, col: 21, offset: 27068},
+								pos: position{line: 1124, col: 21, offset: 27154},
 								expr: &actionExpr{
-									pos: position{line: 1123, col: 22, offset: 27069},
+									pos: position{line: 1124, col: 22, offset: 27155},
 									run: (*parser).callonExprs7,
 									expr: &seqExpr{
-										pos: position{line: 1123, col: 22, offset: 27069},
+										pos: position{line: 1124, col: 22, offset: 27155},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1123, col: 22, offset: 27069},
+												pos:  position{line: 1124, col: 22, offset: 27155},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1123, col: 25, offset: 27072},
+												pos:        position{line: 1124, col: 25, offset: 27158},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1123, col: 29, offset: 27076},
+												pos:  position{line: 1124, col: 29, offset: 27162},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1123, col: 32, offset: 27079},
+												pos:   position{line: 1124, col: 32, offset: 27165},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1123, col: 34, offset: 27081},
+													pos:  position{line: 1124, col: 34, offset: 27167},
 													name: "Expr",
 												},
 											},
@@ -7421,84 +7434,84 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 1127, col: 1, offset: 27154},
+			pos:  position{line: 1128, col: 1, offset: 27240},
 			expr: &choiceExpr{
-				pos: position{line: 1128, col: 5, offset: 27166},
+				pos: position{line: 1129, col: 5, offset: 27252},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1128, col: 5, offset: 27166},
+						pos:  position{line: 1129, col: 5, offset: 27252},
 						name: "CaseExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1129, col: 5, offset: 27179},
+						pos:  position{line: 1130, col: 5, offset: 27265},
 						name: "Record",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1130, col: 5, offset: 27190},
+						pos:  position{line: 1131, col: 5, offset: 27276},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1131, col: 5, offset: 27200},
+						pos:  position{line: 1132, col: 5, offset: 27286},
 						name: "Set",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1132, col: 5, offset: 27208},
+						pos:  position{line: 1133, col: 5, offset: 27294},
 						name: "Map",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1133, col: 5, offset: 27216},
+						pos:  position{line: 1134, col: 5, offset: 27302},
 						name: "SQLTimeExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1134, col: 5, offset: 27232},
+						pos:  position{line: 1135, col: 5, offset: 27318},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 1135, col: 5, offset: 27244},
+						pos: position{line: 1136, col: 5, offset: 27330},
 						run: (*parser).callonPrimary9,
 						expr: &labeledExpr{
-							pos:   position{line: 1135, col: 5, offset: 27244},
+							pos:   position{line: 1136, col: 5, offset: 27330},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1135, col: 8, offset: 27247},
+								pos:  position{line: 1136, col: 8, offset: 27333},
 								name: "Identifier",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1136, col: 5, offset: 27340},
+						pos:  position{line: 1137, col: 5, offset: 27426},
 						name: "Tuple",
 					},
 					&actionExpr{
-						pos: position{line: 1137, col: 5, offset: 27350},
+						pos: position{line: 1138, col: 5, offset: 27436},
 						run: (*parser).callonPrimary13,
 						expr: &seqExpr{
-							pos: position{line: 1137, col: 5, offset: 27350},
+							pos: position{line: 1138, col: 5, offset: 27436},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1137, col: 5, offset: 27350},
+									pos:        position{line: 1138, col: 5, offset: 27436},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1137, col: 9, offset: 27354},
+									pos:  position{line: 1138, col: 9, offset: 27440},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1137, col: 12, offset: 27357},
+									pos:   position{line: 1138, col: 12, offset: 27443},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1137, col: 17, offset: 27362},
+										pos:  position{line: 1138, col: 17, offset: 27448},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1137, col: 22, offset: 27367},
+									pos:  position{line: 1138, col: 22, offset: 27453},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1137, col: 25, offset: 27370},
+									pos:        position{line: 1138, col: 25, offset: 27456},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7507,35 +7520,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1138, col: 5, offset: 27399},
+						pos: position{line: 1139, col: 5, offset: 27485},
 						run: (*parser).callonPrimary21,
 						expr: &seqExpr{
-							pos: position{line: 1138, col: 5, offset: 27399},
+							pos: position{line: 1139, col: 5, offset: 27485},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1138, col: 5, offset: 27399},
+									pos:        position{line: 1139, col: 5, offset: 27485},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1138, col: 9, offset: 27403},
+									pos:  position{line: 1139, col: 9, offset: 27489},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1138, col: 12, offset: 27406},
+									pos:   position{line: 1139, col: 12, offset: 27492},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1138, col: 17, offset: 27411},
+										pos:  position{line: 1139, col: 17, offset: 27497},
 										name: "SubqueryExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1138, col: 30, offset: 27424},
+									pos:  position{line: 1139, col: 30, offset: 27510},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1138, col: 33, offset: 27427},
+									pos:        position{line: 1139, col: 33, offset: 27513},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -7544,35 +7557,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1139, col: 5, offset: 27456},
+						pos: position{line: 1140, col: 5, offset: 27542},
 						run: (*parser).callonPrimary29,
 						expr: &seqExpr{
-							pos: position{line: 1139, col: 5, offset: 27456},
+							pos: position{line: 1140, col: 5, offset: 27542},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1139, col: 5, offset: 27456},
+									pos:        position{line: 1140, col: 5, offset: 27542},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1139, col: 9, offset: 27460},
+									pos:  position{line: 1140, col: 9, offset: 27546},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1139, col: 12, offset: 27463},
+									pos:   position{line: 1140, col: 12, offset: 27549},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1139, col: 17, offset: 27468},
+										pos:  position{line: 1140, col: 17, offset: 27554},
 										name: "SubqueryExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1139, col: 30, offset: 27481},
+									pos:  position{line: 1140, col: 30, offset: 27567},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1139, col: 33, offset: 27484},
+									pos:        position{line: 1140, col: 33, offset: 27570},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -7587,53 +7600,53 @@ var g = &grammar{
 		},
 		{
 			name: "CaseExpr",
-			pos:  position{line: 1144, col: 1, offset: 27566},
+			pos:  position{line: 1145, col: 1, offset: 27652},
 			expr: &choiceExpr{
-				pos: position{line: 1145, col: 5, offset: 27579},
+				pos: position{line: 1146, col: 5, offset: 27665},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1145, col: 5, offset: 27579},
+						pos: position{line: 1146, col: 5, offset: 27665},
 						run: (*parser).callonCaseExpr2,
 						expr: &seqExpr{
-							pos: position{line: 1145, col: 5, offset: 27579},
+							pos: position{line: 1146, col: 5, offset: 27665},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1145, col: 5, offset: 27579},
+									pos:  position{line: 1146, col: 5, offset: 27665},
 									name: "CASE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1145, col: 10, offset: 27584},
+									pos:   position{line: 1146, col: 10, offset: 27670},
 									label: "cases",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1145, col: 16, offset: 27590},
+										pos: position{line: 1146, col: 16, offset: 27676},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1145, col: 16, offset: 27590},
+											pos:  position{line: 1146, col: 16, offset: 27676},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1145, col: 22, offset: 27596},
+									pos:   position{line: 1146, col: 22, offset: 27682},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1145, col: 28, offset: 27602},
+										pos: position{line: 1146, col: 28, offset: 27688},
 										expr: &seqExpr{
-											pos: position{line: 1145, col: 29, offset: 27603},
+											pos: position{line: 1146, col: 29, offset: 27689},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1145, col: 29, offset: 27603},
+													pos:  position{line: 1146, col: 29, offset: 27689},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1145, col: 31, offset: 27605},
+													pos:  position{line: 1146, col: 31, offset: 27691},
 													name: "ELSE",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1145, col: 36, offset: 27610},
+													pos:  position{line: 1146, col: 36, offset: 27696},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1145, col: 38, offset: 27612},
+													pos:  position{line: 1146, col: 38, offset: 27698},
 													name: "Expr",
 												},
 											},
@@ -7641,24 +7654,24 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1145, col: 45, offset: 27619},
+									pos:  position{line: 1146, col: 45, offset: 27705},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1145, col: 47, offset: 27621},
+									pos:  position{line: 1146, col: 47, offset: 27707},
 									name: "END",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1145, col: 51, offset: 27625},
+									pos: position{line: 1146, col: 51, offset: 27711},
 									expr: &seqExpr{
-										pos: position{line: 1145, col: 52, offset: 27626},
+										pos: position{line: 1146, col: 52, offset: 27712},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1145, col: 52, offset: 27626},
+												pos:  position{line: 1146, col: 52, offset: 27712},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1145, col: 54, offset: 27628},
+												pos:  position{line: 1146, col: 54, offset: 27714},
 												name: "CASE",
 											},
 										},
@@ -7668,60 +7681,60 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1169, col: 5, offset: 28265},
+						pos: position{line: 1170, col: 5, offset: 28351},
 						run: (*parser).callonCaseExpr21,
 						expr: &seqExpr{
-							pos: position{line: 1169, col: 5, offset: 28265},
+							pos: position{line: 1170, col: 5, offset: 28351},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1169, col: 5, offset: 28265},
+									pos:  position{line: 1170, col: 5, offset: 28351},
 									name: "CASE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1169, col: 10, offset: 28270},
+									pos:  position{line: 1170, col: 10, offset: 28356},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 1169, col: 12, offset: 28272},
+									pos:   position{line: 1170, col: 12, offset: 28358},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1169, col: 17, offset: 28277},
+										pos:  position{line: 1170, col: 17, offset: 28363},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1169, col: 22, offset: 28282},
+									pos:   position{line: 1170, col: 22, offset: 28368},
 									label: "whens",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1169, col: 28, offset: 28288},
+										pos: position{line: 1170, col: 28, offset: 28374},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1169, col: 28, offset: 28288},
+											pos:  position{line: 1170, col: 28, offset: 28374},
 											name: "When",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1169, col: 34, offset: 28294},
+									pos:   position{line: 1170, col: 34, offset: 28380},
 									label: "else_",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1169, col: 40, offset: 28300},
+										pos: position{line: 1170, col: 40, offset: 28386},
 										expr: &seqExpr{
-											pos: position{line: 1169, col: 41, offset: 28301},
+											pos: position{line: 1170, col: 41, offset: 28387},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1169, col: 41, offset: 28301},
+													pos:  position{line: 1170, col: 41, offset: 28387},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1169, col: 43, offset: 28303},
+													pos:  position{line: 1170, col: 43, offset: 28389},
 													name: "ELSE",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1169, col: 48, offset: 28308},
+													pos:  position{line: 1170, col: 48, offset: 28394},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1169, col: 50, offset: 28310},
+													pos:  position{line: 1170, col: 50, offset: 28396},
 													name: "Expr",
 												},
 											},
@@ -7729,24 +7742,24 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1169, col: 57, offset: 28317},
+									pos:  position{line: 1170, col: 57, offset: 28403},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1169, col: 59, offset: 28319},
+									pos:  position{line: 1170, col: 59, offset: 28405},
 									name: "END",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1169, col: 63, offset: 28323},
+									pos: position{line: 1170, col: 63, offset: 28409},
 									expr: &seqExpr{
-										pos: position{line: 1169, col: 64, offset: 28324},
+										pos: position{line: 1170, col: 64, offset: 28410},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1169, col: 64, offset: 28324},
+												pos:  position{line: 1170, col: 64, offset: 28410},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1169, col: 66, offset: 28326},
+												pos:  position{line: 1170, col: 66, offset: 28412},
 												name: "CASE",
 											},
 										},
@@ -7762,50 +7775,50 @@ var g = &grammar{
 		},
 		{
 			name: "When",
-			pos:  position{line: 1182, col: 1, offset: 28632},
+			pos:  position{line: 1183, col: 1, offset: 28718},
 			expr: &actionExpr{
-				pos: position{line: 1183, col: 5, offset: 28641},
+				pos: position{line: 1184, col: 5, offset: 28727},
 				run: (*parser).callonWhen1,
 				expr: &seqExpr{
-					pos: position{line: 1183, col: 5, offset: 28641},
+					pos: position{line: 1184, col: 5, offset: 28727},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1183, col: 5, offset: 28641},
+							pos:  position{line: 1184, col: 5, offset: 28727},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1183, col: 7, offset: 28643},
+							pos:  position{line: 1184, col: 7, offset: 28729},
 							name: "WHEN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1183, col: 12, offset: 28648},
+							pos:  position{line: 1184, col: 12, offset: 28734},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1183, col: 14, offset: 28650},
+							pos:   position{line: 1184, col: 14, offset: 28736},
 							label: "cond",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1183, col: 19, offset: 28655},
+								pos:  position{line: 1184, col: 19, offset: 28741},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1183, col: 24, offset: 28660},
+							pos:  position{line: 1184, col: 24, offset: 28746},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1183, col: 26, offset: 28662},
+							pos:  position{line: 1184, col: 26, offset: 28748},
 							name: "THEN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1183, col: 31, offset: 28667},
+							pos:  position{line: 1184, col: 31, offset: 28753},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1183, col: 33, offset: 28669},
+							pos:   position{line: 1184, col: 33, offset: 28755},
 							label: "then",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1183, col: 38, offset: 28674},
+								pos:  position{line: 1184, col: 38, offset: 28760},
 								name: "Expr",
 							},
 						},
@@ -7817,15 +7830,15 @@ var g = &grammar{
 		},
 		{
 			name: "SubqueryExpr",
-			pos:  position{line: 1191, col: 1, offset: 28807},
+			pos:  position{line: 1192, col: 1, offset: 28893},
 			expr: &actionExpr{
-				pos: position{line: 1192, col: 5, offset: 28824},
+				pos: position{line: 1193, col: 5, offset: 28910},
 				run: (*parser).callonSubqueryExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 1192, col: 5, offset: 28824},
+					pos:   position{line: 1193, col: 5, offset: 28910},
 					label: "body",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1192, col: 10, offset: 28829},
+						pos:  position{line: 1193, col: 10, offset: 28915},
 						name: "Seq",
 					},
 				},
@@ -7835,37 +7848,37 @@ var g = &grammar{
 		},
 		{
 			name: "Record",
-			pos:  position{line: 1200, col: 1, offset: 28973},
+			pos:  position{line: 1201, col: 1, offset: 29059},
 			expr: &actionExpr{
-				pos: position{line: 1201, col: 5, offset: 28984},
+				pos: position{line: 1202, col: 5, offset: 29070},
 				run: (*parser).callonRecord1,
 				expr: &seqExpr{
-					pos: position{line: 1201, col: 5, offset: 28984},
+					pos: position{line: 1202, col: 5, offset: 29070},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1201, col: 5, offset: 28984},
+							pos:        position{line: 1202, col: 5, offset: 29070},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1201, col: 9, offset: 28988},
+							pos:  position{line: 1202, col: 9, offset: 29074},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1201, col: 12, offset: 28991},
+							pos:   position{line: 1202, col: 12, offset: 29077},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1201, col: 18, offset: 28997},
+								pos:  position{line: 1202, col: 18, offset: 29083},
 								name: "RecordElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1201, col: 30, offset: 29009},
+							pos:  position{line: 1202, col: 30, offset: 29095},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1201, col: 33, offset: 29012},
+							pos:        position{line: 1202, col: 33, offset: 29098},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -7878,31 +7891,31 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElems",
-			pos:  position{line: 1209, col: 1, offset: 29170},
+			pos:  position{line: 1210, col: 1, offset: 29256},
 			expr: &choiceExpr{
-				pos: position{line: 1210, col: 5, offset: 29186},
+				pos: position{line: 1211, col: 5, offset: 29272},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1210, col: 5, offset: 29186},
+						pos: position{line: 1211, col: 5, offset: 29272},
 						run: (*parser).callonRecordElems2,
 						expr: &seqExpr{
-							pos: position{line: 1210, col: 5, offset: 29186},
+							pos: position{line: 1211, col: 5, offset: 29272},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1210, col: 5, offset: 29186},
+									pos:   position{line: 1211, col: 5, offset: 29272},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1210, col: 11, offset: 29192},
+										pos:  position{line: 1211, col: 11, offset: 29278},
 										name: "RecordElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1210, col: 22, offset: 29203},
+									pos:   position{line: 1211, col: 22, offset: 29289},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1210, col: 27, offset: 29208},
+										pos: position{line: 1211, col: 27, offset: 29294},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1210, col: 27, offset: 29208},
+											pos:  position{line: 1211, col: 27, offset: 29294},
 											name: "RecordElemTail",
 										},
 									},
@@ -7911,10 +7924,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1213, col: 5, offset: 29271},
+						pos: position{line: 1214, col: 5, offset: 29357},
 						run: (*parser).callonRecordElems9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1213, col: 5, offset: 29271},
+							pos:  position{line: 1214, col: 5, offset: 29357},
 							name: "__",
 						},
 					},
@@ -7925,32 +7938,32 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElemTail",
-			pos:  position{line: 1215, col: 1, offset: 29295},
+			pos:  position{line: 1216, col: 1, offset: 29381},
 			expr: &actionExpr{
-				pos: position{line: 1215, col: 18, offset: 29312},
+				pos: position{line: 1216, col: 18, offset: 29398},
 				run: (*parser).callonRecordElemTail1,
 				expr: &seqExpr{
-					pos: position{line: 1215, col: 18, offset: 29312},
+					pos: position{line: 1216, col: 18, offset: 29398},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1215, col: 18, offset: 29312},
+							pos:  position{line: 1216, col: 18, offset: 29398},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1215, col: 21, offset: 29315},
+							pos:        position{line: 1216, col: 21, offset: 29401},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1215, col: 25, offset: 29319},
+							pos:  position{line: 1216, col: 25, offset: 29405},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1215, col: 28, offset: 29322},
+							pos:   position{line: 1216, col: 28, offset: 29408},
 							label: "elem",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1215, col: 33, offset: 29327},
+								pos:  position{line: 1216, col: 33, offset: 29413},
 								name: "RecordElem",
 							},
 						},
@@ -7962,20 +7975,20 @@ var g = &grammar{
 		},
 		{
 			name: "RecordElem",
-			pos:  position{line: 1217, col: 1, offset: 29360},
+			pos:  position{line: 1218, col: 1, offset: 29446},
 			expr: &choiceExpr{
-				pos: position{line: 1217, col: 14, offset: 29373},
+				pos: position{line: 1218, col: 14, offset: 29459},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1217, col: 14, offset: 29373},
+						pos:  position{line: 1218, col: 14, offset: 29459},
 						name: "SpreadElem",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1217, col: 27, offset: 29386},
+						pos:  position{line: 1218, col: 27, offset: 29472},
 						name: "FieldElem",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1217, col: 39, offset: 29398},
+						pos:  position{line: 1218, col: 39, offset: 29484},
 						name: "ExprElem",
 					},
 				},
@@ -7985,28 +7998,28 @@ var g = &grammar{
 		},
 		{
 			name: "SpreadElem",
-			pos:  position{line: 1219, col: 1, offset: 29408},
+			pos:  position{line: 1220, col: 1, offset: 29494},
 			expr: &actionExpr{
-				pos: position{line: 1220, col: 5, offset: 29423},
+				pos: position{line: 1221, col: 5, offset: 29509},
 				run: (*parser).callonSpreadElem1,
 				expr: &seqExpr{
-					pos: position{line: 1220, col: 5, offset: 29423},
+					pos: position{line: 1221, col: 5, offset: 29509},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1220, col: 5, offset: 29423},
+							pos:        position{line: 1221, col: 5, offset: 29509},
 							val:        "...",
 							ignoreCase: false,
 							want:       "\"...\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1220, col: 11, offset: 29429},
+							pos:  position{line: 1221, col: 11, offset: 29515},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1220, col: 14, offset: 29432},
+							pos:   position{line: 1221, col: 14, offset: 29518},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1220, col: 19, offset: 29437},
+								pos:  position{line: 1221, col: 19, offset: 29523},
 								name: "Expr",
 							},
 						},
@@ -8018,40 +8031,40 @@ var g = &grammar{
 		},
 		{
 			name: "FieldElem",
-			pos:  position{line: 1224, col: 1, offset: 29541},
+			pos:  position{line: 1225, col: 1, offset: 29627},
 			expr: &actionExpr{
-				pos: position{line: 1225, col: 5, offset: 29555},
+				pos: position{line: 1226, col: 5, offset: 29641},
 				run: (*parser).callonFieldElem1,
 				expr: &seqExpr{
-					pos: position{line: 1225, col: 5, offset: 29555},
+					pos: position{line: 1226, col: 5, offset: 29641},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1225, col: 5, offset: 29555},
+							pos:   position{line: 1226, col: 5, offset: 29641},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1225, col: 10, offset: 29560},
+								pos:  position{line: 1226, col: 10, offset: 29646},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1225, col: 15, offset: 29565},
+							pos:  position{line: 1226, col: 15, offset: 29651},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1225, col: 18, offset: 29568},
+							pos:        position{line: 1226, col: 18, offset: 29654},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1225, col: 22, offset: 29572},
+							pos:  position{line: 1226, col: 22, offset: 29658},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1225, col: 25, offset: 29575},
+							pos:   position{line: 1226, col: 25, offset: 29661},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1225, col: 31, offset: 29581},
+								pos:  position{line: 1226, col: 31, offset: 29667},
 								name: "Expr",
 							},
 						},
@@ -8063,15 +8076,15 @@ var g = &grammar{
 		},
 		{
 			name: "ExprElem",
-			pos:  position{line: 1234, col: 1, offset: 29750},
+			pos:  position{line: 1235, col: 1, offset: 29836},
 			expr: &actionExpr{
-				pos: position{line: 1235, col: 5, offset: 29763},
+				pos: position{line: 1236, col: 5, offset: 29849},
 				run: (*parser).callonExprElem1,
 				expr: &labeledExpr{
-					pos:   position{line: 1235, col: 5, offset: 29763},
+					pos:   position{line: 1236, col: 5, offset: 29849},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1235, col: 10, offset: 29768},
+						pos:  position{line: 1236, col: 10, offset: 29854},
 						name: "Expr",
 					},
 				},
@@ -8081,37 +8094,37 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 1239, col: 1, offset: 29868},
+			pos:  position{line: 1240, col: 1, offset: 29954},
 			expr: &actionExpr{
-				pos: position{line: 1240, col: 5, offset: 29878},
+				pos: position{line: 1241, col: 5, offset: 29964},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 1240, col: 5, offset: 29878},
+					pos: position{line: 1241, col: 5, offset: 29964},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1240, col: 5, offset: 29878},
+							pos:        position{line: 1241, col: 5, offset: 29964},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1240, col: 9, offset: 29882},
+							pos:  position{line: 1241, col: 9, offset: 29968},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1240, col: 12, offset: 29885},
+							pos:   position{line: 1241, col: 12, offset: 29971},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1240, col: 18, offset: 29891},
+								pos:  position{line: 1241, col: 18, offset: 29977},
 								name: "ArrayElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1240, col: 29, offset: 29902},
+							pos:  position{line: 1241, col: 29, offset: 29988},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1240, col: 32, offset: 29905},
+							pos:        position{line: 1241, col: 32, offset: 29991},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -8124,37 +8137,37 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 1248, col: 1, offset: 30060},
+			pos:  position{line: 1249, col: 1, offset: 30146},
 			expr: &actionExpr{
-				pos: position{line: 1249, col: 5, offset: 30068},
+				pos: position{line: 1250, col: 5, offset: 30154},
 				run: (*parser).callonSet1,
 				expr: &seqExpr{
-					pos: position{line: 1249, col: 5, offset: 30068},
+					pos: position{line: 1250, col: 5, offset: 30154},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1249, col: 5, offset: 30068},
+							pos:        position{line: 1250, col: 5, offset: 30154},
 							val:        "|[",
 							ignoreCase: false,
 							want:       "\"|[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1249, col: 10, offset: 30073},
+							pos:  position{line: 1250, col: 10, offset: 30159},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1249, col: 13, offset: 30076},
+							pos:   position{line: 1250, col: 13, offset: 30162},
 							label: "elems",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1249, col: 19, offset: 30082},
+								pos:  position{line: 1250, col: 19, offset: 30168},
 								name: "ArrayElems",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1249, col: 30, offset: 30093},
+							pos:  position{line: 1250, col: 30, offset: 30179},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1249, col: 33, offset: 30096},
+							pos:        position{line: 1250, col: 33, offset: 30182},
 							val:        "]|",
 							ignoreCase: false,
 							want:       "\"]|\"",
@@ -8167,54 +8180,54 @@ var g = &grammar{
 		},
 		{
 			name: "ArrayElems",
-			pos:  position{line: 1257, col: 1, offset: 30248},
+			pos:  position{line: 1258, col: 1, offset: 30334},
 			expr: &choiceExpr{
-				pos: position{line: 1258, col: 5, offset: 30263},
+				pos: position{line: 1259, col: 5, offset: 30349},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1258, col: 5, offset: 30263},
+						pos: position{line: 1259, col: 5, offset: 30349},
 						run: (*parser).callonArrayElems2,
 						expr: &seqExpr{
-							pos: position{line: 1258, col: 5, offset: 30263},
+							pos: position{line: 1259, col: 5, offset: 30349},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1258, col: 5, offset: 30263},
+									pos:   position{line: 1259, col: 5, offset: 30349},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1258, col: 11, offset: 30269},
+										pos:  position{line: 1259, col: 11, offset: 30355},
 										name: "ArrayElem",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1258, col: 21, offset: 30279},
+									pos:   position{line: 1259, col: 21, offset: 30365},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1258, col: 26, offset: 30284},
+										pos: position{line: 1259, col: 26, offset: 30370},
 										expr: &actionExpr{
-											pos: position{line: 1258, col: 27, offset: 30285},
+											pos: position{line: 1259, col: 27, offset: 30371},
 											run: (*parser).callonArrayElems8,
 											expr: &seqExpr{
-												pos: position{line: 1258, col: 27, offset: 30285},
+												pos: position{line: 1259, col: 27, offset: 30371},
 												exprs: []any{
 													&ruleRefExpr{
-														pos:  position{line: 1258, col: 27, offset: 30285},
+														pos:  position{line: 1259, col: 27, offset: 30371},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 1258, col: 30, offset: 30288},
+														pos:        position{line: 1259, col: 30, offset: 30374},
 														val:        ",",
 														ignoreCase: false,
 														want:       "\",\"",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1258, col: 34, offset: 30292},
+														pos:  position{line: 1259, col: 34, offset: 30378},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 1258, col: 37, offset: 30295},
+														pos:   position{line: 1259, col: 37, offset: 30381},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 1258, col: 39, offset: 30297},
+															pos:  position{line: 1259, col: 39, offset: 30383},
 															name: "ArrayElem",
 														},
 													},
@@ -8227,10 +8240,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1261, col: 5, offset: 30378},
+						pos: position{line: 1262, col: 5, offset: 30464},
 						run: (*parser).callonArrayElems15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1261, col: 5, offset: 30378},
+							pos:  position{line: 1262, col: 5, offset: 30464},
 							name: "__",
 						},
 					},
@@ -8241,16 +8254,16 @@ var g = &grammar{
 		},
 		{
 			name: "ArrayElem",
-			pos:  position{line: 1263, col: 1, offset: 30402},
+			pos:  position{line: 1264, col: 1, offset: 30488},
 			expr: &choiceExpr{
-				pos: position{line: 1263, col: 13, offset: 30414},
+				pos: position{line: 1264, col: 13, offset: 30500},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1263, col: 13, offset: 30414},
+						pos:  position{line: 1264, col: 13, offset: 30500},
 						name: "SpreadElem",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1263, col: 26, offset: 30427},
+						pos:  position{line: 1264, col: 26, offset: 30513},
 						name: "ExprElem",
 					},
 				},
@@ -8260,37 +8273,37 @@ var g = &grammar{
 		},
 		{
 			name: "Map",
-			pos:  position{line: 1265, col: 1, offset: 30437},
+			pos:  position{line: 1266, col: 1, offset: 30523},
 			expr: &actionExpr{
-				pos: position{line: 1266, col: 5, offset: 30445},
+				pos: position{line: 1267, col: 5, offset: 30531},
 				run: (*parser).callonMap1,
 				expr: &seqExpr{
-					pos: position{line: 1266, col: 5, offset: 30445},
+					pos: position{line: 1267, col: 5, offset: 30531},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1266, col: 5, offset: 30445},
+							pos:        position{line: 1267, col: 5, offset: 30531},
 							val:        "|{",
 							ignoreCase: false,
 							want:       "\"|{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1266, col: 10, offset: 30450},
+							pos:  position{line: 1267, col: 10, offset: 30536},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1266, col: 13, offset: 30453},
+							pos:   position{line: 1267, col: 13, offset: 30539},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1266, col: 19, offset: 30459},
+								pos:  position{line: 1267, col: 19, offset: 30545},
 								name: "Entries",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1266, col: 27, offset: 30467},
+							pos:  position{line: 1267, col: 27, offset: 30553},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1266, col: 30, offset: 30470},
+							pos:        position{line: 1267, col: 30, offset: 30556},
 							val:        "}|",
 							ignoreCase: false,
 							want:       "\"}|\"",
@@ -8303,31 +8316,31 @@ var g = &grammar{
 		},
 		{
 			name: "Entries",
-			pos:  position{line: 1274, col: 1, offset: 30623},
+			pos:  position{line: 1275, col: 1, offset: 30709},
 			expr: &choiceExpr{
-				pos: position{line: 1275, col: 5, offset: 30635},
+				pos: position{line: 1276, col: 5, offset: 30721},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1275, col: 5, offset: 30635},
+						pos: position{line: 1276, col: 5, offset: 30721},
 						run: (*parser).callonEntries2,
 						expr: &seqExpr{
-							pos: position{line: 1275, col: 5, offset: 30635},
+							pos: position{line: 1276, col: 5, offset: 30721},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1275, col: 5, offset: 30635},
+									pos:   position{line: 1276, col: 5, offset: 30721},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1275, col: 11, offset: 30641},
+										pos:  position{line: 1276, col: 11, offset: 30727},
 										name: "Entry",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1275, col: 17, offset: 30647},
+									pos:   position{line: 1276, col: 17, offset: 30733},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1275, col: 22, offset: 30652},
+										pos: position{line: 1276, col: 22, offset: 30738},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1275, col: 22, offset: 30652},
+											pos:  position{line: 1276, col: 22, offset: 30738},
 											name: "EntryTail",
 										},
 									},
@@ -8336,10 +8349,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1278, col: 5, offset: 30710},
+						pos: position{line: 1279, col: 5, offset: 30796},
 						run: (*parser).callonEntries9,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1278, col: 5, offset: 30710},
+							pos:  position{line: 1279, col: 5, offset: 30796},
 							name: "__",
 						},
 					},
@@ -8350,32 +8363,32 @@ var g = &grammar{
 		},
 		{
 			name: "EntryTail",
-			pos:  position{line: 1281, col: 1, offset: 30735},
+			pos:  position{line: 1282, col: 1, offset: 30821},
 			expr: &actionExpr{
-				pos: position{line: 1281, col: 13, offset: 30747},
+				pos: position{line: 1282, col: 13, offset: 30833},
 				run: (*parser).callonEntryTail1,
 				expr: &seqExpr{
-					pos: position{line: 1281, col: 13, offset: 30747},
+					pos: position{line: 1282, col: 13, offset: 30833},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1281, col: 13, offset: 30747},
+							pos:  position{line: 1282, col: 13, offset: 30833},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1281, col: 16, offset: 30750},
+							pos:        position{line: 1282, col: 16, offset: 30836},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1281, col: 20, offset: 30754},
+							pos:  position{line: 1282, col: 20, offset: 30840},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1281, col: 23, offset: 30757},
+							pos:   position{line: 1282, col: 23, offset: 30843},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1281, col: 25, offset: 30759},
+								pos:  position{line: 1282, col: 25, offset: 30845},
 								name: "Entry",
 							},
 						},
@@ -8387,40 +8400,40 @@ var g = &grammar{
 		},
 		{
 			name: "Entry",
-			pos:  position{line: 1283, col: 1, offset: 30784},
+			pos:  position{line: 1284, col: 1, offset: 30870},
 			expr: &actionExpr{
-				pos: position{line: 1284, col: 5, offset: 30794},
+				pos: position{line: 1285, col: 5, offset: 30880},
 				run: (*parser).callonEntry1,
 				expr: &seqExpr{
-					pos: position{line: 1284, col: 5, offset: 30794},
+					pos: position{line: 1285, col: 5, offset: 30880},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1284, col: 5, offset: 30794},
+							pos:   position{line: 1285, col: 5, offset: 30880},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1284, col: 9, offset: 30798},
+								pos:  position{line: 1285, col: 9, offset: 30884},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1284, col: 14, offset: 30803},
+							pos:  position{line: 1285, col: 14, offset: 30889},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1284, col: 17, offset: 30806},
+							pos:        position{line: 1285, col: 17, offset: 30892},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1284, col: 21, offset: 30810},
+							pos:  position{line: 1285, col: 21, offset: 30896},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1284, col: 24, offset: 30813},
+							pos:   position{line: 1285, col: 24, offset: 30899},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1284, col: 30, offset: 30819},
+								pos:  position{line: 1285, col: 30, offset: 30905},
 								name: "Expr",
 							},
 						},
@@ -8432,61 +8445,61 @@ var g = &grammar{
 		},
 		{
 			name: "Tuple",
-			pos:  position{line: 1288, col: 1, offset: 30921},
+			pos:  position{line: 1289, col: 1, offset: 31007},
 			expr: &actionExpr{
-				pos: position{line: 1289, col: 5, offset: 30931},
+				pos: position{line: 1290, col: 5, offset: 31017},
 				run: (*parser).callonTuple1,
 				expr: &seqExpr{
-					pos: position{line: 1289, col: 5, offset: 30931},
+					pos: position{line: 1290, col: 5, offset: 31017},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1289, col: 5, offset: 30931},
+							pos:        position{line: 1290, col: 5, offset: 31017},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1289, col: 9, offset: 30935},
+							pos:  position{line: 1290, col: 9, offset: 31021},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1289, col: 12, offset: 30938},
+							pos:   position{line: 1290, col: 12, offset: 31024},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1289, col: 18, offset: 30944},
+								pos:  position{line: 1290, col: 18, offset: 31030},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1289, col: 23, offset: 30949},
+							pos:   position{line: 1290, col: 23, offset: 31035},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1289, col: 28, offset: 30954},
+								pos: position{line: 1290, col: 28, offset: 31040},
 								expr: &actionExpr{
-									pos: position{line: 1289, col: 29, offset: 30955},
+									pos: position{line: 1290, col: 29, offset: 31041},
 									run: (*parser).callonTuple9,
 									expr: &seqExpr{
-										pos: position{line: 1289, col: 29, offset: 30955},
+										pos: position{line: 1290, col: 29, offset: 31041},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1289, col: 29, offset: 30955},
+												pos:  position{line: 1290, col: 29, offset: 31041},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1289, col: 32, offset: 30958},
+												pos:        position{line: 1290, col: 32, offset: 31044},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1289, col: 36, offset: 30962},
+												pos:  position{line: 1290, col: 36, offset: 31048},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1289, col: 39, offset: 30965},
+												pos:   position{line: 1290, col: 39, offset: 31051},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1289, col: 41, offset: 30967},
+													pos:  position{line: 1290, col: 41, offset: 31053},
 													name: "Expr",
 												},
 											},
@@ -8496,11 +8509,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1289, col: 66, offset: 30992},
+							pos:  position{line: 1290, col: 66, offset: 31078},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1289, col: 69, offset: 30995},
+							pos:        position{line: 1290, col: 69, offset: 31081},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -8513,39 +8526,39 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTimeExpr",
-			pos:  position{line: 1297, col: 1, offset: 31154},
+			pos:  position{line: 1298, col: 1, offset: 31240},
 			expr: &actionExpr{
-				pos: position{line: 1298, col: 5, offset: 31170},
+				pos: position{line: 1299, col: 5, offset: 31256},
 				run: (*parser).callonSQLTimeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1298, col: 5, offset: 31170},
+					pos: position{line: 1299, col: 5, offset: 31256},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1298, col: 5, offset: 31170},
+							pos:   position{line: 1299, col: 5, offset: 31256},
 							label: "typ",
 							expr: &choiceExpr{
-								pos: position{line: 1298, col: 10, offset: 31175},
+								pos: position{line: 1299, col: 10, offset: 31261},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1298, col: 10, offset: 31175},
+										pos:  position{line: 1299, col: 10, offset: 31261},
 										name: "DATE",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1298, col: 17, offset: 31182},
+										pos:  position{line: 1299, col: 17, offset: 31268},
 										name: "TIMESTAMP",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1298, col: 28, offset: 31193},
+							pos:  position{line: 1299, col: 28, offset: 31279},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1298, col: 30, offset: 31195},
+							pos:   position{line: 1299, col: 30, offset: 31281},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1298, col: 32, offset: 31197},
+								pos:  position{line: 1299, col: 32, offset: 31283},
 								name: "StringLiteral",
 							},
 						},
@@ -8557,56 +8570,56 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 1309, col: 1, offset: 31412},
+			pos:  position{line: 1310, col: 1, offset: 31498},
 			expr: &choiceExpr{
-				pos: position{line: 1310, col: 5, offset: 31424},
+				pos: position{line: 1311, col: 5, offset: 31510},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1310, col: 5, offset: 31424},
+						pos:  position{line: 1311, col: 5, offset: 31510},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1311, col: 5, offset: 31440},
+						pos:  position{line: 1312, col: 5, offset: 31526},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1312, col: 5, offset: 31458},
+						pos:  position{line: 1313, col: 5, offset: 31544},
 						name: "FString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1313, col: 5, offset: 31470},
+						pos:  position{line: 1314, col: 5, offset: 31556},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1314, col: 5, offset: 31488},
+						pos:  position{line: 1315, col: 5, offset: 31574},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1315, col: 5, offset: 31507},
+						pos:  position{line: 1316, col: 5, offset: 31593},
 						name: "BytesLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1316, col: 5, offset: 31524},
+						pos:  position{line: 1317, col: 5, offset: 31610},
 						name: "Duration",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1317, col: 5, offset: 31537},
+						pos:  position{line: 1318, col: 5, offset: 31623},
 						name: "Time",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1318, col: 5, offset: 31546},
+						pos:  position{line: 1319, col: 5, offset: 31632},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1319, col: 5, offset: 31563},
+						pos:  position{line: 1320, col: 5, offset: 31649},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1320, col: 5, offset: 31582},
+						pos:  position{line: 1321, col: 5, offset: 31668},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1321, col: 5, offset: 31601},
+						pos:  position{line: 1322, col: 5, offset: 31687},
 						name: "NullLiteral",
 					},
 				},
@@ -8616,28 +8629,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 1323, col: 1, offset: 31614},
+			pos:  position{line: 1324, col: 1, offset: 31700},
 			expr: &choiceExpr{
-				pos: position{line: 1324, col: 5, offset: 31632},
+				pos: position{line: 1325, col: 5, offset: 31718},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1324, col: 5, offset: 31632},
+						pos: position{line: 1325, col: 5, offset: 31718},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1324, col: 5, offset: 31632},
+							pos: position{line: 1325, col: 5, offset: 31718},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1324, col: 5, offset: 31632},
+									pos:   position{line: 1325, col: 5, offset: 31718},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1324, col: 7, offset: 31634},
+										pos:  position{line: 1325, col: 7, offset: 31720},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1324, col: 14, offset: 31641},
+									pos: position{line: 1325, col: 14, offset: 31727},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1324, col: 15, offset: 31642},
+										pos:  position{line: 1325, col: 15, offset: 31728},
 										name: "IdentifierRest",
 									},
 								},
@@ -8645,13 +8658,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1327, col: 5, offset: 31722},
+						pos: position{line: 1328, col: 5, offset: 31808},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1327, col: 5, offset: 31722},
+							pos:   position{line: 1328, col: 5, offset: 31808},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1327, col: 7, offset: 31724},
+								pos:  position{line: 1328, col: 7, offset: 31810},
 								name: "IP4Net",
 							},
 						},
@@ -8663,35 +8676,35 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 1331, col: 1, offset: 31793},
+			pos:  position{line: 1332, col: 1, offset: 31879},
 			expr: &choiceExpr{
-				pos: position{line: 1332, col: 5, offset: 31812},
+				pos: position{line: 1333, col: 5, offset: 31898},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1332, col: 5, offset: 31812},
+						pos: position{line: 1333, col: 5, offset: 31898},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 1332, col: 5, offset: 31812},
+							pos: position{line: 1333, col: 5, offset: 31898},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1332, col: 5, offset: 31812},
+									pos:   position{line: 1333, col: 5, offset: 31898},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1332, col: 7, offset: 31814},
+										pos:  position{line: 1333, col: 7, offset: 31900},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1332, col: 11, offset: 31818},
+									pos: position{line: 1333, col: 11, offset: 31904},
 									expr: &choiceExpr{
-										pos: position{line: 1332, col: 13, offset: 31820},
+										pos: position{line: 1333, col: 13, offset: 31906},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1332, col: 13, offset: 31820},
+												pos:  position{line: 1333, col: 13, offset: 31906},
 												name: "IdentifierRest",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1332, col: 30, offset: 31837},
+												pos:  position{line: 1333, col: 30, offset: 31923},
 												name: "TypeLiteral",
 											},
 										},
@@ -8701,13 +8714,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1335, col: 5, offset: 31914},
+						pos: position{line: 1336, col: 5, offset: 32000},
 						run: (*parser).callonAddressLiteral10,
 						expr: &labeledExpr{
-							pos:   position{line: 1335, col: 5, offset: 31914},
+							pos:   position{line: 1336, col: 5, offset: 32000},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1335, col: 7, offset: 31916},
+								pos:  position{line: 1336, col: 7, offset: 32002},
 								name: "IP",
 							},
 						},
@@ -8719,15 +8732,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 1339, col: 1, offset: 31980},
+			pos:  position{line: 1340, col: 1, offset: 32066},
 			expr: &actionExpr{
-				pos: position{line: 1340, col: 5, offset: 31997},
+				pos: position{line: 1341, col: 5, offset: 32083},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1340, col: 5, offset: 31997},
+					pos:   position{line: 1341, col: 5, offset: 32083},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1340, col: 7, offset: 31999},
+						pos:  position{line: 1341, col: 7, offset: 32085},
 						name: "FloatString",
 					},
 				},
@@ -8737,15 +8750,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 1344, col: 1, offset: 32077},
+			pos:  position{line: 1345, col: 1, offset: 32163},
 			expr: &actionExpr{
-				pos: position{line: 1345, col: 5, offset: 32096},
+				pos: position{line: 1346, col: 5, offset: 32182},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 1345, col: 5, offset: 32096},
+					pos:   position{line: 1346, col: 5, offset: 32182},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1345, col: 7, offset: 32098},
+						pos:  position{line: 1346, col: 7, offset: 32184},
 						name: "IntString",
 					},
 				},
@@ -8755,23 +8768,23 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 1349, col: 1, offset: 32172},
+			pos:  position{line: 1350, col: 1, offset: 32258},
 			expr: &choiceExpr{
-				pos: position{line: 1350, col: 5, offset: 32191},
+				pos: position{line: 1351, col: 5, offset: 32277},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1350, col: 5, offset: 32191},
+						pos: position{line: 1351, col: 5, offset: 32277},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1350, col: 5, offset: 32191},
+							pos:  position{line: 1351, col: 5, offset: 32277},
 							name: "TRUE",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1351, col: 5, offset: 32249},
+						pos: position{line: 1352, col: 5, offset: 32335},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1351, col: 5, offset: 32249},
+							pos:  position{line: 1352, col: 5, offset: 32335},
 							name: "FALSE",
 						},
 					},
@@ -8782,12 +8795,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 1353, col: 1, offset: 32305},
+			pos:  position{line: 1354, col: 1, offset: 32391},
 			expr: &actionExpr{
-				pos: position{line: 1354, col: 5, offset: 32321},
+				pos: position{line: 1355, col: 5, offset: 32407},
 				run: (*parser).callonNullLiteral1,
 				expr: &ruleRefExpr{
-					pos:  position{line: 1354, col: 5, offset: 32321},
+					pos:  position{line: 1355, col: 5, offset: 32407},
 					name: "NULL",
 				},
 			},
@@ -8796,23 +8809,23 @@ var g = &grammar{
 		},
 		{
 			name: "BytesLiteral",
-			pos:  position{line: 1356, col: 1, offset: 32371},
+			pos:  position{line: 1357, col: 1, offset: 32457},
 			expr: &actionExpr{
-				pos: position{line: 1357, col: 5, offset: 32388},
+				pos: position{line: 1358, col: 5, offset: 32474},
 				run: (*parser).callonBytesLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1357, col: 5, offset: 32388},
+					pos: position{line: 1358, col: 5, offset: 32474},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1357, col: 5, offset: 32388},
+							pos:        position{line: 1358, col: 5, offset: 32474},
 							val:        "0x",
 							ignoreCase: false,
 							want:       "\"0x\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1357, col: 10, offset: 32393},
+							pos: position{line: 1358, col: 10, offset: 32479},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1357, col: 10, offset: 32393},
+								pos:  position{line: 1358, col: 10, offset: 32479},
 								name: "HexDigit",
 							},
 						},
@@ -8824,29 +8837,29 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 1361, col: 1, offset: 32467},
+			pos:  position{line: 1362, col: 1, offset: 32553},
 			expr: &actionExpr{
-				pos: position{line: 1362, col: 5, offset: 32483},
+				pos: position{line: 1363, col: 5, offset: 32569},
 				run: (*parser).callonTypeLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 1362, col: 5, offset: 32483},
+					pos: position{line: 1363, col: 5, offset: 32569},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1362, col: 5, offset: 32483},
+							pos:        position{line: 1363, col: 5, offset: 32569},
 							val:        "<",
 							ignoreCase: false,
 							want:       "\"<\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1362, col: 9, offset: 32487},
+							pos:   position{line: 1363, col: 9, offset: 32573},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1362, col: 13, offset: 32491},
+								pos:  position{line: 1363, col: 13, offset: 32577},
 								name: "Type",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1362, col: 18, offset: 32496},
+							pos:        position{line: 1363, col: 18, offset: 32582},
 							val:        ">",
 							ignoreCase: false,
 							want:       "\">\"",
@@ -8859,27 +8872,27 @@ var g = &grammar{
 		},
 		{
 			name: "TypeAsValue",
-			pos:  position{line: 1370, col: 1, offset: 32629},
+			pos:  position{line: 1371, col: 1, offset: 32715},
 			expr: &choiceExpr{
-				pos: position{line: 1371, col: 5, offset: 32645},
+				pos: position{line: 1372, col: 5, offset: 32731},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1371, col: 5, offset: 32645},
+						pos: position{line: 1372, col: 5, offset: 32731},
 						run: (*parser).callonTypeAsValue2,
 						expr: &seqExpr{
-							pos: position{line: 1371, col: 5, offset: 32645},
+							pos: position{line: 1372, col: 5, offset: 32731},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1371, col: 5, offset: 32645},
+									pos:        position{line: 1372, col: 5, offset: 32731},
 									val:        "=",
 									ignoreCase: false,
 									want:       "\"=\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1371, col: 9, offset: 32649},
+									pos:   position{line: 1372, col: 9, offset: 32735},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1371, col: 14, offset: 32654},
+										pos:  position{line: 1372, col: 14, offset: 32740},
 										name: "Name",
 									},
 								},
@@ -8887,13 +8900,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1372, col: 5, offset: 32728},
+						pos: position{line: 1373, col: 5, offset: 32814},
 						run: (*parser).callonTypeAsValue7,
 						expr: &labeledExpr{
-							pos:   position{line: 1372, col: 5, offset: 32728},
+							pos:   position{line: 1373, col: 5, offset: 32814},
 							label: "t",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1372, col: 7, offset: 32730},
+								pos:  position{line: 1373, col: 7, offset: 32816},
 								name: "EasyType",
 							},
 						},
@@ -8905,16 +8918,16 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 1380, col: 1, offset: 32866},
+			pos:  position{line: 1381, col: 1, offset: 32952},
 			expr: &choiceExpr{
-				pos: position{line: 1381, col: 5, offset: 32875},
+				pos: position{line: 1382, col: 5, offset: 32961},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1381, col: 5, offset: 32875},
+						pos:  position{line: 1382, col: 5, offset: 32961},
 						name: "TypeUnion",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1382, col: 5, offset: 32889},
+						pos:  position{line: 1383, col: 5, offset: 32975},
 						name: "ComponentType",
 					},
 				},
@@ -8924,52 +8937,52 @@ var g = &grammar{
 		},
 		{
 			name: "ComponentType",
-			pos:  position{line: 1384, col: 1, offset: 32904},
+			pos:  position{line: 1385, col: 1, offset: 32990},
 			expr: &choiceExpr{
-				pos: position{line: 1385, col: 5, offset: 32922},
+				pos: position{line: 1386, col: 5, offset: 33008},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1385, col: 5, offset: 32922},
+						pos:  position{line: 1386, col: 5, offset: 33008},
 						name: "EasyType",
 					},
 					&actionExpr{
-						pos: position{line: 1386, col: 5, offset: 32935},
+						pos: position{line: 1387, col: 5, offset: 33021},
 						run: (*parser).callonComponentType3,
 						expr: &seqExpr{
-							pos: position{line: 1386, col: 5, offset: 32935},
+							pos: position{line: 1387, col: 5, offset: 33021},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1386, col: 5, offset: 32935},
+									pos:   position{line: 1387, col: 5, offset: 33021},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1386, col: 10, offset: 32940},
+										pos:  position{line: 1387, col: 10, offset: 33026},
 										name: "Name",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1386, col: 15, offset: 32945},
+									pos:   position{line: 1387, col: 15, offset: 33031},
 									label: "opt",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1386, col: 19, offset: 32949},
+										pos: position{line: 1387, col: 19, offset: 33035},
 										expr: &seqExpr{
-											pos: position{line: 1386, col: 20, offset: 32950},
+											pos: position{line: 1387, col: 20, offset: 33036},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1386, col: 20, offset: 32950},
+													pos:  position{line: 1387, col: 20, offset: 33036},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 1386, col: 23, offset: 32953},
+													pos:        position{line: 1387, col: 23, offset: 33039},
 													val:        "=",
 													ignoreCase: false,
 													want:       "\"=\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1386, col: 27, offset: 32957},
+													pos:  position{line: 1387, col: 27, offset: 33043},
 													name: "__",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1386, col: 30, offset: 32960},
+													pos:  position{line: 1387, col: 30, offset: 33046},
 													name: "Type",
 												},
 											},
@@ -8986,40 +8999,40 @@ var g = &grammar{
 		},
 		{
 			name: "EasyType",
-			pos:  position{line: 1398, col: 1, offset: 33282},
+			pos:  position{line: 1399, col: 1, offset: 33368},
 			expr: &choiceExpr{
-				pos: position{line: 1399, col: 5, offset: 33295},
+				pos: position{line: 1400, col: 5, offset: 33381},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1399, col: 5, offset: 33295},
+						pos: position{line: 1400, col: 5, offset: 33381},
 						run: (*parser).callonEasyType2,
 						expr: &seqExpr{
-							pos: position{line: 1399, col: 5, offset: 33295},
+							pos: position{line: 1400, col: 5, offset: 33381},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1399, col: 5, offset: 33295},
+									pos:        position{line: 1400, col: 5, offset: 33381},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1399, col: 9, offset: 33299},
+									pos:  position{line: 1400, col: 9, offset: 33385},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1399, col: 12, offset: 33302},
+									pos:   position{line: 1400, col: 12, offset: 33388},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1399, col: 16, offset: 33306},
+										pos:  position{line: 1400, col: 16, offset: 33392},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1399, col: 21, offset: 33311},
+									pos:  position{line: 1400, col: 21, offset: 33397},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1399, col: 24, offset: 33314},
+									pos:        position{line: 1400, col: 24, offset: 33400},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9028,23 +9041,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1400, col: 5, offset: 33341},
+						pos: position{line: 1401, col: 5, offset: 33427},
 						run: (*parser).callonEasyType10,
 						expr: &seqExpr{
-							pos: position{line: 1400, col: 5, offset: 33341},
+							pos: position{line: 1401, col: 5, offset: 33427},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1400, col: 5, offset: 33341},
+									pos:   position{line: 1401, col: 5, offset: 33427},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1400, col: 10, offset: 33346},
+										pos:  position{line: 1401, col: 10, offset: 33432},
 										name: "PrimitiveType",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1400, col: 24, offset: 33360},
+									pos: position{line: 1401, col: 24, offset: 33446},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1400, col: 25, offset: 33361},
+										pos:  position{line: 1401, col: 25, offset: 33447},
 										name: "IdentifierRest",
 									},
 								},
@@ -9052,43 +9065,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1401, col: 5, offset: 33401},
+						pos: position{line: 1402, col: 5, offset: 33487},
 						run: (*parser).callonEasyType16,
 						expr: &seqExpr{
-							pos: position{line: 1401, col: 5, offset: 33401},
+							pos: position{line: 1402, col: 5, offset: 33487},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1401, col: 5, offset: 33401},
+									pos:  position{line: 1402, col: 5, offset: 33487},
 									name: "ERROR",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1401, col: 11, offset: 33407},
+									pos:  position{line: 1402, col: 11, offset: 33493},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1401, col: 14, offset: 33410},
+									pos:        position{line: 1402, col: 14, offset: 33496},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1401, col: 18, offset: 33414},
+									pos:  position{line: 1402, col: 18, offset: 33500},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1401, col: 21, offset: 33417},
+									pos:   position{line: 1402, col: 21, offset: 33503},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1401, col: 23, offset: 33419},
+										pos:  position{line: 1402, col: 23, offset: 33505},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1401, col: 28, offset: 33424},
+									pos:  position{line: 1402, col: 28, offset: 33510},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1401, col: 31, offset: 33427},
+									pos:        position{line: 1402, col: 31, offset: 33513},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9097,43 +9110,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1408, col: 5, offset: 33567},
+						pos: position{line: 1409, col: 5, offset: 33653},
 						run: (*parser).callonEasyType26,
 						expr: &seqExpr{
-							pos: position{line: 1408, col: 5, offset: 33567},
+							pos: position{line: 1409, col: 5, offset: 33653},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1408, col: 5, offset: 33567},
+									pos:  position{line: 1409, col: 5, offset: 33653},
 									name: "ENUM",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1408, col: 10, offset: 33572},
+									pos:  position{line: 1409, col: 10, offset: 33658},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1408, col: 13, offset: 33575},
+									pos:        position{line: 1409, col: 13, offset: 33661},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1408, col: 17, offset: 33579},
+									pos:  position{line: 1409, col: 17, offset: 33665},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1408, col: 20, offset: 33582},
+									pos:   position{line: 1409, col: 20, offset: 33668},
 									label: "names",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1408, col: 26, offset: 33588},
+										pos:  position{line: 1409, col: 26, offset: 33674},
 										name: "Names",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1408, col: 32, offset: 33594},
+									pos:  position{line: 1409, col: 32, offset: 33680},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1408, col: 35, offset: 33597},
+									pos:        position{line: 1409, col: 35, offset: 33683},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -9142,35 +9155,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1415, col: 5, offset: 33751},
+						pos: position{line: 1416, col: 5, offset: 33837},
 						run: (*parser).callonEasyType36,
 						expr: &seqExpr{
-							pos: position{line: 1415, col: 5, offset: 33751},
+							pos: position{line: 1416, col: 5, offset: 33837},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1415, col: 5, offset: 33751},
+									pos:        position{line: 1416, col: 5, offset: 33837},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1415, col: 9, offset: 33755},
+									pos:  position{line: 1416, col: 9, offset: 33841},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1415, col: 12, offset: 33758},
+									pos:   position{line: 1416, col: 12, offset: 33844},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1415, col: 19, offset: 33765},
+										pos:  position{line: 1416, col: 19, offset: 33851},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1415, col: 33, offset: 33779},
+									pos:  position{line: 1416, col: 33, offset: 33865},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1415, col: 36, offset: 33782},
+									pos:        position{line: 1416, col: 36, offset: 33868},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -9179,35 +9192,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1422, col: 5, offset: 33944},
+						pos: position{line: 1423, col: 5, offset: 34030},
 						run: (*parser).callonEasyType44,
 						expr: &seqExpr{
-							pos: position{line: 1422, col: 5, offset: 33944},
+							pos: position{line: 1423, col: 5, offset: 34030},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1422, col: 5, offset: 33944},
+									pos:        position{line: 1423, col: 5, offset: 34030},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1422, col: 9, offset: 33948},
+									pos:  position{line: 1423, col: 9, offset: 34034},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1422, col: 12, offset: 33951},
+									pos:   position{line: 1423, col: 12, offset: 34037},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1422, col: 16, offset: 33955},
+										pos:  position{line: 1423, col: 16, offset: 34041},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1422, col: 21, offset: 33960},
+									pos:  position{line: 1423, col: 21, offset: 34046},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1422, col: 24, offset: 33963},
+									pos:        position{line: 1423, col: 24, offset: 34049},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -9216,35 +9229,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1429, col: 5, offset: 34105},
+						pos: position{line: 1430, col: 5, offset: 34191},
 						run: (*parser).callonEasyType52,
 						expr: &seqExpr{
-							pos: position{line: 1429, col: 5, offset: 34105},
+							pos: position{line: 1430, col: 5, offset: 34191},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1429, col: 5, offset: 34105},
+									pos:        position{line: 1430, col: 5, offset: 34191},
 									val:        "|[",
 									ignoreCase: false,
 									want:       "\"|[\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1429, col: 10, offset: 34110},
+									pos:  position{line: 1430, col: 10, offset: 34196},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1429, col: 13, offset: 34113},
+									pos:   position{line: 1430, col: 13, offset: 34199},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1429, col: 17, offset: 34117},
+										pos:  position{line: 1430, col: 17, offset: 34203},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1429, col: 22, offset: 34122},
+									pos:  position{line: 1430, col: 22, offset: 34208},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1429, col: 25, offset: 34125},
+									pos:        position{line: 1430, col: 25, offset: 34211},
 									val:        "]|",
 									ignoreCase: false,
 									want:       "\"]|\"",
@@ -9253,57 +9266,57 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1436, col: 5, offset: 34264},
+						pos: position{line: 1437, col: 5, offset: 34350},
 						run: (*parser).callonEasyType60,
 						expr: &seqExpr{
-							pos: position{line: 1436, col: 5, offset: 34264},
+							pos: position{line: 1437, col: 5, offset: 34350},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1436, col: 5, offset: 34264},
+									pos:        position{line: 1437, col: 5, offset: 34350},
 									val:        "|{",
 									ignoreCase: false,
 									want:       "\"|{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1436, col: 10, offset: 34269},
+									pos:  position{line: 1437, col: 10, offset: 34355},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1436, col: 13, offset: 34272},
+									pos:   position{line: 1437, col: 13, offset: 34358},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1436, col: 21, offset: 34280},
+										pos:  position{line: 1437, col: 21, offset: 34366},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1436, col: 26, offset: 34285},
+									pos:  position{line: 1437, col: 26, offset: 34371},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1436, col: 29, offset: 34288},
+									pos:        position{line: 1437, col: 29, offset: 34374},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1436, col: 33, offset: 34292},
+									pos:  position{line: 1437, col: 33, offset: 34378},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1436, col: 36, offset: 34295},
+									pos:   position{line: 1437, col: 36, offset: 34381},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1436, col: 44, offset: 34303},
+										pos:  position{line: 1437, col: 44, offset: 34389},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1436, col: 49, offset: 34308},
+									pos:  position{line: 1437, col: 49, offset: 34394},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1436, col: 52, offset: 34311},
+									pos:        position{line: 1437, col: 52, offset: 34397},
 									val:        "}|",
 									ignoreCase: false,
 									want:       "\"}|\"",
@@ -9318,15 +9331,15 @@ var g = &grammar{
 		},
 		{
 			name: "TypeUnion",
-			pos:  position{line: 1445, col: 1, offset: 34485},
+			pos:  position{line: 1446, col: 1, offset: 34571},
 			expr: &actionExpr{
-				pos: position{line: 1446, col: 5, offset: 34499},
+				pos: position{line: 1447, col: 5, offset: 34585},
 				run: (*parser).callonTypeUnion1,
 				expr: &labeledExpr{
-					pos:   position{line: 1446, col: 5, offset: 34499},
+					pos:   position{line: 1447, col: 5, offset: 34585},
 					label: "types",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1446, col: 11, offset: 34505},
+						pos:  position{line: 1447, col: 11, offset: 34591},
 						name: "TypeList",
 					},
 				},
@@ -9336,28 +9349,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 1454, col: 1, offset: 34642},
+			pos:  position{line: 1455, col: 1, offset: 34728},
 			expr: &actionExpr{
-				pos: position{line: 1455, col: 5, offset: 34655},
+				pos: position{line: 1456, col: 5, offset: 34741},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 1455, col: 5, offset: 34655},
+					pos: position{line: 1456, col: 5, offset: 34741},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1455, col: 5, offset: 34655},
+							pos:   position{line: 1456, col: 5, offset: 34741},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1455, col: 11, offset: 34661},
+								pos:  position{line: 1456, col: 11, offset: 34747},
 								name: "ComponentType",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1455, col: 25, offset: 34675},
+							pos:   position{line: 1456, col: 25, offset: 34761},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1455, col: 30, offset: 34680},
+								pos: position{line: 1456, col: 30, offset: 34766},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1455, col: 30, offset: 34680},
+									pos:  position{line: 1456, col: 30, offset: 34766},
 									name: "TypeListTail",
 								},
 							},
@@ -9370,32 +9383,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 1459, col: 1, offset: 34738},
+			pos:  position{line: 1460, col: 1, offset: 34824},
 			expr: &actionExpr{
-				pos: position{line: 1459, col: 16, offset: 34753},
+				pos: position{line: 1460, col: 16, offset: 34839},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1459, col: 16, offset: 34753},
+					pos: position{line: 1460, col: 16, offset: 34839},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1459, col: 16, offset: 34753},
+							pos:  position{line: 1460, col: 16, offset: 34839},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1459, col: 19, offset: 34756},
+							pos:        position{line: 1460, col: 19, offset: 34842},
 							val:        "|",
 							ignoreCase: false,
 							want:       "\"|\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1459, col: 23, offset: 34760},
+							pos:  position{line: 1460, col: 23, offset: 34846},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1459, col: 26, offset: 34763},
+							pos:   position{line: 1460, col: 26, offset: 34849},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1459, col: 30, offset: 34767},
+								pos:  position{line: 1460, col: 30, offset: 34853},
 								name: "ComponentType",
 							},
 						},
@@ -9407,42 +9420,42 @@ var g = &grammar{
 		},
 		{
 			name: "StringLiteral",
-			pos:  position{line: 1461, col: 1, offset: 34802},
+			pos:  position{line: 1462, col: 1, offset: 34888},
 			expr: &choiceExpr{
-				pos: position{line: 1462, col: 5, offset: 34820},
+				pos: position{line: 1463, col: 5, offset: 34906},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1462, col: 5, offset: 34820},
+						pos: position{line: 1463, col: 5, offset: 34906},
 						run: (*parser).callonStringLiteral2,
 						expr: &labeledExpr{
-							pos:   position{line: 1462, col: 5, offset: 34820},
+							pos:   position{line: 1463, col: 5, offset: 34906},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1462, col: 7, offset: 34822},
+								pos:  position{line: 1463, col: 7, offset: 34908},
 								name: "DoubleQuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1463, col: 5, offset: 34937},
+						pos: position{line: 1464, col: 5, offset: 35023},
 						run: (*parser).callonStringLiteral5,
 						expr: &labeledExpr{
-							pos:   position{line: 1463, col: 5, offset: 34937},
+							pos:   position{line: 1464, col: 5, offset: 35023},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1463, col: 7, offset: 34939},
+								pos:  position{line: 1464, col: 7, offset: 35025},
 								name: "SingleQuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1464, col: 5, offset: 35016},
+						pos: position{line: 1465, col: 5, offset: 35102},
 						run: (*parser).callonStringLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 1464, col: 5, offset: 35016},
+							pos:   position{line: 1465, col: 5, offset: 35102},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1464, col: 7, offset: 35018},
+								pos:  position{line: 1465, col: 7, offset: 35104},
 								name: "RString",
 							},
 						},
@@ -9454,35 +9467,35 @@ var g = &grammar{
 		},
 		{
 			name: "FString",
-			pos:  position{line: 1466, col: 1, offset: 35081},
+			pos:  position{line: 1467, col: 1, offset: 35167},
 			expr: &choiceExpr{
-				pos: position{line: 1467, col: 5, offset: 35093},
+				pos: position{line: 1468, col: 5, offset: 35179},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1467, col: 5, offset: 35093},
+						pos: position{line: 1468, col: 5, offset: 35179},
 						run: (*parser).callonFString2,
 						expr: &seqExpr{
-							pos: position{line: 1467, col: 5, offset: 35093},
+							pos: position{line: 1468, col: 5, offset: 35179},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1467, col: 5, offset: 35093},
+									pos:        position{line: 1468, col: 5, offset: 35179},
 									val:        "f\"",
 									ignoreCase: false,
 									want:       "\"f\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1467, col: 11, offset: 35099},
+									pos:   position{line: 1468, col: 11, offset: 35185},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1467, col: 13, offset: 35101},
+										pos: position{line: 1468, col: 13, offset: 35187},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1467, col: 13, offset: 35101},
+											pos:  position{line: 1468, col: 13, offset: 35187},
 											name: "FStringDoubleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1467, col: 38, offset: 35126},
+									pos:        position{line: 1468, col: 38, offset: 35212},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -9491,30 +9504,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1474, col: 5, offset: 35280},
+						pos: position{line: 1475, col: 5, offset: 35366},
 						run: (*parser).callonFString9,
 						expr: &seqExpr{
-							pos: position{line: 1474, col: 5, offset: 35280},
+							pos: position{line: 1475, col: 5, offset: 35366},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1474, col: 5, offset: 35280},
+									pos:        position{line: 1475, col: 5, offset: 35366},
 									val:        "f'",
 									ignoreCase: false,
 									want:       "\"f'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1474, col: 10, offset: 35285},
+									pos:   position{line: 1475, col: 10, offset: 35371},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1474, col: 12, offset: 35287},
+										pos: position{line: 1475, col: 12, offset: 35373},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1474, col: 12, offset: 35287},
+											pos:  position{line: 1475, col: 12, offset: 35373},
 											name: "FStringSingleQuotedElem",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1474, col: 37, offset: 35312},
+									pos:        position{line: 1475, col: 37, offset: 35398},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -9529,24 +9542,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedElem",
-			pos:  position{line: 1482, col: 1, offset: 35463},
+			pos:  position{line: 1483, col: 1, offset: 35549},
 			expr: &choiceExpr{
-				pos: position{line: 1483, col: 5, offset: 35491},
+				pos: position{line: 1484, col: 5, offset: 35577},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1483, col: 5, offset: 35491},
+						pos:  position{line: 1484, col: 5, offset: 35577},
 						name: "FStringExprElem",
 					},
 					&actionExpr{
-						pos: position{line: 1484, col: 5, offset: 35511},
+						pos: position{line: 1485, col: 5, offset: 35597},
 						run: (*parser).callonFStringDoubleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1484, col: 5, offset: 35511},
+							pos:   position{line: 1485, col: 5, offset: 35597},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1484, col: 7, offset: 35513},
+								pos: position{line: 1485, col: 7, offset: 35599},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1484, col: 7, offset: 35513},
+									pos:  position{line: 1485, col: 7, offset: 35599},
 									name: "FStringDoubleQuotedChar",
 								},
 							},
@@ -9559,27 +9572,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringDoubleQuotedChar",
-			pos:  position{line: 1488, col: 1, offset: 35644},
+			pos:  position{line: 1489, col: 1, offset: 35730},
 			expr: &choiceExpr{
-				pos: position{line: 1489, col: 5, offset: 35672},
+				pos: position{line: 1490, col: 5, offset: 35758},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1489, col: 5, offset: 35672},
+						pos: position{line: 1490, col: 5, offset: 35758},
 						run: (*parser).callonFStringDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1489, col: 5, offset: 35672},
+							pos: position{line: 1490, col: 5, offset: 35758},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1489, col: 5, offset: 35672},
+									pos:        position{line: 1490, col: 5, offset: 35758},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1489, col: 10, offset: 35677},
+									pos:   position{line: 1490, col: 10, offset: 35763},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1489, col: 12, offset: 35679},
+										pos:        position{line: 1490, col: 12, offset: 35765},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9589,25 +9602,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1490, col: 5, offset: 35705},
+						pos: position{line: 1491, col: 5, offset: 35791},
 						run: (*parser).callonFStringDoubleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1490, col: 5, offset: 35705},
+							pos: position{line: 1491, col: 5, offset: 35791},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1490, col: 5, offset: 35705},
+									pos: position{line: 1491, col: 5, offset: 35791},
 									expr: &litMatcher{
-										pos:        position{line: 1490, col: 7, offset: 35707},
+										pos:        position{line: 1491, col: 7, offset: 35793},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1490, col: 12, offset: 35712},
+									pos:   position{line: 1491, col: 12, offset: 35798},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1490, col: 14, offset: 35714},
+										pos:  position{line: 1491, col: 14, offset: 35800},
 										name: "DoubleQuotedChar",
 									},
 								},
@@ -9621,24 +9634,24 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedElem",
-			pos:  position{line: 1492, col: 1, offset: 35750},
+			pos:  position{line: 1493, col: 1, offset: 35836},
 			expr: &choiceExpr{
-				pos: position{line: 1493, col: 5, offset: 35778},
+				pos: position{line: 1494, col: 5, offset: 35864},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1493, col: 5, offset: 35778},
+						pos:  position{line: 1494, col: 5, offset: 35864},
 						name: "FStringExprElem",
 					},
 					&actionExpr{
-						pos: position{line: 1494, col: 5, offset: 35798},
+						pos: position{line: 1495, col: 5, offset: 35884},
 						run: (*parser).callonFStringSingleQuotedElem3,
 						expr: &labeledExpr{
-							pos:   position{line: 1494, col: 5, offset: 35798},
+							pos:   position{line: 1495, col: 5, offset: 35884},
 							label: "v",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1494, col: 7, offset: 35800},
+								pos: position{line: 1495, col: 7, offset: 35886},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1494, col: 7, offset: 35800},
+									pos:  position{line: 1495, col: 7, offset: 35886},
 									name: "FStringSingleQuotedChar",
 								},
 							},
@@ -9651,27 +9664,27 @@ var g = &grammar{
 		},
 		{
 			name: "FStringSingleQuotedChar",
-			pos:  position{line: 1498, col: 1, offset: 35931},
+			pos:  position{line: 1499, col: 1, offset: 36017},
 			expr: &choiceExpr{
-				pos: position{line: 1499, col: 5, offset: 35959},
+				pos: position{line: 1500, col: 5, offset: 36045},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1499, col: 5, offset: 35959},
+						pos: position{line: 1500, col: 5, offset: 36045},
 						run: (*parser).callonFStringSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1499, col: 5, offset: 35959},
+							pos: position{line: 1500, col: 5, offset: 36045},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1499, col: 5, offset: 35959},
+									pos:        position{line: 1500, col: 5, offset: 36045},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1499, col: 10, offset: 35964},
+									pos:   position{line: 1500, col: 10, offset: 36050},
 									label: "v",
 									expr: &litMatcher{
-										pos:        position{line: 1499, col: 12, offset: 35966},
+										pos:        position{line: 1500, col: 12, offset: 36052},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
@@ -9681,25 +9694,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1500, col: 5, offset: 35992},
+						pos: position{line: 1501, col: 5, offset: 36078},
 						run: (*parser).callonFStringSingleQuotedChar7,
 						expr: &seqExpr{
-							pos: position{line: 1500, col: 5, offset: 35992},
+							pos: position{line: 1501, col: 5, offset: 36078},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1500, col: 5, offset: 35992},
+									pos: position{line: 1501, col: 5, offset: 36078},
 									expr: &litMatcher{
-										pos:        position{line: 1500, col: 7, offset: 35994},
+										pos:        position{line: 1501, col: 7, offset: 36080},
 										val:        "{",
 										ignoreCase: false,
 										want:       "\"{\"",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1500, col: 12, offset: 35999},
+									pos:   position{line: 1501, col: 12, offset: 36085},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1500, col: 14, offset: 36001},
+										pos:  position{line: 1501, col: 14, offset: 36087},
 										name: "SingleQuotedChar",
 									},
 								},
@@ -9713,37 +9726,37 @@ var g = &grammar{
 		},
 		{
 			name: "FStringExprElem",
-			pos:  position{line: 1502, col: 1, offset: 36037},
+			pos:  position{line: 1503, col: 1, offset: 36123},
 			expr: &actionExpr{
-				pos: position{line: 1503, col: 5, offset: 36057},
+				pos: position{line: 1504, col: 5, offset: 36143},
 				run: (*parser).callonFStringExprElem1,
 				expr: &seqExpr{
-					pos: position{line: 1503, col: 5, offset: 36057},
+					pos: position{line: 1504, col: 5, offset: 36143},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1503, col: 5, offset: 36057},
+							pos:        position{line: 1504, col: 5, offset: 36143},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1503, col: 9, offset: 36061},
+							pos:  position{line: 1504, col: 9, offset: 36147},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1503, col: 12, offset: 36064},
+							pos:   position{line: 1504, col: 12, offset: 36150},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1503, col: 14, offset: 36066},
+								pos:  position{line: 1504, col: 14, offset: 36152},
 								name: "Expr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1503, col: 19, offset: 36071},
+							pos:  position{line: 1504, col: 19, offset: 36157},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1503, col: 22, offset: 36074},
+							pos:        position{line: 1504, col: 22, offset: 36160},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -9756,129 +9769,129 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 1511, col: 1, offset: 36217},
+			pos:  position{line: 1512, col: 1, offset: 36303},
 			expr: &actionExpr{
-				pos: position{line: 1512, col: 5, offset: 36235},
+				pos: position{line: 1513, col: 5, offset: 36321},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 1512, col: 9, offset: 36239},
+					pos: position{line: 1513, col: 9, offset: 36325},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1512, col: 9, offset: 36239},
+							pos:        position{line: 1513, col: 9, offset: 36325},
 							val:        "uint8",
 							ignoreCase: false,
 							want:       "\"uint8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1512, col: 19, offset: 36249},
+							pos:        position{line: 1513, col: 19, offset: 36335},
 							val:        "uint16",
 							ignoreCase: false,
 							want:       "\"uint16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1512, col: 30, offset: 36260},
+							pos:        position{line: 1513, col: 30, offset: 36346},
 							val:        "uint32",
 							ignoreCase: false,
 							want:       "\"uint32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1512, col: 41, offset: 36271},
+							pos:        position{line: 1513, col: 41, offset: 36357},
 							val:        "uint64",
 							ignoreCase: false,
 							want:       "\"uint64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1513, col: 9, offset: 36288},
+							pos:        position{line: 1514, col: 9, offset: 36374},
 							val:        "int8",
 							ignoreCase: false,
 							want:       "\"int8\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1513, col: 18, offset: 36297},
+							pos:        position{line: 1514, col: 18, offset: 36383},
 							val:        "int16",
 							ignoreCase: false,
 							want:       "\"int16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1513, col: 28, offset: 36307},
+							pos:        position{line: 1514, col: 28, offset: 36393},
 							val:        "int32",
 							ignoreCase: false,
 							want:       "\"int32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1513, col: 38, offset: 36317},
+							pos:        position{line: 1514, col: 38, offset: 36403},
 							val:        "int64",
 							ignoreCase: false,
 							want:       "\"int64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1514, col: 9, offset: 36333},
+							pos:        position{line: 1515, col: 9, offset: 36419},
 							val:        "float16",
 							ignoreCase: false,
 							want:       "\"float16\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1514, col: 21, offset: 36345},
+							pos:        position{line: 1515, col: 21, offset: 36431},
 							val:        "float32",
 							ignoreCase: false,
 							want:       "\"float32\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1514, col: 33, offset: 36357},
+							pos:        position{line: 1515, col: 33, offset: 36443},
 							val:        "float64",
 							ignoreCase: false,
 							want:       "\"float64\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1515, col: 9, offset: 36375},
+							pos:        position{line: 1516, col: 9, offset: 36461},
 							val:        "bool",
 							ignoreCase: false,
 							want:       "\"bool\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1515, col: 18, offset: 36384},
+							pos:        position{line: 1516, col: 18, offset: 36470},
 							val:        "string",
 							ignoreCase: false,
 							want:       "\"string\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1516, col: 9, offset: 36401},
+							pos:        position{line: 1517, col: 9, offset: 36487},
 							val:        "duration",
 							ignoreCase: false,
 							want:       "\"duration\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1516, col: 22, offset: 36414},
+							pos:        position{line: 1517, col: 22, offset: 36500},
 							val:        "time",
 							ignoreCase: false,
 							want:       "\"time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1517, col: 9, offset: 36429},
+							pos:        position{line: 1518, col: 9, offset: 36515},
 							val:        "bytes",
 							ignoreCase: false,
 							want:       "\"bytes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1518, col: 9, offset: 36445},
+							pos:        position{line: 1519, col: 9, offset: 36531},
 							val:        "ip",
 							ignoreCase: false,
 							want:       "\"ip\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1518, col: 16, offset: 36452},
+							pos:        position{line: 1519, col: 16, offset: 36538},
 							val:        "net",
 							ignoreCase: false,
 							want:       "\"net\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1519, col: 9, offset: 36466},
+							pos:        position{line: 1520, col: 9, offset: 36552},
 							val:        "type",
 							ignoreCase: false,
 							want:       "\"type\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1519, col: 18, offset: 36475},
+							pos:        position{line: 1520, col: 18, offset: 36561},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
@@ -9891,31 +9904,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1527, col: 1, offset: 36660},
+			pos:  position{line: 1528, col: 1, offset: 36746},
 			expr: &choiceExpr{
-				pos: position{line: 1528, col: 5, offset: 36678},
+				pos: position{line: 1529, col: 5, offset: 36764},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1528, col: 5, offset: 36678},
+						pos: position{line: 1529, col: 5, offset: 36764},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1528, col: 5, offset: 36678},
+							pos: position{line: 1529, col: 5, offset: 36764},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1528, col: 5, offset: 36678},
+									pos:   position{line: 1529, col: 5, offset: 36764},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1528, col: 11, offset: 36684},
+										pos:  position{line: 1529, col: 11, offset: 36770},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1528, col: 21, offset: 36694},
+									pos:   position{line: 1529, col: 21, offset: 36780},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1528, col: 26, offset: 36699},
+										pos: position{line: 1529, col: 26, offset: 36785},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1528, col: 26, offset: 36699},
+											pos:  position{line: 1529, col: 26, offset: 36785},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -9924,10 +9937,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1531, col: 5, offset: 36765},
+						pos: position{line: 1532, col: 5, offset: 36851},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1531, col: 5, offset: 36765},
+							pos:        position{line: 1532, col: 5, offset: 36851},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -9940,32 +9953,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1533, col: 1, offset: 36789},
+			pos:  position{line: 1534, col: 1, offset: 36875},
 			expr: &actionExpr{
-				pos: position{line: 1533, col: 21, offset: 36809},
+				pos: position{line: 1534, col: 21, offset: 36895},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1533, col: 21, offset: 36809},
+					pos: position{line: 1534, col: 21, offset: 36895},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1533, col: 21, offset: 36809},
+							pos:  position{line: 1534, col: 21, offset: 36895},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1533, col: 24, offset: 36812},
+							pos:        position{line: 1534, col: 24, offset: 36898},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1533, col: 28, offset: 36816},
+							pos:  position{line: 1534, col: 28, offset: 36902},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1533, col: 31, offset: 36819},
+							pos:   position{line: 1534, col: 31, offset: 36905},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1533, col: 35, offset: 36823},
+								pos:  position{line: 1534, col: 35, offset: 36909},
 								name: "TypeField",
 							},
 						},
@@ -9977,40 +9990,40 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1535, col: 1, offset: 36854},
+			pos:  position{line: 1536, col: 1, offset: 36940},
 			expr: &actionExpr{
-				pos: position{line: 1536, col: 5, offset: 36868},
+				pos: position{line: 1537, col: 5, offset: 36954},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1536, col: 5, offset: 36868},
+					pos: position{line: 1537, col: 5, offset: 36954},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1536, col: 5, offset: 36868},
+							pos:   position{line: 1537, col: 5, offset: 36954},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1536, col: 10, offset: 36873},
+								pos:  position{line: 1537, col: 10, offset: 36959},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1536, col: 15, offset: 36878},
+							pos:  position{line: 1537, col: 15, offset: 36964},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1536, col: 18, offset: 36881},
+							pos:        position{line: 1537, col: 18, offset: 36967},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1536, col: 22, offset: 36885},
+							pos:  position{line: 1537, col: 22, offset: 36971},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1536, col: 25, offset: 36888},
+							pos:   position{line: 1537, col: 25, offset: 36974},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1536, col: 29, offset: 36892},
+								pos:  position{line: 1537, col: 29, offset: 36978},
 								name: "Type",
 							},
 						},
@@ -10022,26 +10035,26 @@ var g = &grammar{
 		},
 		{
 			name: "Name",
-			pos:  position{line: 1544, col: 1, offset: 37041},
+			pos:  position{line: 1545, col: 1, offset: 37127},
 			expr: &actionExpr{
-				pos: position{line: 1545, col: 4, offset: 37049},
+				pos: position{line: 1546, col: 4, offset: 37135},
 				run: (*parser).callonName1,
 				expr: &labeledExpr{
-					pos:   position{line: 1545, col: 4, offset: 37049},
+					pos:   position{line: 1546, col: 4, offset: 37135},
 					label: "s",
 					expr: &choiceExpr{
-						pos: position{line: 1545, col: 7, offset: 37052},
+						pos: position{line: 1546, col: 7, offset: 37138},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1545, col: 7, offset: 37052},
+								pos:  position{line: 1546, col: 7, offset: 37138},
 								name: "IdentifierName",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1545, col: 24, offset: 37069},
+								pos:  position{line: 1546, col: 24, offset: 37155},
 								name: "DoubleQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1545, col: 45, offset: 37090},
+								pos:  position{line: 1546, col: 45, offset: 37176},
 								name: "SingleQuotedString",
 							},
 						},
@@ -10053,51 +10066,51 @@ var g = &grammar{
 		},
 		{
 			name: "Names",
-			pos:  position{line: 1549, col: 1, offset: 37190},
+			pos:  position{line: 1550, col: 1, offset: 37276},
 			expr: &actionExpr{
-				pos: position{line: 1550, col: 5, offset: 37200},
+				pos: position{line: 1551, col: 5, offset: 37286},
 				run: (*parser).callonNames1,
 				expr: &seqExpr{
-					pos: position{line: 1550, col: 5, offset: 37200},
+					pos: position{line: 1551, col: 5, offset: 37286},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1550, col: 5, offset: 37200},
+							pos:   position{line: 1551, col: 5, offset: 37286},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1550, col: 11, offset: 37206},
+								pos:  position{line: 1551, col: 11, offset: 37292},
 								name: "Name",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1550, col: 16, offset: 37211},
+							pos:   position{line: 1551, col: 16, offset: 37297},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1550, col: 21, offset: 37216},
+								pos: position{line: 1551, col: 21, offset: 37302},
 								expr: &actionExpr{
-									pos: position{line: 1550, col: 22, offset: 37217},
+									pos: position{line: 1551, col: 22, offset: 37303},
 									run: (*parser).callonNames7,
 									expr: &seqExpr{
-										pos: position{line: 1550, col: 22, offset: 37217},
+										pos: position{line: 1551, col: 22, offset: 37303},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1550, col: 22, offset: 37217},
+												pos:  position{line: 1551, col: 22, offset: 37303},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1550, col: 25, offset: 37220},
+												pos:        position{line: 1551, col: 25, offset: 37306},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1550, col: 29, offset: 37224},
+												pos:  position{line: 1551, col: 29, offset: 37310},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1550, col: 32, offset: 37227},
+												pos:   position{line: 1551, col: 32, offset: 37313},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1550, col: 37, offset: 37232},
+													pos:  position{line: 1551, col: 37, offset: 37318},
 													name: "Name",
 												},
 											},
@@ -10114,15 +10127,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1554, col: 1, offset: 37304},
+			pos:  position{line: 1555, col: 1, offset: 37390},
 			expr: &actionExpr{
-				pos: position{line: 1555, col: 5, offset: 37319},
+				pos: position{line: 1556, col: 5, offset: 37405},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1555, col: 5, offset: 37319},
+					pos:   position{line: 1556, col: 5, offset: 37405},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1555, col: 8, offset: 37322},
+						pos:  position{line: 1556, col: 8, offset: 37408},
 						name: "IdentifierName",
 					},
 				},
@@ -10132,51 +10145,51 @@ var g = &grammar{
 		},
 		{
 			name: "Identifiers",
-			pos:  position{line: 1562, col: 1, offset: 37433},
+			pos:  position{line: 1563, col: 1, offset: 37519},
 			expr: &actionExpr{
-				pos: position{line: 1563, col: 5, offset: 37449},
+				pos: position{line: 1564, col: 5, offset: 37535},
 				run: (*parser).callonIdentifiers1,
 				expr: &seqExpr{
-					pos: position{line: 1563, col: 5, offset: 37449},
+					pos: position{line: 1564, col: 5, offset: 37535},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1563, col: 5, offset: 37449},
+							pos:   position{line: 1564, col: 5, offset: 37535},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1563, col: 11, offset: 37455},
+								pos:  position{line: 1564, col: 11, offset: 37541},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1563, col: 22, offset: 37466},
+							pos:   position{line: 1564, col: 22, offset: 37552},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1563, col: 27, offset: 37471},
+								pos: position{line: 1564, col: 27, offset: 37557},
 								expr: &actionExpr{
-									pos: position{line: 1563, col: 28, offset: 37472},
+									pos: position{line: 1564, col: 28, offset: 37558},
 									run: (*parser).callonIdentifiers7,
 									expr: &seqExpr{
-										pos: position{line: 1563, col: 28, offset: 37472},
+										pos: position{line: 1564, col: 28, offset: 37558},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1563, col: 28, offset: 37472},
+												pos:  position{line: 1564, col: 28, offset: 37558},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1563, col: 31, offset: 37475},
+												pos:        position{line: 1564, col: 31, offset: 37561},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1563, col: 35, offset: 37479},
+												pos:  position{line: 1564, col: 35, offset: 37565},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1563, col: 38, offset: 37482},
+												pos:   position{line: 1564, col: 38, offset: 37568},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1563, col: 43, offset: 37487},
+													pos:  position{line: 1564, col: 43, offset: 37573},
 													name: "Identifier",
 												},
 											},
@@ -10193,22 +10206,22 @@ var g = &grammar{
 		},
 		{
 			name: "SQLIdentifier",
-			pos:  position{line: 1567, col: 1, offset: 37565},
+			pos:  position{line: 1568, col: 1, offset: 37651},
 			expr: &choiceExpr{
-				pos: position{line: 1568, col: 5, offset: 37583},
+				pos: position{line: 1569, col: 5, offset: 37669},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1568, col: 5, offset: 37583},
+						pos:  position{line: 1569, col: 5, offset: 37669},
 						name: "Identifier",
 					},
 					&actionExpr{
-						pos: position{line: 1569, col: 5, offset: 37598},
+						pos: position{line: 1570, col: 5, offset: 37684},
 						run: (*parser).callonSQLIdentifier3,
 						expr: &labeledExpr{
-							pos:   position{line: 1569, col: 5, offset: 37598},
+							pos:   position{line: 1570, col: 5, offset: 37684},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1569, col: 7, offset: 37600},
+								pos:  position{line: 1570, col: 7, offset: 37686},
 								name: "DoubleQuotedString",
 							},
 						},
@@ -10220,29 +10233,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1571, col: 1, offset: 37674},
+			pos:  position{line: 1572, col: 1, offset: 37760},
 			expr: &choiceExpr{
-				pos: position{line: 1572, col: 5, offset: 37693},
+				pos: position{line: 1573, col: 5, offset: 37779},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1572, col: 5, offset: 37693},
+						pos: position{line: 1573, col: 5, offset: 37779},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1572, col: 5, offset: 37693},
+							pos: position{line: 1573, col: 5, offset: 37779},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1572, col: 5, offset: 37693},
+									pos: position{line: 1573, col: 5, offset: 37779},
 									expr: &seqExpr{
-										pos: position{line: 1572, col: 7, offset: 37695},
+										pos: position{line: 1573, col: 7, offset: 37781},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1572, col: 7, offset: 37695},
+												pos:  position{line: 1573, col: 7, offset: 37781},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1572, col: 15, offset: 37703},
+												pos: position{line: 1573, col: 15, offset: 37789},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1572, col: 16, offset: 37704},
+													pos:  position{line: 1573, col: 16, offset: 37790},
 													name: "IdentifierRest",
 												},
 											},
@@ -10250,13 +10263,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1572, col: 32, offset: 37720},
+									pos:  position{line: 1573, col: 32, offset: 37806},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1572, col: 48, offset: 37736},
+									pos: position{line: 1573, col: 48, offset: 37822},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1572, col: 48, offset: 37736},
+										pos:  position{line: 1573, col: 48, offset: 37822},
 										name: "IdentifierRest",
 									},
 								},
@@ -10264,7 +10277,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1573, col: 5, offset: 37787},
+						pos:  position{line: 1574, col: 5, offset: 37873},
 						name: "BacktickString",
 					},
 				},
@@ -10274,22 +10287,22 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1575, col: 1, offset: 37803},
+			pos:  position{line: 1576, col: 1, offset: 37889},
 			expr: &choiceExpr{
-				pos: position{line: 1576, col: 5, offset: 37823},
+				pos: position{line: 1577, col: 5, offset: 37909},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1576, col: 5, offset: 37823},
+						pos:  position{line: 1577, col: 5, offset: 37909},
 						name: "UnicodeLetter",
 					},
 					&litMatcher{
-						pos:        position{line: 1577, col: 5, offset: 37841},
+						pos:        position{line: 1578, col: 5, offset: 37927},
 						val:        "$",
 						ignoreCase: false,
 						want:       "\"$\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1578, col: 5, offset: 37849},
+						pos:        position{line: 1579, col: 5, offset: 37935},
 						val:        "_",
 						ignoreCase: false,
 						want:       "\"_\"",
@@ -10301,24 +10314,24 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1580, col: 1, offset: 37854},
+			pos:  position{line: 1581, col: 1, offset: 37940},
 			expr: &choiceExpr{
-				pos: position{line: 1581, col: 5, offset: 37873},
+				pos: position{line: 1582, col: 5, offset: 37959},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1581, col: 5, offset: 37873},
+						pos:  position{line: 1582, col: 5, offset: 37959},
 						name: "IdentifierStart",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1582, col: 5, offset: 37893},
+						pos:  position{line: 1583, col: 5, offset: 37979},
 						name: "UnicodeCombiningMark",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1583, col: 5, offset: 37918},
+						pos:  position{line: 1584, col: 5, offset: 38004},
 						name: "UnicodeDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1584, col: 5, offset: 37935},
+						pos:  position{line: 1585, col: 5, offset: 38021},
 						name: "UnicodeConnectorPunctuation",
 					},
 				},
@@ -10328,24 +10341,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1586, col: 1, offset: 37964},
+			pos:  position{line: 1587, col: 1, offset: 38050},
 			expr: &choiceExpr{
-				pos: position{line: 1587, col: 5, offset: 37976},
+				pos: position{line: 1588, col: 5, offset: 38062},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1587, col: 5, offset: 37976},
+						pos:  position{line: 1588, col: 5, offset: 38062},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1588, col: 5, offset: 37995},
+						pos:  position{line: 1589, col: 5, offset: 38081},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1589, col: 5, offset: 38011},
+						pos:  position{line: 1590, col: 5, offset: 38097},
 						name: "NaN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1590, col: 5, offset: 38019},
+						pos:  position{line: 1591, col: 5, offset: 38105},
 						name: "Infinity",
 					},
 				},
@@ -10355,25 +10368,25 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1592, col: 1, offset: 38029},
+			pos:  position{line: 1593, col: 1, offset: 38115},
 			expr: &actionExpr{
-				pos: position{line: 1593, col: 5, offset: 38038},
+				pos: position{line: 1594, col: 5, offset: 38124},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1593, col: 5, offset: 38038},
+					pos: position{line: 1594, col: 5, offset: 38124},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1593, col: 5, offset: 38038},
+							pos:  position{line: 1594, col: 5, offset: 38124},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1593, col: 14, offset: 38047},
+							pos:        position{line: 1594, col: 14, offset: 38133},
 							val:        "T",
 							ignoreCase: false,
 							want:       "\"T\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1593, col: 18, offset: 38051},
+							pos:  position{line: 1594, col: 18, offset: 38137},
 							name: "FullTime",
 						},
 					},
@@ -10384,32 +10397,32 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1597, col: 1, offset: 38127},
+			pos:  position{line: 1598, col: 1, offset: 38213},
 			expr: &seqExpr{
-				pos: position{line: 1597, col: 12, offset: 38138},
+				pos: position{line: 1598, col: 12, offset: 38224},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1597, col: 12, offset: 38138},
+						pos:  position{line: 1598, col: 12, offset: 38224},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1597, col: 15, offset: 38141},
+						pos:        position{line: 1598, col: 15, offset: 38227},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1597, col: 19, offset: 38145},
+						pos:  position{line: 1598, col: 19, offset: 38231},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1597, col: 22, offset: 38148},
+						pos:        position{line: 1598, col: 22, offset: 38234},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1597, col: 26, offset: 38152},
+						pos:  position{line: 1598, col: 26, offset: 38238},
 						name: "D2",
 					},
 				},
@@ -10419,33 +10432,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1599, col: 1, offset: 38156},
+			pos:  position{line: 1600, col: 1, offset: 38242},
 			expr: &seqExpr{
-				pos: position{line: 1599, col: 6, offset: 38161},
+				pos: position{line: 1600, col: 6, offset: 38247},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1599, col: 6, offset: 38161},
+						pos:        position{line: 1600, col: 6, offset: 38247},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1599, col: 11, offset: 38166},
+						pos:        position{line: 1600, col: 11, offset: 38252},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1599, col: 16, offset: 38171},
+						pos:        position{line: 1600, col: 16, offset: 38257},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1599, col: 21, offset: 38176},
+						pos:        position{line: 1600, col: 21, offset: 38262},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10458,19 +10471,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1600, col: 1, offset: 38182},
+			pos:  position{line: 1601, col: 1, offset: 38268},
 			expr: &seqExpr{
-				pos: position{line: 1600, col: 6, offset: 38187},
+				pos: position{line: 1601, col: 6, offset: 38273},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1600, col: 6, offset: 38187},
+						pos:        position{line: 1601, col: 6, offset: 38273},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1600, col: 11, offset: 38192},
+						pos:        position{line: 1601, col: 11, offset: 38278},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10483,16 +10496,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1602, col: 1, offset: 38199},
+			pos:  position{line: 1603, col: 1, offset: 38285},
 			expr: &seqExpr{
-				pos: position{line: 1602, col: 12, offset: 38210},
+				pos: position{line: 1603, col: 12, offset: 38296},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1602, col: 12, offset: 38210},
+						pos:  position{line: 1603, col: 12, offset: 38296},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1602, col: 24, offset: 38222},
+						pos:  position{line: 1603, col: 24, offset: 38308},
 						name: "TimeOffset",
 					},
 				},
@@ -10502,49 +10515,49 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1604, col: 1, offset: 38234},
+			pos:  position{line: 1605, col: 1, offset: 38320},
 			expr: &seqExpr{
-				pos: position{line: 1604, col: 15, offset: 38248},
+				pos: position{line: 1605, col: 15, offset: 38334},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1604, col: 15, offset: 38248},
+						pos:  position{line: 1605, col: 15, offset: 38334},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1604, col: 18, offset: 38251},
+						pos:        position{line: 1605, col: 18, offset: 38337},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1604, col: 22, offset: 38255},
+						pos:  position{line: 1605, col: 22, offset: 38341},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1604, col: 25, offset: 38258},
+						pos:        position{line: 1605, col: 25, offset: 38344},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1604, col: 29, offset: 38262},
+						pos:  position{line: 1605, col: 29, offset: 38348},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1604, col: 32, offset: 38265},
+						pos: position{line: 1605, col: 32, offset: 38351},
 						expr: &seqExpr{
-							pos: position{line: 1604, col: 33, offset: 38266},
+							pos: position{line: 1605, col: 33, offset: 38352},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1604, col: 33, offset: 38266},
+									pos:        position{line: 1605, col: 33, offset: 38352},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1604, col: 37, offset: 38270},
+									pos: position{line: 1605, col: 37, offset: 38356},
 									expr: &charClassMatcher{
-										pos:        position{line: 1604, col: 37, offset: 38270},
+										pos:        position{line: 1605, col: 37, offset: 38356},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10561,30 +10574,30 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1606, col: 1, offset: 38280},
+			pos:  position{line: 1607, col: 1, offset: 38366},
 			expr: &choiceExpr{
-				pos: position{line: 1607, col: 5, offset: 38295},
+				pos: position{line: 1608, col: 5, offset: 38381},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1607, col: 5, offset: 38295},
+						pos:        position{line: 1608, col: 5, offset: 38381},
 						val:        "Z",
 						ignoreCase: false,
 						want:       "\"Z\"",
 					},
 					&seqExpr{
-						pos: position{line: 1608, col: 5, offset: 38303},
+						pos: position{line: 1609, col: 5, offset: 38389},
 						exprs: []any{
 							&choiceExpr{
-								pos: position{line: 1608, col: 6, offset: 38304},
+								pos: position{line: 1609, col: 6, offset: 38390},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 1608, col: 6, offset: 38304},
+										pos:        position{line: 1609, col: 6, offset: 38390},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 1608, col: 12, offset: 38310},
+										pos:        position{line: 1609, col: 12, offset: 38396},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
@@ -10592,34 +10605,34 @@ var g = &grammar{
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1608, col: 17, offset: 38315},
+								pos:  position{line: 1609, col: 17, offset: 38401},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1608, col: 20, offset: 38318},
+								pos:        position{line: 1609, col: 20, offset: 38404},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1608, col: 24, offset: 38322},
+								pos:  position{line: 1609, col: 24, offset: 38408},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1608, col: 27, offset: 38325},
+								pos: position{line: 1609, col: 27, offset: 38411},
 								expr: &seqExpr{
-									pos: position{line: 1608, col: 28, offset: 38326},
+									pos: position{line: 1609, col: 28, offset: 38412},
 									exprs: []any{
 										&litMatcher{
-											pos:        position{line: 1608, col: 28, offset: 38326},
+											pos:        position{line: 1609, col: 28, offset: 38412},
 											val:        ".",
 											ignoreCase: false,
 											want:       "\".\"",
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1608, col: 32, offset: 38330},
+											pos: position{line: 1609, col: 32, offset: 38416},
 											expr: &charClassMatcher{
-												pos:        position{line: 1608, col: 32, offset: 38330},
+												pos:        position{line: 1609, col: 32, offset: 38416},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -10638,33 +10651,33 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1610, col: 1, offset: 38340},
+			pos:  position{line: 1611, col: 1, offset: 38426},
 			expr: &actionExpr{
-				pos: position{line: 1611, col: 5, offset: 38353},
+				pos: position{line: 1612, col: 5, offset: 38439},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1611, col: 5, offset: 38353},
+					pos: position{line: 1612, col: 5, offset: 38439},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 1611, col: 5, offset: 38353},
+							pos: position{line: 1612, col: 5, offset: 38439},
 							expr: &litMatcher{
-								pos:        position{line: 1611, col: 5, offset: 38353},
+								pos:        position{line: 1612, col: 5, offset: 38439},
 								val:        "-",
 								ignoreCase: false,
 								want:       "\"-\"",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1611, col: 10, offset: 38358},
+							pos: position{line: 1612, col: 10, offset: 38444},
 							expr: &seqExpr{
-								pos: position{line: 1611, col: 11, offset: 38359},
+								pos: position{line: 1612, col: 11, offset: 38445},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1611, col: 11, offset: 38359},
+										pos:  position{line: 1612, col: 11, offset: 38445},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1611, col: 19, offset: 38367},
+										pos:  position{line: 1612, col: 19, offset: 38453},
 										name: "TimeUnit",
 									},
 								},
@@ -10678,27 +10691,27 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1615, col: 1, offset: 38449},
+			pos:  position{line: 1616, col: 1, offset: 38535},
 			expr: &seqExpr{
-				pos: position{line: 1615, col: 11, offset: 38459},
+				pos: position{line: 1616, col: 11, offset: 38545},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1615, col: 11, offset: 38459},
+						pos:  position{line: 1616, col: 11, offset: 38545},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1615, col: 16, offset: 38464},
+						pos: position{line: 1616, col: 16, offset: 38550},
 						expr: &seqExpr{
-							pos: position{line: 1615, col: 17, offset: 38465},
+							pos: position{line: 1616, col: 17, offset: 38551},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1615, col: 17, offset: 38465},
+									pos:        position{line: 1616, col: 17, offset: 38551},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1615, col: 21, offset: 38469},
+									pos:  position{line: 1616, col: 21, offset: 38555},
 									name: "UInt",
 								},
 							},
@@ -10711,60 +10724,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1617, col: 1, offset: 38477},
+			pos:  position{line: 1618, col: 1, offset: 38563},
 			expr: &choiceExpr{
-				pos: position{line: 1618, col: 5, offset: 38490},
+				pos: position{line: 1619, col: 5, offset: 38576},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1618, col: 5, offset: 38490},
+						pos:        position{line: 1619, col: 5, offset: 38576},
 						val:        "ns",
 						ignoreCase: false,
 						want:       "\"ns\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1619, col: 5, offset: 38499},
+						pos:        position{line: 1620, col: 5, offset: 38585},
 						val:        "us",
 						ignoreCase: false,
 						want:       "\"us\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1620, col: 5, offset: 38508},
+						pos:        position{line: 1621, col: 5, offset: 38594},
 						val:        "ms",
 						ignoreCase: false,
 						want:       "\"ms\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1621, col: 5, offset: 38517},
+						pos:        position{line: 1622, col: 5, offset: 38603},
 						val:        "s",
 						ignoreCase: false,
 						want:       "\"s\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1622, col: 5, offset: 38525},
+						pos:        position{line: 1623, col: 5, offset: 38611},
 						val:        "m",
 						ignoreCase: false,
 						want:       "\"m\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1623, col: 5, offset: 38533},
+						pos:        position{line: 1624, col: 5, offset: 38619},
 						val:        "h",
 						ignoreCase: false,
 						want:       "\"h\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1624, col: 5, offset: 38541},
+						pos:        position{line: 1625, col: 5, offset: 38627},
 						val:        "d",
 						ignoreCase: false,
 						want:       "\"d\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1625, col: 5, offset: 38549},
+						pos:        position{line: 1626, col: 5, offset: 38635},
 						val:        "w",
 						ignoreCase: false,
 						want:       "\"w\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1626, col: 5, offset: 38557},
+						pos:        position{line: 1627, col: 5, offset: 38643},
 						val:        "y",
 						ignoreCase: false,
 						want:       "\"y\"",
@@ -10776,45 +10789,45 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1628, col: 1, offset: 38562},
+			pos:  position{line: 1629, col: 1, offset: 38648},
 			expr: &actionExpr{
-				pos: position{line: 1629, col: 5, offset: 38569},
+				pos: position{line: 1630, col: 5, offset: 38655},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1629, col: 5, offset: 38569},
+					pos: position{line: 1630, col: 5, offset: 38655},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1629, col: 5, offset: 38569},
+							pos:  position{line: 1630, col: 5, offset: 38655},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1629, col: 10, offset: 38574},
+							pos:        position{line: 1630, col: 10, offset: 38660},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1629, col: 14, offset: 38578},
+							pos:  position{line: 1630, col: 14, offset: 38664},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1629, col: 19, offset: 38583},
+							pos:        position{line: 1630, col: 19, offset: 38669},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1629, col: 23, offset: 38587},
+							pos:  position{line: 1630, col: 23, offset: 38673},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1629, col: 28, offset: 38592},
+							pos:        position{line: 1630, col: 28, offset: 38678},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1629, col: 32, offset: 38596},
+							pos:  position{line: 1630, col: 32, offset: 38682},
 							name: "UInt",
 						},
 					},
@@ -10825,43 +10838,43 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1631, col: 1, offset: 38633},
+			pos:  position{line: 1632, col: 1, offset: 38719},
 			expr: &actionExpr{
-				pos: position{line: 1632, col: 5, offset: 38641},
+				pos: position{line: 1633, col: 5, offset: 38727},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1632, col: 5, offset: 38641},
+					pos: position{line: 1633, col: 5, offset: 38727},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1632, col: 5, offset: 38641},
+							pos: position{line: 1633, col: 5, offset: 38727},
 							expr: &seqExpr{
-								pos: position{line: 1632, col: 7, offset: 38643},
+								pos: position{line: 1633, col: 7, offset: 38729},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1632, col: 7, offset: 38643},
+										pos:  position{line: 1633, col: 7, offset: 38729},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1632, col: 11, offset: 38647},
+										pos:        position{line: 1633, col: 11, offset: 38733},
 										val:        ":",
 										ignoreCase: false,
 										want:       "\":\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1632, col: 15, offset: 38651},
+										pos:  position{line: 1633, col: 15, offset: 38737},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1632, col: 19, offset: 38655},
+										pos: position{line: 1633, col: 19, offset: 38741},
 										expr: &choiceExpr{
-											pos: position{line: 1632, col: 21, offset: 38657},
+											pos: position{line: 1633, col: 21, offset: 38743},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1632, col: 21, offset: 38657},
+													pos:  position{line: 1633, col: 21, offset: 38743},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1632, col: 32, offset: 38668},
+													pos:        position{line: 1633, col: 32, offset: 38754},
 													val:        ":",
 													ignoreCase: false,
 													want:       "\":\"",
@@ -10873,10 +10886,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1632, col: 38, offset: 38674},
+							pos:   position{line: 1633, col: 38, offset: 38760},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1632, col: 40, offset: 38676},
+								pos:  position{line: 1633, col: 40, offset: 38762},
 								name: "IP6Variations",
 							},
 						},
@@ -10888,32 +10901,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1636, col: 1, offset: 38840},
+			pos:  position{line: 1637, col: 1, offset: 38926},
 			expr: &choiceExpr{
-				pos: position{line: 1637, col: 5, offset: 38858},
+				pos: position{line: 1638, col: 5, offset: 38944},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1637, col: 5, offset: 38858},
+						pos: position{line: 1638, col: 5, offset: 38944},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1637, col: 5, offset: 38858},
+							pos: position{line: 1638, col: 5, offset: 38944},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1637, col: 5, offset: 38858},
+									pos:   position{line: 1638, col: 5, offset: 38944},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1637, col: 7, offset: 38860},
+										pos: position{line: 1638, col: 7, offset: 38946},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1637, col: 7, offset: 38860},
+											pos:  position{line: 1638, col: 7, offset: 38946},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1637, col: 17, offset: 38870},
+									pos:   position{line: 1638, col: 17, offset: 38956},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1637, col: 19, offset: 38872},
+										pos:  position{line: 1638, col: 19, offset: 38958},
 										name: "IP6Tail",
 									},
 								},
@@ -10921,52 +10934,52 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1640, col: 5, offset: 38936},
+						pos: position{line: 1641, col: 5, offset: 39022},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1640, col: 5, offset: 38936},
+							pos: position{line: 1641, col: 5, offset: 39022},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1640, col: 5, offset: 38936},
+									pos:   position{line: 1641, col: 5, offset: 39022},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1640, col: 7, offset: 38938},
+										pos:  position{line: 1641, col: 7, offset: 39024},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1640, col: 11, offset: 38942},
+									pos:   position{line: 1641, col: 11, offset: 39028},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1640, col: 13, offset: 38944},
+										pos: position{line: 1641, col: 13, offset: 39030},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1640, col: 13, offset: 38944},
+											pos:  position{line: 1641, col: 13, offset: 39030},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1640, col: 23, offset: 38954},
+									pos:        position{line: 1641, col: 23, offset: 39040},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1640, col: 28, offset: 38959},
+									pos:   position{line: 1641, col: 28, offset: 39045},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1640, col: 30, offset: 38961},
+										pos: position{line: 1641, col: 30, offset: 39047},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1640, col: 30, offset: 38961},
+											pos:  position{line: 1641, col: 30, offset: 39047},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1640, col: 40, offset: 38971},
+									pos:   position{line: 1641, col: 40, offset: 39057},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1640, col: 42, offset: 38973},
+										pos:  position{line: 1641, col: 42, offset: 39059},
 										name: "IP6Tail",
 									},
 								},
@@ -10974,33 +10987,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1643, col: 5, offset: 39072},
+						pos: position{line: 1644, col: 5, offset: 39158},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1643, col: 5, offset: 39072},
+							pos: position{line: 1644, col: 5, offset: 39158},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1643, col: 5, offset: 39072},
+									pos:        position{line: 1644, col: 5, offset: 39158},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1643, col: 10, offset: 39077},
+									pos:   position{line: 1644, col: 10, offset: 39163},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1643, col: 12, offset: 39079},
+										pos: position{line: 1644, col: 12, offset: 39165},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1643, col: 12, offset: 39079},
+											pos:  position{line: 1644, col: 12, offset: 39165},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1643, col: 22, offset: 39089},
+									pos:   position{line: 1644, col: 22, offset: 39175},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1643, col: 24, offset: 39091},
+										pos:  position{line: 1644, col: 24, offset: 39177},
 										name: "IP6Tail",
 									},
 								},
@@ -11008,40 +11021,40 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1646, col: 5, offset: 39162},
+						pos: position{line: 1647, col: 5, offset: 39248},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1646, col: 5, offset: 39162},
+							pos: position{line: 1647, col: 5, offset: 39248},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1646, col: 5, offset: 39162},
+									pos:   position{line: 1647, col: 5, offset: 39248},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1646, col: 7, offset: 39164},
+										pos:  position{line: 1647, col: 7, offset: 39250},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1646, col: 11, offset: 39168},
+									pos:   position{line: 1647, col: 11, offset: 39254},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1646, col: 13, offset: 39170},
+										pos: position{line: 1647, col: 13, offset: 39256},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1646, col: 13, offset: 39170},
+											pos:  position{line: 1647, col: 13, offset: 39256},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1646, col: 23, offset: 39180},
+									pos:        position{line: 1647, col: 23, offset: 39266},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&notExpr{
-									pos: position{line: 1646, col: 28, offset: 39185},
+									pos: position{line: 1647, col: 28, offset: 39271},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1646, col: 29, offset: 39186},
+										pos:  position{line: 1647, col: 29, offset: 39272},
 										name: "TypeAsValue",
 									},
 								},
@@ -11049,10 +11062,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1649, col: 5, offset: 39261},
+						pos: position{line: 1650, col: 5, offset: 39347},
 						run: (*parser).callonIP6Variations40,
 						expr: &litMatcher{
-							pos:        position{line: 1649, col: 5, offset: 39261},
+							pos:        position{line: 1650, col: 5, offset: 39347},
 							val:        "::",
 							ignoreCase: false,
 							want:       "\"::\"",
@@ -11065,16 +11078,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1653, col: 1, offset: 39298},
+			pos:  position{line: 1654, col: 1, offset: 39384},
 			expr: &choiceExpr{
-				pos: position{line: 1654, col: 5, offset: 39310},
+				pos: position{line: 1655, col: 5, offset: 39396},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1654, col: 5, offset: 39310},
+						pos:  position{line: 1655, col: 5, offset: 39396},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1655, col: 5, offset: 39317},
+						pos:  position{line: 1656, col: 5, offset: 39403},
 						name: "Hex",
 					},
 				},
@@ -11084,24 +11097,24 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1657, col: 1, offset: 39322},
+			pos:  position{line: 1658, col: 1, offset: 39408},
 			expr: &actionExpr{
-				pos: position{line: 1657, col: 12, offset: 39333},
+				pos: position{line: 1658, col: 12, offset: 39419},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1657, col: 12, offset: 39333},
+					pos: position{line: 1658, col: 12, offset: 39419},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1657, col: 12, offset: 39333},
+							pos:        position{line: 1658, col: 12, offset: 39419},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1657, col: 16, offset: 39337},
+							pos:   position{line: 1658, col: 16, offset: 39423},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1657, col: 18, offset: 39339},
+								pos:  position{line: 1658, col: 18, offset: 39425},
 								name: "Hex",
 							},
 						},
@@ -11113,23 +11126,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1659, col: 1, offset: 39377},
+			pos:  position{line: 1660, col: 1, offset: 39463},
 			expr: &actionExpr{
-				pos: position{line: 1659, col: 12, offset: 39388},
+				pos: position{line: 1660, col: 12, offset: 39474},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1659, col: 12, offset: 39388},
+					pos: position{line: 1660, col: 12, offset: 39474},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1659, col: 12, offset: 39388},
+							pos:   position{line: 1660, col: 12, offset: 39474},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1659, col: 14, offset: 39390},
+								pos:  position{line: 1660, col: 14, offset: 39476},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1659, col: 18, offset: 39394},
+							pos:        position{line: 1660, col: 18, offset: 39480},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
@@ -11142,32 +11155,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1661, col: 1, offset: 39432},
+			pos:  position{line: 1662, col: 1, offset: 39518},
 			expr: &actionExpr{
-				pos: position{line: 1662, col: 5, offset: 39443},
+				pos: position{line: 1663, col: 5, offset: 39529},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1662, col: 5, offset: 39443},
+					pos: position{line: 1663, col: 5, offset: 39529},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1662, col: 5, offset: 39443},
+							pos:   position{line: 1663, col: 5, offset: 39529},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1662, col: 7, offset: 39445},
+								pos:  position{line: 1663, col: 7, offset: 39531},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1662, col: 10, offset: 39448},
+							pos:        position{line: 1663, col: 10, offset: 39534},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1662, col: 14, offset: 39452},
+							pos:   position{line: 1663, col: 14, offset: 39538},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1662, col: 16, offset: 39454},
+								pos:  position{line: 1663, col: 16, offset: 39540},
 								name: "UIntString",
 							},
 						},
@@ -11179,32 +11192,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1666, col: 1, offset: 39522},
+			pos:  position{line: 1667, col: 1, offset: 39608},
 			expr: &actionExpr{
-				pos: position{line: 1667, col: 5, offset: 39533},
+				pos: position{line: 1668, col: 5, offset: 39619},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1667, col: 5, offset: 39533},
+					pos: position{line: 1668, col: 5, offset: 39619},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1667, col: 5, offset: 39533},
+							pos:   position{line: 1668, col: 5, offset: 39619},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1667, col: 7, offset: 39535},
+								pos:  position{line: 1668, col: 7, offset: 39621},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1667, col: 11, offset: 39539},
+							pos:        position{line: 1668, col: 11, offset: 39625},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1667, col: 15, offset: 39543},
+							pos:   position{line: 1668, col: 15, offset: 39629},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1667, col: 17, offset: 39545},
+								pos:  position{line: 1668, col: 17, offset: 39631},
 								name: "UIntString",
 							},
 						},
@@ -11216,15 +11229,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1671, col: 1, offset: 39613},
+			pos:  position{line: 1672, col: 1, offset: 39699},
 			expr: &actionExpr{
-				pos: position{line: 1672, col: 4, offset: 39621},
+				pos: position{line: 1673, col: 4, offset: 39707},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1672, col: 4, offset: 39621},
+					pos:   position{line: 1673, col: 4, offset: 39707},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1672, col: 6, offset: 39623},
+						pos:  position{line: 1673, col: 6, offset: 39709},
 						name: "UIntString",
 					},
 				},
@@ -11234,16 +11247,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1674, col: 1, offset: 39663},
+			pos:  position{line: 1675, col: 1, offset: 39749},
 			expr: &choiceExpr{
-				pos: position{line: 1675, col: 5, offset: 39677},
+				pos: position{line: 1676, col: 5, offset: 39763},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1675, col: 5, offset: 39677},
+						pos:  position{line: 1676, col: 5, offset: 39763},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1676, col: 5, offset: 39692},
+						pos:  position{line: 1677, col: 5, offset: 39778},
 						name: "MinusIntString",
 					},
 				},
@@ -11253,14 +11266,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1678, col: 1, offset: 39708},
+			pos:  position{line: 1679, col: 1, offset: 39794},
 			expr: &actionExpr{
-				pos: position{line: 1678, col: 14, offset: 39721},
+				pos: position{line: 1679, col: 14, offset: 39807},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1678, col: 14, offset: 39721},
+					pos: position{line: 1679, col: 14, offset: 39807},
 					expr: &charClassMatcher{
-						pos:        position{line: 1678, col: 14, offset: 39721},
+						pos:        position{line: 1679, col: 14, offset: 39807},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11273,21 +11286,21 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1680, col: 1, offset: 39760},
+			pos:  position{line: 1681, col: 1, offset: 39846},
 			expr: &actionExpr{
-				pos: position{line: 1681, col: 5, offset: 39779},
+				pos: position{line: 1682, col: 5, offset: 39865},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1681, col: 5, offset: 39779},
+					pos: position{line: 1682, col: 5, offset: 39865},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1681, col: 5, offset: 39779},
+							pos:        position{line: 1682, col: 5, offset: 39865},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1681, col: 9, offset: 39783},
+							pos:  position{line: 1682, col: 9, offset: 39869},
 							name: "UIntString",
 						},
 					},
@@ -11298,29 +11311,29 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1683, col: 1, offset: 39826},
+			pos:  position{line: 1684, col: 1, offset: 39912},
 			expr: &choiceExpr{
-				pos: position{line: 1684, col: 5, offset: 39842},
+				pos: position{line: 1685, col: 5, offset: 39928},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1684, col: 5, offset: 39842},
+						pos: position{line: 1685, col: 5, offset: 39928},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1684, col: 5, offset: 39842},
+							pos: position{line: 1685, col: 5, offset: 39928},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1684, col: 5, offset: 39842},
+									pos: position{line: 1685, col: 5, offset: 39928},
 									expr: &litMatcher{
-										pos:        position{line: 1684, col: 5, offset: 39842},
+										pos:        position{line: 1685, col: 5, offset: 39928},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1684, col: 10, offset: 39847},
+									pos: position{line: 1685, col: 10, offset: 39933},
 									expr: &charClassMatcher{
-										pos:        position{line: 1684, col: 10, offset: 39847},
+										pos:        position{line: 1685, col: 10, offset: 39933},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11328,15 +11341,15 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1684, col: 17, offset: 39854},
+									pos:        position{line: 1685, col: 17, offset: 39940},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1684, col: 21, offset: 39858},
+									pos: position{line: 1685, col: 21, offset: 39944},
 									expr: &charClassMatcher{
-										pos:        position{line: 1684, col: 21, offset: 39858},
+										pos:        position{line: 1685, col: 21, offset: 39944},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11344,9 +11357,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1684, col: 28, offset: 39865},
+									pos: position{line: 1685, col: 28, offset: 39951},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1684, col: 28, offset: 39865},
+										pos:  position{line: 1685, col: 28, offset: 39951},
 										name: "ExponentPart",
 									},
 								},
@@ -11354,30 +11367,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1685, col: 5, offset: 39914},
+						pos: position{line: 1686, col: 5, offset: 40000},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1685, col: 5, offset: 39914},
+							pos: position{line: 1686, col: 5, offset: 40000},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1685, col: 5, offset: 39914},
+									pos: position{line: 1686, col: 5, offset: 40000},
 									expr: &litMatcher{
-										pos:        position{line: 1685, col: 5, offset: 39914},
+										pos:        position{line: 1686, col: 5, offset: 40000},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1685, col: 10, offset: 39919},
+									pos:        position{line: 1686, col: 10, offset: 40005},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1685, col: 14, offset: 39923},
+									pos: position{line: 1686, col: 14, offset: 40009},
 									expr: &charClassMatcher{
-										pos:        position{line: 1685, col: 14, offset: 39923},
+										pos:        position{line: 1686, col: 14, offset: 40009},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11385,9 +11398,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1685, col: 21, offset: 39930},
+									pos: position{line: 1686, col: 21, offset: 40016},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1685, col: 21, offset: 39930},
+										pos:  position{line: 1686, col: 21, offset: 40016},
 										name: "ExponentPart",
 									},
 								},
@@ -11395,17 +11408,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1686, col: 5, offset: 39979},
+						pos: position{line: 1687, col: 5, offset: 40065},
 						run: (*parser).callonFloatString22,
 						expr: &choiceExpr{
-							pos: position{line: 1686, col: 6, offset: 39980},
+							pos: position{line: 1687, col: 6, offset: 40066},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1686, col: 6, offset: 39980},
+									pos:  position{line: 1687, col: 6, offset: 40066},
 									name: "NaN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1686, col: 12, offset: 39986},
+									pos:  position{line: 1687, col: 12, offset: 40072},
 									name: "Infinity",
 								},
 							},
@@ -11418,20 +11431,20 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1689, col: 1, offset: 40029},
+			pos:  position{line: 1690, col: 1, offset: 40115},
 			expr: &seqExpr{
-				pos: position{line: 1689, col: 16, offset: 40044},
+				pos: position{line: 1690, col: 16, offset: 40130},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1689, col: 16, offset: 40044},
+						pos:        position{line: 1690, col: 16, offset: 40130},
 						val:        "e",
 						ignoreCase: true,
 						want:       "\"e\"i",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1689, col: 21, offset: 40049},
+						pos: position{line: 1690, col: 21, offset: 40135},
 						expr: &charClassMatcher{
-							pos:        position{line: 1689, col: 21, offset: 40049},
+							pos:        position{line: 1690, col: 21, offset: 40135},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -11439,7 +11452,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1689, col: 27, offset: 40055},
+						pos:  position{line: 1690, col: 27, offset: 40141},
 						name: "UIntString",
 					},
 				},
@@ -11449,9 +11462,9 @@ var g = &grammar{
 		},
 		{
 			name: "NaN",
-			pos:  position{line: 1691, col: 1, offset: 40067},
+			pos:  position{line: 1692, col: 1, offset: 40153},
 			expr: &litMatcher{
-				pos:        position{line: 1691, col: 7, offset: 40073},
+				pos:        position{line: 1692, col: 7, offset: 40159},
 				val:        "NaN",
 				ignoreCase: false,
 				want:       "\"NaN\"",
@@ -11461,23 +11474,23 @@ var g = &grammar{
 		},
 		{
 			name: "Infinity",
-			pos:  position{line: 1693, col: 1, offset: 40080},
+			pos:  position{line: 1694, col: 1, offset: 40166},
 			expr: &seqExpr{
-				pos: position{line: 1693, col: 12, offset: 40091},
+				pos: position{line: 1694, col: 12, offset: 40177},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 1693, col: 12, offset: 40091},
+						pos: position{line: 1694, col: 12, offset: 40177},
 						expr: &choiceExpr{
-							pos: position{line: 1693, col: 13, offset: 40092},
+							pos: position{line: 1694, col: 13, offset: 40178},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1693, col: 13, offset: 40092},
+									pos:        position{line: 1694, col: 13, offset: 40178},
 									val:        "-",
 									ignoreCase: false,
 									want:       "\"-\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1693, col: 19, offset: 40098},
+									pos:        position{line: 1694, col: 19, offset: 40184},
 									val:        "+",
 									ignoreCase: false,
 									want:       "\"+\"",
@@ -11486,7 +11499,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1693, col: 25, offset: 40104},
+						pos:        position{line: 1694, col: 25, offset: 40190},
 						val:        "Inf",
 						ignoreCase: false,
 						want:       "\"Inf\"",
@@ -11498,14 +11511,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1695, col: 1, offset: 40111},
+			pos:  position{line: 1696, col: 1, offset: 40197},
 			expr: &actionExpr{
-				pos: position{line: 1695, col: 7, offset: 40117},
+				pos: position{line: 1696, col: 7, offset: 40203},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1695, col: 7, offset: 40117},
+					pos: position{line: 1696, col: 7, offset: 40203},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1695, col: 7, offset: 40117},
+						pos:  position{line: 1696, col: 7, offset: 40203},
 						name: "HexDigit",
 					},
 				},
@@ -11515,9 +11528,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1697, col: 1, offset: 40159},
+			pos:  position{line: 1698, col: 1, offset: 40245},
 			expr: &charClassMatcher{
-				pos:        position{line: 1697, col: 12, offset: 40170},
+				pos:        position{line: 1698, col: 12, offset: 40256},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -11528,32 +11541,32 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedString",
-			pos:  position{line: 1699, col: 1, offset: 40183},
+			pos:  position{line: 1700, col: 1, offset: 40269},
 			expr: &actionExpr{
-				pos: position{line: 1700, col: 5, offset: 40206},
+				pos: position{line: 1701, col: 5, offset: 40292},
 				run: (*parser).callonSingleQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 1700, col: 5, offset: 40206},
+					pos: position{line: 1701, col: 5, offset: 40292},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1700, col: 5, offset: 40206},
+							pos:        position{line: 1701, col: 5, offset: 40292},
 							val:        "'",
 							ignoreCase: false,
 							want:       "\"'\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1700, col: 9, offset: 40210},
+							pos:   position{line: 1701, col: 9, offset: 40296},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1700, col: 11, offset: 40212},
+								pos: position{line: 1701, col: 11, offset: 40298},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1700, col: 11, offset: 40212},
+									pos:  position{line: 1701, col: 11, offset: 40298},
 									name: "SingleQuotedChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1700, col: 29, offset: 40230},
+							pos:        position{line: 1701, col: 29, offset: 40316},
 							val:        "'",
 							ignoreCase: false,
 							want:       "\"'\"",
@@ -11566,32 +11579,32 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedString",
-			pos:  position{line: 1702, col: 1, offset: 40264},
+			pos:  position{line: 1703, col: 1, offset: 40350},
 			expr: &actionExpr{
-				pos: position{line: 1703, col: 5, offset: 40287},
+				pos: position{line: 1704, col: 5, offset: 40373},
 				run: (*parser).callonDoubleQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 1703, col: 5, offset: 40287},
+					pos: position{line: 1704, col: 5, offset: 40373},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1703, col: 5, offset: 40287},
+							pos:        position{line: 1704, col: 5, offset: 40373},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1703, col: 9, offset: 40291},
+							pos:   position{line: 1704, col: 9, offset: 40377},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1703, col: 11, offset: 40293},
+								pos: position{line: 1704, col: 11, offset: 40379},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1703, col: 11, offset: 40293},
+									pos:  position{line: 1704, col: 11, offset: 40379},
 									name: "DoubleQuotedChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1703, col: 29, offset: 40311},
+							pos:        position{line: 1704, col: 29, offset: 40397},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11604,57 +11617,57 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1705, col: 1, offset: 40345},
+			pos:  position{line: 1706, col: 1, offset: 40431},
 			expr: &choiceExpr{
-				pos: position{line: 1706, col: 5, offset: 40366},
+				pos: position{line: 1707, col: 5, offset: 40452},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1706, col: 5, offset: 40366},
+						pos: position{line: 1707, col: 5, offset: 40452},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1706, col: 5, offset: 40366},
+							pos: position{line: 1707, col: 5, offset: 40452},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1706, col: 5, offset: 40366},
+									pos: position{line: 1707, col: 5, offset: 40452},
 									expr: &choiceExpr{
-										pos: position{line: 1706, col: 7, offset: 40368},
+										pos: position{line: 1707, col: 7, offset: 40454},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1706, col: 7, offset: 40368},
+												pos:        position{line: 1707, col: 7, offset: 40454},
 												val:        "\"",
 												ignoreCase: false,
 												want:       "\"\\\"\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1706, col: 13, offset: 40374},
+												pos:  position{line: 1707, col: 13, offset: 40460},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1706, col: 26, offset: 40387,
+									line: 1707, col: 26, offset: 40473,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1707, col: 5, offset: 40424},
+						pos: position{line: 1708, col: 5, offset: 40510},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1707, col: 5, offset: 40424},
+							pos: position{line: 1708, col: 5, offset: 40510},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1707, col: 5, offset: 40424},
+									pos:        position{line: 1708, col: 5, offset: 40510},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1707, col: 10, offset: 40429},
+									pos:   position{line: 1708, col: 10, offset: 40515},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1707, col: 12, offset: 40431},
+										pos:  position{line: 1708, col: 12, offset: 40517},
 										name: "EscapeSequence",
 									},
 								},
@@ -11668,32 +11681,32 @@ var g = &grammar{
 		},
 		{
 			name: "RString",
-			pos:  position{line: 1709, col: 1, offset: 40465},
+			pos:  position{line: 1710, col: 1, offset: 40551},
 			expr: &choiceExpr{
-				pos: position{line: 1710, col: 5, offset: 40477},
+				pos: position{line: 1711, col: 5, offset: 40563},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1710, col: 5, offset: 40477},
+						pos: position{line: 1711, col: 5, offset: 40563},
 						run: (*parser).callonRString2,
 						expr: &seqExpr{
-							pos: position{line: 1710, col: 5, offset: 40477},
+							pos: position{line: 1711, col: 5, offset: 40563},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1710, col: 5, offset: 40477},
+									pos:        position{line: 1711, col: 5, offset: 40563},
 									val:        "r'",
 									ignoreCase: false,
 									want:       "\"r'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1710, col: 10, offset: 40482},
+									pos:   position{line: 1711, col: 10, offset: 40568},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1710, col: 12, offset: 40484},
+										pos:  position{line: 1711, col: 12, offset: 40570},
 										name: "NoSingleQuotes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1710, col: 27, offset: 40499},
+									pos:        position{line: 1711, col: 27, offset: 40585},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -11702,33 +11715,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1711, col: 5, offset: 40534},
+						pos: position{line: 1712, col: 5, offset: 40620},
 						run: (*parser).callonRString8,
 						expr: &seqExpr{
-							pos: position{line: 1711, col: 5, offset: 40534},
+							pos: position{line: 1712, col: 5, offset: 40620},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1711, col: 5, offset: 40534},
+									pos:        position{line: 1712, col: 5, offset: 40620},
 									val:        "r",
 									ignoreCase: false,
 									want:       "\"r\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1711, col: 9, offset: 40538},
+									pos:        position{line: 1712, col: 9, offset: 40624},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1711, col: 13, offset: 40542},
+									pos:   position{line: 1712, col: 13, offset: 40628},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1711, col: 15, offset: 40544},
+										pos:  position{line: 1712, col: 15, offset: 40630},
 										name: "NoDoubleQuotes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1711, col: 30, offset: 40559},
+									pos:        position{line: 1712, col: 30, offset: 40645},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -11743,26 +11756,26 @@ var g = &grammar{
 		},
 		{
 			name: "NoSingleQuotes",
-			pos:  position{line: 1713, col: 1, offset: 40591},
+			pos:  position{line: 1714, col: 1, offset: 40677},
 			expr: &actionExpr{
-				pos: position{line: 1714, col: 5, offset: 40610},
+				pos: position{line: 1715, col: 5, offset: 40696},
 				run: (*parser).callonNoSingleQuotes1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 1714, col: 5, offset: 40610},
+					pos: position{line: 1715, col: 5, offset: 40696},
 					expr: &seqExpr{
-						pos: position{line: 1714, col: 6, offset: 40611},
+						pos: position{line: 1715, col: 6, offset: 40697},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 1714, col: 6, offset: 40611},
+								pos: position{line: 1715, col: 6, offset: 40697},
 								expr: &litMatcher{
-									pos:        position{line: 1714, col: 7, offset: 40612},
+									pos:        position{line: 1715, col: 7, offset: 40698},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 							},
 							&anyMatcher{
-								line: 1714, col: 11, offset: 40616,
+								line: 1715, col: 11, offset: 40702,
 							},
 						},
 					},
@@ -11773,26 +11786,26 @@ var g = &grammar{
 		},
 		{
 			name: "NoDoubleQuotes",
-			pos:  position{line: 1716, col: 1, offset: 40652},
+			pos:  position{line: 1717, col: 1, offset: 40738},
 			expr: &actionExpr{
-				pos: position{line: 1717, col: 5, offset: 40671},
+				pos: position{line: 1718, col: 5, offset: 40757},
 				run: (*parser).callonNoDoubleQuotes1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 1717, col: 5, offset: 40671},
+					pos: position{line: 1718, col: 5, offset: 40757},
 					expr: &seqExpr{
-						pos: position{line: 1717, col: 6, offset: 40672},
+						pos: position{line: 1718, col: 6, offset: 40758},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 1717, col: 6, offset: 40672},
+								pos: position{line: 1718, col: 6, offset: 40758},
 								expr: &litMatcher{
-									pos:        position{line: 1717, col: 7, offset: 40673},
+									pos:        position{line: 1718, col: 7, offset: 40759},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 							},
 							&anyMatcher{
-								line: 1717, col: 11, offset: 40677,
+								line: 1718, col: 11, offset: 40763,
 							},
 						},
 					},
@@ -11803,32 +11816,32 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickString",
-			pos:  position{line: 1719, col: 1, offset: 40713},
+			pos:  position{line: 1720, col: 1, offset: 40799},
 			expr: &actionExpr{
-				pos: position{line: 1720, col: 5, offset: 40732},
+				pos: position{line: 1721, col: 5, offset: 40818},
 				run: (*parser).callonBacktickString1,
 				expr: &seqExpr{
-					pos: position{line: 1720, col: 5, offset: 40732},
+					pos: position{line: 1721, col: 5, offset: 40818},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1720, col: 5, offset: 40732},
+							pos:        position{line: 1721, col: 5, offset: 40818},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1720, col: 9, offset: 40736},
+							pos:   position{line: 1721, col: 9, offset: 40822},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1720, col: 11, offset: 40738},
+								pos: position{line: 1721, col: 11, offset: 40824},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1720, col: 11, offset: 40738},
+									pos:  position{line: 1721, col: 11, offset: 40824},
 									name: "BacktickChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1720, col: 25, offset: 40752},
+							pos:        position{line: 1721, col: 25, offset: 40838},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
@@ -11841,57 +11854,57 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickChar",
-			pos:  position{line: 1722, col: 1, offset: 40786},
+			pos:  position{line: 1723, col: 1, offset: 40872},
 			expr: &choiceExpr{
-				pos: position{line: 1723, col: 5, offset: 40803},
+				pos: position{line: 1724, col: 5, offset: 40889},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1723, col: 5, offset: 40803},
+						pos: position{line: 1724, col: 5, offset: 40889},
 						run: (*parser).callonBacktickChar2,
 						expr: &seqExpr{
-							pos: position{line: 1723, col: 5, offset: 40803},
+							pos: position{line: 1724, col: 5, offset: 40889},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1723, col: 5, offset: 40803},
+									pos: position{line: 1724, col: 5, offset: 40889},
 									expr: &choiceExpr{
-										pos: position{line: 1723, col: 7, offset: 40805},
+										pos: position{line: 1724, col: 7, offset: 40891},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1723, col: 7, offset: 40805},
+												pos:        position{line: 1724, col: 7, offset: 40891},
 												val:        "`",
 												ignoreCase: false,
 												want:       "\"`\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1723, col: 13, offset: 40811},
+												pos:  position{line: 1724, col: 13, offset: 40897},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1723, col: 26, offset: 40824,
+									line: 1724, col: 26, offset: 40910,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1724, col: 5, offset: 40861},
+						pos: position{line: 1725, col: 5, offset: 40947},
 						run: (*parser).callonBacktickChar9,
 						expr: &seqExpr{
-							pos: position{line: 1724, col: 5, offset: 40861},
+							pos: position{line: 1725, col: 5, offset: 40947},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1724, col: 5, offset: 40861},
+									pos:        position{line: 1725, col: 5, offset: 40947},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1724, col: 10, offset: 40866},
+									pos:   position{line: 1725, col: 10, offset: 40952},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1724, col: 12, offset: 40868},
+										pos:  position{line: 1725, col: 12, offset: 40954},
 										name: "EscapeSequence",
 									},
 								},
@@ -11905,28 +11918,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1726, col: 1, offset: 40902},
+			pos:  position{line: 1727, col: 1, offset: 40988},
 			expr: &actionExpr{
-				pos: position{line: 1727, col: 5, offset: 40914},
+				pos: position{line: 1728, col: 5, offset: 41000},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1727, col: 5, offset: 40914},
+					pos: position{line: 1728, col: 5, offset: 41000},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1727, col: 5, offset: 40914},
+							pos:   position{line: 1728, col: 5, offset: 41000},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1727, col: 10, offset: 40919},
+								pos:  position{line: 1728, col: 10, offset: 41005},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1727, col: 23, offset: 40932},
+							pos:   position{line: 1728, col: 23, offset: 41018},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1727, col: 28, offset: 40937},
+								pos: position{line: 1728, col: 28, offset: 41023},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1727, col: 28, offset: 40937},
+									pos:  position{line: 1728, col: 28, offset: 41023},
 									name: "KeyWordRest",
 								},
 							},
@@ -11939,16 +11952,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1729, col: 1, offset: 40999},
+			pos:  position{line: 1730, col: 1, offset: 41085},
 			expr: &choiceExpr{
-				pos: position{line: 1730, col: 5, offset: 41016},
+				pos: position{line: 1731, col: 5, offset: 41102},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1730, col: 5, offset: 41016},
+						pos:  position{line: 1731, col: 5, offset: 41102},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1731, col: 5, offset: 41033},
+						pos:  position{line: 1732, col: 5, offset: 41119},
 						name: "KeyWordEsc",
 					},
 				},
@@ -11958,16 +11971,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1733, col: 1, offset: 41045},
+			pos:  position{line: 1734, col: 1, offset: 41131},
 			expr: &choiceExpr{
-				pos: position{line: 1734, col: 5, offset: 41061},
+				pos: position{line: 1735, col: 5, offset: 41147},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1734, col: 5, offset: 41061},
+						pos:  position{line: 1735, col: 5, offset: 41147},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1735, col: 5, offset: 41078},
+						pos:        position{line: 1736, col: 5, offset: 41164},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11980,19 +11993,19 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1737, col: 1, offset: 41085},
+			pos:  position{line: 1738, col: 1, offset: 41171},
 			expr: &actionExpr{
-				pos: position{line: 1737, col: 16, offset: 41100},
+				pos: position{line: 1738, col: 16, offset: 41186},
 				run: (*parser).callonKeyWordChars1,
 				expr: &choiceExpr{
-					pos: position{line: 1737, col: 17, offset: 41101},
+					pos: position{line: 1738, col: 17, offset: 41187},
 					alternatives: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1737, col: 17, offset: 41101},
+							pos:  position{line: 1738, col: 17, offset: 41187},
 							name: "UnicodeLetter",
 						},
 						&charClassMatcher{
-							pos:        position{line: 1737, col: 33, offset: 41117},
+							pos:        position{line: 1738, col: 33, offset: 41203},
 							val:        "[_.:/%#@~]",
 							chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 							ignoreCase: false,
@@ -12006,31 +12019,31 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1739, col: 1, offset: 41161},
+			pos:  position{line: 1740, col: 1, offset: 41247},
 			expr: &actionExpr{
-				pos: position{line: 1739, col: 14, offset: 41174},
+				pos: position{line: 1740, col: 14, offset: 41260},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1739, col: 14, offset: 41174},
+					pos: position{line: 1740, col: 14, offset: 41260},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1739, col: 14, offset: 41174},
+							pos:        position{line: 1740, col: 14, offset: 41260},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1739, col: 19, offset: 41179},
+							pos:   position{line: 1740, col: 19, offset: 41265},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1739, col: 22, offset: 41182},
+								pos: position{line: 1740, col: 22, offset: 41268},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1739, col: 22, offset: 41182},
+										pos:  position{line: 1740, col: 22, offset: 41268},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1739, col: 38, offset: 41198},
+										pos:  position{line: 1740, col: 38, offset: 41284},
 										name: "EscapeSequence",
 									},
 								},
@@ -12044,42 +12057,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1741, col: 1, offset: 41233},
+			pos:  position{line: 1742, col: 1, offset: 41319},
 			expr: &actionExpr{
-				pos: position{line: 1742, col: 5, offset: 41249},
+				pos: position{line: 1743, col: 5, offset: 41335},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1742, col: 5, offset: 41249},
+					pos: position{line: 1743, col: 5, offset: 41335},
 					exprs: []any{
 						&andExpr{
-							pos: position{line: 1742, col: 5, offset: 41249},
+							pos: position{line: 1743, col: 5, offset: 41335},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1742, col: 6, offset: 41250},
+								pos:  position{line: 1743, col: 6, offset: 41336},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1742, col: 22, offset: 41266},
+							pos: position{line: 1743, col: 22, offset: 41352},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1742, col: 23, offset: 41267},
+								pos:  position{line: 1743, col: 23, offset: 41353},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1742, col: 35, offset: 41279},
+							pos:   position{line: 1743, col: 35, offset: 41365},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1742, col: 40, offset: 41284},
+								pos:  position{line: 1743, col: 40, offset: 41370},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1742, col: 50, offset: 41294},
+							pos:   position{line: 1743, col: 50, offset: 41380},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1742, col: 55, offset: 41299},
+								pos: position{line: 1743, col: 55, offset: 41385},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1742, col: 55, offset: 41299},
+									pos:  position{line: 1743, col: 55, offset: 41385},
 									name: "GlobRest",
 								},
 							},
@@ -12092,28 +12105,28 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1746, col: 1, offset: 41368},
+			pos:  position{line: 1747, col: 1, offset: 41454},
 			expr: &choiceExpr{
-				pos: position{line: 1746, col: 19, offset: 41386},
+				pos: position{line: 1747, col: 19, offset: 41472},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1746, col: 19, offset: 41386},
+						pos:  position{line: 1747, col: 19, offset: 41472},
 						name: "KeyWordStart",
 					},
 					&seqExpr{
-						pos: position{line: 1746, col: 34, offset: 41401},
+						pos: position{line: 1747, col: 34, offset: 41487},
 						exprs: []any{
 							&oneOrMoreExpr{
-								pos: position{line: 1746, col: 34, offset: 41401},
+								pos: position{line: 1747, col: 34, offset: 41487},
 								expr: &litMatcher{
-									pos:        position{line: 1746, col: 34, offset: 41401},
+									pos:        position{line: 1747, col: 34, offset: 41487},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1746, col: 39, offset: 41406},
+								pos:  position{line: 1747, col: 39, offset: 41492},
 								name: "KeyWordRest",
 							},
 						},
@@ -12125,19 +12138,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1747, col: 1, offset: 41418},
+			pos:  position{line: 1748, col: 1, offset: 41504},
 			expr: &seqExpr{
-				pos: position{line: 1747, col: 15, offset: 41432},
+				pos: position{line: 1748, col: 15, offset: 41518},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1747, col: 15, offset: 41432},
+						pos: position{line: 1748, col: 15, offset: 41518},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1747, col: 15, offset: 41432},
+							pos:  position{line: 1748, col: 15, offset: 41518},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1747, col: 28, offset: 41445},
+						pos:        position{line: 1748, col: 28, offset: 41531},
 						val:        "*",
 						ignoreCase: false,
 						want:       "\"*\"",
@@ -12149,23 +12162,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1749, col: 1, offset: 41450},
+			pos:  position{line: 1750, col: 1, offset: 41536},
 			expr: &choiceExpr{
-				pos: position{line: 1750, col: 5, offset: 41464},
+				pos: position{line: 1751, col: 5, offset: 41550},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1750, col: 5, offset: 41464},
+						pos:  position{line: 1751, col: 5, offset: 41550},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1751, col: 5, offset: 41481},
+						pos:  position{line: 1752, col: 5, offset: 41567},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1752, col: 5, offset: 41493},
+						pos: position{line: 1753, col: 5, offset: 41579},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1752, col: 5, offset: 41493},
+							pos:        position{line: 1753, col: 5, offset: 41579},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -12178,16 +12191,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1754, col: 1, offset: 41518},
+			pos:  position{line: 1755, col: 1, offset: 41604},
 			expr: &choiceExpr{
-				pos: position{line: 1755, col: 5, offset: 41531},
+				pos: position{line: 1756, col: 5, offset: 41617},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1755, col: 5, offset: 41531},
+						pos:  position{line: 1756, col: 5, offset: 41617},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1756, col: 5, offset: 41545},
+						pos:        position{line: 1757, col: 5, offset: 41631},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -12200,31 +12213,31 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1758, col: 1, offset: 41552},
+			pos:  position{line: 1759, col: 1, offset: 41638},
 			expr: &actionExpr{
-				pos: position{line: 1758, col: 11, offset: 41562},
+				pos: position{line: 1759, col: 11, offset: 41648},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1758, col: 11, offset: 41562},
+					pos: position{line: 1759, col: 11, offset: 41648},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1758, col: 11, offset: 41562},
+							pos:        position{line: 1759, col: 11, offset: 41648},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1758, col: 16, offset: 41567},
+							pos:   position{line: 1759, col: 16, offset: 41653},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1758, col: 19, offset: 41570},
+								pos: position{line: 1759, col: 19, offset: 41656},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1758, col: 19, offset: 41570},
+										pos:  position{line: 1759, col: 19, offset: 41656},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1758, col: 32, offset: 41583},
+										pos:  position{line: 1759, col: 32, offset: 41669},
 										name: "EscapeSequence",
 									},
 								},
@@ -12238,32 +12251,32 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1760, col: 1, offset: 41618},
+			pos:  position{line: 1761, col: 1, offset: 41704},
 			expr: &choiceExpr{
-				pos: position{line: 1761, col: 5, offset: 41633},
+				pos: position{line: 1762, col: 5, offset: 41719},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1761, col: 5, offset: 41633},
+						pos: position{line: 1762, col: 5, offset: 41719},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1761, col: 5, offset: 41633},
+							pos:        position{line: 1762, col: 5, offset: 41719},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1762, col: 5, offset: 41661},
+						pos: position{line: 1763, col: 5, offset: 41747},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1762, col: 5, offset: 41661},
+							pos:        position{line: 1763, col: 5, offset: 41747},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1763, col: 5, offset: 41691},
+						pos:        position{line: 1764, col: 5, offset: 41777},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -12276,57 +12289,57 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1765, col: 1, offset: 41697},
+			pos:  position{line: 1766, col: 1, offset: 41783},
 			expr: &choiceExpr{
-				pos: position{line: 1766, col: 5, offset: 41718},
+				pos: position{line: 1767, col: 5, offset: 41804},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1766, col: 5, offset: 41718},
+						pos: position{line: 1767, col: 5, offset: 41804},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1766, col: 5, offset: 41718},
+							pos: position{line: 1767, col: 5, offset: 41804},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1766, col: 5, offset: 41718},
+									pos: position{line: 1767, col: 5, offset: 41804},
 									expr: &choiceExpr{
-										pos: position{line: 1766, col: 7, offset: 41720},
+										pos: position{line: 1767, col: 7, offset: 41806},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1766, col: 7, offset: 41720},
+												pos:        position{line: 1767, col: 7, offset: 41806},
 												val:        "'",
 												ignoreCase: false,
 												want:       "\"'\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1766, col: 13, offset: 41726},
+												pos:  position{line: 1767, col: 13, offset: 41812},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1766, col: 26, offset: 41739,
+									line: 1767, col: 26, offset: 41825,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1767, col: 5, offset: 41776},
+						pos: position{line: 1768, col: 5, offset: 41862},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1767, col: 5, offset: 41776},
+							pos: position{line: 1768, col: 5, offset: 41862},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1767, col: 5, offset: 41776},
+									pos:        position{line: 1768, col: 5, offset: 41862},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1767, col: 10, offset: 41781},
+									pos:   position{line: 1768, col: 10, offset: 41867},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1767, col: 12, offset: 41783},
+										pos:  position{line: 1768, col: 12, offset: 41869},
 										name: "EscapeSequence",
 									},
 								},
@@ -12340,16 +12353,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1769, col: 1, offset: 41817},
+			pos:  position{line: 1770, col: 1, offset: 41903},
 			expr: &choiceExpr{
-				pos: position{line: 1770, col: 5, offset: 41836},
+				pos: position{line: 1771, col: 5, offset: 41922},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1770, col: 5, offset: 41836},
+						pos:  position{line: 1771, col: 5, offset: 41922},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1771, col: 5, offset: 41857},
+						pos:  position{line: 1772, col: 5, offset: 41943},
 						name: "UnicodeEscape",
 					},
 				},
@@ -12359,87 +12372,87 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1773, col: 1, offset: 41872},
+			pos:  position{line: 1774, col: 1, offset: 41958},
 			expr: &choiceExpr{
-				pos: position{line: 1774, col: 5, offset: 41893},
+				pos: position{line: 1775, col: 5, offset: 41979},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1774, col: 5, offset: 41893},
+						pos:        position{line: 1775, col: 5, offset: 41979},
 						val:        "'",
 						ignoreCase: false,
 						want:       "\"'\"",
 					},
 					&actionExpr{
-						pos: position{line: 1775, col: 5, offset: 41901},
+						pos: position{line: 1776, col: 5, offset: 41987},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1775, col: 5, offset: 41901},
+							pos:        position{line: 1776, col: 5, offset: 41987},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1776, col: 5, offset: 41941},
+						pos:        position{line: 1777, col: 5, offset: 42027},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
 					},
 					&actionExpr{
-						pos: position{line: 1777, col: 5, offset: 41950},
+						pos: position{line: 1778, col: 5, offset: 42036},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1777, col: 5, offset: 41950},
+							pos:        position{line: 1778, col: 5, offset: 42036},
 							val:        "b",
 							ignoreCase: false,
 							want:       "\"b\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1778, col: 5, offset: 41979},
+						pos: position{line: 1779, col: 5, offset: 42065},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1778, col: 5, offset: 41979},
+							pos:        position{line: 1779, col: 5, offset: 42065},
 							val:        "f",
 							ignoreCase: false,
 							want:       "\"f\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1779, col: 5, offset: 42008},
+						pos: position{line: 1780, col: 5, offset: 42094},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1779, col: 5, offset: 42008},
+							pos:        position{line: 1780, col: 5, offset: 42094},
 							val:        "n",
 							ignoreCase: false,
 							want:       "\"n\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1780, col: 5, offset: 42037},
+						pos: position{line: 1781, col: 5, offset: 42123},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1780, col: 5, offset: 42037},
+							pos:        position{line: 1781, col: 5, offset: 42123},
 							val:        "r",
 							ignoreCase: false,
 							want:       "\"r\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1781, col: 5, offset: 42066},
+						pos: position{line: 1782, col: 5, offset: 42152},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1781, col: 5, offset: 42066},
+							pos:        position{line: 1782, col: 5, offset: 42152},
 							val:        "t",
 							ignoreCase: false,
 							want:       "\"t\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1782, col: 5, offset: 42095},
+						pos: position{line: 1783, col: 5, offset: 42181},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1782, col: 5, offset: 42095},
+							pos:        position{line: 1783, col: 5, offset: 42181},
 							val:        "v",
 							ignoreCase: false,
 							want:       "\"v\"",
@@ -12452,32 +12465,32 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1784, col: 1, offset: 42121},
+			pos:  position{line: 1785, col: 1, offset: 42207},
 			expr: &choiceExpr{
-				pos: position{line: 1785, col: 5, offset: 42139},
+				pos: position{line: 1786, col: 5, offset: 42225},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1785, col: 5, offset: 42139},
+						pos: position{line: 1786, col: 5, offset: 42225},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1785, col: 5, offset: 42139},
+							pos:        position{line: 1786, col: 5, offset: 42225},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1786, col: 5, offset: 42167},
+						pos: position{line: 1787, col: 5, offset: 42253},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1786, col: 5, offset: 42167},
+							pos:        position{line: 1787, col: 5, offset: 42253},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1787, col: 5, offset: 42195},
+						pos:        position{line: 1788, col: 5, offset: 42281},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -12490,42 +12503,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1789, col: 1, offset: 42201},
+			pos:  position{line: 1790, col: 1, offset: 42287},
 			expr: &choiceExpr{
-				pos: position{line: 1790, col: 5, offset: 42219},
+				pos: position{line: 1791, col: 5, offset: 42305},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1790, col: 5, offset: 42219},
+						pos: position{line: 1791, col: 5, offset: 42305},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1790, col: 5, offset: 42219},
+							pos: position{line: 1791, col: 5, offset: 42305},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1790, col: 5, offset: 42219},
+									pos:        position{line: 1791, col: 5, offset: 42305},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1790, col: 9, offset: 42223},
+									pos:   position{line: 1791, col: 9, offset: 42309},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1790, col: 16, offset: 42230},
+										pos: position{line: 1791, col: 16, offset: 42316},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1790, col: 16, offset: 42230},
+												pos:  position{line: 1791, col: 16, offset: 42316},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1790, col: 25, offset: 42239},
+												pos:  position{line: 1791, col: 25, offset: 42325},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1790, col: 34, offset: 42248},
+												pos:  position{line: 1791, col: 34, offset: 42334},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1790, col: 43, offset: 42257},
+												pos:  position{line: 1791, col: 43, offset: 42343},
 												name: "HexDigit",
 											},
 										},
@@ -12535,65 +12548,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1793, col: 5, offset: 42320},
+						pos: position{line: 1794, col: 5, offset: 42406},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1793, col: 5, offset: 42320},
+							pos: position{line: 1794, col: 5, offset: 42406},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1793, col: 5, offset: 42320},
+									pos:        position{line: 1794, col: 5, offset: 42406},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1793, col: 9, offset: 42324},
+									pos:        position{line: 1794, col: 9, offset: 42410},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1793, col: 13, offset: 42328},
+									pos:   position{line: 1794, col: 13, offset: 42414},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1793, col: 20, offset: 42335},
+										pos: position{line: 1794, col: 20, offset: 42421},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1793, col: 20, offset: 42335},
+												pos:  position{line: 1794, col: 20, offset: 42421},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1793, col: 29, offset: 42344},
+												pos: position{line: 1794, col: 29, offset: 42430},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1793, col: 29, offset: 42344},
+													pos:  position{line: 1794, col: 29, offset: 42430},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1793, col: 39, offset: 42354},
+												pos: position{line: 1794, col: 39, offset: 42440},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1793, col: 39, offset: 42354},
+													pos:  position{line: 1794, col: 39, offset: 42440},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1793, col: 49, offset: 42364},
+												pos: position{line: 1794, col: 49, offset: 42450},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1793, col: 49, offset: 42364},
+													pos:  position{line: 1794, col: 49, offset: 42450},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1793, col: 59, offset: 42374},
+												pos: position{line: 1794, col: 59, offset: 42460},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1793, col: 59, offset: 42374},
+													pos:  position{line: 1794, col: 59, offset: 42460},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1793, col: 69, offset: 42384},
+												pos: position{line: 1794, col: 69, offset: 42470},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1793, col: 69, offset: 42384},
+													pos:  position{line: 1794, col: 69, offset: 42470},
 													name: "HexDigit",
 												},
 											},
@@ -12601,7 +12614,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1793, col: 80, offset: 42395},
+									pos:        position{line: 1794, col: 80, offset: 42481},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -12616,9 +12629,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1798, col: 1, offset: 42450},
+			pos:  position{line: 1799, col: 1, offset: 42536},
 			expr: &charClassMatcher{
-				pos:        position{line: 1799, col: 5, offset: 42466},
+				pos:        position{line: 1800, col: 5, offset: 42552},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -12630,11 +12643,11 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1801, col: 1, offset: 42481},
+			pos:  position{line: 1802, col: 1, offset: 42567},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1801, col: 5, offset: 42485},
+				pos: position{line: 1802, col: 5, offset: 42571},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1801, col: 5, offset: 42485},
+					pos:  position{line: 1802, col: 5, offset: 42571},
 					name: "AnySpace",
 				},
 			},
@@ -12643,11 +12656,11 @@ var g = &grammar{
 		},
 		{
 			name: "__",
-			pos:  position{line: 1803, col: 1, offset: 42496},
+			pos:  position{line: 1804, col: 1, offset: 42582},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1803, col: 6, offset: 42501},
+				pos: position{line: 1804, col: 6, offset: 42587},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1803, col: 6, offset: 42501},
+					pos:  position{line: 1804, col: 6, offset: 42587},
 					name: "AnySpace",
 				},
 			},
@@ -12656,20 +12669,20 @@ var g = &grammar{
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1805, col: 1, offset: 42512},
+			pos:  position{line: 1806, col: 1, offset: 42598},
 			expr: &choiceExpr{
-				pos: position{line: 1806, col: 5, offset: 42525},
+				pos: position{line: 1807, col: 5, offset: 42611},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1806, col: 5, offset: 42525},
+						pos:  position{line: 1807, col: 5, offset: 42611},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1807, col: 5, offset: 42540},
+						pos:  position{line: 1808, col: 5, offset: 42626},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1808, col: 5, offset: 42559},
+						pos:  position{line: 1809, col: 5, offset: 42645},
 						name: "Comment",
 					},
 				},
@@ -12679,32 +12692,32 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeLetter",
-			pos:  position{line: 1810, col: 1, offset: 42568},
+			pos:  position{line: 1811, col: 1, offset: 42654},
 			expr: &choiceExpr{
-				pos: position{line: 1811, col: 5, offset: 42586},
+				pos: position{line: 1812, col: 5, offset: 42672},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1811, col: 5, offset: 42586},
+						pos:  position{line: 1812, col: 5, offset: 42672},
 						name: "Lu",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1812, col: 5, offset: 42593},
+						pos:  position{line: 1813, col: 5, offset: 42679},
 						name: "Ll",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1813, col: 5, offset: 42600},
+						pos:  position{line: 1814, col: 5, offset: 42686},
 						name: "Lt",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1814, col: 5, offset: 42607},
+						pos:  position{line: 1815, col: 5, offset: 42693},
 						name: "Lm",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1815, col: 5, offset: 42614},
+						pos:  position{line: 1816, col: 5, offset: 42700},
 						name: "Lo",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1816, col: 5, offset: 42621},
+						pos:  position{line: 1817, col: 5, offset: 42707},
 						name: "Nl",
 					},
 				},
@@ -12714,16 +12727,16 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeCombiningMark",
-			pos:  position{line: 1818, col: 1, offset: 42625},
+			pos:  position{line: 1819, col: 1, offset: 42711},
 			expr: &choiceExpr{
-				pos: position{line: 1819, col: 5, offset: 42650},
+				pos: position{line: 1820, col: 5, offset: 42736},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1819, col: 5, offset: 42650},
+						pos:  position{line: 1820, col: 5, offset: 42736},
 						name: "Mn",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1820, col: 5, offset: 42657},
+						pos:  position{line: 1821, col: 5, offset: 42743},
 						name: "Mc",
 					},
 				},
@@ -12733,9 +12746,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeDigit",
-			pos:  position{line: 1822, col: 1, offset: 42661},
+			pos:  position{line: 1823, col: 1, offset: 42747},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1823, col: 5, offset: 42678},
+				pos:  position{line: 1824, col: 5, offset: 42764},
 				name: "Nd",
 			},
 			leader:        false,
@@ -12743,9 +12756,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeConnectorPunctuation",
-			pos:  position{line: 1825, col: 1, offset: 42682},
+			pos:  position{line: 1826, col: 1, offset: 42768},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1826, col: 5, offset: 42714},
+				pos:  position{line: 1827, col: 5, offset: 42800},
 				name: "Pc",
 			},
 			leader:        false,
@@ -12753,9 +12766,9 @@ var g = &grammar{
 		},
 		{
 			name: "Ll",
-			pos:  position{line: 1832, col: 1, offset: 42895},
+			pos:  position{line: 1833, col: 1, offset: 42981},
 			expr: &charClassMatcher{
-				pos:        position{line: 1832, col: 6, offset: 42900},
+				pos:        position{line: 1833, col: 6, offset: 42986},
 				val:        "[\\u0061-\\u007A\\u00B5\\u00DF-\\u00F6\\u00F8-\\u00FF\\u0101\\u0103\\u0105\\u0107\\u0109\\u010B\\u010D\\u010F\\u0111\\u0113\\u0115\\u0117\\u0119\\u011B\\u011D\\u011F\\u0121\\u0123\\u0125\\u0127\\u0129\\u012B\\u012D\\u012F\\u0131\\u0133\\u0135\\u0137-\\u0138\\u013A\\u013C\\u013E\\u0140\\u0142\\u0144\\u0146\\u0148-\\u0149\\u014B\\u014D\\u014F\\u0151\\u0153\\u0155\\u0157\\u0159\\u015B\\u015D\\u015F\\u0161\\u0163\\u0165\\u0167\\u0169\\u016B\\u016D\\u016F\\u0171\\u0173\\u0175\\u0177\\u017A\\u017C\\u017E-\\u0180\\u0183\\u0185\\u0188\\u018C-\\u018D\\u0192\\u0195\\u0199-\\u019B\\u019E\\u01A1\\u01A3\\u01A5\\u01A8\\u01AA-\\u01AB\\u01AD\\u01B0\\u01B4\\u01B6\\u01B9-\\u01BA\\u01BD-\\u01BF\\u01C6\\u01C9\\u01CC\\u01CE\\u01D0\\u01D2\\u01D4\\u01D6\\u01D8\\u01DA\\u01DC-\\u01DD\\u01DF\\u01E1\\u01E3\\u01E5\\u01E7\\u01E9\\u01EB\\u01ED\\u01EF-\\u01F0\\u01F3\\u01F5\\u01F9\\u01FB\\u01FD\\u01FF\\u0201\\u0203\\u0205\\u0207\\u0209\\u020B\\u020D\\u020F\\u0211\\u0213\\u0215\\u0217\\u0219\\u021B\\u021D\\u021F\\u0221\\u0223\\u0225\\u0227\\u0229\\u022B\\u022D\\u022F\\u0231\\u0233-\\u0239\\u023C\\u023F-\\u0240\\u0242\\u0247\\u0249\\u024B\\u024D\\u024F-\\u0293\\u0295-\\u02AF\\u0371\\u0373\\u0377\\u037B-\\u037D\\u0390\\u03AC-\\u03CE\\u03D0-\\u03D1\\u03D5-\\u03D7\\u03D9\\u03DB\\u03DD\\u03DF\\u03E1\\u03E3\\u03E5\\u03E7\\u03E9\\u03EB\\u03ED\\u03EF-\\u03F3\\u03F5\\u03F8\\u03FB-\\u03FC\\u0430-\\u045F\\u0461\\u0463\\u0465\\u0467\\u0469\\u046B\\u046D\\u046F\\u0471\\u0473\\u0475\\u0477\\u0479\\u047B\\u047D\\u047F\\u0481\\u048B\\u048D\\u048F\\u0491\\u0493\\u0495\\u0497\\u0499\\u049B\\u049D\\u049F\\u04A1\\u04A3\\u04A5\\u04A7\\u04A9\\u04AB\\u04AD\\u04AF\\u04B1\\u04B3\\u04B5\\u04B7\\u04B9\\u04BB\\u04BD\\u04BF\\u04C2\\u04C4\\u04C6\\u04C8\\u04CA\\u04CC\\u04CE-\\u04CF\\u04D1\\u04D3\\u04D5\\u04D7\\u04D9\\u04DB\\u04DD\\u04DF\\u04E1\\u04E3\\u04E5\\u04E7\\u04E9\\u04EB\\u04ED\\u04EF\\u04F1\\u04F3\\u04F5\\u04F7\\u04F9\\u04FB\\u04FD\\u04FF\\u0501\\u0503\\u0505\\u0507\\u0509\\u050B\\u050D\\u050F\\u0511\\u0513\\u0515\\u0517\\u0519\\u051B\\u051D\\u051F\\u0521\\u0523\\u0525\\u0527\\u0529\\u052B\\u052D\\u052F\\u0560-\\u0588\\u10D0-\\u10FA\\u10FD-\\u10FF\\u13F8-\\u13FD\\u1C80-\\u1C88\\u1D00-\\u1D2B\\u1D6B-\\u1D77\\u1D79-\\u1D9A\\u1E01\\u1E03\\u1E05\\u1E07\\u1E09\\u1E0B\\u1E0D\\u1E0F\\u1E11\\u1E13\\u1E15\\u1E17\\u1E19\\u1E1B\\u1E1D\\u1E1F\\u1E21\\u1E23\\u1E25\\u1E27\\u1E29\\u1E2B\\u1E2D\\u1E2F\\u1E31\\u1E33\\u1E35\\u1E37\\u1E39\\u1E3B\\u1E3D\\u1E3F\\u1E41\\u1E43\\u1E45\\u1E47\\u1E49\\u1E4B\\u1E4D\\u1E4F\\u1E51\\u1E53\\u1E55\\u1E57\\u1E59\\u1E5B\\u1E5D\\u1E5F\\u1E61\\u1E63\\u1E65\\u1E67\\u1E69\\u1E6B\\u1E6D\\u1E6F\\u1E71\\u1E73\\u1E75\\u1E77\\u1E79\\u1E7B\\u1E7D\\u1E7F\\u1E81\\u1E83\\u1E85\\u1E87\\u1E89\\u1E8B\\u1E8D\\u1E8F\\u1E91\\u1E93\\u1E95-\\u1E9D\\u1E9F\\u1EA1\\u1EA3\\u1EA5\\u1EA7\\u1EA9\\u1EAB\\u1EAD\\u1EAF\\u1EB1\\u1EB3\\u1EB5\\u1EB7\\u1EB9\\u1EBB\\u1EBD\\u1EBF\\u1EC1\\u1EC3\\u1EC5\\u1EC7\\u1EC9\\u1ECB\\u1ECD\\u1ECF\\u1ED1\\u1ED3\\u1ED5\\u1ED7\\u1ED9\\u1EDB\\u1EDD\\u1EDF\\u1EE1\\u1EE3\\u1EE5\\u1EE7\\u1EE9\\u1EEB\\u1EED\\u1EEF\\u1EF1\\u1EF3\\u1EF5\\u1EF7\\u1EF9\\u1EFB\\u1EFD\\u1EFF-\\u1F07\\u1F10-\\u1F15\\u1F20-\\u1F27\\u1F30-\\u1F37\\u1F40-\\u1F45\\u1F50-\\u1F57\\u1F60-\\u1F67\\u1F70-\\u1F7D\\u1F80-\\u1F87\\u1F90-\\u1F97\\u1FA0-\\u1FA7\\u1FB0-\\u1FB4\\u1FB6-\\u1FB7\\u1FBE\\u1FC2-\\u1FC4\\u1FC6-\\u1FC7\\u1FD0-\\u1FD3\\u1FD6-\\u1FD7\\u1FE0-\\u1FE7\\u1FF2-\\u1FF4\\u1FF6-\\u1FF7\\u210A\\u210E-\\u210F\\u2113\\u212F\\u2134\\u2139\\u213C-\\u213D\\u2146-\\u2149\\u214E\\u2184\\u2C30-\\u2C5E\\u2C61\\u2C65-\\u2C66\\u2C68\\u2C6A\\u2C6C\\u2C71\\u2C73-\\u2C74\\u2C76-\\u2C7B\\u2C81\\u2C83\\u2C85\\u2C87\\u2C89\\u2C8B\\u2C8D\\u2C8F\\u2C91\\u2C93\\u2C95\\u2C97\\u2C99\\u2C9B\\u2C9D\\u2C9F\\u2CA1\\u2CA3\\u2CA5\\u2CA7\\u2CA9\\u2CAB\\u2CAD\\u2CAF\\u2CB1\\u2CB3\\u2CB5\\u2CB7\\u2CB9\\u2CBB\\u2CBD\\u2CBF\\u2CC1\\u2CC3\\u2CC5\\u2CC7\\u2CC9\\u2CCB\\u2CCD\\u2CCF\\u2CD1\\u2CD3\\u2CD5\\u2CD7\\u2CD9\\u2CDB\\u2CDD\\u2CDF\\u2CE1\\u2CE3-\\u2CE4\\u2CEC\\u2CEE\\u2CF3\\u2D00-\\u2D25\\u2D27\\u2D2D\\uA641\\uA643\\uA645\\uA647\\uA649\\uA64B\\uA64D\\uA64F\\uA651\\uA653\\uA655\\uA657\\uA659\\uA65B\\uA65D\\uA65F\\uA661\\uA663\\uA665\\uA667\\uA669\\uA66B\\uA66D\\uA681\\uA683\\uA685\\uA687\\uA689\\uA68B\\uA68D\\uA68F\\uA691\\uA693\\uA695\\uA697\\uA699\\uA69B\\uA723\\uA725\\uA727\\uA729\\uA72B\\uA72D\\uA72F-\\uA731\\uA733\\uA735\\uA737\\uA739\\uA73B\\uA73D\\uA73F\\uA741\\uA743\\uA745\\uA747\\uA749\\uA74B\\uA74D\\uA74F\\uA751\\uA753\\uA755\\uA757\\uA759\\uA75B\\uA75D\\uA75F\\uA761\\uA763\\uA765\\uA767\\uA769\\uA76B\\uA76D\\uA76F\\uA771-\\uA778\\uA77A\\uA77C\\uA77F\\uA781\\uA783\\uA785\\uA787\\uA78C\\uA78E\\uA791\\uA793-\\uA795\\uA797\\uA799\\uA79B\\uA79D\\uA79F\\uA7A1\\uA7A3\\uA7A5\\uA7A7\\uA7A9\\uA7AF\\uA7B5\\uA7B7\\uA7B9\\uA7FA\\uAB30-\\uAB5A\\uAB60-\\uAB65\\uAB70-\\uABBF\\uFB00-\\uFB06\\uFB13-\\uFB17\\uFF41-\\uFF5A]",
 				chars:      []rune{'µ', 'ā', 'ă', 'ą', 'ć', 'ĉ', 'ċ', 'č', 'ď', 'đ', 'ē', 'ĕ', 'ė', 'ę', 'ě', 'ĝ', 'ğ', 'ġ', 'ģ', 'ĥ', 'ħ', 'ĩ', 'ī', 'ĭ', 'į', 'ı', 'ĳ', 'ĵ', 'ĺ', 'ļ', 'ľ', 'ŀ', 'ł', 'ń', 'ņ', 'ŋ', 'ō', 'ŏ', 'ő', 'œ', 'ŕ', 'ŗ', 'ř', 'ś', 'ŝ', 'ş', 'š', 'ţ', 'ť', 'ŧ', 'ũ', 'ū', 'ŭ', 'ů', 'ű', 'ų', 'ŵ', 'ŷ', 'ź', 'ż', 'ƃ', 'ƅ', 'ƈ', 'ƒ', 'ƕ', 'ƞ', 'ơ', 'ƣ', 'ƥ', 'ƨ', 'ƭ', 'ư', 'ƴ', 'ƶ', 'ǆ', 'ǉ', 'ǌ', 'ǎ', 'ǐ', 'ǒ', 'ǔ', 'ǖ', 'ǘ', 'ǚ', 'ǟ', 'ǡ', 'ǣ', 'ǥ', 'ǧ', 'ǩ', 'ǫ', 'ǭ', 'ǳ', 'ǵ', 'ǹ', 'ǻ', 'ǽ', 'ǿ', 'ȁ', 'ȃ', 'ȅ', 'ȇ', 'ȉ', 'ȋ', 'ȍ', 'ȏ', 'ȑ', 'ȓ', 'ȕ', 'ȗ', 'ș', 'ț', 'ȝ', 'ȟ', 'ȡ', 'ȣ', 'ȥ', 'ȧ', 'ȩ', 'ȫ', 'ȭ', 'ȯ', 'ȱ', 'ȼ', 'ɂ', 'ɇ', 'ɉ', 'ɋ', 'ɍ', 'ͱ', 'ͳ', 'ͷ', 'ΐ', 'ϙ', 'ϛ', 'ϝ', 'ϟ', 'ϡ', 'ϣ', 'ϥ', 'ϧ', 'ϩ', 'ϫ', 'ϭ', 'ϵ', 'ϸ', 'ѡ', 'ѣ', 'ѥ', 'ѧ', 'ѩ', 'ѫ', 'ѭ', 'ѯ', 'ѱ', 'ѳ', 'ѵ', 'ѷ', 'ѹ', 'ѻ', 'ѽ', 'ѿ', 'ҁ', 'ҋ', 'ҍ', 'ҏ', 'ґ', 'ғ', 'ҕ', 'җ', 'ҙ', 'қ', 'ҝ', 'ҟ', 'ҡ', 'ң', 'ҥ', 'ҧ', 'ҩ', 'ҫ', 'ҭ', 'ү', 'ұ', 'ҳ', 'ҵ', 'ҷ', 'ҹ', 'һ', 'ҽ', 'ҿ', 'ӂ', 'ӄ', 'ӆ', 'ӈ', 'ӊ', 'ӌ', 'ӑ', 'ӓ', 'ӕ', 'ӗ', 'ә', 'ӛ', 'ӝ', 'ӟ', 'ӡ', 'ӣ', 'ӥ', 'ӧ', 'ө', 'ӫ', 'ӭ', 'ӯ', 'ӱ', 'ӳ', 'ӵ', 'ӷ', 'ӹ', 'ӻ', 'ӽ', 'ӿ', 'ԁ', 'ԃ', 'ԅ', 'ԇ', 'ԉ', 'ԋ', 'ԍ', 'ԏ', 'ԑ', 'ԓ', 'ԕ', 'ԗ', 'ԙ', 'ԛ', 'ԝ', 'ԟ', 'ԡ', 'ԣ', 'ԥ', 'ԧ', 'ԩ', 'ԫ', 'ԭ', 'ԯ', 'ḁ', 'ḃ', 'ḅ', 'ḇ', 'ḉ', 'ḋ', 'ḍ', 'ḏ', 'ḑ', 'ḓ', 'ḕ', 'ḗ', 'ḙ', 'ḛ', 'ḝ', 'ḟ', 'ḡ', 'ḣ', 'ḥ', 'ḧ', 'ḩ', 'ḫ', 'ḭ', 'ḯ', 'ḱ', 'ḳ', 'ḵ', 'ḷ', 'ḹ', 'ḻ', 'ḽ', 'ḿ', 'ṁ', 'ṃ', 'ṅ', 'ṇ', 'ṉ', 'ṋ', 'ṍ', 'ṏ', 'ṑ', 'ṓ', 'ṕ', 'ṗ', 'ṙ', 'ṛ', 'ṝ', 'ṟ', 'ṡ', 'ṣ', 'ṥ', 'ṧ', 'ṩ', 'ṫ', 'ṭ', 'ṯ', 'ṱ', 'ṳ', 'ṵ', 'ṷ', 'ṹ', 'ṻ', 'ṽ', 'ṿ', 'ẁ', 'ẃ', 'ẅ', 'ẇ', 'ẉ', 'ẋ', 'ẍ', 'ẏ', 'ẑ', 'ẓ', 'ẟ', 'ạ', 'ả', 'ấ', 'ầ', 'ẩ', 'ẫ', 'ậ', 'ắ', 'ằ', 'ẳ', 'ẵ', 'ặ', 'ẹ', 'ẻ', 'ẽ', 'ế', 'ề', 'ể', 'ễ', 'ệ', 'ỉ', 'ị', 'ọ', 'ỏ', 'ố', 'ồ', 'ổ', 'ỗ', 'ộ', 'ớ', 'ờ', 'ở', 'ỡ', 'ợ', 'ụ', 'ủ', 'ứ', 'ừ', 'ử', 'ữ', 'ự', 'ỳ', 'ỵ', 'ỷ', 'ỹ', 'ỻ', 'ỽ', 'ι', 'ℊ', 'ℓ', 'ℯ', 'ℴ', 'ℹ', 'ⅎ', 'ↄ', 'ⱡ', 'ⱨ', 'ⱪ', 'ⱬ', 'ⱱ', 'ⲁ', 'ⲃ', 'ⲅ', 'ⲇ', 'ⲉ', 'ⲋ', 'ⲍ', 'ⲏ', 'ⲑ', 'ⲓ', 'ⲕ', 'ⲗ', 'ⲙ', 'ⲛ', 'ⲝ', 'ⲟ', 'ⲡ', 'ⲣ', 'ⲥ', 'ⲧ', 'ⲩ', 'ⲫ', 'ⲭ', 'ⲯ', 'ⲱ', 'ⲳ', 'ⲵ', 'ⲷ', 'ⲹ', 'ⲻ', 'ⲽ', 'ⲿ', 'ⳁ', 'ⳃ', 'ⳅ', 'ⳇ', 'ⳉ', 'ⳋ', 'ⳍ', 'ⳏ', 'ⳑ', 'ⳓ', 'ⳕ', 'ⳗ', 'ⳙ', 'ⳛ', 'ⳝ', 'ⳟ', 'ⳡ', 'ⳬ', 'ⳮ', 'ⳳ', 'ⴧ', 'ⴭ', 'ꙁ', 'ꙃ', 'ꙅ', 'ꙇ', 'ꙉ', 'ꙋ', 'ꙍ', 'ꙏ', 'ꙑ', 'ꙓ', 'ꙕ', 'ꙗ', 'ꙙ', 'ꙛ', 'ꙝ', 'ꙟ', 'ꙡ', 'ꙣ', 'ꙥ', 'ꙧ', 'ꙩ', 'ꙫ', 'ꙭ', 'ꚁ', 'ꚃ', 'ꚅ', 'ꚇ', 'ꚉ', 'ꚋ', 'ꚍ', 'ꚏ', 'ꚑ', 'ꚓ', 'ꚕ', 'ꚗ', 'ꚙ', 'ꚛ', 'ꜣ', 'ꜥ', 'ꜧ', 'ꜩ', 'ꜫ', 'ꜭ', 'ꜳ', 'ꜵ', 'ꜷ', 'ꜹ', 'ꜻ', 'ꜽ', 'ꜿ', 'ꝁ', 'ꝃ', 'ꝅ', 'ꝇ', 'ꝉ', 'ꝋ', 'ꝍ', 'ꝏ', 'ꝑ', 'ꝓ', 'ꝕ', 'ꝗ', 'ꝙ', 'ꝛ', 'ꝝ', 'ꝟ', 'ꝡ', 'ꝣ', 'ꝥ', 'ꝧ', 'ꝩ', 'ꝫ', 'ꝭ', 'ꝯ', 'ꝺ', 'ꝼ', 'ꝿ', 'ꞁ', 'ꞃ', 'ꞅ', 'ꞇ', 'ꞌ', 'ꞎ', 'ꞑ', 'ꞗ', 'ꞙ', 'ꞛ', 'ꞝ', 'ꞟ', 'ꞡ', 'ꞣ', 'ꞥ', 'ꞧ', 'ꞩ', 'ꞯ', 'ꞵ', 'ꞷ', 'ꞹ', 'ꟺ'},
 				ranges:     []rune{'a', 'z', 'ß', 'ö', 'ø', 'ÿ', 'ķ', 'ĸ', 'ň', 'ŉ', 'ž', 'ƀ', 'ƌ', 'ƍ', 'ƙ', 'ƛ', 'ƪ', 'ƫ', 'ƹ', 'ƺ', 'ƽ', 'ƿ', 'ǜ', 'ǝ', 'ǯ', 'ǰ', 'ȳ', 'ȹ', 'ȿ', 'ɀ', 'ɏ', 'ʓ', 'ʕ', 'ʯ', 'ͻ', 'ͽ', 'ά', 'ώ', 'ϐ', 'ϑ', 'ϕ', 'ϗ', 'ϯ', 'ϳ', 'ϻ', 'ϼ', 'а', 'џ', 'ӎ', 'ӏ', 'ՠ', 'ֈ', 'ა', 'ჺ', 'ჽ', 'ჿ', 'ᏸ', 'ᏽ', 'ᲀ', 'ᲈ', 'ᴀ', 'ᴫ', 'ᵫ', 'ᵷ', 'ᵹ', 'ᶚ', 'ẕ', 'ẝ', 'ỿ', 'ἇ', 'ἐ', 'ἕ', 'ἠ', 'ἧ', 'ἰ', 'ἷ', 'ὀ', 'ὅ', 'ὐ', 'ὗ', 'ὠ', 'ὧ', 'ὰ', 'ώ', 'ᾀ', 'ᾇ', 'ᾐ', 'ᾗ', 'ᾠ', 'ᾧ', 'ᾰ', 'ᾴ', 'ᾶ', 'ᾷ', 'ῂ', 'ῄ', 'ῆ', 'ῇ', 'ῐ', 'ΐ', 'ῖ', 'ῗ', 'ῠ', 'ῧ', 'ῲ', 'ῴ', 'ῶ', 'ῷ', 'ℎ', 'ℏ', 'ℼ', 'ℽ', 'ⅆ', 'ⅉ', 'ⰰ', 'ⱞ', 'ⱥ', 'ⱦ', 'ⱳ', 'ⱴ', 'ⱶ', 'ⱻ', 'ⳣ', 'ⳤ', 'ⴀ', 'ⴥ', 'ꜯ', 'ꜱ', 'ꝱ', 'ꝸ', 'ꞓ', 'ꞕ', 'ꬰ', 'ꭚ', 'ꭠ', 'ꭥ', 'ꭰ', 'ꮿ', 'ﬀ', 'ﬆ', 'ﬓ', 'ﬗ', 'ａ', 'ｚ'},
@@ -12767,9 +12780,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lm",
-			pos:  position{line: 1835, col: 1, offset: 47052},
+			pos:  position{line: 1836, col: 1, offset: 47138},
 			expr: &charClassMatcher{
-				pos:        position{line: 1835, col: 6, offset: 47057},
+				pos:        position{line: 1836, col: 6, offset: 47143},
 				val:        "[\\u02B0-\\u02C1\\u02C6-\\u02D1\\u02E0-\\u02E4\\u02EC\\u02EE\\u0374\\u037A\\u0559\\u0640\\u06E5-\\u06E6\\u07F4-\\u07F5\\u07FA\\u081A\\u0824\\u0828\\u0971\\u0E46\\u0EC6\\u10FC\\u17D7\\u1843\\u1AA7\\u1C78-\\u1C7D\\u1D2C-\\u1D6A\\u1D78\\u1D9B-\\u1DBF\\u2071\\u207F\\u2090-\\u209C\\u2C7C-\\u2C7D\\u2D6F\\u2E2F\\u3005\\u3031-\\u3035\\u303B\\u309D-\\u309E\\u30FC-\\u30FE\\uA015\\uA4F8-\\uA4FD\\uA60C\\uA67F\\uA69C-\\uA69D\\uA717-\\uA71F\\uA770\\uA788\\uA7F8-\\uA7F9\\uA9CF\\uA9E6\\uAA70\\uAADD\\uAAF3-\\uAAF4\\uAB5C-\\uAB5F\\uFF70\\uFF9E-\\uFF9F]",
 				chars:      []rune{'ˬ', 'ˮ', 'ʹ', 'ͺ', 'ՙ', 'ـ', 'ߺ', 'ࠚ', 'ࠤ', 'ࠨ', 'ॱ', 'ๆ', 'ໆ', 'ჼ', 'ៗ', 'ᡃ', 'ᪧ', 'ᵸ', 'ⁱ', 'ⁿ', 'ⵯ', 'ⸯ', '々', '〻', 'ꀕ', 'ꘌ', 'ꙿ', 'ꝰ', 'ꞈ', 'ꧏ', 'ꧦ', 'ꩰ', 'ꫝ', 'ｰ'},
 				ranges:     []rune{'ʰ', 'ˁ', 'ˆ', 'ˑ', 'ˠ', 'ˤ', 'ۥ', 'ۦ', 'ߴ', 'ߵ', 'ᱸ', 'ᱽ', 'ᴬ', 'ᵪ', 'ᶛ', 'ᶿ', 'ₐ', 'ₜ', 'ⱼ', 'ⱽ', '〱', '〵', 'ゝ', 'ゞ', 'ー', 'ヾ', 'ꓸ', 'ꓽ', 'ꚜ', 'ꚝ', 'ꜗ', 'ꜟ', 'ꟸ', 'ꟹ', 'ꫳ', 'ꫴ', 'ꭜ', 'ꭟ', 'ﾞ', 'ﾟ'},
@@ -12781,9 +12794,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lo",
-			pos:  position{line: 1838, col: 1, offset: 47542},
+			pos:  position{line: 1839, col: 1, offset: 47628},
 			expr: &charClassMatcher{
-				pos:        position{line: 1838, col: 6, offset: 47547},
+				pos:        position{line: 1839, col: 6, offset: 47633},
 				val:        "[\\u00AA\\u00BA\\u01BB\\u01C0-\\u01C3\\u0294\\u05D0-\\u05EA\\u05EF-\\u05F2\\u0620-\\u063F\\u0641-\\u064A\\u066E-\\u066F\\u0671-\\u06D3\\u06D5\\u06EE-\\u06EF\\u06FA-\\u06FC\\u06FF\\u0710\\u0712-\\u072F\\u074D-\\u07A5\\u07B1\\u07CA-\\u07EA\\u0800-\\u0815\\u0840-\\u0858\\u0860-\\u086A\\u08A0-\\u08B4\\u08B6-\\u08BD\\u0904-\\u0939\\u093D\\u0950\\u0958-\\u0961\\u0972-\\u0980\\u0985-\\u098C\\u098F-\\u0990\\u0993-\\u09A8\\u09AA-\\u09B0\\u09B2\\u09B6-\\u09B9\\u09BD\\u09CE\\u09DC-\\u09DD\\u09DF-\\u09E1\\u09F0-\\u09F1\\u09FC\\u0A05-\\u0A0A\\u0A0F-\\u0A10\\u0A13-\\u0A28\\u0A2A-\\u0A30\\u0A32-\\u0A33\\u0A35-\\u0A36\\u0A38-\\u0A39\\u0A59-\\u0A5C\\u0A5E\\u0A72-\\u0A74\\u0A85-\\u0A8D\\u0A8F-\\u0A91\\u0A93-\\u0AA8\\u0AAA-\\u0AB0\\u0AB2-\\u0AB3\\u0AB5-\\u0AB9\\u0ABD\\u0AD0\\u0AE0-\\u0AE1\\u0AF9\\u0B05-\\u0B0C\\u0B0F-\\u0B10\\u0B13-\\u0B28\\u0B2A-\\u0B30\\u0B32-\\u0B33\\u0B35-\\u0B39\\u0B3D\\u0B5C-\\u0B5D\\u0B5F-\\u0B61\\u0B71\\u0B83\\u0B85-\\u0B8A\\u0B8E-\\u0B90\\u0B92-\\u0B95\\u0B99-\\u0B9A\\u0B9C\\u0B9E-\\u0B9F\\u0BA3-\\u0BA4\\u0BA8-\\u0BAA\\u0BAE-\\u0BB9\\u0BD0\\u0C05-\\u0C0C\\u0C0E-\\u0C10\\u0C12-\\u0C28\\u0C2A-\\u0C39\\u0C3D\\u0C58-\\u0C5A\\u0C60-\\u0C61\\u0C80\\u0C85-\\u0C8C\\u0C8E-\\u0C90\\u0C92-\\u0CA8\\u0CAA-\\u0CB3\\u0CB5-\\u0CB9\\u0CBD\\u0CDE\\u0CE0-\\u0CE1\\u0CF1-\\u0CF2\\u0D05-\\u0D0C\\u0D0E-\\u0D10\\u0D12-\\u0D3A\\u0D3D\\u0D4E\\u0D54-\\u0D56\\u0D5F-\\u0D61\\u0D7A-\\u0D7F\\u0D85-\\u0D96\\u0D9A-\\u0DB1\\u0DB3-\\u0DBB\\u0DBD\\u0DC0-\\u0DC6\\u0E01-\\u0E30\\u0E32-\\u0E33\\u0E40-\\u0E45\\u0E81-\\u0E82\\u0E84\\u0E87-\\u0E88\\u0E8A\\u0E8D\\u0E94-\\u0E97\\u0E99-\\u0E9F\\u0EA1-\\u0EA3\\u0EA5\\u0EA7\\u0EAA-\\u0EAB\\u0EAD-\\u0EB0\\u0EB2-\\u0EB3\\u0EBD\\u0EC0-\\u0EC4\\u0EDC-\\u0EDF\\u0F00\\u0F40-\\u0F47\\u0F49-\\u0F6C\\u0F88-\\u0F8C\\u1000-\\u102A\\u103F\\u1050-\\u1055\\u105A-\\u105D\\u1061\\u1065-\\u1066\\u106E-\\u1070\\u1075-\\u1081\\u108E\\u1100-\\u1248\\u124A-\\u124D\\u1250-\\u1256\\u1258\\u125A-\\u125D\\u1260-\\u1288\\u128A-\\u128D\\u1290-\\u12B0\\u12B2-\\u12B5\\u12B8-\\u12BE\\u12C0\\u12C2-\\u12C5\\u12C8-\\u12D6\\u12D8-\\u1310\\u1312-\\u1315\\u1318-\\u135A\\u1380-\\u138F\\u1401-\\u166C\\u166F-\\u167F\\u1681-\\u169A\\u16A0-\\u16EA\\u16F1-\\u16F8\\u1700-\\u170C\\u170E-\\u1711\\u1720-\\u1731\\u1740-\\u1751\\u1760-\\u176C\\u176E-\\u1770\\u1780-\\u17B3\\u17DC\\u1820-\\u1842\\u1844-\\u1878\\u1880-\\u1884\\u1887-\\u18A8\\u18AA\\u18B0-\\u18F5\\u1900-\\u191E\\u1950-\\u196D\\u1970-\\u1974\\u1980-\\u19AB\\u19B0-\\u19C9\\u1A00-\\u1A16\\u1A20-\\u1A54\\u1B05-\\u1B33\\u1B45-\\u1B4B\\u1B83-\\u1BA0\\u1BAE-\\u1BAF\\u1BBA-\\u1BE5\\u1C00-\\u1C23\\u1C4D-\\u1C4F\\u1C5A-\\u1C77\\u1CE9-\\u1CEC\\u1CEE-\\u1CF1\\u1CF5-\\u1CF6\\u2135-\\u2138\\u2D30-\\u2D67\\u2D80-\\u2D96\\u2DA0-\\u2DA6\\u2DA8-\\u2DAE\\u2DB0-\\u2DB6\\u2DB8-\\u2DBE\\u2DC0-\\u2DC6\\u2DC8-\\u2DCE\\u2DD0-\\u2DD6\\u2DD8-\\u2DDE\\u3006\\u303C\\u3041-\\u3096\\u309F\\u30A1-\\u30FA\\u30FF\\u3105-\\u312F\\u3131-\\u318E\\u31A0-\\u31BA\\u31F0-\\u31FF\\u3400-\\u4DB5\\u4E00-\\u9FEF\\uA000-\\uA014\\uA016-\\uA48C\\uA4D0-\\uA4F7\\uA500-\\uA60B\\uA610-\\uA61F\\uA62A-\\uA62B\\uA66E\\uA6A0-\\uA6E5\\uA78F\\uA7F7\\uA7FB-\\uA801\\uA803-\\uA805\\uA807-\\uA80A\\uA80C-\\uA822\\uA840-\\uA873\\uA882-\\uA8B3\\uA8F2-\\uA8F7\\uA8FB\\uA8FD-\\uA8FE\\uA90A-\\uA925\\uA930-\\uA946\\uA960-\\uA97C\\uA984-\\uA9B2\\uA9E0-\\uA9E4\\uA9E7-\\uA9EF\\uA9FA-\\uA9FE\\uAA00-\\uAA28\\uAA40-\\uAA42\\uAA44-\\uAA4B\\uAA60-\\uAA6F\\uAA71-\\uAA76\\uAA7A\\uAA7E-\\uAAAF\\uAAB1\\uAAB5-\\uAAB6\\uAAB9-\\uAABD\\uAAC0\\uAAC2\\uAADB-\\uAADC\\uAAE0-\\uAAEA\\uAAF2\\uAB01-\\uAB06\\uAB09-\\uAB0E\\uAB11-\\uAB16\\uAB20-\\uAB26\\uAB28-\\uAB2E\\uABC0-\\uABE2\\uAC00-\\uD7A3\\uD7B0-\\uD7C6\\uD7CB-\\uD7FB\\uF900-\\uFA6D\\uFA70-\\uFAD9\\uFB1D\\uFB1F-\\uFB28\\uFB2A-\\uFB36\\uFB38-\\uFB3C\\uFB3E\\uFB40-\\uFB41\\uFB43-\\uFB44\\uFB46-\\uFBB1\\uFBD3-\\uFD3D\\uFD50-\\uFD8F\\uFD92-\\uFDC7\\uFDF0-\\uFDFB\\uFE70-\\uFE74\\uFE76-\\uFEFC\\uFF66-\\uFF6F\\uFF71-\\uFF9D\\uFFA0-\\uFFBE\\uFFC2-\\uFFC7\\uFFCA-\\uFFCF\\uFFD2-\\uFFD7\\uFFDA-\\uFFDC]",
 				chars:      []rune{'ª', 'º', 'ƻ', 'ʔ', 'ە', 'ۿ', 'ܐ', 'ޱ', 'ऽ', 'ॐ', 'ল', 'ঽ', 'ৎ', 'ৼ', 'ਫ਼', 'ઽ', 'ૐ', 'ૹ', 'ଽ', 'ୱ', 'ஃ', 'ஜ', 'ௐ', 'ఽ', 'ಀ', 'ಽ', 'ೞ', 'ഽ', 'ൎ', 'ල', 'ຄ', 'ຊ', 'ຍ', 'ລ', 'ວ', 'ຽ', 'ༀ', 'ဿ', 'ၡ', 'ႎ', 'ቘ', 'ዀ', 'ៜ', 'ᢪ', '〆', '〼', 'ゟ', 'ヿ', 'ꙮ', 'ꞏ', 'ꟷ', 'ꣻ', 'ꩺ', 'ꪱ', 'ꫀ', 'ꫂ', 'ꫲ', 'יִ', 'מּ'},
 				ranges:     []rune{'ǀ', 'ǃ', 'א', 'ת', 'ׯ', 'ײ', 'ؠ', 'ؿ', 'ف', 'ي', 'ٮ', 'ٯ', 'ٱ', 'ۓ', 'ۮ', 'ۯ', 'ۺ', 'ۼ', 'ܒ', 'ܯ', 'ݍ', 'ޥ', 'ߊ', 'ߪ', 'ࠀ', 'ࠕ', 'ࡀ', 'ࡘ', 'ࡠ', 'ࡪ', 'ࢠ', 'ࢴ', 'ࢶ', 'ࢽ', 'ऄ', 'ह', 'क़', 'ॡ', 'ॲ', 'ঀ', 'অ', 'ঌ', 'এ', 'ঐ', 'ও', 'ন', 'প', 'র', 'শ', 'হ', 'ড়', 'ঢ়', 'য়', 'ৡ', 'ৰ', 'ৱ', 'ਅ', 'ਊ', 'ਏ', 'ਐ', 'ਓ', 'ਨ', 'ਪ', 'ਰ', 'ਲ', 'ਲ਼', 'ਵ', 'ਸ਼', 'ਸ', 'ਹ', 'ਖ਼', 'ੜ', 'ੲ', 'ੴ', 'અ', 'ઍ', 'એ', 'ઑ', 'ઓ', 'ન', 'પ', 'ર', 'લ', 'ળ', 'વ', 'હ', 'ૠ', 'ૡ', 'ଅ', 'ଌ', 'ଏ', 'ଐ', 'ଓ', 'ନ', 'ପ', 'ର', 'ଲ', 'ଳ', 'ଵ', 'ହ', 'ଡ଼', 'ଢ଼', 'ୟ', 'ୡ', 'அ', 'ஊ', 'எ', 'ஐ', 'ஒ', 'க', 'ங', 'ச', 'ஞ', 'ட', 'ண', 'த', 'ந', 'ப', 'ம', 'ஹ', 'అ', 'ఌ', 'ఎ', 'ఐ', 'ఒ', 'న', 'ప', 'హ', 'ౘ', 'ౚ', 'ౠ', 'ౡ', 'ಅ', 'ಌ', 'ಎ', 'ಐ', 'ಒ', 'ನ', 'ಪ', 'ಳ', 'ವ', 'ಹ', 'ೠ', 'ೡ', 'ೱ', 'ೲ', 'അ', 'ഌ', 'എ', 'ഐ', 'ഒ', 'ഺ', 'ൔ', 'ൖ', 'ൟ', 'ൡ', 'ൺ', 'ൿ', 'අ', 'ඖ', 'ක', 'න', 'ඳ', 'ර', 'ව', 'ෆ', 'ก', 'ะ', 'า', 'ำ', 'เ', 'ๅ', 'ກ', 'ຂ', 'ງ', 'ຈ', 'ດ', 'ທ', 'ນ', 'ຟ', 'ມ', 'ຣ', 'ສ', 'ຫ', 'ອ', 'ະ', 'າ', 'ຳ', 'ເ', 'ໄ', 'ໜ', 'ໟ', 'ཀ', 'ཇ', 'ཉ', 'ཬ', 'ྈ', 'ྌ', 'က', 'ဪ', 'ၐ', 'ၕ', 'ၚ', 'ၝ', 'ၥ', 'ၦ', 'ၮ', 'ၰ', 'ၵ', 'ႁ', 'ᄀ', 'ቈ', 'ቊ', 'ቍ', 'ቐ', 'ቖ', 'ቚ', 'ቝ', 'በ', 'ኈ', 'ኊ', 'ኍ', 'ነ', 'ኰ', 'ኲ', 'ኵ', 'ኸ', 'ኾ', 'ዂ', 'ዅ', 'ወ', 'ዖ', 'ዘ', 'ጐ', 'ጒ', 'ጕ', 'ጘ', 'ፚ', 'ᎀ', 'ᎏ', 'ᐁ', 'ᙬ', 'ᙯ', 'ᙿ', 'ᚁ', 'ᚚ', 'ᚠ', 'ᛪ', 'ᛱ', 'ᛸ', 'ᜀ', 'ᜌ', 'ᜎ', 'ᜑ', 'ᜠ', 'ᜱ', 'ᝀ', 'ᝑ', 'ᝠ', 'ᝬ', 'ᝮ', 'ᝰ', 'ក', 'ឳ', 'ᠠ', 'ᡂ', 'ᡄ', 'ᡸ', 'ᢀ', 'ᢄ', 'ᢇ', 'ᢨ', 'ᢰ', 'ᣵ', 'ᤀ', 'ᤞ', 'ᥐ', 'ᥭ', 'ᥰ', 'ᥴ', 'ᦀ', 'ᦫ', 'ᦰ', 'ᧉ', 'ᨀ', 'ᨖ', 'ᨠ', 'ᩔ', 'ᬅ', 'ᬳ', 'ᭅ', 'ᭋ', 'ᮃ', 'ᮠ', 'ᮮ', 'ᮯ', 'ᮺ', 'ᯥ', 'ᰀ', 'ᰣ', 'ᱍ', 'ᱏ', 'ᱚ', 'ᱷ', 'ᳩ', 'ᳬ', 'ᳮ', 'ᳱ', 'ᳵ', 'ᳶ', 'ℵ', 'ℸ', 'ⴰ', 'ⵧ', 'ⶀ', 'ⶖ', 'ⶠ', 'ⶦ', 'ⶨ', 'ⶮ', 'ⶰ', 'ⶶ', 'ⶸ', 'ⶾ', 'ⷀ', 'ⷆ', 'ⷈ', 'ⷎ', 'ⷐ', 'ⷖ', 'ⷘ', 'ⷞ', 'ぁ', 'ゖ', 'ァ', 'ヺ', 'ㄅ', 'ㄯ', 'ㄱ', 'ㆎ', 'ㆠ', 'ㆺ', 'ㇰ', 'ㇿ', '㐀', '䶵', '一', '鿯', 'ꀀ', 'ꀔ', 'ꀖ', 'ꒌ', 'ꓐ', 'ꓷ', 'ꔀ', 'ꘋ', 'ꘐ', 'ꘟ', 'ꘪ', 'ꘫ', 'ꚠ', 'ꛥ', 'ꟻ', 'ꠁ', 'ꠃ', 'ꠅ', 'ꠇ', 'ꠊ', 'ꠌ', 'ꠢ', 'ꡀ', 'ꡳ', 'ꢂ', 'ꢳ', 'ꣲ', 'ꣷ', 'ꣽ', 'ꣾ', 'ꤊ', 'ꤥ', 'ꤰ', 'ꥆ', 'ꥠ', 'ꥼ', 'ꦄ', 'ꦲ', 'ꧠ', 'ꧤ', 'ꧧ', 'ꧯ', 'ꧺ', 'ꧾ', 'ꨀ', 'ꨨ', 'ꩀ', 'ꩂ', 'ꩄ', 'ꩋ', 'ꩠ', 'ꩯ', 'ꩱ', 'ꩶ', 'ꩾ', 'ꪯ', 'ꪵ', 'ꪶ', 'ꪹ', 'ꪽ', 'ꫛ', 'ꫜ', 'ꫠ', 'ꫪ', 'ꬁ', 'ꬆ', 'ꬉ', 'ꬎ', 'ꬑ', 'ꬖ', 'ꬠ', 'ꬦ', 'ꬨ', 'ꬮ', 'ꯀ', 'ꯢ', '가', '힣', 'ힰ', 'ퟆ', 'ퟋ', 'ퟻ', '豈', '舘', '並', '龎', 'ײַ', 'ﬨ', 'שׁ', 'זּ', 'טּ', 'לּ', 'נּ', 'סּ', 'ףּ', 'פּ', 'צּ', 'ﮱ', 'ﯓ', 'ﴽ', 'ﵐ', 'ﶏ', 'ﶒ', 'ﷇ', 'ﷰ', 'ﷻ', 'ﹰ', 'ﹴ', 'ﹶ', 'ﻼ', 'ｦ', 'ｯ', 'ｱ', 'ﾝ', 'ﾠ', 'ﾾ', 'ￂ', 'ￇ', 'ￊ', 'ￏ', 'ￒ', 'ￗ', 'ￚ', 'ￜ'},
@@ -12795,9 +12808,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lt",
-			pos:  position{line: 1841, col: 1, offset: 50994},
+			pos:  position{line: 1842, col: 1, offset: 51080},
 			expr: &charClassMatcher{
-				pos:        position{line: 1841, col: 6, offset: 50999},
+				pos:        position{line: 1842, col: 6, offset: 51085},
 				val:        "[\\u01C5\\u01C8\\u01CB\\u01F2\\u1F88-\\u1F8F\\u1F98-\\u1F9F\\u1FA8-\\u1FAF\\u1FBC\\u1FCC\\u1FFC]",
 				chars:      []rune{'ǅ', 'ǈ', 'ǋ', 'ǲ', 'ᾼ', 'ῌ', 'ῼ'},
 				ranges:     []rune{'ᾈ', 'ᾏ', 'ᾘ', 'ᾟ', 'ᾨ', 'ᾯ'},
@@ -12809,9 +12822,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lu",
-			pos:  position{line: 1844, col: 1, offset: 51105},
+			pos:  position{line: 1845, col: 1, offset: 51191},
 			expr: &charClassMatcher{
-				pos:        position{line: 1844, col: 6, offset: 51110},
+				pos:        position{line: 1845, col: 6, offset: 51196},
 				val:        "[\\u0041-\\u005A\\u00C0-\\u00D6\\u00D8-\\u00DE\\u0100\\u0102\\u0104\\u0106\\u0108\\u010A\\u010C\\u010E\\u0110\\u0112\\u0114\\u0116\\u0118\\u011A\\u011C\\u011E\\u0120\\u0122\\u0124\\u0126\\u0128\\u012A\\u012C\\u012E\\u0130\\u0132\\u0134\\u0136\\u0139\\u013B\\u013D\\u013F\\u0141\\u0143\\u0145\\u0147\\u014A\\u014C\\u014E\\u0150\\u0152\\u0154\\u0156\\u0158\\u015A\\u015C\\u015E\\u0160\\u0162\\u0164\\u0166\\u0168\\u016A\\u016C\\u016E\\u0170\\u0172\\u0174\\u0176\\u0178-\\u0179\\u017B\\u017D\\u0181-\\u0182\\u0184\\u0186-\\u0187\\u0189-\\u018B\\u018E-\\u0191\\u0193-\\u0194\\u0196-\\u0198\\u019C-\\u019D\\u019F-\\u01A0\\u01A2\\u01A4\\u01A6-\\u01A7\\u01A9\\u01AC\\u01AE-\\u01AF\\u01B1-\\u01B3\\u01B5\\u01B7-\\u01B8\\u01BC\\u01C4\\u01C7\\u01CA\\u01CD\\u01CF\\u01D1\\u01D3\\u01D5\\u01D7\\u01D9\\u01DB\\u01DE\\u01E0\\u01E2\\u01E4\\u01E6\\u01E8\\u01EA\\u01EC\\u01EE\\u01F1\\u01F4\\u01F6-\\u01F8\\u01FA\\u01FC\\u01FE\\u0200\\u0202\\u0204\\u0206\\u0208\\u020A\\u020C\\u020E\\u0210\\u0212\\u0214\\u0216\\u0218\\u021A\\u021C\\u021E\\u0220\\u0222\\u0224\\u0226\\u0228\\u022A\\u022C\\u022E\\u0230\\u0232\\u023A-\\u023B\\u023D-\\u023E\\u0241\\u0243-\\u0246\\u0248\\u024A\\u024C\\u024E\\u0370\\u0372\\u0376\\u037F\\u0386\\u0388-\\u038A\\u038C\\u038E-\\u038F\\u0391-\\u03A1\\u03A3-\\u03AB\\u03CF\\u03D2-\\u03D4\\u03D8\\u03DA\\u03DC\\u03DE\\u03E0\\u03E2\\u03E4\\u03E6\\u03E8\\u03EA\\u03EC\\u03EE\\u03F4\\u03F7\\u03F9-\\u03FA\\u03FD-\\u042F\\u0460\\u0462\\u0464\\u0466\\u0468\\u046A\\u046C\\u046E\\u0470\\u0472\\u0474\\u0476\\u0478\\u047A\\u047C\\u047E\\u0480\\u048A\\u048C\\u048E\\u0490\\u0492\\u0494\\u0496\\u0498\\u049A\\u049C\\u049E\\u04A0\\u04A2\\u04A4\\u04A6\\u04A8\\u04AA\\u04AC\\u04AE\\u04B0\\u04B2\\u04B4\\u04B6\\u04B8\\u04BA\\u04BC\\u04BE\\u04C0-\\u04C1\\u04C3\\u04C5\\u04C7\\u04C9\\u04CB\\u04CD\\u04D0\\u04D2\\u04D4\\u04D6\\u04D8\\u04DA\\u04DC\\u04DE\\u04E0\\u04E2\\u04E4\\u04E6\\u04E8\\u04EA\\u04EC\\u04EE\\u04F0\\u04F2\\u04F4\\u04F6\\u04F8\\u04FA\\u04FC\\u04FE\\u0500\\u0502\\u0504\\u0506\\u0508\\u050A\\u050C\\u050E\\u0510\\u0512\\u0514\\u0516\\u0518\\u051A\\u051C\\u051E\\u0520\\u0522\\u0524\\u0526\\u0528\\u052A\\u052C\\u052E\\u0531-\\u0556\\u10A0-\\u10C5\\u10C7\\u10CD\\u13A0-\\u13F5\\u1C90-\\u1CBA\\u1CBD-\\u1CBF\\u1E00\\u1E02\\u1E04\\u1E06\\u1E08\\u1E0A\\u1E0C\\u1E0E\\u1E10\\u1E12\\u1E14\\u1E16\\u1E18\\u1E1A\\u1E1C\\u1E1E\\u1E20\\u1E22\\u1E24\\u1E26\\u1E28\\u1E2A\\u1E2C\\u1E2E\\u1E30\\u1E32\\u1E34\\u1E36\\u1E38\\u1E3A\\u1E3C\\u1E3E\\u1E40\\u1E42\\u1E44\\u1E46\\u1E48\\u1E4A\\u1E4C\\u1E4E\\u1E50\\u1E52\\u1E54\\u1E56\\u1E58\\u1E5A\\u1E5C\\u1E5E\\u1E60\\u1E62\\u1E64\\u1E66\\u1E68\\u1E6A\\u1E6C\\u1E6E\\u1E70\\u1E72\\u1E74\\u1E76\\u1E78\\u1E7A\\u1E7C\\u1E7E\\u1E80\\u1E82\\u1E84\\u1E86\\u1E88\\u1E8A\\u1E8C\\u1E8E\\u1E90\\u1E92\\u1E94\\u1E9E\\u1EA0\\u1EA2\\u1EA4\\u1EA6\\u1EA8\\u1EAA\\u1EAC\\u1EAE\\u1EB0\\u1EB2\\u1EB4\\u1EB6\\u1EB8\\u1EBA\\u1EBC\\u1EBE\\u1EC0\\u1EC2\\u1EC4\\u1EC6\\u1EC8\\u1ECA\\u1ECC\\u1ECE\\u1ED0\\u1ED2\\u1ED4\\u1ED6\\u1ED8\\u1EDA\\u1EDC\\u1EDE\\u1EE0\\u1EE2\\u1EE4\\u1EE6\\u1EE8\\u1EEA\\u1EEC\\u1EEE\\u1EF0\\u1EF2\\u1EF4\\u1EF6\\u1EF8\\u1EFA\\u1EFC\\u1EFE\\u1F08-\\u1F0F\\u1F18-\\u1F1D\\u1F28-\\u1F2F\\u1F38-\\u1F3F\\u1F48-\\u1F4D\\u1F59\\u1F5B\\u1F5D\\u1F5F\\u1F68-\\u1F6F\\u1FB8-\\u1FBB\\u1FC8-\\u1FCB\\u1FD8-\\u1FDB\\u1FE8-\\u1FEC\\u1FF8-\\u1FFB\\u2102\\u2107\\u210B-\\u210D\\u2110-\\u2112\\u2115\\u2119-\\u211D\\u2124\\u2126\\u2128\\u212A-\\u212D\\u2130-\\u2133\\u213E-\\u213F\\u2145\\u2183\\u2C00-\\u2C2E\\u2C60\\u2C62-\\u2C64\\u2C67\\u2C69\\u2C6B\\u2C6D-\\u2C70\\u2C72\\u2C75\\u2C7E-\\u2C80\\u2C82\\u2C84\\u2C86\\u2C88\\u2C8A\\u2C8C\\u2C8E\\u2C90\\u2C92\\u2C94\\u2C96\\u2C98\\u2C9A\\u2C9C\\u2C9E\\u2CA0\\u2CA2\\u2CA4\\u2CA6\\u2CA8\\u2CAA\\u2CAC\\u2CAE\\u2CB0\\u2CB2\\u2CB4\\u2CB6\\u2CB8\\u2CBA\\u2CBC\\u2CBE\\u2CC0\\u2CC2\\u2CC4\\u2CC6\\u2CC8\\u2CCA\\u2CCC\\u2CCE\\u2CD0\\u2CD2\\u2CD4\\u2CD6\\u2CD8\\u2CDA\\u2CDC\\u2CDE\\u2CE0\\u2CE2\\u2CEB\\u2CED\\u2CF2\\uA640\\uA642\\uA644\\uA646\\uA648\\uA64A\\uA64C\\uA64E\\uA650\\uA652\\uA654\\uA656\\uA658\\uA65A\\uA65C\\uA65E\\uA660\\uA662\\uA664\\uA666\\uA668\\uA66A\\uA66C\\uA680\\uA682\\uA684\\uA686\\uA688\\uA68A\\uA68C\\uA68E\\uA690\\uA692\\uA694\\uA696\\uA698\\uA69A\\uA722\\uA724\\uA726\\uA728\\uA72A\\uA72C\\uA72E\\uA732\\uA734\\uA736\\uA738\\uA73A\\uA73C\\uA73E\\uA740\\uA742\\uA744\\uA746\\uA748\\uA74A\\uA74C\\uA74E\\uA750\\uA752\\uA754\\uA756\\uA758\\uA75A\\uA75C\\uA75E\\uA760\\uA762\\uA764\\uA766\\uA768\\uA76A\\uA76C\\uA76E\\uA779\\uA77B\\uA77D-\\uA77E\\uA780\\uA782\\uA784\\uA786\\uA78B\\uA78D\\uA790\\uA792\\uA796\\uA798\\uA79A\\uA79C\\uA79E\\uA7A0\\uA7A2\\uA7A4\\uA7A6\\uA7A8\\uA7AA-\\uA7AE\\uA7B0-\\uA7B4\\uA7B6\\uA7B8\\uFF21-\\uFF3A]",
 				chars:      []rune{'Ā', 'Ă', 'Ą', 'Ć', 'Ĉ', 'Ċ', 'Č', 'Ď', 'Đ', 'Ē', 'Ĕ', 'Ė', 'Ę', 'Ě', 'Ĝ', 'Ğ', 'Ġ', 'Ģ', 'Ĥ', 'Ħ', 'Ĩ', 'Ī', 'Ĭ', 'Į', 'İ', 'Ĳ', 'Ĵ', 'Ķ', 'Ĺ', 'Ļ', 'Ľ', 'Ŀ', 'Ł', 'Ń', 'Ņ', 'Ň', 'Ŋ', 'Ō', 'Ŏ', 'Ő', 'Œ', 'Ŕ', 'Ŗ', 'Ř', 'Ś', 'Ŝ', 'Ş', 'Š', 'Ţ', 'Ť', 'Ŧ', 'Ũ', 'Ū', 'Ŭ', 'Ů', 'Ű', 'Ų', 'Ŵ', 'Ŷ', 'Ż', 'Ž', 'Ƅ', 'Ƣ', 'Ƥ', 'Ʃ', 'Ƭ', 'Ƶ', 'Ƽ', 'Ǆ', 'Ǉ', 'Ǌ', 'Ǎ', 'Ǐ', 'Ǒ', 'Ǔ', 'Ǖ', 'Ǘ', 'Ǚ', 'Ǜ', 'Ǟ', 'Ǡ', 'Ǣ', 'Ǥ', 'Ǧ', 'Ǩ', 'Ǫ', 'Ǭ', 'Ǯ', 'Ǳ', 'Ǵ', 'Ǻ', 'Ǽ', 'Ǿ', 'Ȁ', 'Ȃ', 'Ȅ', 'Ȇ', 'Ȉ', 'Ȋ', 'Ȍ', 'Ȏ', 'Ȑ', 'Ȓ', 'Ȕ', 'Ȗ', 'Ș', 'Ț', 'Ȝ', 'Ȟ', 'Ƞ', 'Ȣ', 'Ȥ', 'Ȧ', 'Ȩ', 'Ȫ', 'Ȭ', 'Ȯ', 'Ȱ', 'Ȳ', 'Ɂ', 'Ɉ', 'Ɋ', 'Ɍ', 'Ɏ', 'Ͱ', 'Ͳ', 'Ͷ', 'Ϳ', 'Ά', 'Ό', 'Ϗ', 'Ϙ', 'Ϛ', 'Ϝ', 'Ϟ', 'Ϡ', 'Ϣ', 'Ϥ', 'Ϧ', 'Ϩ', 'Ϫ', 'Ϭ', 'Ϯ', 'ϴ', 'Ϸ', 'Ѡ', 'Ѣ', 'Ѥ', 'Ѧ', 'Ѩ', 'Ѫ', 'Ѭ', 'Ѯ', 'Ѱ', 'Ѳ', 'Ѵ', 'Ѷ', 'Ѹ', 'Ѻ', 'Ѽ', 'Ѿ', 'Ҁ', 'Ҋ', 'Ҍ', 'Ҏ', 'Ґ', 'Ғ', 'Ҕ', 'Җ', 'Ҙ', 'Қ', 'Ҝ', 'Ҟ', 'Ҡ', 'Ң', 'Ҥ', 'Ҧ', 'Ҩ', 'Ҫ', 'Ҭ', 'Ү', 'Ұ', 'Ҳ', 'Ҵ', 'Ҷ', 'Ҹ', 'Һ', 'Ҽ', 'Ҿ', 'Ӄ', 'Ӆ', 'Ӈ', 'Ӊ', 'Ӌ', 'Ӎ', 'Ӑ', 'Ӓ', 'Ӕ', 'Ӗ', 'Ә', 'Ӛ', 'Ӝ', 'Ӟ', 'Ӡ', 'Ӣ', 'Ӥ', 'Ӧ', 'Ө', 'Ӫ', 'Ӭ', 'Ӯ', 'Ӱ', 'Ӳ', 'Ӵ', 'Ӷ', 'Ӹ', 'Ӻ', 'Ӽ', 'Ӿ', 'Ԁ', 'Ԃ', 'Ԅ', 'Ԇ', 'Ԉ', 'Ԋ', 'Ԍ', 'Ԏ', 'Ԑ', 'Ԓ', 'Ԕ', 'Ԗ', 'Ԙ', 'Ԛ', 'Ԝ', 'Ԟ', 'Ԡ', 'Ԣ', 'Ԥ', 'Ԧ', 'Ԩ', 'Ԫ', 'Ԭ', 'Ԯ', 'Ⴧ', 'Ⴭ', 'Ḁ', 'Ḃ', 'Ḅ', 'Ḇ', 'Ḉ', 'Ḋ', 'Ḍ', 'Ḏ', 'Ḑ', 'Ḓ', 'Ḕ', 'Ḗ', 'Ḙ', 'Ḛ', 'Ḝ', 'Ḟ', 'Ḡ', 'Ḣ', 'Ḥ', 'Ḧ', 'Ḩ', 'Ḫ', 'Ḭ', 'Ḯ', 'Ḱ', 'Ḳ', 'Ḵ', 'Ḷ', 'Ḹ', 'Ḻ', 'Ḽ', 'Ḿ', 'Ṁ', 'Ṃ', 'Ṅ', 'Ṇ', 'Ṉ', 'Ṋ', 'Ṍ', 'Ṏ', 'Ṑ', 'Ṓ', 'Ṕ', 'Ṗ', 'Ṙ', 'Ṛ', 'Ṝ', 'Ṟ', 'Ṡ', 'Ṣ', 'Ṥ', 'Ṧ', 'Ṩ', 'Ṫ', 'Ṭ', 'Ṯ', 'Ṱ', 'Ṳ', 'Ṵ', 'Ṷ', 'Ṹ', 'Ṻ', 'Ṽ', 'Ṿ', 'Ẁ', 'Ẃ', 'Ẅ', 'Ẇ', 'Ẉ', 'Ẋ', 'Ẍ', 'Ẏ', 'Ẑ', 'Ẓ', 'Ẕ', 'ẞ', 'Ạ', 'Ả', 'Ấ', 'Ầ', 'Ẩ', 'Ẫ', 'Ậ', 'Ắ', 'Ằ', 'Ẳ', 'Ẵ', 'Ặ', 'Ẹ', 'Ẻ', 'Ẽ', 'Ế', 'Ề', 'Ể', 'Ễ', 'Ệ', 'Ỉ', 'Ị', 'Ọ', 'Ỏ', 'Ố', 'Ồ', 'Ổ', 'Ỗ', 'Ộ', 'Ớ', 'Ờ', 'Ở', 'Ỡ', 'Ợ', 'Ụ', 'Ủ', 'Ứ', 'Ừ', 'Ử', 'Ữ', 'Ự', 'Ỳ', 'Ỵ', 'Ỷ', 'Ỹ', 'Ỻ', 'Ỽ', 'Ỿ', 'Ὑ', 'Ὓ', 'Ὕ', 'Ὗ', 'ℂ', 'ℇ', 'ℕ', 'ℤ', 'Ω', 'ℨ', 'ⅅ', 'Ↄ', 'Ⱡ', 'Ⱨ', 'Ⱪ', 'Ⱬ', 'Ⱳ', 'Ⱶ', 'Ⲃ', 'Ⲅ', 'Ⲇ', 'Ⲉ', 'Ⲋ', 'Ⲍ', 'Ⲏ', 'Ⲑ', 'Ⲓ', 'Ⲕ', 'Ⲗ', 'Ⲙ', 'Ⲛ', 'Ⲝ', 'Ⲟ', 'Ⲡ', 'Ⲣ', 'Ⲥ', 'Ⲧ', 'Ⲩ', 'Ⲫ', 'Ⲭ', 'Ⲯ', 'Ⲱ', 'Ⲳ', 'Ⲵ', 'Ⲷ', 'Ⲹ', 'Ⲻ', 'Ⲽ', 'Ⲿ', 'Ⳁ', 'Ⳃ', 'Ⳅ', 'Ⳇ', 'Ⳉ', 'Ⳋ', 'Ⳍ', 'Ⳏ', 'Ⳑ', 'Ⳓ', 'Ⳕ', 'Ⳗ', 'Ⳙ', 'Ⳛ', 'Ⳝ', 'Ⳟ', 'Ⳡ', 'Ⳣ', 'Ⳬ', 'Ⳮ', 'Ⳳ', 'Ꙁ', 'Ꙃ', 'Ꙅ', 'Ꙇ', 'Ꙉ', 'Ꙋ', 'Ꙍ', 'Ꙏ', 'Ꙑ', 'Ꙓ', 'Ꙕ', 'Ꙗ', 'Ꙙ', 'Ꙛ', 'Ꙝ', 'Ꙟ', 'Ꙡ', 'Ꙣ', 'Ꙥ', 'Ꙧ', 'Ꙩ', 'Ꙫ', 'Ꙭ', 'Ꚁ', 'Ꚃ', 'Ꚅ', 'Ꚇ', 'Ꚉ', 'Ꚋ', 'Ꚍ', 'Ꚏ', 'Ꚑ', 'Ꚓ', 'Ꚕ', 'Ꚗ', 'Ꚙ', 'Ꚛ', 'Ꜣ', 'Ꜥ', 'Ꜧ', 'Ꜩ', 'Ꜫ', 'Ꜭ', 'Ꜯ', 'Ꜳ', 'Ꜵ', 'Ꜷ', 'Ꜹ', 'Ꜻ', 'Ꜽ', 'Ꜿ', 'Ꝁ', 'Ꝃ', 'Ꝅ', 'Ꝇ', 'Ꝉ', 'Ꝋ', 'Ꝍ', 'Ꝏ', 'Ꝑ', 'Ꝓ', 'Ꝕ', 'Ꝗ', 'Ꝙ', 'Ꝛ', 'Ꝝ', 'Ꝟ', 'Ꝡ', 'Ꝣ', 'Ꝥ', 'Ꝧ', 'Ꝩ', 'Ꝫ', 'Ꝭ', 'Ꝯ', 'Ꝺ', 'Ꝼ', 'Ꞁ', 'Ꞃ', 'Ꞅ', 'Ꞇ', 'Ꞌ', 'Ɥ', 'Ꞑ', 'Ꞓ', 'Ꞗ', 'Ꞙ', 'Ꞛ', 'Ꞝ', 'Ꞟ', 'Ꞡ', 'Ꞣ', 'Ꞥ', 'Ꞧ', 'Ꞩ', 'Ꞷ', 'Ꞹ'},
 				ranges:     []rune{'A', 'Z', 'À', 'Ö', 'Ø', 'Þ', 'Ÿ', 'Ź', 'Ɓ', 'Ƃ', 'Ɔ', 'Ƈ', 'Ɖ', 'Ƌ', 'Ǝ', 'Ƒ', 'Ɠ', 'Ɣ', 'Ɩ', 'Ƙ', 'Ɯ', 'Ɲ', 'Ɵ', 'Ơ', 'Ʀ', 'Ƨ', 'Ʈ', 'Ư', 'Ʊ', 'Ƴ', 'Ʒ', 'Ƹ', 'Ƕ', 'Ǹ', 'Ⱥ', 'Ȼ', 'Ƚ', 'Ⱦ', 'Ƀ', 'Ɇ', 'Έ', 'Ί', 'Ύ', 'Ώ', 'Α', 'Ρ', 'Σ', 'Ϋ', 'ϒ', 'ϔ', 'Ϲ', 'Ϻ', 'Ͻ', 'Я', 'Ӏ', 'Ӂ', 'Ա', 'Ֆ', 'Ⴀ', 'Ⴥ', 'Ꭰ', 'Ᏽ', 'Ა', 'Ჺ', 'Ჽ', 'Ჿ', 'Ἀ', 'Ἇ', 'Ἐ', 'Ἕ', 'Ἠ', 'Ἧ', 'Ἰ', 'Ἷ', 'Ὀ', 'Ὅ', 'Ὠ', 'Ὧ', 'Ᾰ', 'Ά', 'Ὲ', 'Ή', 'Ῐ', 'Ί', 'Ῠ', 'Ῥ', 'Ὸ', 'Ώ', 'ℋ', 'ℍ', 'ℐ', 'ℒ', 'ℙ', 'ℝ', 'K', 'ℭ', 'ℰ', 'ℳ', 'ℾ', 'ℿ', 'Ⰰ', 'Ⱞ', 'Ɫ', 'Ɽ', 'Ɑ', 'Ɒ', 'Ȿ', 'Ⲁ', 'Ᵹ', 'Ꝿ', 'Ɦ', 'Ɪ', 'Ʞ', 'Ꞵ', 'Ａ', 'Ｚ'},
@@ -12823,9 +12836,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mc",
-			pos:  position{line: 1847, col: 1, offset: 55111},
+			pos:  position{line: 1848, col: 1, offset: 55197},
 			expr: &charClassMatcher{
-				pos:        position{line: 1847, col: 6, offset: 55116},
+				pos:        position{line: 1848, col: 6, offset: 55202},
 				val:        "[\\u0903\\u093B\\u093E-\\u0940\\u0949-\\u094C\\u094E-\\u094F\\u0982-\\u0983\\u09BE-\\u09C0\\u09C7-\\u09C8\\u09CB-\\u09CC\\u09D7\\u0A03\\u0A3E-\\u0A40\\u0A83\\u0ABE-\\u0AC0\\u0AC9\\u0ACB-\\u0ACC\\u0B02-\\u0B03\\u0B3E\\u0B40\\u0B47-\\u0B48\\u0B4B-\\u0B4C\\u0B57\\u0BBE-\\u0BBF\\u0BC1-\\u0BC2\\u0BC6-\\u0BC8\\u0BCA-\\u0BCC\\u0BD7\\u0C01-\\u0C03\\u0C41-\\u0C44\\u0C82-\\u0C83\\u0CBE\\u0CC0-\\u0CC4\\u0CC7-\\u0CC8\\u0CCA-\\u0CCB\\u0CD5-\\u0CD6\\u0D02-\\u0D03\\u0D3E-\\u0D40\\u0D46-\\u0D48\\u0D4A-\\u0D4C\\u0D57\\u0D82-\\u0D83\\u0DCF-\\u0DD1\\u0DD8-\\u0DDF\\u0DF2-\\u0DF3\\u0F3E-\\u0F3F\\u0F7F\\u102B-\\u102C\\u1031\\u1038\\u103B-\\u103C\\u1056-\\u1057\\u1062-\\u1064\\u1067-\\u106D\\u1083-\\u1084\\u1087-\\u108C\\u108F\\u109A-\\u109C\\u17B6\\u17BE-\\u17C5\\u17C7-\\u17C8\\u1923-\\u1926\\u1929-\\u192B\\u1930-\\u1931\\u1933-\\u1938\\u1A19-\\u1A1A\\u1A55\\u1A57\\u1A61\\u1A63-\\u1A64\\u1A6D-\\u1A72\\u1B04\\u1B35\\u1B3B\\u1B3D-\\u1B41\\u1B43-\\u1B44\\u1B82\\u1BA1\\u1BA6-\\u1BA7\\u1BAA\\u1BE7\\u1BEA-\\u1BEC\\u1BEE\\u1BF2-\\u1BF3\\u1C24-\\u1C2B\\u1C34-\\u1C35\\u1CE1\\u1CF2-\\u1CF3\\u1CF7\\u302E-\\u302F\\uA823-\\uA824\\uA827\\uA880-\\uA881\\uA8B4-\\uA8C3\\uA952-\\uA953\\uA983\\uA9B4-\\uA9B5\\uA9BA-\\uA9BB\\uA9BD-\\uA9C0\\uAA2F-\\uAA30\\uAA33-\\uAA34\\uAA4D\\uAA7B\\uAA7D\\uAAEB\\uAAEE-\\uAAEF\\uAAF5\\uABE3-\\uABE4\\uABE6-\\uABE7\\uABE9-\\uABEA\\uABEC]",
 				chars:      []rune{'ः', 'ऻ', 'ৗ', 'ਃ', 'ઃ', 'ૉ', 'ା', 'ୀ', 'ୗ', 'ௗ', 'ಾ', 'ൗ', 'ཿ', 'ေ', 'း', 'ႏ', 'ា', 'ᩕ', 'ᩗ', 'ᩡ', 'ᬄ', 'ᬵ', 'ᬻ', 'ᮂ', 'ᮡ', '᮪', 'ᯧ', 'ᯮ', '᳡', '᳷', 'ꠧ', 'ꦃ', 'ꩍ', 'ꩻ', 'ꩽ', 'ꫫ', 'ꫵ', '꯬'},
 				ranges:     []rune{'ा', 'ी', 'ॉ', 'ौ', 'ॎ', 'ॏ', 'ং', 'ঃ', 'া', 'ী', 'ে', 'ৈ', 'ো', 'ৌ', 'ਾ', 'ੀ', 'ા', 'ી', 'ો', 'ૌ', 'ଂ', 'ଃ', 'େ', 'ୈ', 'ୋ', 'ୌ', 'ா', 'ி', 'ு', 'ூ', 'ெ', 'ை', 'ொ', 'ௌ', 'ఁ', 'ః', 'ు', 'ౄ', 'ಂ', 'ಃ', 'ೀ', 'ೄ', 'ೇ', 'ೈ', 'ೊ', 'ೋ', 'ೕ', 'ೖ', 'ം', 'ഃ', 'ാ', 'ീ', 'െ', 'ൈ', 'ൊ', 'ൌ', 'ං', 'ඃ', 'ා', 'ෑ', 'ෘ', 'ෟ', 'ෲ', 'ෳ', '༾', '༿', 'ါ', 'ာ', 'ျ', 'ြ', 'ၖ', 'ၗ', 'ၢ', 'ၤ', 'ၧ', 'ၭ', 'ႃ', 'ႄ', 'ႇ', 'ႌ', 'ႚ', 'ႜ', 'ើ', 'ៅ', 'ះ', 'ៈ', 'ᤣ', 'ᤦ', 'ᤩ', 'ᤫ', 'ᤰ', 'ᤱ', 'ᤳ', 'ᤸ', 'ᨙ', 'ᨚ', 'ᩣ', 'ᩤ', 'ᩭ', 'ᩲ', 'ᬽ', 'ᭁ', 'ᭃ', '᭄', 'ᮦ', 'ᮧ', 'ᯪ', 'ᯬ', '᯲', '᯳', 'ᰤ', 'ᰫ', 'ᰴ', 'ᰵ', 'ᳲ', 'ᳳ', '〮', '〯', 'ꠣ', 'ꠤ', 'ꢀ', 'ꢁ', 'ꢴ', 'ꣃ', 'ꥒ', '꥓', 'ꦴ', 'ꦵ', 'ꦺ', 'ꦻ', 'ꦽ', '꧀', 'ꨯ', 'ꨰ', 'ꨳ', 'ꨴ', 'ꫮ', 'ꫯ', 'ꯣ', 'ꯤ', 'ꯦ', 'ꯧ', 'ꯩ', 'ꯪ'},
@@ -12837,9 +12850,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mn",
-			pos:  position{line: 1850, col: 1, offset: 56304},
+			pos:  position{line: 1851, col: 1, offset: 56390},
 			expr: &charClassMatcher{
-				pos:        position{line: 1850, col: 6, offset: 56309},
+				pos:        position{line: 1851, col: 6, offset: 56395},
 				val:        "[\\u0300-\\u036F\\u0483-\\u0487\\u0591-\\u05BD\\u05BF\\u05C1-\\u05C2\\u05C4-\\u05C5\\u05C7\\u0610-\\u061A\\u064B-\\u065F\\u0670\\u06D6-\\u06DC\\u06DF-\\u06E4\\u06E7-\\u06E8\\u06EA-\\u06ED\\u0711\\u0730-\\u074A\\u07A6-\\u07B0\\u07EB-\\u07F3\\u07FD\\u0816-\\u0819\\u081B-\\u0823\\u0825-\\u0827\\u0829-\\u082D\\u0859-\\u085B\\u08D3-\\u08E1\\u08E3-\\u0902\\u093A\\u093C\\u0941-\\u0948\\u094D\\u0951-\\u0957\\u0962-\\u0963\\u0981\\u09BC\\u09C1-\\u09C4\\u09CD\\u09E2-\\u09E3\\u09FE\\u0A01-\\u0A02\\u0A3C\\u0A41-\\u0A42\\u0A47-\\u0A48\\u0A4B-\\u0A4D\\u0A51\\u0A70-\\u0A71\\u0A75\\u0A81-\\u0A82\\u0ABC\\u0AC1-\\u0AC5\\u0AC7-\\u0AC8\\u0ACD\\u0AE2-\\u0AE3\\u0AFA-\\u0AFF\\u0B01\\u0B3C\\u0B3F\\u0B41-\\u0B44\\u0B4D\\u0B56\\u0B62-\\u0B63\\u0B82\\u0BC0\\u0BCD\\u0C00\\u0C04\\u0C3E-\\u0C40\\u0C46-\\u0C48\\u0C4A-\\u0C4D\\u0C55-\\u0C56\\u0C62-\\u0C63\\u0C81\\u0CBC\\u0CBF\\u0CC6\\u0CCC-\\u0CCD\\u0CE2-\\u0CE3\\u0D00-\\u0D01\\u0D3B-\\u0D3C\\u0D41-\\u0D44\\u0D4D\\u0D62-\\u0D63\\u0DCA\\u0DD2-\\u0DD4\\u0DD6\\u0E31\\u0E34-\\u0E3A\\u0E47-\\u0E4E\\u0EB1\\u0EB4-\\u0EB9\\u0EBB-\\u0EBC\\u0EC8-\\u0ECD\\u0F18-\\u0F19\\u0F35\\u0F37\\u0F39\\u0F71-\\u0F7E\\u0F80-\\u0F84\\u0F86-\\u0F87\\u0F8D-\\u0F97\\u0F99-\\u0FBC\\u0FC6\\u102D-\\u1030\\u1032-\\u1037\\u1039-\\u103A\\u103D-\\u103E\\u1058-\\u1059\\u105E-\\u1060\\u1071-\\u1074\\u1082\\u1085-\\u1086\\u108D\\u109D\\u135D-\\u135F\\u1712-\\u1714\\u1732-\\u1734\\u1752-\\u1753\\u1772-\\u1773\\u17B4-\\u17B5\\u17B7-\\u17BD\\u17C6\\u17C9-\\u17D3\\u17DD\\u180B-\\u180D\\u1885-\\u1886\\u18A9\\u1920-\\u1922\\u1927-\\u1928\\u1932\\u1939-\\u193B\\u1A17-\\u1A18\\u1A1B\\u1A56\\u1A58-\\u1A5E\\u1A60\\u1A62\\u1A65-\\u1A6C\\u1A73-\\u1A7C\\u1A7F\\u1AB0-\\u1ABD\\u1B00-\\u1B03\\u1B34\\u1B36-\\u1B3A\\u1B3C\\u1B42\\u1B6B-\\u1B73\\u1B80-\\u1B81\\u1BA2-\\u1BA5\\u1BA8-\\u1BA9\\u1BAB-\\u1BAD\\u1BE6\\u1BE8-\\u1BE9\\u1BED\\u1BEF-\\u1BF1\\u1C2C-\\u1C33\\u1C36-\\u1C37\\u1CD0-\\u1CD2\\u1CD4-\\u1CE0\\u1CE2-\\u1CE8\\u1CED\\u1CF4\\u1CF8-\\u1CF9\\u1DC0-\\u1DF9\\u1DFB-\\u1DFF\\u20D0-\\u20DC\\u20E1\\u20E5-\\u20F0\\u2CEF-\\u2CF1\\u2D7F\\u2DE0-\\u2DFF\\u302A-\\u302D\\u3099-\\u309A\\uA66F\\uA674-\\uA67D\\uA69E-\\uA69F\\uA6F0-\\uA6F1\\uA802\\uA806\\uA80B\\uA825-\\uA826\\uA8C4-\\uA8C5\\uA8E0-\\uA8F1\\uA8FF\\uA926-\\uA92D\\uA947-\\uA951\\uA980-\\uA982\\uA9B3\\uA9B6-\\uA9B9\\uA9BC\\uA9E5\\uAA29-\\uAA2E\\uAA31-\\uAA32\\uAA35-\\uAA36\\uAA43\\uAA4C\\uAA7C\\uAAB0\\uAAB2-\\uAAB4\\uAAB7-\\uAAB8\\uAABE-\\uAABF\\uAAC1\\uAAEC-\\uAAED\\uAAF6\\uABE5\\uABE8\\uABED\\uFB1E\\uFE00-\\uFE0F\\uFE20-\\uFE2F]",
 				chars:      []rune{'ֿ', 'ׇ', 'ٰ', 'ܑ', '߽', 'ऺ', '़', '्', 'ঁ', '়', '্', '৾', '਼', 'ੑ', 'ੵ', '઼', '્', 'ଁ', '଼', 'ି', '୍', 'ୖ', 'ஂ', 'ீ', '்', 'ఀ', 'ఄ', 'ಁ', '಼', 'ಿ', 'ೆ', '്', '්', 'ූ', 'ั', 'ັ', '༵', '༷', '༹', '࿆', 'ႂ', 'ႍ', 'ႝ', 'ំ', '៝', 'ᢩ', 'ᤲ', 'ᨛ', 'ᩖ', '᩠', 'ᩢ', '᩿', '᬴', 'ᬼ', 'ᭂ', '᯦', 'ᯭ', '᳭', '᳴', '⃡', '⵿', '꙯', 'ꠂ', '꠆', 'ꠋ', 'ꣿ', '꦳', 'ꦼ', 'ꧥ', 'ꩃ', 'ꩌ', 'ꩼ', 'ꪰ', '꫁', '꫶', 'ꯥ', 'ꯨ', '꯭', 'ﬞ'},
 				ranges:     []rune{'̀', 'ͯ', '҃', '҇', '֑', 'ֽ', 'ׁ', 'ׂ', 'ׄ', 'ׅ', 'ؐ', 'ؚ', 'ً', 'ٟ', 'ۖ', 'ۜ', '۟', 'ۤ', 'ۧ', 'ۨ', '۪', 'ۭ', 'ܰ', '݊', 'ަ', 'ް', '߫', '߳', 'ࠖ', '࠙', 'ࠛ', 'ࠣ', 'ࠥ', 'ࠧ', 'ࠩ', '࠭', '࡙', '࡛', '࣓', '࣡', 'ࣣ', 'ं', 'ु', 'ै', '॑', 'ॗ', 'ॢ', 'ॣ', 'ু', 'ৄ', 'ৢ', 'ৣ', 'ਁ', 'ਂ', 'ੁ', 'ੂ', 'ੇ', 'ੈ', 'ੋ', '੍', 'ੰ', 'ੱ', 'ઁ', 'ં', 'ુ', 'ૅ', 'ે', 'ૈ', 'ૢ', 'ૣ', 'ૺ', '૿', 'ୁ', 'ୄ', 'ୢ', 'ୣ', 'ా', 'ీ', 'ె', 'ై', 'ొ', '్', 'ౕ', 'ౖ', 'ౢ', 'ౣ', 'ೌ', '್', 'ೢ', 'ೣ', 'ഀ', 'ഁ', '഻', '഼', 'ു', 'ൄ', 'ൢ', 'ൣ', 'ි', 'ු', 'ิ', 'ฺ', '็', '๎', 'ິ', 'ູ', 'ົ', 'ຼ', '່', 'ໍ', '༘', '༙', 'ཱ', 'ཾ', 'ྀ', '྄', '྆', '྇', 'ྍ', 'ྗ', 'ྙ', 'ྼ', 'ိ', 'ူ', 'ဲ', '့', '္', '်', 'ွ', 'ှ', 'ၘ', 'ၙ', 'ၞ', 'ၠ', 'ၱ', 'ၴ', 'ႅ', 'ႆ', '፝', '፟', 'ᜒ', '᜔', 'ᜲ', '᜴', 'ᝒ', 'ᝓ', 'ᝲ', 'ᝳ', '឴', '឵', 'ិ', 'ួ', '៉', '៓', '᠋', '᠍', 'ᢅ', 'ᢆ', 'ᤠ', 'ᤢ', 'ᤧ', 'ᤨ', '᤹', '᤻', 'ᨗ', 'ᨘ', 'ᩘ', 'ᩞ', 'ᩥ', 'ᩬ', 'ᩳ', '᩼', '᪰', '᪽', 'ᬀ', 'ᬃ', 'ᬶ', 'ᬺ', '᭫', '᭳', 'ᮀ', 'ᮁ', 'ᮢ', 'ᮥ', 'ᮨ', 'ᮩ', '᮫', 'ᮭ', 'ᯨ', 'ᯩ', 'ᯯ', 'ᯱ', 'ᰬ', 'ᰳ', 'ᰶ', '᰷', '᳐', '᳒', '᳔', '᳠', '᳢', '᳨', '᳸', '᳹', '᷀', '᷹', '᷻', '᷿', '⃐', '⃜', '⃥', '⃰', '⳯', '⳱', 'ⷠ', 'ⷿ', '〪', '〭', '゙', '゚', 'ꙴ', '꙽', 'ꚞ', 'ꚟ', '꛰', '꛱', 'ꠥ', 'ꠦ', '꣄', 'ꣅ', '꣠', '꣱', 'ꤦ', '꤭', 'ꥇ', 'ꥑ', 'ꦀ', 'ꦂ', 'ꦶ', 'ꦹ', 'ꨩ', 'ꨮ', 'ꨱ', 'ꨲ', 'ꨵ', 'ꨶ', 'ꪲ', 'ꪴ', 'ꪷ', 'ꪸ', 'ꪾ', '꪿', 'ꫬ', 'ꫭ', '︀', '️', '︠', '︯'},
@@ -12851,9 +12864,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nd",
-			pos:  position{line: 1853, col: 1, offset: 58489},
+			pos:  position{line: 1854, col: 1, offset: 58575},
 			expr: &charClassMatcher{
-				pos:        position{line: 1853, col: 6, offset: 58494},
+				pos:        position{line: 1854, col: 6, offset: 58580},
 				val:        "[\\u0030-\\u0039\\u0660-\\u0669\\u06F0-\\u06F9\\u07C0-\\u07C9\\u0966-\\u096F\\u09E6-\\u09EF\\u0A66-\\u0A6F\\u0AE6-\\u0AEF\\u0B66-\\u0B6F\\u0BE6-\\u0BEF\\u0C66-\\u0C6F\\u0CE6-\\u0CEF\\u0D66-\\u0D6F\\u0DE6-\\u0DEF\\u0E50-\\u0E59\\u0ED0-\\u0ED9\\u0F20-\\u0F29\\u1040-\\u1049\\u1090-\\u1099\\u17E0-\\u17E9\\u1810-\\u1819\\u1946-\\u194F\\u19D0-\\u19D9\\u1A80-\\u1A89\\u1A90-\\u1A99\\u1B50-\\u1B59\\u1BB0-\\u1BB9\\u1C40-\\u1C49\\u1C50-\\u1C59\\uA620-\\uA629\\uA8D0-\\uA8D9\\uA900-\\uA909\\uA9D0-\\uA9D9\\uA9F0-\\uA9F9\\uAA50-\\uAA59\\uABF0-\\uABF9\\uFF10-\\uFF19]",
 				ranges:     []rune{'0', '9', '٠', '٩', '۰', '۹', '߀', '߉', '०', '९', '০', '৯', '੦', '੯', '૦', '૯', '୦', '୯', '௦', '௯', '౦', '౯', '೦', '೯', '൦', '൯', '෦', '෯', '๐', '๙', '໐', '໙', '༠', '༩', '၀', '၉', '႐', '႙', '០', '៩', '᠐', '᠙', '᥆', '᥏', '᧐', '᧙', '᪀', '᪉', '᪐', '᪙', '᭐', '᭙', '᮰', '᮹', '᱀', '᱉', '᱐', '᱙', '꘠', '꘩', '꣐', '꣙', '꤀', '꤉', '꧐', '꧙', '꧰', '꧹', '꩐', '꩙', '꯰', '꯹', '０', '９'},
 				ignoreCase: false,
@@ -12864,9 +12877,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nl",
-			pos:  position{line: 1856, col: 1, offset: 58997},
+			pos:  position{line: 1857, col: 1, offset: 59083},
 			expr: &charClassMatcher{
-				pos:        position{line: 1856, col: 6, offset: 59002},
+				pos:        position{line: 1857, col: 6, offset: 59088},
 				val:        "[\\u16EE-\\u16F0\\u2160-\\u2182\\u2185-\\u2188\\u3007\\u3021-\\u3029\\u3038-\\u303A\\uA6E6-\\uA6EF]",
 				chars:      []rune{'〇'},
 				ranges:     []rune{'ᛮ', 'ᛰ', 'Ⅰ', 'ↂ', 'ↅ', 'ↈ', '〡', '〩', '〸', '〺', 'ꛦ', 'ꛯ'},
@@ -12878,9 +12891,9 @@ var g = &grammar{
 		},
 		{
 			name: "Pc",
-			pos:  position{line: 1859, col: 1, offset: 59116},
+			pos:  position{line: 1860, col: 1, offset: 59202},
 			expr: &charClassMatcher{
-				pos:        position{line: 1859, col: 6, offset: 59121},
+				pos:        position{line: 1860, col: 6, offset: 59207},
 				val:        "[\\u005F\\u203F-\\u2040\\u2054\\uFE33-\\uFE34\\uFE4D-\\uFE4F\\uFF3F]",
 				chars:      []rune{'_', '⁔', '＿'},
 				ranges:     []rune{'‿', '⁀', '︳', '︴', '﹍', '﹏'},
@@ -12892,9 +12905,9 @@ var g = &grammar{
 		},
 		{
 			name: "Zs",
-			pos:  position{line: 1862, col: 1, offset: 59202},
+			pos:  position{line: 1863, col: 1, offset: 59288},
 			expr: &charClassMatcher{
-				pos:        position{line: 1862, col: 6, offset: 59207},
+				pos:        position{line: 1863, col: 6, offset: 59293},
 				val:        "[\\u0020\\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000]",
 				chars:      []rune{' ', '\u00a0', '\u1680', '\u202f', '\u205f', '\u3000'},
 				ranges:     []rune{'\u2000', '\u200a'},
@@ -12906,9 +12919,9 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1864, col: 1, offset: 59260},
+			pos:  position{line: 1865, col: 1, offset: 59346},
 			expr: &anyMatcher{
-				line: 1865, col: 5, offset: 59280,
+				line: 1866, col: 5, offset: 59366,
 			},
 			leader:        false,
 			leftRecursive: false,
@@ -12916,48 +12929,48 @@ var g = &grammar{
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1867, col: 1, offset: 59283},
+			pos:         position{line: 1868, col: 1, offset: 59369},
 			expr: &choiceExpr{
-				pos: position{line: 1868, col: 5, offset: 59311},
+				pos: position{line: 1869, col: 5, offset: 59397},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1868, col: 5, offset: 59311},
+						pos:        position{line: 1869, col: 5, offset: 59397},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1869, col: 5, offset: 59320},
+						pos:        position{line: 1870, col: 5, offset: 59406},
 						val:        "\v",
 						ignoreCase: false,
 						want:       "\"\\v\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1870, col: 5, offset: 59329},
+						pos:        position{line: 1871, col: 5, offset: 59415},
 						val:        "\f",
 						ignoreCase: false,
 						want:       "\"\\f\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1871, col: 5, offset: 59338},
+						pos:        position{line: 1872, col: 5, offset: 59424},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 1872, col: 5, offset: 59346},
+						pos:        position{line: 1873, col: 5, offset: 59432},
 						val:        "\u00a0",
 						ignoreCase: false,
 						want:       "\"\\u00a0\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1873, col: 5, offset: 59359},
+						pos:        position{line: 1874, col: 5, offset: 59445},
 						val:        "\ufeff",
 						ignoreCase: false,
 						want:       "\"\\ufeff\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1874, col: 5, offset: 59372},
+						pos:  position{line: 1875, col: 5, offset: 59458},
 						name: "Zs",
 					},
 				},
@@ -12967,9 +12980,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1876, col: 1, offset: 59376},
+			pos:  position{line: 1877, col: 1, offset: 59462},
 			expr: &charClassMatcher{
-				pos:        position{line: 1877, col: 5, offset: 59395},
+				pos:        position{line: 1878, col: 5, offset: 59481},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -12981,16 +12994,16 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1879, col: 1, offset: 59415},
+			pos:         position{line: 1880, col: 1, offset: 59501},
 			expr: &choiceExpr{
-				pos: position{line: 1880, col: 5, offset: 59437},
+				pos: position{line: 1881, col: 5, offset: 59523},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1880, col: 5, offset: 59437},
+						pos:  position{line: 1881, col: 5, offset: 59523},
 						name: "MultiLineComment",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1881, col: 5, offset: 59458},
+						pos:  position{line: 1882, col: 5, offset: 59544},
 						name: "SingleLineComment",
 					},
 				},
@@ -13000,39 +13013,39 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1883, col: 1, offset: 59477},
+			pos:  position{line: 1884, col: 1, offset: 59563},
 			expr: &seqExpr{
-				pos: position{line: 1884, col: 5, offset: 59498},
+				pos: position{line: 1885, col: 5, offset: 59584},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1884, col: 5, offset: 59498},
+						pos:        position{line: 1885, col: 5, offset: 59584},
 						val:        "/*",
 						ignoreCase: false,
 						want:       "\"/*\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1884, col: 10, offset: 59503},
+						pos: position{line: 1885, col: 10, offset: 59589},
 						expr: &seqExpr{
-							pos: position{line: 1884, col: 11, offset: 59504},
+							pos: position{line: 1885, col: 11, offset: 59590},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1884, col: 11, offset: 59504},
+									pos: position{line: 1885, col: 11, offset: 59590},
 									expr: &litMatcher{
-										pos:        position{line: 1884, col: 12, offset: 59505},
+										pos:        position{line: 1885, col: 12, offset: 59591},
 										val:        "*/",
 										ignoreCase: false,
 										want:       "\"*/\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1884, col: 17, offset: 59510},
+									pos:  position{line: 1885, col: 17, offset: 59596},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1884, col: 35, offset: 59528},
+						pos:        position{line: 1885, col: 35, offset: 59614},
 						val:        "*/",
 						ignoreCase: false,
 						want:       "\"*/\"",
@@ -13044,30 +13057,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1886, col: 1, offset: 59534},
+			pos:  position{line: 1887, col: 1, offset: 59620},
 			expr: &seqExpr{
-				pos: position{line: 1887, col: 5, offset: 59556},
+				pos: position{line: 1888, col: 5, offset: 59642},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1887, col: 5, offset: 59556},
+						pos:        position{line: 1888, col: 5, offset: 59642},
 						val:        "--",
 						ignoreCase: false,
 						want:       "\"--\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1887, col: 10, offset: 59561},
+						pos: position{line: 1888, col: 10, offset: 59647},
 						expr: &seqExpr{
-							pos: position{line: 1887, col: 11, offset: 59562},
+							pos: position{line: 1888, col: 11, offset: 59648},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1887, col: 11, offset: 59562},
+									pos: position{line: 1888, col: 11, offset: 59648},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1887, col: 12, offset: 59563},
+										pos:  position{line: 1888, col: 12, offset: 59649},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1887, col: 27, offset: 59578},
+									pos:  position{line: 1888, col: 27, offset: 59664},
 									name: "SourceCharacter",
 								},
 							},
@@ -13080,19 +13093,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1889, col: 1, offset: 59597},
+			pos:  position{line: 1890, col: 1, offset: 59683},
 			expr: &seqExpr{
-				pos: position{line: 1889, col: 7, offset: 59603},
+				pos: position{line: 1890, col: 7, offset: 59689},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1889, col: 7, offset: 59603},
+						pos: position{line: 1890, col: 7, offset: 59689},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1889, col: 7, offset: 59603},
+							pos:  position{line: 1890, col: 7, offset: 59689},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1889, col: 19, offset: 59615},
+						pos:  position{line: 1890, col: 19, offset: 59701},
 						name: "LineTerminator",
 					},
 				},
@@ -13102,16 +13115,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1891, col: 1, offset: 59631},
+			pos:  position{line: 1892, col: 1, offset: 59717},
 			expr: &choiceExpr{
-				pos: position{line: 1891, col: 7, offset: 59637},
+				pos: position{line: 1892, col: 7, offset: 59723},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1891, col: 7, offset: 59637},
+						pos:  position{line: 1892, col: 7, offset: 59723},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1891, col: 11, offset: 59641},
+						pos:  position{line: 1892, col: 11, offset: 59727},
 						name: "EOF",
 					},
 				},
@@ -13121,11 +13134,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1893, col: 1, offset: 59646},
+			pos:  position{line: 1894, col: 1, offset: 59732},
 			expr: &notExpr{
-				pos: position{line: 1893, col: 7, offset: 59652},
+				pos: position{line: 1894, col: 7, offset: 59738},
 				expr: &anyMatcher{
-					line: 1893, col: 8, offset: 59653,
+					line: 1894, col: 8, offset: 59739,
 				},
 			},
 			leader:        false,
@@ -13133,15 +13146,15 @@ var g = &grammar{
 		},
 		{
 			name: "SQLPipe",
-			pos:  position{line: 1897, col: 1, offset: 59678},
+			pos:  position{line: 1898, col: 1, offset: 59764},
 			expr: &actionExpr{
-				pos: position{line: 1898, col: 5, offset: 59690},
+				pos: position{line: 1899, col: 5, offset: 59776},
 				run: (*parser).callonSQLPipe1,
 				expr: &labeledExpr{
-					pos:   position{line: 1898, col: 5, offset: 59690},
+					pos:   position{line: 1899, col: 5, offset: 59776},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1898, col: 7, offset: 59692},
+						pos:  position{line: 1899, col: 7, offset: 59778},
 						name: "Seq",
 					},
 				},
@@ -13151,15 +13164,15 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOp",
-			pos:  position{line: 1906, col: 1, offset: 59839},
+			pos:  position{line: 1907, col: 1, offset: 59925},
 			expr: &actionExpr{
-				pos: position{line: 1907, col: 5, offset: 59849},
+				pos: position{line: 1908, col: 5, offset: 59935},
 				run: (*parser).callonSQLOp1,
 				expr: &labeledExpr{
-					pos:   position{line: 1907, col: 5, offset: 59849},
+					pos:   position{line: 1908, col: 5, offset: 59935},
 					label: "query",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1907, col: 11, offset: 59855},
+						pos:  position{line: 1908, col: 11, offset: 59941},
 						name: "SQLQuery",
 					},
 				},
@@ -13169,42 +13182,42 @@ var g = &grammar{
 		},
 		{
 			name: "SQLQuery",
-			pos:  position{line: 1915, col: 1, offset: 59992},
+			pos:  position{line: 1916, col: 1, offset: 60078},
 			expr: &actionExpr{
-				pos: position{line: 1916, col: 5, offset: 60005},
+				pos: position{line: 1917, col: 5, offset: 60091},
 				run: (*parser).callonSQLQuery1,
 				expr: &seqExpr{
-					pos: position{line: 1916, col: 5, offset: 60005},
+					pos: position{line: 1917, col: 5, offset: 60091},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1916, col: 5, offset: 60005},
+							pos:   position{line: 1917, col: 5, offset: 60091},
 							label: "with",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1916, col: 10, offset: 60010},
+								pos:  position{line: 1917, col: 10, offset: 60096},
 								name: "OptWithClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1917, col: 5, offset: 60028},
+							pos:   position{line: 1918, col: 5, offset: 60114},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1917, col: 10, offset: 60033},
+								pos:  position{line: 1918, col: 10, offset: 60119},
 								name: "SQLBodySetOp",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1918, col: 5, offset: 60050},
+							pos:   position{line: 1919, col: 5, offset: 60136},
 							label: "orderby",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1918, col: 13, offset: 60058},
+								pos:  position{line: 1919, col: 13, offset: 60144},
 								name: "OptOrderByClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1919, col: 5, offset: 60079},
+							pos:   position{line: 1920, col: 5, offset: 60165},
 							label: "loff",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1919, col: 10, offset: 60084},
+								pos:  position{line: 1920, col: 10, offset: 60170},
 								name: "OptSQLLimitOffset",
 							},
 						},
@@ -13216,39 +13229,39 @@ var g = &grammar{
 		},
 		{
 			name: "SQLBodySetOp",
-			pos:  position{line: 1937, col: 1, offset: 60501},
+			pos:  position{line: 1938, col: 1, offset: 60587},
 			expr: &actionExpr{
-				pos: position{line: 1938, col: 5, offset: 60518},
+				pos: position{line: 1939, col: 5, offset: 60604},
 				run: (*parser).callonSQLBodySetOp1,
 				expr: &seqExpr{
-					pos: position{line: 1938, col: 5, offset: 60518},
+					pos: position{line: 1939, col: 5, offset: 60604},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1938, col: 5, offset: 60518},
+							pos:   position{line: 1939, col: 5, offset: 60604},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1938, col: 11, offset: 60524},
+								pos:  position{line: 1939, col: 11, offset: 60610},
 								name: "SQLQueryBody",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1938, col: 24, offset: 60537},
+							pos:   position{line: 1939, col: 24, offset: 60623},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1938, col: 29, offset: 60542},
+								pos: position{line: 1939, col: 29, offset: 60628},
 								expr: &seqExpr{
-									pos: position{line: 1938, col: 30, offset: 60543},
+									pos: position{line: 1939, col: 30, offset: 60629},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1938, col: 30, offset: 60543},
+											pos:  position{line: 1939, col: 30, offset: 60629},
 											name: "SetOp",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1938, col: 36, offset: 60549},
+											pos:  position{line: 1939, col: 36, offset: 60635},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1938, col: 38, offset: 60551},
+											pos:  position{line: 1939, col: 38, offset: 60637},
 											name: "SQLQueryBody",
 										},
 									},
@@ -13263,52 +13276,52 @@ var g = &grammar{
 		},
 		{
 			name: "SQLQueryBody",
-			pos:  position{line: 1952, col: 1, offset: 60868},
+			pos:  position{line: 1953, col: 1, offset: 60954},
 			expr: &choiceExpr{
-				pos: position{line: 1953, col: 5, offset: 60885},
+				pos: position{line: 1954, col: 5, offset: 60971},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1953, col: 5, offset: 60885},
+						pos:  position{line: 1954, col: 5, offset: 60971},
 						name: "Select",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1954, col: 5, offset: 60896},
+						pos:  position{line: 1955, col: 5, offset: 60982},
 						name: "FromSelect",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1955, col: 5, offset: 60911},
+						pos:  position{line: 1956, col: 5, offset: 60997},
 						name: "SQLValues",
 					},
 					&actionExpr{
-						pos: position{line: 1956, col: 5, offset: 60925},
+						pos: position{line: 1957, col: 5, offset: 61011},
 						run: (*parser).callonSQLQueryBody5,
 						expr: &seqExpr{
-							pos: position{line: 1956, col: 5, offset: 60925},
+							pos: position{line: 1957, col: 5, offset: 61011},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1956, col: 5, offset: 60925},
+									pos:        position{line: 1957, col: 5, offset: 61011},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1956, col: 9, offset: 60929},
+									pos:  position{line: 1957, col: 9, offset: 61015},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1956, col: 12, offset: 60932},
+									pos:   position{line: 1957, col: 12, offset: 61018},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1956, col: 14, offset: 60934},
+										pos:  position{line: 1957, col: 14, offset: 61020},
 										name: "SQLQueryOrSetExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1956, col: 32, offset: 60952},
+									pos:  position{line: 1957, col: 32, offset: 61038},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1956, col: 34, offset: 60954},
+									pos:        position{line: 1957, col: 34, offset: 61040},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -13323,16 +13336,16 @@ var g = &grammar{
 		},
 		{
 			name: "SQLQueryOrSetExpr",
-			pos:  position{line: 1958, col: 1, offset: 60977},
+			pos:  position{line: 1959, col: 1, offset: 61063},
 			expr: &choiceExpr{
-				pos: position{line: 1958, col: 21, offset: 60997},
+				pos: position{line: 1959, col: 21, offset: 61083},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1958, col: 21, offset: 60997},
+						pos:  position{line: 1959, col: 21, offset: 61083},
 						name: "SQLQuery",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1958, col: 32, offset: 61008},
+						pos:  position{line: 1959, col: 32, offset: 61094},
 						name: "SQLBodySetOp",
 					},
 				},
@@ -13342,74 +13355,74 @@ var g = &grammar{
 		},
 		{
 			name: "Select",
-			pos:  position{line: 1960, col: 1, offset: 61022},
+			pos:  position{line: 1961, col: 1, offset: 61108},
 			expr: &actionExpr{
-				pos: position{line: 1961, col: 5, offset: 61033},
+				pos: position{line: 1962, col: 5, offset: 61119},
 				run: (*parser).callonSelect1,
 				expr: &seqExpr{
-					pos: position{line: 1961, col: 5, offset: 61033},
+					pos: position{line: 1962, col: 5, offset: 61119},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1961, col: 5, offset: 61033},
+							pos:  position{line: 1962, col: 5, offset: 61119},
 							name: "SELECT",
 						},
 						&labeledExpr{
-							pos:   position{line: 1962, col: 5, offset: 61044},
+							pos:   position{line: 1963, col: 5, offset: 61130},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1962, col: 14, offset: 61053},
+								pos:  position{line: 1963, col: 14, offset: 61139},
 								name: "OptDistinct",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1963, col: 5, offset: 61069},
+							pos:   position{line: 1964, col: 5, offset: 61155},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1963, col: 11, offset: 61075},
+								pos:  position{line: 1964, col: 11, offset: 61161},
 								name: "OptSelectValue",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1966, col: 5, offset: 61214},
+							pos:  position{line: 1967, col: 5, offset: 61300},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1966, col: 7, offset: 61216},
+							pos:   position{line: 1967, col: 7, offset: 61302},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1966, col: 17, offset: 61226},
+								pos:  position{line: 1967, col: 17, offset: 61312},
 								name: "Selection",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1967, col: 5, offset: 61240},
+							pos:   position{line: 1968, col: 5, offset: 61326},
 							label: "from",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1967, col: 10, offset: 61245},
+								pos:  position{line: 1968, col: 10, offset: 61331},
 								name: "OptFromClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1968, col: 5, offset: 61263},
+							pos:   position{line: 1969, col: 5, offset: 61349},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1968, col: 11, offset: 61269},
+								pos:  position{line: 1969, col: 11, offset: 61355},
 								name: "OptWhereClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1969, col: 5, offset: 61288},
+							pos:   position{line: 1970, col: 5, offset: 61374},
 							label: "group",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1969, col: 11, offset: 61294},
+								pos:  position{line: 1970, col: 11, offset: 61380},
 								name: "OptGroupClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1970, col: 5, offset: 61313},
+							pos:   position{line: 1971, col: 5, offset: 61399},
 							label: "having",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1970, col: 12, offset: 61320},
+								pos:  position{line: 1971, col: 12, offset: 61406},
 								name: "OptHavingClause",
 							},
 						},
@@ -13421,78 +13434,78 @@ var g = &grammar{
 		},
 		{
 			name: "FromSelect",
-			pos:  position{line: 1996, col: 1, offset: 61937},
+			pos:  position{line: 1997, col: 1, offset: 62023},
 			expr: &actionExpr{
-				pos: position{line: 1997, col: 5, offset: 61952},
+				pos: position{line: 1998, col: 5, offset: 62038},
 				run: (*parser).callonFromSelect1,
 				expr: &seqExpr{
-					pos: position{line: 1997, col: 5, offset: 61952},
+					pos: position{line: 1998, col: 5, offset: 62038},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1997, col: 5, offset: 61952},
+							pos:   position{line: 1998, col: 5, offset: 62038},
 							label: "from",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1997, col: 10, offset: 61957},
+								pos:  position{line: 1998, col: 10, offset: 62043},
 								name: "FromOp",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1997, col: 17, offset: 61964},
+							pos:  position{line: 1998, col: 17, offset: 62050},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1997, col: 19, offset: 61966},
+							pos:  position{line: 1998, col: 19, offset: 62052},
 							name: "SELECT",
 						},
 						&labeledExpr{
-							pos:   position{line: 1998, col: 5, offset: 61977},
+							pos:   position{line: 1999, col: 5, offset: 62063},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1998, col: 14, offset: 61986},
+								pos:  position{line: 1999, col: 14, offset: 62072},
 								name: "OptDistinct",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1999, col: 5, offset: 62002},
+							pos:   position{line: 2000, col: 5, offset: 62088},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1999, col: 11, offset: 62008},
+								pos:  position{line: 2000, col: 11, offset: 62094},
 								name: "OptSelectValue",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2002, col: 5, offset: 62147},
+							pos:  position{line: 2003, col: 5, offset: 62233},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2002, col: 7, offset: 62149},
+							pos:   position{line: 2003, col: 7, offset: 62235},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2002, col: 17, offset: 62159},
+								pos:  position{line: 2003, col: 17, offset: 62245},
 								name: "Selection",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2003, col: 5, offset: 62173},
+							pos:   position{line: 2004, col: 5, offset: 62259},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2003, col: 11, offset: 62179},
+								pos:  position{line: 2004, col: 11, offset: 62265},
 								name: "OptWhereClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2004, col: 5, offset: 62198},
+							pos:   position{line: 2005, col: 5, offset: 62284},
 							label: "group",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2004, col: 11, offset: 62204},
+								pos:  position{line: 2005, col: 11, offset: 62290},
 								name: "OptGroupClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2005, col: 5, offset: 62223},
+							pos:   position{line: 2006, col: 5, offset: 62309},
 							label: "having",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2005, col: 12, offset: 62230},
+								pos:  position{line: 2006, col: 12, offset: 62316},
 								name: "OptHavingClause",
 							},
 						},
@@ -13504,26 +13517,26 @@ var g = &grammar{
 		},
 		{
 			name: "SQLValues",
-			pos:  position{line: 2029, col: 1, offset: 62814},
+			pos:  position{line: 2030, col: 1, offset: 62900},
 			expr: &actionExpr{
-				pos: position{line: 2030, col: 5, offset: 62828},
+				pos: position{line: 2031, col: 5, offset: 62914},
 				run: (*parser).callonSQLValues1,
 				expr: &seqExpr{
-					pos: position{line: 2030, col: 5, offset: 62828},
+					pos: position{line: 2031, col: 5, offset: 62914},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2030, col: 5, offset: 62828},
+							pos:  position{line: 2031, col: 5, offset: 62914},
 							name: "VALUES",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2030, col: 12, offset: 62835},
+							pos:  position{line: 2031, col: 12, offset: 62921},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2030, col: 15, offset: 62838},
+							pos:   position{line: 2031, col: 15, offset: 62924},
 							label: "tuples",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2030, col: 22, offset: 62845},
+								pos:  position{line: 2031, col: 22, offset: 62931},
 								name: "SQLTuples",
 							},
 						},
@@ -13535,26 +13548,26 @@ var g = &grammar{
 		},
 		{
 			name: "ValuesOp",
-			pos:  position{line: 2038, col: 1, offset: 63002},
+			pos:  position{line: 2039, col: 1, offset: 63088},
 			expr: &actionExpr{
-				pos: position{line: 2039, col: 5, offset: 63015},
+				pos: position{line: 2040, col: 5, offset: 63101},
 				run: (*parser).callonValuesOp1,
 				expr: &seqExpr{
-					pos: position{line: 2039, col: 5, offset: 63015},
+					pos: position{line: 2040, col: 5, offset: 63101},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2039, col: 5, offset: 63015},
+							pos:  position{line: 2040, col: 5, offset: 63101},
 							name: "VALUES",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2039, col: 12, offset: 63022},
+							pos:  position{line: 2040, col: 12, offset: 63108},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2039, col: 14, offset: 63024},
+							pos:   position{line: 2040, col: 14, offset: 63110},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2039, col: 20, offset: 63030},
+								pos:  position{line: 2040, col: 20, offset: 63116},
 								name: "Exprs",
 							},
 						},
@@ -13566,51 +13579,51 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTuples",
-			pos:  position{line: 2048, col: 1, offset: 63181},
+			pos:  position{line: 2049, col: 1, offset: 63267},
 			expr: &actionExpr{
-				pos: position{line: 2049, col: 5, offset: 63195},
+				pos: position{line: 2050, col: 5, offset: 63281},
 				run: (*parser).callonSQLTuples1,
 				expr: &seqExpr{
-					pos: position{line: 2049, col: 5, offset: 63195},
+					pos: position{line: 2050, col: 5, offset: 63281},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2049, col: 5, offset: 63195},
+							pos:   position{line: 2050, col: 5, offset: 63281},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2049, col: 11, offset: 63201},
+								pos:  position{line: 2050, col: 11, offset: 63287},
 								name: "SQLTuple",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2049, col: 20, offset: 63210},
+							pos:   position{line: 2050, col: 20, offset: 63296},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2049, col: 25, offset: 63215},
+								pos: position{line: 2050, col: 25, offset: 63301},
 								expr: &actionExpr{
-									pos: position{line: 2049, col: 26, offset: 63216},
+									pos: position{line: 2050, col: 26, offset: 63302},
 									run: (*parser).callonSQLTuples7,
 									expr: &seqExpr{
-										pos: position{line: 2049, col: 26, offset: 63216},
+										pos: position{line: 2050, col: 26, offset: 63302},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2049, col: 26, offset: 63216},
+												pos:  position{line: 2050, col: 26, offset: 63302},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2049, col: 29, offset: 63219},
+												pos:        position{line: 2050, col: 29, offset: 63305},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2049, col: 33, offset: 63223},
+												pos:  position{line: 2050, col: 33, offset: 63309},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2049, col: 36, offset: 63226},
+												pos:   position{line: 2050, col: 36, offset: 63312},
 												label: "t",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2049, col: 38, offset: 63228},
+													pos:  position{line: 2050, col: 38, offset: 63314},
 													name: "SQLTuple",
 												},
 											},
@@ -13627,37 +13640,37 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTuple",
-			pos:  position{line: 2053, col: 1, offset: 63305},
+			pos:  position{line: 2054, col: 1, offset: 63391},
 			expr: &actionExpr{
-				pos: position{line: 2054, col: 5, offset: 63318},
+				pos: position{line: 2055, col: 5, offset: 63404},
 				run: (*parser).callonSQLTuple1,
 				expr: &seqExpr{
-					pos: position{line: 2054, col: 5, offset: 63318},
+					pos: position{line: 2055, col: 5, offset: 63404},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2054, col: 5, offset: 63318},
+							pos:        position{line: 2055, col: 5, offset: 63404},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2054, col: 9, offset: 63322},
+							pos:  position{line: 2055, col: 9, offset: 63408},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2054, col: 12, offset: 63325},
+							pos:   position{line: 2055, col: 12, offset: 63411},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2054, col: 18, offset: 63331},
+								pos:  position{line: 2055, col: 18, offset: 63417},
 								name: "Exprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2054, col: 24, offset: 63337},
+							pos:  position{line: 2055, col: 24, offset: 63423},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2054, col: 27, offset: 63340},
+							pos:        position{line: 2055, col: 27, offset: 63426},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -13670,49 +13683,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptDistinct",
-			pos:  position{line: 2062, col: 1, offset: 63484},
+			pos:  position{line: 2063, col: 1, offset: 63570},
 			expr: &choiceExpr{
-				pos: position{line: 2063, col: 5, offset: 63500},
+				pos: position{line: 2064, col: 5, offset: 63586},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2063, col: 5, offset: 63500},
+						pos: position{line: 2064, col: 5, offset: 63586},
 						run: (*parser).callonOptDistinct2,
 						expr: &seqExpr{
-							pos: position{line: 2063, col: 5, offset: 63500},
+							pos: position{line: 2064, col: 5, offset: 63586},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2063, col: 5, offset: 63500},
+									pos:  position{line: 2064, col: 5, offset: 63586},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2063, col: 7, offset: 63502},
+									pos:  position{line: 2064, col: 7, offset: 63588},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2064, col: 5, offset: 63539},
+						pos: position{line: 2065, col: 5, offset: 63625},
 						run: (*parser).callonOptDistinct6,
 						expr: &seqExpr{
-							pos: position{line: 2064, col: 5, offset: 63539},
+							pos: position{line: 2065, col: 5, offset: 63625},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2064, col: 5, offset: 63539},
+									pos:  position{line: 2065, col: 5, offset: 63625},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2064, col: 7, offset: 63541},
+									pos:  position{line: 2065, col: 7, offset: 63627},
 									name: "DISTINCT",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2065, col: 5, offset: 63577},
+						pos: position{line: 2066, col: 5, offset: 63663},
 						run: (*parser).callonOptDistinct10,
 						expr: &litMatcher{
-							pos:        position{line: 2065, col: 5, offset: 63577},
+							pos:        position{line: 2066, col: 5, offset: 63663},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13725,57 +13738,57 @@ var g = &grammar{
 		},
 		{
 			name: "OptSelectValue",
-			pos:  position{line: 2067, col: 1, offset: 63616},
+			pos:  position{line: 2068, col: 1, offset: 63702},
 			expr: &choiceExpr{
-				pos: position{line: 2068, col: 5, offset: 63635},
+				pos: position{line: 2069, col: 5, offset: 63721},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2068, col: 5, offset: 63635},
+						pos: position{line: 2069, col: 5, offset: 63721},
 						run: (*parser).callonOptSelectValue2,
 						expr: &seqExpr{
-							pos: position{line: 2068, col: 5, offset: 63635},
+							pos: position{line: 2069, col: 5, offset: 63721},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2068, col: 5, offset: 63635},
+									pos:  position{line: 2069, col: 5, offset: 63721},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2068, col: 7, offset: 63637},
+									pos:  position{line: 2069, col: 7, offset: 63723},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2068, col: 10, offset: 63640},
+									pos:  position{line: 2069, col: 10, offset: 63726},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2068, col: 12, offset: 63642},
+									pos:  position{line: 2069, col: 12, offset: 63728},
 									name: "VALUE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2069, col: 5, offset: 63674},
+						pos: position{line: 2070, col: 5, offset: 63760},
 						run: (*parser).callonOptSelectValue8,
 						expr: &seqExpr{
-							pos: position{line: 2069, col: 5, offset: 63674},
+							pos: position{line: 2070, col: 5, offset: 63760},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2069, col: 5, offset: 63674},
+									pos:  position{line: 2070, col: 5, offset: 63760},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2069, col: 7, offset: 63676},
+									pos:  position{line: 2070, col: 7, offset: 63762},
 									name: "VALUE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2070, col: 5, offset: 63747},
+						pos: position{line: 2071, col: 5, offset: 63833},
 						run: (*parser).callonOptSelectValue12,
 						expr: &litMatcher{
-							pos:        position{line: 2070, col: 5, offset: 63747},
+							pos:        position{line: 2071, col: 5, offset: 63833},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13788,19 +13801,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptWithClause",
-			pos:  position{line: 2072, col: 1, offset: 63790},
+			pos:  position{line: 2073, col: 1, offset: 63876},
 			expr: &choiceExpr{
-				pos: position{line: 2073, col: 5, offset: 63808},
+				pos: position{line: 2074, col: 5, offset: 63894},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2073, col: 5, offset: 63808},
+						pos:  position{line: 2074, col: 5, offset: 63894},
 						name: "WithClause",
 					},
 					&actionExpr{
-						pos: position{line: 2074, col: 5, offset: 63823},
+						pos: position{line: 2075, col: 5, offset: 63909},
 						run: (*parser).callonOptWithClause3,
 						expr: &litMatcher{
-							pos:        position{line: 2074, col: 5, offset: 63823},
+							pos:        position{line: 2075, col: 5, offset: 63909},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13813,39 +13826,39 @@ var g = &grammar{
 		},
 		{
 			name: "WithClause",
-			pos:  position{line: 2076, col: 1, offset: 63856},
+			pos:  position{line: 2077, col: 1, offset: 63942},
 			expr: &actionExpr{
-				pos: position{line: 2077, col: 5, offset: 63871},
+				pos: position{line: 2078, col: 5, offset: 63957},
 				run: (*parser).callonWithClause1,
 				expr: &seqExpr{
-					pos: position{line: 2077, col: 5, offset: 63871},
+					pos: position{line: 2078, col: 5, offset: 63957},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2077, col: 5, offset: 63871},
+							pos:  position{line: 2078, col: 5, offset: 63957},
 							name: "WITH",
 						},
 						&labeledExpr{
-							pos:   position{line: 2077, col: 10, offset: 63876},
+							pos:   position{line: 2078, col: 10, offset: 63962},
 							label: "r",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2077, col: 12, offset: 63878},
+								pos:  position{line: 2078, col: 12, offset: 63964},
 								name: "OptRecursive",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2077, col: 25, offset: 63891},
+							pos:  position{line: 2078, col: 25, offset: 63977},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2077, col: 27, offset: 63893},
+							pos:   position{line: 2078, col: 27, offset: 63979},
 							label: "ctes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2077, col: 32, offset: 63898},
+								pos:  position{line: 2078, col: 32, offset: 63984},
 								name: "CteList",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2077, col: 40, offset: 63906},
+							pos:  position{line: 2078, col: 40, offset: 63992},
 							name: "__",
 						},
 					},
@@ -13856,32 +13869,32 @@ var g = &grammar{
 		},
 		{
 			name: "OptRecursive",
-			pos:  position{line: 2085, col: 1, offset: 64065},
+			pos:  position{line: 2086, col: 1, offset: 64151},
 			expr: &choiceExpr{
-				pos: position{line: 2086, col: 5, offset: 64082},
+				pos: position{line: 2087, col: 5, offset: 64168},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2086, col: 5, offset: 64082},
+						pos: position{line: 2087, col: 5, offset: 64168},
 						run: (*parser).callonOptRecursive2,
 						expr: &seqExpr{
-							pos: position{line: 2086, col: 5, offset: 64082},
+							pos: position{line: 2087, col: 5, offset: 64168},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2086, col: 5, offset: 64082},
+									pos:  position{line: 2087, col: 5, offset: 64168},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2086, col: 7, offset: 64084},
+									pos:  position{line: 2087, col: 7, offset: 64170},
 									name: "RECURSIVE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2087, col: 5, offset: 64120},
+						pos: position{line: 2088, col: 5, offset: 64206},
 						run: (*parser).callonOptRecursive6,
 						expr: &litMatcher{
-							pos:        position{line: 2087, col: 5, offset: 64120},
+							pos:        position{line: 2088, col: 5, offset: 64206},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13894,51 +13907,51 @@ var g = &grammar{
 		},
 		{
 			name: "CteList",
-			pos:  position{line: 2089, col: 1, offset: 64159},
+			pos:  position{line: 2090, col: 1, offset: 64245},
 			expr: &actionExpr{
-				pos: position{line: 2089, col: 11, offset: 64169},
+				pos: position{line: 2090, col: 11, offset: 64255},
 				run: (*parser).callonCteList1,
 				expr: &seqExpr{
-					pos: position{line: 2089, col: 11, offset: 64169},
+					pos: position{line: 2090, col: 11, offset: 64255},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2089, col: 11, offset: 64169},
+							pos:   position{line: 2090, col: 11, offset: 64255},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2089, col: 17, offset: 64175},
+								pos:  position{line: 2090, col: 17, offset: 64261},
 								name: "Cte",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2089, col: 21, offset: 64179},
+							pos:   position{line: 2090, col: 21, offset: 64265},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2089, col: 26, offset: 64184},
+								pos: position{line: 2090, col: 26, offset: 64270},
 								expr: &actionExpr{
-									pos: position{line: 2089, col: 28, offset: 64186},
+									pos: position{line: 2090, col: 28, offset: 64272},
 									run: (*parser).callonCteList7,
 									expr: &seqExpr{
-										pos: position{line: 2089, col: 28, offset: 64186},
+										pos: position{line: 2090, col: 28, offset: 64272},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2089, col: 28, offset: 64186},
+												pos:  position{line: 2090, col: 28, offset: 64272},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2089, col: 31, offset: 64189},
+												pos:        position{line: 2090, col: 31, offset: 64275},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2089, col: 35, offset: 64193},
+												pos:  position{line: 2090, col: 35, offset: 64279},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2089, col: 38, offset: 64196},
+												pos:   position{line: 2090, col: 38, offset: 64282},
 												label: "cte",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2089, col: 42, offset: 64200},
+													pos:  position{line: 2090, col: 42, offset: 64286},
 													name: "Cte",
 												},
 											},
@@ -13955,65 +13968,65 @@ var g = &grammar{
 		},
 		{
 			name: "Cte",
-			pos:  position{line: 2093, col: 1, offset: 64268},
+			pos:  position{line: 2094, col: 1, offset: 64354},
 			expr: &actionExpr{
-				pos: position{line: 2094, col: 5, offset: 64276},
+				pos: position{line: 2095, col: 5, offset: 64362},
 				run: (*parser).callonCte1,
 				expr: &seqExpr{
-					pos: position{line: 2094, col: 5, offset: 64276},
+					pos: position{line: 2095, col: 5, offset: 64362},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2094, col: 5, offset: 64276},
+							pos:   position{line: 2095, col: 5, offset: 64362},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2094, col: 10, offset: 64281},
+								pos:  position{line: 2095, col: 10, offset: 64367},
 								name: "SQLIdentifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2094, col: 24, offset: 64295},
+							pos:  position{line: 2095, col: 24, offset: 64381},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2094, col: 26, offset: 64297},
+							pos:  position{line: 2095, col: 26, offset: 64383},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 2094, col: 29, offset: 64300},
+							pos:   position{line: 2095, col: 29, offset: 64386},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2094, col: 31, offset: 64302},
+								pos:  position{line: 2095, col: 31, offset: 64388},
 								name: "OptMaterialized",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2094, col: 47, offset: 64318},
+							pos:  position{line: 2095, col: 47, offset: 64404},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2094, col: 50, offset: 64321},
+							pos:        position{line: 2095, col: 50, offset: 64407},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2094, col: 54, offset: 64325},
+							pos:  position{line: 2095, col: 54, offset: 64411},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2094, col: 57, offset: 64328},
+							pos:   position{line: 2095, col: 57, offset: 64414},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2094, col: 59, offset: 64330},
+								pos:  position{line: 2095, col: 59, offset: 64416},
 								name: "SQLQueryOrSetExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2094, col: 77, offset: 64348},
+							pos:  position{line: 2095, col: 77, offset: 64434},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2094, col: 80, offset: 64351},
+							pos:        position{line: 2095, col: 80, offset: 64437},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -14026,65 +14039,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptMaterialized",
-			pos:  position{line: 2103, col: 1, offset: 64541},
+			pos:  position{line: 2104, col: 1, offset: 64627},
 			expr: &choiceExpr{
-				pos: position{line: 2104, col: 5, offset: 64561},
+				pos: position{line: 2105, col: 5, offset: 64647},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2104, col: 5, offset: 64561},
+						pos: position{line: 2105, col: 5, offset: 64647},
 						run: (*parser).callonOptMaterialized2,
 						expr: &seqExpr{
-							pos: position{line: 2104, col: 5, offset: 64561},
+							pos: position{line: 2105, col: 5, offset: 64647},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2104, col: 5, offset: 64561},
+									pos:  position{line: 2105, col: 5, offset: 64647},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2104, col: 7, offset: 64563},
+									pos:  position{line: 2105, col: 7, offset: 64649},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2104, col: 20, offset: 64576},
+									pos:  position{line: 2105, col: 20, offset: 64662},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2105, col: 5, offset: 64615},
+						pos: position{line: 2106, col: 5, offset: 64701},
 						run: (*parser).callonOptMaterialized7,
 						expr: &seqExpr{
-							pos: position{line: 2105, col: 5, offset: 64615},
+							pos: position{line: 2106, col: 5, offset: 64701},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2105, col: 5, offset: 64615},
+									pos:  position{line: 2106, col: 5, offset: 64701},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2105, col: 7, offset: 64617},
+									pos:  position{line: 2106, col: 7, offset: 64703},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2105, col: 11, offset: 64621},
+									pos:  position{line: 2106, col: 11, offset: 64707},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2105, col: 13, offset: 64623},
+									pos:  position{line: 2106, col: 13, offset: 64709},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2105, col: 26, offset: 64636},
+									pos:  position{line: 2106, col: 26, offset: 64722},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2106, col: 5, offset: 64667},
+						pos: position{line: 2107, col: 5, offset: 64753},
 						run: (*parser).callonOptMaterialized14,
 						expr: &litMatcher{
-							pos:        position{line: 2106, col: 5, offset: 64667},
+							pos:        position{line: 2107, col: 5, offset: 64753},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14097,25 +14110,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAllClause",
-			pos:  position{line: 2108, col: 1, offset: 64722},
+			pos:  position{line: 2109, col: 1, offset: 64808},
 			expr: &choiceExpr{
-				pos: position{line: 2109, col: 5, offset: 64739},
+				pos: position{line: 2110, col: 5, offset: 64825},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 2109, col: 5, offset: 64739},
+						pos: position{line: 2110, col: 5, offset: 64825},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2109, col: 5, offset: 64739},
+								pos:  position{line: 2110, col: 5, offset: 64825},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2109, col: 7, offset: 64741},
+								pos:  position{line: 2110, col: 7, offset: 64827},
 								name: "ALL",
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 2110, col: 5, offset: 64749},
+						pos:        position{line: 2111, col: 5, offset: 64835},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -14127,25 +14140,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptFromClause",
-			pos:  position{line: 2112, col: 1, offset: 64753},
+			pos:  position{line: 2113, col: 1, offset: 64839},
 			expr: &choiceExpr{
-				pos: position{line: 2113, col: 5, offset: 64771},
+				pos: position{line: 2114, col: 5, offset: 64857},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2113, col: 5, offset: 64771},
+						pos: position{line: 2114, col: 5, offset: 64857},
 						run: (*parser).callonOptFromClause2,
 						expr: &seqExpr{
-							pos: position{line: 2113, col: 5, offset: 64771},
+							pos: position{line: 2114, col: 5, offset: 64857},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2113, col: 5, offset: 64771},
+									pos:  position{line: 2114, col: 5, offset: 64857},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2113, col: 7, offset: 64773},
+									pos:   position{line: 2114, col: 7, offset: 64859},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2113, col: 12, offset: 64778},
+										pos:  position{line: 2114, col: 12, offset: 64864},
 										name: "FromOp",
 									},
 								},
@@ -14153,10 +14166,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2116, col: 5, offset: 64820},
+						pos: position{line: 2117, col: 5, offset: 64906},
 						run: (*parser).callonOptFromClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2116, col: 5, offset: 64820},
+							pos:        position{line: 2117, col: 5, offset: 64906},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14169,27 +14182,27 @@ var g = &grammar{
 		},
 		{
 			name: "OptWhereClause",
-			pos:  position{line: 2118, col: 1, offset: 64861},
+			pos:  position{line: 2119, col: 1, offset: 64947},
 			expr: &choiceExpr{
-				pos: position{line: 2119, col: 5, offset: 64880},
+				pos: position{line: 2120, col: 5, offset: 64966},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2119, col: 5, offset: 64880},
+						pos: position{line: 2120, col: 5, offset: 64966},
 						run: (*parser).callonOptWhereClause2,
 						expr: &labeledExpr{
-							pos:   position{line: 2119, col: 5, offset: 64880},
+							pos:   position{line: 2120, col: 5, offset: 64966},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2119, col: 11, offset: 64886},
+								pos:  position{line: 2120, col: 11, offset: 64972},
 								name: "WhereClause",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2120, col: 5, offset: 64928},
+						pos: position{line: 2121, col: 5, offset: 65014},
 						run: (*parser).callonOptWhereClause5,
 						expr: &litMatcher{
-							pos:        position{line: 2120, col: 5, offset: 64928},
+							pos:        position{line: 2121, col: 5, offset: 65014},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14202,25 +14215,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptGroupClause",
-			pos:  position{line: 2122, col: 1, offset: 64973},
+			pos:  position{line: 2123, col: 1, offset: 65059},
 			expr: &choiceExpr{
-				pos: position{line: 2123, col: 5, offset: 64992},
+				pos: position{line: 2124, col: 5, offset: 65078},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2123, col: 5, offset: 64992},
+						pos: position{line: 2124, col: 5, offset: 65078},
 						run: (*parser).callonOptGroupClause2,
 						expr: &seqExpr{
-							pos: position{line: 2123, col: 5, offset: 64992},
+							pos: position{line: 2124, col: 5, offset: 65078},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2123, col: 5, offset: 64992},
+									pos:  position{line: 2124, col: 5, offset: 65078},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2123, col: 7, offset: 64994},
+									pos:   position{line: 2124, col: 7, offset: 65080},
 									label: "group",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2123, col: 13, offset: 65000},
+										pos:  position{line: 2124, col: 13, offset: 65086},
 										name: "GroupClause",
 									},
 								},
@@ -14228,10 +14241,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2124, col: 5, offset: 65038},
+						pos: position{line: 2125, col: 5, offset: 65124},
 						run: (*parser).callonOptGroupClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2124, col: 5, offset: 65038},
+							pos:        position{line: 2125, col: 5, offset: 65124},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14244,34 +14257,34 @@ var g = &grammar{
 		},
 		{
 			name: "GroupClause",
-			pos:  position{line: 2126, col: 1, offset: 65079},
+			pos:  position{line: 2127, col: 1, offset: 65165},
 			expr: &actionExpr{
-				pos: position{line: 2127, col: 5, offset: 65095},
+				pos: position{line: 2128, col: 5, offset: 65181},
 				run: (*parser).callonGroupClause1,
 				expr: &seqExpr{
-					pos: position{line: 2127, col: 5, offset: 65095},
+					pos: position{line: 2128, col: 5, offset: 65181},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2127, col: 5, offset: 65095},
+							pos:  position{line: 2128, col: 5, offset: 65181},
 							name: "GROUP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2127, col: 11, offset: 65101},
+							pos:  position{line: 2128, col: 11, offset: 65187},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2127, col: 13, offset: 65103},
+							pos:  position{line: 2128, col: 13, offset: 65189},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2127, col: 16, offset: 65106},
+							pos:  position{line: 2128, col: 16, offset: 65192},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2127, col: 18, offset: 65108},
+							pos:   position{line: 2128, col: 18, offset: 65194},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2127, col: 23, offset: 65113},
+								pos:  position{line: 2128, col: 23, offset: 65199},
 								name: "GroupByList",
 							},
 						},
@@ -14283,51 +14296,51 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByList",
-			pos:  position{line: 2129, col: 1, offset: 65147},
+			pos:  position{line: 2130, col: 1, offset: 65233},
 			expr: &actionExpr{
-				pos: position{line: 2130, col: 5, offset: 65163},
+				pos: position{line: 2131, col: 5, offset: 65249},
 				run: (*parser).callonGroupByList1,
 				expr: &seqExpr{
-					pos: position{line: 2130, col: 5, offset: 65163},
+					pos: position{line: 2131, col: 5, offset: 65249},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2130, col: 5, offset: 65163},
+							pos:   position{line: 2131, col: 5, offset: 65249},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2130, col: 11, offset: 65169},
+								pos:  position{line: 2131, col: 11, offset: 65255},
 								name: "GroupByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2130, col: 23, offset: 65181},
+							pos:   position{line: 2131, col: 23, offset: 65267},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2130, col: 28, offset: 65186},
+								pos: position{line: 2131, col: 28, offset: 65272},
 								expr: &actionExpr{
-									pos: position{line: 2130, col: 30, offset: 65188},
+									pos: position{line: 2131, col: 30, offset: 65274},
 									run: (*parser).callonGroupByList7,
 									expr: &seqExpr{
-										pos: position{line: 2130, col: 30, offset: 65188},
+										pos: position{line: 2131, col: 30, offset: 65274},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2130, col: 30, offset: 65188},
+												pos:  position{line: 2131, col: 30, offset: 65274},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2130, col: 33, offset: 65191},
+												pos:        position{line: 2131, col: 33, offset: 65277},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2130, col: 37, offset: 65195},
+												pos:  position{line: 2131, col: 37, offset: 65281},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2130, col: 40, offset: 65198},
+												pos:   position{line: 2131, col: 40, offset: 65284},
 												label: "g",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2130, col: 42, offset: 65200},
+													pos:  position{line: 2131, col: 42, offset: 65286},
 													name: "GroupByItem",
 												},
 											},
@@ -14344,9 +14357,9 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByItem",
-			pos:  position{line: 2134, col: 1, offset: 65281},
+			pos:  position{line: 2135, col: 1, offset: 65367},
 			expr: &ruleRefExpr{
-				pos:  position{line: 2134, col: 15, offset: 65295},
+				pos:  position{line: 2135, col: 15, offset: 65381},
 				name: "Expr",
 			},
 			leader:        false,
@@ -14354,25 +14367,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptHavingClause",
-			pos:  position{line: 2136, col: 1, offset: 65301},
+			pos:  position{line: 2137, col: 1, offset: 65387},
 			expr: &choiceExpr{
-				pos: position{line: 2137, col: 5, offset: 65321},
+				pos: position{line: 2138, col: 5, offset: 65407},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2137, col: 5, offset: 65321},
+						pos: position{line: 2138, col: 5, offset: 65407},
 						run: (*parser).callonOptHavingClause2,
 						expr: &seqExpr{
-							pos: position{line: 2137, col: 5, offset: 65321},
+							pos: position{line: 2138, col: 5, offset: 65407},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2137, col: 5, offset: 65321},
+									pos:  position{line: 2138, col: 5, offset: 65407},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2137, col: 7, offset: 65323},
+									pos:   position{line: 2138, col: 7, offset: 65409},
 									label: "h",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2137, col: 9, offset: 65325},
+										pos:  position{line: 2138, col: 9, offset: 65411},
 										name: "HavingClause",
 									},
 								},
@@ -14380,10 +14393,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2138, col: 5, offset: 65360},
+						pos: position{line: 2139, col: 5, offset: 65446},
 						run: (*parser).callonOptHavingClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2138, col: 5, offset: 65360},
+							pos:        position{line: 2139, col: 5, offset: 65446},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14396,26 +14409,26 @@ var g = &grammar{
 		},
 		{
 			name: "HavingClause",
-			pos:  position{line: 2140, col: 1, offset: 65384},
+			pos:  position{line: 2141, col: 1, offset: 65470},
 			expr: &actionExpr{
-				pos: position{line: 2141, col: 5, offset: 65401},
+				pos: position{line: 2142, col: 5, offset: 65487},
 				run: (*parser).callonHavingClause1,
 				expr: &seqExpr{
-					pos: position{line: 2141, col: 5, offset: 65401},
+					pos: position{line: 2142, col: 5, offset: 65487},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2141, col: 5, offset: 65401},
+							pos:  position{line: 2142, col: 5, offset: 65487},
 							name: "HAVING",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2141, col: 12, offset: 65408},
+							pos:  position{line: 2142, col: 12, offset: 65494},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2141, col: 14, offset: 65410},
+							pos:   position{line: 2142, col: 14, offset: 65496},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2141, col: 16, offset: 65412},
+								pos:  position{line: 2142, col: 16, offset: 65498},
 								name: "Expr",
 							},
 						},
@@ -14427,16 +14440,16 @@ var g = &grammar{
 		},
 		{
 			name: "JoinOperation",
-			pos:  position{line: 2143, col: 1, offset: 65436},
+			pos:  position{line: 2144, col: 1, offset: 65522},
 			expr: &choiceExpr{
-				pos: position{line: 2144, col: 5, offset: 65454},
+				pos: position{line: 2145, col: 5, offset: 65540},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2144, col: 5, offset: 65454},
+						pos:  position{line: 2145, col: 5, offset: 65540},
 						name: "CrossJoin",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2145, col: 5, offset: 65468},
+						pos:  position{line: 2146, col: 5, offset: 65554},
 						name: "ConditionJoin",
 					},
 				},
@@ -14446,30 +14459,30 @@ var g = &grammar{
 		},
 		{
 			name: "CrossJoin",
-			pos:  position{line: 2147, col: 1, offset: 65483},
+			pos:  position{line: 2148, col: 1, offset: 65569},
 			expr: &actionExpr{
-				pos: position{line: 2148, col: 5, offset: 65497},
+				pos: position{line: 2149, col: 5, offset: 65583},
 				run: (*parser).callonCrossJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2148, col: 5, offset: 65497},
+					pos: position{line: 2149, col: 5, offset: 65583},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2148, col: 5, offset: 65497},
+							pos:   position{line: 2149, col: 5, offset: 65583},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2148, col: 10, offset: 65502},
+								pos:  position{line: 2149, col: 10, offset: 65588},
 								name: "FromElem",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2148, col: 19, offset: 65511},
+							pos:  position{line: 2149, col: 19, offset: 65597},
 							name: "CrossJoinOp",
 						},
 						&labeledExpr{
-							pos:   position{line: 2148, col: 31, offset: 65523},
+							pos:   position{line: 2149, col: 31, offset: 65609},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2148, col: 37, offset: 65529},
+								pos:  position{line: 2149, col: 37, offset: 65615},
 								name: "FromElem",
 							},
 						},
@@ -14481,50 +14494,50 @@ var g = &grammar{
 		},
 		{
 			name: "CrossJoinOp",
-			pos:  position{line: 2157, col: 1, offset: 65737},
+			pos:  position{line: 2158, col: 1, offset: 65823},
 			expr: &choiceExpr{
-				pos: position{line: 2158, col: 5, offset: 65753},
+				pos: position{line: 2159, col: 5, offset: 65839},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 2158, col: 5, offset: 65753},
+						pos: position{line: 2159, col: 5, offset: 65839},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2158, col: 5, offset: 65753},
+								pos:  position{line: 2159, col: 5, offset: 65839},
 								name: "__",
 							},
 							&litMatcher{
-								pos:        position{line: 2158, col: 8, offset: 65756},
+								pos:        position{line: 2159, col: 8, offset: 65842},
 								val:        ",",
 								ignoreCase: false,
 								want:       "\",\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2158, col: 12, offset: 65760},
+								pos:  position{line: 2159, col: 12, offset: 65846},
 								name: "__",
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 2159, col: 5, offset: 65767},
+						pos: position{line: 2160, col: 5, offset: 65853},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2159, col: 5, offset: 65767},
+								pos:  position{line: 2160, col: 5, offset: 65853},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2159, col: 7, offset: 65769},
+								pos:  position{line: 2160, col: 7, offset: 65855},
 								name: "CROSS",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2159, col: 13, offset: 65775},
+								pos:  position{line: 2160, col: 13, offset: 65861},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2159, col: 15, offset: 65777},
+								pos:  position{line: 2160, col: 15, offset: 65863},
 								name: "JOIN",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2159, col: 20, offset: 65782},
+								pos:  position{line: 2160, col: 20, offset: 65868},
 								name: "_",
 							},
 						},
@@ -14536,50 +14549,50 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionJoin",
-			pos:  position{line: 2161, col: 1, offset: 65785},
+			pos:  position{line: 2162, col: 1, offset: 65871},
 			expr: &actionExpr{
-				pos: position{line: 2162, col: 5, offset: 65803},
+				pos: position{line: 2163, col: 5, offset: 65889},
 				run: (*parser).callonConditionJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2162, col: 5, offset: 65803},
+					pos: position{line: 2163, col: 5, offset: 65889},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2162, col: 5, offset: 65803},
+							pos:   position{line: 2163, col: 5, offset: 65889},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2162, col: 10, offset: 65808},
+								pos:  position{line: 2163, col: 10, offset: 65894},
 								name: "FromElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2162, col: 19, offset: 65817},
+							pos:   position{line: 2163, col: 19, offset: 65903},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2162, col: 25, offset: 65823},
+								pos:  position{line: 2163, col: 25, offset: 65909},
 								name: "SQLJoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2162, col: 38, offset: 65836},
+							pos:  position{line: 2163, col: 38, offset: 65922},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2162, col: 40, offset: 65838},
+							pos:   position{line: 2163, col: 40, offset: 65924},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2162, col: 46, offset: 65844},
+								pos:  position{line: 2163, col: 46, offset: 65930},
 								name: "FromElem",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2162, col: 55, offset: 65853},
+							pos:  position{line: 2163, col: 55, offset: 65939},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2162, col: 57, offset: 65855},
+							pos:   position{line: 2163, col: 57, offset: 65941},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2162, col: 59, offset: 65857},
+								pos:  position{line: 2163, col: 59, offset: 65943},
 								name: "JoinCond",
 							},
 						},
@@ -14591,186 +14604,186 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoinStyle",
-			pos:  position{line: 2173, col: 1, offset: 66126},
+			pos:  position{line: 2174, col: 1, offset: 66212},
 			expr: &choiceExpr{
-				pos: position{line: 2174, col: 5, offset: 66143},
+				pos: position{line: 2175, col: 5, offset: 66229},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2174, col: 5, offset: 66143},
+						pos: position{line: 2175, col: 5, offset: 66229},
 						run: (*parser).callonSQLJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 2174, col: 5, offset: 66143},
+							pos: position{line: 2175, col: 5, offset: 66229},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 2174, col: 5, offset: 66143},
+									pos: position{line: 2175, col: 5, offset: 66229},
 									expr: &seqExpr{
-										pos: position{line: 2174, col: 6, offset: 66144},
+										pos: position{line: 2175, col: 6, offset: 66230},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2174, col: 6, offset: 66144},
+												pos:  position{line: 2175, col: 6, offset: 66230},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2174, col: 8, offset: 66146},
+												pos:  position{line: 2175, col: 8, offset: 66232},
 												name: "INNER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2174, col: 16, offset: 66154},
+									pos:  position{line: 2175, col: 16, offset: 66240},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2174, col: 18, offset: 66156},
+									pos:  position{line: 2175, col: 18, offset: 66242},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2175, col: 5, offset: 66201},
+						pos: position{line: 2176, col: 5, offset: 66287},
 						run: (*parser).callonSQLJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 2175, col: 5, offset: 66201},
+							pos: position{line: 2176, col: 5, offset: 66287},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2175, col: 5, offset: 66201},
+									pos:  position{line: 2176, col: 5, offset: 66287},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2175, col: 7, offset: 66203},
+									pos:  position{line: 2176, col: 7, offset: 66289},
 									name: "ANTI",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2175, col: 12, offset: 66208},
+									pos:  position{line: 2176, col: 12, offset: 66294},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2175, col: 14, offset: 66210},
+									pos:  position{line: 2176, col: 14, offset: 66296},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2176, col: 5, offset: 66242},
+						pos: position{line: 2177, col: 5, offset: 66328},
 						run: (*parser).callonSQLJoinStyle16,
 						expr: &seqExpr{
-							pos: position{line: 2176, col: 5, offset: 66242},
+							pos: position{line: 2177, col: 5, offset: 66328},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2176, col: 5, offset: 66242},
+									pos:  position{line: 2177, col: 5, offset: 66328},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2176, col: 7, offset: 66244},
+									pos:  position{line: 2177, col: 7, offset: 66330},
 									name: "FULL",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2176, col: 12, offset: 66249},
+									pos: position{line: 2177, col: 12, offset: 66335},
 									expr: &seqExpr{
-										pos: position{line: 2176, col: 13, offset: 66250},
+										pos: position{line: 2177, col: 13, offset: 66336},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2176, col: 13, offset: 66250},
+												pos:  position{line: 2177, col: 13, offset: 66336},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2176, col: 15, offset: 66252},
+												pos:  position{line: 2177, col: 15, offset: 66338},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2176, col: 23, offset: 66260},
+									pos:  position{line: 2177, col: 23, offset: 66346},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2176, col: 25, offset: 66262},
+									pos:  position{line: 2177, col: 25, offset: 66348},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2177, col: 5, offset: 66296},
+						pos: position{line: 2178, col: 5, offset: 66382},
 						run: (*parser).callonSQLJoinStyle26,
 						expr: &seqExpr{
-							pos: position{line: 2177, col: 5, offset: 66296},
+							pos: position{line: 2178, col: 5, offset: 66382},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2177, col: 5, offset: 66296},
+									pos:  position{line: 2178, col: 5, offset: 66382},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2177, col: 7, offset: 66298},
+									pos:  position{line: 2178, col: 7, offset: 66384},
 									name: "LEFT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2177, col: 12, offset: 66303},
+									pos: position{line: 2178, col: 12, offset: 66389},
 									expr: &seqExpr{
-										pos: position{line: 2177, col: 13, offset: 66304},
+										pos: position{line: 2178, col: 13, offset: 66390},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2177, col: 13, offset: 66304},
+												pos:  position{line: 2178, col: 13, offset: 66390},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2177, col: 15, offset: 66306},
+												pos:  position{line: 2178, col: 15, offset: 66392},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2177, col: 23, offset: 66314},
+									pos:  position{line: 2178, col: 23, offset: 66400},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2177, col: 25, offset: 66316},
+									pos:  position{line: 2178, col: 25, offset: 66402},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2178, col: 5, offset: 66350},
+						pos: position{line: 2179, col: 5, offset: 66436},
 						run: (*parser).callonSQLJoinStyle36,
 						expr: &seqExpr{
-							pos: position{line: 2178, col: 5, offset: 66350},
+							pos: position{line: 2179, col: 5, offset: 66436},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2178, col: 5, offset: 66350},
+									pos:  position{line: 2179, col: 5, offset: 66436},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2178, col: 7, offset: 66352},
+									pos:  position{line: 2179, col: 7, offset: 66438},
 									name: "RIGHT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2178, col: 13, offset: 66358},
+									pos: position{line: 2179, col: 13, offset: 66444},
 									expr: &seqExpr{
-										pos: position{line: 2178, col: 14, offset: 66359},
+										pos: position{line: 2179, col: 14, offset: 66445},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2178, col: 14, offset: 66359},
+												pos:  position{line: 2179, col: 14, offset: 66445},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2178, col: 16, offset: 66361},
+												pos:  position{line: 2179, col: 16, offset: 66447},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2178, col: 24, offset: 66369},
+									pos:  position{line: 2179, col: 24, offset: 66455},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2178, col: 26, offset: 66371},
+									pos:  position{line: 2179, col: 26, offset: 66457},
 									name: "JOIN",
 								},
 							},
@@ -14783,29 +14796,29 @@ var g = &grammar{
 		},
 		{
 			name: "JoinCond",
-			pos:  position{line: 2180, col: 1, offset: 66403},
+			pos:  position{line: 2181, col: 1, offset: 66489},
 			expr: &choiceExpr{
-				pos: position{line: 2181, col: 5, offset: 66416},
+				pos: position{line: 2182, col: 5, offset: 66502},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2181, col: 5, offset: 66416},
+						pos: position{line: 2182, col: 5, offset: 66502},
 						run: (*parser).callonJoinCond2,
 						expr: &seqExpr{
-							pos: position{line: 2181, col: 5, offset: 66416},
+							pos: position{line: 2182, col: 5, offset: 66502},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2181, col: 5, offset: 66416},
+									pos:  position{line: 2182, col: 5, offset: 66502},
 									name: "ON",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2181, col: 8, offset: 66419},
+									pos:  position{line: 2182, col: 8, offset: 66505},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2181, col: 10, offset: 66421},
+									pos:   position{line: 2182, col: 10, offset: 66507},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2181, col: 12, offset: 66423},
+										pos:  position{line: 2182, col: 12, offset: 66509},
 										name: "Expr",
 									},
 								},
@@ -14813,43 +14826,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2188, col: 5, offset: 66576},
+						pos: position{line: 2189, col: 5, offset: 66662},
 						run: (*parser).callonJoinCond8,
 						expr: &seqExpr{
-							pos: position{line: 2188, col: 5, offset: 66576},
+							pos: position{line: 2189, col: 5, offset: 66662},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2188, col: 5, offset: 66576},
+									pos:  position{line: 2189, col: 5, offset: 66662},
 									name: "USING",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2188, col: 11, offset: 66582},
+									pos:  position{line: 2189, col: 11, offset: 66668},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2188, col: 14, offset: 66585},
+									pos:        position{line: 2189, col: 14, offset: 66671},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2188, col: 18, offset: 66589},
+									pos:  position{line: 2189, col: 18, offset: 66675},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 2188, col: 21, offset: 66592},
+									pos:   position{line: 2189, col: 21, offset: 66678},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2188, col: 28, offset: 66599},
+										pos:  position{line: 2189, col: 28, offset: 66685},
 										name: "Lvals",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2188, col: 34, offset: 66605},
+									pos:  position{line: 2189, col: 34, offset: 66691},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2188, col: 37, offset: 66608},
+									pos:        position{line: 2189, col: 37, offset: 66694},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -14864,40 +14877,40 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrdinality",
-			pos:  position{line: 2196, col: 1, offset: 66778},
+			pos:  position{line: 2197, col: 1, offset: 66864},
 			expr: &choiceExpr{
-				pos: position{line: 2197, col: 5, offset: 66796},
+				pos: position{line: 2198, col: 5, offset: 66882},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2197, col: 5, offset: 66796},
+						pos: position{line: 2198, col: 5, offset: 66882},
 						run: (*parser).callonOptOrdinality2,
 						expr: &seqExpr{
-							pos: position{line: 2197, col: 5, offset: 66796},
+							pos: position{line: 2198, col: 5, offset: 66882},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2197, col: 5, offset: 66796},
+									pos:  position{line: 2198, col: 5, offset: 66882},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2197, col: 7, offset: 66798},
+									pos:  position{line: 2198, col: 7, offset: 66884},
 									name: "WITH",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2197, col: 12, offset: 66803},
+									pos:  position{line: 2198, col: 12, offset: 66889},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2197, col: 14, offset: 66805},
+									pos:  position{line: 2198, col: 14, offset: 66891},
 									name: "ORDINALITY",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2202, col: 5, offset: 66902},
+						pos: position{line: 2203, col: 5, offset: 66988},
 						run: (*parser).callonOptOrdinality8,
 						expr: &litMatcher{
-							pos:        position{line: 2202, col: 5, offset: 66902},
+							pos:        position{line: 2203, col: 5, offset: 66988},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14910,25 +14923,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAlias",
-			pos:  position{line: 2204, col: 1, offset: 66951},
+			pos:  position{line: 2205, col: 1, offset: 67037},
 			expr: &choiceExpr{
-				pos: position{line: 2205, col: 5, offset: 66964},
+				pos: position{line: 2206, col: 5, offset: 67050},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2205, col: 5, offset: 66964},
+						pos: position{line: 2206, col: 5, offset: 67050},
 						run: (*parser).callonOptAlias2,
 						expr: &seqExpr{
-							pos: position{line: 2205, col: 5, offset: 66964},
+							pos: position{line: 2206, col: 5, offset: 67050},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2205, col: 5, offset: 66964},
+									pos:  position{line: 2206, col: 5, offset: 67050},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2205, col: 7, offset: 66966},
+									pos:   position{line: 2206, col: 7, offset: 67052},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2205, col: 9, offset: 66968},
+										pos:  position{line: 2206, col: 9, offset: 67054},
 										name: "AliasClause",
 									},
 								},
@@ -14936,10 +14949,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2206, col: 5, offset: 67002},
+						pos: position{line: 2207, col: 5, offset: 67088},
 						run: (*parser).callonOptAlias7,
 						expr: &litMatcher{
-							pos:        position{line: 2206, col: 5, offset: 67002},
+							pos:        position{line: 2207, col: 5, offset: 67088},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14952,51 +14965,51 @@ var g = &grammar{
 		},
 		{
 			name: "AliasClause",
-			pos:  position{line: 2208, col: 1, offset: 67039},
+			pos:  position{line: 2209, col: 1, offset: 67125},
 			expr: &actionExpr{
-				pos: position{line: 2209, col: 4, offset: 67054},
+				pos: position{line: 2210, col: 4, offset: 67140},
 				run: (*parser).callonAliasClause1,
 				expr: &seqExpr{
-					pos: position{line: 2209, col: 4, offset: 67054},
+					pos: position{line: 2210, col: 4, offset: 67140},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2209, col: 4, offset: 67054},
+							pos: position{line: 2210, col: 4, offset: 67140},
 							expr: &seqExpr{
-								pos: position{line: 2209, col: 5, offset: 67055},
+								pos: position{line: 2210, col: 5, offset: 67141},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2209, col: 5, offset: 67055},
+										pos:  position{line: 2210, col: 5, offset: 67141},
 										name: "AS",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2209, col: 8, offset: 67058},
+										pos:  position{line: 2210, col: 8, offset: 67144},
 										name: "_",
 									},
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 2209, col: 12, offset: 67062},
+							pos: position{line: 2210, col: 12, offset: 67148},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2209, col: 13, offset: 67063},
+								pos:  position{line: 2210, col: 13, offset: 67149},
 								name: "SQLGuard",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2209, col: 22, offset: 67072},
+							pos:   position{line: 2210, col: 22, offset: 67158},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2209, col: 27, offset: 67077},
+								pos:  position{line: 2210, col: 27, offset: 67163},
 								name: "IdentifierName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2209, col: 42, offset: 67092},
+							pos:   position{line: 2210, col: 42, offset: 67178},
 							label: "cols",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2209, col: 47, offset: 67097},
+								pos: position{line: 2210, col: 47, offset: 67183},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2209, col: 47, offset: 67097},
+									pos:  position{line: 2210, col: 47, offset: 67183},
 									name: "Columns",
 								},
 							},
@@ -15009,65 +15022,65 @@ var g = &grammar{
 		},
 		{
 			name: "Columns",
-			pos:  position{line: 2217, col: 1, offset: 67276},
+			pos:  position{line: 2218, col: 1, offset: 67362},
 			expr: &actionExpr{
-				pos: position{line: 2218, col: 5, offset: 67288},
+				pos: position{line: 2219, col: 5, offset: 67374},
 				run: (*parser).callonColumns1,
 				expr: &seqExpr{
-					pos: position{line: 2218, col: 5, offset: 67288},
+					pos: position{line: 2219, col: 5, offset: 67374},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2218, col: 5, offset: 67288},
+							pos:  position{line: 2219, col: 5, offset: 67374},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2218, col: 8, offset: 67291},
+							pos:        position{line: 2219, col: 8, offset: 67377},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2218, col: 12, offset: 67295},
+							pos:  position{line: 2219, col: 12, offset: 67381},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2218, col: 15, offset: 67298},
+							pos:   position{line: 2219, col: 15, offset: 67384},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2218, col: 21, offset: 67304},
+								pos:  position{line: 2219, col: 21, offset: 67390},
 								name: "SQLIdentifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2218, col: 35, offset: 67318},
+							pos:   position{line: 2219, col: 35, offset: 67404},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2218, col: 40, offset: 67323},
+								pos: position{line: 2219, col: 40, offset: 67409},
 								expr: &actionExpr{
-									pos: position{line: 2218, col: 42, offset: 67325},
+									pos: position{line: 2219, col: 42, offset: 67411},
 									run: (*parser).callonColumns10,
 									expr: &seqExpr{
-										pos: position{line: 2218, col: 42, offset: 67325},
+										pos: position{line: 2219, col: 42, offset: 67411},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2218, col: 42, offset: 67325},
+												pos:  position{line: 2219, col: 42, offset: 67411},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2218, col: 45, offset: 67328},
+												pos:        position{line: 2219, col: 45, offset: 67414},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2218, col: 49, offset: 67332},
+												pos:  position{line: 2219, col: 49, offset: 67418},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2218, col: 52, offset: 67335},
+												pos:   position{line: 2219, col: 52, offset: 67421},
 												label: "s",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2218, col: 54, offset: 67337},
+													pos:  position{line: 2219, col: 54, offset: 67423},
 													name: "SQLIdentifier",
 												},
 											},
@@ -15077,11 +15090,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2218, col: 87, offset: 67370},
+							pos:  position{line: 2219, col: 87, offset: 67456},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2218, col: 90, offset: 67373},
+							pos:        position{line: 2219, col: 90, offset: 67459},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -15094,51 +15107,51 @@ var g = &grammar{
 		},
 		{
 			name: "Selection",
-			pos:  position{line: 2222, col: 1, offset: 67444},
+			pos:  position{line: 2223, col: 1, offset: 67530},
 			expr: &actionExpr{
-				pos: position{line: 2223, col: 5, offset: 67458},
+				pos: position{line: 2224, col: 5, offset: 67544},
 				run: (*parser).callonSelection1,
 				expr: &seqExpr{
-					pos: position{line: 2223, col: 5, offset: 67458},
+					pos: position{line: 2224, col: 5, offset: 67544},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2223, col: 5, offset: 67458},
+							pos:   position{line: 2224, col: 5, offset: 67544},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2223, col: 11, offset: 67464},
+								pos:  position{line: 2224, col: 11, offset: 67550},
 								name: "SelectElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2223, col: 22, offset: 67475},
+							pos:   position{line: 2224, col: 22, offset: 67561},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2223, col: 27, offset: 67480},
+								pos: position{line: 2224, col: 27, offset: 67566},
 								expr: &actionExpr{
-									pos: position{line: 2223, col: 29, offset: 67482},
+									pos: position{line: 2224, col: 29, offset: 67568},
 									run: (*parser).callonSelection7,
 									expr: &seqExpr{
-										pos: position{line: 2223, col: 29, offset: 67482},
+										pos: position{line: 2224, col: 29, offset: 67568},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2223, col: 29, offset: 67482},
+												pos:  position{line: 2224, col: 29, offset: 67568},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2223, col: 32, offset: 67485},
+												pos:        position{line: 2224, col: 32, offset: 67571},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2223, col: 36, offset: 67489},
+												pos:  position{line: 2224, col: 36, offset: 67575},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2223, col: 39, offset: 67492},
+												pos:   position{line: 2224, col: 39, offset: 67578},
 												label: "s",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2223, col: 41, offset: 67494},
+													pos:  position{line: 2224, col: 41, offset: 67580},
 													name: "SelectElem",
 												},
 											},
@@ -15155,38 +15168,38 @@ var g = &grammar{
 		},
 		{
 			name: "SelectElem",
-			pos:  position{line: 2231, col: 1, offset: 67699},
+			pos:  position{line: 2232, col: 1, offset: 67785},
 			expr: &choiceExpr{
-				pos: position{line: 2232, col: 5, offset: 67714},
+				pos: position{line: 2233, col: 5, offset: 67800},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2232, col: 5, offset: 67714},
+						pos: position{line: 2233, col: 5, offset: 67800},
 						run: (*parser).callonSelectElem2,
 						expr: &seqExpr{
-							pos: position{line: 2232, col: 5, offset: 67714},
+							pos: position{line: 2233, col: 5, offset: 67800},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2232, col: 5, offset: 67714},
+									pos:   position{line: 2233, col: 5, offset: 67800},
 									label: "expr",
 									expr: &choiceExpr{
-										pos: position{line: 2232, col: 11, offset: 67720},
+										pos: position{line: 2233, col: 11, offset: 67806},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2232, col: 11, offset: 67720},
-												name: "AggDistinct",
+												pos:  position{line: 2233, col: 11, offset: 67806},
+												name: "AggAllOrDistinct",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2232, col: 25, offset: 67734},
+												pos:  position{line: 2233, col: 30, offset: 67825},
 												name: "Expr",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2232, col: 31, offset: 67740},
+									pos:   position{line: 2233, col: 36, offset: 67831},
 									label: "as",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2232, col: 34, offset: 67743},
+										pos:  position{line: 2233, col: 39, offset: 67834},
 										name: "OptAsClause",
 									},
 								},
@@ -15194,10 +15207,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2243, col: 5, offset: 67971},
+						pos: position{line: 2244, col: 5, offset: 68062},
 						run: (*parser).callonSelectElem10,
 						expr: &litMatcher{
-							pos:        position{line: 2243, col: 5, offset: 67971},
+							pos:        position{line: 2244, col: 5, offset: 68062},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -15210,33 +15223,33 @@ var g = &grammar{
 		},
 		{
 			name: "OptAsClause",
-			pos:  position{line: 2248, col: 1, offset: 68076},
+			pos:  position{line: 2249, col: 1, offset: 68167},
 			expr: &choiceExpr{
-				pos: position{line: 2249, col: 5, offset: 68092},
+				pos: position{line: 2250, col: 5, offset: 68183},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2249, col: 5, offset: 68092},
+						pos: position{line: 2250, col: 5, offset: 68183},
 						run: (*parser).callonOptAsClause2,
 						expr: &seqExpr{
-							pos: position{line: 2249, col: 5, offset: 68092},
+							pos: position{line: 2250, col: 5, offset: 68183},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2249, col: 5, offset: 68092},
+									pos:  position{line: 2250, col: 5, offset: 68183},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2249, col: 7, offset: 68094},
+									pos:  position{line: 2250, col: 7, offset: 68185},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2249, col: 10, offset: 68097},
+									pos:  position{line: 2250, col: 10, offset: 68188},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2249, col: 12, offset: 68099},
+									pos:   position{line: 2250, col: 12, offset: 68190},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2249, col: 15, offset: 68102},
+										pos:  position{line: 2250, col: 15, offset: 68193},
 										name: "SQLIdentifier",
 									},
 								},
@@ -15244,27 +15257,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2250, col: 5, offset: 68139},
+						pos: position{line: 2251, col: 5, offset: 68230},
 						run: (*parser).callonOptAsClause9,
 						expr: &seqExpr{
-							pos: position{line: 2250, col: 5, offset: 68139},
+							pos: position{line: 2251, col: 5, offset: 68230},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2250, col: 5, offset: 68139},
+									pos:  position{line: 2251, col: 5, offset: 68230},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 2250, col: 7, offset: 68141},
+									pos: position{line: 2251, col: 7, offset: 68232},
 									expr: &ruleRefExpr{
-										pos:  position{line: 2250, col: 8, offset: 68142},
+										pos:  position{line: 2251, col: 8, offset: 68233},
 										name: "SQLGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2250, col: 17, offset: 68151},
+									pos:   position{line: 2251, col: 17, offset: 68242},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2250, col: 20, offset: 68154},
+										pos:  position{line: 2251, col: 20, offset: 68245},
 										name: "SQLIdentifier",
 									},
 								},
@@ -15272,10 +15285,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2251, col: 5, offset: 68191},
+						pos: position{line: 2252, col: 5, offset: 68282},
 						run: (*parser).callonOptAsClause16,
 						expr: &litMatcher{
-							pos:        position{line: 2251, col: 5, offset: 68191},
+							pos:        position{line: 2252, col: 5, offset: 68282},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15288,41 +15301,41 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrderByClause",
-			pos:  position{line: 2253, col: 1, offset: 68216},
+			pos:  position{line: 2254, col: 1, offset: 68307},
 			expr: &choiceExpr{
-				pos: position{line: 2254, col: 5, offset: 68237},
+				pos: position{line: 2255, col: 5, offset: 68328},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2254, col: 5, offset: 68237},
+						pos: position{line: 2255, col: 5, offset: 68328},
 						run: (*parser).callonOptOrderByClause2,
 						expr: &seqExpr{
-							pos: position{line: 2254, col: 5, offset: 68237},
+							pos: position{line: 2255, col: 5, offset: 68328},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2254, col: 5, offset: 68237},
+									pos:  position{line: 2255, col: 5, offset: 68328},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2254, col: 7, offset: 68239},
+									pos:  position{line: 2255, col: 7, offset: 68330},
 									name: "ORDER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2254, col: 13, offset: 68245},
+									pos:  position{line: 2255, col: 13, offset: 68336},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2254, col: 15, offset: 68247},
+									pos:  position{line: 2255, col: 15, offset: 68338},
 									name: "BY",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2254, col: 18, offset: 68250},
+									pos:  position{line: 2255, col: 18, offset: 68341},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2254, col: 20, offset: 68252},
+									pos:   position{line: 2255, col: 20, offset: 68343},
 									label: "list",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2254, col: 25, offset: 68257},
+										pos:  position{line: 2255, col: 25, offset: 68348},
 										name: "OrderByList",
 									},
 								},
@@ -15330,10 +15343,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2260, col: 5, offset: 68391},
+						pos: position{line: 2261, col: 5, offset: 68482},
 						run: (*parser).callonOptOrderByClause11,
 						expr: &litMatcher{
-							pos:        position{line: 2260, col: 5, offset: 68391},
+							pos:        position{line: 2261, col: 5, offset: 68482},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15346,51 +15359,51 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByList",
-			pos:  position{line: 2262, col: 1, offset: 68424},
+			pos:  position{line: 2263, col: 1, offset: 68515},
 			expr: &actionExpr{
-				pos: position{line: 2263, col: 5, offset: 68440},
+				pos: position{line: 2264, col: 5, offset: 68531},
 				run: (*parser).callonOrderByList1,
 				expr: &seqExpr{
-					pos: position{line: 2263, col: 5, offset: 68440},
+					pos: position{line: 2264, col: 5, offset: 68531},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2263, col: 5, offset: 68440},
+							pos:   position{line: 2264, col: 5, offset: 68531},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2263, col: 11, offset: 68446},
+								pos:  position{line: 2264, col: 11, offset: 68537},
 								name: "OrderByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2263, col: 23, offset: 68458},
+							pos:   position{line: 2264, col: 23, offset: 68549},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2263, col: 28, offset: 68463},
+								pos: position{line: 2264, col: 28, offset: 68554},
 								expr: &actionExpr{
-									pos: position{line: 2263, col: 30, offset: 68465},
+									pos: position{line: 2264, col: 30, offset: 68556},
 									run: (*parser).callonOrderByList7,
 									expr: &seqExpr{
-										pos: position{line: 2263, col: 30, offset: 68465},
+										pos: position{line: 2264, col: 30, offset: 68556},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2263, col: 30, offset: 68465},
+												pos:  position{line: 2264, col: 30, offset: 68556},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2263, col: 33, offset: 68468},
+												pos:        position{line: 2264, col: 33, offset: 68559},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2263, col: 37, offset: 68472},
+												pos:  position{line: 2264, col: 37, offset: 68563},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2263, col: 40, offset: 68475},
+												pos:   position{line: 2264, col: 40, offset: 68566},
 												label: "o",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2263, col: 42, offset: 68477},
+													pos:  position{line: 2264, col: 42, offset: 68568},
 													name: "OrderByItem",
 												},
 											},
@@ -15407,34 +15420,34 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByItem",
-			pos:  position{line: 2267, col: 1, offset: 68578},
+			pos:  position{line: 2268, col: 1, offset: 68669},
 			expr: &actionExpr{
-				pos: position{line: 2268, col: 5, offset: 68594},
+				pos: position{line: 2269, col: 5, offset: 68685},
 				run: (*parser).callonOrderByItem1,
 				expr: &seqExpr{
-					pos: position{line: 2268, col: 5, offset: 68594},
+					pos: position{line: 2269, col: 5, offset: 68685},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2268, col: 5, offset: 68594},
+							pos:   position{line: 2269, col: 5, offset: 68685},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2268, col: 7, offset: 68596},
+								pos:  position{line: 2269, col: 7, offset: 68687},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2268, col: 12, offset: 68601},
+							pos:   position{line: 2269, col: 12, offset: 68692},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2268, col: 18, offset: 68607},
+								pos:  position{line: 2269, col: 18, offset: 68698},
 								name: "OptAscDesc",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2268, col: 29, offset: 68618},
+							pos:   position{line: 2269, col: 29, offset: 68709},
 							label: "nulls",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2268, col: 35, offset: 68624},
+								pos:  position{line: 2269, col: 35, offset: 68715},
 								name: "OptNullsOrder",
 							},
 						},
@@ -15446,49 +15459,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptAscDesc",
-			pos:  position{line: 2279, col: 1, offset: 68856},
+			pos:  position{line: 2280, col: 1, offset: 68947},
 			expr: &choiceExpr{
-				pos: position{line: 2280, col: 5, offset: 68871},
+				pos: position{line: 2281, col: 5, offset: 68962},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2280, col: 5, offset: 68871},
+						pos: position{line: 2281, col: 5, offset: 68962},
 						run: (*parser).callonOptAscDesc2,
 						expr: &seqExpr{
-							pos: position{line: 2280, col: 5, offset: 68871},
+							pos: position{line: 2281, col: 5, offset: 68962},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2280, col: 5, offset: 68871},
+									pos:  position{line: 2281, col: 5, offset: 68962},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2280, col: 7, offset: 68873},
+									pos:  position{line: 2281, col: 7, offset: 68964},
 									name: "ASC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2281, col: 5, offset: 68933},
+						pos: position{line: 2282, col: 5, offset: 69024},
 						run: (*parser).callonOptAscDesc6,
 						expr: &seqExpr{
-							pos: position{line: 2281, col: 5, offset: 68933},
+							pos: position{line: 2282, col: 5, offset: 69024},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2281, col: 5, offset: 68933},
+									pos:  position{line: 2282, col: 5, offset: 69024},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2281, col: 7, offset: 68935},
+									pos:  position{line: 2282, col: 7, offset: 69026},
 									name: "DESC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2282, col: 5, offset: 68995},
+						pos: position{line: 2283, col: 5, offset: 69086},
 						run: (*parser).callonOptAscDesc10,
 						expr: &litMatcher{
-							pos:        position{line: 2282, col: 5, offset: 68995},
+							pos:        position{line: 2283, col: 5, offset: 69086},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15501,65 +15514,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptNullsOrder",
-			pos:  position{line: 2284, col: 1, offset: 69027},
+			pos:  position{line: 2285, col: 1, offset: 69118},
 			expr: &choiceExpr{
-				pos: position{line: 2285, col: 5, offset: 69045},
+				pos: position{line: 2286, col: 5, offset: 69136},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2285, col: 5, offset: 69045},
+						pos: position{line: 2286, col: 5, offset: 69136},
 						run: (*parser).callonOptNullsOrder2,
 						expr: &seqExpr{
-							pos: position{line: 2285, col: 5, offset: 69045},
+							pos: position{line: 2286, col: 5, offset: 69136},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2285, col: 5, offset: 69045},
+									pos:  position{line: 2286, col: 5, offset: 69136},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2285, col: 7, offset: 69047},
+									pos:  position{line: 2286, col: 7, offset: 69138},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2285, col: 13, offset: 69053},
+									pos:  position{line: 2286, col: 13, offset: 69144},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2285, col: 15, offset: 69055},
+									pos:  position{line: 2286, col: 15, offset: 69146},
 									name: "FIRST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2286, col: 5, offset: 69119},
+						pos: position{line: 2287, col: 5, offset: 69210},
 						run: (*parser).callonOptNullsOrder8,
 						expr: &seqExpr{
-							pos: position{line: 2286, col: 5, offset: 69119},
+							pos: position{line: 2287, col: 5, offset: 69210},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2286, col: 5, offset: 69119},
+									pos:  position{line: 2287, col: 5, offset: 69210},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2286, col: 7, offset: 69121},
+									pos:  position{line: 2287, col: 7, offset: 69212},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2286, col: 13, offset: 69127},
+									pos:  position{line: 2287, col: 13, offset: 69218},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2286, col: 15, offset: 69129},
+									pos:  position{line: 2287, col: 15, offset: 69220},
 									name: "LAST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2287, col: 5, offset: 69192},
+						pos: position{line: 2288, col: 5, offset: 69283},
 						run: (*parser).callonOptNullsOrder14,
 						expr: &litMatcher{
-							pos:        position{line: 2287, col: 5, offset: 69192},
+							pos:        position{line: 2288, col: 5, offset: 69283},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15572,25 +15585,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptSQLLimitOffset",
-			pos:  position{line: 2289, col: 1, offset: 69237},
+			pos:  position{line: 2290, col: 1, offset: 69328},
 			expr: &choiceExpr{
-				pos: position{line: 2290, col: 5, offset: 69259},
+				pos: position{line: 2291, col: 5, offset: 69350},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2290, col: 5, offset: 69259},
+						pos: position{line: 2291, col: 5, offset: 69350},
 						run: (*parser).callonOptSQLLimitOffset2,
 						expr: &seqExpr{
-							pos: position{line: 2290, col: 5, offset: 69259},
+							pos: position{line: 2291, col: 5, offset: 69350},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2290, col: 5, offset: 69259},
+									pos:  position{line: 2291, col: 5, offset: 69350},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2290, col: 7, offset: 69261},
+									pos:   position{line: 2291, col: 7, offset: 69352},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2290, col: 10, offset: 69264},
+										pos:  position{line: 2291, col: 10, offset: 69355},
 										name: "SQLLimitOffset",
 									},
 								},
@@ -15598,10 +15611,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2291, col: 5, offset: 69302},
+						pos: position{line: 2292, col: 5, offset: 69393},
 						run: (*parser).callonOptSQLLimitOffset7,
 						expr: &litMatcher{
-							pos:        position{line: 2291, col: 5, offset: 69302},
+							pos:        position{line: 2292, col: 5, offset: 69393},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15614,29 +15627,29 @@ var g = &grammar{
 		},
 		{
 			name: "SQLLimitOffset",
-			pos:  position{line: 2293, col: 1, offset: 69343},
+			pos:  position{line: 2294, col: 1, offset: 69434},
 			expr: &choiceExpr{
-				pos: position{line: 2294, col: 5, offset: 69362},
+				pos: position{line: 2295, col: 5, offset: 69453},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2294, col: 5, offset: 69362},
+						pos: position{line: 2295, col: 5, offset: 69453},
 						run: (*parser).callonSQLLimitOffset2,
 						expr: &seqExpr{
-							pos: position{line: 2294, col: 5, offset: 69362},
+							pos: position{line: 2295, col: 5, offset: 69453},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2294, col: 5, offset: 69362},
+									pos:   position{line: 2295, col: 5, offset: 69453},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2294, col: 7, offset: 69364},
+										pos:  position{line: 2295, col: 7, offset: 69455},
 										name: "LimitClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2294, col: 19, offset: 69376},
+									pos:   position{line: 2295, col: 19, offset: 69467},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2294, col: 21, offset: 69378},
+										pos:  position{line: 2295, col: 21, offset: 69469},
 										name: "OptOffsetClause",
 									},
 								},
@@ -15644,24 +15657,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2306, col: 5, offset: 69610},
+						pos: position{line: 2307, col: 5, offset: 69701},
 						run: (*parser).callonSQLLimitOffset8,
 						expr: &seqExpr{
-							pos: position{line: 2306, col: 5, offset: 69610},
+							pos: position{line: 2307, col: 5, offset: 69701},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2306, col: 5, offset: 69610},
+									pos:   position{line: 2307, col: 5, offset: 69701},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2306, col: 7, offset: 69612},
+										pos:  position{line: 2307, col: 7, offset: 69703},
 										name: "OffsetClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2306, col: 20, offset: 69625},
+									pos:   position{line: 2307, col: 20, offset: 69716},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2306, col: 22, offset: 69627},
+										pos:  position{line: 2307, col: 22, offset: 69718},
 										name: "OptLimitClause",
 									},
 								},
@@ -15675,25 +15688,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptLimitClause",
-			pos:  position{line: 2317, col: 1, offset: 69824},
+			pos:  position{line: 2318, col: 1, offset: 69915},
 			expr: &choiceExpr{
-				pos: position{line: 2318, col: 5, offset: 69843},
+				pos: position{line: 2319, col: 5, offset: 69934},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2318, col: 5, offset: 69843},
+						pos: position{line: 2319, col: 5, offset: 69934},
 						run: (*parser).callonOptLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2318, col: 5, offset: 69843},
+							pos: position{line: 2319, col: 5, offset: 69934},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2318, col: 5, offset: 69843},
+									pos:  position{line: 2319, col: 5, offset: 69934},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2318, col: 7, offset: 69845},
+									pos:   position{line: 2319, col: 7, offset: 69936},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2318, col: 9, offset: 69847},
+										pos:  position{line: 2319, col: 9, offset: 69938},
 										name: "LimitClause",
 									},
 								},
@@ -15701,10 +15714,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2319, col: 5, offset: 69881},
+						pos: position{line: 2320, col: 5, offset: 69972},
 						run: (*parser).callonOptLimitClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2319, col: 5, offset: 69881},
+							pos:        position{line: 2320, col: 5, offset: 69972},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15717,50 +15730,50 @@ var g = &grammar{
 		},
 		{
 			name: "LimitClause",
-			pos:  position{line: 2321, col: 1, offset: 69918},
+			pos:  position{line: 2322, col: 1, offset: 70009},
 			expr: &choiceExpr{
-				pos: position{line: 2322, col: 5, offset: 69934},
+				pos: position{line: 2323, col: 5, offset: 70025},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2322, col: 5, offset: 69934},
+						pos: position{line: 2323, col: 5, offset: 70025},
 						run: (*parser).callonLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2322, col: 5, offset: 69934},
+							pos: position{line: 2323, col: 5, offset: 70025},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2322, col: 5, offset: 69934},
+									pos:  position{line: 2323, col: 5, offset: 70025},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2322, col: 11, offset: 69940},
+									pos:  position{line: 2323, col: 11, offset: 70031},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2322, col: 13, offset: 69942},
+									pos:  position{line: 2323, col: 13, offset: 70033},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2323, col: 5, offset: 69970},
+						pos: position{line: 2324, col: 5, offset: 70061},
 						run: (*parser).callonLimitClause7,
 						expr: &seqExpr{
-							pos: position{line: 2323, col: 5, offset: 69970},
+							pos: position{line: 2324, col: 5, offset: 70061},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2323, col: 5, offset: 69970},
+									pos:  position{line: 2324, col: 5, offset: 70061},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2323, col: 11, offset: 69976},
+									pos:  position{line: 2324, col: 11, offset: 70067},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2323, col: 13, offset: 69978},
+									pos:   position{line: 2324, col: 13, offset: 70069},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2323, col: 15, offset: 69980},
+										pos:  position{line: 2324, col: 15, offset: 70071},
 										name: "Expr",
 									},
 								},
@@ -15774,25 +15787,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptOffsetClause",
-			pos:  position{line: 2325, col: 1, offset: 70004},
+			pos:  position{line: 2326, col: 1, offset: 70095},
 			expr: &choiceExpr{
-				pos: position{line: 2326, col: 5, offset: 70024},
+				pos: position{line: 2327, col: 5, offset: 70115},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2326, col: 5, offset: 70024},
+						pos: position{line: 2327, col: 5, offset: 70115},
 						run: (*parser).callonOptOffsetClause2,
 						expr: &seqExpr{
-							pos: position{line: 2326, col: 5, offset: 70024},
+							pos: position{line: 2327, col: 5, offset: 70115},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2326, col: 5, offset: 70024},
+									pos:  position{line: 2327, col: 5, offset: 70115},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2326, col: 7, offset: 70026},
+									pos:   position{line: 2327, col: 7, offset: 70117},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2326, col: 9, offset: 70028},
+										pos:  position{line: 2327, col: 9, offset: 70119},
 										name: "OffsetClause",
 									},
 								},
@@ -15800,10 +15813,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2327, col: 5, offset: 70064},
+						pos: position{line: 2328, col: 5, offset: 70155},
 						run: (*parser).callonOptOffsetClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2327, col: 5, offset: 70064},
+							pos:        position{line: 2328, col: 5, offset: 70155},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15816,26 +15829,26 @@ var g = &grammar{
 		},
 		{
 			name: "OffsetClause",
-			pos:  position{line: 2329, col: 1, offset: 70089},
+			pos:  position{line: 2330, col: 1, offset: 70180},
 			expr: &actionExpr{
-				pos: position{line: 2330, col: 5, offset: 70106},
+				pos: position{line: 2331, col: 5, offset: 70197},
 				run: (*parser).callonOffsetClause1,
 				expr: &seqExpr{
-					pos: position{line: 2330, col: 5, offset: 70106},
+					pos: position{line: 2331, col: 5, offset: 70197},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2330, col: 5, offset: 70106},
+							pos:  position{line: 2331, col: 5, offset: 70197},
 							name: "OFFSET",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2330, col: 12, offset: 70113},
+							pos:  position{line: 2331, col: 12, offset: 70204},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2330, col: 14, offset: 70115},
+							pos:   position{line: 2331, col: 14, offset: 70206},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2330, col: 16, offset: 70117},
+								pos:  position{line: 2331, col: 16, offset: 70208},
 								name: "Expr",
 							},
 						},
@@ -15847,60 +15860,60 @@ var g = &grammar{
 		},
 		{
 			name: "SetOp",
-			pos:  position{line: 2332, col: 1, offset: 70142},
+			pos:  position{line: 2333, col: 1, offset: 70233},
 			expr: &choiceExpr{
-				pos: position{line: 2333, col: 5, offset: 70152},
+				pos: position{line: 2334, col: 5, offset: 70243},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2333, col: 5, offset: 70152},
+						pos: position{line: 2334, col: 5, offset: 70243},
 						run: (*parser).callonSetOp2,
 						expr: &seqExpr{
-							pos: position{line: 2333, col: 5, offset: 70152},
+							pos: position{line: 2334, col: 5, offset: 70243},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2333, col: 5, offset: 70152},
+									pos:  position{line: 2334, col: 5, offset: 70243},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2333, col: 7, offset: 70154},
+									pos:  position{line: 2334, col: 7, offset: 70245},
 									name: "UNION",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2333, col: 13, offset: 70160},
+									pos:  position{line: 2334, col: 13, offset: 70251},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2333, col: 15, offset: 70162},
+									pos:  position{line: 2334, col: 15, offset: 70253},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2334, col: 5, offset: 70198},
+						pos: position{line: 2335, col: 5, offset: 70289},
 						run: (*parser).callonSetOp8,
 						expr: &seqExpr{
-							pos: position{line: 2334, col: 5, offset: 70198},
+							pos: position{line: 2335, col: 5, offset: 70289},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2334, col: 5, offset: 70198},
+									pos:  position{line: 2335, col: 5, offset: 70289},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2334, col: 7, offset: 70200},
+									pos:  position{line: 2335, col: 7, offset: 70291},
 									name: "UNION",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2334, col: 13, offset: 70206},
+									pos: position{line: 2335, col: 13, offset: 70297},
 									expr: &seqExpr{
-										pos: position{line: 2334, col: 14, offset: 70207},
+										pos: position{line: 2335, col: 14, offset: 70298},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2334, col: 14, offset: 70207},
+												pos:  position{line: 2335, col: 14, offset: 70298},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2334, col: 16, offset: 70209},
+												pos:  position{line: 2335, col: 16, offset: 70300},
 												name: "DISTINCT",
 											},
 										},
@@ -15916,88 +15929,88 @@ var g = &grammar{
 		},
 		{
 			name: "SQLGuard",
-			pos:  position{line: 2337, col: 1, offset: 70261},
+			pos:  position{line: 2338, col: 1, offset: 70352},
 			expr: &choiceExpr{
-				pos: position{line: 2338, col: 5, offset: 70276},
+				pos: position{line: 2339, col: 5, offset: 70367},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2338, col: 5, offset: 70276},
+						pos:  position{line: 2339, col: 5, offset: 70367},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2338, col: 12, offset: 70283},
+						pos:  position{line: 2339, col: 12, offset: 70374},
 						name: "GROUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2338, col: 20, offset: 70291},
+						pos:  position{line: 2339, col: 20, offset: 70382},
 						name: "HAVING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2338, col: 29, offset: 70300},
+						pos:  position{line: 2339, col: 29, offset: 70391},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2338, col: 38, offset: 70309},
+						pos:  position{line: 2339, col: 38, offset: 70400},
 						name: "RECURSIVE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2339, col: 5, offset: 70323},
+						pos:  position{line: 2340, col: 5, offset: 70414},
 						name: "ANTI",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2339, col: 12, offset: 70330},
+						pos:  position{line: 2340, col: 12, offset: 70421},
 						name: "INNER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2339, col: 20, offset: 70338},
+						pos:  position{line: 2340, col: 20, offset: 70429},
 						name: "LEFT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2339, col: 27, offset: 70345},
+						pos:  position{line: 2340, col: 27, offset: 70436},
 						name: "RIGHT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2339, col: 35, offset: 70353},
+						pos:  position{line: 2340, col: 35, offset: 70444},
 						name: "OUTER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2339, col: 43, offset: 70361},
+						pos:  position{line: 2340, col: 43, offset: 70452},
 						name: "CROSS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2339, col: 51, offset: 70369},
+						pos:  position{line: 2340, col: 51, offset: 70460},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2340, col: 5, offset: 70378},
+						pos:  position{line: 2341, col: 5, offset: 70469},
 						name: "UNION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2341, col: 5, offset: 70388},
+						pos:  position{line: 2342, col: 5, offset: 70479},
 						name: "ORDER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2342, col: 5, offset: 70398},
+						pos:  position{line: 2343, col: 5, offset: 70489},
 						name: "OFFSET",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2343, col: 5, offset: 70409},
+						pos:  position{line: 2344, col: 5, offset: 70500},
 						name: "LIMIT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2344, col: 5, offset: 70419},
+						pos:  position{line: 2345, col: 5, offset: 70510},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2345, col: 5, offset: 70429},
+						pos:  position{line: 2346, col: 5, offset: 70520},
 						name: "WITH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2346, col: 5, offset: 70438},
+						pos:  position{line: 2347, col: 5, offset: 70529},
 						name: "USING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2347, col: 5, offset: 70448},
+						pos:  position{line: 2348, col: 5, offset: 70539},
 						name: "ON",
 					},
 				},
@@ -16007,20 +16020,20 @@ var g = &grammar{
 		},
 		{
 			name: "AGGREGATE",
-			pos:  position{line: 2349, col: 1, offset: 70452},
+			pos:  position{line: 2350, col: 1, offset: 70543},
 			expr: &seqExpr{
-				pos: position{line: 2349, col: 14, offset: 70465},
+				pos: position{line: 2350, col: 14, offset: 70556},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2349, col: 14, offset: 70465},
+						pos:        position{line: 2350, col: 14, offset: 70556},
 						val:        "aggregate",
 						ignoreCase: true,
 						want:       "\"AGGREGATE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2349, col: 33, offset: 70484},
+						pos: position{line: 2350, col: 33, offset: 70575},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2349, col: 34, offset: 70485},
+							pos:  position{line: 2350, col: 34, offset: 70576},
 							name: "IdentifierRest",
 						},
 					},
@@ -16031,20 +16044,20 @@ var g = &grammar{
 		},
 		{
 			name: "ALL",
-			pos:  position{line: 2350, col: 1, offset: 70500},
+			pos:  position{line: 2351, col: 1, offset: 70591},
 			expr: &seqExpr{
-				pos: position{line: 2350, col: 14, offset: 70513},
+				pos: position{line: 2351, col: 14, offset: 70604},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2350, col: 14, offset: 70513},
+						pos:        position{line: 2351, col: 14, offset: 70604},
 						val:        "all",
 						ignoreCase: true,
 						want:       "\"ALL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2350, col: 33, offset: 70532},
+						pos: position{line: 2351, col: 33, offset: 70623},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2350, col: 34, offset: 70533},
+							pos:  position{line: 2351, col: 34, offset: 70624},
 							name: "IdentifierRest",
 						},
 					},
@@ -16055,23 +16068,23 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 2351, col: 1, offset: 70548},
+			pos:  position{line: 2352, col: 1, offset: 70639},
 			expr: &actionExpr{
-				pos: position{line: 2351, col: 14, offset: 70561},
+				pos: position{line: 2352, col: 14, offset: 70652},
 				run: (*parser).callonAND1,
 				expr: &seqExpr{
-					pos: position{line: 2351, col: 14, offset: 70561},
+					pos: position{line: 2352, col: 14, offset: 70652},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2351, col: 14, offset: 70561},
+							pos:        position{line: 2352, col: 14, offset: 70652},
 							val:        "and",
 							ignoreCase: true,
 							want:       "\"AND\"i",
 						},
 						&notExpr{
-							pos: position{line: 2351, col: 33, offset: 70580},
+							pos: position{line: 2352, col: 33, offset: 70671},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2351, col: 34, offset: 70581},
+								pos:  position{line: 2352, col: 34, offset: 70672},
 								name: "IdentifierRest",
 							},
 						},
@@ -16083,20 +16096,20 @@ var g = &grammar{
 		},
 		{
 			name: "ANTI",
-			pos:  position{line: 2352, col: 1, offset: 70618},
+			pos:  position{line: 2353, col: 1, offset: 70709},
 			expr: &seqExpr{
-				pos: position{line: 2352, col: 14, offset: 70631},
+				pos: position{line: 2353, col: 14, offset: 70722},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2352, col: 14, offset: 70631},
+						pos:        position{line: 2353, col: 14, offset: 70722},
 						val:        "anti",
 						ignoreCase: true,
 						want:       "\"ANTI\"i",
 					},
 					&notExpr{
-						pos: position{line: 2352, col: 33, offset: 70650},
+						pos: position{line: 2353, col: 33, offset: 70741},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2352, col: 34, offset: 70651},
+							pos:  position{line: 2353, col: 34, offset: 70742},
 							name: "IdentifierRest",
 						},
 					},
@@ -16107,20 +16120,20 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 2353, col: 1, offset: 70666},
+			pos:  position{line: 2354, col: 1, offset: 70757},
 			expr: &seqExpr{
-				pos: position{line: 2353, col: 14, offset: 70679},
+				pos: position{line: 2354, col: 14, offset: 70770},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2353, col: 14, offset: 70679},
+						pos:        position{line: 2354, col: 14, offset: 70770},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2353, col: 33, offset: 70698},
+						pos: position{line: 2354, col: 33, offset: 70789},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2353, col: 34, offset: 70699},
+							pos:  position{line: 2354, col: 34, offset: 70790},
 							name: "IdentifierRest",
 						},
 					},
@@ -16131,23 +16144,23 @@ var g = &grammar{
 		},
 		{
 			name: "ASC",
-			pos:  position{line: 2354, col: 1, offset: 70714},
+			pos:  position{line: 2355, col: 1, offset: 70805},
 			expr: &actionExpr{
-				pos: position{line: 2354, col: 14, offset: 70727},
+				pos: position{line: 2355, col: 14, offset: 70818},
 				run: (*parser).callonASC1,
 				expr: &seqExpr{
-					pos: position{line: 2354, col: 14, offset: 70727},
+					pos: position{line: 2355, col: 14, offset: 70818},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2354, col: 14, offset: 70727},
+							pos:        position{line: 2355, col: 14, offset: 70818},
 							val:        "asc",
 							ignoreCase: true,
 							want:       "\"ASC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2354, col: 33, offset: 70746},
+							pos: position{line: 2355, col: 33, offset: 70837},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2354, col: 34, offset: 70747},
+								pos:  position{line: 2355, col: 34, offset: 70838},
 								name: "IdentifierRest",
 							},
 						},
@@ -16159,20 +16172,20 @@ var g = &grammar{
 		},
 		{
 			name: "ASSERT",
-			pos:  position{line: 2355, col: 1, offset: 70784},
+			pos:  position{line: 2356, col: 1, offset: 70875},
 			expr: &seqExpr{
-				pos: position{line: 2355, col: 14, offset: 70797},
+				pos: position{line: 2356, col: 14, offset: 70888},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2355, col: 14, offset: 70797},
+						pos:        position{line: 2356, col: 14, offset: 70888},
 						val:        "assert",
 						ignoreCase: true,
 						want:       "\"ASSERT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2355, col: 33, offset: 70816},
+						pos: position{line: 2356, col: 33, offset: 70907},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2355, col: 34, offset: 70817},
+							pos:  position{line: 2356, col: 34, offset: 70908},
 							name: "IdentifierRest",
 						},
 					},
@@ -16183,20 +16196,20 @@ var g = &grammar{
 		},
 		{
 			name: "AT",
-			pos:  position{line: 2356, col: 1, offset: 70832},
+			pos:  position{line: 2357, col: 1, offset: 70923},
 			expr: &seqExpr{
-				pos: position{line: 2356, col: 14, offset: 70845},
+				pos: position{line: 2357, col: 14, offset: 70936},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2356, col: 14, offset: 70845},
+						pos:        position{line: 2357, col: 14, offset: 70936},
 						val:        "at",
 						ignoreCase: true,
 						want:       "\"AT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2356, col: 33, offset: 70864},
+						pos: position{line: 2357, col: 33, offset: 70955},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2356, col: 34, offset: 70865},
+							pos:  position{line: 2357, col: 34, offset: 70956},
 							name: "IdentifierRest",
 						},
 					},
@@ -16207,20 +16220,20 @@ var g = &grammar{
 		},
 		{
 			name: "BETWEEN",
-			pos:  position{line: 2357, col: 1, offset: 70880},
+			pos:  position{line: 2358, col: 1, offset: 70971},
 			expr: &seqExpr{
-				pos: position{line: 2357, col: 14, offset: 70893},
+				pos: position{line: 2358, col: 14, offset: 70984},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2357, col: 14, offset: 70893},
+						pos:        position{line: 2358, col: 14, offset: 70984},
 						val:        "between",
 						ignoreCase: true,
 						want:       "\"BETWEEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2357, col: 33, offset: 70912},
+						pos: position{line: 2358, col: 33, offset: 71003},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2357, col: 34, offset: 70913},
+							pos:  position{line: 2358, col: 34, offset: 71004},
 							name: "IdentifierRest",
 						},
 					},
@@ -16231,20 +16244,20 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 2358, col: 1, offset: 70928},
+			pos:  position{line: 2359, col: 1, offset: 71019},
 			expr: &seqExpr{
-				pos: position{line: 2358, col: 14, offset: 70941},
+				pos: position{line: 2359, col: 14, offset: 71032},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2358, col: 14, offset: 70941},
+						pos:        position{line: 2359, col: 14, offset: 71032},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2358, col: 33, offset: 70960},
+						pos: position{line: 2359, col: 33, offset: 71051},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2358, col: 34, offset: 70961},
+							pos:  position{line: 2359, col: 34, offset: 71052},
 							name: "IdentifierRest",
 						},
 					},
@@ -16255,20 +16268,20 @@ var g = &grammar{
 		},
 		{
 			name: "CALL",
-			pos:  position{line: 2359, col: 1, offset: 70976},
+			pos:  position{line: 2360, col: 1, offset: 71067},
 			expr: &seqExpr{
-				pos: position{line: 2359, col: 14, offset: 70989},
+				pos: position{line: 2360, col: 14, offset: 71080},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2359, col: 14, offset: 70989},
+						pos:        position{line: 2360, col: 14, offset: 71080},
 						val:        "call",
 						ignoreCase: true,
 						want:       "\"CALL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2359, col: 33, offset: 71008},
+						pos: position{line: 2360, col: 33, offset: 71099},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2359, col: 34, offset: 71009},
+							pos:  position{line: 2360, col: 34, offset: 71100},
 							name: "IdentifierRest",
 						},
 					},
@@ -16279,20 +16292,20 @@ var g = &grammar{
 		},
 		{
 			name: "CASE",
-			pos:  position{line: 2360, col: 1, offset: 71024},
+			pos:  position{line: 2361, col: 1, offset: 71115},
 			expr: &seqExpr{
-				pos: position{line: 2360, col: 14, offset: 71037},
+				pos: position{line: 2361, col: 14, offset: 71128},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2360, col: 14, offset: 71037},
+						pos:        position{line: 2361, col: 14, offset: 71128},
 						val:        "case",
 						ignoreCase: true,
 						want:       "\"CASE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2360, col: 33, offset: 71056},
+						pos: position{line: 2361, col: 33, offset: 71147},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2360, col: 34, offset: 71057},
+							pos:  position{line: 2361, col: 34, offset: 71148},
 							name: "IdentifierRest",
 						},
 					},
@@ -16303,20 +16316,20 @@ var g = &grammar{
 		},
 		{
 			name: "CAST",
-			pos:  position{line: 2361, col: 1, offset: 71072},
+			pos:  position{line: 2362, col: 1, offset: 71163},
 			expr: &seqExpr{
-				pos: position{line: 2361, col: 14, offset: 71085},
+				pos: position{line: 2362, col: 14, offset: 71176},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2361, col: 14, offset: 71085},
+						pos:        position{line: 2362, col: 14, offset: 71176},
 						val:        "cast",
 						ignoreCase: true,
 						want:       "\"CAST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2361, col: 33, offset: 71104},
+						pos: position{line: 2362, col: 33, offset: 71195},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2361, col: 34, offset: 71105},
+							pos:  position{line: 2362, col: 34, offset: 71196},
 							name: "IdentifierRest",
 						},
 					},
@@ -16327,20 +16340,20 @@ var g = &grammar{
 		},
 		{
 			name: "CONST",
-			pos:  position{line: 2362, col: 1, offset: 71120},
+			pos:  position{line: 2363, col: 1, offset: 71211},
 			expr: &seqExpr{
-				pos: position{line: 2362, col: 14, offset: 71133},
+				pos: position{line: 2363, col: 14, offset: 71224},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2362, col: 14, offset: 71133},
+						pos:        position{line: 2363, col: 14, offset: 71224},
 						val:        "const",
 						ignoreCase: true,
 						want:       "\"CONST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2362, col: 33, offset: 71152},
+						pos: position{line: 2363, col: 33, offset: 71243},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2362, col: 34, offset: 71153},
+							pos:  position{line: 2363, col: 34, offset: 71244},
 							name: "IdentifierRest",
 						},
 					},
@@ -16351,20 +16364,20 @@ var g = &grammar{
 		},
 		{
 			name: "COUNT",
-			pos:  position{line: 2363, col: 1, offset: 71168},
+			pos:  position{line: 2364, col: 1, offset: 71259},
 			expr: &seqExpr{
-				pos: position{line: 2363, col: 14, offset: 71181},
+				pos: position{line: 2364, col: 14, offset: 71272},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2363, col: 14, offset: 71181},
+						pos:        position{line: 2364, col: 14, offset: 71272},
 						val:        "count",
 						ignoreCase: true,
 						want:       "\"COUNT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2363, col: 33, offset: 71200},
+						pos: position{line: 2364, col: 33, offset: 71291},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2363, col: 34, offset: 71201},
+							pos:  position{line: 2364, col: 34, offset: 71292},
 							name: "IdentifierRest",
 						},
 					},
@@ -16375,20 +16388,20 @@ var g = &grammar{
 		},
 		{
 			name: "CROSS",
-			pos:  position{line: 2364, col: 1, offset: 71216},
+			pos:  position{line: 2365, col: 1, offset: 71307},
 			expr: &seqExpr{
-				pos: position{line: 2364, col: 14, offset: 71229},
+				pos: position{line: 2365, col: 14, offset: 71320},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2364, col: 14, offset: 71229},
+						pos:        position{line: 2365, col: 14, offset: 71320},
 						val:        "cross",
 						ignoreCase: true,
 						want:       "\"CROSS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2364, col: 33, offset: 71248},
+						pos: position{line: 2365, col: 33, offset: 71339},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2364, col: 34, offset: 71249},
+							pos:  position{line: 2365, col: 34, offset: 71340},
 							name: "IdentifierRest",
 						},
 					},
@@ -16399,20 +16412,20 @@ var g = &grammar{
 		},
 		{
 			name: "CUT",
-			pos:  position{line: 2365, col: 1, offset: 71264},
+			pos:  position{line: 2366, col: 1, offset: 71355},
 			expr: &seqExpr{
-				pos: position{line: 2365, col: 14, offset: 71277},
+				pos: position{line: 2366, col: 14, offset: 71368},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2365, col: 14, offset: 71277},
+						pos:        position{line: 2366, col: 14, offset: 71368},
 						val:        "cut",
 						ignoreCase: true,
 						want:       "\"CUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2365, col: 33, offset: 71296},
+						pos: position{line: 2366, col: 33, offset: 71387},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2365, col: 34, offset: 71297},
+							pos:  position{line: 2366, col: 34, offset: 71388},
 							name: "IdentifierRest",
 						},
 					},
@@ -16423,23 +16436,23 @@ var g = &grammar{
 		},
 		{
 			name: "DATE",
-			pos:  position{line: 2366, col: 1, offset: 71312},
+			pos:  position{line: 2367, col: 1, offset: 71403},
 			expr: &actionExpr{
-				pos: position{line: 2366, col: 14, offset: 71325},
+				pos: position{line: 2367, col: 14, offset: 71416},
 				run: (*parser).callonDATE1,
 				expr: &seqExpr{
-					pos: position{line: 2366, col: 14, offset: 71325},
+					pos: position{line: 2367, col: 14, offset: 71416},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2366, col: 14, offset: 71325},
+							pos:        position{line: 2367, col: 14, offset: 71416},
 							val:        "date",
 							ignoreCase: true,
 							want:       "\"DATE\"i",
 						},
 						&notExpr{
-							pos: position{line: 2366, col: 33, offset: 71344},
+							pos: position{line: 2367, col: 33, offset: 71435},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2366, col: 34, offset: 71345},
+								pos:  position{line: 2367, col: 34, offset: 71436},
 								name: "IdentifierRest",
 							},
 						},
@@ -16451,20 +16464,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEBUG",
-			pos:  position{line: 2367, col: 1, offset: 71383},
+			pos:  position{line: 2368, col: 1, offset: 71474},
 			expr: &seqExpr{
-				pos: position{line: 2367, col: 14, offset: 71396},
+				pos: position{line: 2368, col: 14, offset: 71487},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2367, col: 14, offset: 71396},
+						pos:        position{line: 2368, col: 14, offset: 71487},
 						val:        "debug",
 						ignoreCase: true,
 						want:       "\"DEBUG\"i",
 					},
 					&notExpr{
-						pos: position{line: 2367, col: 33, offset: 71415},
+						pos: position{line: 2368, col: 33, offset: 71506},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2367, col: 34, offset: 71416},
+							pos:  position{line: 2368, col: 34, offset: 71507},
 							name: "IdentifierRest",
 						},
 					},
@@ -16475,20 +16488,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEFAULT",
-			pos:  position{line: 2368, col: 1, offset: 71431},
+			pos:  position{line: 2369, col: 1, offset: 71522},
 			expr: &seqExpr{
-				pos: position{line: 2368, col: 14, offset: 71444},
+				pos: position{line: 2369, col: 14, offset: 71535},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2368, col: 14, offset: 71444},
+						pos:        position{line: 2369, col: 14, offset: 71535},
 						val:        "default",
 						ignoreCase: true,
 						want:       "\"DEFAULT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2368, col: 33, offset: 71463},
+						pos: position{line: 2369, col: 33, offset: 71554},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2368, col: 34, offset: 71464},
+							pos:  position{line: 2369, col: 34, offset: 71555},
 							name: "IdentifierRest",
 						},
 					},
@@ -16499,23 +16512,23 @@ var g = &grammar{
 		},
 		{
 			name: "DESC",
-			pos:  position{line: 2369, col: 1, offset: 71479},
+			pos:  position{line: 2370, col: 1, offset: 71570},
 			expr: &actionExpr{
-				pos: position{line: 2369, col: 14, offset: 71492},
+				pos: position{line: 2370, col: 14, offset: 71583},
 				run: (*parser).callonDESC1,
 				expr: &seqExpr{
-					pos: position{line: 2369, col: 14, offset: 71492},
+					pos: position{line: 2370, col: 14, offset: 71583},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2369, col: 14, offset: 71492},
+							pos:        position{line: 2370, col: 14, offset: 71583},
 							val:        "desc",
 							ignoreCase: true,
 							want:       "\"DESC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2369, col: 33, offset: 71511},
+							pos: position{line: 2370, col: 33, offset: 71602},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2369, col: 34, offset: 71512},
+								pos:  position{line: 2370, col: 34, offset: 71603},
 								name: "IdentifierRest",
 							},
 						},
@@ -16527,20 +16540,20 @@ var g = &grammar{
 		},
 		{
 			name: "DISTINCT",
-			pos:  position{line: 2370, col: 1, offset: 71550},
+			pos:  position{line: 2371, col: 1, offset: 71641},
 			expr: &seqExpr{
-				pos: position{line: 2370, col: 14, offset: 71563},
+				pos: position{line: 2371, col: 14, offset: 71654},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2370, col: 14, offset: 71563},
+						pos:        position{line: 2371, col: 14, offset: 71654},
 						val:        "distinct",
 						ignoreCase: true,
 						want:       "\"DISTINCT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2370, col: 33, offset: 71582},
+						pos: position{line: 2371, col: 33, offset: 71673},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2370, col: 34, offset: 71583},
+							pos:  position{line: 2371, col: 34, offset: 71674},
 							name: "IdentifierRest",
 						},
 					},
@@ -16551,20 +16564,20 @@ var g = &grammar{
 		},
 		{
 			name: "DROP",
-			pos:  position{line: 2371, col: 1, offset: 71598},
+			pos:  position{line: 2372, col: 1, offset: 71689},
 			expr: &seqExpr{
-				pos: position{line: 2371, col: 14, offset: 71611},
+				pos: position{line: 2372, col: 14, offset: 71702},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2371, col: 14, offset: 71611},
+						pos:        position{line: 2372, col: 14, offset: 71702},
 						val:        "drop",
 						ignoreCase: true,
 						want:       "\"DROP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2371, col: 33, offset: 71630},
+						pos: position{line: 2372, col: 33, offset: 71721},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2371, col: 34, offset: 71631},
+							pos:  position{line: 2372, col: 34, offset: 71722},
 							name: "IdentifierRest",
 						},
 					},
@@ -16575,20 +16588,20 @@ var g = &grammar{
 		},
 		{
 			name: "ELSE",
-			pos:  position{line: 2372, col: 1, offset: 71646},
+			pos:  position{line: 2373, col: 1, offset: 71737},
 			expr: &seqExpr{
-				pos: position{line: 2372, col: 14, offset: 71659},
+				pos: position{line: 2373, col: 14, offset: 71750},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2372, col: 14, offset: 71659},
+						pos:        position{line: 2373, col: 14, offset: 71750},
 						val:        "else",
 						ignoreCase: true,
 						want:       "\"ELSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2372, col: 33, offset: 71678},
+						pos: position{line: 2373, col: 33, offset: 71769},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2372, col: 34, offset: 71679},
+							pos:  position{line: 2373, col: 34, offset: 71770},
 							name: "IdentifierRest",
 						},
 					},
@@ -16599,20 +16612,20 @@ var g = &grammar{
 		},
 		{
 			name: "END",
-			pos:  position{line: 2373, col: 1, offset: 71694},
+			pos:  position{line: 2374, col: 1, offset: 71785},
 			expr: &seqExpr{
-				pos: position{line: 2373, col: 14, offset: 71707},
+				pos: position{line: 2374, col: 14, offset: 71798},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2373, col: 14, offset: 71707},
+						pos:        position{line: 2374, col: 14, offset: 71798},
 						val:        "end",
 						ignoreCase: true,
 						want:       "\"END\"i",
 					},
 					&notExpr{
-						pos: position{line: 2373, col: 33, offset: 71726},
+						pos: position{line: 2374, col: 33, offset: 71817},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2373, col: 34, offset: 71727},
+							pos:  position{line: 2374, col: 34, offset: 71818},
 							name: "IdentifierRest",
 						},
 					},
@@ -16623,20 +16636,20 @@ var g = &grammar{
 		},
 		{
 			name: "ENUM",
-			pos:  position{line: 2374, col: 1, offset: 71742},
+			pos:  position{line: 2375, col: 1, offset: 71833},
 			expr: &seqExpr{
-				pos: position{line: 2374, col: 14, offset: 71755},
+				pos: position{line: 2375, col: 14, offset: 71846},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2374, col: 14, offset: 71755},
+						pos:        position{line: 2375, col: 14, offset: 71846},
 						val:        "enum",
 						ignoreCase: true,
 						want:       "\"ENUM\"i",
 					},
 					&notExpr{
-						pos: position{line: 2374, col: 33, offset: 71774},
+						pos: position{line: 2375, col: 33, offset: 71865},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2374, col: 34, offset: 71775},
+							pos:  position{line: 2375, col: 34, offset: 71866},
 							name: "IdentifierRest",
 						},
 					},
@@ -16647,20 +16660,20 @@ var g = &grammar{
 		},
 		{
 			name: "ERROR",
-			pos:  position{line: 2375, col: 1, offset: 71790},
+			pos:  position{line: 2376, col: 1, offset: 71881},
 			expr: &seqExpr{
-				pos: position{line: 2375, col: 14, offset: 71803},
+				pos: position{line: 2376, col: 14, offset: 71894},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2375, col: 14, offset: 71803},
+						pos:        position{line: 2376, col: 14, offset: 71894},
 						val:        "error",
 						ignoreCase: true,
 						want:       "\"ERROR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2375, col: 33, offset: 71822},
+						pos: position{line: 2376, col: 33, offset: 71913},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2375, col: 34, offset: 71823},
+							pos:  position{line: 2376, col: 34, offset: 71914},
 							name: "IdentifierRest",
 						},
 					},
@@ -16671,20 +16684,20 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL",
-			pos:  position{line: 2376, col: 1, offset: 71838},
+			pos:  position{line: 2377, col: 1, offset: 71929},
 			expr: &seqExpr{
-				pos: position{line: 2376, col: 14, offset: 71851},
+				pos: position{line: 2377, col: 14, offset: 71942},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2376, col: 14, offset: 71851},
+						pos:        position{line: 2377, col: 14, offset: 71942},
 						val:        "eval",
 						ignoreCase: true,
 						want:       "\"EVAL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2376, col: 33, offset: 71870},
+						pos: position{line: 2377, col: 33, offset: 71961},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2376, col: 34, offset: 71871},
+							pos:  position{line: 2377, col: 34, offset: 71962},
 							name: "IdentifierRest",
 						},
 					},
@@ -16695,20 +16708,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXISTS",
-			pos:  position{line: 2377, col: 1, offset: 71886},
+			pos:  position{line: 2378, col: 1, offset: 71977},
 			expr: &seqExpr{
-				pos: position{line: 2377, col: 14, offset: 71899},
+				pos: position{line: 2378, col: 14, offset: 71990},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2377, col: 14, offset: 71899},
+						pos:        position{line: 2378, col: 14, offset: 71990},
 						val:        "exists",
 						ignoreCase: true,
 						want:       "\"EXISTS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2377, col: 33, offset: 71918},
+						pos: position{line: 2378, col: 33, offset: 72009},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2377, col: 34, offset: 71919},
+							pos:  position{line: 2378, col: 34, offset: 72010},
 							name: "IdentifierRest",
 						},
 					},
@@ -16719,20 +16732,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXPLODE",
-			pos:  position{line: 2378, col: 1, offset: 71934},
+			pos:  position{line: 2379, col: 1, offset: 72025},
 			expr: &seqExpr{
-				pos: position{line: 2378, col: 14, offset: 71947},
+				pos: position{line: 2379, col: 14, offset: 72038},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2378, col: 14, offset: 71947},
+						pos:        position{line: 2379, col: 14, offset: 72038},
 						val:        "explode",
 						ignoreCase: true,
 						want:       "\"EXPLODE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2378, col: 33, offset: 71966},
+						pos: position{line: 2379, col: 33, offset: 72057},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2378, col: 34, offset: 71967},
+							pos:  position{line: 2379, col: 34, offset: 72058},
 							name: "IdentifierRest",
 						},
 					},
@@ -16743,20 +16756,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXTRACT",
-			pos:  position{line: 2379, col: 1, offset: 71982},
+			pos:  position{line: 2380, col: 1, offset: 72073},
 			expr: &seqExpr{
-				pos: position{line: 2379, col: 14, offset: 71995},
+				pos: position{line: 2380, col: 14, offset: 72086},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2379, col: 14, offset: 71995},
+						pos:        position{line: 2380, col: 14, offset: 72086},
 						val:        "extract",
 						ignoreCase: true,
 						want:       "\"EXTRACT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2379, col: 33, offset: 72014},
+						pos: position{line: 2380, col: 33, offset: 72105},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2379, col: 34, offset: 72015},
+							pos:  position{line: 2380, col: 34, offset: 72106},
 							name: "IdentifierRest",
 						},
 					},
@@ -16767,20 +16780,20 @@ var g = &grammar{
 		},
 		{
 			name: "FALSE",
-			pos:  position{line: 2380, col: 1, offset: 72030},
+			pos:  position{line: 2381, col: 1, offset: 72121},
 			expr: &seqExpr{
-				pos: position{line: 2380, col: 14, offset: 72043},
+				pos: position{line: 2381, col: 14, offset: 72134},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2380, col: 14, offset: 72043},
+						pos:        position{line: 2381, col: 14, offset: 72134},
 						val:        "false",
 						ignoreCase: true,
 						want:       "\"FALSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2380, col: 33, offset: 72062},
+						pos: position{line: 2381, col: 33, offset: 72153},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2380, col: 34, offset: 72063},
+							pos:  position{line: 2381, col: 34, offset: 72154},
 							name: "IdentifierRest",
 						},
 					},
@@ -16791,20 +16804,20 @@ var g = &grammar{
 		},
 		{
 			name: "FIRST",
-			pos:  position{line: 2381, col: 1, offset: 72078},
+			pos:  position{line: 2382, col: 1, offset: 72169},
 			expr: &seqExpr{
-				pos: position{line: 2381, col: 14, offset: 72091},
+				pos: position{line: 2382, col: 14, offset: 72182},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2381, col: 14, offset: 72091},
+						pos:        position{line: 2382, col: 14, offset: 72182},
 						val:        "first",
 						ignoreCase: true,
 						want:       "\"FIRST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2381, col: 33, offset: 72110},
+						pos: position{line: 2382, col: 33, offset: 72201},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2381, col: 34, offset: 72111},
+							pos:  position{line: 2382, col: 34, offset: 72202},
 							name: "IdentifierRest",
 						},
 					},
@@ -16815,20 +16828,20 @@ var g = &grammar{
 		},
 		{
 			name: "FN",
-			pos:  position{line: 2382, col: 1, offset: 72126},
+			pos:  position{line: 2383, col: 1, offset: 72217},
 			expr: &seqExpr{
-				pos: position{line: 2382, col: 14, offset: 72139},
+				pos: position{line: 2383, col: 14, offset: 72230},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2382, col: 14, offset: 72139},
+						pos:        position{line: 2383, col: 14, offset: 72230},
 						val:        "fn",
 						ignoreCase: true,
 						want:       "\"FN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2382, col: 33, offset: 72158},
+						pos: position{line: 2383, col: 33, offset: 72249},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2382, col: 34, offset: 72159},
+							pos:  position{line: 2383, col: 34, offset: 72250},
 							name: "IdentifierRest",
 						},
 					},
@@ -16839,20 +16852,20 @@ var g = &grammar{
 		},
 		{
 			name: "FOR",
-			pos:  position{line: 2383, col: 1, offset: 72174},
+			pos:  position{line: 2384, col: 1, offset: 72265},
 			expr: &seqExpr{
-				pos: position{line: 2383, col: 14, offset: 72187},
+				pos: position{line: 2384, col: 14, offset: 72278},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2383, col: 14, offset: 72187},
+						pos:        position{line: 2384, col: 14, offset: 72278},
 						val:        "for",
 						ignoreCase: true,
 						want:       "\"FOR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2383, col: 33, offset: 72206},
+						pos: position{line: 2384, col: 33, offset: 72297},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2383, col: 34, offset: 72207},
+							pos:  position{line: 2384, col: 34, offset: 72298},
 							name: "IdentifierRest",
 						},
 					},
@@ -16863,20 +16876,20 @@ var g = &grammar{
 		},
 		{
 			name: "FORK",
-			pos:  position{line: 2384, col: 1, offset: 72222},
+			pos:  position{line: 2385, col: 1, offset: 72313},
 			expr: &seqExpr{
-				pos: position{line: 2384, col: 14, offset: 72235},
+				pos: position{line: 2385, col: 14, offset: 72326},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2384, col: 14, offset: 72235},
+						pos:        position{line: 2385, col: 14, offset: 72326},
 						val:        "fork",
 						ignoreCase: true,
 						want:       "\"FORK\"i",
 					},
 					&notExpr{
-						pos: position{line: 2384, col: 33, offset: 72254},
+						pos: position{line: 2385, col: 33, offset: 72345},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2384, col: 34, offset: 72255},
+							pos:  position{line: 2385, col: 34, offset: 72346},
 							name: "IdentifierRest",
 						},
 					},
@@ -16887,20 +16900,20 @@ var g = &grammar{
 		},
 		{
 			name: "FROM",
-			pos:  position{line: 2385, col: 1, offset: 72270},
+			pos:  position{line: 2386, col: 1, offset: 72361},
 			expr: &seqExpr{
-				pos: position{line: 2385, col: 14, offset: 72283},
+				pos: position{line: 2386, col: 14, offset: 72374},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2385, col: 14, offset: 72283},
+						pos:        position{line: 2386, col: 14, offset: 72374},
 						val:        "from",
 						ignoreCase: true,
 						want:       "\"FROM\"i",
 					},
 					&notExpr{
-						pos: position{line: 2385, col: 33, offset: 72302},
+						pos: position{line: 2386, col: 33, offset: 72393},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2385, col: 34, offset: 72303},
+							pos:  position{line: 2386, col: 34, offset: 72394},
 							name: "IdentifierRest",
 						},
 					},
@@ -16911,20 +16924,20 @@ var g = &grammar{
 		},
 		{
 			name: "FULL",
-			pos:  position{line: 2386, col: 1, offset: 72318},
+			pos:  position{line: 2387, col: 1, offset: 72409},
 			expr: &seqExpr{
-				pos: position{line: 2386, col: 14, offset: 72331},
+				pos: position{line: 2387, col: 14, offset: 72422},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2386, col: 14, offset: 72331},
+						pos:        position{line: 2387, col: 14, offset: 72422},
 						val:        "full",
 						ignoreCase: true,
 						want:       "\"FULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2386, col: 33, offset: 72350},
+						pos: position{line: 2387, col: 33, offset: 72441},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2386, col: 34, offset: 72351},
+							pos:  position{line: 2387, col: 34, offset: 72442},
 							name: "IdentifierRest",
 						},
 					},
@@ -16935,20 +16948,20 @@ var g = &grammar{
 		},
 		{
 			name: "FUSE",
-			pos:  position{line: 2387, col: 1, offset: 72366},
+			pos:  position{line: 2388, col: 1, offset: 72457},
 			expr: &seqExpr{
-				pos: position{line: 2387, col: 14, offset: 72379},
+				pos: position{line: 2388, col: 14, offset: 72470},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2387, col: 14, offset: 72379},
+						pos:        position{line: 2388, col: 14, offset: 72470},
 						val:        "fuse",
 						ignoreCase: true,
 						want:       "\"FUSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2387, col: 33, offset: 72398},
+						pos: position{line: 2388, col: 33, offset: 72489},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2387, col: 34, offset: 72399},
+							pos:  position{line: 2388, col: 34, offset: 72490},
 							name: "IdentifierRest",
 						},
 					},
@@ -16959,20 +16972,20 @@ var g = &grammar{
 		},
 		{
 			name: "GROUP",
-			pos:  position{line: 2388, col: 1, offset: 72414},
+			pos:  position{line: 2389, col: 1, offset: 72505},
 			expr: &seqExpr{
-				pos: position{line: 2388, col: 14, offset: 72427},
+				pos: position{line: 2389, col: 14, offset: 72518},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2388, col: 14, offset: 72427},
+						pos:        position{line: 2389, col: 14, offset: 72518},
 						val:        "group",
 						ignoreCase: true,
 						want:       "\"GROUP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2388, col: 33, offset: 72446},
+						pos: position{line: 2389, col: 33, offset: 72537},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2388, col: 34, offset: 72447},
+							pos:  position{line: 2389, col: 34, offset: 72538},
 							name: "IdentifierRest",
 						},
 					},
@@ -16983,20 +16996,20 @@ var g = &grammar{
 		},
 		{
 			name: "HAVING",
-			pos:  position{line: 2389, col: 1, offset: 72462},
+			pos:  position{line: 2390, col: 1, offset: 72553},
 			expr: &seqExpr{
-				pos: position{line: 2389, col: 14, offset: 72475},
+				pos: position{line: 2390, col: 14, offset: 72566},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2389, col: 14, offset: 72475},
+						pos:        position{line: 2390, col: 14, offset: 72566},
 						val:        "having",
 						ignoreCase: true,
 						want:       "\"HAVING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2389, col: 33, offset: 72494},
+						pos: position{line: 2390, col: 33, offset: 72585},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2389, col: 34, offset: 72495},
+							pos:  position{line: 2390, col: 34, offset: 72586},
 							name: "IdentifierRest",
 						},
 					},
@@ -17007,20 +17020,20 @@ var g = &grammar{
 		},
 		{
 			name: "HEAD",
-			pos:  position{line: 2390, col: 1, offset: 72510},
+			pos:  position{line: 2391, col: 1, offset: 72601},
 			expr: &seqExpr{
-				pos: position{line: 2390, col: 14, offset: 72523},
+				pos: position{line: 2391, col: 14, offset: 72614},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2390, col: 14, offset: 72523},
+						pos:        position{line: 2391, col: 14, offset: 72614},
 						val:        "head",
 						ignoreCase: true,
 						want:       "\"HEAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2390, col: 33, offset: 72542},
+						pos: position{line: 2391, col: 33, offset: 72633},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2390, col: 34, offset: 72543},
+							pos:  position{line: 2391, col: 34, offset: 72634},
 							name: "IdentifierRest",
 						},
 					},
@@ -17031,20 +17044,20 @@ var g = &grammar{
 		},
 		{
 			name: "IN",
-			pos:  position{line: 2391, col: 1, offset: 72558},
+			pos:  position{line: 2392, col: 1, offset: 72649},
 			expr: &seqExpr{
-				pos: position{line: 2391, col: 14, offset: 72571},
+				pos: position{line: 2392, col: 14, offset: 72662},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2391, col: 14, offset: 72571},
+						pos:        position{line: 2392, col: 14, offset: 72662},
 						val:        "in",
 						ignoreCase: true,
 						want:       "\"IN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2391, col: 33, offset: 72590},
+						pos: position{line: 2392, col: 33, offset: 72681},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2391, col: 34, offset: 72591},
+							pos:  position{line: 2392, col: 34, offset: 72682},
 							name: "IdentifierRest",
 						},
 					},
@@ -17055,20 +17068,20 @@ var g = &grammar{
 		},
 		{
 			name: "INNER",
-			pos:  position{line: 2392, col: 1, offset: 72606},
+			pos:  position{line: 2393, col: 1, offset: 72697},
 			expr: &seqExpr{
-				pos: position{line: 2392, col: 14, offset: 72619},
+				pos: position{line: 2393, col: 14, offset: 72710},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2392, col: 14, offset: 72619},
+						pos:        position{line: 2393, col: 14, offset: 72710},
 						val:        "inner",
 						ignoreCase: true,
 						want:       "\"INNER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2392, col: 33, offset: 72638},
+						pos: position{line: 2393, col: 33, offset: 72729},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2392, col: 34, offset: 72639},
+							pos:  position{line: 2393, col: 34, offset: 72730},
 							name: "IdentifierRest",
 						},
 					},
@@ -17079,20 +17092,20 @@ var g = &grammar{
 		},
 		{
 			name: "IS",
-			pos:  position{line: 2393, col: 1, offset: 72654},
+			pos:  position{line: 2394, col: 1, offset: 72745},
 			expr: &seqExpr{
-				pos: position{line: 2393, col: 14, offset: 72667},
+				pos: position{line: 2394, col: 14, offset: 72758},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2393, col: 14, offset: 72667},
+						pos:        position{line: 2394, col: 14, offset: 72758},
 						val:        "is",
 						ignoreCase: true,
 						want:       "\"IS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2393, col: 33, offset: 72686},
+						pos: position{line: 2394, col: 33, offset: 72777},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2393, col: 34, offset: 72687},
+							pos:  position{line: 2394, col: 34, offset: 72778},
 							name: "IdentifierRest",
 						},
 					},
@@ -17103,20 +17116,20 @@ var g = &grammar{
 		},
 		{
 			name: "JOIN",
-			pos:  position{line: 2394, col: 1, offset: 72702},
+			pos:  position{line: 2395, col: 1, offset: 72793},
 			expr: &seqExpr{
-				pos: position{line: 2394, col: 14, offset: 72715},
+				pos: position{line: 2395, col: 14, offset: 72806},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2394, col: 14, offset: 72715},
+						pos:        position{line: 2395, col: 14, offset: 72806},
 						val:        "join",
 						ignoreCase: true,
 						want:       "\"JOIN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2394, col: 33, offset: 72734},
+						pos: position{line: 2395, col: 33, offset: 72825},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2394, col: 34, offset: 72735},
+							pos:  position{line: 2395, col: 34, offset: 72826},
 							name: "IdentifierRest",
 						},
 					},
@@ -17127,20 +17140,20 @@ var g = &grammar{
 		},
 		{
 			name: "LAMBDA",
-			pos:  position{line: 2395, col: 1, offset: 72750},
+			pos:  position{line: 2396, col: 1, offset: 72841},
 			expr: &seqExpr{
-				pos: position{line: 2395, col: 14, offset: 72763},
+				pos: position{line: 2396, col: 14, offset: 72854},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2395, col: 14, offset: 72763},
+						pos:        position{line: 2396, col: 14, offset: 72854},
 						val:        "lambda",
 						ignoreCase: true,
 						want:       "\"LAMBDA\"i",
 					},
 					&notExpr{
-						pos: position{line: 2395, col: 33, offset: 72782},
+						pos: position{line: 2396, col: 33, offset: 72873},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2395, col: 34, offset: 72783},
+							pos:  position{line: 2396, col: 34, offset: 72874},
 							name: "IdentifierRest",
 						},
 					},
@@ -17151,20 +17164,20 @@ var g = &grammar{
 		},
 		{
 			name: "LAST",
-			pos:  position{line: 2396, col: 1, offset: 72798},
+			pos:  position{line: 2397, col: 1, offset: 72889},
 			expr: &seqExpr{
-				pos: position{line: 2396, col: 14, offset: 72811},
+				pos: position{line: 2397, col: 14, offset: 72902},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2396, col: 14, offset: 72811},
+						pos:        position{line: 2397, col: 14, offset: 72902},
 						val:        "last",
 						ignoreCase: true,
 						want:       "\"LAST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2396, col: 33, offset: 72830},
+						pos: position{line: 2397, col: 33, offset: 72921},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2396, col: 34, offset: 72831},
+							pos:  position{line: 2397, col: 34, offset: 72922},
 							name: "IdentifierRest",
 						},
 					},
@@ -17175,20 +17188,20 @@ var g = &grammar{
 		},
 		{
 			name: "LEFT",
-			pos:  position{line: 2397, col: 1, offset: 72846},
+			pos:  position{line: 2398, col: 1, offset: 72937},
 			expr: &seqExpr{
-				pos: position{line: 2397, col: 14, offset: 72859},
+				pos: position{line: 2398, col: 14, offset: 72950},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2397, col: 14, offset: 72859},
+						pos:        position{line: 2398, col: 14, offset: 72950},
 						val:        "left",
 						ignoreCase: true,
 						want:       "\"LEFT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2397, col: 33, offset: 72878},
+						pos: position{line: 2398, col: 33, offset: 72969},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2397, col: 34, offset: 72879},
+							pos:  position{line: 2398, col: 34, offset: 72970},
 							name: "IdentifierRest",
 						},
 					},
@@ -17199,20 +17212,20 @@ var g = &grammar{
 		},
 		{
 			name: "LET",
-			pos:  position{line: 2398, col: 1, offset: 72894},
+			pos:  position{line: 2399, col: 1, offset: 72985},
 			expr: &seqExpr{
-				pos: position{line: 2398, col: 14, offset: 72907},
+				pos: position{line: 2399, col: 14, offset: 72998},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2398, col: 14, offset: 72907},
+						pos:        position{line: 2399, col: 14, offset: 72998},
 						val:        "let",
 						ignoreCase: true,
 						want:       "\"LET\"i",
 					},
 					&notExpr{
-						pos: position{line: 2398, col: 33, offset: 72926},
+						pos: position{line: 2399, col: 33, offset: 73017},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2398, col: 34, offset: 72927},
+							pos:  position{line: 2399, col: 34, offset: 73018},
 							name: "IdentifierRest",
 						},
 					},
@@ -17223,20 +17236,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIKE",
-			pos:  position{line: 2399, col: 1, offset: 72942},
+			pos:  position{line: 2400, col: 1, offset: 73033},
 			expr: &seqExpr{
-				pos: position{line: 2399, col: 14, offset: 72955},
+				pos: position{line: 2400, col: 14, offset: 73046},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2399, col: 14, offset: 72955},
+						pos:        position{line: 2400, col: 14, offset: 73046},
 						val:        "like",
 						ignoreCase: true,
 						want:       "\"LIKE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2399, col: 33, offset: 72974},
+						pos: position{line: 2400, col: 33, offset: 73065},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2399, col: 34, offset: 72975},
+							pos:  position{line: 2400, col: 34, offset: 73066},
 							name: "IdentifierRest",
 						},
 					},
@@ -17247,20 +17260,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIMIT",
-			pos:  position{line: 2400, col: 1, offset: 72990},
+			pos:  position{line: 2401, col: 1, offset: 73081},
 			expr: &seqExpr{
-				pos: position{line: 2400, col: 14, offset: 73003},
+				pos: position{line: 2401, col: 14, offset: 73094},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2400, col: 14, offset: 73003},
+						pos:        position{line: 2401, col: 14, offset: 73094},
 						val:        "limit",
 						ignoreCase: true,
 						want:       "\"LIMIT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2400, col: 33, offset: 73022},
+						pos: position{line: 2401, col: 33, offset: 73113},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2400, col: 34, offset: 73023},
+							pos:  position{line: 2401, col: 34, offset: 73114},
 							name: "IdentifierRest",
 						},
 					},
@@ -17271,20 +17284,20 @@ var g = &grammar{
 		},
 		{
 			name: "LOAD",
-			pos:  position{line: 2401, col: 1, offset: 73038},
+			pos:  position{line: 2402, col: 1, offset: 73129},
 			expr: &seqExpr{
-				pos: position{line: 2401, col: 14, offset: 73051},
+				pos: position{line: 2402, col: 14, offset: 73142},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2401, col: 14, offset: 73051},
+						pos:        position{line: 2402, col: 14, offset: 73142},
 						val:        "load",
 						ignoreCase: true,
 						want:       "\"LOAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2401, col: 33, offset: 73070},
+						pos: position{line: 2402, col: 33, offset: 73161},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2401, col: 34, offset: 73071},
+							pos:  position{line: 2402, col: 34, offset: 73162},
 							name: "IdentifierRest",
 						},
 					},
@@ -17295,20 +17308,20 @@ var g = &grammar{
 		},
 		{
 			name: "MATERIALIZED",
-			pos:  position{line: 2402, col: 1, offset: 73086},
+			pos:  position{line: 2403, col: 1, offset: 73177},
 			expr: &seqExpr{
-				pos: position{line: 2402, col: 16, offset: 73101},
+				pos: position{line: 2403, col: 16, offset: 73192},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2402, col: 16, offset: 73101},
+						pos:        position{line: 2403, col: 16, offset: 73192},
 						val:        "materialized",
 						ignoreCase: true,
 						want:       "\"MATERIALIZED\"i",
 					},
 					&notExpr{
-						pos: position{line: 2402, col: 33, offset: 73118},
+						pos: position{line: 2403, col: 33, offset: 73209},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2402, col: 34, offset: 73119},
+							pos:  position{line: 2403, col: 34, offset: 73210},
 							name: "IdentifierRest",
 						},
 					},
@@ -17319,20 +17332,20 @@ var g = &grammar{
 		},
 		{
 			name: "MAP",
-			pos:  position{line: 2403, col: 1, offset: 73134},
+			pos:  position{line: 2404, col: 1, offset: 73225},
 			expr: &seqExpr{
-				pos: position{line: 2403, col: 14, offset: 73147},
+				pos: position{line: 2404, col: 14, offset: 73238},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2403, col: 14, offset: 73147},
+						pos:        position{line: 2404, col: 14, offset: 73238},
 						val:        "map",
 						ignoreCase: true,
 						want:       "\"MAP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2403, col: 33, offset: 73166},
+						pos: position{line: 2404, col: 33, offset: 73257},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2403, col: 34, offset: 73167},
+							pos:  position{line: 2404, col: 34, offset: 73258},
 							name: "IdentifierRest",
 						},
 					},
@@ -17343,20 +17356,20 @@ var g = &grammar{
 		},
 		{
 			name: "MERGE",
-			pos:  position{line: 2404, col: 1, offset: 73182},
+			pos:  position{line: 2405, col: 1, offset: 73273},
 			expr: &seqExpr{
-				pos: position{line: 2404, col: 14, offset: 73195},
+				pos: position{line: 2405, col: 14, offset: 73286},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2404, col: 14, offset: 73195},
+						pos:        position{line: 2405, col: 14, offset: 73286},
 						val:        "merge",
 						ignoreCase: true,
 						want:       "\"MERGE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2404, col: 33, offset: 73214},
+						pos: position{line: 2405, col: 33, offset: 73305},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2404, col: 34, offset: 73215},
+							pos:  position{line: 2405, col: 34, offset: 73306},
 							name: "IdentifierRest",
 						},
 					},
@@ -17367,20 +17380,20 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 2405, col: 1, offset: 73230},
+			pos:  position{line: 2406, col: 1, offset: 73321},
 			expr: &seqExpr{
-				pos: position{line: 2405, col: 14, offset: 73243},
+				pos: position{line: 2406, col: 14, offset: 73334},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2405, col: 14, offset: 73243},
+						pos:        position{line: 2406, col: 14, offset: 73334},
 						val:        "not",
 						ignoreCase: true,
 						want:       "\"NOT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2405, col: 33, offset: 73262},
+						pos: position{line: 2406, col: 33, offset: 73353},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2405, col: 34, offset: 73263},
+							pos:  position{line: 2406, col: 34, offset: 73354},
 							name: "IdentifierRest",
 						},
 					},
@@ -17391,20 +17404,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULL",
-			pos:  position{line: 2406, col: 1, offset: 73278},
+			pos:  position{line: 2407, col: 1, offset: 73369},
 			expr: &seqExpr{
-				pos: position{line: 2406, col: 14, offset: 73291},
+				pos: position{line: 2407, col: 14, offset: 73382},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2406, col: 14, offset: 73291},
+						pos:        position{line: 2407, col: 14, offset: 73382},
 						val:        "null",
 						ignoreCase: true,
 						want:       "\"NULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2406, col: 33, offset: 73310},
+						pos: position{line: 2407, col: 33, offset: 73401},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2406, col: 34, offset: 73311},
+							pos:  position{line: 2407, col: 34, offset: 73402},
 							name: "IdentifierRest",
 						},
 					},
@@ -17415,20 +17428,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULLS",
-			pos:  position{line: 2407, col: 1, offset: 73326},
+			pos:  position{line: 2408, col: 1, offset: 73417},
 			expr: &seqExpr{
-				pos: position{line: 2407, col: 14, offset: 73339},
+				pos: position{line: 2408, col: 14, offset: 73430},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2407, col: 14, offset: 73339},
+						pos:        position{line: 2408, col: 14, offset: 73430},
 						val:        "nulls",
 						ignoreCase: true,
 						want:       "\"NULLS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2407, col: 33, offset: 73358},
+						pos: position{line: 2408, col: 33, offset: 73449},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2407, col: 34, offset: 73359},
+							pos:  position{line: 2408, col: 34, offset: 73450},
 							name: "IdentifierRest",
 						},
 					},
@@ -17439,20 +17452,20 @@ var g = &grammar{
 		},
 		{
 			name: "OFFSET",
-			pos:  position{line: 2408, col: 1, offset: 73374},
+			pos:  position{line: 2409, col: 1, offset: 73465},
 			expr: &seqExpr{
-				pos: position{line: 2408, col: 14, offset: 73387},
+				pos: position{line: 2409, col: 14, offset: 73478},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2408, col: 14, offset: 73387},
+						pos:        position{line: 2409, col: 14, offset: 73478},
 						val:        "offset",
 						ignoreCase: true,
 						want:       "\"OFFSET\"i",
 					},
 					&notExpr{
-						pos: position{line: 2408, col: 33, offset: 73406},
+						pos: position{line: 2409, col: 33, offset: 73497},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2408, col: 34, offset: 73407},
+							pos:  position{line: 2409, col: 34, offset: 73498},
 							name: "IdentifierRest",
 						},
 					},
@@ -17463,20 +17476,20 @@ var g = &grammar{
 		},
 		{
 			name: "ON",
-			pos:  position{line: 2409, col: 1, offset: 73422},
+			pos:  position{line: 2410, col: 1, offset: 73513},
 			expr: &seqExpr{
-				pos: position{line: 2409, col: 14, offset: 73435},
+				pos: position{line: 2410, col: 14, offset: 73526},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2409, col: 14, offset: 73435},
+						pos:        position{line: 2410, col: 14, offset: 73526},
 						val:        "on",
 						ignoreCase: true,
 						want:       "\"ON\"i",
 					},
 					&notExpr{
-						pos: position{line: 2409, col: 33, offset: 73454},
+						pos: position{line: 2410, col: 33, offset: 73545},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2409, col: 34, offset: 73455},
+							pos:  position{line: 2410, col: 34, offset: 73546},
 							name: "IdentifierRest",
 						},
 					},
@@ -17487,20 +17500,20 @@ var g = &grammar{
 		},
 		{
 			name: "OP",
-			pos:  position{line: 2410, col: 1, offset: 73470},
+			pos:  position{line: 2411, col: 1, offset: 73561},
 			expr: &seqExpr{
-				pos: position{line: 2410, col: 14, offset: 73483},
+				pos: position{line: 2411, col: 14, offset: 73574},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2410, col: 14, offset: 73483},
+						pos:        position{line: 2411, col: 14, offset: 73574},
 						val:        "op",
 						ignoreCase: true,
 						want:       "\"OP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2410, col: 33, offset: 73502},
+						pos: position{line: 2411, col: 33, offset: 73593},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2410, col: 34, offset: 73503},
+							pos:  position{line: 2411, col: 34, offset: 73594},
 							name: "IdentifierRest",
 						},
 					},
@@ -17511,23 +17524,23 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 2411, col: 1, offset: 73518},
+			pos:  position{line: 2412, col: 1, offset: 73609},
 			expr: &actionExpr{
-				pos: position{line: 2411, col: 14, offset: 73531},
+				pos: position{line: 2412, col: 14, offset: 73622},
 				run: (*parser).callonOR1,
 				expr: &seqExpr{
-					pos: position{line: 2411, col: 14, offset: 73531},
+					pos: position{line: 2412, col: 14, offset: 73622},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2411, col: 14, offset: 73531},
+							pos:        position{line: 2412, col: 14, offset: 73622},
 							val:        "or",
 							ignoreCase: true,
 							want:       "\"OR\"i",
 						},
 						&notExpr{
-							pos: position{line: 2411, col: 33, offset: 73550},
+							pos: position{line: 2412, col: 33, offset: 73641},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2411, col: 34, offset: 73551},
+								pos:  position{line: 2412, col: 34, offset: 73642},
 								name: "IdentifierRest",
 							},
 						},
@@ -17539,20 +17552,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDER",
-			pos:  position{line: 2412, col: 1, offset: 73587},
+			pos:  position{line: 2413, col: 1, offset: 73678},
 			expr: &seqExpr{
-				pos: position{line: 2412, col: 14, offset: 73600},
+				pos: position{line: 2413, col: 14, offset: 73691},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2412, col: 14, offset: 73600},
+						pos:        position{line: 2413, col: 14, offset: 73691},
 						val:        "order",
 						ignoreCase: true,
 						want:       "\"ORDER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2412, col: 33, offset: 73619},
+						pos: position{line: 2413, col: 33, offset: 73710},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2412, col: 34, offset: 73620},
+							pos:  position{line: 2413, col: 34, offset: 73711},
 							name: "IdentifierRest",
 						},
 					},
@@ -17563,20 +17576,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDINALITY",
-			pos:  position{line: 2413, col: 1, offset: 73635},
+			pos:  position{line: 2414, col: 1, offset: 73726},
 			expr: &seqExpr{
-				pos: position{line: 2413, col: 14, offset: 73648},
+				pos: position{line: 2414, col: 14, offset: 73739},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2413, col: 14, offset: 73648},
+						pos:        position{line: 2414, col: 14, offset: 73739},
 						val:        "ordinality",
 						ignoreCase: true,
 						want:       "\"ORDINALITY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2413, col: 33, offset: 73667},
+						pos: position{line: 2414, col: 33, offset: 73758},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2413, col: 34, offset: 73668},
+							pos:  position{line: 2414, col: 34, offset: 73759},
 							name: "IdentifierRest",
 						},
 					},
@@ -17587,20 +17600,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTER",
-			pos:  position{line: 2414, col: 1, offset: 73683},
+			pos:  position{line: 2415, col: 1, offset: 73774},
 			expr: &seqExpr{
-				pos: position{line: 2414, col: 14, offset: 73696},
+				pos: position{line: 2415, col: 14, offset: 73787},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2414, col: 14, offset: 73696},
+						pos:        position{line: 2415, col: 14, offset: 73787},
 						val:        "outer",
 						ignoreCase: true,
 						want:       "\"OUTER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2414, col: 33, offset: 73715},
+						pos: position{line: 2415, col: 33, offset: 73806},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2414, col: 34, offset: 73716},
+							pos:  position{line: 2415, col: 34, offset: 73807},
 							name: "IdentifierRest",
 						},
 					},
@@ -17611,20 +17624,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTPUT",
-			pos:  position{line: 2415, col: 1, offset: 73731},
+			pos:  position{line: 2416, col: 1, offset: 73822},
 			expr: &seqExpr{
-				pos: position{line: 2415, col: 14, offset: 73744},
+				pos: position{line: 2416, col: 14, offset: 73835},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2415, col: 14, offset: 73744},
+						pos:        position{line: 2416, col: 14, offset: 73835},
 						val:        "output",
 						ignoreCase: true,
 						want:       "\"OUTPUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2415, col: 33, offset: 73763},
+						pos: position{line: 2416, col: 33, offset: 73854},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2415, col: 34, offset: 73764},
+							pos:  position{line: 2416, col: 34, offset: 73855},
 							name: "IdentifierRest",
 						},
 					},
@@ -17635,20 +17648,20 @@ var g = &grammar{
 		},
 		{
 			name: "PASS",
-			pos:  position{line: 2416, col: 1, offset: 73779},
+			pos:  position{line: 2417, col: 1, offset: 73870},
 			expr: &seqExpr{
-				pos: position{line: 2416, col: 14, offset: 73792},
+				pos: position{line: 2417, col: 14, offset: 73883},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2416, col: 14, offset: 73792},
+						pos:        position{line: 2417, col: 14, offset: 73883},
 						val:        "pass",
 						ignoreCase: true,
 						want:       "\"PASS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2416, col: 33, offset: 73811},
+						pos: position{line: 2417, col: 33, offset: 73902},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2416, col: 34, offset: 73812},
+							pos:  position{line: 2417, col: 34, offset: 73903},
 							name: "IdentifierRest",
 						},
 					},
@@ -17659,20 +17672,20 @@ var g = &grammar{
 		},
 		{
 			name: "PUT",
-			pos:  position{line: 2417, col: 1, offset: 73827},
+			pos:  position{line: 2418, col: 1, offset: 73918},
 			expr: &seqExpr{
-				pos: position{line: 2417, col: 14, offset: 73840},
+				pos: position{line: 2418, col: 14, offset: 73931},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2417, col: 14, offset: 73840},
+						pos:        position{line: 2418, col: 14, offset: 73931},
 						val:        "put",
 						ignoreCase: true,
 						want:       "\"PUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2417, col: 33, offset: 73859},
+						pos: position{line: 2418, col: 33, offset: 73950},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2417, col: 34, offset: 73860},
+							pos:  position{line: 2418, col: 34, offset: 73951},
 							name: "IdentifierRest",
 						},
 					},
@@ -17683,20 +17696,20 @@ var g = &grammar{
 		},
 		{
 			name: "RECURSIVE",
-			pos:  position{line: 2418, col: 1, offset: 73875},
+			pos:  position{line: 2419, col: 1, offset: 73966},
 			expr: &seqExpr{
-				pos: position{line: 2418, col: 14, offset: 73888},
+				pos: position{line: 2419, col: 14, offset: 73979},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2418, col: 14, offset: 73888},
+						pos:        position{line: 2419, col: 14, offset: 73979},
 						val:        "recursive",
 						ignoreCase: true,
 						want:       "\"RECURSIVE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2418, col: 33, offset: 73907},
+						pos: position{line: 2419, col: 33, offset: 73998},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2418, col: 34, offset: 73908},
+							pos:  position{line: 2419, col: 34, offset: 73999},
 							name: "IdentifierRest",
 						},
 					},
@@ -17707,20 +17720,20 @@ var g = &grammar{
 		},
 		{
 			name: "RENAME",
-			pos:  position{line: 2419, col: 1, offset: 73923},
+			pos:  position{line: 2420, col: 1, offset: 74014},
 			expr: &seqExpr{
-				pos: position{line: 2419, col: 14, offset: 73936},
+				pos: position{line: 2420, col: 14, offset: 74027},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2419, col: 14, offset: 73936},
+						pos:        position{line: 2420, col: 14, offset: 74027},
 						val:        "rename",
 						ignoreCase: true,
 						want:       "\"RENAME\"i",
 					},
 					&notExpr{
-						pos: position{line: 2419, col: 33, offset: 73955},
+						pos: position{line: 2420, col: 33, offset: 74046},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2419, col: 34, offset: 73956},
+							pos:  position{line: 2420, col: 34, offset: 74047},
 							name: "IdentifierRest",
 						},
 					},
@@ -17731,20 +17744,20 @@ var g = &grammar{
 		},
 		{
 			name: "RIGHT",
-			pos:  position{line: 2420, col: 1, offset: 73971},
+			pos:  position{line: 2421, col: 1, offset: 74062},
 			expr: &seqExpr{
-				pos: position{line: 2420, col: 14, offset: 73984},
+				pos: position{line: 2421, col: 14, offset: 74075},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2420, col: 14, offset: 73984},
+						pos:        position{line: 2421, col: 14, offset: 74075},
 						val:        "right",
 						ignoreCase: true,
 						want:       "\"RIGHT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2420, col: 33, offset: 74003},
+						pos: position{line: 2421, col: 33, offset: 74094},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2420, col: 34, offset: 74004},
+							pos:  position{line: 2421, col: 34, offset: 74095},
 							name: "IdentifierRest",
 						},
 					},
@@ -17755,20 +17768,20 @@ var g = &grammar{
 		},
 		{
 			name: "SHAPES",
-			pos:  position{line: 2421, col: 1, offset: 74019},
+			pos:  position{line: 2422, col: 1, offset: 74110},
 			expr: &seqExpr{
-				pos: position{line: 2421, col: 14, offset: 74032},
+				pos: position{line: 2422, col: 14, offset: 74123},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2421, col: 14, offset: 74032},
+						pos:        position{line: 2422, col: 14, offset: 74123},
 						val:        "shapes",
 						ignoreCase: true,
 						want:       "\"SHAPES\"i",
 					},
 					&notExpr{
-						pos: position{line: 2421, col: 33, offset: 74051},
+						pos: position{line: 2422, col: 33, offset: 74142},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2421, col: 34, offset: 74052},
+							pos:  position{line: 2422, col: 34, offset: 74143},
 							name: "IdentifierRest",
 						},
 					},
@@ -17779,20 +17792,20 @@ var g = &grammar{
 		},
 		{
 			name: "SEARCH",
-			pos:  position{line: 2422, col: 1, offset: 74067},
+			pos:  position{line: 2423, col: 1, offset: 74158},
 			expr: &seqExpr{
-				pos: position{line: 2422, col: 14, offset: 74080},
+				pos: position{line: 2423, col: 14, offset: 74171},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2422, col: 14, offset: 74080},
+						pos:        position{line: 2423, col: 14, offset: 74171},
 						val:        "search",
 						ignoreCase: true,
 						want:       "\"SEARCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2422, col: 33, offset: 74099},
+						pos: position{line: 2423, col: 33, offset: 74190},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2422, col: 34, offset: 74100},
+							pos:  position{line: 2423, col: 34, offset: 74191},
 							name: "IdentifierRest",
 						},
 					},
@@ -17803,20 +17816,20 @@ var g = &grammar{
 		},
 		{
 			name: "SELECT",
-			pos:  position{line: 2423, col: 1, offset: 74115},
+			pos:  position{line: 2424, col: 1, offset: 74206},
 			expr: &seqExpr{
-				pos: position{line: 2423, col: 14, offset: 74128},
+				pos: position{line: 2424, col: 14, offset: 74219},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2423, col: 14, offset: 74128},
+						pos:        position{line: 2424, col: 14, offset: 74219},
 						val:        "select",
 						ignoreCase: true,
 						want:       "\"SELECT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2423, col: 33, offset: 74147},
+						pos: position{line: 2424, col: 33, offset: 74238},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2423, col: 34, offset: 74148},
+							pos:  position{line: 2424, col: 34, offset: 74239},
 							name: "IdentifierRest",
 						},
 					},
@@ -17827,20 +17840,20 @@ var g = &grammar{
 		},
 		{
 			name: "SHAPE",
-			pos:  position{line: 2424, col: 1, offset: 74163},
+			pos:  position{line: 2425, col: 1, offset: 74254},
 			expr: &seqExpr{
-				pos: position{line: 2424, col: 14, offset: 74176},
+				pos: position{line: 2425, col: 14, offset: 74267},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2424, col: 14, offset: 74176},
+						pos:        position{line: 2425, col: 14, offset: 74267},
 						val:        "shape",
 						ignoreCase: true,
 						want:       "\"SHAPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2424, col: 33, offset: 74195},
+						pos: position{line: 2425, col: 33, offset: 74286},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2424, col: 34, offset: 74196},
+							pos:  position{line: 2425, col: 34, offset: 74287},
 							name: "IdentifierRest",
 						},
 					},
@@ -17851,20 +17864,20 @@ var g = &grammar{
 		},
 		{
 			name: "SKIP",
-			pos:  position{line: 2425, col: 1, offset: 74211},
+			pos:  position{line: 2426, col: 1, offset: 74302},
 			expr: &seqExpr{
-				pos: position{line: 2425, col: 14, offset: 74224},
+				pos: position{line: 2426, col: 14, offset: 74315},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2425, col: 14, offset: 74224},
+						pos:        position{line: 2426, col: 14, offset: 74315},
 						val:        "skip",
 						ignoreCase: true,
 						want:       "\"SKIP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2425, col: 33, offset: 74243},
+						pos: position{line: 2426, col: 33, offset: 74334},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2425, col: 34, offset: 74244},
+							pos:  position{line: 2426, col: 34, offset: 74335},
 							name: "IdentifierRest",
 						},
 					},
@@ -17875,20 +17888,20 @@ var g = &grammar{
 		},
 		{
 			name: "SORT",
-			pos:  position{line: 2426, col: 1, offset: 74259},
+			pos:  position{line: 2427, col: 1, offset: 74350},
 			expr: &seqExpr{
-				pos: position{line: 2426, col: 14, offset: 74272},
+				pos: position{line: 2427, col: 14, offset: 74363},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2426, col: 14, offset: 74272},
+						pos:        position{line: 2427, col: 14, offset: 74363},
 						val:        "sort",
 						ignoreCase: true,
 						want:       "\"SORT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2426, col: 33, offset: 74291},
+						pos: position{line: 2427, col: 33, offset: 74382},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2426, col: 34, offset: 74292},
+							pos:  position{line: 2427, col: 34, offset: 74383},
 							name: "IdentifierRest",
 						},
 					},
@@ -17899,20 +17912,20 @@ var g = &grammar{
 		},
 		{
 			name: "SUBSTRING",
-			pos:  position{line: 2427, col: 1, offset: 74307},
+			pos:  position{line: 2428, col: 1, offset: 74398},
 			expr: &seqExpr{
-				pos: position{line: 2427, col: 14, offset: 74320},
+				pos: position{line: 2428, col: 14, offset: 74411},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2427, col: 14, offset: 74320},
+						pos:        position{line: 2428, col: 14, offset: 74411},
 						val:        "substring",
 						ignoreCase: true,
 						want:       "\"SUBSTRING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2427, col: 33, offset: 74339},
+						pos: position{line: 2428, col: 33, offset: 74430},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2427, col: 34, offset: 74340},
+							pos:  position{line: 2428, col: 34, offset: 74431},
 							name: "IdentifierRest",
 						},
 					},
@@ -17923,20 +17936,20 @@ var g = &grammar{
 		},
 		{
 			name: "SUMMARIZE",
-			pos:  position{line: 2428, col: 1, offset: 74355},
+			pos:  position{line: 2429, col: 1, offset: 74446},
 			expr: &seqExpr{
-				pos: position{line: 2428, col: 14, offset: 74368},
+				pos: position{line: 2429, col: 14, offset: 74459},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2428, col: 14, offset: 74368},
+						pos:        position{line: 2429, col: 14, offset: 74459},
 						val:        "summarize",
 						ignoreCase: true,
 						want:       "\"SUMMARIZE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2428, col: 33, offset: 74387},
+						pos: position{line: 2429, col: 33, offset: 74478},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2428, col: 34, offset: 74388},
+							pos:  position{line: 2429, col: 34, offset: 74479},
 							name: "IdentifierRest",
 						},
 					},
@@ -17947,20 +17960,20 @@ var g = &grammar{
 		},
 		{
 			name: "SWITCH",
-			pos:  position{line: 2429, col: 1, offset: 74403},
+			pos:  position{line: 2430, col: 1, offset: 74494},
 			expr: &seqExpr{
-				pos: position{line: 2429, col: 14, offset: 74416},
+				pos: position{line: 2430, col: 14, offset: 74507},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2429, col: 14, offset: 74416},
+						pos:        position{line: 2430, col: 14, offset: 74507},
 						val:        "switch",
 						ignoreCase: true,
 						want:       "\"SWITCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2429, col: 33, offset: 74435},
+						pos: position{line: 2430, col: 33, offset: 74526},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2429, col: 34, offset: 74436},
+							pos:  position{line: 2430, col: 34, offset: 74527},
 							name: "IdentifierRest",
 						},
 					},
@@ -17971,20 +17984,20 @@ var g = &grammar{
 		},
 		{
 			name: "TAIL",
-			pos:  position{line: 2430, col: 1, offset: 74451},
+			pos:  position{line: 2431, col: 1, offset: 74542},
 			expr: &seqExpr{
-				pos: position{line: 2430, col: 14, offset: 74464},
+				pos: position{line: 2431, col: 14, offset: 74555},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2430, col: 14, offset: 74464},
+						pos:        position{line: 2431, col: 14, offset: 74555},
 						val:        "tail",
 						ignoreCase: true,
 						want:       "\"TAIL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2430, col: 33, offset: 74483},
+						pos: position{line: 2431, col: 33, offset: 74574},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2430, col: 34, offset: 74484},
+							pos:  position{line: 2431, col: 34, offset: 74575},
 							name: "IdentifierRest",
 						},
 					},
@@ -17995,20 +18008,20 @@ var g = &grammar{
 		},
 		{
 			name: "THEN",
-			pos:  position{line: 2431, col: 1, offset: 74499},
+			pos:  position{line: 2432, col: 1, offset: 74590},
 			expr: &seqExpr{
-				pos: position{line: 2431, col: 14, offset: 74512},
+				pos: position{line: 2432, col: 14, offset: 74603},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2431, col: 14, offset: 74512},
+						pos:        position{line: 2432, col: 14, offset: 74603},
 						val:        "then",
 						ignoreCase: true,
 						want:       "\"THEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2431, col: 33, offset: 74531},
+						pos: position{line: 2432, col: 33, offset: 74622},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2431, col: 34, offset: 74532},
+							pos:  position{line: 2432, col: 34, offset: 74623},
 							name: "IdentifierRest",
 						},
 					},
@@ -18019,23 +18032,23 @@ var g = &grammar{
 		},
 		{
 			name: "TIMESTAMP",
-			pos:  position{line: 2432, col: 1, offset: 74547},
+			pos:  position{line: 2433, col: 1, offset: 74638},
 			expr: &actionExpr{
-				pos: position{line: 2432, col: 14, offset: 74560},
+				pos: position{line: 2433, col: 14, offset: 74651},
 				run: (*parser).callonTIMESTAMP1,
 				expr: &seqExpr{
-					pos: position{line: 2432, col: 14, offset: 74560},
+					pos: position{line: 2433, col: 14, offset: 74651},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2432, col: 14, offset: 74560},
+							pos:        position{line: 2433, col: 14, offset: 74651},
 							val:        "timestamp",
 							ignoreCase: true,
 							want:       "\"TIMESTAMP\"i",
 						},
 						&notExpr{
-							pos: position{line: 2432, col: 33, offset: 74579},
+							pos: position{line: 2433, col: 33, offset: 74670},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2432, col: 34, offset: 74580},
+								pos:  position{line: 2433, col: 34, offset: 74671},
 								name: "IdentifierRest",
 							},
 						},
@@ -18047,20 +18060,20 @@ var g = &grammar{
 		},
 		{
 			name: "TOP",
-			pos:  position{line: 2433, col: 1, offset: 74623},
+			pos:  position{line: 2434, col: 1, offset: 74714},
 			expr: &seqExpr{
-				pos: position{line: 2433, col: 14, offset: 74636},
+				pos: position{line: 2434, col: 14, offset: 74727},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2433, col: 14, offset: 74636},
+						pos:        position{line: 2434, col: 14, offset: 74727},
 						val:        "top",
 						ignoreCase: true,
 						want:       "\"TOP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2433, col: 33, offset: 74655},
+						pos: position{line: 2434, col: 33, offset: 74746},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2433, col: 34, offset: 74656},
+							pos:  position{line: 2434, col: 34, offset: 74747},
 							name: "IdentifierRest",
 						},
 					},
@@ -18071,20 +18084,20 @@ var g = &grammar{
 		},
 		{
 			name: "TRUE",
-			pos:  position{line: 2434, col: 1, offset: 74671},
+			pos:  position{line: 2435, col: 1, offset: 74762},
 			expr: &seqExpr{
-				pos: position{line: 2434, col: 14, offset: 74684},
+				pos: position{line: 2435, col: 14, offset: 74775},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2434, col: 14, offset: 74684},
+						pos:        position{line: 2435, col: 14, offset: 74775},
 						val:        "true",
 						ignoreCase: true,
 						want:       "\"TRUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2434, col: 33, offset: 74703},
+						pos: position{line: 2435, col: 33, offset: 74794},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2434, col: 34, offset: 74704},
+							pos:  position{line: 2435, col: 34, offset: 74795},
 							name: "IdentifierRest",
 						},
 					},
@@ -18095,20 +18108,20 @@ var g = &grammar{
 		},
 		{
 			name: "TYPE",
-			pos:  position{line: 2435, col: 1, offset: 74719},
+			pos:  position{line: 2436, col: 1, offset: 74810},
 			expr: &seqExpr{
-				pos: position{line: 2435, col: 14, offset: 74732},
+				pos: position{line: 2436, col: 14, offset: 74823},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2435, col: 14, offset: 74732},
+						pos:        position{line: 2436, col: 14, offset: 74823},
 						val:        "type",
 						ignoreCase: true,
 						want:       "\"TYPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2435, col: 33, offset: 74751},
+						pos: position{line: 2436, col: 33, offset: 74842},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2435, col: 34, offset: 74752},
+							pos:  position{line: 2436, col: 34, offset: 74843},
 							name: "IdentifierRest",
 						},
 					},
@@ -18119,20 +18132,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNION",
-			pos:  position{line: 2436, col: 1, offset: 74767},
+			pos:  position{line: 2437, col: 1, offset: 74858},
 			expr: &seqExpr{
-				pos: position{line: 2436, col: 14, offset: 74780},
+				pos: position{line: 2437, col: 14, offset: 74871},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2436, col: 14, offset: 74780},
+						pos:        position{line: 2437, col: 14, offset: 74871},
 						val:        "union",
 						ignoreCase: true,
 						want:       "\"UNION\"i",
 					},
 					&notExpr{
-						pos: position{line: 2436, col: 33, offset: 74799},
+						pos: position{line: 2437, col: 33, offset: 74890},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2436, col: 34, offset: 74800},
+							pos:  position{line: 2437, col: 34, offset: 74891},
 							name: "IdentifierRest",
 						},
 					},
@@ -18143,20 +18156,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNIQ",
-			pos:  position{line: 2437, col: 1, offset: 74815},
+			pos:  position{line: 2438, col: 1, offset: 74906},
 			expr: &seqExpr{
-				pos: position{line: 2437, col: 14, offset: 74828},
+				pos: position{line: 2438, col: 14, offset: 74919},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2437, col: 14, offset: 74828},
+						pos:        position{line: 2438, col: 14, offset: 74919},
 						val:        "uniq",
 						ignoreCase: true,
 						want:       "\"UNIQ\"i",
 					},
 					&notExpr{
-						pos: position{line: 2437, col: 33, offset: 74847},
+						pos: position{line: 2438, col: 33, offset: 74938},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2437, col: 34, offset: 74848},
+							pos:  position{line: 2438, col: 34, offset: 74939},
 							name: "IdentifierRest",
 						},
 					},
@@ -18167,20 +18180,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNNEST",
-			pos:  position{line: 2438, col: 1, offset: 74863},
+			pos:  position{line: 2439, col: 1, offset: 74954},
 			expr: &seqExpr{
-				pos: position{line: 2438, col: 14, offset: 74876},
+				pos: position{line: 2439, col: 14, offset: 74967},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2438, col: 14, offset: 74876},
+						pos:        position{line: 2439, col: 14, offset: 74967},
 						val:        "unnest",
 						ignoreCase: true,
 						want:       "\"UNNEST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2438, col: 33, offset: 74895},
+						pos: position{line: 2439, col: 33, offset: 74986},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2438, col: 34, offset: 74896},
+							pos:  position{line: 2439, col: 34, offset: 74987},
 							name: "IdentifierRest",
 						},
 					},
@@ -18191,20 +18204,20 @@ var g = &grammar{
 		},
 		{
 			name: "USING",
-			pos:  position{line: 2439, col: 1, offset: 74911},
+			pos:  position{line: 2440, col: 1, offset: 75002},
 			expr: &seqExpr{
-				pos: position{line: 2439, col: 14, offset: 74924},
+				pos: position{line: 2440, col: 14, offset: 75015},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2439, col: 14, offset: 74924},
+						pos:        position{line: 2440, col: 14, offset: 75015},
 						val:        "using",
 						ignoreCase: true,
 						want:       "\"USING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2439, col: 33, offset: 74943},
+						pos: position{line: 2440, col: 33, offset: 75034},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2439, col: 34, offset: 74944},
+							pos:  position{line: 2440, col: 34, offset: 75035},
 							name: "IdentifierRest",
 						},
 					},
@@ -18215,20 +18228,20 @@ var g = &grammar{
 		},
 		{
 			name: "VALUE",
-			pos:  position{line: 2440, col: 1, offset: 74959},
+			pos:  position{line: 2441, col: 1, offset: 75050},
 			expr: &seqExpr{
-				pos: position{line: 2440, col: 14, offset: 74972},
+				pos: position{line: 2441, col: 14, offset: 75063},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2440, col: 14, offset: 74972},
+						pos:        position{line: 2441, col: 14, offset: 75063},
 						val:        "value",
 						ignoreCase: true,
 						want:       "\"VALUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2440, col: 33, offset: 74991},
+						pos: position{line: 2441, col: 33, offset: 75082},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2440, col: 34, offset: 74992},
+							pos:  position{line: 2441, col: 34, offset: 75083},
 							name: "IdentifierRest",
 						},
 					},
@@ -18239,20 +18252,20 @@ var g = &grammar{
 		},
 		{
 			name: "VALUES",
-			pos:  position{line: 2441, col: 1, offset: 75007},
+			pos:  position{line: 2442, col: 1, offset: 75098},
 			expr: &seqExpr{
-				pos: position{line: 2441, col: 14, offset: 75020},
+				pos: position{line: 2442, col: 14, offset: 75111},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2441, col: 14, offset: 75020},
+						pos:        position{line: 2442, col: 14, offset: 75111},
 						val:        "values",
 						ignoreCase: true,
 						want:       "\"VALUES\"i",
 					},
 					&notExpr{
-						pos: position{line: 2441, col: 33, offset: 75039},
+						pos: position{line: 2442, col: 33, offset: 75130},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2441, col: 34, offset: 75040},
+							pos:  position{line: 2442, col: 34, offset: 75131},
 							name: "IdentifierRest",
 						},
 					},
@@ -18263,20 +18276,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHEN",
-			pos:  position{line: 2442, col: 1, offset: 75055},
+			pos:  position{line: 2443, col: 1, offset: 75146},
 			expr: &seqExpr{
-				pos: position{line: 2442, col: 14, offset: 75068},
+				pos: position{line: 2443, col: 14, offset: 75159},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2442, col: 14, offset: 75068},
+						pos:        position{line: 2443, col: 14, offset: 75159},
 						val:        "when",
 						ignoreCase: true,
 						want:       "\"WHEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2442, col: 33, offset: 75087},
+						pos: position{line: 2443, col: 33, offset: 75178},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2442, col: 34, offset: 75088},
+							pos:  position{line: 2443, col: 34, offset: 75179},
 							name: "IdentifierRest",
 						},
 					},
@@ -18287,20 +18300,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHERE",
-			pos:  position{line: 2443, col: 1, offset: 75103},
+			pos:  position{line: 2444, col: 1, offset: 75194},
 			expr: &seqExpr{
-				pos: position{line: 2443, col: 14, offset: 75116},
+				pos: position{line: 2444, col: 14, offset: 75207},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2443, col: 14, offset: 75116},
+						pos:        position{line: 2444, col: 14, offset: 75207},
 						val:        "where",
 						ignoreCase: true,
 						want:       "\"WHERE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2443, col: 33, offset: 75135},
+						pos: position{line: 2444, col: 33, offset: 75226},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2443, col: 34, offset: 75136},
+							pos:  position{line: 2444, col: 34, offset: 75227},
 							name: "IdentifierRest",
 						},
 					},
@@ -18311,20 +18324,20 @@ var g = &grammar{
 		},
 		{
 			name: "WITH",
-			pos:  position{line: 2444, col: 1, offset: 75151},
+			pos:  position{line: 2445, col: 1, offset: 75242},
 			expr: &seqExpr{
-				pos: position{line: 2444, col: 14, offset: 75164},
+				pos: position{line: 2445, col: 14, offset: 75255},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2444, col: 14, offset: 75164},
+						pos:        position{line: 2445, col: 14, offset: 75255},
 						val:        "with",
 						ignoreCase: true,
 						want:       "\"WITH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2444, col: 33, offset: 75183},
+						pos: position{line: 2445, col: 33, offset: 75274},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2444, col: 34, offset: 75184},
+							pos:  position{line: 2445, col: 34, offset: 75275},
 							name: "IdentifierRest",
 						},
 					},
@@ -18921,8 +18934,8 @@ func (p *parser) callonAggAssignment11() (any, error) {
 	return p.cur.onAggAssignment11(stack["agg"])
 }
 
-func (c *current) onAgg2(aggDistinct, where any) (any, error) {
-	agg := aggDistinct.(*ast.Agg)
+func (c *current) onAgg2(a, where any) (any, error) {
+	agg := a.(*ast.Agg)
 	agg.Loc = loc(c)
 	if where != nil {
 		agg.Where = where.(ast.Expr)
@@ -18934,7 +18947,7 @@ func (c *current) onAgg2(aggDistinct, where any) (any, error) {
 func (p *parser) callonAgg2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onAgg2(stack["aggDistinct"], stack["where"])
+	return p.cur.onAgg2(stack["a"], stack["where"])
 }
 
 func (c *current) onAgg9(name, expr, where any) (any, error) {
@@ -18974,21 +18987,22 @@ func (p *parser) callonAgg24() (any, error) {
 	return p.cur.onAgg24(stack["cs"])
 }
 
-func (c *current) onAggDistinct1(name, expr any) (any, error) {
+func (c *current) onAggAllOrDistinct1(name, q, expr any) (any, error) {
+	qualifier := string(q.([]any)[0].([]byte))
 	return &ast.Agg{
 		Kind:     "Agg",
 		Name:     name.(string),
-		Distinct: true,
+		Distinct: strings.EqualFold(qualifier, "distinct"),
 		Expr:     expr.(ast.Expr),
 		Loc:      loc(c),
 	}, nil
 
 }
 
-func (p *parser) callonAggDistinct1() (any, error) {
+func (p *parser) callonAggAllOrDistinct1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onAggDistinct1(stack["name"], stack["expr"])
+	return p.cur.onAggAllOrDistinct1(stack["name"], stack["q"], stack["expr"])
 }
 
 func (c *current) onWhereClause1(expr any) (any, error) {

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -256,8 +256,8 @@ AggAssignment
     }
 
 Agg
-  = aggDistinct:AggDistinct where:WhereClause? {
-      agg := aggDistinct.(*ast.Agg)
+  = a:AggAllOrDistinct where:WhereClause? {
+      agg := a.(*ast.Agg)
       agg.Loc = loc(c)
       if where != nil {
         agg.Where = where.(ast.Expr)
@@ -286,12 +286,13 @@ Agg
       }, nil
     }
 
-AggDistinct
-  = name:AggName __ "(" __ DISTINCT _ expr:Expr __ ")" {
+AggAllOrDistinct
+  = name:AggName __ "(" __ q:(ALL / DISTINCT)  _ expr:Expr __ ")" {
+      qualifier := string(q.([]any)[0].([]byte))
       return &ast.Agg{
           Kind: "Agg",
           Name: name.(string),
-          Distinct: true,
+          Distinct: strings.EqualFold(qualifier, "distinct"),
           Expr: expr.(ast.Expr),
           Loc: loc(c),
       }, nil
@@ -2229,7 +2230,7 @@ Selection
 
 //XXX need to add *, id.*, except, replace
 SelectElem
-  = expr:(AggDistinct / Expr) as:OptAsClause {
+  = expr:(AggAllOrDistinct / Expr) as:OptAsClause {
       elem := ast.SQLAsExpr{
         Kind: "SQLAsExpr",
         Expr: expr.(ast.Expr),

--- a/compiler/ztests/sql/agg-all.yaml
+++ b/compiler/ztests/sql/agg-all.yaml
@@ -1,0 +1,30 @@
+spq: |
+  select
+      key,
+      and(all b),
+      any(all n),
+      avg(all n),
+      collect(all key),
+      count(all n),
+      dcount(all n),
+      -- fuse() is not yet supported by vector runtime.
+      max(all n),
+      min(all n),
+      or(all b),
+      sum(all n),
+      union(all n)
+  group by key
+  order by key
+
+vector: true
+
+input: |
+  {key:"a",n:1,b:true}
+  {key:"a",n:2,b:false}
+  {key:"b",n:1,b:true}
+  {key:"b",n:0,b:true}
+  {key:"a",n:1,b:false}
+
+output: |
+  {key:"a",and:false,any:1,avg:1.3333333333333333,collect:["a","a","a"],count:3::uint64,dcount:2::uint64,max:2,min:1,or:true,sum:4,union:|[1,2]|}
+  {key:"b",and:true,any:1,avg:0.5,collect:["b","b"],count:2::uint64,dcount:2::uint64,max:1,min:0,or:true,sum:1,union:|[0,1]|}


### PR DESCRIPTION
This enables "count(all a)" etc.

Closes #6258.