### PR TITLE
change GET /query/describe to send aggregate input keys

### DIFF
--- a/compiler/describe/analyze.go
+++ b/compiler/describe/analyze.go
@@ -165,7 +165,7 @@ func describeOpAggs(op dag.Op, parents []field.List) []field.List {
 		// not nil.
 		keys := field.List{}
 		for _, k := range op.Keys {
-			keys = append(keys, k.LHS.(*dag.ThisExpr).Path)
+			keys = append(keys, k.RHS.(*dag.ThisExpr).Path)
 		}
 		return []field.List{keys}
 	case *dag.ForkOp:

--- a/service/ztests/query-describe.yaml
+++ b/service/ztests/query-describe.yaml
@@ -89,7 +89,7 @@ outputs:
             "name": "main",
             "aggregation_keys": [
               [
-                "key1"
+                "v1"
               ],
               [
                 "key2"


### PR DESCRIPTION
The GET /query/describe route sends a response containing the output keys for aggregation operations but Zui is interested in the input keys, so send those instead.

This wasn't a problem for Zui for most queries until #6263, which changed the output key for "aggregate by a.b" from a.b (the path of the input key) to b (the last path component of the input key).

Fixes brimdata/zui#3210.