### PR TITLE
book/super-example: prepare for multi-word data-layout

### DIFF
--- a/book/super-example/super-example.css
+++ b/book/super-example/super-example.css
@@ -18,7 +18,15 @@
     'input result';
   border-radius: var(--radius);
 
-  &[data-layout='no-input'] {
+  &[data-layout='stacked']:not(.no-input) {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      'query'
+      'input'
+      'result';
+  }
+
+  &.no-input {
     grid-template-columns: minmax(0, 1fr);
     grid-template-areas:
       'query'
@@ -26,14 +34,6 @@
     .input {
       display: none;
     }
-  }
-
-  &[data-layout='stacked'] {
-    grid-template-columns: minmax(0, 1fr);
-    grid-template-areas:
-      'query'
-      'input'
-      'result';
   }
 
   & > * {

--- a/book/super-example/super-example.js
+++ b/book/super-example/super-example.js
@@ -19,12 +19,9 @@ for (const [i, pre] of preNodes.entries()) {
         .filter((c) => c.match(/^{.*}$/))
         .map((c) => c.slice(1, -1))
         .join(' ');
-  if (input.length === 0) {
-    attributes += 'data-layout="no-input"';
-  }
 
   const html = `
-  <article class="super-example" ${attributes}>
+  <article class="super-example ${input.length === 0 ? 'no-input' : ''}" ${attributes}>
     <div class="editor query">
       <header class="repel"><label>Query</label></header>
       <pre><code></code></pre>


### PR DESCRIPTION
A subsequent change will add support for `<article>` data-layout attribute values containing multiple words.  Make that easier by moving the CSS property that hides an empty input div from the data-layout attribute to a class.