### PR TITLE
sio/anyio: fix infinite loop reading /dev/zero

### DIFF
--- a/sio/anyio/reader.go
+++ b/sio/anyio/reader.go
@@ -2,11 +2,11 @@ package anyio
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
-	"strings"
 
 	"github.com/brimdata/super"
 	"github.com/brimdata/super/pkg/field"
@@ -177,9 +177,9 @@ func isArrowStream(track *Track) error {
 }
 
 func isCSVStream(track *Track, delim rune, name string) error {
-	if s, err := bufio.NewReader(track).ReadString('\n'); err != nil {
+	if line, err := bufio.NewReader(track).ReadSlice('\n'); err != nil {
 		return fmt.Errorf("%s: line 1: %w", name, err)
-	} else if !strings.Contains(s, string(delim)) {
+	} else if !bytes.ContainsRune(line, delim) {
 		return fmt.Errorf("%s: line 1: delimiter %q not found", name, delim)
 	}
 	track.Reset()

--- a/sio/anyio/ztests/detector-dev-zero.yaml
+++ b/sio/anyio/ztests/detector-dev-zero.yaml
@@ -1,0 +1,18 @@
+script: |
+  ! super /dev/zero
+
+outputs:
+  - name: stderr
+    data: |
+      /dev/zero: format detection error
+      	arrows: arrow/ipc: could not read message schema: EOF
+      	bsup: bsupio: frame length (0) too small
+      	csup: invalid CSUP header
+      	csv: line 1: bufio: buffer full
+      	json: invalid character '\x00' looking for beginning of value
+      	line: auto-detection not supported
+      	parquet: parquet: file too small (size=0)
+      	sup: short buffer
+      	tsv: line 1: bufio: buffer full
+      	zeek: line 1: line too long
+      	jsup: line 1: line too long


### PR DESCRIPTION
Replace bufio.Reader.ReadString with ReadSlice, which will not read forever in search of the delimiter byte.