### PR TITLE
vam/expr.Compare: Flip true null values to false null

### DIFF
--- a/runtime/ztests/expr/compare-issue-6277.yaml
+++ b/runtime/ztests/expr/compare-issue-6277.yaml
@@ -1,0 +1,10 @@
+spq: |
+  values a >= b or a <= b
+
+vector: true
+
+input: |
+  {a:1,b:null}
+
+output: |
+  null::bool


### PR DESCRIPTION
Change the logic the vam.Comparison function so that comparisons that result in a null true value get the value flipped to false. This fixes an issue where true results would get falsely reported when these were values were or'd against a false value.

Closes #6277