### PR TITLE
book: update config for mdbook 0.5

### DIFF
--- a/book/.gitignore
+++ b/book/.gitignore
@@ -1,5 +1,4 @@
 book
-theme
 
 package-lock.json
 src/super.wasm

--- a/book/README.md
+++ b/book/README.md
@@ -9,11 +9,6 @@ You'll need `mdbook`.  Install it with brew
 brew install mdbook
 ```
 
-You'll also need the "table of contents" preprocessor. Install it with cargo
-```
-cargo install mdbook-pagetoc
-```
-
 The easiest way to work on docs is to run an mdbook service in this directory
 and point your browser at its embedded web server, e.g.,
 ```

--- a/book/book.toml
+++ b/book/book.toml
@@ -7,16 +7,10 @@ title = "SuperDB"
 [output.html.fold]
 enable = true
 
-[preprocessor.pagetoc]
-
 [output.html]
-additional-css = ["super-example/super-example.css", "copy-button/copy-button.css", "theme/pagetoc.css"]
-additional-js = ["super-example.bundle.js", "copy-button/copy-button.js", "theme/pagetoc.js"]
+additional-css = ["super-example/super-example.css", "copy-button/copy-button.css"]
+additional-js = ["super-example.bundle.js", "copy-button/copy-button.js"]
 git-repository-url = "https://github.com/brimdata/super/tree/main/book"
-# This directive embeds content hashes in the certain asset file names 
-# to work around a problem where cached files cause the sidebar not to reflect
-# changes to SUMMARY.md.  See https://github.com/rust-lang/mdBook/issues/2547
-hash-files = true
 no-section-label = true
 
 [output.html.playground]


### PR DESCRIPTION
* Remove the mdbook-pagetoc preprocessor since the sidebar now contains page header navigation by default.

* Remove output.html.hash-files from book.toml since it now defaults to true.