### PR TITLE
Handle no else clause on case expressions

### DIFF
--- a/compiler/semantic/expr.go
+++ b/compiler/semantic/expr.go
@@ -613,7 +613,14 @@ func (t *translator) semDotted(e *ast.BinaryExpr, lval bool) ([]string, sem.Expr
 
 func (t *translator) semCaseExpr(c *ast.CaseExpr) sem.Expr {
 	e := t.expr(c.Expr)
-	out := t.exprNullable(c.Else)
+	var out sem.Expr
+	if c.Else != nil {
+		out = t.expr(c.Else)
+	} else if t.scope.schema != nil {
+		out = &sem.LiteralExpr{Node: c, Value: "null"}
+	} else {
+		out = sem.NewStructuredError(c, "case: no clause matched and no else provided", e)
+	}
 	for i := len(c.Whens) - 1; i >= 0; i-- {
 		when := c.Whens[i]
 		out = &sem.CondExpr{

--- a/compiler/ztests/sql/case-noelse.yaml
+++ b/compiler/ztests/sql/case-noelse.yaml
@@ -1,0 +1,8 @@
+spq: |
+  select case x when 1 then 'foo' end as x from (values (1),(2)) T(x)
+
+vector: true
+
+output: |
+  {x:"foo"}
+  {x:null}

--- a/runtime/ztests/expr/case-noelse.yaml
+++ b/runtime/ztests/expr/case-noelse.yaml
@@ -1,0 +1,8 @@
+spq: |
+  values 1,2 | values case this when 1 then 'foo' end
+
+vector: true
+
+output: |
+  "foo"
+  error({message:"case: no clause matched and no else provided",on:2})


### PR DESCRIPTION
The commit changes case expressions so that in a pipe query if an expression does not match any clause and there is no else clause a structured error is returned. In a SQL query a null value is returned.

Closes #6333