### PR TITLE
mdtest: run mdtest-spq without input when input is empty

### DIFF
--- a/mdtest/mdtest.go
+++ b/mdtest/mdtest.go
@@ -51,7 +51,9 @@
 // contains an SPQ test.  The content of the block must comprise three sections,
 // each preceeded by one or more "#"-prefixed lines.  The first section contains
 // an SPQ program, the second contains input provided to the program when the
-// test runs, and the third contains the program's expected output.
+// test runs, and the third contains the program's expected output.  If the
+// second section contains only whitespace, no input is provided when the test
+// runs.
 //
 // SPQ tests are run via the super command.  The command's exit status must
 // indicate success (i.e., be zero) unless the mdtest-spq block's info string

--- a/mdtest/test.go
+++ b/mdtest/test.go
@@ -33,8 +33,11 @@ func (t *Test) Run() error {
 	}
 	var c *exec.Cmd
 	if t.SPQ != "" {
-		c = exec.Command("super", "-s", "-c", t.SPQ, "-")
-		c.Stdin = strings.NewReader(t.Input)
+		c = exec.Command("super", "-s", "-c", t.SPQ)
+		if s := t.Input; strings.TrimSpace(s) != "" {
+			c.Args = append(c.Args, "-")
+			c.Stdin = strings.NewReader(s)
+		}
 	} else {
 		c = exec.Command("bash", "-e", "-o", "pipefail")
 		c.Dir = t.Dir


### PR DESCRIPTION
An mdtest-spq test with empty input (i.e., containing only whitespace) runs with this command:

    echo '' | super -s -c "$spq" -

Run it with this command instead:

    super -s -c "$spq"

Closes #5629