### PR TITLE
sio/zeekio: fix infinite loop reading /dev/zero

### DIFF
--- a/sio/zeekio/ztests/dev-zero.yaml
+++ b/sio/zeekio/ztests/dev-zero.yaml
@@ -1,0 +1,7 @@
+script: |
+  ! super -i zeek /dev/zero
+
+outputs:
+  - name: stderr
+    data: |
+      /dev/zero: line 1: line too long


### PR DESCRIPTION
Replace pkg/skim.Scanner with bufio.Scanner, which has nearly identical behavior except that it will not read forever in search of a newline.