### PR TITLE
Allow group by keys to be used in arbitrary expressions

### DIFF
--- a/compiler/ztests/sql/group-by-key-expr.yaml
+++ b/compiler/ztests/sql/group-by-key-expr.yaml
@@ -1,0 +1,22 @@
+# Test that group by expressions can be combined into complex select clauses.
+script: |
+  super -s -c '
+    select a+b+c
+    from (values (1,1,1),(2,2,2)) t(a,b,c)
+    group by a+b, c
+    order by 1'
+  ! super -s -c '
+    select b+a+c
+    from (values (1,1,1),(2,2,2)) t(a,b,c)
+    group by a+b,c'
+
+outputs:
+  - name: stdout
+    data: |
+      {"a+b+c":3}
+      {"a+b+c":6}
+  - name: stderr
+    data: |
+      no corresponding grouping element for non-aggregate "b+a+c" at line 2, column 10:
+        select b+a+c
+               ~~~~~

--- a/compiler/ztests/sql/group-by-ordinal.yaml
+++ b/compiler/ztests/sql/group-by-ordinal.yaml
@@ -42,9 +42,9 @@ outputs:
       select a, b, c, d group by 5, 0
                       ~
       // ===
-      aggregate functions are not allowed in GROUP BY at line 1, column 33:
+      aggregate functions are not allowed in GROUP BY at line 1, column 8:
       select count() as c, a group by 1,2
-                                      ~
+             ~~~~~~~
 
 output: |
   {c:1::uint64}

--- a/compiler/ztests/sql/select-agg-and-literal.yaml
+++ b/compiler/ztests/sql/select-agg-and-literal.yaml
@@ -1,0 +1,8 @@
+# Test that a select statement can include an aggregation expression and a
+# literal expression.
+
+spq: |
+  SELECT - 82 + - 61 + 13, 11 - - - COUNT ( * ) AS col1
+
+output: |
+  {"-82+-61+13":-130,col1:10}


### PR DESCRIPTION
Previously group by keys could only be used in select clauses if the select expression exactly matched the expression in a group by. This change allows them to be used in any abitrary expression including expressions that involve multiple group-by keys.

Closes #5973