### PR TITLE
vam.toBool: convert const null bool vector

### DIFF
--- a/runtime/vam/expr/logic.go
+++ b/runtime/vam/expr/logic.go
@@ -174,9 +174,10 @@ func toBool(vec vector.Any) *vector.Bool {
 			out := vector.NewTrue(vec.Len())
 			out.Nulls = vec.Nulls
 			return out
-		} else {
-			return vector.NewBoolEmpty(vec.Len(), vec.Nulls)
+		} else if val.IsNull() {
+			return vector.NewBoolEmpty(vec.Len(), bitvec.NewTrue(vec.Len()))
 		}
+		return vector.NewBoolEmpty(vec.Len(), vec.Nulls)
 	case *vector.Dynamic:
 		nulls := bitvec.NewFalse(vec.Len())
 		out := vector.NewBoolEmpty(vec.Len(), nulls)


### PR DESCRIPTION
This commit fixes an issue where const vectors of type null::bool where not getting properly converted to vector.Bool.