### PR TITLE
Add colored backgrounds for mdbook admonitions

### DIFF
--- a/book/admonitions/admonitions.css
+++ b/book/admonitions/admonitions.css
@@ -1,0 +1,25 @@
+/* Add light background colors to mdbook admonitions */
+.blockquote-tag {
+  padding: 1em;
+  border-radius: 4px;
+}
+
+.blockquote-tag-note {
+  background-color: rgba(68, 138, 255, 0.1);
+}
+
+.blockquote-tag-tip {
+  background-color: rgba(0, 191, 165, 0.1);
+}
+
+.blockquote-tag-important {
+  background-color: rgba(137, 87, 229, 0.1);
+}
+
+.blockquote-tag-warning {
+  background-color: rgba(255, 152, 0, 0.1);
+}
+
+.blockquote-tag-caution {
+  background-color: rgba(244, 67, 54, 0.1);
+}

--- a/book/book.toml
+++ b/book/book.toml
@@ -8,7 +8,7 @@ title = "SuperDB"
 enable = true
 
 [output.html]
-additional-css = ["super-example/super-example.css", "copy-button/copy-button.css"]
+additional-css = ["super-example/super-example.css", "copy-button/copy-button.css", "admonitions/admonitions.css"]
 additional-js = ["super-example.bundle.js", "copy-button/copy-button.js"]
 git-repository-url = "https://github.com/brimdata/super/tree/main/book"
 no-section-label = true


### PR DESCRIPTION
## tl;dr

This enables colored backgrounds for mdbook [admonitions](https://rust-lang.github.io/mdBook/format/markdown.html#admonitions).

## Details

This is a handy feature we can take advantage of now that we're running mdbook v0.5 which improves on the simple blockquotes we've been doing:

https://github.com/brimdata/super/blob/a3c31a5470d8d2a89a9427397dd15ed803eb96cf/book/src/intro.md?plain=1#L386-L387

Now can become:

<img width="639" height="86" alt="image" src="https://github.com/user-attachments/assets/7ffcbc68-8ee5-4ecd-b7ca-3c0f1dd492f1" />

I happen to be partial to the colored backgrounds like we had with Docusaurus admonitions, and the CSS I've added here gets us that. I mostly reach for "Tip" and "Note", in my writing, but here's the full set:

<img width="768" height="596" alt="image" src="https://github.com/user-attachments/assets/6f8b67f2-aca7-4c07-9ba7-fa7a4db2949b" />
