### PR TITLE
aggfunc.subst: Use original ast.Node for sem.This.Node

### DIFF
--- a/compiler/semantic/projection.go
+++ b/compiler/semantic/projection.go
@@ -83,7 +83,7 @@ func (a *aggfuncs) subst(e sem.Expr) sem.Expr {
 		// the generated aggregate operator.
 		tmp := a.tmp()
 		*a = append(*a, namedAgg{name: tmp, agg: e})
-		return sem.NewThis(e, []string{"in", tmp})
+		return sem.NewThis(e.Node, []string{"in", tmp})
 	case *sem.ArrayExpr:
 		e.Elems = a.substArrayElems(e.Elems)
 	case *sem.BinaryExpr:


### PR DESCRIPTION
This commit fixes a bug where the Node for the newly created sem.This object was being set as a sem.Expr (which implements ast.Node) where it should be the original ast.Node. This change will be tested in an upcoming pr.