### PR TITLE
Convert single null #input sections to empty

### DIFF
--- a/book/src/super-sql/declarations/constants.md
+++ b/book/src/super-sql/declarations/constants.md
@@ -45,7 +45,7 @@ const ABC = [
 ]
 values ABC
 # input
-null
+
 # expected output
 ["A","B","C"]
 ```

--- a/book/src/super-sql/declarations/functions.md
+++ b/book/src/super-sql/declarations/functions.md
@@ -115,7 +115,7 @@ _A simple recursive function_
 fn fact(n): n<=1 ? 1 : n*fact(n-1)
 values fact(5)
 # input
-null
+
 # expected output
 120
 ```
@@ -176,7 +176,7 @@ fn apply(a,val): (
 )
 values apply([1,2,3], 1)
 # input
-null
+
 # expected output
 "val" no such field at line 3, column 18:
   | collect(this+val)
@@ -193,7 +193,7 @@ fn apply(a,val): (
 )
 values apply([1,2,3], 1)
 # input
-null
+
 # expected output
 [2,3,4]
 ```

--- a/book/src/super-sql/declarations/queries.md
+++ b/book/src/super-sql/declarations/queries.md
@@ -44,7 +44,7 @@ _Simplest named query_
 let hello = (values 'hello, world')
 from hello
 # input
-null
+
 # expected output
 "hello, world"
 ```
@@ -58,7 +58,7 @@ _Use an array subquery if multiple values expected_
 let q = (values 1,2,3)
 values [q]
 # input
-null
+
 # expected output
 [1,2,3]
 ```
@@ -74,7 +74,7 @@ let q2 = (values 3,4)
 let q3 = (values 5)
 values {a:[q1],b:[q2],c:q3}
 # input
-null
+
 # expected output
 {a:[1,2,3],b:[3,4],c:5}
 ```

--- a/book/src/super-sql/expressions/arithmetic.md
+++ b/book/src/super-sql/expressions/arithmetic.md
@@ -24,7 +24,7 @@ where `<expr>` is any [expression](intro.md) that results in a number type.
 # spq
 values 2*3+1, 11%5, 1/0, "foo"+"bar", +1, -1
 # input
-null
+
 # expected output
 7
 1

--- a/book/src/super-sql/expressions/cast.md
+++ b/book/src/super-sql/expressions/cast.md
@@ -225,7 +225,7 @@ values
   cast(80::uint16, 'port'),
   cast(cast(80, <uint16>), 'port')
 # input
-null
+
 # expected output
 80::(port=uint16)
 80::(port=uint16)

--- a/book/src/super-sql/expressions/comparisons.md
+++ b/book/src/super-sql/expressions/comparisons.md
@@ -82,7 +82,7 @@ _Various scalar comparisons_
 # spq
 values 1 > 2, 1 < 2, "b" > "a", 1 > "a", 1 > x
 # input
-null
+
 # expected output
 false
 true

--- a/book/src/super-sql/expressions/concat.md
+++ b/book/src/super-sql/expressions/concat.md
@@ -36,7 +36,7 @@ _Cast non-string values to concatenate_
 # spq
 values "foo" || 123::string
 # input
-null
+
 # expected output
 "foo123"
 ```

--- a/book/src/super-sql/expressions/exists.md
+++ b/book/src/super-sql/expressions/exists.md
@@ -22,7 +22,7 @@ _Simple example showing true for non-empty result_
 # spq
 values exists (values 1,2,3)
 # input
-null
+
 # expected output
 true
 ```
@@ -40,7 +40,7 @@ WHERE EXISTS (
     FROM Orders
 )
 # input
-null
+
 # expected output
 {s:"there are orders in the system"}
 ```

--- a/book/src/super-sql/expressions/functions.md
+++ b/book/src/super-sql/expressions/functions.md
@@ -85,7 +85,7 @@ _Sample calls to various built-in functions_
 # spq
 values pow(2,3), lower("ABC")+upper("def"), typeof(1)
 # input
-null
+
 # expected output
 8.
 "abcDEF"
@@ -100,7 +100,7 @@ _Calling a lambda function_
 # spq
 values lambda x:x+1 (2)
 # input
-null
+
 # expected output
 3
 ```
@@ -113,7 +113,7 @@ _Passing a lambda function_
 fn square(g,val):g(val)*g(val)
 values square(lambda x:x+1, 2)
 # input
-null
+
 # expected output
 9
 ```
@@ -150,7 +150,7 @@ _Function references may not be assigned to super-structured values_
 fn f():null
 values {x:&f}
 # input
-null
+
 # expected output
 parse error at line 2, column 11:
 values {x:&f}

--- a/book/src/super-sql/expressions/inputs.md
+++ b/book/src/super-sql/expressions/inputs.md
@@ -120,7 +120,7 @@ let input = (
 )
 SELECT x FROM input
 # input
-null
+
 # expected output
 {x:1}
 {x:2}

--- a/book/src/super-sql/expressions/subqueries.md
+++ b/book/src/super-sql/expressions/subqueries.md
@@ -174,7 +174,7 @@ _Multi-valued subqueries emit an error_
 # spq
 values (values 1,2,3)
 # input
-null
+
 # expected output
 error("query expression produced multiple values (consider [subquery])")
 ```
@@ -186,7 +186,7 @@ _Multi-valued subqueries can be invoked as an array subquery_
 # spq
 values [values 1,2,3]
 # input
-null
+
 # expected output
 [1,2,3]
 ```
@@ -219,7 +219,7 @@ select *
 from input
 where x >= (select avg(x) from input)  
 # input
-null
+
 # expected output
 {x:2}
 {x:3}

--- a/book/src/super-sql/functions/types/typeof.md
+++ b/book/src/super-sql/functions/types/typeof.md
@@ -49,7 +49,7 @@ _The type of a type is type [`type`](../../types/type.md)_
 # spq
 values typeof(typeof(this))
 # input
-null
+
 # expected output
 <type>
 ```

--- a/book/src/super-sql/operators/unnest.md
+++ b/book/src/super-sql/operators/unnest.md
@@ -92,7 +92,7 @@ _unnest unrolls the elements of an array_
 # spq
 unnest [1,2,"foo"]
 # input
-null
+
 # expected output
 1
 2

--- a/book/src/super-sql/operators/values.md
+++ b/book/src/super-sql/operators/values.md
@@ -75,7 +75,7 @@ _Hello, world_
 # spq
 values "hello, world"
 # input
-null
+
 # expected output
 "hello, world"
 ```

--- a/book/src/super-sql/queries.md
+++ b/book/src/super-sql/queries.md
@@ -195,7 +195,7 @@ values 1, 2 -- , 3
 */
 | aggregate sum(this / 2.0)
 # input
-null
+
 # expected output
 1.5
 ```

--- a/book/src/super-sql/types/array.md
+++ b/book/src/super-sql/types/array.md
@@ -68,7 +68,7 @@ tied together with the corresponding [union type](union.md).
 # spq
 values [1,2,3],["hello","world"]
 # input
-null
+
 # expected output
 [1,2,3]
 ["hello","world"]
@@ -93,7 +93,7 @@ _Arrays with mixed type are tied together with a union type_
 # spq
 values typeof([1,"foo"])
 # input
-null
+
 # expected output
 <[int64|string]>
 ```

--- a/book/src/super-sql/types/bool.md
+++ b/book/src/super-sql/types/bool.md
@@ -15,7 +15,7 @@ _Comparisons produces Boolean values_
 # spq
 values 1==1, 1>2
 # input
-null
+
 # expected output
 true
 false
@@ -28,7 +28,7 @@ _Booleans are used as predicates_
 # spq
 values 1==1, 1>2
 # input
-null
+
 # expected output
 true
 false

--- a/book/src/super-sql/types/bytes.md
+++ b/book/src/super-sql/types/bytes.md
@@ -20,7 +20,7 @@ values
   0x,
   null::bytes
 # input
-null
+
 # expected output
 0x0102beef
 0x68656c6c6f2c20776f726c64

--- a/book/src/super-sql/types/map.md
+++ b/book/src/super-sql/types/map.md
@@ -56,7 +56,7 @@ tied together with the corresponding [union type](union.md).
 # spq
 values |{"foo":1,"bar"+"baz":2+3}|
 # input
-null
+
 # expected output
 |{"foo":1,"barbaz":5}|
 ```

--- a/book/src/super-sql/types/network.md
+++ b/book/src/super-sql/types/network.md
@@ -45,7 +45,7 @@ values
   2001:0db8:0000:0000:0000:0000:0000:0001
 | values this, typeof(this)
 # input
-null
+
 # expected output
 128.32.130.100
 <ip>
@@ -63,7 +63,7 @@ null
 values 128.32.130.100/24, fc00::/7
 | values this, typeof(this)
 # input
-null
+
 # expected output
 128.32.130.0/24
 <net>

--- a/book/src/super-sql/types/null.md
+++ b/book/src/super-sql/types/null.md
@@ -37,7 +37,7 @@ _The null value_
 # spq
 values typeof(null)
 # input
-null
+
 # expected output
 <null>
 ```
@@ -54,7 +54,7 @@ values
   this IS NULL,
   this IS NOT NULL
 # input
-null
+
 # expected output
 null::bool
 null::bool

--- a/book/src/super-sql/types/numbers.md
+++ b/book/src/super-sql/types/numbers.md
@@ -104,7 +104,7 @@ _Signed integers_
 values 1, 0, -1, 9223372036854775807
 | values f"{this} is type {typeof(this)}"
 # input
-null
+
 # expected output
 "1 is type <int64>"
 "0 is type <int64>"
@@ -121,7 +121,7 @@ _Other signed integer types_
 values 1, 200, 70000, 9223372036854775807
 | values this::int8, this::int16, this::int32, this::int64
 # input
-null
+
 # expected output
 1::int8
 1::int16
@@ -151,7 +151,7 @@ values 1, 200, 70000, 9223372036854775807
 | values this::uint8, this::uint16, this::uint32, this::uint64
 | values f"{this} is type {typeof(this)}"
 # input
-null
+
 # expected output
 "1 is type <uint8>"
 "1 is type <uint16>"
@@ -180,7 +180,7 @@ _Floating-point numbers_
 values 1., 1.23, 18446744073709551615., 1.e100, +Inf, -Inf, NaN
 | values f"{this} is type {typeof(this)}"
 # input
-null
+
 # expected output
 "1 is type <float64>"
 "1.23 is type <float64>"
@@ -200,7 +200,7 @@ values 1., 1.23, 18446744073709551615., 1.e100, +Inf, -Inf, NaN
 | values this::float16, this::float32, this::float64
 | values f"{this} is type {typeof(this)}"
 # input
-null
+
 # expected output
 "1 is type <float16>"
 "1 is type <float32>"

--- a/book/src/super-sql/types/record.md
+++ b/book/src/super-sql/types/record.md
@@ -75,7 +75,7 @@ _A simple record literal_
 # spq
 values {a:1,b:2,s:"hello"}
 # input
-null
+
 # expected output
 {a:1,b:2,s:"hello"}
 ```
@@ -104,7 +104,7 @@ _A record literal with casts_
 # spq
 values {b:true,u:1::uint8,a:[1,2,3],s:"hello"::=CustomString}
 # input
-null
+
 # expected output
 {b:true,u:1::uint8,a:[1,2,3],s:"hello"::=CustomString}
 ```
@@ -117,7 +117,7 @@ _A record expression with an unnamed expression_
 # spq
 values {1+2*3}
 # input
-null
+
 # expected output
 {"1+2*3":7}
 ```
@@ -130,7 +130,7 @@ _Selecting a record expression with an unnamed expression_
 # spq
 select {1+2*3} as x
 # input
-null
+
 # expected output
 {x:{"1+2*3":7}}
 ```

--- a/book/src/super-sql/types/set.md
+++ b/book/src/super-sql/types/set.md
@@ -68,7 +68,7 @@ tied together with the corresponding [union type](union.md).
 # spq
 values |[3,1,2]|,|["hello","world","hello"]|
 # input
-null
+
 # expected output
 |[1,2,3]|
 |["hello","world"]|
@@ -91,7 +91,7 @@ values |[...a,...b,4]|
 # spq
 values [1,2,3],["hello","world"]
 # input
-null
+
 # expected output
 [1,2,3]
 ["hello","world"]
@@ -104,7 +104,7 @@ _Sets with mixed types are tied together with a union type_
 # spq
 values typeof(|[1,"foo"]|)
 # input
-null
+
 # expected output
 <|[int64|string]|>
 ```

--- a/book/src/super-sql/types/string.md
+++ b/book/src/super-sql/types/string.md
@@ -68,7 +68,7 @@ _Various strings_
 # spq
 values 'hello, world', len('foo'), "SuperDB", "\"quoted\"", 'foo'+'bar'
 # input
-null
+
 # expected output
 "hello, world"
 3
@@ -109,7 +109,7 @@ _Raw strings_
 # spq
 values r'foo\nbar\t'
 # input
-null
+
 # expected output
 "foo\\nbar\\t"
 ```
@@ -121,7 +121,7 @@ _Raw strings with embedded newline_
 values r'foo
 bar'
 # input
-null
+
 # expected output
 "foo\nbar"
 ```


### PR DESCRIPTION
Leverage the changes in #6359 by emptying these mdtest `#input` sections, which will drop the rendering of the "Input" box hence simplifying the presentation of the example.

Found these via:

```
find . -name \*.md -exec pcre2grep -i -M -e '# input\nnull\n#' {} \; -ls
```