### PR TITLE
compiler/parser: recognize some PostgreSQL primitive types

### DIFF
--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -4499,7 +4499,7 @@ var g = &grammar{
 					},
 				},
 			},
-			leader:        true,
+			leader:        false,
 			leftRecursive: true,
 		},
 		{
@@ -4699,7 +4699,7 @@ var g = &grammar{
 					},
 				},
 			},
-			leader:        false,
+			leader:        true,
 			leftRecursive: true,
 		},
 		{
@@ -9770,131 +9770,373 @@ var g = &grammar{
 		{
 			name: "PrimitiveType",
 			pos:  position{line: 1512, col: 1, offset: 36303},
-			expr: &actionExpr{
+			expr: &choiceExpr{
 				pos: position{line: 1513, col: 5, offset: 36321},
-				run: (*parser).callonPrimitiveType1,
-				expr: &choiceExpr{
-					pos: position{line: 1513, col: 9, offset: 36325},
-					alternatives: []any{
-						&litMatcher{
-							pos:        position{line: 1513, col: 9, offset: 36325},
-							val:        "uint8",
-							ignoreCase: false,
-							want:       "\"uint8\"",
+				alternatives: []any{
+					&actionExpr{
+						pos: position{line: 1513, col: 5, offset: 36321},
+						run: (*parser).callonPrimitiveType2,
+						expr: &labeledExpr{
+							pos:   position{line: 1513, col: 5, offset: 36321},
+							label: "name",
+							expr: &ruleRefExpr{
+								pos:  position{line: 1513, col: 10, offset: 36326},
+								name: "PostgreSQLPrimitiveType",
+							},
 						},
-						&litMatcher{
-							pos:        position{line: 1513, col: 19, offset: 36335},
-							val:        "uint16",
-							ignoreCase: false,
-							want:       "\"uint16\"",
+					},
+					&actionExpr{
+						pos: position{line: 1520, col: 5, offset: 36501},
+						run: (*parser).callonPrimitiveType5,
+						expr: &choiceExpr{
+							pos: position{line: 1520, col: 9, offset: 36505},
+							alternatives: []any{
+								&litMatcher{
+									pos:        position{line: 1520, col: 9, offset: 36505},
+									val:        "uint8",
+									ignoreCase: false,
+									want:       "\"uint8\"",
+								},
+								&litMatcher{
+									pos:        position{line: 1520, col: 19, offset: 36515},
+									val:        "uint16",
+									ignoreCase: false,
+									want:       "\"uint16\"",
+								},
+								&litMatcher{
+									pos:        position{line: 1520, col: 30, offset: 36526},
+									val:        "uint32",
+									ignoreCase: false,
+									want:       "\"uint32\"",
+								},
+								&litMatcher{
+									pos:        position{line: 1520, col: 41, offset: 36537},
+									val:        "uint64",
+									ignoreCase: false,
+									want:       "\"uint64\"",
+								},
+								&litMatcher{
+									pos:        position{line: 1521, col: 9, offset: 36554},
+									val:        "int8",
+									ignoreCase: false,
+									want:       "\"int8\"",
+								},
+								&litMatcher{
+									pos:        position{line: 1521, col: 18, offset: 36563},
+									val:        "int16",
+									ignoreCase: false,
+									want:       "\"int16\"",
+								},
+								&litMatcher{
+									pos:        position{line: 1521, col: 28, offset: 36573},
+									val:        "int32",
+									ignoreCase: false,
+									want:       "\"int32\"",
+								},
+								&litMatcher{
+									pos:        position{line: 1521, col: 38, offset: 36583},
+									val:        "int64",
+									ignoreCase: false,
+									want:       "\"int64\"",
+								},
+								&litMatcher{
+									pos:        position{line: 1522, col: 9, offset: 36599},
+									val:        "float16",
+									ignoreCase: false,
+									want:       "\"float16\"",
+								},
+								&litMatcher{
+									pos:        position{line: 1522, col: 21, offset: 36611},
+									val:        "float32",
+									ignoreCase: false,
+									want:       "\"float32\"",
+								},
+								&litMatcher{
+									pos:        position{line: 1522, col: 33, offset: 36623},
+									val:        "float64",
+									ignoreCase: false,
+									want:       "\"float64\"",
+								},
+								&litMatcher{
+									pos:        position{line: 1523, col: 9, offset: 36641},
+									val:        "bool",
+									ignoreCase: false,
+									want:       "\"bool\"",
+								},
+								&litMatcher{
+									pos:        position{line: 1523, col: 18, offset: 36650},
+									val:        "string",
+									ignoreCase: false,
+									want:       "\"string\"",
+								},
+								&litMatcher{
+									pos:        position{line: 1524, col: 9, offset: 36667},
+									val:        "duration",
+									ignoreCase: false,
+									want:       "\"duration\"",
+								},
+								&litMatcher{
+									pos:        position{line: 1524, col: 22, offset: 36680},
+									val:        "time",
+									ignoreCase: false,
+									want:       "\"time\"",
+								},
+								&litMatcher{
+									pos:        position{line: 1525, col: 9, offset: 36695},
+									val:        "bytes",
+									ignoreCase: false,
+									want:       "\"bytes\"",
+								},
+								&litMatcher{
+									pos:        position{line: 1526, col: 9, offset: 36711},
+									val:        "ip",
+									ignoreCase: false,
+									want:       "\"ip\"",
+								},
+								&litMatcher{
+									pos:        position{line: 1526, col: 16, offset: 36718},
+									val:        "net",
+									ignoreCase: false,
+									want:       "\"net\"",
+								},
+								&litMatcher{
+									pos:        position{line: 1527, col: 9, offset: 36732},
+									val:        "type",
+									ignoreCase: false,
+									want:       "\"type\"",
+								},
+								&litMatcher{
+									pos:        position{line: 1527, col: 18, offset: 36741},
+									val:        "null",
+									ignoreCase: false,
+									want:       "\"null\"",
+								},
+							},
 						},
-						&litMatcher{
-							pos:        position{line: 1513, col: 30, offset: 36346},
-							val:        "uint32",
-							ignoreCase: false,
-							want:       "\"uint32\"",
+					},
+				},
+			},
+			leader:        false,
+			leftRecursive: false,
+		},
+		{
+			name: "PostgreSQLPrimitiveType",
+			pos:  position{line: 1536, col: 1, offset: 36998},
+			expr: &choiceExpr{
+				pos: position{line: 1537, col: 5, offset: 37026},
+				alternatives: []any{
+					&actionExpr{
+						pos: position{line: 1537, col: 5, offset: 37026},
+						run: (*parser).callonPostgreSQLPrimitiveType2,
+						expr: &litMatcher{
+							pos:        position{line: 1537, col: 5, offset: 37026},
+							val:        "bigint",
+							ignoreCase: true,
+							want:       "\"bigint\"i",
 						},
-						&litMatcher{
-							pos:        position{line: 1513, col: 41, offset: 36357},
-							val:        "uint64",
-							ignoreCase: false,
-							want:       "\"uint64\"",
+					},
+					&actionExpr{
+						pos: position{line: 1538, col: 5, offset: 37075},
+						run: (*parser).callonPostgreSQLPrimitiveType4,
+						expr: &litMatcher{
+							pos:        position{line: 1538, col: 5, offset: 37075},
+							val:        "boolean",
+							ignoreCase: true,
+							want:       "\"boolean\"i",
 						},
-						&litMatcher{
-							pos:        position{line: 1514, col: 9, offset: 36374},
-							val:        "int8",
-							ignoreCase: false,
-							want:       "\"int8\"",
+					},
+					&actionExpr{
+						pos: position{line: 1539, col: 5, offset: 37123},
+						run: (*parser).callonPostgreSQLPrimitiveType6,
+						expr: &litMatcher{
+							pos:        position{line: 1539, col: 5, offset: 37123},
+							val:        "bytea",
+							ignoreCase: true,
+							want:       "\"bytea\"i",
 						},
-						&litMatcher{
-							pos:        position{line: 1514, col: 18, offset: 36383},
-							val:        "int16",
-							ignoreCase: false,
-							want:       "\"int16\"",
+					},
+					&actionExpr{
+						pos: position{line: 1540, col: 5, offset: 37172},
+						run: (*parser).callonPostgreSQLPrimitiveType8,
+						expr: &seqExpr{
+							pos: position{line: 1540, col: 5, offset: 37172},
+							exprs: []any{
+								&litMatcher{
+									pos:        position{line: 1540, col: 5, offset: 37172},
+									val:        "char",
+									ignoreCase: true,
+									want:       "\"char\"i",
+								},
+								&notExpr{
+									pos: position{line: 1540, col: 13, offset: 37180},
+									expr: &litMatcher{
+										pos:        position{line: 1540, col: 14, offset: 37181},
+										val:        "a",
+										ignoreCase: true,
+										want:       "\"a\"i",
+									},
+								},
+							},
 						},
-						&litMatcher{
-							pos:        position{line: 1514, col: 28, offset: 36393},
-							val:        "int32",
-							ignoreCase: false,
-							want:       "\"int32\"",
+					},
+					&actionExpr{
+						pos: position{line: 1541, col: 5, offset: 37222},
+						run: (*parser).callonPostgreSQLPrimitiveType13,
+						expr: &litMatcher{
+							pos:        position{line: 1541, col: 5, offset: 37222},
+							val:        "character varying",
+							ignoreCase: true,
+							want:       "\"character varying\"i",
 						},
-						&litMatcher{
-							pos:        position{line: 1514, col: 38, offset: 36403},
-							val:        "int64",
-							ignoreCase: false,
-							want:       "\"int64\"",
+					},
+					&actionExpr{
+						pos: position{line: 1542, col: 5, offset: 37272},
+						run: (*parser).callonPostgreSQLPrimitiveType15,
+						expr: &litMatcher{
+							pos:        position{line: 1542, col: 5, offset: 37272},
+							val:        "character",
+							ignoreCase: true,
+							want:       "\"character\"i",
 						},
-						&litMatcher{
-							pos:        position{line: 1515, col: 9, offset: 36419},
-							val:        "float16",
-							ignoreCase: false,
-							want:       "\"float16\"",
+					},
+					&actionExpr{
+						pos: position{line: 1543, col: 5, offset: 37322},
+						run: (*parser).callonPostgreSQLPrimitiveType17,
+						expr: &litMatcher{
+							pos:        position{line: 1543, col: 5, offset: 37322},
+							val:        "cidr",
+							ignoreCase: true,
+							want:       "\"cidr\"i",
 						},
-						&litMatcher{
-							pos:        position{line: 1515, col: 21, offset: 36431},
-							val:        "float32",
-							ignoreCase: false,
-							want:       "\"float32\"",
+					},
+					&actionExpr{
+						pos: position{line: 1544, col: 5, offset: 37369},
+						run: (*parser).callonPostgreSQLPrimitiveType19,
+						expr: &litMatcher{
+							pos:        position{line: 1544, col: 5, offset: 37369},
+							val:        "double precision",
+							ignoreCase: true,
+							want:       "\"double precision\"i",
 						},
-						&litMatcher{
-							pos:        position{line: 1515, col: 33, offset: 36443},
-							val:        "float64",
-							ignoreCase: false,
-							want:       "\"float64\"",
+					},
+					&actionExpr{
+						pos: position{line: 1545, col: 5, offset: 37420},
+						run: (*parser).callonPostgreSQLPrimitiveType21,
+						expr: &seqExpr{
+							pos: position{line: 1545, col: 5, offset: 37420},
+							exprs: []any{
+								&litMatcher{
+									pos:        position{line: 1545, col: 5, offset: 37420},
+									val:        "float",
+									ignoreCase: true,
+									want:       "\"float\"i",
+								},
+								&notExpr{
+									pos: position{line: 1545, col: 14, offset: 37429},
+									expr: &charClassMatcher{
+										pos:        position{line: 1545, col: 15, offset: 37430},
+										val:        "[136]",
+										chars:      []rune{'1', '3', '6'},
+										ignoreCase: false,
+										inverted:   false,
+									},
+								},
+							},
 						},
-						&litMatcher{
-							pos:        position{line: 1516, col: 9, offset: 36461},
-							val:        "bool",
-							ignoreCase: false,
-							want:       "\"bool\"",
+					},
+					&actionExpr{
+						pos: position{line: 1546, col: 5, offset: 37471},
+						run: (*parser).callonPostgreSQLPrimitiveType26,
+						expr: &litMatcher{
+							pos:        position{line: 1546, col: 5, offset: 37471},
+							val:        "inet",
+							ignoreCase: true,
+							want:       "\"inet\"i",
 						},
-						&litMatcher{
-							pos:        position{line: 1516, col: 18, offset: 36470},
-							val:        "string",
-							ignoreCase: false,
-							want:       "\"string\"",
+					},
+					&actionExpr{
+						pos: position{line: 1547, col: 5, offset: 37517},
+						run: (*parser).callonPostgreSQLPrimitiveType28,
+						expr: &seqExpr{
+							pos: position{line: 1547, col: 5, offset: 37517},
+							exprs: []any{
+								&litMatcher{
+									pos:        position{line: 1547, col: 5, offset: 37517},
+									val:        "int",
+									ignoreCase: true,
+									want:       "\"int\"i",
+								},
+								&notExpr{
+									pos: position{line: 1547, col: 12, offset: 37524},
+									expr: &charClassMatcher{
+										pos:        position{line: 1547, col: 13, offset: 37525},
+										val:        "[1368e]i",
+										chars:      []rune{'1', '3', '6', '8', 'e'},
+										ignoreCase: true,
+										inverted:   false,
+									},
+								},
+							},
 						},
-						&litMatcher{
-							pos:        position{line: 1517, col: 9, offset: 36487},
-							val:        "duration",
-							ignoreCase: false,
-							want:       "\"duration\"",
+					},
+					&actionExpr{
+						pos: position{line: 1548, col: 5, offset: 37566},
+						run: (*parser).callonPostgreSQLPrimitiveType33,
+						expr: &litMatcher{
+							pos:        position{line: 1548, col: 5, offset: 37566},
+							val:        "integer",
+							ignoreCase: true,
+							want:       "\"integer\"i",
 						},
-						&litMatcher{
-							pos:        position{line: 1517, col: 22, offset: 36500},
-							val:        "time",
-							ignoreCase: false,
-							want:       "\"time\"",
+					},
+					&actionExpr{
+						pos: position{line: 1549, col: 5, offset: 37615},
+						run: (*parser).callonPostgreSQLPrimitiveType35,
+						expr: &litMatcher{
+							pos:        position{line: 1549, col: 5, offset: 37615},
+							val:        "interval",
+							ignoreCase: true,
+							want:       "\"interval\"i",
 						},
-						&litMatcher{
-							pos:        position{line: 1518, col: 9, offset: 36515},
-							val:        "bytes",
-							ignoreCase: false,
-							want:       "\"bytes\"",
+					},
+					&actionExpr{
+						pos: position{line: 1550, col: 5, offset: 37667},
+						run: (*parser).callonPostgreSQLPrimitiveType37,
+						expr: &litMatcher{
+							pos:        position{line: 1550, col: 5, offset: 37667},
+							val:        "real",
+							ignoreCase: true,
+							want:       "\"real\"i",
 						},
-						&litMatcher{
-							pos:        position{line: 1519, col: 9, offset: 36531},
-							val:        "ip",
-							ignoreCase: false,
-							want:       "\"ip\"",
+					},
+					&actionExpr{
+						pos: position{line: 1551, col: 5, offset: 37718},
+						run: (*parser).callonPostgreSQLPrimitiveType39,
+						expr: &litMatcher{
+							pos:        position{line: 1551, col: 5, offset: 37718},
+							val:        "smallint",
+							ignoreCase: true,
+							want:       "\"smallint\"i",
 						},
-						&litMatcher{
-							pos:        position{line: 1519, col: 16, offset: 36538},
-							val:        "net",
-							ignoreCase: false,
-							want:       "\"net\"",
+					},
+					&actionExpr{
+						pos: position{line: 1552, col: 5, offset: 37767},
+						run: (*parser).callonPostgreSQLPrimitiveType41,
+						expr: &litMatcher{
+							pos:        position{line: 1552, col: 5, offset: 37767},
+							val:        "text",
+							ignoreCase: true,
+							want:       "\"text\"i",
 						},
-						&litMatcher{
-							pos:        position{line: 1520, col: 9, offset: 36552},
-							val:        "type",
-							ignoreCase: false,
-							want:       "\"type\"",
-						},
-						&litMatcher{
-							pos:        position{line: 1520, col: 18, offset: 36561},
-							val:        "null",
-							ignoreCase: false,
-							want:       "\"null\"",
+					},
+					&actionExpr{
+						pos: position{line: 1553, col: 5, offset: 37817},
+						run: (*parser).callonPostgreSQLPrimitiveType43,
+						expr: &litMatcher{
+							pos:        position{line: 1553, col: 5, offset: 37817},
+							val:        "varchar",
+							ignoreCase: true,
+							want:       "\"varchar\"i",
 						},
 					},
 				},
@@ -9904,31 +10146,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 1528, col: 1, offset: 36746},
+			pos:  position{line: 1555, col: 1, offset: 37864},
 			expr: &choiceExpr{
-				pos: position{line: 1529, col: 5, offset: 36764},
+				pos: position{line: 1556, col: 5, offset: 37882},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1529, col: 5, offset: 36764},
+						pos: position{line: 1556, col: 5, offset: 37882},
 						run: (*parser).callonTypeFieldList2,
 						expr: &seqExpr{
-							pos: position{line: 1529, col: 5, offset: 36764},
+							pos: position{line: 1556, col: 5, offset: 37882},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1529, col: 5, offset: 36764},
+									pos:   position{line: 1556, col: 5, offset: 37882},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1529, col: 11, offset: 36770},
+										pos:  position{line: 1556, col: 11, offset: 37888},
 										name: "TypeField",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1529, col: 21, offset: 36780},
+									pos:   position{line: 1556, col: 21, offset: 37898},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1529, col: 26, offset: 36785},
+										pos: position{line: 1556, col: 26, offset: 37903},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1529, col: 26, offset: 36785},
+											pos:  position{line: 1556, col: 26, offset: 37903},
 											name: "TypeFieldListTail",
 										},
 									},
@@ -9937,10 +10179,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1532, col: 5, offset: 36851},
+						pos: position{line: 1559, col: 5, offset: 37969},
 						run: (*parser).callonTypeFieldList9,
 						expr: &litMatcher{
-							pos:        position{line: 1532, col: 5, offset: 36851},
+							pos:        position{line: 1559, col: 5, offset: 37969},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -9953,32 +10195,32 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 1534, col: 1, offset: 36875},
+			pos:  position{line: 1561, col: 1, offset: 37993},
 			expr: &actionExpr{
-				pos: position{line: 1534, col: 21, offset: 36895},
+				pos: position{line: 1561, col: 21, offset: 38013},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 1534, col: 21, offset: 36895},
+					pos: position{line: 1561, col: 21, offset: 38013},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1534, col: 21, offset: 36895},
+							pos:  position{line: 1561, col: 21, offset: 38013},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1534, col: 24, offset: 36898},
+							pos:        position{line: 1561, col: 24, offset: 38016},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1534, col: 28, offset: 36902},
+							pos:  position{line: 1561, col: 28, offset: 38020},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1534, col: 31, offset: 36905},
+							pos:   position{line: 1561, col: 31, offset: 38023},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1534, col: 35, offset: 36909},
+								pos:  position{line: 1561, col: 35, offset: 38027},
 								name: "TypeField",
 							},
 						},
@@ -9990,40 +10232,40 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 1536, col: 1, offset: 36940},
+			pos:  position{line: 1563, col: 1, offset: 38058},
 			expr: &actionExpr{
-				pos: position{line: 1537, col: 5, offset: 36954},
+				pos: position{line: 1564, col: 5, offset: 38072},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 1537, col: 5, offset: 36954},
+					pos: position{line: 1564, col: 5, offset: 38072},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1537, col: 5, offset: 36954},
+							pos:   position{line: 1564, col: 5, offset: 38072},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1537, col: 10, offset: 36959},
+								pos:  position{line: 1564, col: 10, offset: 38077},
 								name: "Name",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1537, col: 15, offset: 36964},
+							pos:  position{line: 1564, col: 15, offset: 38082},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 1537, col: 18, offset: 36967},
+							pos:        position{line: 1564, col: 18, offset: 38085},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1537, col: 22, offset: 36971},
+							pos:  position{line: 1564, col: 22, offset: 38089},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 1537, col: 25, offset: 36974},
+							pos:   position{line: 1564, col: 25, offset: 38092},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1537, col: 29, offset: 36978},
+								pos:  position{line: 1564, col: 29, offset: 38096},
 								name: "Type",
 							},
 						},
@@ -10035,26 +10277,26 @@ var g = &grammar{
 		},
 		{
 			name: "Name",
-			pos:  position{line: 1545, col: 1, offset: 37127},
+			pos:  position{line: 1572, col: 1, offset: 38245},
 			expr: &actionExpr{
-				pos: position{line: 1546, col: 4, offset: 37135},
+				pos: position{line: 1573, col: 4, offset: 38253},
 				run: (*parser).callonName1,
 				expr: &labeledExpr{
-					pos:   position{line: 1546, col: 4, offset: 37135},
+					pos:   position{line: 1573, col: 4, offset: 38253},
 					label: "s",
 					expr: &choiceExpr{
-						pos: position{line: 1546, col: 7, offset: 37138},
+						pos: position{line: 1573, col: 7, offset: 38256},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1546, col: 7, offset: 37138},
+								pos:  position{line: 1573, col: 7, offset: 38256},
 								name: "IdentifierName",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1546, col: 24, offset: 37155},
+								pos:  position{line: 1573, col: 24, offset: 38273},
 								name: "DoubleQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1546, col: 45, offset: 37176},
+								pos:  position{line: 1573, col: 45, offset: 38294},
 								name: "SingleQuotedString",
 							},
 						},
@@ -10066,51 +10308,51 @@ var g = &grammar{
 		},
 		{
 			name: "Names",
-			pos:  position{line: 1550, col: 1, offset: 37276},
+			pos:  position{line: 1577, col: 1, offset: 38394},
 			expr: &actionExpr{
-				pos: position{line: 1551, col: 5, offset: 37286},
+				pos: position{line: 1578, col: 5, offset: 38404},
 				run: (*parser).callonNames1,
 				expr: &seqExpr{
-					pos: position{line: 1551, col: 5, offset: 37286},
+					pos: position{line: 1578, col: 5, offset: 38404},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1551, col: 5, offset: 37286},
+							pos:   position{line: 1578, col: 5, offset: 38404},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1551, col: 11, offset: 37292},
+								pos:  position{line: 1578, col: 11, offset: 38410},
 								name: "Name",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1551, col: 16, offset: 37297},
+							pos:   position{line: 1578, col: 16, offset: 38415},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1551, col: 21, offset: 37302},
+								pos: position{line: 1578, col: 21, offset: 38420},
 								expr: &actionExpr{
-									pos: position{line: 1551, col: 22, offset: 37303},
+									pos: position{line: 1578, col: 22, offset: 38421},
 									run: (*parser).callonNames7,
 									expr: &seqExpr{
-										pos: position{line: 1551, col: 22, offset: 37303},
+										pos: position{line: 1578, col: 22, offset: 38421},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1551, col: 22, offset: 37303},
+												pos:  position{line: 1578, col: 22, offset: 38421},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1551, col: 25, offset: 37306},
+												pos:        position{line: 1578, col: 25, offset: 38424},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1551, col: 29, offset: 37310},
+												pos:  position{line: 1578, col: 29, offset: 38428},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1551, col: 32, offset: 37313},
+												pos:   position{line: 1578, col: 32, offset: 38431},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1551, col: 37, offset: 37318},
+													pos:  position{line: 1578, col: 37, offset: 38436},
 													name: "Name",
 												},
 											},
@@ -10127,15 +10369,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 1555, col: 1, offset: 37390},
+			pos:  position{line: 1582, col: 1, offset: 38508},
 			expr: &actionExpr{
-				pos: position{line: 1556, col: 5, offset: 37405},
+				pos: position{line: 1583, col: 5, offset: 38523},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 1556, col: 5, offset: 37405},
+					pos:   position{line: 1583, col: 5, offset: 38523},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1556, col: 8, offset: 37408},
+						pos:  position{line: 1583, col: 8, offset: 38526},
 						name: "IdentifierName",
 					},
 				},
@@ -10145,51 +10387,51 @@ var g = &grammar{
 		},
 		{
 			name: "Identifiers",
-			pos:  position{line: 1563, col: 1, offset: 37519},
+			pos:  position{line: 1590, col: 1, offset: 38637},
 			expr: &actionExpr{
-				pos: position{line: 1564, col: 5, offset: 37535},
+				pos: position{line: 1591, col: 5, offset: 38653},
 				run: (*parser).callonIdentifiers1,
 				expr: &seqExpr{
-					pos: position{line: 1564, col: 5, offset: 37535},
+					pos: position{line: 1591, col: 5, offset: 38653},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1564, col: 5, offset: 37535},
+							pos:   position{line: 1591, col: 5, offset: 38653},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1564, col: 11, offset: 37541},
+								pos:  position{line: 1591, col: 11, offset: 38659},
 								name: "Identifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1564, col: 22, offset: 37552},
+							pos:   position{line: 1591, col: 22, offset: 38670},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1564, col: 27, offset: 37557},
+								pos: position{line: 1591, col: 27, offset: 38675},
 								expr: &actionExpr{
-									pos: position{line: 1564, col: 28, offset: 37558},
+									pos: position{line: 1591, col: 28, offset: 38676},
 									run: (*parser).callonIdentifiers7,
 									expr: &seqExpr{
-										pos: position{line: 1564, col: 28, offset: 37558},
+										pos: position{line: 1591, col: 28, offset: 38676},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1564, col: 28, offset: 37558},
+												pos:  position{line: 1591, col: 28, offset: 38676},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 1564, col: 31, offset: 37561},
+												pos:        position{line: 1591, col: 31, offset: 38679},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1564, col: 35, offset: 37565},
+												pos:  position{line: 1591, col: 35, offset: 38683},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 1564, col: 38, offset: 37568},
+												pos:   position{line: 1591, col: 38, offset: 38686},
 												label: "name",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1564, col: 43, offset: 37573},
+													pos:  position{line: 1591, col: 43, offset: 38691},
 													name: "Identifier",
 												},
 											},
@@ -10206,22 +10448,22 @@ var g = &grammar{
 		},
 		{
 			name: "SQLIdentifier",
-			pos:  position{line: 1568, col: 1, offset: 37651},
+			pos:  position{line: 1595, col: 1, offset: 38769},
 			expr: &choiceExpr{
-				pos: position{line: 1569, col: 5, offset: 37669},
+				pos: position{line: 1596, col: 5, offset: 38787},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1569, col: 5, offset: 37669},
+						pos:  position{line: 1596, col: 5, offset: 38787},
 						name: "Identifier",
 					},
 					&actionExpr{
-						pos: position{line: 1570, col: 5, offset: 37684},
+						pos: position{line: 1597, col: 5, offset: 38802},
 						run: (*parser).callonSQLIdentifier3,
 						expr: &labeledExpr{
-							pos:   position{line: 1570, col: 5, offset: 37684},
+							pos:   position{line: 1597, col: 5, offset: 38802},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1570, col: 7, offset: 37686},
+								pos:  position{line: 1597, col: 7, offset: 38804},
 								name: "DoubleQuotedString",
 							},
 						},
@@ -10233,29 +10475,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 1572, col: 1, offset: 37760},
+			pos:  position{line: 1599, col: 1, offset: 38878},
 			expr: &choiceExpr{
-				pos: position{line: 1573, col: 5, offset: 37779},
+				pos: position{line: 1600, col: 5, offset: 38897},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1573, col: 5, offset: 37779},
+						pos: position{line: 1600, col: 5, offset: 38897},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 1573, col: 5, offset: 37779},
+							pos: position{line: 1600, col: 5, offset: 38897},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1573, col: 5, offset: 37779},
+									pos: position{line: 1600, col: 5, offset: 38897},
 									expr: &seqExpr{
-										pos: position{line: 1573, col: 7, offset: 37781},
+										pos: position{line: 1600, col: 7, offset: 38899},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1573, col: 7, offset: 37781},
+												pos:  position{line: 1600, col: 7, offset: 38899},
 												name: "IDGuard",
 											},
 											&notExpr{
-												pos: position{line: 1573, col: 15, offset: 37789},
+												pos: position{line: 1600, col: 15, offset: 38907},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1573, col: 16, offset: 37790},
+													pos:  position{line: 1600, col: 16, offset: 38908},
 													name: "IdentifierRest",
 												},
 											},
@@ -10263,13 +10505,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1573, col: 32, offset: 37806},
+									pos:  position{line: 1600, col: 32, offset: 38924},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1573, col: 48, offset: 37822},
+									pos: position{line: 1600, col: 48, offset: 38940},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1573, col: 48, offset: 37822},
+										pos:  position{line: 1600, col: 48, offset: 38940},
 										name: "IdentifierRest",
 									},
 								},
@@ -10277,7 +10519,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1574, col: 5, offset: 37873},
+						pos:  position{line: 1601, col: 5, offset: 38991},
 						name: "BacktickString",
 					},
 				},
@@ -10287,22 +10529,22 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 1576, col: 1, offset: 37889},
+			pos:  position{line: 1603, col: 1, offset: 39007},
 			expr: &choiceExpr{
-				pos: position{line: 1577, col: 5, offset: 37909},
+				pos: position{line: 1604, col: 5, offset: 39027},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1577, col: 5, offset: 37909},
+						pos:  position{line: 1604, col: 5, offset: 39027},
 						name: "UnicodeLetter",
 					},
 					&litMatcher{
-						pos:        position{line: 1578, col: 5, offset: 37927},
+						pos:        position{line: 1605, col: 5, offset: 39045},
 						val:        "$",
 						ignoreCase: false,
 						want:       "\"$\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1579, col: 5, offset: 37935},
+						pos:        position{line: 1606, col: 5, offset: 39053},
 						val:        "_",
 						ignoreCase: false,
 						want:       "\"_\"",
@@ -10314,24 +10556,24 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 1581, col: 1, offset: 37940},
+			pos:  position{line: 1608, col: 1, offset: 39058},
 			expr: &choiceExpr{
-				pos: position{line: 1582, col: 5, offset: 37959},
+				pos: position{line: 1609, col: 5, offset: 39077},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1582, col: 5, offset: 37959},
+						pos:  position{line: 1609, col: 5, offset: 39077},
 						name: "IdentifierStart",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1583, col: 5, offset: 37979},
+						pos:  position{line: 1610, col: 5, offset: 39097},
 						name: "UnicodeCombiningMark",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1584, col: 5, offset: 38004},
+						pos:  position{line: 1611, col: 5, offset: 39122},
 						name: "UnicodeDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1585, col: 5, offset: 38021},
+						pos:  position{line: 1612, col: 5, offset: 39139},
 						name: "UnicodeConnectorPunctuation",
 					},
 				},
@@ -10341,24 +10583,24 @@ var g = &grammar{
 		},
 		{
 			name: "IDGuard",
-			pos:  position{line: 1587, col: 1, offset: 38050},
+			pos:  position{line: 1614, col: 1, offset: 39168},
 			expr: &choiceExpr{
-				pos: position{line: 1588, col: 5, offset: 38062},
+				pos: position{line: 1615, col: 5, offset: 39180},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1588, col: 5, offset: 38062},
+						pos:  position{line: 1615, col: 5, offset: 39180},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1589, col: 5, offset: 38081},
+						pos:  position{line: 1616, col: 5, offset: 39199},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1590, col: 5, offset: 38097},
+						pos:  position{line: 1617, col: 5, offset: 39215},
 						name: "NaN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1591, col: 5, offset: 38105},
+						pos:  position{line: 1618, col: 5, offset: 39223},
 						name: "Infinity",
 					},
 				},
@@ -10368,25 +10610,25 @@ var g = &grammar{
 		},
 		{
 			name: "Time",
-			pos:  position{line: 1593, col: 1, offset: 38115},
+			pos:  position{line: 1620, col: 1, offset: 39233},
 			expr: &actionExpr{
-				pos: position{line: 1594, col: 5, offset: 38124},
+				pos: position{line: 1621, col: 5, offset: 39242},
 				run: (*parser).callonTime1,
 				expr: &seqExpr{
-					pos: position{line: 1594, col: 5, offset: 38124},
+					pos: position{line: 1621, col: 5, offset: 39242},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1594, col: 5, offset: 38124},
+							pos:  position{line: 1621, col: 5, offset: 39242},
 							name: "FullDate",
 						},
 						&litMatcher{
-							pos:        position{line: 1594, col: 14, offset: 38133},
+							pos:        position{line: 1621, col: 14, offset: 39251},
 							val:        "T",
 							ignoreCase: false,
 							want:       "\"T\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1594, col: 18, offset: 38137},
+							pos:  position{line: 1621, col: 18, offset: 39255},
 							name: "FullTime",
 						},
 					},
@@ -10397,32 +10639,32 @@ var g = &grammar{
 		},
 		{
 			name: "FullDate",
-			pos:  position{line: 1598, col: 1, offset: 38213},
+			pos:  position{line: 1625, col: 1, offset: 39331},
 			expr: &seqExpr{
-				pos: position{line: 1598, col: 12, offset: 38224},
+				pos: position{line: 1625, col: 12, offset: 39342},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1598, col: 12, offset: 38224},
+						pos:  position{line: 1625, col: 12, offset: 39342},
 						name: "D4",
 					},
 					&litMatcher{
-						pos:        position{line: 1598, col: 15, offset: 38227},
+						pos:        position{line: 1625, col: 15, offset: 39345},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1598, col: 19, offset: 38231},
+						pos:  position{line: 1625, col: 19, offset: 39349},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1598, col: 22, offset: 38234},
+						pos:        position{line: 1625, col: 22, offset: 39352},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1598, col: 26, offset: 38238},
+						pos:  position{line: 1625, col: 26, offset: 39356},
 						name: "D2",
 					},
 				},
@@ -10432,33 +10674,33 @@ var g = &grammar{
 		},
 		{
 			name: "D4",
-			pos:  position{line: 1600, col: 1, offset: 38242},
+			pos:  position{line: 1627, col: 1, offset: 39360},
 			expr: &seqExpr{
-				pos: position{line: 1600, col: 6, offset: 38247},
+				pos: position{line: 1627, col: 6, offset: 39365},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1600, col: 6, offset: 38247},
+						pos:        position{line: 1627, col: 6, offset: 39365},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1600, col: 11, offset: 38252},
+						pos:        position{line: 1627, col: 11, offset: 39370},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1600, col: 16, offset: 38257},
+						pos:        position{line: 1627, col: 16, offset: 39375},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1600, col: 21, offset: 38262},
+						pos:        position{line: 1627, col: 21, offset: 39380},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10471,19 +10713,19 @@ var g = &grammar{
 		},
 		{
 			name: "D2",
-			pos:  position{line: 1601, col: 1, offset: 38268},
+			pos:  position{line: 1628, col: 1, offset: 39386},
 			expr: &seqExpr{
-				pos: position{line: 1601, col: 6, offset: 38273},
+				pos: position{line: 1628, col: 6, offset: 39391},
 				exprs: []any{
 					&charClassMatcher{
-						pos:        position{line: 1601, col: 6, offset: 38273},
+						pos:        position{line: 1628, col: 6, offset: 39391},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&charClassMatcher{
-						pos:        position{line: 1601, col: 11, offset: 38278},
+						pos:        position{line: 1628, col: 11, offset: 39396},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10496,16 +10738,16 @@ var g = &grammar{
 		},
 		{
 			name: "FullTime",
-			pos:  position{line: 1603, col: 1, offset: 38285},
+			pos:  position{line: 1630, col: 1, offset: 39403},
 			expr: &seqExpr{
-				pos: position{line: 1603, col: 12, offset: 38296},
+				pos: position{line: 1630, col: 12, offset: 39414},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1603, col: 12, offset: 38296},
+						pos:  position{line: 1630, col: 12, offset: 39414},
 						name: "PartialTime",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1603, col: 24, offset: 38308},
+						pos:  position{line: 1630, col: 24, offset: 39426},
 						name: "TimeOffset",
 					},
 				},
@@ -10515,49 +10757,49 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTime",
-			pos:  position{line: 1605, col: 1, offset: 38320},
+			pos:  position{line: 1632, col: 1, offset: 39438},
 			expr: &seqExpr{
-				pos: position{line: 1605, col: 15, offset: 38334},
+				pos: position{line: 1632, col: 15, offset: 39452},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1605, col: 15, offset: 38334},
+						pos:  position{line: 1632, col: 15, offset: 39452},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1605, col: 18, offset: 38337},
+						pos:        position{line: 1632, col: 18, offset: 39455},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1605, col: 22, offset: 38341},
+						pos:  position{line: 1632, col: 22, offset: 39459},
 						name: "D2",
 					},
 					&litMatcher{
-						pos:        position{line: 1605, col: 25, offset: 38344},
+						pos:        position{line: 1632, col: 25, offset: 39462},
 						val:        ":",
 						ignoreCase: false,
 						want:       "\":\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1605, col: 29, offset: 38348},
+						pos:  position{line: 1632, col: 29, offset: 39466},
 						name: "D2",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1605, col: 32, offset: 38351},
+						pos: position{line: 1632, col: 32, offset: 39469},
 						expr: &seqExpr{
-							pos: position{line: 1605, col: 33, offset: 38352},
+							pos: position{line: 1632, col: 33, offset: 39470},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1605, col: 33, offset: 38352},
+									pos:        position{line: 1632, col: 33, offset: 39470},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1605, col: 37, offset: 38356},
+									pos: position{line: 1632, col: 37, offset: 39474},
 									expr: &charClassMatcher{
-										pos:        position{line: 1605, col: 37, offset: 38356},
+										pos:        position{line: 1632, col: 37, offset: 39474},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10574,30 +10816,30 @@ var g = &grammar{
 		},
 		{
 			name: "TimeOffset",
-			pos:  position{line: 1607, col: 1, offset: 38366},
+			pos:  position{line: 1634, col: 1, offset: 39484},
 			expr: &choiceExpr{
-				pos: position{line: 1608, col: 5, offset: 38381},
+				pos: position{line: 1635, col: 5, offset: 39499},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1608, col: 5, offset: 38381},
+						pos:        position{line: 1635, col: 5, offset: 39499},
 						val:        "Z",
 						ignoreCase: false,
 						want:       "\"Z\"",
 					},
 					&seqExpr{
-						pos: position{line: 1609, col: 5, offset: 38389},
+						pos: position{line: 1636, col: 5, offset: 39507},
 						exprs: []any{
 							&choiceExpr{
-								pos: position{line: 1609, col: 6, offset: 38390},
+								pos: position{line: 1636, col: 6, offset: 39508},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 1609, col: 6, offset: 38390},
+										pos:        position{line: 1636, col: 6, offset: 39508},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 1609, col: 12, offset: 38396},
+										pos:        position{line: 1636, col: 12, offset: 39514},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
@@ -10605,34 +10847,34 @@ var g = &grammar{
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1609, col: 17, offset: 38401},
+								pos:  position{line: 1636, col: 17, offset: 39519},
 								name: "D2",
 							},
 							&litMatcher{
-								pos:        position{line: 1609, col: 20, offset: 38404},
+								pos:        position{line: 1636, col: 20, offset: 39522},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1609, col: 24, offset: 38408},
+								pos:  position{line: 1636, col: 24, offset: 39526},
 								name: "D2",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1609, col: 27, offset: 38411},
+								pos: position{line: 1636, col: 27, offset: 39529},
 								expr: &seqExpr{
-									pos: position{line: 1609, col: 28, offset: 38412},
+									pos: position{line: 1636, col: 28, offset: 39530},
 									exprs: []any{
 										&litMatcher{
-											pos:        position{line: 1609, col: 28, offset: 38412},
+											pos:        position{line: 1636, col: 28, offset: 39530},
 											val:        ".",
 											ignoreCase: false,
 											want:       "\".\"",
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1609, col: 32, offset: 38416},
+											pos: position{line: 1636, col: 32, offset: 39534},
 											expr: &charClassMatcher{
-												pos:        position{line: 1609, col: 32, offset: 38416},
+												pos:        position{line: 1636, col: 32, offset: 39534},
 												val:        "[0-9]",
 												ranges:     []rune{'0', '9'},
 												ignoreCase: false,
@@ -10651,33 +10893,33 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 1611, col: 1, offset: 38426},
+			pos:  position{line: 1638, col: 1, offset: 39544},
 			expr: &actionExpr{
-				pos: position{line: 1612, col: 5, offset: 38439},
+				pos: position{line: 1639, col: 5, offset: 39557},
 				run: (*parser).callonDuration1,
 				expr: &seqExpr{
-					pos: position{line: 1612, col: 5, offset: 38439},
+					pos: position{line: 1639, col: 5, offset: 39557},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 1612, col: 5, offset: 38439},
+							pos: position{line: 1639, col: 5, offset: 39557},
 							expr: &litMatcher{
-								pos:        position{line: 1612, col: 5, offset: 38439},
+								pos:        position{line: 1639, col: 5, offset: 39557},
 								val:        "-",
 								ignoreCase: false,
 								want:       "\"-\"",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1612, col: 10, offset: 38444},
+							pos: position{line: 1639, col: 10, offset: 39562},
 							expr: &seqExpr{
-								pos: position{line: 1612, col: 11, offset: 38445},
+								pos: position{line: 1639, col: 11, offset: 39563},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1612, col: 11, offset: 38445},
+										pos:  position{line: 1639, col: 11, offset: 39563},
 										name: "Decimal",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1612, col: 19, offset: 38453},
+										pos:  position{line: 1639, col: 19, offset: 39571},
 										name: "TimeUnit",
 									},
 								},
@@ -10691,27 +10933,27 @@ var g = &grammar{
 		},
 		{
 			name: "Decimal",
-			pos:  position{line: 1616, col: 1, offset: 38535},
+			pos:  position{line: 1643, col: 1, offset: 39653},
 			expr: &seqExpr{
-				pos: position{line: 1616, col: 11, offset: 38545},
+				pos: position{line: 1643, col: 11, offset: 39663},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1616, col: 11, offset: 38545},
+						pos:  position{line: 1643, col: 11, offset: 39663},
 						name: "UInt",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1616, col: 16, offset: 38550},
+						pos: position{line: 1643, col: 16, offset: 39668},
 						expr: &seqExpr{
-							pos: position{line: 1616, col: 17, offset: 38551},
+							pos: position{line: 1643, col: 17, offset: 39669},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1616, col: 17, offset: 38551},
+									pos:        position{line: 1643, col: 17, offset: 39669},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1616, col: 21, offset: 38555},
+									pos:  position{line: 1643, col: 21, offset: 39673},
 									name: "UInt",
 								},
 							},
@@ -10724,60 +10966,60 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 1618, col: 1, offset: 38563},
+			pos:  position{line: 1645, col: 1, offset: 39681},
 			expr: &choiceExpr{
-				pos: position{line: 1619, col: 5, offset: 38576},
+				pos: position{line: 1646, col: 5, offset: 39694},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1619, col: 5, offset: 38576},
+						pos:        position{line: 1646, col: 5, offset: 39694},
 						val:        "ns",
 						ignoreCase: false,
 						want:       "\"ns\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1620, col: 5, offset: 38585},
+						pos:        position{line: 1647, col: 5, offset: 39703},
 						val:        "us",
 						ignoreCase: false,
 						want:       "\"us\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1621, col: 5, offset: 38594},
+						pos:        position{line: 1648, col: 5, offset: 39712},
 						val:        "ms",
 						ignoreCase: false,
 						want:       "\"ms\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1622, col: 5, offset: 38603},
+						pos:        position{line: 1649, col: 5, offset: 39721},
 						val:        "s",
 						ignoreCase: false,
 						want:       "\"s\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1623, col: 5, offset: 38611},
+						pos:        position{line: 1650, col: 5, offset: 39729},
 						val:        "m",
 						ignoreCase: false,
 						want:       "\"m\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1624, col: 5, offset: 38619},
+						pos:        position{line: 1651, col: 5, offset: 39737},
 						val:        "h",
 						ignoreCase: false,
 						want:       "\"h\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1625, col: 5, offset: 38627},
+						pos:        position{line: 1652, col: 5, offset: 39745},
 						val:        "d",
 						ignoreCase: false,
 						want:       "\"d\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1626, col: 5, offset: 38635},
+						pos:        position{line: 1653, col: 5, offset: 39753},
 						val:        "w",
 						ignoreCase: false,
 						want:       "\"w\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1627, col: 5, offset: 38643},
+						pos:        position{line: 1654, col: 5, offset: 39761},
 						val:        "y",
 						ignoreCase: false,
 						want:       "\"y\"",
@@ -10789,45 +11031,45 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 1629, col: 1, offset: 38648},
+			pos:  position{line: 1656, col: 1, offset: 39766},
 			expr: &actionExpr{
-				pos: position{line: 1630, col: 5, offset: 38655},
+				pos: position{line: 1657, col: 5, offset: 39773},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 1630, col: 5, offset: 38655},
+					pos: position{line: 1657, col: 5, offset: 39773},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1630, col: 5, offset: 38655},
+							pos:  position{line: 1657, col: 5, offset: 39773},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1630, col: 10, offset: 38660},
+							pos:        position{line: 1657, col: 10, offset: 39778},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1630, col: 14, offset: 38664},
+							pos:  position{line: 1657, col: 14, offset: 39782},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1630, col: 19, offset: 38669},
+							pos:        position{line: 1657, col: 19, offset: 39787},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1630, col: 23, offset: 38673},
+							pos:  position{line: 1657, col: 23, offset: 39791},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 1630, col: 28, offset: 38678},
+							pos:        position{line: 1657, col: 28, offset: 39796},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1630, col: 32, offset: 38682},
+							pos:  position{line: 1657, col: 32, offset: 39800},
 							name: "UInt",
 						},
 					},
@@ -10838,43 +11080,43 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 1632, col: 1, offset: 38719},
+			pos:  position{line: 1659, col: 1, offset: 39837},
 			expr: &actionExpr{
-				pos: position{line: 1633, col: 5, offset: 38727},
+				pos: position{line: 1660, col: 5, offset: 39845},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 1633, col: 5, offset: 38727},
+					pos: position{line: 1660, col: 5, offset: 39845},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1633, col: 5, offset: 38727},
+							pos: position{line: 1660, col: 5, offset: 39845},
 							expr: &seqExpr{
-								pos: position{line: 1633, col: 7, offset: 38729},
+								pos: position{line: 1660, col: 7, offset: 39847},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1633, col: 7, offset: 38729},
+										pos:  position{line: 1660, col: 7, offset: 39847},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 1633, col: 11, offset: 38733},
+										pos:        position{line: 1660, col: 11, offset: 39851},
 										val:        ":",
 										ignoreCase: false,
 										want:       "\":\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1633, col: 15, offset: 38737},
+										pos:  position{line: 1660, col: 15, offset: 39855},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 1633, col: 19, offset: 38741},
+										pos: position{line: 1660, col: 19, offset: 39859},
 										expr: &choiceExpr{
-											pos: position{line: 1633, col: 21, offset: 38743},
+											pos: position{line: 1660, col: 21, offset: 39861},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1633, col: 21, offset: 38743},
+													pos:  position{line: 1660, col: 21, offset: 39861},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 1633, col: 32, offset: 38754},
+													pos:        position{line: 1660, col: 32, offset: 39872},
 													val:        ":",
 													ignoreCase: false,
 													want:       "\":\"",
@@ -10886,10 +11128,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1633, col: 38, offset: 38760},
+							pos:   position{line: 1660, col: 38, offset: 39878},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1633, col: 40, offset: 38762},
+								pos:  position{line: 1660, col: 40, offset: 39880},
 								name: "IP6Variations",
 							},
 						},
@@ -10901,32 +11143,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 1637, col: 1, offset: 38926},
+			pos:  position{line: 1664, col: 1, offset: 40044},
 			expr: &choiceExpr{
-				pos: position{line: 1638, col: 5, offset: 38944},
+				pos: position{line: 1665, col: 5, offset: 40062},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1638, col: 5, offset: 38944},
+						pos: position{line: 1665, col: 5, offset: 40062},
 						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
-							pos: position{line: 1638, col: 5, offset: 38944},
+							pos: position{line: 1665, col: 5, offset: 40062},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1638, col: 5, offset: 38944},
+									pos:   position{line: 1665, col: 5, offset: 40062},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1638, col: 7, offset: 38946},
+										pos: position{line: 1665, col: 7, offset: 40064},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1638, col: 7, offset: 38946},
+											pos:  position{line: 1665, col: 7, offset: 40064},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1638, col: 17, offset: 38956},
+									pos:   position{line: 1665, col: 17, offset: 40074},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1638, col: 19, offset: 38958},
+										pos:  position{line: 1665, col: 19, offset: 40076},
 										name: "IP6Tail",
 									},
 								},
@@ -10934,52 +11176,52 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1641, col: 5, offset: 39022},
+						pos: position{line: 1668, col: 5, offset: 40140},
 						run: (*parser).callonIP6Variations9,
 						expr: &seqExpr{
-							pos: position{line: 1641, col: 5, offset: 39022},
+							pos: position{line: 1668, col: 5, offset: 40140},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1641, col: 5, offset: 39022},
+									pos:   position{line: 1668, col: 5, offset: 40140},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1641, col: 7, offset: 39024},
+										pos:  position{line: 1668, col: 7, offset: 40142},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1641, col: 11, offset: 39028},
+									pos:   position{line: 1668, col: 11, offset: 40146},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1641, col: 13, offset: 39030},
+										pos: position{line: 1668, col: 13, offset: 40148},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1641, col: 13, offset: 39030},
+											pos:  position{line: 1668, col: 13, offset: 40148},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1641, col: 23, offset: 39040},
+									pos:        position{line: 1668, col: 23, offset: 40158},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1641, col: 28, offset: 39045},
+									pos:   position{line: 1668, col: 28, offset: 40163},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1641, col: 30, offset: 39047},
+										pos: position{line: 1668, col: 30, offset: 40165},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1641, col: 30, offset: 39047},
+											pos:  position{line: 1668, col: 30, offset: 40165},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1641, col: 40, offset: 39057},
+									pos:   position{line: 1668, col: 40, offset: 40175},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1641, col: 42, offset: 39059},
+										pos:  position{line: 1668, col: 42, offset: 40177},
 										name: "IP6Tail",
 									},
 								},
@@ -10987,33 +11229,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1644, col: 5, offset: 39158},
+						pos: position{line: 1671, col: 5, offset: 40276},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 1644, col: 5, offset: 39158},
+							pos: position{line: 1671, col: 5, offset: 40276},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1644, col: 5, offset: 39158},
+									pos:        position{line: 1671, col: 5, offset: 40276},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1644, col: 10, offset: 39163},
+									pos:   position{line: 1671, col: 10, offset: 40281},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1644, col: 12, offset: 39165},
+										pos: position{line: 1671, col: 12, offset: 40283},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1644, col: 12, offset: 39165},
+											pos:  position{line: 1671, col: 12, offset: 40283},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1644, col: 22, offset: 39175},
+									pos:   position{line: 1671, col: 22, offset: 40293},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1644, col: 24, offset: 39177},
+										pos:  position{line: 1671, col: 24, offset: 40295},
 										name: "IP6Tail",
 									},
 								},
@@ -11021,40 +11263,40 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1647, col: 5, offset: 39248},
+						pos: position{line: 1674, col: 5, offset: 40366},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 1647, col: 5, offset: 39248},
+							pos: position{line: 1674, col: 5, offset: 40366},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1647, col: 5, offset: 39248},
+									pos:   position{line: 1674, col: 5, offset: 40366},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1647, col: 7, offset: 39250},
+										pos:  position{line: 1674, col: 7, offset: 40368},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1647, col: 11, offset: 39254},
+									pos:   position{line: 1674, col: 11, offset: 40372},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1647, col: 13, offset: 39256},
+										pos: position{line: 1674, col: 13, offset: 40374},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1647, col: 13, offset: 39256},
+											pos:  position{line: 1674, col: 13, offset: 40374},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1647, col: 23, offset: 39266},
+									pos:        position{line: 1674, col: 23, offset: 40384},
 									val:        "::",
 									ignoreCase: false,
 									want:       "\"::\"",
 								},
 								&notExpr{
-									pos: position{line: 1647, col: 28, offset: 39271},
+									pos: position{line: 1674, col: 28, offset: 40389},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1647, col: 29, offset: 39272},
+										pos:  position{line: 1674, col: 29, offset: 40390},
 										name: "TypeAsValue",
 									},
 								},
@@ -11062,10 +11304,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1650, col: 5, offset: 39347},
+						pos: position{line: 1677, col: 5, offset: 40465},
 						run: (*parser).callonIP6Variations40,
 						expr: &litMatcher{
-							pos:        position{line: 1650, col: 5, offset: 39347},
+							pos:        position{line: 1677, col: 5, offset: 40465},
 							val:        "::",
 							ignoreCase: false,
 							want:       "\"::\"",
@@ -11078,16 +11320,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 1654, col: 1, offset: 39384},
+			pos:  position{line: 1681, col: 1, offset: 40502},
 			expr: &choiceExpr{
-				pos: position{line: 1655, col: 5, offset: 39396},
+				pos: position{line: 1682, col: 5, offset: 40514},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1655, col: 5, offset: 39396},
+						pos:  position{line: 1682, col: 5, offset: 40514},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1656, col: 5, offset: 39403},
+						pos:  position{line: 1683, col: 5, offset: 40521},
 						name: "Hex",
 					},
 				},
@@ -11097,24 +11339,24 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 1658, col: 1, offset: 39408},
+			pos:  position{line: 1685, col: 1, offset: 40526},
 			expr: &actionExpr{
-				pos: position{line: 1658, col: 12, offset: 39419},
+				pos: position{line: 1685, col: 12, offset: 40537},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 1658, col: 12, offset: 39419},
+					pos: position{line: 1685, col: 12, offset: 40537},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1658, col: 12, offset: 39419},
+							pos:        position{line: 1685, col: 12, offset: 40537},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1658, col: 16, offset: 39423},
+							pos:   position{line: 1685, col: 16, offset: 40541},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1658, col: 18, offset: 39425},
+								pos:  position{line: 1685, col: 18, offset: 40543},
 								name: "Hex",
 							},
 						},
@@ -11126,23 +11368,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 1660, col: 1, offset: 39463},
+			pos:  position{line: 1687, col: 1, offset: 40581},
 			expr: &actionExpr{
-				pos: position{line: 1660, col: 12, offset: 39474},
+				pos: position{line: 1687, col: 12, offset: 40592},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 1660, col: 12, offset: 39474},
+					pos: position{line: 1687, col: 12, offset: 40592},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1660, col: 12, offset: 39474},
+							pos:   position{line: 1687, col: 12, offset: 40592},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1660, col: 14, offset: 39476},
+								pos:  position{line: 1687, col: 14, offset: 40594},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1660, col: 18, offset: 39480},
+							pos:        position{line: 1687, col: 18, offset: 40598},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
@@ -11155,32 +11397,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 1662, col: 1, offset: 39518},
+			pos:  position{line: 1689, col: 1, offset: 40636},
 			expr: &actionExpr{
-				pos: position{line: 1663, col: 5, offset: 39529},
+				pos: position{line: 1690, col: 5, offset: 40647},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 1663, col: 5, offset: 39529},
+					pos: position{line: 1690, col: 5, offset: 40647},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1663, col: 5, offset: 39529},
+							pos:   position{line: 1690, col: 5, offset: 40647},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1663, col: 7, offset: 39531},
+								pos:  position{line: 1690, col: 7, offset: 40649},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1663, col: 10, offset: 39534},
+							pos:        position{line: 1690, col: 10, offset: 40652},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1663, col: 14, offset: 39538},
+							pos:   position{line: 1690, col: 14, offset: 40656},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1663, col: 16, offset: 39540},
+								pos:  position{line: 1690, col: 16, offset: 40658},
 								name: "UIntString",
 							},
 						},
@@ -11192,32 +11434,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 1667, col: 1, offset: 39608},
+			pos:  position{line: 1694, col: 1, offset: 40726},
 			expr: &actionExpr{
-				pos: position{line: 1668, col: 5, offset: 39619},
+				pos: position{line: 1695, col: 5, offset: 40737},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 1668, col: 5, offset: 39619},
+					pos: position{line: 1695, col: 5, offset: 40737},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1668, col: 5, offset: 39619},
+							pos:   position{line: 1695, col: 5, offset: 40737},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1668, col: 7, offset: 39621},
+								pos:  position{line: 1695, col: 7, offset: 40739},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1668, col: 11, offset: 39625},
+							pos:        position{line: 1695, col: 11, offset: 40743},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1668, col: 15, offset: 39629},
+							pos:   position{line: 1695, col: 15, offset: 40747},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1668, col: 17, offset: 39631},
+								pos:  position{line: 1695, col: 17, offset: 40749},
 								name: "UIntString",
 							},
 						},
@@ -11229,15 +11471,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 1672, col: 1, offset: 39699},
+			pos:  position{line: 1699, col: 1, offset: 40817},
 			expr: &actionExpr{
-				pos: position{line: 1673, col: 4, offset: 39707},
+				pos: position{line: 1700, col: 4, offset: 40825},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 1673, col: 4, offset: 39707},
+					pos:   position{line: 1700, col: 4, offset: 40825},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1673, col: 6, offset: 39709},
+						pos:  position{line: 1700, col: 6, offset: 40827},
 						name: "UIntString",
 					},
 				},
@@ -11247,16 +11489,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 1675, col: 1, offset: 39749},
+			pos:  position{line: 1702, col: 1, offset: 40867},
 			expr: &choiceExpr{
-				pos: position{line: 1676, col: 5, offset: 39763},
+				pos: position{line: 1703, col: 5, offset: 40881},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1676, col: 5, offset: 39763},
+						pos:  position{line: 1703, col: 5, offset: 40881},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1677, col: 5, offset: 39778},
+						pos:  position{line: 1704, col: 5, offset: 40896},
 						name: "MinusIntString",
 					},
 				},
@@ -11266,14 +11508,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 1679, col: 1, offset: 39794},
+			pos:  position{line: 1706, col: 1, offset: 40912},
 			expr: &actionExpr{
-				pos: position{line: 1679, col: 14, offset: 39807},
+				pos: position{line: 1706, col: 14, offset: 40925},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1679, col: 14, offset: 39807},
+					pos: position{line: 1706, col: 14, offset: 40925},
 					expr: &charClassMatcher{
-						pos:        position{line: 1679, col: 14, offset: 39807},
+						pos:        position{line: 1706, col: 14, offset: 40925},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11286,21 +11528,21 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 1681, col: 1, offset: 39846},
+			pos:  position{line: 1708, col: 1, offset: 40964},
 			expr: &actionExpr{
-				pos: position{line: 1682, col: 5, offset: 39865},
+				pos: position{line: 1709, col: 5, offset: 40983},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 1682, col: 5, offset: 39865},
+					pos: position{line: 1709, col: 5, offset: 40983},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1682, col: 5, offset: 39865},
+							pos:        position{line: 1709, col: 5, offset: 40983},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1682, col: 9, offset: 39869},
+							pos:  position{line: 1709, col: 9, offset: 40987},
 							name: "UIntString",
 						},
 					},
@@ -11311,29 +11553,29 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 1684, col: 1, offset: 39912},
+			pos:  position{line: 1711, col: 1, offset: 41030},
 			expr: &choiceExpr{
-				pos: position{line: 1685, col: 5, offset: 39928},
+				pos: position{line: 1712, col: 5, offset: 41046},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1685, col: 5, offset: 39928},
+						pos: position{line: 1712, col: 5, offset: 41046},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 1685, col: 5, offset: 39928},
+							pos: position{line: 1712, col: 5, offset: 41046},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1685, col: 5, offset: 39928},
+									pos: position{line: 1712, col: 5, offset: 41046},
 									expr: &litMatcher{
-										pos:        position{line: 1685, col: 5, offset: 39928},
+										pos:        position{line: 1712, col: 5, offset: 41046},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1685, col: 10, offset: 39933},
+									pos: position{line: 1712, col: 10, offset: 41051},
 									expr: &charClassMatcher{
-										pos:        position{line: 1685, col: 10, offset: 39933},
+										pos:        position{line: 1712, col: 10, offset: 41051},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11341,15 +11583,15 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1685, col: 17, offset: 39940},
+									pos:        position{line: 1712, col: 17, offset: 41058},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1685, col: 21, offset: 39944},
+									pos: position{line: 1712, col: 21, offset: 41062},
 									expr: &charClassMatcher{
-										pos:        position{line: 1685, col: 21, offset: 39944},
+										pos:        position{line: 1712, col: 21, offset: 41062},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11357,9 +11599,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1685, col: 28, offset: 39951},
+									pos: position{line: 1712, col: 28, offset: 41069},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1685, col: 28, offset: 39951},
+										pos:  position{line: 1712, col: 28, offset: 41069},
 										name: "ExponentPart",
 									},
 								},
@@ -11367,30 +11609,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1686, col: 5, offset: 40000},
+						pos: position{line: 1713, col: 5, offset: 41118},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 1686, col: 5, offset: 40000},
+							pos: position{line: 1713, col: 5, offset: 41118},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 1686, col: 5, offset: 40000},
+									pos: position{line: 1713, col: 5, offset: 41118},
 									expr: &litMatcher{
-										pos:        position{line: 1686, col: 5, offset: 40000},
+										pos:        position{line: 1713, col: 5, offset: 41118},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1686, col: 10, offset: 40005},
+									pos:        position{line: 1713, col: 10, offset: 41123},
 									val:        ".",
 									ignoreCase: false,
 									want:       "\".\"",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1686, col: 14, offset: 40009},
+									pos: position{line: 1713, col: 14, offset: 41127},
 									expr: &charClassMatcher{
-										pos:        position{line: 1686, col: 14, offset: 40009},
+										pos:        position{line: 1713, col: 14, offset: 41127},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11398,9 +11640,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1686, col: 21, offset: 40016},
+									pos: position{line: 1713, col: 21, offset: 41134},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1686, col: 21, offset: 40016},
+										pos:  position{line: 1713, col: 21, offset: 41134},
 										name: "ExponentPart",
 									},
 								},
@@ -11408,17 +11650,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1687, col: 5, offset: 40065},
+						pos: position{line: 1714, col: 5, offset: 41183},
 						run: (*parser).callonFloatString22,
 						expr: &choiceExpr{
-							pos: position{line: 1687, col: 6, offset: 40066},
+							pos: position{line: 1714, col: 6, offset: 41184},
 							alternatives: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1687, col: 6, offset: 40066},
+									pos:  position{line: 1714, col: 6, offset: 41184},
 									name: "NaN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1687, col: 12, offset: 40072},
+									pos:  position{line: 1714, col: 12, offset: 41190},
 									name: "Infinity",
 								},
 							},
@@ -11431,20 +11673,20 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 1690, col: 1, offset: 40115},
+			pos:  position{line: 1717, col: 1, offset: 41233},
 			expr: &seqExpr{
-				pos: position{line: 1690, col: 16, offset: 40130},
+				pos: position{line: 1717, col: 16, offset: 41248},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1690, col: 16, offset: 40130},
+						pos:        position{line: 1717, col: 16, offset: 41248},
 						val:        "e",
 						ignoreCase: true,
 						want:       "\"e\"i",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 1690, col: 21, offset: 40135},
+						pos: position{line: 1717, col: 21, offset: 41253},
 						expr: &charClassMatcher{
-							pos:        position{line: 1690, col: 21, offset: 40135},
+							pos:        position{line: 1717, col: 21, offset: 41253},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -11452,7 +11694,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1690, col: 27, offset: 40141},
+						pos:  position{line: 1717, col: 27, offset: 41259},
 						name: "UIntString",
 					},
 				},
@@ -11462,9 +11704,9 @@ var g = &grammar{
 		},
 		{
 			name: "NaN",
-			pos:  position{line: 1692, col: 1, offset: 40153},
+			pos:  position{line: 1719, col: 1, offset: 41271},
 			expr: &litMatcher{
-				pos:        position{line: 1692, col: 7, offset: 40159},
+				pos:        position{line: 1719, col: 7, offset: 41277},
 				val:        "NaN",
 				ignoreCase: false,
 				want:       "\"NaN\"",
@@ -11474,23 +11716,23 @@ var g = &grammar{
 		},
 		{
 			name: "Infinity",
-			pos:  position{line: 1694, col: 1, offset: 40166},
+			pos:  position{line: 1721, col: 1, offset: 41284},
 			expr: &seqExpr{
-				pos: position{line: 1694, col: 12, offset: 40177},
+				pos: position{line: 1721, col: 12, offset: 41295},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 1694, col: 12, offset: 40177},
+						pos: position{line: 1721, col: 12, offset: 41295},
 						expr: &choiceExpr{
-							pos: position{line: 1694, col: 13, offset: 40178},
+							pos: position{line: 1721, col: 13, offset: 41296},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1694, col: 13, offset: 40178},
+									pos:        position{line: 1721, col: 13, offset: 41296},
 									val:        "-",
 									ignoreCase: false,
 									want:       "\"-\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1694, col: 19, offset: 40184},
+									pos:        position{line: 1721, col: 19, offset: 41302},
 									val:        "+",
 									ignoreCase: false,
 									want:       "\"+\"",
@@ -11499,7 +11741,7 @@ var g = &grammar{
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1694, col: 25, offset: 40190},
+						pos:        position{line: 1721, col: 25, offset: 41308},
 						val:        "Inf",
 						ignoreCase: false,
 						want:       "\"Inf\"",
@@ -11511,14 +11753,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 1696, col: 1, offset: 40197},
+			pos:  position{line: 1723, col: 1, offset: 41315},
 			expr: &actionExpr{
-				pos: position{line: 1696, col: 7, offset: 40203},
+				pos: position{line: 1723, col: 7, offset: 41321},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1696, col: 7, offset: 40203},
+					pos: position{line: 1723, col: 7, offset: 41321},
 					expr: &ruleRefExpr{
-						pos:  position{line: 1696, col: 7, offset: 40203},
+						pos:  position{line: 1723, col: 7, offset: 41321},
 						name: "HexDigit",
 					},
 				},
@@ -11528,9 +11770,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 1698, col: 1, offset: 40245},
+			pos:  position{line: 1725, col: 1, offset: 41363},
 			expr: &charClassMatcher{
-				pos:        position{line: 1698, col: 12, offset: 40256},
+				pos:        position{line: 1725, col: 12, offset: 41374},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -11541,32 +11783,32 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedString",
-			pos:  position{line: 1700, col: 1, offset: 40269},
+			pos:  position{line: 1727, col: 1, offset: 41387},
 			expr: &actionExpr{
-				pos: position{line: 1701, col: 5, offset: 40292},
+				pos: position{line: 1728, col: 5, offset: 41410},
 				run: (*parser).callonSingleQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 1701, col: 5, offset: 40292},
+					pos: position{line: 1728, col: 5, offset: 41410},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1701, col: 5, offset: 40292},
+							pos:        position{line: 1728, col: 5, offset: 41410},
 							val:        "'",
 							ignoreCase: false,
 							want:       "\"'\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1701, col: 9, offset: 40296},
+							pos:   position{line: 1728, col: 9, offset: 41414},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1701, col: 11, offset: 40298},
+								pos: position{line: 1728, col: 11, offset: 41416},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1701, col: 11, offset: 40298},
+									pos:  position{line: 1728, col: 11, offset: 41416},
 									name: "SingleQuotedChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1701, col: 29, offset: 40316},
+							pos:        position{line: 1728, col: 29, offset: 41434},
 							val:        "'",
 							ignoreCase: false,
 							want:       "\"'\"",
@@ -11579,32 +11821,32 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedString",
-			pos:  position{line: 1703, col: 1, offset: 40350},
+			pos:  position{line: 1730, col: 1, offset: 41468},
 			expr: &actionExpr{
-				pos: position{line: 1704, col: 5, offset: 40373},
+				pos: position{line: 1731, col: 5, offset: 41491},
 				run: (*parser).callonDoubleQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 1704, col: 5, offset: 40373},
+					pos: position{line: 1731, col: 5, offset: 41491},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1704, col: 5, offset: 40373},
+							pos:        position{line: 1731, col: 5, offset: 41491},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1704, col: 9, offset: 40377},
+							pos:   position{line: 1731, col: 9, offset: 41495},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1704, col: 11, offset: 40379},
+								pos: position{line: 1731, col: 11, offset: 41497},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1704, col: 11, offset: 40379},
+									pos:  position{line: 1731, col: 11, offset: 41497},
 									name: "DoubleQuotedChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1704, col: 29, offset: 40397},
+							pos:        position{line: 1731, col: 29, offset: 41515},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11617,57 +11859,57 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 1706, col: 1, offset: 40431},
+			pos:  position{line: 1733, col: 1, offset: 41549},
 			expr: &choiceExpr{
-				pos: position{line: 1707, col: 5, offset: 40452},
+				pos: position{line: 1734, col: 5, offset: 41570},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1707, col: 5, offset: 40452},
+						pos: position{line: 1734, col: 5, offset: 41570},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1707, col: 5, offset: 40452},
+							pos: position{line: 1734, col: 5, offset: 41570},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1707, col: 5, offset: 40452},
+									pos: position{line: 1734, col: 5, offset: 41570},
 									expr: &choiceExpr{
-										pos: position{line: 1707, col: 7, offset: 40454},
+										pos: position{line: 1734, col: 7, offset: 41572},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1707, col: 7, offset: 40454},
+												pos:        position{line: 1734, col: 7, offset: 41572},
 												val:        "\"",
 												ignoreCase: false,
 												want:       "\"\\\"\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1707, col: 13, offset: 40460},
+												pos:  position{line: 1734, col: 13, offset: 41578},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1707, col: 26, offset: 40473,
+									line: 1734, col: 26, offset: 41591,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1708, col: 5, offset: 40510},
+						pos: position{line: 1735, col: 5, offset: 41628},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1708, col: 5, offset: 40510},
+							pos: position{line: 1735, col: 5, offset: 41628},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1708, col: 5, offset: 40510},
+									pos:        position{line: 1735, col: 5, offset: 41628},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1708, col: 10, offset: 40515},
+									pos:   position{line: 1735, col: 10, offset: 41633},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1708, col: 12, offset: 40517},
+										pos:  position{line: 1735, col: 12, offset: 41635},
 										name: "EscapeSequence",
 									},
 								},
@@ -11681,32 +11923,32 @@ var g = &grammar{
 		},
 		{
 			name: "RString",
-			pos:  position{line: 1710, col: 1, offset: 40551},
+			pos:  position{line: 1737, col: 1, offset: 41669},
 			expr: &choiceExpr{
-				pos: position{line: 1711, col: 5, offset: 40563},
+				pos: position{line: 1738, col: 5, offset: 41681},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1711, col: 5, offset: 40563},
+						pos: position{line: 1738, col: 5, offset: 41681},
 						run: (*parser).callonRString2,
 						expr: &seqExpr{
-							pos: position{line: 1711, col: 5, offset: 40563},
+							pos: position{line: 1738, col: 5, offset: 41681},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1711, col: 5, offset: 40563},
+									pos:        position{line: 1738, col: 5, offset: 41681},
 									val:        "r'",
 									ignoreCase: false,
 									want:       "\"r'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1711, col: 10, offset: 40568},
+									pos:   position{line: 1738, col: 10, offset: 41686},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1711, col: 12, offset: 40570},
+										pos:  position{line: 1738, col: 12, offset: 41688},
 										name: "NoSingleQuotes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1711, col: 27, offset: 40585},
+									pos:        position{line: 1738, col: 27, offset: 41703},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -11715,33 +11957,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1712, col: 5, offset: 40620},
+						pos: position{line: 1739, col: 5, offset: 41738},
 						run: (*parser).callonRString8,
 						expr: &seqExpr{
-							pos: position{line: 1712, col: 5, offset: 40620},
+							pos: position{line: 1739, col: 5, offset: 41738},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1712, col: 5, offset: 40620},
+									pos:        position{line: 1739, col: 5, offset: 41738},
 									val:        "r",
 									ignoreCase: false,
 									want:       "\"r\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1712, col: 9, offset: 40624},
+									pos:        position{line: 1739, col: 9, offset: 41742},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1712, col: 13, offset: 40628},
+									pos:   position{line: 1739, col: 13, offset: 41746},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1712, col: 15, offset: 40630},
+										pos:  position{line: 1739, col: 15, offset: 41748},
 										name: "NoDoubleQuotes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1712, col: 30, offset: 40645},
+									pos:        position{line: 1739, col: 30, offset: 41763},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
@@ -11756,26 +11998,26 @@ var g = &grammar{
 		},
 		{
 			name: "NoSingleQuotes",
-			pos:  position{line: 1714, col: 1, offset: 40677},
+			pos:  position{line: 1741, col: 1, offset: 41795},
 			expr: &actionExpr{
-				pos: position{line: 1715, col: 5, offset: 40696},
+				pos: position{line: 1742, col: 5, offset: 41814},
 				run: (*parser).callonNoSingleQuotes1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 1715, col: 5, offset: 40696},
+					pos: position{line: 1742, col: 5, offset: 41814},
 					expr: &seqExpr{
-						pos: position{line: 1715, col: 6, offset: 40697},
+						pos: position{line: 1742, col: 6, offset: 41815},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 1715, col: 6, offset: 40697},
+								pos: position{line: 1742, col: 6, offset: 41815},
 								expr: &litMatcher{
-									pos:        position{line: 1715, col: 7, offset: 40698},
+									pos:        position{line: 1742, col: 7, offset: 41816},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 							},
 							&anyMatcher{
-								line: 1715, col: 11, offset: 40702,
+								line: 1742, col: 11, offset: 41820,
 							},
 						},
 					},
@@ -11786,26 +12028,26 @@ var g = &grammar{
 		},
 		{
 			name: "NoDoubleQuotes",
-			pos:  position{line: 1717, col: 1, offset: 40738},
+			pos:  position{line: 1744, col: 1, offset: 41856},
 			expr: &actionExpr{
-				pos: position{line: 1718, col: 5, offset: 40757},
+				pos: position{line: 1745, col: 5, offset: 41875},
 				run: (*parser).callonNoDoubleQuotes1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 1718, col: 5, offset: 40757},
+					pos: position{line: 1745, col: 5, offset: 41875},
 					expr: &seqExpr{
-						pos: position{line: 1718, col: 6, offset: 40758},
+						pos: position{line: 1745, col: 6, offset: 41876},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 1718, col: 6, offset: 40758},
+								pos: position{line: 1745, col: 6, offset: 41876},
 								expr: &litMatcher{
-									pos:        position{line: 1718, col: 7, offset: 40759},
+									pos:        position{line: 1745, col: 7, offset: 41877},
 									val:        "\"",
 									ignoreCase: false,
 									want:       "\"\\\"\"",
 								},
 							},
 							&anyMatcher{
-								line: 1718, col: 11, offset: 40763,
+								line: 1745, col: 11, offset: 41881,
 							},
 						},
 					},
@@ -11816,32 +12058,32 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickString",
-			pos:  position{line: 1720, col: 1, offset: 40799},
+			pos:  position{line: 1747, col: 1, offset: 41917},
 			expr: &actionExpr{
-				pos: position{line: 1721, col: 5, offset: 40818},
+				pos: position{line: 1748, col: 5, offset: 41936},
 				run: (*parser).callonBacktickString1,
 				expr: &seqExpr{
-					pos: position{line: 1721, col: 5, offset: 40818},
+					pos: position{line: 1748, col: 5, offset: 41936},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1721, col: 5, offset: 40818},
+							pos:        position{line: 1748, col: 5, offset: 41936},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1721, col: 9, offset: 40822},
+							pos:   position{line: 1748, col: 9, offset: 41940},
 							label: "v",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1721, col: 11, offset: 40824},
+								pos: position{line: 1748, col: 11, offset: 41942},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1721, col: 11, offset: 40824},
+									pos:  position{line: 1748, col: 11, offset: 41942},
 									name: "BacktickChar",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1721, col: 25, offset: 40838},
+							pos:        position{line: 1748, col: 25, offset: 41956},
 							val:        "`",
 							ignoreCase: false,
 							want:       "\"`\"",
@@ -11854,57 +12096,57 @@ var g = &grammar{
 		},
 		{
 			name: "BacktickChar",
-			pos:  position{line: 1723, col: 1, offset: 40872},
+			pos:  position{line: 1750, col: 1, offset: 41990},
 			expr: &choiceExpr{
-				pos: position{line: 1724, col: 5, offset: 40889},
+				pos: position{line: 1751, col: 5, offset: 42007},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1724, col: 5, offset: 40889},
+						pos: position{line: 1751, col: 5, offset: 42007},
 						run: (*parser).callonBacktickChar2,
 						expr: &seqExpr{
-							pos: position{line: 1724, col: 5, offset: 40889},
+							pos: position{line: 1751, col: 5, offset: 42007},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1724, col: 5, offset: 40889},
+									pos: position{line: 1751, col: 5, offset: 42007},
 									expr: &choiceExpr{
-										pos: position{line: 1724, col: 7, offset: 40891},
+										pos: position{line: 1751, col: 7, offset: 42009},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1724, col: 7, offset: 40891},
+												pos:        position{line: 1751, col: 7, offset: 42009},
 												val:        "`",
 												ignoreCase: false,
 												want:       "\"`\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1724, col: 13, offset: 40897},
+												pos:  position{line: 1751, col: 13, offset: 42015},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1724, col: 26, offset: 40910,
+									line: 1751, col: 26, offset: 42028,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1725, col: 5, offset: 40947},
+						pos: position{line: 1752, col: 5, offset: 42065},
 						run: (*parser).callonBacktickChar9,
 						expr: &seqExpr{
-							pos: position{line: 1725, col: 5, offset: 40947},
+							pos: position{line: 1752, col: 5, offset: 42065},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1725, col: 5, offset: 40947},
+									pos:        position{line: 1752, col: 5, offset: 42065},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1725, col: 10, offset: 40952},
+									pos:   position{line: 1752, col: 10, offset: 42070},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1725, col: 12, offset: 40954},
+										pos:  position{line: 1752, col: 12, offset: 42072},
 										name: "EscapeSequence",
 									},
 								},
@@ -11918,28 +12160,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 1727, col: 1, offset: 40988},
+			pos:  position{line: 1754, col: 1, offset: 42106},
 			expr: &actionExpr{
-				pos: position{line: 1728, col: 5, offset: 41000},
+				pos: position{line: 1755, col: 5, offset: 42118},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 1728, col: 5, offset: 41000},
+					pos: position{line: 1755, col: 5, offset: 42118},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1728, col: 5, offset: 41000},
+							pos:   position{line: 1755, col: 5, offset: 42118},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1728, col: 10, offset: 41005},
+								pos:  position{line: 1755, col: 10, offset: 42123},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1728, col: 23, offset: 41018},
+							pos:   position{line: 1755, col: 23, offset: 42136},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1728, col: 28, offset: 41023},
+								pos: position{line: 1755, col: 28, offset: 42141},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1728, col: 28, offset: 41023},
+									pos:  position{line: 1755, col: 28, offset: 42141},
 									name: "KeyWordRest",
 								},
 							},
@@ -11952,16 +12194,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 1730, col: 1, offset: 41085},
+			pos:  position{line: 1757, col: 1, offset: 42203},
 			expr: &choiceExpr{
-				pos: position{line: 1731, col: 5, offset: 41102},
+				pos: position{line: 1758, col: 5, offset: 42220},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1731, col: 5, offset: 41102},
+						pos:  position{line: 1758, col: 5, offset: 42220},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1732, col: 5, offset: 41119},
+						pos:  position{line: 1759, col: 5, offset: 42237},
 						name: "KeyWordEsc",
 					},
 				},
@@ -11971,16 +12213,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 1734, col: 1, offset: 41131},
+			pos:  position{line: 1761, col: 1, offset: 42249},
 			expr: &choiceExpr{
-				pos: position{line: 1735, col: 5, offset: 41147},
+				pos: position{line: 1762, col: 5, offset: 42265},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1735, col: 5, offset: 41147},
+						pos:  position{line: 1762, col: 5, offset: 42265},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1736, col: 5, offset: 41164},
+						pos:        position{line: 1763, col: 5, offset: 42282},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11993,19 +12235,19 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordChars",
-			pos:  position{line: 1738, col: 1, offset: 41171},
+			pos:  position{line: 1765, col: 1, offset: 42289},
 			expr: &actionExpr{
-				pos: position{line: 1738, col: 16, offset: 41186},
+				pos: position{line: 1765, col: 16, offset: 42304},
 				run: (*parser).callonKeyWordChars1,
 				expr: &choiceExpr{
-					pos: position{line: 1738, col: 17, offset: 41187},
+					pos: position{line: 1765, col: 17, offset: 42305},
 					alternatives: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1738, col: 17, offset: 41187},
+							pos:  position{line: 1765, col: 17, offset: 42305},
 							name: "UnicodeLetter",
 						},
 						&charClassMatcher{
-							pos:        position{line: 1738, col: 33, offset: 41203},
+							pos:        position{line: 1765, col: 33, offset: 42321},
 							val:        "[_.:/%#@~]",
 							chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 							ignoreCase: false,
@@ -12019,31 +12261,31 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 1740, col: 1, offset: 41247},
+			pos:  position{line: 1767, col: 1, offset: 42365},
 			expr: &actionExpr{
-				pos: position{line: 1740, col: 14, offset: 41260},
+				pos: position{line: 1767, col: 14, offset: 42378},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1740, col: 14, offset: 41260},
+					pos: position{line: 1767, col: 14, offset: 42378},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1740, col: 14, offset: 41260},
+							pos:        position{line: 1767, col: 14, offset: 42378},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1740, col: 19, offset: 41265},
+							pos:   position{line: 1767, col: 19, offset: 42383},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1740, col: 22, offset: 41268},
+								pos: position{line: 1767, col: 22, offset: 42386},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1740, col: 22, offset: 41268},
+										pos:  position{line: 1767, col: 22, offset: 42386},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1740, col: 38, offset: 41284},
+										pos:  position{line: 1767, col: 38, offset: 42402},
 										name: "EscapeSequence",
 									},
 								},
@@ -12057,42 +12299,42 @@ var g = &grammar{
 		},
 		{
 			name: "GlobPattern",
-			pos:  position{line: 1742, col: 1, offset: 41319},
+			pos:  position{line: 1769, col: 1, offset: 42437},
 			expr: &actionExpr{
-				pos: position{line: 1743, col: 5, offset: 41335},
+				pos: position{line: 1770, col: 5, offset: 42453},
 				run: (*parser).callonGlobPattern1,
 				expr: &seqExpr{
-					pos: position{line: 1743, col: 5, offset: 41335},
+					pos: position{line: 1770, col: 5, offset: 42453},
 					exprs: []any{
 						&andExpr{
-							pos: position{line: 1743, col: 5, offset: 41335},
+							pos: position{line: 1770, col: 5, offset: 42453},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1743, col: 6, offset: 41336},
+								pos:  position{line: 1770, col: 6, offset: 42454},
 								name: "GlobProperStart",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1743, col: 22, offset: 41352},
+							pos: position{line: 1770, col: 22, offset: 42470},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1743, col: 23, offset: 41353},
+								pos:  position{line: 1770, col: 23, offset: 42471},
 								name: "GlobHasStar",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1743, col: 35, offset: 41365},
+							pos:   position{line: 1770, col: 35, offset: 42483},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1743, col: 40, offset: 41370},
+								pos:  position{line: 1770, col: 40, offset: 42488},
 								name: "GlobStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1743, col: 50, offset: 41380},
+							pos:   position{line: 1770, col: 50, offset: 42498},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1743, col: 55, offset: 41385},
+								pos: position{line: 1770, col: 55, offset: 42503},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1743, col: 55, offset: 41385},
+									pos:  position{line: 1770, col: 55, offset: 42503},
 									name: "GlobRest",
 								},
 							},
@@ -12105,28 +12347,28 @@ var g = &grammar{
 		},
 		{
 			name: "GlobProperStart",
-			pos:  position{line: 1747, col: 1, offset: 41454},
+			pos:  position{line: 1774, col: 1, offset: 42572},
 			expr: &choiceExpr{
-				pos: position{line: 1747, col: 19, offset: 41472},
+				pos: position{line: 1774, col: 19, offset: 42590},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1747, col: 19, offset: 41472},
+						pos:  position{line: 1774, col: 19, offset: 42590},
 						name: "KeyWordStart",
 					},
 					&seqExpr{
-						pos: position{line: 1747, col: 34, offset: 41487},
+						pos: position{line: 1774, col: 34, offset: 42605},
 						exprs: []any{
 							&oneOrMoreExpr{
-								pos: position{line: 1747, col: 34, offset: 41487},
+								pos: position{line: 1774, col: 34, offset: 42605},
 								expr: &litMatcher{
-									pos:        position{line: 1747, col: 34, offset: 41487},
+									pos:        position{line: 1774, col: 34, offset: 42605},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1747, col: 39, offset: 41492},
+								pos:  position{line: 1774, col: 39, offset: 42610},
 								name: "KeyWordRest",
 							},
 						},
@@ -12138,19 +12380,19 @@ var g = &grammar{
 		},
 		{
 			name: "GlobHasStar",
-			pos:  position{line: 1748, col: 1, offset: 41504},
+			pos:  position{line: 1775, col: 1, offset: 42622},
 			expr: &seqExpr{
-				pos: position{line: 1748, col: 15, offset: 41518},
+				pos: position{line: 1775, col: 15, offset: 42636},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1748, col: 15, offset: 41518},
+						pos: position{line: 1775, col: 15, offset: 42636},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1748, col: 15, offset: 41518},
+							pos:  position{line: 1775, col: 15, offset: 42636},
 							name: "KeyWordRest",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1748, col: 28, offset: 41531},
+						pos:        position{line: 1775, col: 28, offset: 42649},
 						val:        "*",
 						ignoreCase: false,
 						want:       "\"*\"",
@@ -12162,23 +12404,23 @@ var g = &grammar{
 		},
 		{
 			name: "GlobStart",
-			pos:  position{line: 1750, col: 1, offset: 41536},
+			pos:  position{line: 1777, col: 1, offset: 42654},
 			expr: &choiceExpr{
-				pos: position{line: 1751, col: 5, offset: 41550},
+				pos: position{line: 1778, col: 5, offset: 42668},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1751, col: 5, offset: 41550},
+						pos:  position{line: 1778, col: 5, offset: 42668},
 						name: "KeyWordChars",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1752, col: 5, offset: 41567},
+						pos:  position{line: 1779, col: 5, offset: 42685},
 						name: "GlobEsc",
 					},
 					&actionExpr{
-						pos: position{line: 1753, col: 5, offset: 41579},
+						pos: position{line: 1780, col: 5, offset: 42697},
 						run: (*parser).callonGlobStart4,
 						expr: &litMatcher{
-							pos:        position{line: 1753, col: 5, offset: 41579},
+							pos:        position{line: 1780, col: 5, offset: 42697},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -12191,16 +12433,16 @@ var g = &grammar{
 		},
 		{
 			name: "GlobRest",
-			pos:  position{line: 1755, col: 1, offset: 41604},
+			pos:  position{line: 1782, col: 1, offset: 42722},
 			expr: &choiceExpr{
-				pos: position{line: 1756, col: 5, offset: 41617},
+				pos: position{line: 1783, col: 5, offset: 42735},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1756, col: 5, offset: 41617},
+						pos:  position{line: 1783, col: 5, offset: 42735},
 						name: "GlobStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 1757, col: 5, offset: 41631},
+						pos:        position{line: 1784, col: 5, offset: 42749},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -12213,31 +12455,31 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEsc",
-			pos:  position{line: 1759, col: 1, offset: 41638},
+			pos:  position{line: 1786, col: 1, offset: 42756},
 			expr: &actionExpr{
-				pos: position{line: 1759, col: 11, offset: 41648},
+				pos: position{line: 1786, col: 11, offset: 42766},
 				run: (*parser).callonGlobEsc1,
 				expr: &seqExpr{
-					pos: position{line: 1759, col: 11, offset: 41648},
+					pos: position{line: 1786, col: 11, offset: 42766},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1759, col: 11, offset: 41648},
+							pos:        position{line: 1786, col: 11, offset: 42766},
 							val:        "\\",
 							ignoreCase: false,
 							want:       "\"\\\\\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1759, col: 16, offset: 41653},
+							pos:   position{line: 1786, col: 16, offset: 42771},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 1759, col: 19, offset: 41656},
+								pos: position{line: 1786, col: 19, offset: 42774},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1759, col: 19, offset: 41656},
+										pos:  position{line: 1786, col: 19, offset: 42774},
 										name: "GlobEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1759, col: 32, offset: 41669},
+										pos:  position{line: 1786, col: 32, offset: 42787},
 										name: "EscapeSequence",
 									},
 								},
@@ -12251,32 +12493,32 @@ var g = &grammar{
 		},
 		{
 			name: "GlobEscape",
-			pos:  position{line: 1761, col: 1, offset: 41704},
+			pos:  position{line: 1788, col: 1, offset: 42822},
 			expr: &choiceExpr{
-				pos: position{line: 1762, col: 5, offset: 41719},
+				pos: position{line: 1789, col: 5, offset: 42837},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1762, col: 5, offset: 41719},
+						pos: position{line: 1789, col: 5, offset: 42837},
 						run: (*parser).callonGlobEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1762, col: 5, offset: 41719},
+							pos:        position{line: 1789, col: 5, offset: 42837},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1763, col: 5, offset: 41747},
+						pos: position{line: 1790, col: 5, offset: 42865},
 						run: (*parser).callonGlobEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1763, col: 5, offset: 41747},
+							pos:        position{line: 1790, col: 5, offset: 42865},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1764, col: 5, offset: 41777},
+						pos:        position{line: 1791, col: 5, offset: 42895},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -12289,57 +12531,57 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 1766, col: 1, offset: 41783},
+			pos:  position{line: 1793, col: 1, offset: 42901},
 			expr: &choiceExpr{
-				pos: position{line: 1767, col: 5, offset: 41804},
+				pos: position{line: 1794, col: 5, offset: 42922},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1767, col: 5, offset: 41804},
+						pos: position{line: 1794, col: 5, offset: 42922},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 1767, col: 5, offset: 41804},
+							pos: position{line: 1794, col: 5, offset: 42922},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1767, col: 5, offset: 41804},
+									pos: position{line: 1794, col: 5, offset: 42922},
 									expr: &choiceExpr{
-										pos: position{line: 1767, col: 7, offset: 41806},
+										pos: position{line: 1794, col: 7, offset: 42924},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1767, col: 7, offset: 41806},
+												pos:        position{line: 1794, col: 7, offset: 42924},
 												val:        "'",
 												ignoreCase: false,
 												want:       "\"'\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1767, col: 13, offset: 41812},
+												pos:  position{line: 1794, col: 13, offset: 42930},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 1767, col: 26, offset: 41825,
+									line: 1794, col: 26, offset: 42943,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1768, col: 5, offset: 41862},
+						pos: position{line: 1795, col: 5, offset: 42980},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1768, col: 5, offset: 41862},
+							pos: position{line: 1795, col: 5, offset: 42980},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1768, col: 5, offset: 41862},
+									pos:        position{line: 1795, col: 5, offset: 42980},
 									val:        "\\",
 									ignoreCase: false,
 									want:       "\"\\\\\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1768, col: 10, offset: 41867},
+									pos:   position{line: 1795, col: 10, offset: 42985},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1768, col: 12, offset: 41869},
+										pos:  position{line: 1795, col: 12, offset: 42987},
 										name: "EscapeSequence",
 									},
 								},
@@ -12353,16 +12595,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1770, col: 1, offset: 41903},
+			pos:  position{line: 1797, col: 1, offset: 43021},
 			expr: &choiceExpr{
-				pos: position{line: 1771, col: 5, offset: 41922},
+				pos: position{line: 1798, col: 5, offset: 43040},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1771, col: 5, offset: 41922},
+						pos:  position{line: 1798, col: 5, offset: 43040},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1772, col: 5, offset: 41943},
+						pos:  position{line: 1799, col: 5, offset: 43061},
 						name: "UnicodeEscape",
 					},
 				},
@@ -12372,87 +12614,87 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1774, col: 1, offset: 41958},
+			pos:  position{line: 1801, col: 1, offset: 43076},
 			expr: &choiceExpr{
-				pos: position{line: 1775, col: 5, offset: 41979},
+				pos: position{line: 1802, col: 5, offset: 43097},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1775, col: 5, offset: 41979},
+						pos:        position{line: 1802, col: 5, offset: 43097},
 						val:        "'",
 						ignoreCase: false,
 						want:       "\"'\"",
 					},
 					&actionExpr{
-						pos: position{line: 1776, col: 5, offset: 41987},
+						pos: position{line: 1803, col: 5, offset: 43105},
 						run: (*parser).callonSingleCharEscape3,
 						expr: &litMatcher{
-							pos:        position{line: 1776, col: 5, offset: 41987},
+							pos:        position{line: 1803, col: 5, offset: 43105},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1777, col: 5, offset: 42027},
+						pos:        position{line: 1804, col: 5, offset: 43145},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
 					},
 					&actionExpr{
-						pos: position{line: 1778, col: 5, offset: 42036},
+						pos: position{line: 1805, col: 5, offset: 43154},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1778, col: 5, offset: 42036},
+							pos:        position{line: 1805, col: 5, offset: 43154},
 							val:        "b",
 							ignoreCase: false,
 							want:       "\"b\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1779, col: 5, offset: 42065},
+						pos: position{line: 1806, col: 5, offset: 43183},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1779, col: 5, offset: 42065},
+							pos:        position{line: 1806, col: 5, offset: 43183},
 							val:        "f",
 							ignoreCase: false,
 							want:       "\"f\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1780, col: 5, offset: 42094},
+						pos: position{line: 1807, col: 5, offset: 43212},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1780, col: 5, offset: 42094},
+							pos:        position{line: 1807, col: 5, offset: 43212},
 							val:        "n",
 							ignoreCase: false,
 							want:       "\"n\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1781, col: 5, offset: 42123},
+						pos: position{line: 1808, col: 5, offset: 43241},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1781, col: 5, offset: 42123},
+							pos:        position{line: 1808, col: 5, offset: 43241},
 							val:        "r",
 							ignoreCase: false,
 							want:       "\"r\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1782, col: 5, offset: 42152},
+						pos: position{line: 1809, col: 5, offset: 43270},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1782, col: 5, offset: 42152},
+							pos:        position{line: 1809, col: 5, offset: 43270},
 							val:        "t",
 							ignoreCase: false,
 							want:       "\"t\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1783, col: 5, offset: 42181},
+						pos: position{line: 1810, col: 5, offset: 43299},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1783, col: 5, offset: 42181},
+							pos:        position{line: 1810, col: 5, offset: 43299},
 							val:        "v",
 							ignoreCase: false,
 							want:       "\"v\"",
@@ -12465,32 +12707,32 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1785, col: 1, offset: 42207},
+			pos:  position{line: 1812, col: 1, offset: 43325},
 			expr: &choiceExpr{
-				pos: position{line: 1786, col: 5, offset: 42225},
+				pos: position{line: 1813, col: 5, offset: 43343},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1786, col: 5, offset: 42225},
+						pos: position{line: 1813, col: 5, offset: 43343},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1786, col: 5, offset: 42225},
+							pos:        position{line: 1813, col: 5, offset: 43343},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1787, col: 5, offset: 42253},
+						pos: position{line: 1814, col: 5, offset: 43371},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1787, col: 5, offset: 42253},
+							pos:        position{line: 1814, col: 5, offset: 43371},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1788, col: 5, offset: 42281},
+						pos:        position{line: 1815, col: 5, offset: 43399},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -12503,42 +12745,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1790, col: 1, offset: 42287},
+			pos:  position{line: 1817, col: 1, offset: 43405},
 			expr: &choiceExpr{
-				pos: position{line: 1791, col: 5, offset: 42305},
+				pos: position{line: 1818, col: 5, offset: 43423},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1791, col: 5, offset: 42305},
+						pos: position{line: 1818, col: 5, offset: 43423},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1791, col: 5, offset: 42305},
+							pos: position{line: 1818, col: 5, offset: 43423},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1791, col: 5, offset: 42305},
+									pos:        position{line: 1818, col: 5, offset: 43423},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1791, col: 9, offset: 42309},
+									pos:   position{line: 1818, col: 9, offset: 43427},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1791, col: 16, offset: 42316},
+										pos: position{line: 1818, col: 16, offset: 43434},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1791, col: 16, offset: 42316},
+												pos:  position{line: 1818, col: 16, offset: 43434},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1791, col: 25, offset: 42325},
+												pos:  position{line: 1818, col: 25, offset: 43443},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1791, col: 34, offset: 42334},
+												pos:  position{line: 1818, col: 34, offset: 43452},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1791, col: 43, offset: 42343},
+												pos:  position{line: 1818, col: 43, offset: 43461},
 												name: "HexDigit",
 											},
 										},
@@ -12548,65 +12790,65 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1794, col: 5, offset: 42406},
+						pos: position{line: 1821, col: 5, offset: 43524},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1794, col: 5, offset: 42406},
+							pos: position{line: 1821, col: 5, offset: 43524},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1794, col: 5, offset: 42406},
+									pos:        position{line: 1821, col: 5, offset: 43524},
 									val:        "u",
 									ignoreCase: false,
 									want:       "\"u\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1794, col: 9, offset: 42410},
+									pos:        position{line: 1821, col: 9, offset: 43528},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1794, col: 13, offset: 42414},
+									pos:   position{line: 1821, col: 13, offset: 43532},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1794, col: 20, offset: 42421},
+										pos: position{line: 1821, col: 20, offset: 43539},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1794, col: 20, offset: 42421},
+												pos:  position{line: 1821, col: 20, offset: 43539},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1794, col: 29, offset: 42430},
+												pos: position{line: 1821, col: 29, offset: 43548},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1794, col: 29, offset: 42430},
+													pos:  position{line: 1821, col: 29, offset: 43548},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1794, col: 39, offset: 42440},
+												pos: position{line: 1821, col: 39, offset: 43558},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1794, col: 39, offset: 42440},
+													pos:  position{line: 1821, col: 39, offset: 43558},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1794, col: 49, offset: 42450},
+												pos: position{line: 1821, col: 49, offset: 43568},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1794, col: 49, offset: 42450},
+													pos:  position{line: 1821, col: 49, offset: 43568},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1794, col: 59, offset: 42460},
+												pos: position{line: 1821, col: 59, offset: 43578},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1794, col: 59, offset: 42460},
+													pos:  position{line: 1821, col: 59, offset: 43578},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1794, col: 69, offset: 42470},
+												pos: position{line: 1821, col: 69, offset: 43588},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1794, col: 69, offset: 42470},
+													pos:  position{line: 1821, col: 69, offset: 43588},
 													name: "HexDigit",
 												},
 											},
@@ -12614,7 +12856,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1794, col: 80, offset: 42481},
+									pos:        position{line: 1821, col: 80, offset: 43599},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -12629,9 +12871,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1799, col: 1, offset: 42536},
+			pos:  position{line: 1826, col: 1, offset: 43654},
 			expr: &charClassMatcher{
-				pos:        position{line: 1800, col: 5, offset: 42552},
+				pos:        position{line: 1827, col: 5, offset: 43670},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -12643,11 +12885,11 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1802, col: 1, offset: 42567},
+			pos:  position{line: 1829, col: 1, offset: 43685},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1802, col: 5, offset: 42571},
+				pos: position{line: 1829, col: 5, offset: 43689},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1802, col: 5, offset: 42571},
+					pos:  position{line: 1829, col: 5, offset: 43689},
 					name: "AnySpace",
 				},
 			},
@@ -12656,11 +12898,11 @@ var g = &grammar{
 		},
 		{
 			name: "__",
-			pos:  position{line: 1804, col: 1, offset: 42582},
+			pos:  position{line: 1831, col: 1, offset: 43700},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1804, col: 6, offset: 42587},
+				pos: position{line: 1831, col: 6, offset: 43705},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1804, col: 6, offset: 42587},
+					pos:  position{line: 1831, col: 6, offset: 43705},
 					name: "AnySpace",
 				},
 			},
@@ -12669,20 +12911,20 @@ var g = &grammar{
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1806, col: 1, offset: 42598},
+			pos:  position{line: 1833, col: 1, offset: 43716},
 			expr: &choiceExpr{
-				pos: position{line: 1807, col: 5, offset: 42611},
+				pos: position{line: 1834, col: 5, offset: 43729},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1807, col: 5, offset: 42611},
+						pos:  position{line: 1834, col: 5, offset: 43729},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1808, col: 5, offset: 42626},
+						pos:  position{line: 1835, col: 5, offset: 43744},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1809, col: 5, offset: 42645},
+						pos:  position{line: 1836, col: 5, offset: 43763},
 						name: "Comment",
 					},
 				},
@@ -12692,32 +12934,32 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeLetter",
-			pos:  position{line: 1811, col: 1, offset: 42654},
+			pos:  position{line: 1838, col: 1, offset: 43772},
 			expr: &choiceExpr{
-				pos: position{line: 1812, col: 5, offset: 42672},
+				pos: position{line: 1839, col: 5, offset: 43790},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1812, col: 5, offset: 42672},
+						pos:  position{line: 1839, col: 5, offset: 43790},
 						name: "Lu",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1813, col: 5, offset: 42679},
+						pos:  position{line: 1840, col: 5, offset: 43797},
 						name: "Ll",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1814, col: 5, offset: 42686},
+						pos:  position{line: 1841, col: 5, offset: 43804},
 						name: "Lt",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1815, col: 5, offset: 42693},
+						pos:  position{line: 1842, col: 5, offset: 43811},
 						name: "Lm",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1816, col: 5, offset: 42700},
+						pos:  position{line: 1843, col: 5, offset: 43818},
 						name: "Lo",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1817, col: 5, offset: 42707},
+						pos:  position{line: 1844, col: 5, offset: 43825},
 						name: "Nl",
 					},
 				},
@@ -12727,16 +12969,16 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeCombiningMark",
-			pos:  position{line: 1819, col: 1, offset: 42711},
+			pos:  position{line: 1846, col: 1, offset: 43829},
 			expr: &choiceExpr{
-				pos: position{line: 1820, col: 5, offset: 42736},
+				pos: position{line: 1847, col: 5, offset: 43854},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1820, col: 5, offset: 42736},
+						pos:  position{line: 1847, col: 5, offset: 43854},
 						name: "Mn",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1821, col: 5, offset: 42743},
+						pos:  position{line: 1848, col: 5, offset: 43861},
 						name: "Mc",
 					},
 				},
@@ -12746,9 +12988,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeDigit",
-			pos:  position{line: 1823, col: 1, offset: 42747},
+			pos:  position{line: 1850, col: 1, offset: 43865},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1824, col: 5, offset: 42764},
+				pos:  position{line: 1851, col: 5, offset: 43882},
 				name: "Nd",
 			},
 			leader:        false,
@@ -12756,9 +12998,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeConnectorPunctuation",
-			pos:  position{line: 1826, col: 1, offset: 42768},
+			pos:  position{line: 1853, col: 1, offset: 43886},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1827, col: 5, offset: 42800},
+				pos:  position{line: 1854, col: 5, offset: 43918},
 				name: "Pc",
 			},
 			leader:        false,
@@ -12766,9 +13008,9 @@ var g = &grammar{
 		},
 		{
 			name: "Ll",
-			pos:  position{line: 1833, col: 1, offset: 42981},
+			pos:  position{line: 1860, col: 1, offset: 44099},
 			expr: &charClassMatcher{
-				pos:        position{line: 1833, col: 6, offset: 42986},
+				pos:        position{line: 1860, col: 6, offset: 44104},
 				val:        "[\\u0061-\\u007A\\u00B5\\u00DF-\\u00F6\\u00F8-\\u00FF\\u0101\\u0103\\u0105\\u0107\\u0109\\u010B\\u010D\\u010F\\u0111\\u0113\\u0115\\u0117\\u0119\\u011B\\u011D\\u011F\\u0121\\u0123\\u0125\\u0127\\u0129\\u012B\\u012D\\u012F\\u0131\\u0133\\u0135\\u0137-\\u0138\\u013A\\u013C\\u013E\\u0140\\u0142\\u0144\\u0146\\u0148-\\u0149\\u014B\\u014D\\u014F\\u0151\\u0153\\u0155\\u0157\\u0159\\u015B\\u015D\\u015F\\u0161\\u0163\\u0165\\u0167\\u0169\\u016B\\u016D\\u016F\\u0171\\u0173\\u0175\\u0177\\u017A\\u017C\\u017E-\\u0180\\u0183\\u0185\\u0188\\u018C-\\u018D\\u0192\\u0195\\u0199-\\u019B\\u019E\\u01A1\\u01A3\\u01A5\\u01A8\\u01AA-\\u01AB\\u01AD\\u01B0\\u01B4\\u01B6\\u01B9-\\u01BA\\u01BD-\\u01BF\\u01C6\\u01C9\\u01CC\\u01CE\\u01D0\\u01D2\\u01D4\\u01D6\\u01D8\\u01DA\\u01DC-\\u01DD\\u01DF\\u01E1\\u01E3\\u01E5\\u01E7\\u01E9\\u01EB\\u01ED\\u01EF-\\u01F0\\u01F3\\u01F5\\u01F9\\u01FB\\u01FD\\u01FF\\u0201\\u0203\\u0205\\u0207\\u0209\\u020B\\u020D\\u020F\\u0211\\u0213\\u0215\\u0217\\u0219\\u021B\\u021D\\u021F\\u0221\\u0223\\u0225\\u0227\\u0229\\u022B\\u022D\\u022F\\u0231\\u0233-\\u0239\\u023C\\u023F-\\u0240\\u0242\\u0247\\u0249\\u024B\\u024D\\u024F-\\u0293\\u0295-\\u02AF\\u0371\\u0373\\u0377\\u037B-\\u037D\\u0390\\u03AC-\\u03CE\\u03D0-\\u03D1\\u03D5-\\u03D7\\u03D9\\u03DB\\u03DD\\u03DF\\u03E1\\u03E3\\u03E5\\u03E7\\u03E9\\u03EB\\u03ED\\u03EF-\\u03F3\\u03F5\\u03F8\\u03FB-\\u03FC\\u0430-\\u045F\\u0461\\u0463\\u0465\\u0467\\u0469\\u046B\\u046D\\u046F\\u0471\\u0473\\u0475\\u0477\\u0479\\u047B\\u047D\\u047F\\u0481\\u048B\\u048D\\u048F\\u0491\\u0493\\u0495\\u0497\\u0499\\u049B\\u049D\\u049F\\u04A1\\u04A3\\u04A5\\u04A7\\u04A9\\u04AB\\u04AD\\u04AF\\u04B1\\u04B3\\u04B5\\u04B7\\u04B9\\u04BB\\u04BD\\u04BF\\u04C2\\u04C4\\u04C6\\u04C8\\u04CA\\u04CC\\u04CE-\\u04CF\\u04D1\\u04D3\\u04D5\\u04D7\\u04D9\\u04DB\\u04DD\\u04DF\\u04E1\\u04E3\\u04E5\\u04E7\\u04E9\\u04EB\\u04ED\\u04EF\\u04F1\\u04F3\\u04F5\\u04F7\\u04F9\\u04FB\\u04FD\\u04FF\\u0501\\u0503\\u0505\\u0507\\u0509\\u050B\\u050D\\u050F\\u0511\\u0513\\u0515\\u0517\\u0519\\u051B\\u051D\\u051F\\u0521\\u0523\\u0525\\u0527\\u0529\\u052B\\u052D\\u052F\\u0560-\\u0588\\u10D0-\\u10FA\\u10FD-\\u10FF\\u13F8-\\u13FD\\u1C80-\\u1C88\\u1D00-\\u1D2B\\u1D6B-\\u1D77\\u1D79-\\u1D9A\\u1E01\\u1E03\\u1E05\\u1E07\\u1E09\\u1E0B\\u1E0D\\u1E0F\\u1E11\\u1E13\\u1E15\\u1E17\\u1E19\\u1E1B\\u1E1D\\u1E1F\\u1E21\\u1E23\\u1E25\\u1E27\\u1E29\\u1E2B\\u1E2D\\u1E2F\\u1E31\\u1E33\\u1E35\\u1E37\\u1E39\\u1E3B\\u1E3D\\u1E3F\\u1E41\\u1E43\\u1E45\\u1E47\\u1E49\\u1E4B\\u1E4D\\u1E4F\\u1E51\\u1E53\\u1E55\\u1E57\\u1E59\\u1E5B\\u1E5D\\u1E5F\\u1E61\\u1E63\\u1E65\\u1E67\\u1E69\\u1E6B\\u1E6D\\u1E6F\\u1E71\\u1E73\\u1E75\\u1E77\\u1E79\\u1E7B\\u1E7D\\u1E7F\\u1E81\\u1E83\\u1E85\\u1E87\\u1E89\\u1E8B\\u1E8D\\u1E8F\\u1E91\\u1E93\\u1E95-\\u1E9D\\u1E9F\\u1EA1\\u1EA3\\u1EA5\\u1EA7\\u1EA9\\u1EAB\\u1EAD\\u1EAF\\u1EB1\\u1EB3\\u1EB5\\u1EB7\\u1EB9\\u1EBB\\u1EBD\\u1EBF\\u1EC1\\u1EC3\\u1EC5\\u1EC7\\u1EC9\\u1ECB\\u1ECD\\u1ECF\\u1ED1\\u1ED3\\u1ED5\\u1ED7\\u1ED9\\u1EDB\\u1EDD\\u1EDF\\u1EE1\\u1EE3\\u1EE5\\u1EE7\\u1EE9\\u1EEB\\u1EED\\u1EEF\\u1EF1\\u1EF3\\u1EF5\\u1EF7\\u1EF9\\u1EFB\\u1EFD\\u1EFF-\\u1F07\\u1F10-\\u1F15\\u1F20-\\u1F27\\u1F30-\\u1F37\\u1F40-\\u1F45\\u1F50-\\u1F57\\u1F60-\\u1F67\\u1F70-\\u1F7D\\u1F80-\\u1F87\\u1F90-\\u1F97\\u1FA0-\\u1FA7\\u1FB0-\\u1FB4\\u1FB6-\\u1FB7\\u1FBE\\u1FC2-\\u1FC4\\u1FC6-\\u1FC7\\u1FD0-\\u1FD3\\u1FD6-\\u1FD7\\u1FE0-\\u1FE7\\u1FF2-\\u1FF4\\u1FF6-\\u1FF7\\u210A\\u210E-\\u210F\\u2113\\u212F\\u2134\\u2139\\u213C-\\u213D\\u2146-\\u2149\\u214E\\u2184\\u2C30-\\u2C5E\\u2C61\\u2C65-\\u2C66\\u2C68\\u2C6A\\u2C6C\\u2C71\\u2C73-\\u2C74\\u2C76-\\u2C7B\\u2C81\\u2C83\\u2C85\\u2C87\\u2C89\\u2C8B\\u2C8D\\u2C8F\\u2C91\\u2C93\\u2C95\\u2C97\\u2C99\\u2C9B\\u2C9D\\u2C9F\\u2CA1\\u2CA3\\u2CA5\\u2CA7\\u2CA9\\u2CAB\\u2CAD\\u2CAF\\u2CB1\\u2CB3\\u2CB5\\u2CB7\\u2CB9\\u2CBB\\u2CBD\\u2CBF\\u2CC1\\u2CC3\\u2CC5\\u2CC7\\u2CC9\\u2CCB\\u2CCD\\u2CCF\\u2CD1\\u2CD3\\u2CD5\\u2CD7\\u2CD9\\u2CDB\\u2CDD\\u2CDF\\u2CE1\\u2CE3-\\u2CE4\\u2CEC\\u2CEE\\u2CF3\\u2D00-\\u2D25\\u2D27\\u2D2D\\uA641\\uA643\\uA645\\uA647\\uA649\\uA64B\\uA64D\\uA64F\\uA651\\uA653\\uA655\\uA657\\uA659\\uA65B\\uA65D\\uA65F\\uA661\\uA663\\uA665\\uA667\\uA669\\uA66B\\uA66D\\uA681\\uA683\\uA685\\uA687\\uA689\\uA68B\\uA68D\\uA68F\\uA691\\uA693\\uA695\\uA697\\uA699\\uA69B\\uA723\\uA725\\uA727\\uA729\\uA72B\\uA72D\\uA72F-\\uA731\\uA733\\uA735\\uA737\\uA739\\uA73B\\uA73D\\uA73F\\uA741\\uA743\\uA745\\uA747\\uA749\\uA74B\\uA74D\\uA74F\\uA751\\uA753\\uA755\\uA757\\uA759\\uA75B\\uA75D\\uA75F\\uA761\\uA763\\uA765\\uA767\\uA769\\uA76B\\uA76D\\uA76F\\uA771-\\uA778\\uA77A\\uA77C\\uA77F\\uA781\\uA783\\uA785\\uA787\\uA78C\\uA78E\\uA791\\uA793-\\uA795\\uA797\\uA799\\uA79B\\uA79D\\uA79F\\uA7A1\\uA7A3\\uA7A5\\uA7A7\\uA7A9\\uA7AF\\uA7B5\\uA7B7\\uA7B9\\uA7FA\\uAB30-\\uAB5A\\uAB60-\\uAB65\\uAB70-\\uABBF\\uFB00-\\uFB06\\uFB13-\\uFB17\\uFF41-\\uFF5A]",
 				chars:      []rune{'µ', 'ā', 'ă', 'ą', 'ć', 'ĉ', 'ċ', 'č', 'ď', 'đ', 'ē', 'ĕ', 'ė', 'ę', 'ě', 'ĝ', 'ğ', 'ġ', 'ģ', 'ĥ', 'ħ', 'ĩ', 'ī', 'ĭ', 'į', 'ı', 'ĳ', 'ĵ', 'ĺ', 'ļ', 'ľ', 'ŀ', 'ł', 'ń', 'ņ', 'ŋ', 'ō', 'ŏ', 'ő', 'œ', 'ŕ', 'ŗ', 'ř', 'ś', 'ŝ', 'ş', 'š', 'ţ', 'ť', 'ŧ', 'ũ', 'ū', 'ŭ', 'ů', 'ű', 'ų', 'ŵ', 'ŷ', 'ź', 'ż', 'ƃ', 'ƅ', 'ƈ', 'ƒ', 'ƕ', 'ƞ', 'ơ', 'ƣ', 'ƥ', 'ƨ', 'ƭ', 'ư', 'ƴ', 'ƶ', 'ǆ', 'ǉ', 'ǌ', 'ǎ', 'ǐ', 'ǒ', 'ǔ', 'ǖ', 'ǘ', 'ǚ', 'ǟ', 'ǡ', 'ǣ', 'ǥ', 'ǧ', 'ǩ', 'ǫ', 'ǭ', 'ǳ', 'ǵ', 'ǹ', 'ǻ', 'ǽ', 'ǿ', 'ȁ', 'ȃ', 'ȅ', 'ȇ', 'ȉ', 'ȋ', 'ȍ', 'ȏ', 'ȑ', 'ȓ', 'ȕ', 'ȗ', 'ș', 'ț', 'ȝ', 'ȟ', 'ȡ', 'ȣ', 'ȥ', 'ȧ', 'ȩ', 'ȫ', 'ȭ', 'ȯ', 'ȱ', 'ȼ', 'ɂ', 'ɇ', 'ɉ', 'ɋ', 'ɍ', 'ͱ', 'ͳ', 'ͷ', 'ΐ', 'ϙ', 'ϛ', 'ϝ', 'ϟ', 'ϡ', 'ϣ', 'ϥ', 'ϧ', 'ϩ', 'ϫ', 'ϭ', 'ϵ', 'ϸ', 'ѡ', 'ѣ', 'ѥ', 'ѧ', 'ѩ', 'ѫ', 'ѭ', 'ѯ', 'ѱ', 'ѳ', 'ѵ', 'ѷ', 'ѹ', 'ѻ', 'ѽ', 'ѿ', 'ҁ', 'ҋ', 'ҍ', 'ҏ', 'ґ', 'ғ', 'ҕ', 'җ', 'ҙ', 'қ', 'ҝ', 'ҟ', 'ҡ', 'ң', 'ҥ', 'ҧ', 'ҩ', 'ҫ', 'ҭ', 'ү', 'ұ', 'ҳ', 'ҵ', 'ҷ', 'ҹ', 'һ', 'ҽ', 'ҿ', 'ӂ', 'ӄ', 'ӆ', 'ӈ', 'ӊ', 'ӌ', 'ӑ', 'ӓ', 'ӕ', 'ӗ', 'ә', 'ӛ', 'ӝ', 'ӟ', 'ӡ', 'ӣ', 'ӥ', 'ӧ', 'ө', 'ӫ', 'ӭ', 'ӯ', 'ӱ', 'ӳ', 'ӵ', 'ӷ', 'ӹ', 'ӻ', 'ӽ', 'ӿ', 'ԁ', 'ԃ', 'ԅ', 'ԇ', 'ԉ', 'ԋ', 'ԍ', 'ԏ', 'ԑ', 'ԓ', 'ԕ', 'ԗ', 'ԙ', 'ԛ', 'ԝ', 'ԟ', 'ԡ', 'ԣ', 'ԥ', 'ԧ', 'ԩ', 'ԫ', 'ԭ', 'ԯ', 'ḁ', 'ḃ', 'ḅ', 'ḇ', 'ḉ', 'ḋ', 'ḍ', 'ḏ', 'ḑ', 'ḓ', 'ḕ', 'ḗ', 'ḙ', 'ḛ', 'ḝ', 'ḟ', 'ḡ', 'ḣ', 'ḥ', 'ḧ', 'ḩ', 'ḫ', 'ḭ', 'ḯ', 'ḱ', 'ḳ', 'ḵ', 'ḷ', 'ḹ', 'ḻ', 'ḽ', 'ḿ', 'ṁ', 'ṃ', 'ṅ', 'ṇ', 'ṉ', 'ṋ', 'ṍ', 'ṏ', 'ṑ', 'ṓ', 'ṕ', 'ṗ', 'ṙ', 'ṛ', 'ṝ', 'ṟ', 'ṡ', 'ṣ', 'ṥ', 'ṧ', 'ṩ', 'ṫ', 'ṭ', 'ṯ', 'ṱ', 'ṳ', 'ṵ', 'ṷ', 'ṹ', 'ṻ', 'ṽ', 'ṿ', 'ẁ', 'ẃ', 'ẅ', 'ẇ', 'ẉ', 'ẋ', 'ẍ', 'ẏ', 'ẑ', 'ẓ', 'ẟ', 'ạ', 'ả', 'ấ', 'ầ', 'ẩ', 'ẫ', 'ậ', 'ắ', 'ằ', 'ẳ', 'ẵ', 'ặ', 'ẹ', 'ẻ', 'ẽ', 'ế', 'ề', 'ể', 'ễ', 'ệ', 'ỉ', 'ị', 'ọ', 'ỏ', 'ố', 'ồ', 'ổ', 'ỗ', 'ộ', 'ớ', 'ờ', 'ở', 'ỡ', 'ợ', 'ụ', 'ủ', 'ứ', 'ừ', 'ử', 'ữ', 'ự', 'ỳ', 'ỵ', 'ỷ', 'ỹ', 'ỻ', 'ỽ', 'ι', 'ℊ', 'ℓ', 'ℯ', 'ℴ', 'ℹ', 'ⅎ', 'ↄ', 'ⱡ', 'ⱨ', 'ⱪ', 'ⱬ', 'ⱱ', 'ⲁ', 'ⲃ', 'ⲅ', 'ⲇ', 'ⲉ', 'ⲋ', 'ⲍ', 'ⲏ', 'ⲑ', 'ⲓ', 'ⲕ', 'ⲗ', 'ⲙ', 'ⲛ', 'ⲝ', 'ⲟ', 'ⲡ', 'ⲣ', 'ⲥ', 'ⲧ', 'ⲩ', 'ⲫ', 'ⲭ', 'ⲯ', 'ⲱ', 'ⲳ', 'ⲵ', 'ⲷ', 'ⲹ', 'ⲻ', 'ⲽ', 'ⲿ', 'ⳁ', 'ⳃ', 'ⳅ', 'ⳇ', 'ⳉ', 'ⳋ', 'ⳍ', 'ⳏ', 'ⳑ', 'ⳓ', 'ⳕ', 'ⳗ', 'ⳙ', 'ⳛ', 'ⳝ', 'ⳟ', 'ⳡ', 'ⳬ', 'ⳮ', 'ⳳ', 'ⴧ', 'ⴭ', 'ꙁ', 'ꙃ', 'ꙅ', 'ꙇ', 'ꙉ', 'ꙋ', 'ꙍ', 'ꙏ', 'ꙑ', 'ꙓ', 'ꙕ', 'ꙗ', 'ꙙ', 'ꙛ', 'ꙝ', 'ꙟ', 'ꙡ', 'ꙣ', 'ꙥ', 'ꙧ', 'ꙩ', 'ꙫ', 'ꙭ', 'ꚁ', 'ꚃ', 'ꚅ', 'ꚇ', 'ꚉ', 'ꚋ', 'ꚍ', 'ꚏ', 'ꚑ', 'ꚓ', 'ꚕ', 'ꚗ', 'ꚙ', 'ꚛ', 'ꜣ', 'ꜥ', 'ꜧ', 'ꜩ', 'ꜫ', 'ꜭ', 'ꜳ', 'ꜵ', 'ꜷ', 'ꜹ', 'ꜻ', 'ꜽ', 'ꜿ', 'ꝁ', 'ꝃ', 'ꝅ', 'ꝇ', 'ꝉ', 'ꝋ', 'ꝍ', 'ꝏ', 'ꝑ', 'ꝓ', 'ꝕ', 'ꝗ', 'ꝙ', 'ꝛ', 'ꝝ', 'ꝟ', 'ꝡ', 'ꝣ', 'ꝥ', 'ꝧ', 'ꝩ', 'ꝫ', 'ꝭ', 'ꝯ', 'ꝺ', 'ꝼ', 'ꝿ', 'ꞁ', 'ꞃ', 'ꞅ', 'ꞇ', 'ꞌ', 'ꞎ', 'ꞑ', 'ꞗ', 'ꞙ', 'ꞛ', 'ꞝ', 'ꞟ', 'ꞡ', 'ꞣ', 'ꞥ', 'ꞧ', 'ꞩ', 'ꞯ', 'ꞵ', 'ꞷ', 'ꞹ', 'ꟺ'},
 				ranges:     []rune{'a', 'z', 'ß', 'ö', 'ø', 'ÿ', 'ķ', 'ĸ', 'ň', 'ŉ', 'ž', 'ƀ', 'ƌ', 'ƍ', 'ƙ', 'ƛ', 'ƪ', 'ƫ', 'ƹ', 'ƺ', 'ƽ', 'ƿ', 'ǜ', 'ǝ', 'ǯ', 'ǰ', 'ȳ', 'ȹ', 'ȿ', 'ɀ', 'ɏ', 'ʓ', 'ʕ', 'ʯ', 'ͻ', 'ͽ', 'ά', 'ώ', 'ϐ', 'ϑ', 'ϕ', 'ϗ', 'ϯ', 'ϳ', 'ϻ', 'ϼ', 'а', 'џ', 'ӎ', 'ӏ', 'ՠ', 'ֈ', 'ა', 'ჺ', 'ჽ', 'ჿ', 'ᏸ', 'ᏽ', 'ᲀ', 'ᲈ', 'ᴀ', 'ᴫ', 'ᵫ', 'ᵷ', 'ᵹ', 'ᶚ', 'ẕ', 'ẝ', 'ỿ', 'ἇ', 'ἐ', 'ἕ', 'ἠ', 'ἧ', 'ἰ', 'ἷ', 'ὀ', 'ὅ', 'ὐ', 'ὗ', 'ὠ', 'ὧ', 'ὰ', 'ώ', 'ᾀ', 'ᾇ', 'ᾐ', 'ᾗ', 'ᾠ', 'ᾧ', 'ᾰ', 'ᾴ', 'ᾶ', 'ᾷ', 'ῂ', 'ῄ', 'ῆ', 'ῇ', 'ῐ', 'ΐ', 'ῖ', 'ῗ', 'ῠ', 'ῧ', 'ῲ', 'ῴ', 'ῶ', 'ῷ', 'ℎ', 'ℏ', 'ℼ', 'ℽ', 'ⅆ', 'ⅉ', 'ⰰ', 'ⱞ', 'ⱥ', 'ⱦ', 'ⱳ', 'ⱴ', 'ⱶ', 'ⱻ', 'ⳣ', 'ⳤ', 'ⴀ', 'ⴥ', 'ꜯ', 'ꜱ', 'ꝱ', 'ꝸ', 'ꞓ', 'ꞕ', 'ꬰ', 'ꭚ', 'ꭠ', 'ꭥ', 'ꭰ', 'ꮿ', 'ﬀ', 'ﬆ', 'ﬓ', 'ﬗ', 'ａ', 'ｚ'},
@@ -12780,9 +13022,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lm",
-			pos:  position{line: 1836, col: 1, offset: 47138},
+			pos:  position{line: 1863, col: 1, offset: 48256},
 			expr: &charClassMatcher{
-				pos:        position{line: 1836, col: 6, offset: 47143},
+				pos:        position{line: 1863, col: 6, offset: 48261},
 				val:        "[\\u02B0-\\u02C1\\u02C6-\\u02D1\\u02E0-\\u02E4\\u02EC\\u02EE\\u0374\\u037A\\u0559\\u0640\\u06E5-\\u06E6\\u07F4-\\u07F5\\u07FA\\u081A\\u0824\\u0828\\u0971\\u0E46\\u0EC6\\u10FC\\u17D7\\u1843\\u1AA7\\u1C78-\\u1C7D\\u1D2C-\\u1D6A\\u1D78\\u1D9B-\\u1DBF\\u2071\\u207F\\u2090-\\u209C\\u2C7C-\\u2C7D\\u2D6F\\u2E2F\\u3005\\u3031-\\u3035\\u303B\\u309D-\\u309E\\u30FC-\\u30FE\\uA015\\uA4F8-\\uA4FD\\uA60C\\uA67F\\uA69C-\\uA69D\\uA717-\\uA71F\\uA770\\uA788\\uA7F8-\\uA7F9\\uA9CF\\uA9E6\\uAA70\\uAADD\\uAAF3-\\uAAF4\\uAB5C-\\uAB5F\\uFF70\\uFF9E-\\uFF9F]",
 				chars:      []rune{'ˬ', 'ˮ', 'ʹ', 'ͺ', 'ՙ', 'ـ', 'ߺ', 'ࠚ', 'ࠤ', 'ࠨ', 'ॱ', 'ๆ', 'ໆ', 'ჼ', 'ៗ', 'ᡃ', 'ᪧ', 'ᵸ', 'ⁱ', 'ⁿ', 'ⵯ', 'ⸯ', '々', '〻', 'ꀕ', 'ꘌ', 'ꙿ', 'ꝰ', 'ꞈ', 'ꧏ', 'ꧦ', 'ꩰ', 'ꫝ', 'ｰ'},
 				ranges:     []rune{'ʰ', 'ˁ', 'ˆ', 'ˑ', 'ˠ', 'ˤ', 'ۥ', 'ۦ', 'ߴ', 'ߵ', 'ᱸ', 'ᱽ', 'ᴬ', 'ᵪ', 'ᶛ', 'ᶿ', 'ₐ', 'ₜ', 'ⱼ', 'ⱽ', '〱', '〵', 'ゝ', 'ゞ', 'ー', 'ヾ', 'ꓸ', 'ꓽ', 'ꚜ', 'ꚝ', 'ꜗ', 'ꜟ', 'ꟸ', 'ꟹ', 'ꫳ', 'ꫴ', 'ꭜ', 'ꭟ', 'ﾞ', 'ﾟ'},
@@ -12794,9 +13036,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lo",
-			pos:  position{line: 1839, col: 1, offset: 47628},
+			pos:  position{line: 1866, col: 1, offset: 48746},
 			expr: &charClassMatcher{
-				pos:        position{line: 1839, col: 6, offset: 47633},
+				pos:        position{line: 1866, col: 6, offset: 48751},
 				val:        "[\\u00AA\\u00BA\\u01BB\\u01C0-\\u01C3\\u0294\\u05D0-\\u05EA\\u05EF-\\u05F2\\u0620-\\u063F\\u0641-\\u064A\\u066E-\\u066F\\u0671-\\u06D3\\u06D5\\u06EE-\\u06EF\\u06FA-\\u06FC\\u06FF\\u0710\\u0712-\\u072F\\u074D-\\u07A5\\u07B1\\u07CA-\\u07EA\\u0800-\\u0815\\u0840-\\u0858\\u0860-\\u086A\\u08A0-\\u08B4\\u08B6-\\u08BD\\u0904-\\u0939\\u093D\\u0950\\u0958-\\u0961\\u0972-\\u0980\\u0985-\\u098C\\u098F-\\u0990\\u0993-\\u09A8\\u09AA-\\u09B0\\u09B2\\u09B6-\\u09B9\\u09BD\\u09CE\\u09DC-\\u09DD\\u09DF-\\u09E1\\u09F0-\\u09F1\\u09FC\\u0A05-\\u0A0A\\u0A0F-\\u0A10\\u0A13-\\u0A28\\u0A2A-\\u0A30\\u0A32-\\u0A33\\u0A35-\\u0A36\\u0A38-\\u0A39\\u0A59-\\u0A5C\\u0A5E\\u0A72-\\u0A74\\u0A85-\\u0A8D\\u0A8F-\\u0A91\\u0A93-\\u0AA8\\u0AAA-\\u0AB0\\u0AB2-\\u0AB3\\u0AB5-\\u0AB9\\u0ABD\\u0AD0\\u0AE0-\\u0AE1\\u0AF9\\u0B05-\\u0B0C\\u0B0F-\\u0B10\\u0B13-\\u0B28\\u0B2A-\\u0B30\\u0B32-\\u0B33\\u0B35-\\u0B39\\u0B3D\\u0B5C-\\u0B5D\\u0B5F-\\u0B61\\u0B71\\u0B83\\u0B85-\\u0B8A\\u0B8E-\\u0B90\\u0B92-\\u0B95\\u0B99-\\u0B9A\\u0B9C\\u0B9E-\\u0B9F\\u0BA3-\\u0BA4\\u0BA8-\\u0BAA\\u0BAE-\\u0BB9\\u0BD0\\u0C05-\\u0C0C\\u0C0E-\\u0C10\\u0C12-\\u0C28\\u0C2A-\\u0C39\\u0C3D\\u0C58-\\u0C5A\\u0C60-\\u0C61\\u0C80\\u0C85-\\u0C8C\\u0C8E-\\u0C90\\u0C92-\\u0CA8\\u0CAA-\\u0CB3\\u0CB5-\\u0CB9\\u0CBD\\u0CDE\\u0CE0-\\u0CE1\\u0CF1-\\u0CF2\\u0D05-\\u0D0C\\u0D0E-\\u0D10\\u0D12-\\u0D3A\\u0D3D\\u0D4E\\u0D54-\\u0D56\\u0D5F-\\u0D61\\u0D7A-\\u0D7F\\u0D85-\\u0D96\\u0D9A-\\u0DB1\\u0DB3-\\u0DBB\\u0DBD\\u0DC0-\\u0DC6\\u0E01-\\u0E30\\u0E32-\\u0E33\\u0E40-\\u0E45\\u0E81-\\u0E82\\u0E84\\u0E87-\\u0E88\\u0E8A\\u0E8D\\u0E94-\\u0E97\\u0E99-\\u0E9F\\u0EA1-\\u0EA3\\u0EA5\\u0EA7\\u0EAA-\\u0EAB\\u0EAD-\\u0EB0\\u0EB2-\\u0EB3\\u0EBD\\u0EC0-\\u0EC4\\u0EDC-\\u0EDF\\u0F00\\u0F40-\\u0F47\\u0F49-\\u0F6C\\u0F88-\\u0F8C\\u1000-\\u102A\\u103F\\u1050-\\u1055\\u105A-\\u105D\\u1061\\u1065-\\u1066\\u106E-\\u1070\\u1075-\\u1081\\u108E\\u1100-\\u1248\\u124A-\\u124D\\u1250-\\u1256\\u1258\\u125A-\\u125D\\u1260-\\u1288\\u128A-\\u128D\\u1290-\\u12B0\\u12B2-\\u12B5\\u12B8-\\u12BE\\u12C0\\u12C2-\\u12C5\\u12C8-\\u12D6\\u12D8-\\u1310\\u1312-\\u1315\\u1318-\\u135A\\u1380-\\u138F\\u1401-\\u166C\\u166F-\\u167F\\u1681-\\u169A\\u16A0-\\u16EA\\u16F1-\\u16F8\\u1700-\\u170C\\u170E-\\u1711\\u1720-\\u1731\\u1740-\\u1751\\u1760-\\u176C\\u176E-\\u1770\\u1780-\\u17B3\\u17DC\\u1820-\\u1842\\u1844-\\u1878\\u1880-\\u1884\\u1887-\\u18A8\\u18AA\\u18B0-\\u18F5\\u1900-\\u191E\\u1950-\\u196D\\u1970-\\u1974\\u1980-\\u19AB\\u19B0-\\u19C9\\u1A00-\\u1A16\\u1A20-\\u1A54\\u1B05-\\u1B33\\u1B45-\\u1B4B\\u1B83-\\u1BA0\\u1BAE-\\u1BAF\\u1BBA-\\u1BE5\\u1C00-\\u1C23\\u1C4D-\\u1C4F\\u1C5A-\\u1C77\\u1CE9-\\u1CEC\\u1CEE-\\u1CF1\\u1CF5-\\u1CF6\\u2135-\\u2138\\u2D30-\\u2D67\\u2D80-\\u2D96\\u2DA0-\\u2DA6\\u2DA8-\\u2DAE\\u2DB0-\\u2DB6\\u2DB8-\\u2DBE\\u2DC0-\\u2DC6\\u2DC8-\\u2DCE\\u2DD0-\\u2DD6\\u2DD8-\\u2DDE\\u3006\\u303C\\u3041-\\u3096\\u309F\\u30A1-\\u30FA\\u30FF\\u3105-\\u312F\\u3131-\\u318E\\u31A0-\\u31BA\\u31F0-\\u31FF\\u3400-\\u4DB5\\u4E00-\\u9FEF\\uA000-\\uA014\\uA016-\\uA48C\\uA4D0-\\uA4F7\\uA500-\\uA60B\\uA610-\\uA61F\\uA62A-\\uA62B\\uA66E\\uA6A0-\\uA6E5\\uA78F\\uA7F7\\uA7FB-\\uA801\\uA803-\\uA805\\uA807-\\uA80A\\uA80C-\\uA822\\uA840-\\uA873\\uA882-\\uA8B3\\uA8F2-\\uA8F7\\uA8FB\\uA8FD-\\uA8FE\\uA90A-\\uA925\\uA930-\\uA946\\uA960-\\uA97C\\uA984-\\uA9B2\\uA9E0-\\uA9E4\\uA9E7-\\uA9EF\\uA9FA-\\uA9FE\\uAA00-\\uAA28\\uAA40-\\uAA42\\uAA44-\\uAA4B\\uAA60-\\uAA6F\\uAA71-\\uAA76\\uAA7A\\uAA7E-\\uAAAF\\uAAB1\\uAAB5-\\uAAB6\\uAAB9-\\uAABD\\uAAC0\\uAAC2\\uAADB-\\uAADC\\uAAE0-\\uAAEA\\uAAF2\\uAB01-\\uAB06\\uAB09-\\uAB0E\\uAB11-\\uAB16\\uAB20-\\uAB26\\uAB28-\\uAB2E\\uABC0-\\uABE2\\uAC00-\\uD7A3\\uD7B0-\\uD7C6\\uD7CB-\\uD7FB\\uF900-\\uFA6D\\uFA70-\\uFAD9\\uFB1D\\uFB1F-\\uFB28\\uFB2A-\\uFB36\\uFB38-\\uFB3C\\uFB3E\\uFB40-\\uFB41\\uFB43-\\uFB44\\uFB46-\\uFBB1\\uFBD3-\\uFD3D\\uFD50-\\uFD8F\\uFD92-\\uFDC7\\uFDF0-\\uFDFB\\uFE70-\\uFE74\\uFE76-\\uFEFC\\uFF66-\\uFF6F\\uFF71-\\uFF9D\\uFFA0-\\uFFBE\\uFFC2-\\uFFC7\\uFFCA-\\uFFCF\\uFFD2-\\uFFD7\\uFFDA-\\uFFDC]",
 				chars:      []rune{'ª', 'º', 'ƻ', 'ʔ', 'ە', 'ۿ', 'ܐ', 'ޱ', 'ऽ', 'ॐ', 'ল', 'ঽ', 'ৎ', 'ৼ', 'ਫ਼', 'ઽ', 'ૐ', 'ૹ', 'ଽ', 'ୱ', 'ஃ', 'ஜ', 'ௐ', 'ఽ', 'ಀ', 'ಽ', 'ೞ', 'ഽ', 'ൎ', 'ල', 'ຄ', 'ຊ', 'ຍ', 'ລ', 'ວ', 'ຽ', 'ༀ', 'ဿ', 'ၡ', 'ႎ', 'ቘ', 'ዀ', 'ៜ', 'ᢪ', '〆', '〼', 'ゟ', 'ヿ', 'ꙮ', 'ꞏ', 'ꟷ', 'ꣻ', 'ꩺ', 'ꪱ', 'ꫀ', 'ꫂ', 'ꫲ', 'יִ', 'מּ'},
 				ranges:     []rune{'ǀ', 'ǃ', 'א', 'ת', 'ׯ', 'ײ', 'ؠ', 'ؿ', 'ف', 'ي', 'ٮ', 'ٯ', 'ٱ', 'ۓ', 'ۮ', 'ۯ', 'ۺ', 'ۼ', 'ܒ', 'ܯ', 'ݍ', 'ޥ', 'ߊ', 'ߪ', 'ࠀ', 'ࠕ', 'ࡀ', 'ࡘ', 'ࡠ', 'ࡪ', 'ࢠ', 'ࢴ', 'ࢶ', 'ࢽ', 'ऄ', 'ह', 'क़', 'ॡ', 'ॲ', 'ঀ', 'অ', 'ঌ', 'এ', 'ঐ', 'ও', 'ন', 'প', 'র', 'শ', 'হ', 'ড়', 'ঢ়', 'য়', 'ৡ', 'ৰ', 'ৱ', 'ਅ', 'ਊ', 'ਏ', 'ਐ', 'ਓ', 'ਨ', 'ਪ', 'ਰ', 'ਲ', 'ਲ਼', 'ਵ', 'ਸ਼', 'ਸ', 'ਹ', 'ਖ਼', 'ੜ', 'ੲ', 'ੴ', 'અ', 'ઍ', 'એ', 'ઑ', 'ઓ', 'ન', 'પ', 'ર', 'લ', 'ળ', 'વ', 'હ', 'ૠ', 'ૡ', 'ଅ', 'ଌ', 'ଏ', 'ଐ', 'ଓ', 'ନ', 'ପ', 'ର', 'ଲ', 'ଳ', 'ଵ', 'ହ', 'ଡ଼', 'ଢ଼', 'ୟ', 'ୡ', 'அ', 'ஊ', 'எ', 'ஐ', 'ஒ', 'க', 'ங', 'ச', 'ஞ', 'ட', 'ண', 'த', 'ந', 'ப', 'ம', 'ஹ', 'అ', 'ఌ', 'ఎ', 'ఐ', 'ఒ', 'న', 'ప', 'హ', 'ౘ', 'ౚ', 'ౠ', 'ౡ', 'ಅ', 'ಌ', 'ಎ', 'ಐ', 'ಒ', 'ನ', 'ಪ', 'ಳ', 'ವ', 'ಹ', 'ೠ', 'ೡ', 'ೱ', 'ೲ', 'അ', 'ഌ', 'എ', 'ഐ', 'ഒ', 'ഺ', 'ൔ', 'ൖ', 'ൟ', 'ൡ', 'ൺ', 'ൿ', 'අ', 'ඖ', 'ක', 'න', 'ඳ', 'ර', 'ව', 'ෆ', 'ก', 'ะ', 'า', 'ำ', 'เ', 'ๅ', 'ກ', 'ຂ', 'ງ', 'ຈ', 'ດ', 'ທ', 'ນ', 'ຟ', 'ມ', 'ຣ', 'ສ', 'ຫ', 'ອ', 'ະ', 'າ', 'ຳ', 'ເ', 'ໄ', 'ໜ', 'ໟ', 'ཀ', 'ཇ', 'ཉ', 'ཬ', 'ྈ', 'ྌ', 'က', 'ဪ', 'ၐ', 'ၕ', 'ၚ', 'ၝ', 'ၥ', 'ၦ', 'ၮ', 'ၰ', 'ၵ', 'ႁ', 'ᄀ', 'ቈ', 'ቊ', 'ቍ', 'ቐ', 'ቖ', 'ቚ', 'ቝ', 'በ', 'ኈ', 'ኊ', 'ኍ', 'ነ', 'ኰ', 'ኲ', 'ኵ', 'ኸ', 'ኾ', 'ዂ', 'ዅ', 'ወ', 'ዖ', 'ዘ', 'ጐ', 'ጒ', 'ጕ', 'ጘ', 'ፚ', 'ᎀ', 'ᎏ', 'ᐁ', 'ᙬ', 'ᙯ', 'ᙿ', 'ᚁ', 'ᚚ', 'ᚠ', 'ᛪ', 'ᛱ', 'ᛸ', 'ᜀ', 'ᜌ', 'ᜎ', 'ᜑ', 'ᜠ', 'ᜱ', 'ᝀ', 'ᝑ', 'ᝠ', 'ᝬ', 'ᝮ', 'ᝰ', 'ក', 'ឳ', 'ᠠ', 'ᡂ', 'ᡄ', 'ᡸ', 'ᢀ', 'ᢄ', 'ᢇ', 'ᢨ', 'ᢰ', 'ᣵ', 'ᤀ', 'ᤞ', 'ᥐ', 'ᥭ', 'ᥰ', 'ᥴ', 'ᦀ', 'ᦫ', 'ᦰ', 'ᧉ', 'ᨀ', 'ᨖ', 'ᨠ', 'ᩔ', 'ᬅ', 'ᬳ', 'ᭅ', 'ᭋ', 'ᮃ', 'ᮠ', 'ᮮ', 'ᮯ', 'ᮺ', 'ᯥ', 'ᰀ', 'ᰣ', 'ᱍ', 'ᱏ', 'ᱚ', 'ᱷ', 'ᳩ', 'ᳬ', 'ᳮ', 'ᳱ', 'ᳵ', 'ᳶ', 'ℵ', 'ℸ', 'ⴰ', 'ⵧ', 'ⶀ', 'ⶖ', 'ⶠ', 'ⶦ', 'ⶨ', 'ⶮ', 'ⶰ', 'ⶶ', 'ⶸ', 'ⶾ', 'ⷀ', 'ⷆ', 'ⷈ', 'ⷎ', 'ⷐ', 'ⷖ', 'ⷘ', 'ⷞ', 'ぁ', 'ゖ', 'ァ', 'ヺ', 'ㄅ', 'ㄯ', 'ㄱ', 'ㆎ', 'ㆠ', 'ㆺ', 'ㇰ', 'ㇿ', '㐀', '䶵', '一', '鿯', 'ꀀ', 'ꀔ', 'ꀖ', 'ꒌ', 'ꓐ', 'ꓷ', 'ꔀ', 'ꘋ', 'ꘐ', 'ꘟ', 'ꘪ', 'ꘫ', 'ꚠ', 'ꛥ', 'ꟻ', 'ꠁ', 'ꠃ', 'ꠅ', 'ꠇ', 'ꠊ', 'ꠌ', 'ꠢ', 'ꡀ', 'ꡳ', 'ꢂ', 'ꢳ', 'ꣲ', 'ꣷ', 'ꣽ', 'ꣾ', 'ꤊ', 'ꤥ', 'ꤰ', 'ꥆ', 'ꥠ', 'ꥼ', 'ꦄ', 'ꦲ', 'ꧠ', 'ꧤ', 'ꧧ', 'ꧯ', 'ꧺ', 'ꧾ', 'ꨀ', 'ꨨ', 'ꩀ', 'ꩂ', 'ꩄ', 'ꩋ', 'ꩠ', 'ꩯ', 'ꩱ', 'ꩶ', 'ꩾ', 'ꪯ', 'ꪵ', 'ꪶ', 'ꪹ', 'ꪽ', 'ꫛ', 'ꫜ', 'ꫠ', 'ꫪ', 'ꬁ', 'ꬆ', 'ꬉ', 'ꬎ', 'ꬑ', 'ꬖ', 'ꬠ', 'ꬦ', 'ꬨ', 'ꬮ', 'ꯀ', 'ꯢ', '가', '힣', 'ힰ', 'ퟆ', 'ퟋ', 'ퟻ', '豈', '舘', '並', '龎', 'ײַ', 'ﬨ', 'שׁ', 'זּ', 'טּ', 'לּ', 'נּ', 'סּ', 'ףּ', 'פּ', 'צּ', 'ﮱ', 'ﯓ', 'ﴽ', 'ﵐ', 'ﶏ', 'ﶒ', 'ﷇ', 'ﷰ', 'ﷻ', 'ﹰ', 'ﹴ', 'ﹶ', 'ﻼ', 'ｦ', 'ｯ', 'ｱ', 'ﾝ', 'ﾠ', 'ﾾ', 'ￂ', 'ￇ', 'ￊ', 'ￏ', 'ￒ', 'ￗ', 'ￚ', 'ￜ'},
@@ -12808,9 +13050,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lt",
-			pos:  position{line: 1842, col: 1, offset: 51080},
+			pos:  position{line: 1869, col: 1, offset: 52198},
 			expr: &charClassMatcher{
-				pos:        position{line: 1842, col: 6, offset: 51085},
+				pos:        position{line: 1869, col: 6, offset: 52203},
 				val:        "[\\u01C5\\u01C8\\u01CB\\u01F2\\u1F88-\\u1F8F\\u1F98-\\u1F9F\\u1FA8-\\u1FAF\\u1FBC\\u1FCC\\u1FFC]",
 				chars:      []rune{'ǅ', 'ǈ', 'ǋ', 'ǲ', 'ᾼ', 'ῌ', 'ῼ'},
 				ranges:     []rune{'ᾈ', 'ᾏ', 'ᾘ', 'ᾟ', 'ᾨ', 'ᾯ'},
@@ -12822,9 +13064,9 @@ var g = &grammar{
 		},
 		{
 			name: "Lu",
-			pos:  position{line: 1845, col: 1, offset: 51191},
+			pos:  position{line: 1872, col: 1, offset: 52309},
 			expr: &charClassMatcher{
-				pos:        position{line: 1845, col: 6, offset: 51196},
+				pos:        position{line: 1872, col: 6, offset: 52314},
 				val:        "[\\u0041-\\u005A\\u00C0-\\u00D6\\u00D8-\\u00DE\\u0100\\u0102\\u0104\\u0106\\u0108\\u010A\\u010C\\u010E\\u0110\\u0112\\u0114\\u0116\\u0118\\u011A\\u011C\\u011E\\u0120\\u0122\\u0124\\u0126\\u0128\\u012A\\u012C\\u012E\\u0130\\u0132\\u0134\\u0136\\u0139\\u013B\\u013D\\u013F\\u0141\\u0143\\u0145\\u0147\\u014A\\u014C\\u014E\\u0150\\u0152\\u0154\\u0156\\u0158\\u015A\\u015C\\u015E\\u0160\\u0162\\u0164\\u0166\\u0168\\u016A\\u016C\\u016E\\u0170\\u0172\\u0174\\u0176\\u0178-\\u0179\\u017B\\u017D\\u0181-\\u0182\\u0184\\u0186-\\u0187\\u0189-\\u018B\\u018E-\\u0191\\u0193-\\u0194\\u0196-\\u0198\\u019C-\\u019D\\u019F-\\u01A0\\u01A2\\u01A4\\u01A6-\\u01A7\\u01A9\\u01AC\\u01AE-\\u01AF\\u01B1-\\u01B3\\u01B5\\u01B7-\\u01B8\\u01BC\\u01C4\\u01C7\\u01CA\\u01CD\\u01CF\\u01D1\\u01D3\\u01D5\\u01D7\\u01D9\\u01DB\\u01DE\\u01E0\\u01E2\\u01E4\\u01E6\\u01E8\\u01EA\\u01EC\\u01EE\\u01F1\\u01F4\\u01F6-\\u01F8\\u01FA\\u01FC\\u01FE\\u0200\\u0202\\u0204\\u0206\\u0208\\u020A\\u020C\\u020E\\u0210\\u0212\\u0214\\u0216\\u0218\\u021A\\u021C\\u021E\\u0220\\u0222\\u0224\\u0226\\u0228\\u022A\\u022C\\u022E\\u0230\\u0232\\u023A-\\u023B\\u023D-\\u023E\\u0241\\u0243-\\u0246\\u0248\\u024A\\u024C\\u024E\\u0370\\u0372\\u0376\\u037F\\u0386\\u0388-\\u038A\\u038C\\u038E-\\u038F\\u0391-\\u03A1\\u03A3-\\u03AB\\u03CF\\u03D2-\\u03D4\\u03D8\\u03DA\\u03DC\\u03DE\\u03E0\\u03E2\\u03E4\\u03E6\\u03E8\\u03EA\\u03EC\\u03EE\\u03F4\\u03F7\\u03F9-\\u03FA\\u03FD-\\u042F\\u0460\\u0462\\u0464\\u0466\\u0468\\u046A\\u046C\\u046E\\u0470\\u0472\\u0474\\u0476\\u0478\\u047A\\u047C\\u047E\\u0480\\u048A\\u048C\\u048E\\u0490\\u0492\\u0494\\u0496\\u0498\\u049A\\u049C\\u049E\\u04A0\\u04A2\\u04A4\\u04A6\\u04A8\\u04AA\\u04AC\\u04AE\\u04B0\\u04B2\\u04B4\\u04B6\\u04B8\\u04BA\\u04BC\\u04BE\\u04C0-\\u04C1\\u04C3\\u04C5\\u04C7\\u04C9\\u04CB\\u04CD\\u04D0\\u04D2\\u04D4\\u04D6\\u04D8\\u04DA\\u04DC\\u04DE\\u04E0\\u04E2\\u04E4\\u04E6\\u04E8\\u04EA\\u04EC\\u04EE\\u04F0\\u04F2\\u04F4\\u04F6\\u04F8\\u04FA\\u04FC\\u04FE\\u0500\\u0502\\u0504\\u0506\\u0508\\u050A\\u050C\\u050E\\u0510\\u0512\\u0514\\u0516\\u0518\\u051A\\u051C\\u051E\\u0520\\u0522\\u0524\\u0526\\u0528\\u052A\\u052C\\u052E\\u0531-\\u0556\\u10A0-\\u10C5\\u10C7\\u10CD\\u13A0-\\u13F5\\u1C90-\\u1CBA\\u1CBD-\\u1CBF\\u1E00\\u1E02\\u1E04\\u1E06\\u1E08\\u1E0A\\u1E0C\\u1E0E\\u1E10\\u1E12\\u1E14\\u1E16\\u1E18\\u1E1A\\u1E1C\\u1E1E\\u1E20\\u1E22\\u1E24\\u1E26\\u1E28\\u1E2A\\u1E2C\\u1E2E\\u1E30\\u1E32\\u1E34\\u1E36\\u1E38\\u1E3A\\u1E3C\\u1E3E\\u1E40\\u1E42\\u1E44\\u1E46\\u1E48\\u1E4A\\u1E4C\\u1E4E\\u1E50\\u1E52\\u1E54\\u1E56\\u1E58\\u1E5A\\u1E5C\\u1E5E\\u1E60\\u1E62\\u1E64\\u1E66\\u1E68\\u1E6A\\u1E6C\\u1E6E\\u1E70\\u1E72\\u1E74\\u1E76\\u1E78\\u1E7A\\u1E7C\\u1E7E\\u1E80\\u1E82\\u1E84\\u1E86\\u1E88\\u1E8A\\u1E8C\\u1E8E\\u1E90\\u1E92\\u1E94\\u1E9E\\u1EA0\\u1EA2\\u1EA4\\u1EA6\\u1EA8\\u1EAA\\u1EAC\\u1EAE\\u1EB0\\u1EB2\\u1EB4\\u1EB6\\u1EB8\\u1EBA\\u1EBC\\u1EBE\\u1EC0\\u1EC2\\u1EC4\\u1EC6\\u1EC8\\u1ECA\\u1ECC\\u1ECE\\u1ED0\\u1ED2\\u1ED4\\u1ED6\\u1ED8\\u1EDA\\u1EDC\\u1EDE\\u1EE0\\u1EE2\\u1EE4\\u1EE6\\u1EE8\\u1EEA\\u1EEC\\u1EEE\\u1EF0\\u1EF2\\u1EF4\\u1EF6\\u1EF8\\u1EFA\\u1EFC\\u1EFE\\u1F08-\\u1F0F\\u1F18-\\u1F1D\\u1F28-\\u1F2F\\u1F38-\\u1F3F\\u1F48-\\u1F4D\\u1F59\\u1F5B\\u1F5D\\u1F5F\\u1F68-\\u1F6F\\u1FB8-\\u1FBB\\u1FC8-\\u1FCB\\u1FD8-\\u1FDB\\u1FE8-\\u1FEC\\u1FF8-\\u1FFB\\u2102\\u2107\\u210B-\\u210D\\u2110-\\u2112\\u2115\\u2119-\\u211D\\u2124\\u2126\\u2128\\u212A-\\u212D\\u2130-\\u2133\\u213E-\\u213F\\u2145\\u2183\\u2C00-\\u2C2E\\u2C60\\u2C62-\\u2C64\\u2C67\\u2C69\\u2C6B\\u2C6D-\\u2C70\\u2C72\\u2C75\\u2C7E-\\u2C80\\u2C82\\u2C84\\u2C86\\u2C88\\u2C8A\\u2C8C\\u2C8E\\u2C90\\u2C92\\u2C94\\u2C96\\u2C98\\u2C9A\\u2C9C\\u2C9E\\u2CA0\\u2CA2\\u2CA4\\u2CA6\\u2CA8\\u2CAA\\u2CAC\\u2CAE\\u2CB0\\u2CB2\\u2CB4\\u2CB6\\u2CB8\\u2CBA\\u2CBC\\u2CBE\\u2CC0\\u2CC2\\u2CC4\\u2CC6\\u2CC8\\u2CCA\\u2CCC\\u2CCE\\u2CD0\\u2CD2\\u2CD4\\u2CD6\\u2CD8\\u2CDA\\u2CDC\\u2CDE\\u2CE0\\u2CE2\\u2CEB\\u2CED\\u2CF2\\uA640\\uA642\\uA644\\uA646\\uA648\\uA64A\\uA64C\\uA64E\\uA650\\uA652\\uA654\\uA656\\uA658\\uA65A\\uA65C\\uA65E\\uA660\\uA662\\uA664\\uA666\\uA668\\uA66A\\uA66C\\uA680\\uA682\\uA684\\uA686\\uA688\\uA68A\\uA68C\\uA68E\\uA690\\uA692\\uA694\\uA696\\uA698\\uA69A\\uA722\\uA724\\uA726\\uA728\\uA72A\\uA72C\\uA72E\\uA732\\uA734\\uA736\\uA738\\uA73A\\uA73C\\uA73E\\uA740\\uA742\\uA744\\uA746\\uA748\\uA74A\\uA74C\\uA74E\\uA750\\uA752\\uA754\\uA756\\uA758\\uA75A\\uA75C\\uA75E\\uA760\\uA762\\uA764\\uA766\\uA768\\uA76A\\uA76C\\uA76E\\uA779\\uA77B\\uA77D-\\uA77E\\uA780\\uA782\\uA784\\uA786\\uA78B\\uA78D\\uA790\\uA792\\uA796\\uA798\\uA79A\\uA79C\\uA79E\\uA7A0\\uA7A2\\uA7A4\\uA7A6\\uA7A8\\uA7AA-\\uA7AE\\uA7B0-\\uA7B4\\uA7B6\\uA7B8\\uFF21-\\uFF3A]",
 				chars:      []rune{'Ā', 'Ă', 'Ą', 'Ć', 'Ĉ', 'Ċ', 'Č', 'Ď', 'Đ', 'Ē', 'Ĕ', 'Ė', 'Ę', 'Ě', 'Ĝ', 'Ğ', 'Ġ', 'Ģ', 'Ĥ', 'Ħ', 'Ĩ', 'Ī', 'Ĭ', 'Į', 'İ', 'Ĳ', 'Ĵ', 'Ķ', 'Ĺ', 'Ļ', 'Ľ', 'Ŀ', 'Ł', 'Ń', 'Ņ', 'Ň', 'Ŋ', 'Ō', 'Ŏ', 'Ő', 'Œ', 'Ŕ', 'Ŗ', 'Ř', 'Ś', 'Ŝ', 'Ş', 'Š', 'Ţ', 'Ť', 'Ŧ', 'Ũ', 'Ū', 'Ŭ', 'Ů', 'Ű', 'Ų', 'Ŵ', 'Ŷ', 'Ż', 'Ž', 'Ƅ', 'Ƣ', 'Ƥ', 'Ʃ', 'Ƭ', 'Ƶ', 'Ƽ', 'Ǆ', 'Ǉ', 'Ǌ', 'Ǎ', 'Ǐ', 'Ǒ', 'Ǔ', 'Ǖ', 'Ǘ', 'Ǚ', 'Ǜ', 'Ǟ', 'Ǡ', 'Ǣ', 'Ǥ', 'Ǧ', 'Ǩ', 'Ǫ', 'Ǭ', 'Ǯ', 'Ǳ', 'Ǵ', 'Ǻ', 'Ǽ', 'Ǿ', 'Ȁ', 'Ȃ', 'Ȅ', 'Ȇ', 'Ȉ', 'Ȋ', 'Ȍ', 'Ȏ', 'Ȑ', 'Ȓ', 'Ȕ', 'Ȗ', 'Ș', 'Ț', 'Ȝ', 'Ȟ', 'Ƞ', 'Ȣ', 'Ȥ', 'Ȧ', 'Ȩ', 'Ȫ', 'Ȭ', 'Ȯ', 'Ȱ', 'Ȳ', 'Ɂ', 'Ɉ', 'Ɋ', 'Ɍ', 'Ɏ', 'Ͱ', 'Ͳ', 'Ͷ', 'Ϳ', 'Ά', 'Ό', 'Ϗ', 'Ϙ', 'Ϛ', 'Ϝ', 'Ϟ', 'Ϡ', 'Ϣ', 'Ϥ', 'Ϧ', 'Ϩ', 'Ϫ', 'Ϭ', 'Ϯ', 'ϴ', 'Ϸ', 'Ѡ', 'Ѣ', 'Ѥ', 'Ѧ', 'Ѩ', 'Ѫ', 'Ѭ', 'Ѯ', 'Ѱ', 'Ѳ', 'Ѵ', 'Ѷ', 'Ѹ', 'Ѻ', 'Ѽ', 'Ѿ', 'Ҁ', 'Ҋ', 'Ҍ', 'Ҏ', 'Ґ', 'Ғ', 'Ҕ', 'Җ', 'Ҙ', 'Қ', 'Ҝ', 'Ҟ', 'Ҡ', 'Ң', 'Ҥ', 'Ҧ', 'Ҩ', 'Ҫ', 'Ҭ', 'Ү', 'Ұ', 'Ҳ', 'Ҵ', 'Ҷ', 'Ҹ', 'Һ', 'Ҽ', 'Ҿ', 'Ӄ', 'Ӆ', 'Ӈ', 'Ӊ', 'Ӌ', 'Ӎ', 'Ӑ', 'Ӓ', 'Ӕ', 'Ӗ', 'Ә', 'Ӛ', 'Ӝ', 'Ӟ', 'Ӡ', 'Ӣ', 'Ӥ', 'Ӧ', 'Ө', 'Ӫ', 'Ӭ', 'Ӯ', 'Ӱ', 'Ӳ', 'Ӵ', 'Ӷ', 'Ӹ', 'Ӻ', 'Ӽ', 'Ӿ', 'Ԁ', 'Ԃ', 'Ԅ', 'Ԇ', 'Ԉ', 'Ԋ', 'Ԍ', 'Ԏ', 'Ԑ', 'Ԓ', 'Ԕ', 'Ԗ', 'Ԙ', 'Ԛ', 'Ԝ', 'Ԟ', 'Ԡ', 'Ԣ', 'Ԥ', 'Ԧ', 'Ԩ', 'Ԫ', 'Ԭ', 'Ԯ', 'Ⴧ', 'Ⴭ', 'Ḁ', 'Ḃ', 'Ḅ', 'Ḇ', 'Ḉ', 'Ḋ', 'Ḍ', 'Ḏ', 'Ḑ', 'Ḓ', 'Ḕ', 'Ḗ', 'Ḙ', 'Ḛ', 'Ḝ', 'Ḟ', 'Ḡ', 'Ḣ', 'Ḥ', 'Ḧ', 'Ḩ', 'Ḫ', 'Ḭ', 'Ḯ', 'Ḱ', 'Ḳ', 'Ḵ', 'Ḷ', 'Ḹ', 'Ḻ', 'Ḽ', 'Ḿ', 'Ṁ', 'Ṃ', 'Ṅ', 'Ṇ', 'Ṉ', 'Ṋ', 'Ṍ', 'Ṏ', 'Ṑ', 'Ṓ', 'Ṕ', 'Ṗ', 'Ṙ', 'Ṛ', 'Ṝ', 'Ṟ', 'Ṡ', 'Ṣ', 'Ṥ', 'Ṧ', 'Ṩ', 'Ṫ', 'Ṭ', 'Ṯ', 'Ṱ', 'Ṳ', 'Ṵ', 'Ṷ', 'Ṹ', 'Ṻ', 'Ṽ', 'Ṿ', 'Ẁ', 'Ẃ', 'Ẅ', 'Ẇ', 'Ẉ', 'Ẋ', 'Ẍ', 'Ẏ', 'Ẑ', 'Ẓ', 'Ẕ', 'ẞ', 'Ạ', 'Ả', 'Ấ', 'Ầ', 'Ẩ', 'Ẫ', 'Ậ', 'Ắ', 'Ằ', 'Ẳ', 'Ẵ', 'Ặ', 'Ẹ', 'Ẻ', 'Ẽ', 'Ế', 'Ề', 'Ể', 'Ễ', 'Ệ', 'Ỉ', 'Ị', 'Ọ', 'Ỏ', 'Ố', 'Ồ', 'Ổ', 'Ỗ', 'Ộ', 'Ớ', 'Ờ', 'Ở', 'Ỡ', 'Ợ', 'Ụ', 'Ủ', 'Ứ', 'Ừ', 'Ử', 'Ữ', 'Ự', 'Ỳ', 'Ỵ', 'Ỷ', 'Ỹ', 'Ỻ', 'Ỽ', 'Ỿ', 'Ὑ', 'Ὓ', 'Ὕ', 'Ὗ', 'ℂ', 'ℇ', 'ℕ', 'ℤ', 'Ω', 'ℨ', 'ⅅ', 'Ↄ', 'Ⱡ', 'Ⱨ', 'Ⱪ', 'Ⱬ', 'Ⱳ', 'Ⱶ', 'Ⲃ', 'Ⲅ', 'Ⲇ', 'Ⲉ', 'Ⲋ', 'Ⲍ', 'Ⲏ', 'Ⲑ', 'Ⲓ', 'Ⲕ', 'Ⲗ', 'Ⲙ', 'Ⲛ', 'Ⲝ', 'Ⲟ', 'Ⲡ', 'Ⲣ', 'Ⲥ', 'Ⲧ', 'Ⲩ', 'Ⲫ', 'Ⲭ', 'Ⲯ', 'Ⲱ', 'Ⲳ', 'Ⲵ', 'Ⲷ', 'Ⲹ', 'Ⲻ', 'Ⲽ', 'Ⲿ', 'Ⳁ', 'Ⳃ', 'Ⳅ', 'Ⳇ', 'Ⳉ', 'Ⳋ', 'Ⳍ', 'Ⳏ', 'Ⳑ', 'Ⳓ', 'Ⳕ', 'Ⳗ', 'Ⳙ', 'Ⳛ', 'Ⳝ', 'Ⳟ', 'Ⳡ', 'Ⳣ', 'Ⳬ', 'Ⳮ', 'Ⳳ', 'Ꙁ', 'Ꙃ', 'Ꙅ', 'Ꙇ', 'Ꙉ', 'Ꙋ', 'Ꙍ', 'Ꙏ', 'Ꙑ', 'Ꙓ', 'Ꙕ', 'Ꙗ', 'Ꙙ', 'Ꙛ', 'Ꙝ', 'Ꙟ', 'Ꙡ', 'Ꙣ', 'Ꙥ', 'Ꙧ', 'Ꙩ', 'Ꙫ', 'Ꙭ', 'Ꚁ', 'Ꚃ', 'Ꚅ', 'Ꚇ', 'Ꚉ', 'Ꚋ', 'Ꚍ', 'Ꚏ', 'Ꚑ', 'Ꚓ', 'Ꚕ', 'Ꚗ', 'Ꚙ', 'Ꚛ', 'Ꜣ', 'Ꜥ', 'Ꜧ', 'Ꜩ', 'Ꜫ', 'Ꜭ', 'Ꜯ', 'Ꜳ', 'Ꜵ', 'Ꜷ', 'Ꜹ', 'Ꜻ', 'Ꜽ', 'Ꜿ', 'Ꝁ', 'Ꝃ', 'Ꝅ', 'Ꝇ', 'Ꝉ', 'Ꝋ', 'Ꝍ', 'Ꝏ', 'Ꝑ', 'Ꝓ', 'Ꝕ', 'Ꝗ', 'Ꝙ', 'Ꝛ', 'Ꝝ', 'Ꝟ', 'Ꝡ', 'Ꝣ', 'Ꝥ', 'Ꝧ', 'Ꝩ', 'Ꝫ', 'Ꝭ', 'Ꝯ', 'Ꝺ', 'Ꝼ', 'Ꞁ', 'Ꞃ', 'Ꞅ', 'Ꞇ', 'Ꞌ', 'Ɥ', 'Ꞑ', 'Ꞓ', 'Ꞗ', 'Ꞙ', 'Ꞛ', 'Ꞝ', 'Ꞟ', 'Ꞡ', 'Ꞣ', 'Ꞥ', 'Ꞧ', 'Ꞩ', 'Ꞷ', 'Ꞹ'},
 				ranges:     []rune{'A', 'Z', 'À', 'Ö', 'Ø', 'Þ', 'Ÿ', 'Ź', 'Ɓ', 'Ƃ', 'Ɔ', 'Ƈ', 'Ɖ', 'Ƌ', 'Ǝ', 'Ƒ', 'Ɠ', 'Ɣ', 'Ɩ', 'Ƙ', 'Ɯ', 'Ɲ', 'Ɵ', 'Ơ', 'Ʀ', 'Ƨ', 'Ʈ', 'Ư', 'Ʊ', 'Ƴ', 'Ʒ', 'Ƹ', 'Ƕ', 'Ǹ', 'Ⱥ', 'Ȼ', 'Ƚ', 'Ⱦ', 'Ƀ', 'Ɇ', 'Έ', 'Ί', 'Ύ', 'Ώ', 'Α', 'Ρ', 'Σ', 'Ϋ', 'ϒ', 'ϔ', 'Ϲ', 'Ϻ', 'Ͻ', 'Я', 'Ӏ', 'Ӂ', 'Ա', 'Ֆ', 'Ⴀ', 'Ⴥ', 'Ꭰ', 'Ᏽ', 'Ა', 'Ჺ', 'Ჽ', 'Ჿ', 'Ἀ', 'Ἇ', 'Ἐ', 'Ἕ', 'Ἠ', 'Ἧ', 'Ἰ', 'Ἷ', 'Ὀ', 'Ὅ', 'Ὠ', 'Ὧ', 'Ᾰ', 'Ά', 'Ὲ', 'Ή', 'Ῐ', 'Ί', 'Ῠ', 'Ῥ', 'Ὸ', 'Ώ', 'ℋ', 'ℍ', 'ℐ', 'ℒ', 'ℙ', 'ℝ', 'K', 'ℭ', 'ℰ', 'ℳ', 'ℾ', 'ℿ', 'Ⰰ', 'Ⱞ', 'Ɫ', 'Ɽ', 'Ɑ', 'Ɒ', 'Ȿ', 'Ⲁ', 'Ᵹ', 'Ꝿ', 'Ɦ', 'Ɪ', 'Ʞ', 'Ꞵ', 'Ａ', 'Ｚ'},
@@ -12836,9 +13078,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mc",
-			pos:  position{line: 1848, col: 1, offset: 55197},
+			pos:  position{line: 1875, col: 1, offset: 56315},
 			expr: &charClassMatcher{
-				pos:        position{line: 1848, col: 6, offset: 55202},
+				pos:        position{line: 1875, col: 6, offset: 56320},
 				val:        "[\\u0903\\u093B\\u093E-\\u0940\\u0949-\\u094C\\u094E-\\u094F\\u0982-\\u0983\\u09BE-\\u09C0\\u09C7-\\u09C8\\u09CB-\\u09CC\\u09D7\\u0A03\\u0A3E-\\u0A40\\u0A83\\u0ABE-\\u0AC0\\u0AC9\\u0ACB-\\u0ACC\\u0B02-\\u0B03\\u0B3E\\u0B40\\u0B47-\\u0B48\\u0B4B-\\u0B4C\\u0B57\\u0BBE-\\u0BBF\\u0BC1-\\u0BC2\\u0BC6-\\u0BC8\\u0BCA-\\u0BCC\\u0BD7\\u0C01-\\u0C03\\u0C41-\\u0C44\\u0C82-\\u0C83\\u0CBE\\u0CC0-\\u0CC4\\u0CC7-\\u0CC8\\u0CCA-\\u0CCB\\u0CD5-\\u0CD6\\u0D02-\\u0D03\\u0D3E-\\u0D40\\u0D46-\\u0D48\\u0D4A-\\u0D4C\\u0D57\\u0D82-\\u0D83\\u0DCF-\\u0DD1\\u0DD8-\\u0DDF\\u0DF2-\\u0DF3\\u0F3E-\\u0F3F\\u0F7F\\u102B-\\u102C\\u1031\\u1038\\u103B-\\u103C\\u1056-\\u1057\\u1062-\\u1064\\u1067-\\u106D\\u1083-\\u1084\\u1087-\\u108C\\u108F\\u109A-\\u109C\\u17B6\\u17BE-\\u17C5\\u17C7-\\u17C8\\u1923-\\u1926\\u1929-\\u192B\\u1930-\\u1931\\u1933-\\u1938\\u1A19-\\u1A1A\\u1A55\\u1A57\\u1A61\\u1A63-\\u1A64\\u1A6D-\\u1A72\\u1B04\\u1B35\\u1B3B\\u1B3D-\\u1B41\\u1B43-\\u1B44\\u1B82\\u1BA1\\u1BA6-\\u1BA7\\u1BAA\\u1BE7\\u1BEA-\\u1BEC\\u1BEE\\u1BF2-\\u1BF3\\u1C24-\\u1C2B\\u1C34-\\u1C35\\u1CE1\\u1CF2-\\u1CF3\\u1CF7\\u302E-\\u302F\\uA823-\\uA824\\uA827\\uA880-\\uA881\\uA8B4-\\uA8C3\\uA952-\\uA953\\uA983\\uA9B4-\\uA9B5\\uA9BA-\\uA9BB\\uA9BD-\\uA9C0\\uAA2F-\\uAA30\\uAA33-\\uAA34\\uAA4D\\uAA7B\\uAA7D\\uAAEB\\uAAEE-\\uAAEF\\uAAF5\\uABE3-\\uABE4\\uABE6-\\uABE7\\uABE9-\\uABEA\\uABEC]",
 				chars:      []rune{'ः', 'ऻ', 'ৗ', 'ਃ', 'ઃ', 'ૉ', 'ା', 'ୀ', 'ୗ', 'ௗ', 'ಾ', 'ൗ', 'ཿ', 'ေ', 'း', 'ႏ', 'ា', 'ᩕ', 'ᩗ', 'ᩡ', 'ᬄ', 'ᬵ', 'ᬻ', 'ᮂ', 'ᮡ', '᮪', 'ᯧ', 'ᯮ', '᳡', '᳷', 'ꠧ', 'ꦃ', 'ꩍ', 'ꩻ', 'ꩽ', 'ꫫ', 'ꫵ', '꯬'},
 				ranges:     []rune{'ा', 'ी', 'ॉ', 'ौ', 'ॎ', 'ॏ', 'ং', 'ঃ', 'া', 'ী', 'ে', 'ৈ', 'ো', 'ৌ', 'ਾ', 'ੀ', 'ા', 'ી', 'ો', 'ૌ', 'ଂ', 'ଃ', 'େ', 'ୈ', 'ୋ', 'ୌ', 'ா', 'ி', 'ு', 'ூ', 'ெ', 'ை', 'ொ', 'ௌ', 'ఁ', 'ః', 'ు', 'ౄ', 'ಂ', 'ಃ', 'ೀ', 'ೄ', 'ೇ', 'ೈ', 'ೊ', 'ೋ', 'ೕ', 'ೖ', 'ം', 'ഃ', 'ാ', 'ീ', 'െ', 'ൈ', 'ൊ', 'ൌ', 'ං', 'ඃ', 'ා', 'ෑ', 'ෘ', 'ෟ', 'ෲ', 'ෳ', '༾', '༿', 'ါ', 'ာ', 'ျ', 'ြ', 'ၖ', 'ၗ', 'ၢ', 'ၤ', 'ၧ', 'ၭ', 'ႃ', 'ႄ', 'ႇ', 'ႌ', 'ႚ', 'ႜ', 'ើ', 'ៅ', 'ះ', 'ៈ', 'ᤣ', 'ᤦ', 'ᤩ', 'ᤫ', 'ᤰ', 'ᤱ', 'ᤳ', 'ᤸ', 'ᨙ', 'ᨚ', 'ᩣ', 'ᩤ', 'ᩭ', 'ᩲ', 'ᬽ', 'ᭁ', 'ᭃ', '᭄', 'ᮦ', 'ᮧ', 'ᯪ', 'ᯬ', '᯲', '᯳', 'ᰤ', 'ᰫ', 'ᰴ', 'ᰵ', 'ᳲ', 'ᳳ', '〮', '〯', 'ꠣ', 'ꠤ', 'ꢀ', 'ꢁ', 'ꢴ', 'ꣃ', 'ꥒ', '꥓', 'ꦴ', 'ꦵ', 'ꦺ', 'ꦻ', 'ꦽ', '꧀', 'ꨯ', 'ꨰ', 'ꨳ', 'ꨴ', 'ꫮ', 'ꫯ', 'ꯣ', 'ꯤ', 'ꯦ', 'ꯧ', 'ꯩ', 'ꯪ'},
@@ -12850,9 +13092,9 @@ var g = &grammar{
 		},
 		{
 			name: "Mn",
-			pos:  position{line: 1851, col: 1, offset: 56390},
+			pos:  position{line: 1878, col: 1, offset: 57508},
 			expr: &charClassMatcher{
-				pos:        position{line: 1851, col: 6, offset: 56395},
+				pos:        position{line: 1878, col: 6, offset: 57513},
 				val:        "[\\u0300-\\u036F\\u0483-\\u0487\\u0591-\\u05BD\\u05BF\\u05C1-\\u05C2\\u05C4-\\u05C5\\u05C7\\u0610-\\u061A\\u064B-\\u065F\\u0670\\u06D6-\\u06DC\\u06DF-\\u06E4\\u06E7-\\u06E8\\u06EA-\\u06ED\\u0711\\u0730-\\u074A\\u07A6-\\u07B0\\u07EB-\\u07F3\\u07FD\\u0816-\\u0819\\u081B-\\u0823\\u0825-\\u0827\\u0829-\\u082D\\u0859-\\u085B\\u08D3-\\u08E1\\u08E3-\\u0902\\u093A\\u093C\\u0941-\\u0948\\u094D\\u0951-\\u0957\\u0962-\\u0963\\u0981\\u09BC\\u09C1-\\u09C4\\u09CD\\u09E2-\\u09E3\\u09FE\\u0A01-\\u0A02\\u0A3C\\u0A41-\\u0A42\\u0A47-\\u0A48\\u0A4B-\\u0A4D\\u0A51\\u0A70-\\u0A71\\u0A75\\u0A81-\\u0A82\\u0ABC\\u0AC1-\\u0AC5\\u0AC7-\\u0AC8\\u0ACD\\u0AE2-\\u0AE3\\u0AFA-\\u0AFF\\u0B01\\u0B3C\\u0B3F\\u0B41-\\u0B44\\u0B4D\\u0B56\\u0B62-\\u0B63\\u0B82\\u0BC0\\u0BCD\\u0C00\\u0C04\\u0C3E-\\u0C40\\u0C46-\\u0C48\\u0C4A-\\u0C4D\\u0C55-\\u0C56\\u0C62-\\u0C63\\u0C81\\u0CBC\\u0CBF\\u0CC6\\u0CCC-\\u0CCD\\u0CE2-\\u0CE3\\u0D00-\\u0D01\\u0D3B-\\u0D3C\\u0D41-\\u0D44\\u0D4D\\u0D62-\\u0D63\\u0DCA\\u0DD2-\\u0DD4\\u0DD6\\u0E31\\u0E34-\\u0E3A\\u0E47-\\u0E4E\\u0EB1\\u0EB4-\\u0EB9\\u0EBB-\\u0EBC\\u0EC8-\\u0ECD\\u0F18-\\u0F19\\u0F35\\u0F37\\u0F39\\u0F71-\\u0F7E\\u0F80-\\u0F84\\u0F86-\\u0F87\\u0F8D-\\u0F97\\u0F99-\\u0FBC\\u0FC6\\u102D-\\u1030\\u1032-\\u1037\\u1039-\\u103A\\u103D-\\u103E\\u1058-\\u1059\\u105E-\\u1060\\u1071-\\u1074\\u1082\\u1085-\\u1086\\u108D\\u109D\\u135D-\\u135F\\u1712-\\u1714\\u1732-\\u1734\\u1752-\\u1753\\u1772-\\u1773\\u17B4-\\u17B5\\u17B7-\\u17BD\\u17C6\\u17C9-\\u17D3\\u17DD\\u180B-\\u180D\\u1885-\\u1886\\u18A9\\u1920-\\u1922\\u1927-\\u1928\\u1932\\u1939-\\u193B\\u1A17-\\u1A18\\u1A1B\\u1A56\\u1A58-\\u1A5E\\u1A60\\u1A62\\u1A65-\\u1A6C\\u1A73-\\u1A7C\\u1A7F\\u1AB0-\\u1ABD\\u1B00-\\u1B03\\u1B34\\u1B36-\\u1B3A\\u1B3C\\u1B42\\u1B6B-\\u1B73\\u1B80-\\u1B81\\u1BA2-\\u1BA5\\u1BA8-\\u1BA9\\u1BAB-\\u1BAD\\u1BE6\\u1BE8-\\u1BE9\\u1BED\\u1BEF-\\u1BF1\\u1C2C-\\u1C33\\u1C36-\\u1C37\\u1CD0-\\u1CD2\\u1CD4-\\u1CE0\\u1CE2-\\u1CE8\\u1CED\\u1CF4\\u1CF8-\\u1CF9\\u1DC0-\\u1DF9\\u1DFB-\\u1DFF\\u20D0-\\u20DC\\u20E1\\u20E5-\\u20F0\\u2CEF-\\u2CF1\\u2D7F\\u2DE0-\\u2DFF\\u302A-\\u302D\\u3099-\\u309A\\uA66F\\uA674-\\uA67D\\uA69E-\\uA69F\\uA6F0-\\uA6F1\\uA802\\uA806\\uA80B\\uA825-\\uA826\\uA8C4-\\uA8C5\\uA8E0-\\uA8F1\\uA8FF\\uA926-\\uA92D\\uA947-\\uA951\\uA980-\\uA982\\uA9B3\\uA9B6-\\uA9B9\\uA9BC\\uA9E5\\uAA29-\\uAA2E\\uAA31-\\uAA32\\uAA35-\\uAA36\\uAA43\\uAA4C\\uAA7C\\uAAB0\\uAAB2-\\uAAB4\\uAAB7-\\uAAB8\\uAABE-\\uAABF\\uAAC1\\uAAEC-\\uAAED\\uAAF6\\uABE5\\uABE8\\uABED\\uFB1E\\uFE00-\\uFE0F\\uFE20-\\uFE2F]",
 				chars:      []rune{'ֿ', 'ׇ', 'ٰ', 'ܑ', '߽', 'ऺ', '़', '्', 'ঁ', '়', '্', '৾', '਼', 'ੑ', 'ੵ', '઼', '્', 'ଁ', '଼', 'ି', '୍', 'ୖ', 'ஂ', 'ீ', '்', 'ఀ', 'ఄ', 'ಁ', '಼', 'ಿ', 'ೆ', '്', '්', 'ූ', 'ั', 'ັ', '༵', '༷', '༹', '࿆', 'ႂ', 'ႍ', 'ႝ', 'ំ', '៝', 'ᢩ', 'ᤲ', 'ᨛ', 'ᩖ', '᩠', 'ᩢ', '᩿', '᬴', 'ᬼ', 'ᭂ', '᯦', 'ᯭ', '᳭', '᳴', '⃡', '⵿', '꙯', 'ꠂ', '꠆', 'ꠋ', 'ꣿ', '꦳', 'ꦼ', 'ꧥ', 'ꩃ', 'ꩌ', 'ꩼ', 'ꪰ', '꫁', '꫶', 'ꯥ', 'ꯨ', '꯭', 'ﬞ'},
 				ranges:     []rune{'̀', 'ͯ', '҃', '҇', '֑', 'ֽ', 'ׁ', 'ׂ', 'ׄ', 'ׅ', 'ؐ', 'ؚ', 'ً', 'ٟ', 'ۖ', 'ۜ', '۟', 'ۤ', 'ۧ', 'ۨ', '۪', 'ۭ', 'ܰ', '݊', 'ަ', 'ް', '߫', '߳', 'ࠖ', '࠙', 'ࠛ', 'ࠣ', 'ࠥ', 'ࠧ', 'ࠩ', '࠭', '࡙', '࡛', '࣓', '࣡', 'ࣣ', 'ं', 'ु', 'ै', '॑', 'ॗ', 'ॢ', 'ॣ', 'ু', 'ৄ', 'ৢ', 'ৣ', 'ਁ', 'ਂ', 'ੁ', 'ੂ', 'ੇ', 'ੈ', 'ੋ', '੍', 'ੰ', 'ੱ', 'ઁ', 'ં', 'ુ', 'ૅ', 'ે', 'ૈ', 'ૢ', 'ૣ', 'ૺ', '૿', 'ୁ', 'ୄ', 'ୢ', 'ୣ', 'ా', 'ీ', 'ె', 'ై', 'ొ', '్', 'ౕ', 'ౖ', 'ౢ', 'ౣ', 'ೌ', '್', 'ೢ', 'ೣ', 'ഀ', 'ഁ', '഻', '഼', 'ു', 'ൄ', 'ൢ', 'ൣ', 'ි', 'ු', 'ิ', 'ฺ', '็', '๎', 'ິ', 'ູ', 'ົ', 'ຼ', '່', 'ໍ', '༘', '༙', 'ཱ', 'ཾ', 'ྀ', '྄', '྆', '྇', 'ྍ', 'ྗ', 'ྙ', 'ྼ', 'ိ', 'ူ', 'ဲ', '့', '္', '်', 'ွ', 'ှ', 'ၘ', 'ၙ', 'ၞ', 'ၠ', 'ၱ', 'ၴ', 'ႅ', 'ႆ', '፝', '፟', 'ᜒ', '᜔', 'ᜲ', '᜴', 'ᝒ', 'ᝓ', 'ᝲ', 'ᝳ', '឴', '឵', 'ិ', 'ួ', '៉', '៓', '᠋', '᠍', 'ᢅ', 'ᢆ', 'ᤠ', 'ᤢ', 'ᤧ', 'ᤨ', '᤹', '᤻', 'ᨗ', 'ᨘ', 'ᩘ', 'ᩞ', 'ᩥ', 'ᩬ', 'ᩳ', '᩼', '᪰', '᪽', 'ᬀ', 'ᬃ', 'ᬶ', 'ᬺ', '᭫', '᭳', 'ᮀ', 'ᮁ', 'ᮢ', 'ᮥ', 'ᮨ', 'ᮩ', '᮫', 'ᮭ', 'ᯨ', 'ᯩ', 'ᯯ', 'ᯱ', 'ᰬ', 'ᰳ', 'ᰶ', '᰷', '᳐', '᳒', '᳔', '᳠', '᳢', '᳨', '᳸', '᳹', '᷀', '᷹', '᷻', '᷿', '⃐', '⃜', '⃥', '⃰', '⳯', '⳱', 'ⷠ', 'ⷿ', '〪', '〭', '゙', '゚', 'ꙴ', '꙽', 'ꚞ', 'ꚟ', '꛰', '꛱', 'ꠥ', 'ꠦ', '꣄', 'ꣅ', '꣠', '꣱', 'ꤦ', '꤭', 'ꥇ', 'ꥑ', 'ꦀ', 'ꦂ', 'ꦶ', 'ꦹ', 'ꨩ', 'ꨮ', 'ꨱ', 'ꨲ', 'ꨵ', 'ꨶ', 'ꪲ', 'ꪴ', 'ꪷ', 'ꪸ', 'ꪾ', '꪿', 'ꫬ', 'ꫭ', '︀', '️', '︠', '︯'},
@@ -12864,9 +13106,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nd",
-			pos:  position{line: 1854, col: 1, offset: 58575},
+			pos:  position{line: 1881, col: 1, offset: 59693},
 			expr: &charClassMatcher{
-				pos:        position{line: 1854, col: 6, offset: 58580},
+				pos:        position{line: 1881, col: 6, offset: 59698},
 				val:        "[\\u0030-\\u0039\\u0660-\\u0669\\u06F0-\\u06F9\\u07C0-\\u07C9\\u0966-\\u096F\\u09E6-\\u09EF\\u0A66-\\u0A6F\\u0AE6-\\u0AEF\\u0B66-\\u0B6F\\u0BE6-\\u0BEF\\u0C66-\\u0C6F\\u0CE6-\\u0CEF\\u0D66-\\u0D6F\\u0DE6-\\u0DEF\\u0E50-\\u0E59\\u0ED0-\\u0ED9\\u0F20-\\u0F29\\u1040-\\u1049\\u1090-\\u1099\\u17E0-\\u17E9\\u1810-\\u1819\\u1946-\\u194F\\u19D0-\\u19D9\\u1A80-\\u1A89\\u1A90-\\u1A99\\u1B50-\\u1B59\\u1BB0-\\u1BB9\\u1C40-\\u1C49\\u1C50-\\u1C59\\uA620-\\uA629\\uA8D0-\\uA8D9\\uA900-\\uA909\\uA9D0-\\uA9D9\\uA9F0-\\uA9F9\\uAA50-\\uAA59\\uABF0-\\uABF9\\uFF10-\\uFF19]",
 				ranges:     []rune{'0', '9', '٠', '٩', '۰', '۹', '߀', '߉', '०', '९', '০', '৯', '੦', '੯', '૦', '૯', '୦', '୯', '௦', '௯', '౦', '౯', '೦', '೯', '൦', '൯', '෦', '෯', '๐', '๙', '໐', '໙', '༠', '༩', '၀', '၉', '႐', '႙', '០', '៩', '᠐', '᠙', '᥆', '᥏', '᧐', '᧙', '᪀', '᪉', '᪐', '᪙', '᭐', '᭙', '᮰', '᮹', '᱀', '᱉', '᱐', '᱙', '꘠', '꘩', '꣐', '꣙', '꤀', '꤉', '꧐', '꧙', '꧰', '꧹', '꩐', '꩙', '꯰', '꯹', '０', '９'},
 				ignoreCase: false,
@@ -12877,9 +13119,9 @@ var g = &grammar{
 		},
 		{
 			name: "Nl",
-			pos:  position{line: 1857, col: 1, offset: 59083},
+			pos:  position{line: 1884, col: 1, offset: 60201},
 			expr: &charClassMatcher{
-				pos:        position{line: 1857, col: 6, offset: 59088},
+				pos:        position{line: 1884, col: 6, offset: 60206},
 				val:        "[\\u16EE-\\u16F0\\u2160-\\u2182\\u2185-\\u2188\\u3007\\u3021-\\u3029\\u3038-\\u303A\\uA6E6-\\uA6EF]",
 				chars:      []rune{'〇'},
 				ranges:     []rune{'ᛮ', 'ᛰ', 'Ⅰ', 'ↂ', 'ↅ', 'ↈ', '〡', '〩', '〸', '〺', 'ꛦ', 'ꛯ'},
@@ -12891,9 +13133,9 @@ var g = &grammar{
 		},
 		{
 			name: "Pc",
-			pos:  position{line: 1860, col: 1, offset: 59202},
+			pos:  position{line: 1887, col: 1, offset: 60320},
 			expr: &charClassMatcher{
-				pos:        position{line: 1860, col: 6, offset: 59207},
+				pos:        position{line: 1887, col: 6, offset: 60325},
 				val:        "[\\u005F\\u203F-\\u2040\\u2054\\uFE33-\\uFE34\\uFE4D-\\uFE4F\\uFF3F]",
 				chars:      []rune{'_', '⁔', '＿'},
 				ranges:     []rune{'‿', '⁀', '︳', '︴', '﹍', '﹏'},
@@ -12905,9 +13147,9 @@ var g = &grammar{
 		},
 		{
 			name: "Zs",
-			pos:  position{line: 1863, col: 1, offset: 59288},
+			pos:  position{line: 1890, col: 1, offset: 60406},
 			expr: &charClassMatcher{
-				pos:        position{line: 1863, col: 6, offset: 59293},
+				pos:        position{line: 1890, col: 6, offset: 60411},
 				val:        "[\\u0020\\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000]",
 				chars:      []rune{' ', '\u00a0', '\u1680', '\u202f', '\u205f', '\u3000'},
 				ranges:     []rune{'\u2000', '\u200a'},
@@ -12919,9 +13161,9 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1865, col: 1, offset: 59346},
+			pos:  position{line: 1892, col: 1, offset: 60464},
 			expr: &anyMatcher{
-				line: 1866, col: 5, offset: 59366,
+				line: 1893, col: 5, offset: 60484,
 			},
 			leader:        false,
 			leftRecursive: false,
@@ -12929,48 +13171,48 @@ var g = &grammar{
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1868, col: 1, offset: 59369},
+			pos:         position{line: 1895, col: 1, offset: 60487},
 			expr: &choiceExpr{
-				pos: position{line: 1869, col: 5, offset: 59397},
+				pos: position{line: 1896, col: 5, offset: 60515},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 1869, col: 5, offset: 59397},
+						pos:        position{line: 1896, col: 5, offset: 60515},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1870, col: 5, offset: 59406},
+						pos:        position{line: 1897, col: 5, offset: 60524},
 						val:        "\v",
 						ignoreCase: false,
 						want:       "\"\\v\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1871, col: 5, offset: 59415},
+						pos:        position{line: 1898, col: 5, offset: 60533},
 						val:        "\f",
 						ignoreCase: false,
 						want:       "\"\\f\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1872, col: 5, offset: 59424},
+						pos:        position{line: 1899, col: 5, offset: 60542},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 1873, col: 5, offset: 59432},
+						pos:        position{line: 1900, col: 5, offset: 60550},
 						val:        "\u00a0",
 						ignoreCase: false,
 						want:       "\"\\u00a0\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1874, col: 5, offset: 59445},
+						pos:        position{line: 1901, col: 5, offset: 60563},
 						val:        "\ufeff",
 						ignoreCase: false,
 						want:       "\"\\ufeff\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1875, col: 5, offset: 59458},
+						pos:  position{line: 1902, col: 5, offset: 60576},
 						name: "Zs",
 					},
 				},
@@ -12980,9 +13222,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1877, col: 1, offset: 59462},
+			pos:  position{line: 1904, col: 1, offset: 60580},
 			expr: &charClassMatcher{
-				pos:        position{line: 1878, col: 5, offset: 59481},
+				pos:        position{line: 1905, col: 5, offset: 60599},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -12994,16 +13236,16 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1880, col: 1, offset: 59501},
+			pos:         position{line: 1907, col: 1, offset: 60619},
 			expr: &choiceExpr{
-				pos: position{line: 1881, col: 5, offset: 59523},
+				pos: position{line: 1908, col: 5, offset: 60641},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1881, col: 5, offset: 59523},
+						pos:  position{line: 1908, col: 5, offset: 60641},
 						name: "MultiLineComment",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1882, col: 5, offset: 59544},
+						pos:  position{line: 1909, col: 5, offset: 60662},
 						name: "SingleLineComment",
 					},
 				},
@@ -13013,39 +13255,39 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1884, col: 1, offset: 59563},
+			pos:  position{line: 1911, col: 1, offset: 60681},
 			expr: &seqExpr{
-				pos: position{line: 1885, col: 5, offset: 59584},
+				pos: position{line: 1912, col: 5, offset: 60702},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1885, col: 5, offset: 59584},
+						pos:        position{line: 1912, col: 5, offset: 60702},
 						val:        "/*",
 						ignoreCase: false,
 						want:       "\"/*\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1885, col: 10, offset: 59589},
+						pos: position{line: 1912, col: 10, offset: 60707},
 						expr: &seqExpr{
-							pos: position{line: 1885, col: 11, offset: 59590},
+							pos: position{line: 1912, col: 11, offset: 60708},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1885, col: 11, offset: 59590},
+									pos: position{line: 1912, col: 11, offset: 60708},
 									expr: &litMatcher{
-										pos:        position{line: 1885, col: 12, offset: 59591},
+										pos:        position{line: 1912, col: 12, offset: 60709},
 										val:        "*/",
 										ignoreCase: false,
 										want:       "\"*/\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1885, col: 17, offset: 59596},
+									pos:  position{line: 1912, col: 17, offset: 60714},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1885, col: 35, offset: 59614},
+						pos:        position{line: 1912, col: 35, offset: 60732},
 						val:        "*/",
 						ignoreCase: false,
 						want:       "\"*/\"",
@@ -13057,30 +13299,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1887, col: 1, offset: 59620},
+			pos:  position{line: 1914, col: 1, offset: 60738},
 			expr: &seqExpr{
-				pos: position{line: 1888, col: 5, offset: 59642},
+				pos: position{line: 1915, col: 5, offset: 60760},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 1888, col: 5, offset: 59642},
+						pos:        position{line: 1915, col: 5, offset: 60760},
 						val:        "--",
 						ignoreCase: false,
 						want:       "\"--\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1888, col: 10, offset: 59647},
+						pos: position{line: 1915, col: 10, offset: 60765},
 						expr: &seqExpr{
-							pos: position{line: 1888, col: 11, offset: 59648},
+							pos: position{line: 1915, col: 11, offset: 60766},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 1888, col: 11, offset: 59648},
+									pos: position{line: 1915, col: 11, offset: 60766},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1888, col: 12, offset: 59649},
+										pos:  position{line: 1915, col: 12, offset: 60767},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1888, col: 27, offset: 59664},
+									pos:  position{line: 1915, col: 27, offset: 60782},
 									name: "SourceCharacter",
 								},
 							},
@@ -13093,19 +13335,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1890, col: 1, offset: 59683},
+			pos:  position{line: 1917, col: 1, offset: 60801},
 			expr: &seqExpr{
-				pos: position{line: 1890, col: 7, offset: 59689},
+				pos: position{line: 1917, col: 7, offset: 60807},
 				exprs: []any{
 					&zeroOrMoreExpr{
-						pos: position{line: 1890, col: 7, offset: 59689},
+						pos: position{line: 1917, col: 7, offset: 60807},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1890, col: 7, offset: 59689},
+							pos:  position{line: 1917, col: 7, offset: 60807},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1890, col: 19, offset: 59701},
+						pos:  position{line: 1917, col: 19, offset: 60819},
 						name: "LineTerminator",
 					},
 				},
@@ -13115,16 +13357,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1892, col: 1, offset: 59717},
+			pos:  position{line: 1919, col: 1, offset: 60835},
 			expr: &choiceExpr{
-				pos: position{line: 1892, col: 7, offset: 59723},
+				pos: position{line: 1919, col: 7, offset: 60841},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1892, col: 7, offset: 59723},
+						pos:  position{line: 1919, col: 7, offset: 60841},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1892, col: 11, offset: 59727},
+						pos:  position{line: 1919, col: 11, offset: 60845},
 						name: "EOF",
 					},
 				},
@@ -13134,11 +13376,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1894, col: 1, offset: 59732},
+			pos:  position{line: 1921, col: 1, offset: 60850},
 			expr: &notExpr{
-				pos: position{line: 1894, col: 7, offset: 59738},
+				pos: position{line: 1921, col: 7, offset: 60856},
 				expr: &anyMatcher{
-					line: 1894, col: 8, offset: 59739,
+					line: 1921, col: 8, offset: 60857,
 				},
 			},
 			leader:        false,
@@ -13146,15 +13388,15 @@ var g = &grammar{
 		},
 		{
 			name: "SQLPipe",
-			pos:  position{line: 1898, col: 1, offset: 59764},
+			pos:  position{line: 1925, col: 1, offset: 60882},
 			expr: &actionExpr{
-				pos: position{line: 1899, col: 5, offset: 59776},
+				pos: position{line: 1926, col: 5, offset: 60894},
 				run: (*parser).callonSQLPipe1,
 				expr: &labeledExpr{
-					pos:   position{line: 1899, col: 5, offset: 59776},
+					pos:   position{line: 1926, col: 5, offset: 60894},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1899, col: 7, offset: 59778},
+						pos:  position{line: 1926, col: 7, offset: 60896},
 						name: "Seq",
 					},
 				},
@@ -13164,15 +13406,15 @@ var g = &grammar{
 		},
 		{
 			name: "SQLOp",
-			pos:  position{line: 1907, col: 1, offset: 59925},
+			pos:  position{line: 1934, col: 1, offset: 61043},
 			expr: &actionExpr{
-				pos: position{line: 1908, col: 5, offset: 59935},
+				pos: position{line: 1935, col: 5, offset: 61053},
 				run: (*parser).callonSQLOp1,
 				expr: &labeledExpr{
-					pos:   position{line: 1908, col: 5, offset: 59935},
+					pos:   position{line: 1935, col: 5, offset: 61053},
 					label: "query",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1908, col: 11, offset: 59941},
+						pos:  position{line: 1935, col: 11, offset: 61059},
 						name: "SQLQuery",
 					},
 				},
@@ -13182,42 +13424,42 @@ var g = &grammar{
 		},
 		{
 			name: "SQLQuery",
-			pos:  position{line: 1916, col: 1, offset: 60078},
+			pos:  position{line: 1943, col: 1, offset: 61196},
 			expr: &actionExpr{
-				pos: position{line: 1917, col: 5, offset: 60091},
+				pos: position{line: 1944, col: 5, offset: 61209},
 				run: (*parser).callonSQLQuery1,
 				expr: &seqExpr{
-					pos: position{line: 1917, col: 5, offset: 60091},
+					pos: position{line: 1944, col: 5, offset: 61209},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1917, col: 5, offset: 60091},
+							pos:   position{line: 1944, col: 5, offset: 61209},
 							label: "with",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1917, col: 10, offset: 60096},
+								pos:  position{line: 1944, col: 10, offset: 61214},
 								name: "OptWithClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1918, col: 5, offset: 60114},
+							pos:   position{line: 1945, col: 5, offset: 61232},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1918, col: 10, offset: 60119},
+								pos:  position{line: 1945, col: 10, offset: 61237},
 								name: "SQLBodySetOp",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1919, col: 5, offset: 60136},
+							pos:   position{line: 1946, col: 5, offset: 61254},
 							label: "orderby",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1919, col: 13, offset: 60144},
+								pos:  position{line: 1946, col: 13, offset: 61262},
 								name: "OptOrderByClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1920, col: 5, offset: 60165},
+							pos:   position{line: 1947, col: 5, offset: 61283},
 							label: "loff",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1920, col: 10, offset: 60170},
+								pos:  position{line: 1947, col: 10, offset: 61288},
 								name: "OptSQLLimitOffset",
 							},
 						},
@@ -13229,39 +13471,39 @@ var g = &grammar{
 		},
 		{
 			name: "SQLBodySetOp",
-			pos:  position{line: 1938, col: 1, offset: 60587},
+			pos:  position{line: 1965, col: 1, offset: 61705},
 			expr: &actionExpr{
-				pos: position{line: 1939, col: 5, offset: 60604},
+				pos: position{line: 1966, col: 5, offset: 61722},
 				run: (*parser).callonSQLBodySetOp1,
 				expr: &seqExpr{
-					pos: position{line: 1939, col: 5, offset: 60604},
+					pos: position{line: 1966, col: 5, offset: 61722},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1939, col: 5, offset: 60604},
+							pos:   position{line: 1966, col: 5, offset: 61722},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1939, col: 11, offset: 60610},
+								pos:  position{line: 1966, col: 11, offset: 61728},
 								name: "SQLQueryBody",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1939, col: 24, offset: 60623},
+							pos:   position{line: 1966, col: 24, offset: 61741},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1939, col: 29, offset: 60628},
+								pos: position{line: 1966, col: 29, offset: 61746},
 								expr: &seqExpr{
-									pos: position{line: 1939, col: 30, offset: 60629},
+									pos: position{line: 1966, col: 30, offset: 61747},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1939, col: 30, offset: 60629},
+											pos:  position{line: 1966, col: 30, offset: 61747},
 											name: "SetOp",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1939, col: 36, offset: 60635},
+											pos:  position{line: 1966, col: 36, offset: 61753},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1939, col: 38, offset: 60637},
+											pos:  position{line: 1966, col: 38, offset: 61755},
 											name: "SQLQueryBody",
 										},
 									},
@@ -13276,52 +13518,52 @@ var g = &grammar{
 		},
 		{
 			name: "SQLQueryBody",
-			pos:  position{line: 1953, col: 1, offset: 60954},
+			pos:  position{line: 1980, col: 1, offset: 62072},
 			expr: &choiceExpr{
-				pos: position{line: 1954, col: 5, offset: 60971},
+				pos: position{line: 1981, col: 5, offset: 62089},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1954, col: 5, offset: 60971},
+						pos:  position{line: 1981, col: 5, offset: 62089},
 						name: "Select",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1955, col: 5, offset: 60982},
+						pos:  position{line: 1982, col: 5, offset: 62100},
 						name: "FromSelect",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1956, col: 5, offset: 60997},
+						pos:  position{line: 1983, col: 5, offset: 62115},
 						name: "SQLValues",
 					},
 					&actionExpr{
-						pos: position{line: 1957, col: 5, offset: 61011},
+						pos: position{line: 1984, col: 5, offset: 62129},
 						run: (*parser).callonSQLQueryBody5,
 						expr: &seqExpr{
-							pos: position{line: 1957, col: 5, offset: 61011},
+							pos: position{line: 1984, col: 5, offset: 62129},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1957, col: 5, offset: 61011},
+									pos:        position{line: 1984, col: 5, offset: 62129},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1957, col: 9, offset: 61015},
+									pos:  position{line: 1984, col: 9, offset: 62133},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 1957, col: 12, offset: 61018},
+									pos:   position{line: 1984, col: 12, offset: 62136},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1957, col: 14, offset: 61020},
+										pos:  position{line: 1984, col: 14, offset: 62138},
 										name: "SQLQueryOrSetExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1957, col: 32, offset: 61038},
+									pos:  position{line: 1984, col: 32, offset: 62156},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 1957, col: 34, offset: 61040},
+									pos:        position{line: 1984, col: 34, offset: 62158},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -13336,16 +13578,16 @@ var g = &grammar{
 		},
 		{
 			name: "SQLQueryOrSetExpr",
-			pos:  position{line: 1959, col: 1, offset: 61063},
+			pos:  position{line: 1986, col: 1, offset: 62181},
 			expr: &choiceExpr{
-				pos: position{line: 1959, col: 21, offset: 61083},
+				pos: position{line: 1986, col: 21, offset: 62201},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 1959, col: 21, offset: 61083},
+						pos:  position{line: 1986, col: 21, offset: 62201},
 						name: "SQLQuery",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1959, col: 32, offset: 61094},
+						pos:  position{line: 1986, col: 32, offset: 62212},
 						name: "SQLBodySetOp",
 					},
 				},
@@ -13355,74 +13597,74 @@ var g = &grammar{
 		},
 		{
 			name: "Select",
-			pos:  position{line: 1961, col: 1, offset: 61108},
+			pos:  position{line: 1988, col: 1, offset: 62226},
 			expr: &actionExpr{
-				pos: position{line: 1962, col: 5, offset: 61119},
+				pos: position{line: 1989, col: 5, offset: 62237},
 				run: (*parser).callonSelect1,
 				expr: &seqExpr{
-					pos: position{line: 1962, col: 5, offset: 61119},
+					pos: position{line: 1989, col: 5, offset: 62237},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1962, col: 5, offset: 61119},
+							pos:  position{line: 1989, col: 5, offset: 62237},
 							name: "SELECT",
 						},
 						&labeledExpr{
-							pos:   position{line: 1963, col: 5, offset: 61130},
+							pos:   position{line: 1990, col: 5, offset: 62248},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1963, col: 14, offset: 61139},
+								pos:  position{line: 1990, col: 14, offset: 62257},
 								name: "OptDistinct",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1964, col: 5, offset: 61155},
+							pos:   position{line: 1991, col: 5, offset: 62273},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1964, col: 11, offset: 61161},
+								pos:  position{line: 1991, col: 11, offset: 62279},
 								name: "OptSelectValue",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1967, col: 5, offset: 61300},
+							pos:  position{line: 1994, col: 5, offset: 62418},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 1967, col: 7, offset: 61302},
+							pos:   position{line: 1994, col: 7, offset: 62420},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1967, col: 17, offset: 61312},
+								pos:  position{line: 1994, col: 17, offset: 62430},
 								name: "Selection",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1968, col: 5, offset: 61326},
+							pos:   position{line: 1995, col: 5, offset: 62444},
 							label: "from",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1968, col: 10, offset: 61331},
+								pos:  position{line: 1995, col: 10, offset: 62449},
 								name: "OptFromClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1969, col: 5, offset: 61349},
+							pos:   position{line: 1996, col: 5, offset: 62467},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1969, col: 11, offset: 61355},
+								pos:  position{line: 1996, col: 11, offset: 62473},
 								name: "OptWhereClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1970, col: 5, offset: 61374},
+							pos:   position{line: 1997, col: 5, offset: 62492},
 							label: "group",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1970, col: 11, offset: 61380},
+								pos:  position{line: 1997, col: 11, offset: 62498},
 								name: "OptGroupClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1971, col: 5, offset: 61399},
+							pos:   position{line: 1998, col: 5, offset: 62517},
 							label: "having",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1971, col: 12, offset: 61406},
+								pos:  position{line: 1998, col: 12, offset: 62524},
 								name: "OptHavingClause",
 							},
 						},
@@ -13434,78 +13676,78 @@ var g = &grammar{
 		},
 		{
 			name: "FromSelect",
-			pos:  position{line: 1997, col: 1, offset: 62023},
+			pos:  position{line: 2024, col: 1, offset: 63141},
 			expr: &actionExpr{
-				pos: position{line: 1998, col: 5, offset: 62038},
+				pos: position{line: 2025, col: 5, offset: 63156},
 				run: (*parser).callonFromSelect1,
 				expr: &seqExpr{
-					pos: position{line: 1998, col: 5, offset: 62038},
+					pos: position{line: 2025, col: 5, offset: 63156},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1998, col: 5, offset: 62038},
+							pos:   position{line: 2025, col: 5, offset: 63156},
 							label: "from",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1998, col: 10, offset: 62043},
+								pos:  position{line: 2025, col: 10, offset: 63161},
 								name: "FromOp",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1998, col: 17, offset: 62050},
+							pos:  position{line: 2025, col: 17, offset: 63168},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1998, col: 19, offset: 62052},
+							pos:  position{line: 2025, col: 19, offset: 63170},
 							name: "SELECT",
 						},
 						&labeledExpr{
-							pos:   position{line: 1999, col: 5, offset: 62063},
+							pos:   position{line: 2026, col: 5, offset: 63181},
 							label: "distinct",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1999, col: 14, offset: 62072},
+								pos:  position{line: 2026, col: 14, offset: 63190},
 								name: "OptDistinct",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2000, col: 5, offset: 62088},
+							pos:   position{line: 2027, col: 5, offset: 63206},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2000, col: 11, offset: 62094},
+								pos:  position{line: 2027, col: 11, offset: 63212},
 								name: "OptSelectValue",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2003, col: 5, offset: 62233},
+							pos:  position{line: 2030, col: 5, offset: 63351},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2003, col: 7, offset: 62235},
+							pos:   position{line: 2030, col: 7, offset: 63353},
 							label: "selection",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2003, col: 17, offset: 62245},
+								pos:  position{line: 2030, col: 17, offset: 63363},
 								name: "Selection",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2004, col: 5, offset: 62259},
+							pos:   position{line: 2031, col: 5, offset: 63377},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2004, col: 11, offset: 62265},
+								pos:  position{line: 2031, col: 11, offset: 63383},
 								name: "OptWhereClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2005, col: 5, offset: 62284},
+							pos:   position{line: 2032, col: 5, offset: 63402},
 							label: "group",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2005, col: 11, offset: 62290},
+								pos:  position{line: 2032, col: 11, offset: 63408},
 								name: "OptGroupClause",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2006, col: 5, offset: 62309},
+							pos:   position{line: 2033, col: 5, offset: 63427},
 							label: "having",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2006, col: 12, offset: 62316},
+								pos:  position{line: 2033, col: 12, offset: 63434},
 								name: "OptHavingClause",
 							},
 						},
@@ -13517,26 +13759,26 @@ var g = &grammar{
 		},
 		{
 			name: "SQLValues",
-			pos:  position{line: 2030, col: 1, offset: 62900},
+			pos:  position{line: 2057, col: 1, offset: 64018},
 			expr: &actionExpr{
-				pos: position{line: 2031, col: 5, offset: 62914},
+				pos: position{line: 2058, col: 5, offset: 64032},
 				run: (*parser).callonSQLValues1,
 				expr: &seqExpr{
-					pos: position{line: 2031, col: 5, offset: 62914},
+					pos: position{line: 2058, col: 5, offset: 64032},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2031, col: 5, offset: 62914},
+							pos:  position{line: 2058, col: 5, offset: 64032},
 							name: "VALUES",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2031, col: 12, offset: 62921},
+							pos:  position{line: 2058, col: 12, offset: 64039},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2031, col: 15, offset: 62924},
+							pos:   position{line: 2058, col: 15, offset: 64042},
 							label: "tuples",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2031, col: 22, offset: 62931},
+								pos:  position{line: 2058, col: 22, offset: 64049},
 								name: "SQLTuples",
 							},
 						},
@@ -13548,26 +13790,26 @@ var g = &grammar{
 		},
 		{
 			name: "ValuesOp",
-			pos:  position{line: 2039, col: 1, offset: 63088},
+			pos:  position{line: 2066, col: 1, offset: 64206},
 			expr: &actionExpr{
-				pos: position{line: 2040, col: 5, offset: 63101},
+				pos: position{line: 2067, col: 5, offset: 64219},
 				run: (*parser).callonValuesOp1,
 				expr: &seqExpr{
-					pos: position{line: 2040, col: 5, offset: 63101},
+					pos: position{line: 2067, col: 5, offset: 64219},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2040, col: 5, offset: 63101},
+							pos:  position{line: 2067, col: 5, offset: 64219},
 							name: "VALUES",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2040, col: 12, offset: 63108},
+							pos:  position{line: 2067, col: 12, offset: 64226},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2040, col: 14, offset: 63110},
+							pos:   position{line: 2067, col: 14, offset: 64228},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2040, col: 20, offset: 63116},
+								pos:  position{line: 2067, col: 20, offset: 64234},
 								name: "Exprs",
 							},
 						},
@@ -13579,51 +13821,51 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTuples",
-			pos:  position{line: 2049, col: 1, offset: 63267},
+			pos:  position{line: 2076, col: 1, offset: 64385},
 			expr: &actionExpr{
-				pos: position{line: 2050, col: 5, offset: 63281},
+				pos: position{line: 2077, col: 5, offset: 64399},
 				run: (*parser).callonSQLTuples1,
 				expr: &seqExpr{
-					pos: position{line: 2050, col: 5, offset: 63281},
+					pos: position{line: 2077, col: 5, offset: 64399},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2050, col: 5, offset: 63281},
+							pos:   position{line: 2077, col: 5, offset: 64399},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2050, col: 11, offset: 63287},
+								pos:  position{line: 2077, col: 11, offset: 64405},
 								name: "SQLTuple",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2050, col: 20, offset: 63296},
+							pos:   position{line: 2077, col: 20, offset: 64414},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2050, col: 25, offset: 63301},
+								pos: position{line: 2077, col: 25, offset: 64419},
 								expr: &actionExpr{
-									pos: position{line: 2050, col: 26, offset: 63302},
+									pos: position{line: 2077, col: 26, offset: 64420},
 									run: (*parser).callonSQLTuples7,
 									expr: &seqExpr{
-										pos: position{line: 2050, col: 26, offset: 63302},
+										pos: position{line: 2077, col: 26, offset: 64420},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2050, col: 26, offset: 63302},
+												pos:  position{line: 2077, col: 26, offset: 64420},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2050, col: 29, offset: 63305},
+												pos:        position{line: 2077, col: 29, offset: 64423},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2050, col: 33, offset: 63309},
+												pos:  position{line: 2077, col: 33, offset: 64427},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2050, col: 36, offset: 63312},
+												pos:   position{line: 2077, col: 36, offset: 64430},
 												label: "t",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2050, col: 38, offset: 63314},
+													pos:  position{line: 2077, col: 38, offset: 64432},
 													name: "SQLTuple",
 												},
 											},
@@ -13640,37 +13882,37 @@ var g = &grammar{
 		},
 		{
 			name: "SQLTuple",
-			pos:  position{line: 2054, col: 1, offset: 63391},
+			pos:  position{line: 2081, col: 1, offset: 64509},
 			expr: &actionExpr{
-				pos: position{line: 2055, col: 5, offset: 63404},
+				pos: position{line: 2082, col: 5, offset: 64522},
 				run: (*parser).callonSQLTuple1,
 				expr: &seqExpr{
-					pos: position{line: 2055, col: 5, offset: 63404},
+					pos: position{line: 2082, col: 5, offset: 64522},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2055, col: 5, offset: 63404},
+							pos:        position{line: 2082, col: 5, offset: 64522},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2055, col: 9, offset: 63408},
+							pos:  position{line: 2082, col: 9, offset: 64526},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2055, col: 12, offset: 63411},
+							pos:   position{line: 2082, col: 12, offset: 64529},
 							label: "exprs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2055, col: 18, offset: 63417},
+								pos:  position{line: 2082, col: 18, offset: 64535},
 								name: "Exprs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2055, col: 24, offset: 63423},
+							pos:  position{line: 2082, col: 24, offset: 64541},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2055, col: 27, offset: 63426},
+							pos:        position{line: 2082, col: 27, offset: 64544},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -13683,49 +13925,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptDistinct",
-			pos:  position{line: 2063, col: 1, offset: 63570},
+			pos:  position{line: 2090, col: 1, offset: 64688},
 			expr: &choiceExpr{
-				pos: position{line: 2064, col: 5, offset: 63586},
+				pos: position{line: 2091, col: 5, offset: 64704},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2064, col: 5, offset: 63586},
+						pos: position{line: 2091, col: 5, offset: 64704},
 						run: (*parser).callonOptDistinct2,
 						expr: &seqExpr{
-							pos: position{line: 2064, col: 5, offset: 63586},
+							pos: position{line: 2091, col: 5, offset: 64704},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2064, col: 5, offset: 63586},
+									pos:  position{line: 2091, col: 5, offset: 64704},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2064, col: 7, offset: 63588},
+									pos:  position{line: 2091, col: 7, offset: 64706},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2065, col: 5, offset: 63625},
+						pos: position{line: 2092, col: 5, offset: 64743},
 						run: (*parser).callonOptDistinct6,
 						expr: &seqExpr{
-							pos: position{line: 2065, col: 5, offset: 63625},
+							pos: position{line: 2092, col: 5, offset: 64743},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2065, col: 5, offset: 63625},
+									pos:  position{line: 2092, col: 5, offset: 64743},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2065, col: 7, offset: 63627},
+									pos:  position{line: 2092, col: 7, offset: 64745},
 									name: "DISTINCT",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2066, col: 5, offset: 63663},
+						pos: position{line: 2093, col: 5, offset: 64781},
 						run: (*parser).callonOptDistinct10,
 						expr: &litMatcher{
-							pos:        position{line: 2066, col: 5, offset: 63663},
+							pos:        position{line: 2093, col: 5, offset: 64781},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13738,57 +13980,57 @@ var g = &grammar{
 		},
 		{
 			name: "OptSelectValue",
-			pos:  position{line: 2068, col: 1, offset: 63702},
+			pos:  position{line: 2095, col: 1, offset: 64820},
 			expr: &choiceExpr{
-				pos: position{line: 2069, col: 5, offset: 63721},
+				pos: position{line: 2096, col: 5, offset: 64839},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2069, col: 5, offset: 63721},
+						pos: position{line: 2096, col: 5, offset: 64839},
 						run: (*parser).callonOptSelectValue2,
 						expr: &seqExpr{
-							pos: position{line: 2069, col: 5, offset: 63721},
+							pos: position{line: 2096, col: 5, offset: 64839},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2069, col: 5, offset: 63721},
+									pos:  position{line: 2096, col: 5, offset: 64839},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2069, col: 7, offset: 63723},
+									pos:  position{line: 2096, col: 7, offset: 64841},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2069, col: 10, offset: 63726},
+									pos:  position{line: 2096, col: 10, offset: 64844},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2069, col: 12, offset: 63728},
+									pos:  position{line: 2096, col: 12, offset: 64846},
 									name: "VALUE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2070, col: 5, offset: 63760},
+						pos: position{line: 2097, col: 5, offset: 64878},
 						run: (*parser).callonOptSelectValue8,
 						expr: &seqExpr{
-							pos: position{line: 2070, col: 5, offset: 63760},
+							pos: position{line: 2097, col: 5, offset: 64878},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2070, col: 5, offset: 63760},
+									pos:  position{line: 2097, col: 5, offset: 64878},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2070, col: 7, offset: 63762},
+									pos:  position{line: 2097, col: 7, offset: 64880},
 									name: "VALUE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2071, col: 5, offset: 63833},
+						pos: position{line: 2098, col: 5, offset: 64951},
 						run: (*parser).callonOptSelectValue12,
 						expr: &litMatcher{
-							pos:        position{line: 2071, col: 5, offset: 63833},
+							pos:        position{line: 2098, col: 5, offset: 64951},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13801,19 +14043,19 @@ var g = &grammar{
 		},
 		{
 			name: "OptWithClause",
-			pos:  position{line: 2073, col: 1, offset: 63876},
+			pos:  position{line: 2100, col: 1, offset: 64994},
 			expr: &choiceExpr{
-				pos: position{line: 2074, col: 5, offset: 63894},
+				pos: position{line: 2101, col: 5, offset: 65012},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2074, col: 5, offset: 63894},
+						pos:  position{line: 2101, col: 5, offset: 65012},
 						name: "WithClause",
 					},
 					&actionExpr{
-						pos: position{line: 2075, col: 5, offset: 63909},
+						pos: position{line: 2102, col: 5, offset: 65027},
 						run: (*parser).callonOptWithClause3,
 						expr: &litMatcher{
-							pos:        position{line: 2075, col: 5, offset: 63909},
+							pos:        position{line: 2102, col: 5, offset: 65027},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13826,39 +14068,39 @@ var g = &grammar{
 		},
 		{
 			name: "WithClause",
-			pos:  position{line: 2077, col: 1, offset: 63942},
+			pos:  position{line: 2104, col: 1, offset: 65060},
 			expr: &actionExpr{
-				pos: position{line: 2078, col: 5, offset: 63957},
+				pos: position{line: 2105, col: 5, offset: 65075},
 				run: (*parser).callonWithClause1,
 				expr: &seqExpr{
-					pos: position{line: 2078, col: 5, offset: 63957},
+					pos: position{line: 2105, col: 5, offset: 65075},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2078, col: 5, offset: 63957},
+							pos:  position{line: 2105, col: 5, offset: 65075},
 							name: "WITH",
 						},
 						&labeledExpr{
-							pos:   position{line: 2078, col: 10, offset: 63962},
+							pos:   position{line: 2105, col: 10, offset: 65080},
 							label: "r",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2078, col: 12, offset: 63964},
+								pos:  position{line: 2105, col: 12, offset: 65082},
 								name: "OptRecursive",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2078, col: 25, offset: 63977},
+							pos:  position{line: 2105, col: 25, offset: 65095},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2078, col: 27, offset: 63979},
+							pos:   position{line: 2105, col: 27, offset: 65097},
 							label: "ctes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2078, col: 32, offset: 63984},
+								pos:  position{line: 2105, col: 32, offset: 65102},
 								name: "CteList",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2078, col: 40, offset: 63992},
+							pos:  position{line: 2105, col: 40, offset: 65110},
 							name: "__",
 						},
 					},
@@ -13869,32 +14111,32 @@ var g = &grammar{
 		},
 		{
 			name: "OptRecursive",
-			pos:  position{line: 2086, col: 1, offset: 64151},
+			pos:  position{line: 2113, col: 1, offset: 65269},
 			expr: &choiceExpr{
-				pos: position{line: 2087, col: 5, offset: 64168},
+				pos: position{line: 2114, col: 5, offset: 65286},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2087, col: 5, offset: 64168},
+						pos: position{line: 2114, col: 5, offset: 65286},
 						run: (*parser).callonOptRecursive2,
 						expr: &seqExpr{
-							pos: position{line: 2087, col: 5, offset: 64168},
+							pos: position{line: 2114, col: 5, offset: 65286},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2087, col: 5, offset: 64168},
+									pos:  position{line: 2114, col: 5, offset: 65286},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2087, col: 7, offset: 64170},
+									pos:  position{line: 2114, col: 7, offset: 65288},
 									name: "RECURSIVE",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2088, col: 5, offset: 64206},
+						pos: position{line: 2115, col: 5, offset: 65324},
 						run: (*parser).callonOptRecursive6,
 						expr: &litMatcher{
-							pos:        position{line: 2088, col: 5, offset: 64206},
+							pos:        position{line: 2115, col: 5, offset: 65324},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -13907,51 +14149,51 @@ var g = &grammar{
 		},
 		{
 			name: "CteList",
-			pos:  position{line: 2090, col: 1, offset: 64245},
+			pos:  position{line: 2117, col: 1, offset: 65363},
 			expr: &actionExpr{
-				pos: position{line: 2090, col: 11, offset: 64255},
+				pos: position{line: 2117, col: 11, offset: 65373},
 				run: (*parser).callonCteList1,
 				expr: &seqExpr{
-					pos: position{line: 2090, col: 11, offset: 64255},
+					pos: position{line: 2117, col: 11, offset: 65373},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2090, col: 11, offset: 64255},
+							pos:   position{line: 2117, col: 11, offset: 65373},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2090, col: 17, offset: 64261},
+								pos:  position{line: 2117, col: 17, offset: 65379},
 								name: "Cte",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2090, col: 21, offset: 64265},
+							pos:   position{line: 2117, col: 21, offset: 65383},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2090, col: 26, offset: 64270},
+								pos: position{line: 2117, col: 26, offset: 65388},
 								expr: &actionExpr{
-									pos: position{line: 2090, col: 28, offset: 64272},
+									pos: position{line: 2117, col: 28, offset: 65390},
 									run: (*parser).callonCteList7,
 									expr: &seqExpr{
-										pos: position{line: 2090, col: 28, offset: 64272},
+										pos: position{line: 2117, col: 28, offset: 65390},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2090, col: 28, offset: 64272},
+												pos:  position{line: 2117, col: 28, offset: 65390},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2090, col: 31, offset: 64275},
+												pos:        position{line: 2117, col: 31, offset: 65393},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2090, col: 35, offset: 64279},
+												pos:  position{line: 2117, col: 35, offset: 65397},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2090, col: 38, offset: 64282},
+												pos:   position{line: 2117, col: 38, offset: 65400},
 												label: "cte",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2090, col: 42, offset: 64286},
+													pos:  position{line: 2117, col: 42, offset: 65404},
 													name: "Cte",
 												},
 											},
@@ -13968,65 +14210,65 @@ var g = &grammar{
 		},
 		{
 			name: "Cte",
-			pos:  position{line: 2094, col: 1, offset: 64354},
+			pos:  position{line: 2121, col: 1, offset: 65472},
 			expr: &actionExpr{
-				pos: position{line: 2095, col: 5, offset: 64362},
+				pos: position{line: 2122, col: 5, offset: 65480},
 				run: (*parser).callonCte1,
 				expr: &seqExpr{
-					pos: position{line: 2095, col: 5, offset: 64362},
+					pos: position{line: 2122, col: 5, offset: 65480},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2095, col: 5, offset: 64362},
+							pos:   position{line: 2122, col: 5, offset: 65480},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2095, col: 10, offset: 64367},
+								pos:  position{line: 2122, col: 10, offset: 65485},
 								name: "SQLIdentifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2095, col: 24, offset: 64381},
+							pos:  position{line: 2122, col: 24, offset: 65499},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2095, col: 26, offset: 64383},
+							pos:  position{line: 2122, col: 26, offset: 65501},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 2095, col: 29, offset: 64386},
+							pos:   position{line: 2122, col: 29, offset: 65504},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2095, col: 31, offset: 64388},
+								pos:  position{line: 2122, col: 31, offset: 65506},
 								name: "OptMaterialized",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2095, col: 47, offset: 64404},
+							pos:  position{line: 2122, col: 47, offset: 65522},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2095, col: 50, offset: 64407},
+							pos:        position{line: 2122, col: 50, offset: 65525},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2095, col: 54, offset: 64411},
+							pos:  position{line: 2122, col: 54, offset: 65529},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2095, col: 57, offset: 64414},
+							pos:   position{line: 2122, col: 57, offset: 65532},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2095, col: 59, offset: 64416},
+								pos:  position{line: 2122, col: 59, offset: 65534},
 								name: "SQLQueryOrSetExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2095, col: 77, offset: 64434},
+							pos:  position{line: 2122, col: 77, offset: 65552},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2095, col: 80, offset: 64437},
+							pos:        position{line: 2122, col: 80, offset: 65555},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -14039,65 +14281,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptMaterialized",
-			pos:  position{line: 2104, col: 1, offset: 64627},
+			pos:  position{line: 2131, col: 1, offset: 65745},
 			expr: &choiceExpr{
-				pos: position{line: 2105, col: 5, offset: 64647},
+				pos: position{line: 2132, col: 5, offset: 65765},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2105, col: 5, offset: 64647},
+						pos: position{line: 2132, col: 5, offset: 65765},
 						run: (*parser).callonOptMaterialized2,
 						expr: &seqExpr{
-							pos: position{line: 2105, col: 5, offset: 64647},
+							pos: position{line: 2132, col: 5, offset: 65765},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2105, col: 5, offset: 64647},
+									pos:  position{line: 2132, col: 5, offset: 65765},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2105, col: 7, offset: 64649},
+									pos:  position{line: 2132, col: 7, offset: 65767},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2105, col: 20, offset: 64662},
+									pos:  position{line: 2132, col: 20, offset: 65780},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2106, col: 5, offset: 64701},
+						pos: position{line: 2133, col: 5, offset: 65819},
 						run: (*parser).callonOptMaterialized7,
 						expr: &seqExpr{
-							pos: position{line: 2106, col: 5, offset: 64701},
+							pos: position{line: 2133, col: 5, offset: 65819},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2106, col: 5, offset: 64701},
+									pos:  position{line: 2133, col: 5, offset: 65819},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2106, col: 7, offset: 64703},
+									pos:  position{line: 2133, col: 7, offset: 65821},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2106, col: 11, offset: 64707},
+									pos:  position{line: 2133, col: 11, offset: 65825},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2106, col: 13, offset: 64709},
+									pos:  position{line: 2133, col: 13, offset: 65827},
 									name: "MATERIALIZED",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2106, col: 26, offset: 64722},
+									pos:  position{line: 2133, col: 26, offset: 65840},
 									name: "_",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2107, col: 5, offset: 64753},
+						pos: position{line: 2134, col: 5, offset: 65871},
 						run: (*parser).callonOptMaterialized14,
 						expr: &litMatcher{
-							pos:        position{line: 2107, col: 5, offset: 64753},
+							pos:        position{line: 2134, col: 5, offset: 65871},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14110,25 +14352,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAllClause",
-			pos:  position{line: 2109, col: 1, offset: 64808},
+			pos:  position{line: 2136, col: 1, offset: 65926},
 			expr: &choiceExpr{
-				pos: position{line: 2110, col: 5, offset: 64825},
+				pos: position{line: 2137, col: 5, offset: 65943},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 2110, col: 5, offset: 64825},
+						pos: position{line: 2137, col: 5, offset: 65943},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2110, col: 5, offset: 64825},
+								pos:  position{line: 2137, col: 5, offset: 65943},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2110, col: 7, offset: 64827},
+								pos:  position{line: 2137, col: 7, offset: 65945},
 								name: "ALL",
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 2111, col: 5, offset: 64835},
+						pos:        position{line: 2138, col: 5, offset: 65953},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -14140,25 +14382,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptFromClause",
-			pos:  position{line: 2113, col: 1, offset: 64839},
+			pos:  position{line: 2140, col: 1, offset: 65957},
 			expr: &choiceExpr{
-				pos: position{line: 2114, col: 5, offset: 64857},
+				pos: position{line: 2141, col: 5, offset: 65975},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2114, col: 5, offset: 64857},
+						pos: position{line: 2141, col: 5, offset: 65975},
 						run: (*parser).callonOptFromClause2,
 						expr: &seqExpr{
-							pos: position{line: 2114, col: 5, offset: 64857},
+							pos: position{line: 2141, col: 5, offset: 65975},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2114, col: 5, offset: 64857},
+									pos:  position{line: 2141, col: 5, offset: 65975},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2114, col: 7, offset: 64859},
+									pos:   position{line: 2141, col: 7, offset: 65977},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2114, col: 12, offset: 64864},
+										pos:  position{line: 2141, col: 12, offset: 65982},
 										name: "FromOp",
 									},
 								},
@@ -14166,10 +14408,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2117, col: 5, offset: 64906},
+						pos: position{line: 2144, col: 5, offset: 66024},
 						run: (*parser).callonOptFromClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2117, col: 5, offset: 64906},
+							pos:        position{line: 2144, col: 5, offset: 66024},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14182,27 +14424,27 @@ var g = &grammar{
 		},
 		{
 			name: "OptWhereClause",
-			pos:  position{line: 2119, col: 1, offset: 64947},
+			pos:  position{line: 2146, col: 1, offset: 66065},
 			expr: &choiceExpr{
-				pos: position{line: 2120, col: 5, offset: 64966},
+				pos: position{line: 2147, col: 5, offset: 66084},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2120, col: 5, offset: 64966},
+						pos: position{line: 2147, col: 5, offset: 66084},
 						run: (*parser).callonOptWhereClause2,
 						expr: &labeledExpr{
-							pos:   position{line: 2120, col: 5, offset: 64966},
+							pos:   position{line: 2147, col: 5, offset: 66084},
 							label: "where",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2120, col: 11, offset: 64972},
+								pos:  position{line: 2147, col: 11, offset: 66090},
 								name: "WhereClause",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2121, col: 5, offset: 65014},
+						pos: position{line: 2148, col: 5, offset: 66132},
 						run: (*parser).callonOptWhereClause5,
 						expr: &litMatcher{
-							pos:        position{line: 2121, col: 5, offset: 65014},
+							pos:        position{line: 2148, col: 5, offset: 66132},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14215,25 +14457,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptGroupClause",
-			pos:  position{line: 2123, col: 1, offset: 65059},
+			pos:  position{line: 2150, col: 1, offset: 66177},
 			expr: &choiceExpr{
-				pos: position{line: 2124, col: 5, offset: 65078},
+				pos: position{line: 2151, col: 5, offset: 66196},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2124, col: 5, offset: 65078},
+						pos: position{line: 2151, col: 5, offset: 66196},
 						run: (*parser).callonOptGroupClause2,
 						expr: &seqExpr{
-							pos: position{line: 2124, col: 5, offset: 65078},
+							pos: position{line: 2151, col: 5, offset: 66196},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2124, col: 5, offset: 65078},
+									pos:  position{line: 2151, col: 5, offset: 66196},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2124, col: 7, offset: 65080},
+									pos:   position{line: 2151, col: 7, offset: 66198},
 									label: "group",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2124, col: 13, offset: 65086},
+										pos:  position{line: 2151, col: 13, offset: 66204},
 										name: "GroupClause",
 									},
 								},
@@ -14241,10 +14483,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2125, col: 5, offset: 65124},
+						pos: position{line: 2152, col: 5, offset: 66242},
 						run: (*parser).callonOptGroupClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2125, col: 5, offset: 65124},
+							pos:        position{line: 2152, col: 5, offset: 66242},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14257,34 +14499,34 @@ var g = &grammar{
 		},
 		{
 			name: "GroupClause",
-			pos:  position{line: 2127, col: 1, offset: 65165},
+			pos:  position{line: 2154, col: 1, offset: 66283},
 			expr: &actionExpr{
-				pos: position{line: 2128, col: 5, offset: 65181},
+				pos: position{line: 2155, col: 5, offset: 66299},
 				run: (*parser).callonGroupClause1,
 				expr: &seqExpr{
-					pos: position{line: 2128, col: 5, offset: 65181},
+					pos: position{line: 2155, col: 5, offset: 66299},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2128, col: 5, offset: 65181},
+							pos:  position{line: 2155, col: 5, offset: 66299},
 							name: "GROUP",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2128, col: 11, offset: 65187},
+							pos:  position{line: 2155, col: 11, offset: 66305},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2128, col: 13, offset: 65189},
+							pos:  position{line: 2155, col: 13, offset: 66307},
 							name: "BY",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2128, col: 16, offset: 65192},
+							pos:  position{line: 2155, col: 16, offset: 66310},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2128, col: 18, offset: 65194},
+							pos:   position{line: 2155, col: 18, offset: 66312},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2128, col: 23, offset: 65199},
+								pos:  position{line: 2155, col: 23, offset: 66317},
 								name: "GroupByList",
 							},
 						},
@@ -14296,51 +14538,51 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByList",
-			pos:  position{line: 2130, col: 1, offset: 65233},
+			pos:  position{line: 2157, col: 1, offset: 66351},
 			expr: &actionExpr{
-				pos: position{line: 2131, col: 5, offset: 65249},
+				pos: position{line: 2158, col: 5, offset: 66367},
 				run: (*parser).callonGroupByList1,
 				expr: &seqExpr{
-					pos: position{line: 2131, col: 5, offset: 65249},
+					pos: position{line: 2158, col: 5, offset: 66367},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2131, col: 5, offset: 65249},
+							pos:   position{line: 2158, col: 5, offset: 66367},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2131, col: 11, offset: 65255},
+								pos:  position{line: 2158, col: 11, offset: 66373},
 								name: "GroupByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2131, col: 23, offset: 65267},
+							pos:   position{line: 2158, col: 23, offset: 66385},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2131, col: 28, offset: 65272},
+								pos: position{line: 2158, col: 28, offset: 66390},
 								expr: &actionExpr{
-									pos: position{line: 2131, col: 30, offset: 65274},
+									pos: position{line: 2158, col: 30, offset: 66392},
 									run: (*parser).callonGroupByList7,
 									expr: &seqExpr{
-										pos: position{line: 2131, col: 30, offset: 65274},
+										pos: position{line: 2158, col: 30, offset: 66392},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2131, col: 30, offset: 65274},
+												pos:  position{line: 2158, col: 30, offset: 66392},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2131, col: 33, offset: 65277},
+												pos:        position{line: 2158, col: 33, offset: 66395},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2131, col: 37, offset: 65281},
+												pos:  position{line: 2158, col: 37, offset: 66399},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2131, col: 40, offset: 65284},
+												pos:   position{line: 2158, col: 40, offset: 66402},
 												label: "g",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2131, col: 42, offset: 65286},
+													pos:  position{line: 2158, col: 42, offset: 66404},
 													name: "GroupByItem",
 												},
 											},
@@ -14357,9 +14599,9 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByItem",
-			pos:  position{line: 2135, col: 1, offset: 65367},
+			pos:  position{line: 2162, col: 1, offset: 66485},
 			expr: &ruleRefExpr{
-				pos:  position{line: 2135, col: 15, offset: 65381},
+				pos:  position{line: 2162, col: 15, offset: 66499},
 				name: "Expr",
 			},
 			leader:        false,
@@ -14367,25 +14609,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptHavingClause",
-			pos:  position{line: 2137, col: 1, offset: 65387},
+			pos:  position{line: 2164, col: 1, offset: 66505},
 			expr: &choiceExpr{
-				pos: position{line: 2138, col: 5, offset: 65407},
+				pos: position{line: 2165, col: 5, offset: 66525},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2138, col: 5, offset: 65407},
+						pos: position{line: 2165, col: 5, offset: 66525},
 						run: (*parser).callonOptHavingClause2,
 						expr: &seqExpr{
-							pos: position{line: 2138, col: 5, offset: 65407},
+							pos: position{line: 2165, col: 5, offset: 66525},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2138, col: 5, offset: 65407},
+									pos:  position{line: 2165, col: 5, offset: 66525},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2138, col: 7, offset: 65409},
+									pos:   position{line: 2165, col: 7, offset: 66527},
 									label: "h",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2138, col: 9, offset: 65411},
+										pos:  position{line: 2165, col: 9, offset: 66529},
 										name: "HavingClause",
 									},
 								},
@@ -14393,10 +14635,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2139, col: 5, offset: 65446},
+						pos: position{line: 2166, col: 5, offset: 66564},
 						run: (*parser).callonOptHavingClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2139, col: 5, offset: 65446},
+							pos:        position{line: 2166, col: 5, offset: 66564},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14409,26 +14651,26 @@ var g = &grammar{
 		},
 		{
 			name: "HavingClause",
-			pos:  position{line: 2141, col: 1, offset: 65470},
+			pos:  position{line: 2168, col: 1, offset: 66588},
 			expr: &actionExpr{
-				pos: position{line: 2142, col: 5, offset: 65487},
+				pos: position{line: 2169, col: 5, offset: 66605},
 				run: (*parser).callonHavingClause1,
 				expr: &seqExpr{
-					pos: position{line: 2142, col: 5, offset: 65487},
+					pos: position{line: 2169, col: 5, offset: 66605},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2142, col: 5, offset: 65487},
+							pos:  position{line: 2169, col: 5, offset: 66605},
 							name: "HAVING",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2142, col: 12, offset: 65494},
+							pos:  position{line: 2169, col: 12, offset: 66612},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2142, col: 14, offset: 65496},
+							pos:   position{line: 2169, col: 14, offset: 66614},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2142, col: 16, offset: 65498},
+								pos:  position{line: 2169, col: 16, offset: 66616},
 								name: "Expr",
 							},
 						},
@@ -14440,16 +14682,16 @@ var g = &grammar{
 		},
 		{
 			name: "JoinOperation",
-			pos:  position{line: 2144, col: 1, offset: 65522},
+			pos:  position{line: 2171, col: 1, offset: 66640},
 			expr: &choiceExpr{
-				pos: position{line: 2145, col: 5, offset: 65540},
+				pos: position{line: 2172, col: 5, offset: 66658},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2145, col: 5, offset: 65540},
+						pos:  position{line: 2172, col: 5, offset: 66658},
 						name: "CrossJoin",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2146, col: 5, offset: 65554},
+						pos:  position{line: 2173, col: 5, offset: 66672},
 						name: "ConditionJoin",
 					},
 				},
@@ -14459,30 +14701,30 @@ var g = &grammar{
 		},
 		{
 			name: "CrossJoin",
-			pos:  position{line: 2148, col: 1, offset: 65569},
+			pos:  position{line: 2175, col: 1, offset: 66687},
 			expr: &actionExpr{
-				pos: position{line: 2149, col: 5, offset: 65583},
+				pos: position{line: 2176, col: 5, offset: 66701},
 				run: (*parser).callonCrossJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2149, col: 5, offset: 65583},
+					pos: position{line: 2176, col: 5, offset: 66701},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2149, col: 5, offset: 65583},
+							pos:   position{line: 2176, col: 5, offset: 66701},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2149, col: 10, offset: 65588},
+								pos:  position{line: 2176, col: 10, offset: 66706},
 								name: "FromElem",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2149, col: 19, offset: 65597},
+							pos:  position{line: 2176, col: 19, offset: 66715},
 							name: "CrossJoinOp",
 						},
 						&labeledExpr{
-							pos:   position{line: 2149, col: 31, offset: 65609},
+							pos:   position{line: 2176, col: 31, offset: 66727},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2149, col: 37, offset: 65615},
+								pos:  position{line: 2176, col: 37, offset: 66733},
 								name: "FromElem",
 							},
 						},
@@ -14494,50 +14736,50 @@ var g = &grammar{
 		},
 		{
 			name: "CrossJoinOp",
-			pos:  position{line: 2158, col: 1, offset: 65823},
+			pos:  position{line: 2185, col: 1, offset: 66941},
 			expr: &choiceExpr{
-				pos: position{line: 2159, col: 5, offset: 65839},
+				pos: position{line: 2186, col: 5, offset: 66957},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 2159, col: 5, offset: 65839},
+						pos: position{line: 2186, col: 5, offset: 66957},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2159, col: 5, offset: 65839},
+								pos:  position{line: 2186, col: 5, offset: 66957},
 								name: "__",
 							},
 							&litMatcher{
-								pos:        position{line: 2159, col: 8, offset: 65842},
+								pos:        position{line: 2186, col: 8, offset: 66960},
 								val:        ",",
 								ignoreCase: false,
 								want:       "\",\"",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2159, col: 12, offset: 65846},
+								pos:  position{line: 2186, col: 12, offset: 66964},
 								name: "__",
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 2160, col: 5, offset: 65853},
+						pos: position{line: 2187, col: 5, offset: 66971},
 						exprs: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2160, col: 5, offset: 65853},
+								pos:  position{line: 2187, col: 5, offset: 66971},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2160, col: 7, offset: 65855},
+								pos:  position{line: 2187, col: 7, offset: 66973},
 								name: "CROSS",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2160, col: 13, offset: 65861},
+								pos:  position{line: 2187, col: 13, offset: 66979},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2160, col: 15, offset: 65863},
+								pos:  position{line: 2187, col: 15, offset: 66981},
 								name: "JOIN",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2160, col: 20, offset: 65868},
+								pos:  position{line: 2187, col: 20, offset: 66986},
 								name: "_",
 							},
 						},
@@ -14549,50 +14791,50 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionJoin",
-			pos:  position{line: 2162, col: 1, offset: 65871},
+			pos:  position{line: 2189, col: 1, offset: 66989},
 			expr: &actionExpr{
-				pos: position{line: 2163, col: 5, offset: 65889},
+				pos: position{line: 2190, col: 5, offset: 67007},
 				run: (*parser).callonConditionJoin1,
 				expr: &seqExpr{
-					pos: position{line: 2163, col: 5, offset: 65889},
+					pos: position{line: 2190, col: 5, offset: 67007},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2163, col: 5, offset: 65889},
+							pos:   position{line: 2190, col: 5, offset: 67007},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2163, col: 10, offset: 65894},
+								pos:  position{line: 2190, col: 10, offset: 67012},
 								name: "FromElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2163, col: 19, offset: 65903},
+							pos:   position{line: 2190, col: 19, offset: 67021},
 							label: "style",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2163, col: 25, offset: 65909},
+								pos:  position{line: 2190, col: 25, offset: 67027},
 								name: "SQLJoinStyle",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2163, col: 38, offset: 65922},
+							pos:  position{line: 2190, col: 38, offset: 67040},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2163, col: 40, offset: 65924},
+							pos:   position{line: 2190, col: 40, offset: 67042},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2163, col: 46, offset: 65930},
+								pos:  position{line: 2190, col: 46, offset: 67048},
 								name: "FromElem",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2163, col: 55, offset: 65939},
+							pos:  position{line: 2190, col: 55, offset: 67057},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2163, col: 57, offset: 65941},
+							pos:   position{line: 2190, col: 57, offset: 67059},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2163, col: 59, offset: 65943},
+								pos:  position{line: 2190, col: 59, offset: 67061},
 								name: "JoinCond",
 							},
 						},
@@ -14604,186 +14846,186 @@ var g = &grammar{
 		},
 		{
 			name: "SQLJoinStyle",
-			pos:  position{line: 2174, col: 1, offset: 66212},
+			pos:  position{line: 2201, col: 1, offset: 67330},
 			expr: &choiceExpr{
-				pos: position{line: 2175, col: 5, offset: 66229},
+				pos: position{line: 2202, col: 5, offset: 67347},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2175, col: 5, offset: 66229},
+						pos: position{line: 2202, col: 5, offset: 67347},
 						run: (*parser).callonSQLJoinStyle2,
 						expr: &seqExpr{
-							pos: position{line: 2175, col: 5, offset: 66229},
+							pos: position{line: 2202, col: 5, offset: 67347},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 2175, col: 5, offset: 66229},
+									pos: position{line: 2202, col: 5, offset: 67347},
 									expr: &seqExpr{
-										pos: position{line: 2175, col: 6, offset: 66230},
+										pos: position{line: 2202, col: 6, offset: 67348},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2175, col: 6, offset: 66230},
+												pos:  position{line: 2202, col: 6, offset: 67348},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2175, col: 8, offset: 66232},
+												pos:  position{line: 2202, col: 8, offset: 67350},
 												name: "INNER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2175, col: 16, offset: 66240},
+									pos:  position{line: 2202, col: 16, offset: 67358},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2175, col: 18, offset: 66242},
+									pos:  position{line: 2202, col: 18, offset: 67360},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2176, col: 5, offset: 66287},
+						pos: position{line: 2203, col: 5, offset: 67405},
 						run: (*parser).callonSQLJoinStyle10,
 						expr: &seqExpr{
-							pos: position{line: 2176, col: 5, offset: 66287},
+							pos: position{line: 2203, col: 5, offset: 67405},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2176, col: 5, offset: 66287},
+									pos:  position{line: 2203, col: 5, offset: 67405},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2176, col: 7, offset: 66289},
+									pos:  position{line: 2203, col: 7, offset: 67407},
 									name: "ANTI",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2176, col: 12, offset: 66294},
+									pos:  position{line: 2203, col: 12, offset: 67412},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2176, col: 14, offset: 66296},
+									pos:  position{line: 2203, col: 14, offset: 67414},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2177, col: 5, offset: 66328},
+						pos: position{line: 2204, col: 5, offset: 67446},
 						run: (*parser).callonSQLJoinStyle16,
 						expr: &seqExpr{
-							pos: position{line: 2177, col: 5, offset: 66328},
+							pos: position{line: 2204, col: 5, offset: 67446},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2177, col: 5, offset: 66328},
+									pos:  position{line: 2204, col: 5, offset: 67446},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2177, col: 7, offset: 66330},
+									pos:  position{line: 2204, col: 7, offset: 67448},
 									name: "FULL",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2177, col: 12, offset: 66335},
+									pos: position{line: 2204, col: 12, offset: 67453},
 									expr: &seqExpr{
-										pos: position{line: 2177, col: 13, offset: 66336},
+										pos: position{line: 2204, col: 13, offset: 67454},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2177, col: 13, offset: 66336},
+												pos:  position{line: 2204, col: 13, offset: 67454},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2177, col: 15, offset: 66338},
+												pos:  position{line: 2204, col: 15, offset: 67456},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2177, col: 23, offset: 66346},
+									pos:  position{line: 2204, col: 23, offset: 67464},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2177, col: 25, offset: 66348},
+									pos:  position{line: 2204, col: 25, offset: 67466},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2178, col: 5, offset: 66382},
+						pos: position{line: 2205, col: 5, offset: 67500},
 						run: (*parser).callonSQLJoinStyle26,
 						expr: &seqExpr{
-							pos: position{line: 2178, col: 5, offset: 66382},
+							pos: position{line: 2205, col: 5, offset: 67500},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2178, col: 5, offset: 66382},
+									pos:  position{line: 2205, col: 5, offset: 67500},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2178, col: 7, offset: 66384},
+									pos:  position{line: 2205, col: 7, offset: 67502},
 									name: "LEFT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2178, col: 12, offset: 66389},
+									pos: position{line: 2205, col: 12, offset: 67507},
 									expr: &seqExpr{
-										pos: position{line: 2178, col: 13, offset: 66390},
+										pos: position{line: 2205, col: 13, offset: 67508},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2178, col: 13, offset: 66390},
+												pos:  position{line: 2205, col: 13, offset: 67508},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2178, col: 15, offset: 66392},
+												pos:  position{line: 2205, col: 15, offset: 67510},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2178, col: 23, offset: 66400},
+									pos:  position{line: 2205, col: 23, offset: 67518},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2178, col: 25, offset: 66402},
+									pos:  position{line: 2205, col: 25, offset: 67520},
 									name: "JOIN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2179, col: 5, offset: 66436},
+						pos: position{line: 2206, col: 5, offset: 67554},
 						run: (*parser).callonSQLJoinStyle36,
 						expr: &seqExpr{
-							pos: position{line: 2179, col: 5, offset: 66436},
+							pos: position{line: 2206, col: 5, offset: 67554},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2179, col: 5, offset: 66436},
+									pos:  position{line: 2206, col: 5, offset: 67554},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2179, col: 7, offset: 66438},
+									pos:  position{line: 2206, col: 7, offset: 67556},
 									name: "RIGHT",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2179, col: 13, offset: 66444},
+									pos: position{line: 2206, col: 13, offset: 67562},
 									expr: &seqExpr{
-										pos: position{line: 2179, col: 14, offset: 66445},
+										pos: position{line: 2206, col: 14, offset: 67563},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2179, col: 14, offset: 66445},
+												pos:  position{line: 2206, col: 14, offset: 67563},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2179, col: 16, offset: 66447},
+												pos:  position{line: 2206, col: 16, offset: 67565},
 												name: "OUTER",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2179, col: 24, offset: 66455},
+									pos:  position{line: 2206, col: 24, offset: 67573},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2179, col: 26, offset: 66457},
+									pos:  position{line: 2206, col: 26, offset: 67575},
 									name: "JOIN",
 								},
 							},
@@ -14796,29 +15038,29 @@ var g = &grammar{
 		},
 		{
 			name: "JoinCond",
-			pos:  position{line: 2181, col: 1, offset: 66489},
+			pos:  position{line: 2208, col: 1, offset: 67607},
 			expr: &choiceExpr{
-				pos: position{line: 2182, col: 5, offset: 66502},
+				pos: position{line: 2209, col: 5, offset: 67620},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2182, col: 5, offset: 66502},
+						pos: position{line: 2209, col: 5, offset: 67620},
 						run: (*parser).callonJoinCond2,
 						expr: &seqExpr{
-							pos: position{line: 2182, col: 5, offset: 66502},
+							pos: position{line: 2209, col: 5, offset: 67620},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2182, col: 5, offset: 66502},
+									pos:  position{line: 2209, col: 5, offset: 67620},
 									name: "ON",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2182, col: 8, offset: 66505},
+									pos:  position{line: 2209, col: 8, offset: 67623},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2182, col: 10, offset: 66507},
+									pos:   position{line: 2209, col: 10, offset: 67625},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2182, col: 12, offset: 66509},
+										pos:  position{line: 2209, col: 12, offset: 67627},
 										name: "Expr",
 									},
 								},
@@ -14826,43 +15068,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2189, col: 5, offset: 66662},
+						pos: position{line: 2216, col: 5, offset: 67780},
 						run: (*parser).callonJoinCond8,
 						expr: &seqExpr{
-							pos: position{line: 2189, col: 5, offset: 66662},
+							pos: position{line: 2216, col: 5, offset: 67780},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2189, col: 5, offset: 66662},
+									pos:  position{line: 2216, col: 5, offset: 67780},
 									name: "USING",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2189, col: 11, offset: 66668},
+									pos:  position{line: 2216, col: 11, offset: 67786},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2189, col: 14, offset: 66671},
+									pos:        position{line: 2216, col: 14, offset: 67789},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2189, col: 18, offset: 66675},
+									pos:  position{line: 2216, col: 18, offset: 67793},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 2189, col: 21, offset: 66678},
+									pos:   position{line: 2216, col: 21, offset: 67796},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2189, col: 28, offset: 66685},
+										pos:  position{line: 2216, col: 28, offset: 67803},
 										name: "Lvals",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2189, col: 34, offset: 66691},
+									pos:  position{line: 2216, col: 34, offset: 67809},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 2189, col: 37, offset: 66694},
+									pos:        position{line: 2216, col: 37, offset: 67812},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -14877,40 +15119,40 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrdinality",
-			pos:  position{line: 2197, col: 1, offset: 66864},
+			pos:  position{line: 2224, col: 1, offset: 67982},
 			expr: &choiceExpr{
-				pos: position{line: 2198, col: 5, offset: 66882},
+				pos: position{line: 2225, col: 5, offset: 68000},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2198, col: 5, offset: 66882},
+						pos: position{line: 2225, col: 5, offset: 68000},
 						run: (*parser).callonOptOrdinality2,
 						expr: &seqExpr{
-							pos: position{line: 2198, col: 5, offset: 66882},
+							pos: position{line: 2225, col: 5, offset: 68000},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2198, col: 5, offset: 66882},
+									pos:  position{line: 2225, col: 5, offset: 68000},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2198, col: 7, offset: 66884},
+									pos:  position{line: 2225, col: 7, offset: 68002},
 									name: "WITH",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2198, col: 12, offset: 66889},
+									pos:  position{line: 2225, col: 12, offset: 68007},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2198, col: 14, offset: 66891},
+									pos:  position{line: 2225, col: 14, offset: 68009},
 									name: "ORDINALITY",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2203, col: 5, offset: 66988},
+						pos: position{line: 2230, col: 5, offset: 68106},
 						run: (*parser).callonOptOrdinality8,
 						expr: &litMatcher{
-							pos:        position{line: 2203, col: 5, offset: 66988},
+							pos:        position{line: 2230, col: 5, offset: 68106},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14923,25 +15165,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptAlias",
-			pos:  position{line: 2205, col: 1, offset: 67037},
+			pos:  position{line: 2232, col: 1, offset: 68155},
 			expr: &choiceExpr{
-				pos: position{line: 2206, col: 5, offset: 67050},
+				pos: position{line: 2233, col: 5, offset: 68168},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2206, col: 5, offset: 67050},
+						pos: position{line: 2233, col: 5, offset: 68168},
 						run: (*parser).callonOptAlias2,
 						expr: &seqExpr{
-							pos: position{line: 2206, col: 5, offset: 67050},
+							pos: position{line: 2233, col: 5, offset: 68168},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2206, col: 5, offset: 67050},
+									pos:  position{line: 2233, col: 5, offset: 68168},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2206, col: 7, offset: 67052},
+									pos:   position{line: 2233, col: 7, offset: 68170},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2206, col: 9, offset: 67054},
+										pos:  position{line: 2233, col: 9, offset: 68172},
 										name: "AliasClause",
 									},
 								},
@@ -14949,10 +15191,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2207, col: 5, offset: 67088},
+						pos: position{line: 2234, col: 5, offset: 68206},
 						run: (*parser).callonOptAlias7,
 						expr: &litMatcher{
-							pos:        position{line: 2207, col: 5, offset: 67088},
+							pos:        position{line: 2234, col: 5, offset: 68206},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14965,51 +15207,51 @@ var g = &grammar{
 		},
 		{
 			name: "AliasClause",
-			pos:  position{line: 2209, col: 1, offset: 67125},
+			pos:  position{line: 2236, col: 1, offset: 68243},
 			expr: &actionExpr{
-				pos: position{line: 2210, col: 4, offset: 67140},
+				pos: position{line: 2237, col: 4, offset: 68258},
 				run: (*parser).callonAliasClause1,
 				expr: &seqExpr{
-					pos: position{line: 2210, col: 4, offset: 67140},
+					pos: position{line: 2237, col: 4, offset: 68258},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2210, col: 4, offset: 67140},
+							pos: position{line: 2237, col: 4, offset: 68258},
 							expr: &seqExpr{
-								pos: position{line: 2210, col: 5, offset: 67141},
+								pos: position{line: 2237, col: 5, offset: 68259},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2210, col: 5, offset: 67141},
+										pos:  position{line: 2237, col: 5, offset: 68259},
 										name: "AS",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2210, col: 8, offset: 67144},
+										pos:  position{line: 2237, col: 8, offset: 68262},
 										name: "_",
 									},
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 2210, col: 12, offset: 67148},
+							pos: position{line: 2237, col: 12, offset: 68266},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2210, col: 13, offset: 67149},
+								pos:  position{line: 2237, col: 13, offset: 68267},
 								name: "SQLGuard",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2210, col: 22, offset: 67158},
+							pos:   position{line: 2237, col: 22, offset: 68276},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2210, col: 27, offset: 67163},
+								pos:  position{line: 2237, col: 27, offset: 68281},
 								name: "IdentifierName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2210, col: 42, offset: 67178},
+							pos:   position{line: 2237, col: 42, offset: 68296},
 							label: "cols",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2210, col: 47, offset: 67183},
+								pos: position{line: 2237, col: 47, offset: 68301},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2210, col: 47, offset: 67183},
+									pos:  position{line: 2237, col: 47, offset: 68301},
 									name: "Columns",
 								},
 							},
@@ -15022,65 +15264,65 @@ var g = &grammar{
 		},
 		{
 			name: "Columns",
-			pos:  position{line: 2218, col: 1, offset: 67362},
+			pos:  position{line: 2245, col: 1, offset: 68480},
 			expr: &actionExpr{
-				pos: position{line: 2219, col: 5, offset: 67374},
+				pos: position{line: 2246, col: 5, offset: 68492},
 				run: (*parser).callonColumns1,
 				expr: &seqExpr{
-					pos: position{line: 2219, col: 5, offset: 67374},
+					pos: position{line: 2246, col: 5, offset: 68492},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2219, col: 5, offset: 67374},
+							pos:  position{line: 2246, col: 5, offset: 68492},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2219, col: 8, offset: 67377},
+							pos:        position{line: 2246, col: 8, offset: 68495},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2219, col: 12, offset: 67381},
+							pos:  position{line: 2246, col: 12, offset: 68499},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 2219, col: 15, offset: 67384},
+							pos:   position{line: 2246, col: 15, offset: 68502},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2219, col: 21, offset: 67390},
+								pos:  position{line: 2246, col: 21, offset: 68508},
 								name: "SQLIdentifier",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2219, col: 35, offset: 67404},
+							pos:   position{line: 2246, col: 35, offset: 68522},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2219, col: 40, offset: 67409},
+								pos: position{line: 2246, col: 40, offset: 68527},
 								expr: &actionExpr{
-									pos: position{line: 2219, col: 42, offset: 67411},
+									pos: position{line: 2246, col: 42, offset: 68529},
 									run: (*parser).callonColumns10,
 									expr: &seqExpr{
-										pos: position{line: 2219, col: 42, offset: 67411},
+										pos: position{line: 2246, col: 42, offset: 68529},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2219, col: 42, offset: 67411},
+												pos:  position{line: 2246, col: 42, offset: 68529},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2219, col: 45, offset: 67414},
+												pos:        position{line: 2246, col: 45, offset: 68532},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2219, col: 49, offset: 67418},
+												pos:  position{line: 2246, col: 49, offset: 68536},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2219, col: 52, offset: 67421},
+												pos:   position{line: 2246, col: 52, offset: 68539},
 												label: "s",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2219, col: 54, offset: 67423},
+													pos:  position{line: 2246, col: 54, offset: 68541},
 													name: "SQLIdentifier",
 												},
 											},
@@ -15090,11 +15332,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2219, col: 87, offset: 67456},
+							pos:  position{line: 2246, col: 87, offset: 68574},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 2219, col: 90, offset: 67459},
+							pos:        position{line: 2246, col: 90, offset: 68577},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -15107,51 +15349,51 @@ var g = &grammar{
 		},
 		{
 			name: "Selection",
-			pos:  position{line: 2223, col: 1, offset: 67530},
+			pos:  position{line: 2250, col: 1, offset: 68648},
 			expr: &actionExpr{
-				pos: position{line: 2224, col: 5, offset: 67544},
+				pos: position{line: 2251, col: 5, offset: 68662},
 				run: (*parser).callonSelection1,
 				expr: &seqExpr{
-					pos: position{line: 2224, col: 5, offset: 67544},
+					pos: position{line: 2251, col: 5, offset: 68662},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2224, col: 5, offset: 67544},
+							pos:   position{line: 2251, col: 5, offset: 68662},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2224, col: 11, offset: 67550},
+								pos:  position{line: 2251, col: 11, offset: 68668},
 								name: "SelectElem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2224, col: 22, offset: 67561},
+							pos:   position{line: 2251, col: 22, offset: 68679},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2224, col: 27, offset: 67566},
+								pos: position{line: 2251, col: 27, offset: 68684},
 								expr: &actionExpr{
-									pos: position{line: 2224, col: 29, offset: 67568},
+									pos: position{line: 2251, col: 29, offset: 68686},
 									run: (*parser).callonSelection7,
 									expr: &seqExpr{
-										pos: position{line: 2224, col: 29, offset: 67568},
+										pos: position{line: 2251, col: 29, offset: 68686},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2224, col: 29, offset: 67568},
+												pos:  position{line: 2251, col: 29, offset: 68686},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2224, col: 32, offset: 67571},
+												pos:        position{line: 2251, col: 32, offset: 68689},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2224, col: 36, offset: 67575},
+												pos:  position{line: 2251, col: 36, offset: 68693},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2224, col: 39, offset: 67578},
+												pos:   position{line: 2251, col: 39, offset: 68696},
 												label: "s",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2224, col: 41, offset: 67580},
+													pos:  position{line: 2251, col: 41, offset: 68698},
 													name: "SelectElem",
 												},
 											},
@@ -15168,38 +15410,38 @@ var g = &grammar{
 		},
 		{
 			name: "SelectElem",
-			pos:  position{line: 2232, col: 1, offset: 67785},
+			pos:  position{line: 2259, col: 1, offset: 68903},
 			expr: &choiceExpr{
-				pos: position{line: 2233, col: 5, offset: 67800},
+				pos: position{line: 2260, col: 5, offset: 68918},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2233, col: 5, offset: 67800},
+						pos: position{line: 2260, col: 5, offset: 68918},
 						run: (*parser).callonSelectElem2,
 						expr: &seqExpr{
-							pos: position{line: 2233, col: 5, offset: 67800},
+							pos: position{line: 2260, col: 5, offset: 68918},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2233, col: 5, offset: 67800},
+									pos:   position{line: 2260, col: 5, offset: 68918},
 									label: "expr",
 									expr: &choiceExpr{
-										pos: position{line: 2233, col: 11, offset: 67806},
+										pos: position{line: 2260, col: 11, offset: 68924},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2233, col: 11, offset: 67806},
+												pos:  position{line: 2260, col: 11, offset: 68924},
 												name: "AggAllOrDistinct",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2233, col: 30, offset: 67825},
+												pos:  position{line: 2260, col: 30, offset: 68943},
 												name: "Expr",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2233, col: 36, offset: 67831},
+									pos:   position{line: 2260, col: 36, offset: 68949},
 									label: "as",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2233, col: 39, offset: 67834},
+										pos:  position{line: 2260, col: 39, offset: 68952},
 										name: "OptAsClause",
 									},
 								},
@@ -15207,10 +15449,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2244, col: 5, offset: 68062},
+						pos: position{line: 2271, col: 5, offset: 69180},
 						run: (*parser).callonSelectElem10,
 						expr: &litMatcher{
-							pos:        position{line: 2244, col: 5, offset: 68062},
+							pos:        position{line: 2271, col: 5, offset: 69180},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
@@ -15223,33 +15465,33 @@ var g = &grammar{
 		},
 		{
 			name: "OptAsClause",
-			pos:  position{line: 2249, col: 1, offset: 68167},
+			pos:  position{line: 2276, col: 1, offset: 69285},
 			expr: &choiceExpr{
-				pos: position{line: 2250, col: 5, offset: 68183},
+				pos: position{line: 2277, col: 5, offset: 69301},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2250, col: 5, offset: 68183},
+						pos: position{line: 2277, col: 5, offset: 69301},
 						run: (*parser).callonOptAsClause2,
 						expr: &seqExpr{
-							pos: position{line: 2250, col: 5, offset: 68183},
+							pos: position{line: 2277, col: 5, offset: 69301},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2250, col: 5, offset: 68183},
+									pos:  position{line: 2277, col: 5, offset: 69301},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2250, col: 7, offset: 68185},
+									pos:  position{line: 2277, col: 7, offset: 69303},
 									name: "AS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2250, col: 10, offset: 68188},
+									pos:  position{line: 2277, col: 10, offset: 69306},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2250, col: 12, offset: 68190},
+									pos:   position{line: 2277, col: 12, offset: 69308},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2250, col: 15, offset: 68193},
+										pos:  position{line: 2277, col: 15, offset: 69311},
 										name: "SQLIdentifier",
 									},
 								},
@@ -15257,27 +15499,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2251, col: 5, offset: 68230},
+						pos: position{line: 2278, col: 5, offset: 69348},
 						run: (*parser).callonOptAsClause9,
 						expr: &seqExpr{
-							pos: position{line: 2251, col: 5, offset: 68230},
+							pos: position{line: 2278, col: 5, offset: 69348},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2251, col: 5, offset: 68230},
+									pos:  position{line: 2278, col: 5, offset: 69348},
 									name: "_",
 								},
 								&notExpr{
-									pos: position{line: 2251, col: 7, offset: 68232},
+									pos: position{line: 2278, col: 7, offset: 69350},
 									expr: &ruleRefExpr{
-										pos:  position{line: 2251, col: 8, offset: 68233},
+										pos:  position{line: 2278, col: 8, offset: 69351},
 										name: "SQLGuard",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2251, col: 17, offset: 68242},
+									pos:   position{line: 2278, col: 17, offset: 69360},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2251, col: 20, offset: 68245},
+										pos:  position{line: 2278, col: 20, offset: 69363},
 										name: "SQLIdentifier",
 									},
 								},
@@ -15285,10 +15527,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2252, col: 5, offset: 68282},
+						pos: position{line: 2279, col: 5, offset: 69400},
 						run: (*parser).callonOptAsClause16,
 						expr: &litMatcher{
-							pos:        position{line: 2252, col: 5, offset: 68282},
+							pos:        position{line: 2279, col: 5, offset: 69400},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15301,41 +15543,41 @@ var g = &grammar{
 		},
 		{
 			name: "OptOrderByClause",
-			pos:  position{line: 2254, col: 1, offset: 68307},
+			pos:  position{line: 2281, col: 1, offset: 69425},
 			expr: &choiceExpr{
-				pos: position{line: 2255, col: 5, offset: 68328},
+				pos: position{line: 2282, col: 5, offset: 69446},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2255, col: 5, offset: 68328},
+						pos: position{line: 2282, col: 5, offset: 69446},
 						run: (*parser).callonOptOrderByClause2,
 						expr: &seqExpr{
-							pos: position{line: 2255, col: 5, offset: 68328},
+							pos: position{line: 2282, col: 5, offset: 69446},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2255, col: 5, offset: 68328},
+									pos:  position{line: 2282, col: 5, offset: 69446},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2255, col: 7, offset: 68330},
+									pos:  position{line: 2282, col: 7, offset: 69448},
 									name: "ORDER",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2255, col: 13, offset: 68336},
+									pos:  position{line: 2282, col: 13, offset: 69454},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2255, col: 15, offset: 68338},
+									pos:  position{line: 2282, col: 15, offset: 69456},
 									name: "BY",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2255, col: 18, offset: 68341},
+									pos:  position{line: 2282, col: 18, offset: 69459},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2255, col: 20, offset: 68343},
+									pos:   position{line: 2282, col: 20, offset: 69461},
 									label: "list",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2255, col: 25, offset: 68348},
+										pos:  position{line: 2282, col: 25, offset: 69466},
 										name: "OrderByList",
 									},
 								},
@@ -15343,10 +15585,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2261, col: 5, offset: 68482},
+						pos: position{line: 2288, col: 5, offset: 69600},
 						run: (*parser).callonOptOrderByClause11,
 						expr: &litMatcher{
-							pos:        position{line: 2261, col: 5, offset: 68482},
+							pos:        position{line: 2288, col: 5, offset: 69600},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15359,51 +15601,51 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByList",
-			pos:  position{line: 2263, col: 1, offset: 68515},
+			pos:  position{line: 2290, col: 1, offset: 69633},
 			expr: &actionExpr{
-				pos: position{line: 2264, col: 5, offset: 68531},
+				pos: position{line: 2291, col: 5, offset: 69649},
 				run: (*parser).callonOrderByList1,
 				expr: &seqExpr{
-					pos: position{line: 2264, col: 5, offset: 68531},
+					pos: position{line: 2291, col: 5, offset: 69649},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2264, col: 5, offset: 68531},
+							pos:   position{line: 2291, col: 5, offset: 69649},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2264, col: 11, offset: 68537},
+								pos:  position{line: 2291, col: 11, offset: 69655},
 								name: "OrderByItem",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2264, col: 23, offset: 68549},
+							pos:   position{line: 2291, col: 23, offset: 69667},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2264, col: 28, offset: 68554},
+								pos: position{line: 2291, col: 28, offset: 69672},
 								expr: &actionExpr{
-									pos: position{line: 2264, col: 30, offset: 68556},
+									pos: position{line: 2291, col: 30, offset: 69674},
 									run: (*parser).callonOrderByList7,
 									expr: &seqExpr{
-										pos: position{line: 2264, col: 30, offset: 68556},
+										pos: position{line: 2291, col: 30, offset: 69674},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2264, col: 30, offset: 68556},
+												pos:  position{line: 2291, col: 30, offset: 69674},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 2264, col: 33, offset: 68559},
+												pos:        position{line: 2291, col: 33, offset: 69677},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2264, col: 37, offset: 68563},
+												pos:  position{line: 2291, col: 37, offset: 69681},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 2264, col: 40, offset: 68566},
+												pos:   position{line: 2291, col: 40, offset: 69684},
 												label: "o",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2264, col: 42, offset: 68568},
+													pos:  position{line: 2291, col: 42, offset: 69686},
 													name: "OrderByItem",
 												},
 											},
@@ -15420,34 +15662,34 @@ var g = &grammar{
 		},
 		{
 			name: "OrderByItem",
-			pos:  position{line: 2268, col: 1, offset: 68669},
+			pos:  position{line: 2295, col: 1, offset: 69787},
 			expr: &actionExpr{
-				pos: position{line: 2269, col: 5, offset: 68685},
+				pos: position{line: 2296, col: 5, offset: 69803},
 				run: (*parser).callonOrderByItem1,
 				expr: &seqExpr{
-					pos: position{line: 2269, col: 5, offset: 68685},
+					pos: position{line: 2296, col: 5, offset: 69803},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2269, col: 5, offset: 68685},
+							pos:   position{line: 2296, col: 5, offset: 69803},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2269, col: 7, offset: 68687},
+								pos:  position{line: 2296, col: 7, offset: 69805},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2269, col: 12, offset: 68692},
+							pos:   position{line: 2296, col: 12, offset: 69810},
 							label: "order",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2269, col: 18, offset: 68698},
+								pos:  position{line: 2296, col: 18, offset: 69816},
 								name: "OptAscDesc",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2269, col: 29, offset: 68709},
+							pos:   position{line: 2296, col: 29, offset: 69827},
 							label: "nulls",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2269, col: 35, offset: 68715},
+								pos:  position{line: 2296, col: 35, offset: 69833},
 								name: "OptNullsOrder",
 							},
 						},
@@ -15459,49 +15701,49 @@ var g = &grammar{
 		},
 		{
 			name: "OptAscDesc",
-			pos:  position{line: 2280, col: 1, offset: 68947},
+			pos:  position{line: 2307, col: 1, offset: 70065},
 			expr: &choiceExpr{
-				pos: position{line: 2281, col: 5, offset: 68962},
+				pos: position{line: 2308, col: 5, offset: 70080},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2281, col: 5, offset: 68962},
+						pos: position{line: 2308, col: 5, offset: 70080},
 						run: (*parser).callonOptAscDesc2,
 						expr: &seqExpr{
-							pos: position{line: 2281, col: 5, offset: 68962},
+							pos: position{line: 2308, col: 5, offset: 70080},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2281, col: 5, offset: 68962},
+									pos:  position{line: 2308, col: 5, offset: 70080},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2281, col: 7, offset: 68964},
+									pos:  position{line: 2308, col: 7, offset: 70082},
 									name: "ASC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2282, col: 5, offset: 69024},
+						pos: position{line: 2309, col: 5, offset: 70142},
 						run: (*parser).callonOptAscDesc6,
 						expr: &seqExpr{
-							pos: position{line: 2282, col: 5, offset: 69024},
+							pos: position{line: 2309, col: 5, offset: 70142},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2282, col: 5, offset: 69024},
+									pos:  position{line: 2309, col: 5, offset: 70142},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2282, col: 7, offset: 69026},
+									pos:  position{line: 2309, col: 7, offset: 70144},
 									name: "DESC",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2283, col: 5, offset: 69086},
+						pos: position{line: 2310, col: 5, offset: 70204},
 						run: (*parser).callonOptAscDesc10,
 						expr: &litMatcher{
-							pos:        position{line: 2283, col: 5, offset: 69086},
+							pos:        position{line: 2310, col: 5, offset: 70204},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15514,65 +15756,65 @@ var g = &grammar{
 		},
 		{
 			name: "OptNullsOrder",
-			pos:  position{line: 2285, col: 1, offset: 69118},
+			pos:  position{line: 2312, col: 1, offset: 70236},
 			expr: &choiceExpr{
-				pos: position{line: 2286, col: 5, offset: 69136},
+				pos: position{line: 2313, col: 5, offset: 70254},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2286, col: 5, offset: 69136},
+						pos: position{line: 2313, col: 5, offset: 70254},
 						run: (*parser).callonOptNullsOrder2,
 						expr: &seqExpr{
-							pos: position{line: 2286, col: 5, offset: 69136},
+							pos: position{line: 2313, col: 5, offset: 70254},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2286, col: 5, offset: 69136},
+									pos:  position{line: 2313, col: 5, offset: 70254},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2286, col: 7, offset: 69138},
+									pos:  position{line: 2313, col: 7, offset: 70256},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2286, col: 13, offset: 69144},
+									pos:  position{line: 2313, col: 13, offset: 70262},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2286, col: 15, offset: 69146},
+									pos:  position{line: 2313, col: 15, offset: 70264},
 									name: "FIRST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2287, col: 5, offset: 69210},
+						pos: position{line: 2314, col: 5, offset: 70328},
 						run: (*parser).callonOptNullsOrder8,
 						expr: &seqExpr{
-							pos: position{line: 2287, col: 5, offset: 69210},
+							pos: position{line: 2314, col: 5, offset: 70328},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2287, col: 5, offset: 69210},
+									pos:  position{line: 2314, col: 5, offset: 70328},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2287, col: 7, offset: 69212},
+									pos:  position{line: 2314, col: 7, offset: 70330},
 									name: "NULLS",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2287, col: 13, offset: 69218},
+									pos:  position{line: 2314, col: 13, offset: 70336},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2287, col: 15, offset: 69220},
+									pos:  position{line: 2314, col: 15, offset: 70338},
 									name: "LAST",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2288, col: 5, offset: 69283},
+						pos: position{line: 2315, col: 5, offset: 70401},
 						run: (*parser).callonOptNullsOrder14,
 						expr: &litMatcher{
-							pos:        position{line: 2288, col: 5, offset: 69283},
+							pos:        position{line: 2315, col: 5, offset: 70401},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15585,25 +15827,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptSQLLimitOffset",
-			pos:  position{line: 2290, col: 1, offset: 69328},
+			pos:  position{line: 2317, col: 1, offset: 70446},
 			expr: &choiceExpr{
-				pos: position{line: 2291, col: 5, offset: 69350},
+				pos: position{line: 2318, col: 5, offset: 70468},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2291, col: 5, offset: 69350},
+						pos: position{line: 2318, col: 5, offset: 70468},
 						run: (*parser).callonOptSQLLimitOffset2,
 						expr: &seqExpr{
-							pos: position{line: 2291, col: 5, offset: 69350},
+							pos: position{line: 2318, col: 5, offset: 70468},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2291, col: 5, offset: 69350},
+									pos:  position{line: 2318, col: 5, offset: 70468},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2291, col: 7, offset: 69352},
+									pos:   position{line: 2318, col: 7, offset: 70470},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2291, col: 10, offset: 69355},
+										pos:  position{line: 2318, col: 10, offset: 70473},
 										name: "SQLLimitOffset",
 									},
 								},
@@ -15611,10 +15853,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2292, col: 5, offset: 69393},
+						pos: position{line: 2319, col: 5, offset: 70511},
 						run: (*parser).callonOptSQLLimitOffset7,
 						expr: &litMatcher{
-							pos:        position{line: 2292, col: 5, offset: 69393},
+							pos:        position{line: 2319, col: 5, offset: 70511},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15627,29 +15869,29 @@ var g = &grammar{
 		},
 		{
 			name: "SQLLimitOffset",
-			pos:  position{line: 2294, col: 1, offset: 69434},
+			pos:  position{line: 2321, col: 1, offset: 70552},
 			expr: &choiceExpr{
-				pos: position{line: 2295, col: 5, offset: 69453},
+				pos: position{line: 2322, col: 5, offset: 70571},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2295, col: 5, offset: 69453},
+						pos: position{line: 2322, col: 5, offset: 70571},
 						run: (*parser).callonSQLLimitOffset2,
 						expr: &seqExpr{
-							pos: position{line: 2295, col: 5, offset: 69453},
+							pos: position{line: 2322, col: 5, offset: 70571},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2295, col: 5, offset: 69453},
+									pos:   position{line: 2322, col: 5, offset: 70571},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2295, col: 7, offset: 69455},
+										pos:  position{line: 2322, col: 7, offset: 70573},
 										name: "LimitClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2295, col: 19, offset: 69467},
+									pos:   position{line: 2322, col: 19, offset: 70585},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2295, col: 21, offset: 69469},
+										pos:  position{line: 2322, col: 21, offset: 70587},
 										name: "OptOffsetClause",
 									},
 								},
@@ -15657,24 +15899,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2307, col: 5, offset: 69701},
+						pos: position{line: 2334, col: 5, offset: 70819},
 						run: (*parser).callonSQLLimitOffset8,
 						expr: &seqExpr{
-							pos: position{line: 2307, col: 5, offset: 69701},
+							pos: position{line: 2334, col: 5, offset: 70819},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2307, col: 5, offset: 69701},
+									pos:   position{line: 2334, col: 5, offset: 70819},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2307, col: 7, offset: 69703},
+										pos:  position{line: 2334, col: 7, offset: 70821},
 										name: "OffsetClause",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2307, col: 20, offset: 69716},
+									pos:   position{line: 2334, col: 20, offset: 70834},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2307, col: 22, offset: 69718},
+										pos:  position{line: 2334, col: 22, offset: 70836},
 										name: "OptLimitClause",
 									},
 								},
@@ -15688,25 +15930,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptLimitClause",
-			pos:  position{line: 2318, col: 1, offset: 69915},
+			pos:  position{line: 2345, col: 1, offset: 71033},
 			expr: &choiceExpr{
-				pos: position{line: 2319, col: 5, offset: 69934},
+				pos: position{line: 2346, col: 5, offset: 71052},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2319, col: 5, offset: 69934},
+						pos: position{line: 2346, col: 5, offset: 71052},
 						run: (*parser).callonOptLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2319, col: 5, offset: 69934},
+							pos: position{line: 2346, col: 5, offset: 71052},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2319, col: 5, offset: 69934},
+									pos:  position{line: 2346, col: 5, offset: 71052},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2319, col: 7, offset: 69936},
+									pos:   position{line: 2346, col: 7, offset: 71054},
 									label: "l",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2319, col: 9, offset: 69938},
+										pos:  position{line: 2346, col: 9, offset: 71056},
 										name: "LimitClause",
 									},
 								},
@@ -15714,10 +15956,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2320, col: 5, offset: 69972},
+						pos: position{line: 2347, col: 5, offset: 71090},
 						run: (*parser).callonOptLimitClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2320, col: 5, offset: 69972},
+							pos:        position{line: 2347, col: 5, offset: 71090},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15730,50 +15972,50 @@ var g = &grammar{
 		},
 		{
 			name: "LimitClause",
-			pos:  position{line: 2322, col: 1, offset: 70009},
+			pos:  position{line: 2349, col: 1, offset: 71127},
 			expr: &choiceExpr{
-				pos: position{line: 2323, col: 5, offset: 70025},
+				pos: position{line: 2350, col: 5, offset: 71143},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2323, col: 5, offset: 70025},
+						pos: position{line: 2350, col: 5, offset: 71143},
 						run: (*parser).callonLimitClause2,
 						expr: &seqExpr{
-							pos: position{line: 2323, col: 5, offset: 70025},
+							pos: position{line: 2350, col: 5, offset: 71143},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2323, col: 5, offset: 70025},
+									pos:  position{line: 2350, col: 5, offset: 71143},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2323, col: 11, offset: 70031},
+									pos:  position{line: 2350, col: 11, offset: 71149},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2323, col: 13, offset: 70033},
+									pos:  position{line: 2350, col: 13, offset: 71151},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2324, col: 5, offset: 70061},
+						pos: position{line: 2351, col: 5, offset: 71179},
 						run: (*parser).callonLimitClause7,
 						expr: &seqExpr{
-							pos: position{line: 2324, col: 5, offset: 70061},
+							pos: position{line: 2351, col: 5, offset: 71179},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2324, col: 5, offset: 70061},
+									pos:  position{line: 2351, col: 5, offset: 71179},
 									name: "LIMIT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2324, col: 11, offset: 70067},
+									pos:  position{line: 2351, col: 11, offset: 71185},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2324, col: 13, offset: 70069},
+									pos:   position{line: 2351, col: 13, offset: 71187},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2324, col: 15, offset: 70071},
+										pos:  position{line: 2351, col: 15, offset: 71189},
 										name: "Expr",
 									},
 								},
@@ -15787,25 +16029,25 @@ var g = &grammar{
 		},
 		{
 			name: "OptOffsetClause",
-			pos:  position{line: 2326, col: 1, offset: 70095},
+			pos:  position{line: 2353, col: 1, offset: 71213},
 			expr: &choiceExpr{
-				pos: position{line: 2327, col: 5, offset: 70115},
+				pos: position{line: 2354, col: 5, offset: 71233},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2327, col: 5, offset: 70115},
+						pos: position{line: 2354, col: 5, offset: 71233},
 						run: (*parser).callonOptOffsetClause2,
 						expr: &seqExpr{
-							pos: position{line: 2327, col: 5, offset: 70115},
+							pos: position{line: 2354, col: 5, offset: 71233},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2327, col: 5, offset: 70115},
+									pos:  position{line: 2354, col: 5, offset: 71233},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 2327, col: 7, offset: 70117},
+									pos:   position{line: 2354, col: 7, offset: 71235},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2327, col: 9, offset: 70119},
+										pos:  position{line: 2354, col: 9, offset: 71237},
 										name: "OffsetClause",
 									},
 								},
@@ -15813,10 +16055,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2328, col: 5, offset: 70155},
+						pos: position{line: 2355, col: 5, offset: 71273},
 						run: (*parser).callonOptOffsetClause7,
 						expr: &litMatcher{
-							pos:        position{line: 2328, col: 5, offset: 70155},
+							pos:        position{line: 2355, col: 5, offset: 71273},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15829,26 +16071,26 @@ var g = &grammar{
 		},
 		{
 			name: "OffsetClause",
-			pos:  position{line: 2330, col: 1, offset: 70180},
+			pos:  position{line: 2357, col: 1, offset: 71298},
 			expr: &actionExpr{
-				pos: position{line: 2331, col: 5, offset: 70197},
+				pos: position{line: 2358, col: 5, offset: 71315},
 				run: (*parser).callonOffsetClause1,
 				expr: &seqExpr{
-					pos: position{line: 2331, col: 5, offset: 70197},
+					pos: position{line: 2358, col: 5, offset: 71315},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2331, col: 5, offset: 70197},
+							pos:  position{line: 2358, col: 5, offset: 71315},
 							name: "OFFSET",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2331, col: 12, offset: 70204},
+							pos:  position{line: 2358, col: 12, offset: 71322},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 2331, col: 14, offset: 70206},
+							pos:   position{line: 2358, col: 14, offset: 71324},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2331, col: 16, offset: 70208},
+								pos:  position{line: 2358, col: 16, offset: 71326},
 								name: "Expr",
 							},
 						},
@@ -15860,60 +16102,60 @@ var g = &grammar{
 		},
 		{
 			name: "SetOp",
-			pos:  position{line: 2333, col: 1, offset: 70233},
+			pos:  position{line: 2360, col: 1, offset: 71351},
 			expr: &choiceExpr{
-				pos: position{line: 2334, col: 5, offset: 70243},
+				pos: position{line: 2361, col: 5, offset: 71361},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2334, col: 5, offset: 70243},
+						pos: position{line: 2361, col: 5, offset: 71361},
 						run: (*parser).callonSetOp2,
 						expr: &seqExpr{
-							pos: position{line: 2334, col: 5, offset: 70243},
+							pos: position{line: 2361, col: 5, offset: 71361},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2334, col: 5, offset: 70243},
+									pos:  position{line: 2361, col: 5, offset: 71361},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2334, col: 7, offset: 70245},
+									pos:  position{line: 2361, col: 7, offset: 71363},
 									name: "UNION",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2334, col: 13, offset: 70251},
+									pos:  position{line: 2361, col: 13, offset: 71369},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2334, col: 15, offset: 70253},
+									pos:  position{line: 2361, col: 15, offset: 71371},
 									name: "ALL",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2335, col: 5, offset: 70289},
+						pos: position{line: 2362, col: 5, offset: 71407},
 						run: (*parser).callonSetOp8,
 						expr: &seqExpr{
-							pos: position{line: 2335, col: 5, offset: 70289},
+							pos: position{line: 2362, col: 5, offset: 71407},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2335, col: 5, offset: 70289},
+									pos:  position{line: 2362, col: 5, offset: 71407},
 									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2335, col: 7, offset: 70291},
+									pos:  position{line: 2362, col: 7, offset: 71409},
 									name: "UNION",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 2335, col: 13, offset: 70297},
+									pos: position{line: 2362, col: 13, offset: 71415},
 									expr: &seqExpr{
-										pos: position{line: 2335, col: 14, offset: 70298},
+										pos: position{line: 2362, col: 14, offset: 71416},
 										exprs: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2335, col: 14, offset: 70298},
+												pos:  position{line: 2362, col: 14, offset: 71416},
 												name: "_",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2335, col: 16, offset: 70300},
+												pos:  position{line: 2362, col: 16, offset: 71418},
 												name: "DISTINCT",
 											},
 										},
@@ -15929,88 +16171,88 @@ var g = &grammar{
 		},
 		{
 			name: "SQLGuard",
-			pos:  position{line: 2338, col: 1, offset: 70352},
+			pos:  position{line: 2365, col: 1, offset: 71470},
 			expr: &choiceExpr{
-				pos: position{line: 2339, col: 5, offset: 70367},
+				pos: position{line: 2366, col: 5, offset: 71485},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2339, col: 5, offset: 70367},
+						pos:  position{line: 2366, col: 5, offset: 71485},
 						name: "FROM",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2339, col: 12, offset: 70374},
+						pos:  position{line: 2366, col: 12, offset: 71492},
 						name: "GROUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2339, col: 20, offset: 70382},
+						pos:  position{line: 2366, col: 20, offset: 71500},
 						name: "HAVING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2339, col: 29, offset: 70391},
+						pos:  position{line: 2366, col: 29, offset: 71509},
 						name: "SELECT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2339, col: 38, offset: 70400},
+						pos:  position{line: 2366, col: 38, offset: 71518},
 						name: "RECURSIVE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2340, col: 5, offset: 70414},
+						pos:  position{line: 2367, col: 5, offset: 71532},
 						name: "ANTI",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2340, col: 12, offset: 70421},
+						pos:  position{line: 2367, col: 12, offset: 71539},
 						name: "INNER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2340, col: 20, offset: 70429},
+						pos:  position{line: 2367, col: 20, offset: 71547},
 						name: "LEFT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2340, col: 27, offset: 70436},
+						pos:  position{line: 2367, col: 27, offset: 71554},
 						name: "RIGHT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2340, col: 35, offset: 70444},
+						pos:  position{line: 2367, col: 35, offset: 71562},
 						name: "OUTER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2340, col: 43, offset: 70452},
+						pos:  position{line: 2367, col: 43, offset: 71570},
 						name: "CROSS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2340, col: 51, offset: 70460},
+						pos:  position{line: 2367, col: 51, offset: 71578},
 						name: "JOIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2341, col: 5, offset: 70469},
+						pos:  position{line: 2368, col: 5, offset: 71587},
 						name: "UNION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2342, col: 5, offset: 70479},
+						pos:  position{line: 2369, col: 5, offset: 71597},
 						name: "ORDER",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2343, col: 5, offset: 70489},
+						pos:  position{line: 2370, col: 5, offset: 71607},
 						name: "OFFSET",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2344, col: 5, offset: 70500},
+						pos:  position{line: 2371, col: 5, offset: 71618},
 						name: "LIMIT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2345, col: 5, offset: 70510},
+						pos:  position{line: 2372, col: 5, offset: 71628},
 						name: "WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2346, col: 5, offset: 70520},
+						pos:  position{line: 2373, col: 5, offset: 71638},
 						name: "WITH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2347, col: 5, offset: 70529},
+						pos:  position{line: 2374, col: 5, offset: 71647},
 						name: "USING",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2348, col: 5, offset: 70539},
+						pos:  position{line: 2375, col: 5, offset: 71657},
 						name: "ON",
 					},
 				},
@@ -16020,20 +16262,20 @@ var g = &grammar{
 		},
 		{
 			name: "AGGREGATE",
-			pos:  position{line: 2350, col: 1, offset: 70543},
+			pos:  position{line: 2377, col: 1, offset: 71661},
 			expr: &seqExpr{
-				pos: position{line: 2350, col: 14, offset: 70556},
+				pos: position{line: 2377, col: 14, offset: 71674},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2350, col: 14, offset: 70556},
+						pos:        position{line: 2377, col: 14, offset: 71674},
 						val:        "aggregate",
 						ignoreCase: true,
 						want:       "\"AGGREGATE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2350, col: 33, offset: 70575},
+						pos: position{line: 2377, col: 33, offset: 71693},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2350, col: 34, offset: 70576},
+							pos:  position{line: 2377, col: 34, offset: 71694},
 							name: "IdentifierRest",
 						},
 					},
@@ -16044,20 +16286,20 @@ var g = &grammar{
 		},
 		{
 			name: "ALL",
-			pos:  position{line: 2351, col: 1, offset: 70591},
+			pos:  position{line: 2378, col: 1, offset: 71709},
 			expr: &seqExpr{
-				pos: position{line: 2351, col: 14, offset: 70604},
+				pos: position{line: 2378, col: 14, offset: 71722},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2351, col: 14, offset: 70604},
+						pos:        position{line: 2378, col: 14, offset: 71722},
 						val:        "all",
 						ignoreCase: true,
 						want:       "\"ALL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2351, col: 33, offset: 70623},
+						pos: position{line: 2378, col: 33, offset: 71741},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2351, col: 34, offset: 70624},
+							pos:  position{line: 2378, col: 34, offset: 71742},
 							name: "IdentifierRest",
 						},
 					},
@@ -16068,23 +16310,23 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 2352, col: 1, offset: 70639},
+			pos:  position{line: 2379, col: 1, offset: 71757},
 			expr: &actionExpr{
-				pos: position{line: 2352, col: 14, offset: 70652},
+				pos: position{line: 2379, col: 14, offset: 71770},
 				run: (*parser).callonAND1,
 				expr: &seqExpr{
-					pos: position{line: 2352, col: 14, offset: 70652},
+					pos: position{line: 2379, col: 14, offset: 71770},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2352, col: 14, offset: 70652},
+							pos:        position{line: 2379, col: 14, offset: 71770},
 							val:        "and",
 							ignoreCase: true,
 							want:       "\"AND\"i",
 						},
 						&notExpr{
-							pos: position{line: 2352, col: 33, offset: 70671},
+							pos: position{line: 2379, col: 33, offset: 71789},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2352, col: 34, offset: 70672},
+								pos:  position{line: 2379, col: 34, offset: 71790},
 								name: "IdentifierRest",
 							},
 						},
@@ -16096,20 +16338,20 @@ var g = &grammar{
 		},
 		{
 			name: "ANTI",
-			pos:  position{line: 2353, col: 1, offset: 70709},
+			pos:  position{line: 2380, col: 1, offset: 71827},
 			expr: &seqExpr{
-				pos: position{line: 2353, col: 14, offset: 70722},
+				pos: position{line: 2380, col: 14, offset: 71840},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2353, col: 14, offset: 70722},
+						pos:        position{line: 2380, col: 14, offset: 71840},
 						val:        "anti",
 						ignoreCase: true,
 						want:       "\"ANTI\"i",
 					},
 					&notExpr{
-						pos: position{line: 2353, col: 33, offset: 70741},
+						pos: position{line: 2380, col: 33, offset: 71859},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2353, col: 34, offset: 70742},
+							pos:  position{line: 2380, col: 34, offset: 71860},
 							name: "IdentifierRest",
 						},
 					},
@@ -16120,20 +16362,20 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 2354, col: 1, offset: 70757},
+			pos:  position{line: 2381, col: 1, offset: 71875},
 			expr: &seqExpr{
-				pos: position{line: 2354, col: 14, offset: 70770},
+				pos: position{line: 2381, col: 14, offset: 71888},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2354, col: 14, offset: 70770},
+						pos:        position{line: 2381, col: 14, offset: 71888},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2354, col: 33, offset: 70789},
+						pos: position{line: 2381, col: 33, offset: 71907},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2354, col: 34, offset: 70790},
+							pos:  position{line: 2381, col: 34, offset: 71908},
 							name: "IdentifierRest",
 						},
 					},
@@ -16144,23 +16386,23 @@ var g = &grammar{
 		},
 		{
 			name: "ASC",
-			pos:  position{line: 2355, col: 1, offset: 70805},
+			pos:  position{line: 2382, col: 1, offset: 71923},
 			expr: &actionExpr{
-				pos: position{line: 2355, col: 14, offset: 70818},
+				pos: position{line: 2382, col: 14, offset: 71936},
 				run: (*parser).callonASC1,
 				expr: &seqExpr{
-					pos: position{line: 2355, col: 14, offset: 70818},
+					pos: position{line: 2382, col: 14, offset: 71936},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2355, col: 14, offset: 70818},
+							pos:        position{line: 2382, col: 14, offset: 71936},
 							val:        "asc",
 							ignoreCase: true,
 							want:       "\"ASC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2355, col: 33, offset: 70837},
+							pos: position{line: 2382, col: 33, offset: 71955},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2355, col: 34, offset: 70838},
+								pos:  position{line: 2382, col: 34, offset: 71956},
 								name: "IdentifierRest",
 							},
 						},
@@ -16172,20 +16414,20 @@ var g = &grammar{
 		},
 		{
 			name: "ASSERT",
-			pos:  position{line: 2356, col: 1, offset: 70875},
+			pos:  position{line: 2383, col: 1, offset: 71993},
 			expr: &seqExpr{
-				pos: position{line: 2356, col: 14, offset: 70888},
+				pos: position{line: 2383, col: 14, offset: 72006},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2356, col: 14, offset: 70888},
+						pos:        position{line: 2383, col: 14, offset: 72006},
 						val:        "assert",
 						ignoreCase: true,
 						want:       "\"ASSERT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2356, col: 33, offset: 70907},
+						pos: position{line: 2383, col: 33, offset: 72025},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2356, col: 34, offset: 70908},
+							pos:  position{line: 2383, col: 34, offset: 72026},
 							name: "IdentifierRest",
 						},
 					},
@@ -16196,20 +16438,20 @@ var g = &grammar{
 		},
 		{
 			name: "AT",
-			pos:  position{line: 2357, col: 1, offset: 70923},
+			pos:  position{line: 2384, col: 1, offset: 72041},
 			expr: &seqExpr{
-				pos: position{line: 2357, col: 14, offset: 70936},
+				pos: position{line: 2384, col: 14, offset: 72054},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2357, col: 14, offset: 70936},
+						pos:        position{line: 2384, col: 14, offset: 72054},
 						val:        "at",
 						ignoreCase: true,
 						want:       "\"AT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2357, col: 33, offset: 70955},
+						pos: position{line: 2384, col: 33, offset: 72073},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2357, col: 34, offset: 70956},
+							pos:  position{line: 2384, col: 34, offset: 72074},
 							name: "IdentifierRest",
 						},
 					},
@@ -16220,20 +16462,20 @@ var g = &grammar{
 		},
 		{
 			name: "BETWEEN",
-			pos:  position{line: 2358, col: 1, offset: 70971},
+			pos:  position{line: 2385, col: 1, offset: 72089},
 			expr: &seqExpr{
-				pos: position{line: 2358, col: 14, offset: 70984},
+				pos: position{line: 2385, col: 14, offset: 72102},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2358, col: 14, offset: 70984},
+						pos:        position{line: 2385, col: 14, offset: 72102},
 						val:        "between",
 						ignoreCase: true,
 						want:       "\"BETWEEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2358, col: 33, offset: 71003},
+						pos: position{line: 2385, col: 33, offset: 72121},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2358, col: 34, offset: 71004},
+							pos:  position{line: 2385, col: 34, offset: 72122},
 							name: "IdentifierRest",
 						},
 					},
@@ -16244,20 +16486,20 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 2359, col: 1, offset: 71019},
+			pos:  position{line: 2386, col: 1, offset: 72137},
 			expr: &seqExpr{
-				pos: position{line: 2359, col: 14, offset: 71032},
+				pos: position{line: 2386, col: 14, offset: 72150},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2359, col: 14, offset: 71032},
+						pos:        position{line: 2386, col: 14, offset: 72150},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2359, col: 33, offset: 71051},
+						pos: position{line: 2386, col: 33, offset: 72169},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2359, col: 34, offset: 71052},
+							pos:  position{line: 2386, col: 34, offset: 72170},
 							name: "IdentifierRest",
 						},
 					},
@@ -16268,20 +16510,20 @@ var g = &grammar{
 		},
 		{
 			name: "CALL",
-			pos:  position{line: 2360, col: 1, offset: 71067},
+			pos:  position{line: 2387, col: 1, offset: 72185},
 			expr: &seqExpr{
-				pos: position{line: 2360, col: 14, offset: 71080},
+				pos: position{line: 2387, col: 14, offset: 72198},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2360, col: 14, offset: 71080},
+						pos:        position{line: 2387, col: 14, offset: 72198},
 						val:        "call",
 						ignoreCase: true,
 						want:       "\"CALL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2360, col: 33, offset: 71099},
+						pos: position{line: 2387, col: 33, offset: 72217},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2360, col: 34, offset: 71100},
+							pos:  position{line: 2387, col: 34, offset: 72218},
 							name: "IdentifierRest",
 						},
 					},
@@ -16292,20 +16534,20 @@ var g = &grammar{
 		},
 		{
 			name: "CASE",
-			pos:  position{line: 2361, col: 1, offset: 71115},
+			pos:  position{line: 2388, col: 1, offset: 72233},
 			expr: &seqExpr{
-				pos: position{line: 2361, col: 14, offset: 71128},
+				pos: position{line: 2388, col: 14, offset: 72246},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2361, col: 14, offset: 71128},
+						pos:        position{line: 2388, col: 14, offset: 72246},
 						val:        "case",
 						ignoreCase: true,
 						want:       "\"CASE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2361, col: 33, offset: 71147},
+						pos: position{line: 2388, col: 33, offset: 72265},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2361, col: 34, offset: 71148},
+							pos:  position{line: 2388, col: 34, offset: 72266},
 							name: "IdentifierRest",
 						},
 					},
@@ -16316,20 +16558,20 @@ var g = &grammar{
 		},
 		{
 			name: "CAST",
-			pos:  position{line: 2362, col: 1, offset: 71163},
+			pos:  position{line: 2389, col: 1, offset: 72281},
 			expr: &seqExpr{
-				pos: position{line: 2362, col: 14, offset: 71176},
+				pos: position{line: 2389, col: 14, offset: 72294},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2362, col: 14, offset: 71176},
+						pos:        position{line: 2389, col: 14, offset: 72294},
 						val:        "cast",
 						ignoreCase: true,
 						want:       "\"CAST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2362, col: 33, offset: 71195},
+						pos: position{line: 2389, col: 33, offset: 72313},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2362, col: 34, offset: 71196},
+							pos:  position{line: 2389, col: 34, offset: 72314},
 							name: "IdentifierRest",
 						},
 					},
@@ -16340,20 +16582,20 @@ var g = &grammar{
 		},
 		{
 			name: "CONST",
-			pos:  position{line: 2363, col: 1, offset: 71211},
+			pos:  position{line: 2390, col: 1, offset: 72329},
 			expr: &seqExpr{
-				pos: position{line: 2363, col: 14, offset: 71224},
+				pos: position{line: 2390, col: 14, offset: 72342},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2363, col: 14, offset: 71224},
+						pos:        position{line: 2390, col: 14, offset: 72342},
 						val:        "const",
 						ignoreCase: true,
 						want:       "\"CONST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2363, col: 33, offset: 71243},
+						pos: position{line: 2390, col: 33, offset: 72361},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2363, col: 34, offset: 71244},
+							pos:  position{line: 2390, col: 34, offset: 72362},
 							name: "IdentifierRest",
 						},
 					},
@@ -16364,20 +16606,20 @@ var g = &grammar{
 		},
 		{
 			name: "COUNT",
-			pos:  position{line: 2364, col: 1, offset: 71259},
+			pos:  position{line: 2391, col: 1, offset: 72377},
 			expr: &seqExpr{
-				pos: position{line: 2364, col: 14, offset: 71272},
+				pos: position{line: 2391, col: 14, offset: 72390},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2364, col: 14, offset: 71272},
+						pos:        position{line: 2391, col: 14, offset: 72390},
 						val:        "count",
 						ignoreCase: true,
 						want:       "\"COUNT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2364, col: 33, offset: 71291},
+						pos: position{line: 2391, col: 33, offset: 72409},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2364, col: 34, offset: 71292},
+							pos:  position{line: 2391, col: 34, offset: 72410},
 							name: "IdentifierRest",
 						},
 					},
@@ -16388,20 +16630,20 @@ var g = &grammar{
 		},
 		{
 			name: "CROSS",
-			pos:  position{line: 2365, col: 1, offset: 71307},
+			pos:  position{line: 2392, col: 1, offset: 72425},
 			expr: &seqExpr{
-				pos: position{line: 2365, col: 14, offset: 71320},
+				pos: position{line: 2392, col: 14, offset: 72438},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2365, col: 14, offset: 71320},
+						pos:        position{line: 2392, col: 14, offset: 72438},
 						val:        "cross",
 						ignoreCase: true,
 						want:       "\"CROSS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2365, col: 33, offset: 71339},
+						pos: position{line: 2392, col: 33, offset: 72457},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2365, col: 34, offset: 71340},
+							pos:  position{line: 2392, col: 34, offset: 72458},
 							name: "IdentifierRest",
 						},
 					},
@@ -16412,20 +16654,20 @@ var g = &grammar{
 		},
 		{
 			name: "CUT",
-			pos:  position{line: 2366, col: 1, offset: 71355},
+			pos:  position{line: 2393, col: 1, offset: 72473},
 			expr: &seqExpr{
-				pos: position{line: 2366, col: 14, offset: 71368},
+				pos: position{line: 2393, col: 14, offset: 72486},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2366, col: 14, offset: 71368},
+						pos:        position{line: 2393, col: 14, offset: 72486},
 						val:        "cut",
 						ignoreCase: true,
 						want:       "\"CUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2366, col: 33, offset: 71387},
+						pos: position{line: 2393, col: 33, offset: 72505},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2366, col: 34, offset: 71388},
+							pos:  position{line: 2393, col: 34, offset: 72506},
 							name: "IdentifierRest",
 						},
 					},
@@ -16436,23 +16678,23 @@ var g = &grammar{
 		},
 		{
 			name: "DATE",
-			pos:  position{line: 2367, col: 1, offset: 71403},
+			pos:  position{line: 2394, col: 1, offset: 72521},
 			expr: &actionExpr{
-				pos: position{line: 2367, col: 14, offset: 71416},
+				pos: position{line: 2394, col: 14, offset: 72534},
 				run: (*parser).callonDATE1,
 				expr: &seqExpr{
-					pos: position{line: 2367, col: 14, offset: 71416},
+					pos: position{line: 2394, col: 14, offset: 72534},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2367, col: 14, offset: 71416},
+							pos:        position{line: 2394, col: 14, offset: 72534},
 							val:        "date",
 							ignoreCase: true,
 							want:       "\"DATE\"i",
 						},
 						&notExpr{
-							pos: position{line: 2367, col: 33, offset: 71435},
+							pos: position{line: 2394, col: 33, offset: 72553},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2367, col: 34, offset: 71436},
+								pos:  position{line: 2394, col: 34, offset: 72554},
 								name: "IdentifierRest",
 							},
 						},
@@ -16464,20 +16706,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEBUG",
-			pos:  position{line: 2368, col: 1, offset: 71474},
+			pos:  position{line: 2395, col: 1, offset: 72592},
 			expr: &seqExpr{
-				pos: position{line: 2368, col: 14, offset: 71487},
+				pos: position{line: 2395, col: 14, offset: 72605},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2368, col: 14, offset: 71487},
+						pos:        position{line: 2395, col: 14, offset: 72605},
 						val:        "debug",
 						ignoreCase: true,
 						want:       "\"DEBUG\"i",
 					},
 					&notExpr{
-						pos: position{line: 2368, col: 33, offset: 71506},
+						pos: position{line: 2395, col: 33, offset: 72624},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2368, col: 34, offset: 71507},
+							pos:  position{line: 2395, col: 34, offset: 72625},
 							name: "IdentifierRest",
 						},
 					},
@@ -16488,20 +16730,20 @@ var g = &grammar{
 		},
 		{
 			name: "DEFAULT",
-			pos:  position{line: 2369, col: 1, offset: 71522},
+			pos:  position{line: 2396, col: 1, offset: 72640},
 			expr: &seqExpr{
-				pos: position{line: 2369, col: 14, offset: 71535},
+				pos: position{line: 2396, col: 14, offset: 72653},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2369, col: 14, offset: 71535},
+						pos:        position{line: 2396, col: 14, offset: 72653},
 						val:        "default",
 						ignoreCase: true,
 						want:       "\"DEFAULT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2369, col: 33, offset: 71554},
+						pos: position{line: 2396, col: 33, offset: 72672},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2369, col: 34, offset: 71555},
+							pos:  position{line: 2396, col: 34, offset: 72673},
 							name: "IdentifierRest",
 						},
 					},
@@ -16512,23 +16754,23 @@ var g = &grammar{
 		},
 		{
 			name: "DESC",
-			pos:  position{line: 2370, col: 1, offset: 71570},
+			pos:  position{line: 2397, col: 1, offset: 72688},
 			expr: &actionExpr{
-				pos: position{line: 2370, col: 14, offset: 71583},
+				pos: position{line: 2397, col: 14, offset: 72701},
 				run: (*parser).callonDESC1,
 				expr: &seqExpr{
-					pos: position{line: 2370, col: 14, offset: 71583},
+					pos: position{line: 2397, col: 14, offset: 72701},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2370, col: 14, offset: 71583},
+							pos:        position{line: 2397, col: 14, offset: 72701},
 							val:        "desc",
 							ignoreCase: true,
 							want:       "\"DESC\"i",
 						},
 						&notExpr{
-							pos: position{line: 2370, col: 33, offset: 71602},
+							pos: position{line: 2397, col: 33, offset: 72720},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2370, col: 34, offset: 71603},
+								pos:  position{line: 2397, col: 34, offset: 72721},
 								name: "IdentifierRest",
 							},
 						},
@@ -16540,20 +16782,20 @@ var g = &grammar{
 		},
 		{
 			name: "DISTINCT",
-			pos:  position{line: 2371, col: 1, offset: 71641},
+			pos:  position{line: 2398, col: 1, offset: 72759},
 			expr: &seqExpr{
-				pos: position{line: 2371, col: 14, offset: 71654},
+				pos: position{line: 2398, col: 14, offset: 72772},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2371, col: 14, offset: 71654},
+						pos:        position{line: 2398, col: 14, offset: 72772},
 						val:        "distinct",
 						ignoreCase: true,
 						want:       "\"DISTINCT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2371, col: 33, offset: 71673},
+						pos: position{line: 2398, col: 33, offset: 72791},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2371, col: 34, offset: 71674},
+							pos:  position{line: 2398, col: 34, offset: 72792},
 							name: "IdentifierRest",
 						},
 					},
@@ -16564,20 +16806,20 @@ var g = &grammar{
 		},
 		{
 			name: "DROP",
-			pos:  position{line: 2372, col: 1, offset: 71689},
+			pos:  position{line: 2399, col: 1, offset: 72807},
 			expr: &seqExpr{
-				pos: position{line: 2372, col: 14, offset: 71702},
+				pos: position{line: 2399, col: 14, offset: 72820},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2372, col: 14, offset: 71702},
+						pos:        position{line: 2399, col: 14, offset: 72820},
 						val:        "drop",
 						ignoreCase: true,
 						want:       "\"DROP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2372, col: 33, offset: 71721},
+						pos: position{line: 2399, col: 33, offset: 72839},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2372, col: 34, offset: 71722},
+							pos:  position{line: 2399, col: 34, offset: 72840},
 							name: "IdentifierRest",
 						},
 					},
@@ -16588,20 +16830,20 @@ var g = &grammar{
 		},
 		{
 			name: "ELSE",
-			pos:  position{line: 2373, col: 1, offset: 71737},
+			pos:  position{line: 2400, col: 1, offset: 72855},
 			expr: &seqExpr{
-				pos: position{line: 2373, col: 14, offset: 71750},
+				pos: position{line: 2400, col: 14, offset: 72868},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2373, col: 14, offset: 71750},
+						pos:        position{line: 2400, col: 14, offset: 72868},
 						val:        "else",
 						ignoreCase: true,
 						want:       "\"ELSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2373, col: 33, offset: 71769},
+						pos: position{line: 2400, col: 33, offset: 72887},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2373, col: 34, offset: 71770},
+							pos:  position{line: 2400, col: 34, offset: 72888},
 							name: "IdentifierRest",
 						},
 					},
@@ -16612,20 +16854,20 @@ var g = &grammar{
 		},
 		{
 			name: "END",
-			pos:  position{line: 2374, col: 1, offset: 71785},
+			pos:  position{line: 2401, col: 1, offset: 72903},
 			expr: &seqExpr{
-				pos: position{line: 2374, col: 14, offset: 71798},
+				pos: position{line: 2401, col: 14, offset: 72916},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2374, col: 14, offset: 71798},
+						pos:        position{line: 2401, col: 14, offset: 72916},
 						val:        "end",
 						ignoreCase: true,
 						want:       "\"END\"i",
 					},
 					&notExpr{
-						pos: position{line: 2374, col: 33, offset: 71817},
+						pos: position{line: 2401, col: 33, offset: 72935},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2374, col: 34, offset: 71818},
+							pos:  position{line: 2401, col: 34, offset: 72936},
 							name: "IdentifierRest",
 						},
 					},
@@ -16636,20 +16878,20 @@ var g = &grammar{
 		},
 		{
 			name: "ENUM",
-			pos:  position{line: 2375, col: 1, offset: 71833},
+			pos:  position{line: 2402, col: 1, offset: 72951},
 			expr: &seqExpr{
-				pos: position{line: 2375, col: 14, offset: 71846},
+				pos: position{line: 2402, col: 14, offset: 72964},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2375, col: 14, offset: 71846},
+						pos:        position{line: 2402, col: 14, offset: 72964},
 						val:        "enum",
 						ignoreCase: true,
 						want:       "\"ENUM\"i",
 					},
 					&notExpr{
-						pos: position{line: 2375, col: 33, offset: 71865},
+						pos: position{line: 2402, col: 33, offset: 72983},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2375, col: 34, offset: 71866},
+							pos:  position{line: 2402, col: 34, offset: 72984},
 							name: "IdentifierRest",
 						},
 					},
@@ -16660,20 +16902,20 @@ var g = &grammar{
 		},
 		{
 			name: "ERROR",
-			pos:  position{line: 2376, col: 1, offset: 71881},
+			pos:  position{line: 2403, col: 1, offset: 72999},
 			expr: &seqExpr{
-				pos: position{line: 2376, col: 14, offset: 71894},
+				pos: position{line: 2403, col: 14, offset: 73012},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2376, col: 14, offset: 71894},
+						pos:        position{line: 2403, col: 14, offset: 73012},
 						val:        "error",
 						ignoreCase: true,
 						want:       "\"ERROR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2376, col: 33, offset: 71913},
+						pos: position{line: 2403, col: 33, offset: 73031},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2376, col: 34, offset: 71914},
+							pos:  position{line: 2403, col: 34, offset: 73032},
 							name: "IdentifierRest",
 						},
 					},
@@ -16684,20 +16926,20 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL",
-			pos:  position{line: 2377, col: 1, offset: 71929},
+			pos:  position{line: 2404, col: 1, offset: 73047},
 			expr: &seqExpr{
-				pos: position{line: 2377, col: 14, offset: 71942},
+				pos: position{line: 2404, col: 14, offset: 73060},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2377, col: 14, offset: 71942},
+						pos:        position{line: 2404, col: 14, offset: 73060},
 						val:        "eval",
 						ignoreCase: true,
 						want:       "\"EVAL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2377, col: 33, offset: 71961},
+						pos: position{line: 2404, col: 33, offset: 73079},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2377, col: 34, offset: 71962},
+							pos:  position{line: 2404, col: 34, offset: 73080},
 							name: "IdentifierRest",
 						},
 					},
@@ -16708,20 +16950,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXISTS",
-			pos:  position{line: 2378, col: 1, offset: 71977},
+			pos:  position{line: 2405, col: 1, offset: 73095},
 			expr: &seqExpr{
-				pos: position{line: 2378, col: 14, offset: 71990},
+				pos: position{line: 2405, col: 14, offset: 73108},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2378, col: 14, offset: 71990},
+						pos:        position{line: 2405, col: 14, offset: 73108},
 						val:        "exists",
 						ignoreCase: true,
 						want:       "\"EXISTS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2378, col: 33, offset: 72009},
+						pos: position{line: 2405, col: 33, offset: 73127},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2378, col: 34, offset: 72010},
+							pos:  position{line: 2405, col: 34, offset: 73128},
 							name: "IdentifierRest",
 						},
 					},
@@ -16732,20 +16974,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXPLODE",
-			pos:  position{line: 2379, col: 1, offset: 72025},
+			pos:  position{line: 2406, col: 1, offset: 73143},
 			expr: &seqExpr{
-				pos: position{line: 2379, col: 14, offset: 72038},
+				pos: position{line: 2406, col: 14, offset: 73156},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2379, col: 14, offset: 72038},
+						pos:        position{line: 2406, col: 14, offset: 73156},
 						val:        "explode",
 						ignoreCase: true,
 						want:       "\"EXPLODE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2379, col: 33, offset: 72057},
+						pos: position{line: 2406, col: 33, offset: 73175},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2379, col: 34, offset: 72058},
+							pos:  position{line: 2406, col: 34, offset: 73176},
 							name: "IdentifierRest",
 						},
 					},
@@ -16756,20 +16998,20 @@ var g = &grammar{
 		},
 		{
 			name: "EXTRACT",
-			pos:  position{line: 2380, col: 1, offset: 72073},
+			pos:  position{line: 2407, col: 1, offset: 73191},
 			expr: &seqExpr{
-				pos: position{line: 2380, col: 14, offset: 72086},
+				pos: position{line: 2407, col: 14, offset: 73204},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2380, col: 14, offset: 72086},
+						pos:        position{line: 2407, col: 14, offset: 73204},
 						val:        "extract",
 						ignoreCase: true,
 						want:       "\"EXTRACT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2380, col: 33, offset: 72105},
+						pos: position{line: 2407, col: 33, offset: 73223},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2380, col: 34, offset: 72106},
+							pos:  position{line: 2407, col: 34, offset: 73224},
 							name: "IdentifierRest",
 						},
 					},
@@ -16780,20 +17022,20 @@ var g = &grammar{
 		},
 		{
 			name: "FALSE",
-			pos:  position{line: 2381, col: 1, offset: 72121},
+			pos:  position{line: 2408, col: 1, offset: 73239},
 			expr: &seqExpr{
-				pos: position{line: 2381, col: 14, offset: 72134},
+				pos: position{line: 2408, col: 14, offset: 73252},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2381, col: 14, offset: 72134},
+						pos:        position{line: 2408, col: 14, offset: 73252},
 						val:        "false",
 						ignoreCase: true,
 						want:       "\"FALSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2381, col: 33, offset: 72153},
+						pos: position{line: 2408, col: 33, offset: 73271},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2381, col: 34, offset: 72154},
+							pos:  position{line: 2408, col: 34, offset: 73272},
 							name: "IdentifierRest",
 						},
 					},
@@ -16804,20 +17046,20 @@ var g = &grammar{
 		},
 		{
 			name: "FIRST",
-			pos:  position{line: 2382, col: 1, offset: 72169},
+			pos:  position{line: 2409, col: 1, offset: 73287},
 			expr: &seqExpr{
-				pos: position{line: 2382, col: 14, offset: 72182},
+				pos: position{line: 2409, col: 14, offset: 73300},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2382, col: 14, offset: 72182},
+						pos:        position{line: 2409, col: 14, offset: 73300},
 						val:        "first",
 						ignoreCase: true,
 						want:       "\"FIRST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2382, col: 33, offset: 72201},
+						pos: position{line: 2409, col: 33, offset: 73319},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2382, col: 34, offset: 72202},
+							pos:  position{line: 2409, col: 34, offset: 73320},
 							name: "IdentifierRest",
 						},
 					},
@@ -16828,20 +17070,20 @@ var g = &grammar{
 		},
 		{
 			name: "FN",
-			pos:  position{line: 2383, col: 1, offset: 72217},
+			pos:  position{line: 2410, col: 1, offset: 73335},
 			expr: &seqExpr{
-				pos: position{line: 2383, col: 14, offset: 72230},
+				pos: position{line: 2410, col: 14, offset: 73348},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2383, col: 14, offset: 72230},
+						pos:        position{line: 2410, col: 14, offset: 73348},
 						val:        "fn",
 						ignoreCase: true,
 						want:       "\"FN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2383, col: 33, offset: 72249},
+						pos: position{line: 2410, col: 33, offset: 73367},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2383, col: 34, offset: 72250},
+							pos:  position{line: 2410, col: 34, offset: 73368},
 							name: "IdentifierRest",
 						},
 					},
@@ -16852,20 +17094,20 @@ var g = &grammar{
 		},
 		{
 			name: "FOR",
-			pos:  position{line: 2384, col: 1, offset: 72265},
+			pos:  position{line: 2411, col: 1, offset: 73383},
 			expr: &seqExpr{
-				pos: position{line: 2384, col: 14, offset: 72278},
+				pos: position{line: 2411, col: 14, offset: 73396},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2384, col: 14, offset: 72278},
+						pos:        position{line: 2411, col: 14, offset: 73396},
 						val:        "for",
 						ignoreCase: true,
 						want:       "\"FOR\"i",
 					},
 					&notExpr{
-						pos: position{line: 2384, col: 33, offset: 72297},
+						pos: position{line: 2411, col: 33, offset: 73415},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2384, col: 34, offset: 72298},
+							pos:  position{line: 2411, col: 34, offset: 73416},
 							name: "IdentifierRest",
 						},
 					},
@@ -16876,20 +17118,20 @@ var g = &grammar{
 		},
 		{
 			name: "FORK",
-			pos:  position{line: 2385, col: 1, offset: 72313},
+			pos:  position{line: 2412, col: 1, offset: 73431},
 			expr: &seqExpr{
-				pos: position{line: 2385, col: 14, offset: 72326},
+				pos: position{line: 2412, col: 14, offset: 73444},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2385, col: 14, offset: 72326},
+						pos:        position{line: 2412, col: 14, offset: 73444},
 						val:        "fork",
 						ignoreCase: true,
 						want:       "\"FORK\"i",
 					},
 					&notExpr{
-						pos: position{line: 2385, col: 33, offset: 72345},
+						pos: position{line: 2412, col: 33, offset: 73463},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2385, col: 34, offset: 72346},
+							pos:  position{line: 2412, col: 34, offset: 73464},
 							name: "IdentifierRest",
 						},
 					},
@@ -16900,20 +17142,20 @@ var g = &grammar{
 		},
 		{
 			name: "FROM",
-			pos:  position{line: 2386, col: 1, offset: 72361},
+			pos:  position{line: 2413, col: 1, offset: 73479},
 			expr: &seqExpr{
-				pos: position{line: 2386, col: 14, offset: 72374},
+				pos: position{line: 2413, col: 14, offset: 73492},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2386, col: 14, offset: 72374},
+						pos:        position{line: 2413, col: 14, offset: 73492},
 						val:        "from",
 						ignoreCase: true,
 						want:       "\"FROM\"i",
 					},
 					&notExpr{
-						pos: position{line: 2386, col: 33, offset: 72393},
+						pos: position{line: 2413, col: 33, offset: 73511},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2386, col: 34, offset: 72394},
+							pos:  position{line: 2413, col: 34, offset: 73512},
 							name: "IdentifierRest",
 						},
 					},
@@ -16924,20 +17166,20 @@ var g = &grammar{
 		},
 		{
 			name: "FULL",
-			pos:  position{line: 2387, col: 1, offset: 72409},
+			pos:  position{line: 2414, col: 1, offset: 73527},
 			expr: &seqExpr{
-				pos: position{line: 2387, col: 14, offset: 72422},
+				pos: position{line: 2414, col: 14, offset: 73540},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2387, col: 14, offset: 72422},
+						pos:        position{line: 2414, col: 14, offset: 73540},
 						val:        "full",
 						ignoreCase: true,
 						want:       "\"FULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2387, col: 33, offset: 72441},
+						pos: position{line: 2414, col: 33, offset: 73559},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2387, col: 34, offset: 72442},
+							pos:  position{line: 2414, col: 34, offset: 73560},
 							name: "IdentifierRest",
 						},
 					},
@@ -16948,20 +17190,20 @@ var g = &grammar{
 		},
 		{
 			name: "FUSE",
-			pos:  position{line: 2388, col: 1, offset: 72457},
+			pos:  position{line: 2415, col: 1, offset: 73575},
 			expr: &seqExpr{
-				pos: position{line: 2388, col: 14, offset: 72470},
+				pos: position{line: 2415, col: 14, offset: 73588},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2388, col: 14, offset: 72470},
+						pos:        position{line: 2415, col: 14, offset: 73588},
 						val:        "fuse",
 						ignoreCase: true,
 						want:       "\"FUSE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2388, col: 33, offset: 72489},
+						pos: position{line: 2415, col: 33, offset: 73607},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2388, col: 34, offset: 72490},
+							pos:  position{line: 2415, col: 34, offset: 73608},
 							name: "IdentifierRest",
 						},
 					},
@@ -16972,20 +17214,20 @@ var g = &grammar{
 		},
 		{
 			name: "GROUP",
-			pos:  position{line: 2389, col: 1, offset: 72505},
+			pos:  position{line: 2416, col: 1, offset: 73623},
 			expr: &seqExpr{
-				pos: position{line: 2389, col: 14, offset: 72518},
+				pos: position{line: 2416, col: 14, offset: 73636},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2389, col: 14, offset: 72518},
+						pos:        position{line: 2416, col: 14, offset: 73636},
 						val:        "group",
 						ignoreCase: true,
 						want:       "\"GROUP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2389, col: 33, offset: 72537},
+						pos: position{line: 2416, col: 33, offset: 73655},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2389, col: 34, offset: 72538},
+							pos:  position{line: 2416, col: 34, offset: 73656},
 							name: "IdentifierRest",
 						},
 					},
@@ -16996,20 +17238,20 @@ var g = &grammar{
 		},
 		{
 			name: "HAVING",
-			pos:  position{line: 2390, col: 1, offset: 72553},
+			pos:  position{line: 2417, col: 1, offset: 73671},
 			expr: &seqExpr{
-				pos: position{line: 2390, col: 14, offset: 72566},
+				pos: position{line: 2417, col: 14, offset: 73684},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2390, col: 14, offset: 72566},
+						pos:        position{line: 2417, col: 14, offset: 73684},
 						val:        "having",
 						ignoreCase: true,
 						want:       "\"HAVING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2390, col: 33, offset: 72585},
+						pos: position{line: 2417, col: 33, offset: 73703},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2390, col: 34, offset: 72586},
+							pos:  position{line: 2417, col: 34, offset: 73704},
 							name: "IdentifierRest",
 						},
 					},
@@ -17020,20 +17262,20 @@ var g = &grammar{
 		},
 		{
 			name: "HEAD",
-			pos:  position{line: 2391, col: 1, offset: 72601},
+			pos:  position{line: 2418, col: 1, offset: 73719},
 			expr: &seqExpr{
-				pos: position{line: 2391, col: 14, offset: 72614},
+				pos: position{line: 2418, col: 14, offset: 73732},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2391, col: 14, offset: 72614},
+						pos:        position{line: 2418, col: 14, offset: 73732},
 						val:        "head",
 						ignoreCase: true,
 						want:       "\"HEAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2391, col: 33, offset: 72633},
+						pos: position{line: 2418, col: 33, offset: 73751},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2391, col: 34, offset: 72634},
+							pos:  position{line: 2418, col: 34, offset: 73752},
 							name: "IdentifierRest",
 						},
 					},
@@ -17044,20 +17286,20 @@ var g = &grammar{
 		},
 		{
 			name: "IN",
-			pos:  position{line: 2392, col: 1, offset: 72649},
+			pos:  position{line: 2419, col: 1, offset: 73767},
 			expr: &seqExpr{
-				pos: position{line: 2392, col: 14, offset: 72662},
+				pos: position{line: 2419, col: 14, offset: 73780},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2392, col: 14, offset: 72662},
+						pos:        position{line: 2419, col: 14, offset: 73780},
 						val:        "in",
 						ignoreCase: true,
 						want:       "\"IN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2392, col: 33, offset: 72681},
+						pos: position{line: 2419, col: 33, offset: 73799},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2392, col: 34, offset: 72682},
+							pos:  position{line: 2419, col: 34, offset: 73800},
 							name: "IdentifierRest",
 						},
 					},
@@ -17068,20 +17310,20 @@ var g = &grammar{
 		},
 		{
 			name: "INNER",
-			pos:  position{line: 2393, col: 1, offset: 72697},
+			pos:  position{line: 2420, col: 1, offset: 73815},
 			expr: &seqExpr{
-				pos: position{line: 2393, col: 14, offset: 72710},
+				pos: position{line: 2420, col: 14, offset: 73828},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2393, col: 14, offset: 72710},
+						pos:        position{line: 2420, col: 14, offset: 73828},
 						val:        "inner",
 						ignoreCase: true,
 						want:       "\"INNER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2393, col: 33, offset: 72729},
+						pos: position{line: 2420, col: 33, offset: 73847},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2393, col: 34, offset: 72730},
+							pos:  position{line: 2420, col: 34, offset: 73848},
 							name: "IdentifierRest",
 						},
 					},
@@ -17092,20 +17334,20 @@ var g = &grammar{
 		},
 		{
 			name: "IS",
-			pos:  position{line: 2394, col: 1, offset: 72745},
+			pos:  position{line: 2421, col: 1, offset: 73863},
 			expr: &seqExpr{
-				pos: position{line: 2394, col: 14, offset: 72758},
+				pos: position{line: 2421, col: 14, offset: 73876},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2394, col: 14, offset: 72758},
+						pos:        position{line: 2421, col: 14, offset: 73876},
 						val:        "is",
 						ignoreCase: true,
 						want:       "\"IS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2394, col: 33, offset: 72777},
+						pos: position{line: 2421, col: 33, offset: 73895},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2394, col: 34, offset: 72778},
+							pos:  position{line: 2421, col: 34, offset: 73896},
 							name: "IdentifierRest",
 						},
 					},
@@ -17116,20 +17358,20 @@ var g = &grammar{
 		},
 		{
 			name: "JOIN",
-			pos:  position{line: 2395, col: 1, offset: 72793},
+			pos:  position{line: 2422, col: 1, offset: 73911},
 			expr: &seqExpr{
-				pos: position{line: 2395, col: 14, offset: 72806},
+				pos: position{line: 2422, col: 14, offset: 73924},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2395, col: 14, offset: 72806},
+						pos:        position{line: 2422, col: 14, offset: 73924},
 						val:        "join",
 						ignoreCase: true,
 						want:       "\"JOIN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2395, col: 33, offset: 72825},
+						pos: position{line: 2422, col: 33, offset: 73943},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2395, col: 34, offset: 72826},
+							pos:  position{line: 2422, col: 34, offset: 73944},
 							name: "IdentifierRest",
 						},
 					},
@@ -17140,20 +17382,20 @@ var g = &grammar{
 		},
 		{
 			name: "LAMBDA",
-			pos:  position{line: 2396, col: 1, offset: 72841},
+			pos:  position{line: 2423, col: 1, offset: 73959},
 			expr: &seqExpr{
-				pos: position{line: 2396, col: 14, offset: 72854},
+				pos: position{line: 2423, col: 14, offset: 73972},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2396, col: 14, offset: 72854},
+						pos:        position{line: 2423, col: 14, offset: 73972},
 						val:        "lambda",
 						ignoreCase: true,
 						want:       "\"LAMBDA\"i",
 					},
 					&notExpr{
-						pos: position{line: 2396, col: 33, offset: 72873},
+						pos: position{line: 2423, col: 33, offset: 73991},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2396, col: 34, offset: 72874},
+							pos:  position{line: 2423, col: 34, offset: 73992},
 							name: "IdentifierRest",
 						},
 					},
@@ -17164,20 +17406,20 @@ var g = &grammar{
 		},
 		{
 			name: "LAST",
-			pos:  position{line: 2397, col: 1, offset: 72889},
+			pos:  position{line: 2424, col: 1, offset: 74007},
 			expr: &seqExpr{
-				pos: position{line: 2397, col: 14, offset: 72902},
+				pos: position{line: 2424, col: 14, offset: 74020},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2397, col: 14, offset: 72902},
+						pos:        position{line: 2424, col: 14, offset: 74020},
 						val:        "last",
 						ignoreCase: true,
 						want:       "\"LAST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2397, col: 33, offset: 72921},
+						pos: position{line: 2424, col: 33, offset: 74039},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2397, col: 34, offset: 72922},
+							pos:  position{line: 2424, col: 34, offset: 74040},
 							name: "IdentifierRest",
 						},
 					},
@@ -17188,20 +17430,20 @@ var g = &grammar{
 		},
 		{
 			name: "LEFT",
-			pos:  position{line: 2398, col: 1, offset: 72937},
+			pos:  position{line: 2425, col: 1, offset: 74055},
 			expr: &seqExpr{
-				pos: position{line: 2398, col: 14, offset: 72950},
+				pos: position{line: 2425, col: 14, offset: 74068},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2398, col: 14, offset: 72950},
+						pos:        position{line: 2425, col: 14, offset: 74068},
 						val:        "left",
 						ignoreCase: true,
 						want:       "\"LEFT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2398, col: 33, offset: 72969},
+						pos: position{line: 2425, col: 33, offset: 74087},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2398, col: 34, offset: 72970},
+							pos:  position{line: 2425, col: 34, offset: 74088},
 							name: "IdentifierRest",
 						},
 					},
@@ -17212,20 +17454,20 @@ var g = &grammar{
 		},
 		{
 			name: "LET",
-			pos:  position{line: 2399, col: 1, offset: 72985},
+			pos:  position{line: 2426, col: 1, offset: 74103},
 			expr: &seqExpr{
-				pos: position{line: 2399, col: 14, offset: 72998},
+				pos: position{line: 2426, col: 14, offset: 74116},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2399, col: 14, offset: 72998},
+						pos:        position{line: 2426, col: 14, offset: 74116},
 						val:        "let",
 						ignoreCase: true,
 						want:       "\"LET\"i",
 					},
 					&notExpr{
-						pos: position{line: 2399, col: 33, offset: 73017},
+						pos: position{line: 2426, col: 33, offset: 74135},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2399, col: 34, offset: 73018},
+							pos:  position{line: 2426, col: 34, offset: 74136},
 							name: "IdentifierRest",
 						},
 					},
@@ -17236,20 +17478,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIKE",
-			pos:  position{line: 2400, col: 1, offset: 73033},
+			pos:  position{line: 2427, col: 1, offset: 74151},
 			expr: &seqExpr{
-				pos: position{line: 2400, col: 14, offset: 73046},
+				pos: position{line: 2427, col: 14, offset: 74164},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2400, col: 14, offset: 73046},
+						pos:        position{line: 2427, col: 14, offset: 74164},
 						val:        "like",
 						ignoreCase: true,
 						want:       "\"LIKE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2400, col: 33, offset: 73065},
+						pos: position{line: 2427, col: 33, offset: 74183},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2400, col: 34, offset: 73066},
+							pos:  position{line: 2427, col: 34, offset: 74184},
 							name: "IdentifierRest",
 						},
 					},
@@ -17260,20 +17502,20 @@ var g = &grammar{
 		},
 		{
 			name: "LIMIT",
-			pos:  position{line: 2401, col: 1, offset: 73081},
+			pos:  position{line: 2428, col: 1, offset: 74199},
 			expr: &seqExpr{
-				pos: position{line: 2401, col: 14, offset: 73094},
+				pos: position{line: 2428, col: 14, offset: 74212},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2401, col: 14, offset: 73094},
+						pos:        position{line: 2428, col: 14, offset: 74212},
 						val:        "limit",
 						ignoreCase: true,
 						want:       "\"LIMIT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2401, col: 33, offset: 73113},
+						pos: position{line: 2428, col: 33, offset: 74231},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2401, col: 34, offset: 73114},
+							pos:  position{line: 2428, col: 34, offset: 74232},
 							name: "IdentifierRest",
 						},
 					},
@@ -17284,20 +17526,20 @@ var g = &grammar{
 		},
 		{
 			name: "LOAD",
-			pos:  position{line: 2402, col: 1, offset: 73129},
+			pos:  position{line: 2429, col: 1, offset: 74247},
 			expr: &seqExpr{
-				pos: position{line: 2402, col: 14, offset: 73142},
+				pos: position{line: 2429, col: 14, offset: 74260},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2402, col: 14, offset: 73142},
+						pos:        position{line: 2429, col: 14, offset: 74260},
 						val:        "load",
 						ignoreCase: true,
 						want:       "\"LOAD\"i",
 					},
 					&notExpr{
-						pos: position{line: 2402, col: 33, offset: 73161},
+						pos: position{line: 2429, col: 33, offset: 74279},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2402, col: 34, offset: 73162},
+							pos:  position{line: 2429, col: 34, offset: 74280},
 							name: "IdentifierRest",
 						},
 					},
@@ -17308,20 +17550,20 @@ var g = &grammar{
 		},
 		{
 			name: "MATERIALIZED",
-			pos:  position{line: 2403, col: 1, offset: 73177},
+			pos:  position{line: 2430, col: 1, offset: 74295},
 			expr: &seqExpr{
-				pos: position{line: 2403, col: 16, offset: 73192},
+				pos: position{line: 2430, col: 16, offset: 74310},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2403, col: 16, offset: 73192},
+						pos:        position{line: 2430, col: 16, offset: 74310},
 						val:        "materialized",
 						ignoreCase: true,
 						want:       "\"MATERIALIZED\"i",
 					},
 					&notExpr{
-						pos: position{line: 2403, col: 33, offset: 73209},
+						pos: position{line: 2430, col: 33, offset: 74327},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2403, col: 34, offset: 73210},
+							pos:  position{line: 2430, col: 34, offset: 74328},
 							name: "IdentifierRest",
 						},
 					},
@@ -17332,20 +17574,20 @@ var g = &grammar{
 		},
 		{
 			name: "MAP",
-			pos:  position{line: 2404, col: 1, offset: 73225},
+			pos:  position{line: 2431, col: 1, offset: 74343},
 			expr: &seqExpr{
-				pos: position{line: 2404, col: 14, offset: 73238},
+				pos: position{line: 2431, col: 14, offset: 74356},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2404, col: 14, offset: 73238},
+						pos:        position{line: 2431, col: 14, offset: 74356},
 						val:        "map",
 						ignoreCase: true,
 						want:       "\"MAP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2404, col: 33, offset: 73257},
+						pos: position{line: 2431, col: 33, offset: 74375},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2404, col: 34, offset: 73258},
+							pos:  position{line: 2431, col: 34, offset: 74376},
 							name: "IdentifierRest",
 						},
 					},
@@ -17356,20 +17598,20 @@ var g = &grammar{
 		},
 		{
 			name: "MERGE",
-			pos:  position{line: 2405, col: 1, offset: 73273},
+			pos:  position{line: 2432, col: 1, offset: 74391},
 			expr: &seqExpr{
-				pos: position{line: 2405, col: 14, offset: 73286},
+				pos: position{line: 2432, col: 14, offset: 74404},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2405, col: 14, offset: 73286},
+						pos:        position{line: 2432, col: 14, offset: 74404},
 						val:        "merge",
 						ignoreCase: true,
 						want:       "\"MERGE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2405, col: 33, offset: 73305},
+						pos: position{line: 2432, col: 33, offset: 74423},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2405, col: 34, offset: 73306},
+							pos:  position{line: 2432, col: 34, offset: 74424},
 							name: "IdentifierRest",
 						},
 					},
@@ -17380,20 +17622,20 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 2406, col: 1, offset: 73321},
+			pos:  position{line: 2433, col: 1, offset: 74439},
 			expr: &seqExpr{
-				pos: position{line: 2406, col: 14, offset: 73334},
+				pos: position{line: 2433, col: 14, offset: 74452},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2406, col: 14, offset: 73334},
+						pos:        position{line: 2433, col: 14, offset: 74452},
 						val:        "not",
 						ignoreCase: true,
 						want:       "\"NOT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2406, col: 33, offset: 73353},
+						pos: position{line: 2433, col: 33, offset: 74471},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2406, col: 34, offset: 73354},
+							pos:  position{line: 2433, col: 34, offset: 74472},
 							name: "IdentifierRest",
 						},
 					},
@@ -17404,20 +17646,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULL",
-			pos:  position{line: 2407, col: 1, offset: 73369},
+			pos:  position{line: 2434, col: 1, offset: 74487},
 			expr: &seqExpr{
-				pos: position{line: 2407, col: 14, offset: 73382},
+				pos: position{line: 2434, col: 14, offset: 74500},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2407, col: 14, offset: 73382},
+						pos:        position{line: 2434, col: 14, offset: 74500},
 						val:        "null",
 						ignoreCase: true,
 						want:       "\"NULL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2407, col: 33, offset: 73401},
+						pos: position{line: 2434, col: 33, offset: 74519},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2407, col: 34, offset: 73402},
+							pos:  position{line: 2434, col: 34, offset: 74520},
 							name: "IdentifierRest",
 						},
 					},
@@ -17428,20 +17670,20 @@ var g = &grammar{
 		},
 		{
 			name: "NULLS",
-			pos:  position{line: 2408, col: 1, offset: 73417},
+			pos:  position{line: 2435, col: 1, offset: 74535},
 			expr: &seqExpr{
-				pos: position{line: 2408, col: 14, offset: 73430},
+				pos: position{line: 2435, col: 14, offset: 74548},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2408, col: 14, offset: 73430},
+						pos:        position{line: 2435, col: 14, offset: 74548},
 						val:        "nulls",
 						ignoreCase: true,
 						want:       "\"NULLS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2408, col: 33, offset: 73449},
+						pos: position{line: 2435, col: 33, offset: 74567},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2408, col: 34, offset: 73450},
+							pos:  position{line: 2435, col: 34, offset: 74568},
 							name: "IdentifierRest",
 						},
 					},
@@ -17452,20 +17694,20 @@ var g = &grammar{
 		},
 		{
 			name: "OFFSET",
-			pos:  position{line: 2409, col: 1, offset: 73465},
+			pos:  position{line: 2436, col: 1, offset: 74583},
 			expr: &seqExpr{
-				pos: position{line: 2409, col: 14, offset: 73478},
+				pos: position{line: 2436, col: 14, offset: 74596},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2409, col: 14, offset: 73478},
+						pos:        position{line: 2436, col: 14, offset: 74596},
 						val:        "offset",
 						ignoreCase: true,
 						want:       "\"OFFSET\"i",
 					},
 					&notExpr{
-						pos: position{line: 2409, col: 33, offset: 73497},
+						pos: position{line: 2436, col: 33, offset: 74615},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2409, col: 34, offset: 73498},
+							pos:  position{line: 2436, col: 34, offset: 74616},
 							name: "IdentifierRest",
 						},
 					},
@@ -17476,20 +17718,20 @@ var g = &grammar{
 		},
 		{
 			name: "ON",
-			pos:  position{line: 2410, col: 1, offset: 73513},
+			pos:  position{line: 2437, col: 1, offset: 74631},
 			expr: &seqExpr{
-				pos: position{line: 2410, col: 14, offset: 73526},
+				pos: position{line: 2437, col: 14, offset: 74644},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2410, col: 14, offset: 73526},
+						pos:        position{line: 2437, col: 14, offset: 74644},
 						val:        "on",
 						ignoreCase: true,
 						want:       "\"ON\"i",
 					},
 					&notExpr{
-						pos: position{line: 2410, col: 33, offset: 73545},
+						pos: position{line: 2437, col: 33, offset: 74663},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2410, col: 34, offset: 73546},
+							pos:  position{line: 2437, col: 34, offset: 74664},
 							name: "IdentifierRest",
 						},
 					},
@@ -17500,20 +17742,20 @@ var g = &grammar{
 		},
 		{
 			name: "OP",
-			pos:  position{line: 2411, col: 1, offset: 73561},
+			pos:  position{line: 2438, col: 1, offset: 74679},
 			expr: &seqExpr{
-				pos: position{line: 2411, col: 14, offset: 73574},
+				pos: position{line: 2438, col: 14, offset: 74692},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2411, col: 14, offset: 73574},
+						pos:        position{line: 2438, col: 14, offset: 74692},
 						val:        "op",
 						ignoreCase: true,
 						want:       "\"OP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2411, col: 33, offset: 73593},
+						pos: position{line: 2438, col: 33, offset: 74711},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2411, col: 34, offset: 73594},
+							pos:  position{line: 2438, col: 34, offset: 74712},
 							name: "IdentifierRest",
 						},
 					},
@@ -17524,23 +17766,23 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 2412, col: 1, offset: 73609},
+			pos:  position{line: 2439, col: 1, offset: 74727},
 			expr: &actionExpr{
-				pos: position{line: 2412, col: 14, offset: 73622},
+				pos: position{line: 2439, col: 14, offset: 74740},
 				run: (*parser).callonOR1,
 				expr: &seqExpr{
-					pos: position{line: 2412, col: 14, offset: 73622},
+					pos: position{line: 2439, col: 14, offset: 74740},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2412, col: 14, offset: 73622},
+							pos:        position{line: 2439, col: 14, offset: 74740},
 							val:        "or",
 							ignoreCase: true,
 							want:       "\"OR\"i",
 						},
 						&notExpr{
-							pos: position{line: 2412, col: 33, offset: 73641},
+							pos: position{line: 2439, col: 33, offset: 74759},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2412, col: 34, offset: 73642},
+								pos:  position{line: 2439, col: 34, offset: 74760},
 								name: "IdentifierRest",
 							},
 						},
@@ -17552,20 +17794,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDER",
-			pos:  position{line: 2413, col: 1, offset: 73678},
+			pos:  position{line: 2440, col: 1, offset: 74796},
 			expr: &seqExpr{
-				pos: position{line: 2413, col: 14, offset: 73691},
+				pos: position{line: 2440, col: 14, offset: 74809},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2413, col: 14, offset: 73691},
+						pos:        position{line: 2440, col: 14, offset: 74809},
 						val:        "order",
 						ignoreCase: true,
 						want:       "\"ORDER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2413, col: 33, offset: 73710},
+						pos: position{line: 2440, col: 33, offset: 74828},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2413, col: 34, offset: 73711},
+							pos:  position{line: 2440, col: 34, offset: 74829},
 							name: "IdentifierRest",
 						},
 					},
@@ -17576,20 +17818,20 @@ var g = &grammar{
 		},
 		{
 			name: "ORDINALITY",
-			pos:  position{line: 2414, col: 1, offset: 73726},
+			pos:  position{line: 2441, col: 1, offset: 74844},
 			expr: &seqExpr{
-				pos: position{line: 2414, col: 14, offset: 73739},
+				pos: position{line: 2441, col: 14, offset: 74857},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2414, col: 14, offset: 73739},
+						pos:        position{line: 2441, col: 14, offset: 74857},
 						val:        "ordinality",
 						ignoreCase: true,
 						want:       "\"ORDINALITY\"i",
 					},
 					&notExpr{
-						pos: position{line: 2414, col: 33, offset: 73758},
+						pos: position{line: 2441, col: 33, offset: 74876},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2414, col: 34, offset: 73759},
+							pos:  position{line: 2441, col: 34, offset: 74877},
 							name: "IdentifierRest",
 						},
 					},
@@ -17600,20 +17842,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTER",
-			pos:  position{line: 2415, col: 1, offset: 73774},
+			pos:  position{line: 2442, col: 1, offset: 74892},
 			expr: &seqExpr{
-				pos: position{line: 2415, col: 14, offset: 73787},
+				pos: position{line: 2442, col: 14, offset: 74905},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2415, col: 14, offset: 73787},
+						pos:        position{line: 2442, col: 14, offset: 74905},
 						val:        "outer",
 						ignoreCase: true,
 						want:       "\"OUTER\"i",
 					},
 					&notExpr{
-						pos: position{line: 2415, col: 33, offset: 73806},
+						pos: position{line: 2442, col: 33, offset: 74924},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2415, col: 34, offset: 73807},
+							pos:  position{line: 2442, col: 34, offset: 74925},
 							name: "IdentifierRest",
 						},
 					},
@@ -17624,20 +17866,20 @@ var g = &grammar{
 		},
 		{
 			name: "OUTPUT",
-			pos:  position{line: 2416, col: 1, offset: 73822},
+			pos:  position{line: 2443, col: 1, offset: 74940},
 			expr: &seqExpr{
-				pos: position{line: 2416, col: 14, offset: 73835},
+				pos: position{line: 2443, col: 14, offset: 74953},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2416, col: 14, offset: 73835},
+						pos:        position{line: 2443, col: 14, offset: 74953},
 						val:        "output",
 						ignoreCase: true,
 						want:       "\"OUTPUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2416, col: 33, offset: 73854},
+						pos: position{line: 2443, col: 33, offset: 74972},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2416, col: 34, offset: 73855},
+							pos:  position{line: 2443, col: 34, offset: 74973},
 							name: "IdentifierRest",
 						},
 					},
@@ -17648,20 +17890,20 @@ var g = &grammar{
 		},
 		{
 			name: "PASS",
-			pos:  position{line: 2417, col: 1, offset: 73870},
+			pos:  position{line: 2444, col: 1, offset: 74988},
 			expr: &seqExpr{
-				pos: position{line: 2417, col: 14, offset: 73883},
+				pos: position{line: 2444, col: 14, offset: 75001},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2417, col: 14, offset: 73883},
+						pos:        position{line: 2444, col: 14, offset: 75001},
 						val:        "pass",
 						ignoreCase: true,
 						want:       "\"PASS\"i",
 					},
 					&notExpr{
-						pos: position{line: 2417, col: 33, offset: 73902},
+						pos: position{line: 2444, col: 33, offset: 75020},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2417, col: 34, offset: 73903},
+							pos:  position{line: 2444, col: 34, offset: 75021},
 							name: "IdentifierRest",
 						},
 					},
@@ -17672,20 +17914,20 @@ var g = &grammar{
 		},
 		{
 			name: "PUT",
-			pos:  position{line: 2418, col: 1, offset: 73918},
+			pos:  position{line: 2445, col: 1, offset: 75036},
 			expr: &seqExpr{
-				pos: position{line: 2418, col: 14, offset: 73931},
+				pos: position{line: 2445, col: 14, offset: 75049},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2418, col: 14, offset: 73931},
+						pos:        position{line: 2445, col: 14, offset: 75049},
 						val:        "put",
 						ignoreCase: true,
 						want:       "\"PUT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2418, col: 33, offset: 73950},
+						pos: position{line: 2445, col: 33, offset: 75068},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2418, col: 34, offset: 73951},
+							pos:  position{line: 2445, col: 34, offset: 75069},
 							name: "IdentifierRest",
 						},
 					},
@@ -17696,20 +17938,20 @@ var g = &grammar{
 		},
 		{
 			name: "RECURSIVE",
-			pos:  position{line: 2419, col: 1, offset: 73966},
+			pos:  position{line: 2446, col: 1, offset: 75084},
 			expr: &seqExpr{
-				pos: position{line: 2419, col: 14, offset: 73979},
+				pos: position{line: 2446, col: 14, offset: 75097},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2419, col: 14, offset: 73979},
+						pos:        position{line: 2446, col: 14, offset: 75097},
 						val:        "recursive",
 						ignoreCase: true,
 						want:       "\"RECURSIVE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2419, col: 33, offset: 73998},
+						pos: position{line: 2446, col: 33, offset: 75116},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2419, col: 34, offset: 73999},
+							pos:  position{line: 2446, col: 34, offset: 75117},
 							name: "IdentifierRest",
 						},
 					},
@@ -17720,20 +17962,20 @@ var g = &grammar{
 		},
 		{
 			name: "RENAME",
-			pos:  position{line: 2420, col: 1, offset: 74014},
+			pos:  position{line: 2447, col: 1, offset: 75132},
 			expr: &seqExpr{
-				pos: position{line: 2420, col: 14, offset: 74027},
+				pos: position{line: 2447, col: 14, offset: 75145},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2420, col: 14, offset: 74027},
+						pos:        position{line: 2447, col: 14, offset: 75145},
 						val:        "rename",
 						ignoreCase: true,
 						want:       "\"RENAME\"i",
 					},
 					&notExpr{
-						pos: position{line: 2420, col: 33, offset: 74046},
+						pos: position{line: 2447, col: 33, offset: 75164},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2420, col: 34, offset: 74047},
+							pos:  position{line: 2447, col: 34, offset: 75165},
 							name: "IdentifierRest",
 						},
 					},
@@ -17744,20 +17986,20 @@ var g = &grammar{
 		},
 		{
 			name: "RIGHT",
-			pos:  position{line: 2421, col: 1, offset: 74062},
+			pos:  position{line: 2448, col: 1, offset: 75180},
 			expr: &seqExpr{
-				pos: position{line: 2421, col: 14, offset: 74075},
+				pos: position{line: 2448, col: 14, offset: 75193},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2421, col: 14, offset: 74075},
+						pos:        position{line: 2448, col: 14, offset: 75193},
 						val:        "right",
 						ignoreCase: true,
 						want:       "\"RIGHT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2421, col: 33, offset: 74094},
+						pos: position{line: 2448, col: 33, offset: 75212},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2421, col: 34, offset: 74095},
+							pos:  position{line: 2448, col: 34, offset: 75213},
 							name: "IdentifierRest",
 						},
 					},
@@ -17768,20 +18010,20 @@ var g = &grammar{
 		},
 		{
 			name: "SHAPES",
-			pos:  position{line: 2422, col: 1, offset: 74110},
+			pos:  position{line: 2449, col: 1, offset: 75228},
 			expr: &seqExpr{
-				pos: position{line: 2422, col: 14, offset: 74123},
+				pos: position{line: 2449, col: 14, offset: 75241},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2422, col: 14, offset: 74123},
+						pos:        position{line: 2449, col: 14, offset: 75241},
 						val:        "shapes",
 						ignoreCase: true,
 						want:       "\"SHAPES\"i",
 					},
 					&notExpr{
-						pos: position{line: 2422, col: 33, offset: 74142},
+						pos: position{line: 2449, col: 33, offset: 75260},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2422, col: 34, offset: 74143},
+							pos:  position{line: 2449, col: 34, offset: 75261},
 							name: "IdentifierRest",
 						},
 					},
@@ -17792,20 +18034,20 @@ var g = &grammar{
 		},
 		{
 			name: "SEARCH",
-			pos:  position{line: 2423, col: 1, offset: 74158},
+			pos:  position{line: 2450, col: 1, offset: 75276},
 			expr: &seqExpr{
-				pos: position{line: 2423, col: 14, offset: 74171},
+				pos: position{line: 2450, col: 14, offset: 75289},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2423, col: 14, offset: 74171},
+						pos:        position{line: 2450, col: 14, offset: 75289},
 						val:        "search",
 						ignoreCase: true,
 						want:       "\"SEARCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2423, col: 33, offset: 74190},
+						pos: position{line: 2450, col: 33, offset: 75308},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2423, col: 34, offset: 74191},
+							pos:  position{line: 2450, col: 34, offset: 75309},
 							name: "IdentifierRest",
 						},
 					},
@@ -17816,20 +18058,20 @@ var g = &grammar{
 		},
 		{
 			name: "SELECT",
-			pos:  position{line: 2424, col: 1, offset: 74206},
+			pos:  position{line: 2451, col: 1, offset: 75324},
 			expr: &seqExpr{
-				pos: position{line: 2424, col: 14, offset: 74219},
+				pos: position{line: 2451, col: 14, offset: 75337},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2424, col: 14, offset: 74219},
+						pos:        position{line: 2451, col: 14, offset: 75337},
 						val:        "select",
 						ignoreCase: true,
 						want:       "\"SELECT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2424, col: 33, offset: 74238},
+						pos: position{line: 2451, col: 33, offset: 75356},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2424, col: 34, offset: 74239},
+							pos:  position{line: 2451, col: 34, offset: 75357},
 							name: "IdentifierRest",
 						},
 					},
@@ -17840,20 +18082,20 @@ var g = &grammar{
 		},
 		{
 			name: "SHAPE",
-			pos:  position{line: 2425, col: 1, offset: 74254},
+			pos:  position{line: 2452, col: 1, offset: 75372},
 			expr: &seqExpr{
-				pos: position{line: 2425, col: 14, offset: 74267},
+				pos: position{line: 2452, col: 14, offset: 75385},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2425, col: 14, offset: 74267},
+						pos:        position{line: 2452, col: 14, offset: 75385},
 						val:        "shape",
 						ignoreCase: true,
 						want:       "\"SHAPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2425, col: 33, offset: 74286},
+						pos: position{line: 2452, col: 33, offset: 75404},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2425, col: 34, offset: 74287},
+							pos:  position{line: 2452, col: 34, offset: 75405},
 							name: "IdentifierRest",
 						},
 					},
@@ -17864,20 +18106,20 @@ var g = &grammar{
 		},
 		{
 			name: "SKIP",
-			pos:  position{line: 2426, col: 1, offset: 74302},
+			pos:  position{line: 2453, col: 1, offset: 75420},
 			expr: &seqExpr{
-				pos: position{line: 2426, col: 14, offset: 74315},
+				pos: position{line: 2453, col: 14, offset: 75433},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2426, col: 14, offset: 74315},
+						pos:        position{line: 2453, col: 14, offset: 75433},
 						val:        "skip",
 						ignoreCase: true,
 						want:       "\"SKIP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2426, col: 33, offset: 74334},
+						pos: position{line: 2453, col: 33, offset: 75452},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2426, col: 34, offset: 74335},
+							pos:  position{line: 2453, col: 34, offset: 75453},
 							name: "IdentifierRest",
 						},
 					},
@@ -17888,20 +18130,20 @@ var g = &grammar{
 		},
 		{
 			name: "SORT",
-			pos:  position{line: 2427, col: 1, offset: 74350},
+			pos:  position{line: 2454, col: 1, offset: 75468},
 			expr: &seqExpr{
-				pos: position{line: 2427, col: 14, offset: 74363},
+				pos: position{line: 2454, col: 14, offset: 75481},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2427, col: 14, offset: 74363},
+						pos:        position{line: 2454, col: 14, offset: 75481},
 						val:        "sort",
 						ignoreCase: true,
 						want:       "\"SORT\"i",
 					},
 					&notExpr{
-						pos: position{line: 2427, col: 33, offset: 74382},
+						pos: position{line: 2454, col: 33, offset: 75500},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2427, col: 34, offset: 74383},
+							pos:  position{line: 2454, col: 34, offset: 75501},
 							name: "IdentifierRest",
 						},
 					},
@@ -17912,20 +18154,20 @@ var g = &grammar{
 		},
 		{
 			name: "SUBSTRING",
-			pos:  position{line: 2428, col: 1, offset: 74398},
+			pos:  position{line: 2455, col: 1, offset: 75516},
 			expr: &seqExpr{
-				pos: position{line: 2428, col: 14, offset: 74411},
+				pos: position{line: 2455, col: 14, offset: 75529},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2428, col: 14, offset: 74411},
+						pos:        position{line: 2455, col: 14, offset: 75529},
 						val:        "substring",
 						ignoreCase: true,
 						want:       "\"SUBSTRING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2428, col: 33, offset: 74430},
+						pos: position{line: 2455, col: 33, offset: 75548},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2428, col: 34, offset: 74431},
+							pos:  position{line: 2455, col: 34, offset: 75549},
 							name: "IdentifierRest",
 						},
 					},
@@ -17936,20 +18178,20 @@ var g = &grammar{
 		},
 		{
 			name: "SUMMARIZE",
-			pos:  position{line: 2429, col: 1, offset: 74446},
+			pos:  position{line: 2456, col: 1, offset: 75564},
 			expr: &seqExpr{
-				pos: position{line: 2429, col: 14, offset: 74459},
+				pos: position{line: 2456, col: 14, offset: 75577},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2429, col: 14, offset: 74459},
+						pos:        position{line: 2456, col: 14, offset: 75577},
 						val:        "summarize",
 						ignoreCase: true,
 						want:       "\"SUMMARIZE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2429, col: 33, offset: 74478},
+						pos: position{line: 2456, col: 33, offset: 75596},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2429, col: 34, offset: 74479},
+							pos:  position{line: 2456, col: 34, offset: 75597},
 							name: "IdentifierRest",
 						},
 					},
@@ -17960,20 +18202,20 @@ var g = &grammar{
 		},
 		{
 			name: "SWITCH",
-			pos:  position{line: 2430, col: 1, offset: 74494},
+			pos:  position{line: 2457, col: 1, offset: 75612},
 			expr: &seqExpr{
-				pos: position{line: 2430, col: 14, offset: 74507},
+				pos: position{line: 2457, col: 14, offset: 75625},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2430, col: 14, offset: 74507},
+						pos:        position{line: 2457, col: 14, offset: 75625},
 						val:        "switch",
 						ignoreCase: true,
 						want:       "\"SWITCH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2430, col: 33, offset: 74526},
+						pos: position{line: 2457, col: 33, offset: 75644},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2430, col: 34, offset: 74527},
+							pos:  position{line: 2457, col: 34, offset: 75645},
 							name: "IdentifierRest",
 						},
 					},
@@ -17984,20 +18226,20 @@ var g = &grammar{
 		},
 		{
 			name: "TAIL",
-			pos:  position{line: 2431, col: 1, offset: 74542},
+			pos:  position{line: 2458, col: 1, offset: 75660},
 			expr: &seqExpr{
-				pos: position{line: 2431, col: 14, offset: 74555},
+				pos: position{line: 2458, col: 14, offset: 75673},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2431, col: 14, offset: 74555},
+						pos:        position{line: 2458, col: 14, offset: 75673},
 						val:        "tail",
 						ignoreCase: true,
 						want:       "\"TAIL\"i",
 					},
 					&notExpr{
-						pos: position{line: 2431, col: 33, offset: 74574},
+						pos: position{line: 2458, col: 33, offset: 75692},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2431, col: 34, offset: 74575},
+							pos:  position{line: 2458, col: 34, offset: 75693},
 							name: "IdentifierRest",
 						},
 					},
@@ -18008,20 +18250,20 @@ var g = &grammar{
 		},
 		{
 			name: "THEN",
-			pos:  position{line: 2432, col: 1, offset: 74590},
+			pos:  position{line: 2459, col: 1, offset: 75708},
 			expr: &seqExpr{
-				pos: position{line: 2432, col: 14, offset: 74603},
+				pos: position{line: 2459, col: 14, offset: 75721},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2432, col: 14, offset: 74603},
+						pos:        position{line: 2459, col: 14, offset: 75721},
 						val:        "then",
 						ignoreCase: true,
 						want:       "\"THEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2432, col: 33, offset: 74622},
+						pos: position{line: 2459, col: 33, offset: 75740},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2432, col: 34, offset: 74623},
+							pos:  position{line: 2459, col: 34, offset: 75741},
 							name: "IdentifierRest",
 						},
 					},
@@ -18032,23 +18274,23 @@ var g = &grammar{
 		},
 		{
 			name: "TIMESTAMP",
-			pos:  position{line: 2433, col: 1, offset: 74638},
+			pos:  position{line: 2460, col: 1, offset: 75756},
 			expr: &actionExpr{
-				pos: position{line: 2433, col: 14, offset: 74651},
+				pos: position{line: 2460, col: 14, offset: 75769},
 				run: (*parser).callonTIMESTAMP1,
 				expr: &seqExpr{
-					pos: position{line: 2433, col: 14, offset: 74651},
+					pos: position{line: 2460, col: 14, offset: 75769},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2433, col: 14, offset: 74651},
+							pos:        position{line: 2460, col: 14, offset: 75769},
 							val:        "timestamp",
 							ignoreCase: true,
 							want:       "\"TIMESTAMP\"i",
 						},
 						&notExpr{
-							pos: position{line: 2433, col: 33, offset: 74670},
+							pos: position{line: 2460, col: 33, offset: 75788},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2433, col: 34, offset: 74671},
+								pos:  position{line: 2460, col: 34, offset: 75789},
 								name: "IdentifierRest",
 							},
 						},
@@ -18060,20 +18302,20 @@ var g = &grammar{
 		},
 		{
 			name: "TOP",
-			pos:  position{line: 2434, col: 1, offset: 74714},
+			pos:  position{line: 2461, col: 1, offset: 75832},
 			expr: &seqExpr{
-				pos: position{line: 2434, col: 14, offset: 74727},
+				pos: position{line: 2461, col: 14, offset: 75845},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2434, col: 14, offset: 74727},
+						pos:        position{line: 2461, col: 14, offset: 75845},
 						val:        "top",
 						ignoreCase: true,
 						want:       "\"TOP\"i",
 					},
 					&notExpr{
-						pos: position{line: 2434, col: 33, offset: 74746},
+						pos: position{line: 2461, col: 33, offset: 75864},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2434, col: 34, offset: 74747},
+							pos:  position{line: 2461, col: 34, offset: 75865},
 							name: "IdentifierRest",
 						},
 					},
@@ -18084,20 +18326,20 @@ var g = &grammar{
 		},
 		{
 			name: "TRUE",
-			pos:  position{line: 2435, col: 1, offset: 74762},
+			pos:  position{line: 2462, col: 1, offset: 75880},
 			expr: &seqExpr{
-				pos: position{line: 2435, col: 14, offset: 74775},
+				pos: position{line: 2462, col: 14, offset: 75893},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2435, col: 14, offset: 74775},
+						pos:        position{line: 2462, col: 14, offset: 75893},
 						val:        "true",
 						ignoreCase: true,
 						want:       "\"TRUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2435, col: 33, offset: 74794},
+						pos: position{line: 2462, col: 33, offset: 75912},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2435, col: 34, offset: 74795},
+							pos:  position{line: 2462, col: 34, offset: 75913},
 							name: "IdentifierRest",
 						},
 					},
@@ -18108,20 +18350,20 @@ var g = &grammar{
 		},
 		{
 			name: "TYPE",
-			pos:  position{line: 2436, col: 1, offset: 74810},
+			pos:  position{line: 2463, col: 1, offset: 75928},
 			expr: &seqExpr{
-				pos: position{line: 2436, col: 14, offset: 74823},
+				pos: position{line: 2463, col: 14, offset: 75941},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2436, col: 14, offset: 74823},
+						pos:        position{line: 2463, col: 14, offset: 75941},
 						val:        "type",
 						ignoreCase: true,
 						want:       "\"TYPE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2436, col: 33, offset: 74842},
+						pos: position{line: 2463, col: 33, offset: 75960},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2436, col: 34, offset: 74843},
+							pos:  position{line: 2463, col: 34, offset: 75961},
 							name: "IdentifierRest",
 						},
 					},
@@ -18132,20 +18374,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNION",
-			pos:  position{line: 2437, col: 1, offset: 74858},
+			pos:  position{line: 2464, col: 1, offset: 75976},
 			expr: &seqExpr{
-				pos: position{line: 2437, col: 14, offset: 74871},
+				pos: position{line: 2464, col: 14, offset: 75989},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2437, col: 14, offset: 74871},
+						pos:        position{line: 2464, col: 14, offset: 75989},
 						val:        "union",
 						ignoreCase: true,
 						want:       "\"UNION\"i",
 					},
 					&notExpr{
-						pos: position{line: 2437, col: 33, offset: 74890},
+						pos: position{line: 2464, col: 33, offset: 76008},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2437, col: 34, offset: 74891},
+							pos:  position{line: 2464, col: 34, offset: 76009},
 							name: "IdentifierRest",
 						},
 					},
@@ -18156,20 +18398,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNIQ",
-			pos:  position{line: 2438, col: 1, offset: 74906},
+			pos:  position{line: 2465, col: 1, offset: 76024},
 			expr: &seqExpr{
-				pos: position{line: 2438, col: 14, offset: 74919},
+				pos: position{line: 2465, col: 14, offset: 76037},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2438, col: 14, offset: 74919},
+						pos:        position{line: 2465, col: 14, offset: 76037},
 						val:        "uniq",
 						ignoreCase: true,
 						want:       "\"UNIQ\"i",
 					},
 					&notExpr{
-						pos: position{line: 2438, col: 33, offset: 74938},
+						pos: position{line: 2465, col: 33, offset: 76056},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2438, col: 34, offset: 74939},
+							pos:  position{line: 2465, col: 34, offset: 76057},
 							name: "IdentifierRest",
 						},
 					},
@@ -18180,20 +18422,20 @@ var g = &grammar{
 		},
 		{
 			name: "UNNEST",
-			pos:  position{line: 2439, col: 1, offset: 74954},
+			pos:  position{line: 2466, col: 1, offset: 76072},
 			expr: &seqExpr{
-				pos: position{line: 2439, col: 14, offset: 74967},
+				pos: position{line: 2466, col: 14, offset: 76085},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2439, col: 14, offset: 74967},
+						pos:        position{line: 2466, col: 14, offset: 76085},
 						val:        "unnest",
 						ignoreCase: true,
 						want:       "\"UNNEST\"i",
 					},
 					&notExpr{
-						pos: position{line: 2439, col: 33, offset: 74986},
+						pos: position{line: 2466, col: 33, offset: 76104},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2439, col: 34, offset: 74987},
+							pos:  position{line: 2466, col: 34, offset: 76105},
 							name: "IdentifierRest",
 						},
 					},
@@ -18204,20 +18446,20 @@ var g = &grammar{
 		},
 		{
 			name: "USING",
-			pos:  position{line: 2440, col: 1, offset: 75002},
+			pos:  position{line: 2467, col: 1, offset: 76120},
 			expr: &seqExpr{
-				pos: position{line: 2440, col: 14, offset: 75015},
+				pos: position{line: 2467, col: 14, offset: 76133},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2440, col: 14, offset: 75015},
+						pos:        position{line: 2467, col: 14, offset: 76133},
 						val:        "using",
 						ignoreCase: true,
 						want:       "\"USING\"i",
 					},
 					&notExpr{
-						pos: position{line: 2440, col: 33, offset: 75034},
+						pos: position{line: 2467, col: 33, offset: 76152},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2440, col: 34, offset: 75035},
+							pos:  position{line: 2467, col: 34, offset: 76153},
 							name: "IdentifierRest",
 						},
 					},
@@ -18228,20 +18470,20 @@ var g = &grammar{
 		},
 		{
 			name: "VALUE",
-			pos:  position{line: 2441, col: 1, offset: 75050},
+			pos:  position{line: 2468, col: 1, offset: 76168},
 			expr: &seqExpr{
-				pos: position{line: 2441, col: 14, offset: 75063},
+				pos: position{line: 2468, col: 14, offset: 76181},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2441, col: 14, offset: 75063},
+						pos:        position{line: 2468, col: 14, offset: 76181},
 						val:        "value",
 						ignoreCase: true,
 						want:       "\"VALUE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2441, col: 33, offset: 75082},
+						pos: position{line: 2468, col: 33, offset: 76200},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2441, col: 34, offset: 75083},
+							pos:  position{line: 2468, col: 34, offset: 76201},
 							name: "IdentifierRest",
 						},
 					},
@@ -18252,20 +18494,20 @@ var g = &grammar{
 		},
 		{
 			name: "VALUES",
-			pos:  position{line: 2442, col: 1, offset: 75098},
+			pos:  position{line: 2469, col: 1, offset: 76216},
 			expr: &seqExpr{
-				pos: position{line: 2442, col: 14, offset: 75111},
+				pos: position{line: 2469, col: 14, offset: 76229},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2442, col: 14, offset: 75111},
+						pos:        position{line: 2469, col: 14, offset: 76229},
 						val:        "values",
 						ignoreCase: true,
 						want:       "\"VALUES\"i",
 					},
 					&notExpr{
-						pos: position{line: 2442, col: 33, offset: 75130},
+						pos: position{line: 2469, col: 33, offset: 76248},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2442, col: 34, offset: 75131},
+							pos:  position{line: 2469, col: 34, offset: 76249},
 							name: "IdentifierRest",
 						},
 					},
@@ -18276,20 +18518,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHEN",
-			pos:  position{line: 2443, col: 1, offset: 75146},
+			pos:  position{line: 2470, col: 1, offset: 76264},
 			expr: &seqExpr{
-				pos: position{line: 2443, col: 14, offset: 75159},
+				pos: position{line: 2470, col: 14, offset: 76277},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2443, col: 14, offset: 75159},
+						pos:        position{line: 2470, col: 14, offset: 76277},
 						val:        "when",
 						ignoreCase: true,
 						want:       "\"WHEN\"i",
 					},
 					&notExpr{
-						pos: position{line: 2443, col: 33, offset: 75178},
+						pos: position{line: 2470, col: 33, offset: 76296},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2443, col: 34, offset: 75179},
+							pos:  position{line: 2470, col: 34, offset: 76297},
 							name: "IdentifierRest",
 						},
 					},
@@ -18300,20 +18542,20 @@ var g = &grammar{
 		},
 		{
 			name: "WHERE",
-			pos:  position{line: 2444, col: 1, offset: 75194},
+			pos:  position{line: 2471, col: 1, offset: 76312},
 			expr: &seqExpr{
-				pos: position{line: 2444, col: 14, offset: 75207},
+				pos: position{line: 2471, col: 14, offset: 76325},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2444, col: 14, offset: 75207},
+						pos:        position{line: 2471, col: 14, offset: 76325},
 						val:        "where",
 						ignoreCase: true,
 						want:       "\"WHERE\"i",
 					},
 					&notExpr{
-						pos: position{line: 2444, col: 33, offset: 75226},
+						pos: position{line: 2471, col: 33, offset: 76344},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2444, col: 34, offset: 75227},
+							pos:  position{line: 2471, col: 34, offset: 76345},
 							name: "IdentifierRest",
 						},
 					},
@@ -18324,20 +18566,20 @@ var g = &grammar{
 		},
 		{
 			name: "WITH",
-			pos:  position{line: 2445, col: 1, offset: 75242},
+			pos:  position{line: 2472, col: 1, offset: 76360},
 			expr: &seqExpr{
-				pos: position{line: 2445, col: 14, offset: 75255},
+				pos: position{line: 2472, col: 14, offset: 76373},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2445, col: 14, offset: 75255},
+						pos:        position{line: 2472, col: 14, offset: 76373},
 						val:        "with",
 						ignoreCase: true,
 						want:       "\"WITH\"i",
 					},
 					&notExpr{
-						pos: position{line: 2445, col: 33, offset: 75274},
+						pos: position{line: 2472, col: 33, offset: 76392},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2445, col: 34, offset: 75275},
+							pos:  position{line: 2472, col: 34, offset: 76393},
 							name: "IdentifierRest",
 						},
 					},
@@ -21615,7 +21857,22 @@ func (p *parser) callonFStringExprElem1() (any, error) {
 	return p.cur.onFStringExprElem1(stack["e"])
 }
 
-func (c *current) onPrimitiveType1() (any, error) {
+func (c *current) onPrimitiveType2(name any) (any, error) {
+	return &ast.TypePrimitive{
+		Kind: "TypePrimitive",
+		Name: name.(string),
+		Loc:  loc(c),
+	}, nil
+
+}
+
+func (p *parser) callonPrimitiveType2() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onPrimitiveType2(stack["name"])
+}
+
+func (c *current) onPrimitiveType5() (any, error) {
 	return &ast.TypePrimitive{
 		Kind: "TypePrimitive",
 		Name: string(c.text),
@@ -21624,10 +21881,180 @@ func (c *current) onPrimitiveType1() (any, error) {
 
 }
 
-func (p *parser) callonPrimitiveType1() (any, error) {
+func (p *parser) callonPrimitiveType5() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onPrimitiveType1()
+	return p.cur.onPrimitiveType5()
+}
+
+func (c *current) onPostgreSQLPrimitiveType2() (any, error) {
+	return "int64", nil
+}
+
+func (p *parser) callonPostgreSQLPrimitiveType2() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onPostgreSQLPrimitiveType2()
+}
+
+func (c *current) onPostgreSQLPrimitiveType4() (any, error) {
+	return "bool", nil
+}
+
+func (p *parser) callonPostgreSQLPrimitiveType4() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onPostgreSQLPrimitiveType4()
+}
+
+func (c *current) onPostgreSQLPrimitiveType6() (any, error) {
+	return "bytes", nil
+}
+
+func (p *parser) callonPostgreSQLPrimitiveType6() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onPostgreSQLPrimitiveType6()
+}
+
+func (c *current) onPostgreSQLPrimitiveType8() (any, error) {
+	return "string", nil
+}
+
+func (p *parser) callonPostgreSQLPrimitiveType8() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onPostgreSQLPrimitiveType8()
+}
+
+func (c *current) onPostgreSQLPrimitiveType13() (any, error) {
+	return "string", nil
+}
+
+func (p *parser) callonPostgreSQLPrimitiveType13() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onPostgreSQLPrimitiveType13()
+}
+
+func (c *current) onPostgreSQLPrimitiveType15() (any, error) {
+	return "string", nil
+}
+
+func (p *parser) callonPostgreSQLPrimitiveType15() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onPostgreSQLPrimitiveType15()
+}
+
+func (c *current) onPostgreSQLPrimitiveType17() (any, error) {
+	return "net", nil
+}
+
+func (p *parser) callonPostgreSQLPrimitiveType17() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onPostgreSQLPrimitiveType17()
+}
+
+func (c *current) onPostgreSQLPrimitiveType19() (any, error) {
+	return "float64", nil
+}
+
+func (p *parser) callonPostgreSQLPrimitiveType19() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onPostgreSQLPrimitiveType19()
+}
+
+func (c *current) onPostgreSQLPrimitiveType21() (any, error) {
+	return "float64", nil
+}
+
+func (p *parser) callonPostgreSQLPrimitiveType21() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onPostgreSQLPrimitiveType21()
+}
+
+func (c *current) onPostgreSQLPrimitiveType26() (any, error) {
+	return "ip", nil
+}
+
+func (p *parser) callonPostgreSQLPrimitiveType26() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onPostgreSQLPrimitiveType26()
+}
+
+func (c *current) onPostgreSQLPrimitiveType28() (any, error) {
+	return "int32", nil
+}
+
+func (p *parser) callonPostgreSQLPrimitiveType28() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onPostgreSQLPrimitiveType28()
+}
+
+func (c *current) onPostgreSQLPrimitiveType33() (any, error) {
+	return "int32", nil
+}
+
+func (p *parser) callonPostgreSQLPrimitiveType33() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onPostgreSQLPrimitiveType33()
+}
+
+func (c *current) onPostgreSQLPrimitiveType35() (any, error) {
+	return "duration", nil
+}
+
+func (p *parser) callonPostgreSQLPrimitiveType35() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onPostgreSQLPrimitiveType35()
+}
+
+func (c *current) onPostgreSQLPrimitiveType37() (any, error) {
+	return "float32", nil
+}
+
+func (p *parser) callonPostgreSQLPrimitiveType37() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onPostgreSQLPrimitiveType37()
+}
+
+func (c *current) onPostgreSQLPrimitiveType39() (any, error) {
+	return "int16", nil
+}
+
+func (p *parser) callonPostgreSQLPrimitiveType39() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onPostgreSQLPrimitiveType39()
+}
+
+func (c *current) onPostgreSQLPrimitiveType41() (any, error) {
+	return "string", nil
+}
+
+func (p *parser) callonPostgreSQLPrimitiveType41() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onPostgreSQLPrimitiveType41()
+}
+
+func (c *current) onPostgreSQLPrimitiveType43() (any, error) {
+	return "string", nil
+}
+
+func (p *parser) callonPostgreSQLPrimitiveType43() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onPostgreSQLPrimitiveType43()
 }
 
 func (c *current) onTypeFieldList2(first, rest any) (any, error) {

--- a/compiler/parser/parser.peg
+++ b/compiler/parser/parser.peg
@@ -1510,7 +1510,14 @@ FStringExprElem
     }
 
 PrimitiveType
-  = (   "uint8" / "uint16" / "uint32" / "uint64"
+  = name:PostgreSQLPrimitiveType {
+        return &ast.TypePrimitive{
+          Kind: "TypePrimitive",
+          Name: name.(string),
+          Loc: loc(c),
+        }, nil
+      }
+  / (   "uint8" / "uint16" / "uint32" / "uint64"
       / "int8" / "int16" / "int32" / "int64"
       / "float16" / "float32" / "float64"
       / "bool" / "string"
@@ -1524,6 +1531,26 @@ PrimitiveType
                 Loc: loc(c),
             }, nil
         }
+
+// https://www.postgresql.org/docs/current/datatype.html#DATATYPE-TABLE
+PostgreSQLPrimitiveType
+  = "bigint"i            { return "int64", nil }
+  / "boolean"i           { return "bool", nil }
+  / "bytea"i             { return "bytes", nil }
+  / "char"i !"a"i        { return "string", nil }
+  / "character varying"i { return "string", nil }
+  / "character"i         { return "string", nil }
+  / "cidr"i              { return "net", nil }
+  / "double precision"i  { return "float64", nil }
+  / "float"i ![136]      { return "float64", nil }
+  / "inet"i              { return "ip", nil }
+  / "int"i ![1368e]i     { return "int32", nil }
+  / "integer"i           { return "int32", nil }
+  / "interval"i          { return "duration", nil }
+  / "real"i              { return "float32", nil }
+  / "smallint"i          { return "int16", nil }
+  / "text"i              { return "string", nil }
+  / "varchar"i           { return "string", nil }
 
 TypeFieldList
   = first:TypeField rest:TypeFieldListTail* {

--- a/compiler/ztests/sql/postgresql-types.yaml
+++ b/compiler/ztests/sql/postgresql-types.yaml
@@ -1,0 +1,38 @@
+spq: |
+  values
+    <bigint>,
+    <boolean>,
+    <bytea>,
+    <char>,
+    <character varying>,
+    <character>,
+    <cidr>,
+    <double precision>,
+    <float>,
+    <inet>,
+    <int>,
+    <integer>,
+    <interval>,
+    <real>,
+    <smallint>,
+    <text>,
+    <varchar>
+
+output: |
+  <int64>
+  <bool>
+  <bytes>
+  <string>
+  <string>
+  <string>
+  <net>
+  <float64>
+  <float64>
+  <ip>
+  <int32>
+  <int32>
+  <duration>
+  <float32>
+  <int16>
+  <string>
+  <string>


### PR DESCRIPTION
In the parser, recognize types listed at
https://www.postgresql.org/docs/current/datatype.html#DATATYPE-TABLE that have Super equivalents and translate them to those equivalents. Exceptions are int2, int4, int8, float4, and float8 since their byte-width naming conflicts with Super's bit-width naming for numeric types.

Closes #5953.