### PR TITLE
sio/jsupio: fix infinite loop reading /dev/zero

### DIFF
--- a/sio/jsupio/ztests/dev-zero.yaml
+++ b/sio/jsupio/ztests/dev-zero.yaml
@@ -1,0 +1,7 @@
+script: |
+  ! super -i jsup /dev/zero
+
+outputs:
+  - name: stderr
+    data: |
+      /dev/zero: line 1: line too long


### PR DESCRIPTION
Replace pkg/skim.Scanner with bufio.Scanner, which has nearly identical behavior except that it will not read forever in search of a newline.