### PR TITLE
coalesce: ignore all errors

### DIFF
--- a/book/src/super-sql/functions/generics/coalesce.md
+++ b/book/src/super-sql/functions/generics/coalesce.md
@@ -10,9 +10,8 @@ coalesce(val: any [, ... val: any]) -> any
 
 ### Description
 
-The `coalesce` function returns the first of its arguments that is not null,
-`error("missing")`, or `error("quiet")`.  It returns null if all its arguments
-are null, `error("missing")`, or `error("quiet")`.
+The `coalesce` function returns the first of its arguments that is not null or
+an error.  It returns null if all its arguments are null or an error.
 
 ### Examples
 
@@ -20,7 +19,7 @@ are null, `error("missing")`, or `error("quiet")`.
 
 ```mdtest-spq
 # spq
-values coalesce(null, error("missing"), error("quiet"), this)
+values coalesce(null, error("missing"), error({x:"foo"}), this)
 # input
 1
 # expected output
@@ -31,7 +30,7 @@ values coalesce(null, error("missing"), error("quiet"), this)
 
 ```mdtest-spq
 # spq
-values coalesce(null, error("missing"), this)
+values coalesce(null, error({x:"foo"}), this)
 # input
 error("quiet")
 # expected output

--- a/runtime/sam/expr/function/coalesce.go
+++ b/runtime/sam/expr/function/coalesce.go
@@ -7,7 +7,7 @@ type Coalesce struct{}
 func (c *Coalesce) Call(args []super.Value) super.Value {
 	for i := range args {
 		val := args[i].Under()
-		if !val.IsNull() && !val.IsMissing() && !val.IsQuiet() {
+		if !val.IsNull() && !val.IsError() {
 			return args[i]
 		}
 	}

--- a/runtime/vam/expr/function/coalesce.go
+++ b/runtime/vam/expr/function/coalesce.go
@@ -51,9 +51,7 @@ func (c *Coalesce) Call(vecs ...vector.Any) vector.Any {
 }
 
 func (c *Coalesce) arg(vec vector.Any, tag uint32) {
-	if errvec, ok := vec.(*vector.Error); ok && errvec.Typ.Type == super.TypeString {
-		c.errString(tag, errvec)
-	} else {
+	if _, ok := vec.(*vector.Error); !ok {
 		c.checkNulls(vec, tag)
 	}
 }
@@ -75,22 +73,6 @@ func (c *Coalesce) checkNulls(vec vector.Any, tag uint32) {
 		}
 	}
 	c.setAll(vector.NullsOf(vec), tag)
-}
-
-func (c *Coalesce) errString(tag uint32, vec *vector.Error) {
-	if cnst, ok := vec.Vals.(*vector.Const); ok {
-		if s, _ := cnst.AsString(); s != "missing" && s != "quiet" {
-			c.setAll(cnst.Nulls, tag)
-		}
-		return
-	}
-	for i := range vec.Len() {
-		s, null := vector.StringValue(vec.Vals, i)
-		if null || s == "missing" || s == "quiet" {
-			continue
-		}
-		c.setTag(i, tag)
-	}
 }
 
 func (c *Coalesce) setAll(nulls bitvec.Bits, tag uint32) {

--- a/runtime/ztests/expr/function/coalesce.yaml
+++ b/runtime/ztests/expr/function/coalesce.yaml
@@ -8,6 +8,7 @@ input: |
   [error("missing")::=missing, 2020::=port, null::string]
   [null::string, error("missing"), error("quiet")]
   [null::error({x:string}), "gotme", "ted sando"]
+  [null, error({x:1}), "foo"]
 
 output: |
   "foo"::(uint64|string)
@@ -15,3 +16,4 @@ output: |
   2020::=port
   null
   "gotme"
+  "foo"


### PR DESCRIPTION
This commit changes the behavior of the coalesce function so that all errors are ignored not just error("missing") and error("quiet").

Fixes #4329