### PR TITLE
modernize by removing "range" clause variable copies

### DIFF
--- a/db/branch.go
+++ b/db/branch.go
@@ -175,8 +175,7 @@ func (b *Branch) DeleteWhere(ctx context.Context, c runtime.Compiler, ast *parse
 			patch.DeleteObject(oid)
 		}
 		for _, o := range w.Objects() {
-			obj := o
-			patch.AddDataObject(&obj)
+			patch.AddDataObject(&o)
 		}
 		if message == "" {
 			var deletedObjs []*data.Object
@@ -186,8 +185,7 @@ func (b *Branch) DeleteWhere(ctx context.Context, c runtime.Compiler, ast *parse
 			}
 			var added []*data.Object
 			for _, o := range w.Objects() {
-				obj := o
-				added = append(added, &obj)
+				added = append(added, &o)
 			}
 			message = deleteWhereMessage(deletedObjs, added)
 		}

--- a/db/pool.go
+++ b/db/pool.go
@@ -222,7 +222,6 @@ func (p *Pool) Vacuum(ctx context.Context, commit ksuid.KSUID, dryrun bool) ([]k
 	var vacuumed []ksuid.KSUID
 	var mu sync.Mutex
 	for o := range ch {
-		o := o
 		if dryrun {
 			// For dryrun just check if the object exists and append existing
 			// objects to list of results.

--- a/mdtest/heavy_test.go
+++ b/mdtest/heavy_test.go
@@ -16,7 +16,6 @@ func TestMarkdownExamples(t *testing.T) {
 	require.NoError(t, err)
 	require.NotZero(t, len(files))
 	for _, f := range files {
-		f := f
 		t.Run(filepath.ToSlash(f.Path), func(t *testing.T) {
 			t.Parallel()
 			f.Run(t)

--- a/mdtest/mdtest_test.go
+++ b/mdtest/mdtest_test.go
@@ -241,7 +241,6 @@ input
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			inputs, tests, err := parseMarkdown([]byte(tc.markdown))
 			if tc.strerror != "" {

--- a/runtime/sam/op/combine/combine.go
+++ b/runtime/sam/op/combine/combine.go
@@ -116,7 +116,6 @@ func (o *Op) propagateDone() error {
 		if parent.blocked {
 			continue
 		}
-		parent := parent
 		// We use a goroutine here because sending to parents[i].doneCh
 		// can block until we've sent to parents[i+1].doneCh, as with
 		// "fork (=> count() => pass) | head".

--- a/spq_test.go
+++ b/spq_test.go
@@ -42,7 +42,6 @@ func TestSPQ(t *testing.T) {
 	})
 
 	for d := range dirs {
-		d := d
 		t.Run(filepath.ToSlash(d), func(t *testing.T) {
 			t.Parallel()
 			ztest.Run(t, d)
@@ -120,7 +119,6 @@ func runAllBoomerangs(t *testing.T, format string, data map[string]string) {
 	t.Run(format, func(t *testing.T) {
 		t.Parallel()
 		for name, data := range data {
-			data := data
 			t.Run(name, func(t *testing.T) {
 				t.Parallel()
 				runOneBoomerang(t, format, data)

--- a/sup/marshal_bsup_test.go
+++ b/sup/marshal_bsup_test.go
@@ -68,9 +68,8 @@ func TestMarshalMap(t *testing.T) {
 		{Name: "nonempty", Map: map[string]int{"a": 1, "b": 2}},
 	}
 	for _, c := range cases {
-		c := c
-		var v s
 		t.Run(c.Name, func(t *testing.T) {
+			var v s
 			boomerang(t, c, &v)
 			assert.Equal(t, c, v)
 		})

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -186,8 +186,7 @@ func Run(t *testing.T, dirname string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, bundle := range bundles {
-		b := bundle
+	for _, b := range bundles {
 		t.Run(b.TestName, func(t *testing.T) {
 			t.Parallel()
 			if b.Error != nil {


### PR DESCRIPTION
These copies haven't been necessary since Go 1.22, which changed the semantics of iteration variables declared in for loop "range" clauses by creating new variables on each iteration.